### PR TITLE
[c10d] Configurable number of algorithm entries per key

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -36,19 +36,19 @@ PyObject* c10d_init(PyObject* _unused) {
   auto module = py::handle(c10d_module).cast<py::module>();
 
   py::class_<::c10d::BroadcastOptions>(module, "BroadcastOptions")
-    .def(py::init<>())
-    .def_readwrite("rootRank", &::c10d::BroadcastOptions::rootRank)
-    .def_readwrite("rootTensor", &::c10d::BroadcastOptions::rootTensor);
+      .def(py::init<>())
+      .def_readwrite("rootRank", &::c10d::BroadcastOptions::rootRank)
+      .def_readwrite("rootTensor", &::c10d::BroadcastOptions::rootTensor);
 
   py::class_<::c10d::AllreduceOptions>(module, "AllreduceOptions")
-    .def(py::init<>())
-    .def_readwrite("reduceOp", &::c10d::AllreduceOptions::reduceOp);
+      .def(py::init<>())
+      .def_readwrite("reduceOp", &::c10d::AllreduceOptions::reduceOp);
 
   py::enum_<::c10d::ReduceOp>(module, "ReduceOp")
-    .value("SUM", ::c10d::ReduceOp::SUM)
-    .value("PRODUCT", ::c10d::ReduceOp::PRODUCT)
-    .value("MIN", ::c10d::ReduceOp::MIN)
-    .value("MAX", ::c10d::ReduceOp::MAX);
+      .value("SUM", ::c10d::ReduceOp::SUM)
+      .value("PRODUCT", ::c10d::ReduceOp::PRODUCT)
+      .value("MIN", ::c10d::ReduceOp::MIN)
+      .value("MAX", ::c10d::ReduceOp::MAX);
 
   auto store =
       shared_ptr_class_<::c10d::Store>(module, "Store")
@@ -131,9 +131,12 @@ PyObject* c10d_init(PyObject* _unused) {
   shared_ptr_class_<::c10d::ProcessGroupGloo::Options>(
       processGroupGloo, "Options")
       .def(py::init<>())
+      .def_readwrite("devices", &::c10d::ProcessGroupGloo::Options::devices)
       .def_readwrite("timeout", &::c10d::ProcessGroupGloo::Options::timeout)
       .def_readwrite("threads", &::c10d::ProcessGroupGloo::Options::threads)
-      .def_readwrite("devices", &::c10d::ProcessGroupGloo::Options::devices);
+      .def_readwrite(
+          "cacheNumAlgorithmEntries",
+          &::c10d::ProcessGroupGloo::Options::cacheNumAlgorithmEntries);
 
   processGroupGloo.def_static(
       "create_tcp_device",

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -199,14 +199,19 @@ void ProcessGroupGloo::WorkGloo::finishWithException(
 }
 
 ProcessGroupGloo::Options::Options()
-    : timeout(std::chrono::milliseconds(10 * 1000)), threads(2) {}
+    : timeout(std::chrono::milliseconds(10 * 1000)),
+      threads(2),
+      cacheNumAlgorithmEntries(1) {}
 
 ProcessGroupGloo::ProcessGroupGloo(
     const std::shared_ptr<Store>& store,
     int rank,
     int size,
     Options options)
-    : ProcessGroup(rank, size), store_(new GlooStore(store)), stop_(false) {
+    : ProcessGroup(rank, size),
+      store_(new GlooStore(store)),
+      stop_(false),
+      cacheNumAlgorithmEntries_(options.cacheNumAlgorithmEntries) {
   auto& devices = options.devices;
   if (devices.empty()) {
     devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
@@ -411,17 +416,23 @@ EntryType ProcessGroupGloo::construct(const AlgorithmKey& key) {
 }
 
 AlgorithmEntry* ProcessGroupGloo::checkout(const AlgorithmKey& key) {
-  auto it = cache_.find(key);
+  auto& vec = cache_[key];
+  const auto i = cacheCurrentEntry_[key];
 
-  // If there is no entry for this key yet, it must be the first time
-  // we see and can create a new entry. Use hard limit of 1 instance
-  // per key until we add support for a dynamic limit.
-  if (it == cache_.end()) {
-    cache_[key] = construct(key);
-    it = cache_.find(key);
+  // Ensure the cache vector is appropriately sized
+  if (vec.size() != cacheNumAlgorithmEntries_) {
+    vec.resize(cacheNumAlgorithmEntries_);
   }
 
-  auto& entry = it->second;
+  // The next call must use the next entry
+  cacheCurrentEntry_[key] = (i + 1) % cacheNumAlgorithmEntries_;
+
+  // If there is no entry for this key, create a new one
+  if (!vec[i]) {
+    vec[i] = construct(key);
+  }
+
+  auto& entry = vec[i];
 
   // Ensure entry is not in use
   std::unique_lock<std::mutex> lock(entry->m);

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -218,6 +218,13 @@ class ProcessGroupGloo : public ProcessGroup {
     std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
     std::chrono::milliseconds timeout;
     int threads;
+
+    // This controls how many Gloo algorithm instances are created for
+    // a single identifying key. If you have many identical calls with
+    // tensors of identical size and need to parallelize, this should
+    // be greater than 1. More cache entries means more memory usage.
+    // The default value is 1.
+    int cacheNumAlgorithmEntries;
   };
 
   explicit ProcessGroupGloo(
@@ -265,7 +272,9 @@ class ProcessGroupGloo : public ProcessGroup {
   // Checkout constructs new AlgorithmEntry or returns existing one.
   AlgorithmEntry* checkout(const KeyType& key);
 
-  std::unordered_map<KeyType, EntryType, HashType> cache_;
+  const int cacheNumAlgorithmEntries_;
+  std::unordered_map<KeyType, int, HashType> cacheCurrentEntry_;
+  std::unordered_map<KeyType, std::vector<EntryType>, HashType> cache_;
 
   std::shared_ptr<Work> enqueue(AlgorithmEntry* entry);
 

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -272,8 +272,14 @@ class ProcessGroupGloo : public ProcessGroup {
   // Checkout constructs new AlgorithmEntry or returns existing one.
   AlgorithmEntry* checkout(const KeyType& key);
 
+  // The maximum number of cached algorithms for a single key.
   const int cacheNumAlgorithmEntries_;
+
+  // Index of the next algorithm to use for a particular key.
+  // Note that this index must be the same for all particating processes.
   std::unordered_map<KeyType, int, HashType> cacheCurrentEntry_;
+
+  // The list of cached algorithms, by algorithm key.
   std::unordered_map<KeyType, std::vector<EntryType>, HashType> cache_;
 
   std::shared_ptr<Work> enqueue(AlgorithmEntry* entry);


### PR DESCRIPTION
This is relevant for benchmarking where you're dealing with the same operation running against identically sized tensors in parallel. Without this change, they will still run sequentially, because they all run the same cached algorithm instance.