### PR TITLE
Add more annotations for arguments in ATen schema

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -358,12 +358,13 @@ def emit_schema(jit_decls, out):
     def emit(decl):
         arguments = [a for a in decl['arguments'] if a['simple_type'] not in default_only_types]
         n = get_name(decl['name'])
+        n_args = len(arguments)
+        n_returns = len(decl['returns'])
+        env['arguments'].append('// Arguments for {} ({} args, {} returns)'.format(decl['name'], n_args, n_returns))
         for a in arguments:
             emit_arg(a, False)
         for a in decl['returns']:
             emit_arg(a, True)
-        n_args = len(arguments)
-        n_returns = len(decl['returns'])
         env['operators'].append('{{ {}, {}, {} }}, // FunctionSchema("{}", <{} arguments>, <{} returns>) '.format(
             n, n_args, n_returns, decl['name'], n_args, n_returns))
 


### PR DESCRIPTION
A completely minor change, but improves readability of ATen schema by a great deal. Our `FunctionSchema` list contains triples with: an offset into our string table, and the number of arguments and returns to be read out from the **current** position in the argument list. This is ok for an automatic parser, but it makes it impossible to associate `FunctionSchema` with its `ArgumentSchema`s automatically. This PR simply adds comments that separate and annotate `ArgumentSchema`s for different functions, which makes them very easy to find.

@zdevito @jamesr66a 

Previously (the output is truncated at some column, because I only copied part of it, not because of the code):
```cpp
{ 210, 1, 0, 0 }, // Argument("tensors", at::nullopt, at::nullopt, ListType::ofTensors())   
{ 15, 0, 8, 2 }, // Argument("dim", as_tensor(int64_t(0)), AttributeInfo{ AttributeKind::i, 
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 469, 0, 0, 2 }, // Argument("chunks", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 15, 0, 8, 2 }, // Argument("dim", as_tensor(int64_t(0)), AttributeInfo{ AttributeKind::i, 
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
{ 461, 0, 0, 0 }, // Argument("input", at::nullopt, at::nullopt, DynamicType::get())        
{ 107, 0, 0, 0 }, // Argument("weight", at::nullopt, at::nullopt, DynamicType::get())       
{ 385, 0, 0, 0 }, // Argument("bias", at::nullopt, at::nullopt, DynamicType::get())         
{ 208, 0, 0, 1 }, // Argument("stride", at::nullopt, AttributeInfo{ AttributeKind::is, at::n
{ 317, 0, 0, 1 }, // Argument("padding", at::nullopt, AttributeInfo{ AttributeKind::is, at::
{ 330, 0, 0, 1 }, // Argument("dilation", at::nullopt, AttributeInfo{ AttributeKind::is, at:
{ 472, 0, 0, 2 }, // Argument("transposed", at::nullopt, AttributeInfo{ AttributeKind::i, at
{ 396, 0, 0, 1 }, // Argument("output_padding", at::nullopt, AttributeInfo{ AttributeKind::i
{ 473, 0, 0, 2 }, // Argument("groups", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
{ 461, 0, 0, 0 }, // Argument("input", at::nullopt, at::nullopt, DynamicType::get())        
{ 107, 0, 0, 0 }, // Argument("weight", at::nullopt, at::nullopt, DynamicType::get())       
{ 385, 0, 0, 0 }, // Argument("bias", at::nullopt, at::nullopt, DynamicType::get())         
{ 208, 0, 0, 1 }, // Argument("stride", at::nullopt, AttributeInfo{ AttributeKind::is, at::n
{ 317, 0, 0, 1 }, // Argument("padding", at::nullopt, AttributeInfo{ AttributeKind::is, at::
{ 330, 0, 0, 1 }, // Argument("dilation", at::nullopt, AttributeInfo{ AttributeKind::is, at:
{ 472, 0, 0, 2 }, // Argument("transposed", at::nullopt, AttributeInfo{ AttributeKind::i, at
{ 396, 0, 0, 1 }, // Argument("output_padding", at::nullopt, AttributeInfo{ AttributeKind::i
{ 473, 0, 0, 2 }, // Argument("groups", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 475, 0, 0, 2 }, // Argument("benchmark", at::nullopt, AttributeInfo{ AttributeKind::i, at:
{ 476, 0, 0, 2 }, // Argument("deterministic", at::nullopt, AttributeInfo{ AttributeKind::i,
{ 462, 0, 0, 2 }, // Argument("cudnn_enabled", at::nullopt, AttributeInfo{ AttributeKind::i,
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
```

