### PR TITLE
Structure THTensor like THCTensor is structured.

### DIFF
--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -8,6 +8,22 @@
 
 #include <atomic>
 
+typedef struct _THTensor
+{
+    int64_t *size;
+    int64_t *stride;
+    int nDimension;
+
+    // Note: storage->size may be greater than the recorded size
+    // of a tensor
+    THStorage *storage;
+    ptrdiff_t storageOffset;
+    std::atomic<int> refcount;
+
+    char flag;
+
+} _THTensor;
+
 #include "generic/THTensor.hpp"
 #include "THGenerateAllTypes.h"
 

--- a/aten/src/TH/generic/THTensor.hpp
+++ b/aten/src/TH/generic/THTensor.hpp
@@ -2,20 +2,9 @@
 #define TH_GENERIC_FILE "generic/THTensor.hpp"
 #else
 
-typedef struct THTensor
-{
-    int64_t *size;
-    int64_t *stride;
-    int nDimension;
-
-    // Note: storage->size may be greater than the recorded size
-    // of a tensor
-    THStorage *storage;
-    ptrdiff_t storageOffset;
-    std::atomic<int> refcount;
-
-    char flag;
-
+// This allows one to write generic functions (i.e. functions that work across all THRealTensor types)
+// without having to explicitly cast the THRealTensor.
+typedef struct THTensor : _THTensor {
 } THTensor;
 
 #endif


### PR DESCRIPTION
In particular, define a base type, _THTensor, that can be used for all THRealTensor structs.
This is just to have less cognitive load when dealing with generic THTensor/THCTensor types (as in templates).

