### PR TITLE
Fix dividing by zero segfault in Reshape

### DIFF
--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -83,8 +83,17 @@ class ReshapeOp : public Operator<Context> {
         size *= dim;
       }
     }
+    if (size == 0 && total_size != 0) {
+      CAFFE_THROW("Can not reshape a non-zero size (", total_size, ") tensor to zero size.");
+    }
 
     if (unknown_idx != -1) {
+      CAFFE_ENFORCE_NE(
+          size,
+          0,
+          "New shape at dim ",
+          unknown_idx,
+          " can not be inferred since new size is zero.");
       CAFFE_ENFORCE(
           total_size % size == 0,
           "Argument `shape` does not agree with the input data.",

--- a/caffe2/python/operator_test/reshape_ops_test.py
+++ b/caffe2/python/operator_test/reshape_ops_test.py
@@ -61,6 +61,10 @@ class TestLengthsToShapeOps(TestCase):
         _test_reshape(old_shape=(4, 3, 2), new_shape=(-1, 0),
                      expected_shape=(8, 3), arg_shape=False)
 
+        self.assertRaisesRegexp(RuntimeError, "size is zero",
+                                _test_reshape, old_shape=(2, 0), new_shape=(-1, 0),
+                                expected_shape=(2, 0), arg_shape=False)
+
     def test_backprop(self):
         old_shape = (4, 2, 1)
         new_shape = (1, 8)


### PR DESCRIPTION
when infer a dimension of zero size new shape

