### PR TITLE
Fix scalar check for sparse tensors.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3885,7 +3885,7 @@
   aten_custom_call: |
     if (self_->isScalar()) {
       // Empty tensor
-      return self_->type().toScalarType(kLong).tensor({0});
+      return toBackend(toDense(backend())).toScalarType(kLong).tensor({0});
     }
 ]]
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -102,12 +102,6 @@ class TestSparse(TestCase):
         # TODO: Put this in torch.cuda.randn
         return self.ValueTensor(*args, **kwargs).normal_()
 
-    def test_factory_empty_indices(self):
-        device = 'cuda' if self.cuda else cpu
-        tensor = torch.sparse_coo_tensor([], [], torch.Size([]), device=device)
-        expected_indices = torch.tensor([], dtype=torch.long, device=device)
-        self.assertEqual(tensor._indices(), expected_indices)
-
     def test_basic(self):
         x, i, v = self._gen_sparse(3, 10, 100)
 
@@ -915,6 +909,12 @@ class TestSparse(TestCase):
         sizes = torch.Size([3, 3, 2])
         with self.assertRaisesRegex(RuntimeError, "values and sizes are inconsistent"):
             self.SparseTensor(indices, values, sizes)
+
+    def test_factory_empty_indices(self):
+        device = 'cuda' if self.is_cuda else 'cpu'
+        tensor = torch.sparse_coo_tensor([], [], torch.Size([]), device=device)
+        expected_indices = torch.tensor([], dtype=torch.long, device=device)
+        self.assertEqual(tensor._indices(), expected_indices)
 
     @cpu_only
     def test_factory_type_inference(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -102,6 +102,12 @@ class TestSparse(TestCase):
         # TODO: Put this in torch.cuda.randn
         return self.ValueTensor(*args, **kwargs).normal_()
 
+    def test_factory_empty_indices(self):
+        device = 'cuda' if self.cuda else cpu
+        tensor = torch.sparse_coo_tensor([], [], torch.Size([]), device=device)
+        expected_indices = torch.tensor([], dtype=torch.long, device=device)
+        self.assertEqual(tensor._indices(), expected_indices)
+
     def test_basic(self):
         x, i, v = self._gen_sparse(3, 10, 100)
 


### PR DESCRIPTION
As discovered in #8152

If `t` is a scalar sparse tensor, `t._indices` used to return a sparse
empty tensor because the scalar check was incorrect. This PR modifies
the scalar check to return a dense tensor instead of a sparse tensor.

i.e.
```
tensor = torch.sparse_coo_tensor([], [], torch.Size([]), device=device)
out = tensor._indices()  # was a sparse tensor, now is dense.
```

