### PR TITLE
Fix broadcast copying device[0] tensor when not using NCCL

### DIFF
--- a/aten/src/ATen/DeviceGuard.h
+++ b/aten/src/ATen/DeviceGuard.h
@@ -56,7 +56,7 @@ struct DeviceGuard {
     }
   }
 
-  /// Sets the device to the given one if its index is not `nullopt`.
+  /// Sets the device to the given one.
   void set_index(int32_t index) {
     if (index == -1) {
       return;

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -35,9 +35,9 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
                              "first on devices list");
   std::vector<Tensor> tensors;
   tensors.reserve(devices.size());
+  tensors.push_back(tensor);
 #ifdef USE_NCCL
   if (nccl::is_available({tensor})) {
-    tensors.push_back(tensor);
     for (auto device : devices.slice(1)) {
       at::DeviceGuard _device_guard(device);
       tensors.push_back(type.tensor(tensor.sizes()));
@@ -48,7 +48,7 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
   {
 #endif
     auto & gpu_type = type.toBackend(type.is_sparse() ? at::kSparseCUDA : at::kCUDA);
-    for (auto device : devices) {
+    for (auto device : devices.slice(1)) {
       at::DeviceGuard _device_guard(device);
       tensors.push_back(gpu_type.copy(tensor, true));
     }

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -9,10 +9,22 @@
 namespace torch { namespace utils {
 
 inline at::Tensor flatten_dense_tensors(at::TensorList tensors) {
-  static auto flatten = [](const at::Tensor &t) { return t.contiguous().view({-1}); };
-  if (tensors.size() == 1)
-    return flatten(tensors[0]);
-  return at::cat(fmap(tensors, flatten));
+  if (tensors.size() == 1) {
+    return tensors[0].reshape({-1});
+  } else {
+    int64_t total_numel = 0;
+    for (const auto & tensor : tensors) {
+      total_numel += tensor.numel();
+    }
+    auto flat = tensors[0].type().tensor({total_numel});
+    int64_t offset = 0;
+    for (const auto & tensor : tensors) {
+      auto numel = tensor.numel();
+      flat.narrow(0, offset, numel).view_as(tensor).copy_(tensor);
+      offset += numel;
+    }
+    return flat;
+  }
 }
 
 inline std::vector<at::Tensor> unflatten_dense_tensors(const at::Tensor& flat, at::TensorList tensors) {


### PR DESCRIPTION
1. Fix broadcast copying device[0] tensor when not using NCCL
2. Avoids potential extra copy in `flatten_dense_tensors`
