### PR TITLE
Shard test_nn to reduce runtime for each test target

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -47,14 +47,15 @@ UNITTEST_ARGS = [sys.argv[0]] + remaining
 torch.manual_seed(SEED)
 
 
-def run_tests():
-    unittest.main(argv=UNITTEST_ARGS)
+def run_tests(argv=UNITTEST_ARGS):
+    unittest.main(argv=argv)
 
 PY3 = sys.version_info > (3, 0)
 PY34 = sys.version_info >= (3, 4)
 
 IS_WINDOWS = sys.platform == "win32"
 IS_PPC = platform.machine() == "ppc64le"
+IN_SANDCASTLE = 'IN_SANDCASTLE' in os.environ
 
 TEST_NUMPY = True
 try:


### PR DESCRIPTION
Summary: The current test_nn would time out and be disabled in GreenWarden, and we need to have an option to split it up in order to pass the stress test. Right now GreenWarden roughly allows running 100 test cases in test_nn before timing out, and here we have an option to divide test_nn into 30 shards (with ~40 tests in each shard) to allow for some test suite growth in the future.

Differential Revision: D8592394
