### PR TITLE
Add c10d/Def.hpp placeholder

### DIFF
--- a/torch/lib/c10d/Def.hpp
+++ b/torch/lib/c10d/Def.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+// This is a placeholder for the header that is generated CMake.
+// It is needed if you include the c10d headers directly from this directory.


### PR DESCRIPTION
This is a placeholder for the header that is generated CMake.
It is needed if you include the c10d headers directly from this directory.

