### PR TITLE
Shard test_nn to reduce runtime for each test target

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -39,7 +39,6 @@ torch.backends.cudnn.disable_global_flags()
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('--seed', type=int, default=1234)
 parser.add_argument('--accept', action='store_true')
-parser.add_argument('--shard', type=int, required=False)
 args, remaining = parser.parse_known_args()
 SEED = args.seed
 ACCEPT = args.accept
@@ -47,8 +46,8 @@ UNITTEST_ARGS = [sys.argv[0]] + remaining
 torch.manual_seed(SEED)
 
 
-def run_tests():
-    unittest.main(argv=UNITTEST_ARGS)
+def run_tests(argv=UNITTEST_ARGS):
+    unittest.main(argv=argv)
 
 PY3 = sys.version_info > (3, 0)
 PY34 = sys.version_info >= (3, 4)

--- a/test/common.py
+++ b/test/common.py
@@ -39,6 +39,7 @@ torch.backends.cudnn.disable_global_flags()
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('--seed', type=int, default=1234)
 parser.add_argument('--accept', action='store_true')
+parser.add_argument('--shard', type=int, required=False)
 args, remaining = parser.parse_known_args()
 SEED = args.seed
 ACCEPT = args.accept
@@ -185,20 +186,28 @@ class TestCase(unittest.TestCase):
     def __init__(self, method_name='runTest'):
         super(TestCase, self).__init__(method_name)
         # Wraps the tested method if we should do CUDA memory check.
-        test_method = getattr(self, method_name)
-        self._do_cuda_memory_leak_check &= getattr(test_method, '_do_cuda_memory_leak_check', True)
-        # FIXME: figure out the flaky -1024 anti-leaks on windows. See #8044
-        if self._do_cuda_memory_leak_check and not IS_WINDOWS:
-            # the import below may initialize CUDA context, so we do it only if
-            # self._do_cuda_memory_leak_check is True.
-            from common_cuda import TEST_CUDA
-            fullname = self.id().lower()  # class_name.method_name
-            if TEST_CUDA and ('gpu' in fullname or 'cuda' in fullname):
-                # initialize context & RNG to prevent false positive detections
-                # when the test is the first to initialize those
-                from common_cuda import initialize_cuda_context_rng
-                initialize_cuda_context_rng()
-                setattr(self, method_name, self.wrap_with_cuda_memory_check(test_method))
+        # This logic is similar to https://github.com/python/cpython/blob/master/Lib/unittest/case.py#L406-L413
+        try:
+            test_method = getattr(self, method_name)
+        except AttributeError:
+            if method_name != 'runTest':
+                # we allow instantiation with no explicit method name
+                # but not an *incorrect* or missing method name
+                raise ValueError("no such test method in %s: %s" % (self.__class__, method_name))
+        else:
+            self._do_cuda_memory_leak_check &= getattr(test_method, '_do_cuda_memory_leak_check', True)
+            # FIXME: figure out the flaky -1024 anti-leaks on windows. See #8044
+            if self._do_cuda_memory_leak_check and not IS_WINDOWS:
+                # the import below may initialize CUDA context, so we do it only if
+                # self._do_cuda_memory_leak_check is True.
+                from common_cuda import TEST_CUDA
+                fullname = self.id().lower()  # class_name.method_name
+                if TEST_CUDA and ('gpu' in fullname or 'cuda' in fullname):
+                    # initialize context & RNG to prevent false positive detections
+                    # when the test is the first to initialize those
+                    from common_cuda import initialize_cuda_context_rng
+                    initialize_cuda_context_rng()
+                    setattr(self, method_name, self.wrap_with_cuda_memory_check(test_method))
 
     def wrap_with_cuda_memory_check(self, method):
         # Assumes that `method` is the tested function in `self`.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7630,7 +7630,7 @@ def parse_args():
 
 if __name__ == '__main__':
     options = parse_args()
-    if options.shard != None:
+    if options.shard is not None:
         def load_tests(loader, tests, pattern):
             test_suite = unittest.TestSuite()
             for test_group in tests:


### PR DESCRIPTION
The current `test_nn` would time out and be disabled in GreenWarden, and we need to have an option to split it up in order to pass the stress test. Right now GreenWarden roughly allows running 100 test cases in `test_nn` before timing out, and here we have an option to divide `test_nn` into 30 shards (with ~40 tests in each shard)  to allow for some test suite growth in the future.

This will unblock the addition of GPU tests to Sandcastle.

We need to make sure that the CUDA memory leak checks are still working correctly in CI after this change.

cc @orionr 