### PR TITLE
[WIP] Use decorators to check CUDA feature availability in CI test

### DIFF
--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -10,6 +10,11 @@ CUDA_DEVICE = TEST_CUDA and torch.device("cuda:0")
 TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1., device=CUDA_DEVICE))
 TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
 
+TEST_MAGMA = TEST_CUDA
+if TEST_CUDA:
+    torch.ones(1).cuda()  # has_magma shows up after cuda is initialized
+    TEST_MAGMA = torch.cuda.has_magma
+
 
 # Used below in `initialize_cuda_context_rng` to ensure that CUDA context and
 # RNG have been initialized.

--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -15,7 +15,6 @@ if TEST_CUDA:
     torch.ones(1).cuda()  # has_magma shows up after cuda is initialized
     TEST_MAGMA = torch.cuda.has_magma
 
-
 # Used below in `initialize_cuda_context_rng` to ensure that CUDA context and
 # RNG have been initialized.
 __cuda_ctx_rng_initialized = False

--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -1,4 +1,7 @@
-r"""This file is allowed to initialize CUDA context when imported."""
+r"""Because this file is allowed to initialize CUDA context when imported,
+we must use __name__ == '__main__' to protect the import, otherwise repeated allocation of
+small tensors in multiple processes (such as the statements for TEST_CUDNN and TEST_MAGMA)
+can cause CUDA OOM error on Windows."""
 
 import torch
 import torch.cuda

--- a/test/common_cuda_utils.py
+++ b/test/common_cuda_utils.py
@@ -1,0 +1,26 @@
+def skipIfNoCuda(function):
+    def wrapper(*args, **kwargs):
+        if TEST_CUDA:
+            return function(*args, **kwargs)
+    return wrapper
+
+
+def skipIfNoMultiGpu(function):
+    def wrapper(*args, **kwargs):
+        if TEST_MULTIGPU:
+            return function(*args, **kwargs)
+    return wrapper
+
+
+def skipIfNoCudnn(function):
+    def wrapper(*args, **kwargs):
+        if TEST_CUDNN:
+            return function(*args, **kwargs)
+    return wrapper
+
+
+def skipIfNoMagma(function):
+    def wrapper(*args, **kwargs):
+        if TEST_MAGMA:
+            return function(*args, **kwargs)
+    return wrapper

--- a/test/common_cuda_utils.py
+++ b/test/common_cuda_utils.py
@@ -1,3 +1,9 @@
+r"""Decorators in this module are the preferred ways to check whether certain CUDA features are available."""
+
+if __name__ == '__main__':
+    from common_cuda import TEST_CUDA, TEST_MULTIGPU, CUDA_DEVICE, TEST_CUDNN, TEST_CUDNN_VERSION, TEST_MAGMA
+
+
 def skipIfNoCuda(function):
     def wrapper(*args, **kwargs):
         if TEST_CUDA:
@@ -23,6 +29,17 @@ def skipIfNoCudnn(function):
         else:
             print("CUDNN not available")
     return wrapper
+
+
+def skipIfCudnnVersionLessThan(min_version):
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            if TEST_CUDNN and TEST_CUDNN_VERSION >= min_version:
+                return function(*args, **kwargs)
+            else:
+                print("needs cudnn >= " + str(min_version))
+        return wrapper
+    return decorator
 
 
 def skipIfNoMagma(function):

--- a/test/common_cuda_utils.py
+++ b/test/common_cuda_utils.py
@@ -2,6 +2,8 @@ def skipIfNoCuda(function):
     def wrapper(*args, **kwargs):
         if TEST_CUDA:
             return function(*args, **kwargs)
+        else:
+            print("CUDA unavailable")
     return wrapper
 
 
@@ -9,6 +11,8 @@ def skipIfNoMultiGpu(function):
     def wrapper(*args, **kwargs):
         if TEST_MULTIGPU:
             return function(*args, **kwargs)
+        else:
+            print("only one GPU detected")
     return wrapper
 
 
@@ -16,6 +20,8 @@ def skipIfNoCudnn(function):
     def wrapper(*args, **kwargs):
         if TEST_CUDNN:
             return function(*args, **kwargs)
