### PR TITLE
[build] Add OpenCV 4 to CMake configuration

### DIFF
--- a/binaries/convert_encoded_to_raw_leveldb.cc
+++ b/binaries/convert_encoded_to_raw_leveldb.cc
@@ -23,6 +23,7 @@
 //   ....
 
 #include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui_c.h>
 
 #include <fstream>  // NOLINT(readability/streams)
 #include <memory>

--- a/binaries/make_image_db.cc
+++ b/binaries/make_image_db.cc
@@ -28,6 +28,7 @@
 //
 
 #include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui_c.h>
 
 #include <algorithm>
 #include <fstream>

--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -3,6 +3,7 @@
 #define CAFFE2_IMAGE_IMAGE_INPUT_OP_H_
 
 #include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui_c.h>
 
 #include <iostream>
 #include <algorithm>

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -275,11 +275,15 @@ endif()
 
 # ---[ OpenCV
 if(USE_OPENCV)
-  # OpenCV 3
-  find_package(OpenCV 3 QUIET COMPONENTS core highgui imgproc imgcodecs videoio video)
+  # OpenCV 4
+  find_package(OpenCV 4 QUIET COMPONENTS core highgui imgproc imgcodecs videoio video)
   if(NOT OpenCV_FOUND)
-    # OpenCV 2
-    find_package(OpenCV QUIET COMPONENTS core highgui imgproc)
+    # OpenCV 3
+    find_package(OpenCV 3 QUIET COMPONENTS core highgui imgproc imgcodecs videoio video)
+    if(NOT OpenCV_FOUND)
+      # OpenCV 2
+      find_package(OpenCV QUIET COMPONENTS core highgui imgproc)
+    endif()
   endif()
   if(OpenCV_FOUND)
     include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})


### PR DESCRIPTION
OpenCV has a planned major release in July 2018 https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4 and the master branch has already [`CV_VERSION_MAJOR 4`](https://github.com/opencv/opencv/blob/2195f0cc6260d67a872bb8895071b5241363ba9c/modules/core/include/opencv2/core/version.hpp#L8)

PR adds a check for OpenCV 4 to CMake configuration and fixes missing `_c.h` includes.