### PR TITLE
[DON'T RETEST] [WIP] Initialize CUDA test flags in common_cuda only once

### DIFF
--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -3,12 +3,32 @@ r"""This file is allowed to initialize CUDA context when imported."""
 import torch
 import torch.cuda
 
+class common_cuda(object):
+    __instance = None
 
-TEST_CUDA = torch.cuda.is_available()
-TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
-CUDA_DEVICE = TEST_CUDA and torch.device("cuda:0")
-TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1., device=CUDA_DEVICE))
-TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
+    def __new__(cls):
+        if cls.__instance == None:
+            cls.__instance = object.__new__(cls)
+        return cls.__instance
+
+    def __init__(self):
+        if not hasattr(self, 'TEST_CUDA'):
+            self.TEST_CUDA = torch.cuda.is_available()
+        if not hasattr(self, 'TEST_MULTIGPU'):
+            self.TEST_MULTIGPU = self.TEST_CUDA and torch.cuda.device_count() >= 2
+        if not hasattr(self, 'CUDA_DEVICE'):
+            self.CUDA_DEVICE = self.TEST_CUDA and torch.device("cuda:0")
+        if not hasattr(self, 'TEST_CUDNN'):
+            self.TEST_CUDNN = self.TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1., device=self.CUDA_DEVICE))
+        if not hasattr(self, 'TEST_CUDNN_VERSION'):
+            self.TEST_CUDNN_VERSION = self.TEST_CUDNN and torch.backends.cudnn.version()
+
+
+TEST_CUDA = common_cuda().TEST_CUDA
+TEST_MULTIGPU = common_cuda().TEST_MULTIGPU
+CUDA_DEVICE = common_cuda().CUDA_DEVICE
+TEST_CUDNN = common_cuda().TEST_CUDNN
+TEST_CUDNN_VERSION = common_cuda().TEST_CUDNN_VERSION
 
 
 # Used below in `initialize_cuda_context_rng` to ensure that CUDA context and

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -13,13 +13,7 @@ from torch import multiprocessing as mp
 
 from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3
-
-# We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,
-# because if we do that, the TEST_CUDNN line from common_cuda will be executed
-# multiple times as well during the execution of this test suite, and it will
-# cause CUDA OOM error on Windows.
-TEST_CUDA = torch.cuda.is_available()
-TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
+from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
 if not TEST_CUDA:
     print('CUDA not available, skipping tests')

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -14,12 +14,8 @@ from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
+from common_cuda import TEST_CUDA
 
-# We cannot import TEST_CUDA from common_nn here, because if we do that,
-# the TEST_CUDNN line from common_nn will be executed multiple times
-# as well during the execution of this test suite, and it will cause
-# CUDA OOM error on Windows.
-TEST_CUDA = torch.cuda.is_available()
 
 # We need spawn start method for test_manager_unclean_exit, but
 # Python 2.7 doesn't allow it.


### PR DESCRIPTION
This PR aims to be a better fix for https://github.com/pytorch/pytorch/pull/8246 by initializing the CUDA test flags in `common_cuda` only once, to avoid the duplicated import of `TEST_CUDNN` -> CUDA OOM issue on Windows. 

We need to loop the test multiple times in CI to make sure there is no CUDA OOM error from this change.