### PR TITLE
Add CUDA to logspace and linspace declarations in Declarations.cwrap

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1974,6 +1974,7 @@
     - Double
   backends:
     - CPU
+    - CUDA
   variants:
     - function
   return: argument 0
@@ -1993,6 +1994,7 @@
     - Double
   backends:
     - CPU
+    - CUDA
   variants:
     - function
   return: argument 0

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1678,6 +1678,16 @@ class TestCuda(TestCase):
             torch.arange(0, 10, out=b)
             self.assertEqual(a, b.cuda())
 
+    def test_linspace(self):
+        a = torch.linspace(0, 10, 10, device='cuda')
+        b = torch.linspace(0, 10, 10)
+        self.assertEqual(a, b.cuda())
+
+    def test_logspace(self):
+        a = torch.logspace(1, 10, 10, device='cuda')
+        b = torch.logspace(1, 10, 10)
+        self.assertEqual(a, b.cuda())
+
     def test_diagonal(self):
         TestTorch._test_diagonal(self, dtype=torch.float32, device='cuda')
 


### PR DESCRIPTION
These functions are already implemented, but were not exposed. Fixes https://github.com/pytorch/pytorch/issues/8786 and https://github.com/pytorch/pytorch/issues/1070 .

