### PR TITLE
adding random quantization caffe2 operators 

### DIFF
--- a/caffe2/operators/fused_rowwise_random_quantization_ops.cc
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.cc
@@ -1,0 +1,73 @@
+#include "caffe2/operators/fused_rowwise_random_quantization_ops.h"
+#include "caffe2/core/registry.h"
+
+namespace caffe2 {
+REGISTER_CPU_OPERATOR(
+    FloatToFusedRandRowwiseQuantized,
+    FloatToFusedRandRowwiseQuantizedOp<CPUContext>);
+OPERATOR_SCHEMA(FloatToFusedRandRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>& in) {
+      ArgumentHelper helper(def);
+      auto bitwidth = helper.GetSingleArgument<int32_t>("bitwidth", 8);
+      size_t data_per_byte = 8 / bitwidth;
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, 10 + (X.dims(1) + data_per_byte - 1) / data_per_byte);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies row-wise random quantization by determining the range of
+each row in the input matrix, and then quantize each element to one of two
+closest discrete levels by randomly drawing Bernoulli distribution.
+The method is extended from TernGrad [1],
+which randomly quantizes gradients to three levels to reduce communication in distributed training.
+The format of each row (x) in the output matrix is [bitwidth][tail][min][max][data]:
+bitwidth[1 Byte]: bitwidth per data [1, 2, 4 or 8];
+tail[1 Byte]: the number of unused buckets [1-8];
+min[4 Bytes]: the minimum floating value min(x);
+max[4 Bytes]: the maximum floating value max(x);
+data: quantized data.
+The quantization is uniform with levels q = min + (max-min)/(2^bitwidth - 1)*[0:1:2^bitwidth].
+During random quantization x'=Quantize(x), for q_j < x_i <= q_{j+1}, we draw quantization x'_i from Bernoulli distributions with
+P(x'_i = q_{j+1}) = (x_i - q_j)/(q_{j+1} - q_j), and
+P(x'_i = q_j) = (q_{j+1} - x_i)/(q_{j+1} - q_j) where x'_i is the quantized value of x_i.
+[1] proved E{x'_i}=x_i, which is an unbiased approximation. More details are in the paper.
+For example, suppose targeted bitwidth = 2 and x = [0.3, -1.4, -0.6, 0.9, 1.0],
+then tail = 3, min = -1.4, max = 1.0 and q = [-1.4, -0.6, 0.2, 1.0].
+x_1 = 0.3 will be quantized to x'_1 = 0.2 with probability 7/8 and to x'_1 = 1.0 with probability 1/8.
+The storage format of quantized data is (the b-th bucket of the i-th byte stores the i-th data of the b-th segment of input row):
+[x'_1|x'_3|x'_5|xxx]-[x'_2|x'_4|xxx|xxx]
+
+[1] Wen, Wei, Cong Xu, Feng Yan, Chunpeng Wu, Yandan Wang, Yiran Chen, and Hai Li.
+"Terngrad: Ternary gradients to reduce communication in distributed deep learning."
+In Advances in Neural Information Processing Systems, pp. 1508-1518. 2017.
+
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused bitwidth, tail, min, max and quantized data")
+    .Arg("bitwidth", "How many bits to quantiz per data (defaults to 8).")
+    .Arg("random", "random or not (True). False is set up for unittest.");
+NO_GRADIENT(FloatToFusedRandRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    FusedRandRowwiseQuantizedToFloat,
+    FusedRandRowwiseQuantizedToFloatOp<CPUContext>);
+OPERATOR_SCHEMA(FusedRandRowwiseQuantizedToFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .SetDoc(R"DOC(
+De-quantizes the result of the FloatToFusedRandRowwiseQuantized operator.
+Refer FloatToFusedRandRowwiseQuantized operator for details.
+)DOC")
+    .Input(
+        0,
+        "quantized_input",
+        "Fused bitwidth, tail, min, max and quantized data")
+    .Output(0, "float_input", "Float32 data");
+NO_GRADIENT(FusedRandRowwiseQuantizedToFloat);
+} // namespace caffe2

--- a/caffe2/operators/fused_rowwise_random_quantization_ops.h
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.h
@@ -1,0 +1,205 @@
+#ifndef CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
+#define CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/reducer_functors.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+#define IS_LITTLE_ENDIAN                                      \
+  [] {                                                        \
+    const int32_t kValue = 1;                                 \
+    return reinterpret_cast<const uint8_t*>(&kValue)[0] == 1; \
+  }()
+
+// define a custom template unary functor
+// random quantization
+template <typename Scalar>
+struct CwiseRandQuantizeOp {
+  CwiseRandQuantizeOp(
+      CPUContext::rand_gen_type& gen,
+      const uint8_t& bw,
+      const bool& r,
+      const Scalar& minv,
+      const Scalar& maxv)
+      : m_gen(gen),
+        m_bitwdith(bw),
+        m_random(r),
+        m_min(minv),
+        m_max(maxv),
+        m_gap((maxv - minv) / ((1 << bw) - 1.f)),
+        m_maxq((1 << bw) - 1) {}
+  uint8_t operator()(const Scalar& fval) const {
+    Scalar thetimes = (fval - m_min) / (m_gap + 1e-8f);
+    thetimes = thetimes < 0 ? 0 : (thetimes > m_maxq ? m_maxq : thetimes);
+    uint8_t floor_times = floor(thetimes);
+    // the probability of quantizing to the larger discrete level
+    Scalar p = thetimes - floor_times;
+    if (!m_random) {
+      p = p > 0.5;
+    }
+    // generate Bernoulli distribution
+    std::bernoulli_distribution dist(p);
+    uint8_t q = floor_times + dist(m_gen); // quantzied value
+    // (1 << m_bitwdith) - 1 is to avoid contamination when q is dirty data
+    return m_maxq & q;
+  }
+
+  CPUContext::rand_gen_type& m_gen;
+  const uint8_t m_bitwdith; // bits per data
+  const bool m_random; // false for unittest
+  const Scalar m_min; // the minimum value
+  const Scalar m_max; // the maximum value
+  const Scalar m_gap; // the gap between two discrete levels
+  const uint8_t m_maxq; // the max quantized value
+};
+
+// define a custom template binary functor
+// left shift and or
+template <typename T>
+struct CwiseLeftShiftOrOp {
+  CwiseLeftShiftOrOp(const size_t& s) : m_shift(s) {}
+  const T operator()(const T& shiftval, const T& orval) const {
+    return (T)(shiftval << m_shift) | orval;
+  }
+  const size_t m_shift; // bits per data
+};
+
+template <class Context>
+class FloatToFusedRandRowwiseQuantizedOp : public Operator<Context> {
+ public:
+  static constexpr float kEqualityThreshold = 1e-7f;
+  static constexpr float kEpsilon = 1e-8f;
+
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  FloatToFusedRandRowwiseQuantizedOp(
+      const OperatorDef& operator_def,
+      Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        bitwidth_(OperatorBase::GetSingleArgument<int32_t>("bitwidth", 8)),
+        random_(OperatorBase::GetSingleArgument<bool>("random", true)) {
+    CAFFE_ENFORCE(
+        bitwidth_ == 1 || bitwidth_ == 2 || bitwidth_ == 4 || bitwidth_ == 8,
+        "Unsupported bitwidth");
+  }
+  ~FloatToFusedRandRowwiseQuantizedOp() {}
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+    const auto& input = Input(DATA_FLOAT);
+    auto* output = Output(DATA_FUSED_QUANTIZED);
+
+    // TODO extend to higher dimensional blob like conv filters and batched
+    // feature maps
+    CAFFE_ENFORCE_EQ(input.ndim(), 2, "Expect input to be a matrix");
+
+    const auto input_rows = input.dim(0);
+    const auto input_columns = input.dim(1);
+
+    // The "fused" representation stores the [bitwidth][tail][min][max]
+    // with the row-wise quantized data in one tensor. Since we store 8/bitwidth
+    // quantized data in one byte, the last buckets of some bytes may have
+    // unused bits. There are totally tail buckets are unused.
+    // We encode *bitwidth* and *tail* at the beginning of
+    // each row, following by 32-bit floating data respresenting min and max.
+    // | bitwidth | tail | min | max | ... int8 data ... |
+    // |    1B    |  1B  |  4B |  4B | ...output_data....|
+    // In output_data: the b-th bucket of the i-th byte stores
+    // the i-th data of the b-th segment of input row
+    size_t data_per_byte = 8 / bitwidth_;
+    size_t tail = input_columns % data_per_byte;
+    tail = tail ? data_per_byte - tail : 0;
+    // How many bytes in the output
+    size_t segment_size = (input_columns + data_per_byte - 1) / data_per_byte;
+    const std::vector<TIndex> output_dimensions = {input_rows,
+                                                   10 + segment_size};
+    output->Resize(output_dimensions);
+
+    const auto* input_data = input.template data<float>();
+    auto* output_data = output->template mutable_data<uint8_t>();
+    const auto output_columns = output->dim(1);
+    memset(output_data, 0, output->size());
+
+    for (size_t row = 0; row < input_rows; ++row) {
+      // memory pointers
+      ConstEigenVectorArrayMap<float> input_row(
+          input_data + row * input_columns, input_columns);
+      uint8_t* output_row = output_data + row * output_columns;
+      EigenVectorArrayMap<uint8_t> output_bitwidth_tail(output_row, 2);
+      EigenVectorArrayMap<float> output_row_min_max(
+          reinterpret_cast<float*>(output_row + 2), 2);
+
+      // basic info
+      const float minimum_element = input_row.minCoeff();
+      const float maximum_element = input_row.maxCoeff();
+      output_bitwidth_tail(0) = bitwidth_;
+      output_bitwidth_tail(1) = tail;
+      output_row_min_max(0) = minimum_element;
+      output_row_min_max(1) = maximum_element;
+
+      CwiseRandQuantizeOp<float> cwiserand(
+          context_.RandGenerator(),
+          bitwidth_,
+          random_,
+          minimum_element,
+          maximum_element);
+      CwiseLeftShiftOrOp<uint8_t> cwiseshftor(bitwidth_);
+
+      for (int start = 0; start < input_columns; start += segment_size) {
+        size_t stride = start + segment_size <= input_columns
+            ? segment_size
+            : input_columns - start;
+        ConstEigenVectorArrayMap<float> sub_input_row(
+            input_data + row * input_columns + start, stride);
+        auto qvals = sub_input_row.unaryExpr(
+            cwiserand); // some last buckets may have unused data
+        EigenVectorArrayMap<uint8_t> output_seg(output_row + 10, stride);
+        // shift previous bits and concatenate current ones
+        output_seg = output_seg.binaryExpr(qvals, cwiseshftor);
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FLOAT);
+  OUTPUT_TAGS(DATA_FUSED_QUANTIZED);
+
+ protected:
+  size_t bitwidth_{8};
+  bool random_{true};
+};
+
+template <class Context>
+class FusedRandRowwiseQuantizedToFloatOp : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  USE_SIMPLE_CTOR_DTOR(FusedRandRowwiseQuantizedToFloatOp)
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+    // const auto& input = Input(DATA_FUSED_QUANTIZED);
+    // auto* output = Output(DATA_FLOAT);
+
+    // TODO out[0].set_data_type(TensorProto_DataType_FLOAT);
+    // ...
+    CAFFE_ENFORCE(0, "Not implemented yet.");
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FUSED_QUANTIZED);
+  OUTPUT_TAGS(DATA_FLOAT);
+};
+
+#undef IS_LITTLE_ENDIAN
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_

--- a/caffe2/python/operator_test/rand_quantization_op_test.py
+++ b/caffe2/python/operator_test/rand_quantization_op_test.py
@@ -1,0 +1,88 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import struct
+
+from hypothesis import given
+import hypothesis.strategies as st
+
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestFloatToFusedRandRowwiseQuantized(hu.HypothesisTestCase):
+    @given(X=hu.tensor(min_dim=2, max_dim=2,
+    min_value=1, max_value=17),  # only matrix is supported
+           bitwidth_=st.sampled_from([1, 2, 4, 8]),
+           random_=st.sampled_from([False]),  # only deterministic supported in unittest
+           **hu.gcs)
+    def test_rand_quantization(self, X, bitwidth_, random_, gc, dc):
+
+        def rand_quantization_ref(X):
+            in_shape = X.shape
+            data_per_byte = 8 // bitwidth_
+            output_cols = 10 + in_shape[1] // data_per_byte
+            tail = 0
+            if in_shape[1] % data_per_byte:
+                output_cols += 1
+                tail = data_per_byte - in_shape[1] % data_per_byte
+            segment = output_cols - 10
+            out = np.zeros((in_shape[0], output_cols), dtype=np.uint8)
+            for r in range(0, in_shape[0]):
+                out[r][0] = bitwidth_
+                out[r][1] = tail
+                min_fval = np.amin(X[r])
+                max_fval = np.amax(X[r])
+                min_bvals = bytearray(struct.pack("f", min_fval))
+                max_bvals = bytearray(struct.pack("f", max_fval))
+                for idx in range(0, 4):
+                    out[r][2 + idx] = min_bvals[idx]
+                    out[r][6 + idx] = max_bvals[idx]
+                for c in range(0, in_shape[1]):
+                    fval = X[r][c]
+                    gap = (max_fval - min_fval) / ((1 << bitwidth_) - 1)
+                    thetimes = (fval - min_fval) / (gap + 1e-8)
+                    thetimes = round(thetimes)
+                    out[r][10 + c % segment] = \
+                        (out[r][10 + c % segment] << bitwidth_) + thetimes
+            print("pY:\n{}\n".format(out))
+
+            return (out,)
+
+        op = core.CreateOperator(
+            "FloatToFusedRandRowwiseQuantized",
+            ["X"], ["Y"],
+            bitwidth=bitwidth_,
+            random=random_)
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        print("X:\n{}\n".format(workspace.FetchBlob("X")))
+        Y = workspace.FetchBlob("Y")
+        print("Y:\n{}\n".format(Y))
+
+        pY = rand_quantization_ref(X)[0]
+
+        # The equality check of encoded floating values in bytes may occasionally fail
+        # because of precision.
+        # Refer to the format of floating values here:
+        #   https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+        ## self.assertReferenceChecks(gc, op, [X], rand_quantization_ref)
+        # Instead of using the above assertReferenceChecks,
+        # we replace the first byte (the least significant byte) of encoded
+        # floating values with zeros, and use assert_array_equal
+        Y[:, 2] = 0
+        Y[:, 6] = 0
+        pY[:, 2] = 0
+        pY[:, 6] = 0
+        np.testing.assert_array_equal(Y, pY)
+
+        # Check over multiple devices -- CUDA implementation is pending
+        # self.assertDeviceChecks(dc, op, [X], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()


### PR DESCRIPTION
This operator implements b (1/2/4/8) bit stochastic quantization of a floating
matrix in a row-wise fashion. 8/b floating values are concatenated to a byte
and returned in uint8 tensor.
(encoder in CPU implemented. Decoder and GPU mode is pending)
