### PR TITLE
Add dev-requirements.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,16 @@ git clone https://github.com/pytorch/pytorch
 cd pytorch
 ```
 
-3. Install PyTorch in `build develop` mode:
+3. Install the most important development requirements
+
+```sh
+pip install -r dev-requirements.txt
+```
+
+This will install `ninja`, `flake`, `numpy`, `scipy` and a few other packages
+useful for developing PyTorch.
+
+4. Install PyTorch in `build develop` mode:
 
 A full set of instructions on installing PyTorch from Source are here:
 https://github.com/pytorch/pytorch#from-source
@@ -165,7 +174,7 @@ Make sure you continue to pass these flags on subsequent builds.
 
 ### Code completion and IDE support
 
-When using `python setup.py develop`, PyTorch will generate 
+When using `python setup.py develop`, PyTorch will generate
 a `compile_commands.json` file that can be used by many editors
 to provide command completion and error highlighting for PyTorch's
 C++ code. You need to `pip install ninja` to generate accurate
@@ -176,12 +185,12 @@ information for the code in `torch/csrc`. More information at:
 
 #### Use Ninja
 Python `setuptools` is pretty dumb, and always rebuilds every C file in a
-project.  If you install the ninja build system with `pip install ninja`, 
+project.  If you install the ninja build system with `pip install ninja`,
 then PyTorch will use it to track dependencies correctly.
 
 #### Use CCache
 
-Even when dependencies are tracked with file modification, 
+Even when dependencies are tracked with file modification,
 there are many situations where files get rebuilt when a previous
 compilation was exactly the same.
 
@@ -247,7 +256,7 @@ than Linux, which are worth keeping in mind when fixing these problems.
    which follow the convention `*_API`, e.g., `AT_API` inside ATen. (Every separate
    shared library needs a unique macro name, because symbol visibility is on a per
    shared library basis.)
-   
+
    The upshot is if you see an "unresolved external" error in your Windows build, this
    is probably because you forgot to mark a function with `*_API`.  However, there is
    one important counterexample to this principle: if you want a *templated* function

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+ninja
+flake8
+numpy
+scipy
+mkl
+mkl-devel


### PR DESCRIPTION
Creates a `dev-requirements.txt` file for developers to quickly run `pip install -r dev-requirements.txt`