### PR TITLE
Use clang 8 to build CUDA in macOS CI

### DIFF
--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -29,8 +29,10 @@ if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
   export CUDA_HOME=/Developer/NVIDIA/CUDA-${CUDA_VERSION}
   export NO_CUDA=0
 
-  # We need to do this for install_name_tool to be found
-  export PATH=/Applications/Xcode9.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$PATH
+  # Use Xcode 8.2 toolchain to build CUDA
+  export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+else
+  export DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
 fi
 
 export MACOSX_DEPLOYMENT_TARGET=10.9

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -29,7 +29,8 @@ if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
   export CUDA_HOME=/Developer/NVIDIA/CUDA-${CUDA_VERSION}
   export NO_CUDA=0
 
-  # Use Xcode 8.2 toolchain to build CUDA
+  # Eigen gives "explicit specialization of class must precede its first use" error
+  # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
   export DEVELOPER_DIR=/Library/Developer/CommandLineTools
 else
   export DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,13 @@ if(APPLE)
   set(CMAKE_FIND_APPBUNDLE LAST)
 endif()
 
+# Get clang version on macOS
+if(APPLE)
+  EXECUTE_PROCESS( COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE clang_full_version_string )
+  string(REGEX REPLACE "Apple LLVM version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
+  MESSAGE( STATUS "CLANG_VERSION_STRING:         " ${CLANG_VERSION_STRING} )
+endif()
+
 # ---[ Options.
 # Note to developers: if you add an option below, make sure you also add it to
 # cmake/Summary.cmake so that the summary prints out the option values.
@@ -232,7 +239,8 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+  if ((APPLE AND (NOT ("${CLANG_VERSION_STRING}" VERSION_LESS "9.0")))
+    OR (CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
   endif()
   if ($ENV{WERROR})


### PR DESCRIPTION
Eigen gives `third_party/eigen/Eigen/src/Core/arch/CUDA/Half.h(508): error: explicit specialization of class "std::__1::numeric_limits<Eigen::half>" must precede its first use` error when trying to compile it with clang 9. The solution seems to be using clang 8 to compile it instead. 

Tested on both master and https://github.com/pytorch/pytorch/pull/8073 branch.