### PR TITLE
[ONNX] Add an ATen fallback pathway for ONNX export

### DIFF
--- a/test/expect/TestPytorchExportModes.test_aten_fallback.expect
+++ b/test/expect/TestPytorchExportModes.test_aten_fallback.expect
@@ -1,0 +1,17 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "0", type:Tensor dims: 3 4},{name: "1", type:Tensor dims: 3 4}]
+      outputs: [{name: "3", type:Tensor dims: 3 3},{name: "4", type:Tensor dims: 3 4}]
+      initializers: []
+      nodes: [
+        Node {type: "Add", inputs: [0,1], outputs: [2], attributes: []},
+        Node {type: "ATen", inputs: [2], outputs: [3,4], attributes: [{ name: 'operator', type: string, value: 'qr'}]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -19,6 +19,7 @@ import torch.onnx
 import torch.onnx.utils
 from torch.autograd import Variable, Function
 from torch.nn import Module
+from torch.onnx import OperatorExportTypes
 
 import onnx
 import onnx.checker
@@ -45,7 +46,7 @@ BATCH_SIZE = 2
 
 class TestModels(TestCase):
     def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7):
-        trace = torch.onnx.utils._trace(model, inputs)
+        trace = torch.onnx.utils._trace(model, inputs, OperatorExportTypes.ONNX)
         torch._C._jit_pass_lint(trace.graph())
         verify(model, inputs, backend, rtol=rtol, atol=atol)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2533,7 +2533,7 @@ class TestScript(JitTestCase):
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3))
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
@@ -2582,7 +2582,7 @@ class TestScript(JitTestCase):
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3))
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
@@ -2607,7 +2607,7 @@ class TestScript(JitTestCase):
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3))
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
@@ -2624,7 +2624,7 @@ class TestScript(JitTestCase):
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3))
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
@@ -2641,7 +2641,7 @@ class TestScript(JitTestCase):
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3, dtype=torch.long))
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
@@ -2671,7 +2671,7 @@ class TestScript(JitTestCase):
         result = mte(torch.zeros(2, 3))
         reference = torch.mm(torch.mm(torch.zeros(2, 3), torch.ones(3, 3)), torch.ones(3, 4))
         self.assertEqual(result, reference)
