### PR TITLE
[READY TO MERGE] Skip test_multinomial_invalid_probs_cuda on Windows

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -12,7 +12,7 @@ import torch.cuda.comm as comm
 from torch import multiprocessing as mp
 
 from test_torch import TestTorch
-from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3
+from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, IS_WINDOWS
 
 # We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,
 # because if we do that, the TEST_CUDNN line from common_cuda will be executed
@@ -1423,6 +1423,7 @@ class TestCuda(TestCase):
         except RuntimeError as e:
             return 'device-side assert triggered' in str(e)
 
+    @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
     @unittest.skipIf(not PY3,
                      "spawn start method is not supported in Python 2, \
                      but we need it for creating another process with CUDA")


### PR DESCRIPTION
`test_multinomial_invalid_probs_cuda` is causing CUDA OOM error (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test2/703/consoleFull) on current master due to repeated executions of `torch.ones(1).cuda()` in  `test_cuda.py` in child processes. The right solution is still being iterated on https://github.com/pytorch/pytorch/pull/8253, and before it's found we should disable the test to avoid the CUDA OOM issue.