### PR TITLE
Add gt lt ge le to the supported operators list

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -165,6 +165,10 @@ The following operators are supported:
 * max
 * min
 * eq
+* gt
+* lt
+* ge
+* le
 * exp
 * permute
 * Conv


### PR DESCRIPTION
Add `gt` `lt` `ge` `le` to the supported operators list