### PR TITLE
Fix the script doesn't stop eariler on error for MSVC and Ninja

### DIFF
--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -47,7 +47,7 @@ mkdir %CD%\\tmp_bin
 if "%REBUILD%"=="" (
   :check_sccache
   %CD%\\tmp_bin\\sccache.exe --show-stats || (
-    taskkill /im sccache.exe /f /t || set ERRORLEVEL=0
+    taskkill /im sccache.exe /f /t || ver > nul
     del %CD%\\tmp_bin\\sccache.exe
     aws s3 cp s3://ossci-windows/sccache.exe %CD%\\tmp_bin\\sccache.exe
     goto :check_sccache
@@ -95,7 +95,8 @@ if "%REBUILD%"=="" (
   set NO_CUDA=1
   python setup.py install
 )
-if %errorlevel% neq 0 exit /b %errorlevel%
+if errorlevel 1 exit /b 1
+if not errorlevel 0 exit /b 1
 if "%REBUILD%"=="" (
   sccache --show-stats
   sccache --zero-stats

--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -162,7 +162,8 @@ goto:eof
                   -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
 
   %MAKE_COMMAND%
-  IF NOT %ERRORLEVEL%==0 exit 1
+  IF ERRORLEVEL 1 exit 1
+  IF NOT ERRORLEVEL 0 exit 1
   cd ../..
   @endlocal
 
@@ -198,7 +199,8 @@ goto:eof
                   -DWITH_ROCM=%WITH_ROCM%
 
   %MAKE_COMMAND%
-  IF NOT %ERRORLEVEL%==0 exit 1
+  IF ERRORLEVEL 1 exit 1
+  IF NOT ERRORLEVEL 0 exit 1
   cd ..
   @endlocal
 


### PR DESCRIPTION
Fixes #4990. Uses the error log to determine whether the build process is actually successful or not.