### PR TITLE
remove unnecessary headers from SpectralOps, add cuda.h include to de…

### DIFF
--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -6,9 +6,6 @@
 #include "ATen/native/SpectralOpsUtils.h"
 #include "ATen/native/cuda/CuFFTUtils.h"
 #include "ATen/native/cuda/CuFFTPlanCache.h"
-
-#include <THC/THCDeviceUtils.cuh>
-#include <THC/THCTensorMathReduce.cuh>
 #include <THC/THCTensorSort.cuh>
 #include <THC/THCThrustAllocator.cuh>
 

--- a/aten/src/THC/THCDeviceUtils.cuh
+++ b/aten/src/THC/THCDeviceUtils.cuh
@@ -1,6 +1,7 @@
 #ifndef THC_DEVICE_UTILS_INC
 #define THC_DEVICE_UTILS_INC
 
+#include <cuda.h>
 /* The largest consecutive integer representable in float32 (2^24) */
 #define FLOAT32_MAX_CONSECUTIVE_INT 16777216.0f
 


### PR DESCRIPTION
…viceutils

deprecated __ballot warnings recently appeared again, because THCDeviceUtils was somehow included without cuda.h. This PR removes what looks like unnecessary includes in SpectralOps.cu (on my machine compiles w/o them), and explicitly adds cuda.h to THCDeviceUtils.cuh, so that CUDA_VERSION is always defined there. 