### PR TITLE
[RFC] Enable script for time-sequence prediction

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4435,20 +4435,20 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
 
             # TODO: could not support tensor constructors in script
             # see https://github.com/pytorch/pytorch/issues/8814
-            def test_tensor():
+            def test_tensor(self):
                 return torch.tensor([], dtype=torch.double)
 
             @torch.jit.script_method
             def forward(self, input):
                 # TODO: add future as input with default val
                 # see https://github.com/pytorch/pytorch/issues/8724
-                outputs = test_tensor()
+                outputs = self.test_tensor()
                 h_t = torch.zeros((3, 51), dtype=torch.double)
                 c_t = torch.zeros((3, 51), dtype=torch.double)
                 h_t2 = torch.zeros((3, 51), dtype=torch.double)
                 c_t2 = torch.zeros((3, 51), dtype=torch.double)
 
-                output = None
+                output = torch.zeros([3, 51])
                 future = 2
 
                 # TODO: chunk call should be input.chunk(input.size(1), dim=1)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4413,7 +4413,6 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
         net = Net(upscale_factor=4)
         self.checkTrace(net, (torch.rand(5, 1, 64, 64),))
 
-    # @unittest.skip('This needs to be re-written into a script module')
     def test_time_sequence_prediction(self):
         class Sequence(torch.jit.ScriptModule):
             def __init__(self):
@@ -4422,6 +4421,10 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                 self.lstm2 = nn.LSTMCell(51, 51)
                 self.linear = nn.Linear(51, 1)
 
+            # TODO: could not pass tuple to a python Op and type annotations
+            # is not descending to python signature, hence the wrapper
+            # see https://github.com/pytorch/pytorch/issues/8778
+            # and https://github.com/pytorch/pytorch/issues/8777
             def test_lstm1(self, input, hx, cx):
                 # type: (Tensor, Tensor, Tensor) -> Tuple[Tensor, Tensor]
                 return self.lstm1(input, (hx, cx))
@@ -4430,21 +4433,27 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                 # type: (Tensor, Tensor, Tensor) -> Tuple[Tensor, Tensor]
                 return self.lstm2(input, (hx, cx))
 
+            # TODO: could not support tensor constructors in script
+            # see https://github.com/pytorch/pytorch/issues/8814
             def test_tensor():
                 return torch.tensor([], dtype=torch.double)
 
             @torch.jit.script_method
             def forward(self, input):
+                # TODO: add future as input with default val
+                # see https://github.com/pytorch/pytorch/issues/8724
                 outputs = test_tensor()
-                h_t = torch.zeros((97, 51), dtype=torch.double)
-                c_t = torch.zeros((97, 51), dtype=torch.double)
-                h_t2 = torch.zeros((97, 51), dtype=torch.double)
-                c_t2 = torch.zeros((97, 51), dtype=torch.double)
+                h_t = torch.zeros((3, 51), dtype=torch.double)
+                c_t = torch.zeros((3, 51), dtype=torch.double)
+                h_t2 = torch.zeros((3, 51), dtype=torch.double)
+                c_t2 = torch.zeros((3, 51), dtype=torch.double)
 
                 output = None
                 future = 2
 
-                for input_t in input.chunk(999, dim=1):
+                # TODO: chunk call should be input.chunk(input.size(1), dim=1)
+                # see https://github.com/pytorch/pytorch/issues/8775
+                for input_t in input.chunk(4, dim=1):
                     h_t, c_t = self.test_lstm1(input_t, h_t, c_t)
                     h_t2, c_t2 = self.test_lstm2(h_t, h_t2, c_t2)
                     output = self.linear(h_t2)
@@ -4456,7 +4465,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                     outputs = torch.cat((outputs, output), 1)
                 return outputs
 
-        self.checkTrace(Sequence(), (torch.rand(97, 999),), verbose=True)
+        self.checkTrace(Sequence(), (torch.rand(3, 4),), verbose=True)
 
     def test_vae(self):
         class VAE(nn.Module):


### PR DESCRIPTION
Enable script for the time-sequence prediction, did bunch of hacks to make the script mode work, and couple of issues discovered while enabling the time-sequence prediction, all noted in #8452, 

Shall we merge this PR and iteratively fix those issues thereafter?