### PR TITLE
[JIT] Improve test coverage for ErrorReport instances

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3253,10 +3253,11 @@ class TestScript(JitTestCase):
 
     def test_print_kwargs(self):
         with self.assertRaisesRegex(RuntimeError, 'print doesn\'t accept any keyword arguments'):
-            @torch.jit.script
+            cu = torch.jit.CompilationUnit('''
             def print_kwargs(x):
                 print(x, flush=True)
                 return x
+            ''')
 
     def test_builtin_use_as_value(self):
         with self.assertRaisesRegex(RuntimeError, 'builtin cannot be used as a value'):
@@ -3323,6 +3324,16 @@ class TestScript(JitTestCase):
                 def forward(self, x, y):
                     return self.foo(x)
             SomeModule()
+
+    def test_single_starred_expr_for_loop(self):
+        with self.assertRaisesRegex(RuntimeError, 'Starred unpacking is currently not supported for for loops'):
+            cu = torch.jit.CompilationUnit('''
+            def test():
+                x = 0
+                for *a in [1, 2, 3]:
+                    x = x + 1
+                return x
+            ''')
 
 
 class TestEndToEndHybridFrontendModels(JitTestCase):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3118,7 +3118,8 @@ class TestScript(JitTestCase):
         self.checkScript(fn, (torch.randn(3, 2, dtype=torch.float), torch.ones(3, 2, dtype=torch.float)))
 
     def test_reassign_module_lhs(self):
-        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'self\' because it has type value. Only reassignments to first-class values are allowed'):
+        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'self\' because it has type '
+                                                  'value. Only reassignments to first-class values are allowed'):
             class ReassignSelfLHS(torch.jit.ScriptModule):
                 @torch.jit.script_method
                 def forward(self, x):
@@ -3129,7 +3130,8 @@ class TestScript(JitTestCase):
             ReassignSelfLHS()
 
     def test_reassign_module_rhs(self):
-        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'x\' to a value of type module. Only reassignments to first-class values are allowed'):
+        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'x\' to a value of type module.'
+                                                  ' Only reassignments to first-class values are allowed'):
             class ReassignSelfRHS(torch.jit.ScriptModule):
                 @torch.jit.script_method
                 def forward(self, x):
@@ -3205,7 +3207,8 @@ class TestScript(JitTestCase):
             ''')
 
     def test_single_starred_lhs(self):
-        with self.assertRaisesRegex(RuntimeError, 'A Starred expression may only appear on the lhs within the presence of another non-starred expression'):
+        with self.assertRaisesRegex(RuntimeError, 'A Starred expression may only appear on the lhs within the presence'
+                                                  'of another non-starred expression'):
             cu = torch.jit.CompilationUnit('''
             def single_starred_lhs(x):
                 a = (x, x, x)
@@ -3214,7 +3217,8 @@ class TestScript(JitTestCase):
             ''')
 
     def test_multi_reduction(self):
-        with self.assertRaisesRegex(RuntimeError, 'reductions are only allowed when there is a single variable on the left-hand side'):
+        with self.assertRaisesRegex(RuntimeError, 'reductions are only allowed when there is a single variable on'
+                                                  'the left-hand side'):
             cu = torch.jit.CompilationUnit('''
             def multi_reduction(x):
                 a, b += x
@@ -3269,6 +3273,7 @@ class TestScript(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, 'cannot be used as a tuple'):
             def test_fn():
                 return 3
+
             @torch.jit.script
             def wrong_use_as_tuple(self):
                 a, b = test_fn
@@ -3294,6 +3299,7 @@ class TestScript(JitTestCase):
             # the function as inputs (including those with defaults) and not kwargs
             def test_fn():
                 return 3
+
             @torch.jit.script
             def wrong_python_kwarg_call(self):
                 return test_fn(attr=6)
@@ -3310,6 +3316,7 @@ class TestScript(JitTestCase):
     def test_wrong_module_attr_lookup(self):
         with self.assertRaisesRegex(RuntimeError, 'unsupported attribute lookup on'):
             import io
+
             @torch.jit.script
             def wrong_module_attr_lookup():
                 return io.BytesIO
@@ -3317,9 +3324,11 @@ class TestScript(JitTestCase):
     def test_wrong_method_call_inputs(self):
         with self.assertRaisesRegex(RuntimeError, 'argument \'y\' not provided'):
             class SomeModule(torch.jit.ScriptModule):
+
                 @torch.jit.script_method
                 def foo(self, x, y):
                     return x
+
                 @torch.jit.script_method
                 def forward(self, x, y):
                     return self.foo(x)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3117,6 +3117,213 @@ class TestScript(JitTestCase):
 
         self.checkScript(fn, (torch.randn(3, 2, dtype=torch.float), torch.ones(3, 2, dtype=torch.float)))
 
