### PR TITLE
 Add file and line to CUDA_CHECK and CUDNN_CHECK

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -86,7 +86,7 @@ template <typename T, cudnnStatus_t (*dtor)(T*)>
 struct DescriptorDeleter {
   void operator()(T* x) {
     if (x != nullptr) {
-      CUDNN_CHECK(dtor(x));
+      AT_CUDNN_CHECK(dtor(x));
     }
   }
 };
@@ -122,7 +122,7 @@ protected:
   void init() {
     if (desc_ == nullptr) {
       T* raw_desc;
-      CUDNN_CHECK(ctor(&raw_desc));
+      AT_CUDNN_CHECK(ctor(&raw_desc));
       desc_.reset(raw_desc);
     }
   }
@@ -162,7 +162,7 @@ public:
 private:
   void set(cudnnDataType_t dataType, int dim, int* size, int* stride) {
     fixSizeOneDimStride(dim, size, stride);
-    CUDNN_CHECK(cudnnSetTensorNdDescriptor(mut_desc(), dataType, dim, size, stride));
+    AT_CUDNN_CHECK(cudnnSetTensorNdDescriptor(mut_desc(), dataType, dim, size, stride));
   }
 };
 
@@ -178,7 +178,7 @@ public:
 
 private:
   void set(cudnnDataType_t dataType, int dim, int* size) {
-    CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, CUDNN_TENSOR_NCHW, dim, size));
+    AT_CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, CUDNN_TENSOR_NCHW, dim, size));
   }
 };
 
@@ -190,13 +190,13 @@ struct AT_CUDA_API ConvolutionDescriptor
   void set(cudnnDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups) {
     cudnnDataType_t mathType = dataType;
     if (dataType == CUDNN_DATA_HALF) mathType = CUDNN_DATA_FLOAT;
-    CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
+    AT_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
                                           CUDNN_CROSS_CORRELATION, mathType));
 #if CUDNN_VERSION >= 7000
-    CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
-    CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_DEFAULT_MATH));
+    AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
+    AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_DEFAULT_MATH));
     if(dataType == CUDNN_DATA_HALF)
-      CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_TENSOR_OP_MATH));
+      AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_TENSOR_OP_MATH));
 #endif
   }
 };
@@ -207,7 +207,7 @@ struct AT_CUDA_API SpatialTransformerDescriptor
                       &cudnnDestroySpatialTransformerDescriptor>
 {
   void set(cudnnDataType_t dataType, int dim, int* size) {
-    CUDNN_CHECK(cudnnSetSpatialTransformerNdDescriptor(mut_desc(), CUDNN_SAMPLER_BILINEAR, dataType, dim, size));
+    AT_CUDNN_CHECK(cudnnSetSpatialTransformerNdDescriptor(mut_desc(), CUDNN_SAMPLER_BILINEAR, dataType, dim, size));
   }
 };
 
@@ -253,11 +253,11 @@ struct AT_CUDA_API DropoutDescriptor
   void initialize_rng(const at::Type& ty, cudnnHandle_t handle, float dropout, long long int seed) {
     AT_ASSERTM(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
     size_t state_size;
-    CUDNN_CHECK(cudnnDropoutGetStatesSize(handle, &state_size));
+    AT_CUDNN_CHECK(cudnnDropoutGetStatesSize(handle, &state_size));
     AT_ASSERT(ty.is_cuda());
     AT_ASSERT(ty.scalarType() == kByte);
     state = ty.tensor({static_cast<int64_t>(state_size)});
-    CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, dropout, state.data_ptr(), state_size, seed));
+    AT_CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, dropout, state.data_ptr(), state_size, seed));
   }
 
   // Restore a dropout descriptor given a dropout probability and existing RNG state.
@@ -268,7 +268,7 @@ struct AT_CUDA_API DropoutDescriptor
     void *state_ptr = state.data_ptr();
     size_t state_size = state.size(0);
     // NB: The seed doesn't actually matter, so we give a dummy value
-    CUDNN_CHECK(cudnnRestoreDropoutDescriptor(mut_desc(), handle, dropout, state_ptr, state_size, 0 /* seed */));
+    AT_CUDNN_CHECK(cudnnRestoreDropoutDescriptor(mut_desc(), handle, dropout, state_ptr, state_size, 0 /* seed */));
   }
 
   // Restore a dropout descriptor corresponding to no dropout
