### PR TITLE
Add the Tags() context, and support conversion between Tags and device_option.extra_info

### DIFF
--- a/caffe2/python/scope_test.py
+++ b/caffe2/python/scope_test.py
@@ -89,6 +89,109 @@ class TestScope(unittest.TestCase):
 
         self.assertEquals(scope.CurrentDeviceScope(), None)
 
+    def testTags(self):
+        self.assertEquals(scope.CurrentTags(), None)
+
+        tags1 = {"key1": "value1"}
+        tags2 = {"key2": "value2"}
+        tags3 = {"key3": "value3"}
+
+        tags_1_2 = tags1.copy()
+        tags_1_2.update(tags2)
+
+        tags_1_3 = tags1.copy()
+        tags_1_3.update(tags3)
+
+        tags_1_2_3 = tags_1_2.copy()
+        tags_1_2_3.update(tags3)
+
+        with scope.Tags(tags1):
+            self.assertEquals(scope.CurrentTags(), tags1)
+
+            with scope.Tags(tags2):
+                self.assertEquals(scope.CurrentTags(), tags_1_2)
+
+                with scope.Tags(tags3):
+                    self.assertEquals(scope.CurrentTags(), tags_1_2_3)
+
+            with scope.Tags(tags2):
+                self.assertEquals(scope.CurrentTags(), tags_1_2)
+
+            self.assertEquals(scope.CurrentTags(), tags1)
+
+            with scope.Tags(tags3):
+                self.assertEquals(scope.CurrentTags(), tags_1_3)
+
+            self.assertEquals(scope.CurrentTags(), tags1)
+        self.assertEquals(scope.CurrentTags(), None)
+
+    def testTagsErrors(self):
+        self.assertEquals(scope.CurrentTags(), None)
+
+        tags1 = {"key1": "value1"}
+        tags2 = {"key1": "value2"}
+        # Test tags value conflict
+        with scope.Tags(tags1):
+            self.assertEquals(scope.CurrentTags(), tags1)
+            try:
+                with scope.Tags(tags2):
+                    print("CurrentTags:".format(scope.CurrentTags()))
+            except ValueError as err:
+                    print("Tags conflict detected as expected: {}".format(err))
+            else:
+                assert False, "Expecting a Tags conflict failure"
+
+    def testTagsAndDeviceScope(self):
+
+        # test empty DeviceScope and empty Tags()
+        test_0_net = core.Net("test0")
+        test_0_net.Add(["X", "Y"], "Z")
+        self.assertEquals(
+            test_0_net.Proto().op[0].device_option.extra_info, []
+        )
+
+        # test empty DeviceScope and Tags()
+        test_1_net = core.Net("test1")
+        tags1 = {"key1": "value1"}
+        with scope.Tags(tags1):
+            test_1_net.Add(["X", "Y"], "Z")
+        self.assertEquals(
+            test_1_net.Proto().op[0].device_option.extra_info[0], "key1:value1"
+        )
+
+        # test DeviceScope with empty extra_info and Tags()
+        dev = core.DeviceOption(0)
+        test_2_net = core.Net("test2")
+        with scope.DeviceScope(dev):
+            with scope.Tags(tags1):
+                test_2_net.Add(["X", "Y"], "Z")
+        self.assertEquals(
+            test_2_net.Proto().op[0].device_option.extra_info[0], "key1:value1"
+        )
+
+        # test DeviceScope with extra_info and Tags(), without value conflicts
+        dev = core.DeviceOption(0, extra_info=["key2:value2"])
+        test_3_net = core.Net("test3")
+        with scope.DeviceScope(dev):
+            with scope.Tags(tags1):
+                test_3_net.Add(["X", "Y"], "Z")
+        self.assertEquals(
+            test_3_net.Proto().op[0].device_option.extra_info,
+            ["key1:value1", "key2:value2"],
+        )
+
+        # test DeviceScope with extra_info and Tags(), with value conflicts
+        dev = core.DeviceOption(0, extra_info=["key1:value2"])
+        test_4_net = core.Net("test4")
+        try:
+            with scope.DeviceScope(dev):
+                with scope.Tags(tags1):
+                    test_4_net.Add(["X", "Y"], "Z")
+        except ValueError as err:
+            print("Tags conflict detected as expected: {}".format(err))
+        else:
+            assert False, "Expecting a Tags conflict failure"
+
     def testMultiThreaded(self):
         """
         Test that name/device scope are properly local to the thread


### PR DESCRIPTION
Tags context would be used as a part of the Tagging API to allow users to pass parameter/operator/module tags to the backend.
Tags will be stored as device_option.extra_info.

