### PR TITLE
[JIT] Add kwarg support to test_autograd and stop using deprecated schema f…

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2749,32 +2749,34 @@ method_tests = [
     ('unfold', (S, S, S), (2, 3, 2), 'lastdim', [0]),
     ('addmm', (S, M), ((S, S), (S, M)),),
     ('addmm', (1,), ((S, S), (S, M)), 'broadcast_lhs'),
-    ('addmm', (S, M), (0.2, 0.6, (S, S), (S, M)), 'coef'),
-    ('addmm', (1,), (0.2, 0.6, (S, S), (S, M)), 'broadcast_lhs_coef'),
+    ('addmm', (S, M), ((S, S), (S, M)), 'coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
+    ('addmm', (1,), ((S, S), (S, M)), 'broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('addmm', (), ((S, S), (S, M)), 'scalar_broadcast_lhs'),
-    ('addmm', (), (0.2, 0.6, (S, S), (S, M)), 'scalar_broadcast_lhs_coef'),
+    ('addmm', (), ((S, S), (S, M)), 'scalar_broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('addbmm', (S, M), ((S, S, S), (S, S, M)),),
     ('addbmm', (1,), ((S, S, S), (S, S, M)), 'broadcast_lhs'),
-    ('addbmm', (S, M), (0.2, 0.6, (S, S, S), (S, S, M)), 'coef'),
-    ('addbmm', (1,), (0.2, 0.6, (S, S, S), (S, S, M)), 'broadcast_lhs_coef'),
+    ('addbmm', (S, M), ((S, S, S), (S, S, M)), 'coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
+    ('addbmm', (1,), ((S, S, S), (S, S, M)), 'broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('addbmm', (), ((S, S, S), (S, S, M)), 'scalar_broadcast_lhs'),
-    ('addbmm', (), (0.2, 0.6, (S, S, S), (S, S, M)), 'scalar_broadcast_lhs_coef'),
+    ('addbmm', (), ((S, S, S), (S, S, M)), 'scalar_broadcast_lhs_coef', (), (), lambda x: x,
+        {'beta': 0.2, 'alpha': 0.6}),
     ('baddbmm', (S, S, M), ((S, S, S), (S, S, M)),),
     ('baddbmm', (1,), ((S, S, S), (S, S, M)), 'broadcast_lhs'),
-    ('baddbmm', (S, S, M), (0.2, 0.6, (S, S, S), (S, S, M)), 'coef'),
-    ('baddbmm', (1,), (0.2, 0.6, (S, S, S), (S, S, M)), 'broadcast_lhs_coef'),
+    ('baddbmm', (S, S, M), ((S, S, S), (S, S, M)), 'coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
+    ('baddbmm', (1,), ((S, S, S), (S, S, M)), 'broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('baddbmm', (), ((S, S, S), (S, S, M)), 'scalar_broadcast_lhs'),
-    ('baddbmm', (), (0.2, 0.6, (S, S, S), (S, S, M)), 'scalar_broadcast_lhs_coef'),
+    ('baddbmm', (), ((S, S, S), (S, S, M)), 'scalar_broadcast_lhs_coef', (), (), lambda x: x,
+        {'beta': 0.2, 'alpha': 0.6}),
     ('addmv', (S,), ((S, M), (M,)),),
     ('addmv', (1,), ((S, M), (M,)), 'broadcast_lhs'),
-    ('addmv', (S,), (0.2, 0.6, (S, M), (M,)), 'coef'),
-    ('addmv', (1,), (0.2, 0.6, (S, M), (M,)), 'broadcast_lhs_coef'),
+    ('addmv', (S,), ((S, M), (M,)), 'coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
+    ('addmv', (1,), ((S, M), (M,)), 'broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('addmv', (), ((S, M), (M,)), 'scalar_broadcast_lhs'),
-    ('addmv', (), (0.2, 0.6, (S, M), (M,)), 'scalar_broadcast_lhs_coef'),
+    ('addmv', (), ((S, M), (M,)), 'scalar_broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('addr', (S, M), ((S,), (M,)),),
     ('addr', (), ((S,), (M,)), 'broadcast_lhs'),
-    ('addr', (S, M), (0.2, 0.6, (S,), (M,)), 'coef'),
-    ('addr', (), (0.2, 0.6, (S,), (M,)), 'broadcast_lhs_coef'),
+    ('addr', (S, M), ((S,), (M,)), 'coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
+    ('addr', (), ((S,), (M,)), 'broadcast_lhs_coef', (), (), lambda x: x, {'beta': 0.2, 'alpha': 0.6}),
     ('dot', (L,), ((L,),),),
     ('mm', (S, M), ((M, S),)),
     ('bmm', (M, S, M), ((M, M, S),)),
@@ -2790,27 +2792,27 @@ method_tests = [
     ('addcmul', (S, S), ((S, S), (S, S))),
     ('addcmul', (S, S), ((S, 1), (1, S)), 'broadcast_rhs'),
     ('addcmul', (1,), ((S, S, 1), (1, S)), 'broadcast_all'),
-    ('addcmul', (S, S), (0.5, (S, S), (S, S)), 'scale'),
-    ('addcmul', (S, S), (0.5, (S, 1), (1, S)), 'scale_broadcast_rhs'),
-    ('addcmul', (1,), (0.5, (S, S, 1), (1, S)), 'scale_broadcast_all'),
+    ('addcmul', (S, S), ((S, S), (S, S)), 'scale', (), (), lambda x: x, {'value': 0.5}),
+    ('addcmul', (S, S), ((S, 1), (1, S)), 'scale_broadcast_rhs', (), (), lambda x: x, {'value': 0.5}),
+    ('addcmul', (1,), ((S, S, 1), (1, S)), 'scale_broadcast_all', (), (), lambda x: x, {'value': 0.5}),
     ('addcmul', (), ((), ()), 'scalar'),
     ('addcmul', (S, S), ((), ()), 'scalar_broadcast_rhs'),
     ('addcmul', (), ((S, S, 1), (1, S)), 'scalar_broadcast_lhs'),
-    ('addcmul', (), (0.5, (), ()), 'scalar_scale'),
-    ('addcmul', (S, S), (0.5, (), ()), 'scalar_scale_broadcast_rhs'),
-    ('addcmul', (), (0.5, (S, S, 1), (1, S)), 'scalar_scale_broadcast_lhs'),
+    ('addcmul', (), ((), ()), 'scalar_scale', (), (), lambda x: x, {'value': 0.5}),
+    ('addcmul', (S, S), ((), ()), 'scalar_scale_broadcast_rhs', (), (), lambda x: x, {'value': 0.5}),
+    ('addcmul', (), ((S, S, 1), (1, S)), 'scalar_scale_broadcast_lhs', (), (), lambda x: x, {'value': 0.5}),
     ('addcdiv', (S, S), ((S, S), (S, S))),
     ('addcdiv', (S, S), ((S, 1), (1, S)), 'broadcast_rhs'),
     ('addcdiv', (1,), ((S, S, 1), (1, S)), 'broadcast_all'),
-    ('addcdiv', (S, S), (0.5, (S, S), (S, S)), 'scale'),
-    ('addcdiv', (S, S), (0.5, (S, 1), (1, S)), 'scale_broadcast_rhs'),
-    ('addcdiv', (1,), (0.5, (S, S, 1), (1, S)), 'scale_broadcast_all'),
+    ('addcdiv', (S, S), ((S, S), (S, S)), 'scale', (), (), lambda x: x, {'value': 0.5}),
+    ('addcdiv', (S, S), ((S, 1), (1, S)), 'scale_broadcast_rhs', (), (), lambda x: x, {'value': 0.5}),
+    ('addcdiv', (1,), ((S, S, 1), (1, S)), 'scale_broadcast_all', (), (), lambda x: x, {'value': 0.5}),
     ('addcdiv', (), ((), ()), 'scalar'),
     ('addcdiv', (S, S), ((), ()), 'scalar_broadcast_rhs'),
     ('addcdiv', (), ((S, S, 1), (1, S)), 'scalar_broadcast_lhs'),
-    ('addcdiv', (), (0.5, (), ()), 'scalar_scale'),
-    ('addcdiv', (S, S), (0.5, (), ()), 'scalar_scale_broadcast_rhs'),
-    ('addcdiv', (), (0.5, (S, S, 1), (1, S)), 'scalar_scale_broadcast_lhs'),
+    ('addcdiv', (), ((), ()), 'scalar_scale', (), (), lambda x: x, {'value': 0.5}),
+    ('addcdiv', (S, S), ((), ()), 'scalar_scale_broadcast_rhs', (), (), lambda x: x, {'value': 0.5}),
+    ('addcdiv', (), ((S, S, 1), (1, S)), 'scalar_scale_broadcast_lhs', (), (), lambda x: x, {'value': 0.5}),
     ('zero_', (S, S, S), NO_ARGS),
     ('zero_', (), NO_ARGS, 'scalar'),
     ('logsumexp', (S, S), (1,)),
@@ -3091,7 +3093,7 @@ method_tests = [
 # TODO: clamp with min/max
 
 
-def create_input(call_args, requires_grad=True, non_contiguous=False):
+def create_input(call_args, requires_grad=True, non_contiguous=False, call_kwargs=None):
     if not isinstance(call_args, tuple):
         call_args = (call_args,)
 
@@ -3121,7 +3123,9 @@ def create_input(call_args, requires_grad=True, non_contiguous=False):
             return map_arg(arg())
         else:
             return arg
-    return tuple(map_arg(arg) for arg in call_args)
+    args_out = tuple(map_arg(arg) for arg in call_args)
+    kwargs_out = {k: map_arg(v) for k, v in call_kwargs.items()} if call_kwargs else {}
+    return args_out, kwargs_out
 
 
 def unpack_variables(args):
@@ -3261,7 +3265,9 @@ def add_test(
         variant_name='',
         dim_args_idx=(),
         skipTestIf=(),
-        output_process_fn=lambda x: x):
+        output_process_fn=lambda x: x,
+        kwargs=None):
+    kwargs = kwargs if kwargs else {}
     basic_test_name = 'test_' + name
     if variant_name != '':
         basic_test_name += '_' + variant_name
@@ -3279,24 +3285,24 @@ def add_test(
             def check(name):
                 is_magic_method = name[:2] == '__' and name[-2:] == '__'
                 is_inplace = name[-1] == "_" and not is_magic_method
-                self_variable = create_input((self_size,))[0]
+                self_variable = create_input((self_size,))[0][0]
                 # FixMe: run grad checks on inplace self
                 if is_inplace:
                     self_variable.requires_grad = False
                 # need to record this because methods can change the szie (e.g. unsqueeze)
-                args_variable = create_input(args, requires_grad=not is_inplace)
+                args_variable, kwargs_variable = create_input(args, requires_grad=not is_inplace, call_kwargs=kwargs)
                 self_tensor = deepcopy(self_variable.data)
                 args_tensor = deepcopy(unpack_variables(args_variable))
-                output_variable = getattr(self_variable, name)(*args_variable)
+                output_variable = getattr(self_variable, name)(*args_variable, **kwargs_variable)
                 if not exclude_tensor_method(name, test_name):
-                    output_tensor = getattr(self_tensor, name)(*args_tensor)
+                    output_tensor = getattr(self_tensor, name)(*args_tensor, **kwargs_variable)
                     if not isinstance(output_tensor, torch.Tensor) and not isinstance(output_tensor, tuple):
                         output_tensor = torch.DoubleTensor((output_tensor,))
                     self.assertEqual(unpack_variables(output_variable), output_tensor)
                     # TODO: check that both have changed after adding all inplace ops
 
                 def fn(*inputs):
-                    output = getattr(inputs[0], name)(*inputs[1:])
+                    output = getattr(inputs[0], name)(*inputs[1:], **kwargs)
                     return output_process_fn(output)
 
                 if not is_inplace and name not in EXCLUDE_GRADCHECK:
@@ -3317,9 +3323,9 @@ def add_test(
 
                 # check for correct type of input.data and input.grad.data
                 if not is_inplace:
-                    self_variable = create_input((self_size,), requires_grad=True)[0]
-                    args_variable = create_input(args, requires_grad=False)
-                    output_variable = getattr(self_variable, name)(*args_variable)
+                    self_variable = create_input((self_size,), requires_grad=True)[0][0]
+                    args_variable, kwargs_variable = create_input(args, requires_grad=False, call_kwargs=kwargs)
+                    output_variable = getattr(self_variable, name)(*args_variable, **kwargs_variable)
                     if isinstance(output_variable, torch.autograd.Variable):
                         output_variable.backward(randn_like(output_variable))
                         self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
@@ -3331,7 +3337,7 @@ def add_test(
                     skip_inplace = ('broadcast_lhs' in test_name or
                                     'broadcast_all' in test_name)
                     if hasattr(torch.ones(1), inplace_name) and not skip_inplace:
-                        output_variable = getattr(self_variable, name)(*args_variable)
+                        output_variable = getattr(self_variable, name)(*args_variable, **kwargs_variable)
                         if not isinstance(output_variable, tuple):
                             output_variable = (output_variable,)
                         inplace_self_variable = deepcopy(self_variable)
@@ -3342,7 +3348,8 @@ def add_test(
                                                            for i in inplace_args_variable)
 
                         inplace_output_variable = (
-                            getattr(inplace_self_variable_copy[0], inplace_name)(*inplace_args_variable_copy))
+                            getattr(inplace_self_variable_copy[0], inplace_name)(*inplace_args_variable_copy,
+                                                                                 **kwargs_variable))
                         if not isinstance(inplace_output_variable, tuple):
                             inplace_output_variable = (inplace_output_variable,)
                         self.assertEqual(inplace_output_variable, output_variable)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3605,18 +3605,6 @@ EXCLUDE_SCRIPT = {
     'test_add_scalar',
     'test_add_scalar_broadcast_lhs',
     'test_add_scalar_broadcast_rhs',
-    'test_addcdiv_scalar_scale',
-    'test_addcdiv_scalar_scale_broadcast_lhs',
-    'test_addcdiv_scalar_scale_broadcast_rhs',
-    'test_addcdiv_scale',
-    'test_addcdiv_scale_broadcast_all',
-    'test_addcdiv_scale_broadcast_rhs',
-    'test_addcmul_scalar_scale',
-    'test_addcmul_scalar_scale_broadcast_lhs',
-    'test_addcmul_scalar_scale_broadcast_rhs',
-    'test_addcmul_scale',
-    'test_addcmul_scale_broadcast_all',
-    'test_addcmul_scale_broadcast_rhs',
     'test_clamp_max',
     'test_clamp_max_scalar',
     'test_clamp_min',
@@ -3649,20 +3637,9 @@ EXCLUDE_SCRIPT = {
     'test_sub_scalar_constant',
     'test_unsqueeze_last_neg0',
     'test_unsqueeze_middle_neg0',
-    'test_addbmm_broadcast_lhs_coef',
-    'test_addbmm_coef',
-    'test_addbmm_scalar_broadcast_lhs_coef',
     'test_addmm_broadcast_lhs_coef',
     'test_addmm_coef',
     'test_addmm_scalar_broadcast_lhs_coef',
-    'test_addmv_broadcast_lhs_coef',
-    'test_addmv_coef',
-    'test_addmv_scalar_broadcast_lhs_coef',
-    'test_addr_broadcast_lhs_coef',
-    'test_addr_coef',
-    'test_baddbmm_broadcast_lhs_coef',
-    'test_baddbmm_coef',
-    'test_baddbmm_scalar_broadcast_lhs_coef',
     'test_expand',
     'test_expand_1_element',
     'test_expand_new_dim',
@@ -3750,19 +3727,19 @@ EXCLUDE_SCRIPT = {
 # make a new function where all non-tensor arguments in 'args' have been partially
 # applied, and all tensor arguments remain.
 # used to trace functions when some arguments are not tensors
-def partial_apply_nontensors(fn, args):
+def partial_apply_nontensors(fn, args, **kwargs):
     source = ['t' if isinstance(arg, torch.Tensor) else 's' for arg in args]
 
     def new_fn(*tensors_):
         tensors = iter(tensors_)
-        return fn(*(args[i] if s == 's' else next(tensors) for i, s in enumerate(source)))
+        return fn(*(args[i] if s == 's' else next(tensors) for i, s in enumerate(source)), **kwargs)
 
     return new_fn, [arg for arg in args if isinstance(arg, torch.Tensor)]
 
 
 def create_traced_fn(fn):
-    def traced_fn(*inputs):
-        fn_tensors, inputs_tensors = partial_apply_nontensors(fn, inputs)
+    def traced_fn(*inputs, **kwargs):
+        fn_tensors, inputs_tensors = partial_apply_nontensors(fn, inputs, **kwargs)
         traced = torch.jit.trace(*inputs_tensors)(fn_tensors)
         return traced(*inputs_tensors)
     return traced_fn
@@ -3774,7 +3751,7 @@ def the_method({}):
 
 
 def create_script_fn(method_name, is_functional, output_process_fn):
-    def script_fn(*args):
+    def script_fn(*args, **kwargs):
         formals = []
         tensors = []
         actuals = []
@@ -3786,17 +3763,22 @@ def create_script_fn(method_name, is_functional, output_process_fn):
                 tensors.append(arg)
             else:
                 actuals.append(str(arg))
+        kwargs_str = ''
+        for k, v in kwargs.items():
+            kwargs_str += ', ' + k + '=' + str(v)
         if is_functional:
-            call = 'torch.{}({})'.format(method_name, ', '.join(actuals))
+            call = 'torch.{}({}{})'.format(method_name, ', '.join(actuals), kwargs_str)
         else:
-            call = '{}.{}({})'.format(actuals[0], method_name, ', '.join(actuals[1:]))
+            call = '{}.{}({}{})'.format(actuals[0], method_name, ', '.join(actuals[1:]), kwargs_str)
         script = script_template.format(', '.join(formals), call)
         CU = torch.jit.CompilationUnit(script)
         return output_process_fn(CU.the_method(*tensors))
     return script_fn
 
 
-def check_against_reference(self, func, reference_func, args, allow_unused=True):
+def check_against_reference(self, func, reference_func, args, kwargs=None, allow_unused=True):
+    kwargs = kwargs if kwargs else {}
+
     def allSum(vs):
         if isinstance(vs, torch.Tensor):
             vs = (vs,)
@@ -3815,16 +3797,16 @@ def check_against_reference(self, func, reference_func, args, allow_unused=True)
     recording_inputs, recording_tensors = clone_inputs(True)
 
     # test no gradients case
-    outputs = reference_func(*nograd_inputs)
-    outputs_test = func(*nograd_inputs)
+    outputs = reference_func(*nograd_inputs, **kwargs)
+    outputs_test = func(*nograd_inputs, **kwargs)
     self.assertEqual(outputs, outputs_test)
 
     # test single grad case
-    outputs = reference_func(*recording_inputs)
+    outputs = reference_func(*recording_inputs, **kwargs)
     grads = torch.autograd.grad(allSum(outputs), recording_tensors,
                                 allow_unused=allow_unused)
 
-    outputs_test = func(*recording_inputs)
+    outputs_test = func(*recording_inputs, **kwargs)
     grads_test = torch.autograd.grad(allSum(outputs_test), recording_tensors,
                                      allow_unused=allow_unused)
     self.assertEqual(outputs, outputs_test)
@@ -3832,7 +3814,7 @@ def check_against_reference(self, func, reference_func, args, allow_unused=True)
 
     # test the grad grad case
 
-    outputs = reference_func(*recording_inputs)
+    outputs = reference_func(*recording_inputs, **kwargs)
     l1 = allSum(outputs)
     grads = torch.autograd.grad(l1, recording_tensors, create_graph=True,
                                 allow_unused=allow_unused)
@@ -3841,7 +3823,7 @@ def check_against_reference(self, func, reference_func, args, allow_unused=True)
 
     recording_inputs, recording_tensors = clone_inputs(True)
 
-    outputs_test = func(*recording_inputs)
+    outputs_test = func(*recording_inputs, **kwargs)
     l1_test = allSum(outputs_test)
     grads_test = torch.autograd.grad(
         l1_test, recording_tensors, create_graph=True, allow_unused=allow_unused)
@@ -3867,7 +3849,8 @@ def add_test(
         variant_name='',
         dim_args_idx=(),
         skipTestIf=(),
-        output_process_fn=lambda x: x):
+        output_process_fn=lambda x: x,
+        kwargs=None):
     basic_test_name = 'test_' + name
     if variant_name != '':
         basic_test_name += '_' + variant_name
@@ -3885,45 +3868,46 @@ def add_test(
             def check(name):
                 is_magic_method = name[:2] == '__' and name[-2:] == '__'
                 is_inplace = name[-1] == "_" and not is_magic_method
-                self_variable = create_input((self_size,))[0]
+                self_variable = create_input((self_size,))[0][0]
                 # FixMe: run grad checks on inplace self
                 if is_inplace:
                     self_variable.requires_grad = False
                 # need to record this because methods can change the szie (e.g. unsqueeze)
-                args_variable = create_input(args, requires_grad=not is_inplace)
+                args_variable, kwargs_variable = create_input(args, requires_grad=not is_inplace, call_kwargs=kwargs)
                 self_tensor = deepcopy(self_variable.data)
                 args_tensor = deepcopy(unpack_variables(args_variable))
-                output_variable = getattr(self_variable, name)(*args_variable)
+                output_variable = getattr(self_variable, name)(*args_variable, **kwargs_variable)
 
-                def fn(*inputs):
-                    output = getattr(inputs[0], name)(*inputs[1:])
+                def fn(*inputs, **kwargs):
+                    output = getattr(inputs[0], name)(*inputs[1:], **kwargs)
                     return output_process_fn(output)
 
                 if not is_inplace and name not in EXCLUDE_GRADCHECK:
                     if test_name not in EXCLUDE_TRACED:
-                        check_against_reference(self, create_traced_fn(fn), fn, (self_variable,) + args_variable)
+                        check_against_reference(self, create_traced_fn(fn),
+                                                fn, (self_variable,) + args_variable, kwargs_variable)
 
                     if not is_magic_method and test_name not in EXCLUDE_SCRIPT:
                         check_against_reference(self,
                                                 create_script_fn(name, False, output_process_fn),
-                                                fn, (self_variable,) + args_variable)
+                                                fn, (self_variable,) + args_variable, kwargs_variable)
 
                 # functional interface tests
                 if hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL:
-                    def fn(*inputs):
-                        output = getattr(torch, name)(*inputs)
+                    def fn(*inputs, **kwargs):
+                        output = getattr(torch, name)(*inputs, **kwargs)
                         return output_process_fn(output)
 
                     f_args_variable = (self_variable,) + args_variable
                     f_args_tensor = (self_tensor,) + args_tensor
 
                     if not is_inplace and test_name not in EXCLUDE_TRACED:
-                        check_against_reference(self, create_traced_fn(fn), fn, f_args_variable)
+                        check_against_reference(self, create_traced_fn(fn), fn, f_args_variable, kwargs_variable)
 
                     if not is_inplace and test_name not in EXCLUDE_SCRIPT:
                         check_against_reference(self,
                                                 create_script_fn(name, True, output_process_fn),
-                                                fn, f_args_variable)
+                                                fn, f_args_variable, kwargs_variable)
 
             check(name)
             inplace_name = name + '_'


### PR DESCRIPTION
…or accumulation ops

Solves https://github.com/pytorch/pytorch/issues/8499

This adds support in `test_autograd` (and `test_jit` by extension) for testing operators with `kwarg_only` inputs. This allows us to stop testing deprecated schema for the `test_add*` fused accumulation operators
