### PR TITLE
[cmake] Add and export Modules_CUDA_fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,10 @@ if (BUILD_SHARED_LIBS)
       ${PROJECT_SOURCE_DIR}/cmake/public/utils.cmake
       DESTINATION share/cmake/Caffe2/public
       COMPONENT dev)
+  install(DIRECTORY
+      ${PROJECT_SOURCE_DIR}/cmake/Modules_CUDA_fix
+      DESTINATION share/cmake/Caffe2/
+      COMPONENT dev)
   install(EXPORT Caffe2Targets DESTINATION share/cmake/Caffe2
       FILE Caffe2Targets.cmake
       COMPONENT dev)

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -261,21 +261,6 @@ endif()
 # ---[ Create CAFFE2_BUILD_SHARED_LIBS for macros.h.in usage.
 set(CAFFE2_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
-# ---[ Check if we will need to include the local Modules_CUDA_fix folder.
-# Add your conditions here if needed.
-if (MSVC)
-  # We know that VS2017 needs the new FindCUDA functionality, so we will
-  # simply enable it for the whole Windows build.
-  set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
-else (${CMAKE_VERSION} VERSION_LESS 3.12 AND ${USE_CUDA})
-  set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
-endif()
-
-if (${CAFFE2_CMAKE_USE_LOCAL_FINDCUDA})
-  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules_CUDA_fix)
-  include(CMakeInitializeConfigs)
-endif()
-
 if (USE_NATIVE_ARCH)
   check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
   if (COMPILER_SUPPORTS_MARCH_NATIVE)

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -14,6 +14,14 @@ message(STATUS "Caffe2: CUDA detected: " ${CUDA_VERSION})
 message(STATUS "Caffe2: CUDA nvcc is: " ${CUDA_NVCC_EXECUTABLE})
 message(STATUS "Caffe2: CUDA toolkit directory: " ${CUDA_TOOLKIT_ROOT_DIR})
 
+# Check if we need to use the new FindCUDA functionalities, which are included
+# since 3.7.0. Also, we know that VS2017 needs the new FindCUDA functionality,
+# so we will simply enable it for the whole Windows build.
+if (MSVC OR ${CMAKE_VERSION} VERSION_LESS 3.7.0)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)
+  include(CMakeInitializeConfigs)
+endif()
+
 if(CUDA_FOUND)
   # Sometimes, we may mismatch nvcc with the CUDA headers we are
   # compiling with, e.g., if a ccache nvcc is fed to us by CUDA_NVCC_EXECUTABLE

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -1,5 +1,13 @@
 # ---[ cuda
 
+# Check if we need to use the new FindCUDA functionalities, which are included
+# since 3.7.0. Also, we know that VS2017 needs the new FindCUDA functionality,
+# so we will simply enable it for the whole Windows build.
+if (MSVC OR ${CMAKE_VERSION} VERSION_LESS 3.7.0)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)
+  include(CMakeInitializeConfigs)
+endif()
+
 # Find CUDA.
 find_package(CUDA 7.0)
 if(NOT CUDA_FOUND)
@@ -13,14 +21,6 @@ endif()
 message(STATUS "Caffe2: CUDA detected: " ${CUDA_VERSION})
 message(STATUS "Caffe2: CUDA nvcc is: " ${CUDA_NVCC_EXECUTABLE})
 message(STATUS "Caffe2: CUDA toolkit directory: " ${CUDA_TOOLKIT_ROOT_DIR})
-
-# Check if we need to use the new FindCUDA functionalities, which are included
-# since 3.7.0. Also, we know that VS2017 needs the new FindCUDA functionality,
-# so we will simply enable it for the whole Windows build.
-if (MSVC OR ${CMAKE_VERSION} VERSION_LESS 3.7.0)
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)
-  include(CMakeInitializeConfigs)
-endif()
 
 if(CUDA_FOUND)
   # Sometimes, we may mismatch nvcc with the CUDA headers we are


### PR DESCRIPTION
This PR puts the discretional inclusion of Modules_CUDA_fix to public/cuda.cmake and also installs the corresponding files. Manually verified the build process but the installation path is not tested (only did a dummy install and eyeballed that the files are there).