### PR TITLE
Move empty size logic from ATen into TH/THC.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -19,7 +19,7 @@
 [[
   name: resize_
   return: self
-  cname: resize
+  cname: resizeLegacy
   cpu_half: True
   arguments:
     - THTensor* self

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -13,11 +13,7 @@ static inline bool is_noelem_tensor_size(ArrayRef<int64_t> size) {
 }
 
 enum class THLongStorageViewKind {
-  SIZE,
-  // noelem_to_empty is to differentiate strides of empty tensors vs scalars.  In ATen, both may have strides [1],
-  // but in TH an empty tensor should have stride [], while a scalar should have stride [1].
-  STRIDE_EMPTY_TENSOR,  // noelem_to_empty = true
-  STRIDE_SCALAR,  // noelem_to_empty = false
+  SIZE_STRIDE,  // represents a size or stride.
   LENGTH,
 };
 
@@ -26,9 +22,6 @@ enum class THLongStorageViewKind {
 class THLongStorageView {
 public:
   operator THLongStorage*() {
-    if (storage.size == 0 && zero_dim_to_null) {
-      return nullptr;
-    }
     return &storage;
   }
 
@@ -48,38 +41,17 @@ public:
   */
 
   THLongStorageView(ArrayRef<int64_t> ref, THLongStorageViewKind kind)
-  : zero_dim_to_null(false)
   {
     // zero_dim_to_one converts an empty ArrayRef into [1]
-    // zero_dim_to_null converts an empty ArrayRef into a null THLongStorage
-    // noelem_to_empty makes an ArrayRef of [0] into an empty THLongStorage
-    bool zero_dim_to_one = false;
-    bool noelem_to_empty = false;
-    switch (kind) {
-      case THLongStorageViewKind::SIZE:
-        zero_dim_to_one = true;
-        break;
-      case THLongStorageViewKind::STRIDE_EMPTY_TENSOR:
-        zero_dim_to_null = true;
-        noelem_to_empty = true;
-        break;
-      case THLongStorageViewKind::STRIDE_SCALAR:
-        zero_dim_to_null = true;
-        break;
-      case THLongStorageViewKind::LENGTH:
-        break;
-    }
+    bool zero_dim_to_one = kind == THLongStorageViewKind::SIZE_STRIDE;
+
     if(zero_dim_to_one && ref.size() == 0) {
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
       storage.data_ptr = &one;
       storage.size = 1;
-    } else if (noelem_to_empty && is_noelem_tensor_size(ref)) {
-      storage.data_ptr = (void*)(ref.data());
-      storage.size = 0;
-    }
-    else {
+    } else {
       storage.data_ptr = (void*)(ref.data());
       storage.size = ref.size();
     }
@@ -92,7 +64,6 @@ public:
 private:
   int64_t one;
   THLongStorage storage;
-  bool zero_dim_to_null;
 };
 
 }

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -6,12 +6,6 @@
 
 namespace at {
 
-// Returns true if size represents an "no element" or "empty" tensor.
-// See Note [empty versus 0-dim tensors]
-static inline bool is_noelem_tensor_size(ArrayRef<int64_t> size) {
-  return size.size() == 1 && size[0] == 0;
-}
-
 enum class THLongStorageViewKind {
   SIZE_STRIDE,  // represents a size or stride.
   LENGTH,
@@ -26,17 +20,15 @@ public:
   }
 
   /*
-  // This is done as an enum, and not as these static constructors, as there
+  // This is done as an enum, and not as static constructors, as there
   // is no move/copy constructor for THLongStorageView
 
   static THLongStorageView makeFromSize(ArrayRef<int64_t> ref) {
-    return THLongStorageView(ref, true, false, false);
+    ...
   }
-  static THLongStorageView makeFromStride(ArrayRef<int64_t> ref, bool noelem_to_empty) {
-    return THLongStorageView(ref, false, true, noelem_to_empty);
-  }
+
   static THLongStorageView makeFromLength(ArrayRef<int64_t> ref) {
-    return THLongStorageView(ref, false, false, false);
+    ...
   }
   */
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1256,20 +1256,17 @@ def create_derived(backend_type_env, declarations):
                     if 'default_init' in arg:
                         default_init.append(arg['default_init'])
 
-                    noelem_to_empty = 'is_noelem_tensor_size(size)' if 'size' in seen_names else 'false'
                     if arg['type'] in DIRECT_CONSTRUCTION_CHECKED_CAST:
                         body.append(CHECKED_CAST[arg['type']].substitute(
                             env, arg_name=arg['name'], arg_pos=count,
                             null_okay=null_okay, default_init=default_init,
                             size=arg.get('size'),
-                            noelem_to_empty=noelem_to_empty,
                             result_name=arg['name'] + '_'))
                     else:
                         check_cast = CHECKED_CAST[arg['type']].substitute(
                             env, arg_name=arg['name'], arg_pos=count,
                             null_okay=null_okay, default_init=default_init,
-                            size=arg.get('size'),
-                            noelem_to_empty=noelem_to_empty)
+                            size=arg.get('size'))
                         body.append("auto {}_ = {};".format(
                             arg['name'], check_cast))
                 if drop_argument(arg, option) or replace_with_null(arg):

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -245,13 +245,9 @@ CHECKED_CAST = {
         CodeTemplate(
             'check_generator<${Backend}Generator>(${arg_name}, &context->defaultGenerator(backend()))'),
     # This is a cast done via direct-construction
-    'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE);'),
+    'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE_STRIDE);'),
     # This is a cast done via direct-construction
-    'THStride*':
-        CodeTemplate(
-            'THLongStorageView ${result_name}(${arg_name}, '
-            '${noelem_to_empty} ? '
-            'THLongStorageViewKind::STRIDE_EMPTY_TENSOR : THLongStorageViewKind::STRIDE_SCALAR);'),
+    'THStride*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE_STRIDE);'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}, Tensor, '

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -245,9 +245,9 @@ CHECKED_CAST = {
         CodeTemplate(
             'check_generator<${Backend}Generator>(${arg_name}, &context->defaultGenerator(backend()))'),
     # This is a cast done via direct-construction
-    'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE_STRIDE);'),
+    'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE);'),
     # This is a cast done via direct-construction
