### PR TITLE
16bit typeid

### DIFF
--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -2,6 +2,8 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/scope_guard.h"
 
+#include <atomic>
+
 #if !defined(_MSC_VER)
 #include <cxxabi.h>
 #endif
@@ -54,6 +56,15 @@ void TypeMeta::_ThrowRuntimeTypeLogicError(const std::string& msg) {
   // In earlier versions it used to be std::abort() but it's a bit hard-core
   // for a library
   CAFFE_THROW(msg);
+}
+
+CaffeTypeId TypeMeta::_createTypeId() {
+  static std::atomic<CaffeTypeId::underlying_type> counter(0);
+  const CaffeTypeId::underlying_type new_value = ++counter; // note: first type id is 1 to avoid confusion of whether 0 means invalid.
+  if (new_value == std::numeric_limits<CaffeTypeId::underlying_type>::max()) {
+    throw std::logic_error("Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase CaffeTypeId to use more than 16 bit.");
+  }
+  return CaffeTypeId(new_value);
 }
 
 namespace {

--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -58,9 +58,9 @@ void TypeMeta::_ThrowRuntimeTypeLogicError(const std::string& msg) {
   CAFFE_THROW(msg);
 }
 
-CaffeTypeId TypeMeta::_createTypeId() {
+CaffeTypeId CaffeTypeId::createTypeId() {
   static std::atomic<CaffeTypeId::underlying_type> counter(0);
-  const CaffeTypeId::underlying_type new_value = ++counter; // note: first type id is 1 to avoid confusion of whether 0 means invalid.
+  const CaffeTypeId::underlying_type new_value = ++counter; // note: first type id is 1 because 0 means uninitialized
   if (new_value == std::numeric_limits<CaffeTypeId::underlying_type>::max()) {
     throw std::logic_error("Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase CaffeTypeId to use more than 16 bit.");
   }


### PR DESCRIPTION
Only use 16bit instead of 64bit for a type id.

This reduces the space needed for dispatch keys from 10 to 4 bytes per tensor, improving cache efficiency, alignment and comparison time when looking up kernels from the dispatch hash table.