+        else:
+            print("CUDNN not available")
     return wrapper
 
 
@@ -23,4 +29,6 @@ def skipIfNoMagma(function):
     def wrapper(*args, **kwargs):
         if TEST_MAGMA:
             return function(*args, **kwargs)
+        else:
+            print("no MAGMA library detected")
     return wrapper

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -7,7 +7,8 @@ from itertools import product
 import torch
 import torch.cuda
 from common import TestCase, to_gpu, freeze_rng_state, is_iterable
-from common_cuda import TEST_CUDA
+if __name__ == '__main__':
+    from common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 import torch.backends.cudnn
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1823,10 +1823,6 @@ def generate_tests():
 
 
 if __name__ == '__main__':
-    if TEST_CUDA:
-        load_ignore_file()
-        generate_tests()
-
     # skip TestTorch tests
     # hide in __name__ == '__main__' because we don't want this to be run when
     # someone imports test_cuda
@@ -1839,4 +1835,7 @@ if __name__ == '__main__':
                 test_suite.addTest(test)
         return test_suite
 
-    run_tests()
+    if TEST_CUDA:
+        load_ignore_file()
+        generate_tests()
+        run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -15,7 +15,7 @@ from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, IS_WINDOWS
 from common_cuda_utils import skipIfNoMultiGpu, skipIfNoMagma
 if __name__ == '__main__':
-    from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_MAGMA
+    from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,
                 torch.cuda.DoubleTensor, torch.HalfTensor, torch.cuda.HalfTensor}

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1344,17 +1344,14 @@ class TestCuda(TestCase):
     def _select_broadcastable_dims(dims_full=None):
         return TestTorch._select_broadcastable_dims(dims_full)
 
-    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipIfNoMagma
     def test_det_logdet_slogdet(self):
         TestTorch._test_det_logdet_slogdet(self, lambda t: t.cuda())
 
-    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipIfNoMagma
     def test_gesv_batched(self):
         TestTorch._test_gesv_batched(self, lambda t: t.cuda())
 
-    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipIfNoMagma
     def test_gesv_batched_dims(self):
         TestTorch._test_gesv_batched_dims(self, lambda t: t.cuda())
@@ -1629,7 +1626,6 @@ class TestCuda(TestCase):
         test(True)
         test(False)
 
-    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipIfNoMagma
     def test_symeig(self):
         # Small case
@@ -1658,7 +1654,6 @@ class TestCuda(TestCase):
     def test_diagflat(self):
         TestTorch._test_diagflat(self, dtype=torch.float32, device='cuda')
 
-    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipIfNoMagma
     def test_trtrs(self):
         TestTorch._test_trtrs(self, lambda t: t.cuda())

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -22,6 +22,12 @@ def skipIfNoMagma(function):
             return function(*args, **kwargs)
     return wrapper
 
+def skipIfNoMultiGpu(function):
+    def wrapper(*args, **kwargs):
+        if TEST_MULTIGPU:
+            return function(*args, **kwargs)
+    return wrapper
+
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,
                 torch.cuda.DoubleTensor, torch.HalfTensor, torch.cuda.HalfTensor}
 
@@ -712,7 +718,7 @@ class TestCuda(TestCase):
         for _ in self._test_memory_stats_generator(self):
             pass
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_memory_stats_multigpu(self):
         # advance a generator with a end flag
         def advance(gen, end):
@@ -749,7 +755,7 @@ class TestCuda(TestCase):
                 end1 = advance(gen1, end1)
                 t += 1
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_autogpu(self):
         x = torch.randn(5, 5).cuda()
         y = torch.randn(5, 5).cuda()
@@ -767,7 +773,7 @@ class TestCuda(TestCase):
         z = z.cuda()
         self.assertEqual(z.get_device(), 0)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_new(self):
         x = torch.randn(3, 3).cuda()
         self.assertEqual(x.new([0, 1, 2]).get_device(), 0)
