### PR TITLE
[DAI] Added the Tags() context

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -82,7 +82,14 @@ def IsOperatorWithEngine(op_type, engine):
     return C.op_registry_key(op_type, engine) in _REGISTERED_OPERATORS
 
 
-def DeviceOption(device_type, cuda_gpu_id=0, random_seed=None, node_name=None, numa_node_id=None):
+def DeviceOption(
+    device_type,
+    cuda_gpu_id=0,
+    random_seed=None,
+    node_name=None,
+    numa_node_id=None,
+    extra_info=None,
+):
     option = caffe2_pb2.DeviceOption()
     option.device_type = device_type
     option.cuda_gpu_id = cuda_gpu_id
@@ -93,6 +100,8 @@ def DeviceOption(device_type, cuda_gpu_id=0, random_seed=None, node_name=None, n
     if numa_node_id is not None:
         assert device_type == caffe2_pb2.CPU
         option.numa_node_id = numa_node_id
+    if extra_info is not None:
+        option.extra_info.extend(extra_info)
     return option
 
 

--- a/caffe2/python/scope.py
+++ b/caffe2/python/scope.py
@@ -71,6 +71,12 @@ def DeviceScope(scope, node_name=None):
     if old_scope and old_scope.HasField('node_name') and \
             not new_scope.HasField('node_name'):
         new_scope.node_name = old_scope.node_name
+
+    # nested scope should inherit the extra_info and merged it with new extra_info
+    if old_scope and hasattr(old_scope, 'extra_info'):
+        new_scope.extra_info.extend(old_scope.extra_info)
+    new_scope.extra_info.sort()
+
     _threadlocal_scope.devicescope = new_scope
     try:
         yield

--- a/caffe2/python/scope_test.py
+++ b/caffe2/python/scope_test.py
@@ -89,6 +89,31 @@ class TestScope(unittest.TestCase):
 
         self.assertEquals(scope.CurrentDeviceScope(), None)
 
+    def testTags(self):
+        self.assertEquals(scope.CurrentDeviceScope(), None)
+
+        extra_info1 = ["key1:value1"]
+        extra_info2 = ["key2:value2"]
+        extra_info3 = ["key3:value3"]
+
+        extra_info_1_2 = ["key1:value1", "key2:value2"]
+        extra_info_1_2_3 = ["key1:value1", "key2:value2", "key3:value3"]
+
+        with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info1)):
+            self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info1)
+
+            with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info2)):
+                self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
+
+                with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info3)):
+                    self.assertEquals(
+                        scope.CurrentDeviceScope().extra_info, extra_info_1_2_3
+                    )
+
+                self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
+            self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info1)
+        self.assertEquals(scope.CurrentDeviceScope(), None)
+
     def testMultiThreaded(self):
         """
         Test that name/device scope are properly local to the thread


### PR DESCRIPTION
Tags context will be used as a part of the Tagging API to allow users to pass paramter/operator tags to backend

