### PR TITLE
[C++ API] Create pooling functions

### DIFF
--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -1,20 +1,19 @@
 #include "ATen/ATen.h"
-#include "ATen/TensorUtils.h"
+
+#include "ATen/Error.h"
 #include "ATen/NativeFunctions.h"
+#include "ATen/TensorUtils.h"
 
-#include <sstream>
 #include <vector>
-
+#include <tuple>
 
 namespace at { namespace native {
 
 static void check1d(const char* name, IntList x) {
-  if (x.size() != 1) {
-    std::ostringstream ss;
-    ss << "max_pool1d() argument '" << name << "' should contain one int (got "
-       << x.size() << ")";
-    throw std::runtime_error(ss.str());
-  }
+  AT_CHECK(
+      x.size() == 1,
+      "max_pool1d() argument '", name,
+      "' should contain one int (got ", x.size(), ")");
 }
 
 Tensor adaptive_avg_pool1d(const Tensor & self, IntList output_size) {
@@ -65,4 +64,30 @@ std::tuple<Tensor,Tensor> max_pool1d(
   return std::make_tuple(output.squeeze(2), indices.squeeze(2));
 }
 
-}}  // namespace at::native
+Tensor avg_pool1d(
+    const Tensor& self,
+    IntList kernel_size,
+    IntList stride,
+    IntList padding,
+    bool ceil_mode,
+    bool count_include_pad) {
+  if (stride.empty()) {
+    stride = kernel_size;
+  }
+  checkDim("avg_pool1d", TensorArg(self, "self", 1), 3);
+  check1d("kernel_size", kernel_size);
+  check1d("stride", stride);
+  check1d("padding", padding);
+
+  auto output = at::avg_pool2d(
+      self.unsqueeze(2),
+      {1, kernel_size[0]},
+      {1, stride[0]},
+      {0, padding[0]},
+      ceil_mode,
+      count_include_pad);
+
+  return output.squeeze(2);
+}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -75,6 +75,9 @@
     CPU: _acos_out_cpu
     CUDA: _acos_out_cuda
 
+- func: avg_pool1d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, bool ceil_mode=false, bool count_include_pad=true) -> Tensor
+  variants: function
+
 - func: adaptive_avg_pool1d(Tensor self, IntList[1] output_size) -> Tensor
   variants: function
 

