### PR TITLE
Add a warning in gradcheck if inputs precision < float64

### DIFF
--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -3,6 +3,7 @@ from collections import Iterable
 import torch.testing
 import sys
 from itertools import product
+import warnings
 
 
 def zero_gradients(x):
@@ -159,6 +160,14 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         True if all differences satisfy allclose condition
     """
     tupled_inputs = _as_tuple(inputs)
+
+    typecheck = [inputs.dtype != torch.float64 for inputs in tupled_inputs]
+    if any(typecheck):
+        warnings.warn(
+            'At least one argument is of single precision. '
+            'The default values are designed for :attr:`input` of double precision. '
+            'This check will likely fail if :attr:`input` is of single precision. ')
+
 
     # Make sure that gradients are saved for all inputs
     for inp in tupled_inputs:

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -167,8 +167,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
             if inp.requires_grad and inp.dtype != torch.float64:
                 warnings.warn(
                     'At least one of the inputs is of single precision. '
-                    'The default values are designed for :attr:`input` of double precision. '
-                    'This check will likely fail if :attr:`input` is of single precision. ')
+                    'This check will likely fail if the inputs are of single precision. ')
             inp.retain_grad()
 
     output = _differentiable_outputs(func(*inputs))

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -161,13 +161,15 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     """
     tupled_inputs = _as_tuple(inputs)
 
-    typecheck = [inputs.dtype != torch.float64 for inputs in tupled_inputs]
+    prec_flag = False
+    for inp in tupled_inputs:
+        if inp.dtype != torch.float64:
+            prec_flag = True
     if any(typecheck):
         warnings.warn(
-            'At least one argument is of single precision. '
+            'At least one of the inputs is of single precision. '
             'The default values are designed for :attr:`input` of double precision. '
             'This check will likely fail if :attr:`input` is of single precision. ')
-
 
     # Make sure that gradients are saved for all inputs
     for inp in tupled_inputs:

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -166,8 +166,10 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         if isinstance(inp, torch.Tensor):
             if inp.requires_grad and inp.dtype != torch.float64:
                 warnings.warn(
-                    'At least one of the inputs is of single precision. '
-                    'This check will likely fail if the inputs are of single precision. ')
+                    'At least one of the inputs that requires gradient \
+                     is not of double precision floating point. '
+                    'This check will likely fail if all the inputs are not of \
+                     double precision floating point. ')
             inp.retain_grad()
 
     output = _differentiable_outputs(func(*inputs))

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -161,11 +161,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     """
     tupled_inputs = _as_tuple(inputs)
 
-    prec_flag = False
-    for inp in tupled_inputs:
-        if inp.dtype != torch.float64:
-            prec_flag = True
-    if any(typecheck):
+    if any((t.requires_grad and t.dtype != torch.float64) for t in tupled_inputs):
         warnings.warn(
             'At least one of the inputs is of single precision. '
             'The default values are designed for :attr:`input` of double precision. '

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -161,15 +161,14 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     """
     tupled_inputs = _as_tuple(inputs)
 
-    if any((t.requires_grad and t.dtype != torch.float64) for t in tupled_inputs):
-        warnings.warn(
-            'At least one of the inputs is of single precision. '
-            'The default values are designed for :attr:`input` of double precision. '
-            'This check will likely fail if :attr:`input` is of single precision. ')
-
     # Make sure that gradients are saved for all inputs
     for inp in tupled_inputs:
         if isinstance(inp, torch.Tensor):
+            if inp.requires_grad and inp.dtype != torch.float64:
+                warnings.warn(
+                    'At least one of the inputs is of single precision. '
+                    'The default values are designed for :attr:`input` of double precision. '
+                    'This check will likely fail if :attr:`input` is of single precision. ')
             inp.retain_grad()
 
     output = _differentiable_outputs(func(*inputs))


### PR DESCRIPTION
Fixes #8659 . This PR adds a warning to alert users about the possibility of a failure in the `gradcheck` and `gradgradcheck` functions.

Why warning? Users might alter the values of `eps`, `atol` and/or `rtol` to make their custom tests pass. Throwing errors in such scenarios could be bad.

cc: @SsnL 