### PR TITLE
Remove all resizeLegacy calls, except for catArray.

### DIFF
--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -320,13 +320,13 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
 
   numel = THLongTensor_nElement(index);
 
-  newSize = THLongStorage_newWithSize(src->_dim());
+  newSize = THLongStorage_newWithSize(src->dim());
   THLongStorage_rawCopy(newSize,src->size);
 #ifdef DEBUG
   THAssert(numel <= LONG_MAX);
 #endif
   THLongStorage_data(newSize)[dim] = numel;
-  THTensor_(resizeLegacy)(tensor,newSize,NULL);
+  THTensor_(resize)(tensor,newSize,NULL);
   THLongStorage_free(newSize);
 
   index = THLongTensor_newContiguous(index);
@@ -2352,8 +2352,8 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(values_, dim, NULL);
-  THLongTensor_resizeLegacy(indices_, dim, NULL);
+  THTensor_(resize)(values_, dim, NULL);
+  THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
@@ -2436,8 +2436,8 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(values_, dim, NULL);
-  THLongTensor_resizeLegacy(indices_, dim, NULL);
+  THTensor_(resize)(values_, dim, NULL);
+  THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
@@ -2518,7 +2518,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -2598,7 +2598,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -2812,12 +2812,6 @@ void THTensor_(cminValue)(THTensor *r, THTensor *t, real value) {
                    *r_data = *t_data > value ? value : *t_data;);  // this order propagates NaN
 }
 
-void THTensor_(zeros)(THTensor *r_, THLongStorage *size)
-{
-  THTensor_(resizeLegacy)(r_, size, NULL);
-  THTensor_(zero)(r_);
-}
-
 void THTensor_(zerosLike)(THTensor *r_, THTensor *input)
 {
   THTensor_(resizeAs)(r_, input);
@@ -2827,12 +2821,6 @@ void THTensor_(zerosLike)(THTensor *r_, THTensor *input)
 void THTensor_(onesLike)(THTensor *r_, THTensor *input)
 {
   THTensor_(resizeAs)(r_, input);
-  THTensor_(fill)(r_, 1);
-}
-
-void THTensor_(ones)(THTensor *r_, THLongStorage *size)
-{
-  THTensor_(resizeLegacy)(r_, size, NULL);
   THTensor_(fill)(r_, 1);
 }
 
@@ -2963,12 +2951,6 @@ void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n)
     r__data[i*r__stride_0] = r__data[(z+i)*r__stride_0];
     r__data[(z+i)*r__stride_0] = sav;
   }