-    'THStride*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE_STRIDE);'),
+    'THStride*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::STRIDE);'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}, Tensor, '

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,12 +1,7 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
-  int64_t d = tensor->_dim();
-  if (d != 0) {
-    return IntList(reinterpret_cast<int64_t*>(tensor->stride),dim());
-  } else {
-    return IntList(kEmptyStrides);
-  }
+  return IntList(tensor->stride,dim());
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -31,23 +31,13 @@ const char * ${Tensor}::toString() const {
 }
 
 IntList ${Tensor}::sizes() const {
-  int64_t d = tensor->_dim();
-  if (d != 0) {
-    // note: this will return "{}" for a scalar because dim() will return 0 in that case.
-    return IntList(reinterpret_cast<int64_t*>(tensor->size),dim());
-  } else {
-    return IntList(kEmptySizes);
-  }
+  return IntList(tensor->size,dim());
 }
 
 int64_t ${Tensor}::dim() const {
   if(isScalar())
     return 0;
-  int64_t d = tensor->_dim();
-  // See Note [Empty versus 0-dim tensors]
-  if (d != 0)
-    return d;
-  return kEmptySizes.size();
+  return tensor->dim();
 }
 
 const char * ${Tensor}::typeString() {

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -32,20 +32,6 @@ struct Allocator;
 struct Generator;
 struct Storage;
 
-// Note [Empty versus 0-dim tensors]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// Unlike Torch, ATen treats zero-dimension tensors as having ONE
-// element (that is to say, a zero-dimensional tensor is a scalar!)
-// This is in contrast to Torch, where a zero-dimension tensor has
-// zero elements.
-//
-// Because we are backed by Torch tensors, we need to be able to
-// represent this state (of numel==0).  These tensors are represented
-// by one-dimensional tensors with size[0] == 0 and stride[0] == 1
-// (the stride is arbitrary but matches the NumPy equivalent).
-constexpr std::array<int64_t, 1> kEmptySizes { {0} };
-constexpr std::array<int64_t, 1> kEmptyStrides { {1} };
-
 static inline void noop_deleter(void*) {}
 
 enum class TypeID {

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -35,7 +35,22 @@ typedef struct THTensor
     // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
     // There will be a dim() function that gives the new view that supports 0-sized dimensions.
     inline int64_t _dim() const {
+      return is_empty() ? 0 : dim_;
+    }
+
+    // NOTE: this is the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
+    inline int64_t dim() const {
       return dim_;
+    }
+
+    // represents that numel() == 0.
+    inline bool is_empty() const {
+      for (int64_t i = 0; i < dim_; ++i) {
+        if (size[i] == 0) {
+          return true;  
+        }
+      }
+      return false;
     }
 } THTensor;
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -732,8 +732,8 @@ static void THTensor_(rawInit)(THTensor *self)
   new (&self->refcount) std::atomic<int>(1);
   self->storage = THStorage_(new)();
   self->storageOffset = 0;
-  self->size = (int64_t *)THAlloc(sizeof(int64_t));
-  self->stride = (int64_t *)THAlloc(sizeof(int64_t));
+  self->size = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
+  self->stride = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
   self->size[0] = 0;
   self->stride[0] = 1;
   self->dim_ = 1;

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -176,7 +176,7 @@ THTensor *THTensor_(newWithSize4d)(int64_t size0, int64_t size1, int64_t size2, 
 
   THTensor *self = (THTensor *)THAlloc(sizeof(THTensor));
   THTensor_(rawInit)(self);
-  THTensor_(resizeNd)(self, 4, size, NULL);
+  THTensor_(resizeNdLegacy)(self, 4, size, NULL);
 
   return self;
 }
@@ -287,7 +287,7 @@ THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size)
 }
 
 /* Resize */
-void THTensor_(resize)(THTensor *self, THLongStorage *size, THLongStorage *stride)
+void THTensor_(resizeLegacy)(THTensor *self, THLongStorage *size, THLongStorage *stride)
 {
   THArgCheck(size != NULL, 2, "invalid size");
   if(stride)
@@ -296,13 +296,13 @@ void THTensor_(resize)(THTensor *self, THLongStorage *size, THLongStorage *strid
 #ifdef DEBUG
   THAssert(size->size <= INT_MAX);
 #endif
-  THTensor_(resizeNd)(self, size->size, THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
+  THTensor_(resizeNdLegacy)(self, size->size, THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
 }
 
 void THTensor_(resizeAs)(THTensor *self, THTensor *src)
 {
   if(!THTensor_(isSameSizeAs)(self, src))
-    THTensor_(resizeNd)(self, src->_dim(), src->size, NULL);
+    THTensor_(resizeNdLegacy)(self, src->_dim(), src->size, NULL);
 }
 
 void THTensor_(resize1d)(THTensor *tensor, int64_t size0)
@@ -324,14 +324,14 @@ void THTensor_(resize4d)(THTensor *self, int64_t size0, int64_t size1, int64_t s
 {
   int64_t size[4] = {size0, size1, size2, size3};
 
-  THTensor_(resizeNd)(self, 4, size, NULL);
+  THTensor_(resizeNdLegacy)(self, 4, size, NULL);
 }
 
 void THTensor_(resize5d)(THTensor *self, int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4)
 {
     int64_t size[5] = {size0, size1, size2, size3, size4};
 
-  THTensor_(resizeNd)(self, 5, size, NULL);
+  THTensor_(resizeNdLegacy)(self, 5, size, NULL);
 }
 
 void THTensor_(set)(THTensor *self, THTensor *src)
@@ -432,13 +432,15 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   if(!src)
     src = self;
 
+#ifndef USE_TH_SCALAR
   THArgCheck(src->_dim() > 1, 1, "cannot select on a vector");
-  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "out of range");
+#endif
+  THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
   THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 3, "out of range");
 
   THTensor_(set)(self, src);
   THTensor_(narrow)(self, NULL, dimension, sliceIndex, 1);
-  for(d = dimension; d < self->_dim()-1; d++)
+  for(d = dimension; d < self->dim()-1; d++)
   {
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
@@ -478,19 +480,19 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   if(!src)
     src = self;
 
-  THArgCheck( (src->_dim() > 0), 1, "cannot unfold an empty tensor");
-  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "out of range");
+  THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
+  THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THTensor_(set)(self, src);
 
-  newSize = (int64_t *)THAlloc(sizeof(int64_t)*(self->_dim()+1));
-  newStride = (int64_t *)THAlloc(sizeof(int64_t)*(self->_dim()+1));
+  newSize = (int64_t *)THAlloc(sizeof(int64_t)*(self->dim()+1));
+  newStride = (int64_t *)THAlloc(sizeof(int64_t)*(self->dim()+1));
 
-  newSize[self->_dim()] = size;
-  newStride[self->_dim()] = self->stride[dimension];
-  for(d = 0; d < self->_dim(); d++)
+  newSize[self->dim()] = size;
+  newStride[self->dim()] = self->stride[dimension];
+  for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {
@@ -523,7 +525,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
 
   THTensor_(set)(self, src);
 
-  for(d = 0; d < src->_dim(); d++)
+  for(d = 0; d < src->dim(); d++)
   {
     if(src->size[d] != 1)
     {
@@ -536,13 +538,15 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
     }
   }
 
+#ifndef USE_TH_SCALAR
   /* right now, we do not handle 0-dimension tensors */
-  if(ndim == 0 && src->_dim() > 0)
+  if(ndim == 0 && src->dim() > 0)
   {
     self->size[0] = 1;
     self->stride[0] = 1;
     ndim = 1;
   }
+#endif
   self->dim_ = ndim;
 }
 
@@ -553,13 +557,17 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
   if(!src)
     src = self;
 
-  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 2, "dimension out of range");
+  THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "dimension out of range");
 
   THTensor_(set)(self, src);
 
-  if(src->size[dimension] == 1 && src->_dim() > 1)
+#ifdef USE_TH_SCALAR
+  if(src->size[dimension] == 1)
+#else
+  if(src->size[dimension] == 1 && src->dim() > 1)
+#endif
   {
-    for(d = dimension; d < self->_dim()-1; d++)
+    for(d = dimension; d < self->dim()-1; d++)
     {
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
@@ -575,19 +583,21 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
   if(!src)
     src = self;
 
-  THArgCheck((dimension >= 0) && (dimension <= src->_dim()), 2, "dimension out of range");
-  THArgCheck(src->_dim() > 0, 2, "cannot unsqueeze empty tensor");
+  THArgCheck((dimension >= 0) && (dimension <= src->dim()), 2, "dimension out of range");
+#ifndef USE_TH_SIZE_ZERO_DIM
+  THArgCheck(!src->is_empty(), 2, "cannot unsqueeze empty tensor");
+#endif
 
   THTensor_(set)(self, src);
 
-  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->_dim()+1));
-  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->_dim()+1));
+  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->dim()+1));
+  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->dim()+1));
   self->dim_++;
