### PR TITLE
[build] Raise in cmake when seeing NVCC{9/9.1} + GCC6 combo

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -298,7 +298,7 @@ else()
   list(APPEND CUDA_NVCC_FLAGS "-DONNX_NAMESPACE=onnx_c2")
 endif()
 
-# CUDA 9.0 & 9.1 requires GCC version <= 5
+# CUDA 9.0 & 9.1 require GCC version <= 5
 # Although they support GCC 6, but a bug that wasn't fixed until 9.2 prevents
 # them from compiling the std::tuple header of GCC 6.
 # See Sec. 2.2.1 of

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -298,16 +298,21 @@ else()
   list(APPEND CUDA_NVCC_FLAGS "-DONNX_NAMESPACE=onnx_c2")
 endif()
 
-# CUDA 9.x requires GCC version <= 6
+# CUDA 9.0 & 9.1 requires GCC version <= 5
+# Although they support GCC 6, but a bug that wasn't fixed until 9.2 prevents
+# them from compiling the std::tuple header of GCC 6.
+# See Sec. 2.2.1 of
+# https://developer.download.nvidia.com/compute/cuda/9.2/Prod/docs/sidebar/CUDA_Toolkit_Release_Notes.pdf
 if ((CUDA_VERSION VERSION_EQUAL   9.0) OR
     (CUDA_VERSION VERSION_GREATER 9.0  AND CUDA_VERSION VERSION_LESS 9.2))
   if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
-      NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0 AND
+      NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0 AND
       CUDA_HOST_COMPILER STREQUAL CMAKE_C_COMPILER)
     message(FATAL_ERROR
-      "CUDA ${CUDA_VERSION} is not compatible with GCC version >= 7. "
-      "Use the following option to use another version (for example): \n"
-      "  -DCUDA_HOST_COMPILER=/usr/bin/gcc-6\n")
+      "CUDA ${CUDA_VERSION} is not compatible with std::tuple from GCC version "
+      ">= 6. Please upgrade to CUDA 9.2 or use the following option to use "
+      "another version (for example): \n"
+      "  -DCUDA_HOST_COMPILER=/usr/bin/gcc-5\n")
   endif()
 elseif (CUDA_VERSION VERSION_EQUAL 8.0)
   # CUDA 8.0 requires GCC version <= 5


### PR DESCRIPTION
NVCC 9/9.1 cannot compile `std::tuple` header from GCC >= 6.
See: 
1. https://devtalk.nvidia.com/default/topic/1028112/cuda-setup-and-installation/nvcc-bug-related-to-gcc-6-lt-tuple-gt-header-/
2. PyTorch: https://github.com/pytorch/pytorch/issues/3963 #8832 https://github.com/pytorch/pytorch/issues/5136 https://github.com/pytorch/pytorch/issues/3807
3. C2: https://github.com/caffe2/caffe2/issues/1898
4. TF: https://github.com/tensorflow/tensorflow/issues/16246
5. More: https://github.com/kokkos/kokkos/issues/1306