### PR TITLE
Create at::tensor

### DIFF
--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -20,6 +20,15 @@ _(at::Half,Half,d) \
 _(float,Float,d) \
 _(double,Double,d)
 
+#define AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(_) \
+_(uint8_t,Byte,i) \
+_(int8_t,Char,i) \
+_(int16_t,Short,i) \
+_(int,Int,i) \
+_(int64_t,Long,i) \
+_(float,Float,d) \
+_(double,Double,d)
+
 enum class ScalarType {
 #define DEFINE_ENUM(_1,n,_2) \
   n,

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -12,6 +12,7 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/ScalarType.h"
 #include "ATen/Deprecated.h"
+#include "ATen/DeviceGuard.h"
 #include "TH/THRandom.h"
 
 #include <algorithm>
@@ -593,5 +594,21 @@ Tensor hann_window(
   return native::hamming_window(
       window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, options);
 }
+
+template <typename T>
+Tensor tensor(ArrayRef<T> values, const TensorOptions& options) {
+  auto result = at::empty(values.size(), options);
+  for (size_t i = 0; i < values.size(); ++i) {
+    result[i] = values[i];
+  }
+  return result;
+}
+
+#define TENSOR(T, _1, _2)                                           \
+  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
+    return tensor<T>(values, options);                              \
+  }
+AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(TENSOR)
+#undef TENSOR
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1573,10 +1573,10 @@
     SparseCPU: new_with_size_sparse
 
 - func: tensor(Type dtype) -> Tensor
-  variants: function
+  variants: []
 
 - func: tensor(Type dtype, IntList size) -> Tensor
-  variants: function
+  variants: []
 
 
 # NB: The function overloads are removed to avoid a nasty bug where
@@ -1598,10 +1598,10 @@
     SparseCPU: new_with_tensor_and_size_sparse
 
 - func: sparse_coo_tensor(IndexTensor indices, Tensor values) -> Tensor
-  variants: function
+  variants: []
 
 - func: sparse_coo_tensor(IndexTensor indices, Tensor values, IntList size) -> Tensor
-  variants: function
+  variants: []
 
 
 - func: _native_sparse_coo_tensor_unsafe(IndexTensor indices, Tensor values, IntList size) -> Tensor

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -15,6 +15,7 @@
 namespace at {
 
 using native::from_blob;
+using native::tensor;
 
 ${function_declarations}
 

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -38,6 +38,28 @@ inline Tensor from_blob(
   return native::from_blob(data, sizes, [](void*) {}, options);
 }
 
+// These functions are defined in native/TensorFactories.cpp.
+#define TENSOR(T, S, _1)                                               \
+  Tensor tensor(ArrayRef<T> values, const TensorOptions& options);     \
+  inline Tensor tensor(                                                \
+      std::initializer_list<T> values, const TensorOptions& options) { \
+    return native::tensor(ArrayRef<T>(values), options);               \
+  }                                                                    \
+  inline Tensor tensor(T value, const TensorOptions& options) {        \
+    return native::tensor(ArrayRef<T>(value), options);                \
+  }                                                                    \
+  inline Tensor tensor(ArrayRef<T> values) {                           \
+    return native::tensor(std::move(values), at::dtype(k##S));         \
+  }                                                                    \
+  inline Tensor tensor(std::initializer_list<T> values) {              \
+    return native::tensor(ArrayRef<T>(values));                        \
+  }                                                                    \
+  inline Tensor tensor(T value) {                                      \
+    return native::tensor(ArrayRef<T>(value));                         \
+  }
+AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(TENSOR)
+#undef TENSOR
+
 ${native_function_declarations}
 
 } // namespace native

--- a/aten/src/TH/THBlasUtils.h
+++ b/aten/src/TH/THBlasUtils.h
@@ -6,15 +6,6 @@
 // rather than by name directly.  Someone should figure out a reasonable way to
 // rewrite these in more idiomatic ATen and move it into ATen proper.
 
-#define AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(_) \
-_(uint8_t,Byte,i) \
-_(int8_t,Char,i) \
-_(int16_t,Short,i) \
-_(int,Int,i) \
-_(int64_t,Long,i) \
-_(float,Float,d) \
-_(double,Double,d)
-
 template<typename T>
 inline void THBlas_axpy(int64_t n, T a, T *x, int64_t incx, T *y, int64_t incy);
 

--- a/test/cpp/api/tensor_cuda.cpp
+++ b/test/cpp/api/tensor_cuda.cpp
@@ -1,0 +1,10 @@
+#include <catch.hpp>
+
+#include <ATen/ATen.h>
+
+#include <cmath>
+
+TEST_CASE("Tensor/AllocatesTensorOnTheCorrectDevice", "[cuda]") {
+  auto tensor = at::tensor({1, 2, 3}, at::device({at::kCUDA, 1}));
+  REQUIRE(tensor.device() == at::Device(at::kCUDA, 1));
+}

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -362,6 +362,7 @@ if (TORCH_BUILD_TEST)
       ${TORCH_API_TEST_DIR}/serialization.cpp
       ${TORCH_API_TEST_DIR}/static.cpp
       ${TORCH_API_TEST_DIR}/tensor.cpp
+      ${TORCH_API_TEST_DIR}/tensor_cuda.cpp
       # Temporary until ATen tests are built with Caffe2
       ${TORCH_API_TEST_DIR}/tensor_options.cpp
       ${TORCH_API_TEST_DIR}/tensor_options_cuda.cpp


### PR DESCRIPTION
PyTorch has `torch.tensor`, which is a convenient way of creating a tensor from a list of values. This PR adds the equivalent to ATen/C++.

It kind of depends on https://github.com/pytorch/pytorch/pull/7869, but putting it here already. The most important file is `aten/src/ATen/ScalarList.h` which can already be reviewed.

I've also named it `values` for now because factory methods still dispatch over `Type`, and `Type::tensor` already exists. After the other PR lands I'll rename it `tensor`.

@colesbury @gchanan @ezyang 