### PR TITLE
[Caffe2] Bump up opset version to 7 in Caffe2 ONNX exporter

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -613,7 +613,7 @@ Caffe2Ops Caffe2Backend::CreateGemm(OnnxNode* onnx_node, int opset_version) {
     BuildOperator(
         c2_op, "MatMul", {input_a, input_b}, {ab}, {arg_trans_a, arg_trans_b});
     c2_op = ret.ops.Add();
-    if (opset_version > 6) {
+    if (opset_version >= 7) {
       BuildOperator(c2_op, "Add", {ab, input_c}, {output});
     } else {
       caffe2::Argument arg_broadcast;
@@ -858,7 +858,7 @@ Caffe2Ops Caffe2Backend::CreateBatchNormalization(
     attributes.remove("consumed_inputs");
   }
 
-  if (opset_version > 6) {
+  if (opset_version >= 7) {
     auto& attributes = onnx_node->attributes;
     auto* attr = attributes.AddRewrittenAttribute("is_test");
     attr->set_i(1);
@@ -918,7 +918,7 @@ Caffe2Ops Caffe2Backend::CreateUpsample(OnnxNode* onnx_node, int opset_version) 
 }
 
 Caffe2Ops Caffe2Backend::CreateDropout(OnnxNode* onnx_node, int opset_version) {
-  if (opset_version > 6) {
+  if (opset_version >= 7) {
     auto& attributes = onnx_node->attributes;
     auto* attr = attributes.AddRewrittenAttribute("is_test");
     attr->set_i(1);

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -616,7 +616,11 @@ Caffe2Ops Caffe2Backend::CreateGemm(OnnxNode* onnx_node, int opset_version) {
     BuildOperator(
         c2_op, "MatMul", {input_a, input_b}, {ab}, {arg_trans_a, arg_trans_b});
     c2_op = ret.ops.Add();
-    BuildOperator(c2_op, "Add", {ab, input_c}, {output}, {arg_broadcast});
+    if (opset_version > 6) {
+      BuildOperator(c2_op, "Add", {ab, input_c}, {output});
+    } else {
+      BuildOperator(c2_op, "Add", {ab, input_c}, {output}, {arg_broadcast});
+    }
   }
 
   return ret;

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -608,9 +608,6 @@ Caffe2Ops Caffe2Backend::CreateGemm(OnnxNode* onnx_node, int opset_version) {
     caffe2::Argument arg_trans_b;
     arg_trans_b.set_name("trans_b");
     arg_trans_b.set_i(trans_b);
-    caffe2::Argument arg_broadcast;
-    arg_broadcast.set_name("broadcast");
-    arg_broadcast.set_i(broadcast);
 
     auto* c2_op = ret.ops.Add();
     BuildOperator(
@@ -619,6 +616,9 @@ Caffe2Ops Caffe2Backend::CreateGemm(OnnxNode* onnx_node, int opset_version) {
     if (opset_version > 6) {
       BuildOperator(c2_op, "Add", {ab, input_c}, {output});
     } else {
+      caffe2::Argument arg_broadcast;
+      arg_broadcast.set_name("broadcast");
+      arg_broadcast.set_i(broadcast);
       BuildOperator(c2_op, "Add", {ab, input_c}, {output}, {arg_broadcast});
     }
   }

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -354,9 +354,9 @@ ConvertedResult OnnxExporter::CommonCaffe2OpToOnnxNodes(
 ConvertedResult OnnxExporter::CreateBinaryElementwiseOpNodes(
     const caffe2::OperatorDef& def,
     const std::unordered_map<std::string, caffe2::TensorShape>& shapes) {
-  caffe2::OperatorDef mdef(def);  // The modified def without broadcast and axis
+  caffe2::OperatorDef mdef(def); // The modified def without broadcast and axis
   const auto& x = mdef.input(0);
-  const auto& y = def.input(1);  // Refer to the old def, later won't change it.
+  const auto& y = def.input(1); // Refer to the old def, later won't change it.
   const auto& x_shape = shapes.at(x);
   const auto& y_shape = shapes.at(y);
   for (int i = 0; i < mdef.arg_size(); ++i) {
@@ -373,7 +373,8 @@ ConvertedResult OnnxExporter::CreateBinaryElementwiseOpNodes(
       int64_t axis = arg.i();
       if (x_shape.dims().size() - axis != y_shape.dims().size()) {
         // The upper bound (excluded) of expanded y.
-        int64_t end_dim = y_shape.dims().size() - 1 - axis + x_shape.dims().size();
+        int64_t end_dim =
+            y_shape.dims().size() - 1 - axis + x_shape.dims().size();
         axes.resize(end_dim - y_shape.dims().size());
         std::iota(axes.begin(), axes.end(), y_shape.dims().size());
         mdef.set_input(1, dummy_->NewDummyName());
@@ -385,11 +386,10 @@ ConvertedResult OnnxExporter::CreateBinaryElementwiseOpNodes(
 
   auto result = CommonCaffe2OpToOnnxNodes(mdef);
   if (axes.size() != 0) {
-    result.first.insert(result.first.begin(), MakeNode(
-          "Unsqueeze",
-          {y},
-          {mdef.input(1)},
-          {MakeAttribute("axes", axes)}));
+    result.first.insert(
+        result.first.begin(),
+        MakeNode(
+            "Unsqueeze", {y}, {mdef.input(1)}, {MakeAttribute("axes", axes)}));
   }
   return result;
 }

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -367,7 +367,7 @@ ConvertedResult OnnxExporter::CreateBinaryElementwiseOpNodes(
     ConvertedResult result;
     auto& nodes = result.first;
 
-    std::vector<int64_t> unsqueezed_dims(y_shape.dims().cbegin(), y_shape.dims().cend());
+    std::vector<int64_t> unsqueezed_dims(y_shape.dims().begin(), y_shape.dims().end());
     std::vector<int64_t> axes;
     for (int64_t i = y_shape.dims().size(); i < end_dim; ++i) {
       axes.emplace_back(i);

--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -52,6 +52,10 @@ class OnnxExporter {
  private:
   ConvertedResult CommonCaffe2OpToOnnxNodes(const caffe2::OperatorDef& def);
 
+  ConvertedResult CreateBinaryElementwiseOpNodes(
+      const caffe2::OperatorDef& def,
+      const std::unordered_map<std::string, caffe2::TensorShape>& shapes);
+
   ConvertedResult CreateCastNodes(
       const caffe2::OperatorDef& def,
       const std::unordered_map<std::string, caffe2::TensorShape>& shapes);

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -38,7 +38,7 @@ class Caffe2Frontend(object):
     # ONNX makes a BC breaking change to semantics of operators, having this set
     # to an accurate number will prevent our models form exporting.  However,
     # we should strive to keep this up-to-date as much as possible.
-    target_opset_version = 6
+    target_opset_version = 7
 
     _renamed_operators = {
         'SpatialBN': 'BatchNormalization',

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -136,7 +136,6 @@ class Caffe2Frontend(object):
     @classmethod
     def caffe2_op_to_onnx_node(cls, op_def, shapes):
         if C.support_onnx_export(op_def.type):
-            shape_list = list(shapes.values())
             node_strs, tensor_strs = C.export_to_onnx(cls._dummy_name, op_def.SerializeToString(), shapes)
             nodes = []
             for s in node_strs:

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -398,6 +398,11 @@ CAFFE2_MAKE_SINGULAR_ARGUMENT(string, s)
 #undef CAFFE2_MAKE_SINGULAR_ARGUMENT
 
 template <>
+bool ArgumentHelper::RemoveArgument(OperatorDef& def, int index);
+template <>
+bool ArgumentHelper::RemoveArgument(NetDef& def, int index);
+
+template <>
 Argument MakeArgument(const string& name, const MessageLite& value) {
   Argument arg;
   arg.set_name(name);

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -234,6 +234,18 @@ class ArgumentHelper {
     return ArgumentHelper(def).GetRepeatedMessageArgument<MessageType>(name);
   }
 
+  template <typename Def>
+  static bool RemoveArgument(Def& def, int index) {
+    if (index >= def.arg_size()) {
+      return false;
+    }
+    if (index < def.arg_size() - 1) {
+      def.mutable_arg()->SwapElements(index, def.arg_size() - 1);
+    }
+    def.mutable_arg()->RemoveLast();
+    return true;
+  }
+
   explicit ArgumentHelper(const OperatorDef& def);
   explicit ArgumentHelper(const NetDef& netdef);
   bool HasArgument(const string& name) const;

--- a/scripts/model_zoo/update-models-from-caffe2.py
+++ b/scripts/model_zoo/update-models-from-caffe2.py
@@ -218,6 +218,7 @@ model_mapping = {
     'inception_v1': 'inception_v1',
     'inception_v2': 'inception_v2',
     'resnet50': 'resnet50',
+    'shufflenet': 'shufflenet',
     'squeezenet': 'squeezenet_old',
     #'vgg16': 'vgg16',
     'vgg19': 'vgg19',


### PR DESCRIPTION
Will bump up to opset 8 in another PR to match the current opset version.

Already tested through generating the models in current model zoo.