-        self.assertExpected(torch.onnx._export_to_pretty_string(
+        self.assertExpected(torch.onnx.export_to_pretty_string(
             mte, (torch.ones(2, 3),), None, verbose=False,
             example_outputs=result, propagate=True))
 
@@ -2730,12 +2730,12 @@ class TestScript(JitTestCase):
         f2 = Foo(linear)
         outputs_f2 = f2(torch.ones(1, 10, dtype=torch.float))
 
-        onnx_ish = torch.onnx._export_to_pretty_string(
+        onnx_ish = torch.onnx.export_to_pretty_string(
             f1,
             (torch.ones(1, 10, dtype=torch.float), ),
             None, verbose=False, example_outputs=outputs_f1)
         self.assertExpected(onnx_ish, subname='f1')
-        onnx_ish = torch.onnx._export_to_pretty_string(
+        onnx_ish = torch.onnx.export_to_pretty_string(
             f2,
             (torch.ones(1, 10, dtype=torch.float), ),
             None, verbose=False, example_outputs=outputs_f2)
@@ -2753,8 +2753,8 @@ class TestScript(JitTestCase):
         foo = torch.jit.trace(torch.zeros(1, 2, 3))(Foo())
         outputs = foo(torch.zeros(1, 2, 3))
         f = io.BytesIO()
-        s = torch.onnx._export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f,
-                                                example_outputs=outputs)
+        s = torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f,
+                                               example_outputs=outputs)
         self.assertExpected(s)
 
     def test_shape_analysis_loop(self):
@@ -3076,7 +3076,7 @@ class TestPytorchExportModes(JitTestCase):
         x = torch.rand(3, 4)
         y = torch.rand(3, 4)
         f = io.BytesIO()
-        exported = torch.onnx._export_to_pretty_string(
+        exported = torch.onnx.export_to_pretty_string(
             ModelWithAtenNotONNXOp(), (x, y), f,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
         self.assertExpected(exported)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -517,6 +517,9 @@ static PyObject* initModule() {
   ASSERT_TRUE(THPVariable_initModule(module));
   ASSERT_TRUE(THPFunction_initModule(module));
   ASSERT_TRUE(THPEngine_initModule(module));
+  // NOTE: We need to be able to access OperatorExportTypes from ONNX for use in
+  // the export side of JIT, so this ONNX init needs to appear before the JIT
+  // init.
   torch::onnx::initONNXBindings(module);
   torch::jit::initJITBindings(module);
   torch::autograd::initNNFunctions(module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -517,8 +517,8 @@ static PyObject* initModule() {
   ASSERT_TRUE(THPVariable_initModule(module));
   ASSERT_TRUE(THPFunction_initModule(module));
   ASSERT_TRUE(THPEngine_initModule(module));
-  torch::jit::initJITBindings(module);
   torch::onnx::initONNXBindings(module);
+  torch::jit::initJITBindings(module);
   torch::autograd::initNNFunctions(module);
   torch::autograd::init_legacy_variable(module);
 #ifdef WITH_CUDA

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -24,8 +24,7 @@ std::string value_name(Value* n) {
 
 struct ExportContext {
   size_t num_blocks = 0;
-  bool export_raw_ir = false;
-  bool aten_fallback = false;
+  onnx::OperatorExportTypes operator_export_type;
 };
 
 void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g,
@@ -225,7 +224,8 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
     encodeValueInfo(v, output);
   }
   for (auto node : b->nodes()) {
-    if (node->kind() == prim::Undefined && !ctx->export_raw_ir) {
+    bool is_raw_export = ctx->operator_export_type == onnx::OperatorExportTypes::RAW;
+    if (node->kind() == prim::Undefined && !is_raw_export) {
       // Undefined nodes are used to implement optional inputs. One
       // way to "not provide" an optional input is to create an
       // Undefined node, and pass its output as that input.
@@ -238,7 +238,7 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
       p_n->set_doc_string(ss.str());
     }
     for(auto input : node->inputs()) {
-      if (input->node()->kind() == prim::Undefined && !ctx->export_raw_ir) {
+      if (input->node()->kind() == prim::Undefined && !is_raw_export) {
         p_n->add_input("");
       } else {
         p_n->add_input(value_name(input));
@@ -247,18 +247,18 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
     for(auto output : node->outputs()) {
       p_n->add_output(value_name(output));
     }
-    if (ctx->export_raw_ir) {
+    if (is_raw_export) {
       JIT_ASSERT(!node->kind().is_onnx());
       p_n->set_domain(node->kind().domainString());
     }
-    else if (!ctx->aten_fallback) {
+    else if (ctx->operator_export_type != onnx::OperatorExportTypes::ONNX_ATEN_FALLBACK) {
       JIT_ASSERT(node->kind().is_onnx());
     }
     p_n->set_op_type(node->kind().toUnqualString());
     for(auto attr_name : node->attributeNames()) {
       addAttribute(p_n, node, attr_name, ctx);
     }
-    if (ctx->export_raw_ir && node->blocks().size() > 0) {
+    if (is_raw_export && node->blocks().size() > 0) {
       auto blocks = p_n->add_attribute();
       blocks->set_name("_blocks");
       blocks->set_type(onnx::aGRAPHS);
@@ -312,11 +312,11 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
 void encodeModel(onnx::ModelProto* p_m, const std::shared_ptr<Graph>& g,
                  const std::vector<at::Tensor>& initializers,
                  RawDataExportMap* raw_data_export_map = nullptr,
-                 bool export_raw_ir = false, bool aten_fallback = false) {
+                 onnx::OperatorExportTypes operator_export_type
+                   = onnx::OperatorExportTypes::ONNX) {
   onnx::GraphProto* p_g = p_m->mutable_graph();
   ExportContext ctx;
-  ctx.export_raw_ir = export_raw_ir;
-  ctx.aten_fallback = aten_fallback;
+  ctx.operator_export_type = operator_export_type;
   encodeGraph(p_g, g, initializers, &ctx, raw_data_export_map);
 }
 
@@ -332,7 +332,7 @@ std::string getNodeStackTraceString(Node* n) {
 }
 } // namespace
 
-void validateGraph(const std::shared_ptr<Graph>& graph, bool aten_fallback) {
+void validateGraph(const std::shared_ptr<Graph>& graph, onnx::OperatorExportTypes operator_export_type) {
   for (auto node : graph->nodes()) {
       // Macro'ed so we get a marginally better line number on failed export
 #define FAIL_EXPORT(name) \
@@ -359,7 +359,8 @@ void validateGraph(const std::shared_ptr<Graph>& graph, bool aten_fallback) {
             "Cannot export individual pack_padded_sequence or pad_packed_sequence; these operations must occur in pairs.\n\nUsage of this operation occurred at:\n" +
             getNodeStackTraceString(node));
       }
-      if (!node->kind().is_onnx() && !aten_fallback && node->kind() != prim::Undefined) {
+      bool is_aten_fallback = operator_export_type == onnx::OperatorExportTypes::ONNX_ATEN_FALLBACK;
+      if (!node->kind().is_onnx() && !is_aten_fallback && node->kind() != prim::Undefined) {
         FAIL_EXPORT(
             "Couldn't export operator " + node->kind().toDisplayString() + "\n\nDefined at:\n" +
             getNodeStackTraceString(node));
@@ -378,11 +379,10 @@ RawDataExportMap ToModelProto(
     const std::vector<at::Tensor> & initializers,
     int64_t onnx_opset_version,
     bool defer_weight_export,
-    bool export_raw_ir,
-    onnx::ModelProto *model_proto,
-    bool aten_fallback) {
-  if (!export_raw_ir) {
-    validateGraph(graph, aten_fallback);
+    onnx::OperatorExportTypes operator_export_type,
+    onnx::ModelProto *model_proto) {
+  if (operator_export_type != onnx::OperatorExportTypes::RAW) {
+    validateGraph(graph, operator_export_type);
   }
 
   model_proto->set_producer_name("pytorch");
@@ -397,10 +397,9 @@ RawDataExportMap ToModelProto(
   // Set up nanopb callbacks and compute the amount of space needed to store
   // the resulting protobuf
   if (defer_weight_export) {
-    encodeModel(model_proto, graph, initializers, &raw_data_export_map, export_raw_ir,
-                aten_fallback);
+    encodeModel(model_proto, graph, initializers, &raw_data_export_map, operator_export_type);
   } else {
-    encodeModel(model_proto, graph, initializers, nullptr, export_raw_ir, aten_fallback);
+    encodeModel(model_proto, graph, initializers, nullptr, operator_export_type);
   }
 
   return raw_data_export_map;
@@ -414,13 +413,12 @@ std::string PrettyPrintExportedGraph(
                         const std::vector<at::Tensor> & initializers,
                         int64_t onnx_opset_version,
                         bool defer_weight_export,
-                        bool export_raw_ir,
-                        bool aten_fallback) {
+                        ::torch::onnx::OperatorExportTypes operator_export_type) {
   ::torch::onnx::ModelProto model_proto;
   RawDataExportMap raw_data_export_map;
   raw_data_export_map = ToModelProto(
-    graph, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
-    &model_proto, aten_fallback);
+    graph, initializers, onnx_opset_version, defer_weight_export, operator_export_type,
+    &model_proto);
   return model_proto.prettyPrint();
 }
 
@@ -434,13 +432,12 @@ std::tuple<std::string, RawDataExportMap> ExportGraph(
                         const std::vector<at::Tensor> & initializers,
                         int64_t onnx_opset_version,
                         bool defer_weight_export,
-                        bool export_raw_ir,
-                        bool aten_fallback) {
+                        ::torch::onnx::OperatorExportTypes operator_export_type) {
   ::torch::onnx::ModelProto model_proto;
   RawDataExportMap raw_data_export_map;
   raw_data_export_map = ToModelProto(
-    graph, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
-    &model_proto, aten_fallback);
+    graph, initializers, onnx_opset_version, defer_weight_export, operator_export_type,
+    &model_proto);
 
   size_t out_size;
   pb_get_encoded_size(&out_size, onnx_ModelProto_fields, &model_proto.proto);

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -19,7 +19,8 @@ std::tuple<std::string, RawDataExportMap> ExportGraph(
     const std::vector<at::Tensor>& initializers,
     int64_t onnx_opset_version,
     bool defer_weight_export = false,
-    bool export_raw_ir = false);
+    bool export_raw_ir = false,
+    bool aten_fallback = false);
 
 // For testing purposes
 std::string PrettyPrintExportedGraph(
@@ -27,6 +28,7 @@ std::string PrettyPrintExportedGraph(
     const std::vector<at::Tensor> & initializers,
     int64_t onnx_opset_version,
     bool defer_weight_export,
-    bool export_raw_ir);
+    bool export_raw_ir,
+    bool aten_fallback = false);
 
 }}

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "torch/csrc/jit/ir.h"
+#include "torch/csrc/onnx/onnx.h"
 
 namespace torch { namespace jit {
 
@@ -19,8 +20,8 @@ std::tuple<std::string, RawDataExportMap> ExportGraph(
     const std::vector<at::Tensor>& initializers,
     int64_t onnx_opset_version,
     bool defer_weight_export = false,
-    bool export_raw_ir = false,
-    bool aten_fallback = false);
+    ::torch::onnx::OperatorExportTypes operator_export_type
+      = ::torch::onnx::OperatorExportTypes::ONNX);
 
 // For testing purposes
 std::string PrettyPrintExportedGraph(
@@ -28,7 +29,7 @@ std::string PrettyPrintExportedGraph(
     const std::vector<at::Tensor> & initializers,
     int64_t onnx_opset_version,
     bool defer_weight_export,
-    bool export_raw_ir,
-    bool aten_fallback = false);
+    ::torch::onnx::OperatorExportTypes operator_export_type
+      = ::torch::onnx::OperatorExportTypes::ONNX);
 
 }}

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -24,15 +24,14 @@ bool hasUsedHandle(Node *node) {
 } // anonymous namespace
 
 // Transform PythonOps and Cpp Ops into Node's that match ONNX semantics.
-// Argument aten indicates whether we should export ops as "ATen" ONNX ops if possible.
-std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten, bool aten_fallback) {
+std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, ::torch::onnx::OperatorExportTypes operator_export_type) {
   auto new_graph = std::make_shared<Graph>(graph->scope_root());
   std::unordered_map<Value*, Value*> env;
-  BlockToONNX(graph->block(), new_graph->block(), aten, aten_fallback, env);
+  BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);
   return new_graph;
 }
 
-void BlockToONNX(Block* old_block, Block* new_block, bool aten, bool aten_fallback, std::unordered_map<Value*, Value*> env) {
+void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExportTypes operator_export_type, std::unordered_map<Value*, Value*> env) {
   torch::autograd::SymbolicContext ctx;
   ctx.block = new_block;
 
@@ -144,7 +143,7 @@ void BlockToONNX(Block* old_block, Block* new_block, bool aten, bool aten_fallba
 
     WithInsertPoint insert_point_guard(ctx.block);
     WithCurrentScope scope_guard(*ctx.block->owningGraph(), n->scope());
-    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.block->owningGraph(), n, py_inputs, env, aten, aten_fallback);
+    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.block->owningGraph(), n, py_inputs, env, operator_export_type);
 
     // TODO: Assert it's an ATen identifier???
     // (Sometimes it's not...)

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -5,7 +5,7 @@
 
 namespace torch { namespace jit {
 
-std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& state, bool aten);
-void BlockToONNX(Block* old_block, Block* new_block, bool aten, std::unordered_map<Value*, Value*> env);
+std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& state, bool aten, bool aten_fallback);
+void BlockToONNX(Block* old_block, Block* new_block, bool aten, bool aten_fallback, std::unordered_map<Value*, Value*> env);
 
 }}

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -2,10 +2,11 @@
 
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/tracer_state.h"
+#include "torch/csrc/onnx/onnx.h"
 
 namespace torch { namespace jit {
 
-std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& state, bool aten, bool aten_fallback);
-void BlockToONNX(Block* old_block, Block* new_block, bool aten, bool aten_fallback, std::unordered_map<Value*, Value*> env);
+std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& state, ::torch::onnx::OperatorExportTypes operator_export_type);
+void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExportTypes operator_export_type, std::unordered_map<Value*, Value*> env);
 
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -148,11 +148,13 @@ void initPythonIRBindings(PyObject * module_) {
       PropagateInputShapes(g, ArgumentSpec(with_grad, variable_tensor_list(std::move(inputs))));
     })
     .def("export", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir) {
+                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir,
+                      bool aten_fallback) {
       std::string graph;
       RawDataExportMap export_map;
       std::tie(graph, export_map) = ExportGraph(
-        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir);
+        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
+        aten_fallback);
       std::unordered_map<std::string, py::bytes> python_serialized_export_map;
       for (auto& kv : export_map) {
         auto t = kv.second;
@@ -166,15 +168,19 @@ void initPythonIRBindings(PyObject * module_) {
     }, py::arg("initializers"),
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
-       py::arg("export_raw_ir")=false )
+       py::arg("export_raw_ir")=false,
+       py::arg("aten_fallback")=false)
     .def("prettyPrintExport", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir) {
+                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir,
+                      bool aten_fallback) {
       return PrettyPrintExportedGraph(
-        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir);
+        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
+        aten_fallback);
     }, py::arg("initializers"),
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
-       py::arg("export_raw_ir")=false )
+       py::arg("export_raw_ir")=false,
+       py::arg("aten_fallback")=false)
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function
       // that should have different behavior when exporting for JIT interpreter

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -148,13 +148,12 @@ void initPythonIRBindings(PyObject * module_) {
       PropagateInputShapes(g, ArgumentSpec(with_grad, variable_tensor_list(std::move(inputs))));
     })
     .def("export", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir,
-                      bool aten_fallback) {
+                      int64_t onnx_opset_version, bool defer_weight_export,
+                      ::torch::onnx::OperatorExportTypes operator_export_type) {
       std::string graph;
       RawDataExportMap export_map;
       std::tie(graph, export_map) = ExportGraph(
-        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
-        aten_fallback);
+        g, initializers, onnx_opset_version, defer_weight_export, operator_export_type);
       std::unordered_map<std::string, py::bytes> python_serialized_export_map;
       for (auto& kv : export_map) {
         auto t = kv.second;
@@ -168,19 +167,16 @@ void initPythonIRBindings(PyObject * module_) {
     }, py::arg("initializers"),
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
-       py::arg("export_raw_ir")=false,
-       py::arg("aten_fallback")=false)
+       py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX)
     .def("prettyPrintExport", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export, bool export_raw_ir,
-                      bool aten_fallback) {
+                      int64_t onnx_opset_version, bool defer_weight_export,
+                      ::torch::onnx::OperatorExportTypes operator_export_type) {
       return PrettyPrintExportedGraph(
-        g, initializers, onnx_opset_version, defer_weight_export, export_raw_ir,
-        aten_fallback);
+        g, initializers, onnx_opset_version, defer_weight_export, operator_export_type);
     }, py::arg("initializers"),
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
-       py::arg("export_raw_ir")=false,
-       py::arg("aten_fallback")=false)
+       py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX)
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function
       // that should have different behavior when exporting for JIT interpreter

--- a/torch/csrc/onnx/init.cpp
+++ b/torch/csrc/onnx/init.cpp
@@ -24,6 +24,12 @@ void initONNXBindings(PyObject* module) {
       .value("COMPLEX64", onnx_TensorProto_DataType_COMPLEX64)
       .value("COMPLEX128", onnx_TensorProto_DataType_COMPLEX128);
 
+  py::enum_<OperatorExportTypes>(onnx, "OperatorExportTypes")
+    .value("ONNX", OperatorExportTypes::ONNX)
+    .value("ONNX_ATEN", OperatorExportTypes::ONNX_ATEN)
+    .value("ONNX_ATEN_FALLBACK", OperatorExportTypes::ONNX_ATEN_FALLBACK)
+    .value("RAW", OperatorExportTypes::RAW);
+
   py::class_<ModelProto>(onnx, "ModelProto")
       .def("prettyPrint", &ModelProto::prettyPrint);
 }

--- a/torch/csrc/onnx/onnx.h
+++ b/torch/csrc/onnx/onnx.h
@@ -425,4 +425,11 @@ public:
   }
 };
 