-}
-
-void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
-{
-  THTensor_(resizeLegacy)(r_, size, NULL);
-  THTensor_(copy)(r_, t);
 }
 
 /* I cut and pasted (slightly adapted) the quicksort code from
@@ -3192,7 +3174,7 @@ void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimensio
 
   {
     THLongStorage *size = THTensor_(newSizeOf)(t);
-    THLongTensor_resizeLegacy(ri_, size, NULL);
+    THLongTensor_resize(ri_, size, NULL);
     THLongStorage_free(size);
   }
 
@@ -3329,8 +3311,8 @@ void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(values_, dim, NULL);
-  THLongTensor_resizeLegacy(indices_, dim, NULL);
+  THTensor_(resize)(values_, dim, NULL);
+  THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   t_size_dim = THTensor_(size)(t, dimension);
@@ -3398,8 +3380,8 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(values_, dim, NULL);
-  THLongTensor_resizeLegacy(indices_, dim, NULL);
+  THTensor_(resize)(values_, dim, NULL);
+  THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
   t_size_dim = THTensor_(size)(t, dimension);
@@ -3461,8 +3443,8 @@ void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, i
 
   THLongStorage *topKSize = THTensor_(newSizeOf)(t);
   THLongStorage_set(topKSize, dim, k);
-  THTensor_(resizeLegacy)(rt_, topKSize, NULL);
-  THLongTensor_resizeLegacy(ri_, topKSize, NULL);
+  THTensor_(resize)(rt_, topKSize, NULL);
+  THLongTensor_resize(ri_, topKSize, NULL);
   THLongStorage_free(topKSize);
 
   if (dir) {
@@ -3916,7 +3898,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -3996,7 +3978,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   int serial_path = 0;
@@ -4150,7 +4132,7 @@ void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -4194,7 +4176,7 @@ void THTensor_(var)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -4238,7 +4220,7 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension, int k
   THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
-  THTensor_(resizeLegacy)(r_, dim, NULL);
+  THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
   #define DIM_REDUCE(reduce, transform) \
@@ -4421,18 +4403,6 @@ void THTensor_(logspace)(THTensor *r_, real a, real b, int64_t n)
         i++;
         );
   }
-}
-
-void THTensor_(rand)(THTensor *r_, THGenerator *_generator, THLongStorage *size)
-{
-  THTensor_(resizeLegacy)(r_, size, NULL);
-  THTensor_(uniform)(r_, _generator, 0, 1);
-}
-
-void THTensor_(randn)(THTensor *r_, THGenerator *_generator, THLongStorage *size)
-{
-  THTensor_(resizeLegacy)(r_, size, NULL);
-  THTensor_(normal)(r_, _generator, 0, 1);
 }
 
 void THTensor_(histc)(THTensor *hist, THTensor *tensor, int64_t nbins, real minvalue, real maxvalue)

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -94,9 +94,7 @@ TH_API void THTensor_(cmin)(THTensor *r, THTensor *t, THTensor *src);
 TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, real value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, real value);
 
-TH_API void THTensor_(zeros)(THTensor *r_, THLongStorage *size);
 TH_API void THTensor_(zerosLike)(THTensor *r_, THTensor *input);
-TH_API void THTensor_(ones)(THTensor *r_, THLongStorage *size);
 TH_API void THTensor_(onesLike)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
 TH_API void THTensor_(eye)(THTensor *r_, int64_t n, int64_t m);
@@ -104,7 +102,6 @@ TH_API void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal 
 TH_API void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step);
 TH_API void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n);
 
-TH_API void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size);
 TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder);
 TH_API void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted);
 TH_API void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k);
@@ -200,8 +197,6 @@ TH_API accreal THTensor_(normall)(THTensor *t, real value);
 
 TH_API void THTensor_(linspace)(THTensor *r_, real a, real b, int64_t n);
 TH_API void THTensor_(logspace)(THTensor *r_, real a, real b, int64_t n);
-TH_API void THTensor_(rand)(THTensor *r_, THGenerator *_generator, THLongStorage *size);
-TH_API void THTensor_(randn)(THTensor *r_, THGenerator *_generator, THLongStorage *size);
 
 TH_API void THTensor_(dirichlet_grad)(THTensor *self, THTensor *x, THTensor *alpha, THTensor *total);
 #endif

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -348,7 +348,7 @@ bool THC_reduceDim(THCState* state,
   // Resize out
   THLongStorage* sizes = THCTensor_newSizeOf(state, in);
   THLongStorage_set(sizes, dim, 1);
-  THCTensor_resizeLegacy(state, out, sizes, NULL);
+  THCTensor_resize(state, out, sizes, NULL);
   THLongStorage_free(sizes);
 
   // It is possible that the tensor dimensions are able to be collapsed,

--- a/aten/src/THC/THCTensorMathCompare.cuh
+++ b/aten/src/THC/THCTensorMathCompare.cuh
@@ -74,7 +74,7 @@ void THC_logicalValue(THCState *state,
                       TensorType *src,
                       Op op) {
   THLongStorage* st = THCTensor_newSizeOf(state, src);
-  THCTensor_resizeLegacy(state, self_, st, NULL);
+  THCTensor_resize(state, self_, st, NULL);
   THLongStorage_free(st);
 
   if (!THC_pointwiseApply2<ScalarTypeOut, ScalarType>(state, self_, src, op)) {

--- a/aten/src/THC/THCTensorMathCompareT.cuh
+++ b/aten/src/THC/THCTensorMathCompareT.cuh
@@ -57,7 +57,7 @@ void THC_logicalTensor(THCState *state,
                        TensorType *src2,
                        Op op) {
   THLongStorage* st = THCTensor_newSizeOf(state, src1);
-  THCTensor_resizeLegacy(state, self_, st, NULL);
+  THCTensor_resize(state, self_, st, NULL);
   THLongStorage_free(st);
 
   THArgCheck(THCTensor_nElement(state, src1) ==

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -668,8 +668,8 @@ THC_reduceDimIndex(THCState *state,
 
   THLongStorage *dim = THCTensor_newSizeOf(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_resizeLegacy(state, tgt1_, dim, NULL);
-  THCTensor_resizeLegacy(state, tgt2_, dim, NULL);
+  THCTensor_resize(state, tgt1_, dim, NULL);
+  THCTensor_resize(state, tgt2_, dim, NULL);
   THLongStorage_free(dim);
 
   TensorTypeK *tgt1 = (TensorTypeK*)THCTensor_newContiguous<ScalarTypeK>(state, tgt1_);

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -534,14 +534,14 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
   if (numIndices == 0) {
     newSize = THCTensor_(newSizeOf)(state, src);
     THLongStorage_set(newSize, 0, numIndices);
-    THCTensor_(resizeLegacy)(state, dst, newSize, NULL);
+    THCTensor_(resize)(state, dst, newSize, NULL);
     THLongStorage_free(newSize);
     return;
   }
 
   newSize = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(newSize, dim, numIndices);
-  THCTensor_(resizeLegacy)(state, dst, newSize, NULL);
+  THCTensor_(resize)(state, dst, newSize, NULL);
   THLongStorage_free(newSize);
 
   int indContig = THCudaLongTensor_isContiguous(state, indices);

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -60,12 +60,12 @@ THCTensor_(maskedCopy)(THCState* state,
   // we're accumulating the prefix sum in (int64_t) to get around it
   THCudaLongTensor* maskLong = THCudaLongTensor_new(state);
   THLongStorage* maskSizes = THCudaByteTensor_newSizeOf(state, mask);
-  THCudaLongTensor_resizeLegacy(state, maskLong, maskSizes, NULL);
+  THCudaLongTensor_resize(state, maskLong, maskSizes, NULL);
   THCudaLongTensor_copyCudaByte(state, maskLong, mask);
 
   // Use a prefix sum to determine the output locations of the masked elements
   THCudaLongTensor* maskPrefixSum = THCudaLongTensor_new(state);
-  THCudaLongTensor_resizeLegacy(state, maskPrefixSum, maskSizes, NULL);
+  THCudaLongTensor_resize(state, maskPrefixSum, maskSizes, NULL);
   THLongStorage_free(maskSizes);
 
   THCThrustAllocator thrustAlloc(state);
@@ -135,12 +135,12 @@ THCTensor_(maskedSelect)(THCState* state,
   // we're accumulating the prefix sum in (int64_t) to get around it
   THCudaLongTensor* maskLong = THCudaLongTensor_new(state);
   THLongStorage* maskSizes = THCudaByteTensor_newSizeOf(state, mask);
-  THCudaLongTensor_resizeLegacy(state, maskLong, maskSizes, NULL);
+  THCudaLongTensor_resize(state, maskLong, maskSizes, NULL);
   THCudaLongTensor_copyCudaByte(state, maskLong, mask);
 
   // Use a prefix sum to determine the output locations of the masked elements
   THCudaLongTensor* maskPrefixSum = THCudaLongTensor_new(state);
-  THCudaLongTensor_resizeLegacy(state, maskPrefixSum, maskSizes, NULL);
+  THCudaLongTensor_resize(state, maskPrefixSum, maskSizes, NULL);
   THLongStorage_free(maskSizes);
 
   THCThrustAllocator thrustAlloc(state);

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -36,14 +36,6 @@ THCTensor_(zero)(THCState *state, THCTensor *self_)
 }
 
 THC_API void
-THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resizeLegacy)(state, r_, size, NULL);
-  THCTensor_(zero)(state, r_);
-}
-
-THC_API void
 THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor *input)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
@@ -52,27 +44,11 @@ THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor *input)
 }
 
 THC_API void
-THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resizeLegacy)(state, r_, size, NULL);
-  THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
-}
-
-THC_API void
 THCTensor_(onesLike)(THCState *state, THCTensor *r_, THCTensor *input)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
   THCTensor_(resizeAs)(state, r_, input);
   THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
-}
-
-THC_API void
-THCTensor_(reshape)(THCState *state, THCTensor *r_, THCTensor *t, THLongStorage *size)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, t));
-  THCTensor_(resizeLegacy)(state, r_, size, NULL);
-  THCTensor_(copy)(state, r_, t);
 }
 
 ptrdiff_t

--- a/aten/src/THC/generic/THCTensorMath.h
+++ b/aten/src/THC/generic/THCTensorMath.h
@@ -5,11 +5,8 @@
 THC_API void THCTensor_(fill)(THCState *state, THCTensor *self, real value);
 THC_API void THCTensor_(zero)(THCState *state, THCTensor *self);
 
-THC_API void THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size);
 THC_API void THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor* input);
-THC_API void THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size);
 THC_API void THCTensor_(onesLike)(THCState *state, THCTensor *r_, THCTensor* input);
-THC_API void THCTensor_(reshape)(THCState *state, THCTensor *r_, THCTensor *t, THLongStorage *size);
 THC_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
 THC_API void THCTensor_(cat)(THCState *state, THCTensor *result, THCTensor *ta, THCTensor *tb, int dimension);
 THC_API void THCTensor_(catArray)(THCState *state, THCTensor *result, THCTensor **inputs, int numInputs, int dimension);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -94,7 +94,7 @@ THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
       state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resizeLegacy)(state, self_, dim, NULL);
+  THCTensor_(resize)(state, self_, dim, NULL);
   THLongStorage_free(dim);
 
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
@@ -123,7 +123,7 @@ THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
       state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resizeLegacy)(state, self_, dim, NULL);
+  THCTensor_(resize)(state, self_, dim, NULL);
   THLongStorage_free(dim);
 
   THCTensor *self = THCTensor_(newContiguous)(state, self_);

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -186,8 +186,8 @@ THC_API void THCTensor_(mode)(THCState *state,
       state, indices, ndim, dimension, keepdim);
   dim = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(dim, dimension, 1);
-  THCTensor_(resizeLegacy)(state, values, dim, NULL);
-  THCudaLongTensor_resizeLegacy(state, indices, dim, NULL);
+  THCTensor_(resize)(state, values, dim, NULL);
+  THCudaLongTensor_resize(state, indices, dim, NULL);
   THLongStorage_free(dim);
 
   // If sliceSize is 1, copy input to values and set indices

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -380,20 +380,6 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
           );
 }
 
-THC_API void THCTensor_(rand)(THCState *state, THCTensor *r_, THLongStorage *size)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resizeLegacy)(state, r_, size, NULL);
-  THCTensor_(uniform)(state, r_, 0, 1);
-}
-
-void THCTensor_(randn)(THCState *state, THCTensor *r_, THLongStorage *size)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THCTensor_(resizeLegacy)(state, r_, size, NULL);
-  THCTensor_(normal)(state, r_, 0, 1);
-}
-
 #endif
 
 #if defined(THC_REAL_IS_DOUBLE)

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -5,8 +5,6 @@
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
 THC_API void THCTensor_(uniform)(struct THCState *state, THCTensor *self, double a, double b);
-THC_API void THCTensor_(rand)(THCState *state, THCTensor *r_, THLongStorage *size);
-THC_API void THCTensor_(randn)(THCState *state, THCTensor *r_, THLongStorage *size);
 THC_API void THCTensor_(normal)(struct THCState *state, THCTensor *self, double mean, double stdv);
 THC_API void THCTensor_(normal_means)(struct THCState *state, THCTensor *self, THCTensor *means, double stddev);
 THC_API void THCTensor_(normal_stddevs)(struct THCState *state, THCTensor *self, double mean, THCTensor *stddevs);

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -293,7 +293,7 @@ THC_API void THCTensor_(sort)(THCState* state,
   // Make sure sufficient output space is allocated
   THCTensor_(resizeAs)(state, sorted, input);
   THLongStorage *inputSize = THCTensor_(newSizeOf)(state, input);
-  THCudaLongTensor_resizeLegacy(state, indices, inputSize, NULL);
+  THCudaLongTensor_resize(state, indices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // How large are the slices that we are sorting?

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -24,8 +24,8 @@ THC_API void THCTensor_(topk)(THCState* state,
   // size k
   THLongStorage* topKSize = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(topKSize, dim, k);
-  THCTensor_(resizeLegacy)(state, topK, topKSize, NULL);
-  THCudaLongTensor_resizeLegacy(state, indices, topKSize, NULL);
+  THCTensor_(resize)(state, topK, topKSize, NULL);
+  THCudaLongTensor_resize(state, indices, topKSize, NULL);
   THLongStorage_free(topKSize);
 
 #define RUN_K(INDEX_T, DIM, DIR)                                        \

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -33,13 +33,6 @@ void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
   self->nnz = 0;
 }
 
-void THCSTensor_(zeros)(THCState *state, THCSTensor *r_, THLongStorage *size)
-{
-  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 1, r_));
-  THCSTensor_(resizeLegacy)(state, r_, size);
-  THCSTensor_(zero)(state, r_);
-}
-
 void THCSTensor_(zerosLike)(THCState *state, THCSTensor *r_, THCSTensor *input)
 {
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 2, 2, r_, input));

--- a/aten/src/THCS/generic/THCSTensorMath.h
+++ b/aten/src/THCS/generic/THCSTensorMath.h
@@ -11,7 +11,6 @@
  */
 
 THC_API void THCSTensor_(zero)(THCState *state, THCSTensor *r_);