@@ -278,7 +278,7 @@ struct AT_CUDA_API DropoutDescriptor
     // initialization actually takes place when there is no dropout.
     // NB: Empirically, cudnnSetDropoutDescriptor is cheap when
     // dropoot == 0
-    CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, 0 /* dropout */, nullptr, 0 /* state_size */, 0 /* seed */));
+    AT_CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, 0 /* dropout */, nullptr, 0 /* state_size */, 0 /* seed */));
   }
 };
 
@@ -292,7 +292,7 @@ struct AT_CUDA_API RNNDescriptor
            cudnnRNNInputMode_t input_mode, cudnnDirectionMode_t bidirectional,
            cudnnRNNMode_t mode, cudnnDataType_t datatype) {
     dropout_desc_ = std::move(dropout_desc);
-    CUDNN_CHECK(cudnnSetRNNDescriptor_v6(
+    AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v6(
           handle,
           mut_desc(),
           hidden_size,

--- a/aten/src/ATen/cudnn/Exceptions.h
+++ b/aten/src/ATen/cudnn/Exceptions.h
@@ -1,43 +1,49 @@
 #pragma once
 
-#include "cudnn-wrapper.h"
-#include <string>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include "cudnn-wrapper.h"
 
 struct THCState;
 
-namespace at { namespace native {
+namespace at {
+namespace native {
 
 class cudnn_exception : public std::runtime_error {
-public:
+ public:
   cudnnStatus_t status;
   cudnn_exception(cudnnStatus_t status, const char* msg)
-      : std::runtime_error(msg)
-      , status(status) {}
+      : std::runtime_error(msg), status(status) {}
   cudnn_exception(cudnnStatus_t status, const std::string& msg)
-      : std::runtime_error(msg)
-      , status(status) {}
+      : std::runtime_error(msg), status(status) {}
 };
 
-inline void CUDNN_CHECK(cudnnStatus_t status)
-{
+inline void cudnnCheck(cudnnStatus_t status, const char* file, int line) {
   if (status != CUDNN_STATUS_SUCCESS) {
+    std::string msg("CuDNN error: ");
+    msg += cudnnGetErrorString(status);
+    msg = msg + " (" + file + ":" + std::to_string(line) + ")";
     if (status == CUDNN_STATUS_NOT_SUPPORTED) {
-        throw cudnn_exception(status, std::string(cudnnGetErrorString(status)) +
-                ". This error may appear if you passed in a non-contiguous input.");
+      msg += ". This error may appear if you passed in a non-contiguous input.";
+      throw cudnn_exception(status, msg);
     }
-    throw cudnn_exception(status, cudnnGetErrorString(status));
+    throw cudnn_exception(status, msg);
   }
 }
 
-inline void CUDA_CHECK(cudaError_t error)
-{
+#define CUDNN_CHECK(ERROR) ::at::native::cudnnCheck(ERROR, __FILE__, __LINE__)
+
+inline void cudaCheck(cudaError_t error, const char* file, int line) {
   if (error != cudaSuccess) {
     std::string msg("CUDA error: ");
     msg += cudaGetErrorString(error);
+    msg = msg + " (" + file + ":" + std::to_string(line) + ")";
     throw std::runtime_error(msg);
   }
 }
 
-}}  // namespace at::cudnn
+#define CUDA_CHECK(ERROR) ::at::native::cudaCheck(ERROR, __FILE__, __LINE__)
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/cudnn/Exceptions.h
+++ b/aten/src/ATen/cudnn/Exceptions.h
@@ -1,48 +1,17 @@
 #pragma once
-
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include "cudnn-wrapper.h"
-
-struct THCState;
-
-namespace at {
-namespace native {
-
-class cudnn_exception : public std::runtime_error {
- public:
-  cudnnStatus_t status;
-  cudnn_exception(cudnnStatus_t status, const char* msg)
-      : std::runtime_error(msg), status(status) {}
-  cudnn_exception(cudnnStatus_t status, const std::string& msg)
-      : std::runtime_error(msg), status(status) {}
-};
-
-inline void cudnnCheck(cudnnStatus_t status, const char* file, int line) {
-  if (status != CUDNN_STATUS_SUCCESS) {
-    std::stringstream msg;
-    msg << file << ":" << line
-        << ": CuDNN error: " << cudnnGetErrorString(status);
-    if (status == CUDNN_STATUS_NOT_SUPPORTED) {
-      msg << ". This error may appear if you passed in a non-contiguous input.";
-      throw cudnn_exception(status, msg.str());
-    }
-    throw cudnn_exception(status, msg.str());
+#include <ATen/Error.h>
+#define AT_CUDNN_CHECK(STATUS)                                                 \
+  if (STATUS != CUDNN_STATUS_SUCCESS) {                                        \
+    if (STATUS == CUDNN_STATUS_NOT_SUPPORTED) {                                \
+      AT_ERROR(                                                                \
+          "CuDNN error: ",                                                     \
+          cudnnGetErrorString(STATUS),                                         \
+          ". This error may appear if you passed in a non-contiguous input."); \
+    } else {                                                                   \
+      AT_ERROR("CuDNN error: ", cudnnGetErrorString(STATUS));                  \
+    }                                                                          \
   }
-}
-
-#define CUDNN_CHECK(ERROR) ::at::native::cudnnCheck(ERROR, __FILE__, __LINE__)
-
-inline void cudaCheck(cudaError_t error, const char* file, int line) {
-  if (error != cudaSuccess) {
-    std::stringstream msg;
-    msg << file << ":" << line << ": CUDA error: " << cudaGetErrorString(error);
-    throw std::runtime_error(msg.str());
+#define AT_CUDA_CHECK(STATUS)                             \
+  if (STATUS != cudaSuccess) {                            \
+    AT_ERROR("CUDA error: ", cudaGetErrorString(STATUS)); \
   }
-}
-
-#define CUDA_CHECK(ERROR) ::at::native::cudaCheck(ERROR, __FILE__, __LINE__)
-
-} // namespace native
-} // namespace at

--- a/aten/src/ATen/cudnn/Exceptions.h
+++ b/aten/src/ATen/cudnn/Exceptions.h
@@ -21,14 +21,13 @@ class cudnn_exception : public std::runtime_error {
 
 inline void cudnnCheck(cudnnStatus_t status, const char* file, int line) {
   if (status != CUDNN_STATUS_SUCCESS) {
-    std::string msg("CuDNN error: ");
-    msg += cudnnGetErrorString(status);
-    msg = msg + " (" + file + ":" + std::to_string(line) + ")";
+    std::stringstream msg;
+    msg << file << ":" << line << ": CuDNN error: " << cudnnGetErrorString(status);
     if (status == CUDNN_STATUS_NOT_SUPPORTED) {
-      msg += ". This error may appear if you passed in a non-contiguous input.";
-      throw cudnn_exception(status, msg);
+      msg << ". This error may appear if you passed in a non-contiguous input.";
+      throw cudnn_exception(status, msg.str());
     }
-    throw cudnn_exception(status, msg);
+    throw cudnn_exception(status, msg.str());
   }
 }
 
@@ -36,10 +35,9 @@ inline void cudnnCheck(cudnnStatus_t status, const char* file, int line) {
 
 inline void cudaCheck(cudaError_t error, const char* file, int line) {
   if (error != cudaSuccess) {
-    std::string msg("CUDA error: ");
-    msg += cudaGetErrorString(error);
-    msg = msg + " (" + file + ":" + std::to_string(line) + ")";
-    throw std::runtime_error(msg);
+    std::stringstream msg;
+    msg << file << ":" << line << ": CUDA error: " << cudaGetErrorString(error);
+    throw std::runtime_error(msg.str());
   }
 }
 

--- a/aten/src/ATen/cudnn/Exceptions.h
+++ b/aten/src/ATen/cudnn/Exceptions.h
@@ -22,7 +22,8 @@ class cudnn_exception : public std::runtime_error {
 inline void cudnnCheck(cudnnStatus_t status, const char* file, int line) {
   if (status != CUDNN_STATUS_SUCCESS) {
     std::stringstream msg;
-    msg << file << ":" << line << ": CuDNN error: " << cudnnGetErrorString(status);
+    msg << file << ":" << line
+        << ": CuDNN error: " << cudnnGetErrorString(status);
     if (status == CUDNN_STATUS_NOT_SUPPORTED) {
       msg << ". This error may appear if you passed in a non-contiguous input.";
       throw cudnn_exception(status, msg.str());

--- a/aten/src/ATen/cudnn/Handles.cpp
+++ b/aten/src/ATen/cudnn/Handles.cpp
@@ -15,7 +15,7 @@ namespace {
 struct Handle {
   cudnnHandle_t handle;
   Handle() : handle(NULL) {
-    CUDNN_CHECK(cudnnCreate(&handle));
+    AT_CUDNN_CHECK(cudnnCreate(&handle));
   }
   ~Handle() {
     if (handle) {
@@ -42,7 +42,7 @@ std::unordered_map<int, Handle> handles;
 cudnnHandle_t getCudnnHandle()
 {
   int device;
-  CUDA_CHECK(cudaGetDevice(&device));
+  AT_CUDA_CHECK(cudaGetDevice(&device));
 
   std::lock_guard<std::mutex> guard(mutex);
   return handles[device].handle;

--- a/aten/src/ATen/cudnn/Utils.h
+++ b/aten/src/ATen/cudnn/Utils.h
@@ -9,7 +9,7 @@ namespace at { namespace native {
 
 inline void setCuDNNStreamToCurrent() {
   // TODO: Should getCurrentStream be a method on Context?
-  CUDNN_CHECK(cudnnSetStream(getCudnnHandle(), THCState_getCurrentStream(globalContext().getTHCState())));
+  AT_CUDNN_CHECK(cudnnSetStream(getCudnnHandle(), THCState_getCurrentStream(globalContext().getTHCState())));
 }
 
 // cuDNN has a buggy check for tensor being contiguous (that is, it does

--- a/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
+++ b/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
@@ -64,7 +64,7 @@ Tensor cudnn_affine_grid_generator_forward(
   auto dataType = getCudnnDataType(*theta);
   SpatialTransformerDescriptor desc;
   setSamplerDescriptor(desc, dataType, N, C, H, W);
-  CUDNN_CHECK(cudnnSpatialTfGridGeneratorForward(getCudnnHandle(), desc.desc(),
+  AT_CUDNN_CHECK(cudnnSpatialTfGridGeneratorForward(getCudnnHandle(), desc.desc(),
                                                  theta->data_ptr(),
                                                  grid_t.data_ptr()));
   return grid_t;
@@ -87,7 +87,7 @@ Tensor cudnn_affine_grid_generator_backward(
   auto dataType = getCudnnDataType(grad_theta_t);
   SpatialTransformerDescriptor desc;
   setSamplerDescriptor(desc, dataType, N, C, H, W);
-  CUDNN_CHECK(cudnnSpatialTfGridGeneratorBackward(getCudnnHandle(), desc.desc(),
+  AT_CUDNN_CHECK(cudnnSpatialTfGridGeneratorBackward(getCudnnHandle(), desc.desc(),
                                                   grad_grid->data_ptr(),
                                                   grad_theta_t.data_ptr()));
   return grad_theta_t;

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -109,7 +109,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
     int64_t num_features = input_t.size(1);
     save_mean = weight_t.type().tensor({ num_features });
     save_var = weight_t.type().tensor({ num_features });
-    CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
+    AT_CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
       handle, mode, &one, &zero,
       idesc.desc(), input->data_ptr(),
       idesc.desc(), output->data_ptr(),
@@ -123,7 +123,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
       save_mean.data_ptr(),
       save_var.data_ptr()));
   } else {
-    CUDNN_CHECK(cudnnBatchNormalizationForwardInference(
+    AT_CUDNN_CHECK(cudnnBatchNormalizationForwardInference(
       handle, mode, &one, &zero,
       idesc.desc(), input->data_ptr(),
       idesc.desc(), output->data_ptr(),
@@ -202,7 +202,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm_backward(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
-  CUDNN_CHECK(cudnnBatchNormalizationBackward(
+  AT_CUDNN_CHECK(cudnnBatchNormalizationBackward(
     handle, mode, &one, &zero, &one, &zero,
     idesc.desc(), input->data_ptr(),
     idesc.desc(), grad_output->data_ptr(),

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -349,7 +349,7 @@ BenchmarkCache<cudnnConvolutionBwdFilterAlgo_t> bwd_filter_algos;
 // tensor instead.
 struct Workspace {
   Workspace(size_t size) : size(size), data(NULL) {
-    CUDA_CHECK(THCudaMalloc(globalContext().lazyInitCUDA(), &data, size));
+    AT_CUDA_CHECK(THCudaMalloc(globalContext().lazyInitCUDA(), &data, size));
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
@@ -478,7 +478,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
     std::unique_ptr<perf_t[]> perf_results(new perf_t[num_algos]);
     size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
     Workspace ws(max_ws_size);
-    CUDNN_CHECK(cudnnFindConvolutionForwardAlgorithmEx(
+    AT_CUDNN_CHECK(cudnnFindConvolutionForwardAlgorithmEx(
         args.handle,
         args.idesc.desc(), args.input.data_ptr(),
         args.wdesc.desc(), args.weight.data_ptr(),
@@ -497,7 +497,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
     algo_t* algo)
   {
     cudnnConvolutionFwdPreference_t pref = CUDNN_CONVOLUTION_FWD_PREFER_FASTEST;
-    CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(
+    AT_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(
         args.handle,
         args.idesc.desc(),
         args.wdesc.desc(),
@@ -512,7 +512,7 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
     const ConvolutionArgs& args,
     algo_t algo, size_t* workspaceSize)
   {
-    CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(
+    AT_CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(
         args.handle,
         args.idesc.desc(),
         args.wdesc.desc(),
@@ -547,7 +547,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
     std::unique_ptr<perf_t[]> perf_results(new perf_t[num_algos]);
     size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
     Workspace ws(max_ws_size);
-    CUDNN_CHECK(cudnnFindConvolutionBackwardDataAlgorithmEx(
+    AT_CUDNN_CHECK(cudnnFindConvolutionBackwardDataAlgorithmEx(
         args.handle,
         args.wdesc.desc(), args.weight.data_ptr(),
         args.odesc.desc(), args.output.data_ptr(),
@@ -562,7 +562,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
   }
 
   static void getAlgorithm(const ConvolutionArgs& args, algo_t* algo) {
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
+    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
         args.handle,
         args.wdesc.desc(),
         args.odesc.desc(),
@@ -577,7 +577,7 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
     const ConvolutionArgs& args,
     cudnnConvolutionBwdDataAlgo_t algo, size_t* workspaceSize)
   {
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(
+    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(
         args.handle,
         args.wdesc.desc(),
         args.odesc.desc(),
@@ -617,7 +617,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
     int perf_count;
     Workspace ws(max_ws_size);
 
-    CUDNN_CHECK(cudnnFindConvolutionBackwardFilterAlgorithmEx(
+    AT_CUDNN_CHECK(cudnnFindConvolutionBackwardFilterAlgorithmEx(
         args.handle,
         args.idesc.desc(), args.input.data_ptr(),
         args.odesc.desc(), args.output.data_ptr(),
@@ -632,7 +632,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
   }
 
   static void getAlgorithm(const ConvolutionArgs& args, algo_t* algo) {
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
+    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
         args.handle,
         args.idesc.desc(),
         args.odesc.desc(),
@@ -646,7 +646,7 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
 
   static void getWorkspaceSize(const ConvolutionArgs& args, algo_t algo, size_t* workspaceSize)
   {
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
+    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
         args.handle,
         args.idesc.desc(),
         args.odesc.desc(),
@@ -696,7 +696,7 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   // needed here because the above benchmarking uses a huge amount of memory,
   // e.g. a few GBs.
   THCDeviceAllocator* allocator = THCCachingAllocator_get();
-  CUDA_CHECK(allocator->emptyCache(allocator->state));
+  AT_CUDA_CHECK(allocator->emptyCache(allocator->state));
 }
 
 template<typename algo_t>
@@ -748,7 +748,7 @@ void cudnn_convolution_add_bias_(CheckedFrom c, const TensorArg& output, const T
   auto dataType = getCudnnDataType(*bias);
   Constant one(dataType, 1);
 
-  CUDNN_CHECK(cudnnAddTensor(handle, &one, bdesc.desc(), bias->data_ptr(),
+  AT_CUDNN_CHECK(cudnnAddTensor(handle, &one, bdesc.desc(), bias->data_ptr(),
                                      &one, odesc.desc(), output->data_ptr()));
 }
 
@@ -820,7 +820,7 @@ void raw_cudnn_convolution_forward_out(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
-  CUDNN_CHECK(cudnnConvolutionForward(
+  AT_CUDNN_CHECK(cudnnConvolutionForward(
     args.handle,
     &one, args.idesc.desc(), input.data_ptr(),
     args.wdesc.desc(), weight.data_ptr(),
@@ -948,7 +948,7 @@ void raw_cudnn_convolution_backward_input_out(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
-  CUDNN_CHECK(cudnnConvolutionBackwardData(
+  AT_CUDNN_CHECK(cudnnConvolutionBackwardData(
       args.handle,
       &one, args.wdesc.desc(), weight.data_ptr(),
       args.odesc.desc(), grad_output.data_ptr(),
@@ -1092,7 +1092,7 @@ void raw_cudnn_convolution_backward_weight_out(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
-  CUDNN_CHECK(cudnnConvolutionBackwardFilter(
+  AT_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
       args.handle,
       &one, args.idesc.desc(), input.data_ptr(),
       args.odesc.desc(), grad_output.data_ptr(),
@@ -1194,7 +1194,7 @@ Tensor cudnn_convolution_backward_bias(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
-  CUDNN_CHECK(cudnnConvolutionBackwardBias(handle, &one, odesc.desc(), grad_output->data_ptr(),
+  AT_CUDNN_CHECK(cudnnConvolutionBackwardBias(handle, &one, odesc.desc(), grad_output->data_ptr(),
                                                    &zero, bdesc.desc(), grad_bias->data_ptr()));
   return *grad_bias;
 }

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -87,7 +87,7 @@ Tensor cudnn_grid_sampler_forward(
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
-  CUDNN_CHECK(cudnnSpatialTfSamplerForward(
+  AT_CUDNN_CHECK(cudnnSpatialTfSamplerForward(
       handle, desc.desc(),
       &one, idesc.desc(), input->data_ptr(),
       grid->data_ptr(),
@@ -129,7 +129,7 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
-  CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+  AT_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
     handle, desc.desc(),
     &one, idesc.desc(), input->data_ptr(),
     &zero, gdesc.desc(), grad_input_t.data_ptr(),

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -350,7 +350,7 @@ namespace {
   int64_t get_num_weights(cudnnHandle_t handle, const RNNDescriptor& rnn_desc,
                           const TensorDescriptor& x_desc, cudnnDataType_t datatype) {
     size_t weight_size;
-    CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
+    AT_CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
     auto elem_size = dataSize(datatype);
     AT_ASSERTM(weight_size % elem_size == 0, "cudnnGetRNNParamsSize returned nonsensical weight_size");
     return weight_size / elem_size;
@@ -410,7 +410,7 @@ namespace {
         for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
           FilterDescriptor lin_layer_mat_desc;
           void* matrix_pointer;
-          CUDNN_CHECK(cudnn_method(
+          AT_CUDNN_CHECK(cudnn_method(
                 handle,
                 rnn_desc.desc(),
                 layer,
@@ -429,7 +429,7 @@ namespace {
           // some sort of alloca would be good enough except that it is
           // kind of convenient to be able to prod() on it.
           Tensor filter_dim_a = at::CPU(kInt).tensor(min_dim);
-          CUDNN_CHECK(cudnnGetFilterNdDescriptor(
+          AT_CUDNN_CHECK(cudnnGetFilterNdDescriptor(
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
@@ -659,7 +659,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   size_t workspace_size;
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
-  CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
+  AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
         handle,
         descs.rnn_desc.desc(),
         fn.tensors.seq_length,
@@ -673,7 +673,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   // this information.  Use 'train' as a proxy.
   if (fn_train) {
     size_t reserve_size;
-    CUDNN_CHECK(cudnnGetRNNTrainingReserveSize(
+    AT_CUDNN_CHECK(cudnnGetRNNTrainingReserveSize(
           handle,
           descs.rnn_desc.desc(),
           fn.tensors.seq_length,
@@ -681,7 +681,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           &reserve_size
           ));
     reserve = input.type().toScalarType(kByte).tensor(reserve_size);
-    CUDNN_CHECK(cudnnRNNForwardTraining(
+    AT_CUDNN_CHECK(cudnnRNNForwardTraining(
           handle,
           descs.rnn_desc.desc(),
           fn.tensors.seq_length,
@@ -697,7 +697,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           ));
   } else { // inference
     reserve = input.type().toScalarType(kByte).tensor();
-    CUDNN_CHECK(cudnnRNNForwardInference(
+    AT_CUDNN_CHECK(cudnnRNNForwardInference(
           handle,
           descs.rnn_desc.desc(),
           fn.tensors.seq_length,
@@ -823,7 +823,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   size_t workspace_size;
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
-  CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
+  AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
         handle,
         descs.rnn_desc.desc(),
         fn.tensors.seq_length,
@@ -833,7 +833,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   // TODO: put this in the correct device???
   Tensor workspace = input.type().toScalarType(kByte).tensor(workspace_size);
 
-  CUDNN_CHECK(cudnnRNNBackwardData(
+  AT_CUDNN_CHECK(cudnnRNNBackwardData(
         handle,
         descs.rnn_desc.desc(),
         fn.tensors.seq_length,
@@ -933,7 +933,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
   size_t workspace_size;
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
-  CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
+  AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
         handle,
         descs.rnn_desc.desc(),
         fn.tensors.seq_length,
@@ -942,7 +942,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
         ));
   Tensor workspace = input.type().toScalarType(kByte).tensor(workspace_size);
 
-  CUDNN_CHECK(cudnnRNNBackwardWeights(
+  AT_CUDNN_CHECK(cudnnRNNBackwardWeights(
         handle,
         descs.rnn_desc.desc(),
         fn.tensors.seq_length,

--- a/test/cpp_extensions/cudnn_extension.cpp
+++ b/test/cpp_extensions/cudnn_extension.cpp
@@ -50,8 +50,8 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
   at::native::TensorDescriptor input_tensor_desc(inputs, 4);
   cudnnActivationDescriptor_t activationDesc;
   // Note: Always check return value of cudnn functions using CUDNN_CHECK
-  at::native::CUDNN_CHECK(cudnnCreateActivationDescriptor(&activationDesc));
-  at::native::CUDNN_CHECK(cudnnSetActivationDescriptor(
+  CUDNN_CHECK(cudnnCreateActivationDescriptor(&activationDesc));
+  CUDNN_CHECK(cudnnSetActivationDescriptor(
       activationDesc,
       /*mode=*/CUDNN_ACTIVATION_RELU,
       /*reluNanOpt=*/CUDNN_PROPAGATE_NAN,
@@ -59,7 +59,7 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
   // Step 3: Apply CuDNN function
   float alpha = 1.;
   float beta = 0.;
-  at::native::CUDNN_CHECK(cudnnActivationForward(
+  CUDNN_CHECK(cudnnActivationForward(
       cuDnn,
       activationDesc,
       &alpha,
@@ -69,7 +69,7 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
       input_tensor_desc.desc(), // output descriptor same as input
       outputs.data_ptr()));
   // Step 4: Destroy descriptors
-  at::native::CUDNN_CHECK(cudnnDestroyActivationDescriptor(activationDesc));
+  CUDNN_CHECK(cudnnDestroyActivationDescriptor(activationDesc));
   // Step 5: Return something (optional)
 }
 

--- a/test/cpp_extensions/cudnn_extension.cpp
+++ b/test/cpp_extensions/cudnn_extension.cpp
@@ -50,8 +50,8 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
   at::native::TensorDescriptor input_tensor_desc(inputs, 4);
   cudnnActivationDescriptor_t activationDesc;
   // Note: Always check return value of cudnn functions using CUDNN_CHECK
-  CUDNN_CHECK(cudnnCreateActivationDescriptor(&activationDesc));
-  CUDNN_CHECK(cudnnSetActivationDescriptor(
+  AT_CUDNN_CHECK(cudnnCreateActivationDescriptor(&activationDesc));
+  AT_CUDNN_CHECK(cudnnSetActivationDescriptor(
       activationDesc,
       /*mode=*/CUDNN_ACTIVATION_RELU,
       /*reluNanOpt=*/CUDNN_PROPAGATE_NAN,
@@ -59,7 +59,7 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
   // Step 3: Apply CuDNN function
   float alpha = 1.;
   float beta = 0.;
-  CUDNN_CHECK(cudnnActivationForward(
+  AT_CUDNN_CHECK(cudnnActivationForward(
       cuDnn,
       activationDesc,
       &alpha,
@@ -69,7 +69,7 @@ void cudnn_relu(const at::Tensor& inputs, const at::Tensor& outputs) {
       input_tensor_desc.desc(), // output descriptor same as input
       outputs.data_ptr()));
   // Step 4: Destroy descriptors
-  CUDNN_CHECK(cudnnDestroyActivationDescriptor(activationDesc));
+  AT_CUDNN_CHECK(cudnnDestroyActivationDescriptor(activationDesc));
   // Step 5: Return something (optional)
 }
 


### PR DESCRIPTION
Add file and line to messages from `CUDA_CHECK` and `CUDNN_CHECK`. Renamed original functions to `cudaCheck` and `cudnnCheck` and made macros with the original names. Should make debugging slightly friendlier.

Also ran clang-format on the file.

Cheers