### PR TITLE
[JIT] Adds fp16 support to the jit

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -460,14 +460,14 @@ class TestJit(JitTestCase):
         inputs = (x.float(), y.float())
         fusion_inputs = (x, y)
         for fn in funcs:
-            local_inputs = [x.clone().requires_grad_() for x in inputs]
-            local_fusion_inputs = [x.clone().requires_grad_() for x in fusion_inputs]
+            local_inputs = [t.clone().requires_grad_() for t in inputs]
+            local_fusion_inputs = [t.clone().requires_grad_() for t in fusion_inputs]
 
             # Verifies outputs
             fusion = torch.jit.trace(*local_fusion_inputs, optimize=True)(fn)
             outputs = fn(*local_inputs)
             fusion_outputs = fusion(*local_fusion_inputs)
-            outputs_half = [x.half() for x in outputs]
+            outputs_half = [t.half() for t in outputs]
             self.assertEqual(outputs_half, fusion_outputs)
 
             # Verifies gradients
@@ -476,7 +476,7 @@ class TestJit(JitTestCase):
                     output.float().sum(), local_inputs, allow_unused=True, retain_graph=True)
                 fusion_grads = torch.autograd.grad(
                     fusion_output.sum(), local_fusion_inputs, allow_unused=True, retain_graph=True)
-                grads_half = [x.half() for x in grads]
+                grads_half = [t.half() for t in grads]
                 self.assertEqual(grads_half, fusion_grads)
 
     # TODO: adapt this test to check that GraphExecutor treats them differently

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -38,12 +38,15 @@ except ImportError:
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 RUN_CUDA = torch.cuda.is_available()
+RUN_CUDA_HALF = RUN_CUDA
 if torch.cuda.is_available():
     CUDA_VERSION = torch._C._cuda_getCompiledVersion()
     for d in range(torch.cuda.device_count()):
         major = torch.cuda.get_device_capability(d)[0]
         if (CUDA_VERSION < 8000 and major >= 6) or (CUDA_VERSION < 9000 and major >= 7):
             RUN_CUDA = False
+        if (CUDA_VERSION < 9000 or major < 6):
+            RUN_CUDA_HALF = False
 
 RUN_CUDA_MULTI_GPU = RUN_CUDA and torch.cuda.device_count() > 1
 
@@ -163,7 +166,6 @@ class JitTestCase(TestCase):
             print(ge.__getattr__('forward').graph)
 
         # test no gradients case
-
         outputs = func(*nograd_inputs)
         outputs_ge = ge(*nograd_inputs)
         self.assertEqual(outputs, outputs_ge)
@@ -386,20 +388,21 @@ class TestJit(JitTestCase):
         ge = self.checkTrace(f, (x, y))
         self.assertExpectedGraph(ge.graph_for(x, y))
 
+    @staticmethod
+    def fn_test_comparison_gt_lt(x, y):
+        mask = (x > 0).type_as(x)
+        z = x * mask + y
+        mask = (x < 0).type_as(x)
+        z = z * mask + y
+        return z
+    
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_comparison_gt_lt(self):
-        def f(x, y):
-            mask = (x > 0).type_as(x)
-            z = x * mask + y
-            mask = (x < 0).type_as(x)
-            z = z * mask + y
-            return z
-
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        ge = self.checkTrace(f, (x, y))
+        ge = self.checkTrace(self.fn_test_comparison_gt_lt, (x, y))
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
@@ -415,28 +418,66 @@ class TestJit(JitTestCase):
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
         ge = self.checkTrace(f, (x, y))