+    def test_reassign_module_lhs(self):
+        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'self\' because it has type value. Only reassignments to first-class values are allowed'):
+            class ReassignSelfLHS(torch.jit.ScriptModule):
+                @torch.jit.script_method
+                def forward(self, x):
+                    for i in range(20):
+                        self = x
+                    return self
+
+            ReassignSelfLHS()
+
+    def test_reassign_module_rhs(self):
+        with self.assertRaisesRegex(RuntimeError, 'cannot re-assign \'x\' to a value of type module. Only reassignments to first-class values are allowed'):
+            class ReassignSelfRHS(torch.jit.ScriptModule):
+                @torch.jit.script_method
+                def forward(self, x):
+                    for i in range(20):
+                        x = self
+                    return self
+
+            ReassignSelfRHS()
+
+    def test_chunk_non_constant(self):
+        with self.assertRaisesRegex(RuntimeError, 'argument \'chunks\' must be a constant'):
+            @torch.jit.script
+            def chunk_non_constant(x, y):
+                return x.chunk(y)
+
+    def test_unknown_builtin(self):
+        with self.assertRaisesRegex(RuntimeError, 'unknown builtin op'):
+            @torch.jit.script
+            def unknown_builtin(x):
+                return x.splork(3)
+
+    def test_expected_tensor_found_tuple(self):
+        with self.assertRaisesRegex(RuntimeError, 'expected a tensor value but found a tuple'):
+            @torch.jit.script
+            def return_tuple_wrong(x):
+                a = (x, x)
+                return a, x
+
+    def test_method_no_self(self):
+        with self.assertRaisesRegex(RuntimeError, 'methods must have a self argument'):
+            class MethodNoSelf(torch.jit.ScriptModule):
+                @torch.jit.script_method
+                def forward():
+                    return torch.zeros(3, 4)
+
+            MethodNoSelf()
+
+    def test_return_stmt_not_at_end(self):
+        with self.assertRaisesRegex(RuntimeError, 'return statements can appear only at the end of the function body'):
+            @torch.jit.script
+            def return_stmt_wrong(x):
+                if x > 3:
+                    return 3
+                else:
+                    return x
+
+    def test_for_range_no_arg(self):
+        with self.assertRaisesRegex(RuntimeError, 'range\(\) expects 1 argument but got 0'):
+            @torch.jit.script
+            def range_no_arg(x):
+                for i in range():
+                    x += 1
+                return x
+
+    def test_list_iterables(self):
+        with self.assertRaisesRegex(RuntimeError, 'List of iterables is not supported currently'):
+            cu = torch.jit.CompilationUnit('''
+            def list_iterables(x):
+                for i, j in [2, 3, 4], [5, 6, 7]:
+                    x += i
+                    x += j
+                return x
+            ''')
+
+    def test_for_tuple_unpack(self):
+        with self.assertRaisesRegex(RuntimeError, 'Iteration variable unpacking is not supported'):
+            cu = torch.jit.CompilationUnit('''
+            def for_tuple_unpack(x, y):
+                for i, j in [[3, 4], [5, 6], [7, 8]]:
+                    x += i
+                    y += j
+                return x, y
+            ''')
+
+    def test_single_starred_lhs(self):
+        with self.assertRaisesRegex(RuntimeError, 'A Starred expression may only appear on the lhs within the presence of another non-starred expression'):
+            cu = torch.jit.CompilationUnit('''
+            def single_starred_lhs(x):
+                a = (x, x, x)
+                *b = a
+                return b
+            ''')
+
+    def test_multi_reduction(self):
+        with self.assertRaisesRegex(RuntimeError, 'reductions are only allowed when there is a single variable on the left-hand side'):
+            cu = torch.jit.CompilationUnit('''
+            def multi_reduction(x):
+                a, b += x
+                return a, b
+            ''')
+
+    def test_invalid_call_arguments(self):
+        with self.assertRaisesRegex(RuntimeError, 'arguments for call are not valid'):
+            @torch.jit.script
+            def invalid_call_arguments(x):
+                return torch.unsqueeze(3, 4, 5, 6, 7, 8)
+
+    def test_invalid_lhs_assignment(self):
+        with self.assertRaisesRegex(RuntimeError, 'lhs of assignment must be a variable or starred expression'):
+            cu = torch.jit.CompilationUnit('''
+            def invalid_lhs_assignment(x):
+                x + 1 = x
+                return x
+            ''')
+
+    def test_multi_starred_expr_lhs(self):
+        with self.assertRaisesRegex(RuntimeError, 'Only one starred expression is allowed on the lhs'):
+            cu = torch.jit.CompilationUnit('''
+            def multi_starred_expr_lhs():
+                a, *b, *c = [1, 2, 3, 4, 5, 6]
+                return a
+            ''')
+
+    def test_pack_tuple_into_non_var(self):
+        with self.assertRaisesRegex(RuntimeError, 'Cannot pack a tuple into a non-variable'):
+            cu = torch.jit.CompilationUnit('''
+            def pack_tuple_into_non_var(x):
+                a, *1 = (3, 4, 5)
+                return x
+            ''')
+
+    def test_print_kwargs(self):
+        with self.assertRaisesRegex(RuntimeError, 'print doesn\'t accept any keyword arguments'):
+            @torch.jit.script
+            def print_kwargs(x):
+                print(x, flush=True)
+                return x
+
+    def test_builtin_use_as_value(self):
+        with self.assertRaisesRegex(RuntimeError, 'builtin cannot be used as a value'):
+            @torch.jit.script
+            def builtin_use_as_value(x):
+                return x.unsqueeze
+
+    def test_wrong_use_as_tuple(self):
+        with self.assertRaisesRegex(RuntimeError, 'cannot be used as a tuple'):
+            def test_fn():
+                return 3
+            @torch.jit.script
+            def wrong_use_as_tuple(self):
+                a, b = test_fn
+                return a
+
+    def test_wrong_attr_lookup(self):
+        with self.assertRaisesRegex(RuntimeError, 'attribute lookup is not defined on builtin'):
+            @torch.jit.script
+            def wrong_attr_lookup(self, x):
+                a = x.unsqueeze.myattr
+                return a
+
+    def test_wrong_use_as_callable(self):
+        with self.assertRaisesRegex(RuntimeError, 'cannot call a value'):
+            @torch.jit.script
+            def wrong_use_as_callable(x):
+                return x(3, 4, 5)
+
+    def test_wrong_python_kwarg_call(self):
+        with self.assertRaisesRegex(RuntimeError, 'keyword arguments in Python calls aren\'t supported'):
+            # NB: the only way I could get to this code path is if I made the
+            # python function have 0 inputs, since we interpret all the inputs to
+            # the function as inputs (including those with defaults) and not kwargs
+            def test_fn():
+                return 3
+            @torch.jit.script
+            def wrong_python_kwarg_call(self):
+                return test_fn(attr=6)
+
+    def test_python_val_doesnt_have_attr(self):
+        with self.assertRaisesRegex(RuntimeError, 'object has no attribute abcd'):
+            def test_fn():
+                return 3
+
+            @torch.jit.script
+            def python_val_doesnt_have_attr():
+                return test_fn.abcd
+
+    def test_wrong_module_attr_lookup(self):
+        with self.assertRaisesRegex(RuntimeError, 'unsupported attribute lookup on'):
+            import io
+            @torch.jit.script
+            def wrong_module_attr_lookup():
+                return io.BytesIO
+
+    def test_wrong_method_call_inputs(self):
+        with self.assertRaisesRegex(RuntimeError, 'argument \'y\' not provided'):
+            class SomeModule(torch.jit.ScriptModule):
+                @torch.jit.script_method
+                def foo(self, x, y):
+                    return x
+                @torch.jit.script_method
+                def forward(self, x, y):
+                    return self.foo(x)
+            SomeModule()
+
 
 class TestEndToEndHybridFrontendModels(JitTestCase):
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -889,7 +889,7 @@ private:
     // TODO: start, stop, step loop
     if (args.size() != 1) {
       throw ErrorReport(range)
-          << "range() expects one argument but got" << args.size();
+          << "range() expects 1 argument but got " << args.size();
     }
     emitLoopCommon(range, {args[0]}, {}, body, target);
   }
