### PR TITLE
Add CUDA implementation of kthvalue using radixSelect

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -880,6 +880,7 @@
   name: kthvalue
   backends:
     - CPU
+    - CUDA
   variants:
     - method
     - function

--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -50,6 +50,7 @@ set(ATen_CUDA_SRCS ${ATen_CUDA_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorRandom.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorScatterGather.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorTopK.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorKthValue.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorSort.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/THCSortUtils.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/THCTensorMode.cu
@@ -109,6 +110,7 @@ INSTALL(FILES
           THCThrustAllocator.cuh
           THCTensorMode.cuh
           THCTensorTopK.cuh
+          THCTensorKthValue.cuh
           THCCachingAllocator.h
           # See Note [TH abstraction violation]
           THCGenerator.hpp
@@ -162,4 +164,6 @@ INSTALL(FILES
           generic/THCTensorMode.cu
           generic/THCTensorTopK.h
           generic/THCTensorTopK.cu
+          generic/THCTensorKthValue.h
+          generic/THCTensorKthValue.cu
           DESTINATION "${ATEN_INSTALL_INCLUDE_SUBDIR}/THC/generic")

--- a/aten/src/THC/THCTensorKthValue.cu
+++ b/aten/src/THC/THCTensorKthValue.cu
@@ -8,11 +8,7 @@
 #include "THCTensorMathReduce.cuh"
 #include <algorithm> // for std::min
 
-#if CUDA_VERSION >= 7000
-#include <thrust/system/cuda/execution_policy.h>
-#endif
+#include "THCTensorKthValue.cuh"
 
-#include "THCTensorTopK.cuh"
-
-#include "generic/THCTensorTopK.cu"
+#include "generic/THCTensorKthValue.cu"
 #include "THCGenerateAllTypes.h"

--- a/aten/src/THC/THCTensorKthValue.cuh
+++ b/aten/src/THC/THCTensorKthValue.cuh
@@ -1,0 +1,67 @@
+#ifndef THC_TENSOR_KTHVALUE_CUH
+#define THC_TENSOR_KTHVALUE_CUH
+
+#include "THCTensorTopK.cuh"
+
+template <typename T, typename IndexType, int Dim>
+__global__ void gatherKthValue(TensorInfo<T, IndexType> input,
+                               IndexType inputSliceSize,
+                               IndexType k,
+
+                               IndexType numInputSlices,
+                               IndexType inputWithinSliceStride,
+
+                               TensorInfo<T, IndexType> kthValue,
+                               TensorInfo<int64_t, IndexType> indices) {
+  // Indices are limited to integer fp precision, so counts can fit in
+  // int32, regardless of IndexType
+  __shared__ int smem[32]; // one per each warp, up to warp limit
+
+  IndexType slice = getLinearBlockId<IndexType>();
+  if (slice >= numInputSlices) {
+    return;
+  }
+
+  // Find the start offset for our slice
+  IndexType sliceStartIndex =
+    IndexToOffset<T, IndexType, Dim>::get(slice, input);
+  IndexType kthValueSliceStartIndex =
+    IndexToOffset<T, IndexType, Dim>::get(slice, kthValue);
+  IndexType indicesSliceStartIndex =
+    IndexToOffset<int64_t, IndexType, Dim>::get(slice, indices);
+
+  T* inputSliceStart = &input.data[sliceStartIndex];
+  T* kthValueSliceStart = &kthValue.data[kthValueSliceStartIndex];
+  int64_t* indicesSliceStart = &indices.data[indicesSliceStartIndex];
+
+  // Find the k-th highest element in our input
+  T kValue = ScalarConvert<int, T>::to(0);
+  radixSelect<T, typename TopKTypeConfig<T>::RadixType, IndexType, false>(
+    inputSliceStart, k,
+    inputSliceSize, inputWithinSliceStride,
+    smem, &kValue);
+
+  // Find the index of the k-th highest element
+  IndexType kValueIndex = 0;
+  bool foundKValue = false;
+
+  for (IndexType i = threadIdx.x; i < inputSliceSize; i += blockDim.x) {
+    bool inRange = (i < inputSliceSize);
+    T v =
+      inRange ? doLdg(&inputSliceStart[i * inputWithinSliceStride]) : ScalarConvert<int, T>::to(0);
+    bool isKValue = inRange && (THCNumerics<T>::eq(v, kValue));
+
+    if (isKValue) {
+      kValueIndex = i;
+      foundKValue = true;
+      break;
+    }
+  }
+
+  if (foundKValue) {
+    kthValueSliceStart[0] = kValue;
+    indicesSliceStart[0] = ScalarConvert<IndexType, int64_t>::to(kValueIndex);
+  }
+}
+
+#endif // THC_TENSOR_KTHVALUE_CUH

--- a/aten/src/THC/THCTensorMath.h
+++ b/aten/src/THC/THCTensorMath.h
@@ -49,6 +49,9 @@
 #include "generic/THCTensorTopK.h"
 #include "THCGenerateAllTypes.h"
 
+#include "generic/THCTensorKthValue.h"
+#include "THCGenerateAllTypes.h"
+
 THC_API int THCudaByteTensor_logicalAndAll(THCState *state, THCudaByteTensor *self);
 THC_API int THCudaByteTensor_logicalAnyAll(THCState *state, THCudaByteTensor *self);
 

--- a/aten/src/THC/generic/THCTensorKthValue.cu
+++ b/aten/src/THC/generic/THCTensorKthValue.cu
@@ -1,0 +1,122 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/THCTensorKthValue.cu"
+#else
+
+THC_API void THCTensor_(kthvalue)(THCState* state,
+                                  THCTensor* kthValue,
+                                  THCudaLongTensor* indices,
+                                  THCTensor* input,
+                                  int64_t k, int dim, int keepDim) {
+  THAssert(kthValue != NULL && indices != NULL && input != NULL);
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, kthValue, indices, input));
+  THArgCheck(THCTensor_(nDimension)(state, kthValue) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  int64_t dims = THCudaLongTensor_nDimension(state, indices);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
+  int numDims = THCTensor_(nDimension)(state, input);
+  THArgCheck(numDims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
+
+  THArgCheck(dim >= 0 && dim < numDims, 6, "dim not in range");
+
+  int64_t sliceSize = THCTensor_(size)(state, input, dim);
+  THArgCheck(k > 0 && k <= sliceSize, 5, "k not in range for dimension");
+
+  // Build the output size, which is the dim being selected set to
+  // size 1
+  THLongStorage* kthValueSize = THCTensor_(newSizeOf)(state, input);
+  THLongStorage_set(kthValueSize, dim, 1);
+  THCTensor_(resize)(state, kthValue, kthValueSize, NULL);
+  THCudaLongTensor_resize(state, indices, kthValueSize, NULL);
+  THLongStorage_free(kthValueSize);
+
+  #define RUN_K(INDEX_T, DIM)                                             \
+    gatherKthValue<real, INDEX_T, DIM>                                    \
+      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(             \
+        inputInfo,                                                        \
+        sliceSize,                                                        \
+        k,                                                                \
+        inputSlices,                                                      \
+        /* The actual dimension that the k-selection is running in */     \
+        /* may have changed from collapseDims() */                        \
+        inputInfo.strides[collapseInputDim],                              \
+        kthValueInfo,                                                     \
+        indicesInfo)
+
+  #define RUN_DIM(INDEX_T)                        \
+    if (allDims == 1) {                           \
+      RUN_K(INDEX_T, 1);                          \
+    } else if (allDims == 2) {                    \
+      RUN_K(INDEX_T, 2);                          \
+    } else if (allDims == 3) {                    \
+      RUN_K(INDEX_T, 3);                          \
+    } else {                                      \
+      RUN_K(INDEX_T, -1);                         \
+    }
+
+  #define RUN_T(INDEX_T)                                                  \
+    TensorInfo<real, INDEX_T> inputInfo =                                 \
+      getTensorInfo<real, THCTensor, INDEX_T>(state, input);              \
+    TensorInfo<real, INDEX_T> kthValueInfo =                              \
+      getTensorInfo<real, THCTensor, INDEX_T>(state, kthValue);           \
+    TensorInfo<int64_t, INDEX_T> indicesInfo =                            \
+      getTensorInfo<int64_t, THCudaLongTensor, INDEX_T>(state, indices);  \
+                                                                          \
+    /* We use these structures solely to find the offset to */            \
+    /* each slice we are operating on */                                  \
+    inputInfo.sizes[dim] = 1;                                             \
+    kthValueInfo.sizes[dim] = 1;                                          \
+    indicesInfo.sizes[dim] = 1;                                           \
+                                                                          \
+    /* Collapse all other dims */                                         \
+    int collapseInputDim = inputInfo.collapseDims(dim);                   \
+    int collapseKthValueDim = kthValueInfo.collapseDims(dim);             \
+    int collapseIndicesDim = indicesInfo.collapseDims(dim);               \
+                                                                          \
+    int64_t inputSlices = 1;                                              \
+    for (int i = 0; i < inputInfo.dims; ++i) {                            \
+      inputSlices *= inputInfo.sizes[i];                                  \
+    }                                                                     \
+    int64_t kthValueSlices = 1;                                           \
+    for (int i = 0; i < kthValueInfo.dims; ++i) {                         \
+      kthValueSlices *= kthValueInfo.sizes[i];                            \
+    }                                                                     \
+                                                                          \
+    dim3 grid;                                                            \
+    if (!THC_getGridFromTiles(inputSlices, grid)) {                       \
+      THError("Slice to select is too large");                            \
+    }                                                                     \
+                                                                          \
+    dim3 block(std::min(THCRoundUp(sliceSize, (int64_t) 32), (int64_t) 1024)); \
+                                                                          \
+    /* This is used as a template parameter to calculate indices. */      \
+    /* We only specialize it if all collapsed dim sizes are the */        \
+    /* same; otherwise, we use -1 which is the specialization */          \
+    /* parameter for arbitrary dimensions */                              \
+    int allDims = inputInfo.dims;                                         \
+    if (kthValueInfo.dims != allDims || indicesInfo.dims != allDims) {    \
+      allDims = -1;                                                       \
+    }                                                                     \
+                                                                          \
+    RUN_DIM(INDEX_T);
+
+  // Based on required index size, run the algorithm with the
+  // appropriate index type
+  if (THCTensor_canUse32BitIndexMath(state, input) &&
+      THCTensor_canUse32BitIndexMath(state, kthValue) &&
+      THCTensor_canUse32BitIndexMath(state, indices)) {
+    RUN_T(uint32_t);
+  } else {
+    RUN_T(uint64_t);
+  }
+  #undef RUN_T
+  #undef RUN_DIM
+  #undef RUN_K
+
+  if (!keepDim) {
+    THCTensor_(select)(state, kthValue, NULL, dim, 0);
+    THCudaLongTensor_select(state, indices, NULL, dim, 0);
+  }
+
+  THCudaCheck(cudaGetLastError());
+}
+
+#endif // THC_GENERIC_FILE

--- a/aten/src/THC/generic/THCTensorKthValue.h
+++ b/aten/src/THC/generic/THCTensorKthValue.h
@@ -1,0 +1,12 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/THCTensorKthValue.h"
+#else
+
+/* Returns the kth smallest element */
+THC_API void THCTensor_(kthvalue)(THCState* state,
+                                  THCTensor* kthValue,
+                                  THCudaLongTensor* indices,
+                                  THCTensor* input,
+                                  int64_t k, int dim, int keepDim);
+
+#endif // THC_GENERIC_FILE

--- a/test/data/test_cuda_ignores.txt
+++ b/test/data/test_cuda_ignores.txt
@@ -4,7 +4,6 @@ torch.ByteTensor.abs
 torch.ByteTensor.abs_
 torch.ByteTensor.dist
 torch.ByteTensor.dot
-torch.ByteTensor.kthvalue
 torch.ByteTensor.lerp
 torch.ByteTensor.lerp_
 torch.ByteTensor.mean
@@ -17,7 +16,6 @@ torch.CharTensor.abs
 torch.CharTensor.abs_
 torch.CharTensor.dist
 torch.CharTensor.dot
-torch.CharTensor.kthvalue
 torch.CharTensor.lerp
 torch.CharTensor.lerp_
 torch.CharTensor.mean
@@ -26,8 +24,6 @@ torch.CharTensor.renorm
 torch.CharTensor.renorm_
 torch.CharTensor.std
 torch.CharTensor.var
-torch.DoubleTensor.kthvalue
-torch.FloatTensor.kthvalue
 torch.HalfTensor.chunk_
 torch.HalfTensor.clone_
 torch.HalfTensor.contiguous_
@@ -51,7 +47,6 @@ torch.HalfTensor.inverse_
 torch.HalfTensor.is_contiguous_
 torch.HalfTensor.is_same_size_
 torch.HalfTensor.is_set_to_
-torch.HalfTensor.kthvalue
 torch.HalfTensor.kthvalue_
 torch.HalfTensor.max_
 torch.HalfTensor.mean_
@@ -91,7 +86,6 @@ torch.HalfTensor.zeros
 torch.HalfTensor.zeros_
 torch.IntTensor.dist
 torch.IntTensor.dot
-torch.IntTensor.kthvalue
 torch.IntTensor.lerp
 torch.IntTensor.lerp_
 torch.IntTensor.mean
@@ -102,7 +96,6 @@ torch.IntTensor.std
 torch.IntTensor.var
 torch.LongTensor.dist
 torch.LongTensor.dot
-torch.LongTensor.kthvalue
 torch.LongTensor.lerp
 torch.LongTensor.lerp_
 torch.LongTensor.mean
@@ -113,7 +106,6 @@ torch.LongTensor.std
 torch.LongTensor.var
 torch.ShortTensor.dist
 torch.ShortTensor.dot
-torch.ShortTensor.kthvalue
 torch.ShortTensor.lerp
 torch.ShortTensor.lerp_
 torch.ShortTensor.mean


### PR DESCRIPTION
This adds an implementation of THCTensor_(kthvalue) which uses the parallel radixSelect implementation used in topk.

Updated test/test_cuda.py to not skip tests for kthvalue.

