### PR TITLE
Prepare for moving 0-sized dimensions in TH/THC.

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -329,10 +329,8 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
         fm.write(env['Storage'] + ".cpp", STORAGE_DERIVED_CPP, env)
         fm.write(env['Storage'] + ".h", STORAGE_DERIVED_H, env)
         env['TensorDenseOrSparse'] = TENSOR_DENSE_CPP.substitute(env)
-        env['THTensor_nDimension'] = 'tensor->nDimension'
     else:
         env['TensorDenseOrSparse'] = TENSOR_SPARSE_CPP.substitute(env)
-        env['THTensor_nDimension'] = 'tensor->nDimensionI + tensor->nDimensionV'
 
     fm.write(env['Type'] + ".cpp", TYPE_DERIVED_CPP, env)
     fm.write(env['Type'] + ".h", TYPE_DERIVED_H, env)

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,7 +1,7 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
-  int64_t d = tensor->nDimension;
+  int64_t d = tensor->_dim();
   if (d != 0) {
     return IntList(reinterpret_cast<int64_t*>(tensor->stride),dim());
   } else {

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -31,7 +31,7 @@ const char * ${Tensor}::toString() const {
 }
 
 IntList ${Tensor}::sizes() const {
-  int64_t d = ${THTensor_nDimension};
+  int64_t d = tensor->_dim();
   if (d != 0) {
     // note: this will return "{}" for a scalar because dim() will return 0 in that case.
     return IntList(reinterpret_cast<int64_t*>(tensor->size),dim());
@@ -43,7 +43,7 @@ IntList ${Tensor}::sizes() const {
 int64_t ${Tensor}::dim() const {
   if(isScalar())
     return 0;
-  int64_t d = ${THTensor_nDimension};
+  int64_t d = tensor->_dim();
   // See Note [Empty versus 0-dim tensors]
   if (d != 0)
     return d;

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -12,7 +12,7 @@ typedef struct THTensor
 {
     int64_t *size;
     int64_t *stride;
-    int nDimension;
+    int64_t dim_;
 
     // Note: storage->size may be greater than the recorded size
     // of a tensor
@@ -30,6 +30,12 @@ typedef struct THTensor
     template <typename T>
     inline T * unsafe_data() const {
       return storage->unsafe_data<T>() + storageOffset;
+    }
+
+    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    inline int64_t _dim() const {
+      return dim_;
     }
 } THTensor;
 

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -35,18 +35,18 @@
   int64_t *TENSOR##_counter = NULL, *TENSOR##_sizes = NULL, *TENSOR##_strides = NULL, *TENSOR##_dimOffset = NULL; \
   int64_t TENSOR##_stride = 0, TENSOR##_size = 0, TENSOR##_dim = 0, TENSOR##_i, TENSOR##_n; \
   int TENSOR##_contiguous = ALLOW_CONTIGUOUS && DIM < 0; \
-  TENSOR##_n = (TENSOR->nDimension ? 1 : 0); \
-  for(TENSOR##_i = 0; TENSOR##_i < TENSOR->nDimension; TENSOR##_i++) \
+  TENSOR##_n = (TENSOR->_dim() ? 1 : 0); \
+  for(TENSOR##_i = 0; TENSOR##_i < TENSOR->_dim(); TENSOR##_i++) \
     TENSOR##_n *= TENSOR->size[TENSOR##_i]; \
 \
-  if(TENSOR->nDimension == 0) \
+  if(TENSOR->_dim() == 0) \
     TH_TENSOR_APPLY_hasFinished = 1; \
   else \
   { \
     TENSOR##_data = TENSOR->storage->data<TYPE>()+TENSOR->storageOffset; \
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
-    for(TENSOR##_i = TENSOR->nDimension-1; TENSOR##_i >= 0; TENSOR##_i--) { \
+    for(TENSOR##_i = TENSOR->_dim()-1; TENSOR##_i >= 0; TENSOR##_i--) { \
       if(TENSOR->size[TENSOR##_i] != 1) { \
         if(TENSOR->stride[TENSOR##_i] == TENSOR##_size && TENSOR##_i != DIM) \
           TENSOR##_size *= TENSOR->size[TENSOR##_i]; \
@@ -59,7 +59,7 @@
     if (!TENSOR##_contiguous) { \
       /* Find the dimension of contiguous sections */ \
       TENSOR##_dim = 1; \
-      for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; TENSOR##_i--) \
+      for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; TENSOR##_i--) \
       { \
         if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
           TENSOR##_dim++; \
@@ -69,19 +69,19 @@
       TENSOR##_sizes = TENSOR##_counter + TENSOR##_dim; \
       TENSOR##_strides = TENSOR##_counter + 2*TENSOR##_dim; \
       TH_TENSOR_dim_index = TENSOR##_dim-1; \
-      TENSOR##_dimOffset = (DIM == TENSOR->nDimension-1) ? &TENSOR##_i : &TENSOR##_counter[DIM]; \
-      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR->nDimension-1]; \
-      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->nDimension-1]; \
+      TENSOR##_dimOffset = (DIM == TENSOR->_dim()-1) ? &TENSOR##_i : &TENSOR##_counter[DIM]; \
+      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR->_dim()-1]; \
+      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->_dim()-1]; \
       /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
       /* storage is given by storage_offset + (i * j), where i is the stride */ \
       /* vector and j is tensor_counter vector. This sets the starting position for the loop. */ \
       for(TENSOR##_i = TENSOR##_dim-1; TENSOR##_i >= 0; --TENSOR##_i) { \
         TENSOR##_counter[TENSOR##_i] = 0; \
       } \
-      for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; --TENSOR##_i) { \
+      for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; --TENSOR##_i) { \
         if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
           TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i] * TENSOR##_sizes[TH_TENSOR_dim_index]; \
-          if (DIM != TENSOR->nDimension-1 && TENSOR##_i < DIM) \
+          if (DIM != TENSOR->_dim()-1 && TENSOR##_i < DIM) \
             TENSOR##_dimOffset--; \
         } else { \
           --TH_TENSOR_dim_index; \
@@ -160,9 +160,9 @@
     elements_equal = 0;                                                 \
   }                                                                     \
   if (elements_equal == 0) {                                            \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->nDimension); \
+    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
+    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->_dim()); \
     THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
             "number of elements, but got %d, %d and %d elements respectively", \
             #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, \
@@ -199,8 +199,8 @@
   __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, DIM, 1) \
 \
     if(TENSOR1##_n != TENSOR2##_n) {                                    \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
+      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
       THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
               "number of elements, but got %d and %d elements respectively", \
               #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, TENSOR1##_n, TENSOR2##_n); \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -9,7 +9,7 @@
 #define TH_TENSOR_DIM_APPLY3_SIZE_EQ_EXCEPT_DIM(TENSOR1, TENSOR2, TENSOR3, DIMENSION) \
 { \
   int shape_check_flag = 0;                                             \
-  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
   { \
     if (TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
@@ -23,9 +23,9 @@
     } \
   } \
   if (shape_check_flag == 1) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->nDimension); \
+    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
+    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->_dim()); \
     THError("Expected %s %s, %s %s and %s %s to have the same size apart from dimension %d", \
             #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, DIMENSION); \
   } \
@@ -43,26 +43,26 @@
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
 \
-  if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->nDimension) ) \
-    THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->nDimension); \
+  if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->_dim()) ) \
+    THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->_dim()); \
   int same_dims = 1;                                                    \
-  if( TENSOR1->nDimension != TENSOR2->nDimension ) {                    \
+  if( TENSOR1->_dim() != TENSOR2->_dim() ) {                    \
     same_dims = 0;                                                      \
   } \
-  if( TENSOR1->nDimension != TENSOR3->nDimension ) { \
+  if( TENSOR1->_dim() != TENSOR3->_dim() ) { \
     same_dims = 0;                                   \
   } \
   if (same_dims == 0) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->nDimension); \
+    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
+    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->_dim()); \
     THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
             "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str); \
   }                                                                     \
   SIZE_CHECK(TENSOR1, TENSOR2, TENSOR3, DIMENSION)                      \
 \
-  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR1->nDimension)); \
-  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR1->_dim())); \
+  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
@@ -81,14 +81,14 @@
   { \
     CODE \
 \
-    if(TENSOR1->nDimension == 1) \
+    if(TENSOR1->_dim() == 1) \
        break; \
  \
-    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     { \
       if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       { \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \
@@ -103,7 +103,7 @@
 \
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size[TH_TENSOR_DIM_APPLY_i]) \
       { \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \
@@ -150,29 +150,29 @@
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
 \
-  if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->nDimension) ) \
-    THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->nDimension); \
-  if( TENSOR1->nDimension != TENSOR2->nDimension ) {                    \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
+  if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->_dim()) ) \
+    THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->_dim()); \
+  if( TENSOR1->_dim() != TENSOR2->_dim() ) {                    \
+    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
     THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
             "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str);        \
   }                                                                     \
   TH_UNUSED int shape_check_flag = 0;                                             \
-  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
   { \
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
     if(TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->nDimension); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->nDimension); \
+      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
+      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
       THError("Expected %s %s and %s %s to have the same size in dimension %d", \
               #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, DIMENSION);   \
     }                                                                   \
   } \
 \
-  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR1->nDimension)); \
-  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR1->_dim())); \
+  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
@@ -187,14 +187,14 @@
   { \
     CODE \
 \
-    if(TENSOR1->nDimension == 1) \
+    if(TENSOR1->_dim() == 1) \
        break; \
  \
-    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     { \
       if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       { \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \
@@ -208,7 +208,7 @@
 \
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size[TH_TENSOR_DIM_APPLY_i]) \
       { \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR1->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \
@@ -274,25 +274,25 @@
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
 \
-  if( (DIMENSION < 0) || (DIMENSION >= TENSOR->nDimension) ) \
+  if( (DIMENSION < 0) || (DIMENSION >= TENSOR->_dim()) ) \
     THError("invalid dimension"); \
 \
   TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storageOffset; \
   TENSOR##_stride = (TENSOR)->stride[DIMENSION]; \
   TENSOR##_size = TENSOR->size[DIMENSION]; \
   /* Counter stores the indices into the Tensor at any time */ \
-  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR->nDimension)); \
-  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+  TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR->_dim())); \
+  for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
   { \
     CODE \
 \
-    if(TENSOR->nDimension == 1) \
+    if(TENSOR->_dim() == 1) \
        break; \
  \
-    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR->nDimension; TH_TENSOR_DIM_APPLY_i++) \
+    for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR->_dim(); TH_TENSOR_DIM_APPLY_i++) \
     { \
        /* Check if the index is equal to DIMENSION. We don't need to update the */ \
        /* offset if this is the case, and can consider the next index. However, */ \
@@ -300,7 +300,7 @@
        /* we have parsed the entire tensor and can exit */ \
       if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       { \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \
@@ -315,7 +315,7 @@
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR->size[TH_TENSOR_DIM_APPLY_i]) \
       { \
         /* Handled TENSOR_size(dim) iterations for DIM_APPLY_i. If this is the last dimension, exit */ \
-        if(TH_TENSOR_DIM_APPLY_i == TENSOR->nDimension-1) \
+        if(TH_TENSOR_DIM_APPLY_i == TENSOR->_dim()-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
           break; \

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -17,33 +17,33 @@ ptrdiff_t THTensor_(storageOffset)(const THTensor *self)
 
 int THTensor_(nDimension)(const THTensor *self)
 {
-  return self->nDimension;
+  return self->_dim();
 }
 
 int64_t THTensor_(size)(const THTensor *self, int dim)
 {
-  THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "dimension %d out of range of %dD tensor",
+  THArgCheck((dim >= 0) && (dim < self->_dim()), 2, "dimension %d out of range of %dD tensor",
       dim+TH_INDEX_BASE, THTensor_(nDimension)(self));
   return self->size[dim];
 }
 
 int64_t THTensor_(stride)(const THTensor *self, int dim)
 {
-  THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "dimension %d out of range of %dD tensor",
+  THArgCheck((dim >= 0) && (dim < self->_dim()), 2, "dimension %d out of range of %dD tensor",
       dim+TH_INDEX_BASE, THTensor_(nDimension)(self));
   return self->stride[dim];
 }
 
 THLongStorage *THTensor_(newSizeOf)(THTensor *self)
 {
-  THLongStorage *size = THLongStorage_newWithSize(self->nDimension);
+  THLongStorage *size = THLongStorage_newWithSize(self->_dim());
   THLongStorage_rawCopy(size, self->size);
   return size;
 }
 
 THLongStorage *THTensor_(newStrideOf)(THTensor *self)
 {
-  THLongStorage *stride = THLongStorage_newWithSize(self->nDimension);
+  THLongStorage *stride = THLongStorage_newWithSize(self->_dim());
   THLongStorage_rawCopy(stride, self->stride);
   return stride;
 }
@@ -87,7 +87,7 @@ THTensor *THTensor_(newWithTensor)(THTensor *tensor)
   THTensor_(setStorageNd)(self,
                           tensor->storage,
                           tensor->storageOffset,
-                          tensor->nDimension,
+                          tensor->_dim(),
                           tensor->size,
                           tensor->stride);
   return self;
@@ -237,7 +237,7 @@ THTensor *THTensor_(newUnfold)(THTensor *tensor, int dimension_, int64_t size_, 
 //    each chunk pair has matching ``numel'', i.e., number of subspaces.
 static int THTensor_(isViewable)(THTensor *tensor, THLongStorage *view_size, THLongStorage *new_stride) {
   // dim indices
-  int64_t tensor_d = tensor->nDimension - 1;
+  int64_t tensor_d = tensor->_dim() - 1;
   if (tensor_d < 0) {
     return 1;
   }
@@ -302,7 +302,7 @@ void THTensor_(resize)(THTensor *self, THLongStorage *size, THLongStorage *strid
 void THTensor_(resizeAs)(THTensor *self, THTensor *src)
 {
   if(!THTensor_(isSameSizeAs)(self, src))
-    THTensor_(resizeNd)(self, src->nDimension, src->size, NULL);
+    THTensor_(resizeNd)(self, src->_dim(), src->size, NULL);
 }
 
 void THTensor_(resize1d)(THTensor *tensor, int64_t size0)
@@ -340,7 +340,7 @@ void THTensor_(set)(THTensor *self, THTensor *src)
     THTensor_(setStorageNd)(self,
                             src->storage,
                             src->storageOffset,
-                            src->nDimension,
+                            src->_dim(),
                             src->size,
                             src->stride);
 }
@@ -413,7 +413,7 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, int64_t fir
   if(!src)
     src = self;
 
-  THArgCheck( (dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
+  THArgCheck( (dimension >= 0) && (dimension < src->_dim()), 2, "out of range");
   THArgCheck( (firstIndex >= 0) && (firstIndex < src->size[dimension]), 3, "out of range");
   THArgCheck( (size > 0) && (firstIndex <= src->size[dimension] - size), 4, "out of range");
 
@@ -432,18 +432,18 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   if(!src)
     src = self;
 
-  THArgCheck(src->nDimension > 1, 1, "cannot select on a vector");
-  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
+  THArgCheck(src->_dim() > 1, 1, "cannot select on a vector");
+  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "out of range");
   THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 3, "out of range");
 
   THTensor_(set)(self, src);
   THTensor_(narrow)(self, NULL, dimension, sliceIndex, 1);
-  for(d = dimension; d < self->nDimension-1; d++)
+  for(d = dimension; d < self->_dim()-1; d++)
   {
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
   }
-  self->nDimension--;
+  self->dim_--;
 }
 
 void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dimension2)
@@ -453,8 +453,8 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
   if(!src)
     src = self;
 
-  THArgCheck( (dimension1 >= 0) && (dimension1 < src->nDimension), 1, "out of range");
-  THArgCheck( (dimension2 >= 0) && (dimension2 < src->nDimension), 2, "out of range");
+  THArgCheck( (dimension1 >= 0) && (dimension1 < src->_dim()), 1, "out of range");
+  THArgCheck( (dimension2 >= 0) && (dimension2 < src->_dim()), 2, "out of range");
 
   THTensor_(set)(self, src);
 
@@ -478,19 +478,19 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   if(!src)
     src = self;
 
-  THArgCheck( (src->nDimension > 0), 1, "cannot unfold an empty tensor");
-  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
+  THArgCheck( (src->_dim() > 0), 1, "cannot unfold an empty tensor");
+  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THTensor_(set)(self, src);
 
-  newSize = (int64_t *)THAlloc(sizeof(int64_t)*(self->nDimension+1));
-  newStride = (int64_t *)THAlloc(sizeof(int64_t)*(self->nDimension+1));
+  newSize = (int64_t *)THAlloc(sizeof(int64_t)*(self->_dim()+1));
+  newStride = (int64_t *)THAlloc(sizeof(int64_t)*(self->_dim()+1));
 
-  newSize[self->nDimension] = size;
-  newStride[self->nDimension] = self->stride[dimension];
-  for(d = 0; d < self->nDimension; d++)
+  newSize[self->_dim()] = size;
+  newStride[self->_dim()] = self->stride[dimension];
+  for(d = 0; d < self->_dim(); d++)
   {
     if(d == dimension)
     {
@@ -509,7 +509,7 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
 
   self->size = newSize;
   self->stride = newStride;
-  self->nDimension++;
+  self->dim_++;
 }
 
 /* we have to handle the case where the result is a number */
@@ -523,7 +523,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
 
   THTensor_(set)(self, src);
 
-  for(d = 0; d < src->nDimension; d++)
+  for(d = 0; d < src->_dim(); d++)
   {
     if(src->size[d] != 1)
     {
@@ -537,13 +537,13 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
   }
 
   /* right now, we do not handle 0-dimension tensors */
-  if(ndim == 0 && src->nDimension > 0)
+  if(ndim == 0 && src->_dim() > 0)
   {
     self->size[0] = 1;
     self->stride[0] = 1;
     ndim = 1;
   }
-  self->nDimension = ndim;
+  self->dim_ = ndim;
 }
 
 void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
@@ -553,18 +553,18 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
   if(!src)
     src = self;
 
-  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "dimension out of range");
+  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "dimension out of range");
 
   THTensor_(set)(self, src);
 
-  if(src->size[dimension] == 1 && src->nDimension > 1)
+  if(src->size[dimension] == 1 && src->_dim() > 1)
   {
-    for(d = dimension; d < self->nDimension-1; d++)
+    for(d = dimension; d < self->_dim()-1; d++)
     {
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }
-    self->nDimension--;
+    self->dim_--;
   }
 }
 
@@ -575,19 +575,19 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
   if(!src)
     src = self;
 
-  THArgCheck((dimension >= 0) && (dimension <= src->nDimension), 2, "dimension out of range");
-  THArgCheck(src->nDimension > 0, 2, "cannot unsqueeze empty tensor");
+  THArgCheck((dimension >= 0) && (dimension <= src->_dim()), 2, "dimension out of range");
+  THArgCheck(src->_dim() > 0, 2, "cannot unsqueeze empty tensor");
 
   THTensor_(set)(self, src);
 
-  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->nDimension+1));
-  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->nDimension+1));
-  self->nDimension++;
-  for (d = self->nDimension-1; d > dimension; d--) {
+  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->_dim()+1));
+  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->_dim()+1));
+  self->dim_++;
+  for (d = self->_dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];
     self->stride[d] = self->stride[d-1];
   }
