### PR TITLE
Temporary solution for having access to Python installation path.

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -36,7 +36,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   sudo chown -R jenkins:jenkins /usr/local
   rm -rf "$(dirname "${BASH_SOURCE[0]}")/../../../pytorch_amd/" || true
   python "$(dirname "${BASH_SOURCE[0]}")/../../tools/amd_build/build_pytorch_amd.py"
-  HIPCC_VERBOSE=1 VERBOSE=1 WITH_ROCM=1 python setup.py install
+  HIPCC_VERBOSE=7 VERBOSE=1 WITH_ROCM=1 python setup.py install
   exit
 fi
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -33,6 +33,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   git clone https://github.com/ROCm-Developer-Tools/pyHIPIFY.git
   chmod a+x pyHIPIFY/*.py
   sudo cp -p pyHIPIFY/*.py /opt/rocm/bin
+  sudo chown -R jenkins:jenkins /usr/local
   rm -rf "$(dirname "${BASH_SOURCE[0]}")/../../../pytorch_amd/" || true
   python "$(dirname "${BASH_SOURCE[0]}")/../../tools/amd_build/build_pytorch_amd.py"
   HIPCC_VERBOSE=1 VERBOSE=1 WITH_ROCM=1 python setup.py install


### PR DESCRIPTION
For our docker images we're using the python installed in the system path (not in an anaconda installation). So in order to have permissions to installing inside the dist-packages path, we need to chown.