### PR TITLE
Create new conda env in every macOS CI build

### DIFF
--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -5,20 +5,15 @@ export PATH="/usr/local/bin:$PATH"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Set up conda environment
-export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
-# If a local installation of conda doesn't exist, we download and install conda
-if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
-  mkdir -p ${PYTORCH_ENV_DIR}
-  curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ${PYTORCH_ENV_DIR}/miniconda3.sh
-  bash ${PYTORCH_ENV_DIR}/miniconda3.sh -b -p ${PYTORCH_ENV_DIR}/miniconda3
-fi
-export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
-source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
+curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $PWD/miniconda3.sh
+rm -rf $PWD/miniconda3
+bash $PWD/miniconda3.sh -b -p $PWD/miniconda3
+export PATH="$PWD/miniconda3/bin:$PATH"
+source $PWD/miniconda3/bin/activate
 conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
-rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 
 git submodule update --init --recursive
-export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
+export CMAKE_PREFIX_PATH=$PWD/miniconda3/
 
 # Build PyTorch
 if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
@@ -40,6 +35,8 @@ export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
 if which sccache > /dev/null; then
+  export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
+
   printf "#!/bin/sh\nexec sccache $(which clang++) \$*" > "${PYTORCH_ENV_DIR}/clang++"
   chmod a+x "${PYTORCH_ENV_DIR}/clang++"
 
@@ -62,5 +59,5 @@ export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
 python setup.py install
 
 # Upload torch binaries when the build job is finished
-7z a ${IMAGE_COMMIT_TAG}.7z ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
+7z a ${IMAGE_COMMIT_TAG}.7z $PWD/miniconda3/lib/python3.6/site-packages/torch*
 aws s3 cp ${IMAGE_COMMIT_TAG}.7z s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z --acl public-read

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -6,20 +6,15 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 export PATH="/usr/local/bin:$PATH"
 
 # Set up conda environment
-export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
-# If a local installation of conda doesn't exist, we download and install conda
-if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
-  mkdir -p ${PYTORCH_ENV_DIR}
-  curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ${PYTORCH_ENV_DIR}/miniconda3.sh
-  bash ${PYTORCH_ENV_DIR}/miniconda3.sh -b -p ${PYTORCH_ENV_DIR}/miniconda3
-fi
-export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
-source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
+curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $PWD/miniconda3.sh
+rm -rf $PWD/miniconda3
+bash $PWD/miniconda3.sh -b -p $PWD/miniconda3
+export PATH="$PWD/miniconda3/bin:$PATH"
+source $PWD/miniconda3/bin/activate
 conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
-rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 
 git submodule update --init --recursive
-export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
+export CMAKE_PREFIX_PATH=$PWD/miniconda3/
 
 # Test PyTorch
 if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
@@ -38,9 +33,9 @@ export MAX_JOBS=2
 export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
 
 # Download torch binaries in the test jobs
-rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
+rm -rf $PWD/miniconda3/lib/python3.6/site-packages/torch*
 aws s3 cp s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z ${IMAGE_COMMIT_TAG}.7z
-7z x ${IMAGE_COMMIT_TAG}.7z -o"${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages"
+7z x ${IMAGE_COMMIT_TAG}.7z -o"$PWD/miniconda3/lib/python3.6/site-packages"
 
 test_python_all() {
   echo "Ninja version: $(ninja --version)"


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/7867 changes the macOS CI builds to be sharing the same conda environment, but it's likely a bad idea since now we won't have environment isolation across builds and it's hard to know what's already in the environment. This PR reverts it back to the old approach by installing a fresh conda and creating a new conda env for every build.