### PR TITLE
Created Tensor::to functions

### DIFF
--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -87,9 +87,8 @@ struct Tensor : public detail::TensorBase {
   inline Tensor toBackend(Backend b) const;
 
   /// New-style `to()` methods.
-  Tensor to(TensorOptions options, bool non_blocking = false);
+  Tensor to(Device device, ScalarType dtype, bool non_blocking = false);
   Tensor to(ScalarType dtype, bool non_blocking = false);
-  Tensor to(Layout layout, bool non_blocking = false);
   Tensor to(Device device, bool non_blocking = false);
 
   /// Returns true if the `Tensor` is actually a `torch::autograd::Variable`.
@@ -198,6 +197,9 @@ struct Tensor : public detail::TensorBase {
   auto m(F func, Args&&... params) const -> decltype(func(*this, std::forward<Args>(params)...)) {
     return func(*this, std::forward<Args>(params)...);
   }
+
+ private:
+  Tensor to(const TensorOptions& options, bool non_blocking = false);
 };
 
 namespace detail {

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -86,6 +86,12 @@ struct Tensor : public detail::TensorBase {
   inline Tensor toType(ScalarType t) const;
   inline Tensor toBackend(Backend b) const;
 
+  /// New-style `to()` methods.
+  Tensor to(TensorOptions options, bool non_blocking = false);
+  Tensor to(ScalarType dtype, bool non_blocking = false);
+  Tensor to(Layout layout, bool non_blocking = false);
+  Tensor to(Device device, bool non_blocking = false);
+
   /// Returns true if the `Tensor` is actually a `torch::autograd::Variable`.
   /// Defined in Type.h because of include order issues.
   bool is_variable() const noexcept;

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -197,9 +197,6 @@ struct Tensor : public detail::TensorBase {
   auto m(F func, Args&&... params) const -> decltype(func(*this, std::forward<Args>(params)...)) {
     return func(*this, std::forward<Args>(params)...);
   }
-
- private:
-  Tensor to(const TensorOptions& options, bool non_blocking = false);
 };
 
 namespace detail {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -239,7 +239,7 @@ TEST_CASE("modules_cuda", "[cuda]") {
   SECTION("1") {
     Linear model(5, 2);
     model->cuda();
-    auto x = torch::randn({10, 5}, at::device(at::kCUDA).requires_grad());
+    auto x = torch::randn({10, 5}, at::device(at::kCUDA).requires_grad(true));
     auto y = model->forward({x})[0];
     Variable s = y.sum();
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1,23 +1,80 @@
 #include <catch.hpp>
 
+#include <torch/functions.h>
+
 #include <ATen/ATen.h>
 
-TEST_CASE("tensor/device-placement") {
-  SECTION("DeviceGuard") {
-    // SECTION("On index zero by default") {
-    //   auto tensor = at::ones({3, 3}, at::kCUDA);
-    //   REQUIRE(tensor.get_device() == 0);
-    // }
+#define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)                \
+  REQUIRE(tensor.device().type() == at::Device((device_), (index_)).type());   \
+  REQUIRE(tensor.device().index() == at::Device((device_), (index_)).index()); \
+  REQUIRE(tensor.dtype() == (type_));                                          \
+  REQUIRE(tensor.layout() == (layout_))
 
-    // // right hand side is TensorOptions
-    // torch::OptionGuard guard = torch::device(torch::kCUDA, 1);
-    // // convenience wrapper over OptionGuard
-    // torch::DeviceGuard guard(torch::kCUDA, 1);
-    // /// default device is CUDA
-    // torch::DeviceGuard guard(1);
+TEST_CASE("Tensor/ToDtype") {
+  auto tensor = at::empty({3, 4});
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
 
-    // note that this is separate from DeviceGuard. DeviceGuard should move into the
-    // detail namespace and do the actual thing. OptionGuard just modifies a
-    // global singleton of option defaults. It operates at a higher level.
-  }
+  tensor = tensor.to(at::kInt);
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kInt, at::kStrided);
+
+  tensor = tensor.to(at::kChar);
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kChar, at::kStrided);
+
+  tensor = tensor.to(at::kDouble);
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kDouble, at::kStrided);
+}
+
+TEST_CASE("Tensor/ToLayout") {
+  // TODO: failing due to unexpected exception with message:
+  // _th_indices is not implemented for type CPUFloatType (_th_indices at /home/
+  // psag/pytorch/pytorch/tools/cpp_build/build/caffe2/aten/src/ATen/Type.cpp:1986)
+  // 1986)
+
+  // auto tensor = at::empty({3, 4});
+  // REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
+  //
+  // tensor = tensor.to(at::kSparse);
+  // REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kSparse);
+  //
+  // tensor = tensor.to(at::kStrided);
+  // REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
+}
+
+TEST_CASE("Tensor/ToDevice", "[cuda]") {
+  auto tensor = at::empty({3, 4});
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
+
+  tensor = tensor.to({at::kCUDA, 1});
+  REQUIRE_TENSOR_OPTIONS(at::kCUDA, 1, at::kFloat, at::kStrided);
+
+  tensor = tensor.to({at::kCUDA, 0});
+  REQUIRE_TENSOR_OPTIONS(at::kCUDA, 0, at::kFloat, at::kStrided);
+
+  tensor = tensor.to({at::kCUDA, 1});
+  REQUIRE_TENSOR_OPTIONS(at::kCUDA, 1, at::kFloat, at::kStrided);
+
+  tensor = tensor.to(at::Device(at::kCPU));
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
+}
+
+TEST_CASE("Tensor/ToOptions", "[cuda]") {
+  auto tensor = at::empty({3, 4});
+  REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kFloat, at::kStrided);
+
+  tensor = tensor.to(at::dtype(at::kInt).device({at::kCUDA, 1}));
+  REQUIRE_TENSOR_OPTIONS(at::kCUDA, 1, at::kInt, at::kStrided);
+}
+
+TEST_CASE("Tensor/ToOptionsRespectsRequiresGrad") {
+  auto tensor = torch::empty({3, 4});
+  REQUIRE(!tensor.requires_grad());
+
+  // `requires_grad` will subsequently always be true because it results from a
+  // copy operation, which gives it a `CopyBackwards` gradient function.
+
+  tensor = tensor.to(at::TensorOptions(tensor).requires_grad(true));
+  REQUIRE(tensor.requires_grad());
+
+  tensor = tensor.to(at::TensorOptions(tensor).requires_grad(false));
+  REQUIRE(tensor.requires_grad());
 }

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -1,8 +1,13 @@
 #include "catch.hpp"
 
+#include <torch/functions.h>
+
 #include <ATen/Context.h>
 #include <ATen/Functions.h>
 #include <ATen/TensorOptions.h>
+
+#include <vector>
+#include <string>
 
 using namespace at;
 
@@ -63,6 +68,16 @@ TEST_CASE("TensorOptions/ConstructsWellFromCPUTensors") {
 
   options = TensorOptions(empty(5, getType(kSparseCPU, kByte)));
   REQUIRE_OPTIONS(kCPU, -1, kByte, kSparse);
+}
+
+TEST_CASE("TensorOptions/ConstructsWellFromVariables") {
+  auto options = TensorOptions(torch::empty(5));
+  REQUIRE_OPTIONS(kCPU, -1, kFloat, kStrided);
+  REQUIRE(!options.requires_grad());
+
+  options = TensorOptions(torch::empty(5, at::requires_grad()));
+  REQUIRE_OPTIONS(kCPU, -1, kFloat, kStrided);
+  REQUIRE(options.requires_grad());
 }
 
 TEST_CASE("Device/ParsesCorrectlyFromString") {

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -77,7 +77,7 @@ TEST_CASE("TensorOptions/ConstructsWellFromVariables") {
 
   options = TensorOptions(torch::empty(5, at::requires_grad()));
   REQUIRE_OPTIONS(kCPU, -1, kFloat, kStrided);
-  REQUIRE(options.requires_grad());
+  REQUIRE(!options.requires_grad());
 }
 
 TEST_CASE("Device/ParsesCorrectlyFromString") {


### PR DESCRIPTION
Creates `Tensor::to()` functions to create a tensor from an existing tensor, with certain different `TensorOptions`. Most importantly, this makes it very easy to move a tensor from one CUDA device to another.

@colesbury @ezyang @zdevito 

CC @ebetica 