### PR TITLE
[build] Fix NCCL NVCC_GENCODE w/ multiple archs

### DIFF
--- a/third_party/nccl/CMakeLists.txt
+++ b/third_party/nccl/CMakeLists.txt
@@ -7,8 +7,7 @@ ENDIF()
 
 include("${CMAKE_UTILS_PATH}")
 torch_cuda_get_nvcc_gencode_flag(NVCC_GENCODE)
-string (REPLACE ";" " " NVCC_GENCODE "${NVCC_GENCODE}")
-string (REPLACE "-gencode " "-gencode=" NVCC_GENCODE "${NVCC_GENCODE}")
+string(REPLACE "-gencode;" "-gencode=" NVCC_GENCODE "${NVCC_GENCODE}")
 message(STATUS "Set NVCC_GENCODE for building NCCL: ${NVCC_GENCODE}")
 
 ADD_CUSTOM_COMMAND(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/8729
and probably https://github.com/pytorch/pytorch/issues/8831

CMake automatically escapes spaces in string into `\[space]` for some reason. So just passing a list will work.