### PR TITLE
Add torch.backends.cudnn.is_available

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -74,12 +74,17 @@ CUDNN_TENSOR_TYPES = {
 }
 
 
+def is_available():
+    r"""Returns a bool indicating if CUDNN is currently available."""
+    return torch._C.has_cudnn
+
+
 def is_acceptable(tensor):
     if not torch._C._get_cudnn_enabled():
         return False
     if tensor.type() not in CUDNN_TENSOR_TYPES:
         return False
-    if not torch._C.has_cudnn:
+    if not is_available():
         warnings.warn(
             "PyTorch was compiled without cuDNN support. To use cuDNN, rebuild "
             "PyTorch making sure the library is visible to the build system.")


### PR DESCRIPTION
Some users are using `torch._C.has_cudnn` to determine if cudnn is available (e.g. https://github.com/pytorch/pytorch/pull/8313/files#diff-52a3dcb763bfba3076c1cc8aef9b1e72R17). There should probably be a friendlier way of doing this. This PR adds this function.

Please advise if `torch._C.has_cudnn` is ok, or better `torch.backends.cudnn.is_acceptable(torch.tensor(1., device=CUDA_DEVICE))` which I've seen in other code.

@soumith @apaszke @colesbury 