### PR TITLE
Don't override Tensor, Storage macros defined outside torch/csrc in t…

### DIFF
--- a/tools/cwrap/plugins/Broadcast.py
+++ b/tools/cwrap/plugins/Broadcast.py
@@ -51,7 +51,7 @@ class Broadcast(CWrapPlugin):
     def getPreArgStringTemplate(self, type=None):
         if type is None:
             ret = """THTensor *${arg_op_other}_save = ${arg_op_other};
-                     THTensorPtr ${arg_op_other}_guard(nullptr);\n"""
+                     THWTensorPtr ${arg_op_other}_guard(nullptr);\n"""
         else:
             cpu_t = "TH" + type + "Tensor"
             gpu_t = "THCuda" + type + "Tensor"

--- a/tools/cwrap/plugins/Broadcast.py
+++ b/tools/cwrap/plugins/Broadcast.py
@@ -51,7 +51,7 @@ class Broadcast(CWrapPlugin):
     def getPreArgStringTemplate(self, type=None):
         if type is None:
             ret = """THTensor *${arg_op_other}_save = ${arg_op_other};
-                     THWTensorPtr ${arg_op_other}_guard(nullptr);\n"""
+                     THTensorPtr ${arg_op_other}_guard(nullptr);\n"""
         else:
             cpu_t = "TH" + type + "Tensor"
             gpu_t = "THCuda" + type + "Tensor"

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -24,6 +24,11 @@
 #define LIBRARY_STATE_TYPE
 #define LIBRARY_STATE_TYPE_NOARGS
 
+#define THWStorage THStorage
+#define THWStorage_(NAME) THStorage_(NAME)
+#define THWTensor THTensor
+#define THWTensor_(NAME) THTensor_(NAME)
+
 #include "PtrWrapper.h"
 #include "Exceptions.h"
 #include "Generator.h"

--- a/torch/csrc/cuda/Storage.cpp
+++ b/torch/csrc/cuda/Storage.cpp
@@ -19,7 +19,7 @@
 #include <THC/THCGenerateAllTypes.h>
 
 template<>
