### PR TITLE
change avg_pool2/3d count_include_pad default (fixes #8644)

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -139,12 +139,12 @@
 - name: adaptive_max_pool3d(Tensor self, IntList[3] output_size)
   cname: VolumetricAdaptiveMaxPooling
 
-- name: avg_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, bool ceil_mode=false, bool count_include_pad=false)
+- name: avg_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, bool ceil_mode=false, bool count_include_pad=true)
   cname: SpatialAveragePooling
   default_init:
     stride: kernel_size
 
-- name: avg_pool3d(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, bool ceil_mode=false, bool count_include_pad=false)
+- name: avg_pool3d(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, bool ceil_mode=false, bool count_include_pad=true)
   cname: VolumetricAveragePooling
   default_init:
     stride: kernel_size


### PR DESCRIPTION
change avg_pool2/3d count_include_pad default (fixes #8644)

This makes count_include_pad=True the default in the functional interface of avg_pool2d/3d.
The module interface had this default all along and so did the functional interface up to PyTorch 0.4

Torchvision uses the module interface for ResNet and SqueezeNet, the functional interface for Inception and a mix for DenseNet (I only grepped but did not analyse which classes).
