### PR TITLE
Adding necessary ENV variables in order for the perl script that HI…

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -25,6 +25,8 @@ pip install -r requirements.txt || true
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   export HCC_AMDGPU_TARGET=gfx900
+  export LANG=C.UTF-8
+  export LC_ALL=C.UTF-8
 
   # TODO: Install pyHIPIFY in the docker image
   rm -rf pyHIPIFY || true


### PR DESCRIPTION
HIP has a few utilities that need these two ENV variables (that should be visible to all child processes) set in order to run successfully on Jenkins.