### PR TITLE
Use env var to pass sharding options to test_nn.py

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7610,16 +7610,19 @@ add_test(NewModuleTest(
     fullname='AdaptiveLogSoftmax'))
 
 
-if __name__ == '__main__':
-    num_shards = int(os.environ.get('TEST_NN_NUM_SHARDS', None))
-    shard = int(os.environ.get('TEST_NN_SHARD', None))
-    if num_shards is not None and shard is not None:
-        def load_tests(loader, tests, pattern):
-            test_suite = unittest.TestSuite()
-            for test_group in tests:
-                for test in test_group:
-                    if int(hashlib.sha256(str(test).encode('utf-8')).hexdigest(), 16) % num_shards == shard:
-                        test_suite.addTest(test)
-            return test_suite
+num_shards = os.environ.get('TEST_NN_NUM_SHARDS', None)
+shard = os.environ.get('TEST_NN_SHARD', None)
+if num_shards is not None and shard is not None:
+    num_shards = int(num_shards)
+    shard = int(shard)
+    def load_tests(loader, tests, pattern):
+        test_suite = unittest.TestSuite()
+        for test_group in tests:
+            for test in test_group:
+                if int(hashlib.sha256(str(test).encode('utf-8')).hexdigest(), 16) % num_shards == shard:
+                    test_suite.addTest(test)
+        return test_suite
 
+
+if __name__ == '__main__':
     run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7615,6 +7615,7 @@ shard = os.environ.get('TEST_NN_SHARD', None)
 if num_shards is not None and shard is not None:
     num_shards = int(num_shards)
     shard = int(shard)
+
     def load_tests(loader, tests, pattern):
         test_suite = unittest.TestSuite()
         for test_group in tests:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12,7 +12,7 @@ from functools import wraps, reduce
 from operator import mul
 from collections import OrderedDict
 import hashlib
-import sys
+import os
 
 import torch
 import torch.backends.cudnn as cudnn
@@ -30,7 +30,7 @@ from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
     TEST_SCIPY, IS_WINDOWS, download_file, PY3, PY34, to_gpu, \
-    get_function_arglist, skipCUDAMemoryLeakCheckIf, parser
+    get_function_arglist, skipCUDAMemoryLeakCheckIf
 from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     TEST_CUDNN_VERSION
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
@@ -7611,27 +7611,15 @@ add_test(NewModuleTest(
 
 
 if __name__ == '__main__':
-    parser.add_argument(
-        '--num-shards',
-        type=int,
-        required=False,
-        help='number of shards')
-    parser.add_argument(
-        '--shard',
-        type=int,
-        required=False,
-        help='which shard to run')
-
-    args, remaining = parser.parse_known_args()
-    unittest_args = [sys.argv[0]] + remaining
-
-    if args.num_shards is not None and args.shard is not None:
+    num_shards = int(os.environ.get('TEST_NN_NUM_SHARDS', None))
+    shard = int(os.environ.get('TEST_NN_SHARD', None))
+    if num_shards is not None and shard is not None:
         def load_tests(loader, tests, pattern):
             test_suite = unittest.TestSuite()
             for test_group in tests:
                 for test in test_group:
-                    if int(hashlib.sha256(str(test).encode('utf-8')).hexdigest(), 16) % args.num_shards == args.shard:
+                    if int(hashlib.sha256(str(test).encode('utf-8')).hexdigest(), 16) % num_shards == shard:
                         test_suite.addTest(test)
             return test_suite
 
-    run_tests(unittest_args)
+    run_tests()


### PR DESCRIPTION
Buck doesn't support passing arguments to Python unit tests, and we have to use environment variables to pass the sharding options instead. Also, buck test doesn't go through the `__name__ == '__main__'` code path and we need to move the env var checking logic to top-level.