### PR TITLE
Always include Modules_CUDA_fix for Caffe2 builds

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -1,12 +1,9 @@
 # ---[ cuda
 
-# Check if we need to use the new FindCUDA functionalities, which are included
-# since 3.7.0. Also, we know that VS2017 needs the new FindCUDA functionality,
-# so we will simply enable it for the whole Windows build.
-if (MSVC OR ${CMAKE_VERSION} VERSION_LESS 3.7.0)
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)
-  include(CMakeInitializeConfigs)
-endif()
+# sccache is only supported in CMake master and not in the newest official
+# release (3.11.3) yet. Hence we need our own Modules_CUDA_fix to enable sccache.
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)
+include(CMakeInitializeConfigs)
 
 # Find CUDA.
 find_package(CUDA 7.0)


### PR DESCRIPTION
sccache is only supported in CMake master and not in the newest official release (3.11.3) yet. Hence we need our own `Modules_CUDA_fix` to enable sccache.

This will fix the CUDA build CI slowdown that occured after https://github.com/pytorch/pytorch/pull/8271.