### PR TITLE
TH Compatibility: write nDimension/_nDimension corresponding to dim()/_d…

### DIFF
--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -32,13 +32,13 @@ typedef struct THTensor
       return storage->unsafe_data<T>() + storageOffset;
     }
 
-    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
-    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    // [NOTE: _dim() vs dim()]
+    // _dim() returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // dim()  returns the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
     inline int64_t _dim() const {
       return is_empty() ? 0 : dim_;
     }
 
-    // NOTE: this is the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
     inline int64_t dim() const {
       return dim_;
     }

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -17,20 +17,25 @@ ptrdiff_t THTensor_(storageOffset)(const THTensor *self)
 
 int THTensor_(nDimension)(const THTensor *self)
 {
+  return self->dim();
+}
+
+int THTensor_(_nDimension)(const THTensor *self)
+{
   return self->_dim();
 }
 
 int64_t THTensor_(size)(const THTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->_dim()), 2, "dimension %d out of range of %dD tensor",
-      dim+TH_INDEX_BASE, THTensor_(nDimension)(self));
+      dim+TH_INDEX_BASE, THTensor_(_nDimension)(self));
   return self->size[dim];
 }
 
 int64_t THTensor_(stride)(const THTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->_dim()), 2, "dimension %d out of range of %dD tensor",
-      dim+TH_INDEX_BASE, THTensor_(nDimension)(self));
+      dim+TH_INDEX_BASE, THTensor_(_nDimension)(self));
   return self->stride[dim];
 }
 

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -23,7 +23,10 @@ typedef struct THTensor THTensor;
 /**** access methods ****/
 TH_API THStorage* THTensor_(storage)(const THTensor *self);
 TH_API ptrdiff_t THTensor_(storageOffset)(const THTensor *self);
+
+// See [NOTE: _dim() vs dim()]; _nDimension corresponds to _dim(), nDimension corresponds to dim().
 TH_API int THTensor_(nDimension)(const THTensor *self);
+TH_API int THTensor_(_nDimension)(const THTensor *self);
 TH_API int64_t THTensor_(size)(const THTensor *self, int dim);
 TH_API int64_t THTensor_(stride)(const THTensor *self, int dim);
 TH_API THLongStorage *THTensor_(newSizeOf)(THTensor *self);

