### PR TITLE
Add CODEOWNERS entry for third_party to track changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,3 +20,4 @@
 /torch/csrc/distributed/ @apaszke @pietern @teng-li
 /torch/distributed/ @apaszke @pietern @teng-li
 /test/test_c10d.py @apaszke @pietern @teng-li
+/third_party/ @orionr


### PR DESCRIPTION
With our switch to commit-level syncs to the internal code base, I need to review and manually update all third_party changes. Using CODEOWNERS to manage that right now. Will remove once we're doing commit-level syncs.

cc @ezyang 