### PR TITLE
Turn off verbose logging for PyTorch ROCm nightly builds.

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -36,7 +36,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   sudo chown -R jenkins:jenkins /usr/local
   rm -rf "$(dirname "${BASH_SOURCE[0]}")/../../../pytorch_amd/" || true
   python "$(dirname "${BASH_SOURCE[0]}")/../../tools/amd_build/build_pytorch_amd.py"
-  HIPCC_VERBOSE=7 VERBOSE=1 WITH_ROCM=1 python setup.py install
+  WITH_ROCM=1 python setup.py install
   exit
 fi
 


### PR DESCRIPTION
Disabling verbose logging since millions of lines were generated. 