### PR TITLE
Remove is_new_object from Blob::GetMutable

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -101,12 +101,10 @@ class Blob {
    * Reset().
    */
   template <class T>
-  T* GetMutable(bool* is_new_object=nullptr) {
+  T* GetMutable() {
     if (IsType<T>()) {
-      if (is_new_object) *is_new_object = false;
       return static_cast<T*>(pointer_);
     } else {
-      if (is_new_object) *is_new_object = true;
       VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<T>();
       return Reset<T>(new T());
     }

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -85,22 +85,6 @@ TEST(BlobTest, Blob) {
   EXPECT_FALSE(blob.IsType<int>());
 }
 
-TEST(BlobTest, BlobNewObjectFlag) {
-  Blob blob;
-
-  bool is_new_object = true;
-
-  blob.GetMutable<int>(&is_new_object);
-  EXPECT_TRUE(is_new_object);
-  blob.GetMutable<int>(&is_new_object);
-  EXPECT_FALSE(is_new_object);
-
-  blob.GetMutable<BlobTestFoo>(&is_new_object);
-  EXPECT_TRUE(is_new_object);
-  blob.GetMutable<BlobTestFoo>(&is_new_object);
-  EXPECT_FALSE(is_new_object);
-}
-
 TEST(BlobTest, BlobUninitialized) {
   Blob blob;
   ASSERT_THROW(blob.Get<int>(), EnforceNotMet);


### PR DESCRIPTION
Landing diff for jiayq :)

This is after 2 years and we do not seem to have a use case for this one, so
for the sake of clean API design we should potentially remove this. This would
allow us to potentially pass in arguments to optionally construct an object,
although it is indeed a little bit unclear how we can reuse existing objects if
constructor arguments are passed in. In any case, we may want to remove this
dangling feature.