--- a/test/cpp/api/pooling.cpp
+++ b/test/cpp/api/pooling.cpp
@@ -1,0 +1,255 @@
+#include <catch.hpp>
+
+#include <torch/functions.h>
+#include <torch/nn/modules/pooling.h>
+
+using namespace torch::nn;
+
+TEST_CASE("Pooling/MaxPool1d") {
+  auto input = torch::arange(0, 10).expand({1, 1, 10});
+
+  {
+    auto output = MaxPool1d(3)->forward({input})[0];
+    REQUIRE(output.numel() == 3);
+    REQUIRE(output.data().allclose(at::tensor({2, 5, 8}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool1d(MaxPool1dOptions(3).stride(1))->forward({input})[0];
+    REQUIRE(output.numel() == 8);
+    REQUIRE(output.data().allclose(
+        at::tensor({2, 3, 4, 5, 6, 7, 8, 9}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool1d(MaxPool1dOptions(3).stride(1).padding(1))
+                      ->forward({input})[0];
+    REQUIRE(output.numel() == 10);
+    REQUIRE(output.data().allclose(
+        at::tensor({1, 2, 3, 4, 5, 6, 7, 8, 9, 9}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool1d(MaxPool1dOptions(3).stride(1).dilation(2))
+                      ->forward({input})[0];
+    REQUIRE(output.numel() == 6);
+    REQUIRE(output.data().allclose(at::tensor({4, 5, 6, 7, 8, 9}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool1d(MaxPool1dOptions(3).ceil_mode(true))->forward({input})[0];
+    REQUIRE(output.numel() == 4);
+    REQUIRE(output.data().allclose(at::tensor({2, 5, 8, 9}, at::kFloat)));
+  }
+}
+
+TEST_CASE("Pooling/MaxPool2d") {
+  auto input = torch::arange(0, 25).reshape({1, 1, 5, 5});
+
+  {
+    auto output = MaxPool2d(2)->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({6, 8, 16, 18}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool2d(MaxPool2dOptions({2, 1}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 5);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({5, 6, 7, 8, 9, 15, 16, 17, 18, 19}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool2d(MaxPool2dOptions(2).stride(3))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({6, 9, 21, 24}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool2d(MaxPool2dOptions(2).stride({1, 2}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 4);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({6, 8, 11, 13, 16, 18, 21, 23}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool2d(MaxPool2dOptions(2).padding(1))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 3);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({0, 2, 4, 10, 12, 14, 20, 22, 24}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool2d(MaxPool2dOptions(2).padding({0, 1}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({5, 7, 9, 15, 17, 19}, at::kFloat)));
+  }
+  {
+    auto output = MaxPool2d(MaxPool2dOptions(2).stride(1).dilation(2))
+                      ->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 3);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({12, 13, 14, 17, 18, 19, 22, 23, 24}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool2d(MaxPool2dOptions(2).dilation({1, 2}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({7, 9, 17, 19}, at::kFloat)));
+  }
+  {
+    auto output =
+        MaxPool2d(MaxPool2dOptions(3).ceil_mode(true))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({12, 14, 22, 24}, at::kFloat)));
+  }
+}
+
+TEST_CASE("Pooling/AvgPool1d") {
+  auto input = torch::arange(0, 10).expand({1, 1, 10});
+
+  {
+    auto output = AvgPool1d(3)->forward({input})[0];
+    REQUIRE(output.numel() == 3);
+    REQUIRE(output.data().allclose(at::tensor({1, 4, 7}, at::kFloat)));
+  }
+  {
+    auto output = AvgPool1d(AvgPool1dOptions(3).stride(1))->forward({input})[0];
+    REQUIRE(output.numel() == 8);
+    REQUIRE(output.data().allclose(
+        at::tensor({1, 2, 3, 4, 5, 6, 7, 8}, at::kFloat)));
+  }
+  {
+    auto output = AvgPool1d(AvgPool1dOptions(3).stride(1).padding(1))
+                      ->forward({input})[0];
+    REQUIRE(output.numel() == 10);
+    REQUIRE(output.data().allclose(at::tensor(
+        {1.0 / 3, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 17.0 / 3},
+        at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool1d(AvgPool1dOptions(3).ceil_mode(true))->forward({input})[0];
+    REQUIRE(output.numel() == 4);
+    REQUIRE(output.data().allclose(at::tensor({1, 4, 7, 9}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool1d(
+            AvgPool1dOptions(3).stride(1).padding(1).count_include_pad(false))
+            ->forward({input})[0];
+    REQUIRE(output.numel() == 10);
+    REQUIRE(output.data().allclose(at::tensor(
+        {0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.5}, at::kFloat)));
+  }
+}
+
+TEST_CASE("Pooling/AvgPool2d") {
+  auto input = torch::arange(0, 25).reshape({1, 1, 5, 5});
+
+  {
+    auto output = AvgPool2d(2)->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({3, 5, 13, 15}, at::kFloat)));
+  }
+  {
+    auto output = AvgPool2d(AvgPool2dOptions({2, 1}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 5);
+    REQUIRE(output.data().flatten().allclose(at::tensor(
+        {2.5, 3.5, 4.5, 5.5, 6.5, 12.5, 13.5, 14.5, 15.5, 16.5}, at::kFloat)));
+  }
+  {
+    auto output = AvgPool2d(AvgPool2dOptions(2).stride(3))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({3, 6, 18, 21}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool2d(AvgPool2dOptions(2).stride({1, 2}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 4);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({3, 5, 8, 10, 13, 15, 18, 20}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool2d(AvgPool2dOptions(2).padding(1))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 3);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(at::tensor(
+        {0.0, 0.75, 1.75, 3.75, 9.0, 11.0, 8.75, 19.0, 21.0}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool2d(AvgPool2dOptions(2).padding({0, 1}))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({1.25, 4.0, 6.0, 6.25, 14.0, 16.0}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool2d(AvgPool2dOptions(3).ceil_mode(true))->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 2);
+    REQUIRE(output.size(3) == 2);
+    REQUIRE(output.data().flatten().allclose(
+        at::tensor({6.0, 8.5, 18.5, 21.0}, at::kFloat)));
+  }
+  {
+    auto output =
+        AvgPool2d(AvgPool2dOptions(2).padding(1).count_include_pad(false))
+            ->forward({input})[0];
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 1);
+    REQUIRE(output.size(2) == 3);
+    REQUIRE(output.size(3) == 3);
+    REQUIRE(output.data().flatten().allclose(at::tensor(
+        {0.0, 1.5, 3.5, 7.5, 9.0, 11.0, 17.5, 19.0, 21.0}, at::kFloat)));
+  }
+}

--- a/test/cpp/api/pooling.cpp
+++ b/test/cpp/api/pooling.cpp
@@ -1,6 +1,5 @@
 #include <catch.hpp>
 
-#include <torch/functions.h>
 #include <torch/nn/modules/pooling.h>
 
 using namespace torch::nn;

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -251,6 +251,7 @@ if (NOT NO_API)
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/embedding.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/functional.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/linear.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/pooling.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/rnn.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/optimizers.cpp
   )
@@ -352,19 +353,20 @@ if (TORCH_BUILD_TEST)
 
     add_executable(test_api
       ${TORCH_API_TEST_DIR}/any.cpp
-      ${TORCH_API_TEST_DIR}/modules.cpp
       ${TORCH_API_TEST_DIR}/cursor.cpp
       ${TORCH_API_TEST_DIR}/integration.cpp
       ${TORCH_API_TEST_DIR}/main.cpp
       ${TORCH_API_TEST_DIR}/misc.cpp
       ${TORCH_API_TEST_DIR}/module.cpp
+      ${TORCH_API_TEST_DIR}/modules.cpp
       ${TORCH_API_TEST_DIR}/optim.cpp
-      ${TORCH_API_TEST_DIR}/sequential.cpp
+      ${TORCH_API_TEST_DIR}/pooling.cpp
       ${TORCH_API_TEST_DIR}/rnn.cpp
+      ${TORCH_API_TEST_DIR}/sequential.cpp
       ${TORCH_API_TEST_DIR}/serialization.cpp
       ${TORCH_API_TEST_DIR}/static.cpp
-      ${TORCH_API_TEST_DIR}/tensor.cpp
       ${TORCH_API_TEST_DIR}/tensor_cuda.cpp
+      ${TORCH_API_TEST_DIR}/tensor.cpp
       # Temporary until ATen tests are built with Caffe2
       ${TORCH_API_TEST_DIR}/tensor_options.cpp
       ${TORCH_API_TEST_DIR}/tensor_options_cuda.cpp

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <torch/expanding_array.h>
+#include <torch/nn/modules/functional.h>
+#include <torch/nn/pimpl.h>
+#include <torch/tensor.h>
+
+#include <ATen/ATen.h>
+
+#include <cstddef>
+#include <functional>
+#include <tuple>
+
+namespace torch {
+namespace nn {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <size_t D>
+struct MaxPoolOptions {
+  MaxPoolOptions(const ExpandingArray<D>& kernel_size);
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+  TORCH_ARG(ExpandingArray<D>, stride); // = kernel_size
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+  TORCH_ARG(ExpandingArray<D>, dilation) = 1;
+  TORCH_ARG(bool, ceil_mode) = false;
+};
+
+namespace detail {
+template <size_t D, typename Derived>
+class MaxPoolImplBase : public FunctionalImpl {
+ public:
+  using MaxPoolFunction = std::function<std::tuple<at::Tensor, at::Tensor>(
+      const at::Tensor&,
+      at::IntList,
+      at::IntList,
+      at::IntList,
+      at::IntList,
+      bool)>;
+
+  explicit MaxPoolImplBase(MaxPoolOptions<D> options, MaxPoolFunction max_pool);
+
+  const MaxPoolOptions<D>& options() const noexcept;
+
+ protected:
+  MaxPoolOptions<D> options_;
+};
+} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using MaxPool1dOptions = MaxPoolOptions<1>;
+
+class MaxPool1dImpl : public detail::MaxPoolImplBase<1, MaxPool1dImpl> {
+ public:
+  explicit MaxPool1dImpl(MaxPool1dOptions options);
+  explicit MaxPool1dImpl(const ExpandingArray<1>& kernel_size);
+};
+
+TORCH_MODULE(MaxPool1d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using MaxPool2dOptions = MaxPoolOptions<2>;
+
+class MaxPool2dImpl : public detail::MaxPoolImplBase<2, MaxPool2dImpl> {
+ public:
+  explicit MaxPool2dImpl(MaxPool2dOptions options);
+  explicit MaxPool2dImpl(const ExpandingArray<2>& kernel_size);
+};
+
+TORCH_MODULE(MaxPool2d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using MaxPool3dOptions = MaxPoolOptions<3>;
+
+class MaxPool3dImpl : public detail::MaxPoolImplBase<3, MaxPool3dImpl> {
+ public:
+  explicit MaxPool3dImpl(MaxPool3dOptions options);
+  explicit MaxPool3dImpl(const ExpandingArray<3>& kernel_size);
+};
+
+TORCH_MODULE(MaxPool3d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <size_t D>
+struct AvgPoolOptions {
+  AvgPoolOptions(const ExpandingArray<D>& kernel_size);
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+  TORCH_ARG(ExpandingArray<D>, stride); // = kernel_size
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+  TORCH_ARG(bool, count_include_pad) = true;
+  TORCH_ARG(bool, ceil_mode) = false;
+};
+
+namespace detail {
+template <size_t D, typename Derived>
+class AvgPoolImplBase : public FunctionalImpl {
+ public:
+  using AvgPoolFunction = std::function<at::Tensor(
+      const at::Tensor&,
+      at::IntList,
+      at::IntList,
+      at::IntList,
+      bool,
+      bool)>;
+
+  explicit AvgPoolImplBase(AvgPoolOptions<D> options, AvgPoolFunction avg_pool);
+
+  const AvgPoolOptions<D>& options() const noexcept;
+
+ protected:
+  AvgPoolOptions<D> options_;
+};
+} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using AvgPool1dOptions = AvgPoolOptions<1>;
+
+class AvgPool1dImpl : public detail::AvgPoolImplBase<1, AvgPool1dImpl> {
+ public:
+  explicit AvgPool1dImpl(AvgPool1dOptions options);
+  explicit AvgPool1dImpl(const ExpandingArray<1>& kernel_size);
+};
+
+TORCH_MODULE(AvgPool1d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using AvgPool2dOptions = AvgPoolOptions<2>;
+
+class AvgPool2dImpl : public detail::AvgPoolImplBase<2, AvgPool2dImpl> {
+ public:
+  explicit AvgPool2dImpl(AvgPool2dOptions options);
+  explicit AvgPool2dImpl(const ExpandingArray<2>& kernel_size);
+};
+
+TORCH_MODULE(AvgPool2d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+using AvgPool3dOptions = AvgPoolOptions<3>;
+
+class AvgPool3dImpl : public detail::AvgPoolImplBase<3, AvgPool3dImpl> {
+ public:
+  explicit AvgPool3dImpl(AvgPool3dOptions options);
+  explicit AvgPool3dImpl(const ExpandingArray<3>& kernel_size);
+};
+
+TORCH_MODULE(AvgPool3d);
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -17,9 +17,9 @@ template <size_t D>
 MaxPoolOptions<D>::MaxPoolOptions(const ExpandingArray<D>& kernel_size)
     : kernel_size_(kernel_size), stride_(kernel_size) {}
 
-template class MaxPoolOptions<1>;
-template class MaxPoolOptions<2>;
-template class MaxPoolOptions<3>;
+template struct MaxPoolOptions<1>;
+template struct MaxPoolOptions<2>;
+template struct MaxPoolOptions<3>;
 
 namespace detail {
 template <size_t D, typename Derived>
@@ -79,9 +79,9 @@ template <size_t D>
 AvgPoolOptions<D>::AvgPoolOptions(const ExpandingArray<D>& kernel_size)
     : kernel_size_(kernel_size), stride_(kernel_size) {}
 
-template class AvgPoolOptions<1>;
-template class AvgPoolOptions<2>;
-template class AvgPoolOptions<3>;
+template struct AvgPoolOptions<1>;
+template struct AvgPoolOptions<2>;
+template struct AvgPoolOptions<3>;
 
 namespace detail {
 template <size_t D, typename Derived>

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -1,0 +1,138 @@
+#include <torch/nn/modules/pooling.h>
+
+#include <torch/expanding_array.h>
+#include <torch/tensor.h>
+
+#include <ATen/ATen.h>
+
+#include <cstddef>
+#include <tuple>
+
+namespace torch {
+namespace nn {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <size_t D>
+MaxPoolOptions<D>::MaxPoolOptions(const ExpandingArray<D>& kernel_size)
+    : kernel_size_(kernel_size), stride_(kernel_size) {}
+
+template class MaxPoolOptions<1>;
+template class MaxPoolOptions<2>;
+template class MaxPoolOptions<3>;
+
+namespace detail {
+template <size_t D, typename Derived>
+MaxPoolImplBase<D, Derived>::MaxPoolImplBase(
+    MaxPoolOptions<D> options,
+    MaxPoolFunction max_pool)
+    : FunctionalImpl([this, max_pool](Variable input) {
+        // ATen pooling functions return (output, indices).
+        return std::get<0>(max_pool(
+            input,
+            this->options_.kernel_size_,
+            this->options_.stride_,
+            this->options_.padding_,
+            this->options_.dilation_,
+            this->options_.ceil_mode_));
+      }),
+      options_(options) {}
+
+template <size_t D, typename Derived>
+const MaxPoolOptions<D>& MaxPoolImplBase<D, Derived>::options() const noexcept {
+  return options_;
+}
+
+template class MaxPoolImplBase<1, MaxPool1d>;
+template class MaxPoolImplBase<2, MaxPool2d>;
+template class MaxPoolImplBase<3, MaxPool3d>;
+
+} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MaxPool1dImpl::MaxPool1dImpl(MaxPool1dOptions options)
+    : detail::MaxPoolImplBase<1, MaxPool1dImpl>(options, at::max_pool1d) {}
+
+MaxPool1dImpl::MaxPool1dImpl(const ExpandingArray<1>& kernel_size)
+    : MaxPool1dImpl(MaxPool1dOptions(kernel_size)) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MaxPool2dImpl::MaxPool2dImpl(MaxPool2dOptions options)
+    : detail::MaxPoolImplBase<2, MaxPool2dImpl>(options, at::max_pool2d) {}
+
+MaxPool2dImpl::MaxPool2dImpl(const ExpandingArray<2>& kernel_size)
+    : MaxPool2dImpl(MaxPool2dOptions(kernel_size)) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MaxPool3dImpl::MaxPool3dImpl(MaxPool3dOptions options)
+    : detail::MaxPoolImplBase<3, MaxPool3dImpl>(options, at::max_pool3d) {}
+
+MaxPool3dImpl::MaxPool3dImpl(const ExpandingArray<3>& kernel_size)
+    : MaxPool3dImpl(MaxPool3dOptions(kernel_size)) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <size_t D>
+AvgPoolOptions<D>::AvgPoolOptions(const ExpandingArray<D>& kernel_size)
+    : kernel_size_(kernel_size), stride_(kernel_size) {}
+
+template class AvgPoolOptions<1>;
+template class AvgPoolOptions<2>;
+template class AvgPoolOptions<3>;
+
+namespace detail {
+template <size_t D, typename Derived>
+AvgPoolImplBase<D, Derived>::AvgPoolImplBase(
+    AvgPoolOptions<D> options,
+    AvgPoolFunction avg_pool)
+    : FunctionalImpl([this, avg_pool](Variable input) {
+        // ATen pooling functions return (output, indices).
+        return avg_pool(
+            input,
+            this->options_.kernel_size_,
+            this->options_.stride_,
+            this->options_.padding_,
+            this->options_.ceil_mode_,
+            this->options_.count_include_pad_);
+      }),
+      options_(options) {}
+
+template <size_t D, typename Derived>
+const AvgPoolOptions<D>& AvgPoolImplBase<D, Derived>::options() const noexcept {
+  return options_;
+}
+
+template class AvgPoolImplBase<1, AvgPool1d>;
+template class AvgPoolImplBase<2, AvgPool2d>;
+template class AvgPoolImplBase<3, AvgPool3d>;
+
+} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AvgPool1dImpl::AvgPool1dImpl(AvgPool1dOptions options)
+    : detail::AvgPoolImplBase<1, AvgPool1dImpl>(options, at::avg_pool1d) {}
+
+AvgPool1dImpl::AvgPool1dImpl(const ExpandingArray<1>& kernel_size)
+    : AvgPool1dImpl(AvgPool1dOptions(kernel_size)) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AvgPool2dImpl::AvgPool2dImpl(AvgPool2dOptions options)
+    : detail::AvgPoolImplBase<2, AvgPool2dImpl>(options, at::avg_pool2d) {}
+
+AvgPool2dImpl::AvgPool2dImpl(const ExpandingArray<2>& kernel_size)
+    : AvgPool2dImpl(AvgPool2dOptions(kernel_size)) {}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AvgPool3dImpl::AvgPool3dImpl(AvgPool3dOptions options)
+    : detail::AvgPoolImplBase<3, AvgPool3dImpl>(options, at::avg_pool3d) {}
+
+AvgPool3dImpl::AvgPool3dImpl(const ExpandingArray<3>& kernel_size)
+    : AvgPool3dImpl(AvgPool3dOptions(kernel_size)) {}
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -26,7 +26,7 @@ template <size_t D, typename Derived>
 MaxPoolImplBase<D, Derived>::MaxPoolImplBase(
     MaxPoolOptions<D> options,
     MaxPoolFunction max_pool)
-    : FunctionalImpl([this, max_pool](Variable input) {
+    : FunctionalImpl([this, max_pool](Tensor input) {
         // ATen pooling functions return (output, indices).
         return std::get<0>(max_pool(
             input,
@@ -88,7 +88,7 @@ template <size_t D, typename Derived>
 AvgPoolImplBase<D, Derived>::AvgPoolImplBase(
     AvgPoolOptions<D> options,
     AvgPoolFunction avg_pool)
-    : FunctionalImpl([this, avg_pool](Variable input) {
+    : FunctionalImpl([this, avg_pool](Tensor input) {
         // ATen pooling functions return (output, indices).
         return avg_pool(
             input,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -212,40 +212,33 @@ def conv_tbc(input, weight, bias, pad=0):
 
 
 # Pooling
-def avg_pool1d(input, kernel_size, stride=None, padding=0,
-               ceil_mode=False, count_include_pad=True):
-    r"""Applies a 1D average pooling over an input signal composed of several
-    input planes.
+avg_pool1d = _add_docstr(torch.avg_pool1d, r"""
+avg_pool1d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
-    See :class:`~torch.nn.AvgPool1d` for details and output shape.
+Applies a 1D average pooling over an input signal composed of several
+input planes.
 
-    Args:
-        input: input tensor of shape (:math:`minibatch \times in\_channels \times iW`)
-        kernel_size: the size of the window. Can be a single number or a
-          tuple `(kW,)`
-        stride: the stride of the window. Can be a single number or a tuple
-          `(sW,)`. Default: :attr:`kernel_size`
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple `(padW,)`. Default: 0
-        ceil_mode: when True, will use `ceil` instead of `floor` to compute the
-            output shape. Default: ``False``
-        count_include_pad: when True, will include the zero-padding in the
-            averaging calculation. Default: ``True``
+See :class:`~torch.nn.AvgPool1d` for details and output shape.
 
-    Example::
-        >>> # pool of square window of size=3, stride=2
-        >>> input = torch.tensor([[[1,2,3,4,5,6,7]]])
-        >>> F.avg_pool1d(input, kernel_size=3, stride=2)
-        tensor([[[ 2.,  4.,  6.]]])
-    """
-    if input.dim() != 3:
-        raise ValueError('expected 3D input (got {} dimensions)'
-                         .format(input.dim()))
-    kernel_size = _single(kernel_size) + (1,)
-    stride = _single(stride) + (1,) if stride is not None else kernel_size
-    padding = _single(padding) + (0,)
-    return avg_pool2d(input.unsqueeze(3), kernel_size, stride, padding,
-                      ceil_mode, count_include_pad).squeeze(3)
+Args:
+    input: input tensor of shape (:math:`minibatch \times in\_channels \times iW`)
+    kernel_size: the size of the window. Can be a single number or a
+      tuple `(kW,)`
+    stride: the stride of the window. Can be a single number or a tuple
+      `(sW,)`. Default: :attr:`kernel_size`
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple `(padW,)`. Default: 0
+    ceil_mode: when True, will use `ceil` instead of `floor` to compute the
+        output shape. Default: ``False``
+    count_include_pad: when True, will include the zero-padding in the
+        averaging calculation. Default: ``True``
+
+Example::
+    >>> # pool of square window of size=3, stride=2
+    >>> input = torch.tensor([[[1,2,3,4,5,6,7]]])
+    >>> F.avg_pool1d(input, kernel_size=3, stride=2)
+    tensor([[[ 2.,  4.,  6.]]])
+""")
 
 
 avg_pool2d = _add_docstr(torch._C._nn.avg_pool2d, r"""


### PR DESCRIPTION
Add pooling modules to C++ API.

Note I also created `at::avg_pool1d` which was currently missing. The Python function now also calls this method. Please check that it is correct. I mostly copied the code from `at::max_pool1d`, which similarly calls into the 2d version. I added plenty of tests for it from C++ side.

@apaszke @ebetica @ezyang 