### PR TITLE
Add a Constant Propagation Pass to the JIT

### DIFF
--- a/test/expect/TestJit.test_constant_prop_nested.expect
+++ b/test/expect/TestJit.test_constant_prop_nested.expect
@@ -1,0 +1,15 @@
+graph(%a : Dynamic) {
+  %1 : Dynamic = aten::lt[other={2}](%a)
+  %2 : int = prim::TensorToNum(%1)
+  %c : int = prim::If(%2)
+    block0() {
+      %4 : int = prim::Constant[value=5]()
+      -> (%4)
+    }
+    block1() {
+      %5 : int = prim::Constant[value=1]()
+      -> (%5)
+    }
+  %6 : Long() = prim::NumToTensor(%c)
+  return (%6);
+}

--- a/test/expect/TestJit.test_constant_prop_nested.expect
+++ b/test/expect/TestJit.test_constant_prop_nested.expect
@@ -1,15 +1,16 @@
 graph(%a : Dynamic) {
-  %1 : Dynamic = aten::lt[other={2}](%a)
-  %2 : int = prim::TensorToNum(%1)
-  %c : int = prim::If(%2)
+  %1 : int = prim::Constant[value=2]()
+  %2 : Dynamic = aten::lt(%a, %1)
+  %3 : int = prim::TensorToNum(%2)
+  %c : int = prim::If(%3)
     block0() {
-      %4 : int = prim::Constant[value=5]()
-      -> (%4)
-    }
-    block1() {
-      %5 : int = prim::Constant[value=1]()
+      %5 : int = prim::Constant[value=5]()
       -> (%5)
     }
-  %6 : Long() = prim::NumToTensor(%c)
-  return (%6);
+    block1() {
+      %6 : int = prim::Constant[value=1]()
+      -> (%6)
+    }
+  %7 : Long() = prim::NumToTensor(%c)
+  return (%7);
 }

--- a/test/expect/TestJit.test_constant_prop_print.expect
+++ b/test/expect/TestJit.test_constant_prop_print.expect
@@ -1,0 +1,9 @@
+graph(%input_tensor : Dynamic) {
+  %1 : int = prim::Constant[value=6]()
+  %2 : Dynamic = ^FIXME_zerol()()
+  %a : Dynamic = aten::add(%1, %2)
+   = prim::Print(%a)
+  %b : Dynamic = aten::add[other={2}, alpha={1}](%a)
+  %5 : Dynamic = aten::add[alpha={1}](%b, %input_tensor)
+  return (%5);
+}

--- a/test/expect/TestJit.test_constant_prop_print.expect
+++ b/test/expect/TestJit.test_constant_prop_print.expect
@@ -3,7 +3,10 @@ graph(%input_tensor : Dynamic) {
   %2 : Dynamic = ^FIXME_zerol()()
   %a : Dynamic = aten::add(%1, %2)
    = prim::Print(%a)
-  %b : Dynamic = aten::add[other={2}, alpha={1}](%a)
-  %5 : Dynamic = aten::add[alpha={1}](%b, %input_tensor)
-  return (%5);
+  %4 : int = prim::Constant[value=2]()
+  %5 : int = prim::Constant[value=1]()
+  %b : Dynamic = aten::add(%a, %4, %5)
+  %7 : int = prim::Constant[value=1]()
+  %8 : Dynamic = aten::add(%b, %input_tensor, %7)
+  return (%8);
 }

--- a/test/expect/TestJit.test_constant_prop_rand.expect
+++ b/test/expect/TestJit.test_constant_prop_rand.expect
@@ -4,6 +4,8 @@ graph() {
   %2 : int[] = prim::Constant[value=[0, -1]]()
   %3 : int[] = prim::Constant[value=[3]]()
   %a : Dynamic = aten::randn(%3, %0, %1, %2)
-  %b : Dynamic = aten::add[other={2}, alpha={1}](%a)
+  %5 : int = prim::Constant[value=2]()
+  %6 : int = prim::Constant[value=1]()
+  %b : Dynamic = aten::add(%a, %5, %6)
   return (%b);
 }

--- a/test/expect/TestJit.test_constant_prop_rand.expect
+++ b/test/expect/TestJit.test_constant_prop_rand.expect
@@ -1,0 +1,9 @@
+graph() {
+  %0 : int = prim::Constant[value=6]()
+  %1 : int = prim::Constant[value=0]()
+  %2 : int[] = prim::Constant[value=[0, -1]]()
+  %3 : int[] = prim::Constant[value=[3]]()
+  %a : Dynamic = aten::randn(%3, %0, %1, %2)
+  %b : Dynamic = aten::add[other={2}, alpha={1}](%a)
+  return (%b);
+}

