### PR TITLE
Mention MPICH_MAX_THREAD_SAFETY=multiple.

### DIFF
--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -103,6 +103,7 @@ bool DataChannelMPI::init() {
   if (provided != MPI_THREAD_MULTIPLE) {
     std::cerr << "WARNING: Used MPI implementation doesn't support multithreading, "
               << "so distributed functions might not work properly."
+              << "If you are using mpich, try setting environment MPICH_MAX_THREAD_SAFETY=multiple and rerun."
               << std::endl;
   }
 


### PR DESCRIPTION
Currently, this is a common step to enable level 3 support on MPICH based systems.