-void THPPointer<THStorage>::free() {
+void THPPointer<THCStorage>::free() {
   if (ptr)
     THCStorage_free(LIBRARY_STATE ptr);
 }

--- a/torch/csrc/cuda/override_macros.h
+++ b/torch/csrc/cuda/override_macros.h
@@ -1,14 +1,14 @@
 #include "undef_macros.h"
 
-#define THStoragePtr THCStoragePtr
+#define THWStoragePtr THCStoragePtr
 #define THPStoragePtr THCPStoragePtr
-#define THTensorPtr THCTensorPtr
+#define THWTensorPtr THCTensorPtr
 #define THPTensorPtr THCPTensorPtr
 
-#define THStorage THCStorage
-#define THStorage_(NAME) THCStorage_(NAME)
-#define THTensor THCTensor
-#define THTensor_(NAME) THCTensor_(NAME)
+#define THWStorage THCStorage
+#define THWStorage_(NAME) THCStorage_(NAME)
+#define THWTensor THCTensor
+#define THWTensor_(NAME) THCTensor_(NAME)
 
 #define THPStorage_(NAME) TH_CONCAT_4(THCP,Real,Storage_,NAME)
 #define THPStorage THCPStorage
@@ -29,10 +29,7 @@
 #define THPTensorStateless THCPTensorStateless
 
 
-#define THSTensorPtr THCSTensorPtr
 #define THSPTensorPtr THCSPTensorPtr
-#define THSTensor THCSTensor
-#define THSTensor_(NAME) THCSTensor_(NAME)
 
 #define THSPTensor_(NAME) TH_CONCAT_4(THCSP,Real,Tensor_,NAME)
 #define THSPTensor_stateless_(NAME) TH_CONCAT_4(THCSP,Real,Tensor_stateless_,NAME)

--- a/torch/csrc/cuda/restore_macros.h
+++ b/torch/csrc/cuda/restore_macros.h
@@ -1,6 +1,6 @@
 
-#define THTensor                    TH_CONCAT_3(TH,Real,Tensor)
-#define THTensor_(NAME)             TH_CONCAT_4(TH,Real,Tensor_,NAME)
+#define THWTensor                    TH_CONCAT_3(TH,Real,Tensor)
+#define THWTensor_(NAME)             TH_CONCAT_4(TH,Real,Tensor_,NAME)
 
 #define THPTensor                   TH_CONCAT_3(THP,Real,Tensor)
 #define THPTensorStr                TH_CONCAT_STRING_3(torch.,Real,Tensor)
@@ -13,8 +13,8 @@
 #define THPStorage_(NAME) TH_CONCAT_4(THP,Real,Storage_,NAME)
 
 #ifdef _THP_CORE
-#define THStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
-#define THTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)
+#define THWStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
+#define THWTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)
 #define THPStoragePtr TH_CONCAT_3(THP,Real,StoragePtr)
 #define THPTensorPtr  TH_CONCAT_3(THP,Real,TensorPtr)
 #endif

--- a/torch/csrc/cuda/undef_macros.h
+++ b/torch/csrc/cuda/undef_macros.h
@@ -22,14 +22,14 @@
 #undef THPStorageClass
 #undef THPStorageType
 
-#undef THStorage
-#undef THStorage_
-#undef THTensor
-#undef THTensor_
+#undef THWStorage
+#undef THWStorage_
+#undef THWTensor
+#undef THWTensor_
 
-#undef THStoragePtr
+#undef THWStoragePtr
 #undef THPStoragePtr
-#undef THTensorPtr
+#undef THWTensorPtr
 #undef THPTensorPtr
 
 
@@ -44,9 +44,6 @@
 #undef THSPTensorStateless
 #undef THSPTensorType
 
-#undef THSTensor
-#undef THSTensor_
-#undef THSTensorPtr
 #undef THSPTensorPtr
 
 

--- a/torch/csrc/distributed/override_macros.h
+++ b/torch/csrc/distributed/override_macros.h
@@ -1,14 +1,14 @@
 #include "undef_macros.h"
 
-#define THStoragePtr THDStoragePtr
+#define THWStoragePtr THDStoragePtr
 #define THPStoragePtr THDPStoragePtr
-#define THTensorPtr THDTensorPtr
+#define THWTensorPtr THDTensorPtr
 #define THPTensorPtr THDPTensorPtr
 
-#define THStorage THDStorage
-#define THStorage_(NAME) THDStorage_(NAME)
-#define THTensor THDTensor
-#define THTensor_(NAME) THDTensor_(NAME)
+#define THWStorage THDStorage
+#define THWStorage_(NAME) THDStorage_(NAME)
+#define THWTensor THDTensor
+#define THWTensor_(NAME) THDTensor_(NAME)
 
 #define THPStorage_(NAME) TH_CONCAT_4(THDP,Real,Storage_,NAME)
 #define THPStorage THDPStorage

--- a/torch/csrc/distributed/undef_macros.h
+++ b/torch/csrc/distributed/undef_macros.h
@@ -20,14 +20,14 @@
 #undef THPStorageClass
 #undef THPStorageType
 
-#undef THStorage
-#undef THStorage_
-#undef THTensor
-#undef THTensor_
+#undef THWStorage
+#undef THWStorage_
+#undef THWTensor
+#undef THWTensor_
 
-#undef THStoragePtr
+#undef THWStoragePtr
 #undef THPStoragePtr
-#undef THTensorPtr
+#undef THWTensorPtr
 #undef THPTensorPtr
 
 #undef THHostTensor

--- a/torch/csrc/generic/Storage.h
+++ b/torch/csrc/generic/Storage.h
@@ -4,10 +4,10 @@
 
 struct THPStorage {
   PyObject_HEAD
-  THStorage *cdata;
+  THWStorage *cdata;
 };
 
-THP_API PyObject * THPStorage_(New)(THStorage *ptr);
+THP_API PyObject * THPStorage_(New)(THWStorage *ptr);
 extern PyObject *THPStorageClass;
 
 #ifdef _THP_CORE

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -5,7 +5,7 @@
 static PyObject * THPStorage_(size)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromLong(THStorage_(size)(LIBRARY_STATE self->cdata));
+  return PyLong_FromLong(THWStorage_(size)(LIBRARY_STATE self->cdata));
   END_HANDLE_TH_ERRORS
 }
 
