### PR TITLE
Skip calling ncclCommDestroy in destructor

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -48,9 +48,21 @@ class NCCLContext {
     }
     DeviceGuard g(master_gpu_id_);
     CUDA_ENFORCE(cudaEventDestroy(master_event_));
+
+    /*
+     * TODO(T30279827) Temporarily disable calling ncclCommDestroy
+     * Calling ncclCommDestroy while program exiting is undefined
+     * according to Nvidia, and will lead to segfault in NCCL 2
+     * (whether it is called before or after the CUDA runtime destructor).
+     * Temporarily disable it in destructor to avoid segfault.
+     * Following up with Nvidia for long term solution.
+     */
+
+    /*
     for (auto& comm : comms_) {
       ncclCommDestroy(comm);
     }
+    */
   }
 
   std::vector<int> devices_;

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -34,6 +34,16 @@ struct NcclCommList {
   }
   NcclCommList(NcclCommList&& foo) = default;
   ~NcclCommList() {
+    /*
+     * TODO(T30279827) Temporarily disable calling ncclCommDestroy
+     * Calling ncclCommDestroy while program exiting is undefined
+     * according to Nvidia, and lead to segfault in NCCL 2
+     * (whether it is called before or after the CUDA runtime destructor).
+     * Temporarily disable it in destructor to avoid segfault.
+     * Following up with Nvidia for long term solution.
+     */
+    return;
+
     if (comms) {
       for (int i = 0; i < ndevices; i++) {
         int dummy_var;

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -38,6 +38,16 @@ static ncclComm_t unpack_nccl_comm(PyObject* capsule) {
 }
 
 static void destroy_nccl_comm(PyObject* capsule) {
+  /*
+   * TODO(T30279827) Temporarily disable calling ncclCommDestroy
+   * Calling ncclCommDestroy while program exiting is undefined
+   * according to Nvidia, and lead to segfault in NCCL 2
+   * (whether it is called before or after the CUDA runtime destructor).
+   * Temporarily disable it in destructor to avoid segfault.
+   * Following up with Nvidia for long term solution.
+   */
+  return;
+
   HANDLE_TH_ERRORS
   ncclComm_t comm = unpack_nccl_comm(capsule);
   with_no_gil([&]{


### PR DESCRIPTION
There is a bug in NCCL that causing seg faults while calling ncclCommDestroy() in the destructor during program exit. According to Nvidia, whether the NCCL destructor will be called before or after the CUDA runtime destructor is undefined, which can lead to crashes.

For the immediate workaround, skip calling ncclCommDestroy ihe NCCL destructor. This is UGLY and we'll follow up with Nvidia to solve this ASAP.

