### PR TITLE
Rename SparseTensor to SparseTensorRef.

### DIFF
--- a/aten/src/ATen/SparseTensorRef.h
+++ b/aten/src/ATen/SparseTensorRef.h
@@ -3,8 +3,8 @@
 namespace at {
 
 struct Tensor;
-struct SparseTensor {
-  explicit SparseTensor(const Tensor& t): tref(t) {}
+struct SparseTensorRef {
+  explicit SparseTensorRef(const Tensor& t): tref(t) {}
   const Tensor& tref;
 };
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -169,7 +169,7 @@ class NYIError(Exception):
 
 TYPE_FORMAL_GENERIC = {
     'THTensor*': 'Tensor &',
-    'THSTensor*': 'SparseTensor',
+    'THSTensor*': 'SparseTensorRef',
     'THBoolTensor*': 'Tensor &',
     'THIndexTensor*': 'Tensor &',
     'THIntegerTensor*': 'Tensor &',
@@ -186,7 +186,7 @@ TYPE_FORMAL_GENERIC = {
 
 DYNAMIC_TYPE = {
     'THTensor*': 'Tensor',
-    'THSTensor*': 'SparseTensor',
+    'THSTensor*': 'SparseTensorRef',
     'THBoolTensor*': 'BoolTensor',
     'THIndexTensor*': 'IndexTensor',
     'THIntegerTensor*': 'IntegerTensor',
@@ -1133,7 +1133,7 @@ def create_derived(backend_type_env, declarations):
             return []
         check_name = option['when_sparse_dispatch']
         sparse_actuals = [arg['name']
-                          if arg['name'] != check_name else "SparseTensor({})".format(arg['name'])
+                          if arg['name'] != check_name else "SparseTensorRef({})".format(arg['name'])
                           for arg in option['formals_list']]
         return [SPARSE_CHECK.substitute(env, check_name=check_name, sparse_actuals=sparse_actuals)]
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -690,7 +690,7 @@
 - name: zero_(Tensor self)
   self: zeros_like(grad)
 
-- name: _sparse_mask(Tensor self, SparseTensor mask)
+- name: _sparse_mask(Tensor self, SparseTensorRef mask)
   self: not_implemented("_sparse_mask")
   mask: not_implemented("_sparse_mask")
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -129,12 +129,12 @@ def should_generate_python_binding(declaration):
             return False
 
     # TODO: fix handling of SparseTensor. We don't want to generate Python
-    # bindings to SparseTensor overloads, such as add(Tensor, SparseTensor),
+    # bindings to SparseTensor overloads, such as add(Tensor, SparseTensorRef),
     # since the Tensor-based signature already dynamically dispatches correctly.
     # However, _sparse_mask only has a SparseTensor signature so we need to bind
     # that function.
     for arg in declaration['arguments']:
-        if arg['type'] == 'SparseTensor' and declaration['name'] != '_sparse_mask':
+        if arg['type'] == 'SparseTensorRef' and declaration['name'] != '_sparse_mask':
             return False
 
     return True
@@ -207,7 +207,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
 
     unpack_methods = {
         'const Tensor &': 'tensor',
-        'SparseTensor': 'tensor',
+        'SparseTensorRef': 'tensor',
         'Tensor &': 'tensor',
         'Generator *': 'generator',
         'Storage &': 'storage',
@@ -310,8 +310,8 @@ def create_python_bindings(python_functions, has_self, is_module=False):
 
             if typename == 'Storage &':
                 expr = '*' + expr
-            if typename == 'SparseTensor':
-                expr = 'SparseTensor({})'.format(expr)
+            if typename == 'SparseTensorRef':
+                expr = 'SparseTensorRef({})'.format(expr)
 
             dispatch_type = typename
             if dispatch_type == 'Tensor':
@@ -542,7 +542,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             if not has_self:
                 # Use 'input' instead of 'self' for NN functions
                 signature = signature.replace('Tensor self', 'Tensor input')
-            signature = signature.replace('SparseTensor', 'Tensor')
+            signature = signature.replace('SparseTensorRef', 'Tensor')
             if dictionary['base'].get('deprecated', False):
                 signature += '|deprecated'
             env['signatures'].append('"{}",'.format(signature))

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -328,7 +328,7 @@ def emit_body(declaration):
     def reference_args(args):
         res = []
         for arg in args:
-            if arg['type'] == 'SparseTensor':
+            if arg['type'] == 'SparseTensorRef':
                 res.append('{}.tref'.format(arg['name']))
             else:
                 res.append(arg['name'])
@@ -538,7 +538,7 @@ def unpack_args(env, declaration):
 
         dynamic_type = arg['dynamic_type']
         is_nullable = arg.get('is_nullable', False)
-        ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensor']
+        ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensorRef']
         suffix = '_opt' if is_nullable else ''
 
         body.append(UNPACK_TENSOR.substitute(

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -36,7 +36,7 @@ namespace torch { namespace autograd {
 // don't want to make the codegen do the dispatch manually)
 static void setattr(jit::Node* n, jit::Symbol name, int64_t v)             { n->i_(name, v); }
 static void setattr(jit::Node* n, jit::Symbol name, const at::Scalar& v)   { n->t_(name, v.toTensor()); }
-static void setattr(jit::Node* n, jit::Symbol name, SparseTensor s)        { n->t_(name, s.tref); }
+static void setattr(jit::Node* n, jit::Symbol name, SparseTensorRef s)     { n->t_(name, s.tref); }
 static void setattr(jit::Node* n, jit::Symbol name, const at::IntList& v)  { n->is_(name, v); }
 static void setattr(jit::Node* n, jit::Symbol name, bool v)                { n->i_(name, v); }
 static void setattr(jit::Node* n, jit::Symbol name, double v)              { n->f_(name, v); }
@@ -60,7 +60,7 @@ void failPositionalAttr() {
 
 static void setposattr(jit::Node* n, size_t idx, const char *name, int64_t v)             { genericInsertInput(n, idx, v); }
 static void setposattr(jit::Node* n, size_t idx, const char *name, const at::Scalar& v)   { genericInsertInput(n, idx, v); }
-static void setposattr(jit::Node* n, size_t idx, const char *name, SparseTensor s)        { failPositionalAttr(); }
+static void setposattr(jit::Node* n, size_t idx, const char *name, SparseTensorRef s)     { failPositionalAttr(); }
 static void setposattr(jit::Node* n, size_t idx, const char *name, const at::IntList& v)  {
   using ArgumentStash = jit::tracer::ArgumentStash;
   if (ArgumentStash::hasIntList(name)) {
@@ -236,8 +236,8 @@ Tensor & VariableType::unpack(const Tensor & t, const char * name, int pos) {
   return checked_cast_variable(t, name, pos).data();
 }
 
-SparseTensor VariableType::unpack(SparseTensor t, const char * name, int pos) {
-  return SparseTensor(checked_cast_variable(t.tref, name, pos).data());
+SparseTensorRef VariableType::unpack(SparseTensorRef t, const char * name, int pos) {
+  return SparseTensorRef(checked_cast_variable(t.tref, name, pos).data());
 }
 
 Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -17,7 +17,7 @@ using at::Context;
 using at::Generator;
 using at::IntList;
 using at::Scalar;
-using at::SparseTensor;
+using at::SparseTensorRef;
 using at::Storage;
 using at::Tensor;
 using at::TensorList;
@@ -62,7 +62,7 @@ private:
   // checks that t is actually a Variable
   static Variable & checked_cast_variable(const Tensor & t, const char * name, int pos);
   static at::Tensor & unpack(const Tensor & t, const char * name, int pos);
-  static at::SparseTensor unpack(SparseTensor t, const char * name, int pos);
+  static at::SparseTensorRef unpack(SparseTensorRef t, const char * name, int pos);
   static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);
   static std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos);
 

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -19,7 +19,7 @@ using at::Scalar;
 using at::TensorList;
 using at::IntList;
 using at::Generator;
-using at::SparseTensor;
+using at::SparseTensorRef;
 using at::Storage;
 
 static at::Type& default_type() {

--- a/tools/autograd/templates/python_variable_methods_dispatch.h
+++ b/tools/autograd/templates/python_variable_methods_dispatch.h
@@ -16,7 +16,7 @@ using at::Scalar;
 using at::TensorList;
 using at::IntList;
 using at::Generator;
-using at::SparseTensor;
+using at::SparseTensorRef;
 using at::Storage;
 
 ${py_method_dispatch}

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -77,7 +77,7 @@ def is_magic_method(api_name):
     return api_name.startswith('__') and api_name.endswith('__')
 
 
-blacklisted_types = {'SparseTensor', 'Storage', 'ScalarType', 'optional<ScalarType>', 'std::string'}
+blacklisted_types = {'SparseTensorRef', 'Storage', 'ScalarType', 'optional<ScalarType>', 'std::string'}
 default_only_types = {'Generator'}
 
 


### PR DESCRIPTION
I want to introduce using SparseTensor = Tensor (as a documentary
type alias for Tensor), but the name is already taken.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

