### PR TITLE
[C++ API] Use torch::Tensor instead of at::Tensor/Variable mix

### DIFF
--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <string>
 
-using namespace torch;
 using namespace torch::nn;
 using namespace torch::detail;
 
@@ -16,7 +15,7 @@ using Catch::StartsWith;
 
 TEST_CASE("any-module") {
   SECTION("int()") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       int forward() {
         return 123;
       }
@@ -25,7 +24,7 @@ TEST_CASE("any-module") {
     REQUIRE(any.forward().get<int>() == 123);
   }
   SECTION("int(int)") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       int forward(int x) {
         return x;
       }
@@ -34,7 +33,7 @@ TEST_CASE("any-module") {
     REQUIRE(any.forward(5).get<int>() == 5);
   }
   SECTION("const char*(const char*)") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       const char* forward(const char* x) {
         return x;
       }
@@ -44,7 +43,7 @@ TEST_CASE("any-module") {
   }
 
   SECTION("string(int, const double)") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       std::string forward(int x, const double f) {
         return std::to_string(static_cast<int>(x + f));
       }
@@ -54,9 +53,9 @@ TEST_CASE("any-module") {
     REQUIRE(any.forward(x, 3.14).get<std::string>() == std::string("7"));
   }
 
-  SECTION("Variable(string, const string&, string&&)") {
-    struct M : nn::Module {
-      autograd::Variable forward(
+  SECTION("Tensor(string, const string&, string&&)") {
+    struct M : torch::nn::Module {
+      torch::Tensor forward(
           std::string a,
           const std::string& b,
           std::string&& c) {
@@ -67,12 +66,12 @@ TEST_CASE("any-module") {
     AnyModule any(M{});
     REQUIRE(
         any.forward(std::string("a"), std::string("ab"), std::string("abc"))
-            .get<autograd::Variable>()
+            .get<torch::Tensor>()
             .sum()
             .toCInt() == 6);
   }
   SECTION("wrong argument type") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       int forward(float x) {
         return x;
       }
@@ -84,7 +83,7 @@ TEST_CASE("any-module") {
                    "but received value of type double"));
   }
   SECTION("wrong number of arguments") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       int forward(int a, int b) {
         return a + b;
       }
@@ -101,8 +100,8 @@ TEST_CASE("any-module") {
         Contains("M's forward() method expects 2 arguments, but received 3"));
   }
   SECTION("get()") {
-    struct M : nn::Module {
-      explicit M(int value_) : nn::Module("M"), value(value_) {}
+    struct M : torch::nn::Module {
+      explicit M(int value_) : torch::nn::Module("M"), value(value_) {}
       int value;
       int forward(float x) {
         return x;
@@ -115,13 +114,13 @@ TEST_CASE("any-module") {
     }
 
     SECTION("bad cast") {
-      struct N : nn::Module {};
+      struct N : torch::nn::Module {};
       REQUIRE_THROWS_WITH(any.get<N>(), StartsWith("Attempted to cast module"));
     }
   }
   SECTION("ptr()") {
-    struct M : nn::Module {
-      explicit M(int value_) : nn::Module("M"), value(value_) {}
+    struct M : torch::nn::Module {
+      explicit M(int value_) : torch::nn::Module("M"), value(value_) {}
       int value;
       int forward(float x) {
         return x;
@@ -142,12 +141,12 @@ TEST_CASE("any-module") {
     }
 
     SECTION("bad downcast") {
-      struct N : nn::Module {};
+      struct N : torch::nn::Module {};
       REQUIRE_THROWS_WITH(any.ptr<N>(), StartsWith("Attempted to cast module"));
     }
   }
   SECTION("default state is empty") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       explicit M(int value_) : value(value_) {}
       int value;
       int forward(float x) {
@@ -161,7 +160,7 @@ TEST_CASE("any-module") {
     REQUIRE(any.get<M>().value == 5);
   }
   SECTION("all methods throw for empty AnyModule") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       int forward(int x) {
         return x;
       }
@@ -182,12 +181,12 @@ TEST_CASE("any-module") {
         StartsWith("Cannot call forward() on an empty AnyModule"));
   }
   SECTION("can move assign differentm modules") {
-    struct M : nn::Module {
+    struct M : torch::nn::Module {
       std::string forward(int x) {
         return std::to_string(x);
       }
     };
-    struct N : nn::Module {
+    struct N : torch::nn::Module {
       int forward(float x) {
         return 3 + x;
       }
@@ -209,8 +208,8 @@ TEST_CASE("any-module") {
     REQUIRE(std::equal(first.begin(), first.end(), second.begin()));
   }
   SECTION("constructs from ModuleHolder") {
-    struct MImpl : nn::Module {
-      explicit MImpl(int value_) : nn::Module("M"), value(value_) {}
+    struct MImpl : torch::nn::Module {
+      explicit MImpl(int value_) : torch::nn::Module("M"), value(value_) {}
       int value;
       int forward(float x) {
         return x;

--- a/test/cpp/api/cursor.cpp
+++ b/test/cpp/api/cursor.cpp
@@ -1,6 +1,5 @@
 #include <catch.hpp>
 
-#include <torch/functions.h>
 #include <torch/nn/cursor.h>
 #include <torch/nn/module.h>
 #include <torch/tensor.h>
@@ -12,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-using namespace torch;
 using namespace torch::nn;
 using namespace torch::detail;
 
@@ -24,8 +22,8 @@ struct TestModule : public torch::nn::Module {
     tensor2 = register_parameter("tensor2", torch::randn({size}));
   }
 
-  autograd::Variable tensor1;
-  autograd::Variable tensor2;
+  torch::Tensor tensor1;
+  torch::Tensor tensor2;
 };
 
 struct Container : public torch::nn::Module {
@@ -249,7 +247,7 @@ TEST_CASE("cursor/parameter") {
       size_t count = 0;
       cursor.apply_items(
           [&count, &model, &first, &second](
-              const std::string& key, autograd::Variable& tensor) {
+              const std::string& key, torch::Tensor& tensor) {
             switch (count) {
               case 0: {
                 REQUIRE(tensor.equal(first->tensor1));

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -1,20 +1,19 @@
 #include <catch.hpp>
 
-#include <torch/functions.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>
 #include <torch/nn/modules/dropout.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/optimizers.h>
+#include <torch/tensor.h>
+#include <torch/tensor_range.h>
 #include <torch/utils.h>
-
-#include <ATen/Error.h>
 
 #include <test/cpp/api/util.h>
 
-using namespace torch;
 using namespace torch::nn;
 
+#include <cmath>
 #include <iostream>
 #include <random>
 
@@ -35,12 +34,12 @@ class CartPole {
   double x_threshold = 2.4;
   int steps_beyond_done = -1;
 
-  Variable state;
+  torch::Tensor state;
   double reward;
   bool done;
   int step_ = 0;
 
-  Variable getState() {
+  torch::Tensor getState() {
     return state;
   }
 
@@ -212,10 +211,10 @@ bool test_mnist(
       if (p % batch_size != batch_size - 1)
         continue;
       inp.set_requires_grad(true);
-      Variable x = forward_op(inp);
+      torch::Tensor x = forward_op(inp);
       inp.set_requires_grad(false);
-      Variable y = lab;
-      Variable loss = at::nll_loss(x, y);
+      torch::Tensor y = lab;
+      torch::Tensor loss = at::nll_loss(x, y);
 
       optim->zero_grad();
       loss.backward();
@@ -223,115 +222,114 @@ bool test_mnist(
     }
   }
 
-  NoGradGuard guard;
+  torch::NoGradGuard guard;
   auto result = std::get<1>(forward_op(tedata).max(1));
-  Variable correct = (result == telabel).toType(torch::kFloat32);
-  std::cout << "Num correct: " << correct.data().sum().toCFloat() << " out of"
+  torch::Tensor correct = (result == telabel).toType(torch::kFloat32);
+  std::cout << "Num correct: " << correct.data().sum().toCFloat() << " out of "
             << telabel.size(0) << std::endl;
   return correct.data().sum().toCFloat() > telabel.size(0) * 0.8;
 };
 
-TEST_CASE("integration") {
-  SECTION("cartpole") {
-    std::cerr
-        << "Training episodic policy gradient with a critic for up to 3000"
-           " episodes, rest your eyes for a bit!\n";
-    auto model = std::make_shared<SimpleContainer>();
-    auto linear = model->add(Linear(4, 128), "linear");
-    auto policyHead = model->add(Linear(128, 2), "policy");
-    auto valueHead = model->add(Linear(128, 1), "action");
-    auto optim = Adam(model, 1e-3).make();
+TEST_CASE("integration/cartpole") {
+  std::cerr << "Training episodic policy gradient with a critic for up to 3000"
+               " episodes, rest your eyes for a bit!\n";
+  auto model = std::make_shared<torch::SimpleContainer>();
+  auto linear = model->add(Linear(4, 128), "linear");
+  auto policyHead = model->add(Linear(128, 2), "policy");
+  auto valueHead = model->add(Linear(128, 1), "action");
+  auto optim = torch::Adam(model, 1e-3).make();
 
-    std::vector<Variable> saved_log_probs;
-    std::vector<Variable> saved_values;
-    std::vector<float> rewards;
+  std::vector<torch::Tensor> saved_log_probs;
+  std::vector<torch::Tensor> saved_values;
+  std::vector<float> rewards;
 
-    auto forward = [&](std::vector<Variable> inp) {
-      auto x = linear->forward(inp)[0].clamp_min(0);
-      Variable actions = policyHead->forward({x})[0];
-      Variable value = valueHead->forward({x})[0];
-      return std::make_tuple(at::softmax(actions, -1), value);
-    };
+  auto forward = [&](std::vector<torch::Tensor> inp) {
+    auto x = linear->forward(inp)[0].clamp_min(0);
+    torch::Tensor actions = policyHead->forward({x})[0];
+    torch::Tensor value = valueHead->forward({x})[0];
+    return std::make_tuple(at::softmax(actions, -1), value);
+  };
 
-    auto selectAction = [&](at::Tensor state) {
-      // Only work on single state right now, change index to gather for batch
-      auto out = forward({state});
-      auto probs = Variable(std::get<0>(out));
-      auto value = Variable(std::get<1>(out));
-      auto action = probs.data().multinomial(1)[0].toCInt();
-      // Compute the log prob of a multinomial distribution.
-      // This should probably be actually implemented in autogradpp...
-      auto p = probs / probs.sum(-1, true);
-      auto log_prob = p[action].log();
-      saved_log_probs.emplace_back(log_prob);
-      saved_values.push_back(value);
-      return action;
-    };
+  auto selectAction = [&](torch::Tensor state) {
+    // Only work on single state now, change index to gather for batch
+    auto out = forward({state});
+    auto probs = torch::Tensor(std::get<0>(out));
+    auto value = torch::Tensor(std::get<1>(out));
+    auto action = probs.data().multinomial(1)[0].toCInt();
+    // Compute the log prob of a multinomial distribution.
+    // This should probably be actually implemented in autogradpp...
+    auto p = probs / probs.sum(-1, true);
+    auto log_prob = p[action].log();
+    saved_log_probs.emplace_back(log_prob);
+    saved_values.push_back(value);
+    return action;
+  };
 
-    auto finishEpisode = [&]() {
-      auto R = 0.;
-      for (int i = rewards.size() - 1; i >= 0; i--) {
-        R = rewards[i] + 0.99 * R;
-        rewards[i] = R;
-      }
-      auto r_t =
-          at::from_blob(rewards.data(), {static_cast<int64_t>(rewards.size())});
-      r_t = (r_t - r_t.mean()) / (r_t.std() + 1e-5);
-
-      std::vector<at::Tensor> policy_loss;
-      std::vector<at::Tensor> value_loss;
-      for (auto i = 0U; i < saved_log_probs.size(); i++) {
-        auto r = rewards[i] - saved_values[i].toCFloat();
-        policy_loss.push_back(-r * saved_log_probs[i]);
-        value_loss.push_back(
-            at::smooth_l1_loss(saved_values[i], torch::ones({1}) * rewards[i]));
-      }
-      auto loss = at::stack(policy_loss).sum() + at::stack(value_loss).sum();
-
-      optim->zero_grad();
-      loss.backward();
-      optim->step();
-
-      rewards.clear();
-      saved_log_probs.clear();
-      saved_values.clear();
-    };
-
-    auto env = CartPole();
-    double running_reward = 10.0;
-    for (auto episode = 0;; episode++) {
-      env.reset();
-      auto state = env.getState();
-      int t = 0;
-      for (; t < 10000; t++) {
-        auto action = selectAction(state);
-        env.step(action);
-        state = env.getState();
-        auto reward = env.getReward();
-        auto done = env.isDone();
-
-        rewards.push_back(reward);
-        if (done)
-          break;
-      }
-
-      running_reward = running_reward * 0.99 + t * 0.01;
-      finishEpisode();
-      /*
-      if (episode % 10 == 0) {
-        printf("Episode %i\tLast length: %5d\tAverage length: %.2f\n",
-                episode, t, running_reward);
-      }
-      */
-      if (running_reward > 150)
-        break;
-      REQUIRE(episode < 3000);
+  auto finishEpisode = [&]() {
+    auto R = 0.;
+    for (int i = rewards.size() - 1; i >= 0; i--) {
+      R = rewards[i] + 0.99 * R;
+      rewards[i] = R;
     }
+    auto r_t =
+        at::from_blob(rewards.data(), {static_cast<int64_t>(rewards.size())});
+    r_t = (r_t - r_t.mean()) / (r_t.std() + 1e-5);
+
+    std::vector<torch::Tensor> policy_loss;
+    std::vector<torch::Tensor> value_loss;
+    for (auto i = 0U; i < saved_log_probs.size(); i++) {
+      auto r = rewards[i] - saved_values[i].toCFloat();
+      policy_loss.push_back(-r * saved_log_probs[i]);
+      value_loss.push_back(
+          at::smooth_l1_loss(saved_values[i], torch::ones({1}) * rewards[i]));
+    }
+
+    auto loss = at::stack(torch::TensorRange(policy_loss)).sum() +
+        at::stack(torch::TensorRange(value_loss)).sum();
+
+    optim->zero_grad();
+    loss.backward();
+    optim->step();
+
+    rewards.clear();
+    saved_log_probs.clear();
+    saved_values.clear();
+  };
+
+  auto env = CartPole();
+  double running_reward = 10.0;
+  for (auto episode = 0;; episode++) {
+    env.reset();
+    auto state = env.getState();
+    int t = 0;
+    for (; t < 10000; t++) {
+      auto action = selectAction(state);
+      env.step(action);
+      state = env.getState();
+      auto reward = env.getReward();
+      auto done = env.isDone();
+
+      rewards.push_back(reward);
+      if (done)
+        break;
+    }
+
+    running_reward = running_reward * 0.99 + t * 0.01;
+    finishEpisode();
+    /*
+    if (episode % 10 == 0) {
+      printf("Episode %i\tLast length: %5d\tAverage length: %.2f\n",
+              episode, t, running_reward);
+    }
+    */
+    if (running_reward > 150)
+      break;
+    REQUIRE(episode < 3000);
   }
 }
 
 TEST_CASE("integration/mnist", "[cuda]") {
-  auto model = std::make_shared<SimpleContainer>();
+  auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto drop = Dropout(0.3);
@@ -339,7 +337,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
   auto linear1 = model->add(Linear(320, 50), "linear1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
-  auto forward = [&](Variable x) {
+  auto forward = [&](torch::Tensor x) {
     x = std::get<0>(at::max_pool2d(conv1->forward({x})[0], {2, 2}))
             .clamp_min(0);
     x = conv2->forward({x})[0];
@@ -354,7 +352,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
     return x;
   };
 
-  auto optim = SGD(model, 1e-2).momentum(0.5).make();
+  auto optim = torch::SGD(model, 1e-2).momentum(0.5).make();
 
   REQUIRE(test_mnist(
       32, // batch_size
@@ -366,7 +364,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
 }
 
 TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
-  auto model = std::make_shared<SimpleContainer>();
+  auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto batchnorm2d =
       model->add(BatchNorm(BatchNormOptions(10).stateful(true)), "batchnorm2d");
@@ -376,7 +374,7 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
       model->add(BatchNorm(BatchNormOptions(50).stateful(true)), "batchnorm1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
-  auto forward = [&](Variable x) {
+  auto forward = [&](torch::Tensor x) {
     x = std::get<0>(at::max_pool2d(conv1->forward({x})[0], {2, 2}))
             .clamp_min(0);
     x = batchnorm2d->forward({x})[0];
@@ -391,7 +389,7 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
     return x;
   };
 
-  auto optim = SGD(model, 1e-2).momentum(0.5).make();
+  auto optim = torch::SGD(model, 1e-2).momentum(0.5).make();
 
   REQUIRE(test_mnist(
       32, // batch_size

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -284,8 +284,8 @@ TEST_CASE("integration/cartpole") {
           at::smooth_l1_loss(saved_values[i], torch::ones({1}) * rewards[i]));
     }
 
-    auto loss = at::stack(torch::TensorRange(policy_loss)).sum() +
-        at::stack(torch::TensorRange(value_loss)).sum();
+    auto loss = at::stack(torch::TensorListView(policy_loss)).sum() +
+        at::stack(torch::TensorListView(value_loss)).sum();
 
     optim->zero_grad();
     loss.backward();

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -2,7 +2,6 @@
 
 #include <torch/detail/ordered_dict.h>
 #include <torch/expanding_array.h>
-#include <torch/functions.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/tensor.h>
 #include <torch/utils.h>
@@ -11,21 +10,20 @@
 
 #include <ATen/optional.h>
 
-using namespace torch;
 using namespace torch::nn;
 
 template <typename T>
-using OrderedDict = detail::OrderedDict<std::string, T>;
+using OrderedDict = torch::detail::OrderedDict<std::string, T>;
 
 using Catch::StartsWith;
 
 TEST_CASE("misc") {
   SECTION("no_grad") {
-    NoGradGuard guard;
+    torch::NoGradGuard guard;
     Linear model(5, 2);
     auto x = torch::randn({10, 5}, at::requires_grad());
     auto y = model->forward({x})[0];
-    Variable s = y.sum();
+    torch::Tensor s = y.sum();
 
     s.backward();
     REQUIRE(!model->parameters()["weight"].grad().defined());
@@ -78,7 +76,7 @@ TEST_CASE("autograd") {
 TEST_CASE("expanding-array") {
   SECTION("successful construction") {
     SECTION("initializer_list") {
-      ExpandingArray<5> e({1, 2, 3, 4, 5});
+      torch::ExpandingArray<5> e({1, 2, 3, 4, 5});
       REQUIRE(e.size() == 5);
       for (size_t i = 0; i < e.size(); ++i) {
         REQUIRE((*e)[i] == i + 1);
@@ -86,7 +84,7 @@ TEST_CASE("expanding-array") {
     }
 
     SECTION("vector") {
-      ExpandingArray<5> e(std::vector<int64_t>{1, 2, 3, 4, 5});
+      torch::ExpandingArray<5> e(std::vector<int64_t>{1, 2, 3, 4, 5});
       REQUIRE(e.size() == 5);
       for (size_t i = 0; i < e.size(); ++i) {
         REQUIRE((*e)[i] == i + 1);
@@ -94,7 +92,7 @@ TEST_CASE("expanding-array") {
     }
 
     SECTION("array") {
-      ExpandingArray<5> e(std::array<int64_t, 5>({1, 2, 3, 4, 5}));
+      torch::ExpandingArray<5> e(std::array<int64_t, 5>({1, 2, 3, 4, 5}));
       REQUIRE(e.size() == 5);
       for (size_t i = 0; i < e.size(); ++i) {
         REQUIRE((*e)[i] == i + 1);
@@ -102,7 +100,7 @@ TEST_CASE("expanding-array") {
     }
 
     SECTION("single value") {
-      ExpandingArray<5> e(5);
+      torch::ExpandingArray<5> e(5);
       REQUIRE(e.size() == 5);
       for (size_t i = 0; i < e.size(); ++i) {
         REQUIRE((*e)[i] == 5);
@@ -112,12 +110,12 @@ TEST_CASE("expanding-array") {
   SECTION("throws for incorrect size on construction") {
     SECTION("initializer_list") {
       REQUIRE_THROWS_WITH(
-          ExpandingArray<5>({1, 2, 3, 4, 5, 6, 7}),
+          torch::ExpandingArray<5>({1, 2, 3, 4, 5, 6, 7}),
           StartsWith("Expected 5 values, but instead got 7"));
     }
     SECTION("vector") {
       REQUIRE_THROWS_WITH(
-          ExpandingArray<5>(std::vector<int64_t>({1, 2, 3, 4, 5, 6, 7})),
+          torch::ExpandingArray<5>(std::vector<int64_t>({1, 2, 3, 4, 5, 6, 7})),
           StartsWith("Expected 5 values, but instead got 7"));
     }
   }

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -1,6 +1,5 @@
 #include <catch.hpp>
 
-#include <torch/functions.h>
 #include <torch/nn/module.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>
@@ -12,10 +11,9 @@
 
 #include <test/cpp/api/util.h>
 
-using namespace torch;
 using namespace torch::nn;
 
-class TestModel : public Module {
+class TestModel : public torch::nn::Module {
  public:
   TestModel() {
     l1 = register_module("l1", Linear(10, 3));
@@ -23,14 +21,14 @@ class TestModel : public Module {
     l3 = register_module("l3", Linear(5, 100));
   }
 
-  std::vector<Variable> forward(std::vector<Variable> input) {
+  std::vector<torch::Tensor> forward(std::vector<torch::Tensor> input) {
     return input;
   }
 
   Linear l1, l2, l3;
 };
 
-class NestedModel : public Module {
+class NestedModel : public torch::nn::Module {
  public:
   NestedModel() {
     l1 = register_module("l1", Linear(5, 20));
@@ -38,11 +36,11 @@ class NestedModel : public Module {
     param_ = register_parameter("param", torch::empty({3, 2, 21}));
   }
 
-  std::vector<Variable> forward(std::vector<Variable> input) {
+  std::vector<torch::Tensor> forward(std::vector<torch::Tensor> input) {
     return input;
   };
 
-  Variable param_;
+  torch::Tensor param_;
   Linear l1;
   std::shared_ptr<TestModel> t;
 };
@@ -53,7 +51,7 @@ TEST_CASE("modules") {
       Conv1d model(Conv1dOptions(3, 2, 3).stride(2));
       auto x = torch::randn({2, 3, 5}, at::requires_grad());
       auto y = model->forward({x})[0];
-      Variable s = y.sum();
+      torch::Tensor s = y.sum();
 
       s.backward();
       REQUIRE(y.ndimension() == 3);
@@ -69,7 +67,7 @@ TEST_CASE("modules") {
         Conv2d model(Conv2dOptions(3, 2, 3).stride(2));
         auto x = torch::randn({2, 3, 5, 5}, at::requires_grad());
         auto y = model->forward({x})[0];
-        Variable s = y.sum();
+        torch::Tensor s = y.sum();
 
         s.backward();
         REQUIRE(y.ndimension() == 4);
@@ -85,7 +83,7 @@ TEST_CASE("modules") {
         Conv2d model(Conv2dOptions(3, 2, {3, 2}).stride({2, 2}));
         auto x = torch::randn({2, 3, 5, 4}, at::requires_grad());
         auto y = model->forward({x})[0];
-        Variable s = y.sum();
+        torch::Tensor s = y.sum();
 
         s.backward();
         REQUIRE(y.ndimension() == 4);
@@ -101,7 +99,7 @@ TEST_CASE("modules") {
       Conv3d model(Conv3dOptions(3, 2, 3).stride(2));
       auto x = torch::randn({2, 3, 5, 5, 5}, at::requires_grad());
       auto y = model->forward({x})[0];
-      Variable s = y.sum();
+      torch::Tensor s = y.sum();
 
       s.backward();
       REQUIRE(y.ndimension() == 5);
@@ -119,7 +117,7 @@ TEST_CASE("modules") {
       Linear model(5, 2);
       auto x = torch::randn({10, 5}, at::requires_grad());
       auto y = model->forward({x})[0];
-      Variable s = y.sum();
+      torch::Tensor s = y.sum();
 
       s.backward();
       REQUIRE(y.ndimension() == 2);
@@ -132,7 +130,7 @@ TEST_CASE("modules") {
   }
 
   SECTION("simple") {
-    auto model = std::make_shared<SimpleContainer>();
+    auto model = std::make_shared<torch::SimpleContainer>();
     auto l1 = model->add(Linear(10, 3), "l1");
     auto l2 = model->add(Linear(3, 5), "l2");
     auto l3 = model->add(Linear(5, 100), "l3");
@@ -157,7 +155,7 @@ TEST_CASE("modules") {
       // params
       auto x = torch::full({10}, dict_size - 1, torch::kInt64);
       auto y = model->forward({x})[0];
-      Variable s = y.sum();
+      torch::Tensor s = y.sum();
 
       s.backward();
       REQUIRE(y.ndimension() == 2);
@@ -172,7 +170,7 @@ TEST_CASE("modules") {
       Embedding model(6, 4);
       auto x = torch::full({2, 3}, 5, torch::kInt64);
       auto y = model->forward({x})[0];
-      Variable s = y.sum();
+      torch::Tensor s = y.sum();
 
       s.backward();
       REQUIRE(y.ndimension() == 3);
@@ -184,8 +182,8 @@ TEST_CASE("modules") {
 
   SECTION("dropout") {
     Dropout dropout(0.5);
-    Variable x = torch::ones(100, at::requires_grad());
-    Variable y = dropout->forward({x})[0];
+    torch::Tensor x = torch::ones(100, at::requires_grad());
+    torch::Tensor y = dropout->forward({x})[0];
 
     y.backward();
     REQUIRE(y.ndimension() == 1);
@@ -223,7 +221,7 @@ TEST_CASE("modules") {
   SECTION("functional") {
     bool was_called = false;
     // clang-format off
-    auto functional = Functional([&was_called](std::vector<Variable> input) {
+    auto functional = Functional([&was_called](std::vector<torch::Tensor> input) {
       was_called = true;
       return input;
     });
@@ -241,7 +239,7 @@ TEST_CASE("modules_cuda", "[cuda]") {
     model->cuda();
     auto x = torch::randn({10, 5}, at::device(at::kCUDA).requires_grad(true));
     auto y = model->forward({x})[0];
-    Variable s = y.sum();
+    torch::Tensor s = y.sum();
 
     s.backward();
     REQUIRE(y.ndimension() == 2);
@@ -258,7 +256,7 @@ TEST_CASE("modules_cuda", "[cuda]") {
     model->cpu();
     auto x = torch::randn({10, 5}, at::requires_grad());
     auto y = model->forward({x})[0];
-    Variable s = y.sum();
+    torch::Tensor s = y.sum();
 
     s.backward();
     REQUIRE(y.ndimension() == 2);

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -1,23 +1,25 @@
 #include <catch.hpp>
 
-#include <torch/torch.h>
+#include <torch/nn/modules/linear.h>
+#include <torch/nn/modules/rnn.h>
+#include <torch/optimizers.h>
+#include <torch/tensor.h>
 
 #include <test/cpp/api/util.h>
 
-using namespace torch;
 using namespace torch::nn;
 
 template <typename R, typename Func>
 bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
   auto nhid = 32;
-  auto model = std::make_shared<SimpleContainer>();
+  auto model = std::make_shared<torch::SimpleContainer>();
   auto l1 = model->add(Linear(1, nhid), "l1");
   auto rnn = model->add(model_maker(nhid), "rnn");
   auto lo = model->add(Linear(nhid, 1), "lo");
 
-  auto optim = Adam(model, 1e-2).make();
+  auto optim = torch::Adam(model, 1e-2).make();
 
-  auto forward_op = [&](Variable x) {
+  auto forward_op = [&](torch::Tensor x) {
     auto T = x.size(0);
     auto B = x.size(1);
     x = x.view({T * B, 1});
@@ -42,10 +44,10 @@ bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
     auto inp = at::rand({nlen, bs, 1}, backend).round().toType(torch::kFloat32);
     auto lab = inp.sum(0);
 
-    auto x = autograd::make_variable(inp, /*requires_grad=*/true);
-    auto y = autograd::make_variable(lab);
+    auto x = torch::autograd::make_variable(inp, /*requires_grad=*/true);
+    auto y = torch::autograd::make_variable(lab);
     x = forward_op(x);
-    Variable loss = at::mse_loss(x, y);
+    torch::Tensor loss = at::mse_loss(x, y);
 
     optim->zero_grad();
     loss.backward();
@@ -60,7 +62,7 @@ bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
   return true;
 };
 
-void check_lstm_sizes(std::vector<Variable> tup) {
+void check_lstm_sizes(std::vector<torch::Tensor> tup) {
   // Expect the LSTM to have 64 outputs and 3 layers, with an input of batch
   // 10 and 16 time steps (10 x 16 x n)
 
@@ -97,7 +99,7 @@ TEST_CASE("rnn") {
 
       check_lstm_sizes(next);
 
-      Variable diff = next[1] - tup[1];
+      torch::Tensor diff = next[1] - tup[1];
 
       // Hiddens changed
       REQUIRE(diff.data().abs().sum().toCFloat() > 1e-3);
@@ -171,8 +173,8 @@ TEST_CASE("rnn/integration/LSTM") {
 }
 
 TEST_CASE("rnn/integration/GRU") {
-  REQUIRE(test_RNN_xor<GRU>(
-      [](int s) { return GRU(GRUOptions(s, s).layers(2)); }));
+  REQUIRE(
+      test_RNN_xor<GRU>([](int s) { return GRU(GRUOptions(s, s).layers(2)); }));
 }
 
 TEST_CASE("rnn/integration/RNN") {
@@ -201,11 +203,11 @@ TEST_CASE("rnn_cuda", "[cuda]") {
 
     check_lstm_sizes(next);
 
-    Variable diff = next[1] - tup[1];
+    torch::Tensor diff = next[1] - tup[1];
 
     // Hiddens changed
     REQUIRE(diff.data().abs().sum().toCFloat() > 1e-3);
-  };
+  }
 
   SECTION("lstm") {
     REQUIRE(test_RNN_xor<LSTM>(
@@ -220,13 +222,11 @@ TEST_CASE("rnn_cuda", "[cuda]") {
   SECTION("rnn") {
     SECTION("relu") {
       REQUIRE(test_RNN_xor<RNN>(
-          [](int s) { return RNN(RNNOptions(s, s).relu().layers(2)); },
-          true));
+          [](int s) { return RNN(RNNOptions(s, s).relu().layers(2)); }, true));
     }
     SECTION("tanh") {
       REQUIRE(test_RNN_xor<RNN>(
-          [](int s) { return RNN(RNNOptions(s, s).tanh().layers(2)); },
-          true));
+          [](int s) { return RNN(RNNOptions(s, s).tanh().layers(2)); }, true));
     }
   }
 }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1,6 +1,6 @@
 #include <catch.hpp>
 
-#include <torch/functions.h>
+#include <torch/tensor.h>
 
 #include <ATen/ATen.h>
 

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 
-#include <torch/functions.h>
+#include <torch/tensor.h>
 
 #include <ATen/Context.h>
 #include <ATen/Functions.h>

--- a/test/cpp/api/util.h
+++ b/test/cpp/api/util.h
@@ -12,7 +12,7 @@ namespace torch {
 // for experimental implementations
 class SimpleContainer : public nn::Cloneable<SimpleContainer> {
  public:
-  virtual std::vector<Variable> forward(std::vector<Variable>) {
+  virtual std::vector<Tensor> forward(std::vector<Tensor>) {
     throw std::runtime_error(
         "SimpleContainer has no forward, maybe you"
         " wanted to subclass and override this function?");
@@ -36,7 +36,7 @@ struct SigmoidLinear : nn::Module {
   explicit SigmoidLinear(nn::Linear linear_) : linear(std::move(linear_)) {
     register_module("linear", linear);
   }
-  Variable forward(Variable input) {
+  Tensor forward(Tensor input) {
     return linear->forward({input}).front().sigmoid();
   }
   nn::Linear linear;

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -7,14 +7,5 @@
 #include <ATen/ATen.h>
 
 namespace torch {
-using at::Generator;
-using at::IntList;
-using at::Scalar;
-using at::Tensor;
-using at::TensorList;
-using at::TensorOptions;
-} // namespace torch::autograd
-
-namespace torch {
 ${function_definitions}
-} // namespace torch::autograd
+} // namespace torch

--- a/torch/csrc/api/README.md
+++ b/torch/csrc/api/README.md
@@ -31,7 +31,7 @@ TORCH_AUTOGRAD_CONTAINER_CLASS(MyModel) {
     myConv_ = add(Conv2d(1, 50, 3, 3).stride(2).make(), "conv");
     myLinear_ = add(Linear(50, 1).make(), "linear");
   }
-  std::vector<Variable> forward(std::vector<Variable> x) override {
+  std::vector<Tensor> forward(std::vector<Tensor> x) override {
     auto v = myConv_->forward(x);
     v = v.mean(-1).mean(-1);
     return myLinear_.forward({v});

--- a/torch/csrc/api/include/torch/functions.h
+++ b/torch/csrc/api/include/torch/functions.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include <torch/csrc/autograd/generated/variable_factories.h>

--- a/torch/csrc/api/include/torch/nn/cursor.h
+++ b/torch/csrc/api/include/torch/nn/cursor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/autograd/variable.h>
+#include <torch/tensor.h>
 
 #include <cstddef>
 #include <iterator>
@@ -169,25 +170,24 @@ class ConstModuleCursor : public detail::CursorBase<const Module> {
 
 // Parameter cursors (`.parameters()`)
 
-class ParameterCursor : public detail::CursorBase<autograd::Variable> {
+class ParameterCursor : public detail::CursorBase<Tensor> {
  public:
   explicit ParameterCursor(Module& module);
 };
 
-class ConstParameterCursor
-    : public detail::CursorBase<const autograd::Variable> {
+class ConstParameterCursor : public detail::CursorBase<const Tensor> {
  public:
   explicit ConstParameterCursor(const Module& module);
 };
 
 // Buffer cursors (`.buffers()`)
 
-class BufferCursor : public detail::CursorBase<autograd::Variable> {
+class BufferCursor : public detail::CursorBase<Tensor> {
  public:
   explicit BufferCursor(Module& module);
 };
 
-class ConstBufferCursor : public detail::CursorBase<const autograd::Variable> {
+class ConstBufferCursor : public detail::CursorBase<const Tensor> {
  public:
   explicit ConstBufferCursor(const Module& module);
 };

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -109,11 +109,11 @@ class Module {
   }
 
  protected:
-  Variable& register_parameter(
+  Tensor& register_parameter(
       std::string name,
-      Variable tensor,
+      Tensor tensor,
       bool requires_grad = true);
-  Variable& register_buffer(std::string name, Variable tensor);
+  Tensor& register_buffer(std::string name, Tensor tensor);
 
   template <
       typename ModuleType,
@@ -144,8 +144,8 @@ class Module {
 
   virtual void clone_(Module& other);
 
-  OrderedDict<autograd::Variable> parameters_;
-  OrderedDict<autograd::Variable> buffers_;
+  OrderedDict<Tensor> parameters_;
+  OrderedDict<Tensor> buffers_;
   OrderedDict<std::shared_ptr<Module>> children_;
 
   /// The module's name (e.g. "LSTM").

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -24,15 +24,15 @@ class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
   explicit BatchNormImpl(BatchNormOptions options);
 
   void reset() override;
-  std::vector<Variable> forward(std::vector<Variable>);
+  std::vector<Tensor> forward(std::vector<Tensor>);
   const BatchNormOptions& options() const noexcept;
 
  private:
   BatchNormOptions options_;
-  Variable weight_;
-  Variable bias_;
-  Variable running_mean_;
-  Variable running_variance_;
+  Tensor weight_;
+  Tensor bias_;
+  Tensor running_mean_;
+  Tensor running_variance_;
 };
 
 TORCH_MODULE(BatchNorm);

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -38,8 +38,8 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
   const ConvOptions<D>& options() const noexcept;
 
  protected:
-  Variable weight_;
-  Variable bias_;
+  Tensor weight_;
+  Tensor bias_;
   ConvOptions<D> options_;
 };
 
@@ -47,7 +47,7 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
   class Conv##D##dImpl : public ConvImpl<D, Conv##D##dImpl> {   \
    public:                                                      \
     using ConvImpl<D, Conv##D##dImpl>::ConvImpl;                \
-    std::vector<Variable> forward(std::vector<Variable> input); \
+    std::vector<Tensor> forward(std::vector<Tensor> input); \
   };                                                            \
   using Conv##D##dOptions = ConvOptions<D>;                     \
   TORCH_MODULE(Conv##D##d)

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -21,11 +21,11 @@ class DropoutImplBase : public torch::nn::Cloneable<Derived> {
   explicit DropoutImplBase(DropoutOptions options);
 
   void reset() override;
-  std::vector<Variable> forward(std::vector<Variable> input);
+  std::vector<Tensor> forward(std::vector<Tensor> input);
   const DropoutOptions& options() const noexcept;
 
  protected:
-  virtual Variable noise_mask(Variable input) const = 0;
+  virtual Tensor noise_mask(Tensor input) const = 0;
 
   DropoutOptions options_;
 };
@@ -34,13 +34,13 @@ class DropoutImplBase : public torch::nn::Cloneable<Derived> {
 class DropoutImpl : public detail::DropoutImplBase<DropoutImpl> {
  public:
   using detail::DropoutImplBase<DropoutImpl>::DropoutImplBase;
-  Variable noise_mask(Variable input) const override;
+  Tensor noise_mask(Tensor input) const override;
 };
 
 class Dropout2dImpl : public detail::DropoutImplBase<Dropout2dImpl> {
  public:
   using detail::DropoutImplBase<Dropout2dImpl>::DropoutImplBase;
-  Variable noise_mask(Variable input) const override;
+  Tensor noise_mask(Tensor input) const override;
 };
 
 TORCH_MODULE(Dropout);

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -21,12 +21,12 @@ class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
   explicit EmbeddingImpl(EmbeddingOptions options);
 
   void reset() override;
-  std::vector<Variable> forward(std::vector<Variable>);
+  std::vector<Tensor> forward(std::vector<Tensor>);
   const EmbeddingOptions& options() const noexcept;
 
  private:
   EmbeddingOptions options_;
-  Variable table_;
+  Tensor table_;
 };
 
 TORCH_MODULE(Embedding);

--- a/torch/csrc/api/include/torch/nn/modules/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/functional.h
@@ -14,13 +14,13 @@ namespace nn {
 // Sequential.
 class FunctionalImpl : public torch::nn::Cloneable<FunctionalImpl> {
  public:
-  using Function = std::function<std::vector<Variable>(std::vector<Variable>)>;
+  using Function = std::function<std::vector<Tensor>(std::vector<Tensor>)>;
 
   explicit FunctionalImpl(Function function);
-  explicit FunctionalImpl(std::function<Variable(Variable)> function);
+  explicit FunctionalImpl(std::function<Tensor(Tensor)> function);
 
   void reset() override;
-  std::vector<Variable> forward(std::vector<Variable> input);
+  std::vector<Tensor> forward(std::vector<Tensor> input);
 
  private:
   Function function_;

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -22,12 +22,12 @@ class LinearImpl : public torch::nn::Cloneable<LinearImpl> {
   explicit LinearImpl(LinearOptions options);
 
   void reset() override;
-  std::vector<Variable> forward(std::vector<Variable>);
+  std::vector<Tensor> forward(std::vector<Tensor>);
   const LinearOptions& options() const noexcept;
 
  private:
-  Variable weight_;
-  Variable bias_;
+  Tensor weight_;
+  Tensor bias_;
   LinearOptions options_;
 };
 

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -39,7 +39,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
       int64_t number_of_gates = 1,
       bool has_cell_state = false);
 
-  std::vector<Variable> forward(std::vector<Variable>);
+  std::vector<Tensor> forward(std::vector<Tensor>);
 
   void reset() override;
 
@@ -47,23 +47,24 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   void to(at::ScalarType scalar_type) override;
   void to(at::Backend backend) override;
 
+  void flatten_parameters_for_cudnn();
+
  protected:
-  virtual std::vector<Variable> cell_forward(
-      std::vector<Variable>,
+  virtual std::vector<Tensor> cell_forward(
+      std::vector<Tensor>,
       int64_t layer) = 0;
 
-  std::vector<Variable> CUDNN_forward(std::vector<Variable>);
-  std::vector<Variable> autograd_forward(std::vector<Variable>);
+  std::vector<Tensor> CUDNN_forward(std::vector<Tensor>);
+  std::vector<Tensor> autograd_forward(std::vector<Tensor>);
 
-  void flatten_parameters_for_cudnn();
-  std::vector<at::Tensor> flat_weights() const;
+  std::vector<Tensor> flat_weights() const;
 
   RNNOptionsBase options_;
 
-  std::vector<Variable> ihw_;
-  std::vector<Variable> ihb_;
-  std::vector<Variable> hhw_;
-  std::vector<Variable> hhb_;
+  std::vector<Tensor> ihw_;
+  std::vector<Tensor> ihb_;
+  std::vector<Tensor> hhw_;
+  std::vector<Tensor> hhb_;
 
   int64_t number_of_gates_;
   bool has_cell_state_;
@@ -77,7 +78,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   // TODO Actually since we are in C++ we can probably just actually check if
   // the parameters are flat, instead of relying on data pointers and stuff.
   std::vector<void*> data_ptrs_;
-  Variable flat_weights_;
+  Tensor flat_weights_;
 };
 } // namespace detail
 
@@ -108,11 +109,10 @@ class RNNImpl : public detail::RNNImplBase<RNNImpl> {
   const RNNOptions& options() const noexcept;
 
  private:
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
-      override;
+  std::vector<Tensor> cell_forward(std::vector<Tensor>, int64_t layer) override;
 
   RNNOptions options_;
-  std::function<Variable(Variable)> activation_function_;
+  std::function<Tensor(Tensor)> activation_function_;
 };
 
 TORCH_MODULE(RNN);
@@ -128,8 +128,7 @@ class LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
   const LSTMOptions& options() const noexcept;
 
  private:
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
-      override;
+  std::vector<Tensor> cell_forward(std::vector<Tensor>, int64_t layer) override;
 };
 
 TORCH_MODULE(LSTM);
@@ -145,8 +144,7 @@ class GRUImpl : public detail::RNNImplBase<GRUImpl> {
   const GRUOptions& options() const noexcept;
 
  private:
-  std::vector<Variable> cell_forward(std::vector<Variable>, int64_t layer)
-      override;
+  std::vector<Tensor> cell_forward(std::vector<Tensor>, int64_t layer) override;
 };
 
 TORCH_MODULE(GRU);

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -4,6 +4,7 @@
 #include <torch/nn/module.h>
 #include <torch/nn/modules/any.h>
 #include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
 
 #include <torch/csrc/autograd/variable.h>
 
@@ -43,7 +44,7 @@ class Sequential : public Cloneable<Sequential> {
 
   /// Feeds the `inputs` to the first module, then chains the output of each
   /// module with the input of the next, in order of construction.
-  template <typename ReturnType = autograd::Variable, typename... ArgumentTypes>
+  template <typename ReturnType = Tensor, typename... ArgumentTypes>
   ReturnType forward(ArgumentTypes&&... arguments) {
     AT_CHECK(!is_empty(), "Cannot call forward() on an empty Sequential");
 

--- a/torch/csrc/api/include/torch/optimizers.h
+++ b/torch/csrc/api/include/torch/optimizers.h
@@ -90,13 +90,13 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(LBFGS) {
  private:
   friend class cereal::access;
   LBFGS() {}
-  at::Tensor gather_flat_grad();
-  void add_grad(const at::Scalar& step_size, const at::Tensor& update);
+  Tensor gather_flat_grad();
+  void add_grad(const at::Scalar& step_size, const Tensor& update);
 
-  at::Tensor d, H_diag, prev_flat_grad;
+  Tensor d, H_diag, prev_flat_grad;
   at::Scalar t, prev_loss;
-  std::vector<at::Tensor> ro, al;
-  std::deque<at::Tensor> old_dirs, old_stps;
+  std::vector<Tensor> ro, al;
+  std::deque<Tensor> old_dirs, old_stps;
   int func_evals, state_n_iter;
 };
 
@@ -128,7 +128,7 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(SGD) {
  private:
   friend class cereal::access;
   SGD() {}
-  std::unordered_map<std::string, at::Tensor> momentum_buffers_;
+  std::unordered_map<std::string, Tensor> momentum_buffers_;
 };
 
 TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
@@ -156,7 +156,7 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
  private:
   friend class cereal::access;
   Adagrad() {}
-  std::unordered_map<std::string, at::Tensor> sum_;
+  std::unordered_map<std::string, Tensor> sum_;
   std::unordered_map<std::string, double> step_;
 };
 
@@ -190,9 +190,9 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(RMSprop) {
  private:
   friend class cereal::access;
   RMSprop() {}
-  std::unordered_map<std::string, at::Tensor> square_avg_buffer_;
-  std::unordered_map<std::string, at::Tensor> momentum_buffer_;
-  std::unordered_map<std::string, at::Tensor> grad_avg_buffer_;
+  std::unordered_map<std::string, Tensor> square_avg_buffer_;
+  std::unordered_map<std::string, Tensor> momentum_buffer_;
+  std::unordered_map<std::string, Tensor> grad_avg_buffer_;
 };
 
 TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adam) {
@@ -226,9 +226,9 @@ TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adam) {
   friend class cereal::access;
   Adam() {}
   std::unordered_map<std::string, int> step_buffer_;
-  std::unordered_map<std::string, at::Tensor> exp_avg_buffer_;
-  std::unordered_map<std::string, at::Tensor> exp_avg_sq_buffer_;
-  std::unordered_map<std::string, at::Tensor> max_exp_avg_sq_buffer_;
+  std::unordered_map<std::string, Tensor> exp_avg_buffer_;
+  std::unordered_map<std::string, Tensor> exp_avg_sq_buffer_;
+  std::unordered_map<std::string, Tensor> max_exp_avg_sq_buffer_;
 };
 
 using Optimizer = std::shared_ptr<OptimizerImpl>;

--- a/torch/csrc/api/include/torch/serialization.h
+++ b/torch/csrc/api/include/torch/serialization.h
@@ -2,7 +2,6 @@
 
 #include <fstream>
 
-#include <torch/functions.h>
 #include <torch/tensor.h>
 
 #include "cereal/archives/binary.hpp"
@@ -163,13 +162,13 @@ loadBinary(BinaryInputArchive& archive, void* data, size_t size) {
 
 // Gradients will not be saved for variables
 template <class Archive>
-void save(Archive& archive, at::Tensor const& tensor) {
+void save(Archive& archive, torch::Tensor const& tensor) {
   if (!tensor.defined()) {
     int32_t typeId = ::torch::detail::scalarTypeId(at::ScalarType::Undefined);
     archive(CEREAL_NVP(typeId));
     return;
   } else {
-    int32_t typeId = ::torch::detail::scalarTypeId(tensor.type().scalarType());
+    int32_t typeId = ::torch::detail::scalarTypeId(tensor.data().type().scalarType());
     archive(CEREAL_NVP(typeId));
   }
   auto sizes = std::vector<int64_t>();
@@ -178,13 +177,13 @@ void save(Archive& archive, at::Tensor const& tensor) {
     sizes.push_back(s);
   }
   auto contig = tensor.toBackend(at::kCPU).contiguous();
-  int32_t backend = ::torch::detail::backendId(tensor.type().backend());
+  int32_t backend = ::torch::detail::backendId(tensor.data().type().backend());
 
   archive(CEREAL_NVP(backend), CEREAL_NVP(sizes));
   agimpl::saveBinary(
       archive,
       contig.data_ptr(),
-      tensor.numel() * tensor.type().elementSizeInBytes());
+      tensor.numel() * tensor.data().type().elementSizeInBytes());
 }
 
 /**
@@ -194,13 +193,13 @@ void save(Archive& archive, at::Tensor const& tensor) {
  * 2. Otherwise, overwrite the provided tensor with the right type and backend
  **/
 template <class Archive>
-void load(Archive& archive, at::Tensor& tensor) {
+void load(Archive& archive, torch::Tensor& tensor) {
   at::ScalarType type;
   int32_t typeId;
   archive(CEREAL_NVP(typeId));
   type = ::torch::detail::scalarTypeFromId(typeId);
   if (type == at::ScalarType::Undefined) {
-    tensor = at::Tensor();
+    tensor = torch::Tensor();
     return;
   }
 
@@ -210,14 +209,14 @@ void load(Archive& archive, at::Tensor& tensor) {
   archive(CEREAL_NVP(backendId), CEREAL_NVP(sizes));
 
   at::Backend backend = ::torch::detail::backendFromId(backendId);
-  if (!tensor.defined() || tensor.type().scalarType() != type) {
-    tensor = at::empty({}, at::getType(backend, type));
+  if (!tensor.defined() || tensor.data().type().scalarType() != type) {
+    tensor = torch::empty({}, at::getType(backend, type));
   }
-  tensor.resize_(sizes);
+  tensor.data().resize_(sizes);
 
   if (tensor.type().is_cuda()) {
     // should actually use cudamemcpy probably
-    auto cputensor = at::empty(sizes, tensor.type().scalarType());
+    auto cputensor = at::empty(sizes, tensor.data().type().scalarType());
     agimpl::loadBinary(
         archive,
         cputensor.data_ptr(),
@@ -227,13 +226,7 @@ void load(Archive& archive, at::Tensor& tensor) {
     agimpl::loadBinary(
         archive,
         tensor.data_ptr(),
-        tensor.numel() * tensor.type().elementSizeInBytes());
+        tensor.numel() * tensor.data().type().elementSizeInBytes());
   }
 }
-
-template <class Archive>
-void load(Archive& archive, torch::autograd::Variable& var) {
-  load(archive, var.data());
-}
-
 } // namespace cereal

--- a/torch/csrc/api/include/torch/tensor.h
+++ b/torch/csrc/api/include/torch/tensor.h
@@ -2,11 +2,11 @@
 
 #include <ATen/ATen.h>
 
+#include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
-// TODO: Rename to `Tensor`.
-using Variable = autograd::Variable;
+using Tensor = autograd::Variable;
 
 /// Fixed width dtypes.
 constexpr auto kUInt8 = at::kByte;
@@ -25,5 +25,4 @@ constexpr auto kI32 = kInt32;
 constexpr auto kI64 = kInt64;
 constexpr auto kF32 = kFloat32;
 constexpr auto kF64 = kFloat64;
-
 } // namespace torch

--- a/torch/csrc/api/include/torch/tensor_range.h
+++ b/torch/csrc/api/include/torch/tensor_range.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <torch/tensor.h>
+
+#include <ATen/ArrayRef.h>
+#include <ATen/Tensor.h>
+
+#include <algorithm>
+#include <array>
+#include <initializer_list>
+#include <iterator>
+#include <vector>
+
+namespace torch {
+class TensorRange {
+ public:
+  /// Constructs an TensorRange from a single element.
+  /*implicit*/ TensorRange(const torch::Tensor& tensor)
+      : backing_vector_({tensor}) {}
+
+  /// Constructs an TensorRange from a std::vector.
+  template <typename A>
+  /*implicit*/ TensorRange(const std::vector<torch::Tensor, A>& vector)
+      : backing_vector_(vector.size()) {
+    std::copy(vector.begin(), vector.end(), backing_vector_.begin());
+  }
+
+  /// Constructs an TensorRange from a std::array
+  template <size_t N>
+  /*implicit*/ TensorRange(const std::array<torch::Tensor, N>& array)
+      : backing_vector_(N) {
+    std::copy(array.begin(), array.end(), backing_vector_.begin());
+  }
+
+  /// Constructs an TensorRange from a C array.
+  template <size_t N>
+  /*implicit*/ TensorRange(const torch::Tensor (&array)[N])
+      : backing_vector_(N) {
+    std::copy(std::begin(array), std::end(array), backing_vector_.begin());
+  }
+
+  /// Constructs an TensorRange from a std::initializer_list.
+  /*implicit*/ TensorRange(const std::initializer_list<torch::Tensor>& list)
+      : backing_vector_(list.size()) {
+    std::copy(list.begin(), list.end(), backing_vector_.begin());
+  }
+
+  /// Implicitly converts the `TensorRange` to an `ArrayRef` of the backing
+  /// vector.
+  operator at::ArrayRef<at::Tensor>() {
+    return backing_vector_;
+  }
+
+ private:
+  std::vector<at::Tensor> backing_vector_;
+};
+} // namespace torch

--- a/torch/csrc/api/include/torch/tensor_range.h
+++ b/torch/csrc/api/include/torch/tensor_range.h
@@ -12,40 +12,40 @@
 #include <vector>
 
 namespace torch {
-class TensorRange {
+class TensorListView {
  public:
-  /// Constructs an TensorRange from a single element.
-  /*implicit*/ TensorRange(const torch::Tensor& tensor)
+  /// Constructs an TensorListView from a single element.
+  /*implicit*/ TensorListView(const torch::Tensor& tensor)
       : backing_vector_({tensor}) {}
 
-  /// Constructs an TensorRange from a std::vector.
+  /// Constructs an TensorListView from a std::vector.
   template <typename A>
-  /*implicit*/ TensorRange(const std::vector<torch::Tensor, A>& vector)
+  /*implicit*/ TensorListView(const std::vector<torch::Tensor, A>& vector)
       : backing_vector_(vector.size()) {
     std::copy(vector.begin(), vector.end(), backing_vector_.begin());
   }
 
-  /// Constructs an TensorRange from a std::array
+  /// Constructs an TensorListView from a std::array
   template <size_t N>
-  /*implicit*/ TensorRange(const std::array<torch::Tensor, N>& array)
+  /*implicit*/ TensorListView(const std::array<torch::Tensor, N>& array)
       : backing_vector_(N) {
     std::copy(array.begin(), array.end(), backing_vector_.begin());
   }
 
-  /// Constructs an TensorRange from a C array.
+  /// Constructs an TensorListView from a C array.
   template <size_t N>
-  /*implicit*/ TensorRange(const torch::Tensor (&array)[N])
+  /*implicit*/ TensorListView(const torch::Tensor (&array)[N])
       : backing_vector_(N) {
     std::copy(std::begin(array), std::end(array), backing_vector_.begin());
   }
 
-  /// Constructs an TensorRange from a std::initializer_list.
-  /*implicit*/ TensorRange(const std::initializer_list<torch::Tensor>& list)
+  /// Constructs an TensorListView from a std::initializer_list.
+  /*implicit*/ TensorListView(const std::initializer_list<torch::Tensor>& list)
       : backing_vector_(list.size()) {
     std::copy(list.begin(), list.end(), backing_vector_.begin());
   }
 
-  /// Implicitly converts the `TensorRange` to an `ArrayRef` of the backing
+  /// Implicitly converts the `TensorListView` to an `ArrayRef` of the backing
   /// vector.
   operator at::ArrayRef<at::Tensor>() {
     return backing_vector_;

--- a/torch/csrc/api/include/torch/torch.h
+++ b/torch/csrc/api/include/torch/torch.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/functions.h>
 #include <torch/nn/module.h>
 #include <torch/nn/modules/modules.h>
 #include <torch/tensor.h>

--- a/torch/csrc/api/src/nn/cursor.cpp
+++ b/torch/csrc/api/src/nn/cursor.cpp
@@ -151,8 +151,8 @@ struct CursorBase<T>::Collector {
 // Explicitly instantiate the CursorBase template for all types we need.
 template class CursorBase<nn::Module>;
 template class CursorBase<const nn::Module>;
-template class CursorBase<autograd::Variable>;
-template class CursorBase<const autograd::Variable>;
+template class CursorBase<Tensor>;
+template class CursorBase<const Tensor>;
 } // namespace detail
 
 namespace nn {
@@ -165,19 +165,19 @@ ConstModuleCursor::ConstModuleCursor(const Module& module, size_t maximum_depth)
           Collector().collect_children(module, maximum_depth)) {}
 
 ParameterCursor::ParameterCursor(Module& module)
-    : detail::CursorBase<autograd::Variable>(
+    : detail::CursorBase<Tensor>(
           Collector().collect_parameters(module)) {}
 
 ConstParameterCursor::ConstParameterCursor(const Module& module)
-    : detail::CursorBase<const autograd::Variable>(
+    : detail::CursorBase<const Tensor>(
           Collector().collect_parameters(module)) {}
 
 BufferCursor::BufferCursor(Module& module)
-    : detail::CursorBase<autograd::Variable>(
+    : detail::CursorBase<Tensor>(
           Collector().collect_buffers(module)) {}
 
 ConstBufferCursor::ConstBufferCursor(const Module& module)
-    : detail::CursorBase<const autograd::Variable>(
+    : detail::CursorBase<const Tensor>(
           Collector().collect_buffers(module)) {}
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -146,15 +146,15 @@ void Module::zero_grad() {
   }
 }
 
-autograd::Variable& Module::register_parameter(
+Tensor& Module::register_parameter(
     std::string name,
-    Variable tensor,
+    Tensor tensor,
     bool requires_grad) {
   tensor.set_requires_grad(requires_grad);
   return parameters_.insert(std::move(name), std::move(tensor));
 }
 
-autograd::Variable& Module::register_buffer(std::string name, Variable tensor) {
+Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return parameters_.insert(std::move(name), std::move(tensor));
 }
 

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -1,7 +1,6 @@
 #include <torch/nn/modules/batchnorm.h>
 
 #include <torch/cuda.h>
-#include <torch/functions.h>
 #include <torch/tensor.h>
 
 #include <ATen/Error.h>
@@ -34,7 +33,7 @@ void BatchNormImpl::reset() {
   }
 }
 
-std::vector<Variable> BatchNormImpl::forward(std::vector<Variable> inputs) {
+std::vector<Tensor> BatchNormImpl::forward(std::vector<Tensor> inputs) {
   auto& input = inputs[0];
   auto& running_mean_ = (options_.stateful_ ? this->running_mean_ : inputs[1]);
   auto& running_variance_ =
@@ -58,7 +57,7 @@ std::vector<Variable> BatchNormImpl::forward(std::vector<Variable> inputs) {
       options_.eps_,
       torch::cuda::cudnn_is_available());
 
-  return std::vector<Variable>({output});
+  return std::vector<Tensor>({output});
 }
 
 const BatchNormOptions& BatchNormImpl::options() const noexcept {

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -1,10 +1,7 @@
 #include <torch/nn/modules/conv.h>
 
 #include <torch/expanding_array.h>
-#include <torch/functions.h>
 #include <torch/tensor.h>
-
-#include <ATen/ATen.h>
 
 #include <cmath>
 #include <cstdint>
@@ -73,7 +70,7 @@ const ConvOptions<D>& ConvImpl<D, Derived>::options() const noexcept {
   return options_;
 }
 
-std::vector<Variable> Conv1dImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> Conv1dImpl::forward(std::vector<Tensor> input) {
   AT_ASSERT(input.front().ndimension() == 3);
 
   if (options_.transposed_) {
@@ -97,7 +94,7 @@ std::vector<Variable> Conv1dImpl::forward(std::vector<Variable> input) {
       options_.groups_)};
 }
 
-std::vector<Variable> Conv2dImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> Conv2dImpl::forward(std::vector<Tensor> input) {
   AT_ASSERT(input.front().ndimension() == 4);
 
   if (options_.transposed_) {
@@ -121,7 +118,7 @@ std::vector<Variable> Conv2dImpl::forward(std::vector<Variable> input) {
       options_.groups_)};
 }
 
-std::vector<Variable> Conv3dImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> Conv3dImpl::forward(std::vector<Tensor> input) {
   AT_ASSERT(input.front().ndimension() == 5);
 
   if (options_.transposed_) {

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -1,6 +1,5 @@
 #include <torch/nn/modules/dropout.h>
 
-#include <torch/functions.h>
 #include <torch/tensor.h>
 
 #include <ATen/Error.h>
@@ -22,12 +21,12 @@ template <typename Derived>
 void DropoutImplBase<Derived>::reset() {}
 
 template <typename Derived>
-std::vector<Variable> DropoutImplBase<Derived>::forward(
-    std::vector<Variable> input) {
+std::vector<Tensor> DropoutImplBase<Derived>::forward(
+    std::vector<Tensor> input) {
   if (options_.rate_ == 0 || !this->is_training()) {
     return input;
   }
-  std::vector<Variable> output;
+  std::vector<Tensor> output;
   for (const auto& value : input) {
     const auto noise = (noise_mask(value).uniform_(0, 1) > options_.rate_)
                            .toType(value.type().scalarType())
@@ -48,11 +47,11 @@ template class DropoutImplBase<Dropout2dImpl>;
 
 DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
 
-Variable DropoutImpl::noise_mask(Variable input) const {
+Tensor DropoutImpl::noise_mask(Tensor input) const {
   return at::empty_like(input);
 }
 
-Variable Dropout2dImpl::noise_mask(Variable input) const {
+Tensor Dropout2dImpl::noise_mask(Tensor input) const {
   return torch::empty({input.size(0), input.size(1), 1, 1}, input.options());
 }
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -1,6 +1,5 @@
 #include <torch/nn/modules/embedding.h>
 
-#include <torch/functions.h>
 #include <torch/tensor.h>
 
 #include <cstddef>
@@ -24,7 +23,7 @@ void EmbeddingImpl::reset() {
   table_.data().normal_(0, 1);
 }
 
-std::vector<Variable> EmbeddingImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> EmbeddingImpl::forward(std::vector<Tensor> input) {
   return {at::embedding(table_, /*indices=*/input[0])};
 }
 

--- a/torch/csrc/api/src/nn/modules/functional.cpp
+++ b/torch/csrc/api/src/nn/modules/functional.cpp
@@ -11,14 +11,14 @@ namespace nn {
 FunctionalImpl::FunctionalImpl(Function function)
     : function_(std::move(function)) {}
 
-FunctionalImpl::FunctionalImpl(std::function<Variable(Variable)> function)
-    : function_([function](std::vector<Variable> input) {
-        return std::vector<Variable>({function(input.front())});
+FunctionalImpl::FunctionalImpl(std::function<Tensor(Tensor)> function)
+    : function_([function](std::vector<Tensor> input) {
+        return std::vector<Tensor>({function(input.front())});
       }) {}
 
 void FunctionalImpl::reset() {}
 
-std::vector<Variable> FunctionalImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> FunctionalImpl::forward(std::vector<Tensor> input) {
   return function_(input);
 }
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -1,9 +1,6 @@
 #include <torch/nn/modules/linear.h>
 
-#include <torch/functions.h>
 #include <torch/tensor.h>
-
-#include <ATen/ATen.h>
 
 #include <cmath>
 #include <cstdint>
@@ -29,7 +26,7 @@ void LinearImpl::reset() {
   }
 }
 
-std::vector<Variable> LinearImpl::forward(std::vector<Variable> input) {
+std::vector<Tensor> LinearImpl::forward(std::vector<Tensor> input) {
   auto x = input[0];
   if (x.ndimension() == 2 && options_.with_bias_) {
     // Fused op is marginally faster

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -1,8 +1,8 @@
 #include <torch/nn/modules/rnn.h>
 
-#include <torch/functions.h>
 #include <torch/nn/modules/dropout.h>
 #include <torch/tensor.h>
+#include <torch/tensor_range.h>
 #include <torch/utils.h>
 
 #include <ATen/Error.h>
@@ -12,7 +12,6 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -23,7 +22,7 @@
 namespace torch {
 namespace nn {
 namespace {
-Variable linear(at::Tensor x, at::Tensor w, at::Tensor b) {
+Tensor linear(Tensor x, Tensor w, Tensor b) {
   if (x.ndimension() == 2 && b.defined()) {
     // Fused op is marginally faster
     assert(x.size(1) == w.size(1));
@@ -89,7 +88,6 @@ void RNNImplBase<Derived>::reset() {
           "bias_hh_l" + std::to_string(layer), torch::empty({gate_size}));
     }
   }
-  flatten_parameters_for_cudnn();
 
   const auto stdv = 1.0 / std::sqrt(options_.hidden_size_);
   for (auto& p : this->parameters()) {
@@ -98,10 +96,9 @@ void RNNImplBase<Derived>::reset() {
 }
 
 template <typename Derived>
-std::vector<Variable> RNNImplBase<Derived>::forward(
-    std::vector<Variable> inputs) {
-  std::vector<Variable> inp = {inputs[0],
-                               inputs.size() > 1 ? inputs[1] : Variable()};
+std::vector<Tensor> RNNImplBase<Derived>::forward(std::vector<Tensor> inputs) {
+  std::vector<Tensor> inp = {inputs[0],
+                             inputs.size() > 1 ? inputs[1] : Tensor()};
   if (cudnn_mode_.has_value() && at::cudnn_is_acceptable(inp[0]) &&
       options_.dropout_ == 0) {
     return {CUDNN_forward(inp)};
@@ -111,8 +108,8 @@ std::vector<Variable> RNNImplBase<Derived>::forward(
 }
 
 template <typename Derived>
-std::vector<at::Tensor> RNNImplBase<Derived>::flat_weights() const {
-  std::vector<at::Tensor> flat;
+std::vector<Tensor> RNNImplBase<Derived>::flat_weights() const {
+  std::vector<Tensor> flat;
   for (int64_t layer = 0; layer < options_.layers_; layer++) {
     flat.push_back(ihw_[layer]);
     flat.push_back(hhw_[layer]);
@@ -125,16 +122,16 @@ std::vector<at::Tensor> RNNImplBase<Derived>::flat_weights() const {
 }
 
 template <typename Derived>
-std::vector<Variable> RNNImplBase<Derived>::autograd_forward(
-    std::vector<Variable> inputs) {
+std::vector<Tensor> RNNImplBase<Derived>::autograd_forward(
+    std::vector<Tensor> inputs) {
   auto inp = inputs[0];
 
-  std::vector<at::Tensor> state;
+  std::vector<Tensor> state;
   auto has_hidden = inputs[1].defined();
   auto layer_dimension = has_hidden ? inputs[1].ndimension() - 3 : -1;
   for (int64_t layer = 0; layer < options_.layers_; layer++) {
     state.push_back(
-        has_hidden ? inputs[1].select(layer_dimension, layer) : Variable());
+        has_hidden ? inputs[1].select(layer_dimension, layer) : Tensor());
   }
 
   auto output = torch::zeros(
@@ -156,11 +153,11 @@ std::vector<Variable> RNNImplBase<Derived>::autograd_forward(
     }
   }
 
-  auto state_output = at::stack(state);
+  auto state_output = at::stack(TensorRange(state));
   if (has_cell_state_) {
     state_output.transpose_(0, 1);
   }
-  return std::vector<Variable>({output, state_output});
+  return std::vector<Tensor>({output, state_output});
 }
 
 template <typename Derived>
@@ -168,7 +165,7 @@ void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
   data_ptrs_.clear();
   const auto any_parameter = ihw_.at(0);
   if (!cudnn_mode_.has_value() || !any_parameter.is_cuda() ||
-      !at::cudnn_is_acceptable(any_parameter) || options_.dropout_ == 0) {
+      !at::cudnn_is_acceptable(any_parameter) || options_.dropout_ > 0) {
     return;
   }
   std::unordered_set<void*> unique_data_ptrs;
@@ -188,14 +185,14 @@ void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
   {
     NoGradGuard guard;
     flat_weights_ = at::_cudnn_rnn_flatten_weight(
-        flat_weights(),
+        TensorRange(flat_weights()),
         /*weight_stride=*/options_.with_bias_ ? 4 : 2,
         options_.input_size_,
         static_cast<int64_t>(*cudnn_mode_),
         options_.hidden_size_,
         options_.layers_,
-        false,
-        false); // batch_first and bidirectional, unsupported
+        /*batch_first=*/false,
+        /*bidirectional=*/false);
   }
   for (auto& p : params) {
     data_ptrs_.emplace_back(p->data().data_ptr());
@@ -203,10 +200,10 @@ void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
 }
 
 template <typename Derived>
-std::vector<Variable> RNNImplBase<Derived>::CUDNN_forward(
-    std::vector<Variable> inputs) {
+std::vector<Tensor> RNNImplBase<Derived>::CUDNN_forward(
+    std::vector<Tensor> inputs) {
   auto x = inputs[0];
-  Variable hx, cx;
+  Tensor hx, cx;
   if (inputs[1].defined()) {
     if (has_cell_state_) {
       hx = inputs[1][0];
@@ -225,24 +222,21 @@ std::vector<Variable> RNNImplBase<Derived>::CUDNN_forward(
   auto dropout_state = torch::empty({}, x.type());
 
   std::vector<void*> weight_data_ptrs;
-  auto params = this->parameters();
-  for (auto& p : params) {
+  for (auto& p : this->parameters()) {
     weight_data_ptrs.emplace_back(p->data().data_ptr());
   }
-  if (weight_data_ptrs != data_ptrs_) {
-    std::cerr
-        << "Parameters are unflattened! Code path might be super slow. "
-        << "Please call flatten_parameters_for_cudnn() when you muck around with "
-        << "storages !" << std::endl;
-    flat_weights_ = Variable();
-  }
 
+  AT_CHECK(
+      weight_data_ptrs == data_ptrs_,
+      "Parameters are unflattened! Code path might be super slow. "
+      "Please call flatten_parameters_for_cudnn() when you muck "
+      "around with storages!")
   AT_CHECK(cudnn_mode_.has_value(), "No CuDNN mode has been supplied!");
 
   // tup = std::tuple of output, hy, cy, reserve, new_weight_buf
   auto tup = _cudnn_rnn(
       x,
-      flat_weights(),
+      TensorRange(flat_weights()),
       /*weight_stride=*/options_.with_bias_ ? 4 : 2,
       flat_weights_,
       hx,
@@ -250,23 +244,24 @@ std::vector<Variable> RNNImplBase<Derived>::CUDNN_forward(
       static_cast<int64_t>(*cudnn_mode_),
       options_.hidden_size_,
       options_.layers_,
-      false, // batch first
+      /*batch_first=*/false,
       0, // TODO Use C++ dropout descriptors
       this->is_training(),
-      false, // bidirectional
-      {}, // packing not supported
+      /*bidirectional=*/false,
+      /*packed=*/{},
       dropout_state // TODO waiting on dropout state descriptor in C++ pytorch
   );
 
-  Variable hidden_output;
+  Tensor hidden_output;
   if (has_cell_state_) {
-    hidden_output = at::stack({std::get<1>(tup), std::get<2>(tup)}, 0);
+    hidden_output =
+        at::stack(TensorRange({std::get<1>(tup), std::get<2>(tup)}), 0);
   } else {
     hidden_output = std::get<1>(tup);
   }
 
-  Variable output = std::get<0>(tup);
-  return std::vector<Variable>({output, hidden_output});
+  Tensor output = std::get<0>(tup);
+  return std::vector<Tensor>({output, hidden_output});
 }
 
 template <typename Derived>
@@ -325,8 +320,8 @@ RNNImpl::RNNImpl(RNNOptions options)
   }
 }
 
-std::vector<Variable> RNNImpl::cell_forward(
-    std::vector<Variable> inputs,
+std::vector<Tensor> RNNImpl::cell_forward(
+    std::vector<Tensor> inputs,
     int64_t layer) {
   auto x = inputs[0];
   auto hx = inputs[1].defined()
@@ -336,7 +331,7 @@ std::vector<Variable> RNNImpl::cell_forward(
   auto h = linear(x, ihw_[layer], ihb_[layer]) +
       linear(hx, hhw_[layer], hhb_[layer]);
 
-  return {at::stack(activation_function_(h))};
+  return {at::stack(TensorRange(activation_function_(h)))};
 }
 
 const RNNOptions& RNNImpl::options() const noexcept {
@@ -352,8 +347,8 @@ LSTMImpl::LSTMImpl(LSTMOptions options)
           /*number_of_gates=*/4,
           /*has_cell_state=*/true) {}
 
-std::vector<Variable> LSTMImpl::cell_forward(
-    std::vector<Variable> inputs,
+std::vector<Tensor> LSTMImpl::cell_forward(
+    std::vector<Tensor> inputs,
     int64_t layer) {
   auto x = inputs[0];
   auto hid = inputs[1].defined()
@@ -374,7 +369,7 @@ std::vector<Variable> LSTMImpl::cell_forward(
   auto cy = (forget_gate * cx) + (in_gate * cell_gate);
   auto hy = out_gate * cy.tanh();
 
-  return {at::stack({hy, cy}, 0)};
+  return {at::stack(TensorRange({hy, cy}), 0)};
 }
 
 const LSTMOptions& LSTMImpl::options() const noexcept {
@@ -389,8 +384,8 @@ GRUImpl::GRUImpl(GRUOptions options)
           /*cudnn_mode=*/CuDNNMode::GRU,
           /*number_of_gates=*/3) {}
 
-std::vector<Variable> GRUImpl::cell_forward(
-    std::vector<Variable> inputs,
+std::vector<Tensor> GRUImpl::cell_forward(
+    std::vector<Tensor> inputs,
     int64_t layer) {
   auto x = inputs[0];
   auto hx = inputs[1].defined()
@@ -407,7 +402,7 @@ std::vector<Variable> GRUImpl::cell_forward(
   auto new_gate = (gic[2] + reset_gate * ghc[2]).tanh_();
   auto hy = new_gate + input_gate * (hx - new_gate);
 
-  return {at::stack(hy)};
+  return {at::stack(TensorRange(hy))};
 }
 
 const GRUOptions& GRUImpl::options() const noexcept {

--- a/torch/csrc/api/src/optimizers.cpp
+++ b/torch/csrc/api/src/optimizers.cpp
@@ -1,8 +1,8 @@
 #include "torch/optimizers.h"
 
 #include <torch/nn/module.h>
-#include <torch/functions.h>
 #include <torch/tensor.h>
+#include <torch/tensor_range.h>
 
 namespace torch {
 
@@ -24,19 +24,20 @@ void OptimizerImpl::set_model(std::shared_ptr<nn::Module> model) {
   model_ = model;
 }
 
-at::Tensor LBFGS::gather_flat_grad() {
-  std::vector<at::Tensor> views;
-  for(auto& parameter : model_->parameters()) {
-    views.push_back(torch::autograd::as_variable_ref(parameter->grad()).data().view(-1));
+Tensor LBFGS::gather_flat_grad() {
+  std::vector<Tensor> views;
+  for (auto& parameter : model_->parameters()) {
+    views.push_back(
+        torch::autograd::as_variable_ref(parameter->grad()).data().view(-1));
   }
-  return at::cat(views);
+  return at::cat(TensorRange(views));
 }
 
-void LBFGS::add_grad(const at::Scalar& step_size, const at::Tensor& update) {
+void LBFGS::add_grad(const at::Scalar& step_size, const Tensor& update) {
   int offset = 0;
-  for(auto& parameter : model_->parameters()) {
+  for (auto& parameter : model_->parameters()) {
     int numel = parameter->numel();
-    at::Tensor& pd = parameter->data();
+    auto& pd = parameter->data();
     pd.add_(update.slice(0, offset, offset + numel, 1).view_as(pd), step_size);
     offset += numel;
   }
@@ -48,33 +49,33 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
   int current_evals = 1;
   func_evals += 1;
 
-  at::Tensor flat_grad = gather_flat_grad();
+  Tensor flat_grad = gather_flat_grad();
   at::Scalar abs_grad_sum = at::Scalar(flat_grad.abs().sum());
 
-  if(at::Scalar(abs_grad_sum).toFloat() <= tolerance_grad_) {
+  if (at::Scalar(abs_grad_sum).toFloat() <= tolerance_grad_) {
     return loss;
   }
 
-  at::Tensor ONE = flat_grad.type().scalarTensor(1);
+  Tensor ONE = flat_grad.type().scalarTensor(1);
 
   int n_iter = 0;
-  while(n_iter < max_iter_) {
+  while (n_iter < max_iter_) {
     n_iter++;
     state_n_iter++;
 
-    if(state_n_iter == 1) {
+    if (state_n_iter == 1) {
       d = flat_grad.neg();
       H_diag = ONE;
       prev_flat_grad = flat_grad.clone();
     } else {
-      at::Tensor y = flat_grad.sub(prev_flat_grad);
-      at::Tensor s = d.mul(t);
+      Tensor y = flat_grad.sub(prev_flat_grad);
+      Tensor s = d.mul(t);
       at::Scalar ys = at::Scalar(y.dot(s));
 
-      if(ys.toFloat() > 1e-10) {
+      if (ys.toFloat() > 1e-10) {
         // updating memory
 
-        if((int)old_dirs.size() == history_size_) {
+        if ((int)old_dirs.size() == history_size_) {
           // shift history by one (limited memory)
           old_dirs.pop_front();
           old_stps.pop_front();
@@ -90,23 +91,23 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
 
       int num_old = old_dirs.size();
 
-      for(int i = 0; i < num_old; i++) {
+      for (int i = 0; i < num_old; i++) {
         ro[i] = ONE / old_dirs[i].dot(old_stps[i]);
       }
 
-      at::Tensor q = flat_grad.neg();
-      for(int i = num_old - 1; i >= 0; i--) {
+      Tensor q = flat_grad.neg();
+      for (int i = num_old - 1; i >= 0; i--) {
         al[i] = old_stps[i].dot(q) * ro[i];
         q.add_(old_dirs[i], at::Scalar(-al[i]));
       }
 
       // Multiply by initial Hessian
       // r/d is the final direction
-      at::Tensor r = q.mul(H_diag);
+      Tensor r = q.mul(H_diag);
       d = r;
 
-      for(int i = 0; i < num_old; i++) {
-        at::Tensor be_i = old_dirs[i].dot(r) * ro[i];
+      for (int i = 0; i < num_old; i++) {
+        Tensor be_i = old_dirs[i].dot(r) * ro[i];
         r.add_(old_stps[i], at::Scalar(al[i] - be_i));
       }
       prev_flat_grad.copy_(flat_grad);
@@ -117,7 +118,7 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
      */
 
     // reset initial guess for step size
-    if(n_iter == 1) {
+    if (n_iter == 1) {
       t = at::Scalar(at::min(ONE, ONE / abs_grad_sum) * lr_);
     } else {
       t = lr_;
@@ -126,7 +127,7 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
     at::Scalar gtd = at::Scalar(flat_grad.dot(d));
     add_grad(t, d);
     int ls_func_evals = 0;
-    if(n_iter != max_iter_) {
+    if (n_iter != max_iter_) {
       // re-evaluate function only if not in last iteration
       // the reason we do this: in a stochastic setting,
       // no use to re-evaluate that function here
@@ -142,7 +143,7 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
      * Check conditions
      */
 
-    if(n_iter == max_iter_) {
+    if (n_iter == max_iter_) {
       break;
     } else if (current_evals >= max_eval_) {
       break;
@@ -150,9 +151,11 @@ at::Scalar LBFGS::step(std::function<at::Scalar()> closure) {
       break;
     } else if (gtd.toFloat() > -tolerance_grad_) {
       break;
-    } else if (at::Scalar(d.mul(t).abs_().sum()).toFloat() <= tolerance_change_) {
+    } else if (
+        at::Scalar(d.mul(t).abs_().sum()).toFloat() <= tolerance_change_) {
       break;
-    } else if (std::abs(loss.toFloat() - prev_loss.toFloat()) < tolerance_change_) {
+    } else if (
+        std::abs(loss.toFloat() - prev_loss.toFloat()) < tolerance_change_) {
       break;
     }
   }
@@ -186,19 +189,19 @@ at::Scalar SGD::step(std::function<at::Scalar()> closure) {
     };
 
     if (momentum_ != 0) {
-      at::Tensor buf;
+      Tensor buf;
       if (momentum_buffers_.find(name) == momentum_buffers_.end()) {
-        buf = momentum_buffers_[name] = at::zeros_like(p);
-        buf.mul_(momentum_).add_(d_p);
+        buf = momentum_buffers_[name] = torch::zeros_like(p);
+        buf.mul_(momentum_).add_(grad);
       } else {
         buf = momentum_buffers_[name];
-        buf.mul_(momentum_).add_(d_p, 1 - dampening_);
+        buf.mul_(momentum_).add_(grad, 1 - dampening_);
       }
 
       if (nesterov_) {
-        d_p = d_p.add(buf, momentum_);
+        d_p = d_p.add(buf.data(), momentum_);
       } else {
-        d_p = buf;
+        d_p = buf.data();
       }
     }
 
@@ -229,16 +232,16 @@ at::Scalar Adagrad::step(std::function<at::Scalar()> closure) {
     auto& step = step_[name];
     step += 1.0;
     auto clr = lr_ / (1.0 + (step - 1.0) * lr_decay_);
-    at::Tensor buf;
+    Tensor buf;
     if (sum_.find(name) == sum_.end()) {
-      buf = sum_[name] = at::zeros_like(p);
+      buf = sum_[name] = torch::zeros_like(p);
     } else {
       buf = sum_[name];
     }
 
-    buf.addcmul_(d_p, d_p, 1.0);
-    at::Tensor std = buf.sqrt().add_(1e-10);
-    p.addcdiv_(d_p, std, -clr);
+    buf.data().addcmul_(d_p, d_p, 1.0);
+    Tensor std = buf.sqrt().add_(1e-10);
+    p.addcdiv_(d_p, std.data(), -clr);
   }
   return loss;
 }
@@ -260,12 +263,12 @@ at::Scalar RMSprop::step(std::function<at::Scalar()> closure) {
       continue;
 
     if (square_avg_buffer_.find(name) == square_avg_buffer_.end()) {
-      square_avg_buffer_[name] = at::zeros_like(p);
+      square_avg_buffer_[name] = torch::zeros_like(p);
       if (momentum_) {
-        momentum_buffer_[name] = at::zeros_like(p);
+        momentum_buffer_[name] = torch::zeros_like(p);
       };
       if (centered_) {
-        grad_avg_buffer_[name] = at::zeros_like(p);
+        grad_avg_buffer_[name] = torch::zeros_like(p);
       };
     };
 
@@ -275,23 +278,23 @@ at::Scalar RMSprop::step(std::function<at::Scalar()> closure) {
     };
 
     auto& square_avg = square_avg_buffer_[name];
-    square_avg.mul_(alpha_).addcmul_(d_p, d_p, 1.0 - alpha_);
+    square_avg.data().mul_(alpha_).addcmul_(d_p, d_p, 1.0 - alpha_);
 
-    at::Tensor avg;
+    Tensor avg;
     if (centered_) {
       auto& grad_avg = grad_avg_buffer_[name];
-      grad_avg.mul_(alpha_).add_(d_p, 1.0 - alpha_);
+      grad_avg.data().mul_(alpha_).add_(d_p, 1.0 - alpha_);
       avg = square_avg.addcmul(grad_avg, grad_avg, -1.0).sqrt().add_(eps_);
     } else {
       avg = square_avg.sqrt().add_(eps_);
-    };
+    }
 
     if (momentum_ > 0) {
       auto& buf = momentum_buffer_[name];
-      buf.mul_(momentum_).addcdiv_(d_p, avg);
-      p.add_(buf, -lr_);
+      buf.data().mul_(momentum_).addcdiv_(d_p, avg.data());
+      p.add_(buf.data(), -lr_);
     } else {
-      p.addcdiv_(d_p, avg, -lr_);
+      p.addcdiv_(d_p, avg.data(), -lr_);
     };
   }
   return loss;
@@ -314,10 +317,10 @@ at::Scalar Adam::step(std::function<at::Scalar()> closure) {
 
     if (step_buffer_.find(name) == step_buffer_.end()) {
       step_buffer_[name] = 0;
-      exp_avg_buffer_[name] = at::zeros_like(p);
-      exp_avg_sq_buffer_[name] = at::zeros_like(p);
+      exp_avg_buffer_[name] = torch::zeros_like(p);
+      exp_avg_sq_buffer_[name] = torch::zeros_like(p);
       if (amsgrad_) {
-        max_exp_avg_sq_buffer_[name] = at::zeros_like(p);
+        max_exp_avg_sq_buffer_[name] = torch::zeros_like(p);
       };
     }
 
@@ -332,10 +335,10 @@ at::Scalar Adam::step(std::function<at::Scalar()> closure) {
       d_p.add_(p, weight_decay_);
     }
 
-    exp_avg.mul_(beta1_).add_(d_p, 1 - beta1_);
-    exp_avg_sq.mul_(beta2_).addcmul_(d_p, d_p, 1 - beta2_);
+    exp_avg.data().mul_(beta1_).add_(d_p, 1 - beta1_);
+    exp_avg_sq.data().mul_(beta2_).addcmul_(d_p, d_p, 1 - beta2_);
 
-    at::Tensor denom;
+    Tensor denom;
     if (amsgrad_) {
       auto& max_exp_avg_sq = max_exp_avg_sq_buffer_[name];
       at::max_out(max_exp_avg_sq, max_exp_avg_sq, exp_avg_sq);
@@ -348,7 +351,7 @@ at::Scalar Adam::step(std::function<at::Scalar()> closure) {
     auto bias_correction2 = 1 - std::pow(beta2_, step);
     auto step_size = lr_ * std::sqrt(bias_correction2) / bias_correction1;
 
-    p.addcdiv_(exp_avg, denom, -step_size);
+    p.addcdiv_(exp_avg.data(), denom.data(), -step_size);
   }
   return loss;
 }

--- a/torch/csrc/api/src/optimizers.cpp
+++ b/torch/csrc/api/src/optimizers.cpp
@@ -30,7 +30,7 @@ Tensor LBFGS::gather_flat_grad() {
     views.push_back(
         torch::autograd::as_variable_ref(parameter->grad()).data().view(-1));
   }
-  return at::cat(TensorRange(views));
+  return at::cat(TensorListView(views));
 }
 
 void LBFGS::add_grad(const at::Scalar& step_size, const Tensor& update) {


### PR DESCRIPTION
This PR creates a `namespace torch { using Tensor = autograd::Variable; }` typedef and uses this type exclusively instead of the current mix of `at::Tensor` and `autograd::Variable`. This is so that users only shall see `torch::Tensor` and not be aware (largely) of `at::Tensor`.

Mostly this PR then codemods the C++ API. Complications arose in:

1. Optimizers had to be updated to store Variables (`torch::Tensor`) instead of `at::Tensor`s,
2. Serialization code had to be updated to use Variables instead of `at::Tensor`,
3. Had to create `TensorRange`, which copies a range of `torch::Tensor`s into a vector of `at::Tensor`, and then converts implicitly to an `ArrayRef<at::Tensor>`. This is to support calling functions like `at::stack()` with a vector of `torch::Tensor`, which is currently not possible since `vector<Variable>` is unrelated to `vector<Tensor>` in C++.

One small caveat: ambiguity arises around `Tensor` when you do `using namespace torch`, but if anything that's a reason not to use such blanket using directives.

@jgehring could you look at serialization stuff (Or raise any other general concerns)? 

@ebetica @ezyang @apaszke 