### PR TITLE
Expose logsumexp docs

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -271,6 +271,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: log2
    .. automethod:: log2_
    .. automethod:: log_normal_
+   .. automethod:: logsumexp
    .. automethod:: long
    .. automethod:: lt
    .. automethod:: lt_

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -203,6 +203,7 @@ Reduction Ops
 .. autofunction:: cumprod
 .. autofunction:: cumsum
 .. autofunction:: dist
+.. autofunction:: logsumexp
 .. autofunction:: mean
 .. autofunction:: median
 .. autofunction:: mode

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2198,7 +2198,8 @@ stabilized.
 
 For summation index :math:`j` given by `dim` and other indices :math:`i`, the result is
 
-           :math:`\text{logsumexp}(x)_{i} = \log \sum_j \exp(x_ij).`
+    .. math::
+        \text{logsumexp}(x)_{i} = \log \sum_j \exp(x_{ij})
 
 If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -1,7 +1,7 @@
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import probs_to_logits, logits_to_probs, log_sum_exp, lazy_property, broadcast_all
+from torch.distributions.utils import probs_to_logits, logits_to_probs, _log_sum_exp, lazy_property, broadcast_all
 
 
 class Categorical(Distribution):
@@ -44,7 +44,7 @@ class Categorical(Distribution):
         if probs is not None:
             self.probs = probs / probs.sum(-1, keepdim=True)
         else:
-            self.logits = logits - log_sum_exp(logits)
+            self.logits = logits - _log_sum_exp(logits)
         self._param = self.probs if probs is not None else self.logits
         self._num_events = self._param.size()[-1]
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -1,7 +1,7 @@
 import torch
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
-from torch.distributions.utils import clamp_probs, broadcast_all, log_sum_exp
+from torch.distributions.utils import clamp_probs, broadcast_all, _log_sum_exp
 from torch.distributions.distribution import Distribution
 from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import ExpTransform
@@ -58,7 +58,7 @@ class ExpRelaxedCategorical(Distribution):
         uniforms = clamp_probs(self.logits.new(self._extended_shape(sample_shape)).uniform_())
         gumbels = -((-(uniforms.log())).log())
         scores = (self.logits + gumbels) / self.temperature
-        return scores - log_sum_exp(scores)
+        return scores - _log_sum_exp(scores)
 
     def log_prob(self, value):
         K = self._categorical._num_events
@@ -68,7 +68,7 @@ class ExpRelaxedCategorical(Distribution):
         log_scale = (self.temperature.new(self.temperature.shape).fill_(K).lgamma() -
                      self.temperature.log().mul(-(K - 1)))
         score = logits - value.mul(self.temperature)
-        score = (score - log_sum_exp(score)).sum(-1)
+        score = (score - _log_sum_exp(score)).sum(-1)
         return score + log_scale
 
 

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -96,7 +96,7 @@ def _sum_rightmost(value, dim):
     return value.reshape(required_shape).sum(-1)
 
 
-def log_sum_exp(tensor, keepdim=True):
+def _log_sum_exp(tensor, keepdim=True):
     r"""
     Numerically stable implementation for the `LogSumExp` operation. The
     summing is done along the last dimension.


### PR DESCRIPTION
 Fixes #8426 .

Also, marks `log_sum_exp` in distributions for internal use to avoid confusion.

