### PR TITLE
Clean up old sccache log before build

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -64,6 +64,7 @@ trap_add cleanup EXIT
 if which sccache > /dev/null; then
   # Save sccache logs to file
   sccache --stop-server || true
+  rm ~/sccache_error.log || true
   SCCACHE_ERROR_LOG=~/sccache_error.log RUST_LOG=sccache::server=error sccache --start-server
 
   # Report sccache stats for easier debugging


### PR DESCRIPTION
Since the macOS workers are static, we need to make sure that the old sccache logs are removed before starting a new build, otherwise errors from old build will mistakenly show up in new ones (e.g. https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-macos-10.13-cuda9.2-cudnn7-py3-build/58/consoleFull)