### PR TITLE
formatting in :math: blocks for fold/unfold docstring

### DIFF
--- a/torch/nn/modules/fold.py
+++ b/torch/nn/modules/fold.py
@@ -4,7 +4,7 @@ from .. import functional as F
 
 class Fold(Module):
     """
-    De-interleaves vectors of length :math:`\prod(kernel_size)` from the "channel"
+    De-interleaves vectors of length :math:`\prod(kernel\_size)` from the "channel"
     dimension of the input tensor to generate blocks of size :math:`kernel_size`
     of the output.  These blocks populate the "spatial" dimensions [2:]
     of the output via a sliding window with positions determined by the
@@ -12,8 +12,8 @@ class Fold(Module):
     is determined by the vectors interleaevd position in the "channel" dimension
     of the input.
 
-    Each element of the output batch dimension 0 has :math:`C / \prod(kernel_size)`
-    channels (dimension 1) and spatial dimensions [2:] of shape :math:`output_size`.
+    Each element of the output batch dimension 0 has :math:`C / \prod(kernel\_size)`
+    channels (dimension 1) and spatial dimensions [2:] of shape :math:`output\_size`.
 
     | If :attr:`padding` is non-zero, then the input is implicitly
     zero-padded on both sides by :attr:`padding` number of points
@@ -41,8 +41,8 @@ class Fold(Module):
 
     Shape:
         - Input: :math:`(N, C, L_{in})`
-        - Output: :math:`(N * C * \prod(kernel_size), L_{out},)` where
-          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1)
+        - Output: :math:`(N * C * \prod(kernel\_size), L_{out},)` where
+          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1)`
 
     Examples::
 
@@ -78,14 +78,14 @@ class Fold(Module):
 class Unfold(Module):
     """
 
-    Converts each sliding :math:`kernel_size` block of the "spatial" dimensions [2:]
+    Converts each sliding :math:`kernel\_size` block of the "spatial" dimensions [2:]
     of the input tensor into a column of the output. These columns are interleaved
     with the "channel" dimension 1 such that in the output the channel dimension combines
     both the spatial position of the block within the input and the original
     channel position. We denote size of the "batch" dimension 0 as :math:`N`.
 
-    Each element of the output batch dimension 0 has :math:`C * \prod(kernel_size)`
-    rows and contains as many columns as there are :math:`kernel_size` neighborhoods
+    Each element of the output batch dimension 0 has :math:`C * \prod(kernel\_size)`
+    rows and contains as many columns as there are :math:`kernel\_size` neighborhoods
     of the input according to the padding, stride and dilation values.
 
     | If :attr:`padding` is non-zero, then the input is implicitly
@@ -112,8 +112,8 @@ class Unfold(Module):
 
     Shape:
         - Input: :math:`(N, C, L_{in})`
-        - Output: :math:`(N, C * \prod(kernel_size), L_{out},)` where
-          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1)
+        - Output: :math:`(N, C * \prod(kernel\_size), L_{out},)` where
+          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1)`
 
     Examples::
 


### PR DESCRIPTION
a few small fixes in the docstrings for fold and unfold. 

I think underscore needs to get escaped in :math: blocks or the following character ends up subscripted.

small, but I hope it is a little helpful :-) 