+enum class OperatorExportTypes {
+  ONNX, // Strict ONNX export
+  ONNX_ATEN, // ONNX With ATen op everywhere
+  ONNX_ATEN_FALLBACK, // ONNX export with ATen fallback
+  RAW, // Raw export (no ONNX)
+};
+
 }} // namespace torch::onnx

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -4,6 +4,7 @@ import types
 import torch._C as _C
 
 TensorProtoDataType = _C._onnx.TensorProtoDataType
+OperatorExportTypes = _C._onnx.OperatorExportTypes
 
 ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
 
@@ -30,9 +31,9 @@ def export(*args, **kwargs):
     return utils.export(*args, **kwargs)
 
 
-def _optimize_trace(trace, aten, aten_fallback):
+def _optimize_trace(trace, operator_export_type):
     from torch.onnx import utils
-    trace.set_graph(utils._optimize_graph(trace.graph(), aten, aten_fallback))
+    trace.set_graph(utils._optimize_graph(trace.graph(), operator_export_type))
 
 
 def set_training(*args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -21,14 +21,19 @@ def _export(*args, **kwargs):
     return utils._export(*args, **kwargs)
 
 
-def _export_to_pretty_string(*args, **kwargs):
-    from torch.onnx import utils
-    return utils._export_to_pretty_string(*args, **kwargs)
-
-
 def export(*args, **kwargs):
     from torch.onnx import utils
     return utils.export(*args, **kwargs)
+
+
+def export_to_pretty_string(*args, **kwargs):
+    from torch.onnx import utils
+    return utils.export_to_pretty_string(*args, **kwargs)
+
+
+def _export_to_pretty_string(*args, **kwargs):
+    from torch.onnx import utils
+    return utils._export_to_pretty_string(*args, **kwargs)
 
 
 def _optimize_trace(trace, operator_export_type):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -30,9 +30,9 @@ def export(*args, **kwargs):
     return utils.export(*args, **kwargs)
 
 
-def _optimize_trace(trace, aten):
+def _optimize_trace(trace, aten, aten_fallback):
     from torch.onnx import utils
-    trace.set_graph(utils._optimize_graph(trace.graph(), aten))
+    trace.set_graph(utils._optimize_graph(trace.graph(), aten, aten_fallback))
 
 
 def set_training(*args, **kwargs):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -87,7 +87,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             aten, export_raw_ir=export_raw_ir)
 
 
