### PR TITLE
Updates autograd engine to respect streams set in forward

### DIFF
--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -84,6 +84,9 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
   Stream getStream(Device d) const noexcept override {
     return getCurrentHIPStreamMasqueradingAsCUDA().unwrap();
   }
+  Stream getDefaultStream(Device d) const override {
+    return getDefaultHIPStreamMasqueradingAsCUDA(d.index());
+  }
   Stream exchangeStream(Stream s) const noexcept override {
     HIPStreamMasqueradingAsCUDA cs(s);
     auto old_stream = getCurrentHIPStreamMasqueradingAsCUDA(s.device().index());

--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -82,7 +82,7 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
     C10_HIP_CHECK_WARN(hipSetDevice(d.index()));
   }
   Stream getStream(Device d) const noexcept override {
-    return getCurrentHIPStreamMasqueradingAsCUDA().unwrap();
+    return getCurrentHIPStreamMasqueradingAsCUDA(d.index()).unwrap();
   }
   Stream getDefaultStream(Device d) const override {
     return getDefaultHIPStreamMasqueradingAsCUDA(d.index());

--- a/aten/src/TH/generic/THStorageCopy.cpp
+++ b/aten/src/TH/generic/THStorageCopy.cpp
@@ -2,18 +2,14 @@
 #define TH_GENERIC_FILE "TH/generic/THStorageCopy.cpp"
 #else
 
-void THStorage_(rawCopy)(THStorage *storage, scalar_t *src)
-{
-  ptrdiff_t i;
-  scalar_t *data = THStorage_(data)(storage);
-  for(i = 0; i < storage->numel(); i++)
-    data[i] = src[i];
-}
-
 void THStorage_(copy)(THStorage *storage, THStorage *src)
 {
   THArgCheck(storage->numel() == src->numel(), 2, "size mismatch");
-  THStorage_(rawCopy)(storage, THStorage_(data)(src));
+  scalar_t *scalar_src = THStorage_(data)(src);
+  scalar_t *data = THStorage_(data)(storage);
+  for (ptrdiff_t i = 0; i < storage->numel(); ++i) {
+    data[i] = scalar_src[i];
+  }
 }
 
 // NOTE: for performance, these macros generally use the raw data pointer in the inner loops,

--- a/aten/src/TH/generic/THStorageCopy.h
+++ b/aten/src/TH/generic/THStorageCopy.h
@@ -3,8 +3,6 @@
 #else
 
 /* Support for copy between different Storage types */
-
-TH_API void THStorage_(rawCopy)(THStorage *storage, scalar_t *src);
 TH_API void THStorage_(copy)(THStorage *storage, THStorage *src);
 TH_API void THStorage_(copyByte)(THStorage *storage, struct THByteStorage *src);
 TH_API void THStorage_(copyChar)(THStorage *storage, struct THCharStorage *src);

--- a/aten/src/THC/generic/THCStorageCopy.cu
+++ b/aten/src/THC/generic/THCStorageCopy.cu
@@ -2,11 +2,6 @@
 #define THC_GENERIC_FILE "THC/generic/THCStorageCopy.cu"
 #else
 
-void THCStorage_(rawCopy)(THCState *state, THCStorage *self, scalar_t *src)
-{
-  THCudaCheck(cudaMemcpyAsync(THCStorage_(data)(state, self), src, self->numel() * sizeof(scalar_t), cudaMemcpyDeviceToDevice, THCState_getCurrentStream(state)));
-}
-
 // conversions are delegated to THCTensor implementation
 #define THC_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC,TYPECUDA)                                 \
 void THCStorage_(copyCuda##TYPEC)(THCState *state, THCStorage *self, struct THCuda##TYPECUDA##Storage *src)  \

--- a/aten/src/THC/generic/THCStorageCopy.h
+++ b/aten/src/THC/generic/THCStorageCopy.h
@@ -4,7 +4,6 @@
 
 /* Support for copy between different Storage types */
 
-THC_API void THCStorage_(rawCopy)(THCState *state, THCStorage *storage, scalar_t *src);
 THC_API void THCStorage_(copy)(THCState *state, THCStorage *storage, THCStorage *src);
 THC_API void THCStorage_(copyByte)(THCState *state, THCStorage *storage, struct THByteStorage *src);
 THC_API void THCStorage_(copyChar)(THCState *state, THCStorage *storage, struct THCharStorage *src);

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -103,6 +103,13 @@ struct C10_API DeviceGuardImplInterface {
   virtual Stream getStream(Device) const noexcept = 0;
 
   /**
+   * Get the default stream for a given device.
+   */
+  virtual Stream getDefaultStream(Device) const {
+    TORCH_CHECK(false, "Backend doesn't support acquiring a default stream.")
+  }
+
+  /**
    * Set a stream to be the thread local current stream for its device.
    * Return the previous stream for that device. You are NOT required
    * to set the current device to match the device of this stream.

--- a/c10/core/impl/VirtualGuardImpl.h
+++ b/c10/core/impl/VirtualGuardImpl.h
@@ -37,6 +37,9 @@ public:
   Stream getStream(Device d) const noexcept override {
     return impl_->getStream(d);
   }
+  Stream getDefaultStream(Device d) const override {
+    return impl_->getDefaultStream(d);
+  }
   Stream exchangeStream(Stream s) const noexcept override {
     return impl_->exchangeStream(s);
   }

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -47,6 +47,9 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   Stream getStream(Device d) const noexcept override {
     return getCurrentCUDAStream().unwrap();
   }
+  Stream getDefaultStream(Device d) const override {
+    return getDefaultCUDAStream(d.index());
+  }
   // NB: These do NOT set the current device
   Stream exchangeStream(Stream s) const noexcept override {
     CUDAStream cs(s);

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -45,7 +45,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     C10_CUDA_CHECK_WARN(cudaSetDevice(d.index()));
   }
   Stream getStream(Device d) const noexcept override {
-    return getCurrentCUDAStream().unwrap();
+    return getCurrentCUDAStream(d.index()).unwrap();
   }
   Stream getDefaultStream(Device d) const override {
     return getDefaultCUDAStream(d.index());

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -12,6 +12,10 @@
 #include <ATen/Parallel.h>
 #include <ATen/ThreadLocalDebugInfo.h>
 #include <c10/util/Exception.h>
+#include <c10/core/Stream.h>
+#include <c10/core/Event.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/util/Optional.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -137,6 +141,35 @@ struct ReadyQueue {
 // When the GraphTask is finished, the parent worker thread that is waiting on
 // the task is notified and the current thread returns to the pool.
 
+// Note [Streaming backwards]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// On CUDA devices the autograd engine's device operations are run on the
+// same stream that ran them in forward. This requires automatically
+// syncing the streams so that function A finishes producing its
+// output before function B consumes it.
+//
+// This synchronization occurs when outputs are placed into input buffers.
+// The functions corresponding to input buffer positions have metadata
+// recording their streams from forward, and during backward this
+// data is used to sync the producer's stream with the consumer's.
+//
+// When a CUDA function is run either all its inputs were accumulated on the
+// stream used to run the function OR the inputs are on different devices
+// and the function is responsible for properly acquiring them.
+//
+// Historically, the autograd engine ran all CUDA operations on their
+// device's DEFAULT stream. This meant that syncing (implicitly or
+// explicitly) with the default streams was required before and after
+// calling backward(). It also meant, however, that syncing with
+// the default streams after backward() was sufficient to ensure
+// that backward() had finished running. To preserve this historic
+// behavior the engine records "leaf streams," the streams of the
+// leaf variables, and syncs them with their device's default stream
+// at the end of backward. All other streams are already synchronized
+// to happen before at least one leaf stream (per the above), so syncing
+// the leaf streams with the default streams is sufficient to implement
+// the historic behavior.
+
 // GraphTask holds metadata needed for a single execution of backward()
 struct GraphTask {
   std::exception_ptr exception_;
@@ -181,6 +214,7 @@ struct GraphTask {
   std::vector<Variable> captured_vars_;
   std::shared_ptr<at::ThreadLocalDebugInfoBase> debug_info_ =
       at::getThreadLocalDebugInfo();
+  std::unordered_set<c10::Stream> leaf_streams;
 
   void init_to_execute(Node& graph_root, const edge_list& outputs);
 
@@ -537,6 +571,15 @@ auto Engine::evaluate_function(NodeTask& task) -> void {
     if (!fn_info.needed_) return;
   }
 
+  // Switches to a function's CUDA stream (if applicable) before calling it
+  const auto opt_parent_stream = (*task.fn_).stream(c10::DeviceType::CUDA);
+  c10::optional<c10::Event> opt_parent_event = c10::nullopt;
+  if (opt_parent_stream) {
+    const auto guard = c10::impl::VirtualGuardImpl{c10::DeviceType::CUDA};
+    guard.exchangeStream(*opt_parent_stream);
+    opt_parent_event = c10::Event{c10::DeviceType::CUDA};
+  }
+
   auto outputs = call_function(task);
 
   auto& fn = *task.fn_;
@@ -545,7 +588,14 @@ auto Engine::evaluate_function(NodeTask& task) -> void {
   }
 
   int num_outputs = outputs.size();
-  if (num_outputs == 0) return; // Don't even acquire the mutex
+  if (num_outputs == 0) { // Note: doesn't acquire the mutex
+    // Records leaf stream (if applicable)
+    // See note "Streaming backwards"
+    if (opt_parent_stream) {
+      task.base_->leaf_streams.emplace(*opt_parent_stream);
+    }
+    return;
+  }
 
   if (AnomalyMode::is_enabled()) {
     AutoGradMode grad_mode(false);
@@ -592,7 +642,15 @@ auto Engine::evaluate_function(NodeTask& task) -> void {
       }
       // No buffers have been allocated for the function
       InputBuffer input_buffer(next.function->num_inputs());
-      input_buffer.add(next.input_nr, std::move(output));
+
+      // Accumulates into buffer
+      const auto child_stream = next.function->input_metadata(next.input_nr).stream();
+      input_buffer.add(next.input_nr,
+                       std::move(output),
+                       opt_parent_stream,
+                       opt_parent_event,
+                       child_stream);
+
       if (is_ready) {
         auto& queue = ready_queue(input_buffer.device());
         queue.push(NodeTask(task.base_, next.function, std::move(input_buffer)));
@@ -602,7 +660,14 @@ auto Engine::evaluate_function(NodeTask& task) -> void {
     } else {
       // The function already has a buffer
       auto &input_buffer = not_ready_it->second;
-      input_buffer.add(next.input_nr, std::move(output));
+
+      // Accumulates into buffer
+      const auto child_stream = next.function->input_metadata(next.input_nr).stream();
+      input_buffer.add(next.input_nr,
+                       std::move(output),
+                       opt_parent_stream,
+                       opt_parent_event,
+                       child_stream);
       if (is_ready) {
         auto& queue = ready_queue(input_buffer.device());
         queue.push(NodeTask(task.base_, next.function, std::move(input_buffer)));
@@ -725,6 +790,18 @@ auto Engine::execute(const edge_list& roots,
     cb_lock.unlock();
     final_callbacks_[i]();
     cb_lock.lock();
+  }
+
+  // Syncs leaf streams with default streams (if necessary)
+  // See note "Streaming backwards"
+  for (const auto& leaf_stream : graph_task.leaf_streams) {
+    const auto guard = c10::impl::VirtualGuardImpl{c10::DeviceType::CUDA};
+    const auto default_stream = guard.getDefaultStream(leaf_stream.device());
+    if (leaf_stream != default_stream) {
+      auto event = c10::Event(c10::DeviceType::CUDA);
+      event.record(leaf_stream);
+      default_stream.wait(event);
+    }
   }
 
   return graph_task.captured_vars_;

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -2,8 +2,6 @@
 
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/StreamGuard.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAStream.h>
 
 #include <cstddef>
 #include <utility>

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -11,9 +11,10 @@
 
 namespace torch { namespace autograd {
 
-  void accumulate(std::vector<Variable>& buffer,
-                  const size_t pos,
-                  Variable&& var) {
+  static void accumulate(std::vector<Variable>& buffer,
+                         const size_t pos,
+                         Variable&& var) {
+    TORCH_INTERNAL_ASSERT(pos < buffer.size());
     auto& old_var = buffer[pos];
     // ATen doesn't route sparse additions correctly...
     // do dense + sparse in-place if possible
@@ -91,7 +92,7 @@ namespace torch { namespace autograd {
     } else {
       // (1) non-CUDA variable
       //     Accumulation happens on variable's device
-      c10::DeviceGuard device_guard{*device_of(var)};
+      c10::OptionalDeviceGuard device_guard{device_of(var)};
       accumulate(buffer, pos, std::move(var));
     }
   }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/StreamGuard.h>
+#include <c10/core/Event.h>
 
 #include <cstddef>
 #include <utility>

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -25,13 +25,12 @@ struct InputBuffer {
   InputBuffer& operator=(InputBuffer&& other) = default;
 
   // Accumulates the variable at a specified index.
-  // Syncs the producer and consumer streams if they're both CUDA streams
-  // using the given event.
+  // The optional CUDA streams determine which stream the accumulation
+  // is run on and how the addition is synchronized.
   void add(size_t pos,
            Variable var,
            const c10::optional<c10::Stream>& opt_producer_stream,
-           c10::optional<c10::Event>& opt_event,
-           const c10::Stream& consumer_stream);
+           const c10::optional<c10::Stream>& opt_consumer_stream);
 
   at::Device device() const;
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -11,6 +11,9 @@
 #include <ATen/ATen.h>
 
 #include <torch/csrc/autograd/variable.h>
+#include <c10/util/Optional.h>
+#include <c10/core/Stream.h>
+#include <c10/core/Event.h>
 
 namespace torch { namespace autograd {
 
@@ -22,7 +25,13 @@ struct InputBuffer {
   InputBuffer& operator=(InputBuffer&& other) = default;
 
   // Accumulates the variable at a specified index.
-  void add(size_t pos, Variable var);
+  // Syncs the producer and consumer streams if they're both CUDA streams
+  // using the given event.
+  void add(size_t pos,
+           Variable var,
+           const c10::optional<c10::Stream>& opt_producer_stream,
+           c10::optional<c10::Event>& opt_event,
+           const c10::Stream& consumer_stream);
 
   at::Device device() const;
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -27,7 +27,7 @@ struct InputBuffer {
   // The optional CUDA streams determine which stream the accumulation
   // is run on and how the addition is synchronized.
   void add(size_t pos,
-           Variable var,
+           Variable&& var,
            const c10::optional<c10::Stream>& opt_producer_stream,
            const c10::optional<c10::Stream>& opt_consumer_stream);
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -13,7 +13,6 @@
 #include <torch/csrc/autograd/variable.h>
 #include <c10/util/Optional.h>
 #include <c10/core/Stream.h>
-#include <c10/core/Event.h>
 
 namespace torch { namespace autograd {
 


### PR DESCRIPTION
This PR addresses issue #7601.

Currently models that use streams explicitly in forward have to do a lot of extra work to make backwards respect those streams. This PR extends the (recently added) input tracing (see TypeAndShape) to record the devices and streams of inputs. The autograd engine then uses this metadata to enact the expected stream parallelism without extra work from the user.

For example, a model with forward declared like (original example courtesy of @ngimel):

```
def forward(self,x):
        x0 = x.clone()
        torch._C._cuda_setStream(self.stream1._cdata)
        y0 = self.fc1(x0)
        self.event1.record(stream = torch.cuda.current_stream())
        
        torch._C._cuda_setStream(self.stream2._cdata)
        y1 = self.fc2(x)
        self.event2.record(stream = torch.cuda.current_stream())
        self.stream2.wait_event(self.event1)
        return y0 + y1
```

currently will backward on a single stream. With this change the kernels will go on the streams they are assigned in forward and both forward and backward will (for appropriate sizes) run the fc1 and fc2 kernels simultaneously.

The crux of this change is, as mentioned, an expansion of the TypeAndShape tracing and a relatively simple change to the autograd engine to use cuda events for stream synchronization. To make this efficient I also added a new AutoGPUAndStream class, exposed getting and setting streams on devices, and removed InputBuffer's AutoGPU (it's now redundant). While making these modifications I also fixed AutoGPU to check before setting the GPU when it's destroyed and to use THCudaCheck instead of its custom error handler. These changes mean that an often excessive cudaSetDevice() is not being called when inputs are added to a buffer.

In addition to allowing users to easily set and use streams that are respected in both forward and backward, this change may encourage modules to do the same and the expanded tracing might allow further optimizations in the autograd engine. (@apaszke, for example, now after initial enumeration we know the number of devices that will be used by a graph task, which might help provide a sense of the "level of parallelism" we should expect.) 

