### PR TITLE
[Caffe2] Make cmake find current Python first

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -326,10 +326,11 @@ if(BUILD_PYTHON)
     COMMAND "python" -c "import sys; sys.stdout.write('%s.%s' % (sys.version_info.major, sys.version_info.minor))"
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _py_version)
+  set(Python_ADDITIONAL_VERSIONS)
   if(${_exitcode} EQUAL 0)
-    set(Python_ADDITIONAL_VERSIONS "${_py_version}" "${Python_ADDITIONAL_VERSIONS}")
+    list(APPEND Python_ADDITIONAL_VERSIONS "${_py_version}")
   endif()
-  set(Python_ADDITIONAL_VERSIONS "${Python_ADDITIONAL_VERSIONS}" 3.6 3.5 2.8 2.7 2.6)
+  list(APPEND Python_ADDITIONAL_VERSIONS 3.6 3.5 2.8 2.7 2.6)
   find_package(PythonInterp 2.7)
   find_package(PythonLibs 2.7)
   find_package(NumPy REQUIRED)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -318,7 +318,18 @@ include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
 # ---[ Python + Numpy
 if(BUILD_PYTHON)
-  set(Python_ADDITIONAL_VERSIONS 3.6 3.5 2.8 2.7 2.6)
+  # Put the currently-activated python version at the front of
+  # Python_ADDITIONAL_VERSIONS so that it is found first. Otherwise there may
+  # be mismatches between Python executables and libraries used at different
+  # stages of build time and at runtime
+  execute_process(
+    COMMAND "python" -c "import sys; sys.stdout.write('%s.%s' % (sys.version_info.major, sys.version_info.minor))"
+    RESULT_VARIABLE _exitcode
+    OUTPUT_VARIABLE _py_version)
+  if(${_exitcode} EQUAL 0)
+    set(Python_ADDITIONAL_VERSIONS "${_py_version}" "${Python_ADDITIONAL_VERSIONS}")
+  endif()
+  set(Python_ADDITIONAL_VERSIONS "${Python_ADDITIONAL_VERSIONS}" 3.6 3.5 2.8 2.7 2.6)
   find_package(PythonInterp 2.7)
   find_package(PythonLibs 2.7)
   find_package(NumPy REQUIRED)


### PR DESCRIPTION
This fixes the conda builds.

The conda3 build was failing because cmake was finding python2 and using that for some things, which led to _PyCObject_Type not found at runtime. Adding "3.6 3.5" to the front of Python_ADDITIONAL_VERSIONS fixed it, but then broke conda2 builds since they started picking up the mac's python3 before conda's python 2.