-def _optimize_graph(graph, aten, export_raw_ir=False):
+def _optimize_graph(graph, aten, aten_fallback, export_raw_ir=False):
     # run dce first to eliminate dead parts of the graph that might have been
     # left behind by things like symbolic_override
 
@@ -97,7 +97,7 @@ def _optimize_graph(graph, aten, export_raw_ir=False):
     torch._C._jit_pass_peephole(graph)
     torch._C._jit_pass_lint(graph)
     if not export_raw_ir:
-        graph = torch._C._jit_pass_onnx(graph, aten)
+        graph = torch._C._jit_pass_onnx(graph, aten, aten_fallback)
         torch._C._jit_pass_lint(graph)
         torch._C._jit_pass_onnx_peephole(graph)
         torch._C._jit_pass_lint(graph)
@@ -110,13 +110,13 @@ def _optimize_graph(graph, aten, export_raw_ir=False):
     return graph
 
 
-def _trace(func, args, return_outs=False, aten=False):
+def _trace(func, args, return_outs=False, aten=False, aten_fallback=False):
     # Special case for common case of passing a single Tensor
     if isinstance(args, torch.Tensor):
         args = (args, )
 
     trace, torch_out = torch.jit.get_trace_graph(func, args)
-    trace.set_graph(_optimize_graph(trace.graph(), aten))
+    trace.set_graph(_optimize_graph(trace.graph(), aten, aten_fallback))
     if return_outs:
         return trace, torch_out
     return trace
