### PR TITLE
Make at::tensor faster

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -12,7 +12,7 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/ScalarType.h"
 #include "ATen/Deprecated.h"
-#include "ATen/DeviceGuard.h"
+#include "ATen/TensorOptions.h"
 #include "TH/THRandom.h"
 
 #include <algorithm>
@@ -596,17 +596,28 @@ Tensor hann_window(
 }
 
 template <typename T>
-Tensor tensor(ArrayRef<T> values, const TensorOptions& options) {
+Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
   auto result = at::empty(values.size(), options);
-  for (size_t i = 0; i < values.size(); ++i) {
-    result[i] = values[i];
-  }
+  AT_ASSERT(result.is_contiguous());
+  AT_DISPATCH_ALL_TYPES(result.type(), "tensor_cpu", [&] {
+    std::copy(values.begin(), values.end(), result.template data<scalar_t>());
+  });
   return result;
+}
+
+template <typename T>
+Tensor tensor_cuda(ArrayRef<T> values, const TensorOptions& options) {
+  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(at::kCPU));
+  return cpu_tensor.to(options.device());
 }
 
 #define TENSOR(T, _1, _2)                                           \
   Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    return tensor<T>(values, options);                              \
+    if (options.device().is_cuda()) {                               \
+      return tensor_cuda(values, options);                          \
+    } else {                                                        \
+      return tensor_cpu(values, options);                           \
+    }                                                               \
   }
 AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(TENSOR)
 #undef TENSOR

--- a/test/cpp/api/tensor_cuda.cpp
+++ b/test/cpp/api/tensor_cuda.cpp
@@ -6,5 +6,6 @@
 
 TEST_CASE("Tensor/AllocatesTensorOnTheCorrectDevice", "[cuda]") {
   auto tensor = at::tensor({1, 2, 3}, at::device({at::kCUDA, 1}));
-  REQUIRE(tensor.device() == at::Device(at::kCUDA, 1));
+  REQUIRE(tensor.device().type() == at::Device::Type::CUDA);
+  REQUIRE(tensor.device().index() == 1);
 }


### PR DESCRIPTION
Use `copy` instead of an explicit for loop to implement `at::tensor`.

@colesbury 