### PR TITLE
Stop pinning nccl version.

### DIFF
--- a/docker/caffe2/jenkins/common/install_nccl.sh
+++ b/docker/caffe2/jenkins/common/install_nccl.sh
@@ -30,9 +30,6 @@ if [ -n "$NCCL_UBUNTU_VER" ]; then
   apt-get install -y wget
   dpkg -i "${NCCL_DEB}"
 
-  # On March 8, 2018 Nvidia began recommending version 2.1.15
-  NCCL_LIB_VERSION="2.1.15-1+cuda${CUDA_VERSION:0:3}"
-
   apt update
-  apt install -y libnccl2=$NCCL_LIB_VERSION libnccl-dev=$NCCL_LIB_VERSION
+  apt install -y libnccl2 libnccl-dev
 fi


### PR DESCRIPTION
CC @pietern 

Right now, caffe2 docker image build fails because the requested version of nccl would be a downgrade.

Previously nccl was pinned in this commit:

```
commit c60d509fdf41de74f757e62a3fbbc289abe21c5c
Author: Pieter Noordhuis <pcnoordhuis@gmail.com>
Date:   Sat Feb 24 09:51:47 2018 -0800

    Pin libnccl2 to version 2.1.2 (#2033)
    
    * Pin libnccl2 to version 2.1.2
    
    Version 2.1.4 exports C++ symbols that it shouldn't, which causes a
    mismatch between raised exceptions and expected exceptions.
    
    Pin this to 2.1.2 until this is solved and NVIDIA releases a new version.
    
    * Fix for 9.1
    
    * Actually pin 2.1.4 for 9.1
```

Since then nccl 2.2 has been released. I'm going to try removing the pin and see if that helps.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

