### PR TITLE
Make at::Tensor::to() const

### DIFF
--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -255,15 +255,16 @@ inline Tensor to(
 }
 } // namespace detail
 
-inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking) {
+inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking)
+    const {
   return detail::to(*this, options().device(device).dtype(dtype), non_blocking);
 }
 
-inline Tensor Tensor::to(ScalarType dtype, bool non_blocking) {
+inline Tensor Tensor::to(ScalarType dtype, bool non_blocking) const {
   return detail::to(*this, options().dtype(dtype), non_blocking);
 }
 
-inline Tensor Tensor::to(Device device, bool non_blocking) {
+inline Tensor Tensor::to(Device device, bool non_blocking) const {
   return detail::to(*this, options().device(device), non_blocking);
 }
 } // namespace at

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -257,14 +257,23 @@ inline Tensor to(
 
 inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking)
     const {
+  if (this->device() == device && this->dtype() == dtype) {
+    return *this;
+  }
   return detail::to(*this, options().device(device).dtype(dtype), non_blocking);
 }
 
 inline Tensor Tensor::to(ScalarType dtype, bool non_blocking) const {
+  if (this->dtype() == dtype) {
+    return *this;
+  }
   return detail::to(*this, options().dtype(dtype), non_blocking);
 }
 
 inline Tensor Tensor::to(Device device, bool non_blocking) const {
+  if (this->device() == device) {
+    return *this;
+  }
   return detail::to(*this, options().device(device), non_blocking);
 }
 } // namespace at

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -87,9 +87,10 @@ struct Tensor : public detail::TensorBase {
   inline Tensor toBackend(Backend b) const;
 
   /// New-style `to()` methods.
-  Tensor to(Device device, ScalarType dtype, bool non_blocking = false);
-  Tensor to(ScalarType dtype, bool non_blocking = false);
-  Tensor to(Device device, bool non_blocking = false);
+  /// NB: These methods are defined in TensorOptions.h.
+  Tensor to(Device device, ScalarType dtype, bool non_blocking = false) const;
+  Tensor to(ScalarType dtype, bool non_blocking = false) const;
+  Tensor to(Device device, bool non_blocking = false) const;
 
   /// Returns true if the `Tensor` is actually a `torch::autograd::Variable`.
   /// Defined in Type.h because of include order issues.


### PR DESCRIPTION
The fix from https://github.com/pytorch/pytorch/pull/8835, which should still happen.
@ezyang 