### PR TITLE
Fixes #8508. Upcasted loc to 1-d if a scalar loc is provided to MultivariateNormal

### DIFF
--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -119,6 +119,8 @@ class MultivariateNormal(Distribution):
     has_rsample = True
 
     def __init__(self, loc, covariance_matrix=None, precision_matrix=None, scale_tril=None, validate_args=None):
+        if loc.dim() < 1:
+            loc.unsqueeze_(0)
         event_shape = torch.Size(loc.shape[-1:])
         if (covariance_matrix is not None) + (scale_tril is not None) + (precision_matrix is not None) != 1:
             raise ValueError("Exactly one of covariance_matrix or precision_matrix or scale_tril may be specified.")

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -120,7 +120,7 @@ class MultivariateNormal(Distribution):
 
     def __init__(self, loc, covariance_matrix=None, precision_matrix=None, scale_tril=None, validate_args=None):
         if loc.dim() < 1:
-            loc.unsqueeze_(0)
+            loc = loc.unsqueeze(0)
         event_shape = torch.Size(loc.shape[-1:])
         if (covariance_matrix is not None) + (scale_tril is not None) + (precision_matrix is not None) != 1:
             raise ValueError("Exactly one of covariance_matrix or precision_matrix or scale_tril may be specified.")


### PR DESCRIPTION
This fix unsqueezes the `loc` argument to make it 1-Dimensional in `torch.distributions.MultivariateNormal.__init__` if the provided `loc` is a scalar thereby preventing the SIGFPE.

This is a simple fix for #8508