@@ -777,7 +783,7 @@ class TestCuda(TestCase):
             self.assertEqual(x.new([0, 1, 2]).get_device(), 0)
             self.assertEqual(x.new([0, 1, 2], device=1).get_device(), 1)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_copy_device(self):
         x = torch.randn(5, 5).cuda()
         with torch.cuda.device(1):
@@ -830,7 +836,7 @@ class TestCuda(TestCase):
         self.assertIsInstance(y.cuda().float().cpu(), torch.FloatStorage)
         self.assertIsInstance(y.cuda().float().cpu().int(), torch.IntStorage)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_type_conversions_same_gpu(self):
         x = torch.randn(5, 5).cuda(1)
         self.assertEqual(x.int().get_device(), 1)
@@ -883,7 +889,7 @@ class TestCuda(TestCase):
             self.assertEqual(bt.get_device(), bct.get_device())
             self.assertIsInstance(bct, type(bt))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_broadcast_coalesced(self):
         numel = 5
         num_bytes = numel * 8
@@ -903,7 +909,7 @@ class TestCuda(TestCase):
         ]
         self._test_broadcast_coalesced(self, tensors, num_bytes * 5 // 2)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_broadcast_coalesced_dense_only(self):
         numel = 5
         num_bytes = numel * 8
@@ -917,7 +923,7 @@ class TestCuda(TestCase):
         ]
         self._test_broadcast_coalesced(self, tensors, num_bytes * 5 // 2)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_reduce_add(self):
         x = torch.randn(5, 5)
         y = torch.randn(5, 5)
@@ -943,7 +949,7 @@ class TestCuda(TestCase):
             self.assertEqual(rc.get_device(), r.get_device())
             self.assertEqual(rc.type(), r.type())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_reduce_add_coalesced(self):
         numel = 5
         num_bytes = numel * 8
@@ -963,7 +969,7 @@ class TestCuda(TestCase):
         ]
         self._test_reduce_add_coalesced(self, tensors, num_bytes * 5 // 2)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_reduce_add_coalesced_dense_only(self):
         numel = 5
         num_bytes = numel * 8
@@ -1070,7 +1076,7 @@ class TestCuda(TestCase):
             self.assertEqual(x, y)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_cat_autogpu(self):
         x = torch.randn(4, 4).cuda(1)
         y = torch.randn(4, 4).cuda(1)
@@ -1151,7 +1157,7 @@ class TestCuda(TestCase):
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), original.get_device())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfNoMultiGpu
     def test_multigpu_serialization(self):
         x = [torch.randn(4, 4).cuda(0), torch.randn(4, 4).cuda(1)]
         with tempfile.NamedTemporaryFile() as f:
@@ -1163,7 +1169,7 @@ class TestCuda(TestCase):
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), original.get_device())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfNoMultiGpu
     def test_multigpu_serialization_remap(self):
         x = [torch.randn(4, 4).cuda(0), torch.randn(4, 4).cuda(1)]
 
@@ -1181,7 +1187,7 @@ class TestCuda(TestCase):
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), 0)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfNoMultiGpu
     def test_multigpu_serialization_remap_dict(self):
         x = [torch.randn(4, 4).cuda(0), torch.randn(4, 4).cuda(1)]
         with tempfile.NamedTemporaryFile() as f:
@@ -1193,7 +1199,7 @@ class TestCuda(TestCase):
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), 0)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfNoMultiGpu
     def test_cuda_set_device(self):
         x = torch.randn(5, 5)
         with torch.cuda.device(1):
@@ -1232,7 +1238,7 @@ class TestCuda(TestCase):
         default_stream.synchronize()
         self.assertTrue(default_stream.query())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfNoMultiGpu
     def test_streams_multi_gpu(self):
         default_stream = torch.cuda.current_stream()
         self.assertEqual(default_stream.device, 0)
@@ -1242,7 +1248,7 @@ class TestCuda(TestCase):
             self.assertEqual(torch.cuda.current_stream().device, 1)
             self.assertNotEqual(torch.cuda.current_stream(), default_stream)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @skipIfNoMultiGpu
     def test_tensor_device(self):
         self.assertEqual(torch.cuda.FloatTensor(1).get_device(), 0)
         self.assertEqual(torch.cuda.FloatTensor(1, device=1).get_device(), 1)
