### PR TITLE
Add cpu() and cuda() implementations to ATen

### DIFF
--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -250,15 +250,15 @@ inline Tensor to(
 }
 } // namespace detail
 
-inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking) {
+inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking) const {
   return detail::to(*this, options().device(device).dtype(dtype), non_blocking);
 }
 
-inline Tensor Tensor::to(ScalarType dtype, bool non_blocking) {
+inline Tensor Tensor::to(ScalarType dtype, bool non_blocking) const {
   return detail::to(*this, options().dtype(dtype), non_blocking);
 }
 
-inline Tensor Tensor::to(Device device, bool non_blocking) {
+inline Tensor Tensor::to(Device device, bool non_blocking) const {
   return detail::to(*this, options().device(device), non_blocking);
 }
 } // namespace at

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -595,6 +595,22 @@ Tensor hann_window(
       window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, options);
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ conversions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tensor cpu(const Tensor& self) {
+  return self.to(kCPU);
+}
+
+Tensor cuda(const Tensor& self, int64_t device_id, bool non_blocking) {
+  if (device_id == -1) { // default argument
+    return self.to(kCUDA, non_blocking);
+  } else {
+    return self.to({kCUDA, device_id}, non_blocking);
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 template <typename T>
 Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
   auto result = at::empty(values.size(), options);
@@ -607,7 +623,7 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 
 template <typename T>
 Tensor tensor_cuda(ArrayRef<T> values, const TensorOptions& options) {
-  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(at::kCPU));
+  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(Device(kCPU)));
   return cpu_tensor.to(options.device());
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1784,3 +1784,10 @@
 
 - func: get_device(Tensor self) -> int64_t
   device_guard: False
+
+- func: cpu(Tensor self) -> Tensor
+  variants: method
+
+# TODO: Would be preferable if this were an at::optional<int64_t> device
+- func: cuda(Tensor self, int64_t device=-1, bool non_blocking=false) -> Tensor
+  variants: method

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -87,9 +87,10 @@ struct Tensor : public detail::TensorBase {
   inline Tensor toBackend(Backend b) const;
 
   /// New-style `to()` methods.
-  Tensor to(Device device, ScalarType dtype, bool non_blocking = false);
-  Tensor to(ScalarType dtype, bool non_blocking = false);
-  Tensor to(Device device, bool non_blocking = false);
+  /// NB: these are defined in TensorOptions.h
+  Tensor to(Device device, ScalarType dtype, bool non_blocking = false) const;
+  Tensor to(ScalarType dtype, bool non_blocking = false) const;
+  Tensor to(Device device, bool non_blocking = false) const;
 
   /// Returns true if the `Tensor` is actually a `torch::autograd::Variable`.
   /// Defined in Type.h because of include order issues.

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -309,40 +309,6 @@ static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPVariable_cpu(PyObject* self, PyObject* args)
-{
-   HANDLE_TH_ERRORS
-   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-   auto backend = self_.is_sparse() ? Backend::SparseCPU : Backend::CPU;
-   auto& type = self_.type().toBackend(backend);
-   return wrap(torch::utils::dispatch_type_conversion(self_, type));
-   END_HANDLE_TH_ERRORS
-}
-
-static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "cuda(Device? device=None, bool non_blocking=False)",
-    "cuda(Device? device=None, bool async=False)|deprecated"
-  });
-  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  ParsedArgs<2> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  auto backend = self_.is_sparse() ? at::kSparseCUDA : at::kCUDA;
-  auto& type = self_.type().toBackend(backend);
-  auto device_obj = r.device(0);
-  if (!r.isNone(0) && device_obj.is_cpu()) {
-    throw std::runtime_error("Invalid device, must be cuda device");
-  }
-  int32_t device_index = -1;
-  if (device_obj.has_index() && device_obj.is_cuda()) {
-    device_index = device_obj.index();
-  }
-  return THPVariable_Wrap(torch::utils::dispatch_type_conversion(self_, type, device_index, r.toBool(1)));
-  END_HANDLE_TH_ERRORS
-}
-
 static PyObject * THPVariable_to_type(PyObject* self, ScalarType scalarType) {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;


### PR DESCRIPTION
- to() is now correctly marked as this-const
- As native functions, cpu/cuda get automatically bound.  I didn't
  see a convenient way to maintain the 'async' kwarg, so it got
  dropped for now. This probably has to be fixed before we can merge this.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @goldsborough 