### PR TITLE
check attribute existence in torch.legay.nn.SpatialFullConvolution in method type

### DIFF
--- a/torch/legacy/nn/SpatialFullConvolution.py
+++ b/torch/legacy/nn/SpatialFullConvolution.py
@@ -191,9 +191,9 @@ class SpatialFullConvolution(Module):
         )
 
     def type(self, type=None, tensorCache=None):
-        if self.finput is not None:
+        if hasattr(self, 'finput') and self.finput is not None:
             self.finput = torch.Tensor()
-        if self.fgradInput is not None:
+        if hasattr(self, 'fgradInput ') and self.fgradInput is not None:
             self.fgradInput = torch.Tensor()
         return super(SpatialFullConvolution, self).type(type, tensorCache)
 

--- a/torch/legacy/nn/SpatialFullConvolution.py
+++ b/torch/legacy/nn/SpatialFullConvolution.py
@@ -193,7 +193,7 @@ class SpatialFullConvolution(Module):
     def type(self, type=None, tensorCache=None):
         if hasattr(self, 'finput') and self.finput is not None:
             self.finput = torch.Tensor()
-        if hasattr(self, 'fgradInput ') and self.fgradInput is not None:
+        if hasattr(self, 'fgradInput') and self.fgradInput is not None:
             self.fgradInput = torch.Tensor()
         return super(SpatialFullConvolution, self).type(type, tensorCache)
 


### PR DESCRIPTION
This is related to #5255 
When adding cuda support for the model, this error comes:
``
AttributeError: 'SpatialFullConvolution' object has no attribute 'finput'
``
here is my short code for test.
https://gist.github.com/kaleaht/26518c3deea5d1d3dda722fbf1f3ecdc

I converted torch7's model also from here.
https://github.com/art-programmer/FloorplanTransformation