@@ -145,7 +145,8 @@ def _trace_and_get_graph_from_model(model, args, training):
 
 def _model_to_graph(model, args, f, verbose=False, training=False,
                     input_names=None, output_names=None, aten=False,
-                    export_raw_ir=False, example_outputs=None, propagate=False):
+                    export_raw_ir=False, example_outputs=None, propagate=False,
+                    aten_fallback=False):
     # Special case for common case of passing a single Variable
     if isinstance(args, torch.Tensor):
         args = (args, )
@@ -167,7 +168,7 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
         graph, torch_out = _trace_and_get_graph_from_model(model, args, training)
         params = list(_unique_state_dict(model).values())
 
-    graph = _optimize_graph(graph, aten, export_raw_ir)
+    graph = _optimize_graph(graph, aten, aten_fallback, export_raw_ir)
 
     _set_input_and_output_names(graph, input_names, output_names)
     if verbose:
@@ -178,14 +179,16 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
 
 def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=False,
                              input_names=None, output_names=None, aten=False, export_raw_ir=False,
-                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False):
+                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False,
+                             aten_fallback=False):
     graph, params, torch_out = _model_to_graph(model, args, f, verbose,
                                                training, input_names,
                                                output_names, aten, export_raw_ir,
-                                               example_outputs, propagate)
+                                               example_outputs, propagate, aten_fallback)
 
     from torch.onnx.symbolic import _onnx_opset_version
