### PR TITLE
allow output_size to contain None in adaptive pooling methods

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7207,6 +7207,12 @@ new_module_tests = [
         desc='tuple',
     ),
     dict(
+        module_name='AdaptiveMaxPool2d',
+        constructor_args=((3, None),),
+        input_fn=lambda: _rand_tensor_non_equal(1, 3, 5, 6),
+        desc='tuple_none',
+    ),
+    dict(
         module_name='AdaptiveMaxPool3d',
         constructor_args=(3,),
         input_fn=lambda: _rand_tensor_non_equal(2, 3, 5, 6, 7),
@@ -7217,6 +7223,12 @@ new_module_tests = [
         constructor_args=((3, 4, 5),),
         input_fn=lambda: _rand_tensor_non_equal(2, 3, 5, 6, 7),
         desc='tuple',
+    ),
+    dict(
+        module_name='AdaptiveMaxPool3d',
+        constructor_args=((3, None, 5),),
+        input_fn=lambda: _rand_tensor_non_equal(2, 3, 5, 6, 7),
+        desc='tuple_none',
     ),
     dict(
         module_name='AdaptiveMaxPool3d',
@@ -7248,6 +7260,12 @@ new_module_tests = [
         desc='tuple',
     ),
     dict(
+        module_name='AdaptiveAvgPool2d',
+        constructor_args=((3, None),),
+        input_fn=lambda: torch.rand(1, 3, 5, 6),
+        desc='tuple_none',
+    ),
+    dict(
         module_name='AdaptiveAvgPool3d',
         constructor_args=(3,),
         input_fn=lambda: torch.rand(2, 3, 5, 2, 7),
@@ -7258,6 +7276,12 @@ new_module_tests = [
         constructor_args=((3, 4, 5),),
         input_fn=lambda: torch.rand(2, 3, 5, 3, 7),
         desc='tuple',
+    ),
+    dict(
+        module_name='AdaptiveAvgPool3d',
+        constructor_args=((None, 4, 5),),
+        input_fn=lambda: torch.rand(2, 3, 5, 3, 7),
+        desc='tuple_none',
     ),
     dict(
         module_name='SELU',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2194,6 +2194,29 @@ class TestNN(NNTestCase):
         indices.add_(1)
         self.assertRaises(RuntimeError, lambda: output.backward(grad_output))
 
+    def test_adaptive_pooling_input_size(self):
+        for numel in (2, 3):
+            for pool_type in ('Max', 'Avg'):
+                cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                module_cls = getattr(nn, cls_name)
+                output_size = (2,) * numel
+                module = module_cls(output_size)
+
+                input = torch.randn(output_size)
+                self.assertRaises(ValueError, lambda: module(input))
+
+    def test_adaptive_pooling_size_none(self):
+        for numel in (2, 3):
+            for pool_type in ('Max', 'Avg'):
+                cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                module_cls = getattr(nn, cls_name)
+                output_size = (2,) * (numel - 1) + (None,)
+                module = module_cls(output_size)
+
+                input = torch.randn((4,) * (numel + 1))
+                output = module(input)
+                self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
+
     def test_Conv2d_naive_groups(self):
         self._test_Conv2d_naive_groups()
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -528,9 +528,9 @@ def adaptive_avg_pool2d(input, output_size):
     r"""
     Applies a 2D adaptive average pooling over an input signal composed of
     several input planes.
-    
+
     See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
-    
+
     Args:
         output_size: the target output size (single integer or
             double-integer tuple)
@@ -543,18 +543,18 @@ def adaptive_avg_pool3d(input, output_size):
     r"""
     Applies a 3D adaptive average pooling over an input signal composed of
     several input planes.
-    
+
     See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
-    
+
     Args:
         output_size: the target output size (single integer or
             triple-integer tuple)
     """
     output_size = set_output_size(input.size()[2:], output_size)
-    return torch._C._nn.adaptive_avg_pool3d(input, output_size) 
+    return torch._C._nn.adaptive_avg_pool3d(input, output_size)
+
 
 # Activation functions
-
 def dropout(input, p=0.5, training=False, inplace=False):
     return _functions.dropout.Dropout.apply(input, p, training, inplace)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -12,7 +12,7 @@ from .modules import utils
 from ._functions.padding import ConstantPadNd
 from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
-from .modules.utils import _single, _pair, _triple, set_output_size
+from .modules.utils import _single, _pair, _triple, _list_with_default
 from . import grad
 
 
@@ -490,7 +490,7 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
             double-integer tuple)
         return_indices: whether to return pooling indices. Default: ``False``
     """
-    output_size = set_output_size(input.size()[2:], output_size)
+    output_size = _list_with_default(output_size, input.size())
     ret = torch._C._nn.adaptive_max_pool2d(input, output_size)
     return ret if return_indices else ret[0]
 
@@ -506,7 +506,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
             triple-integer tuple)
         return_indices: whether to return pooling indices. Default: ``False``
     """
-    output_size = set_output_size(input.size()[2:], output_size)
+    output_size = _list_with_default(output_size, input.size())
     ret = torch._C._nn.adaptive_max_pool3d(input, output_size)
     return ret if return_indices else ret[0]
 
@@ -535,7 +535,7 @@ def adaptive_avg_pool2d(input, output_size):
         output_size: the target output size (single integer or
             double-integer tuple)
     """
-    output_size = set_output_size(input.size()[2:], output_size)
+    output_size = _list_with_default(output_size, input.size())
     return torch._C._nn.adaptive_avg_pool2d(input, output_size)
 
 
@@ -550,7 +550,7 @@ def adaptive_avg_pool3d(input, output_size):
         output_size: the target output size (single integer or
             triple-integer tuple)
     """
-    output_size = set_output_size(input.size()[2:], output_size)
+    output_size = _list_with_default(output_size, input.size())
     return torch._C._nn.adaptive_avg_pool3d(input, output_size)
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -12,7 +12,7 @@ from .modules import utils
 from ._functions.padding import ConstantPadNd
 from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
-from .modules.utils import _single, _pair, _triple
+from .modules.utils import _single, _pair, _triple, set_output_size
 from . import grad
 
 
@@ -490,6 +490,7 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
             double-integer tuple)
         return_indices: whether to return pooling indices. Default: ``False``
     """
+    output_size = set_output_size(input.size()[2:], output_size)
     ret = torch._C._nn.adaptive_max_pool2d(input, output_size)
     return ret if return_indices else ret[0]
 
@@ -505,6 +506,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
             triple-integer tuple)
         return_indices: whether to return pooling indices. Default: ``False``
     """
+    output_size = set_output_size(input.size()[2:], output_size)
     ret = torch._C._nn.adaptive_max_pool3d(input, output_size)
     return ret if return_indices else ret[0]
 
@@ -521,32 +523,35 @@ Args:
     output_size: the target output size (single integer)
 """)
 
-adaptive_avg_pool2d = _add_docstr(torch._C._nn.adaptive_avg_pool2d, r"""
-adaptive_avg_pool2d(input, output_size) -> Tensor
 
-Applies a 2D adaptive average pooling over an input signal composed of
-several input planes.
+def adaptive_avg_pool2d(input, output_size):
+    r"""
+    Applies a 2D adaptive average pooling over an input signal composed of
+    several input planes.
+    
+    See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
+    
+    Args:
+        output_size: the target output size (single integer or
+            double-integer tuple)
+    """
+    output_size = set_output_size(input.size()[2:], output_size)
+    return torch._C._nn.adaptive_avg_pool2d(input, output_size)
 
-See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
 
-Args:
-    output_size: the target output size (single integer or
-        double-integer tuple)
-""")
-
-adaptive_avg_pool3d = _add_docstr(torch._C._nn.adaptive_avg_pool3d, r"""
-adaptive_avg_pool3d(input, output_size) -> Tensor
-
-Applies a 3D adaptive average pooling over an input signal composed of
-several input planes.
-
-See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
-
-Args:
-    output_size: the target output size (single integer or
-        triple-integer tuple)
-""")
-
+def adaptive_avg_pool3d(input, output_size):
+    r"""
+    Applies a 3D adaptive average pooling over an input signal composed of
+    several input planes.
+    
+    See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
+    
+    Args:
+        output_size: the target output size (single integer or
+            triple-integer tuple)
+    """
+    output_size = set_output_size(input.size()[2:], output_size)
+    return torch._C._nn.adaptive_avg_pool3d(input, output_size) 
 
 # Activation functions
 

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -15,16 +15,9 @@ _triple = _ntuple(3)
 _quadruple = _ntuple(4)
 
 
-def set_output_size(input_size, output_size):
-    dim = len(input_size)
-    if isinstance(output_size, int):
-        return _ntuple(dim)(output_size)
-    if len(output_size) == 1:
-        return _ntuple(dim)(output_size[0])
-    assert(len(output_size) == dim)
-
-    shape = ()
-    for i, s in enumerate(output_size):
-        shape += ((s or input_size[i]), )
-
-    return shape
+def _list_with_default(out_size, defaults):
+    if isinstance(out_size, int):
+        return out_size
+    if len(defaults) <= len(out_size):
+        raise ValueError('Input dimension should be at least {}'.format(len(out_size) + 1))
+    return [v if v is not None else d for v, d in zip(out_size, defaults[-len(out_size):])]

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -14,6 +14,7 @@ _pair = _ntuple(2)
 _triple = _ntuple(3)
 _quadruple = _ntuple(4)
 
+
 def set_output_size(input_size, output_size):
     dim = len(input_size)
     if isinstance(output_size, int):
@@ -23,7 +24,7 @@ def set_output_size(input_size, output_size):
     assert(len(output_size) == dim)
 
     shape = ()
-    for i,s in enumerate(output_size):
-        shape += ((s or input_size[i]),)
+    for i, s in enumerate(output_size):
+        shape += ((s or input_size[i]), )
 
     return shape

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -13,3 +13,17 @@ _single = _ntuple(1)
 _pair = _ntuple(2)
 _triple = _ntuple(3)
 _quadruple = _ntuple(4)
+
+def set_output_size(input_size, output_size):
+    dim = len(input_size)
+    if isinstance(output_size, int):
+        return _ntuple(dim)(output_size)
+    if len(output_size) == 1:
+        return _ntuple(dim)(output_size[0])
+    assert(len(output_size) == dim)
+
+    shape = ()
+    for i,s in enumerate(output_size):
+        shape += ((s or input_size[i]),)
+
+    return shape


### PR DESCRIPTION
This PR fixes #7884.
Since #3127 we support output_size to contain None (use corresponding number in input_size), but this got lost in TH refactor. Adding it back and add some test cases in test_nn.py.