+    
+    @staticmethod
+    def fn_test_relu(x, y):
+        return F.relu(x + .5 * y)
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_relu(self):
-        def f(x, y):
-            return F.relu(x + .5 * y)
-
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        ge = self.checkTrace(f, (x, y))
+        ge = self.checkTrace(self.fn_test_relu, (x, y))
+
+    @staticmethod 
+    def fn_test_exp(x, y):
+        return (x + .5 * y).exp()
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_exp(self):
-        def f(x, y):
-            return (x + .5 * y).exp()
-
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        ge = self.checkTrace(f, (x, y))
+        ge = self.checkTrace(self.fn_test_exp, (x, y))
+
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    @unittest.skipIf(not RUN_CUDA_HALF, "no half support")
+    def test_cuda_half(self):
+        x = torch.randn(4, 4, dtype=torch.half, device='cuda')
+        y = torch.randn(4, 4, dtype=torch.half, device='cuda')
+        
+        funcs = [
+            self.fn_test_comparison_gt_lt, 
+            self.fn_test_relu, 
+            self.fn_test_exp
+        ]
+        
+        #Note: Non fused inputs must be float to prevent loss of precision
+        inputs = (x.float(), y.float())
+        fusion_inputs = (x, y)
+        for fn in funcs:
+            local_inputs = [x.clone().requires_grad_() for x in inputs]
+            local_fusion_inputs = [x.clone().requires_grad_() for x in fusion_inputs]    
+            
+            # Verifies outputs
+            fusion = torch.jit.trace(*local_fusion_inputs, optimize = True)(fn)
+            outputs = fn(*local_inputs)
+            fusion_outputs = fusion(*local_fusion_inputs)
+            outputs_half = [x.half() for x in outputs]
+            self.assertEqual(outputs_half, fusion_outputs)
+
+            # Verifies gradients
+            for output, fusion_output in zip(outputs_half, fusion_outputs):
+                grads = torch.autograd.grad(
+                    output.float().sum(), local_inputs, allow_unused=True, retain_graph=True)
+                fusion_grads = torch.autograd.grad(
+                    fusion_output.sum(), local_fusion_inputs, allow_unused=True, retain_graph=True)
+                grads_half = [x.half() for x in grads]
+                self.assertEqual(grads_half, fusion_grads)
 
     # TODO: adapt this test to check that GraphExecutor treats them differently
     @unittest.skip("Need to be adjusted to Graph Executor")

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -395,7 +395,7 @@ class TestJit(JitTestCase):
         mask = (x < 0).type_as(x)
         z = z * mask + y
         return z
-    
+
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_comparison_gt_lt(self):
@@ -418,7 +418,7 @@ class TestJit(JitTestCase):
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
         ge = self.checkTrace(f, (x, y))
-    
+
     @staticmethod
     def fn_test_relu(x, y):
         return F.relu(x + .5 * y)
@@ -431,7 +431,7 @@ class TestJit(JitTestCase):
 
         ge = self.checkTrace(self.fn_test_relu, (x, y))
 
-    @staticmethod 
+    @staticmethod
     def fn_test_exp(x, y):
         return (x + .5 * y).exp()
 
@@ -449,22 +449,22 @@ class TestJit(JitTestCase):
     def test_cuda_half(self):
         x = torch.randn(4, 4, dtype=torch.half, device='cuda')
         y = torch.randn(4, 4, dtype=torch.half, device='cuda')
-        
+
         funcs = [
-            self.fn_test_comparison_gt_lt, 
-            self.fn_test_relu, 
+            self.fn_test_comparison_gt_lt,
+            self.fn_test_relu,
             self.fn_test_exp
         ]
-        
-        #Note: Non fused inputs must be float to prevent loss of precision
+
+        # Note: Non fused inputs must be float to prevent loss of precision
         inputs = (x.float(), y.float())
         fusion_inputs = (x, y)
         for fn in funcs:
             local_inputs = [x.clone().requires_grad_() for x in inputs]
-            local_fusion_inputs = [x.clone().requires_grad_() for x in fusion_inputs]    
-            
+            local_fusion_inputs = [x.clone().requires_grad_() for x in fusion_inputs]
+
             # Verifies outputs
