### PR TITLE
[READY TO MERGE] Skip test_multinomial_invalid_probs on Windows

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2385,6 +2385,7 @@ class TestTorch(TestCase):
         except RuntimeError as e:
             return 'invalid multinomial distribution' in str(e)
 
+    @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
     @unittest.skipIf(not PY3,
                      "spawn start method is not supported in Python 2, \
                      but we need it for for testing failure case for CPU RNG on Windows")


### PR DESCRIPTION
`test_multinomial_invalid_probs` has the same problem as https://github.com/pytorch/pytorch/pull/8324 and is causing CUDA OOM error on current master (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test2/821/consoleFull). The right solution is still being iterated on #8253, and before it's found we should disable the test to avoid the CUDA OOM issue.