-  if (dimension+1 < self->nDimension) {
+  if (dimension+1 < self->_dim()) {
     self->stride[dimension] = self->size[dimension+1] * self->stride[dimension+1];
   } else {
     self->stride[dimension] = 1;
@@ -604,7 +604,7 @@ int THTensor_(isTransposed)(const THTensor *self)
   int64_t size_max_stride = 1;
   int64_t z = 1;
   int d;
-  for (d = 0; d < self->nDimension; ++d) {
+  for (d = 0; d < self->_dim(); ++d) {
     if (self->stride[d] == 0 && self->size[d] != 1)
       return 0;
     if (self->stride[d] > max_stride) {
@@ -623,7 +623,7 @@ int THTensor_(isContiguous)(const THTensor *self)
 {
   int64_t z = 1;
   int d;
-  for(d = self->nDimension-1; d >= 0; d--)
+  for(d = self->_dim()-1; d >= 0; d--)
   {
     if(self->size[d] != 1)
     {
@@ -639,10 +639,10 @@ int THTensor_(isContiguous)(const THTensor *self)
 int THTensor_(isSize)(const THTensor *self, const THLongStorage *dims)
 {
   int d;
-  if (self->nDimension != dims->size)
+  if (self->_dim() != dims->size)
     return 0;
 
-  for(d = 0; d < self->nDimension; ++d)
+  for(d = 0; d < self->_dim(); ++d)
   {
     if(self->size[d] != THLongStorage_data(dims)[d])
       return 0;
@@ -653,9 +653,9 @@ int THTensor_(isSize)(const THTensor *self, const THLongStorage *dims)
 int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor* src)
 {
   int d;
-  if (self->nDimension != src->nDimension)
+  if (self->_dim() != src->_dim())
     return 0;
-  for(d = 0; d < self->nDimension; ++d)
+  for(d = 0; d < self->_dim(); ++d)
   {
     if(self->size[d] != src->size[d])
       return 0;
@@ -669,10 +669,10 @@ int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
     return 0;
   if (self->storage == src->storage &&
       self->storageOffset == src->storageOffset &&
-      self->nDimension == src->nDimension)
+      self->_dim() == src->_dim())
   {
     int d;
-    for (d = 0; d < self->nDimension; ++d)
+    for (d = 0; d < self->_dim(); ++d)
     {
       if (self->size[d] != src->size[d] || self->stride[d] != src->stride[d])
         return 0;
@@ -684,13 +684,13 @@ int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
 
 ptrdiff_t THTensor_(nElement)(const THTensor *self)
 {
-  if(self->nDimension == 0)
+  if(self->_dim() == 0)
     return 0;
   else
   {
     ptrdiff_t nElement = 1;
     int d;
-    for(d = 0; d < self->nDimension; d++)
+    for(d = 0; d < self->_dim(); d++)
       nElement *= self->size[d];
     return nElement;
   }
@@ -724,7 +724,7 @@ static void THTensor_(rawInit)(THTensor *self)
   self->storageOffset = 0;
   self->size = NULL;
   self->stride = NULL;
-  self->nDimension = 0;
+  self->dim_ = 0;
   self->flag = TH_TENSOR_REFCOUNTED;
 }
 
@@ -767,10 +767,10 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
     if(size[d] > 0)
     {
       nDimension_++;
-      if((self->nDimension > d) && (size[d] != self->size[d]))
+      if((self->_dim() > d) && (size[d] != self->size[d]))
         hascorrectsize = 0;
 
-      if((self->nDimension > d) && stride && (stride[d] >= 0) && (stride[d] != self->stride[d]))
+      if((self->_dim() > d) && stride && (stride[d] >= 0) && (stride[d] != self->stride[d]))
         hascorrectsize = 0;
     }
     else
@@ -778,7 +778,7 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
   }
   nDimension = nDimension_;
 
-  if(nDimension != self->nDimension)
+  if(nDimension != self->_dim())
     hascorrectsize = 0;
 
   if(hascorrectsize)
@@ -786,22 +786,22 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
 
   if(nDimension > 0)
   {
-    if(nDimension != self->nDimension)
+    if(nDimension != self->_dim())
     {
       self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t)*nDimension);
       self->stride = (int64_t *)THRealloc(self->stride, sizeof(int64_t)*nDimension);
-      self->nDimension = nDimension;
+      self->dim_ = nDimension;
     }
 
     totalSize = 1;
-    for(d = self->nDimension-1; d >= 0; d--)
+    for(d = self->_dim()-1; d >= 0; d--)
     {
       self->size[d] = size[d];
       if(stride && (stride[d] >= 0) )
         self->stride[d] = stride[d];
       else
       {
-        if(d == self->nDimension-1)
+        if(d == self->_dim()-1)
           self->stride[d] = 1;
         else
           self->stride[d] = self->size[d+1]*self->stride[d+1];
@@ -818,61 +818,61 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
     }
   }
   else
-    self->nDimension = 0;
+    self->dim_ = 0;
 }
 
 void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)
 {
-  THArgCheck(tensor->nDimension == 1, 1, "tensor must have one dimension");
+  THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
 }
 
 real THTensor_(get1d)(const THTensor *tensor, int64_t x0)
 {
-  THArgCheck(tensor->nDimension == 1, 1, "tensor must have one dimension");
+  THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
   return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]);
 }
 
 void THTensor_(set2d)(THTensor *tensor, int64_t x0, int64_t x1, real value)
 {
-  THArgCheck(tensor->nDimension == 2, 1, "tensor must have two dimensions");
+  THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
 }
 
 real THTensor_(get2d)(const THTensor *tensor, int64_t x0, int64_t x1)
 {
-  THArgCheck(tensor->nDimension == 2, 1, "tensor must have two dimensions");
+  THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
   return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]);
 }
 
 void THTensor_(set3d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
-  THArgCheck(tensor->nDimension == 3, 1, "tensor must have three dimensions");
+  THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
 }
 
 real THTensor_(get3d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
-  THArgCheck(tensor->nDimension == 3, 1, "tensor must have three dimensions");
+  THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
   return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]);
 }
 
 void THTensor_(set4d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
-  THArgCheck(tensor->nDimension == 4, 1, "tensor must have four dimensions");
+  THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
 }
 
 real THTensor_(get4d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
-  THArgCheck(tensor->nDimension == 4, 1, "tensor must have four dimensions");
+  THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");
   return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3]);
 }
@@ -886,10 +886,10 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   n += snprintf(str, L-n, "torch." _stringify(x) "Tensor of size ");
 #undef _stringify
   int i;
-  for(i = 0; i < tensor->nDimension; i++) {
+  for(i = 0; i < tensor->_dim(); i++) {
     if(n >= L) break;
     n += snprintf(str+n, L-n, "%" PRId64, tensor->size[i]);
-    if(i < tensor->nDimension-1) {
+    if(i < tensor->_dim()-1) {
       n += snprintf(str+n, L-n, "x");
     }
   }

--- a/aten/src/TH/generic/THTensorConv.cpp
+++ b/aten/src/TH/generic/THTensorConv.cpp
@@ -592,8 +592,8 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 3 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 3 , 4, "kernel: 3D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
 
@@ -698,8 +698,8 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
 
@@ -810,8 +810,8 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 3 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 3 , 4, "kernel: 3D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
   THArgCheck(*vf == 'V' || *vf == 'F', 7, "type of convolution can 'V' or 'F'");
@@ -941,8 +941,8 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
   THArgCheck(*vf == 'V' || *vf == 'F', 7, "type of convolution can 'V' or 'F'");
@@ -1079,8 +1079,8 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   real *output_data;
   int64_t p;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
   THArgCheck(*vf == 'V' || *vf == 'F', 7, "type of convolution can 'V' or 'F'");
@@ -1228,8 +1228,8 @@ void THTensor_(conv2Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   real *output_data;
   ptrdiff_t nelem;
 
-  THArgCheck(t_->nDimension == 2 , 3, "input: 2D Tensor expected");
-  THArgCheck(k_->nDimension == 2 , 4, "kernel: 2D Tensor expected");
+  THArgCheck(t_->_dim() == 2 , 3, "input: 2D Tensor expected");
+  THArgCheck(k_->_dim() == 2 , 4, "kernel: 2D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
 
@@ -1287,8 +1287,8 @@ void THTensor_(conv2Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 3 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 3 , 4, "kernel: 3D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
 
@@ -1365,9 +1365,9 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 3 , 4, "kernel: 3D Tensor expected");
-  THArgCheck(map->nDimension == 2 , 4, "map: 2D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 3 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(map->_dim() == 2 , 4, "map: 2D Tensor expected");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
 
@@ -1453,8 +1453,8 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   ptrdiff_t nelem;
   int64_t k, i;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
   THArgCheck(sdepth >= 1, 5, "Stride should be a positive integer");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
@@ -1539,8 +1539,8 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   ptrdiff_t nelem;
   int64_t k, i;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
   THArgCheck(sdepth >= 1, 5, "Stride should be a positive integer");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
@@ -1630,8 +1630,8 @@ void THTensor_(conv3Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   ptrdiff_t nelem;
   int64_t k, i;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 5 , 4, "kernel: 5D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 5 , 4, "kernel: 5D Tensor expected");
   THArgCheck(sdepth >= 1, 5, "Stride should be a positive integer");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
@@ -1725,8 +1725,8 @@ void THTensor_(conv3Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   real *output_data;
   ptrdiff_t nelem;
 
-  THArgCheck(t_->nDimension == 3 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 3 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(t_->_dim() == 3 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 3 , 4, "kernel: 3D Tensor expected");
   THArgCheck(sdepth >= 1, 5, "Stride should be a positive integer");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
@@ -1792,8 +1792,8 @@ void THTensor_(conv3Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   ptrdiff_t nelem;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 3D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 3D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 3D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 3D Tensor expected");
   THArgCheck(srow >= 1, 5, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 6, "Stride should be a positive integer");
   THArgCheck(*vf == 'V' || *vf == 'F', 7, "type of convolution can 'V' or 'F'");
@@ -1878,9 +1878,9 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   int64_t nmaps;
   int64_t k;
 
-  THArgCheck(t_->nDimension == 4 , 3, "input: 4D Tensor expected");
-  THArgCheck(k_->nDimension == 4 , 4, "kernel: 4D Tensor expected");
-  THArgCheck(map->nDimension == 2 , 4, "map: 2D Tensor expected");
+  THArgCheck(t_->_dim() == 4 , 3, "input: 4D Tensor expected");
+  THArgCheck(k_->_dim() == 4 , 4, "kernel: 4D Tensor expected");
+  THArgCheck(map->_dim() == 2 , 4, "map: 2D Tensor expected");
   THArgCheck(srow >= 1, 6, "Stride should be a positive integer");
   THArgCheck(scol >= 1, 7, "Stride should be a positive integer");
   THArgCheck(*vf == 'V' || *vf == 'F', 8, "type of convolution can 'V' or 'F'");

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -106,16 +106,16 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   int free_b = 0;
   if (a == NULL) a = ra_;
   if (b == NULL) b = rb_;
-  THArgCheck(a->nDimension == 2, 2, "A should have 2 dimensions, but has %d",
-      a->nDimension);
-  THArgCheck(b->nDimension == 1 || b->nDimension == 2, 1, "B should have 1 or 2 "
-      "dimensions, but has %d", b->nDimension);
+  THArgCheck(a->_dim() == 2, 2, "A should have 2 dimensions, but has %d",
+      a->_dim());
+  THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
+      "dimensions, but has %d", b->_dim());
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
       a->size[0], a->size[1]);
   THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
       "rows, B has %ld", a->size[0], b->size[0]);
 
-  if (b->nDimension == 1) {
+  if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
             b->stride[0], 1, 0);
     free_b = 1;
@@ -159,16 +159,16 @@ void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,
   int free_b = 0;
   if (a == NULL) a = ra_;
   if (b == NULL) b = rb_;
-  THArgCheck(a->nDimension == 2, 2, "A should have 2 dimensions, but has %d",
-      a->nDimension);
-  THArgCheck(b->nDimension == 1 || b->nDimension == 2, 1, "B should have 1 or 2 "
-      "dimensions, but has %d", b->nDimension);
+  THArgCheck(a->_dim() == 2, 2, "A should have 2 dimensions, but has %d",
+      a->_dim());
+  THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
+      "dimensions, but has %d", b->_dim());
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
       a->size[0], a->size[1]);
   THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
       "rows, B has %ld", a->size[0], b->size[0]);
 
-  if (b->nDimension == 1) {
+  if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
             b->stride[0], 1, 0);
     free_b = 1;
@@ -209,14 +209,14 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   // Note that a = NULL is interpreted as a = ra_, and b = NULL as b = rb_.
   if (a == NULL) a = ra_;
   if (b == NULL) b = rb_;
-  THArgCheck(a->nDimension == 2, 2, "A should have 2 dimensions, but has %d",
-      a->nDimension);
-  THArgCheck(b->nDimension == 1 || b->nDimension == 2, 1, "B should have 1 or 2 "
-      "dimensions, but has %d", b->nDimension);
+  THArgCheck(a->_dim() == 2, 2, "A should have 2 dimensions, but has %d",
+      a->_dim());
+  THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
+      "dimensions, but has %d", b->_dim());
   THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
       "rows, B has %ld", a->size[0], b->size[0]);
 
-  if (b->nDimension == 1) {
+  if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
             b->stride[0], 1, 0);
     free_b = 1;
@@ -285,7 +285,7 @@ void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *job
   THTensor *re__ = NULL;
   THTensor *rv__ = NULL;
 
-  THArgCheck(a_->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a_->size[0] == a_->size[1], 1,"A should be square");
 
   /* we want to definitely clone a_ for geev*/
@@ -355,7 +355,7 @@ void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *job
 void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz, const char *uplo)
 {
   if (a == NULL) a = rv_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1,"A should be square");
 
   int n, lda, lwork, info;
