### PR TITLE
[easy][caffe2] Enable some reduce operators' ONNX backend tests

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -25,11 +25,8 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_reduce_l1.*'  # Does not support ReduceL1.
                      '|test_reduce_l2.*'  # Does not support ReduceL2.
                      '|test_reduce_log_sum.*'  # Does not support ReduceLogSum.
-                     '|test_reduce_max.*'  # Does not support ReduceMax.
-                     '|test_reduce_min.*'  # Does not support ReduceMin.
-                     '|test_reduce_mean_cuda.*'  # Does not support ReduceMean CUDA.
                      '|test_reduce_prod.*'  # Does not support ReduceProd.
-                     '|test_reduce_sum.*'  # Does not support ReduceSum and ReduceSumSquare
+                     '|test_reduce_sum_square.*'  # Does not support ReduceSumSquare
                      '|test_tile.*'  # Tile's Caffe2 implementation needs some tweak
                      '|test_lstm.*'  # Seems LSTM case has some problem
                      '|test_simple_rnn.*'  # Seems simple RNN case has some problem


### PR DESCRIPTION
Reducemax/min/sum/mean are already supported.