### PR TITLE
[C++ API] Cursors

### DIFF
--- a/test/cpp/api/container.cpp
+++ b/test/cpp/api/container.cpp
@@ -62,7 +62,7 @@ TEST_CASE("containers") {
         REQUIRE(y.size(i) == 2);
       }
 
-      REQUIRE(model->parameters().get("weight").grad().numel() == 3 * 2 * 3);
+      REQUIRE(model->parameters()["weight"].grad().numel() == 3 * 2 * 3);
     }
     SECTION("2d") {
       SECTION("even") {
@@ -79,7 +79,7 @@ TEST_CASE("containers") {
         }
 
         REQUIRE(
-            model->parameters().get("weight").grad().numel() == 3 * 2 * 3 * 3);
+            model->parameters()["weight"].grad().numel() == 3 * 2 * 3 * 3);
       }
 
       SECTION("uneven") {
@@ -96,7 +96,7 @@ TEST_CASE("containers") {
         }
 
         REQUIRE(
-            model->parameters().get("weight").grad().numel() == 3 * 2 * 3 * 2);
+            model->parameters()["weight"].grad().numel() == 3 * 2 * 3 * 2);
       }
     }
     SECTION("3d") {
@@ -113,7 +113,7 @@ TEST_CASE("containers") {
       }
 
       REQUIRE(
-          model->parameters().get("weight").grad().numel() ==
+          model->parameters()["weight"].grad().numel() ==
           3 * 2 * 3 * 3 * 3);
     }
   }
@@ -130,7 +130,7 @@ TEST_CASE("containers") {
       REQUIRE(y.size(0) == 10);
       REQUIRE(y.size(1) == 2);
 
-      REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
+      REQUIRE(model->parameters()["weight"].grad().numel() == 2 * 5);
     }
   }
 
@@ -169,7 +169,7 @@ TEST_CASE("containers") {
       REQUIRE(y.size(1) == 2);
 
       REQUIRE(
-          model->parameters().get("table").grad().numel() == 2 * dict_size);
+          model->parameters()["table"].grad().numel() == 2 * dict_size);
     }
 
     SECTION("list") {
@@ -253,7 +253,7 @@ TEST_CASE("containers_cuda", "[cuda]") {
     REQUIRE(y.size(0) == 10);
     REQUIRE(y.size(1) == 2);
 
-    REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
+    REQUIRE(model->parameters()["weight"].grad().numel() == 2 * 5);
   }
 
   SECTION("2") {
@@ -270,6 +270,6 @@ TEST_CASE("containers_cuda", "[cuda]") {
     REQUIRE(y.size(0) == 10);
     REQUIRE(y.size(1) == 2);
 
-    REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
+    REQUIRE(model->parameters()["weight"].grad().numel() == 2 * 5);
   }
 }

--- a/test/cpp/api/container.cpp
+++ b/test/cpp/api/container.cpp
@@ -62,7 +62,7 @@ TEST_CASE("containers") {
         REQUIRE(y.size(i) == 2);
       }
 
-      REQUIRE(model->parameters().at("weight").grad().numel() == 3 * 2 * 3);
+      REQUIRE(model->parameters().get("weight").grad().numel() == 3 * 2 * 3);
     }
     SECTION("2d") {
       SECTION("even") {
@@ -79,7 +79,7 @@ TEST_CASE("containers") {
         }
 
         REQUIRE(
-            model->parameters().at("weight").grad().numel() == 3 * 2 * 3 * 3);
+            model->parameters().get("weight").grad().numel() == 3 * 2 * 3 * 3);
       }
 
       SECTION("uneven") {
@@ -96,7 +96,7 @@ TEST_CASE("containers") {
         }
 
         REQUIRE(
-            model->parameters().at("weight").grad().numel() == 3 * 2 * 3 * 2);
+            model->parameters().get("weight").grad().numel() == 3 * 2 * 3 * 2);
       }
     }
     SECTION("3d") {
@@ -113,7 +113,8 @@ TEST_CASE("containers") {
       }
 
       REQUIRE(
-          model->parameters().at("weight").grad().numel() == 3 * 2 * 3 * 3 * 3);
+          model->parameters().get("weight").grad().numel() ==
+          3 * 2 * 3 * 3 * 3);
     }
   }
   SECTION("linear") {
@@ -129,7 +130,7 @@ TEST_CASE("containers") {
       REQUIRE(y.size(0) == 10);
       REQUIRE(y.size(1) == 2);
 
-      REQUIRE(model->parameters().at("weight").grad().numel() == 2 * 5);
+      REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
     }
   }
 
