### PR TITLE
Create captured inputs recursively for loop to resolve loop-carried dependencies across nested blocks

### DIFF
--- a/test/expect/TestScript.test_if_for_in_range.expect
+++ b/test/expect/TestScript.test_if_for_in_range.expect
@@ -1,0 +1,26 @@
+graph(%a.1 : Dynamic
+      %b.1 : Dynamic) {
+  %d.1 : Long() = prim::Constant[value={3}]()
+  %3 : Long() = prim::Constant[value={20}]()
+  %4 : Byte() = prim::Constant[value={1}]()
+  %a : Dynamic, %d : Long(), %b : Dynamic = prim::Loop(%3, %4, %a.1, %d.1, %b.1)
+    block0(%_ : Dynamic, %6 : Dynamic, %13 : Long(), %19 : Dynamic) {
+      %7 : Long() = prim::Constant[value={10}]()
+      %8 : Dynamic = aten::gt(%6, %7)
+      %a.3 : Dynamic, %b.3 : Dynamic, %d.3 : Long() = prim::If(%8)
+        block0() {
+          %9 : Long() = prim::Constant[value={3}]()
+          %a.2 : Dynamic = aten::add[alpha={1}](%9, %13)
+          -> (%a.2, %19, %13)
+        }
+        block1() {
+          %14 : Long() = prim::Constant[value={3}]()
+          %b.2 : Dynamic = aten::add[alpha={1}](%14, %13)
+          %d.2 : Long() = prim::Constant[value={4}]()
+          -> (%6, %b.2, %d.2)
+        }
+      %24 : Byte() = prim::Constant[value={1}]()
+      -> (%24, %a.3, %d.3, %b.3)
+    }
+  return (%d);
+}

--- a/test/expect/TestScript.test_if_for_in_range.expect
+++ b/test/expect/TestScript.test_if_for_in_range.expect
@@ -4,23 +4,23 @@ graph(%a.1 : Dynamic
   %3 : Long() = prim::Constant[value={20}]()
   %4 : Byte() = prim::Constant[value={1}]()
   %a : Dynamic, %d : Long(), %b : Dynamic = prim::Loop(%3, %4, %a.1, %d.1, %b.1)
-    block0(%_ : Dynamic, %6 : Dynamic, %13 : Long(), %19 : Dynamic) {
+    block0(%_ : Dynamic, %6 : Dynamic, %10 : Long(), %14 : Dynamic) {
       %7 : Long() = prim::Constant[value={10}]()
       %8 : Dynamic = aten::gt(%6, %7)
       %a.3 : Dynamic, %b.3 : Dynamic, %d.3 : Long() = prim::If(%8)
         block0() {
           %9 : Long() = prim::Constant[value={3}]()
-          %a.2 : Dynamic = aten::add[alpha={1}](%9, %13)
-          -> (%a.2, %19, %13)
+          %a.2 : Dynamic = aten::add[alpha={1}](%9, %10)
+          -> (%a.2, %14, %10)
         }
         block1() {
-          %14 : Long() = prim::Constant[value={3}]()
-          %b.2 : Dynamic = aten::add[alpha={1}](%14, %13)
+          %12 : Long() = prim::Constant[value={3}]()
+          %b.2 : Dynamic = aten::add[alpha={1}](%12, %10)
           %d.2 : Long() = prim::Constant[value={4}]()
           -> (%6, %b.2, %d.2)
         }
-      %24 : Byte() = prim::Constant[value={1}]()
-      -> (%24, %a.3, %d.3, %b.3)
+      %20 : Byte() = prim::Constant[value={1}]()
+      -> (%20, %a.3, %d.3, %b.3)
     }
   return (%d);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1317,6 +1317,23 @@ class TestScript(TestCase):
         inputs = self._make_scalar_vars([1, -1], torch.int64)
         self.checkScript(func, inputs, optimize=True)
 
+    def test_if_for_in_range(self):
+        def func(a, b):
+            d = 3
+            for _ in range(20):
+                if a > 10:
+                    a = 3 + d
+                else:
+                    b = 3 + d
+                    d = 4
+                c = a + b
+            return d
+
+        self.assertExpected(str(torch.jit.script(func).graph))
+
+        inputs = self._make_scalar_vars([1, -1], torch.int64)
+        self.checkScript(func, inputs, optimize=True)
+
     def test_if_noelse(self):
         def func(a, b):
             if a > 10:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1328,9 +1328,6 @@ class TestScript(TestCase):
                     d = 4
                 c = a + b
             return d
-
-        self.assertExpected(str(torch.jit.script(func).graph))
-
         inputs = self._make_scalar_vars([1, -1], torch.int64)
         self.checkScript(func, inputs, optimize=True)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1422,6 +1422,20 @@ class TestScript(TestCase):
 
         self.assertEqual(test_script_for_in_range_ast(*inputs), 161700)
 
+    def test_script_for_in_range_if_ast(self):
+        @torch.jit.script
+        def test_script_for_in_range_if_ast(x):
+            output = 0
+            for i in range(20):
+                if i == 0:
+                    output = x.unsqueeze(0)
+                else:
+                    output = torch.cat((output, x.unsqueeze(0)), dim=0)
+            return output
+        inputs = self._make_scalar_vars([0], torch.int64)
+
+        self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
+
     def test_script_bool_constant(self):
         script = '''
         def test_script_bool_constant():

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -122,7 +122,8 @@ struct Environment {
 
     // recursively create the captured input if it is the loop block
     if (from_parent && getBlockOwningKind() == prim::Loop) {
-      from_parent = createCapturedInput(from_parent->asValue(loc, method), ident);
+      if (Value* simple_val = asSimple(from_parent))
+        from_parent = createCapturedInput(simple_val, ident);
     }
     return from_parent;
   }


### PR DESCRIPTION
This PR fixes #7818 , the bug raises because we did not correctly create the captured inputs for nested loops. we changed the condition when we generate the captured input, recursively create a captured input if the use of ident crosses loops.