-            fusion = torch.jit.trace(*local_fusion_inputs, optimize = True)(fn)
+            fusion = torch.jit.trace(*local_fusion_inputs, optimize=True)(fn)
             outputs = fn(*local_inputs)
             fusion_outputs = fusion(*local_fusion_inputs)
             outputs_half = [x.half() for x in outputs]

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -205,7 +205,7 @@ const char * scalarTypeName(at::ScalarType type) {
   switch(type) {
     #define DEFINE_CASE(ctype,name,_) \
       case at::ScalarType::name: return #ctype;
-    AT_FORALL_SCALAR_TYPES(DEFINE_CASE)
+    AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(DEFINE_CASE)
     #undef DEFINE_CASE
     default:
       throw std::runtime_error("unknown scalar type");

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -122,6 +122,11 @@ void ${kernelName}(IndexType totalElements, void ** args) {
 }
 )");
 
+// This snippet enables half support in the jit. Following the pattern for
+// reductions, fp16 input data is immediately upconverted to float
+// with __half2float(). All mathematical operations are done on float
+// values, and if needed the intermediate float representation is 
+// converted to half with __float2half() when writing to a half tensor.
 constexpr auto half_support_literal  = R"(    
 #define __HALF_TO_US(var) *(reinterpret_cast<unsigned short *>(&(var)))
 #define __HALF_TO_CUS(var) *(reinterpret_cast<const unsigned short *>(&(var)))

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -7,15 +7,13 @@
 #include "torch/csrc/variable_tensor_functions.h"
 
 #include "ATen/ATen.h"
-
 #ifdef USE_CUDA
-  #include "THC/THC.h"
-  #include "torch/csrc/cuda/cuda_check.h"
-  #include <nvrtc.h>
-  #include <cuda.h>
-  #include <cuda_runtime.h>
+#include "THC/THC.h"
+#include "torch/csrc/cuda/cuda_check.h"
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
 #endif
-
 #include <string>
 #include <algorithm>
 #include <unordered_map>
@@ -68,10 +66,10 @@ so typedefs help it handle those cases*/
 
 auto type_declarations_template = CodeTemplate(R"(
 #if defined(__CUDACC_RTC__)
-  typedef unsigned char uint8_t;
-  typedef signed char int8_t;
-  typedef short int  int16_t;
-  typedef long long int int64_t;
+typedef unsigned char uint8_t;
+typedef signed char int8_t;
+typedef short int  int16_t;
+typedef long long int int64_t;
 #endif
 ${HalfHeader}
 typedef ${IndexType} IndexType;
@@ -156,9 +154,6 @@ constexpr auto half_support_literal  = R"(
 
 typedef __half half;
 )";
-
-
-// typedef __half half;
 
 // curDimIndex = linearId % sizes[i]; // % sizes[i] is not needed for d == 0, because we already guard for numel outside the index calculation
 // offset += curDimIndex*strides[i]; // *strides[i] is optional if list_is_cont becaause strides.back() == 1
@@ -339,7 +334,6 @@ std::vector<ConcatDesc> emitCompilationUnit(std::ostream & out,
     for(auto p : subgraph.inputs())
       emitFormal(p,agraph.input_desc[i++]);
   }
-  
   std::vector<ConcatDesc> concat_desc;
   std::vector<Value*> flat_output_nodes;
   {

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -70,8 +70,8 @@ typedef unsigned char uint8_t;
 typedef signed char int8_t;
 typedef short int  int16_t;
 typedef long long int int64_t;
-#endif
 ${HalfHeader}
+#endif
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {
@@ -99,8 +99,8 @@ void ${kernelName}(IndexType totalElements, ${formals}) {
 
 auto cpu_compilation_unit_template = CodeTemplate(R"(
 #include <cstddef>
+#include <cstdint>
 #include <math.h>
-#include <iostream>
 ${type_declarations}
 
 #define OMP_THRESHOLD 100000
@@ -748,7 +748,7 @@ static const std::string compile_string =
 #ifndef __PPC64__
   "-march=native "
 #endif
-  "-std=c++11 -fPIC ${fopenmp} -shared \"${cpp_file}\" -o \"${so_file}\"";
+  "-std=c++11 -fPIC ${fopenmp} -shared \"${cpp_file}\" -o \"${so_file}\" -lm";
 
 static void runCompiler(FusionCompilerConfig & config, const std::string & cpp_file, const std::string & so_file) {
   TemplateEnv env;

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -3,12 +3,13 @@
 #include "torch/csrc/jit/autodiff.h"
 #include <unordered_map>
 
+#ifdef USE_CUDA
+  #include "cuda.h" // for CUDA_VERSION
+#endif 
+
 namespace torch { namespace jit {
 
 namespace {
-
-
-
 
 // What is a simple mappable operator?  It is:
 //    - Has an output with the same sizes as its input
@@ -127,29 +128,42 @@ struct GraphFuser {
   }
   // TODO: the fusion compiler has a lot of float-specific codegen
   // so for now we only consider nodes that operate on floating point numbers
-  bool hasFloatType(Value * node) {
-    if(auto tt = node->type()->cast<TensorType>()) {
-      return tt->scalarType() == at::kFloat;
-    } else {
-      return false;
-    }
+  // and half values when running on a GPU with sufficient CUDA arch
+  bool hasSupportedType(Value* node) {
+    if (auto tt = node->type()->cast<TensorType>()) {
+      if (tt->scalarType() == at::kFloat) return true;
+
+      #ifdef USE_CUDA
+        // Checks for half tensor on GPU
+        // const auto device = tt->device();
+        if (tt->device() != kCPUDevice 
+          && CUDA_VERSION >= 9
+          && tt->scalarType() == at::ScalarType::Half) {
+          return true;
+        }
+      #endif 
+    } 
+
+    return false;
   }
-  bool allFloatList(at::ArrayRef<Value*> list){
-    for (auto & o: list){
-      if(!hasFloatType(o)) {
-        return false;
-      }
+
+  bool allSupportedList(at::ArrayRef<Value*> list){
+    for (auto& o: list){
+      if (!hasSupportedType(o)) return false;
     }
+
     return true;
   }
-  bool allFloatIO(Node * node) {
-    return (allFloatList(node->inputs()) && allFloatList(node->outputs()));
+
+  bool allSupportedIO(Node* node) {
+    return (allSupportedList(node->inputs()) && allSupportedList(node->outputs()));
   }
-  bool isFusable(Node * node) {
+
+  bool isFusable(Node* node) {
     if (node->owningBlock() != block) return false;
     if (node->kind() == prim::FusionGroup) return true;
     if (!isSimpleMap(node)) return false;
-    switch (node->kind()){
+    switch (node->kind()) {
 //comparison operators produce Byte type, and it's ok, check only inputs
       case aten::le:
       case aten::ge:
@@ -157,12 +171,12 @@ struct GraphFuser {
       case aten::gt:
       case aten::ne:
       case aten::eq:
-         return allFloatList(node->inputs());
+         return allSupportedList(node->inputs());
       case aten::type_as:
 //type_as can have different input types as long as output is float, check only output
-         return allFloatList(node->outputs());
+         return allSupportedList(node->outputs());
       default:
-         return allFloatIO(node);
+         return allSupportedIO(node);
     }
   }
 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -159,11 +159,11 @@ struct GraphFuser {
     return (allSupportedList(node->inputs()) && allSupportedList(node->outputs()));
   }
 
-  bool isFusable(Node* node) {
+  bool isFusable(Node * node) {
     if (node->owningBlock() != block) return false;
     if (node->kind() == prim::FusionGroup) return true;
     if (!isSimpleMap(node)) return false;
-    switch (node->kind()) {
+    switch (node->kind()){
 //comparison operators produce Byte type, and it's ok, check only inputs
       case aten::le:
       case aten::ge:


### PR DESCRIPTION
This PR adds support for fp16 tensors to the jit, and it adds a test to ensure they're working properly.

Half tensors are treated just like in reductions. Half inputs are immediately upconverted to float, mathematical operations are performed only on floats, and floats are downconverted to half when writing to half outputs.

To add support for half tensors I extended the (renamed) "SupportedTypes" to include halfs, created a snippet with the appropriate half conversions defined and included it as a string literal (this snippet courtesy of @ngimel), then check for half types and write the appropriate access line.

For testing I added a new test and (very slightly) refactored three existing tests to reuse the functions they defined. Rerunning each test in test_jit.py for every datatype seems excessive, especially since many of the functions deal with graph structure. Further, half types are different from other data types since we cannot simply run a half tensor through an unfused version of the same operations and expect the same final result as the fused version. Instead, a float tensor that's representable in half must be passed through the unfused network while an equivalent tensor in half is passed through the fused model, and the results of the unfused network cast to half for comparison. This process mimics the conversions done by the fused kernel and is tricky to merge with existing code paths without greatly complicating them. 