Now:
```cpp
// Arguments for cat (2 args, 1 returns)                                                    
{ 210, 1, 0, 0 }, // Argument("tensors", at::nullopt, at::nullopt, ListType::ofTensors())   
{ 15, 0, 8, 2 }, // Argument("dim", as_tensor(int64_t(0)), AttributeInfo{ AttributeKind::i, 
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
// Arguments for ceil (1 args, 1 returns)                                                   
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
// Arguments for chunk (3 args, 1 returns)                                                  
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 469, 0, 0, 2 }, // Argument("chunks", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 15, 0, 8, 2 }, // Argument("dim", as_tensor(int64_t(0)), AttributeInfo{ AttributeKind::i, 
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
// Arguments for cudnn_is_acceptable (1 args, 1 returns)                                    
{ 1, 0, 0, 0 }, // Argument("self", at::nullopt, at::nullopt, DynamicType::get())           
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
// Arguments for convolution (9 args, 1 returns)                                            
{ 461, 0, 0, 0 }, // Argument("input", at::nullopt, at::nullopt, DynamicType::get())        
{ 107, 0, 0, 0 }, // Argument("weight", at::nullopt, at::nullopt, DynamicType::get())       
{ 385, 0, 0, 0 }, // Argument("bias", at::nullopt, at::nullopt, DynamicType::get())         
{ 208, 0, 0, 1 }, // Argument("stride", at::nullopt, AttributeInfo{ AttributeKind::is, at::n
{ 317, 0, 0, 1 }, // Argument("padding", at::nullopt, AttributeInfo{ AttributeKind::is, at::
{ 330, 0, 0, 1 }, // Argument("dilation", at::nullopt, AttributeInfo{ AttributeKind::is, at:
{ 472, 0, 0, 2 }, // Argument("transposed", at::nullopt, AttributeInfo{ AttributeKind::i, at
{ 396, 0, 0, 1 }, // Argument("output_padding", at::nullopt, AttributeInfo{ AttributeKind::i
{ 473, 0, 0, 2 }, // Argument("groups", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
// Arguments for _convolution (12 args, 1 returns)                                          
{ 461, 0, 0, 0 }, // Argument("input", at::nullopt, at::nullopt, DynamicType::get())        
{ 107, 0, 0, 0 }, // Argument("weight", at::nullopt, at::nullopt, DynamicType::get())       
{ 385, 0, 0, 0 }, // Argument("bias", at::nullopt, at::nullopt, DynamicType::get())         
{ 208, 0, 0, 1 }, // Argument("stride", at::nullopt, AttributeInfo{ AttributeKind::is, at::n
{ 317, 0, 0, 1 }, // Argument("padding", at::nullopt, AttributeInfo{ AttributeKind::is, at::
{ 330, 0, 0, 1 }, // Argument("dilation", at::nullopt, AttributeInfo{ AttributeKind::is, at:
{ 472, 0, 0, 2 }, // Argument("transposed", at::nullopt, AttributeInfo{ AttributeKind::i, at
{ 396, 0, 0, 1 }, // Argument("output_padding", at::nullopt, AttributeInfo{ AttributeKind::i
{ 473, 0, 0, 2 }, // Argument("groups", at::nullopt, AttributeInfo{ AttributeKind::i, at::nu
{ 475, 0, 0, 2 }, // Argument("benchmark", at::nullopt, AttributeInfo{ AttributeKind::i, at:
{ 476, 0, 0, 2 }, // Argument("deterministic", at::nullopt, AttributeInfo{ AttributeKind::i,
{ 462, 0, 0, 2 }, // Argument("cudnn_enabled", at::nullopt, AttributeInfo{ AttributeKind::i,
{ 2, 0, 0, 0 }, // Argument("result", at::nullopt, at::nullopt, DynamicType::get())         
```