### PR TITLE
Allow TypeMeta hold non-default-constructible types

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -102,11 +102,24 @@ class Blob {
    */
   template <class T>
   T* GetMutable() {
+    static_assert(
+        std::is_default_constructible<T>::value,
+        "GetMutable can't be called with non-default-constructible types. "
+        "Try using specialized methods");
     if (IsType<T>()) {
       return static_cast<T*>(pointer_);
     } else {
       VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<T>();
       return Reset<T>(new T());
+    }
+  }
+
+  template <class T>
+  T* GetMutableOrNull() {
+    if (IsType<T>()) {
+      return static_cast<T*>(pointer_);
+    } else {
+      return nullptr;
     }
   }
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -579,6 +579,11 @@ class Tensor {
       if ((size_ == 0 || data_.get()) && IsType<T>()) {
         return static_cast<T*>(data_.get());
       }
+      // Check it here statically - otherwise TypeMeta would throw the runtime
+      // error in attempt to invoke TypeMeta::ctor()
+      static_assert(
+          std::is_default_constructible<T>::value,
+          "Tensor can't hold non-default-constructible types");
       return static_cast<T*>(raw_mutable_data(TypeMeta::Make<T>()));
     }
 

--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -1,4 +1,5 @@
 #include "caffe2/core/typeid.h"
+#include "caffe2/core/logging.h"
 #include "caffe2/core/scope_guard.h"
 
 #if !defined(_MSC_VER)
@@ -44,6 +45,12 @@ string GetExceptionString(const std::exception& e) {
 #else
   return string("Exception (no RTTI available): ") + e.what();
 #endif // __GXX_RTTI
+}
+
+void TypeMeta::_ThrowRuntimeTypeLogicError(const std::string& msg) {
+  // In earlier versions it used to be std::abort() but it's a bit hard-core
+  // for a library
+  CAFFE_THROW(msg);
 }
 
 namespace {

--- a/caffe2/core/typeid.h
+++ b/caffe2/core/typeid.h
@@ -130,6 +130,12 @@ class TypeMeta {
       TypedDestructor dtor)
       : id_(i), itemsize_(s), ctor_(ctor), copy_(copy), dtor_(dtor) {}
 
+  // Mechanism for throwing errors which can't be prevented at compile time
+  // due to type erasure. E.g. somebody calling TypeMeta::copy() for
+  // non-copiable type. Right now just throws exception but is implemented
+  // in .cpp to manage dependencies
+  static void _ThrowRuntimeTypeLogicError(const std::string& msg);
+
  public:
   /**
    * Returns the type id.
@@ -224,6 +230,29 @@ class TypeMeta {
     }
   }
 
+  template <typename T>
+  static void _CtorNotDefault(void* /*ptr*/, size_t /*n*/) {
+    _ThrowRuntimeTypeLogicError(
+        "Type " + std::string(DemangleType<T>()) +
+        " is not default-constructible.");
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_default_constructible<T>::value>::type* =
+          nullptr>
+  static inline PlacementNew _PickCtor() {
+    return _Ctor<T>;
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<!std::is_default_constructible<T>::value>::type* =
+          nullptr>
+  static inline PlacementNew _PickCtor() {
+    return _CtorNotDefault<T>;
+  }
+
   /**
    * Typed copy function for classes.
    */
@@ -242,9 +271,25 @@ class TypeMeta {
   template <typename T>
   static void
   _CopyNotAllowed(const void* /*src*/, void* /*dst*/, size_t /*n*/) {
-    std::cerr << "Type " << DemangleType<T>() << " does not allow assignment.";
-    // This is an error by design, so we will quit loud.
-    abort();
+    _ThrowRuntimeTypeLogicError(
+        "Type " + std::string(DemangleType<T>()) +
+        " does not allow assignment.");
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_copy_assignable<T>::value>::type* =
+          nullptr>
+  static inline TypedCopy _PickCopy() {
+    return _Copy<T>;
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<!std::is_copy_assignable<T>::value>::type* =
+          nullptr>
+  static inline TypedCopy _PickCopy() {
+    return _CopyNotAllowed<T>;
   }
 
   /**
@@ -269,22 +314,13 @@ class TypeMeta {
     return TypeMeta(Id<T>(), ItemSize<T>(), nullptr, nullptr, nullptr);
   }
 
-  template <
-      typename T,
-      typename std::enable_if<
-          !(std::is_fundamental<T>::value || std::is_pointer<T>::value) &&
-          std::is_copy_assignable<T>::value>::type* = nullptr>
-  static TypeMeta Make() {
-    return TypeMeta(Id<T>(), ItemSize<T>(), _Ctor<T>, _Copy<T>, _Dtor<T>);
-  }
-
   template <typename T>
-  static TypeMeta Make(
-      typename std::enable_if<
-          !(std::is_fundamental<T>::value || std::is_pointer<T>::value) &&
-          !std::is_copy_assignable<T>::value>::type* = 0) {
+  static typename std::enable_if<
+      !(std::is_fundamental<T>::value || std::is_pointer<T>::value),
+      TypeMeta>::type
+  Make() {
     return TypeMeta(
-        Id<T>(), ItemSize<T>(), _Ctor<T>, _CopyNotAllowed<T>, _Dtor<T>);
+        Id<T>(), ItemSize<T>(), _PickCtor<T>(), _PickCopy<T>(), _Dtor<T>);
   }
 
  private:


### PR DESCRIPTION
Necessary for Tensor detemplatization (D8121878) - now tensor won't have default constructor (as we don't know the device).

Thus this diff makes TypeMeta be constructible with non-default-constructible types in which case ctor() is non-null but always throws.

It's dangerous however as we won't catch potential type errors at compile time. Luckily - the only place where ctor() is used is in Blob and Tensor which have templated wrappers there (GetMutable and mutable_data respectively). We can just enforce the necessary type requirements there explicitly as a static_assert.

It also changes the failure behavior to be throw() instead of abort(). Aborting the process is not cool for the library :)