-    return graph.prettyPrintExport(params, _onnx_opset_version, False, export_raw_ir)
+    return graph.prettyPrintExport(params, _onnx_opset_version, False, export_raw_ir,
+                                   aten_fallback)
 
 
 # NOTE: the output `torch_out` will contain the output tensors resulting from
@@ -194,19 +197,21 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
 # directly extracting the graph.
 def _export(model, args, f, export_params=True, verbose=False, training=False,
             input_names=None, output_names=None, aten=False, export_raw_ir=False,
-            export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False):
+            export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False,
+            aten_fallback=False):
     graph, params, torch_out = _model_to_graph(model, args, f, verbose,
                                                training, input_names,
                                                output_names, aten, export_raw_ir,
-                                               example_outputs, propagate)
+                                               example_outputs, propagate,
+                                               aten_fallback)
 
     # TODO: Don't allocate a in-memory string for the protobuf
     from torch.onnx.symbolic import _onnx_opset_version
     defer_weight_export = export_type is not ExportTypes.PROTOBUF_FILE
     if export_params:
-        proto, export_map = graph.export(params, _onnx_opset_version, defer_weight_export, export_raw_ir)
+        proto, export_map = graph.export(params, _onnx_opset_version, defer_weight_export, export_raw_ir, aten_fallback)
     else:
