### PR TITLE
Install vim by default on all Caffe2 docker images.

### DIFF
--- a/docker/caffe2/jenkins/common/install_base.sh
+++ b/docker/caffe2/jenkins/common/install_base.sh
@@ -43,7 +43,8 @@ install_ubuntu() {
           libopencv-dev \
           libpthread-stubs0-dev \
           libsnappy-dev \
-          sudo
+          sudo \
+          vim
 
   # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
   # so we install that here if on 14.04


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@fb.com>

