### PR TITLE
[C++ API] Add activation modules

### DIFF
--- a/test/cpp/api/activations.cpp
+++ b/test/cpp/api/activations.cpp
@@ -1,0 +1,73 @@
+#include <catch.hpp>
+
+#include <torch/functions.h>
+#include <torch/nn/modules/activations.h>
+#include <torch/nn/modules/sequential.h>
+#include <torch/tensor.h>
+
+#include <vector>
+
+using namespace torch::nn;
+
+bool is_between(torch::Variable tensor, double lower, double upper) {
+  return (tensor >= lower).all().toCInt() && (tensor <= upper).all().toCInt();
+}
+
+// These tests are not to test the actual functions, but to ensure we pass on
+// parameters correctly.
+
+TEST_CASE("Activations/Threshold") {
+  Threshold threshold(1.0, -1.0);
+
+  REQUIRE(threshold->forward({torch::ones({1}) * 3})[0].toCFloat() == 3);
+  REQUIRE(threshold->forward({torch::ones({1}) * 2})[0].toCFloat() == 2);
+
+  REQUIRE(threshold->forward({torch::ones({1}) * 0.5})[0].toCFloat() == -1);
+  REQUIRE(threshold->forward({torch::ones({1})})[0].toCFloat() == -1);
+  REQUIRE(threshold->forward({torch::ones({1}) * -3})[0].toCFloat() == -1);
+}
+
+TEST_CASE("Activations/RReLU") {
+  RRelu rrelu(-1.0, 1.0);
+
+  REQUIRE(rrelu->forward({torch::ones({1}) * 0})[0].toCFloat() == 0);
+  REQUIRE(rrelu->forward({torch::ones({1}) * 1})[0].toCFloat() == 1);
+  REQUIRE(rrelu->forward({torch::ones({1}) * 5})[0].toCFloat() == 5);
+
+  REQUIRE(is_between(rrelu->forward({torch::ones(1) * -0.5})[0], -0.5, 0.5));
+  REQUIRE(is_between(rrelu->forward({torch::ones(1) * -1})[0], -1.0, 1.0));
+  REQUIRE(is_between(rrelu->forward({torch::ones(1) * -5})[0], -5.0, 5.0));
+}
+
+TEST_CASE("Activations/GLU") {
+  GLU glu(-1);
+  auto output = glu->forward({torch::ones({2, 3, 4})})[0];
+  auto expected = torch::ones({2, 3, 2}).mul(torch::ones({2, 3, 2}).sigmoid());
+  REQUIRE(output.allclose(expected));
+}
+
+TEST_CASE("Activations/Hardshrink") {
+  Hardshrink hardshrink(1);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * 0})[0].toCFloat() == 0);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * 0.5})[0].toCFloat() == 0);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * -0.5})[0].toCFloat() == 0);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * 1})[0].toCFloat() == 0);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * -1})[0].toCFloat() == 0);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * 5})[0].toCFloat() == 5);
+  REQUIRE(hardshrink->forward({torch::ones({1}) * -5})[0].toCFloat() == -5);
+}
+
+TEST_CASE("Activations/LeakyRelu") {
+  LeakyReLU leaky_relu(0.01);
+  REQUIRE(leaky_relu->forward({torch::ones({1}) * 0})[0].toCFloat() == 0);
+  REQUIRE(leaky_relu->forward({torch::ones({1}) * 1})[0].toCFloat() == 1);
+  REQUIRE(leaky_relu->forward({torch::ones({1}) * 2})[0].toCFloat() == 2);
+  REQUIRE(leaky_relu->forward({torch::ones({1}) * -100})[0].toCFloat() == -1);
+}
+
+TEST_CASE("Activations/Sequential") {
+  Sequential sequential(Sigmoid{}, ReLU{});
+  auto result = sequential.forward<std::vector<torch::Variable>>(
+      std::vector<torch::Variable>{torch::zeros({1})});
+  REQUIRE(result[0].toCFloat() == 0.5);
+}

--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -78,10 +78,10 @@ TEST_CASE("any-module") {
       }
     };
     AnyModule any(M{});
