### PR TITLE
Add CUDA 9.2 + GCC 7 build and test to CI

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -46,8 +46,8 @@ if ! which conda; then
 fi
 
 # sccache will fail for CUDA builds if all cores are used for compiling
-# gcc 7.2 with sccache seems to have intermittent OOM issue if all cores are used
-if ([[ "$BUILD_ENVIRONMENT" == *cuda* ]] || [[ "$BUILD_ENVIRONMENT" == *gcc7.2* ]]) && which sccache > /dev/null; then
+# gcc 7 with sccache seems to have intermittent OOM issue if all cores are used
+if ([[ "$BUILD_ENVIRONMENT" == *cuda* ]] || [[ "$BUILD_ENVIRONMENT" == *gcc7* ]]) && which sccache > /dev/null; then
   export MAX_JOBS=`expr $(nproc) - 1`
 fi
 

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -113,7 +113,7 @@ else
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]] || \
-   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-trusty-py3.6-gcc7.2 ]]; then
+   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-trusty-py3.6-gcc7* ]]; then
   BUILD_TEST_LIBTORCH=1
 else
   BUILD_TEST_LIBTORCH=0

--- a/.jenkins/pytorch/enabled-configs.txt
+++ b/.jenkins/pytorch/enabled-configs.txt
@@ -12,6 +12,8 @@ pytorch-linux-xenial-cuda9-cudnn7-py2-build
 pytorch-linux-xenial-cuda9-cudnn7-py2-test
 pytorch-linux-xenial-cuda9-cudnn7-py3-build
 pytorch-linux-xenial-cuda9-cudnn7-py3-test
+pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
+pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test
 pytorch-linux-xenial-py3-clang5-asan-build
 pytorch-linux-xenial-py3-clang5-asan-test
 pytorch-linux-trusty-py2.7.9-build
@@ -26,6 +28,8 @@ pytorch-linux-trusty-py3.6-gcc5.4-build
 pytorch-linux-trusty-py3.6-gcc5.4-test
 pytorch-linux-trusty-py3.6-gcc7.2-build
 pytorch-linux-trusty-py3.6-gcc7.2-test
+pytorch-linux-trusty-py3.6-gcc7-build
+pytorch-linux-trusty-py3.6-gcc7-test
 pytorch-linux-trusty-pynightly-build
 pytorch-linux-trusty-pynightly-test
 pytorch-win-ws2016-cuda9-cudnn7-py3-build


### PR DESCRIPTION
This PR adds CUDA 9.2 + GCC 7 build and test to `enabled-configs.txt`, and also renames the job from `gcc7.3` to `gcc7`. The version of gcc 7 used will be determined by `apt-get install -y g++-7` from `ppa:ubuntu-toolchain-r/test`, and will usually be the latest version supported by Ubuntu 16.04 (currently gcc 7.3).

This closes #7913.