### PR TITLE
Implement dim_arange operator

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -29,7 +29,7 @@ Tensor& arange_out(Tensor& result, Scalar end) {
   return at::_arange_out(result, end);
 }
 
-Tensor dim_arange(const Tensor& like, int64_t dim) {
+Tensor _dim_arange(const Tensor& like, int64_t dim) {
   return like.type().toScalarType(at::kLong)._arange(like.size(dim));
 }
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -29,6 +29,10 @@ Tensor& arange_out(Tensor& result, Scalar end) {
   return at::_arange_out(result, end);
 }
 
+Tensor dim_arange(const Tensor& like, int64_t dim) {
+  return like.type().toScalarType(at::kLong)._arange(like.size(dim));
+}
+
 Tensor empty(const Type& dtype, IntList size) {
   return dtype.tensor(size);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -110,7 +110,7 @@
 - func: arange_out(Tensor result, Scalar end) -> Tensor
   variants: function
 
-- func: dim_arange(Tensor like, int64_t dim) -> Tensor
+- func: _dim_arange(Tensor like, int64_t dim) -> Tensor
   variants: function
 
 # `argmin` and `argmax` are exposed in C++ but not in Python, where we only

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -110,6 +110,11 @@
 - func: arange_out(Tensor result, Scalar end) -> Tensor
   variants: function
 
+# This function is a temporary hack to allow tracing of arange like constructs with dynamic
+# bounds on arange.  Normal arange is not traceable because it does not take any tensor inputs;
+# if the range you need is based on another tensor, calling this function directly will
+# preserve tracing.  Get rid of this when arange can directly take tensors for bounds
+# (so that it can be traced directly).
 - func: _dim_arange(Tensor like, int64_t dim) -> Tensor
   variants: function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -110,6 +110,9 @@
 - func: arange_out(Tensor result, Scalar end) -> Tensor
   variants: function
 
+- func: dim_arange(Tensor like, int64_t dim) -> Tensor
+  variants: function
+
 # `argmin` and `argmax` are exposed in C++ but not in Python, where we only
 # expose `_argmin` and `_argmax` (which call the first versions). In Python, we
 # then define our own `argmax` and `argmin` that handle passing `dim=None`,

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1000,5 +1000,5 @@ def RNN_variant_symbolic_builder(
     return symbolic
 
 
-def dim_arange(g, like, dim):
-    return g.op('ATen', like, dim_i=dim, operator_s='dim_arange')
+def _dim_arange(g, like, dim):
+    return g.op('ATen', like, dim_i=dim, operator_s='_dim_arange')

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -999,5 +999,6 @@ def RNN_variant_symbolic_builder(
 
     return symbolic
 
+
 def dim_arange(g, like, dim):
     return g.op('ATen', like, dim_i=dim, operator_s='dim_arange')

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -998,3 +998,6 @@ def RNN_variant_symbolic_builder(
             return prev_output, h_outs, c_outs
 
     return symbolic
+
+def dim_arange(g, like, dim):
+    return g.op('ATen', like, dim_i=dim, operator_s='dim_arange')


### PR DESCRIPTION
This is needed to unblock the MT use case. I wanted to call it 'arange_like' but that was getting blocked by a regex in gen_python_functions.py