@@ -1320,7 +1326,7 @@ class TestCuda(TestCase):
         self.assertNotEqual(t.data_ptr(), ptr, 'allocation re-used too soon')
         self.assertEqual(list(gpu_tensor), [1])
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_caching_pinned_memory_multi_gpu(self):
         # checks that the events preventing pinned memory from being re-used
         # too early are recorded on the correct GPU
@@ -1668,7 +1674,7 @@ class TestCuda(TestCase):
     def test_trtrs(self):
         TestTorch._test_trtrs(self, lambda t: t.cuda())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_get_set_rng_state_all(self):
         states = torch.cuda.get_rng_state_all()
         before0 = torch.cuda.FloatTensor(100, device=0).normal_()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,16 +16,10 @@ from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, 
 if __name__ == '__main__':
     from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_MAGMA
 
-def skipIfNoCudnn(function):
-    def wrapper():
-        if TEST_MAGMA:
-            function()
-    return wrapper
-
 def skipIfNoMagma(function):
-    def wrapper():
+    def wrapper(*args, **kwargs):
         if TEST_MAGMA:
-            function()
+            return function(*args, **kwargs)
     return wrapper
 
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,6 +16,18 @@ from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, 
 if __name__ == '__main__':
     from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_MAGMA
 
+def skipIfNoCudnn(function):
+    def wrapper():
+        if TEST_MAGMA:
+            function()
+    return wrapper
+
+def skipIfNoMagma(function):
+    def wrapper():
+        if TEST_MAGMA:
+            function()
+    return wrapper
+
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,
                 torch.cuda.DoubleTensor, torch.HalfTensor, torch.cuda.HalfTensor}
 
