### PR TITLE
[Caffe2] Use virtual dtor for Annotation

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -49,6 +49,7 @@ class Annotation {
 
   Annotation(AnnotationKind K) : Kind(K) {}
   Annotation() : Kind(AnnotationKind::Generic) {}
+  virtual ~Annotation() {}
 
   AnnotationKind getKind() const {
     return Kind;

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -16,6 +16,7 @@ public:
   Caffe2Annotation() : Annotation(AnnotationKind::Caffe2) {}
   Caffe2Annotation(std::string device)
       : Annotation(AnnotationKind::Caffe2), Device(device) {}
+  virtual ~Caffe2Annotation() {}
 
   void setDevice(std::string device) { Device = device; }
   const std::string getDevice() const { return Device; }


### PR DESCRIPTION
The problem is we have setAnnotation whose unique_ptr maintains pointer to base class, while we are creating the derived object Caffe2Annotation. Without virtual dtor, this is undefined behavior and falls through the the check of *SAN, which is really concerning on a separate note.