### PR TITLE
Add order switch op to nomnigraph

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpClasses.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpClasses.h
@@ -619,6 +619,28 @@ class Flatten : public NeuralNetOperator {
  private:
 };
 
+class NCHW2NHWC : public NeuralNetOperator {
+ public:
+  NCHW2NHWC() : NeuralNetOperator(NNKind::NCHW2NHWC) {}
+
+  ~NCHW2NHWC() {}
+
+  NOMNIGRAPH_DEFINE_NN_RTTI(NCHW2NHWC);
+
+ private:
+};
+
+class NHWC2NCHW : public NeuralNetOperator {
+ public:
+  NHWC2NCHW() : NeuralNetOperator(NNKind::NHWC2NCHW) {}
+
+  ~NHWC2NCHW() {}
+
+  NOMNIGRAPH_DEFINE_NN_RTTI(NHWC2NCHW);
+
+ private:
+};
+
 class Int8Quantize : public NeuralNetOperator {
  public:
   Int8Quantize() : NeuralNetOperator(NNKind::Int8Quantize) {}

--- a/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpEnum.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpEnum.h
@@ -1,7 +1,8 @@
 Relu, Conv, ConvRelu, ConvTranspose, AveragePool, AveragePoolRelu, MaxPool,
     MaxPoolRelu, Sum, SumRelu, Send, Receive, BatchNormalization, FC,
     GivenTensorFill, Concat, Softmax, ChannelShuffle, Add, Reshape, Flatten,
-    Int8Quantize, Int8Dequantize, Int8AveragePool, Int8Conv, Int8ConvTranspose,
-    Int8FC, Int8MaxPool, Int8Relu, Int8GivenTensorFill, Int8Concat, Int8Softmax,
-    Int8ChannelShuffle, Int8Sum, Int8Add, Int8Reshape, Int8Flatten,
-    Int8ConvRelu, Int8SumRelu, Int8AveragePoolRelu, Int8MaxPoolRelu
+    NCHW2NHWC, NHWC2NCHW, Int8Quantize, Int8Dequantize, Int8AveragePool,
+    Int8Conv, Int8ConvTranspose, Int8FC, Int8MaxPool, Int8Relu,
+    Int8GivenTensorFill, Int8Concat, Int8Softmax, Int8ChannelShuffle, Int8Sum,
+    Int8Add, Int8Reshape, Int8Flatten, Int8ConvRelu, Int8SumRelu,
+    Int8AveragePoolRelu, Int8MaxPoolRelu

--- a/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpNames.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpNames.h
@@ -40,6 +40,10 @@ case NNKind::Reshape:
   return "Reshape";
 case NNKind::Flatten:
   return "Flatten";
+case NNKind::NCHW2NHWC:
+  return "NCHW2NHWC";
+case NNKind::NHWC2NCHW:
+  return "NHWC2NCHW";
 case NNKind::Int8Quantize:
   return "Int8Quantize";
 case NNKind::Int8Dequantize:

--- a/caffe2/core/nomnigraph/ops.def
+++ b/caffe2/core/nomnigraph/ops.def
@@ -61,6 +61,9 @@ Add
 Reshape
 Flatten
 
+NCHW2NHWC
+NHWC2NCHW
+
 Int8Quantize
 Int8Dequantize
 Int8AveragePool : AveragePool


### PR DESCRIPTION
Adding NCHW2NHWC and NHWC2NCHW to nomnigraph. This is for int8 efforts.