### PR TITLE
Dont show Python frames in backtrace

### DIFF
--- a/aten/src/ATen/Backtrace.h
+++ b/aten/src/ATen/Backtrace.h
@@ -21,5 +21,6 @@ inline const char* demangle_type() {
 
 std::string get_backtrace(
     size_t frames_to_skip = 0,
-    size_t maximum_number_of_frames = 64);
+    size_t maximum_number_of_frames = 64,
+    bool skip_python_frames = true);
 } // namespace at


### PR DESCRIPTION
Attempts to replace frames from libPython in ATen backtraces with `<omitting python frames>`. It's kinda heuristic based and non-trivial because the PyTorch library itself also contains `python3.6m` so looking for `python` in the object file alone is not enough. Also the Python library has different names on different platforms. So far I've seen `python` and `/path/tolibpython2.7`.

@ezyang 

Fixes https://github.com/pytorch/pytorch/issues/8557