### PR TITLE
Add interface to allow private Pybind11 bindings into caffe2_pybind_state and caffe2_pybind_state_gpu

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1581,6 +1581,9 @@ PYBIND11_MODULE(caffe2_pybind11_state, m) {
 
   addGlobalMethods(m);
   addObjectMethods(m);
+#ifdef WITH_PRIVATE_PYBIND_STATE
+  addPrivateMethods(m);
+#endif
 }
 
 } // namespace python

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1318,6 +1318,10 @@ void addGlobalMethods(py::module& m) {
     return python_detail::fetchBlob(gWorkspace, name);
   });
   m.def(
+      "get_blob",
+      [](const std::string& name) { return gWorkspace->GetBlob(name); },
+      py::return_value_policy::reference);
+  m.def(
       "feed_blob",
       [](const std::string& name, py::object arg, py::object device_option) {
         DeviceOption option;

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -40,6 +40,20 @@ void addGlobalMethods(pybind11::module& m);
 // Expose Workspace, Net, Blob
 void addObjectMethods(pybind11::module& m);
 
+/**
+ * Pybind11 would crash on py::gil_scoped_acquired if you call it from a
+ * different translation unit than the one that originated the call (i.e.,
+ * caffe2_pybind11_state or caffe2_pybind11_state_gpu).
+ *
+ * addPrivateMethods() allows you to link private bindings to the main module.
+ *
+ * DO NOT ADD ANYTHING HERE
+ * define NO_IMPORT_ARRAY and include this file in another source file
+ */
+#ifdef WITH_PRIVATE_PYBIND_STATE
+void addPrivateMethods(pybind11::module& m);
+#endif
+
 // Get current workspace
 Workspace* GetCurrentWorkspace();
 

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -151,6 +151,9 @@ PYBIND11_MODULE(caffe2_pybind11_state_gpu, m) {
   addCUDAGlobalMethods(m);
   addObjectMethods(m);
   addCUDAObjectMethods(m);
+#ifdef WITH_PRIVATE_PYBIND_STATE
+  addPrivateMethods(m);
+#endif
 }
 } // namespace python
 } // namespace caffe2


### PR DESCRIPTION
This is necessary because linking pybind11 in other translation unit would crash when the code try to acquire GIL to interface with Python.

get_blob() makes unit testing easier