@@ -404,16 +416,16 @@ tests = [
         lambda t: [2], None, signed_types),
     # lapack tests
     ('qr', small_2d_lapack, lambda t: [], 'square', float_types, False,
-        unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
     ('qr', small_2d_lapack_skinny, lambda t: [], 'skinny', float_types, False,
-        unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
     ('qr', small_2d_lapack_fat, lambda t: [], 'fat', float_types, False,
-        unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
     ('qr', large_2d_lapack, lambda t: [], 'big', float_types, False,
-        unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
     ('inverse', new_t(20, 20), lambda t: [], None, float_types, False),
     ('geqrf', new_t(20, 20), lambda t: [], None, float_types, False,
-        unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
 ]
 
 # TODO: random functions, cat, gather, scatter, index*, masked*,
@@ -1343,15 +1355,18 @@ class TestCuda(TestCase):
     def _select_broadcastable_dims(dims_full=None):
         return TestTorch._select_broadcastable_dims(dims_full)
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    @skipIfNoMagma
     def test_det_logdet_slogdet(self):
         TestTorch._test_det_logdet_slogdet(self, lambda t: t.cuda())
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    @skipIfNoMagma
     def test_gesv_batched(self):
         TestTorch._test_gesv_batched(self, lambda t: t.cuda())
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    @skipIfNoMagma
     def test_gesv_batched_dims(self):
         TestTorch._test_gesv_batched_dims(self, lambda t: t.cuda())
 
@@ -1625,7 +1640,8 @@ class TestCuda(TestCase):
         test(True)
         test(False)
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    @skipIfNoMagma
     def test_symeig(self):
         # Small case
         tensor = torch.randn(3, 3).cuda()
@@ -1653,7 +1669,8 @@ class TestCuda(TestCase):
     def test_diagflat(self):
         TestTorch._test_diagflat(self, dtype=torch.float32, device='cuda')
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    # @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
+    @skipIfNoMagma
     def test_trtrs(self):
         TestTorch._test_trtrs(self, lambda t: t.cuda())
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -13,20 +13,9 @@ from torch import multiprocessing as mp
 
 from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, IS_WINDOWS
+from common_cuda_utils import skipIfNoMultiGpu, skipIfNoMagma
 if __name__ == '__main__':
     from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_MAGMA
-
-def skipIfNoMagma(function):
-    def wrapper(*args, **kwargs):
-        if TEST_MAGMA:
-            return function(*args, **kwargs)
-    return wrapper
-
-def skipIfNoMultiGpu(function):
-    def wrapper(*args, **kwargs):
-        if TEST_MULTIGPU:
-            return function(*args, **kwargs)
-    return wrapper
 
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,
                 torch.cuda.DoubleTensor, torch.HalfTensor, torch.cuda.HalfTensor}
@@ -416,16 +405,16 @@ tests = [
         lambda t: [2], None, signed_types),
     # lapack tests
     ('qr', small_2d_lapack, lambda t: [], 'square', float_types, False,
-        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma),
     ('qr', small_2d_lapack_skinny, lambda t: [], 'skinny', float_types, False,
-        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma),
     ('qr', small_2d_lapack_fat, lambda t: [], 'fat', float_types, False,
-        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma),
     ('qr', large_2d_lapack, lambda t: [], 'big', float_types, False,
-        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma),
     ('inverse', new_t(20, 20), lambda t: [], None, float_types, False),
     ('geqrf', new_t(20, 20), lambda t: [], None, float_types, False,
-        skipIfNoMagma), #, unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")),
+        skipIfNoMagma),
 ]
 
 # TODO: random functions, cat, gather, scatter, index*, masked*,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -13,22 +13,8 @@ from torch import multiprocessing as mp
 
 from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, IS_WINDOWS
-
-# We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,
-# because if we do that, the TEST_CUDNN line from common_cuda will be executed
-# multiple times as well during the execution of this test suite, and it will
-# cause CUDA OOM error on Windows.
-TEST_CUDA = torch.cuda.is_available()
-TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
-
-if not TEST_CUDA:
-    print('CUDA not available, skipping tests')
-    TestCase = object  # noqa: F811
-
-TEST_MAGMA = TEST_CUDA
-if TEST_CUDA:
-    torch.ones(1).cuda()  # has_magma shows up after cuda is initialized
-    TEST_MAGMA = torch.cuda.has_magma
+if __name__ == '__main__':
+    from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_MAGMA
 
 floating_set = {torch.FloatTensor, torch.DoubleTensor, torch.cuda.FloatTensor,
                 torch.cuda.DoubleTensor, torch.HalfTensor, torch.cuda.HalfTensor}

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -335,7 +335,6 @@ class TestDataLoader(TestCase):
         self.assertEqual(len(dataloader_seq), 5)
         self.assertEqual(len(dataloader_shuffle), 5)
 
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_sequential_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
@@ -440,7 +439,6 @@ class TestDataLoader(TestCase):
         self._test_batch_sampler()
         self._test_batch_sampler(num_workers=4)
 
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_shuffle_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
@@ -471,7 +469,6 @@ class TestDataLoader(TestCase):
         self._test_error(DataLoader(ErrorDataset(41), batch_size=2, shuffle=True, num_workers=4))
 
     @unittest.skipIf(IS_WINDOWS, "FIXME: stuck test")
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_partial_workers(self):
         "check that workers exit even if the iterator is not exhausted"
@@ -523,7 +520,6 @@ class TestDataLoader(TestCase):
     @unittest.skipIf(sys.version_info[0] == 2,
                      "spawn start method is not supported in Python 2, \
                      but we need it for creating another process with CUDA")
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_manager_unclean_exit(self):
         '''there might be ConnectionResetError or leaked semaphore warning (due to dirty process exit), \
@@ -627,7 +623,6 @@ class TestStringDataLoader(TestCase):
     def setUp(self):
         self.dataset = StringDataset()
 
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_shuffle_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
@@ -671,7 +666,6 @@ class TestDictDataLoader(TestCase):
             self.assertEqual(n[0], idx)
             self.assertEqual(n[1], idx + 1)
 
-    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfNoCuda
     def test_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -17,6 +17,12 @@ from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 if __name__ == '__main__':
     from common_cuda import TEST_CUDA
 
+def skipIfNoCuda(function):
+    def wrapper():
+        if TEST_CUDA:
+            function()
+    return wrapper
+
 # We need spawn start method for test_manager_unclean_exit, but
 # Python 2.7 doesn't allow it.
 if sys.version_info[0] == 3:
@@ -333,7 +339,8 @@ class TestDataLoader(TestCase):
         self.assertEqual(len(dataloader_seq), 5)
         self.assertEqual(len(dataloader_shuffle), 5)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_sequential_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
         for input, target in loader:
@@ -437,7 +444,8 @@ class TestDataLoader(TestCase):
         self._test_batch_sampler()
         self._test_batch_sampler(num_workers=4)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_shuffle_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
         for input, target in loader:
@@ -467,7 +475,8 @@ class TestDataLoader(TestCase):
         self._test_error(DataLoader(ErrorDataset(41), batch_size=2, shuffle=True, num_workers=4))
 
     @unittest.skipIf(IS_WINDOWS, "FIXME: stuck test")
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_partial_workers(self):
         "check that workers exit even if the iterator is not exhausted"
         loader = iter(DataLoader(self.dataset, batch_size=2, num_workers=4, pin_memory=True))
@@ -518,7 +527,8 @@ class TestDataLoader(TestCase):
     @unittest.skipIf(sys.version_info[0] == 2,
                      "spawn start method is not supported in Python 2, \
                      but we need it for creating another process with CUDA")
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_manager_unclean_exit(self):
         '''there might be ConnectionResetError or leaked semaphore warning (due to dirty process exit), \
 but they are all safe to ignore'''
@@ -621,7 +631,8 @@ class TestStringDataLoader(TestCase):
     def setUp(self):
         self.dataset = StringDataset()
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_shuffle_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
         for batch_ndx, (s, n) in enumerate(loader):
@@ -664,7 +675,8 @@ class TestDictDataLoader(TestCase):
             self.assertEqual(n[0], idx)
             self.assertEqual(n[1], idx + 1)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipIfNoCuda
     def test_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
         for batch_ndx, sample in enumerate(loader):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -15,8 +15,6 @@ from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 from common_cuda_utils import skipIfNoCuda
-if __name__ == '__main__':
-    from common_cuda import TEST_CUDA
 
 
 # We need spawn start method for test_manager_unclean_exit, but

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -18,9 +18,9 @@ if __name__ == '__main__':
     from common_cuda import TEST_CUDA
 
 def skipIfNoCuda(function):
-    def wrapper():
+    def wrapper(*args, **kwargs):
         if TEST_CUDA:
-            function()
+            return function(*args, **kwargs)
     return wrapper
 
 # We need spawn start method for test_manager_unclean_exit, but

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -14,12 +14,8 @@ from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
-
-# We cannot import TEST_CUDA from common_nn here, because if we do that,
-# the TEST_CUDNN line from common_nn will be executed multiple times
-# as well during the execution of this test suite, and it will cause
-# CUDA OOM error on Windows.
-TEST_CUDA = torch.cuda.is_available()
+if __name__ == '__main__':
+    from common_cuda import TEST_CUDA
 
 # We need spawn start method for test_manager_unclean_exit, but
 # Python 2.7 doesn't allow it.

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -14,14 +14,10 @@ from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
+from common_cuda_utils import skipIfNoCuda
 if __name__ == '__main__':
     from common_cuda import TEST_CUDA
 
-def skipIfNoCuda(function):
-    def wrapper(*args, **kwargs):
-        if TEST_CUDA:
-            return function(*args, **kwargs)
-    return wrapper
 
 # We need spawn start method for test_manager_unclean_exit, but
 # Python 2.7 doesn't allow it.

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -31,7 +31,7 @@ from random import shuffle
 
 import torch
 from common import TestCase, run_tests, set_rng_seed
-from common_cuda import TEST_CUDA
+from common_cuda_utils import skipIfNoCuda
 from torch.autograd import grad, gradcheck
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, Dirichlet, Distribution,
@@ -1017,7 +1017,7 @@ class TestDistributions(TestCase):
                                          'Poisson(lambda={})'.format(rate),
                                          failure_rate=1e-3)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @skipIfNoCuda
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_poisson_gpu_sample(self):
         set_rng_seed(1)
@@ -1577,7 +1577,7 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @skipIfNoCuda
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gamma_gpu_shape(self):
         alpha = torch.tensor(torch.exp(torch.randn(2, 3).cuda()), requires_grad=True)
@@ -1607,7 +1607,7 @@ class TestDistributions(TestCase):
                                         scipy.stats.gamma(alpha, scale=1.0 / beta),
                                         'Gamma(concentration={}, rate={})'.format(alpha, beta))
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @skipIfNoCuda
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_gamma_gpu_sample(self):
         set_rng_seed(0)
@@ -3525,7 +3525,7 @@ class TestConstraintRegistry(TestCase):
             j = t.log_abs_det_jacobian(x, y)
             self.assertEqual(j.shape, x.shape[:x.dim() - t.event_dim])
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @skipIfNoCuda
     def test_biject_to_cuda(self):
         for constraint in self.get_constraints(is_cuda=True):
             try:
@@ -3557,7 +3557,7 @@ class TestConstraintRegistry(TestCase):
             y2 = t(x2)
             self.assertEqual(y, y2, message="Error in transform_to({}) pseudoinverse".format(constraint))
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @skipIfNoCuda
     def test_transform_to_cuda(self):
         for constraint in self.get_constraints(is_cuda=True):
             t = transform_to(constraint)

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -5,13 +5,14 @@ import torch.cuda.nccl as nccl
 import torch.cuda
 
 from common import TestCase, run_tests, IS_WINDOWS
-from common_cuda import TEST_CUDA, TEST_MULTIGPU
+from common_cuda_utils import skipIfNoMultiGpu
+if __name__ == '__main__':
+    from common_cuda import TEST_CUDA
 
-
-nGPUs = torch.cuda.device_count()
-if not TEST_CUDA:
-    print('CUDA not available, skipping tests')
-    TestCase = object  # noqa: F811
+    nGPUs = torch.cuda.device_count()
+    if not TEST_CUDA:
+        print('CUDA not available, skipping tests')
+        TestCase = object  # noqa: F811
 
 
 class TestNCCL(TestCase):
@@ -23,7 +24,7 @@ class TestNCCL(TestCase):
         self.assertGreater(len(uid), 1)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_broadcast(self):
         expected = torch.FloatTensor(128).uniform_()
         tensors = [expected.cuda()]
@@ -36,7 +37,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensors[i], expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.FloatTensor(128).zero_()
@@ -49,7 +50,7 @@ class TestNCCL(TestCase):
         self.assertEqual(tensors[0], expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_all_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.FloatTensor(128).zero_()
@@ -63,7 +64,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensor, expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_all_gather(self):
         inputs = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.cat(inputs, 0)
@@ -77,7 +78,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensor, expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @skipIfNoMultiGpu
     def test_reduce_scatter(self):
         in_size = 32 * nGPUs
         out_size = 32

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5,7 +5,7 @@ import itertools
 import random
 import unittest
 from common import TestCase, run_tests
-from common_cuda import TEST_CUDA
+from common_cuda_utils import skipIfNoCuda
 from test_torch import TestTorch
 from numbers import Number
 
@@ -1007,7 +1007,7 @@ class TestUncoalescedSparse(TestSparse):
         self.is_uncoalesced = True
 
 
-@unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+@skipIfNoCuda
 class TestCudaSparse(TestSparse):
     def setUp(self):
         super(TestCudaSparse, self).setUp()
@@ -1017,7 +1017,7 @@ class TestCudaSparse(TestSparse):
         self.SparseTensor = torch.cuda.sparse.DoubleTensor
 
 
-@unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+@skipIfNoCuda
 class TestCudaUncoalescedSparse(TestCudaSparse):
     def setUp(self):
         super(TestCudaUncoalescedSparse, self).setUp()


### PR DESCRIPTION
To avoid CUDA OOM error on Windows, we need to use `__name__ == '__main__'` to protect the import of flags from `common_cuda.py`. However, the `unittest.skipIf` decorators expect the `TEST_CUDA` and other flags to be available regardless of whether it's in `__name__ == '__main__'`.

The current solution is to have new decorators that perform lazy evaluation and check the flags only when we are in `__name__ == '__main__'`.