### PR TITLE
Implement OpSchema and a default DispatchKey

### DIFF
--- a/caffe2/core/dispatch/CMakeLists.txt
+++ b/caffe2/core/dispatch/CMakeLists.txt
@@ -1,15 +1,18 @@
 set(LIB_SOURCES
+        DeviceId.cpp
+        DispatchKey.cpp
+        LayoutId.cpp
+        OpSchema.cpp
         TensorTypeId.cpp
         TensorTypeIdRegistration.cpp
 )
 
 set(TEST_SOURCES
-        dummy_test.cpp
+        OpSchema_test.cpp
 )
 
 add_library(dispatch OBJECT ${LIB_SOURCES})
 target_enable_style_warnings(dispatch)
-target_include_directories(dispatch SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/third_party/flat_hash_map)
 
 if(BUILD_TEST)
     add_executable(dispatch_test ${TEST_SOURCES} $<TARGET_OBJECTS:dispatch>)

--- a/caffe2/core/dispatch/DeviceId.cpp
+++ b/caffe2/core/dispatch/DeviceId.cpp
@@ -1,0 +1,1 @@
+#include "caffe2/core/dispatch/DeviceId.h"

--- a/caffe2/core/dispatch/DeviceId.h
+++ b/caffe2/core/dispatch/DeviceId.h
@@ -5,22 +5,28 @@
 
 namespace c10 {
 
-enum class DeviceId : uint8_t {
-    UNDEFINED,
-    CPU,
-    CUDA
+enum class DeviceTypeId : uint8_t {
+    // Don't use the int values here in the enum (i.e. don't do static_cast to or from int).
+    // Instead, if you want to serialize this, write a function with switch/case.
+    CPU = 0,
+    CUDA = 1,
+    UNDEFINED
 };
 
-inline std::ostream& operator<<(std::ostream& stream, DeviceId device_id) {
-    return stream << static_cast<uint8_t>(device_id);
+inline std::ostream& operator<<(std::ostream& stream, DeviceTypeId device_type_id) {
+    switch(device_type_id) {
+        case DeviceTypeId::CPU: return stream << "DeviceTypeId(CPU)";
+        case DeviceTypeId::CUDA: return stream << "DeviceTypeId(CUDA)";
+        case DeviceTypeId::UNDEFINED: return stream << "DeviceTypeId(UNDEFINED)";
+    }
 }
 
 }
 
 namespace std {
 
-template <> struct hash<c10::DeviceId> {
-    size_t operator()(c10::DeviceId v) const {
+template <> struct hash<c10::DeviceTypeId> {
+    size_t operator()(c10::DeviceTypeId v) const {
         return std::hash<uint8_t>()(static_cast<uint8_t>(v));
     }
 };

--- a/caffe2/core/dispatch/DeviceId.h
+++ b/caffe2/core/dispatch/DeviceId.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <functional>
+#include <iostream>
+
+namespace c10 {
+
+enum class DeviceId : uint8_t {
+    UNDEFINED,
+    CPU,
+    CUDA
+};
+
+inline std::ostream& operator<<(std::ostream& stream, DeviceId device_id) {
+    return stream << static_cast<uint8_t>(device_id);
+}
+
+}
+
+namespace std {
+
+template <> struct hash<c10::DeviceId> {
+    size_t operator()(c10::DeviceId v) const {
+        return std::hash<uint8_t>()(static_cast<uint8_t>(v));
+    }
+};
+
+}

--- a/caffe2/core/dispatch/DispatchKey.cpp
+++ b/caffe2/core/dispatch/DispatchKey.cpp
@@ -1,0 +1,1 @@
+#include "caffe2/core/dispatch/DispatchKey.h"

--- a/caffe2/core/dispatch/DispatchKey.h
+++ b/caffe2/core/dispatch/DispatchKey.h
@@ -12,13 +12,14 @@ namespace c10 {
 
 namespace details {
 struct TensorParameterDispatchKey final {
-  DeviceId deviceId;
+  // note: This dispatch key structure is not final yet and will change. Don't rely on it.
+  DeviceTypeId deviceTypeId;
   LayoutId layoutId;
   // TODO Move this CaffeTypeId to c10 namespace
   caffe2::CaffeTypeId dataType;
 };
 inline constexpr bool operator==(const TensorParameterDispatchKey& lhs, const TensorParameterDispatchKey& rhs) {
-  return lhs.deviceId == rhs.deviceId && lhs.layoutId == rhs.layoutId && lhs.dataType == rhs.dataType;
+  return lhs.deviceTypeId == rhs.deviceTypeId && lhs.layoutId == rhs.layoutId && lhs.dataType == rhs.dataType;
 }
 }  // namespace details
 }  // namespace c10
@@ -28,7 +29,7 @@ namespace std {
   struct hash<c10::details::TensorParameterDispatchKey> {
     // TODO constexpr hashing
     size_t operator()(const c10::details::TensorParameterDispatchKey& obj) const {
-      return std::hash<c10::DeviceId>()(obj.deviceId) ^ std::hash<c10::LayoutId>()(obj.layoutId) ^ std::hash<caffe2::CaffeTypeId>()(obj.dataType);
+      return std::hash<c10::DeviceTypeId>()(obj.deviceTypeId) ^ std::hash<c10::LayoutId>()(obj.layoutId) ^ std::hash<caffe2::CaffeTypeId>()(obj.dataType);
     }
   };
 }  // namespace std
@@ -47,11 +48,9 @@ namespace c10 {
  *
  * @tparam num_dispatch_args The number of dispatchable arguments
  */
-// ezyang to smessmer: You originally called this num_dispatch_args, but we might
-// include things like dtype in this dispatch key, so I renamed it
-template<size_t num_tensor_args>
+template<size_t num_dispatch_args>
 struct DispatchKey final {
-  guts::array<details::TensorParameterDispatchKey, num_tensor_args> argTypes;
+  guts::array<details::TensorParameterDispatchKey, num_dispatch_args> argTypes;
 };
 
 template<size_t num_dispatch_args>

--- a/caffe2/core/dispatch/DispatchKey.h
+++ b/caffe2/core/dispatch/DispatchKey.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "caffe2/core/dispatch/DeviceId.h"
+#include "caffe2/core/dispatch/LayoutId.h"
+#include "caffe2/core/typeid.h"
+
+#include <vector>
+#include <functional>
+#include "caffe2/utils/Array.h"
+
+namespace c10 {
+
+namespace details {
+struct TensorParameterDispatchKey final {
+  DeviceId deviceId;
+  LayoutId layoutId;
+  // TODO Move this CaffeTypeId to c10 namespace
+  caffe2::CaffeTypeId dataType;
+};
+inline constexpr bool operator==(const TensorParameterDispatchKey& lhs, const TensorParameterDispatchKey& rhs) {
+  return lhs.deviceId == rhs.deviceId && lhs.layoutId == rhs.layoutId && lhs.dataType == rhs.dataType;
+}
+}  // namespace details
+}  // namespace c10
+
+namespace std {
+  template<>
+  struct hash<c10::details::TensorParameterDispatchKey> {
+    // TODO constexpr hashing
+    size_t operator()(const c10::details::TensorParameterDispatchKey& obj) const {
+      return std::hash<c10::DeviceId>()(obj.deviceId) ^ std::hash<c10::LayoutId>()(obj.layoutId) ^ std::hash<caffe2::CaffeTypeId>()(obj.dataType);
+    }
+  };
+}  // namespace std
+
+namespace c10 {
+/**
+ * The dispatch key encodes the runtime type identity of a function call arguments,
+ * specifying what aspects of this identity can be dynamically dispatched on.
+ *
+ * Intuitively, given a function signature like f(Tensor, int), a valid dispatch
+ * key for the arguments might be [CPUFloatTensor] (notice that 'f' is NOT included
+ * in the dispatch key, and the runtime type of 'int' is NOT considered for dispatch
+ * (since it is trivial).
+ *
+ * Dispatch keys permit equality tests and are hashable.
+ *
+ * @tparam num_dispatch_args The number of dispatchable arguments
+ */
+// ezyang to smessmer: You originally called this num_dispatch_args, but we might
+// include things like dtype in this dispatch key, so I renamed it
+template<size_t num_tensor_args>
+struct DispatchKey final {
+  guts::array<details::TensorParameterDispatchKey, num_tensor_args> argTypes;
+};
+
+template<size_t num_dispatch_args>
+inline constexpr bool operator==(const DispatchKey<num_dispatch_args> &lhs, const DispatchKey<num_dispatch_args>& rhs) {
+  // TODO: Use AVX instructions to perform this equality test more quickly
+  return lhs.argTypes == rhs.argTypes;
+}
+
+}  // namespace c10
+
+namespace std {
+  template<size_t num_dispatch_args>
+  struct hash<c10::DispatchKey<num_dispatch_args>> {
+    // TODO constexpr hashing
+    size_t operator()(const c10::DispatchKey<num_dispatch_args>& obj) const {
+      size_t hash_value = 0;
+      for (const auto& argType : obj.argTypes) {
+        hash_value *= 10883; // prime
+        hash_value += std::hash<c10::details::TensorParameterDispatchKey>()(argType);
+      }
+      return hash_value;
+    }
+  };
+}  // namespace std

--- a/caffe2/core/dispatch/LayoutId.cpp
+++ b/caffe2/core/dispatch/LayoutId.cpp
@@ -1,0 +1,1 @@
+#include "caffe2/core/dispatch/LayoutId.h"

--- a/caffe2/core/dispatch/LayoutId.h
+++ b/caffe2/core/dispatch/LayoutId.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "caffe2/utils/IdWrapper.h"
+
+namespace c10 {
+
+class LayoutId final : public c10::guts::IdWrapper<LayoutId, uint8_t> {
+public:
+    constexpr explicit LayoutId(underlying_type id): IdWrapper(id) {}
+
+    // Don't use this default constructor!
+    // Unfortunately, a default constructor needs to be defined because of https://reviews.llvm.org/D41223
+    constexpr LayoutId(): IdWrapper(0) {}
+};
+
+}
+
+C10_DEFINE_HASH_FOR_IDWRAPPER(c10::LayoutId)

--- a/caffe2/core/dispatch/OpSchema.cpp
+++ b/caffe2/core/dispatch/OpSchema.cpp
@@ -1,0 +1,1 @@
+#include "caffe2/core/dispatch/OpSchema.h"

--- a/caffe2/core/dispatch/OpSchema.h
+++ b/caffe2/core/dispatch/OpSchema.h
@@ -1,0 +1,233 @@
+#pragma once
+
+#include "caffe2/core/dispatch/DispatchKey.h"
+#include "caffe2/utils/Metaprogramming.h"
+#include "caffe2/utils/Array.h"
+
+namespace caffe2 {
+template<class Context> class Tensor;
+class CPUContext;
+class CUDAContext;
+}  // namespace caffe2
+
+namespace c10 {
+
+namespace details {
+
+/**
+ * If Arg is a Tensor or reference to a Tensor, provide the member constant value equal to true.  Otherwise
+ * return false.
+ */
+template<class Arg> using is_tensor_arg = guts::is_instantiation_of<caffe2::Tensor, guts::remove_cv_t<guts::remove_reference_t<Arg>>>;
+
+// TODO get rid of tensor_to_dispatch_key once c2::Tensor is de-templatized. This then fits into a template lambda instead of a functor.
+template<class TensorType, class Enable = void> struct tensor_to_dispatch_key_ final {};
+template<class TensorType>
+struct tensor_to_dispatch_key_<TensorType, guts::enable_if_t<std::is_same<TensorType, caffe2::Tensor<caffe2::CPUContext>>::value>> final {
+    static TensorParameterDispatchKey call(const TensorType& tensor) {
+      return TensorParameterDispatchKey{DeviceId::CPU, LayoutId(0), tensor.meta().id()};
+    }
+};
+template<class TensorType>
+struct tensor_to_dispatch_key_<TensorType, guts::enable_if_t<std::is_same<TensorType, caffe2::Tensor<caffe2::CUDAContext>>::value>> final {
+    static TensorParameterDispatchKey call(const TensorType& tensor) {
+      return TensorParameterDispatchKey{DeviceId::CUDA, LayoutId(0), tensor.meta().id()};
+    }
+};
+struct tensor_to_dispatch_key final {
+    template<class TensorType>
+    TensorParameterDispatchKey operator()(const TensorType& tensor) const {
+      return tensor_to_dispatch_key_<TensorType, void>::call(tensor);
+    }
+};
+
+/**
+ * Extract the type ids of all tensors in a variadic list of arguments
+ *
+ * @tparam Args Inferred variadic list of argument types
+ * @param args List of arguments to get type ids from
+ * @return guts::array<TensorParameterDispatchKey, n>, where n is the number of tensor arguments (is_tensor_arg) in the class
+ */
+template<class... Args> auto getTensorTypeIds_(const Args&... args)
+-> guts::array<TensorParameterDispatchKey, guts::typelist::count_if<is_tensor_arg, guts::typelist::typelist<Args...>>::value> {
+  return guts::filter_map<TensorParameterDispatchKey, is_tensor_arg>(tensor_to_dispatch_key(), args...);
+}
+
+// TODO Test getTensorTypeIds_
+
+/**
+ * If T is a struct with a type field Signature, provides the member constant
+ * @tparam T
+ */
+template<class T, typename = void>
+struct has_signature_defined : std::false_type {};
+template<class T>
+struct has_signature_defined<T, guts::void_t<
+  typename T::Signature
+>> : std::true_type {};
+
+// TODO Test has_signature_defined
+
+template<class T, typename = void>
+struct has_parameter_names_defined : std::false_type {};
+template<class T>
+struct has_parameter_names_defined<T, guts::void_t<
+  decltype(T::parameter_names)
+>> : std::true_type {};
+
+// TODO Test has_parameter_names_defined
+
+/**
+ * Wrapper class around a user-provided schema definition some useful information about the schema.
+ *
+ * @tparam OpSchemaDef Operator schema definition.  See OpSchema for more details.
+ */
+template<class OpSchemaDef> class OpSignatureSchema final {
+  static_assert(details::has_signature_defined<OpSchemaDef>::value, "Operator schema doesn't define a valid Signature member type.");
+  static_assert(guts::is_function_type<typename OpSchemaDef::Signature>::value, "Signature member of operator schema must be a function type.");
+
+  using signature_traits = guts::function_traits<typename OpSchemaDef::Signature>;
+public:
+  /**
+   * The function type OpSchemaDef::Signature
+   */
+  using func_type = typename signature_traits::func_type;
+  /**
+   * The return type of the function OpSchemaDef::Signature
+   */
+  using return_type = typename signature_traits::return_type;
+  /**
+   * A type list of the parameter types of OpSchemaDef::Signature
+   */
+  using parameter_types = typename signature_traits::parameter_types;
+
+  /**
+   * The number of arguments of OpSchemaDef::Signature
+   */
+  static constexpr size_t num_args = guts::typelist::size<parameter_types>::value;
+  /**
+   * The number of tensor arguments (as per is_tensor_arg) in OpSchemaDef::Signature
+   */
+  static constexpr size_t num_tensor_args = guts::typelist::count_if<details::is_tensor_arg, parameter_types>::value;
+
+private:
+  static_assert(details::has_parameter_names_defined<OpSchemaDef>::value, "Operator schema doesn't define parameter_names member.");
+  // TODO Allow simpler definition of parameter_names without having to spell out the guts::array type in the schema def.
+  static_assert(std::is_same<const guts::array<const char*, num_args>, decltype(OpSchemaDef::parameter_names)>::value, "Operator schema defines parameter_names member, but it isn't the correct type. Must be a static constexpr guts::array of const char* with one entry for each parameter.");
+
+public:
+  /**
+   * The names of the parameters (as per OpSchemaDef::parameter_names)
+   * @return Array
+   */
+  static constexpr const guts::array<const char*, num_args>& parameter_names() {
+    return OpSchemaDef::parameter_names;
+  }
+};
+
+/**
+ * If T has a method dispatch_key, provide a member constant value equal to true.  Otherwise return false.
+ * @tparam T
+ */
+template<class T, typename = void>
+struct has_function_dispatch_key_defined : std::false_type {};
+template<class T>
+struct has_function_dispatch_key_defined<T, guts::void_t<
+  decltype(&T::dispatch_key)
+>> : std::true_type {};
+
+/**
+ * Wrapper class around a user-defined schema definition providing a way of computing a dispatch key
+ * from arguments matching the signature of that schema.
+ *
+ * @tparam OpSchemaDef Operator schema definition.  See OpSchema for more details.
+ * @tparam Enable Inferred, used to control specialization
+ */
+template<class OpSchemaDef, class Enable = void> class OpDispatchKeySchema final {};
+
+// General case. Operator doesn't overwrite DispatchKey generation. Use default.
+template<class OpSchemaDef>
+class OpDispatchKeySchema<OpSchemaDef, guts::enable_if_t<!has_function_dispatch_key_defined<OpSchemaDef>::value>> final {
+  using signature = OpSignatureSchema<OpSchemaDef>;
+
+public:
+  using dispatch_key_type = DispatchKey<signature::num_tensor_args>;
+
+  template<class... Args>
+  static inline dispatch_key_type dispatch_key(const Args&... args) {
+    using guts::typelist::map_t;
+    using guts::typelist::typelist;
+    static_assert(std::is_same<
+      map_t<guts::remove_cv_t, map_t<guts::remove_reference_t, typelist<Args...>>>,
+      map_t<guts::remove_cv_t, map_t<guts::remove_reference_t, typename signature::parameter_types>>
+      >::value, "Invalid argument types passed to OpSchema::dispatch_key()");
+    return dispatch_key_type {
+      details::getTensorTypeIds_(args...)
+    };
+  }
+};
+
+// Special case. Operator overwrites DispatchKey generation. Use that.
+template<class OpSchemaDef>
+class OpDispatchKeySchema<OpSchemaDef, guts::enable_if_t<has_function_dispatch_key_defined<OpSchemaDef>::value>> final {
+  using signature = OpSignatureSchema<OpSchemaDef>;
+
+  static_assert(guts::is_function_type<decltype(OpSchemaDef::dispatch_key)>::value, "Operator schema defines dispatch_key member, but it isn't a function.");
+
+  using dispatch_key_traits = guts::function_traits<decltype(OpSchemaDef::dispatch_key)>;
+
+public:
+  using dispatch_key_type = typename dispatch_key_traits::return_type;
+
+private:
+
+  static_assert(guts::is_equality_comparable<dispatch_key_type>::value, "Operator schema specified custom dispatch_key() derivation function, but the returned dispatch key type doesn't have the equality operator defined. Please define it.");
+  static_assert(guts::is_hashable<dispatch_key_type>::value, "Operator schema specified custom dispatch_key() derivation function, but the returned dispatch key type doesn't have an overload for std::hash. Please define it.");
+
+  static_assert(std::is_same<
+    guts::typelist::map_t<guts::remove_cv_t, guts::typelist::map_t<guts::remove_reference_t, typename dispatch_key_traits::parameter_types>>,
+    guts::typelist::map_t<guts::remove_cv_t, guts::typelist::map_t<guts::remove_reference_t, typename signature::parameter_types>>
+    >::value, "Operator schema defines custom dispatch_key() derivation function, but the arguments don't match the operator signature.");
+
+public:
+
+  template<class... Args>
+  static inline dispatch_key_type dispatch_key(const Args&... args) {
+    using guts::typelist::map_t;
+    using guts::typelist::typelist;
+    static_assert(std::is_same<
+      map_t<guts::remove_cv_t, map_t<guts::remove_reference_t, typelist<Args...>>>,
+      map_t<guts::remove_cv_t, map_t<guts::remove_reference_t, typename signature::parameter_types>>
+      >::value, "Invalid argument types passed to OpSchema::dispatch_key()");
+    return OpSchemaDef::dispatch_key(args...);
+  }
+};
+
+}  // namespace details
+
+/**
+ * Wrapper class for user-defined OpSchemaDef, providing functionality for determining
+ * information about the signature and dispatching on that signature.  This is the
+ * "public" facing class.
+ *
+ * @tparam OpSchemaDef User-defined OpSchemaDef.
+ *   This struct is expected to define:
+ *      - a function type Signature
+ *      - a constexpr guts<const char*, n_args> parameter_names field (where n_args is
+ *        the number of arguments in Signature)
+ */
+template<class OpSchemaDef> class OpSchema final {
+  // TODO static_assert OpSchemaDef isn't an instanciation of OpSchema. If yes, the caller probably passed an OpSchema somewhere where an OpSchemaDef was expected and wants a good error message.
+public:
+  /**
+   * Information about the signature
+   */
+  using signature = details::OpSignatureSchema<OpSchemaDef>;
+  /**
+   * Functionality for dispatching on that signature
+   */
+  using dispatch = details::OpDispatchKeySchema<OpSchemaDef>;
+};
+
+// TODO test OpSchema::dispatch stuff
+}  // namespace c10

--- a/caffe2/core/dispatch/OpSchema.h
+++ b/caffe2/core/dispatch/OpSchema.h
@@ -25,13 +25,13 @@ template<class TensorType, class Enable = void> struct tensor_to_dispatch_key_ f
 template<class TensorType>
 struct tensor_to_dispatch_key_<TensorType, guts::enable_if_t<std::is_same<TensorType, caffe2::Tensor<caffe2::CPUContext>>::value>> final {
     static TensorParameterDispatchKey call(const TensorType& tensor) {
-      return TensorParameterDispatchKey{DeviceId::CPU, LayoutId(0), tensor.meta().id()};
+      return TensorParameterDispatchKey{DeviceTypeId::CPU, LayoutId(0), tensor.meta().id()};
     }
 };
 template<class TensorType>
 struct tensor_to_dispatch_key_<TensorType, guts::enable_if_t<std::is_same<TensorType, caffe2::Tensor<caffe2::CUDAContext>>::value>> final {
     static TensorParameterDispatchKey call(const TensorType& tensor) {
-      return TensorParameterDispatchKey{DeviceId::CUDA, LayoutId(0), tensor.meta().id()};
+      return TensorParameterDispatchKey{DeviceTypeId::CUDA, LayoutId(0), tensor.meta().id()};
     }
 };
 struct tensor_to_dispatch_key final {

--- a/caffe2/core/dispatch/OpSchema_test.cpp
+++ b/caffe2/core/dispatch/OpSchema_test.cpp
@@ -1,0 +1,29 @@
+#include "caffe2/core/dispatch/OpSchema.h"
+#include "caffe2/utils/Array.h"
+
+using namespace c10;
+using namespace caffe2;
+
+static_assert(details::is_tensor_arg<Tensor<CPUContext>>::value, "");
+static_assert(details::is_tensor_arg<const Tensor<CPUContext> &>::value, "");
+static_assert(details::is_tensor_arg<Tensor<CPUContext> &&>::value, "");
+static_assert(details::is_tensor_arg<Tensor<CUDAContext>>::value, "");
+static_assert(details::is_tensor_arg<const Tensor<CUDAContext> &>::value, "");
+static_assert(details::is_tensor_arg<Tensor<CUDAContext> &&>::value, "");
+static_assert(!details::is_tensor_arg<int>::value, "");
+
+struct SchemaDef final {
+  using Signature = bool (int, Tensor<CPUContext>, float, Tensor<CPUContext>, Tensor<CPUContext>, unsigned int);
+  static constexpr guts::array<const char*, 6> parameter_names = {{
+      "1", "2", "3", "4", "5", "6"
+  }};
+};
+static_assert(6 == OpSchema<SchemaDef>::signature::num_args, "test num_dispatch_args");
+static_assert(3 == OpSchema<SchemaDef>::signature::num_tensor_args, "test num_dispatch_args");
+static_assert(std::is_same<bool, typename OpSchema<SchemaDef>::signature::return_type>::value, "test num_dispatch_args");
+static_assert(std::is_same<guts::typelist::typelist<int, Tensor<CPUContext>, float, Tensor<CPUContext>, Tensor<CPUContext>, unsigned int>, typename OpSchema<SchemaDef>::signature::parameter_types>::value, "test num_dispatch_args");
+
+int main() {
+  return 0;
+}
+

--- a/caffe2/core/dispatch/dummy_test.cpp
+++ b/caffe2/core/dispatch/dummy_test.cpp
@@ -1,5 +1,0 @@
-#include <gtest/gtest.h>
-
-TEST(DummyTest, dummy) {
-    EXPECT_TRUE(true);
-}


### PR DESCRIPTION
The DispatchKey implementation is still based on the old design and will probably be changed, I still want to land it to unblock work streams.

The OpSchema implementation is more likely to stay, but still missing a lot of features. Currently, the schema only stores the operator function signature and the parameter names.