### PR TITLE
Implement calling of c10 ops from c2

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -14,6 +14,8 @@
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 
+#include "caffe2/core/operator_c10wrapper.h"
+
 CAFFE2_DEFINE_int(
     caffe2_operator_max_engine_name_length,
     10,
@@ -75,7 +77,7 @@ GlobalEnginePrefType& g_global_engine_pref() {
   return *g_global_engine_pref_;
 }
 
-unique_ptr<OperatorBase> TryCreateOperator(
+unique_ptr<OperatorBase> TryCreateC2Operator(
     const string& key, const OperatorDef& operator_def, Workspace* ws) {
   const auto& type = operator_def.device_option().device_type();
   CAFFE_ENFORCE(
@@ -93,6 +95,23 @@ unique_ptr<OperatorBase> TryCreateOperator(
                  << err.what()
                  << ". Proto is: " << ProtoDebugString(operator_def);
     return nullptr;
+  }
+}
+
+unique_ptr<OperatorBase> TryCreateC10Operator(
+    const string& key, const OperatorDef& operator_def, Workspace* ws) {
+  if (auto op = C10OperatorRegistry()->Create(key, operator_def, ws)) {
+    return op;
+  }
+  return nullptr;
+}
+
+unique_ptr<OperatorBase> TryCreateOperator(
+    const string& key, const OperatorDef& operator_def, Workspace* ws) {
+  if (auto op = TryCreateC10Operator(key, operator_def, ws)) {
+    return op;
+  } else {
+    return TryCreateC2Operator(key, operator_def, ws);
   }
 }
 
@@ -631,8 +650,14 @@ std::set<std::string> GetRegisteredOperators() {
   for (const auto& name : CUDAOperatorRegistry()->Keys()) {
     all_keys.emplace(name);
   }
+
   // HIP operators
   for (const auto& name : HIPOperatorRegistry()->Keys()) {
+    all_keys.emplace(name);
+  }
+
+  // C10 operators
+  for (const auto& name: C10OperatorRegistry()->Keys()) {
     all_keys.emplace(name);
   }
 

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -100,10 +100,7 @@ unique_ptr<OperatorBase> TryCreateC2Operator(
 
 unique_ptr<OperatorBase> TryCreateC10Operator(
     const string& key, const OperatorDef& operator_def, Workspace* ws) {
-  if (auto op = C10OperatorRegistry()->Create(key, operator_def, ws)) {
-    return op;
-  }
-  return nullptr;
+  return C10OperatorRegistry()->Create(key, operator_def, ws);
 }
 
 unique_ptr<OperatorBase> TryCreateOperator(

--- a/caffe2/core/operator_c10wrapper.cc
+++ b/caffe2/core/operator_c10wrapper.cc
@@ -1,0 +1,11 @@
+#include "caffe2/core/operator_c10wrapper.h"
+
+namespace caffe2 {
+
+CAFFE_DEFINE_REGISTRY(
+  C10OperatorRegistry,
+  OperatorBase,
+  const OperatorDef&,
+  Workspace*);
+
+}

--- a/caffe2/core/operator_c10wrapper.h
+++ b/caffe2/core/operator_c10wrapper.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+#include "caffe2/core/dispatch/Dispatcher.h"
+
+namespace caffe2 {
+
+/**
+ * To make a c10 operator "C10Add" callable from caffe2 as "C2MyAddOpName", just write
+ *
+ *     REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(C10Add, C2MyAddOpName)
+ *
+ * Note: This wrapper currently only supports C10 ops that have exactly one output and take that
+ *       in the last parameter as "Tensor* output".
+ * TODO: Figure out a better way to handle output parameters
+ */
+
+template<class OpSchemaDef, class Context>
+class C10OperatorWrapper final : public Operator<Context> {
+    using Schema = c10::OpSchema<OpSchemaDef>;
+public:
+    C10OperatorWrapper(const OperatorDef& operator_def, Workspace* ws)
+            : Operator<Context>(operator_def, ws) {}
+
+    USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+    bool RunOnDevice() override {
+        RunOnDevice_(c10::guts::make_index_sequence<Schema::signature::num_args - 1>());
+        return true;
+    }
+
+private:
+    template<size_t... InputIndex>
+    void RunOnDevice_(c10::guts::index_sequence<InputIndex...>) {
+        c10::Dispatcher<OpSchemaDef>::call(Input(InputIndex)..., Output(0));
+    }
+};
+
+CAFFE_DECLARE_REGISTRY(
+    C10OperatorRegistry,
+    OperatorBase,
+    const OperatorDef&,
+    Workspace*);
+
+#define REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(OpSchemaDef, Name)           \
+  CAFFE_REGISTER_CLASS(C10OperatorRegistry, Name, C10OperatorWrapper<OpSchemaDef, CPUContext>)
+
+}

--- a/caffe2/operators/c10_sigmoid_op.cc
+++ b/caffe2/operators/c10_sigmoid_op.cc
@@ -1,0 +1,12 @@
+#include "c10_sigmoid_op.h"
+#include "caffe2/core/operator_c10wrapper.h"
+#include "caffe2/core/dispatch/OpSchemaRegistration.h"
+
+using caffe2::Tensor;
+using caffe2::CPUContext;
+
+C10_DEFINE_OP_SCHEMA(caffe2::SigmoidOp);
+
+namespace caffe2 {
+    REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(SigmoidOp, C10Sigmoid_DontUseThisOpYet)
+}

--- a/caffe2/operators/c10_sigmoid_op.h
+++ b/caffe2/operators/c10_sigmoid_op.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../core/tensor.h"
+#include "caffe2/core/tensor.h"
 #include "caffe2/utils/Array.h"
 
 namespace caffe2 {
@@ -8,7 +8,7 @@ namespace caffe2 {
 struct SigmoidOp final {
     static constexpr const char* name = "sigmoid";
     
-    using Signature = bool(Tensor<CPUContext> input, Tensor<CPUContext>* output);
+    using Signature = void(Tensor<CPUContext> input, Tensor<CPUContext>* output);
 
     static constexpr c10::guts::array<const char*, 2> parameter_names = {{"input", "output"}};
 };

--- a/caffe2/operators/c10_sigmoid_op.h
+++ b/caffe2/operators/c10_sigmoid_op.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../core/tensor.h"
+#include "caffe2/utils/Array.h"
+
+namespace caffe2 {
+
+struct SigmoidOp final {
+    static constexpr const char* name = "sigmoid";
+    
+    using Signature = bool(Tensor<CPUContext> input, Tensor<CPUContext>* output);
+
+    static constexpr c10::guts::array<const char*, 2> parameter_names = {{"input", "output"}};
+};
+
+}

--- a/caffe2/operators/c10_sigmoid_op_cpu.cc
+++ b/caffe2/operators/c10_sigmoid_op_cpu.cc
@@ -7,13 +7,11 @@ using caffe2::CPUContext;
 
 namespace {
 template<class DataType>
-bool sigmoid_op_cpu_impl(Tensor<CPUContext> input, Tensor<CPUContext> *output) {
+void sigmoid_op_cpu_impl(Tensor<CPUContext> input, Tensor<CPUContext> *output) {
     output->ResizeLike(input);
 
     caffe2::ConstEigenVectorArrayMap<DataType> xM(input.data<DataType>(), input.size());
     caffe2::EigenVectorArrayMap<DataType>(output->mutable_data<DataType>(), input.size()) = 1. / (1. + (-xM).exp());
-
-    return true;
 }
 } // namespace
 

--- a/caffe2/operators/c10_sigmoid_op_cpu.cc
+++ b/caffe2/operators/c10_sigmoid_op_cpu.cc
@@ -1,0 +1,24 @@
+#include "c10_sigmoid_op.h"
+#include "caffe2/core/dispatch/KernelRegistration.h"
+#include "caffe2/utils/math.h"
+
+using caffe2::Tensor;
+using caffe2::CPUContext;
+
+namespace {
+template<class DataType>
+bool sigmoid_op_cpu_impl(Tensor<CPUContext> input, Tensor<CPUContext> *output) {
+    output->ResizeLike(input);
+
+    caffe2::ConstEigenVectorArrayMap<DataType> xM(input.data<DataType>(), input.size());
+    caffe2::EigenVectorArrayMap<DataType>(output->mutable_data<DataType>(), input.size()) = 1. / (1. + (-xM).exp());
+
+    return true;
+}
+} // namespace
+
+namespace c10 {
+    C10_REGISTER_KERNEL(caffe2::SigmoidOp)
+        .kernel(&sigmoid_op_cpu_impl<float>)
+        .dispatchKey({DeviceTypeId::CPU, LayoutId(0), caffe2::TypeMeta::Id<float>()});
+} // namespace c10


### PR DESCRIPTION
This adds the capability for caffe2 to call c10 operators and adds a dummy c10 sigmoid op as a proof of concept.

I used this test script to make sure it works:

    from caffe2.python import workspace, model_helper
    import numpy as np
    
    data1 = np.random.rand(16, 100).astype(np.float32)
    workspace.FeedBlob("data1", data1)
    m = model_helper.ModelHelper(name="my net")
    sigmoid1 = m.net.C10Sigmoid_DontUseThisOpYet("data1", "sigmoid1")
    sigmoid2 = m.net.Sigmoid("data1", "sigmoid2")
    
    workspace.RunNetOnce(m.param_init_net)
    workspace.CreateNet(m.net)
    data1 = np.random.rand(16, 100).astype(np.float32)
    workspace.FeedBlob("data1", data1)
    workspace.RunNet(m.name, 1)
    
    print(workspace.FetchBlob("data1"))
    print(workspace.FetchBlob("sigmoid1"))
    print(workspace.FetchBlob("sigmoid2"))

(and check that both sigmoid outputs are the same)