### PR TITLE
[C++ API] Make pImpl easy to use in modules to enable happy reference semantics

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -236,9 +236,9 @@ TEST_CASE("integration") {
         << "Training episodic policy gradient with a critic for up to 3000"
            " episodes, rest your eyes for a bit!\n";
     auto model = std::make_shared<SimpleContainer>();
-    auto linear = model->add(Linear(4, 128).build(), "linear");
-    auto policyHead = model->add(Linear(128, 2).build(), "policy");
-    auto valueHead = model->add(Linear(128, 1).build(), "action");
+    auto linear = model->add(Linear(4, 128), "linear");
+    auto policyHead = model->add(Linear(128, 2), "policy");
+    auto valueHead = model->add(Linear(128, 1), "action");
     auto optim = Adam(model, 1e-3).make();
 
     std::vector<Variable> saved_log_probs;
@@ -333,12 +333,12 @@ TEST_CASE("integration") {
 
 TEST_CASE("integration/mnist", "[cuda]") {
   auto model = std::make_shared<SimpleContainer>();
-  auto conv1 = model->add(Conv2d(1, 10, 5).build(), "conv1");
-  auto conv2 = model->add(Conv2d(10, 20, 5).build(), "conv2");
-  auto drop = Dropout(0.3).build();
-  auto drop2d = Dropout2d(0.3).build();
-  auto linear1 = model->add(Linear(320, 50).build(), "linear1");
-  auto linear2 = model->add(Linear(50, 10).build(), "linear2");
+  auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
+  auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
+  auto drop = Dropout(0.3);
+  auto drop2d = Dropout2d(0.3);
+  auto linear1 = model->add(Linear(320, 50), "linear1");
+  auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](Variable x) {
     x = std::get<0>(at::max_pool2d(conv1->forward({x})[0], {2, 2}))
@@ -368,14 +368,14 @@ TEST_CASE("integration/mnist", "[cuda]") {
 
 TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   auto model = std::make_shared<SimpleContainer>();
-  auto conv1 = model->add(Conv2d(1, 10, 5).build(), "conv1");
-  auto batchnorm2d =
-      model->add(BatchNorm(10).stateful(true).build(), "batchnorm2d");
-  auto conv2 = model->add(Conv2d(10, 20, 5).build(), "conv2");
-  auto linear1 = model->add(Linear(320, 50).build(), "linear1");
-  auto batchnorm1 =
-      model->add(BatchNorm(50).stateful(true).build(), "batchnorm1");
-  auto linear2 = model->add(Linear(50, 10).build(), "linear2");
+  auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
+  auto batchnorm2d = model->add(
+      BatchNorm(BatchNormOptions(10).stateful(true)), "batchnorm2d");
+  auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
+  auto linear1 = model->add(Linear(320, 50), "linear1");
+  auto batchnorm1 = model->add(
+      BatchNorm(BatchNormOptions(50).stateful(true)), "batchnorm1");
+  auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](Variable x) {
     x = std::get<0>(at::max_pool2d(conv1->forward({x})[0], {2, 2}))

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -22,7 +22,7 @@ using Catch::StartsWith;
 TEST_CASE("misc") {
   SECTION("no_grad") {
     NoGradGuard guard;
-    auto model = Linear(5, 2).build();
+    Linear model(5, 2);
     auto x = torch::randn({10, 5}, at::requires_grad());
     auto y = model->forward({x})[0];
     Variable s = y.sum();

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -53,7 +53,7 @@ TEST_CASE("optim") {
   std::srand(0);
   torch::manual_seed(0);
   auto model = std::make_shared<Sequential>(
-      SigmoidLinear(Linear(2, 8).build()), SigmoidLinear(Linear(8, 1).build()));
+      SigmoidLinear(Linear(2, 8)), SigmoidLinear(Linear(8, 1)));
 
   // Flaky
   // SECTION("lbfgs") {

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -13,23 +13,75 @@ using namespace torch::nn;
 using Catch::StartsWith;
 
 TEST_CASE("sequential") {
-  SECTION("construction") {
+  SECTION("construction from shared pointer") {
+    struct M : nn::Module {
+      explicit M(int value_) : value(value_) {}
+      int value;
+      int forward() {
+        return value;
+      }
+    };
     Sequential sequential(
-        Linear(2, 3).build(), Linear(2, 3), Linear(2, 3).build());
+        std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3));
+    REQUIRE(sequential.size() == 3);
+  }
+  SECTION("construction from concrete type") {
+    struct M : nn::Module {
+      explicit M(int value_) : value(value_) {}
+      int value;
+      int forward() {
+        return value;
+      }
+    };
+
+    Sequential sequential(M(1), M(2), M(3));
+    REQUIRE(sequential.size() == 3);
+  }
+  SECTION("construction from module holders") {
+    struct MImpl : nn::Module {
+      explicit MImpl(int value_) : value(value_) {}
+      int forward() {
+        return value;
+      }
+      int value;
+    };
+
+    struct M : torch::nn::ModuleHolder<MImpl> {
+      using torch::nn::ModuleHolder<MImpl>::ModuleHolder;
+      using torch::nn::ModuleHolder<MImpl>::get;
+    };
+
+    Sequential sequential(M(1), M(2), M(3));
     REQUIRE(sequential.size() == 3);
   }
   SECTION("push_back") {
+    struct M : nn::Module {
+      explicit M(int value_) : value(value_) {}
+      int forward() {
+        return value;
+      }
+      int value;
+    };
     Sequential sequential;
     REQUIRE(sequential.size() == 0);
     REQUIRE(sequential.is_empty());
-    sequential.push_back(Linear(3, 4).build());
+    sequential.push_back(Linear(3, 4));
     REQUIRE(sequential.size() == 1);
-    sequential.push_back(Linear(4, 5).build());
+    sequential.push_back(std::make_shared<M>(1));
     REQUIRE(sequential.size() == 2);
+    sequential.push_back(M(2));
+    REQUIRE(sequential.size() == 3);
   }
   SECTION("access") {
-    std::vector<std::shared_ptr<Linear>> modules = {
-        Linear(2, 3).build(), Linear(3, 4).build(), Linear(4, 5).build()};
+    struct M : nn::Module {
+      explicit M(int value_) : value(value_) {}
+      int forward() {
+        return value;
+      }
+      int value;
+    };
+    std::vector<std::shared_ptr<M>> modules = {
+        std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3)};
 
     Sequential sequential;
     for (auto& module : modules) {
@@ -40,15 +92,15 @@ TEST_CASE("sequential") {
     SECTION("at()") {
       SECTION("returns the correct module for a given index") {
         for (size_t i = 0; i < modules.size(); ++i) {
-          REQUIRE(&sequential.at<Linear>(i) == modules[i].get());
+          REQUIRE(&sequential.at<M>(i) == modules[i].get());
         }
       }
       SECTION("throws for a bad index") {
         REQUIRE_THROWS_WITH(
-            sequential.at<Linear>(modules.size() + 1),
+            sequential.at<M>(modules.size() + 1),
             StartsWith("Index out of range"));
         REQUIRE_THROWS_WITH(
-            sequential.at<Linear>(modules.size() + 1000000),
+            sequential.at<M>(modules.size() + 1000000),
             StartsWith("Index out of range"));
       }
     }
@@ -58,7 +110,7 @@ TEST_CASE("sequential") {
         for (size_t i = 0; i < modules.size(); ++i) {
           REQUIRE(sequential.ptr(i).get() == modules[i].get());
           REQUIRE(sequential[i].get() == modules[i].get());
-          REQUIRE(sequential.ptr<Linear>(i).get() == modules[i].get());
+          REQUIRE(sequential.ptr<M>(i).get() == modules[i].get());
         }
       }
       SECTION("throws for a bad index") {
@@ -123,8 +175,7 @@ TEST_CASE("sequential") {
   }
 
   SECTION("returns the last value") {
-    Sequential sequential(
-        Linear(10, 3).build(), Linear(3, 5).build(), Linear(5, 100).build());
+    Sequential sequential(Linear(10, 3), Linear(3, 5), Linear(5, 100));
 
     auto x = torch::randn({1000, 10}, at::requires_grad());
     auto y = sequential.forward<std::vector<Variable>>(std::vector<Variable>{x})

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -213,16 +213,16 @@ TEST_CASE("serialization") {
   }
 
   SECTION("optim") {
-    auto model1 = Linear(5, 2).build();
-    auto model2 = Linear(5, 2).build();
-    auto model3 = Linear(5, 2).build();
+    auto model1 = Linear(5, 2);
+    auto model2 = Linear(5, 2);
+    auto model3 = Linear(5, 2);
 
     // Models 1, 2, 3 will have the same params
     std::stringstream ss;
-    save(ss, model1);
-    load(ss, model2);
+    save(ss, model1.get());
+    load(ss, model2.get());
     ss.seekg(0, std::ios::beg);
-    load(ss, model3);
+    load(ss, model3.get());
 
     // Make some optimizers with momentum (and thus state)
     auto optim1 = SGD(model1, 1e-1).momentum(0.9).make();
@@ -233,7 +233,7 @@ TEST_CASE("serialization") {
 
     auto x = torch::ones({10, 5}, at::requires_grad());
 
-    auto step = [&](Optimizer optim, std::shared_ptr<Linear> model) {
+    auto step = [&](Optimizer optim, Linear model) {
       optim->zero_grad();
       auto y = model->forward({x})[0].sum();
       y.backward();

--- a/test/cpp/api/static.cpp
+++ b/test/cpp/api/static.cpp
@@ -39,7 +39,7 @@ TEST_CASE("static") {
     REQUIRE(torch::any_of<true, true, false>::value == true);
   }
   SECTION("enable_if_module_t") {
-    REQUIRE(f(torch::nn::Linear(1, 2)) == true);
+    REQUIRE(f(torch::nn::LinearImpl({1, 2})) == true);
     REQUIRE(f(5) == false);
   }
   SECTION("check_not_lvalue_references") {

--- a/test/cpp/api/util.h
+++ b/test/cpp/api/util.h
@@ -10,7 +10,7 @@ namespace torch {
 
 // Lets you use a container without making a new class,
 // for experimental implementations
-class SimpleContainer : public nn::CloneableModule<SimpleContainer> {
+class SimpleContainer : public nn::Cloneable<SimpleContainer> {
  public:
   virtual std::vector<Variable> forward(std::vector<Variable>) {
     throw std::runtime_error(
@@ -18,29 +18,28 @@ class SimpleContainer : public nn::CloneableModule<SimpleContainer> {
         " wanted to subclass and override this function?");
   }
 
-  void reset() {}
+  void reset() override {}
 
-  template <typename Derived>
-  std::shared_ptr<Derived> add(
-      std::shared_ptr<Derived> module,
+  template <typename ModuleHolder>
+  ModuleHolder add(
+      ModuleHolder module_holder,
       std::string name = std::string()) {
-    return Module::register_module(std::move(name), module);
+    return Module::register_module(std::move(name), module_holder);
   }
 };
 
 struct SigmoidLinear : nn::Module {
-  SigmoidLinear(size_t in, size_t out) : linear(nn::Linear(in, out).build()) {
+  SigmoidLinear(int64_t in, int64_t out) : linear(nn::Linear(in, out)) {
     register_module("linear", linear);
   }
 
-  explicit SigmoidLinear(std::shared_ptr<nn::Linear> linear_)
-      : linear(std::move(linear_)) {
+  explicit SigmoidLinear(nn::Linear linear_) : linear(std::move(linear_)) {
     register_module("linear", linear);
   }
   Variable forward(Variable input) {
     return linear->forward({input}).front().sigmoid();
   }
-  std::shared_ptr<nn::Linear> linear;
+  nn::Linear linear;
 };
 
 } // namespace torch

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -350,7 +350,7 @@ if (TORCH_BUILD_TEST)
 
     add_executable(test_api
       ${TORCH_API_TEST_DIR}/any.cpp
-      ${TORCH_API_TEST_DIR}/container.cpp
+      ${TORCH_API_TEST_DIR}/modules.cpp
       ${TORCH_API_TEST_DIR}/cursor.cpp
       ${TORCH_API_TEST_DIR}/integration.cpp
       ${TORCH_API_TEST_DIR}/main.cpp

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <torch/nn/module.h>
+#include <torch/tensor.h>
+
+#include <ATen/Error.h>
+
+#include <memory>
+#include <utility>
+
+namespace torch {
+namespace nn {
+/// The `clone()` method in the base `Module` class does not have knowledge of
+/// the concrete runtime type of its subclasses. Therefore, `clone()` must
+/// either be called from within the subclass, or from a base class that has
+/// knowledge of the concrete type. `Cloneable` uses the CRTP to gain
+/// knowledge of the subclass' static type and provide an implementation of the
+/// `clone()` method. We do not want to use this pattern in the base class,
+/// because then storing a module would always require templatizing it.
+template <typename Derived>
+class Cloneable : public Module {
+ public:
+  using Module::Module;
+
+  /// `reset()` must perform initialization of all members with reference
+  /// semantics, most importantly parameters, buffers and submodules.
+  virtual void reset() = 0;
+
+  /// Moves the `Module` into a `shared_ptr` and calls `reset()` on it.
+  std::shared_ptr<Derived> build() {
+    auto module = std::make_shared<Derived>(static_cast<Derived&&>(*this));
+    module->reset();
+    return module;
+  }
+
+  /// Performs a recursive "deep copy" of the `Module`, such that all parameters
+  /// and submodules in the cloned module are different from those in the
+  /// original module.
+  std::shared_ptr<Module> clone() const override {
+    const auto& self = static_cast<const Derived&>(*this);
+    auto copy = std::make_shared<Derived>(self);
+    copy->parameters_.clear();
+    copy->children_.clear();
+    copy->reset();
+    for (const auto& parameter : parameters_) {
+      copy->parameters_[parameter.key].data().copy_(parameter->data());
+    }
+    for (const auto& child : children_) {
+      copy->children_[child.key]->clone_(*child.value);
+    }
+    return copy;
+  }
+
+ private:
+  void clone_(Module& other) final override {
+    // Here we are *pretty* certain that `other's` type is `Derived` (because it
+    // was registered under the same name as `this`), but you never know what
+    // crazy things `reset()` does, so `dynamic_cast` just to be safe.
+    auto clone = std::dynamic_pointer_cast<Derived>(other.clone());
+    AT_CHECK(
+        clone != nullptr,
+        "Attempted to clone submodule, but it is of a "
+        "different type than the submodule it was to be cloned into");
+    static_cast<Derived&>(*this) = std::move(*clone);
+  }
+};
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -2,6 +2,7 @@
 
 #include <torch/detail/static.h>
 #include <torch/nn/module.h>
+#include <torch/nn/pimpl.h>
 
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/utils/memory.h>
@@ -16,7 +17,7 @@
 namespace torch {
 namespace nn {
 
-/// A class to store a type erasd module, whose `forward()` method can be
+/// A class to store a type erased module, whose `forward()` method can be
 /// invoked, with dynamic type checking. An `AnyModule` has an empty state, into
 /// which it is default constructed. `is_empty()` can be used to query whether
 /// the `AnyModule` is empty.
@@ -33,8 +34,14 @@ class AnyModule {
   explicit AnyModule(std::shared_ptr<ModuleType> module);
 
   /// Constructs an `AnyModule` from a concrete module object.
-  template <typename ModuleType>
+  template <
+      typename ModuleType,
+      typename = torch::detail::disable_if_module_holder_t<ModuleType>>
   explicit AnyModule(ModuleType&& module);
+
+  /// Constructs an `AnyModule` from a module holder.
+  template <typename ModuleType>
+  explicit AnyModule(const ModuleHolder<ModuleType>& module_holder);
 
   /// Move construction and assignment is allowed, and follows the default
   /// behavior of move for `std::unique_ptr`.
@@ -65,6 +72,11 @@ class AnyModule {
   /// exception if the types do not match.
   template <typename T, typename = torch::detail::enable_if_module_t<T>>
   const T& get() const;
+
+  /// Returns the contained module in a `nn::ModuleHolder` subclass if possible
+  /// (i.e. if `T` has a constructor for the underlying module type).
+  template <typename T, typename ContainedType = typename T::ContainedType>
+  T get() const;
 
   /// Returns a `std::shared_ptr` whose dynamic type is that of the underlying
   /// module.
@@ -282,10 +294,14 @@ AnyModule::AnyModule(std::shared_ptr<ModuleType> module)
           std::move(module),
           &std::remove_reference<ModuleType>::type::forward)) {}
 
-template <typename ModuleType>
+template <typename ModuleType, typename>
 AnyModule::AnyModule(ModuleType&& module)
     : AnyModule(
           std::make_shared<ModuleType>(std::forward<ModuleType>(module))) {}
+
+template <typename ModuleType>
+AnyModule::AnyModule(const ModuleHolder<ModuleType>& module_holder)
+    : AnyModule(module_holder.get()) {}
 
 template <typename ModuleType>
 AnyModule& AnyModule::operator=(std::shared_ptr<ModuleType> module) {
@@ -313,6 +329,11 @@ template <typename T, typename>
 const T& AnyModule::get() const {
   AT_CHECK(!is_empty(), "Cannot call get() on an empty AnyModule");
   return get_<T>();
+}
+
+template <typename T, typename ContainedType>
+T AnyModule::get() const {
+  return T(ptr<ContainedType>());
 }
 
 inline std::shared_ptr<Module> AnyModule::ptr() const {

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -1,28 +1,41 @@
 #pragma once
 
-#include <torch/nn/module.h>
+#include <torch/nn/cloneable.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
 #include <torch/csrc/autograd/variable.h>
 
 #include <cstdint>
 
-namespace torch { namespace nn {
-class BatchNorm : public torch::nn::CloneableModule<BatchNorm> {
+namespace torch {
+namespace nn {
+struct BatchNormOptions {
+  /* implicit */ BatchNormOptions(int64_t features);
+  TORCH_ARG(int64_t, features);
+  TORCH_ARG(bool, affine) = true;
+  TORCH_ARG(bool, stateful) = false;
+  TORCH_ARG(double, eps) = 1e-5;
+  TORCH_ARG(double, momentum) = 0.1;
+};
+
+class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
  public:
-  explicit BatchNorm(int64_t features);
+  explicit BatchNormImpl(BatchNormOptions options);
 
   void reset() override;
-
   std::vector<Variable> forward(std::vector<Variable>);
+  const BatchNormOptions& options() const noexcept;
 
-  TORCH_ATTR(int64_t, features);
-  TORCH_ATTR(bool, affine) = true;
-  TORCH_ATTR(bool, stateful) = false;
-  TORCH_ATTR(double, eps) = 1e-5;
-  TORCH_ATTR(double, momentum) = 0.1;
-  TORCH_ATTR(Variable, weight);
-  TORCH_ATTR(Variable, bias);
-  TORCH_ATTR(Variable, running_mean);
-  TORCH_ATTR(Variable, running_variance);
+ private:
+  BatchNormOptions options_;
+  Variable weight_;
+  Variable bias_;
+  Variable running_mean_;
+  Variable running_variance_;
 };
-}} // namespace torch::nn
+
+TORCH_MODULE(BatchNorm);
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -1,42 +1,56 @@
 #pragma once
 
 #include <torch/expanding_array.h>
-#include <torch/nn/module.h>
+#include <torch/nn/cloneable.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
-#include <cstdint>
+#include <cstddef>
+#include <vector>
 
-namespace torch { namespace nn {
-
-template <size_t D, typename Derived>
-class Conv : public torch::nn::CloneableModule<Derived> {
- public:
-  Conv(
+namespace torch {
+namespace nn {
+template <size_t D>
+struct ConvOptions {
+  ConvOptions(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<D> kernel_size);
 
-  void reset() override;
-
-  TORCH_ATTR(int64_t, input_channels);
-  TORCH_ATTR(int64_t, output_channels);
-  TORCH_ATTR(ExpandingArray<D>, kernel_size);
-  TORCH_ATTR(ExpandingArray<D>, stride) = 1;
-  TORCH_ATTR(ExpandingArray<D>, padding) = 0;
-  TORCH_ATTR(ExpandingArray<D>, dilation) = 1;
-  TORCH_ATTR(ExpandingArray<D>, output_padding) = 0;
-  TORCH_ATTR(bool, transposed) = false;
-  TORCH_ATTR(bool, with_bias) = true;
-  TORCH_ATTR(int64_t, groups) = 1;
-  TORCH_ATTR(Variable, weight);
-  TORCH_ATTR(Variable, bias);
+  TORCH_ARG(int64_t, input_channels);
+  TORCH_ARG(int64_t, output_channels);
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+  TORCH_ARG(ExpandingArray<D>, stride) = 1;
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+  TORCH_ARG(ExpandingArray<D>, dilation) = 1;
+  TORCH_ARG(ExpandingArray<D>, output_padding) = 0;
+  TORCH_ARG(bool, transposed) = false;
+  TORCH_ARG(bool, with_bias) = true;
+  TORCH_ARG(int64_t, groups) = 1;
 };
 
-#define CONV_D(dimensions)                                                     \
-  class Conv##dimensions##d : public Conv<(dimensions), Conv##dimensions##d> { \
-   public:                                                                     \
-    using Conv<(dimensions), Conv##dimensions##d>::Conv;                       \
-    std::vector<Variable> forward(std::vector<Variable>);                                      \
-  }
+template <size_t D, typename Derived>
+class ConvImpl : public torch::nn::Cloneable<Derived> {
+ public:
+  explicit ConvImpl(ConvOptions<D> options);
+
+  void reset() override;
+  const ConvOptions<D>& options() const noexcept;
+
+ protected:
+  Variable weight_;
+  Variable bias_;
+  ConvOptions<D> options_;
+};
+
+#define CONV_D(D)                                               \
+  class Conv##D##dImpl : public ConvImpl<D, Conv##D##dImpl> {   \
+   public:                                                      \
+    using ConvImpl<D, Conv##D##dImpl>::ConvImpl;                \
+    std::vector<Variable> forward(std::vector<Variable> input); \
+  };                                                            \
+  using Conv##D##dOptions = ConvOptions<D>;                     \
+  TORCH_MODULE(Conv##D##d)
 
 CONV_D(1);
 CONV_D(2);
@@ -44,4 +58,5 @@ CONV_D(3);
 
 #undef CONV_D
 
-}} // namespace torch::nn
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -1,22 +1,35 @@
 #pragma once
 
-#include <torch/nn/module.h>
+#include <torch/nn/cloneable.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
-#include <torch/csrc/autograd/variable.h>
+#include <cstddef>
+#include <vector>
 
-#include <cstdint>
+namespace torch {
+namespace nn {
 
-namespace torch { namespace nn {
-class Embedding : public torch::nn::CloneableModule<Embedding> {
+struct EmbeddingOptions {
+  EmbeddingOptions(int64_t count, int64_t dimension);
+  TORCH_ARG(int64_t, count);
+  TORCH_ARG(int64_t, dimension);
+};
+
+class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
  public:
-  Embedding(int64_t count, int64_t dimension);
+  explicit EmbeddingImpl(EmbeddingOptions options);
 
   void reset() override;
-
   std::vector<Variable> forward(std::vector<Variable>);
+  const EmbeddingOptions& options() const noexcept;
 
-  TORCH_ATTR(int64_t, count);
-  TORCH_ATTR(int64_t, dimension);
-  TORCH_ATTR(Variable, table);
+ private:
+  EmbeddingOptions options_;
+  Variable table_;
 };
-}} // namespace torch::nn
+
+TORCH_MODULE(Embedding);
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/functional.h
@@ -1,25 +1,32 @@
 #pragma once
 
-#include <torch/nn/module.h>
+#include <torch/nn/cloneable.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
 #include <functional>
+#include <vector>
 
-namespace torch { namespace nn {
+namespace torch {
+namespace nn {
 
 // Lets you create a container from a function, designed for use in
 // Sequential.
-class Functional : public torch::nn::CloneableModule<Functional> {
+class FunctionalImpl : public torch::nn::Cloneable<FunctionalImpl> {
  public:
   using Function = std::function<std::vector<Variable>(std::vector<Variable>)>;
 
-  explicit Functional(Function function);
-  explicit Functional(std::function<Variable(Variable)> function);
+  explicit FunctionalImpl(Function function);
+  explicit FunctionalImpl(std::function<Variable(Variable)> function);
 
   void reset() override;
-
   std::vector<Variable> forward(std::vector<Variable> input);
 
-  TORCH_ATTR(Function, function);
+ private:
+  Function function_;
 };
 
-}} // namespace torch::nn
+TORCH_MODULE(Functional);
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -1,28 +1,37 @@
 #pragma once
 
+#include <torch/nn/cloneable.h>
 #include <torch/nn/module.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
-#include <torch/csrc/autograd/variable.h>
-
-#include <cstdint>
+#include <cstddef>
+#include <vector>
 
 namespace torch {
 namespace nn {
+struct LinearOptions {
+  LinearOptions(int64_t in, int64_t out);
+  TORCH_ARG(int64_t, in);
+  TORCH_ARG(int64_t, out);
+  TORCH_ARG(bool, with_bias) = true;
+};
 
-class Linear : public torch::nn::CloneableModule<Linear> {
+class LinearImpl : public torch::nn::Cloneable<LinearImpl> {
  public:
-  Linear(size_t features_in, size_t features_out);
+  explicit LinearImpl(LinearOptions options);
 
   void reset() override;
-
   std::vector<Variable> forward(std::vector<Variable>);
+  const LinearOptions& options() const noexcept;
 
-  TORCH_ATTR(int64_t, in);
-  TORCH_ATTR(int64_t, out);
-  TORCH_ATTR(bool, with_bias) = true;
-  TORCH_ATTR(Variable, weight);
-  TORCH_ATTR(Variable, bias);
+ private:
+  Variable weight_;
+  Variable bias_;
+  LinearOptions options_;
 };
+
+TORCH_MODULE(Linear);
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -1,62 +1,64 @@
 #pragma once
 
-#include <torch/nn/module.h>
-
-#include <torch/csrc/autograd/variable.h>
+#include <torch/nn/cloneable.h>
+#include <torch/nn/modules/dropout.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
 #include <ATen/Error.h>
 #include <ATen/optional.h>
 
-#include <cstdint>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <vector>
 
 namespace torch {
 namespace nn {
-class Dropout;
-}
-} // namespace torch
-
-namespace torch {
-namespace nn {
+namespace detail {
+struct RNNOptionsBase {
+  RNNOptionsBase(int64_t input_size, int64_t hidden_size);
+  virtual ~RNNOptionsBase() = default;
+  TORCH_ARG(int64_t, input_size);
+  TORCH_ARG(int64_t, hidden_size);
+  TORCH_ARG(int64_t, layers) = 1;
+  TORCH_ARG(bool, with_bias) = true;
+  TORCH_ARG(double, dropout) = 0.0;
+};
 
 template <typename Derived>
-class RNNBase : public CloneableModule<Derived> {
+class RNNImplBase : public torch::nn::Cloneable<Derived> {
  public:
   // These must line up with the CUDNN mode codes:
   // https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnRNNMode_t
   enum class CuDNNMode { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
-  RNNBase(
-      int64_t input_size,
-      int64_t hidden_size,
+  RNNImplBase(
+      RNNOptionsBase options,
       at::optional<CuDNNMode> cudnn_mode = at::nullopt,
       int64_t number_of_gates = 1,
       bool has_cell_state = false);
 
-  void reset() override;
-
   std::vector<Variable> forward(std::vector<Variable>);
+
+  void reset() override;
 
   void to(at::Type& type) override;
   void to(at::ScalarType scalar_type) override;
   void to(at::Backend backend) override;
 
-  TORCH_ATTR(int64_t, input_size);
-  TORCH_ATTR(int64_t, hidden_size);
-  TORCH_ATTR(int64_t, layers) = 1;
-  TORCH_ATTR(bool, with_bias) = true;
-  TORCH_ATTR(double, dropout) = 0.0;
-
  protected:
-  virtual std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer) = 0;
+  virtual std::vector<Variable> cell_forward(
+      std::vector<Variable>,
+      int64_t layer) = 0;
 
   std::vector<Variable> CUDNN_forward(std::vector<Variable>);
   std::vector<Variable> autograd_forward(std::vector<Variable>);
 
   void flatten_parameters_for_cudnn();
   std::vector<at::Tensor> flat_weights() const;
+
+  RNNOptionsBase options_;
 
   std::vector<Variable> ihw_;
   std::vector<Variable> ihb_;
@@ -66,7 +68,7 @@ class RNNBase : public CloneableModule<Derived> {
   int64_t number_of_gates_;
   bool has_cell_state_;
   at::optional<CuDNNMode> cudnn_mode_;
-  std::shared_ptr<Dropout> dropout_module_;
+  Dropout dropout_module_;
 
   // This is copied from pytorch, to determine whether weights are flat for the
   // fast CUDNN route. Otherwise, we have to use non flattened weights, which
@@ -77,42 +79,77 @@ class RNNBase : public CloneableModule<Derived> {
   std::vector<void*> data_ptrs_;
   Variable flat_weights_;
 };
+} // namespace detail
 
-class LSTM : public RNNBase<LSTM> {
- public:
-  LSTM(int64_t input_size, int64_t hidden_size);
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- private:
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer) override;
+// TODO: Replace this with passing an activation module.
+
+enum class RNNActivation { ReLU, Tanh };
+
+struct RNNOptions {
+  RNNOptions(int64_t input_size, int64_t hidden_size);
+
+  RNNOptions& tanh();
+  RNNOptions& relu();
+
+  TORCH_ARG(int64_t, input_size);
+  TORCH_ARG(int64_t, hidden_size);
+  TORCH_ARG(int64_t, layers) = 1;
+  TORCH_ARG(bool, with_bias) = true;
+  TORCH_ARG(double, dropout) = 0.0;
+  TORCH_ARG(RNNActivation, activation) = RNNActivation::ReLU;
 };
 
-class GRU : public RNNBase<GRU> {
+class RNNImpl : public detail::RNNImplBase<RNNImpl> {
  public:
-  GRU(int64_t input_size, int64_t hidden_size);
+  explicit RNNImpl(RNNOptions options);
+
+  const RNNOptions& options() const noexcept;
 
  private:
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer) override;
+  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
+      override;
+
+  RNNOptions options_;
+  std::function<Variable(Variable)> activation_function_;
 };
 
-class RNN : public RNNBase<RNN> {
+TORCH_MODULE(RNN);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using LSTMOptions = detail::RNNOptionsBase;
+
+class LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
  public:
-  enum class Activation { ReLU, Tanh };
+  explicit LSTMImpl(LSTMOptions options);
 
-  RNN(int64_t input_size, int64_t hidden_size);
-
-  void reset() override;
-
-  RNN& relu();
-  RNN& tanh();
-
-  TORCH_ATTR(Activation, activation) = Activation::Tanh;
+  const LSTMOptions& options() const noexcept;
 
  private:
-  using ActivationFunction = std::function<Variable(Variable)>;
-
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer) override;
-
-  ActivationFunction activation_function_;
+  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
+      override;
 };
+
+TORCH_MODULE(LSTM);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using GRUOptions = detail::RNNOptionsBase;
+
+class GRUImpl : public detail::RNNImplBase<GRUImpl> {
+ public:
+  explicit GRUImpl(GRUOptions options);
+
+  const GRUOptions& options() const noexcept;
+
+ private:
+  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
+      override;
+};
+
+TORCH_MODULE(GRU);
+
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <torch/csrc/utils/variadic.h>
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace torch {
+namespace detail {
+/// This class exists  only to do SFINAE on abstract types `T` that are really
+/// `ModuleHolder<ModuleType>`, because there's no good way to say that `T` is a
+/// `ModuleHolder` over some unknown type `ModuleType`. With this, you can do
+/// enable_if_t<is_base_of<ModuleHolderIndicator, T>::value>::type.
+struct ModuleHolderIndicator {};
+
+template <typename T>
+using disable_if_module_holder_t =
+    disable_if_t<std::is_base_of<ModuleHolderIndicator, decay_t<T>>::value>;
+} // namespace detail
+
+namespace nn {
+
+/// A `ModuleHolder` is essentially a wrapper around `std::shared_ptr<M>` where
+/// `M` is an `nn::Module` subclass, with convenient constructors defined for
+/// the kind of constructions we want to allow for our modules.
+template <typename Contained>
+class ModuleHolder : torch::detail::ModuleHolderIndicator {
+ public:
+  using ContainedType = Contained;
+
+  /// Constructs the `ModuleHolder` with an empty contained value.
+  ModuleHolder() = default;
+
+  /// Single argument constructor of the underlying type.
+  /// Example: `Linear(4)` or `Linear(LinearOptions(4))`.
+  template <typename T>
+  explicit ModuleHolder(T&& t)
+      : impl_(std::make_shared<Contained>(std::forward<T>(t))) {}
+
+  /// Multi-argument constructor. This constructor is special in that the
+  /// expectation is that the constructor of the contained type takes an object
+  /// that can be constructed with the given arguments. For our modules, this is
+  /// always the `Options` struct. For this reason, the arguments are forwarded
+  /// inside braces, as to construct the constructor argument.
+  /// Example: `Linear(3, 4)`, equivalent to `Linear(LinearOptions(3, 4))`.
+  template <typename T, typename... Ts>
+  explicit ModuleHolder(T&& t, Ts&&... ts)
+      : impl_(new Contained({std::forward<T>(t), std::forward<Ts>(ts)...})) {}
+
+  /// Constructs the `ModuleHolder` from a pointer to the contained type.
+  /// Example: `Linear(std::make_shared<LinearImpl>(...))`.
+  explicit ModuleHolder(std::shared_ptr<Contained> module)
+      : impl_(std::move(module)) {}
+
+  /// Returns true if the `ModuleHolder` contains a module, or false if it is
+  /// `nullptr`.
+  explicit operator bool() const noexcept {
+    return !is_empty();
+  }
+
+  /// Forwards to the contained module.
+  Contained* operator->() {
+    AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
+    return impl_.get();
+  }
+
+  /// Forwards to the contained module.
+  const Contained* operator->() const {
+    AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
+    return impl_.get();
+  }
+
+  /// Returns the underlying module.
+  const std::shared_ptr<Contained>& get() const {
+    AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
+    return impl_;
+  }
+
+  /// Returns true if the `ModuleHolder` does not contain a module.
+  bool is_empty() const noexcept {
+    return impl_ == nullptr;
+  }
+
+ protected:
+  /// The module pointer this class wraps.
+  std::shared_ptr<Contained> impl_;
+};
+} // namespace nn
+} // namespace torch
+
+#define TORCH_ARG(T, name)                          \
+  auto name(const T& new_##name)->decltype(*this) { \
+    this->name##_ = new_##name;                     \
+    return *this;                                   \
+  }                                                 \
+  auto name(T&& new_##name)->decltype(*this) {      \
+    this->name##_ = std::move(new_##name);          \
+    return *this;                                   \
+  }                                                 \
+  const T& name() const noexcept {                  \
+    return this->name##_;                           \
+  }                                                 \
+  T name##_
+
+/// Defines a class `Name` which inherits from `nn::ModuleHolder` to provide a
+/// wrapper over a `std::shared_ptr<Impl>`.
+#define TORCH_MODULE_IMPL(Name, Impl)                  \
+  class Name : public torch::nn::ModuleHolder<Impl> {  \
+   public:                                             \
+    using torch::nn::ModuleHolder<Impl>::ModuleHolder; \
+    using torch::nn::ModuleHolder<Impl>::operator->;   \
+    using torch::nn::ModuleHolder<Impl>::get;          \
+                                                       \
+   protected:                                          \
+    using torch::nn::ModuleHolder<Impl>::impl_;        \
+  }
+
+/// Like `TORCH_MODULE_IMPL`, but defaults the `Impl` name to `<Name>Impl`.
+#define TORCH_MODULE(Name) TORCH_MODULE_IMPL(Name, Name##Impl)

--- a/torch/csrc/api/include/torch/optimizers.h
+++ b/torch/csrc/api/include/torch/optimizers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/nn/module.h>
+#include <torch/nn/pimpl.h>
 #include <torch/tensor.h>
 
 #include "cereal/access.hpp"
@@ -41,6 +42,11 @@ template <class Derived>
 class Optimizer_CRTP : public OptimizerImpl {
  public:
   Optimizer_CRTP(std::shared_ptr<nn::Module> model) : OptimizerImpl(model) {}
+
+  template <typename ModuleType>
+  Optimizer_CRTP(nn::ModuleHolder<ModuleType> module)
+      : Optimizer_CRTP(module.get()) {}
+
   std::shared_ptr<Derived> make() const {
     auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
     ptr->init_state();
@@ -55,6 +61,11 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(LBFGS) {
  public:
   LBFGS(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
+
+  template <typename ModuleType>
+  LBFGS(nn::ModuleHolder<ModuleType> module_holder, double lr)
+      : LBFGS(module_holder.get(), lr) {}
+
   TORCH_AUTOGRAD_KWARG(LBFGS, int, max_iter, 20, 20);
   TORCH_AUTOGRAD_KWARG(LBFGS, int, max_eval, 25, 25);
   TORCH_AUTOGRAD_KWARG(LBFGS, float, tolerance_grad, 1e-5, 1e-5);
@@ -93,6 +104,11 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(SGD) {
  public:
   SGD(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
+
+  template <typename ModuleType>
+  SGD(nn::ModuleHolder<ModuleType> module_holder, double lr)
+      : SGD(module_holder.get(), lr) {}
+
   TORCH_AUTOGRAD_KWARG(SGD, double, momentum, 0, 0);
   TORCH_AUTOGRAD_KWARG(SGD, double, dampening, 0, 0);
   TORCH_AUTOGRAD_KWARG(SGD, double, weight_decay, 0, 0);
@@ -119,6 +135,11 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
  public:
   Adagrad(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
+
+  template <typename ModuleType>
+  Adagrad(nn::ModuleHolder<ModuleType> module_holder, double lr)
+      : Adagrad(module_holder.get(), lr) {}
+
   TORCH_AUTOGRAD_KWARG(Adagrad, double, lr_decay, 0, 0);
   TORCH_AUTOGRAD_KWARG(Adagrad, double, weight_decay, 0, 0);
   double lr_;
@@ -143,6 +164,11 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(RMSprop) {
  public:
   RMSprop(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
+
+  template <typename ModuleType>
+  RMSprop(nn::ModuleHolder<ModuleType> module_holder, double lr)
+      : RMSprop(module_holder.get(), lr) {}
+
   TORCH_AUTOGRAD_KWARG(RMSprop, double, alpha, 0.99, 0.99);
   TORCH_AUTOGRAD_KWARG(RMSprop, double, eps, 1e-8, 1e-8);
   TORCH_AUTOGRAD_KWARG(RMSprop, double, weight_decay, 0, 0);
@@ -173,6 +199,11 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adam) {
  public:
   Adam(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
+
+  template <typename ModuleType>
+  Adam(nn::ModuleHolder<ModuleType> module_holder, double lr)
+      : Adam(module_holder.get(), lr) {}
+
   TORCH_AUTOGRAD_KWARG(Adam, double, beta1, 0.9, 0.9);
   TORCH_AUTOGRAD_KWARG(Adam, double, beta2, 0.999, 0.999);
   TORCH_AUTOGRAD_KWARG(Adam, double, weight_decay, 0, 0);

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<Module> Module::clone() const {
       "clone() has not been implemented for ",
       name(),
       ". Use the copy constructor if you don't require polymorphic cloning. "
-      "Otherwise, subclass torch::nn::CloneableModule<",
+      "Otherwise, subclass torch::nn::Cloneable<",
       name(),
       "> instead of torch::nn::Module to inherit the ability to clone.");
 }

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -4,38 +4,47 @@
 #include <torch/functions.h>
 #include <torch/tensor.h>
 
-#include <cstdint>
+#include <ATen/Error.h>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace torch {
 namespace nn {
+BatchNormOptions::BatchNormOptions(int64_t features) : features_(features) {}
 
-BatchNorm::BatchNorm(int64_t features) : features_(features) {}
+BatchNormImpl::BatchNormImpl(BatchNormOptions options)
+    : options_(std::move(options)) {
+  reset();
+}
 
-void BatchNorm::reset() {
-  if (affine_) {
-    weight_ =
-        register_parameter("weight", torch::empty({features_}).uniform_());
-    bias_ = register_parameter("bias", torch::zeros({features_}));
+void BatchNormImpl::reset() {
+  if (options_.affine_) {
+    weight_ = register_parameter(
+        "weight", torch::empty({options.features_}).uniform_());
+    bias_ = register_parameter("bias", torch::zeros({options.features_}));
   }
 
   if (stateful_) {
-    running_mean_ = register_buffer("running_mean", torch::zeros({features_}));
+    running_mean_ =
+        register_buffer("running_mean", torch::zeros({options.features_}));
     running_variance_ =
-        register_buffer("running_variance", torch::ones({features_}));
+        register_buffer("running_variance", torch::ones({options.features_}));
   }
 }
 
-std::vector<Variable> BatchNorm::forward(std::vector<Variable> inputs) {
+std::vector<Variable> BatchNormImpl::forward(std::vector<Variable> inputs) {
   auto& input = inputs[0];
-  auto& running_mean_ = (stateful_ ? this->running_mean_ : inputs[1]);
-  auto& running_variance_ = (stateful_ ? this->running_variance_ : inputs[2]);
+  auto& running_mean_ = (options_.stateful_ ? this->running_mean_ : inputs[1]);
+  auto& running_variance_ =
+      (options_.stateful_ ? this->running_variance_ : inputs[2]);
 
   if (is_training()) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
-    if (input.numel() / num_channels <= 1) {
-      throw std::runtime_error(
-          "BatchNorm expected more than 1 value per channel when training!");
-    }
+    AT_CHECK(
+        input.numel() / num_channels > 1,
+        "BatchNorm expected more than 1 value per channel when training!");
   }
 
   auto output = at::batch_norm(
@@ -45,11 +54,16 @@ std::vector<Variable> BatchNorm::forward(std::vector<Variable> inputs) {
       running_mean_,
       running_variance_,
       is_training(),
-      momentum_,
-      eps_,
+      options_.momentum_,
+      options_.eps_,
       torch::cuda::cudnn_is_available());
 
   return std::vector<Variable>({output});
 }
+
+const BatchNormOptions& BatchNormImpl::options() const noexcept {
+  return options_;
+}
+
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -22,15 +22,15 @@ BatchNormImpl::BatchNormImpl(BatchNormOptions options)
 void BatchNormImpl::reset() {
   if (options_.affine_) {
     weight_ = register_parameter(
-        "weight", torch::empty({options.features_}).uniform_());
-    bias_ = register_parameter("bias", torch::zeros({options.features_}));
+        "weight", torch::empty({options_.features_}).uniform_());
+    bias_ = register_parameter("bias", torch::zeros({options_.features_}));
   }
 
-  if (stateful_) {
+  if (options_.stateful_) {
     running_mean_ =
-        register_buffer("running_mean", torch::zeros({options.features_}));
+        register_buffer("running_mean", torch::zeros({options_.features_}));
     running_variance_ =
-        register_buffer("running_variance", torch::ones({options.features_}));
+        register_buffer("running_variance", torch::ones({options_.features_}));
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -13,8 +13,8 @@
 
 namespace torch {
 namespace nn {
-template <size_t D, typename Derived>
-Conv<D, Derived>::Conv(
+template <size_t D>
+ConvOptions<D>::ConvOptions(
     int64_t input_channels,
     int64_t output_channels,
     ExpandingArray<D> kernel_size)
@@ -23,35 +23,45 @@ Conv<D, Derived>::Conv(
       kernel_size_(std::move(kernel_size)) {}
 
 template <size_t D, typename Derived>
-void Conv<D, Derived>::reset() {
-  if (!transposed_) {
-    for (auto pad : *output_padding_) {
+ConvImpl<D, Derived>::ConvImpl(ConvOptions<D> options)
+    : options_(std::move(options)) {
+  reset();
+}
+
+template <size_t D, typename Derived>
+void ConvImpl<D, Derived>::reset() {
+  if (!options_.transposed_) {
+    for (auto pad : *options_.output_padding_) {
       AT_CHECK(
           pad == 0, "Only transposed convolutions support output padding!");
     }
   }
 
   std::vector<int64_t> weights_size;
-  if (transposed_) {
-    weights_size.push_back(input_channels_);
-    weights_size.push_back(output_channels_ / groups_);
+  if (options_.transposed_) {
+    weights_size.push_back(options_.input_channels_);
+    weights_size.push_back(options_.output_channels_ / options_.groups_);
   } else {
-    weights_size.push_back(output_channels_);
-    weights_size.push_back(input_channels_ / groups_);
+    weights_size.push_back(options_.output_channels_);
+    weights_size.push_back(options_.input_channels_ / options_.groups_);
   }
   weights_size.insert(
-      weights_size.end(), kernel_size_->begin(), kernel_size_->end());
-  AT_ASSERT(weights_size.size() == 2 + kernel_size_->size());
+      weights_size.end(),
+      options_.kernel_size_->begin(),
+      options_.kernel_size_->end());
+  AT_ASSERT(weights_size.size() == 2 + options_.kernel_size_->size());
 
-  weight_ = this->register_parameter("weight", torch::empty(weights_size));
+  weight_ =
+      this->register_parameter("weight", torch::empty(options.weights_size));
   if (with_bias_) {
-    bias_ = this->register_parameter("bias", torch::empty(output_channels_));
+    bias_ = this->register_parameter(
+        "bias", torch::empty(options.output_channels_));
   }
 
   const auto number_of_features = std::accumulate(
-      kernel_size_->begin(),
-      kernel_size_->end(),
-      input_channels_,
+      options_.kernel_size_->begin(),
+      options_.kernel_size_->end(),
+      options_.input_channels_,
       std::multiplies<int64_t>{});
   const auto stdv = 1.0 / std::sqrt(number_of_features);
   for (auto& p : this->parameters()) {
@@ -59,64 +69,93 @@ void Conv<D, Derived>::reset() {
   }
 }
 
-std::vector<Variable> Conv1d::forward(std::vector<Variable> input) {
+template <size_t D, typename Derived>
+const ConvOptions<D>& ConvImpl<D, Derived>::options() const noexcept {
+  return options_;
+}
+
+std::vector<Variable> Conv1dImpl::forward(std::vector<Variable> input) {
   AT_ASSERT(input.front().ndimension() == 3);
 
-  if (transposed_) {
+  if (options_.transposed_) {
     return {at::conv_transpose1d(
         input.front(),
         weight_,
         bias_,
-        stride_,
-        padding_,
-        output_padding_,
-        groups_,
-        dilation_)};
+        options_.stride_,
+        options_.padding_,
+        options_.output_padding_,
+        options_.groups_,
+        options_.dilation_)};
   }
   return {at::conv1d(
-      input.front(), weight_, bias_, stride_, padding_, dilation_, groups_)};
+      input.front(),
+      weight_,
+      bias_,
+      options_.stride_,
+      options_.padding_,
+      options_.dilation_,
+      options_.groups_)};
 }
 
-std::vector<Variable> Conv2d::forward(std::vector<Variable> input) {
+std::vector<Variable> Conv2dImpl::forward(std::vector<Variable> input) {
   AT_ASSERT(input.front().ndimension() == 4);
 
-  if (transposed_) {
+  if (options_.transposed_) {
     return {at::conv_transpose2d(
         input.front(),
         weight_,
         bias_,
-        stride_,
-        padding_,
-        output_padding_,
-        groups_,
-        dilation_)};
+        options_.stride_,
+        options_.padding_,
+        options_.output_padding_,
+        options_.groups_,
+        options_.dilation_)};
   }
   return {at::conv2d(
-      input.front(), weight_, bias_, stride_, padding_, dilation_, groups_)};
+      input.front(),
+      weight_,
+      bias_,
+      options_.stride_,
+      options_.padding_,
+      options_.dilation_,
+      options_.groups_)};
 }
 
-std::vector<Variable> Conv3d::forward(std::vector<Variable> input) {
+std::vector<Variable> Conv3dImpl::forward(std::vector<Variable> input) {
   AT_ASSERT(input.front().ndimension() == 5);
 
-  if (transposed_) {
+  if (options_.transposed_) {
     return {at::conv_transpose3d(
         input.front(),
         weight_,
         bias_,
-        stride_,
-        padding_,
-        output_padding_,
-        groups_,
-        dilation_)};
+        options_.stride_,
+        options_.padding_,
+        options_.output_padding_,
+        options_.groups_,
+        options_.dilation_)};
   } else {
     return {at::conv3d(
-        input.front(), weight_, bias_, stride_, padding_, dilation_, groups_)};
+        input.front(),
+        weight_,
+        bias_,
+        options_.stride_,
+        options_.padding_,
+        options_.dilation_,
+        options_.groups_)};
   }
 }
 
-template class Conv<1, Conv1d>;
-template class Conv<2, Conv2d>;
-template class Conv<3, Conv3d>;
+#define CONV_D(D)                 \
+  template struct ConvOptions<D>; \
+  template class ConvImpl<D, Conv##D##dImpl>
+
+CONV_D(1);
+CONV_D(2);
+CONV_D(3);
+
+#undef CONV_D
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -51,11 +51,10 @@ void ConvImpl<D, Derived>::reset() {
       options_.kernel_size_->end());
   AT_ASSERT(weights_size.size() == 2 + options_.kernel_size_->size());
 
-  weight_ =
-      this->register_parameter("weight", torch::empty(options.weights_size));
-  if (with_bias_) {
+  weight_ = this->register_parameter("weight", torch::empty(weights_size));
+  if (options_.with_bias_) {
     bias_ = this->register_parameter(
-        "bias", torch::empty(options.output_channels_));
+        "bias", torch::empty(options_.output_channels_));
   }
 
   const auto number_of_features = std::accumulate(

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -3,43 +3,56 @@
 #include <torch/functions.h>
 #include <torch/tensor.h>
 
-namespace torch {
-namespace detail {
+#include <ATen/Error.h>
 
-template <typename T>
-DropoutBase<T>::DropoutBase(double rate) : rate_(rate) {
-  AT_CHECK(rate >= 0, "Dropout rate must not be less than zero");
-  AT_CHECK(rate < 1, "Dropout rate must be less than one");
+#include <cstddef>
+#include <vector>
+
+namespace torch {
+namespace nn {
+namespace detail {
+template <typename Derived>
+DropoutImplBase<Derived>::DropoutImplBase(DropoutOptions options)
+    : options_(options) {
+  AT_CHECK(options_.rate_ >= 0, "Dropout rate must not be less than zero");
+  AT_CHECK(options_.rate_ <= 1, "Dropout rate must not be greater than one");
 }
 
-template <typename T>
-void DropoutBase<T>::reset() {}
+template <typename Derived>
+void DropoutImplBase<Derived>::reset() {}
 
-template <typename T>
-std::vector<Variable> DropoutBase<T>::forward(std::vector<Variable> input) {
-  if (rate_ == 0 || !is_training()) {
+template <typename Derived>
+std::vector<Variable> DropoutImplBase<Derived>::forward(
+    std::vector<Variable> input) {
+  if (options_.rate_ == 0 || !this->is_training()) {
     return input;
   }
   std::vector<Variable> output;
   for (const auto& value : input) {
-    const auto noise = (noise_mask(value).uniform_(0, 1) > rate_)
+    const auto noise = (noise_mask(value).uniform_(0, 1) > options_.rate_)
                            .toType(value.type().scalarType())
-                           .mul_(1.0f / (1.0f - rate_));
+                           .mul_(1.0f / (1.0f - options_.rate_));
     output.push_back(value * noise);
   }
   return output;
 }
 
-template class detail::DropoutBase<nn::Dropout>;
-template class detail::DropoutBase<nn::Dropout2d>;
+template <typename Derived>
+const DropoutOptions& DropoutImplBase<Derived>::options() const noexcept {
+  return options_;
+}
+
+template class DropoutImplBase<DropoutImpl>;
+template class DropoutImplBase<Dropout2dImpl>;
 } // namespace detail
 
-namespace nn {
-Variable Dropout::noise_mask(Variable input) const {
+DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
+
+Variable DropoutImpl::noise_mask(Variable input) const {
   return at::empty_like(input);
 }
 
-Variable Dropout2d::noise_mask(Variable input) const {
+Variable Dropout2dImpl::noise_mask(Variable input) const {
   return torch::empty(
       {input.size(0), input.size(1), 1, 1}, at::TensorOptions(input));
 }

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -20,7 +20,7 @@ EmbeddingImpl::EmbeddingImpl(EmbeddingOptions options)
 
 void EmbeddingImpl::reset() {
   table_ = register_parameter(
-      "table", torch::empty({options.count_, options.dimension_}));
+      "table", torch::empty({options_.count_, options_.dimension_}));
   table_.data().normal_(0, 1);
 }
 

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -3,21 +3,33 @@
 #include <torch/functions.h>
 #include <torch/tensor.h>
 
-#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace torch {
 namespace nn {
 
-Embedding::Embedding(int64_t count, int64_t dimension)
+EmbeddingOptions::EmbeddingOptions(int64_t count, int64_t dimension)
     : count_(count), dimension_(dimension) {}
 
-void Embedding::reset() {
-  table_ = register_parameter("table", torch::empty({count_, dimension_}));
+EmbeddingImpl::EmbeddingImpl(EmbeddingOptions options)
+    : options_(std::move(options)) {
+  reset();
+}
+
+void EmbeddingImpl::reset() {
+  table_ = register_parameter(
+      "table", torch::empty({options.count_, options.dimension_}));
   table_.data().normal_(0, 1);
 }
 
-std::vector<Variable> Embedding::forward(std::vector<Variable> input) {
+std::vector<Variable> EmbeddingImpl::forward(std::vector<Variable> input) {
   return {at::embedding(table_, /*indices=*/input[0])};
+}
+
+const EmbeddingOptions& EmbeddingImpl::options() const noexcept {
+  return options_;
 }
 
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/functional.cpp
+++ b/torch/csrc/api/src/nn/modules/functional.cpp
@@ -1,20 +1,25 @@
 #include <torch/nn/modules/functional.h>
 
+#include <torch/tensor.h>
+
 #include <functional>
 #include <utility>
+#include <vector>
 
-namespace torch { namespace nn {
+namespace torch {
+namespace nn {
+FunctionalImpl::FunctionalImpl(Function function)
+    : function_(std::move(function)) {}
 
-Functional::Functional(Function function) : function_(std::move(function)) {}
-
-Functional::Functional(std::function<Variable(Variable)> function)
+FunctionalImpl::FunctionalImpl(std::function<Variable(Variable)> function)
     : function_([function](std::vector<Variable> input) {
         return std::vector<Variable>({function(input.front())});
       }) {}
 
-void Functional::reset() {}
+void FunctionalImpl::reset() {}
 
-std::vector<Variable> Functional::forward(std::vector<Variable> input) {
+std::vector<Variable> FunctionalImpl::forward(std::vector<Variable> input) {
   return function_(input);
 }
-}} // namespace torch::nn
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -10,34 +10,43 @@
 
 namespace torch {
 namespace nn {
+LinearOptions::LinearOptions(int64_t in, int64_t out) : in_(in), out_(out) {}
 
-Linear::Linear(size_t features_in, size_t features_out)
-    : in_(features_in), out_(features_out) {}
+LinearImpl::LinearImpl(LinearOptions options) : options_(std::move(options)) {
+  reset();
+}
 
-void Linear::reset() {
+void LinearImpl::reset() {
   weight_ =
-      register_parameter("weight", torch::empty({out_, in_}));
-  bias_ = register_parameter("bias", torch::empty(out_));
+      register_parameter("weight", torch::empty({options.out_, options.in_}));
+  bias_ = register_parameter("bias", torch::empty(options.out_));
+  if (options_.with_bias_) {
+    bias_ = register_parameter("bias", torch::empty(options.out_));
+  }
 
   const auto stdv = 1.0 / std::sqrt(weight_.size(1));
-  for (auto& p : this->parameters()) {
+  for (auto& p : parameters()) {
     p->data().uniform_(-stdv, stdv);
   }
 }
 
-std::vector<Variable> Linear::forward(std::vector<Variable> input) {
+std::vector<Variable> LinearImpl::forward(std::vector<Variable> input) {
   auto x = input[0];
-  if (x.ndimension() == 2 && with_bias_) {
+  if (x.ndimension() == 2 && options_.with_bias_) {
     // Fused op is marginally faster
     AT_ASSERT(x.size(1) == weight_.size(1));
-    return std::vector<Variable>({at::addmm(bias_, x, weight_.t())});
+    return {at::addmm(bias_, x, weight_.t())};
   }
 
   auto output = x.matmul(weight_.t());
-  if (with_bias_) {
+  if (options_.with_bias_) {
     output += bias_;
   }
-  return std::vector<Variable>({output});
+  return {output};
+}
+
+const LinearOptions& LinearImpl::options() const noexcept {
+  return options_;
 }
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -18,10 +18,9 @@ LinearImpl::LinearImpl(LinearOptions options) : options_(std::move(options)) {
 
 void LinearImpl::reset() {
   weight_ =
-      register_parameter("weight", torch::empty({options.out_, options.in_}));
-  bias_ = register_parameter("bias", torch::empty(options.out_));
+      register_parameter("weight", torch::empty({options_.out_, options_.in_}));
   if (options_.with_bias_) {
-    bias_ = register_parameter("bias", torch::empty(options.out_));
+    bias_ = register_parameter("bias", torch::empty(options_.out_));
   }
 
   const auto stdv = 1.0 / std::sqrt(weight_.size(1));

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -38,64 +38,74 @@ Variable linear(at::Tensor x, at::Tensor w, at::Tensor b) {
 }
 } // namespace
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNNBase ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNNOptionsBase ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+namespace detail {
+RNNOptionsBase::RNNOptionsBase(int64_t input_size, int64_t hidden_size)
+    : input_size_(input_size), hidden_size_(hidden_size) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNNImplBase ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename Derived>
-RNNBase<Derived>::RNNBase(
-    int64_t input_size,
-    int64_t hidden_size,
+RNNImplBase<Derived>::RNNImplBase(
+    RNNOptionsBase options,
     at::optional<CuDNNMode> cudnn_mode,
     int64_t number_of_gates,
     bool has_cell_state)
-    : input_size_(input_size),
-      hidden_size_(hidden_size),
+    : options_(options),
       number_of_gates_(number_of_gates),
       has_cell_state_(has_cell_state),
-      cudnn_mode_(std::move(cudnn_mode)) {}
+      cudnn_mode_(std::move(cudnn_mode)) {
+  reset();
+}
 
 template <typename Derived>
-void RNNBase<Derived>::reset() {
-  if (dropout_ > 0.0) {
-    dropout_module_ = Dropout(dropout_).build();
+void RNNImplBase<Derived>::reset() {
+  if (options_.dropout_ > 0.0) {
+    dropout_module_ = Dropout(options_.dropout_);
   }
 
-  ihw_.resize(layers_);
-  hhw_.resize(layers_);
-  ihb_.resize(layers_);
-  hhb_.resize(layers_);
+  ihw_.resize(options_.layers_);
+  hhw_.resize(options_.layers_);
+  ihb_.resize(options_.layers_);
+  hhb_.resize(options_.layers_);
 
-  const int64_t gate_size = hidden_size_ * number_of_gates_;
+  const int64_t gate_size = options_.hidden_size_ * number_of_gates_;
 
   for (int64_t layer = 0; layer < layers_; ++layer) {
-    const int64_t input_size = (layer == 0) ? input_size_ : hidden_size_;
+    const int64_t input_size =
+        (layer == 0) ? options_.input_size_ : options_.hidden_size_;
     ihw_[layer] = this->register_parameter(
         "weight_ih_l" + std::to_string(layer),
-        torch::empty({gate_size, input_size}));
+        torch::empty({options_.gate_size, input_size}));
     hhw_[layer] = this->register_parameter(
         "weight_hh_l" + std::to_string(layer),
-        torch::empty({gate_size, hidden_size_}));
+        torch::empty({options_.gate_size, hidden_size_}));
 
     if (with_bias_) {
       ihb_[layer] = this->register_parameter(
-          "bias_ih_l" + std::to_string(layer), torch::empty({gate_size}));
+          "bias_ih_l" + std::to_string(layer),
+          torch::empty({options_.gate_size}));
       hhb_[layer] = this->register_parameter(
-          "bias_hh_l" + std::to_string(layer), torch::empty({gate_size}));
+          "bias_hh_l" + std::to_string(layer),
+          torch::empty({options_.gate_size}));
     }
   }
   flatten_parameters_for_cudnn();
 
-  auto stdv = 1.0 / std::sqrt(hidden_size_);
+  auto stdv = 1.0 / std::sqrt(options_.hidden_size_);
   for (auto& p : this->parameters()) {
     p->data().uniform_(-stdv, stdv);
   }
 }
 
 template <typename Derived>
-std::vector<Variable> RNNBase<Derived>::forward(std::vector<Variable> inputs) {
+std::vector<Variable> RNNImplBase<Derived>::forward(
+    std::vector<Variable> inputs) {
   std::vector<Variable> inp = {inputs[0],
                                inputs.size() > 1 ? inputs[1] : Variable()};
   if (cudnn_mode_.has_value() && at::cudnn_is_acceptable(inp[0]) &&
-      dropout_ == 0) {
+      options_.dropout_ == 0) {
     return {CUDNN_forward(inp)};
   } else {
     return {autograd_forward(inp)};
@@ -103,12 +113,12 @@ std::vector<Variable> RNNBase<Derived>::forward(std::vector<Variable> inputs) {
 }
 
 template <typename Derived>
-std::vector<at::Tensor> RNNBase<Derived>::flat_weights() const {
+std::vector<at::Tensor> RNNImplBase<Derived>::flat_weights() const {
   std::vector<at::Tensor> flat;
-  for (int64_t layer = 0; layer < layers_; layer++) {
+  for (int64_t layer = 0; layer < options_.layers_; layer++) {
     flat.push_back(ihw_[layer]);
     flat.push_back(hhw_[layer]);
-    if (with_bias_) {
+    if (options_.with_bias_) {
       flat.push_back(ihb_[layer]);
       flat.push_back(hhb_[layer]);
     }
@@ -117,23 +127,23 @@ std::vector<at::Tensor> RNNBase<Derived>::flat_weights() const {
 }
 
 template <typename Derived>
-std::vector<Variable> RNNBase<Derived>::autograd_forward(
+std::vector<Variable> RNNImplBase<Derived>::autograd_forward(
     std::vector<Variable> inputs) {
   auto inp = inputs[0];
 
   std::vector<at::Tensor> state;
   auto has_hidden = inputs[1].defined();
   auto layer_dimension = has_hidden ? inputs[1].ndimension() - 3 : -1;
-  for (int64_t layer = 0; layer < layers_; layer++) {
+  for (int64_t layer = 0; layer < options_.layers_; layer++) {
     state.push_back(
         has_hidden ? inputs[1].select(layer_dimension, layer) : Variable());
   }
 
   auto output = torch::zeros(
-      {inp.size(0), inp.size(1), hidden_size_}, at::TensorOptions(inp));
+      {inp.size(0), inp.size(1), options.hidden_size_}, at::TensorOptions(inp));
   for (int64_t t = 0; t < inp.size(0); t++) {
     auto x = inp.select(0, t);
-    for (int64_t i = 0; i < layers_; i++) {
+    for (int64_t i = 0; i < options_.layers_; i++) {
       // cell_forward() returns a stacked tensor of one or more cell states.
       auto layer_output = cell_forward({x, state[i]}, i);
       // If there are multiple cell states, keep all. If there is only one,
@@ -142,7 +152,7 @@ std::vector<Variable> RNNBase<Derived>::autograd_forward(
       // x should always be the hidden cell state h, assumed to be the zero-th.
       x = layer_output[0][0];
       output.select(0, t).copy_(x);
-      if (dropout_ > 0 && i != layers_ - 1) {
+      if (options_.dropout_ > 0 && i != options_.layers_ - 1) {
         x = dropout_module_->forward({x})[0];
       }
     }
@@ -156,11 +166,11 @@ std::vector<Variable> RNNBase<Derived>::autograd_forward(
 }
 
 template <typename Derived>
-void RNNBase<Derived>::flatten_parameters_for_cudnn() {
+void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
   data_ptrs_.clear();
   const auto any_parameter = ihw_[0];
   if (!cudnn_mode_.has_value() || !any_parameter.is_cuda() ||
-      !at::cudnn_is_acceptable(any_parameter) || dropout_ == 0) {
+      !at::cudnn_is_acceptable(any_parameter) || options_.dropout_ == 0) {
     return;
   }
   std::unordered_set<void*> unique_data_ptrs;
@@ -184,11 +194,11 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
     NoGradGuard guard;
     flat_weights_ = at::_cudnn_rnn_flatten_weight(
         flat_weights(),
-        /*weight_stride=*/with_bias_ ? 4 : 2,
-        input_size_,
+        /*weight_stride=*/options_.with_bias_ ? 4 : 2,
+        options_.input_size_,
         static_cast<int64_t>(*cudnn_mode_),
-        hidden_size_,
-        layers_,
+        options_.hidden_size_,
+        options_.layers_,
         false,
         false); // batch_first and bidirectional, unsupported
   }
@@ -198,7 +208,7 @@ void RNNBase<Derived>::flatten_parameters_for_cudnn() {
 }
 
 template <typename Derived>
-std::vector<Variable> RNNBase<Derived>::CUDNN_forward(
+std::vector<Variable> RNNImplBase<Derived>::CUDNN_forward(
     std::vector<Variable> inputs) {
   auto x = inputs[0];
   Variable hx, cx;
@@ -210,10 +220,13 @@ std::vector<Variable> RNNBase<Derived>::CUDNN_forward(
       hx = inputs[1];
     }
   } else {
-    hx = torch::zeros({layers_, x.size(1), hidden_size_}, at::TensorOptions(x));
+    hx = torch::zeros(
+        {options_.layers_, x.size(1), options_.hidden_size_},
+        at::TensorOptions(x));
     if (has_cell_state_) {
       cx = torch::zeros(
-          {layers_, x.size(1), hidden_size_}, at::TensorOptions(x));
+          {options_.layers_, x.size(1), options_.hidden_size_},
+          at::TensorOptions(x));
     }
   }
   auto dropout_state = torch::empty({}, x.type());
@@ -237,13 +250,13 @@ std::vector<Variable> RNNBase<Derived>::CUDNN_forward(
   auto tup = _cudnn_rnn(
       x,
       flat_weights(),
-      /*weight_stride=*/with_bias_ ? 4 : 2,
+      /*weight_stride=*/options_.with_bias_ ? 4 : 2,
       flat_weights_,
       hx,
       cx,
       static_cast<int64_t>(*cudnn_mode_),
-      hidden_size_,
-      layers_,
+      options_.hidden_size_,
+      options_.layers_,
       false, // batch first
       0, // TODO Use C++ dropout descriptors
       this->is_training(),
@@ -264,44 +277,96 @@ std::vector<Variable> RNNBase<Derived>::CUDNN_forward(
 }
 
 template <typename Derived>
-void RNNBase<Derived>::to(at::Type& type) {
+void RNNImplBase<Derived>::to(at::Type& type) {
   nn::Module::to(type);
   flatten_parameters_for_cudnn();
 }
 
 template <typename Derived>
-void RNNBase<Derived>::to(at::ScalarType scalar_type) {
+void RNNImplBase<Derived>::to(at::ScalarType scalar_type) {
   nn::Module::to(scalar_type);
   flatten_parameters_for_cudnn();
 }
 
 template <typename Derived>
-void RNNBase<Derived>::to(at::Backend backend) {
+void RNNImplBase<Derived>::to(at::Backend backend) {
   nn::Module::to(backend);
   flatten_parameters_for_cudnn();
 }
 
-template class RNNBase<LSTM>;
-template class RNNBase<GRU>;
-template class RNNBase<RNN>;
+template class RNNImplBase<LSTMImpl>;
+template class RNNImplBase<GRUImpl>;
+template class RNNImplBase<RNNImpl>;
+} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RNNOptions::RNNOptions(int64_t input_size, int64_t hidden_size)
+    : input_size_(input_size), hidden_size_(hidden_size) {}
+
+RNNOptions& RNNOptions::tanh() {
+  return activation(RNNActivation::Tanh);
+}
+
+RNNOptions& RNNOptions::relu() {
+  return activation(RNNActivation::ReLU);
+}
+
+RNNImpl::RNNImpl(RNNOptions options)
+    : detail::RNNImplBase<RNNImpl>(
+          detail::RNNOptionsBase(options.input_size_, options.hidden_size_)
+              .layers(options.layers_)
+              .with_bias(options.with_bias_)
+              .dropout(options.dropout_),
+          /*cudnn_mode=*/static_cast<CuDNNMode>(options.activation_)),
+      options_(options) {
+  switch (options_.activation_) {
+    case RNNActivation::ReLU: {
+      activation_function_ = at::relu;
+      break;
+    }
+    case RNNActivation::Tanh: {
+      activation_function_ = at::tanh;
+      break;
+    }
+  }
+}
+
+std::vector<Variable> RNNImpl::cell_forward(
+    std::vector<Variable> inputs,
+    int64_t layer) {
+  auto x = inputs[0];
+  auto hx = inputs[1].defined()
+      ? inputs[1]
+      : torch::zeros({x.size(0), hidden_size_}, torch::TensorOptions(x));
+
+  auto h = linear(x, ihw_[layer], ihb_[layer]) +
+      linear(hx, hhw_[layer], hhb_[layer]);
+
+  return {at::stack(activation_function_(h))};
+}
+
+const RNNOptions& RNNImpl::options() const noexcept {
+  return options_;
+}
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-LSTM::LSTM(int64_t input_size, int64_t hidden_size)
-    : RNNBase(
-          input_size,
-          hidden_size,
-          CuDNNMode::LSTM,
+LSTMImpl::LSTMImpl(LSTMOptions options)
+    : detail::RNNImplBase<LSTMImpl>(
+          options,
+          /*cudnn_mode=*/CuDNNMode::LSTM,
           /*number_of_gates=*/4,
           /*has_cell_state=*/true) {}
 
-std::vector<Variable> LSTM::cell_forward(
+std::vector<Variable> LSTMImpl::cell_forward(
     std::vector<Variable> inputs,
     int64_t layer) {
   auto x = inputs[0];
   auto hid = inputs[1].defined()
       ? inputs[1]
-      : torch::zeros({2, x.size(0), hidden_size_}, torch::TensorOptions(x));
+      : torch::zeros(
+            {2, x.size(0), options_.hidden_size_}, torch::TensorOptions(x));
   auto hx = hid[0];
   auto cx = hid[1];
 
@@ -320,18 +385,26 @@ std::vector<Variable> LSTM::cell_forward(
   return {at::stack({hy, cy}, 0)};
 }
 
+const LSTMOptions& LSTMImpl::options() const noexcept {
+  return options_;
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-GRU::GRU(int64_t input_size, int64_t hidden_size)
-    : RNNBase(input_size, hidden_size, CuDNNMode::GRU, /*number_of_gates=*/3) {}
+GRUImpl::GRUImpl(GRUOptions options)
+    : detail::RNNImplBase<GRUImpl>(
+          options,
+          /*cudnn_mode=*/CuDNNMode::GRU,
+          /*number_of_gates=*/3) {}
 
-std::vector<Variable> GRU::cell_forward(
+std::vector<Variable> GRUImpl::cell_forward(
     std::vector<Variable> inputs,
     int64_t layer) {
   auto x = inputs[0];
   auto hx = inputs[1].defined()
       ? inputs[1]
-      : torch::zeros({x.size(0), hidden_size_}, torch::TensorOptions(x));
+      : torch::zeros(
+            {x.size(0), options_.hidden_size_}, torch::TensorOptions(x));
 
   auto gi = linear(x, ihw_[layer], ihb_[layer]);
   auto gh = linear(x, hhw_[layer], hhb_[layer]);
@@ -346,38 +419,9 @@ std::vector<Variable> GRU::cell_forward(
   return {at::stack(hy)};
 }
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-RNN::RNN(int64_t input_size, int64_t hidden_size)
-    : RNNBase(input_size, hidden_size) {}
-
-void RNN::reset() {
-  static std::array<ActivationFunction, 2> activations = {at::relu, at::tanh};
-  cudnn_mode_ = static_cast<CuDNNMode>(activation_);
-  RNNBase<RNN>::reset();
-  activation_function_ = activations.at(static_cast<int64_t>(activation_));
+const GRUOptions& GRUImpl::options() const noexcept {
+  return options_;
 }
 
-RNN& RNN::tanh() {
-  return activation(Activation::Tanh);
-}
-
-RNN& RNN::relu() {
-  return activation(Activation::ReLU);
-}
-
-std::vector<Variable> RNN::cell_forward(
-    std::vector<Variable> inputs,
-    int64_t layer) {
-  auto x = inputs[0];
-  auto hx = inputs[1].defined()
-      ? inputs[1]
-      : torch::zeros({x.size(0), hidden_size_}, torch::TensorOptions(x));
-
-  auto h = linear(x, ihw_[layer], ihb_[layer]) +
-      linear(hx, hhw_[layer], hhb_[layer]);
-
-  return {at::stack(activation_function_(h))};
-}
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
This PR implements hopefully the last iteration of how modules should be defined and constructed in the C++ API, which was discussed a few weeks ago with @ezyang and @ebetica. The most minimal definition of a module is now:

```
struct LinearImpl : public torch::nn::Module {
  struct Options {
    Options(int64_t in, int64_t out);
    TORCH_ARG(int64_t, in);
    TORCH_ARG(int64_t, out);
  } options;

  explicit LinearImpl(Options options);
  Variable forward(Variable input);

  Variable weight_;
  Variable bias_;
};
TORCH_MODULE(Linear);
```

and usage is

```
Linear model(3, 4);
model->forward(...);
auto clone = model->clone();
```

`TORCH_MODULE` defines a class `Linear` which wraps a `std::shared_ptr<LinearImpl>`, as well as providing convenient mechanisms to forward constructor arguments to the `Options` struct. Notice that I wrote `Linear(3, 4)` and not `Linear(LinearOptions(3, 4))`. This makes usage very convenient in the most common case. When default options need be changed, it becomes `Linear(LinearOptions(4, 5).default(1).default(2))`.

The most important file is `torch/csrc/api/include/torch/nn/pimpl.h`. The rest is mostly codemods.

Thoughts, wishes, improvements? @ebetica @ezyang  