### PR TITLE
[build] Use conda cmake in two CI builds

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -121,12 +121,20 @@ fi
 
 # Use conda cmake in some CI build. Conda cmake will be newer than our supported
 # min version 3.5, so we only do it in two builds that we know should use conda.
-if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda8-cudnn6-py2 ]] ||
-   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]]; then
-  if ! which conda; then
-    echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
-    exit 1
+if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda* ]]; then
+  if [[ "$BUILD_ENVIRONMENT" == *cuda8-cudnn6-py2* ]] || \
+     [[ "$BUILD_ENVIRONMENT" == *cuda9-cudnn7-py3* ]]; then
+    if ! which conda; then
+      echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
+      exit 1
+    else
+      conda install -q -y cmake
+    fi
   else
-    conda install -q -y cmake
+    if ! cmake --version | grep 'cmake version 3\.5'; then
+      echo "Expected ${BUILD_ENVIRONMENT} to have cmake version 3.5.* (min support version), but 'cmake --version' returns:"
+      cmake --version
+      exit 1
+    fi
   fi
 fi

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -125,6 +125,7 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda8-cudnn6-py2 ]] ||
    [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]]; then
   if ! which conda; then
     echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
+    exit 1
   else
     conda install -q -y cmake
   fi

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -118,3 +118,14 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]] || \
 else
   BUILD_TEST_LIBTORCH=0
 fi
+
+# Use conda cmake in some CI build. Conda cmake will be newer than our supported
+# min version 3.5, so we only do it in two builds that we know should use conda.
+if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda8-cudnn6-py2 ]] ||
+   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]]; then
+  if ! which conda; then
+    echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
+  else
+    conda install -q -y cmake
+  fi
+fi

--- a/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
@@ -9,7 +9,7 @@ CMake version: version 3.11.X
 Python version: 3.6
 Is CUDA available: Yes
 CUDA runtime version: 9.0.X
-GPU models and configuration:
+GPU models and configuration: 
 GPU 0: Tesla M60
 GPU 1: Tesla M60
 

--- a/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
@@ -9,11 +9,11 @@ CMake version: version 3.11.X
 Python version: 3.6
 Is CUDA available: Yes
 CUDA runtime version: 9.0.X
-GPU models and configuration: 
+GPU models and configuration:
 GPU 0: Tesla M60
 GPU 1: Tesla M60
 
-Nvidia driver version: 390.X
+Nvidia driver version: 396.X
 cuDNN version: Probably one of the following:
 /usr/lib/x86_64-linux-gnu/libcudnn.so.7.1.4
 /usr/lib/x86_64-linux-gnu/libcudnn_static_v7.a

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -673,7 +673,6 @@ class TestCollectEnv(TestCase):
         self.assertTrue(info_output.count('\n') >= 17)
 
     @unittest.skipIf('BUILD_ENVIRONMENT' not in os.environ.keys(), 'CI-only test')
-    @unittest.skip('temporarily skip to change cmake version in CI')
     def test_expect(self):
         info_output = get_pretty_env_info()
 


### PR DESCRIPTION
Now that we are using `apt-get cmake=3.5*` in most builds, make two builds use conda cmake (currently `3.11.1`): `pytorch-linux-xenial-cuda8-cudnn6-py2` and `pytorch-linux-xenial-cuda9-cudnn7-py3`.