### PR TITLE
Add a new class for an updated prof_dag.proto

### DIFF
--- a/caffe2/contrib/prof/profiling_annotations.h
+++ b/caffe2/contrib/prof/profiling_annotations.h
@@ -3,54 +3,97 @@
 #pragma once
 
 #include "caffe2/contrib/prof/prof_dag_net.h"
-#include "caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h"
-
-using nom::repr::Annotation;
 
 namespace caffe2 {
+namespace contrib {
+namespace prof {
+
+// Accumulates data points and generates two point summary: mean, stddev.
+class TwoNumberStats {
+ public:
+  TwoNumberStats() : sum_(0), squareSum_(0), count_(0) {}
+  // To prepopulate state of the TwoNumberStats accumulator.
+  TwoNumberStats(float mean, float stddev, int count)
+      : sum_(mean * count),
+        squareSum_((stddev * stddev + mean * mean) * count),
+        count_(count) {}
+  void addPoint(float point) {
+    sum_ += point;
+    squareSum_ += point * point;
+    count_++;
+  }
+  float getMean() const {
+    if (count_ == 0) {
+      return 0;
+    }
+    return sum_ / count_;
+  }
+  // Returns population stddev.
+  float getStddev() const {
+    if (count_ == 0) {
+      return 0;
+    }
+    return sqrt((count_ * squareSum_ - sum_ * sum_) / (count_ * count_));
+  }
+
+ private:
+  // Sum of data points.
+  float sum_;
+  // Sum of square of data points.
+  float squareSum_;
+  // Sample count.
+  int count_;
+};
 
 // Annotations used when profiling a NeuralNetOperator.
-class ProfilingOperatorAnnotation : public Annotation {
+class ProfilingOperatorAnnotation {
  public:
-  ProfilingOperatorAnnotation()
-      : Annotation(AnnotationKind::ProfilingOperator) {}
-  // LLVM-style RTTI implementation.
-  static bool classof(const Annotation* annotation) {
-    return annotation->getKind() == AnnotationKind::ProfilingOperator;
-  }
+  ProfilingOperatorAnnotation() {}
+  explicit ProfilingOperatorAnnotation(const ProfDAGProto& stats_proto)
+      : execution_time_ms_(
+            stats_proto.execution_time().mean(),
+            stats_proto.execution_time().stddev(),
+            stats_proto.execution_time().count()) {}
+  ProfilingOperatorAnnotation(ProfilingOperatorAnnotation&&) = default;
   // Accessors
-  const Stats& execution_time_ms() const {
+  const TwoNumberStats& getExecutionTimeMs() const {
     return execution_time_ms_;
   }
-  Stats* mutable_execution_time_ms() {
+  TwoNumberStats* getMutableExecutionTimeMs() {
     return &execution_time_ms_;
   }
 
  private:
   // Statistics for how long this op took to execute.
-  Stats execution_time_ms_;
+  TwoNumberStats execution_time_ms_;
 };
 
-// Annotations used when profiling a NeuralNetData.
-class ProfilingDataAnnotation : public Annotation {
+// Annotations used when profiling a NeuralNetData. Data this class
+// stores is translatable to/from BlobProfile. Note: translation
+// may be lossy due to use of floating point arithmetic.
+class ProfilingDataAnnotation {
  public:
-  ProfilingDataAnnotation() : Annotation(AnnotationKind::ProfilingData) {}
-  // LLVM-style RTTI implementation.
-  static bool classof(const Annotation* annotation) {
-    return annotation->getKind() == AnnotationKind::ProfilingData;
-  }
+  ProfilingDataAnnotation() {}
+  explicit ProfilingDataAnnotation(const BlobProfile& profile)
+      : used_bytes_(
+            profile.bytes_used().mean(),
+            profile.bytes_used().stddev(),
+            profile.bytes_used().count()) {}
+  ProfilingDataAnnotation(ProfilingDataAnnotation&&) = default;
   // Accessors
-  const Stats& used_bytes() const {
+  const TwoNumberStats& getUsedBytes() const {
     return used_bytes_;
   }
-  Stats* mutable_used_bytes() {
+  TwoNumberStats* getMutableUsedBytes() {
     return &used_bytes_;
   }
 
  private:
   // Statistics for how much data this tensor/parameter used (per invocation of
   // the op that generated the data).
-  Stats used_bytes_;
+  TwoNumberStats used_bytes_;
 };
 
+} // namespace prof
+} // namespace contrib
 } // namespace caffe2

--- a/caffe2/contrib/prof/profiling_annotations_test.cc
+++ b/caffe2/contrib/prof/profiling_annotations_test.cc
@@ -4,24 +4,41 @@
 #include <gtest/gtest.h>
 
 namespace caffe2 {
+namespace contrib {
+namespace prof {
 namespace {
 
-TEST(ProfilingAnnotationsTest, BasicAccess) {
+TEST(TwoNumberStatsTest, ComputeAndGetOpStatsSummary) {
+  // e.g., 2 and 3
+  TwoNumberStats stats;
+  stats.addPoint(2);
+  stats.addPoint(3);
+  EXPECT_FLOAT_EQ(2.5, stats.getMean());
+  // Population standard deviation.
+  EXPECT_FLOAT_EQ(0.5, stats.getStddev());
+}
+
+TEST(TwoNumberStatsTest, TestRestore) {
+  // Expect that restore&recompute is still the same.
+  // E.g., 2 and 3 (above).
+  TwoNumberStats stats(2.5, 0.5, 2);
+  // Expect that restore&recompute is still the same.
+  EXPECT_FLOAT_EQ(2.5, stats.getMean());
+  // Population standard deviation.
+  EXPECT_FLOAT_EQ(0.5, stats.getStddev());
+}
+
+TEST(ProfilingAnnotationsTest, BasicAccessToActiveData) {
   ProfilingOperatorAnnotation op_annotation;
-  op_annotation.mutable_execution_time_ms()->sum = 5;
+  op_annotation.getMutableExecutionTimeMs()->addPoint(5);
+  EXPECT_EQ(5, op_annotation.getExecutionTimeMs().getMean());
+
   ProfilingDataAnnotation data_annotation;
-  data_annotation.mutable_used_bytes()->sum = 7;
-  auto* op_annotation_ptr =
-      dyn_cast<ProfilingOperatorAnnotation>(&op_annotation);
-  ASSERT_NE(nullptr, op_annotation_ptr);
-  EXPECT_EQ(5, op_annotation_ptr->execution_time_ms().sum);
-  auto* data_annotation_ptr =
-      dyn_cast<ProfilingDataAnnotation>(&data_annotation);
-  ASSERT_NE(nullptr, data_annotation_ptr);
-  EXPECT_EQ(7, data_annotation_ptr->used_bytes().sum);
-  EXPECT_EQ(nullptr, dyn_cast<ProfilingOperatorAnnotation>(&data_annotation));
-  EXPECT_EQ(nullptr, dyn_cast<ProfilingDataAnnotation>(&op_annotation));
+  data_annotation.getMutableUsedBytes()->addPoint(7);
+  EXPECT_EQ(7, data_annotation.getUsedBytes().getMean());
 }
 
 } // namespace
+} // namespace prof
+} // namespace contrib
 } // namespace caffe2

--- a/caffe2/contrib/prof/profiling_info.cc
+++ b/caffe2/contrib/prof/profiling_info.cc
@@ -1,0 +1,71 @@
+// Implements ProfilingInfo class.
+#include "caffe2/contrib/prof/profiling_info.h"
+
+namespace caffe2 {
+namespace contrib {
+namespace prof {
+
+bool ProfilingInfo::Init(const NetDef& netDef, const ProfDAGProtos& profile) {
+  blobMap_.clear();
+  operatorMap_.clear();
+  bool success = true;
+  int opIdx = 0;
+  for (const auto& op : netDef.op()) {
+    if (!addOperatorAnnotation(profile, opIdx, op.name())) {
+      success = false;
+    }
+    int blobIdx = 0;
+    for (const auto& output : op.output()) {
+      if (!addDataAnnotation(profile, opIdx, blobIdx, output)) {
+        success = false;
+      }
+      ++blobIdx;
+    }
+    ++opIdx;
+  }
+  return success;
+}
+
+bool ProfilingInfo::addOperatorAnnotation(
+    const ProfDAGProtos& profile,
+    int idx,
+    const string& opName) {
+  if (idx >= profile.stats_size()) {
+    LOG(ERROR) << __func__ << ": indexing " << idx << " within "
+               << profile.stats_size();
+    return false;
+  }
+  const auto& op_node = profile.stats(idx);
+  if (op_node.name() != opName) {
+    LOG(ERROR) << "Unmatched name in ProfDAGProtos and NetDef. Respectively: "
+               << op_node.name() << ", " << opName;
+    return false;
+  }
+  return operatorMap_.emplace(idx, ProfilingOperatorAnnotation(op_node)).second;
+}
+
+bool ProfilingInfo::addDataAnnotation(
+    const ProfDAGProtos& profile,
+    int opIdx,
+    int blobIdx,
+    const string& output_name) {
+  if (opIdx >= profile.stats_size() ||
+      blobIdx >= profile.stats(opIdx).output_profile_size()) {
+    LOG(ERROR) << __func__ << ": indexing " << opIdx << " within "
+               << profile.stats_size() << ", and " << blobIdx << "within"
+               << profile.stats(opIdx).output_profile_size();
+    return false;
+  }
+  const auto& data_node = profile.stats(opIdx).output_profile(blobIdx);
+  if (output_name != data_node.name()) {
+    LOG(ERROR) << "Unmatched name in ProfDAGProtos and NetDef. Respectively: "
+               << data_node.name() << ", " << output_name;
+    return false;
+  }
+  return blobMap_.emplace(output_name, ProfilingDataAnnotation(data_node))
+      .second;
+}
+
+} // namespace prof
+} // namespace contrib
+} // namespace caffe2

--- a/caffe2/contrib/prof/profiling_info.h
+++ b/caffe2/contrib/prof/profiling_info.h
@@ -1,0 +1,54 @@
+// Defines the class for storing profiling information for a neural net.
+#pragma once
+
+#include <unordered_map>
+
+#include "caffe2/contrib/prof/profiling_annotations.h"
+
+namespace caffe2 {
+namespace contrib {
+namespace prof {
+
+// Holds the profiling data for the execution of a net.
+class ProfilingInfo {
+ public:
+  using BlobMapType = std::unordered_map<std::string, ProfilingDataAnnotation>;
+  using OperatorMapType = std::unordered_map<int, ProfilingOperatorAnnotation>;
+  // Generates a fresh data structured to be initialized. Use Init() below to
+  // restore a previous profile.
+  ProfilingInfo() {}
+  // Uses ProfDAGProtos for existing profile, and NetDef for graph definition,
+  // and restores the state. Returns whether profile and net_def were
+  // consistent. This is defined over the "indices" of operators and outputs:
+  // the indices within the net_def should exist with the profile, and the names
+  // should match. Errors are handled with best effort: matching state is
+  // populated.
+  bool Init(const NetDef& net_def, const ProfDAGProtos& profile);
+  // Accessors.
+  const BlobMapType& getBlobMap() {
+    return blobMap_;
+  }
+  const OperatorMapType& getOperatorMap() {
+    return operatorMap_;
+  }
+
+ private:
+  bool addOperatorAnnotation(
+      const ProfDAGProtos& profile,
+      int idx,
+      const string& opName);
+  bool addDataAnnotation(
+      const ProfDAGProtos& profile,
+      int opIdx,
+      int blobIdx,
+      const string& output_name);
+
+  // Maps blob name to its node int he dataFlowGraph_.
+  BlobMapType blobMap_;
+  // Maps a node index to its NodeRef.
+  OperatorMapType operatorMap_;
+};
+
+} // namespace prof
+} // namespace contrib
+} // namespace caffe2

--- a/caffe2/contrib/prof/profiling_info_test.cc
+++ b/caffe2/contrib/prof/profiling_info_test.cc
@@ -1,0 +1,151 @@
+// Unit tests for ProfilingInfo.
+#include "caffe2/contrib/prof/profiling_info.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "caffe2/utils/proto_utils.h"
+
+namespace caffe2 {
+namespace contrib {
+namespace prof {
+namespace {
+
+const char* kTestProfile = R"(
+  stats {
+    name: "op1"
+    mean: 0
+    stddev: 0
+
+    execution_time {
+      mean: 5
+      stddev: 7
+      count: 11
+    }
+
+    output_profile {
+      name: "var1"
+      bytes_used {
+        mean: 13
+        stddev: 17
+        count: 10
+      }
+    }
+    output_profile {
+      name: "var12"
+      bytes_used {
+        mean: 43
+        stddev: 47
+        count: 53
+      }
+    }
+  }
+  stats {
+    name: ""
+    mean: 0
+    stddev: 0
+
+    execution_time {
+      mean: 19
+      stddev: 23
+      count: 29
+    }
+
+    output_profile {
+      name: "var2"
+
+      bytes_used {
+        mean: 31
+        stddev: 37
+        count: 41
+      }
+    }
+  }
+)";
+
+const char* kTestNetDefCorrect = R"(
+  op {
+    name: "op1"
+    output: "var1"
+    output: "var12"
+  }
+  op {
+    name: ""
+    output: "var2"
+  }
+)";
+
+const char* kTestNetDefPartial = R"(
+  op {
+    name: "op1"
+    output: "var1"
+  }
+  op {
+    name: ""
+    output: "var_NET_WRONG"
+  }
+  op {
+    name: "op_NET_WRONG"
+  }
+)";
+
+TEST(ProfilingInfo, CorrectParse) {
+  NetDef net_def;
+  ProfDAGProtos profile;
+  ASSERT_TRUE(TextFormat::ParseFromString(string(kTestProfile), &profile));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(string(kTestNetDefCorrect), &net_def));
+  ProfilingInfo info;
+  EXPECT_TRUE(info.Init(net_def, profile));
+  EXPECT_EQ(3, info.getBlobMap().size());
+  EXPECT_EQ(2, info.getOperatorMap().size());
+
+  auto it = info.getBlobMap().find("var1");
+  ASSERT_NE(info.getBlobMap().end(), it);
+  EXPECT_FLOAT_EQ(13, it->second.getUsedBytes().getMean());
+
+  it = info.getBlobMap().find("var12");
+  ASSERT_NE(info.getBlobMap().end(), it);
+  EXPECT_FLOAT_EQ(47, it->second.getUsedBytes().getStddev());
+
+  it = info.getBlobMap().find("var2");
+  ASSERT_NE(info.getBlobMap().end(), it);
+  EXPECT_FLOAT_EQ(31, it->second.getUsedBytes().getMean());
+
+  auto it2 = info.getOperatorMap().find(0);
+  ASSERT_NE(info.getOperatorMap().end(), it2);
+  EXPECT_FLOAT_EQ(5, it2->second.getExecutionTimeMs().getMean());
+
+  it2 = info.getOperatorMap().find(1);
+  ASSERT_NE(info.getOperatorMap().end(), it2);
+  EXPECT_FLOAT_EQ(23, it2->second.getExecutionTimeMs().getStddev());
+}
+
+TEST(ProfilingInfo, PartialParse) {
+  NetDef net_def;
+  ProfDAGProtos profile;
+  ASSERT_TRUE(TextFormat::ParseFromString(string(kTestProfile), &profile));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(string(kTestNetDefPartial), &net_def));
+  ProfilingInfo info;
+  EXPECT_FALSE(info.Init(net_def, profile));
+  EXPECT_EQ(1, info.getBlobMap().size());
+  EXPECT_EQ(2, info.getOperatorMap().size());
+
+  auto it = info.getBlobMap().find("var1");
+  ASSERT_NE(info.getBlobMap().end(), it);
+  EXPECT_FLOAT_EQ(13, it->second.getUsedBytes().getMean());
+
+  auto it2 = info.getOperatorMap().find(0);
+  ASSERT_NE(info.getOperatorMap().end(), it2);
+  EXPECT_FLOAT_EQ(5, it2->second.getExecutionTimeMs().getMean());
+
+  it2 = info.getOperatorMap().find(1);
+  ASSERT_NE(info.getOperatorMap().end(), it2);
+  EXPECT_FLOAT_EQ(23, it2->second.getExecutionTimeMs().getStddev());
+}
+
+} // namespace
+} // namespace prof
+} // namespace contrib
+} // namespace caffe2

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -40,12 +40,7 @@ class NeuralNetData;
 /// to use them.
 class Annotation {
  public:
-  enum class AnnotationKind {
-    Generic,
-    Caffe2,
-    ProfilingOperator,
-    ProfilingData
-  };
+  enum class AnnotationKind { Generic, Caffe2 };
 
   Annotation(AnnotationKind K) : Kind(K) {}
   Annotation() : Kind(AnnotationKind::Generic) {}

--- a/caffe2/proto/prof_dag.proto
+++ b/caffe2/proto/prof_dag.proto
@@ -8,10 +8,27 @@ package caffe2;
 // (2) We do not use extension because that used to create quite some conflicts
 //     in Caffe's protobuf design.
 // (3) We have not used any proto3 specific features, such as Any or Map. This
-//     is mainly for backward compability purposes but we may consider using
+//     is mainly for backward compatibility purposes but we may consider using
 //     those in the future.
 
-// Protobuf format to serialize profiler data
+// A two number summary for a value. It also has count for restoring.
+message TwoNumberStatsProto {
+  optional float mean = 1;
+  optional float stddev = 2;
+  optional int64 count = 3;
+}
+
+// Blob profiling information. Profile for a blob is created every time
+// a node outputs to the blob.
+message BlobProfile {
+  // Name of the blob (corresponds to OperatorDef.output).
+  optional string name = 1;  // required
+
+  // Profiling statistics.
+  optional TwoNumberStatsProto bytes_used = 3;
+}
+
+// Protobuf format to serialize profiler data.
 message ProfDAGProto {
   // The name for the operator
   required string name = 1;
@@ -19,8 +36,20 @@ message ProfDAGProto {
   required float mean = 2;
   // The standard deviation
   required float stddev = 3;
+
+  // New field to represent the numbers above, and with count.
+  optional TwoNumberStatsProto execution_time = 4;
+
+  // Blob profiles that this node outputs.
+  repeated BlobProfile output_profile = 5;
 }
 
+// Operator profiling information.
+//
+// Note: The indices for elements of 'stats' and the indices of
+// 'output_profile' inside each 'stats' are assumed to match the
+// indices of 'op' elements of a corresponding NetDef and the 'output'
+// indices within each 'op'.
 message ProfDAGProtos {
   repeated ProfDAGProto stats = 1;
 }


### PR DESCRIPTION
This diff contains:
- An updated prof_dag.proto that contains blob profiles.
- A class to deserialize this information (serialization is in a follow up diff)
- Update to separate profiling information from NeuralNet (and use it as part of the class above).
- Unit tests

