### PR TITLE
[JIT] Remove TK_WHERE

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3078,6 +3078,12 @@ class TestScript(JitTestCase):
         self.checkScript(fn, (torch.tensor(1),))
         self.checkScript(fn, (torch.tensor(2),))
 
+    def test_where(self):
+        def fn(x, y):
+            return torch.where(x > 0.0, x, y)
+
+        self.checkScript(fn, (torch.randn(3, 2, dtype=torch.float), torch.ones(3, 2, dtype=torch.float)))
+
 
 class TestEndToEndHybridFrontendModels(JitTestCase):
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -30,7 +30,6 @@ namespace script {
   _(TK_NEWLINE, "newline", "")                   \
   _(TK_INDENT, "indent", "")                     \
   _(TK_DEDENT, "dedent", "")                     \
-  _(TK_WHERE, "where", "where")                  \
   _(TK_FLOAT, "float", "float")                  \
   _(TK_DOUBLE, "double", "double")               \
   _(TK_LONG, "long", "long")                     \


### PR DESCRIPTION
Solves https://github.com/pytorch/pytorch/issues/8526.

Note that the auto-generated tests still fail because the tests pass in a Double tensor where the operator expects a Byte tensor