-        proto, export_map = graph.export([], _onnx_opset_version, False, export_raw_ir)
+        proto, export_map = graph.export([], _onnx_opset_version, False, export_raw_ir, aten_fallback)
 
     if export_type == ExportTypes.PROTOBUF_FILE:
         assert(len(export_map) == 0)
@@ -384,7 +389,7 @@ def _graph_op(g, opname, *raw_args, **kwargs):
 # inplace annotations, but we are losing information this way.
 
 
-def _run_symbolic_function(g, n, inputs, env, aten=False):
+def _run_symbolic_function(g, n, inputs, env, aten=False, aten_fallback=False):
     # NB: Returning None means the node gets cloned as is into
     # the new graph
     try:
@@ -403,7 +408,8 @@ def _run_symbolic_function(g, n, inputs, env, aten=False):
             return None
 
         elif ns == "aten":
-            if aten:
+            is_exportable_aten_op = hasattr(torch.onnx.symbolic, op_name)
+            if aten or (not is_exportable_aten_op and aten_fallback):
                 # Direct ATen export requested
                 attrs = {k + "_" + n.kindOf(k)[0]: n[k] for k in n.attributeNames()}
                 outputs = n.outputsSize()
@@ -413,7 +419,7 @@ def _run_symbolic_function(g, n, inputs, env, aten=False):
             else:
                 # Export it regularly
                 attrs = {k: n[k] for k in n.attributeNames()}
-                if not hasattr(torch.onnx.symbolic, op_name):
+                if not is_exportable_aten_op:
                     warnings.warn("ONNX export failed on ATen operator {} because torch.onnx.symbolic.{} does not exist"
                                   .format(op_name, op_name))
                     return None
@@ -433,7 +439,7 @@ def _run_symbolic_function(g, n, inputs, env, aten=False):
                 new_node = new_op_outputs[0].node() if n.outputsSize() > 1 else new_op_outputs.node()
                 for b in n.blocks():
                     new_block = new_node.addBlock()
-                    torch._C._jit_pass_onnx_block(b, new_block, aten, env)
+                    torch._C._jit_pass_onnx_block(b, new_block, aten, aten_fallback, env)
                 return new_op_outputs
             else:
                 warnings.warn("ONNX export failed on primitive operator {}; please report a bug".format(op_name))


### PR DESCRIPTION
This adds a flag that makes it so that if we cannot export an operator, we will fall back to exporting an op of type ATen with the appropriate schema. This will help smooth over our production use cases, where if ONNX supports and op we want to use that translation pathway, but if it does not we want to simply use ATen for speed of deployment