### PR TITLE
Enable open registration of VariableType objects

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -26,7 +26,8 @@ static inline void argErrorHandler(int arg, const char * msg, void * data) {
 }
 
 Context::Context()
-: thc_state(nullptr, [](THCState* p){ /* no-op */ } ) {
+: next_id(static_cast<size_t>(TypeID::NumOptions))
+, thc_state(nullptr, [](THCState* p){ /* no-op */ } ) {
 
   THSetDefaultErrorHandler(errorHandler,nullptr);
   THSetDefaultArgErrorHandler(argErrorHandler,nullptr);

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -30,19 +30,21 @@ enum class IsVariable {
 class AT_API Context {
 public:
   Context();
+  Type* getTypeRaw(Backend p, ScalarType s) {
+    return type_registry[static_cast<int>(p)][static_cast<int>(s)].get();
+  }
   Type * getTypeOpt(Backend p, ScalarType s) {
     initCUDAIfNeeded(p);
-    auto & type = type_registry[static_cast<int>(IsVariable::NotVariable)][static_cast<int>(p)][static_cast<int>(s)];
+    auto type = getTypeRaw(p, s);
 
     if(!type) {
       // there is only a single Undefined Type.
       if (p == Backend::Undefined || s == ScalarType::Undefined) {
-        auto & undef = type_registry[static_cast<int>(IsVariable::NotVariable)][static_cast<int>(Backend::Undefined)][static_cast<int>(ScalarType::Undefined)];
-        if (undef) return undef.get();
+        return getTypeRaw(Backend::Undefined, ScalarType::Undefined);
       }
-      return nullptr;
     }
-    return type.get();
+
+    return type;
   }
   Type & getType(Backend p, ScalarType s) {
     auto* type = getTypeOpt(p, s);
@@ -98,7 +100,9 @@ public:
   int getNumGPUs() const {
     return detail::getCUDAHooks().getNumGPUs();
   }
-
+  size_t freshTypeID() {
+    return next_id++;
+  }
   bool setFlushDenormal(bool on);
 
   // NB: This method is *purely* whether or not a user requested
@@ -113,13 +117,12 @@ public:
   void setDeterministicCuDNN(bool);
   std::unique_ptr<Generator>
     generator_registry[static_cast<int>(Backend::NumOptions)];
+private:
   // NB: type_registry has nullptr for all CUDA backends until
   // CUDA initialization has occurred
   std::unique_ptr<Type> type_registry
-    [static_cast<int>(IsVariable::NumOptions)]
     [static_cast<int>(Backend::NumOptions)]
     [static_cast<int>(ScalarType::NumOptions)];
-private:
   void initCUDAIfNeeded(Backend p) {
     if(p == Backend::CUDA)
       lazyInitCUDA();
@@ -128,7 +131,10 @@ private:
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
   bool benchmark_cudnn = false;
+  std::atomic<size_t> next_id;
   std::unique_ptr<THCState, void(*)(THCState*)> thc_state;
+  friend struct Type;
+  friend void register_cuda_types(Context * context);
 };
 
 AT_API Context & globalContext();

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -132,8 +132,7 @@ FUNCTIONS_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Functions.h")
 NATIVE_FUNCTIONS_H = CodeTemplate.from_file(TEMPLATE_PATH + "/NativeFunctions.h")
 
 TYPE_REGISTER = CodeTemplate("""\
-context->type_registry[static_cast<int>(IsVariable::NotVariable)]
-                      [static_cast<int>(Backend::${backend})]
+context->type_registry[static_cast<int>(Backend::${backend})]
                       [static_cast<int>(ScalarType::${scalar_type})]
                       .reset(new ${type_name}(context));
 detail::getVariableHooks().registerVariableTypeFor(context, Backend::${backend}, ScalarType::${scalar_type});

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -18,8 +18,7 @@ namespace at {
 
 void Type::registerCPU(Context * context) {
   ${cpu_type_registrations}
-  context->type_registry[static_cast<int>(IsVariable::NotVariable)]
-                        [static_cast<int>(Backend::Undefined)]
+  context->type_registry[static_cast<int>(Backend::Undefined)]
                         [static_cast<int>(ScalarType::Undefined)].reset(new UndefinedType(context));
 }
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -54,7 +54,6 @@ enum class TypeID {
   NumOptions
 };
 
-
 struct AT_API Type {
   explicit Type(Context* context, bool is_variable, bool is_undefined)
       : context(context), is_variable_(is_variable), is_undefined_(is_undefined) {}
@@ -105,6 +104,7 @@ protected:
   Context* context;
   bool is_variable_;
   bool is_undefined_;
+
 };
 
 inline bool Tensor::is_variable() const noexcept {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -25,7 +25,7 @@ using at::Type;
 using at::ScalarType;
 using at::optional;
 
-void register_variable_type_for(Context*, at::Backend, at::ScalarType);
+void register_variable_type_for(at::Type* baseType);
 
 struct VariableType final : public at::Type {
   VariableType(Context* context, at::Type* baseType);
@@ -68,6 +68,7 @@ private:
 
   at::Type* baseType;
   std::string str;
+  size_t id_;
 };
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/aten_variable_hooks.cpp
+++ b/torch/csrc/autograd/aten_variable_hooks.cpp
@@ -16,7 +16,8 @@ REGISTER_VARIABLE_HOOKS(VariableHooks)
 
 // Pre-condition: backend/scalar_type is a valid type in the type_registry
 void VariableHooks::registerVariableTypeFor(at::Context* context, at::Backend backend, at::ScalarType scalar_type) const {
-  register_variable_type_for(context, backend, scalar_type);
+  auto* baseType = context->getTypeRaw(backend, scalar_type);
+  register_variable_type_for(baseType);
 }
 
 }} // torch::autograd


### PR DESCRIPTION
We have 2 use cases where we want to experiment with new base ATen
tensor types:

* BatchTensor for matchbox
* Tensors that live on accelerators

It is possible to subclass TensorImpl to implement these but VariableType
does not work with them because it cannot find the equivalent variable type
in the registry.

This commit changes the way we implement type -> variable(type) lookup so that
torch::register_variable_type_for can be called on any at::Type.

Lookups are still done using arrays so there should be no perf impact from the change.