-    REQUIRE_THROWS_WITH(
-        any.forward(5.0),
-        StartsWith("Expected argument #0 to be of type float, "
-                   "but received value of type double"));
+
+    auto message = std::string("Expected argument #0 to module ") + M{}.name() +
+        " to be of type float, but received value of type double";
+    REQUIRE_THROWS_WITH(any.forward(5.0), StartsWith(message));
   }
   SECTION("wrong number of arguments") {
     struct M : nn::Module {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -133,7 +133,7 @@ TEST_CASE("module/clone") {
         l3 = register_module("l3", Linear(5, 100));
       }
 
-      Linear l1, l2, l3;
+      Linear l1{nullptr}, l2{nullptr}, l3{nullptr};
     };
 
     auto module = TestModule().build();

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -17,11 +17,10 @@ using namespace torch::nn;
 
 class TestModel : public Module {
  public:
-  TestModel() {
-    l1 = register_module("l1", Linear(10, 3));
-    l2 = register_module("l2", Linear(3, 5));
-    l3 = register_module("l3", Linear(5, 100));
-  }
+  TestModel()
+      : l1(register_module("l1", Linear(10, 3))),
+        l2(register_module("l2", Linear(3, 5))),
+        l3(register_module("l3", Linear(5, 100))) {}
 
   std::vector<Variable> forward(std::vector<Variable> input) {
     return input;
@@ -32,9 +31,9 @@ class TestModel : public Module {
 
 class NestedModel : public Module {
  public:
-  NestedModel() {
-    l1 = register_module("l1", Linear(5, 20));
-    t = register_module("test", std::make_shared<TestModel>());
+  NestedModel()
+      : l1(register_module("l1", Linear(5, 20))),
+        t(register_module("test", std::make_shared<TestModel>())) {
     param_ = register_parameter("param", torch::empty({3, 2, 21}));
   }
 

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -1,6 +1,7 @@
 #include <catch.hpp>
 
 #include <torch/functions.h>
+#include <torch/nn/modules/activations.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/sequential.h>
 #include <torch/optimizers.h>
@@ -21,7 +22,8 @@ using namespace torch::nn;
 
 namespace {
 std::shared_ptr<Sequential> xor_model() {
-  return std::make_shared<Sequential>(SigmoidLinear(2, 8), SigmoidLinear(8, 1));
+  return std::make_shared<Sequential>(
+      Linear(2, 8), Sigmoid{}, Linear(8, 1), Sigmoid{});
 }
 } // namespace
 
@@ -181,7 +183,8 @@ TEST_CASE("serialization") {
       }
 
       // forward
-      auto x = model->forward<Variable>(inp);
+      auto x =
+          model->forward<std::vector<Variable>>(std::vector<Variable>{inp})[0];
       return at::binary_cross_entropy(x, lab);
     };
 
@@ -283,7 +286,8 @@ TEST_CASE("serialization_cuda", "[cuda]") {
       }
 
       // forward
-      auto x = model->forward<Variable>(inp);
+      auto x =
+          model->forward<std::vector<Variable>>(std::vector<Variable>{inp})[0];
       return at::binary_cross_entropy(x, lab);
     };
 

--- a/test/cpp/api/util.h
+++ b/test/cpp/api/util.h
@@ -27,19 +27,4 @@ class SimpleContainer : public nn::Cloneable<SimpleContainer> {
     return Module::register_module(std::move(name), module_holder);
   }
 };
-
-struct SigmoidLinear : nn::Module {
-  SigmoidLinear(int64_t in, int64_t out) : linear(nn::Linear(in, out)) {
-    register_module("linear", linear);
-  }
-
-  explicit SigmoidLinear(nn::Linear linear_) : linear(std::move(linear_)) {
-    register_module("linear", linear);
-  }
-  Variable forward(Variable input) {
-    return linear->forward({input}).front().sigmoid();
-  }
-  nn::Linear linear;
-};
-
 } // namespace torch

--- a/tools/shared/_utils_internal.py
+++ b/tools/shared/_utils_internal.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+# this arbitrary-looking assortment of functionality is provided here
+# to have a central place for overrideable behavior. The motivating
+# use is the FB build environment, where this source file is replaced
+# by an equivalent.
+
+if os.path.basename(os.path.dirname(__file__)) == 'shared':
+    torch_parent = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+else:
+    torch_parent = os.path.dirname(os.path.dirname(__file__))
+
+
+def get_file_path(*path_components):
+    return os.path.join(torch_parent, *path_components)
+
+
+def get_file_path_2(*path_components):
+    return os.path.join(*path_components)
+
+
+def get_writable_path(path):
+    return path
+
+
+def prepare_multiprocessing_environment(path):
+    pass
+
+
+TEST_MASTER_ADDR = '127.0.0.1'

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -247,6 +247,7 @@ if (NOT NO_API)
     ${TORCH_SRC_DIR}/csrc/api/src/cuda.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/cursor.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/module.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/activations.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/batchnorm.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/conv.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/dropout.cpp
@@ -354,6 +355,7 @@ if (TORCH_BUILD_TEST)
 
     add_executable(test_api
       ${TORCH_API_TEST_DIR}/any.cpp
+      ${TORCH_API_TEST_DIR}/activations.cpp
       ${TORCH_API_TEST_DIR}/modules.cpp
       ${TORCH_API_TEST_DIR}/cursor.cpp
       ${TORCH_API_TEST_DIR}/integration.cpp

--- a/torch/csrc/api/include/torch/nn/modules/activations.h
+++ b/torch/csrc/api/include/torch/nn/modules/activations.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <torch/nn/modules/functional.h>
+#include <torch/nn/pimpl.h>
+
+namespace torch {
+namespace nn {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct ThresholdOptions {
+  ThresholdOptions(double threshold, double value);
+  TORCH_ARG(double, threshold);
+  TORCH_ARG(double, value);
+};
+
+struct ThresholdImpl : FunctionalImpl {
+  explicit ThresholdImpl(ThresholdOptions options);
+  ThresholdOptions options;
+};
+
+TORCH_MODULE(Threshold);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct ReLUImpl : ThresholdImpl {
+  ReLUImpl();
+};
+
+TORCH_MODULE(ReLU);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct RReluOptions {
+  RReluOptions(double lower, double upper);
+  TORCH_ARG(double, lower) = 1.0 / 8;
+  TORCH_ARG(double, upper) = 1.0 / 3;
+};
+
+struct RReluImpl : FunctionalImpl {
+  explicit RReluImpl(RReluOptions options);
+  RReluOptions options;
+};
+
+TORCH_MODULE(RRelu);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct SigmoidImpl : FunctionalImpl {
+  SigmoidImpl();
+};
+
+TORCH_MODULE(Sigmoid);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct TanhImpl : FunctionalImpl {
+  TanhImpl();
+};
+
+TORCH_MODULE(Tanh);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct ELUOptions {
+  ELUOptions(double alpha);
+  TORCH_ARG(double, alpha) = 1.0;
+};
+
+struct ELUImpl : FunctionalImpl {
+  explicit ELUImpl(ELUOptions options);
+  ELUOptions options;
+};
+
+TORCH_MODULE(ELU);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct SELUImpl : FunctionalImpl {
+  SELUImpl();
+};
+
+TORCH_MODULE(SELU);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct GLUOptions {
+  GLUOptions(int64_t dim);
+  TORCH_ARG(int64_t, dim);
+};
+
+struct GLUImpl : FunctionalImpl {
+  explicit GLUImpl(GLUOptions options);
+  GLUOptions options;
+};
+
+TORCH_MODULE(GLU);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct HardshrinkOptions {
+  HardshrinkOptions(double lambda);
+  TORCH_ARG(double, lambda);
+};
+
+struct HardshrinkImpl : FunctionalImpl {
+  explicit HardshrinkImpl(HardshrinkOptions options);
+  HardshrinkOptions options;
+};
+
+TORCH_MODULE(Hardshrink);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct HardtanhOptions {
+  HardtanhOptions(double min_val, double max_val);
+  TORCH_ARG(double, min_val);
+  TORCH_ARG(double, max_val);
+};
+
+struct HardtanhImpl : FunctionalImpl {
+  explicit HardtanhImpl(HardtanhOptions options);
+  HardtanhOptions options;
+};
+
+TORCH_MODULE(Hardtanh);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct LeakyReLUOptions {
+  LeakyReLUOptions(double negative_slope);
+  TORCH_ARG(double, negative_slope);
+};
+
+struct LeakyReLUImpl : FunctionalImpl {
+  explicit LeakyReLUImpl(LeakyReLUOptions options);
+  LeakyReLUOptions options;
+};
+
+TORCH_MODULE(LeakyReLU);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct SoftplusOptions {
+  SoftplusOptions(double beta);
+  TORCH_ARG(double, beta);
+  TORCH_ARG(double, threshold) = 20;
+};
+
+struct SoftplusImpl : FunctionalImpl {
+  explicit SoftplusImpl(SoftplusOptions options);
+  SoftplusOptions options;
+};
+
+TORCH_MODULE(Softplus);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct SoftsignImpl : FunctionalImpl {
+  SoftsignImpl();
+};
+
+TORCH_MODULE(Softsign);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct SoftmaxOptions {
+  SoftmaxOptions(int64_t dim);
+  TORCH_ARG(int64_t, dim);
+};
+
+struct SoftmaxImpl : FunctionalImpl {
+  explicit SoftmaxImpl(SoftmaxOptions options);
+  SoftmaxOptions options;
+};
+
+TORCH_MODULE(Softmax);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+struct LogSoftmaxOptions {
+  LogSoftmaxOptions(int64_t dim);
+  TORCH_ARG(int64_t, dim);
+};
+
+struct LogSoftmaxImpl : FunctionalImpl {
+  explicit LogSoftmaxImpl(LogSoftmaxOptions options);
+  LogSoftmaxOptions options;
+};
+
+TORCH_MODULE(LogSoftmax);
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -242,12 +242,15 @@ struct AnyModule::Holder : public AnyModule::Placeholder {
       AT_ERROR(
           "Expected argument #",
           index,
+          " to module ",
+          module.name(),
           " to be of type ",
           at::demangle(typeid(T).name()),
           ", but received value of type ",
           at::demangle(value.type_info().name()));
     }
     std::vector<Value>& arguments_;
+    ModuleType& module;
   };
 
   struct InvokeForward {
@@ -275,7 +278,7 @@ struct AnyModule::Holder : public AnyModule::Placeholder {
     // FYI: During invocation of a module's `forward()` method, the values live
     // in the `arguments` vector inside this function.
     return torch::unpack<ArgumentTypes...>(
-        InvokeForward{module}, CheckedGetter{arguments});
+        InvokeForward{module}, CheckedGetter{arguments, *module});
   }
 
   std::shared_ptr<Module> ptr() override {

--- a/torch/csrc/api/include/torch/nn/modules/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/functional.h
@@ -7,6 +7,10 @@
 #include <functional>
 #include <vector>
 
+namespace at {
+struct Tensor;
+} // namespace at
+
 namespace torch {
 namespace nn {
 
@@ -18,6 +22,7 @@ class FunctionalImpl : public torch::nn::Cloneable<FunctionalImpl> {
 
   explicit FunctionalImpl(Function function);
   explicit FunctionalImpl(std::function<Variable(Variable)> function);
+  explicit FunctionalImpl(at::Tensor (*function)(at::Tensor));
 
   void reset() override;
   std::vector<Variable> forward(std::vector<Variable> input);

--- a/torch/csrc/api/src/nn/modules/activations.cpp
+++ b/torch/csrc/api/src/nn/modules/activations.cpp
@@ -1,0 +1,141 @@
+#include <torch/nn/modules/activations.h>
+
+#include <torch/nn/modules/functional.h>
+
+#include <ATen/ATen.h>
+
+namespace torch {
+namespace nn {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ThresholdOptions::ThresholdOptions(double threshold, double value)
+    : threshold_(threshold), value_(value) {}
+
+ThresholdImpl::ThresholdImpl(ThresholdOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::threshold(
+            input, this->options.threshold_, this->options.value_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ReLUImpl::ReLUImpl() : ThresholdImpl({/*threshold=*/0, /*value=*/0}) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RReluOptions::RReluOptions(double lower, double upper)
+    : lower_(lower), upper_(upper) {}
+
+RReluImpl::RReluImpl(RReluOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::rrelu(
+            input, this->options.lower_, this->options.upper_, is_training());
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SigmoidImpl::SigmoidImpl() : FunctionalImpl(at::sigmoid) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TanhImpl::TanhImpl() : FunctionalImpl(at::tanh) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ELUOptions::ELUOptions(double alpha) : alpha_(alpha) {}
+
+ELUImpl::ELUImpl(ELUOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::elu(input, this->options.alpha_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SELUImpl::SELUImpl() : FunctionalImpl(at::selu) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+GLUOptions::GLUOptions(int64_t dim) : dim_(dim) {}
+
+GLUImpl::GLUImpl(GLUOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::glu(input, this->options.dim_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+HardshrinkOptions::HardshrinkOptions(double lambda) : lambda_(lambda) {}
+
+HardshrinkImpl::HardshrinkImpl(HardshrinkOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::hardshrink(input, this->options.lambda_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+HardtanhOptions::HardtanhOptions(double min_val, double max_val)
+    : min_val_(min_val), max_val_(max_val) {}
+
+HardtanhImpl::HardtanhImpl(HardtanhOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::hardtanh(
+            input, this->options.min_val_, this->options.max_val_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+LeakyReLUOptions::LeakyReLUOptions(double negative_slope)
+    : negative_slope_(negative_slope) {}
+
+LeakyReLUImpl::LeakyReLUImpl(LeakyReLUOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::leaky_relu(input, this->options.negative_slope_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SoftplusOptions::SoftplusOptions(double beta) : beta_(beta) {}
+
+SoftplusImpl::SoftplusImpl(SoftplusOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::softplus(
+            input, this->options.beta_, this->options.threshold_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SoftsignImpl::SoftsignImpl()
+    : FunctionalImpl([](Variable input) { return input / (input.abs() + 1); }) {
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SoftmaxOptions::SoftmaxOptions(int64_t dim) : dim_(dim) {}
+
+SoftmaxImpl::SoftmaxImpl(SoftmaxOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::softmax(input, this->options.dim_);
+      }),
+      options(options) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+LogSoftmaxOptions::LogSoftmaxOptions(int64_t dim) : dim_(dim) {}
+
+LogSoftmaxImpl::LogSoftmaxImpl(LogSoftmaxOptions options)
+    : FunctionalImpl([this](Variable input) {
+        return at::log_softmax(input, this->options.dim_);
+      }),
+      options(options) {}
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/functional.cpp
+++ b/torch/csrc/api/src/nn/modules/functional.cpp
@@ -16,6 +16,11 @@ FunctionalImpl::FunctionalImpl(std::function<Variable(Variable)> function)
         return std::vector<Variable>({function(input.front())});
       }) {}
 
+FunctionalImpl::FunctionalImpl(at::Tensor (*function)(at::Tensor))
+    : function_([function](std::vector<Variable> input) {
+        return std::vector<Variable>({function(input.front())});
+      }) {}
+
 void FunctionalImpl::reset() {}
 
 std::vector<Variable> FunctionalImpl::forward(std::vector<Variable> input) {

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -55,7 +55,8 @@ RNNImplBase<Derived>::RNNImplBase(
     : options_(options),
       number_of_gates_(number_of_gates),
       has_cell_state_(has_cell_state),
-      cudnn_mode_(cudnn_mode) {
+      cudnn_mode_(cudnn_mode),
+      dropout_module_(nullptr) {
   reset();
 }
 


### PR DESCRIPTION
I don't intend to replicate all PyTorch modules in the C++ API (rather rely on community to ask for them, I would say), but I think activation modules are sufficiently basic to add.

In this PR I replicate a handful of the most important PyTorch activation modules in C++.

There is some follow up work I need to do to improve all modules to have saner `forward()` methods than `vector<Variable> forward(vector<Variable>)` -- at that point I will also make these modules take single `Variables` instead of `vector<Variable>`.

@apaszke @ebetica @ezyang 