### PR TITLE
[WIP] Better support for literals in the jit

### DIFF
--- a/test/expect/TestScript.test_tensor_literal_math_expect-graph.expect
+++ b/test/expect/TestScript.test_tensor_literal_math_expect-graph.expect
@@ -1,0 +1,15 @@
+graph(%x : Dynamic) {
+  %a : int = prim::Constant[value={17}]()
+  %2 : float = prim::Constant[value={3.14}]()
+  %3 : Dynamic = prim::Cast(%2)
+  %b : float = aten::neg(%3)
+  %6 : Dynamic = prim::Cast(%a)
+  %7 : Dynamic = aten::type_as(%6, %b)
+  %8 : Dynamic = prim::Cast(%b)
+  %9 : Dynamic = aten::type_as(%8, %b)
+  %c : float = aten::add[alpha={1}](%7, %9)
+  %12 : Dynamic = prim::Cast(%c)
+  %13 : Dynamic = aten::type_as(%12, %x)
+  %14 : Dynamic = aten::add[alpha={1}](%x, %13)
+  return (%14);
+}

--- a/test/expect/TestScript.test_tensor_literal_math_expect-graph_for.expect
+++ b/test/expect/TestScript.test_tensor_literal_math_expect-graph_for.expect
@@ -1,0 +1,15 @@
+graph(%x : Float(2, 3)) {
+  %a : Long() = prim::Constant[value={17}]()
+  %2 : Float() = prim::Constant[value={3.14}]()
+  %3 : Float() = prim::Cast(%2)
+  %b : Float() = aten::neg(%3)
+  %5 : Long() = prim::Cast(%a)
+  %6 : Dynamic = aten::type_as(%5, %b)
+  %7 : Float() = prim::Cast(%b)
+  %8 : Float() = aten::type_as(%7, %b)
+  %c : Dynamic = aten::add[alpha={1}](%6, %8)
+  %10 : Dynamic = prim::Cast(%c)
+  %11 : Dynamic = aten::type_as(%10, %x)
+  %12 : Dynamic = aten::add[alpha={1}](%x, %11)
+  return (%12);
+}

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -360,6 +360,10 @@ def emit_schema(jit_decls, out):
         n = get_name(arg['name'])
         if arg.get('type') == 'TensorList':
             typ = 'ListType::ofTensors()'
+        elif arg.get('type') == 'int64_t':
+            typ = 'IntType::get()'
+        elif arg.get('type') == 'bool':
+            typ = 'IntType::get()'
         else:
             typ = 'DynamicType::get()'
         tensor = 'at::nullopt'

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -29,11 +29,17 @@ enum class SymbolNamespace : unsigned char {
 //
 // TODO: Consider moving the synthetic onnx operators to their own
 // namespace.
+//
+// prim::Cast
+// Right now this is a dummy node that holds no information. The script frontend 
+// uses it by sending in an input and declaring the type of the output.
+// During shape propagation, the type of the input is propagated to the output.
 
 #define FORALL_PRIM_SYMBOLS(_) \
 _(prim, Assign) \
 _(prim, Constant) \
 _(prim, CppOp) \
+_(prim, Cast) \
 _(prim, Drop) \
 _(prim, Eval) \
 _(prim, Expand) /* onnx */ \

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -671,6 +671,11 @@ struct CodeImpl {
         stack.push_back(t);
         return 0;
       };
+    IR_ELSEIF(Cast)
+      // no-op
+      return [](Stack& stack) {
+        return 0;
+      };
     IR_ELSEIF(Undefined)
       return [](Stack & stack) {
         stack.push_back(at::Tensor());

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -335,6 +335,11 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
       node->output()->inferTypeFrom(node->t(attr::value));
       handled = true;
     } break;
+    case prim::Cast: {
+      auto ten = types.at(0);
+      node->output()->setType(ten->shared_from_this());
+      handled = true;
+    } break;
     case prim::Undefined: {
       node->output()->setType(DynamicType::get());
       handled = true;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -522,7 +522,11 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         err() << "argument '" << schema.arguments[i].name << "' not provided.\n" << loc;
         return at::nullopt;
       }
-      positional_inputs[i] = NamedValue(loc, i, createConstant(graph, loc, *default_value));
+      if (isPythonScalarType(schema.arguments[i].type)) {
+        positional_inputs[i] = NamedValue(loc, i, createPythonScalar(graph, loc, *default_value));
+      } else {
+        positional_inputs[i] = NamedValue(loc, i, createConstant(graph, loc, *default_value));
+      }
     }
 
     // check input types

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -29,6 +29,10 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "Dynamic";
   } else if(t.kind() == TypeKind::TupleType) {
     out << "Tuple";
+  } else if(t.kind() == TypeKind::FloatType) {
+    out << "float";
+  } else if(t.kind() == TypeKind::IntType) {
+    out << "int";
   } else {
     barf("unknown type kind");
   }
