### PR TITLE
Support n-dimensional empty tensors in (most of) THNN.

### DIFF
--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -7,6 +7,7 @@
 #include "THStorage.hpp"
 
 #include <atomic>
+#include <ATen/ATen.h>
 
 typedef struct THTensor
 {
@@ -51,6 +52,10 @@ typedef struct THTensor
         }
       }
       return false;
+    }
+
+    inline at::IntList sizes() {
+      return at::IntList(size, dim_);
     }
 } THTensor;
 

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -8,6 +8,7 @@
 #include "THCStorage.hpp"
 
 #include <atomic>
+#include <ATen/ATen.h>
 
 typedef struct THCTensor
 {
@@ -50,6 +51,10 @@ typedef struct THCTensor
         }
       }
       return false;
+    }
+
+    inline at::IntList sizes() {
+      return at::IntList(size, dim_);
     }
 } THCTensor;
 

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -124,9 +124,9 @@ static inline void THNN_(Col2Im_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "dilation should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = THTensor_(_nDimension)(input);
-  THNN_ARGCHECK(ndim == 2 || ndim == 3, 2, input,
-                "2D or 3D input tensor expected but got %s");
+  int ndim = THTensor_(nDimension)(input);
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 2 || ndim == 3), 2, input,
+                "non-empty 2D or 3D input tensor expected but got %s");
 
   int batch_dim = (ndim == 4) ? 0 : -1;
   long nInputPlane  = input->size[batch_dim + 1];
@@ -155,7 +155,7 @@ void THNN_(Col2Im_updateOutput)(
                            kH, kW, dH, dW, padH, padW, sH, sW);
 
   bool batched_input = true;
-  if (input->_dim() == 2) {
+  if (input->dim() == 2) {
       // Force batch
       batched_input = false;
       THTensor_(resize3d)(input, 1, input->size[0], input->size[1]);

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -16,9 +16,9 @@ static inline void THNN_(Im2Col_shapeCheck)(
   THArgCheck(sW > 0 && sH > 0, 10,
              "stride should be greater than zero, but got sH: %d sW: %d", sH, sW);
 
-  int ndim = THTensor_(_nDimension)(input);
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-                "3D or 4D input tensor expected but got: %s");
+  int ndim = THTensor_(nDimension)(input);
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+                "non-empty 3D or 4D input tensor expected but got: %s");
 
   int dim_batch = 0;
   if (ndim == 3) {
@@ -52,7 +52,7 @@ void THNN_(Im2Col_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   bool batched_input = true;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     batched_input = false;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
   }

--- a/aten/src/THNN/generic/LookupTable.c
+++ b/aten/src/THNN/generic/LookupTable.c
@@ -48,9 +48,9 @@ void THNN_(LookupTable_accGradParameters)(
     THError("gradWeight must be contiguous");
   if (!THIndexTensor_(isContiguous)(input))
     THError("input must be contiguous");
-  if (THIndexTensor_(_nDimension)(input) != 1 && THIndexTensor_(_nDimension)(input) != 2) {
+  if (input->is_empty() || (THIndexTensor_(nDimension)(input) != 1 && THIndexTensor_(nDimension)(input) != 2)) {
     THDescBuff s1 = THIndexTensor_(sizeDesc)(input);
-    THError("input must be a vector or matrix, but is of shape: %s", s1.str);
+    THError("input must be a non-empty vector or matrix, but is of shape: %s", s1.str);
   }
 
   THIndex_t *input_data = THIndexTensor_(data)(input);
@@ -173,8 +173,8 @@ void THNN_(LookupTable_renorm)(
     THError("weight must be contiguous");
   if (!THIndexTensor_(isContiguous)(idx))
     THError("input must be contiguous");
-  if (THIndexTensor_(_nDimension)(idx) != 1)
-    THError("idx must be a vector");
+  if (idx->is_empty() || THIndexTensor_(nDimension)(idx) != 1)
+    THError("idx must be a non-empty vector");
   if (normType <= 0)
     THError("non-positive-norm not supported");
 

--- a/aten/src/THNN/generic/MultiLabelMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiLabelMarginCriterion.c
@@ -18,22 +18,22 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   int64_t t, d, dt, ddt;
   real sum;
 
-  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
-	     "vector or matrix expected");
+  AT_CHECK(!input->is_empty() && (input->dim() == 1 || input->dim() == 2),
+           "non-empty vector or matrix expected, got size: ", input->sizes());
 
-  if (input->_dim() == 1)
+  if (input->dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
-	       "inconsistent target size");
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == dim),
+             "inconsistent target size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
-	       && (target->size[1] == dim), 3, "inconsistent target size");
+    AT_CHECK(!target->is_empty() && target->dim() == 2 && (target->size[0] == nframe)
+             && (target->size[1] == dim), "inconsistent target size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");
@@ -157,26 +157,26 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   int64_t t, d, dt;
   real g;
 
-  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
-	     "vector or matrix expected");
+  AT_CHECK(!input->is_empty() && (input->dim() == 1 || input->dim() == 2),
+           "vector or matrix expected, got size: ", input->sizes());
 
-  if (input->_dim() == 1)
+  if (input->dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->_dim() == 1) && (target->size[0] == dim), 3,
-	       "inconsistent target size");
-    THArgCheck((isTarget->_dim() == 1) && (isTarget->size[0] == dim), 3,
-	       "inconsistent isTarget size");
+    AT_CHECK((!target->is_empty() && target->dim() == 1) && (target->size[0] == dim),
+             "inconsistent target size");
+    AT_CHECK((!isTarget->is_empty() && isTarget->dim() == 1) && (isTarget->size[0] == dim),
+             "inconsistent isTarget size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->_dim() == 2) && (target->size[0] == nframe)
-	       && (target->size[1] == dim), 3, "inconsistent target size");
-    THArgCheck((isTarget->_dim() == 2) && (isTarget->size[0] == nframe)
-	       && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
+    AT_CHECK(!target->is_empty() && (target->dim() == 2) && (target->size[0] == nframe)
+             && (target->size[1] == dim), 3, "inconsistent target size");
+    AT_CHECK(!isTarget->is_empty() && (isTarget->dim() == 2) && (isTarget->size[0] == nframe)
+             && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -21,10 +21,10 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   int64_t t, d;
   real sum;
 
-  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
-	     "vector or matrix expected");
+  AT_CHECK(!input->is_empty() && (input->dim() == 1 || input->dim() == 2),
+           "non-empty vector or matrix expected, got size: ", input->sizes());
 
-  if (input->_dim() == 1)
+  if (input->dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
@@ -33,8 +33,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
-	       "inconsistent target size");
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe),
+             "inconsistent target size, got: ", target->sizes());
   }
 
   for (t = 0; t < nframe; t++)