@@ -13,7 +13,7 @@ static PyObject * THPStorage_(size)(THPStorage *self)
 static PyObject * THPStorage_(dataPtr)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromVoidPtr(THStorage_(data)(LIBRARY_STATE self->cdata));
+  return PyLong_FromVoidPtr(THWStorage_(data)(LIBRARY_STATE self->cdata));
   END_HANDLE_TH_ERRORS
 }
 #endif
@@ -21,7 +21,7 @@ static PyObject * THPStorage_(dataPtr)(THPStorage *self)
 static PyObject * THPStorage_(copy_)(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   HANDLE_TH_ERRORS
-  return THPStorageCopyMethod(THStorage_(copy_functions), self, args, kwargs);
+  return THPStorageCopyMethod(THWStorage_(copy_functions), self, args, kwargs);
   END_HANDLE_TH_ERRORS
 }
 
@@ -31,7 +31,7 @@ static PyObject * THPStorage_(isPinned)(THPStorage *self)
   HANDLE_TH_ERRORS
 #if defined(WITH_CUDA)
   cudaPointerAttributes attr;
-  cudaError_t err = cudaPointerGetAttributes(&attr, THStorage_(data)(LIBRARY_STATE self->cdata));
+  cudaError_t err = cudaPointerGetAttributes(&attr, THWStorage_(data)(LIBRARY_STATE self->cdata));
   if (err != cudaSuccess) {
     cudaGetLastError();
     Py_RETURN_FALSE;
@@ -47,14 +47,14 @@ static PyObject * THPStorage_(isPinned)(THPStorage *self)
 static PyObject * THPStorage_(elementSize)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromLong(THStorage_(elementSize)(LIBRARY_STATE_NOARGS));
+  return PyLong_FromLong(THWStorage_(elementSize)(LIBRARY_STATE_NOARGS));
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject * THPStorage_(new)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THStoragePtr new_storage(THStorage_(new)(LIBRARY_STATE_NOARGS));
+  THWStoragePtr new_storage(THWStorage_(new)(LIBRARY_STATE_NOARGS));
   PyObject *_ret = THPStorage_(New)(new_storage);
   new_storage.release();
   return _ret;
@@ -67,7 +67,7 @@ static PyObject * THPStorage_(resize_)(THPStorage *self, PyObject *number_arg)
   THPUtils_assert(THPUtils_checkLong(number_arg), "resize_ expects an int, "
       "but got %s", THPUtils_typename(number_arg));
   int64_t newsize = THPUtils_unpackLong(number_arg);
-  THStorage_(resize)(LIBRARY_STATE self->cdata, newsize);
+  THWStorage_(resize)(LIBRARY_STATE self->cdata, newsize);
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS
@@ -79,7 +79,7 @@ static PyObject * THPStorage_(fill_)(THPStorage *self, PyObject *number_arg)
   THPUtils_assert(THPUtils_(checkReal)(number_arg), "fill_ expects %s, "
       "but got %s", THPUtils_typeTraits<real>::python_type_str,
       THPUtils_typename(number_arg));
-  THStorage_(fill)(LIBRARY_STATE self->cdata, THPUtils_(unpackReal)(number_arg));
+  THWStorage_(fill)(LIBRARY_STATE self->cdata, THPUtils_(unpackReal)(number_arg));
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS
@@ -152,23 +152,23 @@ static PyObject * THPStorage_(fromBuffer)(PyObject *_unused, PyObject *args, PyO
   }
 
   uint8_t* src = (uint8_t*) buffer.buf;
-  THStorage* storage = THStorage_(newWithSize)(count);
+  THWStorage* storage = THWStorage_(newWithSize)(count);
 
 #if defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR)
-  memcpy(THStorage_(data)(storage), src + offset, count);
+  memcpy(THWStorage_(data)(storage), src + offset, count);
 #elif defined(TH_REAL_IS_SHORT)
-  THP_decodeInt16Buffer(THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeInt16Buffer(THWStorage_(data)(storage), src + offset, byte_order, count);
 #elif defined(TH_REAL_IS_INT)
-  THP_decodeInt32Buffer(THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeInt32Buffer(THWStorage_(data)(storage), src + offset, byte_order, count);
 #elif defined(TH_REAL_IS_LONG)
   // TODO: remove the cast
-  THP_decodeInt64Buffer((int64_t*) THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeInt64Buffer((int64_t*) THWStorage_(data)(storage), src + offset, byte_order, count);
 #elif defined(TH_REAL_IS_HALF)
-  THP_decodeHalfBuffer(THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeHalfBuffer(THWStorage_(data)(storage), src + offset, byte_order, count);
 #elif defined(TH_REAL_IS_FLOAT)
-  THP_decodeFloatBuffer(THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeFloatBuffer(THWStorage_(data)(storage), src + offset, byte_order, count);
 #elif defined(TH_REAL_IS_DOUBLE)
-  THP_decodeDoubleBuffer(THStorage_(data)(storage), src + offset, byte_order, count);
+  THP_decodeDoubleBuffer(THWStorage_(data)(storage), src + offset, byte_order, count);
 #else
 #error "Unknown type"
 #endif
@@ -192,7 +192,7 @@ static PyObject * THPStorage_(fromFile)(PyObject *_unused, PyObject *args, PyObj
   }
   if (shared)
     shared = TH_ALLOCATOR_MAPPED_SHARED;
-  THStorage *storage = THStorage_(newWithMapping)(LIBRARY_STATE filename, size, shared);
+  THWStorage *storage = THWStorage_(newWithMapping)(LIBRARY_STATE filename, size, shared);
   return (PyObject*)THPStorage_(New)(storage);
   END_HANDLE_TH_ERRORS
 }
@@ -223,7 +223,7 @@ PyObject * THPStorage_(newWithFile)(PyObject *_unused, PyObject *file)
   int fd = PyObject_AsFileDescriptor(file);
   THPUtils_assert(fd != -1, "_new_with_file couldn't retrieve a file "
       "descriptor from given object");
-  THStorage *storage = THPStorage_(readFileRaw<int>)(fd, nullptr);
+  THWStorage *storage = THPStorage_(readFileRaw<int>)(fd, nullptr);
   if (storage == nullptr)
     return nullptr;
   PyObject *result = THPStorage_(New)(storage);
@@ -243,7 +243,7 @@ static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
     // but it is currently unnecessary to support this.
     THPUtils_assert(offset == Py_None,
                     "_set_from_file: offset is NYI for filelike objects");
-    THStorage *storage = THPStorage_(readFileRaw<PyObject*>)(file, self->cdata);
+    THWStorage *storage = THPStorage_(readFileRaw<PyObject*>)(file, self->cdata);
     if (storage == nullptr) {
       return nullptr;
     }
@@ -258,7 +258,7 @@ static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
   }
   THPUtils_assert(fd != -1, "_set_from_file couldn't retrieve a file "
       "descriptor from given object");
-  THStorage *storage = THPStorage_(readFileRaw<int>)(fd, self->cdata);
+  THWStorage *storage = THPStorage_(readFileRaw<int>)(fd, self->cdata);
   if (storage == nullptr)
     return nullptr;
   Py_INCREF(self);
@@ -283,9 +283,9 @@ PyObject * THPStorage_(_setCdata)(THPStorage *self, PyObject *new_cdata)
   THPUtils_assert(THPUtils_checkLong(new_cdata), "given an invalid argument to "
       "_set_cdata - expected an int or long, but got %s",
       THPUtils_typename(new_cdata));
-  THStorage *ptr = (THStorage*)PyLong_AsVoidPtr(new_cdata);
-  THStorage_(retain)(LIBRARY_STATE ptr);
-  THStorage_(free)(LIBRARY_STATE self->cdata);
+  THWStorage *ptr = (THWStorage*)PyLong_AsVoidPtr(new_cdata);
+  THWStorage_(retain)(LIBRARY_STATE ptr);
+  THWStorage_(free)(LIBRARY_STATE self->cdata);
   self->cdata = ptr;
   Py_INCREF(self);
   return (PyObject*)self;
@@ -299,11 +299,11 @@ PyObject * THPStorage_(_rootStorage)(THPStorage *self)
   if (!(self->cdata->flag & TH_STORAGE_VIEW)) {
     return Py_BuildValue("(ON)", self, PyLong_FromLong(0));
   }
-  THStorage *root = self->cdata;
+  THWStorage *root = self->cdata;
   while (root->flag & TH_STORAGE_VIEW)
     root = root->view;
-  size_t offset = THStorage_(data)(LIBRARY_STATE self->cdata) - THStorage_(data)(LIBRARY_STATE root);
-  THStorage_(retain)(LIBRARY_STATE root);
+  size_t offset = THWStorage_(data)(LIBRARY_STATE self->cdata) - THWStorage_(data)(LIBRARY_STATE root);
+  THWStorage_(retain)(LIBRARY_STATE root);
   THPObjectPtr storage(THPStorage_(New)(root));
   PyObject *result = Py_BuildValue("(NN)", storage.get(), PyLong_FromLong(offset));
   storage.release();

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -9,7 +9,7 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
   libshm_context *ctx = NULL;
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   if (storage->allocator == &THManagedSharedAllocator) {
     ctx = (libshm_context*)storage->allocatorContext;
   } else if (storage->allocator == &THStorageWeakRefAllocator) {
@@ -18,7 +18,7 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
       ctx = (libshm_context*)allocator_obj->allocatorContext;
   }
   if (ctx)
-    THRefcountedMapAllocator_decref(ctx->th_context, THStorage_(data)(storage));
+    THRefcountedMapAllocator_decref(ctx->th_context, THWStorage_(data)(storage));
 #endif
   Py_INCREF(self);
   return (PyObject *)self;
@@ -30,7 +30,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
   libshm_context *ctx = NULL;
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   if (storage->allocator == &THManagedSharedAllocator) {
     ctx = (libshm_context*)storage->allocatorContext;
   } else if (storage->allocator == &THStorageWeakRefAllocator) {
@@ -39,19 +39,19 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
       ctx = (libshm_context*)allocator_obj->allocatorContext;
   }
   if (ctx)
-    THRefcountedMapAllocator_incref(ctx->th_context, THStorage_(data)(storage));
+    THRefcountedMapAllocator_incref(ctx->th_context, THWStorage_(data)(storage));
 #endif
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(newTHView)(THStorage *base, ptrdiff_t offset, size_t size)
+static PyObject * THPStorage_(newTHView)(THWStorage *base, ptrdiff_t offset, size_t size)
 {
   void *data = (char*)base->data<real>() + offset;
-  THStoragePtr view(THStorage_(newWithData)(LIBRARY_STATE (real*)data, size));
+  THWStoragePtr view(THWStorage_(newWithData)(LIBRARY_STATE (real*)data, size));
   view->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
   view->view = base;
-  THStorage_(retain)(LIBRARY_STATE base);
+  THWStorage_(retain)(LIBRARY_STATE base);
   return THPStorage_(New)(view.release());
 }
 
@@ -69,12 +69,12 @@ static std::string THPStorage_(__newHandle)() {
   return handle;
 }
 
-static THStorage* THPStorage_(newFilenameStorage)(ptrdiff_t size)
+static THWStorage* THPStorage_(newFilenameStorage)(ptrdiff_t size)
 {
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM | TH_ALLOCATOR_MAPPED_EXCLUSIVE;
   std::string handle = THPStorage_(__newHandle)();
   auto ctx = libshm_context_new(NULL, handle.c_str(), flags);
-  return THStorage_(newWithAllocator)(size, &THManagedSharedAllocator, (void*)ctx);
+  return THWStorage_(newWithAllocator)(size, &THManagedSharedAllocator, (void*)ctx);
 }
 
 static PyObject * THPStorage_(pyNewFilenameStorage)(PyObject *_unused, PyObject *args)
@@ -91,7 +91,7 @@ static PyObject * THPStorage_(pyNewFilenameStorage)(PyObject *_unused, PyObject 
 static PyObject * THPStorage_(shareFilename)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   libshm_context *ctx;
   // Storage is already in shared memory, just return a handle
   if (storage->allocator == &THManagedSharedAllocator) {
@@ -102,9 +102,9 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self)
   } else {
     // TODO: retry on collision
     AutoNoGIL no_gil;
-    THStoragePtr new_storage(THPStorage_(newFilenameStorage)(storage->size));
-    THStorage_(copy)(new_storage, storage);
-    THStorage_(swap)(storage, new_storage);
+    THWStoragePtr new_storage(THPStorage_(newFilenameStorage)(storage->size));
+    THWStorage_(copy)(new_storage, storage);
+    THWStorage_(swap)(storage, new_storage);
     ctx = (libshm_context*)storage->allocatorContext;
   }
 
@@ -143,12 +143,12 @@ static PyObject * THPStorage_(newSharedFilename)(PyObject *_unused, PyObject *ar
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM |
               TH_ALLOCATOR_MAPPED_NOCREATE;
   libshm_context *ctx = libshm_context_new(manager_handle, object_handle, flags);
-  return THPStorage_(New)(THStorage_(newWithAllocator)(size,
+  return THPStorage_(New)(THWStorage_(newWithAllocator)(size,
       &THManagedSharedAllocator, (void*)ctx));
   END_HANDLE_TH_ERRORS
 }
 
-static THStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
+static THWStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
 {
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM |
               TH_ALLOCATOR_MAPPED_EXCLUSIVE |
@@ -156,7 +156,7 @@ static THStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
               TH_ALLOCATOR_MAPPED_UNLINK;
   std::string handle = THPStorage_(__newHandle)();
   auto ctx = THMapAllocatorContext_new(handle.c_str(), flags);
-  return THStorage_(newWithAllocator)(size, &THMapAllocator, (void*)ctx);
+  return THWStorage_(newWithAllocator)(size, &THMapAllocator, (void*)ctx);
 }
 
 static PyObject * THPStorage_(pyNewFdStorage)(PyObject *_unused, PyObject *args)
@@ -173,7 +173,7 @@ static PyObject * THPStorage_(pyNewFdStorage)(PyObject *_unused, PyObject *args)
 static PyObject * THPStorage_(shareFd)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   THMapAllocatorContext *ctx;
   // Storage is already in shared memory, just return a handle
   if (storage->allocator == &THMapAllocator) {
@@ -183,9 +183,9 @@ static PyObject * THPStorage_(shareFd)(THPStorage *self)
     ctx = (THMapAllocatorContext*)allocator_obj->allocatorContext;
   } else {
     AutoNoGIL no_gil;
-    THStoragePtr new_storage(THPStorage_(newFdStorage)(storage->size));
-    THStorage_(copy)(new_storage, storage);
-    THStorage_(swap)(storage, new_storage);
+    THWStoragePtr new_storage(THPStorage_(newFdStorage)(storage->size));
+    THWStorage_(copy)(new_storage, storage);
+    THWStorage_(swap)(storage, new_storage);
     ctx = (THMapAllocatorContext*)storage->allocatorContext;
   }
 
@@ -226,7 +226,7 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
               TH_ALLOCATOR_MAPPED_KEEPFD |
               TH_ALLOCATOR_MAPPED_FROMFD;
   THMapAllocatorContext *ctx = THMapAllocatorContext_newWithFd(NULL, fd, flags);
-  return THPStorage_(New)(THStorage_(newWithAllocator)(size, &THMapAllocator,
+  return THPStorage_(New)(THWStorage_(newWithAllocator)(size, &THMapAllocator,
       (void*)ctx));
   END_HANDLE_TH_ERRORS
 }
@@ -236,7 +236,7 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
 static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   AutoGPU gpu_guard(storage->device);
   THPObjectPtr tuple(PyTuple_New(5));
   THPObjectPtr device(PyLong_FromLong(storage->device));
@@ -245,9 +245,9 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
   THPObjectPtr size(PyLong_FromLong(storage->size));
   THPObjectPtr _offset(PyLong_FromLong(0));
   THPObjectPtr view_size(PyLong_FromLong(storage->size));
-  if (THStorage_(data)(LIBRARY_STATE storage)) {
+  if (THWStorage_(data)(LIBRARY_STATE storage)) {
     size_t base_size;
-    void *base_ptr = THCCachingAllocator_getBaseAllocation(THStorage_(data)(LIBRARY_STATE storage), &base_size);
+    void *base_ptr = THCCachingAllocator_getBaseAllocation(THWStorage_(data)(LIBRARY_STATE storage), &base_size);
     ptrdiff_t offset = (char*)storage->data<real>() - (char*)base_ptr;
 
     cudaIpcMemHandle_t handle;
@@ -304,7 +304,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   void *devPtr = NULL;
   THCudaCheck(cudaIpcOpenMemHandle(&devPtr, handle, cudaIpcMemLazyEnablePeerAccess));
 
-  THStoragePtr base(THStorage_(newWithDataAndAllocator)(
+  THWStoragePtr base(THWStorage_(newWithDataAndAllocator)(
       LIBRARY_STATE (real*)devPtr, storage_size, &THCIpcAllocator, (void*)device));
   base->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_FREEMEM;
 
@@ -317,13 +317,13 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 }
 #endif
 
-// Returns an object that holds a "weak" pointer to the THStorage. The
-// pointer is set to None when the THStorage is deallocated. This is done by
+// Returns an object that holds a "weak" pointer to the THWStorage. The
+// pointer is set to None when the THWStorage is deallocated. This is done by
 // wrapping the storages allocator with THStorageWeakRefAllocator which is
 // responsible for clearing the weak reference.
 static PyObject * THPStorage_(weakRef)(THPStorage *self, PyObject *weak_ref_class) {
   HANDLE_TH_ERRORS
-  THStorage* storage = self->cdata;
+  THWStorage* storage = self->cdata;
   while (storage->flag & TH_STORAGE_VIEW) {
     storage = storage->view;
   }
@@ -367,8 +367,8 @@ PyObject * THPStorage_(newWithWeakPtr)(PyObject *_unused, PyObject *arg)
   }
   THPUtils_assert(THPUtils_checkLong(ref.get()),
       "_new_with_weak_ptr(): arg.cdata must be an 'int'");
-  THStorage *storage = (THStorage*)PyLong_AsVoidPtr(ref.get());
-  if (THStorage_(retainIfLive)(LIBRARY_STATE storage)) {
+  THWStorage *storage = (THWStorage*)PyLong_AsVoidPtr(ref.get());
+  if (THWStorage_(retainIfLive)(LIBRARY_STATE storage)) {
     return THPStorage_(New)(storage);
   }
   Py_RETURN_NONE;
@@ -380,7 +380,7 @@ PyObject * THPStorage_(sharedFd)(THPStorage *self)
   HANDLE_TH_ERRORS
   THMapAllocatorContext *ctx = NULL;
 #ifndef THC_GENERIC_FILE
-  THStorage *storage = self->cdata;
+  THWStorage *storage = self->cdata;
   if (storage->allocator == &THMapAllocator) {
     ctx = (THMapAllocatorContext*)storage->allocatorContext;
   } else if (storage->allocator == &THStorageWeakRefAllocator) {

--- a/torch/csrc/generic/serialization.h
+++ b/torch/csrc/generic/serialization.h
@@ -3,9 +3,9 @@
 #else
 
 template <class io>
-void THPStorage_(writeFileRaw)(THStorage *self, io fd);
+void THPStorage_(writeFileRaw)(THWStorage *self, io fd);
 
 template <class io>
-THStorage * THPStorage_(readFileRaw)(io fd, THStorage *storage);
+THWStorage * THPStorage_(readFileRaw)(io fd, THWStorage *storage);
 
 #endif

--- a/torch/csrc/generic/utils.cpp
+++ b/torch/csrc/generic/utils.cpp
@@ -9,9 +9,9 @@
 #endif
 
 template<>
-void THPPointer<THTensor>::free() {
+void THPPointer<THWTensor>::free() {
   if (ptr)
-    THTensor_(free)(LIBRARY_STATE ptr);
+    THWTensor_(free)(LIBRARY_STATE ptr);
 }
 
 template<>
@@ -20,20 +20,8 @@ void THPPointer<THPStorage>::free() {
     Py_DECREF(ptr);
 }
 
-#if GENERATE_SPARSE
-template<>
-void THPPointer<THSTensor>::free() {
-  if (ptr)
-    THSTensor_(free)(LIBRARY_STATE ptr);
-}
-#endif
-
-
-template class THPPointer<THTensor>;
+template class THPPointer<THWTensor>;
 template class THPPointer<THPStorage>;
-#if GENERATE_SPARSE
-template class THPPointer<THSTensor>;
-#endif
 
 #undef GENERATE_SPARSE
 

--- a/torch/csrc/generic/utils.h
+++ b/torch/csrc/generic/utils.h
@@ -11,13 +11,9 @@
 struct THPStorage;
 struct THSPTensor;
 
-typedef class THPPointer<THStorage>      THStoragePtr;
-typedef class THPPointer<THTensor>       THTensorPtr;
+typedef class THPPointer<THWStorage>      THWStoragePtr;
+typedef class THPPointer<THWTensor>       THWTensorPtr;
 typedef class THPPointer<THPStorage>     THPStoragePtr;
-
-#if GENERATE_SPARSE
-typedef class THPPointer<THSTensor>      THSTensorPtr;
-#endif
 
 #if (!defined(THC_GENERIC_FILE) || defined(THC_REAL_IS_HALF)) && \
     (!defined(THD_GENERIC_FILE))

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -133,11 +133,10 @@ void THPUtils_addPyMethodDefs(std::vector<PyMethodDef>& vector, PyMethodDef* met
 
 int THPUtils_getCallable(PyObject *arg, PyObject **result);
 
-#define THStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
-#define THTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)
+#define THWStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
+#define THWTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)
 #define THPStoragePtr TH_CONCAT_3(THP,Real,StoragePtr)
 #define THPTensorPtr  TH_CONCAT_3(THP,Real,TensorPtr)
-#define THSTensorPtr  TH_CONCAT_3(THS,Real,TensorPtr)
 #define THSPTensorPtr  TH_CONCAT_3(THSP,Real,TensorPtr)
 
 typedef THPPointer<THPGenerator> THPGeneratorPtr;


### PR DESCRIPTION
…orch/csrc.

This PR does the following:
1) Removes THSTensor macros in torch/csrc, which aren't used.
2) For macros defined outside of torch/csrc (THTensor, THTensor_, THStorage, THStorage_):
a) No longer override them, i.e. previously THTensor could actually be THCTensor if a generic file was included from a file including THCP.h.
b) Instead, introduce new macros THW* (e.g. THWTensor) to represent a (potentially empty) wildcard character.

In addition to making this code easier to read and codemod, this allows us to more freely change TH/THC; for example:
currently in the THC random code, the state is casted to THByteTensor*; this happens to work because the macros don't happen to override THByteTensor.

But if THByteTensor just becomes an alias of THTensor (which is the plan for a single tensor type), then this no longer works (THByteTensor is now THCTensor!).

The whole thing is a bit of a mess previously because you really have to understand which macros and redefined and which aren't.

We could also rename the macros that live in torch/csrc (e.g. the THPTensor macros), but since that is more self contained, I punted for now.