### PR TITLE
Remove extraneous addmm check in autodiff

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -16,14 +16,8 @@ bool isDifferentiable(Node * n) {
   static std::unordered_set<Symbol> differentiable_kinds = {
     aten::add, aten::sub, aten::mul, prim::Constant, prim::ReplaceIfUndef,
     aten::sigmoid, aten::tanh, aten::mm, aten::chunk, aten::split, aten::t, aten::neg,
-    aten::unsqueeze, aten::expand, aten::addmm, aten::gt, aten::lt, aten::eq, aten::ne, aten::ge, aten::le, aten::type_as
+    aten::unsqueeze, aten::expand, aten::gt, aten::lt, aten::eq, aten::ne, aten::ge, aten::le, aten::type_as
   };
-  // TODO: check this more generally via schema
-  // This check ensures that the `alpha` and `beta` attributes on this addmm
-  // node are constant and equivalent to 1.0
-  if (n->kind() == aten::addmm && n->inputs().size() > 3) {
-    return false;
-  }
   if (n->kind() == aten::type_as && !n->inputs().at(1)->isTensor()) {
     return false;
   }


### PR DESCRIPTION
Solves https://github.com/pytorch/pytorch/issues/8501

This was actually stray code from an earlier iteration that should have been removed. This was causing autogenerated `addmm` operator-level tests to fail becuase is_symbolically_differentiable was true even though we don't have direct support for autodiff on addmm.

These tests now fail on another issue, namely https://github.com/pytorch/pytorch/issues/8499