### PR TITLE
adding stochastic quantization caffe2 operators (encoder and decoder in CPU are implemented. GPU mode is pending)

### DIFF
--- a/caffe2/operators/fused_rowwise_random_quantization_ops.cc
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.cc
@@ -1,0 +1,86 @@
+#include "caffe2/operators/fused_rowwise_random_quantization_ops.h"
+#include "caffe2/core/registry.h"
+
+namespace caffe2 {
+REGISTER_CPU_OPERATOR(
+    FloatToFusedRandRowwiseQuantized,
+    FloatToFusedRandRowwiseQuantizedOp<CPUContext>);
+OPERATOR_SCHEMA(FloatToFusedRandRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>& in) {
+      ArgumentHelper helper(def);
+      auto bitwidth = helper.GetSingleArgument<int32_t>("bitwidth", 8);
+      size_t data_per_byte = 8 / bitwidth;
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, 10 + (X.dims(1) + data_per_byte - 1) / data_per_byte);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies row-wise stochastic/random quantization by determining the range of
+each row in the input matrix, and then quantize each element to one of two
+closest discrete levels by randomly drawing Bernoulli distribution.
+The method is extended from TernGrad [1],
+which randomly quantizes gradients to three levels to reduce communication in distributed training.
+The format of each row (x) in the output matrix is [bitwidth][tail][min][max][data]:
+bitwidth[1 Byte]: bitwidth per data [1, 2, 4 or 8];
+tail[1 Byte]: the number of unused buckets [1-8] (One byte is split to 8/bitwidth buckets and each bucket stores one low-precision data in bitwidth bits);
+min[4 Bytes]: the minimum floating value min(x);
+max[4 Bytes]: the maximum floating value max(x);
+data: quantized data.
+The quantization is uniform with levels q = min + (max-min)/(2^bitwidth - 1)*[0:1:2^bitwidth].
+During stochastic/random quantization x'=Quantize(x), for q_j < x_i <= q_{j+1}, we draw quantization x'_i from Bernoulli distributions with
+P(x'_i = q_{j+1}) = (x_i - q_j)/(q_{j+1} - q_j), and
+P(x'_i = q_j) = (q_{j+1} - x_i)/(q_{j+1} - q_j) where x'_i is the quantized value of x_i.
+[1] proved E{x'_i}=x_i, which is an unbiased approximation. More details are in the paper.
+For example, suppose targeted bitwidth = 2 and x = [0.3, -1.4, -0.6, 0.9, 1.0],
+then tail = 3, min = -1.4, max = 1.0 and q = [-1.4, -0.6, 0.2, 1.0].
+x_1 = 0.3 will be quantized to x'_1 = 0.2 with probability 7/8 and to x'_1 = 1.0 with probability 1/8.
+The storage format of quantized data is: [x'_1|x'_3|x'_5|xxx]-[x'_2|x'_4|xxx|xxx].
+In general, a input row is split to multiple segments. One segment is a continuous subarray of the row,
+and its length is the number of bytes storing quantized data in the output matrix.
+The b-th bucket of the i-th byte stores the i-th data of the b-th segment of input row.
+
+[1] Wen, Wei, Cong Xu, Feng Yan, Chunpeng Wu, Yandan Wang, Yiran Chen, and Hai Li.
+"Terngrad: Ternary gradients to reduce communication in distributed deep learning."
+In Advances in Neural Information Processing Systems, pp. 1508-1518. 2017.
+
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused bitwidth, tail, min, max and quantized data")
+    .Arg("bitwidth", "How many bits to quantiz per data (defaults to 8).")
+    .Arg("random", "random or not (True). False is set up for unittest.");
+NO_GRADIENT(FloatToFusedRandRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    FusedRandRowwiseQuantizedToFloat,
+    FusedRandRowwiseQuantizedToFloatOp<CPUContext>);
+OPERATOR_SCHEMA(FusedRandRowwiseQuantizedToFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>&) {
+      vector<TensorShape> out;
+      for (int i = 0; i < def.output_size(); i++) {
+        TensorShape ts;
+        ts.set_unknown_shape(true);
+        ts.set_data_type(TensorProto_DataType_FLOAT);
+        out.push_back(ts);
+      }
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the FloatToFusedRandRowwiseQuantized operator.
+Refer FloatToFusedRandRowwiseQuantized operator for details.
+)DOC")
+    .Input(
+        0,
+        "quantized_input",
+        "Fused bitwidth, tail, min, max and quantized data")
+    .Output(0, "float_input", "Float32 data");
+NO_GRADIENT(FusedRandRowwiseQuantizedToFloat);
+} // namespace caffe2

--- a/caffe2/operators/fused_rowwise_random_quantization_ops.h
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.h
@@ -1,0 +1,272 @@
+#ifndef CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
+#define CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/reducer_functors.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+#define IS_LITTLE_ENDIAN                                      \
+  [] {                                                        \
+    const int32_t kValue = 1;                                 \
+    return reinterpret_cast<const uint8_t*>(&kValue)[0] == 1; \
+  }()
+
+#define QEPSILON 1e-8f
+// define a custom template unary functor
+// stochastic quantization
+template <typename Scalar>
+struct CwiseRandQuantizeOp {
+  CwiseRandQuantizeOp(
+      CPUContext::rand_gen_type& gen,
+      const uint8_t& bitwidth,
+      const bool& r,
+      const Scalar& minv,
+      const Scalar& maxv)
+      : gen_(gen),
+        bitwidth_(bitwidth),
+        random_(r),
+        min_(minv),
+        max_(maxv),
+        gap_((maxv - minv) / ((1 << bitwidth) - 1.f)),
+        maxq_((1 << bitwidth) - 1) {}
+  uint8_t operator()(const Scalar& fval) const {
+    Scalar thetimes = (fval - min_) / (gap_ + QEPSILON);
+    thetimes = thetimes < 0 ? 0 : (thetimes > maxq_ ? maxq_ : thetimes);
+    uint8_t floor_times = floor(thetimes);
+    // the probability of quantizing to the larger discrete level
+    Scalar p = thetimes - floor_times;
+    if (!random_) {
+      p = p > 0.5;
+    }
+    // generate Bernoulli distribution
+    std::bernoulli_distribution dist(p);
+    uint8_t q = floor_times + dist(gen_); // quantized value
+    // (1 << bitwidth_) - 1 is to avoid contamination when q is dirty data
+    return maxq_ & q;
+  }
+
+  CPUContext::rand_gen_type& gen_;
+  const uint8_t bitwidth_; // bits per data
+  const bool random_; // false for unittest
+  const Scalar min_; // the minimum value
+  const Scalar max_; // the maximum value
+  const Scalar gap_; // the gap between two discrete levels
+  const uint8_t maxq_; // the max quantized value
+};
+
+// define a custom template binary functor
+// left shift and or
+template <typename T>
+struct CwiseLeftShiftOrOp {
+  CwiseLeftShiftOrOp(const size_t& s) : shift_(s) {}
+  const T operator()(const T& orval, const T& shiftval) const {
+    return orval | (T)(shiftval << shift_);
+  }
+  const size_t shift_; // bits per data
+};
+
+// define a custom template unary functor
+// select [start, start+bitwidth) bits and convert to a value
+template <typename T, typename D>
+struct CwiseBitsValueOp {
+  CwiseBitsValueOp(const size_t& start, const size_t& bitwidth)
+      : start_(start), mask_((1 << bitwidth) - 1) {}
+  const T operator()(const D& bytes) const {
+    return (T)((bytes >> start_) & mask_);
+  }
+  const size_t start_; // start index of the bits
+  const D mask_;
+};
+
+template <class Context>
+class FloatToFusedRandRowwiseQuantizedOp : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  FloatToFusedRandRowwiseQuantizedOp(
+      const OperatorDef& operator_def,
+      Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        bitwidth_(OperatorBase::GetSingleArgument<int32_t>("bitwidth", 8)),
+        random_(OperatorBase::GetSingleArgument<bool>("random", true)) {
+    CAFFE_ENFORCE(
+        bitwidth_ == 1 || bitwidth_ == 2 || bitwidth_ == 4 || bitwidth_ == 8,
+        "Unsupported bitwidth");
+  }
+  ~FloatToFusedRandRowwiseQuantizedOp() {}
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+    const auto& input = Input(DATA_FLOAT);
+    auto* output = Output(DATA_FUSED_QUANTIZED);
+
+    CAFFE_ENFORCE_EQ(
+        input.ndim(),
+        2,
+        "Expect input to be a matrix. Reshape the input tensor to a matrix for usage.");
+
+    const auto input_rows = input.dim(0);
+    const auto input_columns = input.dim(1);
+
+    // The "fused" representation stores the [bitwidth][tail][min][max]
+    // with the row-wise quantized data in one tensor. Since we store 8/bitwidth
+    // quantized data in one byte, the last buckets of some bytes may have
+    // unused bits. There are totally tail buckets are unused.
+    // We encode *bitwidth* and *tail* at the beginning of
+    // each row, following by 32-bit floating data respresenting min and max.
+    // | bitwidth | tail | min | max | ... int8 data ... |
+    // |    1B    |  1B  |  4B |  4B | ...output_data....|
+    // In output_data: the b-th bucket of the i-th byte stores
+    // the i-th data of the b-th segment of input row
+    size_t data_per_byte = 8 / bitwidth_;
+    size_t tail = input_columns % data_per_byte;
+    tail = tail ? data_per_byte - tail : 0;
+    // How many bytes in the output
+    size_t segment_size = (input_columns + data_per_byte - 1) / data_per_byte;
+    const std::vector<TIndex> output_dimensions = {input_rows,
+                                                   10 + segment_size};
+    output->Resize(output_dimensions);
+
+    const auto* input_data = input.template data<float>();
+    auto* output_data = output->template mutable_data<uint8_t>();
+    const auto output_columns = output->dim(1);
+    memset(output_data, 0, output->size());
+
+    for (size_t row = 0; row < input_rows; ++row) {
+      // memory pointers
+      ConstEigenVectorArrayMap<float> input_row(
+          input_data + row * input_columns, input_columns);
+      uint8_t* output_row = output_data + row * output_columns;
+      EigenVectorArrayMap<uint8_t> output_bitwidth_tail(output_row, 2);
+      EigenVectorArrayMap<float> output_row_min_max(
+          reinterpret_cast<float*>(output_row + 2), 2);
+
+      // basic info
+      const float minimum_element = input_row.minCoeff();
+      const float maximum_element = input_row.maxCoeff();
+      output_bitwidth_tail(0) = bitwidth_;
+      output_bitwidth_tail(1) = tail;
+      output_row_min_max(0) = minimum_element;
+      output_row_min_max(1) = maximum_element;
+
+      CwiseRandQuantizeOp<float> cwiserand(
+          context_.RandGenerator(),
+          bitwidth_,
+          random_,
+          minimum_element,
+          maximum_element);
+      size_t bit_start = 0;
+      for (int start = 0; start < input_columns; start += segment_size) {
+        CwiseLeftShiftOrOp<uint8_t> cwiseshftor(bit_start);
+        bit_start += bitwidth_;
+        size_t stride = start + segment_size <= input_columns
+            ? segment_size
+            : input_columns - start;
+        ConstEigenVectorArrayMap<float> sub_input_row(
+            input_data + row * input_columns + start, stride);
+        auto qvals = sub_input_row.unaryExpr(
+            cwiserand); // some last buckets may have unused data
+        EigenVectorArrayMap<uint8_t> output_seg(output_row + 10, stride);
+        // shift and concatenate current ones
+        output_seg = output_seg.binaryExpr(qvals, cwiseshftor);
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FLOAT);
+  OUTPUT_TAGS(DATA_FUSED_QUANTIZED);
+
+ protected:
+  size_t bitwidth_{8};
+  bool random_{true};
+};
+
+template <class Context>
+class FusedRandRowwiseQuantizedToFloatOp : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  USE_SIMPLE_CTOR_DTOR(FusedRandRowwiseQuantizedToFloatOp)
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+    const auto& input = Input(DATA_FUSED_QUANTIZED);
+    auto* output = Output(DATA_FLOAT);
+    CAFFE_ENFORCE_EQ(input.ndim(), 2, "Expect input to be a matrix.");
+    CAFFE_ENFORCE_GE(
+        input.size(),
+        4,
+        "Expect input to have size greater than or equal to 4.");
+
+    const auto input_rows = input.dim(0);
+    const auto input_columns = input.dim(1);
+    const auto* input_data = input.template data<uint8_t>();
+    const size_t bitwidth = input_data[0];
+    CAFFE_ENFORCE(
+        bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+        "Unsupported bitwidth");
+    const size_t tail = input_data[1];
+    const size_t output_columns = (input_columns - 10) * (8 / bitwidth) - tail;
+    const std::vector<TIndex> output_dimensions = {input_rows, output_columns};
+    output->Resize(output_dimensions);
+    auto* output_data = output->template mutable_data<float>();
+    for (size_t row = 0; row < input_rows; ++row) {
+      // memory pointers
+      const uint8_t* input_row = input_data + row * input_columns;
+      ConstEigenVectorArrayMap<uint8_t> input_bitwidth_tail(input_row, 2);
+      ConstEigenVectorArrayMap<float> input_row_min_max(
+          reinterpret_cast<const float*>(input_row + 2), 2);
+      EigenVectorArrayMap<float> output_row(
+          output_data + row * output_columns, output_columns);
+
+      // basic info
+      const float minimum_element = input_row_min_max(0);
+      const float maximum_element = input_row_min_max(1);
+      const float gap =
+          (maximum_element - minimum_element) / ((1 << bitwidth) - 1.f) +
+          QEPSILON; // for exact recovering
+      CAFFE_ENFORCE_EQ(
+          bitwidth,
+          input_bitwidth_tail(0),
+          "Expect each row have the same bitwidth");
+      CAFFE_ENFORCE_EQ(
+          tail, input_bitwidth_tail(1), "Expect each row have the same tail");
+
+      // decoding
+      size_t bit_start = 0;
+      const size_t segment_size = input_columns - 10;
+      for (int start = 0; start < output_columns; start += segment_size) {
+        CwiseBitsValueOp<float, uint8_t> cwisedec(bit_start, bitwidth);
+        bit_start += bitwidth;
+        size_t stride = start + segment_size <= output_columns
+            ? segment_size
+            : output_columns - start;
+        EigenVectorArrayMap<float> sub_output_row(
+            output_data + row * output_columns + start, stride);
+        ConstEigenVectorArrayMap<uint8_t> input_seg(input_row + 10, stride);
+        sub_output_row = input_seg.unaryExpr(cwisedec);
+      }
+      // scaling and biasing
+      output_row = output_row * gap + minimum_element;
+    }
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FUSED_QUANTIZED);
+  OUTPUT_TAGS(DATA_FLOAT);
+};
+
+#undef IS_LITTLE_ENDIAN
+#undef QEPSILON
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_

--- a/caffe2/python/operator_test/rand_quantization_op_test.py
+++ b/caffe2/python/operator_test/rand_quantization_op_test.py
@@ -1,0 +1,152 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import struct
+
+from hypothesis import given, example
+import hypothesis.strategies as st
+
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+
+np.set_printoptions(precision=6)
+
+
+class TestFloatToFusedRandRowwiseQuantized(hu.HypothesisTestCase):
+    @given(X=hu.tensor(min_dim=2, max_dim=2,
+                        min_value=1, max_value=17),  # only matrix is supported
+           bitwidth_=st.sampled_from([1, 2, 4, 8]),
+           random_=st.sampled_from([True, False]),
+           **hu.gcs)
+    @example(X=np.array([[0., 0., 0., 0.264019]]).astype(np.float32),
+            bitwidth_=2,
+            random_=False,
+            **hu.gcs)
+    def test_rand_quantization(self, X, bitwidth_, random_, gc, dc):
+
+        # python reference of encoder
+        def rand_quantization_ref(X):
+            in_shape = X.shape
+            data_per_byte = 8 // bitwidth_
+            output_cols = 10 + in_shape[1] // data_per_byte
+            tail = 0
+            if in_shape[1] % data_per_byte:
+                output_cols += 1
+                tail = data_per_byte - in_shape[1] % data_per_byte
+            segment = output_cols - 10
+            out = np.zeros((in_shape[0], output_cols), dtype=np.uint8)
+            for r in range(0, in_shape[0]):
+                out[r][0] = bitwidth_
+                out[r][1] = tail
+                min_fval = np.amin(X[r])
+                max_fval = np.amax(X[r])
+                min_bvals = bytearray(struct.pack("f", min_fval))
+                max_bvals = bytearray(struct.pack("f", max_fval))
+                for idx in range(0, 4):
+                    out[r][2 + idx] = min_bvals[idx]
+                    out[r][6 + idx] = max_bvals[idx]
+                for c in range(0, in_shape[1]):
+                    fval = X[r][c]
+                    gap = (max_fval - min_fval) / ((1 << bitwidth_) - 1)
+                    thetimes = (fval - min_fval) / (gap + 1e-8)
+                    thetimes = np.around(thetimes).astype(np.uint8)
+                    out[r][10 + c % segment] += \
+                        (thetimes << (bitwidth_ * (c // segment)))
+            print("pY:\n{}\n".format(out))
+            return (out,)
+
+        # the maximum quantization error
+        def get_allowed_errors(X):
+            out = np.zeros_like(X)
+            for r in range(0, X.shape[0]):
+                min_fval = np.amin(X[r])
+                max_fval = np.amax(X[r])
+                gap = (max_fval - min_fval) / (2 ** bitwidth_ - 1) + 1e-8
+                out[r] = gap
+            return out
+
+        # python reference of decoder
+        def dec_ref(Y):
+            in_shape = Y.shape
+            bitwidth = Y[0][0]
+            tail = Y[0][1]
+            mask = np.array([(1 << bitwidth) - 1]).astype(np.uint8)[0]
+            data_per_byte = 8 // bitwidth
+            output_cols = (in_shape[1] - 10) * data_per_byte - tail
+            segment = in_shape[1] - 10
+            out = np.zeros((in_shape[0], output_cols), dtype=np.float)
+            for r in range(0, in_shape[0]):
+                min_fval = struct.unpack('f', Y[r][2:6])[0]
+                max_fval = struct.unpack('f', Y[r][6:10])[0]
+                print(min_fval, max_fval)
+                gap = (max_fval - min_fval) / (2 ** bitwidth - 1.) + 1e-8
+                for out_c in range(0, output_cols):
+                    bit_start = (out_c // segment) * bitwidth
+                    out[r][out_c] = min_fval + gap * \
+                        ((Y[r][10 + out_c % segment] >> bit_start) & mask)
+            print("pdecX:\n{}\n".format(out))
+            return (out,)
+
+        enc_op = core.CreateOperator(
+            "FloatToFusedRandRowwiseQuantized",
+            ["X"], ["Y"],
+            bitwidth=bitwidth_,
+            random=random_)
+        dec_op = core.CreateOperator(
+            "FusedRandRowwiseQuantizedToFloat",
+            ["Y"], ["decX"])
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(enc_op)
+        print("X:\n{}\n".format(workspace.FetchBlob("X")))
+        Y = workspace.FetchBlob("Y")
+        print("Y:\n{}\n".format(Y))
+
+        pY = rand_quantization_ref(X)[0]
+        pdecX = dec_ref(Y)[0]
+
+        # The equality check of encoded floating values in bytes may occasionally fail
+        # because of precision.
+        # Refer to the format of floating values here:
+        #   https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+        ## self.assertReferenceChecks(gc, op, [X], rand_quantization_ref)
+        # Instead of using the above assertReferenceChecks, we
+        if not random_:
+            for r in range(0, Y.shape[0]):
+                # compare min
+                np.testing.assert_almost_equal(
+                    struct.unpack('f', Y[r][2:6])[0],
+                    struct.unpack('f', pY[r][2:6])[0])
+                # compare max
+                np.testing.assert_almost_equal(
+                    struct.unpack('f', Y[r][6:10])[0],
+                    struct.unpack('f', pY[r][6:10])[0])
+            np.testing.assert_array_equal(Y[:][0:2], pY[:][0:2])
+            np.testing.assert_array_equal(Y[:][10:], pY[:][10:])
+
+        # check decoded floating values are within error thresholds
+        workspace.RunOperatorOnce(dec_op)
+        decX = workspace.FetchBlob("decX")
+        print("decX:\n{}\n".format(decX))
+        if random_:
+            err_thre = get_allowed_errors(X) + 1e-6
+        else:
+            err_thre = get_allowed_errors(X) / 2.0 + 1e-6
+        err = decX - X
+        print("err_thre:\n{}\n".format(err_thre))
+        print("err:\n{}\n".format(err))
+        np.testing.assert_almost_equal(decX, pdecX, decimal=6)
+
+        np.testing.assert_array_less(
+            np.absolute(err),
+            err_thre)
+
+        # Check over multiple devices -- CUDA implementation is pending
+        # self.assertDeviceChecks(dc, op, [X], [0])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()


### PR DESCRIPTION
This operator implements b (1/2/4/8) bit stochastic quantization of a floating
matrix in a row-wise fashion. 8/b floating values are concatenated to a byte
and returned in uint8 tensor. PR: https://github.com/pytorch/pytorch/pull/8629

