### PR TITLE
Eliminates noisy assert spew when running test_cuda.py

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1416,7 +1416,10 @@ class TestCuda(TestCase):
         except RuntimeError:
             pass
         with mp.Pool(1, initializer = self.mute) as pool:
-            self.assertTrue(pool.map(method, [arg]))
+            errors = pool.map(method, [arg])
+            for e in errors:
+                if not 'device-side assert triggered' in str(e):
+                    self.fail(e)
 
     @staticmethod
     def _test_multinomial_invalid_probs_cuda(probs):
@@ -1426,7 +1429,7 @@ class TestCuda(TestCase):
                 torch.cuda.synchronize()
             return False  # Should not be reached
         except RuntimeError as e:
-            return 'device-side assert triggered' in str(e)
+            return e
 
     @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
     @unittest.skipIf(not PY3,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1405,7 +1405,7 @@ class TestCuda(TestCase):
         torch.cuda.manual_seed(11042)
         sample = torch.multinomial(freqs, 1000, True)
         self.assertNotEqual(freqs[sample].min(), 0)
-    
+
     @staticmethod
     def mute():
         os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())
@@ -1415,10 +1415,10 @@ class TestCuda(TestCase):
             mp.set_start_method('spawn')
         except RuntimeError:
             pass
-        with mp.Pool(1, initializer = self.mute) as pool:
+        with mp.Pool(1, initializer=self.mute) as pool:
             errors = pool.map(method, [arg])
             for e in errors:
-                if not 'device-side assert triggered' in str(e):
+                if 'device-side assert triggered' not in str(e):
                     self.fail(e)
 
     @staticmethod

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5,6 +5,7 @@ import re
 import unittest
 import sys
 from itertools import repeat
+import os
 
 import torch
 import torch.cuda
@@ -1404,13 +1405,17 @@ class TestCuda(TestCase):
         torch.cuda.manual_seed(11042)
         sample = torch.multinomial(freqs, 1000, True)
         self.assertNotEqual(freqs[sample].min(), 0)
+    
+    @staticmethod
+    def mute():
+        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())
 
     def _spawn_method(self, method, arg):
         try:
             mp.set_start_method('spawn')
         except RuntimeError:
             pass
-        with mp.Pool(1) as pool:
+        with mp.Pool(1, initializer = self.mute) as pool:
             self.assertTrue(pool.map(method, [arg]))
 
     @staticmethod


### PR DESCRIPTION
This PR addresses issue #8342.

Currently, running test_cuda.py results in some asserts triggering and writing to stderr. This can be seen in all recent CI runs, for example. These asserts are expected, however. They and the test that intentionally triggers them were added in #7647.

Printing asserts during the tests is noisy and misleading. This PR address the issue by "muting" stderr on the existing subprocesses used by this test. The actual RuntimeError is captured separately and returned for examination, so if the error differs from what's expected it will still be reported. Muting the stderr on these subprocesses does not affect the main process, and other errors will be reported as usual. 

