### PR TITLE
De-support calling _copy_from directly, fix #8331

### DIFF
--- a/aten/src/ATen/copy_wrapper.py
+++ b/aten/src/ATen/copy_wrapper.py
@@ -96,12 +96,12 @@ Tensor & ${Type}::_s_copy_from(const Tensor & src, Tensor & dst, bool non_blocki
 }
 """)
 
-# Technically, no code should actually call _s_copy_from with a CPU self (this
-# only can happen when the src is CUDA from a CPU kernel) but for
-# completeness we fill out with a swap.
+# NB: Hypothetically, someone could call s_copy_from directly and get an error
+# message which claims something is not supported, when it actually is.  But
+# the correct fix in this case was to NOT call copy_from
 FUNCTION_FROM_SWAP = CodeTemplate("""\
 Tensor & ${Type}::_s_copy_from(const Tensor & src, Tensor & dst, bool non_blocking) const {
-  return dst.type().s_copy_(dst, src, non_blocking);
+  AT_ERROR("copy does not support ", src.type().toString(), " to ", dst.type().toString(), " copy (s_copy_from case).");
 }
 """)
 


### PR DESCRIPTION
We can probably support _copy_from directly by adding
a bunch more code to detect if the sparse-dense case has
occurred, but I didn't feel like it.  Instead, just undo
the "generalization."

There's an extra tag on the error message in case someone
runs into the error.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