--- a/aten/src/TH/generic/THTensorCopy.cpp
+++ b/aten/src/TH/generic/THTensorCopy.cpp
@@ -16,7 +16,7 @@
 int THTensor_(copyTransposeValid)(THTensor *tensor, THTensor *src) {
   const int MIN_SZ = 60 * 60;
   return THTensor_(isContiguous)(tensor) &&
-         THTensor_(nDimension)(src) == 2 &&
+         THTensor_(_nDimension)(src) == 2 &&
          THTensor_(stride)(src, 0) == 1 &&
          THTensor_(stride)(src, 1) == THTensor_(size)(src, 0) &&
          THTensor_(nElement)(tensor) >= MIN_SZ;

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -948,7 +948,7 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, co
 
 void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinfo_, int pivot, THTensor *a)
 {
-  THArgCheck(THTensor_(nDimension)(a) == 3, 1, "expected 3D tensor, got %dD", THTensor_(nDimension)(a));
+  THArgCheck(THTensor_(_nDimension)(a) == 3, 1, "expected 3D tensor, got %dD", THTensor_(_nDimension)(a));
   if (!pivot) {
     THError("btrifact without pivoting is not implemented on the CPU");
   }
@@ -1023,10 +1023,10 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
 
 void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor *pivots)
 {
-  THArgCheck(THTensor_(nDimension)(atf) == 3, 1, "expected 3D tensor, got %dD",
-             THTensor_(nDimension)(atf));
-  THArgCheck(THTensor_(nDimension)(b) == 3 ||
-             THTensor_(nDimension)(b) == 2, 4, "expected 2D or 3D tensor");
+  THArgCheck(THTensor_(_nDimension)(atf) == 3, 1, "expected 3D tensor, got %dD",
+             THTensor_(_nDimension)(atf));
+  THArgCheck(THTensor_(_nDimension)(b) == 3 ||
+             THTensor_(_nDimension)(b) == 2, 4, "expected 2D or 3D tensor");
   THArgCheck(THTensor_(size)(atf, 0) ==
              THTensor_(size)(b, 0), 3, "number of batches must be equal");
   THArgCheck(THTensor_(size)(atf, 1) ==

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -581,11 +581,11 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
 {
   int64_t elems_per_row, i, idx;
 
-  THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(src), 4,
+  THArgCheck(THLongTensor__nDimension(index) == THTensor_(_nDimension)(src), 4,
              "Index tensor must have same dimensions as input tensor");
-  THArgCheck(dim >= 0 && dim < THTensor_(nDimension)(tensor), 3,
+  THArgCheck(dim >= 0 && dim < THTensor_(_nDimension)(tensor), 3,
              "Index dimension is out of bounds");
-  THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 2,
+  THArgCheck(THTensor_(_nDimension)(src) == THTensor_(_nDimension)(tensor), 2,
              "Input tensor must have same dimensions as output tensor");
 
   elems_per_row = THLongTensor_size(index, dim);
@@ -608,10 +608,10 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
 {
   int64_t elems_per_row, i, idx;
 
-  THArgCheck(dim < THTensor_(nDimension)(tensor), 2, "Index dimension is out of bounds");
-  THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(tensor), 3,
+  THArgCheck(dim < THTensor_(_nDimension)(tensor), 2, "Index dimension is out of bounds");
+  THArgCheck(THLongTensor__nDimension(index) == THTensor_(_nDimension)(tensor), 3,
              "Index tensor must have same dimensions as output tensor");
-  THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 4,
+  THArgCheck(THTensor_(_nDimension)(src) == THTensor_(_nDimension)(tensor), 4,
              "Input tensor must have same dimensions as output tensor");
 
   elems_per_row = THLongTensor_size(index, dim);
@@ -634,10 +634,10 @@ void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTen
 {
   int64_t elems_per_row, i, idx;
 
-  THArgCheck(dim < THTensor_(nDimension)(tensor), 2, "Index dimension is out of bounds");
-  THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(tensor), 3,
+  THArgCheck(dim < THTensor_(_nDimension)(tensor), 2, "Index dimension is out of bounds");
+  THArgCheck(THLongTensor__nDimension(index) == THTensor_(_nDimension)(tensor), 3,
              "Index tensor must have same dimensions as output tensor");
-  THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 4,
+  THArgCheck(THTensor_(_nDimension)(src) == THTensor_(_nDimension)(tensor), 4,
              "Input tensor must have same dimensions as output tensor");
 
   elems_per_row = THLongTensor_size(index, dim);
@@ -660,8 +660,8 @@ void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, real
 {
   int64_t elems_per_row, i, idx;
 
-  THArgCheck(dim < THTensor_(nDimension)(tensor), 2, "Index dimension is out of bounds");
-  THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(tensor), 3,
+  THArgCheck(dim < THTensor_(_nDimension)(tensor), 2, "Index dimension is out of bounds");
+  THArgCheck(THLongTensor__nDimension(index) == THTensor_(_nDimension)(tensor), 3,
              "Index tensor must have same dimensions as output tensor");
 
   elems_per_row = THLongTensor_size(index, dim);
@@ -2236,8 +2236,8 @@ void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THT
 {
   int64_t batch;
 
-  THArgCheck(THTensor_(nDimension)(batch1) == 3, 1, "expected 3D tensor");
-  THArgCheck(THTensor_(nDimension)(batch2) == 3, 2, "expected 3D tensor");
+  THArgCheck(THTensor_(_nDimension)(batch1) == 3, 1, "expected 3D tensor");
+  THArgCheck(THTensor_(_nDimension)(batch2) == 3, 2, "expected 3D tensor");
   THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
              "equal number of batches expected, got %d, %d",
              THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
@@ -2277,8 +2277,8 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
 {
   int64_t batch;
 
-  THArgCheck(THTensor_(nDimension)(batch1) == 3, 1, "expected 3D tensor, got %dD", THTensor_(nDimension)(batch1));
-  THArgCheck(THTensor_(nDimension)(batch2) == 3, 2, "expected 3D tensor, got %dD", THTensor_(nDimension)(batch2));
+  THArgCheck(THTensor_(_nDimension)(batch1) == 3, 1, "expected 3D tensor, got %dD", THTensor_(_nDimension)(batch1));
+  THArgCheck(THTensor_(_nDimension)(batch2) == 3, 2, "expected 3D tensor, got %dD", THTensor_(_nDimension)(batch2));
   THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
              "equal number of batches expected, got %d, %d",
              THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
@@ -2334,8 +2334,8 @@ ptrdiff_t THTensor_(numel)(THTensor *t)
 void THTensor_(preserveReduceDimSemantics)(
     THTensor *r_, int in_dims, int reduce_dimension, int keepdim) {
   if (r_ && !keepdim &&
-      THTensor_(nDimension)(r_) == in_dims - 1 &&
-      THTensor_(nDimension)(r_) != 0) {
+      THTensor_(_nDimension)(r_) == in_dims - 1 &&
+      THTensor_(_nDimension)(r_) != 0) {
     THTensor_(unsqueeze1d)(r_, r_, reduce_dimension);
   }
 }
@@ -2344,10 +2344,10 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  int in_dims = THTensor_(nDimension)(t);
+  int in_dims = THTensor_(_nDimension)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
@@ -2381,7 +2381,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
                          *indices__data = theIndex;
                          *values__data = theMax;);
   } else {
-    if (THTensor_(nDimension)(t) > 1) {
+    if (THTensor_(_nDimension)(t) > 1) {
       THTensor *t0 = THTensor_(newSelect)(t, dimension, 0);
       THTensor_(copy)(values_, t0);
       THTensor_(free)(t0);
@@ -2428,10 +2428,10 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  int in_dims = THTensor_(nDimension)(t);
+  int in_dims = THTensor_(_nDimension)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
@@ -2465,7 +2465,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
                          *indices__data = theIndex;
                          *values__data = theMax;);
   } else {
-    if (THTensor_(nDimension)(t) > 1) {
+    if (THTensor_(_nDimension)(t) > 1) {
       THTensor *t0 = THTensor_(newSelect)(t, dimension, 0);
       THTensor_(copy)(values_, t0);
       THTensor_(free)(t0);
@@ -2512,10 +2512,10 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -2592,10 +2592,10 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -2670,7 +2670,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
 void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension)
 {
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
   THTensor_(resizeAs)(r_, t);
@@ -2687,7 +2687,7 @@ void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension)
 
 void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension)
 {
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
   THTensor_(resizeAs)(r_, t);
@@ -2727,7 +2727,7 @@ accreal THTensor_(trace)(THTensor *t)
   int64_t i = 0;
   int64_t t_stride_0, t_stride_1, t_diag_size;
 
-  THArgCheck(THTensor_(nDimension)(t) == 2, 1, "expected a matrix");
+  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a matrix");
 
   t_stride_0 = THTensor_(stride)(t, 0);
   t_stride_1 = THTensor_(stride)(t, 1);
@@ -2745,11 +2745,11 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
 {
   int i;
 
-  if(THTensor_(nDimension)(a) != THTensor_(nDimension)(b))
+  if(THTensor_(_nDimension)(a) != THTensor_(_nDimension)(b))
     THError("inconsistent tensor dimension %dD, %dD",
-        THTensor_(nDimension)(a), THTensor_(nDimension)(b));
+        THTensor_(_nDimension)(a), THTensor_(_nDimension)(b));
 
-  for(i = 0; i < THTensor_(nDimension)(a); i++)
+  for(i = 0; i < THTensor_(_nDimension)(a); i++)
   {
     if(THTensor_(size)(a, i) != THTensor_(size)(b, i)) {
         THDescBuff ba = THTensor_(sizeDesc)(a);
@@ -2760,7 +2760,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
 
   if(dimension < 0)
   {
-    for(i = 0; i < THTensor_(nDimension)(a); i++)
+    for(i = 0; i < THTensor_(_nDimension)(a); i++)
     {
       if(THTensor_(size)(a, i) == 3)
       {
@@ -2774,7 +2774,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
     }
   }
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(a), 3, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(a), 3, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
   THArgCheck(THTensor_(size)(a, dimension) == 3, 3, "dimension %d does not have size 3",
       dimension + TH_INDEX_BASE);
@@ -2826,9 +2826,9 @@ void THTensor_(onesLike)(THTensor *r_, THTensor *input)
 
 void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
 {
-  THArgCheck(THTensor_(nDimension)(t) == 1 || THTensor_(nDimension)(t) == 2, 1, "matrix or a vector expected");
+  THArgCheck(THTensor_(_nDimension)(t) == 1 || THTensor_(_nDimension)(t) == 2, 1, "matrix or a vector expected");
 
-  if(THTensor_(nDimension)(t) == 1)
+  if(THTensor_(_nDimension)(t) == 1)
   {
     real *t_data = THTensor_(data)(t);
     int64_t t_stride_0 = THTensor_(stride)(t, 0);
@@ -3166,7 +3166,7 @@ static void THTensor_(quicksortdescend)(real *arr, int64_t *idx, int64_t element
 
 void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder)
 {
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
   THTensor_(resizeAs)(rt_, t);
@@ -3304,9 +3304,9 @@ void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int
   int64_t *tempi__data;
   int64_t t_size_dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "dimension out of range");
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "dimension out of range");
 
-  int in_dims = THTensor_(nDimension)(t);
+  int in_dims = THTensor_(_nDimension)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
@@ -3372,10 +3372,10 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   int64_t *tempi__data;
   int64_t t_size_dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "dimension out of range");
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "dimension out of range");
   THArgCheck(k > 0 && k <= t->size[dimension], 2, "selected index out of range");
 
-  int in_dims = THTensor_(nDimension)(t);
+  int in_dims = THTensor_(_nDimension)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
   THLongTensor_preserveReduceDimSemantics(indices_, in_dims, dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
@@ -3417,7 +3417,7 @@ void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, i
 {
   int64_t t_size_dim, k;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "dimension out of range");
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "dimension out of range");
 
   t_size_dim = THTensor_(size)(t, dimension);
   k = (t_size_dim-1) >> 1; /* take middle or one-before-middle element */
@@ -3427,7 +3427,7 @@ void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, i
 
 void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted)
 {
-  int numDims = THTensor_(nDimension)(t);
+  int numDims = THTensor_(_nDimension)(t);
   THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
 
   int64_t sliceSize = THTensor_(size)(t, dim);
@@ -3500,7 +3500,7 @@ void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k)
   real *t_data, *r__data;
   int64_t r, c;
 
-  THArgCheck(THTensor_(nDimension)(t) == 2, 1, "expected a matrix");
+  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a matrix");
 
   THTensor_(resizeAs)(r_, t);
 
@@ -3531,7 +3531,7 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   real *t_data, *r__data;
   int64_t r, c;
 
-  THArgCheck(THTensor_(nDimension)(t) == 2, 1, "expected a matrix");
+  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a matrix");
 
   THTensor_(resizeAs)(r_, t);
 
@@ -3892,10 +3892,10 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -3972,10 +3972,10 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -4115,7 +4115,7 @@ void THTensor_(lerp)(THTensor *r_, THTensor *a, THTensor *b, real weight)
 
 void THTensor_(mean)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 {
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 2, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
   THTensor_(sum)(r_, t, dimension, keepdim);
@@ -4126,10 +4126,10 @@ void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -4170,10 +4170,10 @@ void THTensor_(var)(THTensor *r_, THTensor *t, int dimension, int biased, int ke
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -4214,10 +4214,10 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension, int k
 {
   THLongStorage *dim;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 3, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
-  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(nDimension)(t), dimension, keepdim);
+  THTensor_(preserveReduceDimSemantics)(r_, THTensor_(_nDimension)(t), dimension, keepdim);
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -4287,11 +4287,11 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
   int i;
   THTensor *rowR, *rowS;
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(src), 3, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(src), 3, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
   THArgCheck(value > 0, 2, "non-positive-norm not supported");
-  THArgCheck(THTensor_(nDimension)(src) > 1, 1, "need at least 2 dimensions, got %d dimensions",
-      THTensor_(nDimension)(src));
+  THArgCheck(THTensor_(_nDimension)(src) > 1, 1, "need at least 2 dimensions, got %d dimensions",
+      THTensor_(_nDimension)(src));
 
   rowR = THTensor_(new)();
   rowS = THTensor_(new)();
@@ -4438,10 +4438,10 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, int64_t nbins, real minv
 
 void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, real minvalue, real maxvalue)
 {
-  THArgCheck(THTensor_(nDimension)(tensor) < 3, 2, "invalid dimension %d, the input must be a 2d tensor", THTensor_(nDimension)(tensor));
+  THArgCheck(THTensor_(_nDimension)(tensor) < 3, 2, "invalid dimension %d, the input must be a 2d tensor", THTensor_(_nDimension)(tensor));
 
   int dimension = 1;
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(tensor), 2, "invalid dimension %d",
+  THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(tensor), 2, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
 
   real minval;

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -357,7 +357,7 @@ void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator
 void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
 {
   std::lock_guard<std::mutex> lock(_generator->mutex);
-  int64_t start_dim = THTensor_(nDimension)(prob_dist);
+  int64_t start_dim = THTensor_(_nDimension)(prob_dist);
   int64_t n_dist;
   int64_t n_categories;
   THDoubleTensor* cum_dist;

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -190,11 +190,11 @@ bool THC_pointwiseApply1(THCState* state,
                          TensorTypeA* a,
                          const Op& op,
                          TensorArgType aType = ReadWrite) {
-  if (THCTensor_nDimension(state, a) > MAX_CUTORCH_DIMS) {
+  if (THCTensor__nDimension(state, a) > MAX_CUTORCH_DIMS) {
     return false;
   }
 
-  if (THCTensor_nDimension(state, a) == 0) {
+  if (THCTensor__nDimension(state, a) == 0) {
     // Zero-dim tensor; do nothing
     return true;
   }
@@ -333,12 +333,12 @@ bool THC_pointwiseApply2(THCState* state,
     return false;
   }
 
-  if (THCTensor_nDimension(state, a) > MAX_CUTORCH_DIMS ||
-      THCTensor_nDimension(state, b) > MAX_CUTORCH_DIMS) {
+  if (THCTensor__nDimension(state, a) > MAX_CUTORCH_DIMS ||
+      THCTensor__nDimension(state, b) > MAX_CUTORCH_DIMS) {
     return false;
   }
 
-  if (THCTensor_nDimension(state, a) == 0) {
+  if (THCTensor__nDimension(state, a) == 0) {
     // Zero-dim tensor; do nothing
     return true;
   }
@@ -527,13 +527,13 @@ bool THC_pointwiseApply3(THCState* state,
     return false;
   }
 
-  if (THCTensor_nDimension(state, a) > MAX_CUTORCH_DIMS ||
-      THCTensor_nDimension(state, b) > MAX_CUTORCH_DIMS ||
-      THCTensor_nDimension(state, c) > MAX_CUTORCH_DIMS) {
+  if (THCTensor__nDimension(state, a) > MAX_CUTORCH_DIMS ||
+      THCTensor__nDimension(state, b) > MAX_CUTORCH_DIMS ||
+      THCTensor__nDimension(state, c) > MAX_CUTORCH_DIMS) {
     return false;
   }
 
-  if (THCTensor_nDimension(state, a) == 0) {
+  if (THCTensor__nDimension(state, a) == 0) {
     // Zero-dim tensor; do nothing
     return true;
   }

--- a/aten/src/THC/THCDeviceTensorUtils-inl.cuh
+++ b/aten/src/THC/THCDeviceTensorUtils-inl.cuh
@@ -95,7 +95,7 @@ template <typename T, int NewDim,
           typename IndexT, template <typename U> class PtrTraits>
 THCDeviceTensor<T, NewDim, IndexT, PtrTraits>
 toDeviceTensorCast(THCState* state, THCudaTensor* t) {
-  switch (THCudaTensor_nDimension(state, t)) {
+  switch (THCudaTensor__nDimension(state, t)) {
     SWITCH_UNROLL_CUDA_CAST_FACTORY(1);
     SWITCH_UNROLL_CUDA_CAST_FACTORY(2);
     SWITCH_UNROLL_CUDA_CAST_FACTORY(3);

--- a/aten/src/THC/THCDeviceTensorUtils.cuh
+++ b/aten/src/THC/THCDeviceTensorUtils.cuh
@@ -48,7 +48,7 @@ template <typename T, int Dim,
           typename IndexT, template <typename U> class PtrTraits>
 THCDeviceTensor<T, Dim, IndexT, PtrTraits>
 toDeviceTensor(THCState* state, THCTensor* t) {
-  if (Dim != THCTensor_nDimension(state, t)) {
+  if (Dim != THCTensor__nDimension(state, t)) {
     THError("THCudaTensor dimension mismatch");
   }
   // Determine the maximum offset into the tensor achievable; `IndexT`

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -288,12 +288,12 @@ bool THC_reduceDim(THCState* state,
   int64_t reductionStride = THCTensor_stride(state, in, dim);
   ptrdiff_t outElements = inElements / reductionSize;
 
-  if (THCTensor_nDimension(state, out) > MAX_CUTORCH_DIMS ||
-      THCTensor_nDimension(state, in) > MAX_CUTORCH_DIMS) {
+  if (THCTensor__nDimension(state, out) > MAX_CUTORCH_DIMS ||
+      THCTensor__nDimension(state, in) > MAX_CUTORCH_DIMS) {
     return false;
   }
 
-  if (THCTensor_nDimension(state, in) == 0) {
+  if (THCTensor__nDimension(state, in) == 0) {
     // Zero-dim tensor; do nothing
     return true;
   }
@@ -343,7 +343,7 @@ bool THC_reduceDim(THCState* state,
 
   // Preserve noncontiguities by unsqueezing out if necessary
   THCTensor_preserveReduceDimSemantics(
-      state, out, THCTensor_nDimension(state, in), dim, keepdim);
+      state, out, THCTensor__nDimension(state, in), dim, keepdim);
 
   // Resize out
   THLongStorage* sizes = THCTensor_newSizeOf(state, in);

--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -233,11 +233,11 @@ bool THC_reduceAll(THCState* state,
                    int outOnDevice) {
   ptrdiff_t inElements = THCTensor_nElement(state, in);
 
-  if (THCTensor_nDimension(state, in) > MAX_CUTORCH_DIMS) {
+  if (THCTensor__nDimension(state, in) > MAX_CUTORCH_DIMS) {
     return false;
   }
 
-  if (THCTensor_nDimension(state, in) == 0) {
+  if (THCTensor__nDimension(state, in) == 0) {
     // Zero-dim tensor; do nothing
     *out = init;
     return true;

--- a/aten/src/THC/THCReduceApplyUtils.cu
+++ b/aten/src/THC/THCReduceApplyUtils.cu
@@ -7,7 +7,7 @@
 #define MAX_GRID_SIZE 65535LL
 
 void THCCheckTensorDims(THCState* state, THCudaTensor* tensor, int arg) {
-  int64_t dims = THCudaTensor_nDimension(state, tensor);
+  int64_t dims = THCudaTensor__nDimension(state, tensor);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, arg, CUTORCH_DIM_WARNING);
 }
 

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -10,6 +10,10 @@
 #include "THCTensorInfo.cuh"
 
 int THCTensor_nDimension(THCState *state, const THCTensor *self) {
+  return self->dim();
+}
+
+int THCTensor__nDimension(THCState *state, const THCTensor *self) {
   return self->_dim();
 }
 
@@ -421,7 +425,7 @@ bool THCTensor_canUse32BitIndexMath(THCState* state, const THCTensor* t, ptrdiff
   ptrdiff_t offset = 0;
   ptrdiff_t linearId = elements - 1;
 
-  for (int i = THCTensor_nDimension(state, t) - 1; i >= 0; --i) {
+  for (int i = THCTensor__nDimension(state, t) - 1; i >= 0; --i) {
     ptrdiff_t curDimIndex =
       linearId % THCTensor_size(state, t, i);
     ptrdiff_t curDimOffset = curDimIndex *
@@ -456,7 +460,7 @@ bool THCTensor_all32BitIndexable(THCState* state, THCTensor** inputs, int numInp
 /* the contiguity guarantees of the resize semantics.                */ \
 void THCTensor_preserveReduceDimSemantics(THCState *state, THCTensor *tensor,
                                           int in_dims, int64_t dimension, int keepdim) {
-  int out_dims = THCTensor_nDimension(state, tensor);
+  int out_dims = THCTensor__nDimension(state, tensor);
   if (out_dims > 0 && !keepdim && out_dims == in_dims - 1) {
     THCTensor_unsqueeze1d(state, tensor, tensor, dimension);
   }
@@ -497,7 +501,7 @@ bool THCTensor_maybeOverlappingIndices(THCState* state, const THCTensor* t) {
   /* Extract size/stride arrays; only consider size >1 dims. */
   SizeAndStride info[MAX_CUTORCH_DIMS];
 
-  int dims = THCTensor_nDimension(state, t);
+  int dims = THCTensor__nDimension(state, t);
   int nonSize1Dims = 0;
   for (int i = 0; i < dims; ++i) {
     int64_t size = THCTensor_size(state, t, i);

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -31,13 +31,13 @@ typedef struct THCTensor
       return storage->unsafe_data<T>() + storageOffset;
     }
 
-    // NOTE: this returns the "old" TH dimension view where no dimensions represents an empty tensor.
-    // There will be a dim() function that gives the new view that supports 0-sized dimensions.
+    // [NOTE: _dim() vs dim()]
+    // _dim() returns the "old" TH dimension view where no dimensions represents an empty tensor.
+    // dim()  returns the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
     inline int64_t _dim() const {
       return is_empty() ? 0: dim_;
     }
 
-    // NOTE: this is the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
     inline int64_t dim() const {
       return dim_;
     }
@@ -53,7 +53,10 @@ typedef struct THCTensor
     }
 } THCTensor;
 
+// See [NOTE: _dim() vs dim()]; _nDimension corresponds to _dim(), nDimension corresponds to dim().
 THC_API int THCTensor_nDimension(THCState *state, const THCTensor *self);
+THC_API int THCTensor__nDimension(THCState *state, const THCTensor *self);
+
 THC_API int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim);
 THC_API int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim);
 THC_API THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self);

--- a/aten/src/THC/THCTensorCopy.cu
+++ b/aten/src/THC/THCTensorCopy.cu
@@ -32,7 +32,7 @@ void THC_copyTensor(THCState* state, THCTensor* dst, THCTensor* src) {
              THCTensor_nElement(state, src),
              2, "sizes do not match");
 
-  if (THCTensor_nDimension(state, dst) == 0) {
+  if (THCTensor__nDimension(state, dst) == 0) {
     // Zero-dim tensor; copy nothing
     return;
   }

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -296,7 +296,7 @@ __global__ void THCTensor_kernel_varOuterDim(T *tgt, T *src_, unsigned num_orows
 
 template<typename TensorTypeK, typename T, typename AccT, bool apply_sqrt>
 __host__ void THCTensor_varOuterDim(THCState *state, TensorTypeK *tgt, TensorTypeK *src, int64_t dimension, int flag) {
-  unsigned ndim = THCTensor_nDimension(state, src);
+  unsigned ndim = THCTensor__nDimension(state, src);
   // Treat all outer dimensions (i.e. dim < dimension) as one.
   unsigned num_orows = 1;
   for (int64_t dim = 0; dim < dimension; dim++) {
@@ -442,7 +442,7 @@ __global__ void THCTensor_kernel_varInnermostDim(T *tgt, T *src_, unsigned num_r
 
 template<typename TensorTypeK, typename T, typename AccT, bool apply_sqrt>
 __host__ void THCTensor_varInnermostDim(THCState *state, TensorTypeK *tgt, TensorTypeK *src, int flag) {
-  unsigned ndim = THCTensor_nDimension(state, src);
+  unsigned ndim = THCTensor__nDimension(state, src);
   // Treat all outer dimensions as a single dimension.
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
@@ -515,7 +515,7 @@ THC_transformReduceOuterDimIndex(THCState *state,
                                  int64_t rdim,
                                  const thrust::pair<ScalarTypeK, ScalarTypeIndex>& init,
                                  BinaryFunction binary_op) {
-  unsigned ndim = THCTensor_nDimension(state, src);
+  unsigned ndim = THCTensor__nDimension(state, src);
   unsigned num_orows = 1;
   for (int64_t dim = 0; dim < rdim; dim++) {
     num_orows *= THCTensor_size(state, src, dim);
@@ -618,7 +618,7 @@ THC_transformReduceInnermostDimIndex(THCState *state,
                                      TensorTypeK *src,
                                      const thrust::pair<ScalarTypeK, ScalarTypeIndex>& init,
                                      BinaryFunction binary_op) {
-  unsigned ndim = THCTensor_nDimension(state, src);
+  unsigned ndim = THCTensor__nDimension(state, src);
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
     num_rows *= THCTensor_size(state, src, dim);
@@ -654,13 +654,13 @@ THC_reduceDimIndex(THCState *state,
                    BinaryFunction binary_op)
 {
   THArgCheck(dimension >= 0 &&
-             dimension < THCTensor_nDimension(state, src),
+             dimension < THCTensor__nDimension(state, src),
              3, "dimension out of range");
 
 
   // Unsqueeze tgt1_/tgt_2 if necessary so that their contiguity traits
   // are preserved if they are the same size as the correct reduction output.
-  int src_dims = THCTensor_nDimension(state, src);
+  int src_dims = THCTensor__nDimension(state, src);
   THCTensor_preserveReduceDimSemantics(
       state, tgt1_, src_dims, dimension, keepdim);
   THCTensor_preserveReduceDimSemantics(
@@ -676,7 +676,7 @@ THC_reduceDimIndex(THCState *state,
   TensorTypeIndex *tgt2 = (TensorTypeIndex*)THCTensor_newContiguous<ScalarTypeIndex>(state, tgt2_);
   src = (TensorTypeK*)THCTensor_newContiguous<ScalarTypeK>(state, src);
 
-  if (dimension == THCTensor_nDimension(state, src) - 1) {
+  if (dimension == THCTensor__nDimension(state, src) - 1) {
     THC_transformReduceInnermostDimIndex(state, tgt1, tgt2, src, init, binary_op);
   } else {
     THC_transformReduceOuterDimIndex(state, tgt1, tgt2, src, dimension, init, binary_op);

--- a/aten/src/THC/THCTensorSort.cu
+++ b/aten/src/THC/THCTensorSort.cu
@@ -3,7 +3,7 @@
 void THCudaLongTensor_fillSliceWithIndex(THCState* state,
                                          THCudaLongTensor* t,
                                          int dim) {
-  int64_t dims = THCudaLongTensor_nDimension(state, t);
+  int64_t dims = THCudaLongTensor__nDimension(state, t);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
 
   ptrdiff_t inElements = THCudaLongTensor_nElement(state, t);

--- a/aten/src/THC/THCTensorTypeUtils.cuh
+++ b/aten/src/THC/THCTensorTypeUtils.cuh
@@ -60,7 +60,7 @@ getTensorInfo(THCState* state, TensorType* t) {
   IndexType sz[MAX_CUTORCH_DIMS];
   IndexType st[MAX_CUTORCH_DIMS];
 
-  int dims = THCTensor_nDimension(state, t);
+  int dims = THCTensor__nDimension(state, t);
   for (int i = 0; i < dims; ++i) {
     sz[i] = THCTensor_size(state, t, i);
     st[i] = THCTensor_stride(state, t, i);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -18,6 +18,11 @@ int THCTensor_(nDimension)(THCState *state, const THCTensor *self)
   return THCTensor_nDimension(state, self);
 }
 
+int THCTensor_(_nDimension)(THCState *state, const THCTensor *self)
+{
+  return THCTensor__nDimension(state, self);
+}
+
 int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim)
 {
   return THCTensor_size(state, self, dim);
@@ -288,7 +293,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
 // Collapses the first two dimensions of a tensor.
 // Assumes the input tensor is contiguous.
 THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
-  int in_dims = THCTensor_(nDimension)(state, input);
+  int in_dims = THCTensor_(_nDimension)(state, input);
   THArgCheck(in_dims >= 2, 1, "Tensor needs to have at least two dimensions");
   THArgCheck(THCTensor_(isContiguous)(state, input), 1,
              "Tensor must be contiguous");

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -22,7 +22,11 @@ typedef struct THCTensor THCTensor;
 /**** access methods ****/
 THC_API THCStorage* THCTensor_(storage)(THCState *state, const THCTensor *self);
 THC_API ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *self);
+
+// See [NOTE: _dim() vs dim()]; _nDimension corresponds to _dim(), nDimension corresponds to dim().
 THC_API int THCTensor_(nDimension)(THCState *state, const THCTensor *self);
+THC_API int THCTensor_(_nDimension)(THCState *state, const THCTensor *self);
+
 THC_API int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim);
 THC_API int64_t THCTensor_(stride)(THCState *state, const THCTensor *self, int dim);
 THC_API THLongStorage *THCTensor_(newSizeOf)(THCState *state, THCTensor *self);

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -9,10 +9,10 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
                                           THCudaLongTensor *index,
                                           THCTensor *src)
 {
-  int dstDims = THCTensor_(nDimension)(state, dst);
-  int srcDims = (src == nullptr) ? dstDims : THCTensor_(nDimension)(state, src);
+  int dstDims = THCTensor_(_nDimension)(state, dst);
+  int srcDims = (src == nullptr) ? dstDims : THCTensor_(_nDimension)(state, src);
 
-  THArgCheck(THCudaLongTensor_nDimension(state, index) == 1, 4,
+  THArgCheck(THCudaLongTensor__nDimension(state, index) == 1, 4,
              "expecting vector of indices");
   THArgCheck(dim >= 0 && dim < dstDims, 2, "Indexing dim is out of bounds");
 
@@ -97,11 +97,11 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, dst, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
 
-  int dims = THCTensor_(nDimension)(state, dst);
+  int dims = THCTensor_(_nDimension)(state, dst);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimension)(state, src);
+  dims = THCTensor_(_nDimension)(state, src);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimension(state, indices);
+  dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
 
   // The `src` is partitioned into two parts:
@@ -218,10 +218,10 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, dst, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(THCTensor_(nDimension)(state, src) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  THArgCheck(THCTensor_(nDimension)(state, dst) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  THArgCheck(THCudaLongTensor_nDimension(state, index) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  THArgCheck(!(THCTensor_(nDimension)(state, src) == 0 && THCudaLongTensor_nDimension(state, index) != 0), 2,
+  THArgCheck(THCTensor_(_nDimension)(state, src) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCTensor_(_nDimension)(state, dst) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCudaLongTensor__nDimension(state, index) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(!(THCTensor_(_nDimension)(state, src) == 0 && THCudaLongTensor__nDimension(state, index) != 0), 2,
              "tried to take from an empty tensor");
 
   THCTensor_(resizeNd)(state, dst, index->dim(), index->size, NULL);
@@ -255,9 +255,9 @@ void THCTensor_(put)(THCState *state, THCTensor *dst, THCudaLongTensor *index, T
   THArgCheck(THCTensor_(nElement)(state, src) == numIndices,
     3, "src should have the same number of elements as index");
 
-  THArgCheck(THCTensor_(nDimension)(state, dst) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  THArgCheck(THCTensor_(nDimension)(state, src) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  THArgCheck(THCudaLongTensor_nDimension(state, index) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCTensor_(_nDimension)(state, dst) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCTensor_(_nDimension)(state, src) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCudaLongTensor__nDimension(state, index) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
 
   if (numIndices == 0) {
     return;
@@ -286,11 +286,11 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, dst, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
 
-  int dims = THCTensor_(nDimension)(state, dst);
+  int dims = THCTensor_(_nDimension)(state, dst);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimension)(state, src);
+  dims = THCTensor_(_nDimension)(state, src);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimension(state, indices);
+  dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
 
   // The `src` is partitioned into two parts:
@@ -406,9 +406,9 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, dst));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
-  int dims = THCTensor_(nDimension)(state, dst);
+  int dims = THCTensor_(_nDimension)(state, dst);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimension(state, indices);
+  dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
 
   // The `src` is partitioned into two parts:
@@ -512,19 +512,19 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, dst, src, indices));
 
-  int dims = THCTensor_(nDimension)(state, dst);
+  int dims = THCTensor_(_nDimension)(state, dst);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimension)(state, src);
+  dims = THCTensor_(_nDimension)(state, src);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimension(state, indices);
+  dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
 
   ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
 
-  int srcDims = THCTensor_(nDimension)(state, src);
+  int srcDims = THCTensor_(_nDimension)(state, src);
   cudaStream_t stream = THCState_getCurrentStream(state);
 
-  THArgCheck(THCudaLongTensor_nDimension(state, indices) <= 1, 3,
+  THArgCheck(THCudaLongTensor__nDimension(state, indices) <= 1, 3,
              "Index is supposed to be an empty tensor or a vector");
   THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
   THArgCheck(srcDims > 0, 2, "Source tensor is empty");

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -71,8 +71,8 @@ void THCTensor_(check_shape_except_dim)(THCState *state,
 inline void THCTensor_(check_shape_except_dim)(THCState *state, 
     THCTensor *first, THCTensor *second, int dimension)
 {
-  int first_dims = THCTensor_(nDimension)(state, first);
-  int second_dims = THCTensor_(nDimension)(state, second);
+  int first_dims = THCTensor_(_nDimension)(state, first);
+  int second_dims = THCTensor_(_nDimension)(state, second);
   THArgCheck(first_dims == second_dims, 0,
       "Tensors must have same number of dimensions: got %d and %d",
       first_dims, second_dims);
@@ -107,7 +107,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
 
   for (i = 0; i < numInputs; i++)
   {
-    int inputDim = THCTensor_(nDimension)(state, inputs[i]);
+    int inputDim = THCTensor_(_nDimension)(state, inputs[i]);
     hasEmptyInput |= !inputDim;
     if (inputDim > 0) {
       nDims = inputDim;
@@ -137,7 +137,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
   int64_t cat_dim_size = 0;
   for (int i = 0; i < numInputs; i++) {
     THCTensor *tensor = inputs[i];
-    if (THCTensor_(nDimension)(state, tensor) == 0) {
+    if (THCTensor_(_nDimension)(state, tensor) == 0) {
       continue;
     }
     THCTensor_(check_shape_except_dim)(state, notEmptyTensor, tensor, cat_dimension);
@@ -167,7 +167,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
 
   if (numInputs > 1 &&
       !hasEmptyInput &&
-      THCTensor_(nDimension)(state, result) <= CAT_ARRAY_MAX_INPUT_DIMS &&
+      THCTensor_(_nDimension)(state, result) <= CAT_ARRAY_MAX_INPUT_DIMS &&
       THCTensor_canUse32BitIndexMath(state, result) &&
       THCTensor_allContiguous(state, inputs, numInputs) &&
       THCTensor_all32BitIndexable(state, inputs, numInputs) &&
@@ -203,7 +203,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
       CatArrInputTensor<real, unsigned int>* stackInputs = (CatArrInputTensor<real, unsigned int>*) THCudaHostAlloc(state, tensorMetadataSize);
       cohortMax = 0;
       for (j = 0; j < CAT_ARRAY_BATCH_SIZE && (i+j) < numInputs; ++j) {
-        int64_t dimSize = cat_dimension < THCTensor_(nDimension)(state, inputs[i+j])
+        int64_t dimSize = cat_dimension < THCTensor_(_nDimension)(state, inputs[i+j])
           ? THCTensor_(size)(state, inputs[i+j], cat_dimension)
           : 1;
 
@@ -260,9 +260,9 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
     for (j = 0; j < numInputs; j++)
     {
       // No reason to copy when input is empty
-      if (!THCTensor_(nDimension)(state, inputs[j])) continue;
+      if (!THCTensor_(_nDimension)(state, inputs[j])) continue;
 
-      int64_t dimSize = cat_dimension < THCTensor_(nDimension)(state, inputs[j])
+      int64_t dimSize = cat_dimension < THCTensor_(_nDimension)(state, inputs[j])
                ? THCTensor_(size)(state, inputs[j], cat_dimension)
                : 1;
 
@@ -287,7 +287,7 @@ void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor,
   self = THCTensor_(newContiguous)(state, self);
   thrust::device_ptr<real> self_data(THCTensor_(data)(state, self));
 
-  int num_dim = THCTensor_(nDimension)(state, self);
+  int num_dim = THCTensor_(_nDimension)(state, self);
   int64_t N = THCTensor_(nElement)(state, self);
 
   THCudaLongTensor_resize2d(state, tensor, N, num_dim);
@@ -344,7 +344,7 @@ void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor,
 
 void THCTensor_(diag)(THCState *state, THCTensor *self_, THCTensor *src_, int64_t k){
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
-  int nDimension = THCTensor_(nDimension)(state, src_);
+  int nDimension = THCTensor_(_nDimension)(state, src_);
   THArgCheck((nDimension == 2) || (nDimension == 1), 1, "expected a matrix or a vector");
   if (nDimension == 2) {
     int64_t stride0 = THCTensor_(stride)(state, src_, 0);

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -397,9 +397,9 @@ THCTensor_(addbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
                    real alpha, THCTensor *batch1, THCTensor *batch2) {
 #if defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, result, t, batch1, batch2));
-  THArgCheck(THCTensor_(nDimension)(state, t) == 2, 4, "expected 2D tensor");
-  THArgCheck(THCTensor_(nDimension)(state, batch1) == 3, 6, "expected 3D tensor");
-  THArgCheck(THCTensor_(nDimension)(state, batch2) == 3, 7, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, t) == 2, 4, "expected 2D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, batch1) == 3, 6, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, batch2) == 3, 7, "expected 3D tensor");
 
   int64_t batchnum = THCTensor_(size)(state, batch1, 0);
   int64_t m1d1 = THCTensor_(size)(state, batch1, 1);
@@ -462,9 +462,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
                     real alpha, THCTensor *batch1, THCTensor *batch2) {
 #if defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, result, t, batch1, batch2));
-  THArgCheck(THCTensor_(nDimension)(state, t) == 3, 4, "expected 3D tensor");
-  THArgCheck(THCTensor_(nDimension)(state, batch1) == 3, 6, "expected 3D tensor");
-  THArgCheck(THCTensor_(nDimension)(state, batch2) == 3, 7, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, t) == 3, 4, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, batch1) == 3, 6, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, batch2) == 3, 7, "expected 3D tensor");
   THArgCheck(THCTensor_(size)(state, t, 0) == THCTensor_(size)(state, batch1, 0), 6,
              "equal number of batches expected");
   THArgCheck(THCTensor_(size)(state, t, 0) == THCTensor_(size)(state, batch2, 0), 7,
@@ -730,7 +730,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
 {
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   THAssert(THCTensor_(checkGPU)(state, 2, ra_, a));
-  THArgCheck(THCTensor_(nDimension)(state, a) == 3, 3, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, a) == 3, 3, "expected 3D tensor");
   THArgCheck(THCTensor_(size)(state, a, 1) ==
              THCTensor_(size)(state, a, 2), 3, "matrices must be square");
 
@@ -833,9 +833,9 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
 {
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   THAssert(THCTensor_(checkGPU)(state, 3, rb_, atf, b));
-  THArgCheck(THCTensor_(nDimension)(state, atf) == 3, 3, "expected 3D tensor");
-  THArgCheck(THCTensor_(nDimension)(state, b) == 3 ||
-             THCTensor_(nDimension)(state, b) == 2, 4, "expected 2D or 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, atf) == 3, 3, "expected 3D tensor");
+  THArgCheck(THCTensor_(_nDimension)(state, b) == 3 ||
+             THCTensor_(_nDimension)(state, b) == 2, 4, "expected 2D or 3D tensor");
   THArgCheck(THCTensor_(size)(state, atf, 0) ==
              THCTensor_(size)(state, b, 0), 3, "number of batches must be equal");
   THArgCheck(THCTensor_(size)(state, atf, 1) ==

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -113,9 +113,9 @@ THCTensor_(cross)(THCState *state, THCTensor *self, THCTensor *x, THCTensor *y, 
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self, x, y));
 
   int i;
-  int nd = THCTensor_(nDimension)(state, x);
+  int nd = THCTensor_(_nDimension)(state, x);
   ptrdiff_t nelem = THCTensor_(nElement)(state, x);
-  THArgCheck(nd == THCTensor_(nDimension)(state, y), 1, "tensors must have same number of dimensions");
+  THArgCheck(nd == THCTensor_(_nDimension)(state, y), 1, "tensors must have same number of dimensions");
   for (i = 0; i < nd; i++) {
     THArgCheck(THCTensor_(size)(state, x, i) == THCTensor_(size)(state, y, i), 1, "dimension %i of x and y does not match", i);
     if (dimension < 0 && THCTensor_(size)(state, x, i) == 3) {

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -63,9 +63,9 @@ THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, real value,
   THCTensor *data = THCTensor_(newClone)(state, src_);
   ptrdiff_t size = THCTensor_(nElement)(state, data)/data->size[0];
 
-  THArgCheck(dimension >= 0 && dimension < THCTensor_(nDimension)(state, src), 3, "invalid dimension");
+  THArgCheck(dimension >= 0 && dimension < THCTensor_(_nDimension)(state, src), 3, "invalid dimension");
   THArgCheck(THCNumerics<real>::gt(value, scalar_cast<real>(0)), 2, "non-positive-norm not supported");
-  THArgCheck(THCTensor_(nDimension)(state, src) > 1, 1, "need at least 2 dimensions");
+  THArgCheck(THCTensor_(_nDimension)(state, src) > 1, 1, "need at least 2 dimensions");
 
   dim3 grid(data->size[0]);
   dim3 threads(32);
@@ -91,7 +91,7 @@ THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
   THCTensor_preserveReduceDimSemantics(
-      state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
+      state, self_, THCTensor_(_nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
   THCTensor_(resize)(state, self_, dim, NULL);
@@ -100,7 +100,7 @@ THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   src = THCTensor_(newContiguous)(state, src);
 
-  if (dimension == THCTensor_(nDimension)(state, src) - 1) {
+  if (dimension == THCTensor_(_nDimension)(state, src) - 1) {
     THCTensor_varInnermostDim<THCTensor, real, accreal, true>(state, self, src, biased);
   } else {
     THCTensor_varOuterDim<THCTensor, real, accreal, true>(state, self, src, dimension, biased);
@@ -120,7 +120,7 @@ THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
   THCTensor_preserveReduceDimSemantics(
-      state, self_, THCTensor_(nDimension)(state, src), dimension, keepdim);
+      state, self_, THCTensor_(_nDimension)(state, src), dimension, keepdim);
   THLongStorage *dim = THCTensor_(newSizeOf)(state, src);
   THLongStorage_set(dim, dimension, 1);
   THCTensor_(resize)(state, self_, dim, NULL);
@@ -129,7 +129,7 @@ THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   src = THCTensor_(newContiguous)(state, src);
 
-  if (dimension == THCTensor_(nDimension)(state, src) - 1) {
+  if (dimension == THCTensor_(_nDimension)(state, src) - 1) {
     THCTensor_varInnermostDim<THCTensor, real, accreal, false>(state, self, src, biased);
   } else {
     THCTensor_varOuterDim<THCTensor, real, accreal, false>(state, self, src, dimension, biased);

--- a/aten/src/THC/generic/THCTensorMathScan.cu
+++ b/aten/src/THC/generic/THCTensorMathScan.cu
@@ -28,7 +28,7 @@ __host__ void THCTensor_(scanOuterDim)(THCState *state, THCTensor *tgt,
                                        THCTensor *src, int dimension,
                                        real init, BinaryOp binary_op)
 {
-  unsigned ndim = THCTensor_(nDimension)(state, src);
+  unsigned ndim = THCTensor_(_nDimension)(state, src);
   // Treat all outer dimensions (i.e. dim < dimension) as one.
   unsigned num_orows = 1;
   for (int dim = 0; dim < dimension; dim++) {
@@ -57,7 +57,7 @@ __host__ void THCTensor_(scanInnermostDim)(THCState *state, THCTensor *tgt,
                                            THCTensor *src, real init,
                                            BinaryFunction binary_op)
 {
-  unsigned ndim = THCTensor_(nDimension)(state, src);
+  unsigned ndim = THCTensor_(_nDimension)(state, src);
   // Treat all outer dimensions as a single dimension.
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
@@ -79,7 +79,7 @@ void THCTensor_(scanDim)(THCState *state, THCTensor *self_, THCTensor *src,
                          int dimension, real init, BinaryFunction binary_op)
 {
   // "init" must be the identity element for binary_op
-  int ndim = THCTensor_(nDimension)(state, src);
+  int ndim = THCTensor_(_nDimension)(state, src);
   THArgCheck(dimension >= 0 && dimension < ndim, 3, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
 

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -20,7 +20,7 @@ THC_API void THCTensor_(calculateMode)(THCState *state,
     data += THLongStorage_data(position)[i] * THCTensor_(stride)(state, input, i);
   }
 
-  int64_t nElement = THCTensor_(size)(state, input, THCTensor_(nDimension)(state, input) - 1);
+  int64_t nElement = THCTensor_(size)(state, input, THCTensor_(_nDimension)(state, input) - 1);
   THCThrustAllocator thrustAlloc(state);
 
   // Wrap input data, sortBuffer, in Thrust device vectors
@@ -137,7 +137,7 @@ THC_API void THCTensor_(dimApplyMode)(THCState *state,
                                int dimension,
                                THLongStorage *position,
                                int curDim) {
-  int64_t ndim = THCTensor_(nDimension)(state, input);
+  int64_t ndim = THCTensor_(_nDimension)(state, input);
 
   // Because we have transposed the Tensor, the data for the dimension we are mode'ing along
   // is always in the innermost dimension
@@ -172,7 +172,7 @@ THC_API void THCTensor_(mode)(THCState *state,
   THAssert(THCTensor_(checkGPU)(state, 1, values));
 
   // Verify they are asking for a valid dimension
-  ndim = THCTensor_(nDimension)(state, input);
+  ndim = THCTensor_(_nDimension)(state, input);
   THArgCheck(dimension >= 0 && dimension < ndim, 4, "Dimension of out bounds");
 
   sliceSize = THCTensor_(size)(state, input, dimension);

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -109,7 +109,7 @@ THC_API void THCTensor_(cauchy)(THCState* state, THCTensor *self_, double median
 
 void THCTensor_(renormRows)(struct THCState* state,
                              THCTensor* t) {
-  THAssert(THCTensor_(nDimension)(state, t) == 2);
+  THAssert(THCTensor_(_nDimension)(state, t) == 2);
   int64_t rows = THCTensor_(size)(state, t, 0);
   int64_t cols = THCTensor_(size)(state, t, 1);
 
@@ -137,7 +137,7 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, prob_dist));
   THCGenerator* gen = THCRandom_getGenerator(state);
 
-  int inputSize = THCTensor_(nDimension)(state, prob_dist);
+  int inputSize = THCTensor_(_nDimension)(state, prob_dist);
   THArgCheck(inputSize > 0 && inputSize <= 2, 2,
              "prob_dist must be 1 or 2 dim");
 

--- a/aten/src/THC/generic/THCTensorScatterGather.cu
+++ b/aten/src/THC/generic/THCTensorScatterGather.cu
@@ -12,25 +12,25 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(THCudaLongTensor_nDimension(state, index) == THCTensor_(nDimension)(state, src), 4,
+  THArgCheck(THCudaLongTensor__nDimension(state, index) == THCTensor_(_nDimension)(state, src), 4,
              "Index tensor must have same dimensions as input tensor");
   THLongStorage *indexSize = THCudaLongTensor_newSizeOf(state, index);
   THArgCheck(THCTensor_(isSize)(state, tensor, indexSize), 4,
              "Index tensor must have the same size as output tensor.");
   THLongStorage_free(indexSize);
-  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 3,
+  THArgCheck(dim >= 0 && dim < THCTensor_(_nDimension)(state, tensor), 3,
              "Index dimension is out of bounds");
-  THArgCheck(THCTensor_(nDimension)(state, src) == THCTensor_(nDimension)(state, tensor), 2,
+  THArgCheck(THCTensor_(_nDimension)(state, src) == THCTensor_(_nDimension)(state, tensor), 2,
              "Input tensor must have same dimensions as output tensor");
 
-  for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
+  for (int d = 0; d < THCTensor_(_nDimension)(state, tensor); d++) {
     if (d != dim) {
       THArgCheck(THCTensor_(size)(state, tensor, d) == THCTensor_(size)(state, src, d), 2,
                  "Input tensor must have same size as output tensor apart from the specified dimension");
     }
   }
 
-  THArgCheck(THCTensor_(nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
+  THArgCheck(THCTensor_(_nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
              1, CUTORCH_DIM_WARNING);
 
 
@@ -107,14 +107,14 @@ void THCTensor_(scatter)(THCState* state, THCTensor *tensor, int dim, THCudaLong
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 2,
+  THArgCheck(dim >= 0 && dim < THCTensor_(_nDimension)(state, tensor), 2,
              "Index dimension is out of bounds");
-  THArgCheck(THCudaLongTensor_nDimension(state, index) == THCTensor_(nDimension)(state, src), 3,
+  THArgCheck(THCudaLongTensor__nDimension(state, index) == THCTensor_(_nDimension)(state, src), 3,
              "Index tensor must have same dimensions as input tensor");
-  THArgCheck(THCTensor_(nDimension)(state, src) == THCTensor_(nDimension)(state, tensor), 4,
+  THArgCheck(THCTensor_(_nDimension)(state, src) == THCTensor_(_nDimension)(state, tensor), 4,
              "Input tensor must have same dimensions as output tensor");
 
-  for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
+  for (int d = 0; d < THCTensor_(_nDimension)(state, tensor); d++) {
     int64_t indexSizeD = THCudaLongTensor_size(state, index, d);
     if (d != dim) {
       THArgCheck(indexSizeD <= THCTensor_(size)(state, tensor, d), 3,
@@ -126,7 +126,7 @@ void THCTensor_(scatter)(THCState* state, THCTensor *tensor, int dim, THCudaLong
                THCudaLongTensor_sizeDesc(state, index).str, THCTensor_(sizeDesc)(state, src).str);
   }
 
-  THArgCheck(THCTensor_(nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
+  THArgCheck(THCTensor_(_nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
              1, CUTORCH_DIM_WARNING);
 
   const ptrdiff_t totalElements = THCudaLongTensor_nElement(state, index);
@@ -197,25 +197,25 @@ void THCTensor_(scatterAdd)(THCState* state, THCTensor *tensor, int dim, THCudaL
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 2,
+  THArgCheck(dim >= 0 && dim < THCTensor_(_nDimension)(state, tensor), 2,
              "Index dimension is out of bounds");
-  THArgCheck(THCudaLongTensor_nDimension(state, index) == THCTensor_(nDimension)(state, src), 3,
+  THArgCheck(THCudaLongTensor__nDimension(state, index) == THCTensor_(_nDimension)(state, src), 3,
              "Index tensor must have same dimensions as input tensor");
-  THArgCheck(THCTensor_(nDimension)(state, src) == THCTensor_(nDimension)(state, tensor), 4,
+  THArgCheck(THCTensor_(_nDimension)(state, src) == THCTensor_(_nDimension)(state, tensor), 4,
              "Input tensor must have same dimensions as output tensor");
   THLongStorage *indexDims = THCudaLongTensor_newSizeOf(state, index);
   THArgCheck(THCTensor_(isSize)(state, src, indexDims), 3,
              "Index tensor must have the same size as input tensor.");
   THLongStorage_free(indexDims);
 
-  for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
+  for (int d = 0; d < THCTensor_(_nDimension)(state, tensor); d++) {
     if (d != dim) {
       THArgCheck(THCTensor_(size)(state, tensor, d) == THCTensor_(size)(state, src, d), 4,
                  "Input tensor must have same size as output tensor apart from the specified dimension");
     }
   }
 
-  THArgCheck(THCTensor_(nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
+  THArgCheck(THCTensor_(_nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
              1, CUTORCH_DIM_WARNING);
 
   const ptrdiff_t totalElements = THCudaLongTensor_nElement(state, index);
@@ -288,13 +288,13 @@ THCTensor_(scatterFill)(THCState* state, THCTensor *tensor,
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, tensor));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 2,
+  THArgCheck(dim >= 0 && dim < THCTensor_(_nDimension)(state, tensor), 2,
              "Index dimension is out of bounds");
-  THArgCheck(THCudaLongTensor_nDimension(state, index) ==
-             THCTensor_(nDimension)(state, tensor), 3,
+  THArgCheck(THCudaLongTensor__nDimension(state, index) ==
+             THCTensor_(_nDimension)(state, tensor), 3,
              "Index tensor must have same dimensions as output tensor");
 
-  for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
+  for (int d = 0; d < THCTensor_(_nDimension)(state, tensor); d++) {
     if (d != dim) {
       THArgCheck(THCTensor_(size)(state, tensor, d) ==
                  THCudaLongTensor_size(state, index, d), 4,
@@ -302,7 +302,7 @@ THCTensor_(scatterFill)(THCState* state, THCTensor *tensor,
     }
   }
 
-  THArgCheck(THCTensor_(nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
+  THArgCheck(THCTensor_(_nDimension)(state, tensor) <= MAX_CUTORCH_DIMS,
              1, CUTORCH_DIM_WARNING);
 
   const ptrdiff_t totalElements = THCudaLongTensor_nElement(state, index);

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -13,16 +13,16 @@ THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
   THArgCheck(THCTensor_(isSize)(state, key, valueSize), 2,
              "Key tensor must have same size as value tensor");
   THLongStorage_free(valueSize);
-  int dims = THCudaLongTensor_nDimension(state, value);
+  int dims = THCudaLongTensor__nDimension(state, value);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimension)(state, key);
+  dims = THCTensor_(_nDimension)(state, key);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
 
   ptrdiff_t inElements = THCTensor_(nElement)(state, key);
   int64_t keySliceSize = THCTensor_(size)(state, key, dim);
   ptrdiff_t keySlices = inElements / keySliceSize;
 
-  if (THCTensor_(nDimension)(state, key) == 0) {
+  if (THCTensor_(_nDimension)(state, key) == 0) {
     // Zero-dim tensor; do nothing
     return;
   }
@@ -158,7 +158,7 @@ void THCTensor_(sortViaThrust)(THCState* state,
                                THCudaLongTensor* indices,
                                THCTensor* input,
                                int dim, bool dir) {
-  int nDims = THCTensor_(nDimension)(state, input);
+  int nDims = THCTensor_(_nDimension)(state, input);
 
   ptrdiff_t totalElements = THCTensor_(nElement)(state, input);
   int64_t sliceSize = THCTensor_(size)(state, input, dim);
@@ -283,11 +283,11 @@ THC_API void THCTensor_(sort)(THCState* state,
                                int dim, int order) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, sorted, input));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
-  int64_t dims = THCTensor_(nDimension)(state, sorted);
+  int64_t dims = THCTensor_(_nDimension)(state, sorted);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimension)(state, input);
+  dims = THCTensor_(_nDimension)(state, input);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimension(state, indices);
+  dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
 
   // Make sure sufficient output space is allocated

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -9,10 +9,10 @@ THC_API void THCTensor_(topk)(THCState* state,
                                int64_t k, int dim, int dir, int sorted) {
   THAssert(topK != NULL && indices != NULL && input != NULL);
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, topK, indices, input));
-  THArgCheck(THCTensor_(nDimension)(state, topK) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  int64_t dims = THCudaLongTensor_nDimension(state, indices);
+  THArgCheck(THCTensor_(_nDimension)(state, topK) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  int64_t dims = THCudaLongTensor__nDimension(state, indices);
   THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
-  int numDims = THCTensor_(nDimension)(state, input);
+  int numDims = THCTensor_(_nDimension)(state, input);
   THArgCheck(numDims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
 
   THArgCheck(dim >= 0 && dim < numDims, 6, "dim not in range");

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -6,7 +6,7 @@
  * access methods
  ******************************************************************************/
 
-int THCSTensor_(nDimension)(THCState *state, const THCSTensor *self)
+int THCSTensor_(_nDimension)(THCState *state, const THCSTensor *self)
 {
   return self->nDimensionI + self->nDimensionV;
 }
@@ -25,7 +25,7 @@ int64_t THCSTensor_(size)(THCState *state, const THCSTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->nDimensionI + self->nDimensionV),
       1, "dimension %d out of range of %dD tensor",
-      dim+1, THCSTensor_(nDimension)(state, self));
+      dim+1, THCSTensor_(_nDimension)(state, self));
   return self->size[dim];
 }
 
@@ -93,18 +93,18 @@ THCSTensor* THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI,
 
 // directly assign without cloning or retaining (internal method)
 THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values) {
-  int empty = THCTensor_(nDimension)(state, values) == 0;
+  int empty = THCTensor_(_nDimension)(state, values) == 0;
   if (!empty) {
-    THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 2, 2,
+    THArgCheck(THCIndexTensor_(_nDimension)(state, indices) == 2, 2,
         "indices must be nDim x nnz");
     THArgCheck(THCIndexTensor_(size)(state, indices, 1) == THCTensor_(size)(state, values, 0), 2,
         "indices and values must have same nnz");
     THArgCheck(THCIndexTensor_(size)(state, indices, 0) == self->nDimensionI, 2,
         "indices has incorrect first dimension, expected %d, got %d", self->nDimensionI, THCIndexTensor_(size)(state, indices, 0));
-    THArgCheck(THCTensor_(nDimension)(state, values) == self->nDimensionV + 1, 3,
-        "values has incorrect number of dimensions, expected %d, got %d", self->nDimensionV + 1, THCTensor_(nDimension)(state, values));
+    THArgCheck(THCTensor_(_nDimension)(state, values) == self->nDimensionV + 1, 3,
+        "values has incorrect number of dimensions, expected %d, got %d", self->nDimensionV + 1, THCTensor_(_nDimension)(state, values));
   } else {
-    THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 0, 2,
+    THArgCheck(THCIndexTensor_(_nDimension)(state, indices) == 0, 2,
         "if values is empty, indices must be empty too");
   }
   THCIndexTensor_(free)(state, self->indices);
@@ -148,7 +148,7 @@ THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices,
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
 
   int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
-  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+  int64_t nDimV = THCTensor_(_nDimension)(state, values) - 1;
 
   // TODO Make it work with N-dimensional values
   THArgCheck(nDimV > 0, 3, "size must be provided when nDimV > 0");
@@ -177,14 +177,14 @@ THCSTensor *THCSTensor_(newWithTensorAndSizeUnsafe)(THCState *state, THCIndexTen
   if (sizes == NULL) {
     return THCSTensor_(newWithTensor)(state, indices, values);
   }
-  if (THCudaLongTensor_nDimension(state, indices) == 0 && THCTensor_(nDimension)(state, values) == 0) {
+  if (THCudaLongTensor__nDimension(state, indices) == 0 && THCTensor_(_nDimension)(state, values) == 0) {
     return THCSTensor_(newWithSize)(state, sizes, NULL);
   }
 
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
 
   int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
-  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+  int64_t nDimV = THCTensor_(_nDimension)(state, values) - 1;
 
   return THCSTensor_(_newWithDimsAndTensor)(state, nDimI, nDimV, THLongStorage_data(sizes), indices, values);
 }
@@ -194,14 +194,14 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
   if (sizes == NULL) {
     return THCSTensor_(newWithTensor)(state, indices, values);
   }
-  if (THCudaLongTensor_nDimension(state, indices) == 0 && THCTensor_(nDimension)(state, values) == 0) {
+  if (THCudaLongTensor__nDimension(state, indices) == 0 && THCTensor_(_nDimension)(state, values) == 0) {
     return THCSTensor_(newWithSize)(state, sizes, NULL);
   }
 
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
 
   int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
-  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+  int64_t nDimV = THCTensor_(_nDimension)(state, values) - 1;
   THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 3,
       "number of dimensions must be nDimI + nDimV");
 
@@ -286,7 +286,7 @@ THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self, int d1,
 
 THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, int64_t nnz) {
   THCTensor *new_values;
-  if (THCTensor_(nDimension)(state, values) == 0) { // values tensor uninitialized
+  if (THCTensor_(_nDimension)(state, values) == 0) { // values tensor uninitialized
     new_values = THCTensor_(newWithSize1d)(state, nnz);
   } else {
     THLongStorage *size = THCTensor_(newSizeOf)(state, values);

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -5,7 +5,7 @@
 typedef struct THCSTensor THCSTensor;
 
 /**** access methods ****/
-THC_API int THCSTensor_(nDimension)(THCState *state, const THCSTensor *self);
+THC_API int THCSTensor_(_nDimension)(THCState *state, const THCSTensor *self);
 THC_API int THCSTensor_(nDimensionI)(THCState *state, const THCSTensor *self);
 THC_API int THCSTensor_(nDimensionV)(THCState *state, const THCSTensor *self);
 THC_API int64_t THCSTensor_(size)(THCState *state, const THCSTensor *self, int dim);

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -253,7 +253,7 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
 
   THCIndexTensor *indices = THCSTensor_(newIndices)(state, sparse);
   THCTensor *values = THCSTensor_(newValues)(state, sparse);
-  int64_t nDim = THCTensor_(nDimension)(state, dense);
+  int64_t nDim = THCTensor_(_nDimension)(state, dense);
   int64_t nDimI = THCSTensor_(nDimensionI)(state, sparse);
 
  if (THCSTensor_(isCoalesced)(state, sparse)) {

--- a/aten/src/THCUNN/common.h
+++ b/aten/src/THCUNN/common.h
@@ -61,7 +61,7 @@ inline int GET_BLOCKS(const int N)
   }
 
 #define THCUNN_check_dim_size(STATE, T, DIM, DIM_SIZE, SIZE) \
-  if (THCTensor_(nDimension)(STATE, T) != DIM ||             \
+  if (THCTensor_(_nDimension)(STATE, T) != DIM ||             \
       THCTensor_(size)(STATE, T, DIM_SIZE) != SIZE) {        \
       THCDescBuff s1 = THCTensor_(sizeDesc)(state, T);       \
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
@@ -69,7 +69,7 @@ inline int GET_BLOCKS(const int N)
   }
 
 #define THCUNN_check_dim_size_indices(STATE, T, DIM, DIM_SIZE, SIZE)  \
-  if (THCIndexTensor_(nDimension)(STATE, T) != DIM ||                 \
+  if (THCIndexTensor_(_nDimension)(STATE, T) != DIM ||                 \
       THCIndexTensor_(size)(STATE, T, DIM_SIZE) != SIZE) {            \
       THCDescBuff s1 = THCIndexTensor_(sizeDesc)(state, T);           \
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d" \

--- a/aten/src/THCUNN/generic/BatchNormalization.cu
+++ b/aten/src/THCUNN/generic/BatchNormalization.cu
@@ -11,7 +11,7 @@ static THCDeviceTensor<real, Dim> THNN_(devicetensor)(THCState *state, THCTensor
     return THCDeviceTensor<real, Dim>();
   }
 
-  int inDim = THCTensor_nDimension(state, t);
+  int inDim = THCTensor__nDimension(state, t);
   if (inDim == Dim) {
     return toDeviceTensor<real, Dim>(state, t);
   }

--- a/aten/src/THCUNN/generic/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/ClassNLLCriterion.cu
@@ -12,11 +12,11 @@ void THNN_(ClassNLLCriterion_updateOutput)(
            THCTensor *total_weight,
            int64_t ignore_index,
            bool reduce) {
-  if (THCIndexTensor_(nDimension)(state, target) > 1) {
+  if (THCIndexTensor_(_nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
 
-  int n_dims = THCTensor_(nDimension)(state, input);
+  int n_dims = THCTensor_(_nDimension)(state, input);
   int n_classes = THCTensor_(size)(state, input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
@@ -85,7 +85,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
   real *output_data = THCTensor_(data)(state, output);
   real *total_weight_data = THCTensor_(data)(state, total_weight);
 
-  if (THCTensor_(nDimension)(state, input) == 1) {
+  if (THCTensor_(_nDimension)(state, input) == 1) {
     cunn_ClassNLLCriterion_updateOutput_kernel1<real>
       <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
         output_data,
@@ -98,7 +98,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         ignore_index
     );
 
-  } else if (THCTensor_(nDimension)(state, input) == 2) {
+  } else if (THCTensor_(_nDimension)(state, input) == 2) {
     cunn_ClassNLLCriterion_updateOutput_kernel<real, accreal>
       <<<1, NTHREADS, 0, THCState_getCurrentStream(state)>>>(
         output_data,
@@ -133,11 +133,11 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
            THCTensor *total_weight,
            int64_t ignore_index,
            bool reduce) {
-  if (THCIndexTensor_(nDimension)(state, target) > 1) {
+  if (THCIndexTensor_(_nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
 
-  int n_dims = THCTensor_(nDimension)(state, input);
+  int n_dims = THCTensor_(_nDimension)(state, input);
   int n_classes = THCTensor_(size)(state, input, n_dims - 1);
 
   THCTensor_(resizeAs)(state, gradInput, input);
@@ -207,7 +207,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   THCIndex_t  *target_data = THCIndexTensor_(data)(state, target);
   real *total_weight_data = THCTensor_(data)(state, total_weight);
 
-  if (THCTensor_(nDimension)(state, input) == 1) {
+  if (THCTensor_(_nDimension)(state, input) == 1) {
     cunn_ClassNLLCriterion_updateGradInput_kernel1<real>
       <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
         gradInput_data,

--- a/aten/src/THCUNN/generic/Col2Im.cu
+++ b/aten/src/THCUNN/generic/Col2Im.cu
@@ -17,7 +17,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "dilation should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = THCTensor_(nDimension)(state, input);
+  int ndim = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, ndim == 2 || ndim == 3, 2, input,
                   "2D or 3D input tensor expected but got %s");
 

--- a/aten/src/THCUNN/generic/FeatureLPPooling.cu
+++ b/aten/src/THCUNN/generic/FeatureLPPooling.cu
@@ -15,7 +15,7 @@
 // [batch dim][feature dim][opt dim 1][opt dim 2]
 THCDeviceTensor<real, 4>
 THNN_(FeatureLPPooling_upcast)(THCState* state, THCTensor* t, bool batchMode) {
-  int inputDim = THCTensor_(nDimension)(state, t);
+  int inputDim = THCTensor_(_nDimension)(state, t);
 
   if (inputDim == 1) {
     // [feature dim]
@@ -58,7 +58,7 @@ THNN_(FeatureLPPooling_resizeForOutput)(THCState* state,
                                         bool batchMode,
                                         int width,
                                         int stride) {
-  int inputDim = THCTensor_(nDimension)(state, input);
+  int inputDim = THCTensor_(_nDimension)(state, input);
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   int64_t outSize =
@@ -109,7 +109,7 @@ void
 THNN_(FeatureLPPooling_resize)(THCState* state,
                                THCTensor* toResize,
                                THCTensor* src) {
-  int inputDim = THCTensor_(nDimension)(state, src);
+  int inputDim = THCTensor_(_nDimension)(state, src);
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   if (inputDim == 1) {
@@ -149,7 +149,7 @@ void THNN_(FeatureLPPooling_updateOutput)(THCState* state,
                                           bool batchMode) {
   THCUNN_assertSameGPU(state, 2, inputTH, outputTH);
 
-  int inputDim = THCTensor_(nDimension)(state, inputTH);
+  int inputDim = THCTensor_(_nDimension)(state, inputTH);
 
   if (batchMode) {
     THArgCheck(inputDim >= 2 && inputDim <= 4, 2,
@@ -207,7 +207,7 @@ void THNN_(FeatureLPPooling_updateGradInput)(THCState* state,
                 "input tensor must fit into 32-bit index math");
   THCUNN_assertSameGPU(state, 4, gradOutputTH, inputTH, outputTH, gradInputTH);
 
-  int inputDim = THCTensor_(nDimension)(state, inputTH);
+  int inputDim = THCTensor_(_nDimension)(state, inputTH);
 
   if (batchMode) {
     THArgCheck(inputDim >= 2 && inputDim <= 4, 2,

--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -18,10 +18,10 @@ void THNN_(FusedRNNAssertSizes)(THCState *state, int factor, int count, ...)
              THCTensor_(nElement)(state, hidden),
              3, "Input and Hidden tensor sizes should be the same.");
 
-  THAssertMsg(THCTensor_nDimension(state, input) <= MAX_CUTORCH_DIMS,
+  THAssertMsg(THCTensor__nDimension(state, input) <= MAX_CUTORCH_DIMS,
               "Tensor dimension is too large.");
 
-  THAssertMsg(THCTensor_nDimension(state, hidden) <= MAX_CUTORCH_DIMS,
+  THAssertMsg(THCTensor__nDimension(state, hidden) <= MAX_CUTORCH_DIMS,
               "Tensor dimension is too large.");
 
   for (int arg=2; arg < count; ++arg){
@@ -29,7 +29,7 @@ void THNN_(FusedRNNAssertSizes)(THCState *state, int factor, int count, ...)
     THArgCheck(THCTensor_(nElement)(state, input) ==
                THCTensor_(nElement)(state, tens)*factor,
                3, "A pointwise tensor was not the right size, should have 1/%u the elements of input/hidden tensor.", arg, factor);
-    THAssertMsg(THCTensor_nDimension(state, tens) <= MAX_CUTORCH_DIMS,
+    THAssertMsg(THCTensor__nDimension(state, tens) <= MAX_CUTORCH_DIMS,
          "Tensor dimension is too large.");
   }
 
@@ -42,13 +42,13 @@ int THNN_(minIndexType)(THCState *state, int count, ...)
   va_start(list, count);
 
   THCTensor* tens = va_arg(list, THCTensor*);
-  int startDim = THCTensor_nDimension(state, tens);
+  int startDim = THCTensor__nDimension(state, tens);
   bool canCollapse = THCTensor_(isContiguous)(state,tens);
 
   for (int arg=1; arg < count; ++arg){
     tens = va_arg(list, THCTensor*);
     canCollapse = canCollapse && THCTensor_(isContiguous)(state, tens);
-    if(THCTensor_nDimension(state, tens) != startDim){
+    if(THCTensor__nDimension(state, tens) != startDim){
       va_end(list);
       return -1;
     }

--- a/aten/src/THCUNN/generic/Im2Col.cu
+++ b/aten/src/THCUNN/generic/Im2Col.cu
@@ -18,7 +18,7 @@ static inline void THNN_(Im2Col_shapeCheck)(
   THArgCheck(sW > 0 && sH > 0, 10,
              "stride should be greater than zero, but got sH: %d sW: %d", sH, sW);
 
-  int ndim = THCTensor_(nDimension)(state, input);
+  int ndim = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, ndim == 3 || ndim == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
 

--- a/aten/src/THCUNN/generic/IndexLinear.cu
+++ b/aten/src/THCUNN/generic/IndexLinear.cu
@@ -6,8 +6,8 @@ static bool THNN_(checkKeysValues)(THCState *state, THCudaLongTensor* keys,
                                    THCTensor* values)
 {
     return THCudaLongTensor_size(state, keys, 0) == THCTensor_(nElement)(state, values)
-        && THCTensor_(nDimension)(state, values) == 1
-        && THCudaLongTensor_nDimension(state, keys) == 1;
+        && THCTensor_(_nDimension)(state, values) == 1
+        && THCudaLongTensor__nDimension(state, keys) == 1;
 }
 
 void THNN_(IndexLinear_updateOutput)(

--- a/aten/src/THCUNN/generic/LookupTable.cu
+++ b/aten/src/THCUNN/generic/LookupTable.cu
@@ -22,8 +22,8 @@ void THNN_(LookupTable_accGradParameters)(
     THError("Tensors must be contiguous");
   }
 
-  int nDim = THCIndexTensor_(nDimension)(state, input);
-  if (THCIndexTensor_(nDimension)(state, input) != 1 && THCIndexTensor_(nDimension)(state, input) != 2) {
+  int nDim = THCIndexTensor_(_nDimension)(state, input);
+  if (THCIndexTensor_(_nDimension)(state, input) != 1 && THCIndexTensor_(_nDimension)(state, input) != 2) {
     THCDescBuff s1 = THCIndexTensor_(sizeDesc)(state, input);
     THError("input must be a vector or matrix, but is of shape: %s", s1.str);
   }
@@ -170,7 +170,7 @@ void THNN_(LookupTable_renorm)(
     THError("Tensors must be contiguous");
   }
 
-  if (THCIndexTensor_(nDimension)(state, idx) != 1) {
+  if (THCIndexTensor_(_nDimension)(state, idx) != 1) {
     THError("idx must be a vector");
   }
 

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -88,8 +88,8 @@ void THNN_(LookupTableBag_accGradParameters)(
     bag_size_data = THCIndexTensor_(data)(state, bag_size);
   }
 
-  int nDim = THCIndexTensor_(nDimension)(state, input);
-  if (THCIndexTensor_(nDimension)(state, input) != 1 && THCIndexTensor_(nDimension)(state, input) != 2) {
+  int nDim = THCIndexTensor_(_nDimension)(state, input);
+  if (THCIndexTensor_(_nDimension)(state, input) != 1 && THCIndexTensor_(_nDimension)(state, input) != 2) {
     THCDescBuff s1 = THCIndexTensor_(sizeDesc)(state, input);
     THError("input must be a vector or matrix, but is of shape: %s", s1.str);
   }

--- a/aten/src/THCUNN/generic/PReLU.cu
+++ b/aten/src/THCUNN/generic/PReLU.cu
@@ -20,7 +20,7 @@ void THNN_(PReLU_updateOutput)(
   }
   else
   {
-    int ndim = THCTensor_(nDimension)(state, input);
+    int ndim = THCTensor_(_nDimension)(state, input);
     input = THCTensor_(newContiguous)(state, input);
 
     int n = THCTensor_(nElement)(state, input);
@@ -64,7 +64,7 @@ void THNN_(PReLU_updateGradInput)(
   }
   else
   {
-    int ndim = THCTensor_(nDimension)(state, input);
+    int ndim = THCTensor_(_nDimension)(state, input);
     input = THCTensor_(newContiguous)(state, input);
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
@@ -119,7 +119,7 @@ void THNN_(PReLU_accGradParameters)(
   }
   else
   {
-    int ndim = THCTensor_(nDimension)(state, input);
+    int ndim = THCTensor_(_nDimension)(state, input);
 
     if (ndim == 1)
     {

--- a/aten/src/THCUNN/generic/SparseLinear.cu
+++ b/aten/src/THCUNN/generic/SparseLinear.cu
@@ -41,7 +41,7 @@ void THNN_(SparseLinear_updateOutput)(
   int64_t inDim = THCTensor_(size)(state, weight, 1);
 
   THArgCheck(THNN_(checkInput)(input), 2, "input size must be nnz x 3");
-  THArgCheck(THCTensor_(nDimension)(state, output) == 2, 3, "output must be batchsize x outputsize");
+  THArgCheck(THCTensor_(_nDimension)(state, output) == 2, 3, "output must be batchsize x outputsize");
   THArgCheck(THNN_(checkSize1D)(bias, outDim), 5, "bias size wrong");
 
   weight = THCTensor_(newContiguous)(state, weight);

--- a/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -8,13 +8,13 @@ void THNN_(SpatialClassNLLCriterion_shapeCheck)(
            THCIndexTensor *target,
            THCTensor *weights)
 {
-  THArgCheck(THCIndexTensor_(nDimension)(state, target) == 3, 1,
+  THArgCheck(THCIndexTensor_(_nDimension)(state, target) == 3, 1,
              "only batches of spatial targets supported (3D tensors)" \
              " but got targets of dimension: %d",
-             THCIndexTensor_(nDimension)(state, target));
-  THArgCheck(THCTensor_(nDimension)(state, input) == 4, 2,
+             THCIndexTensor_(_nDimension)(state, target));
+  THArgCheck(THCTensor_(_nDimension)(state, input) == 4, 2,
              "only batches of spatial inputs supported (4D tensors), "      \
-             "but got input of dimension: %d", THCTensor_(nDimension)(state, input));
+             "but got input of dimension: %d", THCTensor_(_nDimension)(state, input));
   if (THCTensor_(size)(state, input, 0) != THCIndexTensor_(size)(state, target, 0) ||
       THCTensor_(size)(state, input, 2) != THCIndexTensor_(size)(state, target, 1) ||
       THCTensor_(size)(state, input, 3) != THCIndexTensor_(size)(state, target, 2)) {
@@ -34,9 +34,9 @@ static void THNN_(SpatialClassNLLCriterion_gradOutput_no_reduce_shapeCheck)(
            THCTensor *gradOutput,
            THCIndexTensor *target)
 {
-  THArgCheck(THCTensor_(nDimension)(state, gradOutput) == 3, 2,
+  THArgCheck(THCTensor_(_nDimension)(state, gradOutput) == 3, 2,
              "Expected dimension 3 but got gradOutput of dimension: %d",
-             THCTensor_(nDimension)(state, gradOutput));
+             THCTensor_(_nDimension)(state, gradOutput));
   if (THCTensor_(size)(state, gradOutput, 0) != THCIndexTensor_(size)(state, target, 0) ||
       THCTensor_(size)(state, gradOutput, 1) != THCIndexTensor_(size)(state, target, 1) ||
       THCTensor_(size)(state, gradOutput, 2) != THCIndexTensor_(size)(state, target, 2)) {

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -16,8 +16,8 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   THCUNN_assertSameGPU(state, 3, input, output, weight);
 
   // Only handle 4D Input Tensors for now
-  THAssert(THCTensor_(nDimension)(state, input) == 4);
-  THAssert(THCTensor_(nDimension)(state, weight) == 4);
+  THAssert(THCTensor_(_nDimension)(state, input) == 4);
+  THAssert(THCTensor_(_nDimension)(state, weight) == 4);
 
   // We assume that the input and weight Tensors are shaped properly by
   // the caller, so we verify that here to some extent
@@ -107,9 +107,9 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
   THCUNN_assertSameGPU(state, 3, gradOutput, gradInput, weight);
 
   // Only handle 4D Input Tensors for now
-  THAssert(THCTensor_(nDimension)(state, input) == 4);
-  THAssert(THCTensor_(nDimension)(state, weight) == 4);
-  THAssert(THCTensor_(nDimension)(state, gradOutput) == 4);
+  THAssert(THCTensor_(_nDimension)(state, input) == 4);
+  THAssert(THCTensor_(_nDimension)(state, weight) == 4);
+  THAssert(THCTensor_(_nDimension)(state, gradOutput) == 4);
 
   // Minimal shape checking, as above
   // Same # of elements in batch
@@ -204,9 +204,9 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   THCUNN_assertSameGPU(state, 3, input, gradOutput, gradWeight);
 
   // Only handle 4D Input Tensors for now
-  THAssert(THCTensor_(nDimension)(state, input) == 4);
-  THAssert(THCTensor_(nDimension)(state, gradOutput) == 4);
-  THAssert(THCTensor_(nDimension)(state, gradWeight) == 4);
+  THAssert(THCTensor_(_nDimension)(state, input) == 4);
+  THAssert(THCTensor_(_nDimension)(state, gradOutput) == 4);
+  THAssert(THCTensor_(_nDimension)(state, gradWeight) == 4);
 
   // Minimal shape checking as above
   // Same # of elements in batch

--- a/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
@@ -16,7 +16,7 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int dimw = 2;
   int64_t numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 3 || numInputDims == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
@@ -106,7 +106,7 @@ void THNN_(SpatialFractionalMaxPooling_updateGradInput)(
   int dimh = 1;
   int dimw = 2;
 
-  int64_t numInputDims = THCTensor_(nDimension)(state, input);
+  int64_t numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 4) {
     dimh++;
     dimw++;

--- a/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -7,9 +7,9 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)(
     THCTensor *input,
     THCTensor *grid,
     THCTensor *gradOutput) {
-  THCUNN_argCheck(state, THCTensor_(nDimension)(state, input) == 4, 2, input,
+  THCUNN_argCheck(state, THCTensor_(_nDimension)(state, input) == 4, 2, input,
       "4D input tensor expected but got: %s");
-  THCUNN_argCheck(state, THCTensor_(nDimension)(state, grid) == 4, 2, grid,
+  THCUNN_argCheck(state, THCTensor_(_nDimension)(state, grid) == 4, 2, grid,
       "4D grid tensor expected but got: %s");
 
   int64_t nbatch   = THCTensor_(size)(state, input, 0);

--- a/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
@@ -15,7 +15,7 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THCState *state,
   int dimw = 2;
   int numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 3 || numInputDims == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
@@ -91,7 +91,7 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(
   int dimh = 1;
   int dimw = 2;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 4) {
     planeDim++;
     dimh++;

--- a/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
@@ -16,7 +16,7 @@ void THNN_(SpatialReplicationPadding_updateOutput)(
   int dimw = 2;
   int numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 3 || numInputDims == 4, 2, input,
                   "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
@@ -81,7 +81,7 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(
   int dimh = 1;
   int dimw = 2;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 4) {
     planeDim++;
     dimh++;

--- a/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
@@ -13,7 +13,7 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THCState *state,
   int dimw = 1;
   int numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 2 || numInputDims == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s")
 
@@ -79,7 +79,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(
   int planeDim = 0;
   int dimw = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 3) {
     planeDim++;
     dimw++;

--- a/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
@@ -14,7 +14,7 @@ void THNN_(TemporalReplicationPadding_updateOutput)(
   int dimw = 1;
   int numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 2 || numInputDims == 3, 2, input,
                   "2D or 3D (batch mode) tensor expected for input, but got: %s")
 
@@ -74,7 +74,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(
   int planeDim = 0;
   int dimw = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 3) {
     planeDim++;
     dimw++;

--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -30,7 +30,7 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
     dimw++;
   }
 
-  if (THCTensor_(nDimension)(state, input) == 4)
+  if (THCTensor_(_nDimension)(state, input) == 4)
   {
     THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
                && input->size[dimt] >= kT, 2,
@@ -45,7 +45,7 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
     inputHeight = THCTensor_(size)(state, input, 2);
     inputWidth  = THCTensor_(size)(state, input, 3);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else if (THCTensor_(_nDimension)(state, input) == 5)
   {
     THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
                && input->size[dimt] >= kT, 2,
@@ -128,7 +128,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
   if (fiveDimensionalInput)
   {
     dimt++;
@@ -284,7 +284,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   int outputHeight;
   int outputWidth;
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
   if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -51,7 +51,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
     dimw++;
   }
 
-  if (THCTensor_(nDimension)(state, input) == 4)
+  if (THCTensor_(_nDimension)(state, input) == 4)
   {
     /* sizes */
     inputSlices = THCTensor_(size)(state, input, 0);
@@ -59,7 +59,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
     inputHeight = THCTensor_(size)(state, input, 2);
     inputWidth  = THCTensor_(size)(state, input, 3);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else if (THCTensor_(_nDimension)(state, input) == 5)
   {
     /* sizes */
     inputSlices = THCTensor_(size)(state, input, 1);
@@ -69,7 +69,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
   }
   else
   {
-    THArgError(2, "4D or 5D tensor expected, got %d", THCTensor_(nDimension)(state, input));
+    THArgError(2, "4D or 5D tensor expected, got %d", THCTensor_(_nDimension)(state, input));
   }
 
   THArgCheck(kT/2 >= padT && kW/2 >= padW && kH/2 >= padH, 13,
@@ -142,7 +142,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
 
   if (fiveDimensionalInput)
   {
@@ -157,7 +157,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
         dT, dW, dH, padT, padW, padH,
         dilationT, dilationW, dilationH, ceilMode);
 
-  if (THCTensor_(nDimension)(state, input) == 4)
+  if (THCTensor_(_nDimension)(state, input) == 4)
   {
     /* sizes */
     batchSize   = 1;
@@ -177,7 +177,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   }
   else
   {
-    THArgError(2, "4D or 5D tensor expected, got %d", THCTensor_(nDimension)(state, input));
+    THArgError(2, "4D or 5D tensor expected, got %d", THCTensor_(_nDimension)(state, input));
   }
 
   if (ceilMode)
@@ -316,7 +316,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   int outputTime, outputHeight, outputWidth;
   int inputTime, inputHeight, inputWidth;
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
 
   THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
   THNN_(VolumetricDilatedMaxPooling_shapeCheck)(

--- a/aten/src/THCUNN/generic/VolumetricFractionalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricFractionalMaxPooling.cu
@@ -17,7 +17,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
   int dimt = 3;
   int64_t numBatch = 1;
 
-  int64_t numInputDims = THCTensor_(nDimension)(state, input);
+  int64_t numInputDims = THCTensor_(_nDimension)(state, input);
   THCUNN_argCheck(state, numInputDims == 4 || numInputDims == 5, 2, input,
                   "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
@@ -113,7 +113,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
   int dimw = 2;
   int dimt = 3;
 
-  int64_t numInputDims = THCTensor_(nDimension)(state, input);
+  int64_t numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 5) {
     dimh++;
     dimw++;

--- a/aten/src/THCUNN/generic/VolumetricGridSamplerBilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricGridSamplerBilinear.cu
@@ -7,9 +7,9 @@ static inline void THNN_(VolumetricGridSamplerBilinear_shapeCheck)(
     THCTensor *input,
     THCTensor *grid,
     THCTensor *gradOutput) {
-  THCUNN_argCheck(state, THCTensor_(nDimension)(state, input) == 5, 2, input,
+  THCUNN_argCheck(state, THCTensor_(_nDimension)(state, input) == 5, 2, input,
       "5D input tensor expected but got: %s");
-  THCUNN_argCheck(state, THCTensor_(nDimension)(state, grid) == 5, 2, grid,
+  THCUNN_argCheck(state, THCTensor_(_nDimension)(state, grid) == 5, 2, grid,
       "5D grid tensor expected but got: %s");
 
   int64_t nbatch   = THCTensor_(size)(state, input, 0);

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -24,18 +24,18 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d",
              dT, dH, dW);
 
-  if (THCTensor_(nDimension)(state, input) == 4)
+  if (THCTensor_(_nDimension)(state, input) == 4)
   {
     inputSlices = THCTensor_(size)(state, input, 0);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else if (THCTensor_(_nDimension)(state, input) == 5)
   {
     inputSlices = THCTensor_(size)(state, input, 1);
   }
   else
   {
     THArgCheck(false, 2, "4D or 5D tensor expected, got %d",
-               THCTensor_(nDimension)(state, input));
+               THCTensor_(_nDimension)(state, input));
   }
 
   int dimw = 3;
@@ -83,8 +83,8 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
         dT, dW, dH, padT, padW, padH);
   THCUNN_assertSameGPU(state, 3, input, indices, output);
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
-  if (THCTensor_(nDimension)(state, input) == 4)
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
+  if (THCTensor_(_nDimension)(state, input) == 4)
   {
     /* sizes */
     batchSize   = 1;
@@ -192,7 +192,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
         dT, dW, dH, padT, padW, padH);
   THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
 
-  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  int fiveDimensionalInput = THCTensor_(_nDimension)(state, input) == 5;
   if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;

--- a/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
@@ -11,7 +11,7 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
                          int pfront, int pback) {
   THArgCheck(THCTensor_canUse32BitIndexMath(state, input), 2,
              "input tensor must fit into 32-bit index math");
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
 
   THCUNN_argCheck(state, numInputDims == 4 || numInputDims == 5, 2, input,
     "4D or 5D (batch mode) tensor expected for input, but got: %s");
@@ -75,7 +75,7 @@ void THNN_(VolumetricReplicationPadding_updateOutput)(
   int dimw = 3;
   int numBatch = 1;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
 
   if (numInputDims == 5) {
     numBatch = THCTensor_(size)(state, input, 0);
@@ -137,7 +137,7 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(
   int dimh = 2;
   int dimw = 3;
 
-  int numInputDims = THCTensor_(nDimension)(state, input);
+  int numInputDims = THCTensor_(_nDimension)(state, input);
   if (numInputDims == 5) {
     planeDim++;
     dimd++;

--- a/aten/src/THNN/generic/ClassNLLCriterion.c
+++ b/aten/src/THNN/generic/ClassNLLCriterion.c
@@ -14,14 +14,14 @@ void THNN_(ClassNLLCriterion_updateOutput)(
           bool reduce)
 {
   THTensor_(resize1d)(total_weight, 1);
-  int n_dims = THTensor_(nDimension)(input);
+  int n_dims = THTensor_(_nDimension)(input);
   int n_classes = THTensor_(size)(input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
-  if (THIndexTensor_(nDimension)(target) > 1) {
+  if (THIndexTensor_(_nDimension)(target) > 1) {
     THError("multi-target not supported");
   }
-  if (THTensor_(nDimension)(input) > 2) {
+  if (THTensor_(_nDimension)(input) > 2) {
     THError("input tensor should be 1D or 2D");
   }
   if (weights && THTensor_(nElement)(weights) != n_classes) {
@@ -78,14 +78,14 @@ void THNN_(ClassNLLCriterion_updateOutput)(
 
   output_data[0] = total_weight_data[0] = 0.0;
 
-  if (THTensor_(nDimension)(input) == 1) {
+  if (THTensor_(_nDimension)(input) == 1) {
     int cur_target = target_data[0] - TH_INDEX_BASE;
     if (cur_target != ignore_index) {
       THAssert(cur_target >= 0 && cur_target < n_classes);
       total_weight_data[0] = weights ? weights_data[cur_target] : 1.0f;
       output_data[0] = -input_data[cur_target] * total_weight_data[0];
     }
-  } else if (THTensor_(nDimension)(input) == 2) {
+  } else if (THTensor_(_nDimension)(input) == 2) {
     int batch_size = THTensor_(size)(input, 0);
     THAssert(THIndexTensor_(size)(target, 0) == batch_size);
 
@@ -130,7 +130,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  int n_dims = THTensor_(nDimension)(input);
+  int n_dims = THTensor_(_nDimension)(input);
   int n_classes = THTensor_(size)(input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
@@ -138,11 +138,11 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
     THError("gradInput must be contiguous");
   }
 
-  if (THIndexTensor_(nDimension)(target) > 1) {
+  if (THIndexTensor_(_nDimension)(target) > 1) {
     THError("multi-target not supported");
   }
 
-  if (THTensor_(nDimension)(input) > 2) {
+  if (THTensor_(_nDimension)(input) > 2) {
     THError("input tensor should be 1D or 2D");
   }
 
@@ -187,7 +187,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
 
   real gradOutput_value = THTensor_(get1d)(gradOutput, 0);
 
-  if (THTensor_(nDimension)(input) == 1) {
+  if (THTensor_(_nDimension)(input) == 1) {
     int cur_target = target_data[0] - TH_INDEX_BASE;
     if (cur_target != ignore_index) {
       THAssert(cur_target >= 0 && cur_target < n_classes);
@@ -197,7 +197,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
       gradInput_data[cur_target] *= gradOutput_value;
     }
 
-  } else if (THTensor_(nDimension)(input) == 2) {
+  } else if (THTensor_(_nDimension)(input) == 2) {
     int batch_size = THTensor_(size)(input, 0);
     THAssert(THIndexTensor_(size)(target, 0) == batch_size);
 

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -124,7 +124,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "dilation should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = THTensor_(nDimension)(input);
+  int ndim = THTensor_(_nDimension)(input);
   THNN_ARGCHECK(ndim == 2 || ndim == 3, 2, input,
                 "2D or 3D input tensor expected but got %s");
 

--- a/aten/src/THNN/generic/FeatureLPPooling.c
+++ b/aten/src/THNN/generic/FeatureLPPooling.c
@@ -39,7 +39,7 @@ static inline size_t flpOutputSize(FEATURE_LP_SIZE_TYPE inputSize,
 
 FeatureLPPoolingSizes
 THNN_(FeatureLPPooling_upcastCPU)(THTensor* t, bool batchMode) {
-  int dim = THTensor_(nDimension)(t);
+  int dim = THTensor_(_nDimension)(t);
 
   // Upcast to [batch dim][feature dim][opt dim 1][opt dim 2]
   FeatureLPPoolingSizes s;
@@ -99,7 +99,7 @@ THNN_(FeatureLPPooling_resizeForOutputCPU)(THTensor* toResize,
                                            bool batchMode,
                                            int width,
                                            int stride) {
-  int inputDim = THTensor_(nDimension)(input);
+  int inputDim = THTensor_(_nDimension)(input);
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   int64_t outSize =
@@ -147,7 +147,7 @@ THNN_(FeatureLPPooling_resizeForOutputCPU)(THTensor* toResize,
 void
 THNN_(FeatureLPPooling_resizeCPU)(THTensor* toResize,
                                   THTensor* src) {
-  int inputDim = THTensor_(nDimension)(src);
+  int inputDim = THTensor_(_nDimension)(src);
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   if (inputDim == 1) {
@@ -183,7 +183,7 @@ THNN_(FeatureLPPooling_updateOutput)(
   int width,
   int stride,
   bool batchMode) {
-  int inputDim = THTensor_(nDimension)(input);
+  int inputDim = THTensor_(_nDimension)(input);
 
   if (batchMode) {
     THArgCheck(inputDim >= 2 && inputDim <= 4, 2,
@@ -261,7 +261,7 @@ THNN_(FeatureLPPooling_updateGradInput)(
   int width,
   int stride,
   bool batchMode) {
-  int inputDim = THTensor_(nDimension)(input);
+  int inputDim = THTensor_(_nDimension)(input);
 
   if (batchMode) {
     THArgCheck(inputDim >= 2 && inputDim <= 4, 3,

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -16,7 +16,7 @@ static inline void THNN_(Im2Col_shapeCheck)(
   THArgCheck(sW > 0 && sH > 0, 10,
              "stride should be greater than zero, but got sH: %d sW: %d", sH, sW);
 
-  int ndim = THTensor_(nDimension)(input);
+  int ndim = THTensor_(_nDimension)(input);
   THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
                 "3D or 4D input tensor expected but got: %s");
 

--- a/aten/src/THNN/generic/IndexLinear.c
+++ b/aten/src/THNN/generic/IndexLinear.c
@@ -24,8 +24,8 @@
 static bool THNN_(checkKeysValues)(THLongTensor* keys, THTensor* values)
 {
   return THLongTensor_size(keys, 0) == THTensor_(nElement)(values)
-                && THTensor_(nDimension)(values) == 1
-                && THLongTensor_nDimension(keys) == 1;
+                && THTensor_(_nDimension)(values) == 1
+                && THLongTensor__nDimension(keys) == 1;
 }
 
 void THNN_(IndexLinear_updateOutput)(

--- a/aten/src/THNN/generic/Linear.c
+++ b/aten/src/THNN/generic/Linear.c
@@ -23,7 +23,7 @@ void THNN_(Linear_updateOutput)(
           THTensor *bias,
           THTensor *addBuffer)
 {
-  int64_t dim = THTensor_(nDimension)(input);
+  int64_t dim = THTensor_(_nDimension)(input);
   if (dim == 1) {
     THTensor_(resize1d)(output,THTensor_(size)(weight,0));
     if (bias) {
@@ -66,7 +66,7 @@ void THNN_(Linear_updateGradInput)(
       THTensor_(zero)(gradInput);
     }
 
-    int64_t dim = THTensor_(nDimension)(input);
+    int64_t dim = THTensor_(_nDimension)(input);
     if (dim == 1) {
       THTensor *tweight = THTensor_(new)();
       THTensor_(transpose)(tweight,weight,0,1);
@@ -92,7 +92,7 @@ void THNN_(Linear_accGradParameters)(
           accreal scale_)
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
-  int64_t dim = THTensor_(nDimension)(input);
+  int64_t dim = THTensor_(_nDimension)(input);
   if (dim == 1) {
     THTensor_(addr)(gradWeight,1,gradWeight,scale,gradOutput,input);
     if (bias) {

--- a/aten/src/THNN/generic/LookupTable.c
+++ b/aten/src/THNN/generic/LookupTable.c
@@ -48,7 +48,7 @@ void THNN_(LookupTable_accGradParameters)(
     THError("gradWeight must be contiguous");
   if (!THIndexTensor_(isContiguous)(input))
     THError("input must be contiguous");
-  if (THIndexTensor_(nDimension)(input) != 1 && THIndexTensor_(nDimension)(input) != 2) {
+  if (THIndexTensor_(_nDimension)(input) != 1 && THIndexTensor_(_nDimension)(input) != 2) {
     THDescBuff s1 = THIndexTensor_(sizeDesc)(input);
     THError("input must be a vector or matrix, but is of shape: %s", s1.str);
   }
@@ -173,7 +173,7 @@ void THNN_(LookupTable_renorm)(
     THError("weight must be contiguous");
   if (!THIndexTensor_(isContiguous)(idx))
     THError("input must be contiguous");
-  if (THIndexTensor_(nDimension)(idx) != 1)
+  if (THIndexTensor_(_nDimension)(idx) != 1)
     THError("idx must be a vector");
   if (normType <= 0)
     THError("non-positive-norm not supported");

--- a/aten/src/THNN/generic/PReLU.c
+++ b/aten/src/THNN/generic/PReLU.c
@@ -24,7 +24,7 @@ void THNN_(PReLU_updateOutput)(
   input = THTensor_(newContiguous)(input);
   int64_t bs = 1, ks = 1;
   {
-    int64_t input_ndim = THTensor_(nDimension)(input);
+    int64_t input_ndim = THTensor_(_nDimension)(input);
     if (input->size[input_ndim > 1] != nOutputPlane)
       THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
 
@@ -89,7 +89,7 @@ void THNN_(PReLU_updateGradInput)(
 
   int64_t bs = 1, ks = 1;
   {
-    int64_t input_ndim = THTensor_(nDimension)(input);
+    int64_t input_ndim = THTensor_(_nDimension)(input);
     if (input->size[input_ndim > 1] != nOutputPlane)
       THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
 
@@ -160,7 +160,7 @@ void THNN_(PReLU_accGradParameters)(
   weight = THTensor_(newContiguous)(weight);
   int64_t bs = 1, ks = 1;
   {
-    int64_t input_ndim = THTensor_(nDimension)(input);
+    int64_t input_ndim = THTensor_(_nDimension)(input);
     if (input->size[input_ndim > 1] != nOutputPlane)
       THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
 

--- a/aten/src/THNN/generic/SpatialClassNLLCriterion.c
+++ b/aten/src/THNN/generic/SpatialClassNLLCriterion.c
@@ -3,13 +3,13 @@
 #else
 
 #define INITIAL_CHECK                                                            \
-  THArgCheck(THIndexTensor_(nDimension)(target) == 3, 3,                         \
+  THArgCheck(THIndexTensor_(_nDimension)(target) == 3, 3,                         \
     "only batches of spatial targets supported (3D tensors)"		         \
 	     " but got targets of dimension: %d",			         \
-	     THIndexTensor_(nDimension)(target));			         \
-  THArgCheck(THTensor_(nDimension)(input) == 4, 2,			         \
+	     THIndexTensor_(_nDimension)(target));			         \
+  THArgCheck(THTensor_(_nDimension)(input) == 4, 2,			         \
 	     "only batches of spatial inputs supported (4D tensors), "	         \
-	     "but got input of dimension: %d", THTensor_(nDimension)(input));    \
+	     "but got input of dimension: %d", THTensor_(_nDimension)(input));    \
   if (weights && THTensor_(nElement)(weights) != THTensor_(size)(input, 1)) {    \
     THError("weight tensor should be defined either for all or no classes");     \
   }                                                                              \
@@ -28,10 +28,10 @@
   }
 
 #define GRADOUTPUT_SHAPE_CHECK                                                \
-  THArgCheck(THTensor_(nDimension)(gradOutput) == 3, 3,                       \
+  THArgCheck(THTensor_(_nDimension)(gradOutput) == 3, 3,                       \
     "gradOutput must have same dimension as target (3)"                       \
 	     " but got dimension: %d",			                                        \
-	     THTensor_(nDimension)(gradOutput));			                              \
+	     THTensor_(_nDimension)(gradOutput));			                              \
   {                                                                           \
     int64_t gradOutput0 = THTensor_(size)(gradOutput, 0);                     \
     int64_t gradOutput1 = THTensor_(size)(gradOutput, 1);                     \

--- a/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
@@ -102,7 +102,7 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int heightDim = 1;
   int widthDim = 2;
 
-  int64_t numInputDims = THTensor_(nDimension)(input);
+  int64_t numInputDims = THTensor_(_nDimension)(input);
   THNN_ARGCHECK(numInputDims == 3 || numInputDims == 4, 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
@@ -202,7 +202,7 @@ void THNN_(SpatialFractionalMaxPooling_updateGradInput)(
   int heightDim = 1;
   int widthDim = 2;
 
-  int64_t numInputDims = THTensor_(nDimension)(input);
+  int64_t numInputDims = THTensor_(_nDimension)(input);
   if (numInputDims == 4) {
     numBatch = THTensor_(size)(input, 0);
     planeDim = 1;

--- a/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
@@ -114,7 +114,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
   int widthDim = 2;
   int timeDim = 3;
 
-  int64_t numInputDims = THTensor_(nDimension)(input);
+  int64_t numInputDims = THTensor_(_nDimension)(input);
   THNN_ARGCHECK(numInputDims == 4 || numInputDims == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
@@ -224,7 +224,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
   int widthDim = 2;
   int timeDim = 3;
 
-  int64_t numInputDims = THTensor_(nDimension)(input);
+  int64_t numInputDims = THTensor_(_nDimension)(input);
   if (numInputDims == 5) {
     numBatch = THTensor_(size)(input, 0);
     planeDim = 1;

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -44,7 +44,7 @@
   }
 
 #define THNN_CHECK_DIM_SIZE(T, DIM, DIM_SIZE, SIZE)			\
-  if (THTensor_(nDimension)(T) != DIM ||				\
+  if (THTensor_(_nDimension)(T) != DIM ||				\
       THTensor_(size)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
@@ -52,7 +52,7 @@
   }
 
 #define THNN_CHECK_DIM_SIZE_INDICES(T, DIM, DIM_SIZE, SIZE)			\
-  if (THIndexTensor_(nDimension)(T) != DIM ||				\
+  if (THIndexTensor_(_nDimension)(T) != DIM ||				\
       THIndexTensor_(size)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THIndexTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -6,9 +6,9 @@
  * access methods
  ******************************************************************************/
 
-int THSTensor_(nDimension)(const THSTensor *self)
+int THSTensor_(_nDimension)(const THSTensor *self)
 {
-  THError("Internal error! THSTensor_(nDimension)(self) shouldn't be called; use self.dim() instead");
+  THError("Internal error! THSTensor_(_nDimension)(self) shouldn't be called; use self.dim() instead");
 }
 
 int THSTensor_(nDimensionI)(const THSTensor *self)

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -6,7 +6,7 @@
 typedef struct THSTensor THSTensor;
 
 /**** access methods ****/
-TH_API int THSTensor_(nDimension)(const THSTensor *self);
+TH_API int THSTensor_(_nDimension)(const THSTensor *self);
 TH_API int THSTensor_(nDimensionI)(const THSTensor *self);
 TH_API int THSTensor_(nDimensionV)(const THSTensor *self);
 TH_API int64_t THSTensor_(size)(const THSTensor *self, int dim);


### PR DESCRIPTION
…im().

Currently, THTensor_(nDimension) goes to _dim(), which makes it difficult to move individual usages over to the new API.
Instead, let's create a THTensor_(_nDimension) going to _dim() and THTensor_(nDimension) going to _dim().  To do this, we will redirect all current
calls and move them over as we did for _dim() and dim().

