### PR TITLE
Exposing `get_blob()` in workspace

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1318,6 +1318,10 @@ void addGlobalMethods(py::module& m) {
     return python_detail::fetchBlob(gWorkspace, name);
   });
   m.def(
+      "get_blob",
+      [](const std::string& name) { return gWorkspace->GetBlob(name); },
+      py::return_value_policy::reference);
+  m.def(
       "feed_blob",
       [](const std::string& name, py::object arg, py::object device_option) {
         DeviceOption option;

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -492,6 +492,11 @@ class TestCWorkspace(htu.HypothesisTestCase):
         with self.assertRaises(TypeError):
             ws.create_net("...")
 
+    def test_get_blob(self):
+        workspace.C.create_blob("b")
+        blob = workspace.C.get_blob("b")
+        self.assertIsInstance(blob, workspace.C.Blob)
+
 
 class TestPredictor(unittest.TestCase):
     def _create_model(self):


### PR DESCRIPTION
This is useful in unit test where C++ binding is needed