### PR TITLE
Fix c10d compiler warnings

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -49,6 +49,14 @@ set(C10D_SRCS
   )
 
 add_library(c10d ${C10D_SRCS})
+target_compile_options(c10d PUBLIC
+  -Wall
+  -Wextra
+  -Wno-unused-parameter
+  -Wno-missing-field-initializers
+  -Wno-write-strings
+  -Wno-unknown-pragmas
+  )
 target_link_libraries(c10d PUBLIC caffe2_gpu)
 
 # c10d links to Caffe2/ATen, but the targets don't add TH/THC to the include path

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -5,20 +5,8 @@
 namespace c10d {
 
 enum class CollectiveType : std::uint8_t {
-  ALLGATHER = 0,
-  GATHER,
-  SCATTER,
-  ALLREDUCE,
-  REDUCE,
   BROADCAST,
-  SEND,
-  BARRIER,
-  UNUSED,
-};
-
-enum class DeviceType : std::uint8_t {
-  CPU = 0,
-  CUDA,
+  ALLREDUCE,
   UNUSED,
 };
 

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -23,7 +23,7 @@ namespace c10d {
 inline std::string toString(at::IntList l) {
   std::stringstream ss;
   ss << "(";
-  for (int i = 0; i < l.size(); i++) {
+  for (size_t i = 0; i < l.size(); i++) {
     if (i > 0) {
       ss << ", ";
     }
@@ -42,7 +42,7 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   // Ensure all tensors have identical type and shape
   auto& type = tensors[0].type();
   auto sizes = tensors[0].sizes();
-  for (auto i = 1; i < tensors.size(); i++) {
+  for (size_t i = 1; i < tensors.size(); i++) {
     if (tensors[i].type() != type) {
       const std::string expected = type.toString();
       const std::string actual = tensors[i].type().toString();
@@ -63,7 +63,7 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
 inline std::vector<std::vector<int64_t>> getSizes(
     const std::vector<at::Tensor>& tensors) {
   std::vector<std::vector<int64_t>> sizes(tensors.size());
-  for (auto i = 0; i < tensors.size(); i++) {
+  for (size_t i = 0; i < tensors.size(); i++) {
     sizes[i] = tensors[i].sizes();
   }
   return sizes;
@@ -72,7 +72,7 @@ inline std::vector<std::vector<int64_t>> getSizes(
 inline std::vector<int> getDevices(const std::vector<at::Tensor>& tensors) {
   std::vector<int> devices(tensors.size(), -1);
   if (tensors[0].type().is_cuda()) {
-    for (auto i = 0; i < tensors.size(); i++) {
+    for (size_t i = 0; i < tensors.size(); i++) {
       devices[i] = tensors[i].storage()->getDevice();
     }
   }
@@ -82,7 +82,7 @@ inline std::vector<int> getDevices(const std::vector<at::Tensor>& tensors) {
 template <typename T>
 std::vector<T*> getDataPointers(const std::vector<at::Tensor>& tensors) {
   std::vector<T*> ptrs(tensors.size());
-  for (auto i = 0; i < tensors.size(); i++) {
+  for (size_t i = 0; i < tensors.size(); i++) {
     ptrs[i] = static_cast<T*>(tensors[i].storage()->data());
   }
   return ptrs;

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -186,25 +186,25 @@ class AsyncBroadcastTest : public AsyncInputIsOutputTest {
 
 void runAsyncAllreduceTest(
     const std::string& path,
-    int numProcesses,
-    int numTensors) {
+    size_t numProcesses,
+    size_t numTensors) {
   auto tests = initialize<AsyncAllreduceTest>(path, numProcesses, numTensors);
   std::vector<std::shared_ptr<c10d::ProcessGroup::Work>> work(numProcesses);
-  for (auto i = 0; i < numProcesses; i++) {
+  for (size_t i = 0; i < numProcesses; i++) {
     work[i] = tests[i].run();
   }
 
   // Wait for work to complete
-  for (auto i = 0; i < numProcesses; i++) {
+  for (size_t i = 0; i < numProcesses; i++) {
     tests[i].wait(work[i]);
   }
 
   // Check results
-  for (auto i = 0; i < numProcesses; i++) {
+  for (size_t i = 0; i < numProcesses; i++) {
     const auto size = numProcesses * numTensors;
     const auto expected = (size * (size - 1)) / 2;
     auto tensors = tests[i].getTensors();
-    for (auto j = 0; j < tensors.size(); j++) {
+    for (size_t j = 0; j < tensors.size(); j++) {
       auto& tensor = tensors[j];
       auto data = tensor.data<float>();
       for (auto k = 0; k < tensor.numel(); k++) {
@@ -218,28 +218,28 @@ void runAsyncAllreduceTest(
 
 void runAsyncBroadcastTest(
     const std::string& path,
-    int numProcesses,
-    int numTensors) {
+    size_t numProcesses,
+    size_t numTensors) {
   auto tests = initialize<AsyncBroadcastTest>(path, numProcesses, numTensors);
 
   // Try every permutation of root rank and root tensor
-  for (auto rootRank = 0; rootRank < numProcesses; rootRank++) {
-    for (auto rootTensor = 0; rootTensor < numTensors; rootTensor++) {
+  for (size_t rootRank = 0; rootRank < numProcesses; rootRank++) {
+    for (size_t rootTensor = 0; rootTensor < numTensors; rootTensor++) {
       std::vector<std::shared_ptr<c10d::ProcessGroup::Work>> work(numProcesses);
-      for (auto i = 0; i < numProcesses; i++) {
+      for (size_t i = 0; i < numProcesses; i++) {
         work[i] = tests[i].run(rootRank, rootTensor);
       }
 
       // Wait for work to complete
-      for (auto i = 0; i < numProcesses; i++) {
+      for (size_t i = 0; i < numProcesses; i++) {
         tests[i].wait(work[i]);
       }
 
       // Check results
       const auto expected = (rootRank * numTensors + rootTensor);
-      for (auto i = 0; i < numProcesses; i++) {
+      for (size_t i = 0; i < numProcesses; i++) {
         auto tensors = tests[i].getTensors();
-        for (auto j = 0; j < tensors.size(); j++) {
+        for (size_t j = 0; j < tensors.size(); j++) {
           auto& tensor = tensors[j];
           auto data = tensor.data<float>();
           for (auto k = 0; k < tensor.numel(); k++) {

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -139,10 +139,10 @@ class CollectiveTest {
 std::vector<std::vector<at::Tensor>> copyTensors(
     const std::vector<std::vector<at::Tensor>>& inputs) {
   std::vector<std::vector<at::Tensor>> outputs(inputs.size());
-  for (auto i = 0; i < inputs.size(); i++) {
+  for (size_t i = 0; i < inputs.size(); i++) {
     const auto& input = inputs[i];
     std::vector<at::Tensor> output(input.size());
-    for (auto j = 0; j < input.size(); j++) {
+    for (size_t j = 0; j < input.size(); j++) {
       output[j] = input[j].toBackend(at::kCPU);
     }
     outputs[i] = std::move(output);


### PR DESCRIPTION
Copy compiler flags from the ones used in setup.py and fix warnings.
This makes the root build that includes c10d headers warning free.