@@ -908,10 +908,6 @@ private:
       throw ErrorReport(stmt) << "Iteration variable unpacking is not supported";
     }
 
-    if (targets[0].kind() != TK_VAR) {
-      throw ErrorReport(targets[0]) << "Starred unpacking is currently not"
-          << " supported for for loops.";
-    }
     auto target = Var(targets[0]).name();
 
     // match range(<expr>) style loops

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1435,9 +1435,7 @@ void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, cons
     // so the methods can see each other
     if(!self) {
       auto result = table.emplace(name, method);
-      if(!result.second) {
-        throw ErrorReport(def) << "duplicate definition of function '" << name << "'";
-      }
+      JIT_ASSERT(result.second);
     }
     methods.push_back(&method);
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -908,6 +908,10 @@ private:
       throw ErrorReport(stmt) << "Iteration variable unpacking is not supported";
     }
 
+    if (targets[0].kind() != TK_VAR) {
+      throw ErrorReport(targets[0]) << "Starred unpacking is currently not"
+          << " supported for for loops.";
+    }
     auto target = Var(targets[0]).name();
 
     // match range(<expr>) style loops


### PR DESCRIPTION
Baseline is here: https://github.com/pytorch/pytorch/issues/8634

New coverage for `test/test_jit.py`:`(line number, # calls, code)`:

```
torch/csrc/jit/script/compiler.cpp:
  148|      1|        throw ErrorReport(loc) << "cannot re-assign '" << name << "' to a value of type " << value->kind()
  153|      1|        throw ErrorReport(loc) << "cannot re-assign '" << name << "' because it has type " << value->kind()
  157|      2|        throw ErrorReport(loc) << "variable '" << name << "' previously has type " << simple_parent->type()->name()
  192|      4|      throw ErrorReport(range) << "undefined value " << ident;
  475|      1|      throw ErrorReport(loc) << "argument 'chunks' must be a constant";
  527|      1|    throw ErrorReport(loc) << "unknown builtin op";
  529|     11|  throw ErrorReport(loc) << "arguments for call are not valid:\n"
  543|      1|    throw ErrorReport(range) << "expected a tensor value but found a tuple";
  594|      1|        throw ErrorReport(def.params().range()) << "methods must have a self argument";
  691|      1|          throw ErrorReport(stmt) << "return statements can appear only at the end "
  891|      1|      throw ErrorReport(range)
  904|      1|      throw ErrorReport(stmt)
  908|      1|      throw ErrorReport(stmt) << "Iteration variable unpacking is not supported";
  912|      1|      throw ErrorReport(targets[0]) << "Starred unpacking is currently not"
  970|      1|        throw ErrorReport(assignee)
  976|      1|      throw ErrorReport(r)
  981|      1|      throw ErrorReport(r) << "A Starred expression may only appear on the "
  993|      1|        throw ErrorReport(stmt)
 1020|      3|      throw ErrorReport(stmt)
 1026|      4|      throw ErrorReport(stmt)
 1038|      1|          throw ErrorReport(var) << "Cannot pack a tuple into a non-variable.";
 1147|      1|        throw ErrorReport(ident) << "print doesn't accept any keyword arguments";
 1227|      0|        throw ErrorReport(tree) << "Unexpected starred expansion. File a bug report.";
 1262|      0|        throw ErrorReport(tree) << "NYI: " << tree;
 1283|      0|        throw ErrorReport(input) << "Unrecognized type: " << type;
 1342|      0|      throw ErrorReport(loc)
 1471|      4|  throw ErrorReport(loc) << value->type()->name() << " cannot be used as a tuple";
 1476|      1|    throw ErrorReport(loc) << "expected " << expected << " " << what << " but found " << actual;
torch/csrc/jit/script/compiler.h:
   41|      1|    throw ErrorReport(loc) << kind() << " cannot be used as a value";
   46|      1|    throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
   52|      1|    throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   78|      1|    throw ErrorReport(loc) << "cannot call a " << kind();
torch/csrc/jit/script/init.cpp:
   63|      3|      throw ErrorReport(loc) << "calling a Python function with an incorrect number "
   68|      1|        throw ErrorReport(loc) << "type mismatch at argument " << i << ": expected "
   77|      1|      throw ErrorReport(loc) << "keyword arguments in Python calls aren't supported";
  110|      1|        throw ErrorReport(loc) << "Python functions can currently only return Tensors";
  141|      1|      throw ErrorReport(loc) << "object has no attribute " << name;
  218|      2|  throw ErrorReport(loc) << "unsupported attribute lookup on " << py::repr(self) << ".";
  284|      2|        throw ErrorReport(loc) << "attribute '" << field << "' of type '" << typeString(attr) << "' is not usable in a script method (did you forget to add it __constants__?)";
  287|      0|    throw ErrorReport(loc) << "module has no attribute '" << field << "'";
torch/csrc/jit/script/module.cpp:
   34|      1|    throw ErrorReport(loc) << " method '" << callee.name()
   44|      1|    throw ErrorReport(loc) << failure_messages.str();
torch/csrc/jit/script/tree_views.h:
  169|      0|      throw ErrorReport(tree) << "Maybe trees can have at most one subtree";
  211|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Type";
  228|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Stmt";
  266|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Expr";
  333|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid ScalarType";
  451|      0|        throw ErrorReport(tree) << "is not a valid AssignKind";
  525|      0|          throw ErrorReport(tree) << "BinOp expected 2 subtrees, found " << tree->trees().size();
  528|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid BinOp";
  548|      0|          throw ErrorReport(tree) << "UnaryOp expected 1 subtree, found " << tree->trees().size();
  551|      0|        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid UnaryOp";
```