### PR TITLE
HOTFIX: Fix TEST_CUDA import in test_cuda

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -13,8 +13,13 @@ from torch import multiprocessing as mp
 
 from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3
-from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
+# We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,
+# because if we do that, the TEST_CUDNN line from common_cuda will be executed
+# multiple times as well during the execution of this test suite, and it will
+# cause CUDA OOM error on Windows.
+TEST_CUDA = torch.cuda.is_available()
+TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
 
 if not TEST_CUDA:
     print('CUDA not available, skipping tests')


### PR DESCRIPTION
This aims to fix the CUDA OOM error in https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test2/540/consoleFull by assigning TEST_CUDA value in `test_cuda` instead of importing it from `common_cuda`, which is known to cause CUDA OOM when used with multiprocessing on Windows.

Later I will also work on an improvement suggested by @apaszke at https://github.com/pytorch/pytorch/pull/6779#discussion_r183345463 to better address this issue.