-  for (d = self->_dim()-1; d > dimension; d--) {
+  for (d = self->dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];
     self->stride[d] = self->stride[d-1];
   }
-  if (dimension+1 < self->_dim()) {
+  if (dimension+1 < self->dim()) {
     self->stride[dimension] = self->size[dimension+1] * self->stride[dimension+1];
   } else {
     self->stride[dimension] = 1;
@@ -722,9 +732,11 @@ static void THTensor_(rawInit)(THTensor *self)
   new (&self->refcount) std::atomic<int>(1);
   self->storage = THStorage_(new)();
   self->storageOffset = 0;
-  self->size = NULL;
-  self->stride = NULL;
-  self->dim_ = 0;
+  self->size = (int64_t *)THAlloc(sizeof(int64_t));
+  self->stride = (int64_t *)THAlloc(sizeof(int64_t));
+  self->size[0] = 0;
+  self->stride[0] = 1;
+  self->dim_ = 1;
   self->flag = TH_TENSOR_REFCOUNTED;
 }
 
@@ -751,10 +763,10 @@ void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t stora
   self->storageOffset = storageOffset;
 
   /* size and stride */
-  THTensor_(resizeNd)(self, nDimension, size, stride);
+  THTensor_(resizeNdLegacy)(self, nDimension, size, stride);
 }
 
-void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t *stride)
+void THTensor_(resizeNdLegacy)(THTensor *self, int nDimension, int64_t *size, int64_t *stride)
 {
   int d;
   int nDimension_;
@@ -794,14 +806,15 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
     }
 
     totalSize = 1;
-    for(d = self->_dim()-1; d >= 0; d--)
+    // note: can't use _dim() here because there is junk in size
+    for(d = nDimension-1; d >= 0; d--)
     {
       self->size[d] = size[d];
       if(stride && (stride[d] >= 0) )
         self->stride[d] = stride[d];
       else
       {
-        if(d == self->_dim()-1)
+        if(d == nDimension-1)
           self->stride[d] = 1;
         else
           self->stride[d] = self->size[d+1]*self->stride[d+1];
@@ -817,8 +830,13 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
         THStorage_(resize)(self->storage, totalSize+self->storageOffset);
     }
   }
-  else
-    self->dim_ = 0;
+  else {
+    self->dim_ = 1;
+    self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t));
+    self->stride = (int64_t *)THRealloc(self->stride, sizeof(int64_t));
+    self->size[0] = 0;
+    self->stride[0] = 1;
+  }
 }
 
 void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -72,14 +72,16 @@ TH_API THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size);
 // resize* methods simply resize the storage. So they may not retain the current data at current indices.
 // This is especially likely to happen when the tensor is not contiguous. In general, if you still need the
 // values, unless you are doing some size and stride tricks, do not use resize*.
-TH_API void THTensor_(resize)(THTensor *tensor, THLongStorage *size, THLongStorage *stride);
 TH_API void THTensor_(resizeAs)(THTensor *tensor, THTensor *src);
