### PR TITLE
Spectral norm improvements

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1437,9 +1437,9 @@ class TestNN(NNTestCase):
         # weight_u should be just a reused buffer
         self.assertTrue(hasattr(m, 'weight_u'))
         self.assertTrue('weight_u' in m._buffers)
+        self.assertTrue('weight' in m._buffers)
         # weight should be a plain attribute, not counted as a buffer or a param
-        self.assertTrue(hasattr(m, 'weight'))
-        self.assertFalse('weight' in m._buffers or 'weight' in m._parameters)
+        self.assertFalse('weight' in m._parameters)
         # it should also be sharing storage as `weight_orig`
         self.assertEqual(m.weight_orig.storage(), m.weight.storage())
         self.assertEqual(m.weight_orig.size(), m.weight.size())
@@ -1451,6 +1451,26 @@ class TestNN(NNTestCase):
         # weight should be converted back as a parameter
         self.assertTrue(hasattr(m, 'weight'))
         self.assertTrue('weight' in m._parameters)
+
+    def test_spectral_norm_eval(self):
+        inp = torch.randn(3, 5)
+        m = nn.Linear(5, 7)
+        m = torch.nn.utils.spectral_norm(m)
+        x0 = m(inp)
+        m.eval()
+        x1 = m(inp)
+        x2 = m(inp)
+        self.assertEqual(x0, x1)
+        self.assertEqual(x0, x2)
+
+    def test_spectral_norm_dim(self):
+        inp = torch.randn(2, 3, 10, 12)
+        m = nn.ConvTranspose2d(3, 4, (5, 6))
+        m = torch.nn.utils.spectral_norm(m)
+        # this should not run into incompatible shapes
+        x = m(inp)
+        # check that u refers to the same dimension
+        self.assertEqual(m.weight_u.shape, m.weight_orig[0, :, 0, 0].shape)
 
     def test_spectral_norm_forward(self):
         input = torch.randn(3, 5)

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -8,8 +8,9 @@ from torch.nn.parameter import Parameter
 
 class SpectralNorm(object):
 
-    def __init__(self, name='weight', n_power_iterations=1, eps=1e-12):
+    def __init__(self, name='weight', n_power_iterations=1, dim=0, eps=1e-12):
         self.name = name
+        self.dim = dim
         if n_power_iterations <= 0:
             raise ValueError('Expected n_power_iterations to be positive, but '
                              'got n_power_iterations={}'.format(n_power_iterations))
@@ -19,8 +20,13 @@ class SpectralNorm(object):
     def compute_weight(self, module):
         weight = getattr(module, self.name + '_orig')
         u = getattr(module, self.name + '_u')
-        height = weight.size(0)
-        weight_mat = weight.view(height, -1)
+        weight_mat = weight
+        if self.dim != 0:
+            # permute dim to front
+            weight_mat = weight_mat.permute(self.dim,
+                                            *[d for d in range(weight_mat.dim()) if d != self.dim])
+        height = weight_mat.size(0)
+        weight_mat = weight_mat.reshape(height, -1)
         with torch.no_grad():
             for _ in range(self.n_power_iterations):
                 # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
@@ -34,22 +40,23 @@ class SpectralNorm(object):
         return weight, u
 
     def remove(self, module):
-        weight = module._parameters[self.name + '_orig']
+        weight = getattr(module, self.name)
         delattr(module, self.name)
         delattr(module, self.name + '_u')
         delattr(module, self.name + '_orig')
-        module.register_parameter(self.name, weight)
+        module.register_parameter(self.name, torch.nn.Parameter(weight))
 
     def __call__(self, module, inputs):
-        weight, u = self.compute_weight(module)
-        setattr(module, self.name, weight)
-        setattr(module, self.name + '_u', u)
+        if module.training:
+            weight, u = self.compute_weight(module)
+            setattr(module, self.name, weight)
+            setattr(module, self.name + '_u', u)
 
     @staticmethod
-    def apply(module, name, n_power_iterations, eps):
-        fn = SpectralNorm(name, n_power_iterations, eps)
+    def apply(module, name, n_power_iterations, dim, eps):
+        fn = SpectralNorm(name, n_power_iterations, dim, eps)
         weight = module._parameters[name]
-        height = weight.size(0)
+        height = weight.size(dim)
 
         u = normalize(weight.new_empty(height).normal_(0, 1), dim=0, eps=fn.eps)
         delattr(module, fn.name)
@@ -57,17 +64,17 @@ class SpectralNorm(object):
         # We still need to assign weight back as fn.name because all sorts of
         # things may assume that it exists, e.g., when initializing weights.
         # However, we can't directly assign as it could be an nn.Parameter and
-        # gets added as a parameter. Instead, we assign weight.data, which will
-        # just be added as plain attribute, and also supports nn.init due to
-        # shared storage.
-        setattr(module, fn.name, weight.data)
+        # gets added as a parameter. Instead, we register weight.data as a
+        # buffer, which will cause weight to be included in the state dict
+        # and also supports nn.init due to shared storage.
+        module.register_buffer(fn.name, weight.data)
         module.register_buffer(fn.name + "_u", u)
 
         module.register_forward_pre_hook(fn)
         return fn
 
 
-def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
+def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=None):
     r"""Applies spectral normalization to a parameter in the given module.
 
     .. math::
@@ -93,6 +100,9 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
             calculate spectal norm
         eps (float, optional): epsilon for numerical stability in
             calculating norms
+        dim (int, optional): dimension corresponding to number of outputs,
+            the default is 0, except for modules that are instances of
+            ConvTranspose1/2/3d, when it is 1
 
     Returns:
         The original module with the spectal norm hook
@@ -105,7 +115,14 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
         torch.Size([20])
 
     """
-    SpectralNorm.apply(module, name, n_power_iterations, eps)
+    if dim is None:
+        if isinstance(module, (torch.nn.ConvTranspose1d,
+                               torch.nn.ConvTranspose2d,
+                               torch.nn.ConvTranspose3d)):
+            dim = 1
+        else:
+            dim = 0
+    SpectralNorm.apply(module, name, n_power_iterations, dim, eps)
     return module
 
 


### PR DESCRIPTION
- Don't do iterations on weight in eval mode
  To facilitate this, register weight as buffer in order to be able
  to use module with spectral norm in eval mode after immediately
  after loading state dict (#8208)
- Use weight instead of weight_orig as weight when removing
  spectral norm
- Add dim parameter in case the normalization should occur w.r.t.
  a dimension other than 0 (#7865)


@SsnL is this about what you had in mind?

I have to add tests. What would be resonable here
- test that three calls in eval mode give the exact same thing and after remove
- test convergence of SN in the right dimension using fixed random weights for Linear and ConvTranspose2d?