@@ -138,10 +138,10 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   int64_t t, d;
   real g;
 
-  THArgCheck((input->_dim() == 1) || (input->_dim() == 2), 2,
-	     "vector or matrix expected");
+  AT_CHECK(!input->is_empty() && (input->dim() == 1 || input->dim() == 2),
+           "non-empty vector or matrix expected, got size: ", input->sizes());
 
-  if (input->_dim() == 1)
+  if (input->dim() == 1)
   {
     nframe = 1;
     dim = input->size[0];
@@ -150,8 +150,8 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->_dim() == 1) && (target->size[0] == nframe), 3,
-	       "inconsistent target size");
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe),
+             "inconsistent target size, got: ", target->sizes());
   }
 
   g = (sizeAverage && reduce ? 1./((real)(nframe*dim)) : 1./((real)dim));

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -11,22 +11,22 @@
 
 static bool THNN_(checkLegacyInput)(THTensor* t)
 {
-  return t->_dim() == 3 && t->size[2] == 2;
+  return !t->is_empty() && t->dim() == 3 && t->size[2] == 2;
 }
 
 static bool THNN_(checkInput)(THTensor* t)
 {
-  return t->_dim() == 2 && t->size[1] == 3;
+  return!t->is_empty() && t->dim() == 2 && t->size[1] == 3;
 }
 
 static bool THNN_(checkSize2D)(THTensor* t, int64_t size0, int64_t size1)
 {
-  return t->_dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
+  return !t->is_empty() && t->dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
 }
 
 static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 {
-  return t->_dim() == 1 && t->size[0] == size0;
+  return !t->is_empty() && t->dim() == 1 && t->size[0] == size0;
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {

--- a/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
@@ -87,10 +87,10 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   real *output_data = nullptr;
 
 
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
+		"non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -109,7 +109,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, sizeD, osizeH, osizeW);
 
@@ -217,7 +217,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     sizeB = input->size[0];
     dimD++;
     dimH++;
@@ -236,7 +236,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THNN_(SpatialAdaptiveAveragePooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          sizeD,

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -97,10 +97,10 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   THIndex_t *indices_data = nullptr;
 
 
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
+		"non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -118,7 +118,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, sizeD, osizeH, osizeW);
     /* indices will contain i,j locations for each output point */
@@ -222,7 +222,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     sizeB = input->size[0];
     dimW++;
     dimH++;
@@ -241,7 +241,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                            indices_data,

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -12,7 +12,7 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 8,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -23,8 +23,8 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
 
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
 	     "pad should be smaller than half of kernel size, but got "
@@ -102,7 +102,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   THNN_(SpatialAveragePooling_shapeCheck)
     (input, NULL, kH, kW, dH, dW, padH, padW, ceil_mode);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -133,7 +133,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
       --outputWidth;
   }
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
     THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
@@ -231,7 +231,7 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
     (input, gradOutput, kH, kW, dH, dW, padH, padW, ceil_mode);
 
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -15,7 +15,7 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THArgCheck(dW > 0 && dH > 0, 11,
          "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -26,8 +26,8 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-        "3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+        "non-empty 3D or 4D input tensor expected but got: %s");
 
   int64_t nInputPlane = weight->size[2] / (kH * kW);
   int64_t nOutputPlane = weight->size[1];
@@ -50,9 +50,9 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
 static THTensor* THNN_(view_weight_local)(THTensor *_weight)
 {
   THTensor *weight = THTensor_(newContiguous)(_weight);
-  THArgCheck(weight->_dim() == 3 || weight->_dim() == 6, 4,
-          "weight tensor should be 3D or 6D - got %dD", weight->_dim());
-  if (weight->_dim() == 6) {
+  AT_CHECK(!weight->is_empty() && (weight->dim() == 3 || weight->dim() == 6),
+           "weight tensor should be (non-empty) 3D or 6D - got size: ", weight->sizes());
+  if (weight->dim() == 6) {
     int64_t s1 = weight->size[0] * weight->size[1];
     int64_t s2 = weight->size[2];
     int64_t s3 = weight->size[3] * weight->size[4] * weight->size[5];
@@ -127,7 +127,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   int64_t nInputPlane = THTensor_(size)(weight, 2)/ (kW * kH);
   int64_t nOutputPlane = THTensor_(size)(weight, 1);
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THTensor_(resize2d)(finput, kW*kH*nInputPlane, outputHeight*outputWidth);
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
@@ -233,7 +233,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 1, 2);
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THNN_(SpatialConvolutionLocal_updateGradInput_frame)
       (gradInput, gradOutput, tweight,
@@ -329,7 +329,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   int64_t nInputPlane = THTensor_(size)(gradWeight,2)/(kW*kH);
   int64_t nOutputPlane = THTensor_(size)(gradWeight,1);
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THNN_(SpatialConvolutionLocal_accGradParameters_frame)
       (gradOutput, gradWeight, gradBias, finput, scale,

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -13,8 +13,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
-                    "2D or 4D weight tensor expected, but got: %s");
+    THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
+                    "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
     }
@@ -22,7 +22,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -33,8 +33,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
 
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
@@ -59,7 +59,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (weight != NULL) {
     int64_t nInputPlane = weight->size[1];
-    if (weight->_dim() == 2) {
+    if (weight->dim() == 2) {
       nInputPlane /= (kH * kW);
     }
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
@@ -80,7 +80,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
 static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
   weight = THTensor_(newContiguous)(weight);
-  if (weight->_dim() == 4) {
+  if (weight->dim() == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     THTensor *old_weight = weight;
@@ -155,7 +155,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, 0);
 
   input = THTensor_(newContiguous)(input);
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -173,7 +173,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THTensor_(resize2d)(finput, kW*kH*nInputPlane, outputHeight*outputWidth);
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
@@ -275,7 +275,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 0, 1);
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THNN_(SpatialConvolutionMM_updateGradInput_frame)(gradInput, gradOutput,
 						      tweight, fgradInput,
@@ -375,7 +375,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
-  if(input->_dim() == 3)
+  if(input->dim() == 3)
   {
     THNN_(SpatialConvolutionMM_accGradParameters_frame)(gradOutput, gradWeight,
 							gradBias, finput, scale);

--- a/aten/src/THNN/generic/SpatialConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMap.c
@@ -8,9 +8,9 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->_dim() == 3
+    weight != NULL && !weight->is_empty() && weight->dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 4,
-    "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
+    "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
   int dimw = 2;
@@ -18,9 +18,9 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   int dimc = 0;
   int64_t nbatch = 1;
 
-  THArgCheck(input->_dim() == 3 || input->_dim() == 4, 2, "3D or 4D(batch mode) tensor expected");
+  THArgCheck(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, "non-empty 3D or 4D(batch mode) tensor expected");
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimc++;
@@ -39,7 +39,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
   const int64_t output_w = (input_w - kW) / dW + 1;
   const int64_t output_h = (input_h - kH) / dH + 1;
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
     THTensor_(resize3d)(output, nOutputPlane, output_h, output_w);
   else
     THTensor_(resize4d)(output, input->size[0], nOutputPlane, output_h, output_w);
@@ -109,16 +109,16 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->_dim() == 3
+    weight != NULL && !weight->is_empty() && weight->dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 5,
-    "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
+    "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
   /* and dims */
   int dimw = 2;
   int dimh = 1;
   int64_t nbatch = 1;
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -196,7 +196,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
-    gradWeight != NULL && gradWeight->_dim() == 3
+    gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
     && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
     "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
@@ -205,7 +205,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   int dimw = 2;
   int dimh = 1;
   int64_t nbatch = 1;
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;

--- a/aten/src/THNN/generic/SpatialDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialDilatedConvolution.c
@@ -16,8 +16,8 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
              dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 4, 4, weight,
-                  "4D weight tensor (nOutputPlane, nInputPlane, kH, kW) expected, "
+    THNN_ARGCHECK(!weight->is_empty() && weight->dim() == 4, 4, weight,
+                  "non-empty 4D weight tensor (nOutputPlane, nInputPlane, kH, kW) expected, "
                   "but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
@@ -26,7 +26,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -37,8 +37,8 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
 
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
@@ -100,7 +100,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -123,7 +123,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (!THTensor_(isContiguous)(ones) || ones->_dim() != 2 ||
+  if (!THTensor_(isContiguous)(ones) || ones->dim() != 2 ||
       ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
@@ -228,7 +228,7 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   gradOutput = THTensor_(newContiguous)(gradOutput);
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -335,7 +335,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     THArgCheck(THTensor_(isContiguous)(ones), 7, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -405,7 +405,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
 
       // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       // Define a buffer of ones, for bias accumulation
-      if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+      if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
         // Resize plane and fill with ones...
         THTensor_(resize2d)(ones, outputHeight, outputWidth);
         THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -15,7 +15,7 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than zero, but got dilationH: %d dilationW: %d",
              dilationH, dilationW);
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -26,8 +26,8 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
 
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
 	     "pad should be smaller than half of kernel size, but got "
@@ -182,7 +182,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
     (input, NULL, NULL, kH, kW, dH, dW,
      padH, padW, dilationH, dilationW, ceil_mode);
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -218,7 +218,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
     /* indices will contain the locations for each output point */
@@ -348,7 +348,7 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -367,7 +367,7 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THNN_(SpatialDilatedMaxPooling_updateGradInput_frame)
       (gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
@@ -102,9 +102,9 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int heightDim = 1;
   int widthDim = 2;
 
-  int64_t numInputDims = THTensor_(_nDimension)(input);
-  THNN_ARGCHECK(numInputDims == 3 || numInputDims == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  int64_t numInputDims = THTensor_(nDimension)(input);
+  THNN_ARGCHECK(!input->is_empty() && (numInputDims == 3 || numInputDims == 4), 2, input,
+		"non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 4) {
     numBatch = THTensor_(size)(input, 0);
@@ -202,7 +202,7 @@ void THNN_(SpatialFractionalMaxPooling_updateGradInput)(
   int heightDim = 1;
   int widthDim = 2;
 
-  int64_t numInputDims = THTensor_(_nDimension)(input);
+  int64_t numInputDims = THTensor_(nDimension)(input);
   if (numInputDims == 4) {
     numBatch = THTensor_(size)(input, 0);
     planeDim = 1;

--- a/aten/src/THNN/generic/SpatialFullConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialFullConvolutionMap.c
@@ -9,16 +9,17 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
 {
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
   THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
+  // What does this mean?
   THArgCheck(
-    weight != NULL && weight->_dim() == 3
+    weight != NULL && !weight->is_empty() && weight->dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 4,
-    "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
+    "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
   const int kH = (int)weight->size[1];
   const int kW = (int)weight->size[2];
 
-  THArgCheck(input != NULL && input->_dim() == 3, 2, "3D tensor expected");
+  THArgCheck(input != NULL && !input->is_empty() && input->dim() == 3, 2, "non-empty 3D tensor expected");
   THArgCheck(input->size[0] >= nInputPlane, 2, "invalid number of input planes");
 
   THTensor_(resize3d)(
@@ -91,9 +92,9 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   int dW, int dH)
 {
   THArgCheck(
-    weight != NULL && weight->_dim() == 3
+    weight != NULL && !weight->is_empty() && weight->dim() == 3
     && connTable != NULL && connTable->size[0] == weight->size[0], 5,
-    "3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
+    "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
   /* contiguous */
@@ -162,9 +163,9 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
-    gradWeight != NULL && gradWeight->_dim() == 3
+    gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
     && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
-    "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
+    "non-empty 3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
   /* contiguous */

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -20,8 +20,8 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
              adjH, adjW, dH, dW, dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 4, 5, weight,
-  		"2D or 4D weight tensor expected, but got: %s");
+    THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
+                  "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
     }
@@ -29,7 +29,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimh = 1;
   int dimw = 2;
@@ -40,8 +40,8 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
-  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
 
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
@@ -102,7 +102,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   }
 
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -126,7 +126,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -230,7 +230,7 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
 
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -349,7 +349,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
@@ -365,7 +365,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->_dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
@@ -12,10 +12,10 @@
 
 static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
      (THTensor *input, THTensor *grid, THTensor *gradOutput) {
-  THNN_ARGCHECK(input->_dim() == 4, 2, input,
-    "4D input tensor expected but got: %s");
-  THNN_ARGCHECK(grid->_dim() == 4, 2, grid,
-    "4D grid tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && input->dim() == 4, 2, input,
+    "non-empty 4D input tensor expected but got: %s");
+  THNN_ARGCHECK(!grid->is_empty() && grid->dim() == 4, 2, grid,
+    "non-empty 4D grid tensor expected but got: %s");
 
   int nbatch   = THTensor_(size)(input, 0);
   int channels = THTensor_(size)(input, 1);

--- a/aten/src/THNN/generic/SpatialMaxUnpooling.c
+++ b/aten/src/THNN/generic/SpatialMaxUnpooling.c
@@ -61,11 +61,11 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   THIndex_t *indices_data;
 
 
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  AT_CHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4),
+           "non-empty 3D or 4D (batch mode) tensor expected for input, but got sizes: ", input->sizes());
   THNN_CHECK_SHAPE_INDICES(input, indices);
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -82,7 +82,7 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   indices = THIndexTensor_(newContiguous)(indices);
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
     THTensor_(zero)(output);
@@ -183,7 +183,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -205,7 +205,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THNN_(SpatialMaxUnpooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                  indices_data,

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -67,10 +67,10 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
+		"non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -86,12 +86,12 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->_dim()).str);
+             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
 
   THArgCheck(pad_t < iheight && pad_b < iheight, 6,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->_dim()).str);
+             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->dim()).str);
 
   /* output sizes */
   oheight = iheight + pad_t + pad_b;
@@ -106,7 +106,7 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
 
@@ -211,7 +211,7 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -241,7 +241,7 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     THNN_(SpatialReflectionPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/SpatialReplicationPadding.c
+++ b/aten/src/THNN/generic/SpatialReplicationPadding.c
@@ -66,10 +66,10 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
 		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -94,7 +94,7 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     THTensor_(resize3d)(output, nslices, oheight, owidth);
 
@@ -198,7 +198,7 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     nbatch = input->size[0];
     dimw++;
@@ -228,7 +228,7 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     THNN_(SpatialReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/SpatialSubSampling.c
+++ b/aten/src/THNN/generic/SpatialSubSampling.c
@@ -7,7 +7,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
                          THTensor *gradOutput,
                          THTensor *weight,
                          int kW, int kH) {
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
                   "3D or 4D input tensor expected but got: %s");
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
 
@@ -19,7 +19,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
   int64_t inputWidth;
   int64_t inputHeight;
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     dimw++;
     dimh++;
   }
@@ -62,7 +62,7 @@ void THNN_(SpatialSubSampling_updateOutput)(
 
   THNN_(SpatialSubSampling_shapeCheck)(input, NULL, weight, kW, kH);
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -73,7 +73,7 @@ void THNN_(SpatialSubSampling_updateOutput)(
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
     THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
@@ -151,7 +151,7 @@ void THNN_(SpatialSubSampling_updateGradInput)(
 
   int64_t k;
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     nbatch = input->size[0];
     dimw++;
     dimh++;
@@ -236,7 +236,7 @@ void THNN_(SpatialSubSampling_accGradParameters)(
 
   int64_t k;
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     dimw++;
     dimh++;
     nbatch = input->size[0];

--- a/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
@@ -16,8 +16,8 @@ static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
 	     " but got input (H: %d, W: %d) output (H: %d, W: %d)",
 	     inputHeight, inputWidth, outputHeight, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->_dim() == 4, 2, input,
-		  "4D input tensor expected but got: %s");
+    THNN_ARGCHECK(!input->is_empty() && input->dim() == 4, 2, input,
+		  "non-empty 4D input tensor expected but got: %s");
   }
 
   if (gradOutput != NULL) {

--- a/aten/src/THNN/generic/SpatialUpSamplingNearest.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(SpatialUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->_dim() == 3 || input->_dim() == 4, 2, input,
-		"3D or 4D input tensor expected but got: %s");
-  if (input->_dim() == 3) {
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
+		"non-empty 3D or 4D input tensor expected but got: %s");
+  if (input->dim() == 3) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputHeight  = THTensor_(size)(input, 1);
     int inputWidth   = THTensor_(size)(input, 2);
@@ -45,12 +45,12 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(SpatialUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputHeight = THTensor_(size)(input, input->_dim()-2);
-  int inputWidth  = THTensor_(size)(input,  input->_dim()-1);
+  int inputHeight = THTensor_(size)(input, input->dim()-2);
+  int inputWidth  = THTensor_(size)(input,  input->dim()-1);
   int outputHeight = inputHeight * scale_factor;
   int outputWidth = inputWidth * scale_factor;
 
-  if (input->_dim() == 3) {
+  if (input->dim() == 3) {
     THTensor_(resize3d)(output,
 			THTensor_(size)(input, 0),
 			outputHeight, outputWidth);    
@@ -63,11 +63,11 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
 
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = input->_dim()-2;
-  int yDim = input->_dim()-1;
+  int xDim = input->dim()-2;
+  int yDim = input->dim()-1;
 
   // dims
-  int idim = input->_dim();
+  int idim = input->dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = output->size[2];
@@ -132,11 +132,11 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
 
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = gradInput->_dim()-2;
-  int yDim = gradInput->_dim()-1;
+  int xDim = gradInput->dim()-2;
+  int yDim = gradInput->dim()-1;
 
   // dims
-  int idim = gradInput->_dim();  // Guaranteed to be between 3 and 5
+  int idim = gradInput->dim();  // Guaranteed to be between 3 and 5
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = gradInput->size[2];

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -17,13 +17,13 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     dimS = 1;
     dimF = 2;
   }
-  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
-                  "2D or 3D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
+                  "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
     THArgCheck(input->size[dimF] == *inputFrameSize, 2,
                "invalid input frame size. Got: %d, Expected: %d",
@@ -51,7 +51,7 @@ void THNN_(TemporalConvolution_updateOutput)(
 
   int dimS = 0; // sequence dimension
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     dimS = 1;
   }
@@ -67,7 +67,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   nInputFrame = input->size[dimS];
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     THTensor_(resize2d)(output,
                         nOutputFrame,
@@ -180,7 +180,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
 
   int dimS = 0; // sequence dimension
 
-  if (gradOutput->_dim() == 3)
+  if (gradOutput->dim() == 3)
   {
     dimS = 1;
   }
@@ -200,7 +200,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (gradOutput->_dim() == 2)
+  if (gradOutput->dim() == 2)
   {
     /* ouch */
     for(k = 0; nOutputFrame > 0; k++)
@@ -287,7 +287,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   int dimS = 0; // sequence dimension
 
-  if (gradOutput->_dim() == 3)
+  if (gradOutput->dim() == 3)
   {
     dimS = 1;
   }
@@ -302,7 +302,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   gradOutputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     /* bias first */
     for(k = 0; k < nOutputFrame; k++)

--- a/aten/src/THNN/generic/TemporalMaxPooling.c
+++ b/aten/src/THNN/generic/TemporalMaxPooling.c
@@ -15,9 +15,9 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
-  int ndims = input->_dim();
+  int ndims = input->dim();
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -32,8 +32,8 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
   THArgCheck(dW > 0, 6,
              "stride should be greater than zero, but got dW: %d", dW);
 
-  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
-                  "2D or 3D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
+                "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(input->size[dimS] >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
              input->size[dimS], kW);
@@ -71,7 +71,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
 
   THNN_(TemporalMaxPooling_shapeCheck)(state, input, NULL, NULL, kW, dW);
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -85,7 +85,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     /* resize output */
     THTensor_(resize2d)(output, noframe, framesize);
@@ -215,7 +215,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     dimS = 1;
     dimF = 2;
@@ -230,7 +230,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
   indices_data = THIndexTensor_(data)(indices);
 
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     for(t = 0; t < noframe; t++)
     {

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -50,10 +50,10 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
-		"2D or 3D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
+		"non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -67,7 +67,7 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
              "Padding size should be less than the corresponding input dimension, "
              "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->_dim()).str);
+             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
 
   /* output size */
   owidth  = iwidth + pad_l + pad_r;
@@ -81,7 +81,7 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     THTensor_(resize2d)(output, nslices, owidth);
 
@@ -166,7 +166,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
   long iwidth;
   long owidth;
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -190,7 +190,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->_dim() == 2) {
+  if (input->dim() == 2) {
     THNN_(TemporalReflectionPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/TemporalReplicationPadding.c
+++ b/aten/src/THNN/generic/TemporalReplicationPadding.c
@@ -48,10 +48,10 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
-		"2D or 3D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
+		"non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -73,7 +73,7 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 2)
+  if (input->dim() == 2)
   {
     THTensor_(resize2d)(output, nslices, owidth);
 
@@ -157,7 +157,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
   long iwidth;
   long owidth;
 
-  if (input->_dim() == 3)
+  if (input->dim() == 3)
   {
     nbatch = input->size[0];
     dimw++;
@@ -181,7 +181,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->_dim() == 2) {
+  if (input->dim() == 2) {
     THNN_(TemporalReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -16,8 +16,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	           "kernel size should be greater than zero, but got kW: %d", kW);
 	THArgCheck(dW > 0, 6,
 	           "stride should be greater than zero, but got dW: %d", dW);
-	THNN_ARGCHECK(weight->_dim() == 3, 3, weight,
-	              "3D weight tensor expected, but got: %s");
+	THNN_ARGCHECK(!weight->is_empty() && weight->dim() == 3, 3, weight,
+	              "non-empty 3D weight tensor expected, but got: %s");
     THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
     THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
 
@@ -26,7 +26,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	}
 
 	// we're always looking at (possibly batch) x feats x seq
-	int ndim = input->_dim();
+	int ndim = input->dim();
 	int dimF = 0;
 	int dimS = 1;
 
@@ -35,8 +35,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 		++dimF;
 	}
 
-	THNN_ARGCHECK(ndim == 2 || ndim == 3, 1, input,
-	              "2D or 3D (batch mode) input tensor expected, but got :%s");
+	THNN_ARGCHECK(!input->is_empty() && (ndim == 2 || ndim == 3), 1, input,
+	              "non-empty 2D or 3D (batch mode) input tensor expected, but got :%s");
 
 	int64_t inputFrameSize = weight->size[0];
 	int64_t nInputFrame = input->size[dimS];
@@ -184,7 +184,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 	int padW,
 	bool featFirst) {
 
-	int ndim = input->_dim();
+	int ndim = input->dim();
 
 	THTensor *tinput;
 	if (!featFirst) {
@@ -292,7 +292,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 	int padW,
 	bool featFirst) {
 
-	int ndim = input->_dim();
+	int ndim = input->dim();
 
 	THTensor *tinput, *tgradOutput;
 
@@ -419,7 +419,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
 	accreal scale_) {
 
     real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
-	int ndim = input->_dim();
+	int ndim = input->dim();
 
 	THTensor *tinput, *tgradOutput;
 

--- a/aten/src/THNN/generic/TemporalSubSampling.c
+++ b/aten/src/THNN/generic/TemporalSubSampling.c
@@ -16,8 +16,8 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   THArgCheck(dW > 0, 7,
              "stride should be greater than zero, but got dW: %d", dW);
 
-  THNN_ARGCHECK(input->_dim() == 2, 2, input,
-                  "2D or 3D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && input->dim() == 2, 2, input,
+                  "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
     THArgCheck( input->size[1] == *inputFrameSize, 2,
                 "invalid input frame size.  Got: %d, Expected: %d",
@@ -31,9 +31,9 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (gradOutput != NULL) {
-    THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), 0, nOutputFrame);
+    THNN_CHECK_DIM_SIZE(gradOutput, input->dim(), 0, nOutputFrame);
     if (inputFrameSize != NULL) {
-      THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), 1, *inputFrameSize);
+      THNN_CHECK_DIM_SIZE(gradOutput, input->dim(), 1, *inputFrameSize);
     }
   }
 }

--- a/aten/src/THNN/generic/TemporalUpSamplingLinear.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingLinear.c
@@ -14,8 +14,8 @@ static inline void THNN_(TemporalUpSamplingLinear_shapeCheck)
 	     " but got input (W: %d) output (W: %d)",
 	     inputWidth, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->_dim() == 3, 2, input,
-		  "3D input tensor expected but got: %s");
+    THNN_ARGCHECK(!input->is_empty() && input->dim() == 3, 2, input,
+		  "non-empty 3D input tensor expected but got: %s");
   }
 
   if (gradOutput != NULL) {

--- a/aten/src/THNN/generic/TemporalUpSamplingNearest.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(TemporalUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "3D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->_dim() == 2 || input->_dim() == 3, 2, input,
-		"2D or 3D input tensor expected but got: %s");
-  if (input->_dim() == 2) {
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
+		"non-empty 2D or 3D input tensor expected but got: %s");
+  if (input->dim() == 2) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputWidth   = THTensor_(size)(input, 1);
     int outputWidth  = inputWidth  * scale_factor;
@@ -39,10 +39,10 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(TemporalUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputWidth  = THTensor_(size)(input,  input->_dim()-1);
+  int inputWidth  = THTensor_(size)(input,  input->dim()-1);
   int outputWidth = inputWidth * scale_factor;
 
-  if (input->_dim() == 2) {
+  if (input->dim() == 2) {
     THTensor_(resize2d)(output,
 			THTensor_(size)(input, 0),
       outputWidth);
@@ -54,10 +54,10 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   }
 
   int dW = scale_factor;
-  int xDim = input->_dim()-1;
+  int xDim = input->dim()-1;
 
   // dims
-  int idim = input->_dim();
+  int idim = input->dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = 1;
@@ -115,10 +115,10 @@ void THNN_(TemporalUpSamplingNearest_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
 
   int dW = scale_factor;
-  int xDim = gradInput->_dim()-1;
+  int xDim = gradInput->dim()-1;
 
   // dims
-  int idim = gradInput->_dim();  // Guaranteed to be between 2 and 4
+  int idim = gradInput->dim();  // Guaranteed to be between 2 and 4
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = 1;

--- a/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
@@ -104,10 +104,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   real *output_data = nullptr;
 
 
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+		"non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -129,7 +129,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THTensor_(resize4d)(output, sizeD, osizeT, osizeH, osizeW);
 
@@ -252,7 +252,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 5) {
+  if (input->dim() == 5) {
     sizeB = input->size[0];
     dimD++;
     dimT++;
@@ -274,7 +274,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THNN_(VolumetricAdaptiveAveragePooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          sizeD,

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -115,10 +115,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   real *output_data = nullptr;
   THIndex_t *indices_data = nullptr;
 
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-    "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+    "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     istrideB = input->stride[0];
     sizeB = input->size[0];
@@ -140,7 +140,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   istrideW = input->stride[dimW];
 
   /* resize output */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THTensor_(resize4d)(output, sizeD, osizeT, osizeH, osizeW);
     /* indices will contain max input locations for each output point */
@@ -253,7 +253,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 5) {
+  if (input->dim() == 5) {
     sizeB = input->size[0];
     dimD++;
     dimT++;
@@ -276,7 +276,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THNN_(VolumetricAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                          indices_data,

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -24,13 +24,13 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   int64_t otime;
   int64_t oheight;
   int64_t owidth;
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimN = 0;
   int dimt = 1;
   int dimh = 2;
   int dimw = 3;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -44,8 +44,8 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 8,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d",
              dT, dH, dW);
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
              && input->size[dimt] >= kT, 2,
@@ -222,7 +222,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -262,7 +262,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->_dim() == 4) /* non-batch mode */
+  if (input->dim() == 4) /* non-batch mode */
   {
     /* resize output */
     THTensor_(resize4d)(output, nslices, otime, oheight, owidth);
@@ -436,7 +436,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -458,7 +458,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   gradOutput_data = THTensor_(data)(gradOutput);
 
   /* backprop */
-  if (input->_dim() == 4) /* non-batch mode*/
+  if (input->dim() == 4) /* non-batch mode*/
   {
     THNN_(VolumetricAveragePooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data, nslices,

--- a/aten/src/THNN/generic/VolumetricConvolution.c
+++ b/aten/src/THNN/generic/VolumetricConvolution.c
@@ -19,14 +19,14 @@ void THNN_(VolumetricConvolution_updateOutput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+		"non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int dimt = 1;
   int dimh = 2;
   int dimw = 3;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimt++;
     dimh++;
@@ -45,7 +45,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   int64_t outputHeight = (inputHeight - kH) / dH + 1;
   THTensor *outn = THTensor_(new)();
   int64_t i, j;
-  if (input->_dim() == 4) /* non-batch mode */
+  if (input->dim() == 4) /* non-batch mode */
   {
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
 
@@ -113,18 +113,18 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
-		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+  THNN_ARGCHECK(!weight->is_empty() && weight->dim() == 5, 4, weight,
+		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for weight, but got: %s");
 
   int nOutputPlane = (int)weight->size[0];
 
-  THNN_ARGCHECK(gradOutput->_dim() == 4 || gradOutput->_dim() == 5, 3,
+  THNN_ARGCHECK(!gradOutput->is_empty() && (gradOutput->dim() == 4 || gradOutput->dim() == 5), 3,
 		gradOutput,
-		"4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
+		"non-empty 4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
 
   int dimPlane = 0;
-  if (gradOutput->_dim() == 5)
+  if (gradOutput->dim() == 5)
   {
     dimPlane++;
   }
@@ -135,7 +135,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 
   /* gradient to input */
   THTensor *tweight = THTensor_(newTranspose)(weight, 0, 1);
-  if (gradOutput->_dim() == 4) /* non-batch mode */
+  if (gradOutput->dim() == 4) /* non-batch mode */
   {
     THTensor_(conv3Dmv)(gradInput, 0.0, 1.0, gradOutput, tweight, dT, dH, dW, "F", "C");
   }
@@ -183,13 +183,13 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THNN_ARGCHECK(gradWeight->_dim() == 5, 4, gradWeight,
-		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+  THNN_ARGCHECK(!gradWeight->is_empty() && gradWeight->dim() == 5, 4, gradWeight,
+		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for gradWeight, but got: %s");
 
   int nOutputPlane = (int)gradWeight->size[0];
   if (gradBias) {
-    THArgCheck(gradBias->_dim() == 1 && gradBias->size[0] == nOutputPlane, 5,
+    THArgCheck(!gradBias->is_empty() && gradBias->dim() == 1 && gradBias->size[0] == nOutputPlane, 5,
       "gradBias tensor has wrong size"
     );
   }
@@ -198,7 +198,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   real *gradBias_data;
   THTensor *gradOutSlice;
   int dimPlane = 0;
-  if (gradOutput->_dim() == 5)
+  if (gradOutput->dim() == 5)
   {
     dimPlane++;
   }
@@ -207,7 +207,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
     "Number of output features is not equal to nOutputPlane"
   );
 
-  if (gradOutput->_dim() == 4) /* non-batch mode */
+  if (gradOutput->dim() == 4) /* non-batch mode */
   {
     /* gradient to bias */
     if (gradBias) {

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -28,7 +28,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim()) == 5, 5, weight,
+    THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 5), 5, weight,
                     "non-empty 2D or 5D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -20,16 +20,16 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
                          int pW,
                          int pH,
                          int weight_nullable) {
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 2 || weight->_dim() == 5, 5, weight,
-                    "2D or 5D weight tensor expected, but got: %s");
+    THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim()) == 5, 5, weight,
+                    "non-empty 2D or 5D weight tensor expected, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
     }
@@ -37,7 +37,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimt = 1;
   int dimh = 2;
@@ -89,7 +89,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
 
   if (weight != NULL) {
     int64_t nInputPlane = weight->size[1];
-    if (weight->_dim() == 2) {
+    if (weight->dim() == 2) {
       nInputPlane /= (kT * kH * kW);
     }
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
@@ -112,7 +112,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
 static THTensor* THNN_(newViewWeight)(THTensor *weight)
 {
   weight = THTensor_(newContiguous)(weight);
-  if (weight->_dim() == 5) {
+  if (weight->dim() == 5) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
     THTensor *old_weight = weight;
@@ -486,7 +486,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
         kT, kW, kH, dT, dW, dH, pT, pW, pH, 0);
   input = THTensor_(newContiguous)(input);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimf++;
     dimt++;
@@ -505,7 +505,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
 
   weight = THNN_(newViewWeight)(weight);
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THTensor_(resize2d)(finput, kT*kW*kH*nInputPlane, outputDepth*outputHeight*outputWidth);
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -625,7 +625,7 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
   THTensor *tweight = THTensor_(new)();
   THTensor_(transpose)(tweight, weight, 0, 1);
 
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
       gradInput, gradOutput, tweight, fgradInput,
@@ -729,7 +729,7 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
     gradWeight = THNN_(newViewWeight)(gradWeight);
   }
 
-  if (input->_dim() == 4)   // non-batch mode
+  if (input->dim() == 4)   // non-batch mode
   {
     THNN_(VolumetricConvolutionMM_accGradParameters_frame)(gradOutput, gradWeight, gradBias, finput, scale);
   }

--- a/aten/src/THNN/generic/VolumetricDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricDilatedConvolution.c
@@ -9,8 +9,8 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                          int padT, int padH, int padW,
                          int dilationT, int dilationH, int dilationW,
                          int weight_nullable) {
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 11,
@@ -20,8 +20,8 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
              dilationT, dilationH, dilationW);
 
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
-                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+    THNN_ARGCHECK(!weight->is_empty() && weight->dim() == 5, 4, weight,
+                  "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
@@ -31,7 +31,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
   }
 
   // Params
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -106,7 +106,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
     THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
   }
   int is_batch = 1;
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -132,7 +132,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->_dim() != 3 ||
+  if (ones->dim() != 3 ||
       ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -239,7 +239,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
 
   int is_batch = 1;
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -349,7 +349,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
     THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
@@ -369,7 +369,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -12,7 +12,7 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
                          int pT, int pW, int pH,
                          int dilationT, int dilationW, int dilationH,
                          bool ceilMode) {
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimN = 0;
   int dimt = 1;
   int dimh = 2;
@@ -35,10 +35,10 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "dilation should be greater than 0, but got dilationT: %d dilationH: %d dilationW: %d",
              dilationT, dilationH, dilationW);
 
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -226,7 +226,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   int dimh = 2;
   int dimw = 3;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -272,7 +272,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
 
-  if (input->_dim() == 4) /* non-batch mode */
+  if (input->dim() == 4) /* non-batch mode */
   {
     /* resize output */
     THTensor_(resize4d)(output, nslices, otime, oheight, owidth);
@@ -435,7 +435,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimN++;
     dimt++;
@@ -458,7 +458,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 4) /* non-batch mode*/
+  if (input->dim() == 4) /* non-batch mode*/
   {
     THNN_(VolumetricDilatedMaxPooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
@@ -114,9 +114,9 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
   int widthDim = 2;
   int timeDim = 3;
 
-  int64_t numInputDims = THTensor_(_nDimension)(input);
-  THNN_ARGCHECK(numInputDims == 4 || numInputDims == 5, 2, input,
-		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  int64_t numInputDims = THTensor_(nDimension)(input);
+  THNN_ARGCHECK(!input->is_empty() && (numInputDims == 4 || numInputDims == 5), 2, input,
+		"non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 5) {
     numBatch = THTensor_(size)(input, 0);
@@ -224,7 +224,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
   int widthDim = 2;
   int timeDim = 3;
 
-  int64_t numInputDims = THTensor_(_nDimension)(input);
+  int64_t numInputDims = THTensor_(nDimension)(input);
   if (numInputDims == 5) {
     numBatch = THTensor_(size)(input, 0);
     planeDim = 1;

--- a/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
@@ -91,8 +91,8 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                          int pT, int pW, int pH,
                          int dilationT, int dilationW, int dilationH,
                          int aT, int aW, int aH, int weight_nullable) {
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
   THArgCheck(dilationT > 0 && dilationW > 0 && dilationH > 0, 15,
@@ -108,8 +108,8 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
 
   // number of input & output planes and kernel size is indirectly defined by the weight tensor
   if (weight != NULL) {
-    THNN_ARGCHECK(weight->_dim() == 5, 4, weight,
-                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+    THNN_ARGCHECK(!weight->is_empty() && weight->dim() == 5, 4, weight,
+                  "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
       THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
@@ -118,7 +118,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
     THError("weight tensor is expected to be non-nullable");
   }
 
-  int ndim = input->_dim();
+  int ndim = input->dim();
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -191,7 +191,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   weight = THTensor_(newContiguous)(weight);
   bias = bias ? THTensor_(newContiguous)(bias) : bias;
   int is_batch = 1;
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -218,7 +218,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -332,7 +332,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
   int is_batch = 1;
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -460,7 +460,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   }
 
   int is_batch = 1;
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     // Force batch
     is_batch = 0;
@@ -479,7 +479,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   const int64_t batchSize = input->size[0];
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->_dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);

--- a/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
@@ -12,10 +12,10 @@
 
 static inline void THNN_(VolumetricGridSamplerBilinear_shapeCheck)
      (THTensor *input, THTensor *grid, THTensor *gradOutput) {
-  THNN_ARGCHECK(input->_dim() == 5, 2, input,
-    "5D input tensor expected but got: %s");
-  THNN_ARGCHECK(grid->_dim() == 5, 2, grid,
-    "5D grid tensor expected but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && input->dim() == 5, 2, input,
+    "non-empty 5D input tensor expected but got: %s");
+  THNN_ARGCHECK(!grid->is_empty() && grid->dim() == 5, 2, grid,
+    "non-empty 5D grid tensor expected but got: %s");
 
   int nbatch   = THTensor_(size)(input, 0);
   int channels = THTensor_(size)(input, 1);

--- a/aten/src/THNN/generic/VolumetricMaxUnpooling.c
+++ b/aten/src/THNN/generic/VolumetricMaxUnpooling.c
@@ -17,8 +17,8 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
                          int pW,
                          int pH)
 {
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-                "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+                "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   THNN_CHECK_SHAPE_INDICES(input, indices);
 
@@ -31,7 +31,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
   int dimt = 1;
   int dimn = 0;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimt++;
     dimw++;
@@ -49,7 +49,7 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
       );
     }
 
-    THNN_CHECK_DIM_SIZE(gradOutput, input->_dim(), dimn, nslices);
+    THNN_CHECK_DIM_SIZE(gradOutput, input->dim(), dimn, nslices);
   }
 }
 
@@ -138,7 +138,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
         state, input, NULL, indices,
         oT, oW, oH, dT, dW, dH, pT, pW, pH);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     nbatch = input->size[0];
     dimt++;
@@ -157,7 +157,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   indices = THIndexTensor_(newContiguous)(indices);
 
   /* resize output */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THTensor_(resize4d)(output, nslices, oT, oH, oW);
     THTensor_(zero)(output);
@@ -285,7 +285,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     nbatch = input->size[0];
     dimt++;
@@ -305,7 +305,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   indices_data = THIndexTensor_(data)(indices);
 
   /* backprop */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THNN_(VolumetricMaxUnpooling_updateGradInput_frame)(
       gradInput_data, gradOutput_data,

--- a/aten/src/THNN/generic/VolumetricReplicationPadding.c
+++ b/aten/src/THNN/generic/VolumetricReplicationPadding.c
@@ -21,10 +21,10 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
   int64_t oheight;
   int64_t owidth;
 
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+		"non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     dimw++;
     dimh++;
@@ -149,7 +149,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
       state, input, NULL, pleft, pright,
       ptop, pbottom, pfront, pback);
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     nbatch = input->size[0];
     dimw++;
@@ -171,7 +171,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   input = THTensor_(newContiguous)(input);
 
   /* resize output */
-  if (input->_dim() == 4)
+  if (input->dim() == 4)
   {
     THTensor_(resize4d)(output, nslices, odepth, oheight, owidth);
 
@@ -293,7 +293,7 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
   int64_t oheight;
   int64_t owidth;
 
-  if (input->_dim() == 5)
+  if (input->dim() == 5)
   {
     nbatch = input->size[0];
     dimw++;
@@ -324,7 +324,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   THTensor_(zero)(gradInput);
 
   /* backprop */
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     THNN_(VolumetricReplicationPadding_updateGradInput_frame)(
       THTensor_(data)(gradInput),
       THTensor_(data)(gradOutput),

--- a/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
@@ -9,9 +9,9 @@ static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
   THArgCheck(input != NULL, 2, "5D input tensor expected but got NULL");
   THArgCheck(scale_factor > 1, 4,
 	     "scale_factor must be greater than 1, but got: %d", scale_factor);
-  THNN_ARGCHECK(input->_dim() == 4 || input->_dim() == 5, 2, input,
-		"4D or 5D input tensor expected but got: %s");
-  if (input->_dim() == 4) {
+  THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
+		"non-empty 4D or 5D input tensor expected but got: %s");
+  if (input->dim() == 4) {
     int nChannels    = THTensor_(size)(input, 0);
     int inputDepth   = THTensor_(size)(input, 1);
     int inputHeight  = THTensor_(size)(input, 2);
@@ -51,14 +51,14 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
     int scale_factor)
 {
   THNN_(VolumetricUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
-  int inputDepth   = THTensor_(size)(input, input->_dim()-3);
-  int inputHeight  = THTensor_(size)(input, input->_dim()-2);
-  int inputWidth   = THTensor_(size)(input,  input->_dim()-1);
+  int inputDepth   = THTensor_(size)(input, input->dim()-3);
+  int inputHeight  = THTensor_(size)(input, input->dim()-2);
+  int inputWidth   = THTensor_(size)(input,  input->dim()-1);
   int outputDepth  = inputDepth * scale_factor;
   int outputHeight = inputHeight * scale_factor;
   int outputWidth  = inputWidth * scale_factor;
 
-  if (input->_dim() == 4) {
+  if (input->dim() == 4) {
     THTensor_(resize4d)(output,
 			THTensor_(size)(input, 0),
 			outputDepth, outputHeight, outputWidth);    
@@ -72,12 +72,12 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   int dT = scale_factor;
   int dW = scale_factor;
   int dH = scale_factor;
-  int xDim = input->_dim()-3;
-  int yDim = input->_dim()-2;
-  int zDim = input->_dim()-1;
+  int xDim = input->dim()-3;
+  int yDim = input->dim()-2;
+  int zDim = input->dim()-1;
 
   // dims
-  int idim = input->_dim();
+  int idim = input->dim();
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = output->size[2];
@@ -149,12 +149,12 @@ void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
   int dW = scale_factor;
   int dH = scale_factor;
   int dT = scale_factor;
-  int xDim = gradInput->_dim()-3;
-  int yDim = gradInput->_dim()-2;
-  int zDim = gradInput->_dim()-1;
+  int xDim = gradInput->dim()-3;
+  int yDim = gradInput->dim()-2;
+  int zDim = gradInput->dim()-1;
 
   // dims
-  int idim = gradInput->_dim();  // Guaranteed to be between 3 and 5
+  int idim = gradInput->dim();  // Guaranteed to be between 3 and 5
   int isz0 = gradInput->size[0];
   int isz1 = gradInput->size[1];
   int isz2 = gradInput->size[2];

--- a/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
@@ -16,8 +16,8 @@ static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
 	     " but got input (D: %d, H: %d, W: %d) output (D: %d, H: %d, W: %d)",
 	     inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
   if (input != NULL) {
-    THNN_ARGCHECK(input->_dim() == 5, 2, input,
-		  "5D input tensor expected but got: %s");
+    THNN_ARGCHECK(!input->is_empty() && input->dim() == 5, 2, input,
+		  "non-empty 5D input tensor expected but got: %s");
   }
 
   if (gradOutput != NULL) {

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -44,7 +44,7 @@
   }
 
 #define THNN_CHECK_DIM_SIZE(T, DIM, DIM_SIZE, SIZE)			\
-  if (THTensor_(_nDimension)(T) != DIM ||				\
+  if (THTensor_(nDimension)(T) != DIM ||				\
       THTensor_(size)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
@@ -52,7 +52,7 @@
   }
 
 #define THNN_CHECK_DIM_SIZE_INDICES(T, DIM, DIM_SIZE, SIZE)			\
-  if (THIndexTensor_(_nDimension)(T) != DIM ||				\
+  if (THIndexTensor_(nDimension)(T) != DIM ||				\
       THIndexTensor_(size)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THIndexTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\


### PR DESCRIPTION
Most of the argument checking in THNN is directly around dimensionality, which doesn't work in general for n-dimensional empty tensors, because
you will end up dividing by 0 or similar.  Instead, we change these to check for empty and give error messages for those cases as well.
In some cases, the error messages are improved as well.

