### PR TITLE
[README.md] Use GitLab URL for CMake

### DIFF
--- a/cmake/Modules_CUDA_fix/README.md
+++ b/cmake/Modules_CUDA_fix/README.md
@@ -23,5 +23,5 @@ to allow submodules to use these fixes because we can't patch their
 `CMakeList.txt`.
 
 If you need to update files under `./upstream` folder, we recommend you issue PRs
-against [the CMake mainline branch](https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA.cmake),
+against [the CMake mainline branch](https://gitlab.kitware.com/cmake/cmake/tree/master/Modules/FindCUDA.cmake),
 and then backport it here for earlier CMake compatibility.

--- a/cmake/Modules_CUDA_fix/upstream/README.md
+++ b/cmake/Modules_CUDA_fix/upstream/README.md
@@ -1,5 +1,5 @@
 If you need to update files under this folder, we recommend you issue PRs
-against [the CMake mainline branch](https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA.cmake),
+against [the CMake mainline branch](https://gitlab.kitware.com/cmake/cmake/tree/master/Modules/FindCUDA.cmake),
 and then backport it here for earlier CMake compatibility.
 
 See [this](../README.md) for more details.


### PR DESCRIPTION
CMake has moved to GitLab. Use that as the URL if people want to submit patch upstream.