@@ -47,6 +51,20 @@ TypePtr DynamicType::get() {
 
 TypePtr ListType::ofTensors() {
   static auto value = std::make_shared<ListType>(DynamicType::get());
+  return value;
+}
+TypePtr ListType::ofInts() {
+  static auto value = std::make_shared<ListType>(IntType::get());
+  return value;
+}
+
+
+TypePtr FloatType::get() {
+  static auto value = std::make_shared<FloatType>();
+  return value;
+}
+TypePtr IntType::get() {
+  static auto value = std::make_shared<IntType>();
   return value;
 }
 

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -15,7 +15,9 @@ _(DynamicType) \
 _(TensorType) \
 _(HandleType) \
 _(TupleType) \
-_(ListType)
+_(ListType) \
+_(FloatType) \
+_(IntType)
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -223,7 +225,8 @@ struct ListType : public Type {
     return elem;
   }
   // common cast List[Tensor]
-  static TypePtr ofTensors();  
+  static TypePtr ofTensors();
+  static TypePtr ofInts();
 private:
   TypePtr elem;
 };
@@ -284,6 +287,35 @@ private:
   std::vector<TypePtr> elements_;
 };
 
+// This node represents a Python float literal value
+struct FloatType : public Type {
+  FloatType()
+  : Type(TypeKind::FloatType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string name() const override {
+    return "float";
+  }
+  static const TypeKind Kind = TypeKind::FloatType;
+  // global singleton
+  static TypePtr get();
+};
+
+// This node represents a Python int literal value
+struct IntType : public Type {
+  IntType()
+  : Type(TypeKind::IntType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string name() const override {
+    return "int";
+  }
+  static const TypeKind Kind = TypeKind::IntType;
+  // global singleton
+  static TypePtr get();
+};
 
 
 std::ostream& operator<<(std::ostream & out, const Type & t);


### PR DESCRIPTION
Second iteration of #8177

WIP because some test cases are failing (loop unrolling and constant propagation of "Scalar" args)

General approach:
- Add FloatType and IntType to type.h and assign these to constant literals (python numbers)
- Add a `prim::Cast` node to represent implicit type conversions. The `prim::Cast` node itself holds no information; the frontend assigns types to the output of the `prim::Cast` node as it sees fit. In additional, in `interpreter.cpp`, a `prim::Cast` node is a no-op. This is helpful to have because otherwise implicit casting becomes a series of if-statements to see if one can pass in an arg for something else.
- Implicitly cast python numbers to Tensors (if the schema requires a Tensor) and Tensors to python numbers (if the schema requires a python number). 
- Propagate IntType / FloatType on basic math (+-*/) on python numbers.
- When adding tensors and python numbers, i.e. (x + 1) `prim::Cast` node is emitted such that the input is the python number (1) and the output type is `DynamicType`. The output of the `prim::Cast` node (1) is then changed via `aten::type_as` to match the type of the tensor (`x`).

Patches to the other parts of the JIT to make this work:
- aten_schema now labels "int64_t" and "bool" arguments as IntType. This makes it so that constant propagation of things like `torch.unsqueeze(dim=0)` works.
- Before, one can only re-assign a variable if the types match (one is a subtype of the other). I overrode this logic such that you can re-assign a variable if the types "can be implicitly casted to the other type". There's a test case where `var = (0, (0, 0))` is being reassigned a `(t, (t, t))` where `t` is a scalar tensor.
- All IntLists that are emitted are still treated as Tensors rather than ListType::ofInt(). 

Some problems that might need to be resolved:
- Loop unrolling fails, but I haven't looked into that yet.
- Constant propagation stops working for things in aten_schema that have a `Scalar` argument. For example, `t.addmm(x, y, alpha=1.0, beta=1.0)` does not get transformed into `addmm[alpha=1.0, beta=1.0](t, x, y)`, but `t.addmm(x, y)` does get transformed into `addmm[alpha=1.0, beta=1.0](t, x, y)`

cc @zdevito 