### PR TITLE
Set MKL VML error mode to ignore

### DIFF
--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -56,11 +56,11 @@ inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
   inline void v##op(scalar_t* out, scalar_t* in, int64_t size);               \
   template <>                                                                 \
   inline void v##op(float* out, float* in, int64_t size) {                    \
-    vms##mklop(size, in, out, VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_DEFAULT); \
+    vms##mklop(size, in, out, VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_IGNORE); \
   }                                                                           \
   template <>                                                                 \
   inline void v##op(double* out, double* in, int64_t size) {                  \
-    vmd##mklop(size, in, out, VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_DEFAULT); \
+    vmd##mklop(size, in, out, VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_IGNORE); \
   }
 
 // NB: abs, cosh and sinh were temporarily disabled due to issues with Apple clang

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -263,6 +263,7 @@ class TestTorch(TestCase):
         if input is None:
             input = []
             input.append(list(range(-5, 5)))
+            input.append([0 for x in range(-5, 5)])
             input.append([x + 1e-6 for x in range(-5, 5)])
             # Some vectorized implementations don't support large ranges
             input.append([x + 1e10 for x in range(-5, 5)])


### PR DESCRIPTION
Consistent with [Caffe2 settings](https://github.com/pytorch/pytorch/blob/master/caffe2/utils/math_cpu.cc#L534).