-THC_API void THCSTensor_(zeros)(THCState *state, THCSTensor *r_, THLongStorage *size);
 THC_API void THCSTensor_(zerosLike)(THCState *state, THCSTensor *r_, THCSTensor *input);
 
 THC_API void THCTensor_(spaddcmul)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2);

--- a/aten/src/THCUNN/common.h
+++ b/aten/src/THCUNN/common.h
@@ -21,7 +21,7 @@ inline int GET_BLOCKS(const int N)
   THLongStorage *size2 = THCTensor_(newSizeOf)(STATE, I2);  \
   if (!THCIndexTensor_(isSize)(STATE, I1, size2))           \
   { \
-    THCudaLongTensor_resizeLegacy(STATE, I1, size2, NULL);        \
+    THCudaLongTensor_resize(STATE, I1, size2, NULL);        \
   } \
   THLongStorage_free(size2);
 

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -18,7 +18,7 @@ void THNN_(GatedLinear_updateOutput)(
   const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
   THLongStorage *newSizes = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(newSizes, dim, inputSize);
-  THCTensor_(resizeLegacy)(state, output, newSizes, NULL);
+  THCTensor_(resize)(state, output, newSizes, NULL);
 
   // halve tensor
   THCTensor *firstHalf = THCTensor_(newNarrow)(state, input, dim, 0, inputSize);

--- a/aten/src/THCUNN/generic/LookupTable.cu
+++ b/aten/src/THCUNN/generic/LookupTable.cu
@@ -57,8 +57,8 @@ void THNN_(LookupTable_accGradParameters)(
   }
 
   THLongStorage *inputSize = THCIndexTensor_(newSizeOf)(state, input);
-  THCIndexTensor_(resizeLegacy)(state, sortedIndices, inputSize, NULL);
-  THCIndexTensor_(resizeLegacy)(state, origIndices, inputSize, NULL);
+  THCIndexTensor_(resize)(state, sortedIndices, inputSize, NULL);
+  THCIndexTensor_(resize)(state, origIndices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // Sort the inputs into sorted with the corresponding indices; we

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -35,9 +35,9 @@ void THNN_(LookupTableBag_updateOutput)(
   THLongStorage *outputSize = THLongStorage_newWithSize(2);
   THLongStorage_data(outputSize)[0] = numBags;
   THLongStorage_data(outputSize)[1] = stride;
-  THCTensor_(resizeLegacy)(state, output, outputSize, NULL);
+  THCTensor_(resize)(state, output, outputSize, NULL);
   THCTensor_(zero)(state, output);
-  THCIndexTensor_(resizeLegacy)(state, offset2bag, inputSize, NULL);
+  THCIndexTensor_(resize)(state, offset2bag, inputSize, NULL);
   THLongStorage_free(inputSize);
   THLongStorage_free(outputSize);
 
@@ -100,8 +100,8 @@ void THNN_(LookupTableBag_accGradParameters)(
   cudaStream_t stream = THCState_getCurrentStream(state);
 
   THLongStorage *inputSize = THCIndexTensor_(newSizeOf)(state, input);
-  THCIndexTensor_(resizeLegacy)(state, sortedIndices, inputSize, NULL);
-  THCIndexTensor_(resizeLegacy)(state, origIndices, inputSize, NULL);
+  THCIndexTensor_(resize)(state, sortedIndices, inputSize, NULL);
+  THCIndexTensor_(resize)(state, origIndices, inputSize, NULL);
   THLongStorage_free(inputSize);
 
   // Sort the inputs into sorted with the corresponding indices; we

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -137,11 +137,6 @@ int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor* src)
   THError("Internal error! This API is deprecated. Shout if you need it.");
 }
 
-THSTensor *THSTensor_(resizeLegacy)(THSTensor *self, THLongStorage *size)
-{
-  THError("Internal error! This API is deprecated. Shout if you need it.");
-}
-
 THSTensor *THSTensor_(resizeAs)(THSTensor *self, THSTensor *src)
 {
   THError("Internal error! This API is deprecated. Shout if you need it.");

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -37,7 +37,6 @@ TH_API THSTensor *THSTensor_(resize1d)(THSTensor *self, int64_t size0);
 TH_API THSTensor *THSTensor_(resize2d)(THSTensor *self, int64_t size0, int64_t size1);
 TH_API THSTensor *THSTensor_(resize3d)(THSTensor *self, int64_t size0, int64_t size1, int64_t size2);
 TH_API THSTensor *THSTensor_(resize4d)(THSTensor *self, int64_t size0, int64_t size1, int64_t size2, int64_t size3);
-TH_API THSTensor *THSTensor_(resizeLegacy)(THSTensor *self, THLongStorage *size);
 
 TH_API THTensor *THSTensor_(toDense)(THSTensor *self);
 TH_API void THSTensor_(copy)(THSTensor *self, THSTensor *src);


### PR DESCRIPTION
catArray is more complicated because it requires real 0-size dimension support.  The other changes are safe in that the functions are never called (and are now deleted), or they are used on a result of THTensor_(newSizeOf), which has a valid size.

