### PR TITLE
Set DEBUG=1 in trusty-py3.6-gcc5.4 CI build

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -54,6 +54,10 @@ fi
 # Target only our CI GPU machine's CUDA arch to speed up the build
 export TORCH_CUDA_ARCH_LIST=5.2
 
+if [[ "$BUILD_ENVIRONMENT" == *trusty-py3.6-gcc5.4* ]]; then
+  export DEBUG=1
+fi
+
 WERROR=1 python setup.py install
 
 # Add the test binaries so that they won't be git clean'ed away


### PR DESCRIPTION
This closes https://github.com/pytorch/pytorch/issues/4119. We need to make sure `DEBUG=1` is taking effect by checking the CI in this PR.