### PR TITLE
net_async tracing use enable_profile arg from NetDef

### DIFF
--- a/caffe2/core/net_async_tracing.cc
+++ b/caffe2/core/net_async_tracing.cc
@@ -16,6 +16,7 @@
 
 #include "caffe2/core/net_async_tracing.h"
 
+#include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 
 CAFFE2_DEFINE_string(
@@ -30,14 +31,33 @@ CAFFE2_DEFINE_string(
 
 CAFFE2_DEFINE_int(caffe2_net_async_tracing_nth, 100, "Trace every Nth batch");
 
+// For every Nth iterations, we will dump the tracing results to a json file
+// The file is appended with the iteration number.
+CAFFE2_DEFINE_int(
+    caffe2_net_async_tracing_dumping_nth,
+    10000,
+    "Dump profiling result file every Nth batch");
+
 namespace caffe2 {
 namespace tracing {
+
+int getCounterForNetName(const std::string& net_name) {
+  // Append a unique number suffix because there could be multiple instances
+  // of the same net and we want to uniquely associate each instance with
+  // a profiling trace.
+  static std::unordered_map<std::string, int> net_name_to_counter;
+  static std::mutex map_mutex;
+  std::unique_lock<std::mutex> map_lock(map_mutex);
+  int counter = net_name_to_counter[net_name] + 1;
+  net_name_to_counter[net_name] = counter;
+  return counter;
+}
 
 Tracer::Tracer(const NetBase* net, const std::string& net_name)
     : net_(net), filename_(net_name), iter_(0) {
   std::replace(filename_.begin(), filename_.end(), '/', '_');
-  filename_ =
-      FLAGS_caffe2_net_async_tracing_filepath + "/" + filename_ + ".json";
+  filename_ = FLAGS_caffe2_net_async_tracing_filepath + "/" + filename_ +
+      +"_id_" + caffe2::to_string(getCounterForNetName(net_name));
   timer_.Start();
 }
 
@@ -230,7 +250,7 @@ int Tracer::bumpIter() {
   return iter_++;
 }
 
-Tracer::~Tracer() {
+void Tracer::dumpTracingResultAndClearEvents(const std::string& file_suffix) {
   if (events_.empty() || filename_.empty()) {
     return;
   }
@@ -245,7 +265,13 @@ Tracer::~Tracer() {
     }
   }
   serialized << "\n]\n";
-  WriteStringToFile(serialized.str(), filename_.c_str());
+  WriteStringToFile(
+      serialized.str(), (filename_ + "_iter_" + file_suffix + ".json").c_str());
+  events_.clear();
+}
+
+Tracer::~Tracer() {
+  dumpTracingResultAndClearEvents("final_batch");
 }
 
 void TracerGuard::init(Tracer* tracer) {
@@ -345,17 +371,27 @@ int getUniqueShardId(const OperatorDef& op_def) {
   return unique_shard_id;
 }
 
-bool isTraceableNet(const std::string& net_name) {
+bool isTraceableNetName(const std::string& net_name) {
   auto tracing_nets = caffe2::split(',', FLAGS_caffe2_net_async_names_to_trace);
   return !net_name.empty() &&
       std::find(tracing_nets.begin(), tracing_nets.end(), net_name) !=
       tracing_nets.end();
 }
 
+bool hasEnableTracingFlag(const NetBase* net) {
+  if (!net->has_debug_def()) {
+    return false;
+  }
+  return GetFlagArgument(net->debug_def(), "enable_tracing", false);
+}
+
 std::shared_ptr<Tracer> create(
     const NetBase* net,
     const std::string& net_name) {
-  bool trace_net = isTraceableNet(net_name);
+  // Enable the tracer if the net has the "enable_tracing" argument set OR
+  // if the command line option includes the net name option in the list of
+  // tracable nets.
+  bool trace_net = hasEnableTracingFlag(net) || isTraceableNetName(net_name);
   return trace_net ? std::make_shared<Tracer>(net, net_name) : nullptr;
 }
 
@@ -366,6 +402,10 @@ bool startIter(const std::shared_ptr<Tracer>& tracer) {
   auto iter = tracer->bumpIter();
   auto is_enabled = iter % FLAGS_caffe2_net_async_tracing_nth == 0;
   tracer->setEnabled(is_enabled);
+  if (iter % FLAGS_caffe2_net_async_tracing_dumping_nth == 0) {
+    int dumping_iter = iter / FLAGS_caffe2_net_async_tracing_dumping_nth;
+    tracer->dumpTracingResultAndClearEvents(caffe2::to_string(dumping_iter));
+  }
   return is_enabled;
 }
 

--- a/caffe2/core/net_async_tracing.h
+++ b/caffe2/core/net_async_tracing.h
@@ -63,6 +63,9 @@ class Tracer {
   void setEnabled(bool enabled);
   bool isEnabled() const;
   int bumpIter();
+  // Dump the tracing result to file with given suffix, and then
+  // clear current events.
+  void dumpTracingResultAndClearEvents(const std::string& file_suffix);
 
   virtual ~Tracer();
 
@@ -108,7 +111,9 @@ class TracerGuard {
 // Return -1 if there is no shard found
 int extractShardId(const std::string& name);
 
-bool isTraceableNet(const std::string& net_name);
+// Check if the net name is white-listed for tracing (specified via a command
+// line flag)
+bool isTraceableNetName(const std::string& net_name);
 
 std::shared_ptr<Tracer> create(const NetBase* net, const std::string& net_name);
 bool startIter(const std::shared_ptr<Tracer>& tracer);

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1880,6 +1880,9 @@ class Net(object):
         self._ExtendOps(grad_ops)
         return input_to_grad
 
+    def AddArgument(self, arg_name, arg_value):
+        self._net.arg.extend([utils.MakeArgument(arg_name, arg_value)])
+
     def AddExternalInput(self, *inputs):
         assert len(inputs) > 0
         refs = []

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -457,31 +457,72 @@ bool HasInput(const OperatorDef& op, const std::string& input) {
   return false;
 }
 
-const Argument& GetArgument(const OperatorDef& def, const string& name) {
-  for (const Argument& arg : def.arg()) {
+// Return the argument index or -1 if it does not exist.
+int GetArgumentIndex(
+    const google::protobuf::RepeatedPtrField<Argument>& args,
+    const string& name) {
+  int index = 0;
+  for (const Argument& arg : args) {
     if (arg.name() == name) {
-      return arg;
+      return index;
     }
+    index++;
   }
-  CAFFE_THROW(
-      "Argument named ",
-      name,
-      " does not exist in operator ",
-      ProtoDebugString(def));
+  return -1;
+}
+
+const Argument& GetArgument(const OperatorDef& def, const string& name) {
+  int index = GetArgumentIndex(def.arg(), name);
+  if (index != -1) {
+    return def.arg(index);
+  } else {
+    CAFFE_THROW(
+        "Argument named ",
+        name,
+        " does not exist in operator ",
+        ProtoDebugString(def));
+  }
+}
+
+const Argument& GetArgument(const NetDef& def, const string& name) {
+  int index = GetArgumentIndex(def.arg(), name);
+  if (index != -1) {
+    return def.arg(index);
+  } else {
+    CAFFE_THROW(
+        "Argument named ",
+        name,
+        " does not exist in net ",
+        ProtoDebugString(def));
+  }
+}
+
+bool GetFlagArgument(
+    const google::protobuf::RepeatedPtrField<Argument>& args,
+    const string& name,
+    bool default_value) {
+  int index = GetArgumentIndex(args, name);
+  if (index != -1) {
+    auto arg = args.Get(index);
+    CAFFE_ENFORCE(
+        arg.has_i(), "Can't parse argument as bool: ", ProtoDebugString(arg));
+    return arg.i();
+  }
+  return default_value;
 }
 
 bool GetFlagArgument(
     const OperatorDef& def,
     const string& name,
-    bool def_value) {
-  for (const Argument& arg : def.arg()) {
-    if (arg.name() == name) {
-      CAFFE_ENFORCE(
-          arg.has_i(), "Can't parse argument as bool: ", ProtoDebugString(arg));
-      return arg.i();
-    }
-  }
-  return def_value;
+    bool default_value) {
+  return GetFlagArgument(def.arg(), name, default_value);
+}
+
+bool GetFlagArgument(
+    const NetDef& def,
+    const string& name,
+    bool default_value) {
+  return GetFlagArgument(def.arg(), name, default_value);
 }
 
 Argument* GetMutableArgument(

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -280,11 +280,24 @@ class ArgumentHelper {
   CaffeMap<string, Argument> arg_map_;
 };
 
+// **** Arguments Utils *****
+
+// Helper methods to get an argument from OperatorDef or NetDef given argument
+// name. Throws if argument does not exist.
 const Argument& GetArgument(const OperatorDef& def, const string& name);
+const Argument& GetArgument(const NetDef& def, const string& name);
+
+// Helper methods to query a boolean argument flag from OperatorDef or NetDef
+// given argument name. If argument does not exist, return default value.
+// Throws if argument exists but the type is not boolean.
 bool GetFlagArgument(
     const OperatorDef& def,
     const string& name,
-    bool def_value = false);
+    bool default_value = false);
+bool GetFlagArgument(
+    const NetDef& def,
+    const string& name,
+    bool default_value = false);
 
 Argument* GetMutableArgument(
     const string& name,
@@ -298,6 +311,7 @@ template <typename T>
 inline void AddArgument(const string& name, const T& value, OperatorDef* def) {
   GetMutableArgument(name, true, def)->CopyFrom(MakeArgument(name, value));
 }
+// **** End Arguments Utils *****
 
 bool inline operator==(const DeviceOption& dl, const DeviceOption& dr) {
   return IsSameDevice(dl, dr);


### PR DESCRIPTION
Summary:
- Add parameter `enable_tracing` to the Arg field of NetDef. `net_async_tracing` will only enable Tracer for Net instances that have this field set (unless the command line argument also include the net name).
- Append a unique id to the json profiling result file because there could be multiple instances of the same net running.
- Dump json profling file regularly instead of just when the Tracer object is destroyed

Differential Revision: D8372378