--- a/test/expect/TestJit.test_constant_prop_simple.expect
+++ b/test/expect/TestJit.test_constant_prop_simple.expect
@@ -1,0 +1,5 @@
+graph(%input_tensor : Dynamic) {
+  %1 : int = prim::Constant[value=8]()
+  %2 : Dynamic = aten::add(%1, %input_tensor)
+  return (%2);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1111,6 +1111,87 @@ class TestJit(JitTestCase):
         ten = torch.rand(3, 3)
         self.assertEqual(test_fn(ten, mask), traced_test_fn(ten, mask))
 
+    def test_constant_prop_simple(self):
+        @torch.jit.script
+        def constant_prop(input_tensor):
+            a = 2 * 3
+            b = a + 2
+            return b + input_tensor
+
+        x = torch.tensor(2)
+        out_ref = constant_prop(x)
+        self.run_pass('constant_propagation', constant_prop.graph)
+        out_test = constant_prop(torch.tensor(2))
+        self.assertEqual(out_ref, out_test)
+        self.assertExpected(canonical(constant_prop.graph))
+
+    def test_constant_prop_nested(self):
+        @torch.jit.script
+        def constant_prop(a):
+            b = 2 + 1
+            if a < 2:
+                c = b + 2
+            else:
+                c = b - 2
+            return c
+
+        out_ref = constant_prop(torch.tensor(2))
+        self.run_pass('constant_propagation', constant_prop.graph)
+        out_test = constant_prop(torch.tensor(2))
+        self.assertEqual(out_ref, out_test)
+        self.assertExpected(canonical(constant_prop.graph))
+
+    def test_constant_prop_print(self):
+        @torch.jit.script
+        def constant_prop(input_tensor):
+            a = 2 * 3 + FIXME_zerol()
+            print(a)
+            b = a + 2
+            return b + input_tensor
+
+        self.run_pass('constant_propagation', constant_prop.graph)
+        self.assertExpected(canonical(constant_prop.graph))
+
+    def test_constant_prop_rand(self):
+        @torch.jit.script
+        def constant_prop():
+            a = torch.randn([3])
+            b = a + 2
+            return b
+
+        self.run_pass('constant_propagation', constant_prop.graph)
+        self.assertExpected(canonical(constant_prop.graph))
+
+    # TODO: implement
+    @unittest.expectedFailure
+    def test_constant_prop_if_constant(self):
+        @torch.jit.script
+        def constant_prop():
+            b = 3
+            if True:
+                b = 1
+            if False:
+                b = 2
+            return b
+
+        self.run_pass('constant_propagation', constant_prop.graph)
+        self.assertExpected(canonical(constant_prop.graph))
+
+    # TODO: implement
+    @unittest.expectedFailure
+    def test_constant_prop_loop_constant(self):
+        @torch.jit.script
+        def constant_prop():
+            b = 0
+            while True:
+                b = 1
+            while False:
+                b = 2
+            return b
+
+        self.run_pass('constant_propagation', constant_prop.graph)
+        self.assertExpected(canonical(constant_prop.graph))
+
 
 class TestBatched(TestCase):
     # generate random examples and create an batchtensor with them

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -138,6 +138,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/canonicalize.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/constant_propagation.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/common_subexpression_elimination.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/create_autodiff_subgraphs.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/dead_code_elimination.cpp

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -21,6 +21,7 @@
 #include "torch/csrc/jit/passes/specialize_undef.h"
 #include "torch/csrc/jit/passes/loop_unrolling.h"
 #include "torch/csrc/jit/passes/lower_grad_of.h"
+#include "torch/csrc/jit/passes/constant_propagation.h"
 #include "torch/csrc/jit/symbolic_variable.h"
 #include "torch/csrc/jit/ivalue.h"
 
@@ -554,7 +555,7 @@ void runOptimization(std::shared_ptr<Graph> & graph, bool graphMustSupportVariab
 
     // They also may assume that concrete sizes/strides are availiable
     UnrollLoops(graph);
-
+    ConstantPropagation(graph);
     //TODO: create peephole optimizations that are safe to run
     // when we are using variables, and when we do not know sizes.
     PeepholeOptimize(graph);

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -18,6 +18,7 @@
 #include "torch/csrc/jit/passes/onnx/fixup_onnx_loop.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/decompose_addmm.h"
+#include "torch/csrc/jit/passes/constant_propagation.h"
 #include "torch/csrc/jit/passes/loop_unrolling.h"
 #include "torch/csrc/jit/passes/to_batch.h"
 #include "torch/csrc/jit/passes/specialize_undef.h"
@@ -75,6 +76,9 @@ void initJITBindings(PyObject *module) {
    .def("_jit_pass_remove_expands", RemoveExpands)
    .def("_jit_pass_erase_number_types", EraseNumberTypes)
    .def("_jit_pass_loop_unrolling", UnrollLoops)
+   .def("_jit_pass_constant_propagation", [](std::shared_ptr<Graph>& g) {
+     return ConstantPropagation(g);
+   })
    .def("_jit_run_cpp_tests", [] {
      // We have to release the GIL inside this method, because if we happen to
      // initialize the autograd engine in these tests, the newly spawned worker threads will

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -1,0 +1,95 @@
+#include "torch/csrc/jit/passes/constant_propagation.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/constants.h"
+#include "torch/csrc/jit/interpreter.h"
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/ivalue.h"
+#include "torch/csrc/jit/operator.h"
+#include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/utils/functional.h"
+
+namespace torch { namespace jit {
+
+namespace {
+
+std::unordered_set<Symbol> skip_list = {
+  //FIXME If & Loop require special casing because they cannot be run as a
+  //single node.
+  prim::If,
+  prim::Loop,
+  //FIXME Same problem as in DCE - cpp & python PythonOp and CppOp should be
+  //FIXME treated as having side effects but ONNX depends on them being removed
+  prim::Print,
+  //all the rand functions from native_functions.yaml
+  aten::permute,
+  aten::rand,
+  aten::rand_out,
+  aten::rand_like,
+  aten::randint,
+  aten::randint_out,
+  aten::randint_like,
+  aten::randn,
+  aten::randn_out,
+  aten::randn_like,
+  aten::randperm,
+  aten::randperm_out,
+ };
+
+std::vector<IValue> runNode(Node* n) {
+  auto op = getOperation(n);
+  Stack stack;
+  for (auto input : n->inputs()) {
+    stack.push_back(*(toIValue(input)));
+  }
+  op(stack);
+  auto var_outputs = fmap(stack, [&](IValue v) {
+    if (v.isTensor()) {
+      return IValue(autograd::as_variable_ref(v.toTensor()).data());
+    } else {
+      return v;
+    }
+  });
+  return var_outputs;
+}
+
+void propagateNode(Node* n) {
+  auto outputs = runNode(n);
+  auto graph = n->owningGraph();
+  WithInsertPoint guard(n);
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    auto new_output = insertConstant(*graph, outputs[i]);
+    n->outputs()[i]->replaceAllUsesWith(new_output);
+    // let dce elimination remove n
+  }
+}
+
+} // anonymous namespace
+
+void ConstantPropagation(Node* n, bool recurse) {
+  bool constant_inputs = (n->inputs().size() > 0) &&
+    std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
+      return v->node()->kind() == prim::Constant;
+    });
+  bool supported_node = skip_list.count(n->kind()) == 0;
+  if (constant_inputs && supported_node) {
+    propagateNode(n);
+  }
+  if (recurse) {
+    for (Block * block : n->blocks())
+      ConstantPropagation(block, recurse);
+  }
+}
+
+void ConstantPropagation(Block* block, bool recurse) {
+  ConstantPropagation(block->param_node(), recurse);
+  for (auto n: block->nodes()) {
+    ConstantPropagation(n, recurse);
+  }
+}
+
+void ConstantPropagation(std::shared_ptr<Graph>& graph) {
+  ConstantPropagation(graph->block(), true);
+  EliminateDeadCode(graph);
+}
+
+}}

--- a/torch/csrc/jit/passes/constant_propagation.h
+++ b/torch/csrc/jit/passes/constant_propagation.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+TORCH_API void ConstantPropagation(std::shared_ptr<Graph>& graph);
+TORCH_API void ConstantPropagation(Block* block, bool recurse);
+TORCH_API void ConstantPropagation(Node* n, bool recurse);
+
+}}


### PR DESCRIPTION
Adding a constant propagation pass to the JIT. I have added examples to the expect files. 

There are a couple of special cases which have not been implemented here. IF nodes with constant conditions can be inlined with the correct block. WHILE nodes can be removed if the condition is false.  I have added a test for each case in test_jit.py file as expected failures.

To be consistent with DCE, python ops & CPP ops are treated as not having side-effects.  