### PR TITLE
More efficient kernels that avoid deprecated shuffles in Embedding and LookupTable

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -23,12 +23,6 @@ namespace at { namespace native {
 
 namespace {
 
-#if __CUDACC_VER_MAJOR__ >= 9
-#define __BALLOT(var)  __ballot_sync(0xffffffff, var)
-#else
-#define __BALLOT(var)  __ballot(var)
-#endif
-
 static const int WARP_SIZE = 32;
 static const int BLOCKDIMY = 32;
 
@@ -88,7 +82,7 @@ __global__ void embedding_backward_feature_kernel
           (dst_row == indices_batch[chunk_start - batch_start + threadIdx.x]);
         if(threadIdx.x >= n_this_chunk)
           match_found_this_thread = 0;
-        unsigned int matchmask = __BALLOT(match_found_this_thread);
+        unsigned int matchmask = WARP_BALLOT(match_found_this_thread);
 
         int first_remaining_peer = __ffs(matchmask) - 1;
 

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -23,66 +23,88 @@ namespace at { namespace native {
 
 namespace {
 
+#if __CUDACC_VER_MAJOR__ >= 9
+#define __BALLOT(var)  __ballot_sync(0xffffffff, var)
+#else
+#define __BALLOT(var)  __ballot(var)
+#endif
+
 static const int WARP_SIZE = 32;
+static const int BLOCKDIMY = 32;
 
-__device__ __forceinline__ bool warp_has_collision(int val) {
-  // Compare our value to the values stored in the next 16 lanes,
-  // wrapping around at 32. If any pair of values is the same than
-  // there is a collision in the warp.
-  bool dup = 0;
-  const int laneId = threadIdx.x % 32;
-  #pragma unroll
-  for (int i = 1; i <= 16; i++) {
-    dup |= (WARP_SHFL(val, (laneId + i) % 32) == val);
-  }
-  return __any(dup) != 0;
-}
+template 
+  <typename scalar_t, 
+   typename accscalar_t>
+__global__ void embedding_backward_feature_kernel
+  (int64_t* indices, 
+   const scalar_t* __restrict__ grad, 
+   scalar_t* __restrict__ grad_weight,
+   int n, // OK to pass as int, we don't expect 2 billion+ samples in one shot
+   int64_t stride,
+   int padding_idx)
+{
+  extern __shared__ char buf[];
+  accscalar_t* smem = (accscalar_t*)buf;
+  accscalar_t* my_s = smem + WARP_SIZE*threadIdx.y;
+  int* indices_batch = (int*)(buf + sizeof(accscalar_t)*WARP_SIZE*blockDim.y);
 
-// parallelizes over features
-template <typename scalar_t>
-__global__ void embedding_backward_feature_kernel(
-  int64_t* indices, scalar_t* grad, scalar_t* grad_weight,
-  int64_t num_indices, int64_t stride, int padding_idx) {
+  const int s = (int)stride; // OK to make int, we don't expect 2 billion+ embedding row size
 
-  const int feature_dim = blockIdx.x * 4 + threadIdx.x / 32;
-  if (feature_dim >= stride) {
-    return;
-  }
+  const int f = threadIdx.x + blockIdx.x*blockDim.x; // feature_dim
 
-  // The strategy here is that each warp handles a single feature
-  // dimension.
-  // Within that feature dimension, points in the [batch][element]
-  // dimension can overlap, and we need to determine if threads want
-  // to add to the gradient in a colliding manner.
-  // Typically one would use floating-point atomicAdd() to resolve
-  // these collisions, but that is non-deterministic if there are
-  // collisions. Non-determinism for this code is really bad,
-  // especially in RNNs, and is prone to snowballing error.
-  // In order to get a deterministic order of execution, we handle
-  // non-colliding updates separately from colliding ones. Colliding
-  // updates are serialized in their order of execution by using the
-  // warp-wide collision detector `warp_has_collision`.
-  const int laneId = threadIdx.x % 32;
-  for (int64_t i = laneId; i < num_indices; i += WARP_SIZE) {
-    const int weight_index = (int)indices[i];
-    if (weight_index == padding_idx) {
-      continue;
-    }
+  for(int batch_start = 0; batch_start < n; batch_start += blockDim.x*blockDim.y)
+  {
+    // Entire block cooperates to load a batch of 1024 indices to process
+    int tid = threadIdx.x + threadIdx.y*blockDim.x;
+    if(batch_start + tid < n)
+      indices_batch[tid] = (int)indices[batch_start + tid];
+    
+    // Loop over the batch of <= 1024 loaded indices in chunks of blockDim.y = 32
+    for(int chunk_start = batch_start; chunk_start < n; chunk_start += blockDim.y)
+    {
+      // This does double duty:  it makes sure indices_batch is ready, and it makes sure match-group 
+      // leaders are done with their accumulates before other warps start loading again.
+      __syncthreads();  
+  
+      int n_this_chunk = (n - chunk_start) < blockDim.y ? (n - chunk_start) : blockDim.y; 
 
-    auto value = grad[i * stride + feature_dim];
+      int src_row = chunk_start + threadIdx.y; 
+      int dst_row = indices_batch[src_row - batch_start]; // This warp's target row in grad_weight
+      
+      // All warps load their smem segments with incoming grad data
+      if(src_row < n && f < s && dst_row != padding_idx)
+        my_s[threadIdx.x] = scalar_cast<accscalar_t>(grad[src_row*stride + f]);
+      
+      __syncthreads();
+    
+      // To ensure determinism, we can't just have each warp add its grad data to its dst_row.
+      // We need to check if any other warps pulled grad data targeting dst_row.
+      // If so, we elect the first warp in each matching group as the leader. 
+      // Each leader warp serializes the accumulates targeting dst_row in shared memory,
+      // then finishes by adding the accumulated buffer to dst_row in grad_weight.
+      if(dst_row != padding_idx && src_row < n) // Per-warp exit condition, safe with ballot_sync
+      {
+        int match_found_this_thread = 
+          (dst_row == indices_batch[chunk_start - batch_start + threadIdx.x]);
+        if(threadIdx.x >= n_this_chunk)
+          match_found_this_thread = 0;
+        unsigned int matchmask = __BALLOT(match_found_this_thread);
 
-    // FIXME: should we accumulate as accreal?
-    // Check for collision
-    if (warp_has_collision(weight_index)) {
-      // Run all lanes sequentially; warp divergence
-      for (int i = 0; i < WARP_SIZE; ++i) {
-        if (laneId == i) {
-          grad_weight[weight_index * stride + feature_dim] += value;
+        int first_remaining_peer = __ffs(matchmask) - 1;
+
+        if(threadIdx.y == first_remaining_peer) // Nominate lowest-indexed warp as the leader
+        {
+          matchmask ^= (1 << first_remaining_peer);   
+          while(matchmask)
+          {
+            first_remaining_peer = __ffs(matchmask) - 1;
+            my_s[threadIdx.x] += smem[threadIdx.x + WARP_SIZE*first_remaining_peer];
+            matchmask ^= (1 << first_remaining_peer);
+          }
+          if(f < s)
+            grad_weight[dst_row*stride + f] += scalar_cast<scalar_t>(my_s[threadIdx.x]);
         }
       }
-    } else {
-      // No collision; warp coherence
-      grad_weight[weight_index * stride + feature_dim] += value;
     }
   }
 }
@@ -210,22 +232,31 @@ Tensor embedding_backward_cuda(const Tensor & grad_, const Tensor & indices,
   cudaStream_t stream = globalContext().getCurrentCUDAStream();
 
   if (num_indices <= 768 && !scale_grad_by_freq) {
-   dim3 grid(THCCeilDiv(stride, (int64_t) 4));
-   dim3 block(128);
+    dim3 grid(THCCeilDiv(stride, (int64_t)WARP_SIZE));
+    dim3 block(WARP_SIZE, BLOCKDIMY);
 
-   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "embedding_backward", [&] {
-     using cuda_scalar_t = cuda::into_type<scalar_t>;
-     embedding_backward_feature_kernel<<<grid, block, 0, stream>>>(
-       indices.data<int64_t>(),
-       grad.data<cuda_scalar_t>(),
-       grad_weight.data<cuda_scalar_t>(),
-       num_indices,
-       stride,
-       padding_idx);
-   });
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF
+      (grad.type(), 
+       "embedding_backward", 
+       [&] 
+       {
+         using cuda_scalar_t = cuda::into_type<scalar_t>;
+         using accscalar_t = acc_type<cuda_scalar_t, true>;
+         embedding_backward_feature_kernel<cuda_scalar_t, accscalar_t>
+           <<<grid, 
+              block, 
+              sizeof(accscalar_t)*WARP_SIZE*BLOCKDIMY + sizeof(int)*WARP_SIZE*BLOCKDIMY,
+              stream>>>
+           (indices.data<int64_t>(),
+            grad.data<cuda_scalar_t>(),
+            grad_weight.data<cuda_scalar_t>(),
+            num_indices,
+            stride,
+            padding_idx);
+       });
 
-   THCudaCheck(cudaGetLastError());
-   return grad_weight;
+    THCudaCheck(cudaGetLastError());
+    return grad_weight;
   }
 
   auto sorted_indices = indices.type().tensor(indices.sizes());
@@ -352,3 +383,4 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
 }
 
 }}  // namespace at::native
+

--- a/aten/src/THC/THCDeviceUtils.cuh
+++ b/aten/src/THC/THCDeviceUtils.cuh
@@ -43,7 +43,7 @@ __device__ __forceinline__ unsigned int ACTIVE_MASK()
 #endif
 }
 
-__device__ __forceinline__ int WARP_BALLOT(int predicate, unsigned int mask = 0xffffffff)
+__device__ __forceinline__ unsigned int WARP_BALLOT(int predicate, unsigned int mask = 0xffffffff)
 {
 #if CUDA_VERSION >= 9000
     return __ballot_sync(mask, predicate);

--- a/aten/src/THCUNN/LookupTable.cu
+++ b/aten/src/THCUNN/LookupTable.cu
@@ -8,12 +8,6 @@
 #include "../THC/THCTensorMathReduce.cuh"
 
 const int WARP_SIZE = 32;
-#if __CUDACC_VER_MAJOR__ >= 9
-#define __BALLOT(var)  __ballot_sync(0xffffffff, var)
-#else
-#define __BALLOT(var)  __ballot(var)
-#endif
-
 
 template 
   <typename Dtype, 
@@ -72,7 +66,7 @@ __global__ void cunn_LookupTable_accGradParametersKernelByFeature
           (dst_row == indices_batch[chunk_start - batch_start + threadIdx.x]);
         if(threadIdx.x >= n_this_chunk)
           match_found_this_thread = 0;
-        unsigned int matchmask = __BALLOT(match_found_this_thread);
+        unsigned int matchmask = WARP_BALLOT(match_found_this_thread);
 
         int first_remaining_peer = __ffs(matchmask) - 1;
 

--- a/aten/src/THCUNN/LookupTable.cu
+++ b/aten/src/THCUNN/LookupTable.cu
@@ -8,84 +8,87 @@
 #include "../THC/THCTensorMathReduce.cuh"
 
 const int WARP_SIZE = 32;
-
-__device__ __forceinline__ bool warpHasCollision(int val)
-{
-  // Compare our value to the values stored in the next 16 lanes,
-  // wrapping around at 32. If any pair of values is the same than
-  // there is a collision in the warp.
-  bool dup = 0;
-  const int laneId = threadIdx.x % 32;
-
-#if __CUDA_ARCH__ >= 300
-
-  #pragma unroll
-  for (int i = 1; i <= 16; i++)
-  {
-    dup |= (__shfl(val, (laneId + i) % 32) == val);
-  }
-
+#if __CUDACC_VER_MAJOR__ >= 9
+#define __BALLOT(var)  __ballot_sync(0xffffffff, var)
 #else
-
-  volatile __shared__ int values[128];
-  values[threadIdx.x] = val;
-  const int offset = threadIdx.x - laneId;
-
-  #pragma unroll
-  for (int i = 1; i <= 16; i++)
-  {
-    dup |= (values[offset + ((laneId + i) % 32)] == val);
-  }
-
+#define __BALLOT(var)  __ballot(var)
 #endif
 
-  return __any(dup) != 0;
-}
 
-template <typename Dtype>
-__global__ void cunn_LookupTable_accGradParametersKernelByFeature(
-  int64_t *input, Dtype *gradOutput, Dtype *gradWeight, Dtype scale, ptrdiff_t numel,
-  int64_t stride, int paddingValue) {
+template 
+  <typename Dtype, 
+   typename Acctype>
+__global__ void cunn_LookupTable_accGradParametersKernelByFeature
+  (int64_t *indices, 
+   Dtype *grad, 
+   Dtype *grad_weight, 
+   Dtype scale, 
+   ptrdiff_t n,
+   int64_t stride, 
+   int padding_idx) 
+{
+  extern __shared__ char buf[];
+  Acctype* smem = (Acctype*)buf;
+  Acctype* my_s = smem + WARP_SIZE*threadIdx.y;
+  int* indices_batch = (int*)(buf + sizeof(Acctype)*WARP_SIZE*blockDim.y);
 
-  const int featureDim = blockIdx.x * 4 + threadIdx.x / 32;
-  if (featureDim >= stride) {
-    return;
-  }
+  const int s = (int)stride; // OK to make int, we don't expect 2 billion+ embedding row size
 
-  // The strategy here is that each warp handles a single feature
-  // dimension.
-  // Within that feature dimension, points in the [batch][element]
-  // dimension can overlap, and we need to determine if threads want
-  // to add to the gradient in a colliding manner.
-  // Typically one would use floating-point atomicAdd() to resolve
-  // these collisions, but that is non-deterministic if there are
-  // collisions. Non-determinism for this code is really bad,
-  // especially in RNNs, and is prone to snowballing error.
-  // In order to get a deterministic order of execution, we handle
-  // non-colliding updates separately from colliding ones. Colliding
-  // updates are serialized in their order of execution by using the
-  // warp-wide collision detector `warpHasCollision`.
-  const int laneId = threadIdx.x % 32;
-  for (ptrdiff_t i = laneId; i < numel; i += WARP_SIZE) {
-    const int weightIndex = (int) (input[i] - TH_INDEX_BASE);
-    if (weightIndex == paddingValue - TH_INDEX_BASE) {
-      continue;
-    }
+  const int f = threadIdx.x + blockIdx.x*blockDim.x; // feature_dim
 
-    Dtype update = gradOutput[i*stride + featureDim] * scale;
+  for(int batch_start = 0; batch_start < n; batch_start += blockDim.x*blockDim.y)
+  {
+    // Entire block cooperates to load a batch of 1024 indices to process
+    int tid = threadIdx.x + threadIdx.y*blockDim.x;
+    if(batch_start + tid < n)
+      indices_batch[tid] = (int)(indices[batch_start + tid] - TH_INDEX_BASE);
+    
+    // Loop over the batch of <= 1024 loaded indices in chunks of blockDim.y = 32
+    for(int chunk_start = batch_start; chunk_start < n; chunk_start += blockDim.y)
+    {
+      // This does double duty:  it makes sure indices_batch is ready, and it makes sure match-group 
+      // leaders are done with their accumulates before other warps start loading again.
+      __syncthreads();  
+  
+      int n_this_chunk = (n - chunk_start) < blockDim.y ? (n - chunk_start) : blockDim.y; 
 
-    // FIXME: should we accumulate as accreal?
-    // Check for collision
-    if (warpHasCollision(weightIndex)) {
-      // Run all lanes sequentially; warp divergence
-      for (int i = 0; i < WARP_SIZE; ++i) {
-        if (laneId == i) {
-          gradWeight[weightIndex*stride + featureDim] += update;
+      int src_row = chunk_start + threadIdx.y; 
+      int dst_row = indices_batch[src_row - batch_start]; // This warp's target row in grad_weight
+      
+      // All warps load their smem segments with incoming grad data
+      if(src_row < n && f < s && dst_row != padding_idx - TH_INDEX_BASE)
+        my_s[threadIdx.x] =  ScalarConvert<Dtype, Acctype>::to(scale*grad[src_row*stride + f]);
+     
+      __syncthreads();
+    
+      // To ensure determinism, we can't just have each warp add its grad data to its dst_row.
+      // We need to check if any other warps pulled grad data targeting dst_row.
+      // If so, we elect the first warp in each matching group as the leader. 
+      // Each leader warp serializes the accumulates targeting dst_row in shared memory,
+      // then finishes by adding the accumulated buffer to dst_row in grad_weight.
+      if(dst_row != padding_idx - TH_INDEX_BASE && src_row < n) // Per-warp exit condition
+      {
+        int match_found_this_thread = 
+          (dst_row == indices_batch[chunk_start - batch_start + threadIdx.x]);
+        if(threadIdx.x >= n_this_chunk)
+          match_found_this_thread = 0;
+        unsigned int matchmask = __BALLOT(match_found_this_thread);
+
+        int first_remaining_peer = __ffs(matchmask) - 1;
+
+        if(threadIdx.y == first_remaining_peer) // Nominate lowest-indexed warp as the leader
+        {
+          matchmask ^= (1 << first_remaining_peer);   
+          while(matchmask)
+          {
+            first_remaining_peer = __ffs(matchmask) - 1;
+            my_s[threadIdx.x] += smem[threadIdx.x + WARP_SIZE*first_remaining_peer];
+            matchmask ^= (1 << first_remaining_peer);
+          }
+          if(f < s)
+            grad_weight[dst_row*stride + f] += ScalarConvert<Acctype, Dtype>::to(my_s[threadIdx.x]);
         }
       }
-    } else {
-      // No collision; warp coherence
-      gradWeight[weightIndex*stride + featureDim] += update;
     }
   }
 }


### PR DESCRIPTION
I set out to clean up the deprecated shuffles that were causing warnings in ATen/native/cuda/Embedding.cu and THCUNN/LookupTable.cu, and in the process I noticed the existing implementations that did not use presorting (`embedding_backward_feature_kernel` and `cunn_LookupTable_accGradParametersKernelByFeature`) were very inefficient.  They suffered from uncoalesced memory accesses, 32-way divergence if different threads in the warp wrote to the same (colliding) row of the embedding weight matrix, and more intrinsic calls than was necessary to check for such collisions.

This pull request replaces those kernels with more efficient implementations that also avoid any deprecated shuffles.  Deprecation warnings for these shuffles will no longer appear in the build.  The new implementation is fully deterministic, as required by the old kernel.  It outperforms the old kernel by between 2 and 8X across the range of parameters I tried, with especially significant improvements observed for large embedding sizes and many collisions.  My kernel's blocks do some aggregation of colliding updates in shared memory before writing them out, so it actually performs better in the case of collisions.

I may be able to squeeze some more performance out of the kernel in future updates.  Currently, the kernel uses int64 where necessary (indexing into the big gradient matrices) but in my profiling tests I played with relaxing that requirement, and observed a speedup of 5%ish in some cases.  If we don't anticipate people using embedding matrices with >2 billion elements, int32 indexing is low-hanging fruit for performance.

The kernel launches have also been updated with appropriate arguments.

Finally, I changed `WARP_BALLOT` in THCDeviceUtils.cuh to return an unsigned int, for consistency with the description of `__ballot_sync()` in the CUDA API.