### PR TITLE
[Caffe2] Add IDEEP unit test with zero-dim tensors

### DIFF
--- a/caffe2/python/ideep/copy_op_test.py
+++ b/caffe2/python/ideep/copy_op_test.py
@@ -31,6 +31,21 @@ class CopyTest(unittest.TestCase):
         X_ideep = workspace.FetchBlob("X_ideep")
         np.testing.assert_allclose(X, X_ideep)
 
+    def test_copy_to_ideep_zero_dim(self):
+        op = core.CreateOperator(
+                "CopyCPUToIDEEP",
+                ["X"],
+                ["X_ideep"],
+            )
+        op.device_option.CopyFrom(self._get_deep_device())
+        n = 0
+        c = randint(1, 128)
+        X = np.random.rand(n, c).astype(np.float32)
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        X_ideep = workspace.FetchBlob("X_ideep")
+        np.testing.assert_allclose(X, X_ideep)
+
     def test_copy_from_ideep(self):
         op = core.CreateOperator(
             "CopyIDEEPToCPU",
@@ -43,6 +58,21 @@ class CopyTest(unittest.TestCase):
         h = randint(1, 128)
         w = randint(1, 128)
         X = np.random.rand(n, c, h, w).astype(np.float32)
+        workspace.FeedBlob("X_ideep", X, self._get_deep_device())
+        workspace.RunOperatorOnce(op)
+        X_ideep = workspace.FetchBlob("X")
+        np.testing.assert_allclose(X, X_ideep)
+
+    def test_copy_from_ideep_zero_dim(self):
+        op = core.CreateOperator(
+                "CopyIDEEPToCPU",
+                ["X_ideep"],
+                ["X"],
+            )
+        op.device_option.CopyFrom(self._get_deep_device())
+        n = 0
+        c = randint(1, 64)
+        X = np.random.rand(n, c).astype(np.float32)
         workspace.FeedBlob("X_ideep", X, self._get_deep_device())
         workspace.RunOperatorOnce(op)
         X_ideep = workspace.FetchBlob("X")


### PR DESCRIPTION
This test flushes out the issue that IDEEP cannot handle tensor with dims like (0, 2), which is a valid tensor shape. 