@@ -407,7 +407,7 @@ void THTensor_(gesvd)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *a, 
 void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra_, THTensor *a, const char* jobu)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
 
   int k,m, n, lda, ldu, ldvt, lwork, info;
   THTensor *work;
@@ -489,7 +489,7 @@ void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra
 void THTensor_(getri)(THTensor *ra_, THTensor *a)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int m, n, lda, info, lwork;
@@ -532,7 +532,7 @@ void THTensor_(getri)(THTensor *ra_, THTensor *a)
 
 void THTensor_(clearUpLoTriangle)(THTensor *a, const char *uplo)
 {
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int n = a->size[0];
@@ -565,7 +565,7 @@ void THTensor_(clearUpLoTriangle)(THTensor *a, const char *uplo)
 
 void THTensor_(copyUpLoTriangle)(THTensor *a, const char *uplo)
 {
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int n = a->size[0];
@@ -599,7 +599,7 @@ void THTensor_(copyUpLoTriangle)(THTensor *a, const char *uplo)
 void THTensor_(potrf)(THTensor *ra_, THTensor *a, const char *uplo)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int n, lda, info;
@@ -625,16 +625,16 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
   int free_b = 0;
   if (b == NULL) b = rb_;
 
-  THArgCheck(a->nDimension == 2, 2, "A should have 2 dimensions, but has %d",
-      a->nDimension);
-  THArgCheck(b->nDimension == 1 || b->nDimension == 2, 1, "B should have 1 or 2 "
-      "dimensions, but has %d", b->nDimension);
+  THArgCheck(a->_dim() == 2, 2, "A should have 2 dimensions, but has %d",
+      a->_dim());
+  THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
+      "dimensions, but has %d", b->_dim());
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
       a->size[0], a->size[1]);
   THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
       "rows, B has %ld", a->size[0], b->size[0]);
 
-  if (b->nDimension == 1) {
+  if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
             b->stride[0], 1, 0);
     free_b = 1;
@@ -671,7 +671,7 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
 void THTensor_(potri)(THTensor *ra_, THTensor *a, const char *uplo)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int n, lda, info;
@@ -709,7 +709,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, const char *uplo)
               The algorithm terminates when the pivot <= tol.
  */
 void THTensor_(pstrf)(THTensor *ra_, THIntTensor *rpiv_, THTensor *a, const char *uplo, real tol) {
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
 
   int n = a->size[0];
@@ -795,7 +795,7 @@ void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a)
 void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
 {
   if (a == NULL) ra_ = a;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
 
   THTensor *ra__ = NULL;
 
@@ -851,7 +851,7 @@ void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
 void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
@@ -904,7 +904,7 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, const char *side, const char *trans)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(a->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, c);
@@ -1041,7 +1041,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
 
   int64_t num_batches = atf->size[0];
   int64_t n = atf->size[1];
-  int nrhs = rb_->nDimension > 2 ? rb_->size[2] : 1;
+  int nrhs = rb_->_dim() > 2 ? rb_->size[2] : 1;
 
   int lda, ldb;
   THTensor *atf_;
