### PR TITLE
Fix serialization for Parameters

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6162,6 +6162,19 @@ class TestTorch(TestCase):
         serialized = pickle.dumps(a)
         b = pickle.loads(serialized)
         self.assertTrue(isinstance(b, torch.nn.Parameter))
+        self.assertEqual(a.requires_grad, b.requires_grad)
+        self.assertEqual(a, b)
+
+    def test_pickle_parameter_no_requires_grad(self):
+        if sys.version_info[0] == 2:
+            import cPickle as pickle
+        else:
+            import pickle
+        a = torch.nn.Parameter(torch.randn(5, 5), requires_grad=False)
+        serialized = pickle.dumps(a)
+        b = pickle.loads(serialized)
+        self.assertTrue(isinstance(b, torch.nn.Parameter))
+        self.assertEqual(a.requires_grad, b.requires_grad)
         self.assertEqual(a, b)
 
     def test_norm_fastpaths(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6153,6 +6153,17 @@ class TestTorch(TestCase):
         b = pickle.loads(serialized)
         self.assertEqual(a, b)
 
+    def test_pickle_parameter(self):
+        if sys.version_info[0] == 2:
+            import cPickle as pickle
+        else:
+            import pickle
+        a = torch.nn.Parameter(torch.randn(5, 5))
+        serialized = pickle.dumps(a)
+        b = pickle.loads(serialized)
+        self.assertTrue(isinstance(b, torch.nn.Parameter))
+        self.assertEqual(a, b)
+
     def test_norm_fastpaths(self):
         x = torch.randn(3, 5)
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -25,3 +25,8 @@ class Parameter(torch.Tensor):
 
     def __repr__(self):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()
+
+    def __reduce_ex__(self, proto):
+        tensor = torch._utils._rebuild_tensor_v2(self.storage(), self.storage_offset(), tuple(self.size()),
+                                                 self.stride(), self.requires_grad, self._backward_hooks)
+        return (Parameter, (tensor, self.requires_grad))

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -27,6 +27,4 @@ class Parameter(torch.Tensor):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()
 
     def __reduce_ex__(self, proto):
-        tensor = torch._utils._rebuild_tensor_v2(self.storage(), self.storage_offset(), tuple(self.size()),
-                                                 self.stride(), self.requires_grad, self._backward_hooks)
-        return (Parameter, (tensor, self.requires_grad))
+        return Parameter, (super(Parameter, self), self.requires_grad)


### PR DESCRIPTION
Parameter was inheriting Tensor's `__reduce_ex__()`, which caused pickling to not work properly.

Fixes #8077.

cc: @zou3519 