### PR TITLE
Clarify mp note about sharing a tensor's grad field.

### DIFF
--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -14,7 +14,7 @@ memory and will only send a handle to another process.
     not ``None``, it is also shared. After a :class:`~torch.Tensor` without
     a :attr:`torch.Tensor.grad` field is sent to the other process, it
     creates a standard process-specific ``.grad`` :class:`~torch.Tensor` that
-    is not automatically shared across all processes like how the
+    is not automatically shared across all processes, unlike how the
     :class:`~torch.Tensor`'s data has been shared.
 
 This allows to implement various training methods, like Hogwild, A3C, or any

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -10,11 +10,12 @@ memory and will only send a handle to another process.
 .. note::
 
     When a :class:`~torch.Tensor` is sent to another process, the
-    :attr:`~torch.Tensor` data is shared. If :attr:`torch.Tensor.grad` is
-    not ``None``, it is also shared. If :attr:`torch.Tensor.grad` is ``None``,
-    it is not shared and each shared copy of the :class:`~torch.Tensor`
-    accumulates separate gradients while training in their respective
-    processes.
+    :class:`~torch.Tensor` data is shared. If :attr:`torch.Tensor.grad` is
+    not ``None``, it is also shared. After a :class:`~torch.Tensor` without
+    a :attr:`torch.Tensor.grad` field is sent to the other process, it
+    creates a standard process-specific ``.grad`` :class:`~torch.Tensor` that
+    is not automatically shared across all processes like how the
+    :class:`~torch.Tensor`'s data has been shared.
 
 This allows to implement various training methods, like Hogwild, A3C, or any
 others that require asynchronous operation.

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -9,9 +9,12 @@ memory and will only send a handle to another process.
 
 .. note::
 
-    When a :class:`~torch.Tensor` is sent to another process, both
-    the :attr:`~torch.Tensor` data and :attr:`torch.Tensor.grad` are going to be
-    shared.
+    When a :class:`~torch.Tensor` is sent to another process, the
+    :attr:`~torch.Tensor` data is shared. If :attr:`torch.Tensor.grad` is
+    not ``None``, it is also shared. If :attr:`torch.Tensor.grad` is ``None``,
+    it is not shared and each shared copy of the :class:`~torch.Tensor`
+    accumulates separate gradients while training in their respective
+    processes.
 
 This allows to implement various training methods, like Hogwild, A3C, or any
 others that require asynchronous operation.


### PR DESCRIPTION
Before, the note makes it sound like if `tensor` is shared, then `tensor.grad` will also be shared. This is not the case if `tensor.grad` is None.