@@ -1067,7 +1067,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
   // correct ordering of B
   if (rb_->stride[1] == 1) {
     // column ordered
-    if (rb_->nDimension == 2 || rb_->size[2] == 1) {
+    if (rb_->_dim() == 2 || rb_->size[2] == 1) {
       ldb = n;
     } else {
       ldb = rb_->stride[2];
@@ -1075,7 +1075,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
     rb__ = rb_;
   } else {
     // make column ordered
-    if (rb_->nDimension > 2) {
+    if (rb_->_dim() > 2) {
       THTensor *transp_r_ = THTensor_(newTranspose)(rb_, 1, 2);
       rb__ = THTensor_(newClone)(transp_r_);
       THTensor_(free)(transp_r_);

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -79,7 +79,7 @@ void THTensor_(iBernoulli_generate_copy)(THTensor *self, THGenerator *_generator
 #endif
   } else {
     intTensor = THIntTensor_new();
-    THIntTensor_resizeNd(intTensor, self->nDimension, self->size, NULL);
+    THIntTensor_resizeNd(intTensor, self->_dim(), self->size, NULL);
     tmp = THIntTensor_data(intTensor);
   }
 

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -13,7 +13,7 @@ typedef struct THCTensor
 {
     int64_t *size;
     int64_t *stride;
-    int nDimension;
+    int64_t dim_;
 
     THCStorage *storage;
     ptrdiff_t storageOffset;
@@ -29,6 +29,12 @@ typedef struct THCTensor
     template <typename T>
     inline T * unsafe_data() const {
       return storage->unsafe_data<T>() + storageOffset;
+    }
+
+    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    inline int64_t _dim() const {
+      return dim_;
     }
 } THCTensor;
 

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -224,10 +224,10 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THArgCheck(!(THCTensor_(nDimension)(state, src) == 0 && THCudaLongTensor_nDimension(state, index) != 0), 2,
              "tried to take from an empty tensor");
 
-  THCTensor_(resizeNd)(state, dst, index->nDimension, index->size, NULL);
+  THCTensor_(resizeNd)(state, dst, index->_dim(), index->size, NULL);
 
   // dispatchTakePut only handles non-empty tensors;
-  if (index->nDimension > 0) {
+  if (index->_dim() > 0) {
     dispatchTakePut<real, TensorTakeOp>(state, src, dst, index);
   }
 }

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -424,7 +424,7 @@ void THCTensor_(eye)(THCState *state, THCTensor *self_, int64_t n, int64_t m)
 
 accreal THCTensor_(trace)(THCState *state, THCTensor *src_) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, src_));
-  THArgCheck((src_->nDimension == 2), 1, "expected a matrix");
+  THArgCheck((src_->_dim() == 2), 1, "expected a matrix");
   THCTensor *diag = THCTensor_(new)(state);
   THCTensor_(diag)(state, diag, src_, 0);
   accreal trace = THCTensor_(sumall)(state, diag);

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -49,13 +49,13 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 {
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, mat, vec));
-  if( (mat->nDimension != 2) || (vec->nDimension != 1) )
+  if( (mat->_dim() != 2) || (vec->_dim() != 1) )
     THError("matrix and vector expected");
 
   if( mat->size[1] != vec->size[0] )
     THError("size mismatch");
 
-  if(t->nDimension != 1)
+  if(t->_dim() != 1)
     THError("size mismatch");
 
   if(t->size[0] != mat->size[0])
@@ -140,11 +140,11 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
 {
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, vec1, vec2));
-  if ( (vec1->nDimension != 1) || (vec2->nDimension != 1) ) {
+  if ( (vec1->_dim() != 1) || (vec2->_dim() != 1) ) {
     THError("vector and vector expected");
   }
 
-  if (t->nDimension != 2) {
+  if (t->_dim() != 2) {
     THError("size mismatch");
   }
 
@@ -237,11 +237,11 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   char transpose_r, transpose_m1, transpose_m2;
   THCTensor *r__, *m1_, *m2_;
 
-  if( (m1->nDimension != 2) || (m2->nDimension != 2) )
-    THError("matrices expected, got %dD, %dD tensors", m1->nDimension, m2->nDimension);
+  if( (m1->_dim() != 2) || (m2->_dim() != 2) )
+    THError("matrices expected, got %dD, %dD tensors", m1->_dim(), m2->_dim());
 
-  if(t->nDimension != 2)
-    THError("matrix expected, got %dD tensor for t", t->nDimension);
+  if(t->_dim() != 2)
+    THError("matrix expected, got %dD tensor for t", t->_dim());
 
   if(m1->size[1] != m2->size[0]) {
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
@@ -850,7 +850,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
 
 
   int n = atf->size[1];
-  int nrhs = rb_->nDimension > 2 ? rb_->size[2] : 1;
+  int nrhs = rb_->_dim() > 2 ? rb_->size[2] : 1;
   THCTensor *atf_;
   THCTensor *rb__;
   int lda, ldb;
@@ -875,7 +875,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   // correct ordering of B
   if (rb_->stride[1] == 1) {
     // column ordered
-    if (rb_->nDimension == 2 || rb_->size[2] == 1) {
+    if (rb_->_dim() == 2 || rb_->size[2] == 1) {
       ldb = n;
     } else {
       ldb = rb_->stride[2];
@@ -883,7 +883,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
     rb__ = rb_;
   } else {
     // make column ordered
-    if (rb_->nDimension > 2) {
+    if (rb_->_dim() > 2) {
       THCTensor *transp_r_ = THCTensor_(newTranspose)(state, rb_, 1, 2);
       rb__ = THCTensor_(newClone)(state, transp_r_);
       THCTensor_(free)(state, transp_r_);

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -26,7 +26,7 @@ static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src,
 
 static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self)
 {
-  THAssert(self->nDimension == 2);
+  THAssert(self->_dim() == 2);
   size_t len = THCTensor_(nElement)(state, self)*sizeof(real);
   THCTensor *temp = THCTensor_(newTranspose)(state, self, 0, 1);
   THCTensor *selfc = THCTensor_(newContiguous)(state, temp);
@@ -39,7 +39,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
 
 static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, THCTensor *src)
 {
-  THAssert(src->nDimension == 2);
+  THAssert(src->_dim() == 2);
   if (self == src && self->stride[0] == 1 && self->stride[1] == self->size[0])
   {
     THCTensor_(retain)(state, self);
@@ -63,8 +63,8 @@ static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, T
 THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 1, "A should be 2 dimensional");
-  THArgCheck(b_->nDimension == 2, 2, "b should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 1, "A should be 2 dimensional");
+  THArgCheck(b_->_dim() == 2, 2, "b should be 2 dimensional");
   THArgCheck(a_->size[0] == a_->size[1], 1, "A should be square");
   THArgCheck(b_->size[0] == a_->size[0], 2, "A,b size incompatible");
 
@@ -102,8 +102,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
                                const char *uplo, const char *trans, const char *diag)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 1, "A should be 2 dimensional");
-  THArgCheck(b_->nDimension == 2, 2, "b should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 1, "A should be 2 dimensional");
+  THArgCheck(b_->_dim() == 2, 2, "b should be 2 dimensional");
   THArgCheck(a_->size[0] == a_->size[1], 1, "A should be square");
   THArgCheck(b_->size[0] == a_->size[0], 2, "A,b size incompatible");
 
@@ -138,8 +138,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
 THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 1, "A should be 2 dimensional");
-  THArgCheck(b_->nDimension == 2, 1, "b should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 1, "A should be 2 dimensional");
+  THArgCheck(b_->_dim() == 2, 1, "b should be 2 dimensional");
   THArgCheck(a_->size[0] == b_->size[0], 2, "Expected A and b to have same size "
       "at dim 0, but they have incompatible sizes");
   THArgCheck(a_->size[0] >= a_->size[1], 2, "Expected A with shape (m x n) to have "
@@ -243,7 +243,7 @@ THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
 THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a_, const char *jobvrs)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 3, "A should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 3, "A should be 2 dimensional");
   THArgCheck(a_->size[0] == a_->size[1], 3, "A should be square");
 
   magma_vec_t jobvr = jobvrs[0] == 'N' ? MagmaNoVec : MagmaVec;
@@ -323,7 +323,7 @@ THC_API void THCTensor_(gesvd)(THCState *state, THCTensor *ru_, THCTensor *rs_, 
 THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_, THCTensor *rv_, THCTensor *ra_, THCTensor *a, const char *jobus)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 2, "A should be 2 dimensional");
 
   magma_vec_t jobz = jobus[0] == 'A' ? MagmaAllVec : jobus[0] == 'S' ? MagmaSomeVec : jobus[0] == 'O' ? MagmaOverwriteVec : MagmaNoVec;
 
@@ -386,7 +386,7 @@ THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_,
 
 THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 {
-  THArgCheck(a->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 2, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
 
 #ifdef USE_MAGMA
@@ -518,7 +518,7 @@ __global__ void THCTensor_(copyLowerSymmetric)(real *input, int n, int len)
 THC_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, const char *uplo)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 2, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
 
   int64_t n = a->size[0];
@@ -558,7 +558,7 @@ THC_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, co
 THC_API void THCTensor_(potrf)(THCState *state, THCTensor *ra_, THCTensor *a, const char *uplo)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a->_dim() == 2, 2, "A should be 2 dimensional");
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
 
   int64_t n = a->size[0];
@@ -626,7 +626,7 @@ THC_API void THCTensor_(potrs)(THCState *state, THCTensor *rb_, THCTensor *b, TH
 THC_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_, THCTensor *a_)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 2, "A should be 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
   int64_t m = a->size[0];
@@ -663,7 +663,7 @@ THC_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_
 THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THCTensor *a_)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a_->nDimension == 2, 2, "A should be 2 dimensional");
+  THArgCheck(a_->_dim() == 2, 2, "A should be 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, rr_, a_);
   int64_t m = a->size[0];

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -191,7 +191,7 @@ THCTensor_(remainder)(THCState *state, THCTensor *self_, THCTensor *src_, real v
 void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_t k)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
-  THArgCheck(src_->nDimension == 2, 1, "expected a matrix");
+  THArgCheck(src_->_dim() == 2, 1, "expected a matrix");
 
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);
@@ -220,7 +220,7 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
 void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_t k)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
-  THArgCheck(src_->nDimension == 2, 1, "expected a matrix");
+  THArgCheck(src_->_dim() == 2, 1, "expected a matrix");
 
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -329,7 +329,7 @@ THC_API accreal
 THCTensor_(meanall)(THCState *state, THCTensor *self)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
-  THArgCheck(self->nDimension > 0, 1, "empty Tensor");
+  THArgCheck(self->_dim() > 0, 1, "empty Tensor");
   return THCTensor_(sumall)(state, self)/THCTensor_(nElement)(state, self);
 }
 

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -313,9 +313,9 @@ int THCSTensor_(isSameSizeAs)(THCState *state, const THCSTensor *self, const THC
 
 int THCSTensor_(isSameSizeAsDense)(THCState *state, const THCSTensor *self, const THCTensor* src)
 {
-  if (self->nDimensionI + self->nDimensionV != src->nDimension)
+  if (self->nDimensionI + self->nDimensionV != src->_dim())
     return 0;
-  for(int d = 0; d < src->nDimension; ++d) {
+  for(int d = 0; d < src->_dim(); ++d) {
     if(self->size[d] != src->size[d]) {
       return 0;
     }

--- a/aten/src/THCS/generic/THCSTensor.cu
+++ b/aten/src/THCS/generic/THCSTensor.cu
@@ -100,7 +100,7 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
 
   THCIndexTensor_(resize2d)(state, indices1D, 1, newNnz);
   THCTensor *newValues = THCTensor_(new)(state);
-  THCTensor_(resizeNd)(state, newValues, values->nDimension, values->size, NULL);
+  THCTensor_(resizeNd)(state, newValues, values->_dim(), values->size, NULL);
   newValues->size[0] = newNnz;
 
 

--- a/aten/src/THCS/generic/THCSTensor.hpp
+++ b/aten/src/THCS/generic/THCSTensor.hpp
@@ -19,6 +19,11 @@ typedef struct THCSTensor
     int coalesced;
     std::atomic<int> refcount;
 
+    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    inline int64_t _dim() const {
+      return nDimensionI + nDimensionV;
+    }
 } THCSTensor;
 
 #endif

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -24,10 +24,10 @@ THCudaIntTensor *THCSTensor_(toCSR)(THCState *state, THCIndexTensor *rowIndices,
 }
 
 void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
-  if (self->indices->nDimension) {
+  if (self->indices->_dim()) {
     THCIndexTensor_(resizeNd)(state, self->indices, 0, NULL, NULL);
   }
-  if (self->values->nDimension) {
+  if (self->values->_dim()) {
     THCTensor_(resizeNd)(state, self->values, 0, NULL, NULL);
   }
   self->nnz = 0;
@@ -66,8 +66,8 @@ void THCSTensor_(spaddmm)(THCState *state, THCTensor *r_, real beta, THCTensor *
       "matrices expected, got %dD tensor", sparse_->nDimensionI);
   THArgCheck(sparse_->nDimensionV == 0, 2,
       "scalar values expected, got %dD values", sparse_->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 2,
-      "matrices expected, got %dD tensor", dense->nDimension);
+  THArgCheck(dense->_dim() == 2, 2,
+      "matrices expected, got %dD tensor", dense->_dim());
 
   int64_t m = THCSTensor_(size)(state, sparse_, 0);
   int64_t k = THCSTensor_(size)(state, sparse_, 1);
@@ -186,8 +186,8 @@ void THCSTensor_(hspmm)(THCState *state, THCSTensor *r_, real alpha, THCSTensor 
       "matrices expected, got %dD tensor", sparse_->nDimensionI);
   THArgCheck(sparse_->nDimensionV == 0, 3,
       "scalar values expected, got %dD values", sparse_->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 4,
-      "matrices expected, got %dD tensor", dense->nDimension);
+  THArgCheck(dense->_dim() == 2, 4,
+      "matrices expected, got %dD tensor", dense->_dim());
 
   int64_t m = THCSTensor_(size)(state, sparse_, 0);
   int64_t k = THCSTensor_(size)(state, sparse_, 1);

--- a/aten/src/THCUNN/generic/Col2Im.cu
+++ b/aten/src/THCUNN/generic/Col2Im.cu
@@ -50,7 +50,7 @@ void THNN_(Col2Im_updateOutput)(
                            kH, kW, dH, dW, padH, padW, sH, sW);
 
   bool batched_input = true;
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
       // Force batch
       batched_input = false;
       THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);

--- a/aten/src/THCUNN/generic/Im2Col.cu
+++ b/aten/src/THCUNN/generic/Im2Col.cu
@@ -56,7 +56,7 @@ void THNN_(Im2Col_updateOutput)(
 
   input = THCTensor_(newContiguous)(state, input);
   bool batched_input = true;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     batched_input = false;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
   }

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -17,10 +17,10 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   istarget = THCTensor_(newContiguous)(state, istarget);
   THCTensor_(resizeAs)(state, istarget, input);
 
-  if(input->nDimension == 1)
+  if(input->_dim() == 1)
   {
     int dim = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
         "inconsistent target size");
     THCTensor_(resize1d)(state, output, 1);
 
@@ -38,11 +38,11 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
         );
     THCudaCheck(cudaGetLastError());
   }
-  else if(input->nDimension == 2)
+  else if(input->_dim() == 2)
   {
     int nframe = input->size[0];
     int dim = input->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
                && (target->size[1] == dim), 3, "inconsistent target size");
 
     dim3 blocks(input->size[0]);
@@ -106,12 +106,12 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   THCTensor_(resizeAs)(state, gradInput, input);
 
-  if(gradInput->nDimension == 1)
+  if(gradInput->_dim() == 1)
   {
     int dim = gradInput->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
                "inconsistent target size");
-    THArgCheck((istarget->nDimension == 1) && (istarget->size[0] == dim), 3,
+    THArgCheck((istarget->_dim() == 1) && (istarget->size[0] == dim), 3,
                "inconsistent isTarget size");
     dim3 blocks(1);
     dim3 threads(MULTILABELMARGIN_THREADS);
@@ -128,13 +128,13 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         reduce);
 
   }
-  else if(gradInput->nDimension == 2)
+  else if(gradInput->_dim() == 2)
   {
     int nframe = gradInput->size[0];
     int dim = gradInput->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
                && (target->size[1] == dim), 3, "inconsistent target size");
-    THArgCheck((istarget->nDimension == 2) && (istarget->size[0] == nframe)
+    THArgCheck((istarget->_dim() == 2) && (istarget->size[0] == nframe)
                && (istarget->size[1] == dim), 3, "inconsistent isTarget size");
     dim3 blocks(gradInput->size[0]);
     dim3 threads(MULTILABELMARGIN_THREADS);

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -19,7 +19,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   input = THCTensor_(newContiguous)(state, input);
   if(weights)
     weights = THCTensor_(newContiguous)(state, weights);
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     dim3 blocks(1);
     dim3 threads(MULTIMARGIN_THREADS);
@@ -50,10 +50,10 @@ void THNN_(MultiMarginCriterion_updateOutput)(
     }
     THCudaCheck(cudaGetLastError());
   }
-  else if (input->nDimension == 2)
+  else if (input->_dim() == 2)
   {
     int nframe = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
                "inconsistent target size");
     dim3 blocks(input->size[0]);
     dim3 threads(MULTIMARGIN_THREADS);
@@ -151,7 +151,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   if(weights)
     weights = THCTensor_(newContiguous)(state, weights);
 
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     dim3 blocks(1);
     dim3 threads(MULTIMARGIN_THREADS);
@@ -186,10 +186,10 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   }
-  else if (input->nDimension == 2)
+  else if (input->_dim() == 2)
   {
     int nframe = gradInput->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
                "inconsistent target size");
     dim3 blocks(gradInput->size[0]);
     dim3 threads(MULTIMARGIN_THREADS);

--- a/aten/src/THCUNN/generic/SparseLinear.cu
+++ b/aten/src/THCUNN/generic/SparseLinear.cu
@@ -4,17 +4,17 @@
 
 static bool THNN_(checkInput)(THCTensor* t)
 {
-  return t->nDimension == 2 && t->size[1] == 3;
+  return t->_dim() == 2 && t->size[1] == 3;
 }
 
 static bool THNN_(checkSize2D)(THCTensor* t, int64_t size0, int64_t size1)
 {
-  return t->nDimension == 2 && t->size[0] == size0 && t->size[1] == size1;
+  return t->_dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
 }
 
 static bool THNN_(checkSize1D)(THCTensor* t, int64_t size0)
 {
-  return t->nDimension == 1 && t->size[0] == size0;
+  return t->_dim() == 1 && t->size[0] == size0;
 }
 
 static inline void THNN_(copyCudaFloatingType)(THCState *state, THCudaIntTensor *buf, THCTensor *t) {

--- a/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
@@ -18,10 +18,10 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   real *output_data;
   real *input_data;
 
-  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t sizeD  = input->size[0];
     int64_t isizeH = input->size[1];
     int64_t isizeW = input->size[2];
@@ -94,7 +94,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t sizeD  = input->size[0];
     int64_t isizeH = input->size[1];
     int64_t isizeW = input->size[2];

--- a/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -20,10 +20,10 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   real *output_data;
   real *input_data;
 
-  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t sizeD  = input->size[0];
     int64_t isizeH = input->size[1];
     int64_t isizeW = input->size[2];
@@ -106,7 +106,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t sizeD  = input->size[0];
     int64_t isizeH = input->size[1];
     int64_t isizeW = input->size[2];

--- a/aten/src/THCUNN/generic/SpatialAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAveragePooling.cu
@@ -14,7 +14,7 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -87,7 +87,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
   int64_t nOutputCols, nOutputRows;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputCols = input->size[2];
     nInputRows = input->size[1];
     nInputPlane = input->size[0];
@@ -142,7 +142,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
         kH, kW, dH, dW, padH, padW, output_data);
   THCudaCheck(cudaGetLastError());
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
     THCTensor_(resize3d)(state, output, nInputPlane, nOutputRows, nOutputCols);
 
   THCTensor_(free)(state, input);
@@ -173,7 +173,7 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
   int dimCol = 2;
   int dimRow = 1;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputPlane = input->size[0];
     batchSize = 1;
   }
@@ -205,8 +205,8 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
       --nOutputCols;
   }
 
-  THCUNN_check_dim_size(state, gradOutput, input->nDimension, dimRow, nOutputRows);
-  THCUNN_check_dim_size(state, gradOutput, input->nDimension, dimCol, nOutputCols);
+  THCUNN_check_dim_size(state, gradOutput, input->_dim(), dimRow, nOutputRows);
+  THCUNN_check_dim_size(state, gradOutput, input->_dim(), dimCol, nOutputCols);
   THCTensor_(resizeAs)(state, gradInput, input);
 
   int count = THCTensor_(nElement)(state, input);

--- a/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -16,7 +16,7 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -53,9 +53,9 @@ static THCTensor* THNN_(view_weight_local)(
                  THCTensor *_weight)
 {
   THCTensor *weight = THCTensor_(newContiguous)(state, _weight);
-  THArgCheck(weight->nDimension == 3 || weight->nDimension == 6, 4,
-            "weight tensor should be 3D or 6D - got %dD", weight->nDimension);
-  if (weight->nDimension == 6) {
+  THArgCheck(weight->_dim() == 3 || weight->_dim() == 6, 4,
+            "weight tensor should be 3D or 6D - got %dD", weight->_dim());
+  if (weight->_dim() == 6) {
     int64_t s1 = weight->size[0] * weight->size[1];
     int64_t s2 = weight->size[2];
     int64_t s3 = weight->size[3] * weight->size[4] * weight->size[5];
@@ -98,7 +98,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   int64_t nOutputPlane = THCTensor_(size)(state,weight,1);
 
   int batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     batch = 0;
     THCTensor_(resize4d)(state, input, 1, nInputPlane, inputHeight, inputWidth);
@@ -211,7 +211,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   int64_t nOutputPlane = THCTensor_(size)(state,weight,1);
 
   int batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     batch = 0;
     THCTensor_(resize4d)(state, input, 1, nInputPlane, inputHeight, inputWidth);
@@ -331,7 +331,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   int64_t nOutputPlane = THCTensor_(size)(state,gradWeight,1);
 
   int batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     batch = 0;
     THCTensor_(resize4d)(state, input, 1, nInputPlane, inputHeight, inputWidth);

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -14,7 +14,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+    THCUNN_argCheck(state, weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
                     "2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -60,7 +60,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (weight != NULL) {
     int64_t nInputPlane = weight->size[1];
-    if (weight->nDimension == 2) {
+    if (weight->_dim() == 2) {
       nInputPlane /= (kH * kW);
     }
     THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
@@ -103,10 +103,10 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   int freeWeight = 0;
 
   // Params:
-  int nInputPlane = weight->nDimension == 2 ? weight->size[1]/(kH*kW) : weight->size[1];
+  int nInputPlane = weight->_dim() == 2 ? weight->size[1]/(kH*kW) : weight->size[1];
   int nOutputPlane = weight->size[0];
 
-  if (weight->nDimension == 4) {
+  if (weight->_dim() == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
@@ -118,7 +118,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
 
   input = THCTensor_(newContiguous)(state, input);
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -141,7 +141,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -257,11 +257,11 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
        (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, 0);
 
   // Params
-  int nInputPlane = weight->nDimension == 2 ? weight->size[1]/(kW*kH) : weight->size[1];
+  int nInputPlane = weight->_dim() == 2 ? weight->size[1]/(kW*kH) : weight->size[1];
   int nOutputPlane = weight->size[0];
 
   int freeWeight = 0;
-  if (weight->nDimension == 4) {
+  if (weight->_dim() == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
@@ -272,7 +272,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -384,7 +384,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -395,7 +395,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   int64_t nOutputPlane = gradOutput->size[1];
 
   int freeWeight = 0;
-  if (gradWeight && gradWeight->nDimension == 4) {
+  if (gradWeight && gradWeight->_dim() == 4) {
     int64_t s1 = gradWeight->size[0];
     int64_t s2 = gradWeight->size[1] * gradWeight->size[2] * gradWeight->size[3];
     gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storageOffset, s1, -1, s2, -1);
@@ -411,7 +411,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
+++ b/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
@@ -17,7 +17,7 @@ void THNN_(LRNforward)(THCState* state, THCTensor* input, THCTensor* output,
   int imsize_h;
   int imsize_w;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     batchSize = 1;
     nInputPlane = input->size[0];
     imsize_h = input->size[1];
@@ -62,7 +62,7 @@ void THNN_(LRNbackward)(THCState* state, THCTensor* input, THCTensor* output,
   int imsize_h;
   int imsize_w;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     batchSize = 1;
     nInputPlane = input->size[0];
     imsize_h = input->size[1];

--- a/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
@@ -17,7 +17,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
              dilationH, dilationW);
 
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 4, 4, weight,
+    THCUNN_argCheck(state, weight->_dim() == 4, 4, weight,
                     "4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
                   "but got: %s");
     if (bias != NULL) {
@@ -27,7 +27,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-   int ndim = input->nDimension;
+   int ndim = input->_dim();
    int dimf = 0;
    int dimh = 1;
    int dimw = 2;
@@ -102,7 +102,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   bias = bias ? THCTensor_(newContiguous)(state, bias) : bias;
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -125,7 +125,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -248,7 +248,7 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -364,7 +364,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -382,7 +382,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -18,7 +18,7 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than zero, but got dilationH: %d dilationW: %d",
              dilationH, dilationW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -101,7 +101,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
   int64_t nOutputCols, nOutputRows;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputCols = input->size[2];
     nInputRows = input->size[1];
     nInputPlane = input->size[0];
@@ -151,7 +151,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
       kH, kW, dH, dW, padH, padW, dilationH, dilationW, output_data, indices_data);
   THCudaCheck(cudaGetLastError());
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
     THCTensor_(resize3d)(state, output, nInputPlane, nOutputRows, nOutputCols);
 
   THCTensor_(free)(state, input);
@@ -180,7 +180,7 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
   int64_t nOutputCols, nOutputRows;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputCols = input->size[2];
     nInputRows = input->size[1];
     nInputPlane = input->size[0];

--- a/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
@@ -21,7 +21,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
              adjH, adjW, dH, dW, dilationH, dilationW);
 
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+    THCUNN_argCheck(state, weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
                     "2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THCUNN_check_dim_size(state, bias, 1, 0, weight->size[1]);
@@ -30,7 +30,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -102,7 +102,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -125,7 +125,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -241,7 +241,7 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -368,7 +368,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
@@ -384,7 +384,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
@@ -10,13 +10,13 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
            int owidth, int oheight)
 {
   THCUNN_assertSameGPU(state, 3, input, output, indices);
-  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s");
   THCUNN_check_shape_indices(state, indices, input);
 
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputCols = input->size[2];
     nInputRows = input->size[1];
     nInputPlane = input->size[0];
@@ -42,7 +42,7 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
       batchSize, nInputPlane, nInputRows, nInputCols, oheight, owidth, THCTensor_(data)(state, output));
   THCudaCheck(cudaGetLastError());
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
     THCTensor_(resize3d)(state, output, nInputPlane, oheight, owidth);
 
   THCTensor_(free)(state, input);
@@ -64,7 +64,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   int dimw = 2;
   int dimh = 1;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     nInputPlane = input->size[0];
     batchSize = 1;
   }

--- a/aten/src/THCUNN/generic/SpatialSubSampling.cu
+++ b/aten/src/THCUNN/generic/SpatialSubSampling.cu
@@ -10,7 +10,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
                          THCTensor *gradOutput,
                          THCTensor *weight,
                          int kW, int kH) {
-  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
 
   int nInputPlane = THCTensor_(size)(state, weight, 0);
@@ -19,7 +19,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
   int dimr = 1;
   int dimp = 0;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     dimc++;
     dimr++;
     dimp++;
@@ -50,7 +50,7 @@ void THNN_(SpatialSubSampling_updateOutput)(
   THCUNN_assertSameGPU(state, 4, input, output, weight, bias);
   THNN_(SpatialSubSampling_shapeCheck)(state, input, NULL, weight, kW, kH);
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t nInputCols = input->size[2];
     int64_t nInputRows = input->size[1];
     int64_t nOutputCols = (nInputCols - kW) / dW + 1;
@@ -118,7 +118,7 @@ void THNN_(SpatialSubSampling_updateGradInput)(
 
   int nInputPlane = THCTensor_(size)(state, weight, 0);
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t nInputCols = input->size[2];
     int64_t nInputRows = input->size[1];
 
@@ -198,7 +198,7 @@ void THNN_(SpatialSubSampling_accGradParameters)(
 
   int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int64_t nInputCols = input->size[2];
     int64_t nInputRows = input->size[1];
 

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -16,7 +16,7 @@ static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
              " but got input (H: %d, W: %d) output (H: %d, W: %d)",
              inputHeight, inputWidth, outputHeight, outputWidth);
   if (input != NULL) {
-     THCUNN_argCheck(state, input->nDimension == 4, 2, input,
+     THCUNN_argCheck(state, input->_dim() == 4, 2, input,
                      "4D input tensor expected but got: %s");
   }
 

--- a/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
@@ -10,9 +10,9 @@ static inline void THNN_(SpatialUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
              "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int nChannels    = THCTensor_(size)(state, input, 0);
     int inputHeight  = THCTensor_(size)(state, input, 1);
     int inputWidth   = THCTensor_(size)(state, input, 2);
@@ -49,12 +49,12 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THNN_(SpatialUpSamplingNearest_shapeCheck)(state, input, NULL, scale_factor);
-  int inputHeight = THCTensor_(size)(state, input, input->nDimension-2);
-  int inputWidth  = THCTensor_(size)(state, input,  input->nDimension-1);
+  int inputHeight = THCTensor_(size)(state, input, input->_dim()-2);
+  int inputWidth  = THCTensor_(size)(state, input,  input->_dim()-1);
   int outputHeight = inputHeight * scale_factor;
   int outputWidth = inputWidth * scale_factor;
 
-   if (input->nDimension == 3) {
+   if (input->_dim() == 3) {
      THCTensor_(resize3d)(state, output,
                           THCTensor_(size)(state, input, 0),
                           outputHeight, outputWidth);
@@ -68,7 +68,7 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
   input = THCTensor_(newContiguous)(state, input);
   // This is for allocating output Tensor
   int64_t no_elements = 1;
-  for(int i = 0; i < input->nDimension; i++){
+  for(int i = 0; i < input->_dim(); i++){
     no_elements *= input->size[i];
   }
   no_elements *= scale_factor * scale_factor;
@@ -77,7 +77,7 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
   int d2;
   int d3;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     d1 = output->size[0];
     d2 = output->size[1];
     d3 = output->size[2];
@@ -130,7 +130,7 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
   real *gradOutput_data = THCTensor_(data)(state, gradOutput);
 
   int64_t no_elements = 1;
-  for(int i = 0; i < gradInput->nDimension; i++){
+  for(int i = 0; i < gradInput->_dim(); i++){
     no_elements *= gradInput->size[i];
   }
 
@@ -138,7 +138,7 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
   int d2;
   int d3;
 
-  if (gradInput->nDimension == 3) {
+  if (gradInput->_dim() == 3) {
     d1 = gradInput->size[0];
     d2 = gradInput->size[1];
     d3 = gradInput->size[2];

--- a/aten/src/THCUNN/generic/TemporalConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalConvolution.cu
@@ -17,12 +17,12 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
     dimF = 2;
   }
-  THCUNN_argCheck(state, input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 2 || input->_dim() == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
     THArgCheck(input->size[dimF] == *inputFrameSize, 2,
@@ -56,7 +56,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   THArgCheck(THCTensor_(isContiguous)(state, weight), 4, "weight must be contiguous");
   THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5, "bias must be contiguous");
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
   }
@@ -68,7 +68,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   nInputFrame = input->size[dimS];
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     THCTensor_(resize2d)(state, output,
                           nOutputFrame,
@@ -189,7 +189,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THNN_(TemporalConvolution_shapeCheck)
        (state, input, kW, dW, NULL);
 
-  if (gradOutput->nDimension == 3)
+  if (gradOutput->_dim() == 3)
   {
     dimS = 1;
   }
@@ -205,7 +205,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);
 
-  if (gradOutput->nDimension == 2)
+  if (gradOutput->_dim() == 2)
   {
     /* ouch */
     for(k = 0; nOutputFrame > 0; k++)
@@ -293,7 +293,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   int dimS = 0; // sequence dimension
 
-  if (gradOutput->nDimension == 3)
+  if (gradOutput->_dim() == 3)
   {
     dimS = 1;
   }
@@ -307,7 +307,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   gradOutputWindow = THCTensor_(new)(state);
   inputWindow = THCTensor_(new)(state);
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     /* bias first */
     for(k = 0; k < nOutputFrame; k++)

--- a/aten/src/THCUNN/generic/TemporalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/TemporalMaxPooling.cu
@@ -13,7 +13,7 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
   int input_w;
   int input_n;
   int output_w;
-  int ndims = input->nDimension;
+  int ndims = input->_dim();
 
   if (ndims == 3)
   {
@@ -25,7 +25,7 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
   THArgCheck(dW > 0, 6,
              "stride should be greater than zero, but got dW: %d", dW);
 
-  THCUNN_argCheck(state, input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 2 || input->_dim() == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(input->size[dimT] >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
@@ -67,7 +67,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
 
   THCUNN_assertSameGPU(state, 3, input, output, indices);
   THNN_(TemporalMaxPooling_shapeCheck)(state, input, NULL, NULL, kW, dW);
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimT = 1;
     dimF = 2;
@@ -79,7 +79,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   input_n = input->size[dimF];
   output_w = (input_w - kW) / dW + 1;
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     THCTensor_(resize2d)(state, output, output_w, input->size[dimF]);
     THCIndexTensor_(resize2d)(state, indices, output_w, input->size[dimF]);
@@ -142,7 +142,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimT = 1;
     dimF = 2;

--- a/aten/src/THCUNN/generic/TemporalRowConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalRowConvolution.cu
@@ -10,14 +10,14 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
              "kernel size should be greater than zero, but got kW: %d", kW);
   THArgCheck(dW > 0, 6, "stride should be greater than zero, but got dW: %d",
              dW);
-  THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 3, 3,
+  THCUNN_argCheck(state, weight->_dim() == 2 || weight->_dim() == 3, 3,
                   weight, "2D or 3D weight tensor expected, but got: %s");
 
   if (bias != NULL) {
     THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimF = 0; // feature dimension
   int dimS = 1; // sequence dimension
 
@@ -66,7 +66,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5, "bias must be contiguous");
 
   // reshape weight if necessary
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
 
   THCTensor *tinput;
 
@@ -104,7 +104,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever
   // gets increased and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
+  if (ones->_dim() != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -195,7 +195,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 
   THArgCheck(THCTensor_(isContiguous)(state, weight), 4, "weight must be contiguous");
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
 
   THCTensor *tinput, *tgradOutput;
 
@@ -309,7 +309,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
     THCUNN_assertSameGPU(state, 2, gradWeight, gradBias);
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
 
   THCTensor *tinput, *tgradOutput;
 
@@ -345,7 +345,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
+  if (ones->_dim() != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -15,7 +15,7 @@ static inline void THNN_(TemporalUpSamplingLinear_shapeCheck)
              " but got input (W: %d) output (W: %d)",
              inputWidth, outputWidth);
   if (input != NULL) {
-     THCUNN_argCheck(state, input->nDimension == 3, 2, input,
+     THCUNN_argCheck(state, input->_dim() == 3, 2, input,
                      "3D input tensor expected but got: %s");
   }
 

--- a/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
@@ -10,9 +10,9 @@ static inline void THNN_(TemporalUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "3D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
              "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THCUNN_argCheck(state, input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 2 || input->_dim() == 3, 2, input,
                   "2D or 3D input tensor expected but got: %s");
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     int nChannels    = THCTensor_(size)(state, input, 0);
     int inputWidth   = THCTensor_(size)(state, input, 1);
     int outputWidth  = inputWidth  * scale_factor;
@@ -43,10 +43,10 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THNN_(TemporalUpSamplingNearest_shapeCheck)(state, input, NULL, scale_factor);
-  int inputWidth  = THCTensor_(size)(state, input,  input->nDimension-1);
+  int inputWidth  = THCTensor_(size)(state, input,  input->_dim()-1);
   int outputWidth = inputWidth * scale_factor;
 
-   if (input->nDimension == 2) {
+   if (input->_dim() == 2) {
      THCTensor_(resize2d)(state, output,
                           THCTensor_(size)(state, input, 0),
                           outputWidth);
@@ -60,7 +60,7 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   input = THCTensor_(newContiguous)(state, input);
   // This is for allocating output Tensor
   int64_t no_elements = 1;
-  for(int i = 0; i < input->nDimension; i++){
+  for(int i = 0; i < input->_dim(); i++){
     no_elements *= input->size[i];
   }
   no_elements *= scale_factor;
@@ -68,7 +68,7 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   int d1;
   int d2;
 
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     d1 = output->size[0];
     d2 = output->size[1];
   } else {
@@ -119,14 +119,14 @@ void THNN_(TemporalUpSamplingNearest_updateGradInput)(
   real *gradOutput_data = THCTensor_(data)(state, gradOutput);
 
   int64_t no_elements = 1;
-  for(int i = 0; i < gradInput->nDimension; i++){
+  for(int i = 0; i < gradInput->_dim(); i++){
     no_elements *= gradInput->size[i];
   }
 
   int d1;
   int d2;
 
-  if (gradInput->nDimension == 2) {
+  if (gradInput->_dim() == 2) {
     d1 = gradInput->size[0];
     d2 = gradInput->size[1];
   } else {

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
@@ -16,7 +16,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 2, input, output);
 
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
                   "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
 
@@ -27,7 +27,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   int64_t istrideD, istrideT, istrideH, istrideW;
   int64_t totalZ;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeD = input->size[0];
     isizeT = input->size[1];
     isizeH = input->size[2];
@@ -80,7 +80,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
     THCudaCheck(cudaGetLastError());
   }
 
-  if (input->nDimension == 5) {
+  if (input->_dim() == 5) {
     // clean
     THCTensor_(free)(state, input);
   }
@@ -106,7 +106,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   int64_t osizeT, osizeH, osizeW;
   int64_t totalZ;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeD = input->size[0];
     isizeT = input->size[1];
     isizeH = input->size[2];
@@ -129,7 +129,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   // somehow nonatomic is passing all test for volumetric case.
   bool atomic = false; //(isizeW%osizeW != 0) || (isizeH%osizeH != 0) || (isizeT%osizeT != 0);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     totalZ = atomic ? sizeD * osizeT : sizeD * isizeT;
   } else {
     int sizeB = input->size[0];

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
@@ -17,7 +17,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 3, input, output, indices);
 
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
                   "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   THCIndex_t *indices_data;
@@ -28,7 +28,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   int64_t istrideD, istrideT, istrideH, istrideW;
   int64_t totalZ;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeD = input->size[0];
     isizeT = input->size[1];
     isizeH = input->size[2];
@@ -84,7 +84,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
     THCudaCheck(cudaGetLastError());
   }
 
-  if (input->nDimension == 5) {
+  if (input->_dim() == 5) {
     // clean
     THCTensor_(free)(state, input);
   }
@@ -112,7 +112,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   int64_t osizeT, osizeH, osizeW;
   int64_t totalZ;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeD = input->size[0];
     isizeT = input->size[1];
     isizeH = input->size[2];
@@ -134,7 +134,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
 
   bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0) || (isizeT%osizeT != 0);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     totalZ = sizeD * osizeT;
   } else {
     int sizeB = input->size[0];

--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -16,13 +16,13 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   int inputHeight;
   int inputWidth;
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimN = 0;
   int dimt = 1;
   int dimh = 2;
   int dimw = 3;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -62,7 +62,7 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   }
   else
   {
-    THArgError(2, "4D or 5D tensor expected, but got: %d", input->nDimension);
+    THArgError(2, "4D or 5D tensor expected, but got: %d", input->_dim());
   }
 
   // The second argument is the index of padH.

--- a/aten/src/THCUNN/generic/VolumetricConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricConvolution.cu
@@ -15,7 +15,7 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
                          int padT,
                          int padW,
                          int padH) {
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
                   "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(!weight || THCTensor_(isContiguous)(state, weight), 4,
              "weight tensor has to be contiguous");
@@ -27,19 +27,19 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
 
   if (gradOutput != NULL) {
-    THCUNN_argCheck(state, gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+    THCUNN_argCheck(state, gradOutput->_dim() == 4 || gradOutput->_dim() == 5, 3,
                     gradOutput,
                     "4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
   }
 
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+    THCUNN_argCheck(state, weight->_dim() == 5, 4, weight,
                     "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                     "expected for weight, but got: %s");
   }
 
   if (gradWeight != NULL) {
-    THCUNN_argCheck(state, gradWeight->nDimension == 5, 4, gradWeight,
+    THCUNN_argCheck(state, gradWeight->_dim() == 5, 4, gradWeight,
                     "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                     "expected for gradWeight, but got: %s");
   }
@@ -55,7 +55,7 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
 
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 4,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -135,7 +135,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   int kW           = (int)weight->size[4];
 
   int batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     // Force batch
     batch = 0;
@@ -163,7 +163,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);
@@ -282,7 +282,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     input = THCTensor_(newContiguous)(state, input);
     // Force batch
@@ -397,7 +397,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     // Force batch
     batch = 0;
@@ -416,7 +416,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);

--- a/aten/src/THCUNN/generic/VolumetricDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedConvolution.cu
@@ -13,7 +13,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                          int padT, int padH, int padW,
                          int dilationT, int dilationH, int dilationW,
                          int weight_nullable) {
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
                   "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
@@ -27,7 +27,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
 
    // number of input & output planes and kernel size is indirectly defined by the weight tensor
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+    THCUNN_argCheck(state, weight->_dim() == 5, 4, weight,
                   "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
@@ -37,7 +37,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -113,7 +113,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   bias = bias ? THCTensor_(newContiguous)(state, bias) : bias;
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -138,7 +138,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -262,7 +262,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -372,7 +372,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -392,7 +392,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -20,7 +20,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
                          int padT, int padW, int padH,
                          int dilationT, int dilationW, int dilationH,
                          bool ceilMode) {
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int inputSlices;
   int inputTime;
   int inputHeight;
@@ -43,7 +43,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than 0, but got dilationT: %d dilationH: %d dilationW: %d",
              dilationT, dilationH, dilationW);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimf++;
     dimt++;

--- a/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
@@ -13,7 +13,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                int padT, int padW, int padH,
                int dilationT, int dilationW, int dilationH,
                int adjT, int adjW, int adjH, int weight_nullable) {
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
             "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 8,
          "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
@@ -30,7 +30,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
 
    // number of input & output planes and kernel size is indirectly defined by the weight tensor
   if (weight != NULL) {
-    THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+    THCUNN_argCheck(state, weight->_dim() == 5, 4, weight,
                   "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
@@ -40,7 +40,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -119,7 +119,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -144,7 +144,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -269,7 +269,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -404,7 +404,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -422,7 +422,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -42,7 +42,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
   int dimh = 2;
   int dimt = 1;
   int dimn = 0;
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimt++;
     dimw++;
@@ -58,7 +58,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
         oT, oH, oW, gradOutput->size[dimt], gradOutput->size[dimh], gradOutput->size[dimw]);
     }
 
-    THCUNN_check_dim_size(state, gradOutput, input->nDimension, dimn, inputSlices);
+    THCUNN_check_dim_size(state, gradOutput, input->_dim(), dimn, inputSlices);
   }
 }
 

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
@@ -10,9 +10,9 @@ static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
              "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THCUNN_argCheck(state, input->_dim() == 4 || input->_dim() == 5, 2, input,
                   "4D or 5D input tensor expected but got: %s");
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     int nChannels    = THCTensor_(size)(state, input, 0);
     int inputDepth   = THCTensor_(size)(state, input, 1);
     int inputHeight  = THCTensor_(size)(state, input, 2);
@@ -55,14 +55,14 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THNN_(VolumetricUpSamplingNearest_shapeCheck)(state, input, NULL, scale_factor);
-  int inputDepth = THCTensor_(size)(state, input, input->nDimension-3);
-  int inputHeight = THCTensor_(size)(state, input, input->nDimension-2);
-  int inputWidth  = THCTensor_(size)(state, input,  input->nDimension-1);
+  int inputDepth = THCTensor_(size)(state, input, input->_dim()-3);
+  int inputHeight = THCTensor_(size)(state, input, input->_dim()-2);
+  int inputWidth  = THCTensor_(size)(state, input,  input->_dim()-1);
   int outputDepth = inputDepth * scale_factor;
   int outputHeight = inputHeight * scale_factor;
   int outputWidth = inputWidth * scale_factor;
 
-   if (input->nDimension == 4) {
+   if (input->_dim() == 4) {
      THCTensor_(resize4d)(state, output,
                           THCTensor_(size)(state, input, 0),
                           outputDepth, outputHeight, outputWidth);
@@ -76,7 +76,7 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   input = THCTensor_(newContiguous)(state, input);
   // This is for allocating output Tensor
   int64_t no_elements = 1;
-  for(int i = 0; i < input->nDimension; i++){
+  for(int i = 0; i < input->_dim(); i++){
     no_elements *= input->size[i];
   }
   no_elements *= scale_factor * scale_factor * scale_factor;
@@ -86,7 +86,7 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   int d3;
   int d4;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     d1 = output->size[0];
     d2 = output->size[1];
     d3 = output->size[2];
@@ -141,7 +141,7 @@ void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
   real *gradOutput_data = THCTensor_(data)(state, gradOutput);
 
   int64_t no_elements = 1;
-  for(int i = 0; i < gradInput->nDimension; i++){
+  for(int i = 0; i < gradInput->_dim(); i++){
     no_elements *= gradInput->size[i];
   }
 
@@ -150,7 +150,7 @@ void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
   int d3;
   int d4;
 
-  if (gradInput->nDimension == 4) {
+  if (gradInput->_dim() == 4) {
     d1 = gradInput->size[0];
     d2 = gradInput->size[1];
     d3 = gradInput->size[2];

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -16,7 +16,7 @@ static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
              " but got input (D: %d, H: %d, W: %d) output (D: %d, H: %d, W: %d)",
              inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
   if (input != NULL) {
-     THCUNN_argCheck(state, input->nDimension == 5, 2, input,
+     THCUNN_argCheck(state, input->_dim() == 5, 2, input,
                      "5D input tensor expected but got: %s");
   }
 

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -155,7 +155,7 @@ void THNN_(Col2Im_updateOutput)(
                            kH, kW, dH, dW, padH, padW, sH, sW);
 
   bool batched_input = true;
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
       // Force batch
       batched_input = false;
       THTensor_(resize3d)(input, 1, input->size[0], input->size[1]);

--- a/aten/src/THNN/generic/HardTanh.c
+++ b/aten/src/THNN/generic/HardTanh.c
@@ -17,7 +17,7 @@ void THNN_(HardTanh_updateOutput)(
   else
     THTensor_(resizeAs)(output, input);
 
-  if (input->nDimension == 1 || !THTensor_(isContiguous)(input) || !THTensor_(isContiguous)(output))
+  if (input->_dim() == 1 || !THTensor_(isContiguous)(input) || !THTensor_(isContiguous)(output))
   {
     if (inplace)
     {
@@ -88,7 +88,7 @@ void THNN_(HardTanh_updateGradInput)(
   else
     THTensor_(resizeAs)(gradInput, input);
 
-  if (input->nDimension == 1 ||
+  if (input->_dim() == 1 ||
     !THTensor_(isContiguous)(input) ||
     !THTensor_(isContiguous)(gradOutput) ||
     !THTensor_(isContiguous)(gradInput))

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -52,7 +52,7 @@ void THNN_(Im2Col_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   bool batched_input = true;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     batched_input = false;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
   }

--- a/aten/src/THNN/generic/MultiLabelMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiLabelMarginCriterion.c
@@ -18,21 +18,21 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   int64_t t, d, dt, ddt;
   real sum;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
 	     "vector or matrix expected");
 
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
 	       "inconsistent target size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
 	       && (target->size[1] == dim), 3, "inconsistent target size");
   }
 
@@ -157,25 +157,25 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   int64_t t, d, dt;
   real g;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
 	     "vector or matrix expected");
 
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
 	       "inconsistent target size");
-    THArgCheck((isTarget->nDimension == 1) && (isTarget->size[0] == dim), 3,
+    THArgCheck((isTarget->_dim() == 1) && (isTarget->size[0] == dim), 3,
 	       "inconsistent isTarget size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
 	       && (target->size[1] == dim), 3, "inconsistent target size");
-    THArgCheck((isTarget->nDimension == 2) && (isTarget->size[0] == nframe)
+    THArgCheck((isTarget->_dim() == 2) && (isTarget->size[0] == nframe)
 	       && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
   }
 

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -21,10 +21,10 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   int64_t t, d;
   real sum;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
 	     "vector or matrix expected");
 
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
@@ -33,7 +33,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
 	       "inconsistent target size");
   }
 
@@ -138,10 +138,10 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   int64_t t, d;
   real g;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
 	     "vector or matrix expected");
 
-  if (input->nDimension == 1)
+  if (input->_dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
@@ -150,7 +150,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
 	       "inconsistent target size");
   }
 

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -11,22 +11,22 @@
 
 static bool THNN_(checkLegacyInput)(THTensor* t)
 {
-  return t->nDimension == 3 && t->size[2] == 2;
+  return t->_dim() == 3 && t->size[2] == 2;
 }
 
 static bool THNN_(checkInput)(THTensor* t)
 {
-  return t->nDimension == 2 && t->size[1] == 3;
+  return t->_dim() == 2 && t->size[1] == 3;
 }
 
 static bool THNN_(checkSize2D)(THTensor* t, int64_t size0, int64_t size1)
 {
-  return t->nDimension == 2 && t->size[0] == size0 && t->size[1] == size1;
+  return t->_dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
 }
 
 static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 {
-  return t->nDimension == 1 && t->size[0] == size0;
+  return t->_dim() == 1 && t->size[0] == size0;
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {

--- a/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
@@ -87,10 +87,10 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   real *output_data = nullptr;
 
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -109,7 +109,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, sizeD, osizeH, osizeW);
 
@@ -217,7 +217,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeB = input->size[0];
     dimD++;
     dimH++;
@@ -236,7 +236,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THNN_(SpatialAdaptiveAveragePooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          sizeD,

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -97,10 +97,10 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   THIndex_t *indices_data = nullptr;
 
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -118,7 +118,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, sizeD, osizeH, osizeW);
     /* indices will contain i,j locations for each output point */
@@ -222,7 +222,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     sizeB = input->size[0];
     dimW++;
     dimH++;
@@ -241,7 +241,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                            indices_data,

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -12,7 +12,7 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -102,7 +102,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   THNN_(SpatialAveragePooling_shapeCheck)
     (input, NULL, kH, kW, dH, dW, padH, padW, ceil_mode);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -133,7 +133,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
       --outputWidth;
   }
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
     THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
@@ -231,7 +231,7 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
     (input, gradOutput, kH, kW, dH, dW, padH, padW, ceil_mode);
 
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -15,7 +15,7 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 11,
          "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -50,9 +50,9 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
 static THTensor* THNN_(view_weight_local)(THTensor *_weight)
 {
   THTensor *weight = THTensor_(newContiguous)(_weight);
-  THArgCheck(weight->nDimension == 3 || weight->nDimension == 6, 4,
-          "weight tensor should be 3D or 6D - got %dD", weight->nDimension);
-  if (weight->nDimension == 6) {
+  THArgCheck(weight->_dim() == 3 || weight->_dim() == 6, 4,
+          "weight tensor should be 3D or 6D - got %dD", weight->_dim());
+  if (weight->_dim() == 6) {
     int64_t s1 = weight->size[0] * weight->size[1];
     int64_t s2 = weight->size[2];
     int64_t s3 = weight->size[3] * weight->size[4] * weight->size[5];
@@ -127,7 +127,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   int64_t nInputPlane = THTensor_(size)(weight, 2)/ (kW * kH);
   int64_t nOutputPlane = THTensor_(size)(weight, 1);
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THTensor_(resize2d)(finput, kW*kH*nInputPlane, outputHeight*outputWidth);
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
@@ -233,7 +233,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 1, 2);
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THNN_(SpatialConvolutionLocal_updateGradInput_frame)
       (gradInput, gradOutput, tweight,
@@ -329,7 +329,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   int64_t nInputPlane = THTensor_(size)(gradWeight,2)/(kW*kH);
   int64_t nOutputPlane = THTensor_(size)(gradWeight,1);
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THNN_(SpatialConvolutionLocal_accGradParameters_frame)
       (gradOutput, gradWeight, gradBias, finput, scale,

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -13,7 +13,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
                     "2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
@@ -22,7 +22,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -59,7 +59,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (weight != NULL) {
     int64_t nInputPlane = weight->size[1];
-    if (weight->nDimension == 2) {
+    if (weight->_dim() == 2) {
       nInputPlane /= (kH * kW);
     }
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
@@ -80,7 +80,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
 static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
   weight = THTensor_(newContiguous)(weight);
-  if (weight->nDimension == 4) {
+  if (weight->_dim() == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     THTensor *old_weight = weight;
@@ -155,7 +155,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, 0);
 
   input = THTensor_(newContiguous)(input);
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -173,7 +173,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THTensor_(resize2d)(finput, kW*kH*nInputPlane, outputHeight*outputWidth);
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
@@ -275,7 +275,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 0, 1);
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THNN_(SpatialConvolutionMM_updateGradInput_frame)(gradInput, gradOutput,
 						      tweight, fgradInput,
@@ -375,7 +375,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
-  if(input->nDimension == 3)
+  if(input->_dim() == 3)
   {
     THNN_(SpatialConvolutionMM_accGradParameters_frame)(gradOutput, gradWeight,
 							gradBias, finput, scale);

--- a/aten/src/THNN/generic/SpatialConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMap.c
@@ -8,7 +8,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->nDimension == 3
+    weight != NULL && weight->_dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 4,
     "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -18,9 +18,9 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   int dimc = 0;
   int64_t nbatch = 1;
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D(batch mode) tensor expected");
+  THArgCheck(input->_dim() == 3 || input->_dim() == 4, 2, "3D or 4D(batch mode) tensor expected");
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimc++;
@@ -39,7 +39,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   const int64_t output_w = (input_w - kW) / dW + 1;
   const int64_t output_h = (input_h - kH) / dH + 1;
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
     THTensor_(resize3d)(output, nOutputPlane, output_h, output_w);
   else
     THTensor_(resize4d)(output, input->size[0], nOutputPlane, output_h, output_w);
@@ -109,7 +109,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->nDimension == 3
+    weight != NULL && weight->_dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 5,
     "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -118,7 +118,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
   int dimw = 2;
   int dimh = 1;
   int64_t nbatch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -196,7 +196,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
-    gradWeight != NULL && gradWeight->nDimension == 3
+    gradWeight != NULL && gradWeight->_dim() == 3
     && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
     "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -205,7 +205,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   int dimw = 2;
   int dimh = 1;
   int64_t nbatch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;

--- a/aten/src/THNN/generic/SpatialDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialDilatedConvolution.c
@@ -16,7 +16,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
              dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
+    THNN_ARGCHECK(weight->_dim() == 4, 4, weight,
                   "4D weight tensor (nOutputPlane, nInputPlane, kH, kW) expected, "
                   "but got: %s");
     if (bias != NULL) {
@@ -26,7 +26,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -100,7 +100,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -123,7 +123,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (!THTensor_(isContiguous)(ones) || ones->nDimension != 2 ||
+  if (!THTensor_(isContiguous)(ones) || ones->_dim() != 2 ||
       ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
@@ -228,7 +228,7 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   gradOutput = THTensor_(newContiguous)(gradOutput);
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -335,7 +335,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     THArgCheck(THTensor_(isContiguous)(ones), 7, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -405,7 +405,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
 
       // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       // Define a buffer of ones, for bias accumulation
-      if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+      if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
         // Resize plane and fill with ones...
         THTensor_(resize2d)(ones, outputHeight, outputWidth);
         THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -15,7 +15,7 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than zero, but got dilationH: %d dilationW: %d",
              dilationH, dilationW);
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -182,7 +182,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
     (input, NULL, NULL, kH, kW, dH, dW,
      padH, padW, dilationH, dilationW, ceil_mode);
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -218,7 +218,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
     /* indices will contain the locations for each output point */
@@ -348,7 +348,7 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -367,7 +367,7 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THNN_(SpatialDilatedMaxPooling_updateGradInput_frame)
       (gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/SpatialFullConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialFullConvolutionMap.c
@@ -10,7 +10,7 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
   THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
   THArgCheck(
-    weight != NULL && weight->nDimension == 3
+    weight != NULL && weight->_dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 4,
     "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -18,7 +18,7 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   const int kH = (int)weight->size[1];
   const int kW = (int)weight->size[2];
 
-  THArgCheck(input != NULL && input->nDimension == 3, 2, "3D tensor expected");
+  THArgCheck(input != NULL && input->_dim() == 3, 2, "3D tensor expected");
   THArgCheck(input->size[0] >= nInputPlane, 2, "invalid number of input planes");
 
   THTensor_(resize3d)(
@@ -91,7 +91,7 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->nDimension == 3
+    weight != NULL && weight->_dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 5,
     "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -162,7 +162,7 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
-    gradWeight != NULL && gradWeight->nDimension == 3
+    gradWeight != NULL && gradWeight->_dim() == 3
     && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
     "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -20,7 +20,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
              adjH, adjW, dH, dW, dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
   		"2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
@@ -29,7 +29,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -102,7 +102,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   }
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -126,7 +126,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -230,7 +230,7 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -349,7 +349,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -365,7 +365,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
@@ -12,9 +12,9 @@
 
 static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
      (THTensor *input, THTensor *grid, THTensor *gradOutput) {
-  THNN_ARGCHECK(input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4, 2, input,
     "4D input tensor expected but got: %s");
-  THNN_ARGCHECK(grid->nDimension == 4, 2, grid,
+  THNN_ARGCHECK(grid->_dim() == 4, 2, grid,
     "4D grid tensor expected but got: %s");
 
   int nbatch   = THTensor_(size)(input, 0);

--- a/aten/src/THNN/generic/SpatialMaxUnpooling.c
+++ b/aten/src/THNN/generic/SpatialMaxUnpooling.c
@@ -61,11 +61,11 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   THIndex_t *indices_data;
 
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
   THNN_CHECK_SHAPE_INDICES(input, indices);
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -82,7 +82,7 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   indices = THIndexTensor_(newContiguous)(indices);
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
     THTensor_(zero)(output);
@@ -183,7 +183,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -205,7 +205,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THNN_(SpatialMaxUnpooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                  indices_data,

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -67,10 +67,10 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -86,12 +86,12 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->nDimension).str);
+             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->_dim()).str);
 
   THArgCheck(pad_t < iheight && pad_b < iheight, 6,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->nDimension).str);
+             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->_dim()).str);
 
   /* output sizes */
   oheight = iheight + pad_t + pad_b;
@@ -106,7 +106,7 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
 
@@ -211,7 +211,7 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -241,7 +241,7 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     THNN_(SpatialReflectionPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/SpatialReplicationPadding.c
+++ b/aten/src/THNN/generic/SpatialReplicationPadding.c
@@ -66,10 +66,10 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -94,7 +94,7 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
 
@@ -198,7 +198,7 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -228,7 +228,7 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     THNN_(SpatialReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/SpatialSubSampling.c
+++ b/aten/src/THNN/generic/SpatialSubSampling.c
@@ -7,7 +7,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
                          THTensor *gradOutput,
                          THTensor *weight,
                          int kW, int kH) {
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
 
@@ -19,7 +19,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
   int64_t inputWidth;
   int64_t inputHeight;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     dimw++;
     dimh++;
   }
@@ -62,7 +62,7 @@ void THNN_(SpatialSubSampling_updateOutput)(
 
   THNN_(SpatialSubSampling_shapeCheck)(input, NULL, weight, kW, kH);
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -73,7 +73,7 @@ void THNN_(SpatialSubSampling_updateOutput)(
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
     THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
@@ -151,7 +151,7 @@ void THNN_(SpatialSubSampling_updateGradInput)(
 
   int64_t k;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -236,7 +236,7 @@ void THNN_(SpatialSubSampling_accGradParameters)(
 
   int64_t k;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     dimw++;
     dimh++;
     nbatch = input->size[0];

--- a/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
@@ -16,7 +16,7 @@ static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
 	     " but got input (H: %d, W: %d) output (H: %d, W: %d)",
 	     inputHeight, inputWidth, outputHeight, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->nDimension == 4, 2, input,
+    THNN_ARGCHECK(input->_dim() == 4, 2, input,
 		  "4D input tensor expected but got: %s");
   }
 

--- a/aten/src/THNN/generic/SpatialUpSamplingNearest.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(SpatialUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
 		"3D or 4D input tensor expected but got: %s");
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputHeight  = THTensor_(size)(input, 1);
     int inputWidth   = THTensor_(size)(input, 2);
@@ -45,12 +45,12 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(SpatialUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputHeight = THTensor_(size)(input, input->nDimension-2);
-  int inputWidth  = THTensor_(size)(input,  input->nDimension-1);
+  int inputHeight = THTensor_(size)(input, input->_dim()-2);
+  int inputWidth  = THTensor_(size)(input,  input->_dim()-1);
   int outputHeight = inputHeight * scale_factor;
   int outputWidth = inputWidth * scale_factor;
 
-  if (input->nDimension == 3) {
+  if (input->_dim() == 3) {
     THTensor_(resize3d)(output,
 			THTensor_(size)(input, 0),
 			outputHeight, outputWidth);    
@@ -63,11 +63,11 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
 
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = input->nDimension-2;
-  int yDim = input->nDimension-1;
+  int xDim = input->_dim()-2;
+  int yDim = input->_dim()-1;
 
   // dims
-  int idim = input->nDimension;
+  int idim = input->_dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = output->size[2];
@@ -132,11 +132,11 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
 
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = gradInput->nDimension-2;
-  int yDim = gradInput->nDimension-1;
+  int xDim = gradInput->_dim()-2;
+  int yDim = gradInput->_dim()-1;
 
   // dims
-  int idim = gradInput->nDimension;  // Guaranteed to be between 3 and 5
+  int idim = gradInput->_dim();  // Guaranteed to be between 3 and 5
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = gradInput->size[2];

--- a/aten/src/THNN/generic/Sqrt.c
+++ b/aten/src/THNN/generic/Sqrt.c
@@ -22,7 +22,7 @@ void THNN_(Sqrt_updateGradInput)(
   THNN_CHECK_SHAPE(output, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
-  if (output->nDimension == 1 ||
+  if (output->_dim() == 1 ||
       !THTensor_(isContiguous)(output) ||
       !THTensor_(isContiguous)(gradOutput) ||
       !THTensor_(isContiguous)(gradInput))

--- a/aten/src/THNN/generic/Square.c
+++ b/aten/src/THNN/generic/Square.c
@@ -9,7 +9,7 @@ void THNN_(Square_updateOutput)(
 {
   THTensor_(resizeAs)(output, input);
   
-  if (input->nDimension == 1 || !THTensor_(isContiguous)(input) || !THTensor_(isContiguous)(output))
+  if (input->_dim() == 1 || !THTensor_(isContiguous)(input) || !THTensor_(isContiguous)(output))
   {
     TH_TENSOR_APPLY2(real, output, real, input,
       *output_data = (*input_data) * (*input_data);
@@ -35,7 +35,7 @@ void THNN_(Square_updateGradInput)(
   THNN_CHECK_SHAPE(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
-  if (input->nDimension == 1 || 
+  if (input->_dim() == 1 || 
       !THTensor_(isContiguous)(input) || 
       !THTensor_(isContiguous)(gradOutput) ||
       !THTensor_(isContiguous)(gradInput))

--- a/aten/src/THNN/generic/Tanh.c
+++ b/aten/src/THNN/generic/Tanh.c
@@ -19,7 +19,7 @@ void THNN_(Tanh_updateGradInput)(
   THNN_CHECK_SHAPE(output, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
 
-  if (output->nDimension == 1 ||
+  if (output->_dim() == 1 ||
       !THTensor_(isContiguous)(output) ||
       !THTensor_(isContiguous)(gradOutput) ||
       !THTensor_(isContiguous)(gradInput))

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -17,12 +17,12 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
     dimF = 2;
   }
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
     THArgCheck(input->size[dimF] == *inputFrameSize, 2,
@@ -51,7 +51,7 @@ void THNN_(TemporalConvolution_updateOutput)(
 
   int dimS = 0; // sequence dimension
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
   }
@@ -67,7 +67,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   nInputFrame = input->size[dimS];
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     THTensor_(resize2d)(output,
                         nOutputFrame,
@@ -180,7 +180,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
 
   int dimS = 0; // sequence dimension
 
-  if (gradOutput->nDimension == 3)
+  if (gradOutput->_dim() == 3)
   {
     dimS = 1;
   }
@@ -200,7 +200,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (gradOutput->nDimension == 2)
+  if (gradOutput->_dim() == 2)
   {
     /* ouch */
     for(k = 0; nOutputFrame > 0; k++)
@@ -287,7 +287,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   int dimS = 0; // sequence dimension
 
-  if (gradOutput->nDimension == 3)
+  if (gradOutput->_dim() == 3)
   {
     dimS = 1;
   }
@@ -302,7 +302,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   gradOutputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     /* bias first */
     for(k = 0; k < nOutputFrame; k++)

--- a/aten/src/THNN/generic/TemporalMaxPooling.c
+++ b/aten/src/THNN/generic/TemporalMaxPooling.c
@@ -15,9 +15,9 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
-  int ndims = input->nDimension;
+  int ndims = input->_dim();
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -32,7 +32,7 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
   THArgCheck(dW > 0, 6,
              "stride should be greater than zero, but got dW: %d", dW);
 
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(input->size[dimS] >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
@@ -71,7 +71,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
 
   THNN_(TemporalMaxPooling_shapeCheck)(state, input, NULL, NULL, kW, dW);
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -85,7 +85,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     /* resize output */
     THTensor_(resize2d)(output, noframe, framesize);
@@ -215,7 +215,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -230,7 +230,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
   indices_data = THIndexTensor_(data)(indices);
 
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     for(t = 0; t < noframe; t++)
     {

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -50,10 +50,10 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
 		"2D or 3D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -67,7 +67,7 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->nDimension).str);
+             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->_dim()).str);
 
   /* output size */
   owidth  = iwidth + pad_l + pad_r;
@@ -81,7 +81,7 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     THTensor_(resize2d)(output, nslices, owidth);
 
@@ -166,7 +166,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
   long iwidth;
   long owidth;
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -190,7 +190,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     THNN_(TemporalReflectionPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/TemporalReplicationPadding.c
+++ b/aten/src/THNN/generic/TemporalReplicationPadding.c
@@ -48,10 +48,10 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
 		"2D or 3D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -73,7 +73,7 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 2)
+  if (input->_dim() == 2)
   {
     THTensor_(resize2d)(output, nslices, owidth);
 
@@ -157,7 +157,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
   long iwidth;
   long owidth;
 
-  if (input->nDimension == 3)
+  if (input->_dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -181,7 +181,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     THNN_(TemporalReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -16,7 +16,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	           "kernel size should be greater than zero, but got kW: %d", kW);
 	THArgCheck(dW > 0, 6,
 	           "stride should be greater than zero, but got dW: %d", dW);
-	THNN_ARGCHECK(weight->nDimension == 3, 3, weight,
+	THNN_ARGCHECK(weight->_dim() == 3, 3, weight,
 	              "3D weight tensor expected, but got: %s");
     THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
     THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
@@ -26,7 +26,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	}
 
 	// we're always looking at (possibly batch) x feats x seq
-	int ndim = input->nDimension;
+	int ndim = input->_dim();
 	int dimF = 0;
 	int dimS = 1;
 
@@ -184,7 +184,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 	int padW,
 	bool featFirst) {
 
-	int ndim = input->nDimension;
+	int ndim = input->_dim();
 
 	THTensor *tinput;
 	if (!featFirst) {
@@ -292,7 +292,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 	int padW,
 	bool featFirst) {
 
-	int ndim = input->nDimension;
+	int ndim = input->_dim();
 
 	THTensor *tinput, *tgradOutput;
 
@@ -419,7 +419,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
 	accreal scale_) {
 
     real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
-	int ndim = input->nDimension;
+	int ndim = input->_dim();
 
 	THTensor *tinput, *tgradOutput;
 

--- a/aten/src/THNN/generic/TemporalSubSampling.c
+++ b/aten/src/THNN/generic/TemporalSubSampling.c
@@ -16,7 +16,7 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   THArgCheck(dW > 0, 7,
              "stride should be greater than zero, but got dW: %d", dW);
 
-  THNN_ARGCHECK(input->nDimension == 2, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
     THArgCheck( input->size[1] == *inputFrameSize, 2,
@@ -31,9 +31,9 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (gradOutput != NULL) {
-    THNN_CHECK_DIM_SIZE(gradOutput, input->nDimension, 0, nOutputFrame);
+    THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), 0, nOutputFrame);
     if (inputFrameSize != NULL) {
-      THNN_CHECK_DIM_SIZE(gradOutput, input->nDimension, 1, *inputFrameSize);
+      THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), 1, *inputFrameSize);
     }
   }
 }

--- a/aten/src/THNN/generic/TemporalUpSamplingLinear.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingLinear.c
@@ -14,7 +14,7 @@ static inline void THNN_(TemporalUpSamplingLinear_shapeCheck)
 	     " but got input (W: %d) output (W: %d)",
 	     inputWidth, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->nDimension == 3, 2, input,
+    THNN_ARGCHECK(input->_dim() == 3, 2, input,
 		  "3D input tensor expected but got: %s");
   }
 

--- a/aten/src/THNN/generic/TemporalUpSamplingNearest.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(TemporalUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "3D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
 		"2D or 3D input tensor expected but got: %s");
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputWidth   = THTensor_(size)(input, 1);
     int outputWidth  = inputWidth  * scale_factor;
@@ -39,10 +39,10 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(TemporalUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputWidth  = THTensor_(size)(input,  input->nDimension-1);
+  int inputWidth  = THTensor_(size)(input,  input->_dim()-1);
   int outputWidth = inputWidth * scale_factor;
 
-  if (input->nDimension == 2) {
+  if (input->_dim() == 2) {
     THTensor_(resize2d)(output,
 			THTensor_(size)(input, 0),
       outputWidth);
@@ -54,10 +54,10 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   }
 
   int dW = scale_factor;
-  int xDim = input->nDimension-1;
+  int xDim = input->_dim()-1;
 
   // dims
-  int idim = input->nDimension;
+  int idim = input->_dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = 1;
@@ -115,10 +115,10 @@ void THNN_(TemporalUpSamplingNearest_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
 
   int dW = scale_factor;
-  int xDim = gradInput->nDimension-1;
+  int xDim = gradInput->_dim()-1;
 
   // dims
-  int idim = gradInput->nDimension;  // Guaranteed to be between 2 and 4
+  int idim = gradInput->_dim();  // Guaranteed to be between 2 and 4
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = 1;

--- a/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
@@ -104,10 +104,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   real *output_data = nullptr;
 
 
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -129,7 +129,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THTensor_(resize4d)(output, sizeD, osizeT, osizeH, osizeW);
 
@@ -252,7 +252,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 5) {
+  if (input->_dim() == 5) {
     sizeB = input->size[0];
     dimD++;
     dimT++;
@@ -274,7 +274,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THNN_(VolumetricAdaptiveAveragePooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          sizeD,

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -115,10 +115,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   real *output_data = nullptr;
   THIndex_t *indices_data = nullptr;
 
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
     "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -140,7 +140,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THTensor_(resize4d)(output, sizeD, osizeT, osizeH, osizeW);
     /* indices will contain max input locations for each output point */
@@ -253,7 +253,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 5) {
+  if (input->_dim() == 5) {
     sizeB = input->size[0];
     dimD++;
     dimT++;
@@ -276,7 +276,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THNN_(VolumetricAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          indices_data,

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -24,13 +24,13 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   int64_t otime;
   int64_t oheight;
   int64_t owidth;
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimN = 0;
   int dimt = 1;
   int dimh = 2;
   int dimw = 3;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -44,7 +44,7 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 8,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d",
              dT, dH, dW);
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
@@ -222,7 +222,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -262,7 +262,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->nDimension == 4) /* non-batch mode */
+  if (input->_dim() == 4) /* non-batch mode */
   {
     /* resize output */
     THTensor_(resize4d)(output, nslices, otime, oheight, owidth);
@@ -436,7 +436,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -458,7 +458,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->nDimension == 4) /* non-batch mode*/
+  if (input->_dim() == 4) /* non-batch mode*/
   {
     THNN_(VolumetricAveragePooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data, nslices,

--- a/aten/src/THNN/generic/VolumetricConvolution.c
+++ b/aten/src/THNN/generic/VolumetricConvolution.c
@@ -19,14 +19,14 @@ void THNN_(VolumetricConvolution_updateOutput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int dimt = 1;
   int dimh = 2;
   int dimw = 3;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimt++;
     dimh++;
@@ -45,7 +45,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   int64_t outputHeight = (inputHeight - kH) / dH + 1;
   THTensor *outn = THTensor_(new)();
   int64_t i, j;
-  if (input->nDimension == 4) /* non-batch mode */
+  if (input->_dim() == 4) /* non-batch mode */
   {
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
 
@@ -113,18 +113,18 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+  THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
 		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for weight, but got: %s");
 
   int nOutputPlane = (int)weight->size[0];
 
-  THNN_ARGCHECK(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+  THNN_ARGCHECK(gradOutput->_dim() == 4 || gradOutput->_dim() == 5, 3,
 		gradOutput,
 		"4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
 
   int dimPlane = 0;
-  if (gradOutput->nDimension == 5)
+  if (gradOutput->_dim() == 5)
   {
     dimPlane++;
   }
@@ -135,7 +135,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 
   /* gradient to input */
   THTensor *tweight = THTensor_(newTranspose)(weight, 0, 1);
-  if (gradOutput->nDimension == 4) /* non-batch mode */
+  if (gradOutput->_dim() == 4) /* non-batch mode */
   {
     THTensor_(conv3Dmv)(gradInput, 0.0, 1.0, gradOutput, tweight, dT, dH, dW, "F", "C");
   }
@@ -183,13 +183,13 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(gradWeight->nDimension == 5, 4, gradWeight,
+  THNN_ARGCHECK(gradWeight->_dim() == 5, 4, gradWeight,
 		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for gradWeight, but got: %s");
 
   int nOutputPlane = (int)gradWeight->size[0];
   if (gradBias) {
-    THArgCheck(gradBias->nDimension == 1 && gradBias->size[0] == nOutputPlane, 5,
+    THArgCheck(gradBias->_dim() == 1 && gradBias->size[0] == nOutputPlane, 5,
       "gradBias tensor has wrong size"
     );
   }
@@ -198,7 +198,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   real *gradBias_data;
   THTensor *gradOutSlice;
   int dimPlane = 0;
-  if (gradOutput->nDimension == 5)
+  if (gradOutput->_dim() == 5)
   {
     dimPlane++;
   }
@@ -207,7 +207,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
     "Number of output features is not equal to nOutputPlane"
   );
 
-  if (gradOutput->nDimension == 4) /* non-batch mode */
+  if (gradOutput->_dim() == 4) /* non-batch mode */
   {
     /* gradient to bias */
     if (gradBias) {

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -20,7 +20,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
                          int pW,
                          int pH,
                          int weight_nullable) {
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
@@ -28,7 +28,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 5, 5, weight,
+    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 5, 5, weight,
                     "2D or 5D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
@@ -37,7 +37,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimt = 1;
   int dimh = 2;
@@ -89,7 +89,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
 
   if (weight != NULL) {
     int64_t nInputPlane = weight->size[1];
-    if (weight->nDimension == 2) {
+    if (weight->_dim() == 2) {
       nInputPlane /= (kT * kH * kW);
     }
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
@@ -112,7 +112,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
 static THTensor* THNN_(newViewWeight)(THTensor *weight)
 {
   weight = THTensor_(newContiguous)(weight);
-  if (weight->nDimension == 5) {
+  if (weight->_dim() == 5) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
     THTensor *old_weight = weight;
@@ -486,7 +486,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
         kT, kW, kH, dT, dW, dH, pT, pW, pH, 0);
   input = THTensor_(newContiguous)(input);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimf++;
     dimt++;
@@ -505,7 +505,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
 
   weight = THNN_(newViewWeight)(weight);
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THTensor_(resize2d)(finput, kT*kW*kH*nInputPlane, outputDepth*outputHeight*outputWidth);
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -625,7 +625,7 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 0, 1);
 
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
       gradInput, gradOutput, tweight, fgradInput,
@@ -729,7 +729,7 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
     gradWeight = THNN_(newViewWeight)(gradWeight);
   }
 
-  if (input->nDimension == 4)   // non-batch mode
+  if (input->_dim() == 4)   // non-batch mode
   {
     THNN_(VolumetricConvolutionMM_accGradParameters_frame)(gradOutput, gradWeight, gradBias, finput, scale);
   }

--- a/aten/src/THNN/generic/VolumetricDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricDilatedConvolution.c
@@ -9,7 +9,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                          int padT, int padH, int padW,
                          int dilationT, int dilationH, int dilationW,
                          int weight_nullable) {
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
@@ -20,7 +20,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
              dilationT, dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+    THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
                   "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
@@ -31,7 +31,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
   }
 
   // Params
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -106,7 +106,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
     THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -132,7 +132,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 3 ||
+  if (ones->_dim() != 3 ||
       ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -239,7 +239,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -349,7 +349,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -369,7 +369,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -12,7 +12,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
                          int pT, int pW, int pH,
                          int dilationT, int dilationW, int dilationH,
                          bool ceilMode) {
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimN = 0;
   int dimt = 1;
   int dimh = 2;
@@ -35,10 +35,10 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than 0, but got dilationT: %d dilationH: %d dilationW: %d",
              dilationT, dilationH, dilationW);
 
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -226,7 +226,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -272,7 +272,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->nDimension == 4) /* non-batch mode */
+  if (input->_dim() == 4) /* non-batch mode */
   {
     /* resize output */
     THTensor_(resize4d)(output, nslices, otime, oheight, owidth);
@@ -435,7 +435,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimN++;
     dimt++;
@@ -458,7 +458,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 4) /* non-batch mode*/
+  if (input->_dim() == 4) /* non-batch mode*/
   {
     THNN_(VolumetricDilatedMaxPooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
@@ -91,7 +91,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                          int pT, int pW, int pH,
                          int dilationT, int dilationW, int dilationH,
                          int aT, int aW, int aH, int weight_nullable) {
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
@@ -108,7 +108,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
 
   // number of input & output planes and kernel size is indirectly defined by the weight tensor
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+    THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
                   "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
@@ -118,7 +118,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->nDimension;
+  int ndim = input->_dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -191,7 +191,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   weight = THTensor_(newContiguous)(weight);
   bias = bias ? THTensor_(newContiguous)(bias) : bias;
   int is_batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -218,7 +218,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -332,7 +332,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
   int is_batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -460,7 +460,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -479,7 +479,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   const int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);

--- a/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
@@ -12,9 +12,9 @@
 
 static inline void THNN_(VolumetricGridSamplerBilinear_shapeCheck)
      (THTensor *input, THTensor *grid, THTensor *gradOutput) {
-  THNN_ARGCHECK(input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 5, 2, input,
     "5D input tensor expected but got: %s");
-  THNN_ARGCHECK(grid->nDimension == 5, 2, grid,
+  THNN_ARGCHECK(grid->_dim() == 5, 2, grid,
     "5D grid tensor expected but got: %s");
 
   int nbatch   = THTensor_(size)(input, 0);

--- a/aten/src/THNN/generic/VolumetricMaxUnpooling.c
+++ b/aten/src/THNN/generic/VolumetricMaxUnpooling.c
@@ -17,7 +17,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
                          int pW,
                          int pH)
 {
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   THNN_CHECK_SHAPE_INDICES(input, indices);
@@ -31,7 +31,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
   int dimt = 1;
   int dimn = 0;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimt++;
     dimw++;
@@ -49,7 +49,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
       );
     }
 
-    THNN_CHECK_DIM_SIZE(gradOutput, input->nDimension, dimn, nslices);
+    THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), dimn, nslices);
   }
 }
 
@@ -138,7 +138,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
         state, input, NULL, indices,
         oT, oW, oH, dT, dW, dH, pT, pW, pH);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     nbatch = input->size[0];
     dimt++;
@@ -157,7 +157,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   indices = THIndexTensor_(newContiguous)(indices);
 
   /* resize output */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THTensor_(resize4d)(output, nslices, oT, oH, oW);
     THTensor_(zero)(output);
@@ -285,7 +285,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     nbatch = input->size[0];
     dimt++;
@@ -305,7 +305,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THNN_(VolumetricMaxUnpooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/VolumetricReplicationPadding.c
+++ b/aten/src/THNN/generic/VolumetricReplicationPadding.c
@@ -21,10 +21,10 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
   int64_t oheight;
   int64_t owidth;
 
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     dimw++;
     dimh++;
@@ -149,7 +149,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
       state, input, NULL, pleft, pright,
       ptop, pbottom, pfront, pback);
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     nbatch = input->size[0];
     dimw++;
@@ -171,7 +171,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->nDimension == 4)
+  if (input->_dim() == 4)
   {
     THTensor_(resize4d)(output, nslices, odepth, oheight, owidth);
 
@@ -293,7 +293,7 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->nDimension == 5)
+  if (input->_dim() == 5)
   {
     nbatch = input->size[0];
     dimw++;
@@ -324,7 +324,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     THNN_(VolumetricReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "5D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
 		"4D or 5D input tensor expected but got: %s");
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputDepth   = THTensor_(size)(input, 1);
     int inputHeight  = THTensor_(size)(input, 2);
@@ -51,14 +51,14 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(VolumetricUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputDepth   = THTensor_(size)(input, input->nDimension-3);
-  int inputHeight  = THTensor_(size)(input, input->nDimension-2);
-  int inputWidth   = THTensor_(size)(input,  input->nDimension-1);
+  int inputDepth   = THTensor_(size)(input, input->_dim()-3);
+  int inputHeight  = THTensor_(size)(input, input->_dim()-2);
+  int inputWidth   = THTensor_(size)(input,  input->_dim()-1);
   int outputDepth  = inputDepth * scale_factor;
   int outputHeight = inputHeight * scale_factor;
   int outputWidth  = inputWidth * scale_factor;
 
-  if (input->nDimension == 4) {
+  if (input->_dim() == 4) {
     THTensor_(resize4d)(output,
 			THTensor_(size)(input, 0),
 			outputDepth, outputHeight, outputWidth);    
@@ -72,12 +72,12 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   int dT = scale_factor;
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = input->nDimension-3;
-  int yDim = input->nDimension-2;
-  int zDim = input->nDimension-1;
+  int xDim = input->_dim()-3;
+  int yDim = input->_dim()-2;
+  int zDim = input->_dim()-1;
 
   // dims
-  int idim = input->nDimension;
+  int idim = input->_dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = output->size[2];
@@ -149,12 +149,12 @@ void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
   int dW = scale_factor;
   int dH = scale_factor;
   int dT = scale_factor;
-  int xDim = gradInput->nDimension-3;
-  int yDim = gradInput->nDimension-2;
-  int zDim = gradInput->nDimension-1;
+  int xDim = gradInput->_dim()-3;
+  int yDim = gradInput->_dim()-2;
+  int zDim = gradInput->_dim()-1;
 
   // dims
-  int idim = gradInput->nDimension;  // Guaranteed to be between 3 and 5
+  int idim = gradInput->_dim();  // Guaranteed to be between 3 and 5
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = gradInput->size[2];

--- a/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
@@ -16,7 +16,7 @@ static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
 	     " but got input (D: %d, H: %d, W: %d) output (D: %d, H: %d, W: %d)",
 	     inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->nDimension == 5, 2, input,
+    THNN_ARGCHECK(input->_dim() == 5, 2, input,
 		  "5D input tensor expected but got: %s");
   }
 

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -390,7 +390,7 @@ void THSTensor_(mulSlice)(
   THTensor *dstBuffer, THTensor *src1Buffer, THTensor *src2Buffer,
   THTensor *dst, THTensor *src1, THTensor *src2,
   int64_t dim, int64_t dstIdx, int64_t src1Idx, int64_t src2Idx) {
-  if (src1->nDimension > 1) {
+  if (src1->_dim() > 1) {
     THTensor_(select)(src1Buffer, src1, dim, src1Idx);
     THTensor_(select)(src2Buffer, src2, dim, src2Idx);
     THTensor_(select)(dstBuffer, dst, dim, dstIdx);
@@ -404,7 +404,7 @@ void THSTensor_(divSlice)(
   THTensor *dstBuffer, THTensor *src1Buffer, THTensor *src2Buffer,
   THTensor *dst, THTensor *src1, THTensor *src2,
   int64_t dim, int64_t dstIdx, int64_t src1Idx, int64_t src2Idx) {
-  if (src1->nDimension > 1) {
+  if (src1->_dim() > 1) {
     THTensor_(select)(src1Buffer, src1, dim, src1Idx);
     THTensor_(select)(src2Buffer, src2, dim, src2Idx);
     THTensor_(select)(dstBuffer, dst, dim, dstIdx);

--- a/aten/src/THS/generic/THSTensor.hpp
+++ b/aten/src/THS/generic/THSTensor.hpp
@@ -19,6 +19,11 @@ typedef struct THSTensor
     int coalesced;
     std::atomic<int> refcount;
 
+    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    inline int64_t _dim() const {
+      return nDimensionI + nDimensionV;
+    }
 } THSTensor;
 
 #endif

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -6,10 +6,10 @@
 #define COL_PTR2(t, c) (THTensor_(data)(t) + (c) * (t)->stride[1])
 
 void THSTensor_(zero)(THSTensor *self) {
-  if (self->indices->nDimension) {
+  if (self->indices->_dim()) {
     THLongTensor_resizeNd(self->indices, 0, NULL, NULL);
   }
-  if (self->values->nDimension) {
+  if (self->values->_dim()) {
     THTensor_(resizeNd)(self->values, 0, NULL, NULL);
   }
   self->nnz = 0;
@@ -337,8 +337,8 @@ void THSTensor_(spaddmm)(THTensor *r_,
       "matrices expected, got %dD tensor", sparse_->nDimensionI);
   THArgCheck(sparse_->nDimensionV == 0, 2,
       "scalar values expected, got %dD values", sparse_->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 2,
-      "matrices expected, got %dD tensor", dense->nDimension);
+  THArgCheck(dense->_dim() == 2, 2,
+      "matrices expected, got %dD tensor", dense->_dim());
 
   THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
@@ -410,8 +410,8 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
       "matrices expected, got %dD tensor", sparse_->nDimensionI);
   THArgCheck(sparse_->nDimensionV == 0, 2,
       "scalar values expected, got %dD values", sparse_->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 2,
-      "matrices expected, got %dD tensor", dense->nDimension);
+  THArgCheck(dense->_dim() == 2, 2,
+      "matrices expected, got %dD tensor", dense->_dim());
 
   THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
@@ -498,8 +498,8 @@ void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse_, THTensor *
       "matrices expected, got %dD tensor", sparse_->nDimensionI);
   THArgCheck(sparse_->nDimensionV == 0, 2,
       "scalar values expected, got %dD values", sparse_->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 2,
-      "matrices expected, got %dD tensor", dense->nDimension);
+  THArgCheck(dense->_dim() == 2, 2,
+      "matrices expected, got %dD tensor", dense->_dim());
 
   int64_t m = THSTensor_(size)(sparse_, 0);
   int64_t k = THSTensor_(size)(sparse_, 1);


### PR DESCRIPTION
This does the following:
1) makes nDimension an int64_t (to match ATen)
2) changes the dimension value to dim_ (so we catch direct usages)
3) provide an _dim() that provides access to the "old" view (so we can migrate functions one at a time)
4) have code call ->-_dim() instead of ->nDimension.