-TH_API void THTensor_(resizeNd)(THTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
 TH_API void THTensor_(resize1d)(THTensor *tensor, int64_t size0_);
 TH_API void THTensor_(resize2d)(THTensor *tensor, int64_t size0_, int64_t size1_);
 TH_API void THTensor_(resize3d)(THTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
 TH_API void THTensor_(resize4d)(THTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_);
 TH_API void THTensor_(resize5d)(THTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_, int64_t size4_);
+// Note: these are legacy resize functions that treat sizes as size->size == 0 and size->data<int64_t>() as being 0-terminated.
+// There will be new resize functions to call that fully support dimensions of size 0.
+TH_API void THTensor_(resizeLegacy)(THTensor *tensor, THLongStorage *size, THLongStorage *stride);
+TH_API void THTensor_(resizeNdLegacy)(THTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
 
 TH_API void THTensor_(set)(THTensor *self, THTensor *src);
 TH_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -326,7 +326,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   THAssert(numel <= LONG_MAX);
 #endif
   THLongStorage_data(newSize)[dim] = numel;
-  THTensor_(resize)(tensor,newSize,NULL);
+  THTensor_(resizeLegacy)(tensor,newSize,NULL);
   THLongStorage_free(newSize);
 
   index = THLongTensor_newContiguous(index);
@@ -439,7 +439,7 @@ static inline int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t nu
 
 void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
 {
-  THTensor_(resizeNd)(r_, index->_dim(), index->size, NULL);
+  THTensor_(resizeNdLegacy)(r_, index->_dim(), index->size, NULL);
   THTensor* dst = THTensor_(newContiguous)(r_);
 
   index = THLongTensor_newContiguous(index);
@@ -2352,8 +2352,8 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(values_, dim, NULL);
-  THLongTensor_resize(indices_, dim, NULL);
+  THTensor_(resizeLegacy)(values_, dim, NULL);
+  THLongTensor_resizeLegacy(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
@@ -2436,8 +2436,8 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(values_, dim, NULL);
-  THLongTensor_resize(indices_, dim, NULL);
+  THTensor_(resizeLegacy)(values_, dim, NULL);
+  THLongTensor_resizeLegacy(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
@@ -2518,7 +2518,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -2598,7 +2598,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -2814,7 +2814,7 @@ void THTensor_(cminValue)(THTensor *r, THTensor *t, real value) {
 
 void THTensor_(zeros)(THTensor *r_, THLongStorage *size)
 {
-  THTensor_(resize)(r_, size, NULL);
+  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(zero)(r_);
 }
 
@@ -2832,7 +2832,7 @@ void THTensor_(onesLike)(THTensor *r_, THTensor *input)
 
 void THTensor_(ones)(THTensor *r_, THLongStorage *size)
 {
-  THTensor_(resize)(r_, size, NULL);
+  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(fill)(r_, 1);
 }
 
@@ -2967,7 +2967,7 @@ void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n)
 
 void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
 {
-  THTensor_(resize)(r_, size, NULL);
+  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(copy)(r_, t);
 }
 
@@ -3192,7 +3192,7 @@ void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimensio
 
   {
     THLongStorage *size = THTensor_(newSizeOf)(t);
-    THLongTensor_resize(ri_, size, NULL);
+    THLongTensor_resizeLegacy(ri_, size, NULL);
     THLongStorage_free(size);
   }
 
@@ -3329,8 +3329,8 @@ void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(values_, dim, NULL);
-  THLongTensor_resize(indices_, dim, NULL);
+  THTensor_(resizeLegacy)(values_, dim, NULL);
+  THLongTensor_resizeLegacy(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   t_size_dim = THTensor_(size)(t, dimension);
@@ -3398,8 +3398,8 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(values_, dim, NULL);
-  THLongTensor_resize(indices_, dim, NULL);
+  THTensor_(resizeLegacy)(values_, dim, NULL);
+  THLongTensor_resizeLegacy(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   t_size_dim = THTensor_(size)(t, dimension);
@@ -3461,8 +3461,8 @@ void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, i
 
   THLongStorage *topKSize = THTensor_(newSizeOf)(t);
   THLongStorage_set(topKSize, dim, k);
-  THTensor_(resize)(rt_, topKSize, NULL);
-  THLongTensor_resize(ri_, topKSize, NULL);
+  THTensor_(resizeLegacy)(rt_, topKSize, NULL);
+  THLongTensor_resizeLegacy(ri_, topKSize, NULL);
   THLongStorage_free(topKSize);
 
   if (dir) {
@@ -3652,7 +3652,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
     }
     THLongStorage_data(size)[dim] = result_dim_size;
   }
-  THTensor_(resize)(result, size, NULL);
+  THTensor_(resizeLegacy)(result, size, NULL);
 
   // Check contiguity of all inputs and result
   int allContiguous = 1;
@@ -3722,25 +3722,25 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb)
 #define TENSOR_IMPLEMENT_LOGICAL(NAME,OP)				\
   void THTensor_(NAME##Value)(THByteTensor *r_, THTensor* t, real value)	\
   {									\
-    THByteTensor_resizeNd(r_, t->_dim(), t->size, NULL);		\
+    THByteTensor_resizeNdLegacy(r_, t->_dim(), t->size, NULL);		\
     TH_TENSOR_APPLY2(unsigned char, r_, real, t,			\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##ValueT)(THTensor* r_, THTensor* t, real value)	\
   {									\
-    THTensor_(resizeNd)(r_, t->_dim(), t->size, NULL);		\
+    THTensor_(resizeNdLegacy)(r_, t->_dim(), t->size, NULL);		\
     TH_TENSOR_APPLY2(real, r_, real, t,					\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##Tensor)(THByteTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THByteTensor_resizeNd(r_, ta->_dim(), ta->size, NULL);		\
+    THByteTensor_resizeNdLegacy(r_, ta->_dim(), ta->size, NULL);		\
     TH_TENSOR_APPLY3(unsigned char, r_, real, ta, real, tb,		\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##TensorT)(THTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THTensor_(resizeNd)(r_, ta->_dim(), ta->size, NULL);		\
+    THTensor_(resizeNdLegacy)(r_, ta->_dim(), ta->size, NULL);		\
     TH_TENSOR_APPLY3(real, r_, real, ta, real, tb,			\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\
@@ -3916,7 +3916,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -3996,7 +3996,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -4150,7 +4150,7 @@ void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -4194,7 +4194,7 @@ void THTensor_(var)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -4238,7 +4238,7 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension, int k
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resize)(r_, dim, NULL);
+  THTensor_(resizeLegacy)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   #define DIM_REDUCE(reduce, transform) \
@@ -4425,13 +4425,13 @@ void THTensor_(logspace)(THTensor *r_, real a, real b, int64_t n)
 
 void THTensor_(rand)(THTensor *r_, THGenerator *_generator, THLongStorage *size)
 {
-  THTensor_(resize)(r_, size, NULL);
+  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(uniform)(r_, _generator, 0, 1);
 }
 
 void THTensor_(randn)(THTensor *r_, THGenerator *_generator, THLongStorage *size)
 {
-  THTensor_(resize)(r_, size, NULL);
+  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(normal)(r_, _generator, 0, 1);
 }
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -79,7 +79,7 @@ void THTensor_(iBernoulli_generate_copy)(THTensor *self, THGenerator *_generator
 #endif
   } else {
     intTensor = THIntTensor_new();
-    THIntTensor_resizeNd(intTensor, self->_dim(), self->size, NULL);
+    THIntTensor_resizeNdLegacy(intTensor, self->_dim(), self->size, NULL);
     tmp = THIntTensor_data(intTensor);
   }
 

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -348,7 +348,7 @@ bool THC_reduceDim(THCState* state,
   // Resize out
   THLongStorage* sizes = THCTensor_newSizeOf(state, in);
   THLongStorage_set(sizes, dim, 1);
-  THCTensor_resize(state, out, sizes, NULL);
+  THCTensor_resizeLegacy(state, out, sizes, NULL);
   THLongStorage_free(sizes);
 
   // It is possible that the tensor dimensions are able to be collapsed,

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -34,7 +34,22 @@ typedef struct THCTensor
     // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
     // There will be a dim() function that gives the new view that supports 0-sized dimensions.
     inline int64_t _dim() const {
+      return is_empty() ? 0: dim_;
+    }
+
+    // NOTE: this is the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
+    inline int64_t dim() const {
       return dim_;
+    }
+
+    // represents that numel() == 0.
+    inline bool is_empty() const {
+      for (int64_t i = 0; i < dim_; ++i) {
+        if (size[i] == 0) {
+          return true;  
+        }
+      }
+      return false;
     }
 } THCTensor;
 
@@ -45,9 +60,9 @@ THC_API THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self);
 
 THC_API THCTensor *THCTensor_new(THCState *state, at::ScalarType scalar_type);
 
-THC_API void THCTensor_resize(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
 THC_API void THCTensor_resizeAs(THCState *state, THCTensor *tensor, THCTensor *src);
-THC_API void THCTensor_resizeNd(THCState *state, THCTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
+THC_API void THCTensor_resizeLegacy(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
+THC_API void THCTensor_resizeNdLegacy(THCState *state, THCTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
 
 THC_API void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src);
 THC_API void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride);

--- a/aten/src/THC/THCTensorMathCompare.cuh
+++ b/aten/src/THC/THCTensorMathCompare.cuh
@@ -74,7 +74,7 @@ void THC_logicalValue(THCState *state,
                       TensorType *src,
                       Op op) {
   THLongStorage* st = THCTensor_newSizeOf(state, src);
-  THCTensor_resize(state, self_, st, NULL);
+  THCTensor_resizeLegacy(state, self_, st, NULL);
   THLongStorage_free(st);
 
   if (!THC_pointwiseApply2<ScalarTypeOut, ScalarType>(state, self_, src, op)) {

--- a/aten/src/THC/THCTensorMathCompareT.cuh
+++ b/aten/src/THC/THCTensorMathCompareT.cuh
@@ -57,7 +57,7 @@ void THC_logicalTensor(THCState *state,
                        TensorType *src2,
                        Op op) {
   THLongStorage* st = THCTensor_newSizeOf(state, src1);
-  THCTensor_resize(state, self_, st, NULL);
+  THCTensor_resizeLegacy(state, self_, st, NULL);
   THLongStorage_free(st);
 
   THArgCheck(THCTensor_nElement(state, src1) ==

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -668,8 +668,8 @@ THC_reduceDimIndex(THCState *state,
 
   THLongStorage *dim = THCTensor_newSizeOf(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_resize(state, tgt1_, dim, NULL);
-  THCTensor_resize(state, tgt2_, dim, NULL);
+  THCTensor_resizeLegacy(state, tgt1_, dim, NULL);
+  THCTensor_resizeLegacy(state, tgt2_, dim, NULL);
   THLongStorage_free(dim);
 
   TensorTypeK *tgt1 = (TensorTypeK*)THCTensor_newContiguous<ScalarTypeK>(state, tgt1_);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -630,8 +630,8 @@ static void THCTensor_(rawInit)(THCState *state, THCTensor *self)
   new (&self->refcount) std::atomic<int>(1);
   self->storage = THCStorage_(new)(state);
   self->storageOffset = 0;
-  self->size = (int64_t *)THAlloc(sizeof(int64_t));
-  self->stride = (int64_t *)THAlloc(sizeof(int64_t));
+  self->size = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
+  self->stride = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
   self->size[0] = 0;
   self->stride[0] = 1;
   self->dim_ = 1;

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -167,7 +167,7 @@ THCTensor *THCTensor_(newWithSize4d)(THCState *state, int64_t size0, int64_t siz
 
   THCTensor *self = (THCTensor*)THAlloc(sizeof(THCTensor));
   THCTensor_(rawInit)(state, self);
-  THCTensor_(resizeNd)(state, self, 4, size, NULL);
+  THCTensor_(resizeNdLegacy)(state, self, 4, size, NULL);
 
   return self;
 }
@@ -294,9 +294,9 @@ THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
 }
 
 /* Resize */
-void THCTensor_(resize)(THCState *state, THCTensor *self, THLongStorage *size, THLongStorage *stride)
+void THCTensor_(resizeLegacy)(THCState *state, THCTensor *self, THLongStorage *size, THLongStorage *stride)
 {
-  THCTensor_resize(state, self, size, stride);
+  THCTensor_resizeLegacy(state, self, size, stride);
 }
 
 void THCTensor_(resizeAs)(THCState *state, THCTensor *self, THCTensor *src)
@@ -323,14 +323,14 @@ void THCTensor_(resize4d)(THCState *state, THCTensor *self, int64_t size0, int64
 {
   int64_t size[4] = {size0, size1, size2, size3};
 
-  THCTensor_(resizeNd)(state, self, 4, size, NULL);
+  THCTensor_(resizeNdLegacy)(state, self, 4, size, NULL);
 }
 
 void THCTensor_(resize5d)(THCState *state, THCTensor *self, int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4)
 {
     int64_t size[5] = {size0, size1, size2, size3, size4};
 
-  THCTensor_(resizeNd)(state, self, 5, size, NULL);
+  THCTensor_(resizeNdLegacy)(state, self, 5, size, NULL);
 }
 
 void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src)
@@ -423,13 +423,15 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
   if(!src)
     src = self;
 
+#ifndef USE_TH_SCALAR
   THArgCheck(src->_dim() > 1, 1, "cannot select on a vector");
-  THArgCheck((dimension >= 0) && (dimension < src->_dim()), 3, "out of range");
+#endif
+  THArgCheck((dimension >= 0) && (dimension < src->dim()), 3, "out of range");
   THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 4, "out of range");
 
   THCTensor_(set)(state, self, src);
   THCTensor_(narrow)(state, self, NULL, dimension, sliceIndex, 1);
-  for(d = dimension; d < self->_dim()-1; d++)
+  for(d = dimension; d < self->dim()-1; d++)
   {
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
@@ -469,18 +471,18 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   if(!src)
     src = self;
 
-  THArgCheck( (src->_dim() > 0), 1, "cannot unfold an empty tensor");
-  THArgCheck(dimension < src->_dim(), 2, "out of range");
+  THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
+  THArgCheck(dimension < src->dim(), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THCTensor_(set)(state, self, src);
 
-  newSize = (int64_t*)THAlloc(sizeof(int64_t)*(self->_dim()+1));
-  newStride = (int64_t*)THAlloc(sizeof(int64_t)*(self->_dim()+1));
+  newSize = (int64_t*)THAlloc(sizeof(int64_t)*(self->dim()+1));
+  newStride = (int64_t*)THAlloc(sizeof(int64_t)*(self->dim()+1));
 
-  newSize[self->_dim()] = size;
-  newStride[self->_dim()] = self->stride[dimension];
+  newSize[self->dim()] = size;
+  newStride[self->dim()] = self->stride[dimension];
   for(d = 0; d < self->_dim(); d++)
   {
     if(d == dimension)
@@ -514,7 +516,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
 
   THCTensor_(set)(state, self, src);
 
-  for(d = 0; d < src->_dim(); d++)
+  for(d = 0; d < src->dim(); d++)
   {
     if(src->size[d] != 1)
     {
@@ -527,8 +529,9 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
     }
   }
 
+#ifndef USE_TH_SCALAR
   /* right now, we do not handle 0-dimension tensors */
-  if(ndim == 0 && src->_dim() > 0)
+  if(ndim == 0 && src->dim() > 0)
   {
     self->size[0] = 1;
     self->stride[0] = 1;
@@ -536,6 +539,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
   }
   self->dim_ = ndim;
 }
+#endif
 
 void THCTensor_(squeeze1d)(THCState *state, THCTensor *self, THCTensor *src, int dimension)
 {
@@ -626,9 +630,11 @@ static void THCTensor_(rawInit)(THCState *state, THCTensor *self)
   new (&self->refcount) std::atomic<int>(1);
   self->storage = THCStorage_(new)(state);
   self->storageOffset = 0;
-  self->size = NULL;
-  self->stride = NULL;
-  self->dim_ = 0;
+  self->size = (int64_t *)THAlloc(sizeof(int64_t));
+  self->stride = (int64_t *)THAlloc(sizeof(int64_t));
+  self->size[0] = 0;
+  self->stride[0] = 1;
+  self->dim_ = 1;
   self->flag = TH_TENSOR_REFCOUNTED;
 }
 
@@ -637,9 +643,9 @@ void THCTensor_(setStorageNd)(THCState *state, THCTensor *self, THCStorage *stor
   THCTensor_setStorageNd(state, self, storage, storageOffset, nDimension, size, stride);
 }
 
-void THCTensor_(resizeNd)(THCState *state, THCTensor *self, int nDimension, int64_t *size, int64_t *stride)
+void THCTensor_(resizeNdLegacy)(THCState *state, THCTensor *self, int nDimension, int64_t *size, int64_t *stride)
 {
-  THCTensor_resizeNd(state, self, nDimension, size, stride);
+  THCTensor_resizeNdLegacy(state, self, nDimension, size, stride);
 }
 
 void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real value)

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -72,14 +72,16 @@ THC_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input
 // resize* methods simply resize the storage. So they may not retain the current data at current indices.
 // This is especially likely to happen when the tensor is not contiguous. In general, if you still need the
 // values, unless you are doing some size and stride tricks, do not use resize*.
-THC_API void THCTensor_(resize)(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
 THC_API void THCTensor_(resizeAs)(THCState *state, THCTensor *tensor, THCTensor *src);
 THC_API void THCTensor_(resize1d)(THCState *state, THCTensor *tensor, int64_t size0_);
 THC_API void THCTensor_(resize2d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_);
 THC_API void THCTensor_(resize3d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
 THC_API void THCTensor_(resize4d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_);
 THC_API void THCTensor_(resize5d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_, int64_t size4_);
-THC_API void THCTensor_(resizeNd)(THCState *state, THCTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
+// Note: these are legacy resize functions that treat sizes as size->size == 0 and size->data<int64_t>() as being 0-terminated.
+// There will be new resize functions to call that fully support dimensions of size 0.
+THC_API void THCTensor_(resizeLegacy)(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
+THC_API void THCTensor_(resizeNdLegacy)(THCState *state, THCTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
 
 THC_API void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src);
 THC_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -224,7 +224,7 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THArgCheck(!(THCTensor_(nDimension)(state, src) == 0 && THCudaLongTensor_nDimension(state, index) != 0), 2,
              "tried to take from an empty tensor");
 
-  THCTensor_(resizeNd)(state, dst, index->_dim(), index->size, NULL);
+  THCTensor_(resizeNdLegacy)(state, dst, index->_dim(), index->size, NULL);
 
   // dispatchTakePut only handles non-empty tensors;
   if (index->_dim() > 0) {
@@ -534,14 +534,14 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
   if (numIndices == 0) {
     newSize = THCTensor_(newSizeOf)(state, src);
     THLongStorage_set(newSize, 0, numIndices);
-    THCTensor_(resize)(state, dst, newSize, NULL);
+    THCTensor_(resizeLegacy)(state, dst, newSize, NULL);
     THLongStorage_free(newSize);
     return;
   }
 
   newSize = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(newSize, dim, numIndices);
-  THCTensor_(resize)(state, dst, newSize, NULL);
+  THCTensor_(resizeLegacy)(state, dst, newSize, NULL);
   THLongStorage_free(newSize);
 
   int indContig = THCudaLongTensor_isContiguous(state, indices);

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -60,12 +60,12 @@ THCTensor_(maskedCopy)(THCState* state,
   // we're accumulating the prefix sum in (int64_t) to get around it
   THCudaLongTensor* maskLong = THCudaLongTensor_new(state);
   THLongStorage* maskSizes = THCudaByteTensor_newSizeOf(state, mask);
-  THCudaLongTensor_resize(state, maskLong, maskSizes, NULL);
+  THCudaLongTensor_resizeLegacy(state, maskLong, maskSizes, NULL);
   THCudaLongTensor_copyCudaByte(state, maskLong, mask);
 
   // Use a prefix sum to determine the output locations of the masked elements
   THCudaLongTensor* maskPrefixSum = THCudaLongTensor_new(state);
-  THCudaLongTensor_resize(state, maskPrefixSum, maskSizes, NULL);
+  THCudaLongTensor_resizeLegacy(state, maskPrefixSum, maskSizes, NULL);
   THLongStorage_free(maskSizes);
 
   THCThrustAllocator thrustAlloc(state);
@@ -135,12 +135,12 @@ THCTensor_(maskedSelect)(THCState* state,
   // we're accumulating the prefix sum in (int64_t) to get around it
   THCudaLongTensor* maskLong = THCudaLongTensor_new(state);
   THLongStorage* maskSizes = THCudaByteTensor_newSizeOf(state, mask);
-  THCudaLongTensor_resize(state, maskLong, maskSizes, NULL);
+  THCudaLongTensor_resizeLegacy(state, maskLong, maskSizes, NULL);
   THCudaLongTensor_copyCudaByte(state, maskLong, mask);
 
   // Use a prefix sum to determine the output locations of the masked elements
   THCudaLongTensor* maskPrefixSum = THCudaLongTensor_new(state);
-  THCudaLongTensor_resize(state, maskPrefixSum, maskSizes, NULL);
+  THCudaLongTensor_resizeLegacy(state, maskPrefixSum, maskSizes, NULL);
   THLongStorage_free(maskSizes);
 
   THCThrustAllocator thrustAlloc(state);

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -39,7 +39,7 @@ THC_API void
 THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(resizeLegacy)(state, r_, size, NULL);
   THCTensor_(zero)(state, r_);
 }
 
@@ -55,7 +55,7 @@ THC_API void
 THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(resizeLegacy)(state, r_, size, NULL);
   THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
 }
 
@@ -71,7 +71,7 @@ THC_API void
 THCTensor_(reshape)(THCState *state, THCTensor *r_, THCTensor *t, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, t));
-  THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(resizeLegacy)(state, r_, size, NULL);
   THCTensor_(copy)(state, r_, t);
 }
 
@@ -176,7 +176,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
     }
     THLongStorage_data(size)[dim] = result_dim_size;
   }
-  THCTensor_(resize)(state, result, size, NULL);
+  THCTensor_(resizeLegacy)(state, result, size, NULL);
   THLongStorage_free(size);
 
   // We parallelize the copy if all 6 conditions pass:

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -10,7 +10,7 @@ static void THCTensor_(copyArray1d)(THCState *state, THCTensor *self, real *src,
 {
   int64_t size[1] = { k };
   int64_t stride[1] = { 1 };
-  THCTensor_(resizeNd)(state, self, 1, size, stride);
+  THCTensor_(resizeNdLegacy)(state, self, 1, size, stride);
   size_t len = k * sizeof(real);
   THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
 }
@@ -19,7 +19,7 @@ static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src,
 {
   int64_t size[2] = { m, n };
   int64_t stride[2] = { 1, m };
-  THCTensor_(resizeNd)(state, self, 2, size, stride);
+  THCTensor_(resizeNdLegacy)(state, self, 2, size, stride);
   size_t len = m * n * sizeof(real);
   THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
 }
@@ -54,7 +54,7 @@ static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, T
   int64_t size[2] = { src->size[0], src->size[1] };
   int64_t stride[2] = { 1, src->size[0] };
 
-  THCTensor_(resizeNd)(state, self, 2, size, stride);
+  THCTensor_(resizeNdLegacy)(state, self, 2, size, stride);
   THCTensor_(copy)(state, self, src);
   return self;
 }
@@ -434,7 +434,7 @@ THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 
   // input
   THCTensor *input = THCTensor_(newColumnMajor)(state, a, a);
-  THCTensor_(resizeNd)(state, ra_, 2, input->size, input->stride);
+  THCTensor_(resizeNdLegacy)(state, ra_, 2, input->size, input->stride);
 
   real *matrices1[1] = { THCTensor_(data)(state, input) };
   real *matrices2[1] = { THCTensor_(data)(state, ra_) };

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -94,7 +94,7 @@ THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
       state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resize)(state, self_, dim, NULL);
+  THCTensor_(resizeLegacy)(state, self_, dim, NULL);
   THLongStorage_free(dim);
 
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
@@ -123,7 +123,7 @@ THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
       state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resize)(state, self_, dim, NULL);
+  THCTensor_(resizeLegacy)(state, self_, dim, NULL);
   THLongStorage_free(dim);
 
   THCTensor *self = THCTensor_(newContiguous)(state, self_);

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -186,8 +186,8 @@ THC_API void THCTensor_(mode)(THCState *state,
       state, indices, ndim, dimension, keepdim);
   dim = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resize)(state, values, dim, NULL);
-  THCudaLongTensor_resize(state, indices, dim, NULL);
+  THCTensor_(resizeLegacy)(state, values, dim, NULL);
+  THCudaLongTensor_resizeLegacy(state, indices, dim, NULL);
   THLongStorage_free(dim);
 
   // If sliceSize is 1, copy input to values and set indices

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -383,14 +383,14 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
 THC_API void THCTensor_(rand)(THCState *state, THCTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(resizeLegacy)(state, r_, size, NULL);
   THCTensor_(uniform)(state, r_, 0, 1);
 }
 
 void THCTensor_(randn)(THCState *state, THCTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(resizeLegacy)(state, r_, size, NULL);
   THCTensor_(normal)(state, r_, 0, 1);
 }
 

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -293,7 +293,7 @@ THC_API void THCTensor_(sort)(THCState* state,
   // Make sure sufficient output space is allocated
   THCTensor_(resizeAs)(state, sorted, input);
   THLongStorage *inputSize = THCTensor_(newSizeOf)(state, input);
-  THCudaLongTensor_resize(state, indices, inputSize, NULL);
+  THCudaLongTensor_resizeLegacy(state, indices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // How large are the slices that we are sorting?

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -24,8 +24,8 @@ THC_API void THCTensor_(topk)(THCState* state,
   // size k
   THLongStorage* topKSize = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(topKSize, dim, k);
-  THCTensor_(resize)(state, topK, topKSize, NULL);
-  THCudaLongTensor_resize(state, indices, topKSize, NULL);
+  THCTensor_(resizeLegacy)(state, topK, topKSize, NULL);
+  THCudaLongTensor_resizeLegacy(state, indices, topKSize, NULL);
   THLongStorage_free(topKSize);
 
 #define RUN_K(INDEX_T, DIM, DIR)                                        \

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -66,7 +66,8 @@ THCTensor *THCSTensor_(newValues)(THCState *state, const THCSTensor *self) {
 /*** Helper methods ***/
 static void THCSTensor_(rawInit)(THCState *state, THCSTensor *self)
 {
-  self->size = NULL;
+  self->size = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
+  self->size[0] = 0;
   self->indices = THCIndexTensor_(new)(state);
   self->values = THCTensor_(new)(state);
   self->nDimensionI = 0;
@@ -79,9 +80,10 @@ static void THCSTensor_(rawInit)(THCState *state, THCSTensor *self)
 
 THCSTensor* THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size) {
   // Only resize valid sizes into tensor.
-  self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t)*(nDimI + nDimV));
+  int64_t dims = nDimI + nDimV == 0 ? 1 : nDimI + nDimV; // FIXME: nDimI + nDimV should not be 0.
+  self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t)*(dims));
 
-  for (int64_t d = 0; d < nDimI + nDimV; d++) {
+  for (int64_t d = 0; d < dims; d++) {
     self->size[d] = size[d];
   }
   self->nDimensionI = nDimI;

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -323,7 +323,7 @@ int THCSTensor_(isSameSizeAsDense)(THCState *state, const THCSTensor *self, cons
   return 1;
 }
 
-THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size)
+THCSTensor *THCSTensor_(resizeLegacy)(THCState *state, THCSTensor *self, THLongStorage *size)
 {
   THCSTensor_(rawResize)(state, self, size->size, 0, THLongStorage_data(size));
   return self;

--- a/aten/src/THCS/generic/THCSTensor.cu
+++ b/aten/src/THCS/generic/THCSTensor.cu
@@ -100,7 +100,7 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
 
   THCIndexTensor_(resize2d)(state, indices1D, 1, newNnz);
   THCTensor *newValues = THCTensor_(new)(state);
-  THCTensor_(resizeNd)(state, newValues, values->_dim(), values->size, NULL);
+  THCTensor_(resizeNdLegacy)(state, newValues, values->_dim(), values->size, NULL);
   newValues->size[0] = newNnz;
 
 

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -32,12 +32,12 @@ THC_API THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self,
 /**** reshaping methods ***/
 THC_API int THCSTensor_(isSameSizeAs)(THCState *state, const THCSTensor *self, const THCSTensor* src);
 THC_API int THCSTensor_(isSameSizeAsDense)(THCState *state, const THCSTensor *self, const THCTensor* src);
-THC_API THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size);
 THC_API THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor *src);
 THC_API THCSTensor *THCSTensor_(resize1d)(THCState *state, THCSTensor *self, int64_t size0);
 THC_API THCSTensor *THCSTensor_(resize2d)(THCState *state, THCSTensor *self, int64_t size0, int64_t size1);
 THC_API THCSTensor *THCSTensor_(resize3d)(THCState *state, THCSTensor *self, int64_t size0, int64_t size1, int64_t size2);
 THC_API THCSTensor *THCSTensor_(resize4d)(THCState *state, THCSTensor *self, int64_t size0, int64_t size1, int64_t size2, int64_t size3);
+THC_API THCSTensor *THCSTensor_(resizeLegacy)(THCState *state, THCSTensor *self, THLongStorage *size);
 
 THC_API THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self);
 THC_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src);

--- a/aten/src/THCS/generic/THCSTensor.hpp
+++ b/aten/src/THCS/generic/THCSTensor.hpp
@@ -24,6 +24,11 @@ typedef struct THCSTensor
     inline int64_t _dim() const {
       return nDimensionI + nDimensionV;
     }
+
+    inline int64_t dim() const {
+      // FixME: nDimensionI and nDimensionV should be set correctly by THCS
+      return (nDimensionI + nDimensionV) == 0 ? 1 : (nDimensionI + nDimensionV);
+    }
 } THCSTensor;
 
 #endif

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -25,10 +25,10 @@ THCudaIntTensor *THCSTensor_(toCSR)(THCState *state, THCIndexTensor *rowIndices,
 
 void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
   if (self->indices->_dim()) {
-    THCIndexTensor_(resizeNd)(state, self->indices, 0, NULL, NULL);
+    THCIndexTensor_(resizeNdLegacy)(state, self->indices, 0, NULL, NULL);
   }
   if (self->values->_dim()) {
-    THCTensor_(resizeNd)(state, self->values, 0, NULL, NULL);
+    THCTensor_(resizeNdLegacy)(state, self->values, 0, NULL, NULL);
   }
   self->nnz = 0;
 }
@@ -36,7 +36,7 @@ void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
 void THCSTensor_(zeros)(THCState *state, THCSTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 1, r_));
-  THCSTensor_(resize)(state, r_, size);
+  THCSTensor_(resizeLegacy)(state, r_, size);
   THCSTensor_(zero)(state, r_);
 }
 

--- a/aten/src/THCUNN/common.h
+++ b/aten/src/THCUNN/common.h
@@ -21,7 +21,7 @@ inline int GET_BLOCKS(const int N)
   THLongStorage *size2 = THCTensor_(newSizeOf)(STATE, I2);  \
   if (!THCIndexTensor_(isSize)(STATE, I1, size2))           \
   { \
-    THCudaLongTensor_resize(STATE, I1, size2, NULL);        \
+    THCudaLongTensor_resizeLegacy(STATE, I1, size2, NULL);        \
   } \
   THLongStorage_free(size2);
 

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -18,7 +18,7 @@ void THNN_(GatedLinear_updateOutput)(
   const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
   THLongStorage *newSizes = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(newSizes, dim, inputSize);
-  THCTensor_(resize)(state, output, newSizes, NULL);
+  THCTensor_(resizeLegacy)(state, output, newSizes, NULL);
 
   // halve tensor
   THCTensor *firstHalf = THCTensor_(newNarrow)(state, input, dim, 0, inputSize);

--- a/aten/src/THCUNN/generic/LookupTable.cu
+++ b/aten/src/THCUNN/generic/LookupTable.cu
@@ -51,8 +51,8 @@ void THNN_(LookupTable_accGradParameters)(
   }
 
   THLongStorage *inputSize = THCIndexTensor_(newSizeOf)(state, input);
-  THCIndexTensor_(resize)(state, sortedIndices, inputSize, NULL);
-  THCIndexTensor_(resize)(state, origIndices, inputSize, NULL);
+  THCIndexTensor_(resizeLegacy)(state, sortedIndices, inputSize, NULL);
+  THCIndexTensor_(resizeLegacy)(state, origIndices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // Sort the inputs into sorted with the corresponding indices; we

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -35,9 +35,9 @@ void THNN_(LookupTableBag_updateOutput)(
   THLongStorage *outputSize = THLongStorage_newWithSize(2);
   THLongStorage_data(outputSize)[0] = numBags;
   THLongStorage_data(outputSize)[1] = stride;
-  THCTensor_(resize)(state, output, outputSize, NULL);
+  THCTensor_(resizeLegacy)(state, output, outputSize, NULL);
   THCTensor_(zero)(state, output);
-  THCIndexTensor_(resize)(state, offset2bag, inputSize, NULL);
+  THCIndexTensor_(resizeLegacy)(state, offset2bag, inputSize, NULL);
   THLongStorage_free(inputSize);
   THLongStorage_free(outputSize);
 
@@ -100,8 +100,8 @@ void THNN_(LookupTableBag_accGradParameters)(
   cudaStream_t stream = THCState_getCurrentStream(state);
 
   THLongStorage *inputSize = THCIndexTensor_(newSizeOf)(state, input);
-  THCIndexTensor_(resize)(state, sortedIndices, inputSize, NULL);
-  THCIndexTensor_(resize)(state, origIndices, inputSize, NULL);
+  THCIndexTensor_(resizeLegacy)(state, sortedIndices, inputSize, NULL);
+  THCIndexTensor_(resizeLegacy)(state, origIndices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // Sort the inputs into sorted with the corresponding indices; we

--- a/aten/src/THNN/THNN.h
+++ b/aten/src/THNN/THNN.h
@@ -23,7 +23,7 @@ typedef void THNNState;
   THLongStorage *size2 = THIndexTensor_(newSizeOf)(I2);  \
   if (!THTensor_(isSize)(I1, size2))                     \
   { \
-    THTensor_(resize)(I1, size2, NULL);                  \
+    THTensor_(resizeLegacy)(I1, size2, NULL);            \
   } \
   THLongStorage_free(size2);
 

--- a/aten/src/THNN/generic/GatedLinearUnit.c
+++ b/aten/src/THNN/generic/GatedLinearUnit.c
@@ -17,7 +17,7 @@ void THNN_(GatedLinear_updateOutput)(
   const int64_t inputSize = THTensor_(size)(input, dim) / 2;
   THLongStorage *newSizes = THTensor_(newSizeOf)(input);
   THLongStorage_set(newSizes, dim, inputSize);
-  THTensor_(resize)(output, newSizes, NULL);
+  THTensor_(resizeLegacy)(output, newSizes, NULL);
 
   // halve tensor
   THTensor *firstHalf = THTensor_(newNarrow)(input, dim, 0, inputSize);

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -296,7 +296,7 @@ int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor* src)
   return 1;
 }
 
-THSTensor *THSTensor_(resize)(THSTensor *self, THLongStorage *size)
+THSTensor *THSTensor_(resizeLegacy)(THSTensor *self, THLongStorage *size)
 {
   THSTensor_(rawResize)(self, size->size, 0, THLongStorage_data(size));
   return self;

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -66,7 +66,8 @@ THTensor *THSTensor_(newValues)(const THSTensor *self) {
 static void THSTensor_(rawInit)(THSTensor *self)
 {
   new (&self->refcount) std::atomic<int>(1);
-  self->size = NULL;
+  self->size = static_cast<int64_t *>(THAlloc(sizeof(int64_t)));
+  self->size[0] = 0;
   self->indices = THLongTensor_new();
   self->values = THTensor_(new)();
   self->nDimensionI = 0;
@@ -78,9 +79,10 @@ static void THSTensor_(rawInit)(THSTensor *self)
 
 THSTensor* THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t *size) {
   // Only resize valid sizes into tensor.
-  self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t)*(nDimI + nDimV));
+  int64_t dims = nDimI + nDimV == 0 ? 1 : nDimI + nDimV; // FIXME: nDimI + nDimV should not be 0.
+  self->size = (int64_t *)THRealloc(self->size, sizeof(int64_t)*(dims));
 
-  for (int64_t d = 0; d < nDimI + nDimV; d++) {
+  for (int64_t d = 0; d < dims; d++) {
     self->size[d] = size[d];
   }
   self->nDimensionI = nDimI;

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -32,12 +32,12 @@ TH_API THSTensor *THSTensor_(newClone)(THSTensor *self);
 TH_API THSTensor *THSTensor_(newTranspose)(THSTensor *self, int dimension1_, int dimension2_);
 
 /**** reshaping methods ***/
-TH_API THSTensor *THSTensor_(resize)(THSTensor *self, THLongStorage *size);
 TH_API THSTensor *THSTensor_(resizeAs)(THSTensor *self, THSTensor *src);
 TH_API THSTensor *THSTensor_(resize1d)(THSTensor *self, int64_t size0);
 TH_API THSTensor *THSTensor_(resize2d)(THSTensor *self, int64_t size0, int64_t size1);
 TH_API THSTensor *THSTensor_(resize3d)(THSTensor *self, int64_t size0, int64_t size1, int64_t size2);
 TH_API THSTensor *THSTensor_(resize4d)(THSTensor *self, int64_t size0, int64_t size1, int64_t size2, int64_t size3);
+TH_API THSTensor *THSTensor_(resizeLegacy)(THSTensor *self, THLongStorage *size);
 
 TH_API THTensor *THSTensor_(toDense)(THSTensor *self);
 TH_API void THSTensor_(copy)(THSTensor *self, THSTensor *src);

--- a/aten/src/THS/generic/THSTensor.hpp
+++ b/aten/src/THS/generic/THSTensor.hpp
@@ -26,7 +26,7 @@ typedef struct THSTensor
     }
 
     inline int64_t dim() const {
-      // FixME: nDimensionI and nDimensionV should be set correctly by THS
+      // FIXME: nDimensionI and nDimensionV should be set correctly by THS
       return (nDimensionI + nDimensionV) == 0 ? 1 : (nDimensionI + nDimensionV);
     }
 } THSTensor;

--- a/aten/src/THS/generic/THSTensor.hpp
+++ b/aten/src/THS/generic/THSTensor.hpp
@@ -24,6 +24,11 @@ typedef struct THSTensor
     inline int64_t _dim() const {
       return nDimensionI + nDimensionV;
     }
+
+    inline int64_t dim() const {
+      // FixME: nDimensionI and nDimensionV should be set correctly by THS
+      return (nDimensionI + nDimensionV) == 0 ? 1 : (nDimensionI + nDimensionV);
+    }
 } THSTensor;
 
 #endif

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -7,17 +7,17 @@
 
 void THSTensor_(zero)(THSTensor *self) {
   if (self->indices->_dim()) {
-    THLongTensor_resizeNd(self->indices, 0, NULL, NULL);
+    THLongTensor_resizeNdLegacy(self->indices, 0, NULL, NULL);
   }
   if (self->values->_dim()) {
-    THTensor_(resizeNd)(self->values, 0, NULL, NULL);
+    THTensor_(resizeNdLegacy)(self->values, 0, NULL, NULL);
   }
   self->nnz = 0;
 }
 
 void THSTensor_(zeros)(THSTensor *r_, THLongStorage *size)
 {
-  THSTensor_(resize)(r_, size);
+  THSTensor_(resizeLegacy)(r_, size);
   THSTensor_(zero)(r_);
 }
 


### PR DESCRIPTION
The goal here is to unify the tensor representations; since the "majority" of the representation is in TH, we push the empty size ({0}) and empty stride ({1}) logic into TH.

This PR does the following:
1) Previously THTensor/THCTensor with dim_ == 0, size == nullptr, stride == nullptr are now dim_ == 1, size == {0}, stride == {1}.
2) The logic that previously implemented this at the ATen level (e.g. THLongStorageView STRIDE_EMPTY_TENSOR) is removed.
3) The above is pretty clean except for resize/resizeNd logic -- that is still called with nDimension == 0.  So, we rename these to resizeLegacy, resizeNdLegacy, map nDimension == 1
into the new regime, and will later write a empty-aware resize/resizeNd and move over the calls to resizeLegacy, resizeNdLegacy.
4) Also introduces some ifdefs that are just used for testing:
a) USE_TH_SCALAR: move scalar logic in TH
b) USE_TH_ZERO_SIZE_DIM: support arbitrary 0-sized dimensions, i.e {...,0,...}.
These are just used to write forward-looking correct code while call sites to _dim() (old TH nDimension) and resizeLegacy are updated.

