### PR TITLE
[C++ API] Create fixed width dtypes in torch:: namespace

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -172,7 +172,7 @@ bool test_mnist(
     /* int label_magic = */ rd.read_int();
     int label_count = rd.read_int();
 
-    auto data = torch::empty({label_count}, at::kLong);
+    auto data = torch::empty({label_count}, torch::kInt64);
     auto a_data = data.accessor<int64_t, 1>();
 
     for (int i = 0; i < label_count; ++i) {
@@ -203,7 +203,7 @@ bool test_mnist(
     const auto backend = useGPU ? at::kCUDA : at::kCPU;
     auto inp =
         torch::empty({batch_size, 1, trdata.size(2), trdata.size(3)}, backend);
-    auto lab = torch::empty({batch_size}, at::device(backend).dtype(at::kLong));
+    auto lab = torch::empty({batch_size}, at::device(backend).dtype(torch::kInt64));
     for (auto p = 0U; p < shuffled_inds.size() - batch_size; p++) {
       inp[p % batch_size] = trdata[shuffled_inds[p]];
       lab[p % batch_size] = trlabel[shuffled_inds[p]];
@@ -224,7 +224,7 @@ bool test_mnist(
 
   NoGradGuard guard;
   auto result = std::get<1>(forward_op(tedata).max(1));
-  Variable correct = (result == telabel).toType(at::kFloat);
+  Variable correct = (result == telabel).toType(torch::kFloat32);
   std::cout << "Num correct: " << correct.data().sum().toCFloat() << " out of"
             << telabel.size(0) << std::endl;
   return correct.data().sum().toCFloat() > telabel.size(0) * 0.8;
@@ -274,7 +274,7 @@ TEST_CASE("integration") {
         rewards[i] = R;
       }
       auto r_t =
-          at::CPU(at::kFloat)
+          at::CPU(torch::kFloat32)
               .tensorFromBlob(
                   rewards.data(), {static_cast<int64_t>(rewards.size())});
       r_t = (r_t - r_t.mean()) / (r_t.std() + 1e-5);

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -69,7 +69,7 @@ TEST_CASE("module/conversions", "[cuda]") {
   SECTION("starts as float on CPU") {
     for (auto& parameter : module->parameters()) {
       REQUIRE(parameter->type().backend() == at::kCPU);
-      REQUIRE(parameter->type().scalarType() == at::kFloat);
+      REQUIRE(parameter->type().scalarType() == torch::kFloat32);
     }
   }
   SECTION("to(CUDA)") {
@@ -85,22 +85,22 @@ TEST_CASE("module/conversions", "[cuda]") {
     }
   }
   SECTION("to(Int)") {
-    module->to(at::kInt);
+    module->to(torch::kInt32);
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter->type().scalarType() == at::kInt);
+      REQUIRE(parameter->type().scalarType() == torch::kInt32);
     }
   }
   SECTION("to(Double)") {
-    module->to(at::kDouble);
+    module->to(torch::kFloat64);
     for (auto& parameter : module->parameters()) {
-      REQUIRE(parameter->type().scalarType() == at::kDouble);
+      REQUIRE(parameter->type().scalarType() == torch::kFloat64);
     }
   }
   SECTION("to(CUDA(Float))") {
-    module->to(at::CUDA(at::kFloat));
+    module->to(at::CUDA(torch::kFloat32));
     for (auto& parameter : module->parameters()) {
       REQUIRE(parameter->type().backend() == at::kCUDA);
-      REQUIRE(parameter->type().scalarType() == at::kFloat);
+      REQUIRE(parameter->type().scalarType() == torch::kFloat32);
     }
   }
 }

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -155,7 +155,7 @@ TEST_CASE("modules") {
       Embedding model(dict_size, 2);
       // Cannot get gradients to change indices (input) - only for embedding
       // params
-      auto x = torch::full({10}, dict_size - 1, at::kLong);
+      auto x = torch::full({10}, dict_size - 1, torch::kInt64);
       auto y = model->forward({x})[0];
       Variable s = y.sum();
 
@@ -170,7 +170,7 @@ TEST_CASE("modules") {
 
     SECTION("list") {
       Embedding model(6, 4);
-      auto x = torch::full({2, 3}, 5, at::kLong);
+      auto x = torch::full({2, 3}, 5, torch::kInt64);
       auto y = model->forward({x})[0];
       Variable s = y.sum();
 

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -39,7 +39,7 @@ bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
     auto nlen = 5U;
 
     const auto backend = cuda ? at::kCUDA : at::kCPU;
-    auto inp = at::rand({nlen, bs, 1}, backend).round().toType(at::kFloat);
+    auto inp = at::rand({nlen, bs, 1}, backend).round().toType(torch::kFloat32);
     auto lab = inp.sum(0);
 
     auto x = autograd::make_variable(inp, /*requires_grad=*/true);

--- a/torch/csrc/api/include/torch/tensor.h
+++ b/torch/csrc/api/include/torch/tensor.h
@@ -7,4 +7,24 @@
 namespace torch {
 // TODO: Rename to `Tensor`.
 using Variable = autograd::Variable;
+
+/// Special "raw data" dtype.
+constexpr auto kByte = at::kByte;
+
+/// Fixed width dtypes.
+constexpr auto kInt8 = at::kChar;
+constexpr auto kInt16 = at::kShort;
+constexpr auto kInt32 = at::kInt;
+constexpr auto kInt64 = at::kLong;
+constexpr auto kFloat32 = at::kFloat;
+constexpr auto kFloat64 = at::kDouble;
+
+/// Rust-style short dtypes.
+constexpr auto kI8 = at::kChar;
+constexpr auto kI16 = at::kShort;
+constexpr auto kI32 = at::kInt;
+constexpr auto kI64 = at::kLong;
+constexpr auto kF32 = at::kFloat;
+constexpr auto kF64 = at::kDouble;
+
 } // namespace torch

--- a/torch/csrc/api/include/torch/tensor.h
+++ b/torch/csrc/api/include/torch/tensor.h
@@ -8,10 +8,8 @@ namespace torch {
 // TODO: Rename to `Tensor`.
 using Variable = autograd::Variable;
 
-/// Special "raw data" dtype.
-constexpr auto kByte = at::kByte;
-
 /// Fixed width dtypes.
+constexpr auto kUInt8 = at::kByte;
 constexpr auto kInt8 = at::kChar;
 constexpr auto kInt16 = at::kShort;
 constexpr auto kInt32 = at::kInt;
@@ -20,11 +18,12 @@ constexpr auto kFloat32 = at::kFloat;
 constexpr auto kFloat64 = at::kDouble;
 
 /// Rust-style short dtypes.
-constexpr auto kI8 = at::kChar;
-constexpr auto kI16 = at::kShort;
-constexpr auto kI32 = at::kInt;
-constexpr auto kI64 = at::kLong;
-constexpr auto kF32 = at::kFloat;
-constexpr auto kF64 = at::kDouble;
+constexpr auto kU8 = kUInt8;
+constexpr auto kI8 = kInt8;
+constexpr auto kI16 = kInt16;
+constexpr auto kI32 = kInt32;
+constexpr auto kI64 = kInt64;
+constexpr auto kF32 = kFloat32;
+constexpr auto kF64 = kFloat64;
 
 } // namespace torch


### PR DESCRIPTION
To make dtypes more like PyTorch (or numpy, TF etc.) , I've created fixed width aliases for ATen types, e.g. `using kInt32 = at::kInt`. Since `torch::kInt32` is a bit much to write when not `using namespace torch`, there's also abbreviated versions akin to Rust types, e.g. `kI32 = kInt32`, `kF64  = kFloat64`.

@ebetica @ezyang @apaszke 