@@ -167,7 +168,8 @@ TEST_CASE("containers") {
       REQUIRE(y.size(0) == 10);
       REQUIRE(y.size(1) == 2);
 
-      REQUIRE(model->parameters().at("table").grad().numel() == 2 * dict_size);
+      REQUIRE(
+          model->parameters().get("table").grad().numel() == 2 * dict_size);
     }
 
     SECTION("list") {
@@ -204,21 +206,22 @@ TEST_CASE("containers") {
 
   SECTION("param") {
     auto model = std::make_shared<NestedModel>();
-    REQUIRE(model->param("param").size(0) == 3);
-    REQUIRE(model->param("param").size(1) == 2);
-    REQUIRE(model->param("param").size(2) == 21);
-    REQUIRE(model->param("l1.bias").size(0) == 20);
-    REQUIRE(model->param("l1.weight").size(0) == 20);
-    REQUIRE(model->param("l1.weight").size(1) == 5);
-    REQUIRE(model->param("test.l1.bias").size(0) == 3);
-    REQUIRE(model->param("test.l1.weight").size(0) == 3);
-    REQUIRE(model->param("test.l1.weight").size(1) == 10);
-    REQUIRE(model->param("test.l2.bias").size(0) == 5);
-    REQUIRE(model->param("test.l2.weight").size(0) == 5);
-    REQUIRE(model->param("test.l2.weight").size(1) == 3);
-    REQUIRE(model->param("test.l3.bias").size(0) == 100);
-    REQUIRE(model->param("test.l3.weight").size(0) == 100);
-    REQUIRE(model->param("test.l3.weight").size(1) == 5);
+    auto parameters = model->parameters();
+    REQUIRE(parameters["param"].size(0) == 3);
+    REQUIRE(parameters["param"].size(1) == 2);
+    REQUIRE(parameters["param"].size(2) == 21);
+    REQUIRE(parameters["l1.bias"].size(0) == 20);
+    REQUIRE(parameters["l1.weight"].size(0) == 20);
+    REQUIRE(parameters["l1.weight"].size(1) == 5);
+    REQUIRE(parameters["test.l1.bias"].size(0) == 3);
+    REQUIRE(parameters["test.l1.weight"].size(0) == 3);
+    REQUIRE(parameters["test.l1.weight"].size(1) == 10);
+    REQUIRE(parameters["test.l2.bias"].size(0) == 5);
+    REQUIRE(parameters["test.l2.weight"].size(0) == 5);
+    REQUIRE(parameters["test.l2.weight"].size(1) == 3);
+    REQUIRE(parameters["test.l3.bias"].size(0) == 100);
+    REQUIRE(parameters["test.l3.weight"].size(0) == 100);
+    REQUIRE(parameters["test.l3.weight"].size(1) == 5);
   }
 
   SECTION("functional") {
@@ -250,7 +253,7 @@ TEST_CASE("containers_cuda", "[cuda]") {
     REQUIRE(y.size(0) == 10);
     REQUIRE(y.size(1) == 2);
 
-    REQUIRE(model->parameters().at("weight").grad().numel() == 2 * 5);
+    REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
   }
 
   SECTION("2") {
@@ -267,6 +270,6 @@ TEST_CASE("containers_cuda", "[cuda]") {
     REQUIRE(y.size(0) == 10);
     REQUIRE(y.size(1) == 2);
 
-    REQUIRE(model->parameters().at("weight").grad().numel() == 2 * 5);
+    REQUIRE(model->parameters().get("weight").grad().numel() == 2 * 5);
   }
 }

--- a/test/cpp/api/cursor.cpp
+++ b/test/cpp/api/cursor.cpp
@@ -1,0 +1,327 @@
+#include <catch.hpp>
+
+#include <torch/nn/cursor.h>
+#include <torch/nn/module.h>
+
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace torch;
+using namespace torch::nn;
+using namespace torch::detail;
+
+using Catch::StartsWith;
+
+struct TestModule : public torch::nn::Module {
+  TestModule(int64_t size) {
+    tensor1 =
+        register_parameter("tensor1", at::randn(at::CPU(at::kFloat), {size}));
+    tensor2 =
+        register_parameter("tensor2", at::randn(at::CPU(at::kFloat), {size}));
+  }
+
+  autograd::Variable tensor1;
+  autograd::Variable tensor2;
+};
+
+struct Container : public torch::nn::Module {
+  template <typename... Ms>
+  explicit Container(Ms&&... ms) {
+    add(0, ms...);
+  }
+
+  void add(size_t) {}
+
+  template <typename Head, typename... Tail>
+  void add(size_t index, Head head, Tail... tail) {
+    add(std::to_string(index), std::move(head));
+    add(index + 1, tail...);
+  }
+
+  template <typename M>
+  void add(std::string name, M&& module) {
+    m.push_back(register_module(name, std::make_shared<M>(std::move(module))));
+  }
+
+  template <typename M>
+  void add(std::string name, std::shared_ptr<M>&& module) {
+    m.push_back(register_module(name, std::move(module)));
+  }
+
+  Module& operator[](size_t index) {
+    return *m.at(index);
+  }
+
+  std::vector<std::shared_ptr<Module>> m;
+};
+
+TEST_CASE("cursor/module") {
+  SECTION("Works for flat models (depth = 1)") {
+    Container model(TestModule(1), TestModule(2), TestModule(3));
+    auto cursor = model.modules();
+
+    SECTION("Iterates in the correct order") {
+      auto iterator = cursor.begin();
+      REQUIRE(&iterator->value == &model[0]);
+      REQUIRE(&(++iterator)->value == &model[1]);
+      REQUIRE(&(++iterator)->value == &model[2]);
+      REQUIRE(++iterator == cursor.end());
+    }
+
+    SECTION("names are flat") {
+      auto iterator = cursor.begin();
+      REQUIRE(iterator->key == "0");
+      REQUIRE((++iterator)->key == "1");
+      REQUIRE((++iterator)->key == "2");
+    }
+
+    SECTION("Apply works") {
+      size_t count = 0;
+      cursor.apply([&count, &model](Module& module) {
+        REQUIRE(&module == &model[count]);
+        count += 1;
+      });
+      REQUIRE(count == 3);
+    }
+
+    SECTION("Apply_items works") {
+      size_t count = 0;
+      cursor.apply_items(
+          [&count, &model](const std::string& key, Module& module) {
+            REQUIRE(&module == &model[count]);
+            count += 1;
+          });
+      REQUIRE(count == 3);
+    }
+
+    SECTION("Map works") {
+      std::vector<Module*> vector(3);
+      cursor.map(vector.begin(), [](Module& module) { return &module; });
+
+      std::list<Module*> list;
+      cursor.map(
+          std::back_inserter(list), [](Module& module) { return &module; });
+    }
+
+    SECTION("Map_items works") {
+      std::map<const char*, Module*> output;
+      cursor.map_items(
+          std::inserter(output, output.end()),
+          [](const std::string& key, Module& module) {
+            return std::make_pair(key.c_str(), &module);
+          });
+    }
+
+    SECTION("Count works for flat models") {
+      REQUIRE(cursor.count() == model.m.size());
+    }
+
+    SECTION("find() finds the correct modules when given a valid key") {
+      REQUIRE(cursor.find("0") == &model[0]);
+      REQUIRE(cursor.find("1") == &model[1]);
+      REQUIRE(cursor.find("2") == &model[2]);
+    }
+
+    SECTION("find() returns nullptr when given an invalid key") {
+      REQUIRE(cursor.find("foo") == nullptr);
+      REQUIRE(cursor.find("bar") == nullptr);
+    }
+
+    SECTION("get() returns the correct modules when given a valid key") {
+      REQUIRE(&cursor.get("0") == &model[0]);
+      REQUIRE(&cursor.get("1") == &model[1]);
+      REQUIRE(&cursor.get("2") == &model[2]);
+    }
+
+    SECTION("get() throws when given an invalid key") {
+      REQUIRE_THROWS_WITH(cursor.get("foo"), StartsWith("No such key: 'foo'"));
+      REQUIRE_THROWS_WITH(cursor.get("bar"), StartsWith("No such key: 'bar'"));
+    }
+
+    SECTION("operator[] returns the correct modules when given a valid key") {
+      REQUIRE(&cursor["0"] == &model[0]);
+      REQUIRE(&cursor["1"] == &model[1]);
+      REQUIRE(&cursor["2"] == &model[2]);
+    }
+
+    SECTION("operator[] throws when given an invalid key") {
+      REQUIRE_THROWS_WITH(cursor["foo"], StartsWith("No such key: 'foo'"));
+      REQUIRE_THROWS_WITH(cursor["bar"], StartsWith("No such key: 'bar'"));
+    }
+
+    SECTION("contains() is correct") {
+      REQUIRE(cursor.contains("0"));
+      REQUIRE(cursor.contains("1"));
+      REQUIRE(cursor.contains("2"));
+    }
+  }
+
+  SECTION("Works for deeper hierarchies (depth > 1)") {
+    // clang-format off
+    Container model(
+        Container(
+          TestModule(1),
+          TestModule(2)),
+        TestModule(3),
+        Container(
+          TestModule(4),
+          Container(
+            TestModule(5),
+            TestModule(6))
+        ));
+    // clang-format on
+
+    auto cursor = model.modules();
+    // This is sufficient for the hierarchical case
+    // (other tests build on top)
+    SECTION("Iterates in the correct order") {
+      auto iterator = cursor.begin();
+
+      REQUIRE(&iterator->value == &model[0]);
+
+      auto* seq = dynamic_cast<Container*>(&model[0]);
+      REQUIRE(seq != nullptr);
+      REQUIRE(&(++iterator)->value == &(*seq)[0]);
+      REQUIRE(&(++iterator)->value == &(*seq)[1]);
+
+      REQUIRE(&(++iterator)->value == &model[1]);
+      REQUIRE(&(++iterator)->value == &model[2]);
+
+      seq = dynamic_cast<Container*>(&model[2]);
+      REQUIRE(seq != nullptr);
+      REQUIRE(&(++iterator)->value == &(*seq)[0]);
+      REQUIRE(&(++iterator)->value == &(*seq)[1]);
+
+      seq = dynamic_cast<Container*>(&(*seq)[1]);
+      REQUIRE(seq != nullptr);
+      REQUIRE(&(++iterator)->value == &(*seq)[0]);
+      REQUIRE(&(++iterator)->value == &(*seq)[1]);
+    }
+
+    SECTION("children() returns only the first level of submodules") {
+      auto children = model.children();
+      REQUIRE(children.count() == 3);
+      REQUIRE(&children.get("0") == &model[0]);
+      REQUIRE(&children.get("1") == &model[1]);
+      REQUIRE(&children.get("2") == &model[2]);
+      REQUIRE(!children.contains("0.0"));
+      size_t count = 0;
+      for (auto& child : children) {
+        REQUIRE(child.key == std::to_string(count));
+        REQUIRE(&child.value == &model[count]);
+        count += 1;
+      }
+    }
+  }
+}
+
+TEST_CASE("cursor/parameter") {
+  SECTION("Works for single models") {
+    TestModule model(1);
+    auto cursor = model.parameters();
+
+    SECTION("Iterates in the correct order") {
+      auto iterator = cursor.begin();
+      REQUIRE(iterator->value.equal(model.tensor1));
+      REQUIRE((++iterator)->value.equal(model.tensor2));
+    }
+  }
+
+  SECTION("Works for flat models (depth = 1)") {
+    auto first = std::make_shared<TestModule>(1);
+    auto second = std::make_shared<TestModule>(2);
+    Container model(first, second);
+    auto cursor = model.parameters();
+
+    SECTION("Iterates in the correct order") {
+      auto iterator = cursor.begin();
+      REQUIRE(iterator->value.equal(first->tensor1));
+      REQUIRE((++iterator)->value.equal(first->tensor2));
+      REQUIRE((++iterator)->value.equal(second->tensor1));
+      REQUIRE((++iterator)->value.equal(second->tensor2));
+    }
+
+    SECTION("Apply_items works") {
+      size_t count = 0;
+      cursor.apply_items(
+          [&count, &model, &first, &second](
+              const std::string& key, autograd::Variable& tensor) {
+            switch (count) {
+              case 0: {
+                REQUIRE(tensor.equal(first->tensor1));
+                break;
+              }
+              case 1: {
+                REQUIRE(tensor.equal(first->tensor2));
+                break;
+              }
+              case 2: {
+                REQUIRE(tensor.equal(second->tensor1));
+                break;
+              }
+              case 3: {
+                REQUIRE(tensor.equal(second->tensor2));
+                break;
+              }
+            }
+            count += 1;
+          });
+      REQUIRE(count == 4);
+    }
+
+    // Other tests are correct based on correct iteration behavior and apply
+    // working.
+  }
+
+  SECTION("Works for deeper hierarchies (depth > 1)") {
+    std::vector<std::shared_ptr<TestModule>> modules;
+    for (size_t i = 1; i <= 6; ++i) {
+      modules.push_back(std::make_shared<TestModule>(i));
+    }
+    // clang-format off
+    Container model(
+        Container(
+          modules[0],
+          modules[1]),
+        modules[2],
+        Container(
+          modules[3],
+          Container(
+            modules[4],
+            modules[5])
+        ));
+    // clang-format on
+    auto cursor = model.parameters();
+
+    SECTION("Iterates in the correct order") {
+      auto iterator = cursor.begin();
+      REQUIRE(iterator->value.equal(modules[0]->tensor1));
+      REQUIRE((++iterator)->value.equal(modules[0]->tensor2));
+      for (size_t index = 1; index < 6; ++index) {
+        REQUIRE((++iterator)->value.equal(modules[index]->tensor1));
+        REQUIRE((++iterator)->value.equal(modules[index]->tensor2));
+      }
+    }
+
+    SECTION("names are hierarchical") {
+      auto iterator = cursor.begin();
+      REQUIRE(iterator->key == "0.0.tensor1");
+      REQUIRE((++iterator)->key == "0.0.tensor2");
+      REQUIRE((++iterator)->key == "0.1.tensor1");
+      REQUIRE((++iterator)->key == "0.1.tensor2");
+      REQUIRE((++iterator)->key == "1.tensor1");
+      REQUIRE((++iterator)->key == "1.tensor2");
+      REQUIRE((++iterator)->key == "2.0.tensor1");
+      REQUIRE((++iterator)->key == "2.0.tensor2");
+      REQUIRE((++iterator)->key == "2.1.0.tensor1");
+      REQUIRE((++iterator)->key == "2.1.0.tensor2");
+      REQUIRE((++iterator)->key == "2.1.1.tensor1");
+      REQUIRE((++iterator)->key == "2.1.1.tensor2");
+      REQUIRE(++iterator == cursor.end());
+    }
+  }
+}

--- a/test/cpp/api/cursor.cpp
+++ b/test/cpp/api/cursor.cpp
@@ -117,7 +117,7 @@ TEST_CASE("cursor/module") {
     }
 
     SECTION("Count works for flat models") {
-      REQUIRE(cursor.count() == model.m.size());
+      REQUIRE(cursor.size() == model.m.size());
     }
 
     SECTION("find() finds the correct modules when given a valid key") {
@@ -131,15 +131,15 @@ TEST_CASE("cursor/module") {
       REQUIRE(cursor.find("bar") == nullptr);
     }
 
-    SECTION("get() returns the correct modules when given a valid key") {
-      REQUIRE(&cursor.get("0") == &model[0]);
-      REQUIRE(&cursor.get("1") == &model[1]);
-      REQUIRE(&cursor.get("2") == &model[2]);
+    SECTION("at() returns the correct modules when given a valid key") {
+      REQUIRE(&cursor.at("0") == &model[0]);
+      REQUIRE(&cursor.at("1") == &model[1]);
+      REQUIRE(&cursor.at("2") == &model[2]);
     }
 
-    SECTION("get() throws when given an invalid key") {
-      REQUIRE_THROWS_WITH(cursor.get("foo"), StartsWith("No such key: 'foo'"));
-      REQUIRE_THROWS_WITH(cursor.get("bar"), StartsWith("No such key: 'bar'"));
+    SECTION("at() throws when given an invalid key") {
+      REQUIRE_THROWS_WITH(cursor.at("foo"), StartsWith("No such key: 'foo'"));
+      REQUIRE_THROWS_WITH(cursor.at("bar"), StartsWith("No such key: 'bar'"));
     }
 
     SECTION("operator[] returns the correct modules when given a valid key") {
@@ -204,10 +204,10 @@ TEST_CASE("cursor/module") {
 
     SECTION("children() returns only the first level of submodules") {
       auto children = model.children();
-      REQUIRE(children.count() == 3);
-      REQUIRE(&children.get("0") == &model[0]);
-      REQUIRE(&children.get("1") == &model[1]);
-      REQUIRE(&children.get("2") == &model[2]);
+      REQUIRE(children.size() == 3);
+      REQUIRE(&children.at("0") == &model[0]);
+      REQUIRE(&children.at("1") == &model[1]);
+      REQUIRE(&children.at("2") == &model[2]);
       REQUIRE(!children.contains("0.0"));
       size_t count = 0;
       for (auto& child : children) {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -142,12 +142,12 @@ TEST_CASE("module/clone") {
     auto m1param = module->parameters();
     auto m2param = module2->parameters();
     for (auto& param : m1param) {
-      REQUIRE(!pointer_equal(param.value, m2param.get(param.key)));
-      REQUIRE(param->allclose(m2param.get(param.key)));
+      REQUIRE(!pointer_equal(param.value, m2param[param.key]));
+      REQUIRE(param->allclose(m2param[param.key]));
       param->data().mul_(2);
     }
     for (auto& param : m1param) {
-      REQUIRE(!param->allclose(m2param.get(param.key)));
+      REQUIRE(!param->allclose(m2param[param.key]));
     }
   }
 
@@ -219,7 +219,7 @@ TEST_CASE("module/parameters") {
   TestModule module;
 
   SECTION("has correct number of parameters") {
-    REQUIRE(module.parameters().count() == 3);
+    REQUIRE(module.parameters().size() == 3);
   }
 
   SECTION("contains parameters with the correct name") {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -20,16 +20,6 @@ bool pointer_equal(at::Tensor first, at::Tensor second) {
   return first.data<float>() == second.data<float>();
 }
 
-struct TestModule : public CloneableModule<TestModule> {
-  void reset() override {
-    weight =
-        register_parameter("weight", at::ones(at::CPU(at::kFloat), {4, 4}));
-  }
-
-  Variable weight;
-  int value = 0;
-};
-
 TEST_CASE("module/training-mode") {
   auto module = Linear(3, 4).build();
   REQUIRE(module->is_training());
@@ -49,13 +39,13 @@ TEST_CASE("module/zero-grad") {
   auto loss = module->forward({weight}).front().sum();
   loss.backward();
   for (auto& parameter : module->parameters()) {
-    Variable grad = parameter.second.grad();
+    Variable grad = parameter->grad();
     REQUIRE(grad.defined());
     REQUIRE(grad.sum().toCFloat() != 0);
   }
   module->zero_grad();
   for (auto& parameter : module->parameters()) {
-    Variable grad = parameter.second.grad();
+    Variable grad = parameter->grad();
     REQUIRE(grad.defined());
     REQUIRE(grad.sum().toCFloat() == 0);
   }
@@ -78,39 +68,39 @@ TEST_CASE("module/conversions", "[cuda]") {
   auto module = LSTM(128, 64).layers(3).dropout(0.2).build();
   SECTION("starts as float on CPU") {
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().backend() == at::kCPU);
-      REQUIRE(parameter.second.type().scalarType() == at::kFloat);
+      REQUIRE(parameter->type().backend() == at::kCPU);
+      REQUIRE(parameter->type().scalarType() == at::kFloat);
     }
   }
   SECTION("to(CUDA)") {
     module->cuda();
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().backend() == at::kCUDA);
+      REQUIRE(parameter->type().backend() == at::kCUDA);
     }
   }
   SECTION("to(CPU)") {
     module->to(at::kCPU);
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().backend() == at::kCPU);
+      REQUIRE(parameter->type().backend() == at::kCPU);
     }
   }
   SECTION("to(Int)") {
     module->to(at::kInt);
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().scalarType() == at::kInt);
+      REQUIRE(parameter->type().scalarType() == at::kInt);
     }
   }
   SECTION("to(Double)") {
     module->to(at::kDouble);
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().scalarType() == at::kDouble);
+      REQUIRE(parameter->type().scalarType() == at::kDouble);
     }
   }
   SECTION("to(CUDA(Float))") {
     module->to(at::CUDA(at::kFloat));
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter.second.type().backend() == at::kCUDA);
-      REQUIRE(parameter.second.type().scalarType() == at::kFloat);
+      REQUIRE(parameter->type().backend() == at::kCUDA);
+      REQUIRE(parameter->type().scalarType() == at::kFloat);
     }
   }
 }
@@ -118,11 +108,7 @@ TEST_CASE("module/conversions", "[cuda]") {
 TEST_CASE("module/clone") {
   SECTION(
       "a module that does not override clone() throws when clone() is called") {
-    struct UnCloneable : Module {
-      std::vector<Variable> forward(std::vector<Variable>) {
-        return {};
-      }
-    };
+    struct UnCloneable : Module {};
     UnCloneable module;
     REQUIRE_THROWS_WITH(
         module.clone(), StartsWith("clone() has not been implemented"));
@@ -131,9 +117,6 @@ TEST_CASE("module/clone") {
   SECTION(
       "a module that overrides clone() does not throw when clone() is called ") {
     struct Cloneable : Module {
-      std::vector<Variable> forward(std::vector<Variable>) {
-        return {};
-      }
       std::shared_ptr<Module> clone() const override {
         return nullptr;
       }
@@ -159,17 +142,17 @@ TEST_CASE("module/clone") {
     auto m1param = module->parameters();
     auto m2param = module2->parameters();
     for (auto& param : m1param) {
-      REQUIRE(!pointer_equal(param.second, m2param[param.first]));
-      REQUIRE(param.second.allclose(m2param[param.first]));
-      param.second.data().mul_(2);
+      REQUIRE(!pointer_equal(param.value, m2param.get(param.key)));
+      REQUIRE(param->allclose(m2param.get(param.key)));
+      param->data().mul_(2);
     }
     for (auto& param : m1param) {
-      REQUIRE(!param.second.allclose(m2param[param.first]));
+      REQUIRE(!param->allclose(m2param.get(param.key)));
     }
   }
 
   SECTION("Cloning preserves external references") {
-    struct TestModel : public CloneableModule<TestModel> {
+    struct TestModule : public CloneableModule<TestModule> {
       void reset() override {
         weight =
             register_parameter("weight", at::ones(at::CPU(at::kFloat), {4, 4}));
@@ -178,19 +161,28 @@ TEST_CASE("module/clone") {
     };
     auto module = TestModule().build();
     module->weight.data() += 1;
-    REQUIRE(pointer_equal(module->weight, module->param("weight")));
-    REQUIRE(module->weight.allclose(module->param("weight")));
+    REQUIRE(pointer_equal(module->weight, module->parameters()["weight"]));
+    REQUIRE(module->weight.allclose(module->parameters()["weight"]));
 
     auto module2 = std::dynamic_pointer_cast<TestModule>(
         std::shared_ptr<Module>(module->clone()));
     REQUIRE(!pointer_equal(module2->weight, module->weight));
-    REQUIRE(pointer_equal(module2->weight, module2->param("weight")));
-    REQUIRE(module2->weight.allclose(module2->param("weight")));
+    REQUIRE(pointer_equal(module2->weight, module2->parameters()["weight"]));
+    REQUIRE(module2->weight.allclose(module2->parameters()["weight"]));
     REQUIRE(module2->weight.allclose(module->weight));
-    REQUIRE(!pointer_equal(module2->weight, module->param("weight")));
+    REQUIRE(!pointer_equal(module2->weight, module->parameters()["weight"]));
   }
 
   SECTION("Cloning copies the values of variables of submodules") {
+    struct TestModule : public CloneableModule<TestModule> {
+      void reset() override {
+        weight =
+            register_parameter("weight", at::ones(at::CPU(at::kFloat), {4, 4}));
+      }
+
+      Variable weight;
+      int value = 0;
+    };
     struct NestedModule : public CloneableModule<NestedModule> {
       void reset() override {
         module = register_module("module", TestModule().build());
@@ -205,8 +197,9 @@ TEST_CASE("module/clone") {
     auto b = std::static_pointer_cast<NestedModule>(a->clone());
 
     REQUIRE(!pointer_equal(b->module->weight, a->module->weight));
-    REQUIRE(pointer_equal(b->module->weight, b->module->param("weight")));
-    REQUIRE(b->module->param("weight").allclose(a->module->weight));
+    REQUIRE(
+        pointer_equal(b->module->weight, b->module->parameters()["weight"]));
+    REQUIRE(b->module->parameters()["weight"].allclose(a->module->weight));
     REQUIRE(b->module->weight.allclose(a->module->weight));
     REQUIRE(b->module->value == a->module->value);
   }
@@ -226,13 +219,13 @@ TEST_CASE("module/parameters") {
   TestModule module;
 
   SECTION("has correct number of parameters") {
-    REQUIRE(module.parameters().size() == 3);
+    REQUIRE(module.parameters().count() == 3);
   }
 
   SECTION("contains parameters with the correct name") {
     auto parameters = module.parameters();
-    REQUIRE(parameters.count("a"));
-    REQUIRE(parameters.count("b"));
-    REQUIRE(parameters.count("c"));
+    REQUIRE(parameters.contains("a"));
+    REQUIRE(parameters.contains("b"));
+    REQUIRE(parameters.contains("c"));
   }
 }

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -54,7 +54,7 @@ TEST_CASE("optim") {
   auto model = std::make_shared<Sequential>(
       SigmoidLinear(Linear(2, 8).build()), SigmoidLinear(Linear(8, 1).build()));
 
-  // FLAKY!
+  // Flaky
   // SECTION("lbfgs") {
   //   auto optim = LBFGS(model, 5e-2).max_iter(5).make();
   //   REQUIRE(test_optimizer_xor(optim, model));

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -111,8 +111,8 @@ TEST_CASE("rnn") {
       // Make sure the outputs match pytorch outputs
       auto model = LSTM(2, 2).build();
       for (auto& v : model->parameters()) {
-        float size = v.second.numel();
-        auto p = static_cast<float*>(v.second.data().storage()->data());
+        float size = v->numel();
+        auto p = static_cast<float*>(v->data().storage()->data());
         for (size_t i = 0; i < size; i++) {
           p[i] = i / size;
         }

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -259,7 +259,7 @@ TEST_CASE("serialization") {
     auto param2 = model2->parameters();
     auto param3 = model3->parameters();
     for (auto& p : param1) {
-      auto name = p.first;
+      auto& name = p.key;
       // Model 1 and 3 should be the same
       REQUIRE(param1[name].norm().toCFloat() == param3[name].norm().toCFloat());
       REQUIRE(param1[name].norm().toCFloat() != param2[name].norm().toCFloat());

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -250,6 +250,7 @@ if (NOT NO_API)
   list(APPEND TORCH_SRCS
     ${TORCH_SRC_DIR}/csrc/api/src/utils.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/cuda.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/nn/cursor.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/module.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/batchnorm.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/conv.cpp
@@ -258,7 +259,8 @@ if (NOT NO_API)
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/functional.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/linear.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/rnn.cpp
-    ${TORCH_SRC_DIR}/csrc/api/src/optimizers.cpp)
+    ${TORCH_SRC_DIR}/csrc/api/src/optimizers.cpp
+  )
 endif()
 
 add_library(torch SHARED ${TORCH_SRCS})
@@ -358,6 +360,7 @@ if (TORCH_BUILD_TEST)
     add_executable(test_api
       ${TORCH_API_TEST_DIR}/any.cpp
       ${TORCH_API_TEST_DIR}/container.cpp
+      ${TORCH_API_TEST_DIR}/cursor.cpp
       ${TORCH_API_TEST_DIR}/integration.cpp
       ${TORCH_API_TEST_DIR}/main.cpp
       ${TORCH_API_TEST_DIR}/misc.cpp

--- a/torch/csrc/api/include/torch/nn/cursor.h
+++ b/torch/csrc/api/include/torch/nn/cursor.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <torch/csrc/autograd/variable.h>
+
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <type_traits>
+
+// Forward declarations.
+namespace torch {
+namespace detail {
+template <typename T>
+struct CursorCollector;
+} // namespace detail
+namespace nn {
+class Module;
+} // namespace nn
+} // namespace torch
+
+namespace torch {
+namespace detail {
+/// Provides hierarchical iteration support, with convenient iterator functions
+/// like `map` or `find`.
+template <typename T>
+class CursorBase {
+ public:
+  // NOTE: This is a template class, but we explicitly instantiate it in the
+  // .cpp file for every type necessary, so we can define it in the .cpp file.
+  // Hooray!
+
+  /// A `(key, value)` pair exposed by cursor iterators.
+  struct Item {
+    Item(const std::string& key_, T& module_);
+
+    T& operator*();
+    T* operator->();
+
+    // These are references into a `Module`'s containers
+    const std::string key;
+    T& value;
+  };
+
+  // Picks either `const_iterator` or `iterator` as the iterator type, depending
+  // on whether `T` is const.
+  using Iterator = typename std::conditional<
+      std::is_const<T>::value,
+      typename std::vector<Item>::const_iterator,
+      typename std::vector<Item>::iterator>::type;
+
+  CursorBase() = default;
+
+  /// Constructs the `CursorBase` from a vector of items.
+  explicit CursorBase(std::vector<Item>&& items);
+
+  // No need for a virtual destructor, as cursors are not intended to be used
+  // polymorhpically (i.e. we are relying on non-virtual inheritance).
+
+  // Note that these functions may only be called on lvalues (that's the
+  // ampersand next to the function)! This prevents code like `auto iterator =
+  // module.modules().begin()`, since `iterator` would be pointing to a `vector`
+  // that gets destructed at the end of the expression. This is not a problem
+  // for range loops, as they capture the range expression (the thing to the
+  // right of the colon in `for (auto x : ...)`) before iteration.
+  Iterator begin() & noexcept;
+  Iterator end() & noexcept;
+
+  /// Applies a function to every *value* available. The function should accept
+  /// a single argument, that is a reference to the value type (e.g. `Module&`).
+  template <typename Function>
+  void apply(const Function& function) {
+    for (auto module : *this) {
+      function(*module);
+    }
+  }
+
+  /// Applies a function to every *item* available. The function should accept
+  /// two arguments, one taking a reference to the key type (always `const
+  /// std::string&`) and the other taking a reference to the value type (e.g.
+  /// `Module&`).
+  template <typename Function>
+  void apply_items(const Function& function) {
+    for (auto module : *this) {
+      function(module.key, *module);
+    }
+  }
+
+  /// Applies a function to every *value* available, and stores the return value
+  /// of the function into the iterator. The function should accept
+  /// a single argument, that is a reference to the value type (e.g. `Module&`).
+  template <typename Iterator, typename Function>
+  void map(Iterator output_iterator, Function function) {
+    for (auto module : *this) {
+      *output_iterator = function(*module);
+    }
+  }
+
+  /// Applies a function to every *value* available, and stores the return value
+  /// of the function into the iterator. The function should accept
+  /// two arguments, one taking a reference to the key type (always `const
+  /// std::string&`) and the other taking a referen
+  template <typename Iterator, typename Function>
+  void map_items(Iterator output_iterator, Function function) {
+    for (auto module : *this) {
+      *output_iterator = function(module.key, *module);
+    }
+  }
+
+  /// Attempts to find a value for the given `key`. If found, returns a pointer
+  /// to the value. If not, returns a null pointer.
+  T* find(const std::string& key) noexcept;
+
+  /// Attempts to find a value for the given `key`. If found, returns a
+  /// reference to the value. If not, throws an exception.
+  T& get(const std::string& key);
+
+  /// Equivalent to `get(key)`.
+  T& operator[](const std::string& key);
+
+  /// Returns true if an item with the given `key` exists.
+  bool contains(const std::string& key) noexcept;
+
+  /// Counts the number of items available.
+  size_t count() const noexcept;
+
+ protected:
+  /// Helper struct to collect items.
+  struct Collector;
+
+  /// The (eagerly) collected vector of items.
+  std::vector<Item> items_;
+};
+} // namespace detail
+
+namespace nn {
+
+// Module cursors (`.modules()` and `.children()`)
+
+class ModuleCursor : public detail::CursorBase<Module> {
+ public:
+  explicit ModuleCursor(
+      Module& module,
+      size_t maximum_depth = std::numeric_limits<size_t>::max());
+};
+
+class ConstModuleCursor : public detail::CursorBase<const Module> {
+ public:
+  explicit ConstModuleCursor(
+      const Module& module,
+      size_t maximum_depth = std::numeric_limits<size_t>::max());
+};
+
+// Parameter cursors (`.parameters()`)
+
+class ParameterCursor : public detail::CursorBase<autograd::Variable> {
+ public:
+  explicit ParameterCursor(Module& module);
+};
+
+class ConstParameterCursor
+    : public detail::CursorBase<const autograd::Variable> {
+ public:
+  explicit ConstParameterCursor(const Module& module);
+};
+
+// Buffer cursors (`.buffers()`)
+
+class BufferCursor : public detail::CursorBase<autograd::Variable> {
+ public:
+  explicit BufferCursor(Module& module);
+};
+
+class ConstBufferCursor : public detail::CursorBase<const autograd::Variable> {
+ public:
+  explicit ConstBufferCursor(const Module& module);
+};
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/cursor.h
+++ b/torch/csrc/api/include/torch/nn/cursor.h
@@ -21,9 +21,22 @@ class Module;
 
 namespace torch {
 namespace detail {
-/// Provides hierarchical iteration support, with convenient iterator functions
-/// like `map` or `find`. A cursor's lifetime is bound to the lifetime of the
-/// module hierarchy into which it points.
+/// A cursor provides hierarchical iteration support, with convenient iterator
+/// functions like `map` or `find`.
+///
+/// Fundamentally, cursors are similar to `std::map`, with `[]`, `.at()`,
+/// `.size()` etc. When iterating over a cursor, use `.key()` to get the
+/// associated string, and dereference the returned item or use `.value()` to
+/// get the associated value (e.g. the variable, the module or the buffer).
+///
+/// Note that cursors *eagerly* collect items. So if you want to perform many
+/// operations with a single cursor, it is better to store it in a local
+/// variable. This also you means should not store iterators into a temporary
+/// cursor, e.g. do not write `auto iterator = module.parameters().begin()`, as
+/// the parameter cursor will die at the end of the expression.
+///
+/// A cursor's lifetime is bound to the lifetime of the module hierarchy into
+/// which it points.
 template <typename T>
 class CursorBase {
  public:
@@ -116,16 +129,16 @@ class CursorBase {
 
   /// Attempts to find a value for the given `key`. If found, returns a
   /// reference to the value. If not, throws an exception.
-  T& get(const std::string& key);
+  T& at(const std::string& key);
 
-  /// Equivalent to `get(key)`.
+  /// Equivalent to `at(key)`.
   T& operator[](const std::string& key);
 
   /// Returns true if an item with the given `key` exists.
   bool contains(const std::string& key) noexcept;
 
   /// Counts the number of items available.
-  size_t count() const noexcept;
+  size_t size() const noexcept;
 
  protected:
   /// Helper struct to collect items.

--- a/torch/csrc/api/include/torch/nn/cursor.h
+++ b/torch/csrc/api/include/torch/nn/cursor.h
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/autograd/variable.h>
 
-#include <cstdint>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <string>
@@ -22,7 +22,8 @@ class Module;
 namespace torch {
 namespace detail {
 /// Provides hierarchical iteration support, with convenient iterator functions
-/// like `map` or `find`.
+/// like `map` or `find`. A cursor's lifetime is bound to the lifetime of the
+/// module hierarchy into which it points.
 template <typename T>
 class CursorBase {
  public:
@@ -37,10 +38,11 @@ class CursorBase {
     T& operator*();
     T* operator->();
 
-    // These are references into a `Module`'s containers
     const std::string key;
     T& value;
   };
+
+  // Iterators are valid for the lifetime of the cursor.
 
   // Picks either `const_iterator` or `iterator` as the iterator type, depending
   // on whether `T` is const.
@@ -62,7 +64,8 @@ class CursorBase {
   // module.modules().begin()`, since `iterator` would be pointing to a `vector`
   // that gets destructed at the end of the expression. This is not a problem
   // for range loops, as they capture the range expression (the thing to the
-  // right of the colon in `for (auto x : ...)`) before iteration.
+  // right of the colon in `for (auto x : ...)`) before iteration. This is
+  // smart.
   Iterator begin() & noexcept;
   Iterator end() & noexcept;
 

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -17,7 +17,7 @@
 namespace torch {
 namespace detail {
 template <typename T>
-struct CursorBase;
+class CursorBase;
 } // namespace detail
 } // namespace torch
 
@@ -128,7 +128,7 @@ class Module {
   template <typename Derived>
   friend class CloneableModule;
   template <typename T>
-  friend struct detail::CursorBase;
+  friend class detail::CursorBase;
 
   virtual void clone_(Module& other);
 

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -90,7 +90,7 @@ class Module {
   template <class Archive>
   void save(Archive& ar) const {
     auto params = parameters();
-    size_t size = params.count();
+    size_t size = params.size();
     ar(size);
     for (auto& p : params) {
       ar(p.key, p.value);

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <torch/tensor.h>
 #include <torch/detail/ordered_dict.h>
+#include <torch/nn/cursor.h>
+#include <torch/tensor.h>
 
 #include <torch/csrc/autograd/variable.h>
 
@@ -12,6 +13,13 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+
+namespace torch {
+namespace detail {
+template <typename T>
+struct CursorBase;
+} // namespace detail
+} // namespace torch
 
 namespace torch {
 namespace nn {
@@ -31,18 +39,26 @@ class Module {
   /// Returns the name of the `Module`.
   const std::string& name() const noexcept;
 
+  /// Performs a recursive deep copy of the module and all its registered
+  /// parameters, buffers and submodules.
   virtual std::shared_ptr<Module> clone() const;
 
-  // Only construct parameters in initialize_parameters, and
-  // containers in initialize_containers. Most of the time, the containers are
-  // the only thing you need to add.
-  // You are guaranteed that containers are added before parameters.
-  virtual void initialize_containers() {}
-  virtual void initialize_parameters() {}
-  virtual void reset_parameters() {}
+  /// Provides a means to traverse the `Module` tree.
+  ModuleCursor modules();
+  ConstModuleCursor modules() const;
 
-  std::map<std::string, Variable> parameters() const;
-  Variable& param(std::string const&);
+  /// Traverses the (immediate) children of the `Module`.
+  ModuleCursor children();
+  ConstModuleCursor children() const;
+
+  /// Provides a means to recursively access the parameters of the `Module`
+  /// tree.
+  ParameterCursor parameters();
+  ConstParameterCursor parameters() const;
+
+  /// Provides a means to recursively access the buffers of the `Module` tree.
+  BufferCursor buffers();
+  ConstBufferCursor buffers() const;
 
   /// Enables training mode.
   virtual void train();
@@ -74,10 +90,10 @@ class Module {
   template <class Archive>
   void save(Archive& ar) const {
     auto params = parameters();
-    size_t size = params.size();
+    size_t size = params.count();
     ar(size);
     for (auto& p : params) {
-      ar(p.first, p.second);
+      ar(p.key, p.value);
     }
   }
 
@@ -111,6 +127,8 @@ class Module {
 
   template <typename Derived>
   friend class CloneableModule;
+  template <typename T>
+  friend struct detail::CursorBase;
 
   virtual void clone_(Module& other);
 
@@ -143,7 +161,7 @@ class CloneableModule : public Module {
   std::shared_ptr<Derived> build() {
     auto module = std::make_shared<Derived>(static_cast<Derived&&>(*this));
     module->reset();
-    return std::move(module);
+    return module;
   }
 
   /// Performs a recursive "deep copy" of the `Module`, such that all parameters

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -6,8 +6,7 @@
 
 #include <cstdint>
 
-namespace torch { namespace nn {
-
+namespace torch {
 namespace detail {
 template <typename T>
 class DropoutBase : public torch::nn::CloneableModule<T> {
@@ -27,6 +26,7 @@ class DropoutBase : public torch::nn::CloneableModule<T> {
 };
 } // namespace detail
 
+namespace nn {
 class Dropout : public detail::DropoutBase<Dropout> {
  public:
   using detail::DropoutBase<Dropout>::DropoutBase;
@@ -43,4 +43,5 @@ class Dropout2d : public detail::DropoutBase<Dropout2d> {
   Variable noise_mask(Variable input) const override;
 };
 
-}} // namespace torch::nn
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/cursor.cpp
+++ b/torch/csrc/api/src/nn/cursor.cpp
@@ -1,0 +1,184 @@
+#include <torch/nn/cursor.h>
+#include <torch/nn/module.h>
+
+#include <torch/csrc/autograd/variable.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <queue>
+#include <string>
+#include <vector>
+
+namespace torch {
+namespace detail {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CursorBase::Item ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <typename T>
+CursorBase<T>::Item::Item(const std::string& key_, T& value_)
+    : key(key_), value(value_) {}
+
+template <typename T>
+T& CursorBase<T>::Item::operator*() {
+  return value;
+}
+
+template <typename T>
+T* CursorBase<T>::Item::operator->() {
+  return &value;
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CursorBase ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <typename T>
+CursorBase<T>::CursorBase(std::vector<Item>&& items)
+    : items_(std::move(items)) {}
+
+template <typename T>
+    typename CursorBase<T>::Iterator CursorBase<T>::begin() & noexcept {
+  return items_.begin();
+}
+
+template <typename T>
+    typename CursorBase<T>::Iterator CursorBase<T>::end() & noexcept {
+  return items_.end();
+}
+
+template <typename T>
+T* CursorBase<T>::find(const std::string& key) noexcept {
+  for (auto item : *this) {
+    if (item.key == key) {
+      return &item.value;
+    }
+  }
+  return nullptr;
+}
+
+template <typename T>
+T& CursorBase<T>::get(const std::string& key) {
+  if (auto* value = find(key)) {
+    return *value;
+  }
+  AT_ERROR("No such key: '", key, "'");
+}
+
+template <typename T>
+T& CursorBase<T>::operator[](const std::string& key) {
+  return get(key);
+}
+
+template <typename T>
+bool CursorBase<T>::contains(const std::string& key) noexcept {
+  return find(key) != nullptr;
+}
+
+template <typename T>
+size_t CursorBase<T>::count() const noexcept {
+  return items_.size();
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CursorCollector ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+namespace {
+/// Joins names hierarchically: "prefix.name" if `prefix` is non-empty, else
+/// just "name".
+std::string join_name(const std::string& prefix, const std::string& name) {
+  size_t total_size = name.size();
+  if (!prefix.empty()) {
+    total_size += prefix.size() + 1;
+  }
+  std::string full_name;
+  full_name.reserve(total_size);
+  if (!prefix.empty()) {
+    full_name += prefix;
+    full_name.push_back('.');
+  }
+  full_name += name;
+  return full_name;
+}
+} // namespace
+
+template <typename T>
+struct CursorBase<T>::Collector {
+  Collector() = default;
+
+  template <typename ModuleType>
+  std::vector<Item>&& collect_children(
+      ModuleType& module,
+      size_t maximum_depth,
+      std::string name_prefix = std::string()) {
+    for (auto& child : module.children_) {
+      auto hierarchical_name = join_name(name_prefix, child.key);
+      items.emplace_back(hierarchical_name, *child.value);
+      if (maximum_depth > 1) {
+        collect_children(
+            *child.value, maximum_depth - 1, std::move(hierarchical_name));
+      }
+    }
+    return std::move(items);
+  }
+
+  template <typename ModuleType>
+  std::vector<Item>&& collect_parameters(
+      ModuleType& module,
+      std::string name_prefix = std::string()) {
+    for (auto& parameter : module.parameters_) {
+      items.emplace_back(
+          join_name(name_prefix, parameter.key), parameter.value);
+    }
+    for (auto& child : module.children_) {
+      collect_parameters(*child.value, join_name(name_prefix, child.key));
+    }
+    return std::move(items);
+  }
+
+  template <typename ModuleType>
+  std::vector<Item>&& collect_buffers(
+      ModuleType& module,
+      std::string name_prefix = std::string()) {
+    for (auto& buffer : module.buffers_) {
+      items.emplace_back(join_name(name_prefix, buffer.key), buffer.value);
+    }
+    for (auto& child : module.children_) {
+      collect_buffers(*child.value, join_name(name_prefix, child.key));
+    }
+    return std::move(items);
+  }
+
+  std::vector<Item> items;
+};
+
+// Explicitly instantiate the CursorBase template for all types we need.
+//
+template class CursorBase<nn::Module>;
+template class CursorBase<const nn::Module>;
+template class CursorBase<autograd::Variable>;
+template class CursorBase<const autograd::Variable>;
+} // namespace detail
+
+namespace nn {
+ModuleCursor::ModuleCursor(Module& module, size_t maximum_depth)
+    : detail::CursorBase<Module>(
+          Collector().collect_children(module, maximum_depth)) {}
+
+ConstModuleCursor::ConstModuleCursor(const Module& module, size_t maximum_depth)
+    : detail::CursorBase<const Module>(
+          Collector().collect_children(module, maximum_depth)) {}
+
+ParameterCursor::ParameterCursor(Module& module)
+    : detail::CursorBase<autograd::Variable>(
+          Collector().collect_parameters(module)) {}
+
+ConstParameterCursor::ConstParameterCursor(const Module& module)
+    : detail::CursorBase<const autograd::Variable>(
+          Collector().collect_parameters(module)) {}
+
+BufferCursor::BufferCursor(Module& module)
+    : detail::CursorBase<autograd::Variable>(
+          Collector().collect_buffers(module)) {}
+
+ConstBufferCursor::ConstBufferCursor(const Module& module)
+    : detail::CursorBase<const autograd::Variable>(
+          Collector().collect_buffers(module)) {}
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/cursor.cpp
+++ b/torch/csrc/api/src/nn/cursor.cpp
@@ -55,7 +55,7 @@ T* CursorBase<T>::find(const std::string& key) noexcept {
 }
 
 template <typename T>
-T& CursorBase<T>::get(const std::string& key) {
+T& CursorBase<T>::at(const std::string& key) {
   if (auto* value = find(key)) {
     return *value;
   }
@@ -64,7 +64,7 @@ T& CursorBase<T>::get(const std::string& key) {
 
 template <typename T>
 T& CursorBase<T>::operator[](const std::string& key) {
-  return get(key);
+  return at(key);
 }
 
 template <typename T>
@@ -73,7 +73,7 @@ bool CursorBase<T>::contains(const std::string& key) noexcept {
 }
 
 template <typename T>
-size_t CursorBase<T>::count() const noexcept {
+size_t CursorBase<T>::size() const noexcept {
   return items_.size();
 }
 

--- a/torch/csrc/api/src/nn/cursor.cpp
+++ b/torch/csrc/api/src/nn/cursor.cpp
@@ -149,7 +149,6 @@ struct CursorBase<T>::Collector {
 };
 
 // Explicitly instantiate the CursorBase template for all types we need.
-//
 template class CursorBase<nn::Module>;
 template class CursorBase<const nn::Module>;
 template class CursorBase<autograd::Variable>;

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -55,7 +55,7 @@ void Conv<D, Derived>::reset() {
       std::multiplies<int64_t>{});
   const auto stdv = 1.0 / std::sqrt(number_of_features);
   for (auto& p : this->parameters()) {
-    p.second.data().uniform_(-stdv, stdv);
+    p->data().uniform_(-stdv, stdv);
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -1,6 +1,6 @@
 #include <torch/nn/modules/dropout.h>
 
-namespace torch { namespace nn {
+namespace torch {
 namespace detail {
 
 template <typename T>
@@ -27,10 +27,11 @@ std::vector<Variable> DropoutBase<T>::forward(std::vector<Variable> input) {
   return output;
 }
 
-template class DropoutBase<Dropout>;
-template class DropoutBase<Dropout2d>;
+template class detail::DropoutBase<nn::Dropout>;
+template class detail::DropoutBase<nn::Dropout2d>;
 } // namespace detail
 
+namespace nn {
 Variable Dropout::noise_mask(Variable input) const {
   return at::empty_like(input);
 }
@@ -38,5 +39,5 @@ Variable Dropout::noise_mask(Variable input) const {
 Variable Dropout2d::noise_mask(Variable input) const {
   return input.type().empty({input.size(0), input.size(1), 1, 1});
 }
-
-}} // namespace torch::nn
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -17,8 +17,8 @@ void Linear::reset() {
   bias_ = register_parameter("bias", at::CPU(at::kFloat).empty(out_));
 
   const auto stdv = 1.0 / std::sqrt(weight_.size(1));
-  for (auto& p : parameters()) {
-    p.second.data().uniform_(-stdv, stdv);
+  for (auto& p : this->parameters()) {
+    p->data().uniform_(-stdv, stdv);
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -176,7 +176,7 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
   // alias would break the assumptions of the uniqueness check in
   // Module.named_parameters().
   // But I'm not sure if this is the case for us
-  if (unique_data_ptrs.size() != params.count()) {
+  if (unique_data_ptrs.size() != params.size()) {
     return;
   }
 

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -86,7 +86,7 @@ void RNNBase<Derived>::reset() {
 
   auto stdv = 1.0 / std::sqrt(hidden_size_);
   for (auto& p : this->parameters()) {
-    p.second.data().uniform_(-stdv, stdv);
+    p->data().uniform_(-stdv, stdv);
   }
 }
 
@@ -166,7 +166,7 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
   std::unordered_set<void*> unique_data_ptrs;
   auto params = this->parameters();
   for (auto& p : params) {
-    unique_data_ptrs.insert(p.second.data().data_ptr());
+    unique_data_ptrs.insert(p->data().data_ptr());
   }
   // TODO PyTorch says:
   // If any parameters alias, we fall back to the slower, copying code path.
@@ -176,7 +176,7 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
   // alias would break the assumptions of the uniqueness check in
   // Module.named_parameters().
   // But I'm not sure if this is the case for us
-  if (unique_data_ptrs.size() != params.size()) {
+  if (unique_data_ptrs.size() != params.count()) {
     return;
   }
 
@@ -193,7 +193,7 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
         false); // batch_first and bidirectional, unsupported
   }
   for (auto& p : params) {
-    data_ptrs_.emplace_back(p.second.data().data_ptr());
+    data_ptrs_.emplace_back(p->data().data_ptr());
   }
 }
 
@@ -220,7 +220,7 @@ std::vector<Variable> RNNBase<Derived>::CUDNN_forward(
   std::vector<void*> weight_data_ptrs;
   auto params = this->parameters();
   for (auto& p : params) {
-    weight_data_ptrs.emplace_back(p.second.data().data_ptr());
+    weight_data_ptrs.emplace_back(p->data().data_ptr());
   }
   if (weight_data_ptrs != data_ptrs_) {
     std::cerr

--- a/torch/csrc/api/src/optimizers.cpp
+++ b/torch/csrc/api/src/optimizers.cpp
@@ -5,8 +5,8 @@
 namespace torch {
 
 void OptimizerImpl::zero_grad() {
-  for (auto p : model_->parameters()) {
-    auto& grad = p.second.grad();
+  for (auto& p : model_->parameters()) {
+    auto& grad = p->grad();
     if (grad.defined()) {
       grad = grad.detach();
       torch::autograd::as_variable_ref(grad).data().zero_();
@@ -24,17 +24,17 @@ void OptimizerImpl::set_model(std::shared_ptr<nn::Module> model) {
 
 at::Tensor LBFGS::gather_flat_grad() {
   std::vector<at::Tensor> views;
-  for(auto& pair : model_->parameters()) {
-    views.push_back(torch::autograd::as_variable_ref(pair.second.grad()).data().view(-1));
+  for(auto& parameter : model_->parameters()) {
+    views.push_back(torch::autograd::as_variable_ref(parameter->grad()).data().view(-1));
   }
   return at::cat(views);
 }
 
 void LBFGS::add_grad(const at::Scalar& step_size, const at::Tensor& update) {
   int offset = 0;
-  for(auto& pair : model_->parameters()) {
-    int numel = pair.second.numel();
-    at::Tensor& pd = pair.second.data();
+  for(auto& parameter : model_->parameters()) {
+    int numel = parameter->numel();
+    at::Tensor& pd = parameter->data();
     pd.add_(update.slice(0, offset, offset + numel, 1).view_as(pd), step_size);
     offset += numel;
   }
@@ -171,10 +171,10 @@ void LBFGS::init_state() {
 
 at::Scalar SGD::step(std::function<at::Scalar()> closure) {
   at::Scalar loss = closure();
-  for (auto& pair : model_->parameters()) {
-    auto& name = pair.first;
-    auto& grad = pair.second.grad();
-    auto& p = pair.second.data();
+  for (auto& parameter : model_->parameters()) {
+    auto& name = parameter.key;
+    auto& grad = parameter->grad();
+    auto& p = parameter->data();
     if (!grad.defined())
       continue;
 
@@ -213,10 +213,10 @@ void SGD::init_state() {
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
 at::Scalar Adagrad::step(std::function<at::Scalar()> closure) {
   at::Scalar loss = closure();
-  for (auto& pair : model_->parameters()) {
-    auto& name = pair.first;
-    auto& grad = pair.second.grad();
-    auto& p = pair.second.data();
+  for (auto& parameter : model_->parameters()) {
+    auto& name = parameter.key;
+    auto& grad = parameter->grad();
+    auto& p = parameter->data();
     if (!grad.defined())
       continue;
 
@@ -250,10 +250,10 @@ void Adagrad::init_state() {
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/rmsprop.py
 at::Scalar RMSprop::step(std::function<at::Scalar()> closure) {
   at::Scalar loss = closure();
-  for (auto& pair : model_->parameters()) {
-    auto& name = pair.first;
-    auto& grad = pair.second.grad();
-    auto& p = pair.second.data();
+  for (auto& parameter : model_->parameters()) {
+    auto& name = parameter.key;
+    auto& grad = parameter->grad();
+    auto& p = parameter->data();
     if (!grad.defined())
       continue;
 
@@ -303,10 +303,10 @@ void RMSprop::init_state() {
 
 at::Scalar Adam::step(std::function<at::Scalar()> closure) {
   at::Scalar loss = closure();
-  for (auto& pair : model_->parameters()) {
-    auto& name = pair.first;
-    auto& grad = pair.second.grad();
-    auto& p = pair.second.data();
+  for (auto& parameter : model_->parameters()) {
+    auto& name = parameter.key;
+    auto& grad = parameter->grad();
+    auto& p = parameter->data();
     if (!grad.defined())
       continue;
 


### PR DESCRIPTION
This PR implements the "Cursor" API for navigating the module hierarchy in C++ PyTorch modules. It was originally implemented in https://github.com/pytorch/pytorch/pull/6345, and I've brushed it up and plopped it onto the current C++ API.

Cursors provide convenient access to modules, children, parameters and buffers. They allow iteration:

```
for (auto& parameter : module.parameters()) {
    std:::cout << parameter.key << " " << parameter.value << std::endl;
}
```

as well as useful, hierarchical iterator operations such as

```
auto* weight = module.parameters().find("module.submodule.weight");
size_t count = module.children().count();
module.parameters().apply([](Tensor tensor) { tensor.zero_(); });
bool has_weight = module.parameters().contains("weight");
```

@ebetica @ezyang @apaszke 