### PR TITLE
[JIT][script] Switch to emitting ScriptModule for scripted and traced functions

### DIFF
--- a/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
@@ -1,5 +1,5 @@
-graph(%x : Dynamic
-      %1 : Dynamic) {
+graph(%x : Dynamic) {
+  %1 : Dynamic = aten::zeros[size=[4, 3], dtype=6, device=[0, -1], layout=0]()
   %2 : Dynamic = aten::mm(%x, %1)
   %3 : int = prim::Constant[value={1}]()
   %4 : Dynamic = prim::NumToTensor(%3)

--- a/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
@@ -1,0 +1,9 @@
+graph(%x : Dynamic
+      %1 : Dynamic) {
+  %2 : Dynamic = aten::mm(%x, %1)
+  %3 : int = prim::Constant[value={1}]()
+  %4 : Dynamic = prim::NumToTensor(%3)
+  %5 : Dynamic = aten::type_as(%4, %2)
+  %7 : Dynamic = aten::add[alpha={1}](%2, %5)
+  return (%7);
+}

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,5 +1,5 @@
-graph(%x : Dynamic
-      %1 : Dynamic) {
+graph(%x : Dynamic) {
+  %1 : Double(4, 3) = prim::Constant[value=<Tensor>]()
   %2 : Double(3, 3) = aten::mm(%x, %1)
   %3 : int = prim::Constant[value={1}]()
   %4 : Dynamic = prim::NumToTensor(%3)

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,0 +1,9 @@
+graph(%x : Dynamic
+      %1 : Dynamic) {
+  %2 : Double(3, 3) = aten::mm(%x, %1)
+  %3 : int = prim::Constant[value={1}]()
+  %4 : Dynamic = prim::NumToTensor(%3)
+  %5 : Dynamic = aten::type_as(%4, %2)
+  %7 : Dynamic = aten::add[alpha={1}](%2, %5)
+  return (%7);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4071,7 +4071,7 @@ def func(t):
 
     def test_module_with_params_called_fails(self):
         with self.assertRaisesRegex(RuntimeError, "Attempted to inline a Module with parameters. Stateful "
-                "modules to be inlined must be submodules of the callee."):
+                                                  "modules to be inlined must be submodules of the callee."):
             class ScriptMod(torch.jit.ScriptModule):
                 def __init__(self):
                     super(ScriptMod, self).__init__()
@@ -4086,7 +4086,6 @@ def func(t):
             @torch.jit.script
             def some_func(x):
                 return sm(x)
-
 
 
 class TestEndToEndHybridFrontendModels(JitTestCase):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -834,7 +834,7 @@ class TestJit(JitTestCase):
             return a + b
 
         ge = self.checkTrace(fn, [torch.randn(2, 2)] * 2)
-        self.assertExpectedGraph(ge.graph)
+        self.assertExpectedGraph(ge.__getattr__('forward').graph)
 
     def test_repeated_output(self):
         def fn(a, b):
@@ -842,7 +842,7 @@ class TestJit(JitTestCase):
             return z, z
 
         ge = self.checkTrace(fn, [torch.randn(2, 2) for _ in range(2)])
-        self.assertExpectedGraph(ge.graph)
+        self.assertExpectedGraph(ge.__getattr__('forward').graph)
 
     @skipIfNoTorchVision
     def test_alexnet(self):
@@ -1058,10 +1058,10 @@ class TestJit(JitTestCase):
         beta = torch.FloatTensor([321.0])
 
         out_ref = addmm(mat, mat1, mat2, alpha, beta)
-        self.run_pass('decompose_addmm', addmm.graph)
+        self.run_pass('decompose_addmm', addmm.__getattr__('forward').graph)
         out_test = addmm(mat, mat1, mat2, alpha, beta)
         self.assertEqual(out_ref, out_test)
-        self.assertExpected(canonical(addmm.graph))
+        self.assertExpected(canonical(addmm.__getattr__('forward').graph))
 
     def test_index_put(self):
         ten = torch.zeros(3, 3)
@@ -1304,10 +1304,11 @@ class TestScript(JitTestCase):
         def func2(x):
             return x.sum(dim=4)
 
-        self.assertExpected(canonical(func.graph), subname='1')
+        self.assertExpected(canonical(func.__getattr__('forward').graph), subname='1')
         # test that shape analysis is written correctly for sum with IntList[1] dim argument
-        torch._C._jit_pass_shape_analysis(func2.graph, (torch.zeros(1, 1, 1, 1, 4),), False)
-        self.assertExpected(canonical(func2.graph), subname='2')
+        torch._C._jit_pass_shape_analysis(
+            func2.__getattr__('forward').graph, (torch.zeros(1, 1, 1, 1, 4),), False)
+        self.assertExpected(canonical(func2.__getattr__('forward').graph), subname='2')
 
     def test_cat(self):
         @torch.jit.script
@@ -1336,9 +1337,9 @@ class TestScript(JitTestCase):
             return torch.cat([x], dim=1)
 
         self.assertExpected(
-            canonical(foo.graph) +
-            canonical(foo2.graph) +
-            canonical(foo3.graph))
+            canonical(foo.__getattr__('forward').graph) +
+            canonical(foo2.__getattr__('forward').graph) +
+            canonical(foo3.__getattr__('forward').graph))
 
     def test_func_call(self):
         script = '''
@@ -2792,7 +2793,7 @@ def func(t):
             return foo(b - 1.0, a) + 1.0
 
         # test we propagated shapes through the function
-        self.assertTrue("Dynamic" not in str(use.graph))
+        self.assertTrue("Dynamic" not in str(use.__getattr__('forward').graph))
 
         self.assertEqual(3, use(torch.ones(1, dtype=torch.float)))
         self.assertEqual(2, use(torch.zeros(1, dtype=torch.float)))
@@ -3008,8 +3009,8 @@ def func(t):
 
         a = torch.zeros(2, 2)
         b = torch.zeros(4, dtype=torch.long)
-        foo.graph.propagate_shapes((a, b), False)
-        self.assertExpected(canonical(foo.graph))
+        foo.__getattr__('forward').graph.propagate_shapes((a, b), False)
+        self.assertExpected(canonical(foo.__getattr__('forward').graph))
 
     def test_onnx_export_speculate(self):
 
@@ -3593,7 +3594,7 @@ def func(t):
             ''')
 
     def test_call_ge(self):
-        with self.assertRaisesRegex(RuntimeError, 'expected 1 arguments but found 3'):
+        with self.assertRaisesRegex(RuntimeError, 'expected at most 1 arguments but found 3'):
             @torch.jit.trace(torch.zeros(1, 2, 3))
             def foo(x):
                 return x
@@ -3623,7 +3624,7 @@ def func(t):
 
         # The neg op in the python function should be properly inlined to the
         # graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_python_mod_from_tracing_fn(self):
         class PythonMod(torch.nn.Module):
@@ -3642,7 +3643,7 @@ def func(t):
 
         # Note: the parameter self.param from the Python module is inlined
         # into the graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_traced_fn_from_tracing_fn(self):
         @torch.jit.trace(torch.rand(3, 4))
@@ -3653,7 +3654,7 @@ def func(t):
         def traced_fn(x):
             return traced_fn1(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_traced_mod_from_tracing_fn(self):
         class TracedModule(torch.nn.Module):
@@ -3672,7 +3673,7 @@ def func(t):
 
         # Note: the parameter self.param from the Python module is inlined
         # into the graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_script_fn_from_tracing_fn(self):
         @torch.jit.script
@@ -3683,7 +3684,7 @@ def func(t):
         def traced_fn(x):
             return script_fn(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_script_mod_from_tracing_fn(self):
         class ScriptMod(torch.jit.ScriptModule):
@@ -3701,7 +3702,7 @@ def func(t):
         def traced_fn(x):
             return sm(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(str(traced_fn.__getattr__('forward').graph))
 
     def test_call_python_fn_from_traced_module(self):
         def python_fn(x):
@@ -3839,7 +3840,7 @@ def func(t):
 
         # Note: the call to python_fn appears as `^python_fn()` and is called
         # as a PythonOp in the interpreter
-        self.assertExpected(str(script_fn.graph))
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
     def test_call_python_mod_from_script_fn(self):
         class PythonModule(torch.nn.Module):
@@ -3858,7 +3859,7 @@ def func(t):
 
         # Note: call to pm(x) appears as ^<python_value>() in the trace.
         # Parameters are NOT inlined.
-        self.assertExpected(str(script_fn.graph))
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
     def test_call_traced_fn_from_script_fn(self):
         @torch.jit.trace(torch.rand(3, 4))
@@ -3871,9 +3872,8 @@ def func(t):
 
         # Note: the neg op from traced_fn should be properly inlined into the
         # script function's graph
-        self.assertExpected(str(script_fn.graph))
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
-    @unittest.skip('TODO: Incorrect behavior')
     def test_call_traced_mod_from_script_fn(self):
         class TracedModule(torch.nn.Module):
             def __init__(self):
@@ -3889,18 +3889,9 @@ def func(t):
         def script_fn(x):
             return tm(x) + 1
 
-        # Note: At the time of writing this produces the following graph:
-        # graph(%x : Dynamic) {
-        #   %1 : Dynamic = ^<python_value>()(%x)
-        #   %2 : Long() = prim::Constant[value={1}]()
-        #   %3 : Dynamic = aten::add[alpha={1}](%1, %2)
-        #   return (%3);
-        # }
-        # This seems incorrect. Similarly to calling a traced module from a
-        # traced function, the behavior here should likely be that we inline
-        # the parameter from the traced module as a Constant node and we inline
-        # the ops into the graph of the script function. TODO: fix
-        self.assertExpected(str(script_fn.graph))
+        # Note: the parameter from the traced module should appear as a
+        # parameter on the implicit Module created for script_fn
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
     def test_call_script_fn_from_script_fn(self):
         @torch.jit.script
@@ -3913,9 +3904,8 @@ def func(t):
 
         # Note: the neg op from script_fn1 should be properly inlined into the
         # graph of script_fn
-        self.assertExpected(str(script_fn.graph))
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
-    @unittest.skip('TODO: Incorrect behavior')
     def test_call_script_mod_from_script_fn(self):
         class ScriptMod(torch.jit.ScriptModule):
             def __init__(self):
@@ -3932,18 +3922,9 @@ def func(t):
         def script_fn(x):
             return sm(x) + 1
 
-        # Note: At the time of writing this produces the following graph:
-        # graph(%x : Dynamic) {
-        #   %1 : Dynamic = ^<python_value>()(%x)
-        #   %2 : Long() = prim::Constant[value={1}]()
-        #   %3 : Dynamic = aten::add[alpha={1}](%1, %2)
-        #   return (%3);
-        # }
-        # This seems incorrect. Similarly to calling a script module from a
-        # traced function, the behavior here should likely be that we inline
-        # the parameter from the traced module as a Constant node and we inline
-        # the ops into the graph of the script function. TODO: fix
-        self.assertExpected(str(script_fn.graph))
+        # Note: the parameter from the script module should appear as a
+        # parameter on the implicit Module created for script_fn
+        self.assertExpected(str(script_fn.__getattr__('forward').graph))
 
     @unittest.skip('TODO: Python value resolution broken')
     def test_call_python_fn_from_script_module(self):

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -22,6 +22,7 @@
 #include "torch/csrc/jit/script/init.h"
 #include "torch/csrc/jit/script/python_tree_views.h"
 #include "torch/csrc/jit/python_interpreter.h"
+#include "torch/csrc/jit/pybind_utils.h"
 
 
 namespace torch  { namespace jit {
@@ -38,18 +39,6 @@ bool loadPythonClasses() {
   //PyObject *jit_dict = PyModule_GetDict(jit_module);
 
   return true;
-}
-
-// we cannot use the default py:cast<autograd::Variable> because it currently
-// unwraps the data tensor in the conversion process
-// TODO: replace with bs type
-variable_tensor_list createVariableTensorList(py::tuple tuple, size_t reserve_extra_space = 0) {
-  variable_tensor_list result;
-  result.reserve(tuple.size() + reserve_extra_space);
-  for(auto e : tuple) {
-    result.push_back(py::cast<autograd::Variable>(e));
-  }
-  return result;
 }
 
 } // anonymous namespace

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "torch/csrc/utils/pybind.h"
+
+#include "torch/csrc/jit/variable_tensor_list.h"
+
+namespace torch { namespace jit {
+
+namespace {
+
+// we cannot use the default py:cast<autograd::Variable> because it currently
+// unwraps the data tensor in the conversion process
+// TODO: replace with bs type
+variable_tensor_list createVariableTensorList(py::tuple tuple, size_t reserve_extra_space = 0) {
+  variable_tensor_list result;
+  result.reserve(tuple.size() + reserve_extra_space);
+  for(auto e : tuple) {
+    result.push_back(py::cast<autograd::Variable>(e));
+  }
+  return result;
+}
+
+}  // namespace
+
+} }  // namespace torch::jit

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -438,7 +438,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
     size_t total_inputs = attributes.size() + inputs.size();
     if(total_inputs > schema.arguments.size()) {
       err() << "expected at most " << schema.arguments.size() << " arguments "
-      << " but found " << total_inputs << "\n" << loc << "\n";
+      << "but found " << total_inputs << "\n" << loc << "\n";
       return at::nullopt;
     }
     // fill in positional arguments

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/script/compiler.h"
 #include "torch/csrc/jit/tensor_conversions.h"
 #include "torch/csrc/jit/python_tracer.h"
+#include "torch/csrc/jit/pybind_utils.h"
 
 #include <torch/csrc/api/include/torch/detail/ordered_dict.h>
 
@@ -327,20 +328,6 @@ private:
 };
 
 
-// TODO: dedup with other init
-
-// we cannot use the default py:cast<autograd::Variable> because it currently
-// unwraps the data tensor in the conversion process
-
-variable_tensor_list createVariableTensorList(py::tuple tuple, size_t reserve_extra_space = 0) {
-  variable_tensor_list result;
-  result.reserve(tuple.size() + reserve_extra_space);
-  for(auto e : tuple) {
-    result.push_back(py::cast<autograd::Variable>(e));
-  }
-  return result;
-}
-
 py::object unpackVariableTensorList(std::vector<at::Tensor> outputs) {
   // if we don't tell pybind these are variables it chokes on the
   // conversion.
@@ -473,6 +460,12 @@ void initJitScriptBindings(PyObject* module) {
           }
           auto graph = tracer::createGraphByTracing(func, std::move(inputs), num_inputs);
           self.create_method(name, std::move(graph), std::move(parameters));
+      })
+      .def("graph_for", [](Module& self, py::args args) {
+        if (self.find_method("forward")) {
+          return self.get_method("forward").graph_for(createVariableTensorList(args));
+        }
+        throw std::runtime_error("Attempted to call graph_for on a Module without a compiled forward()");
       });
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
@@ -489,7 +482,10 @@ void initJitScriptBindings(PyObject* module) {
     })
     .def("propagate_shapes", &Method::propagate_shapes)
     .def("propagate_and_assign_input_and_output_shapes", &Method::propagate_and_assign_input_and_output_shapes)
-    .def("params", &Method::params);
+    .def("params", &Method::params)
+    .def("graph_for", [](Method& self, py::args args) {
+      return self.graph_for(createVariableTensorList(args));
+    });
 
   m.def("_jit_script_compile", [](Def def, ResolutionCallback rcb) {
     return compileFunction(def, pythonResolver(rcb));

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -473,7 +473,7 @@ void initJitScriptBindings(PyObject* module) {
         }
         throw std::runtime_error("Attempted to call graph_for on a Module without a compiled forward()");
       })
-      .def("_forward", [](Module& self, py::args args) {
+      .def("forward", [](Module& self, py::args args) {
         // We implement this in C++ to avoid incurring the pybind11 dispatch
         // overhead twice: once to call into the method lookup for "forward"
         // and once to actually invoke the method.

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -54,13 +54,13 @@ struct Method {
   }
 
   variable_tensor_list run(variable_tensor_list && inputs) {
-    std::call_once(executor_init, [&]{
-      executor = GraphExecutor(graph(), optimize);
-    });
     for(auto tp : member_inputs) {
       inputs.push_back(*tp);
     }
-    return executor.run(std::move(inputs));
+    return get_executor().run(std::move(inputs));
+  }
+  std::shared_ptr<Graph> graph_for(const variable_tensor_list& inputs) {
+    return get_executor().graphFor(inputs);
   }
   std::shared_ptr<Graph> graph() const {
     return graph_;
@@ -137,10 +137,19 @@ struct Method {
     schema.reset(new FunctionSchema(std::move(schema_)));
     return *this;
   }
+
 private:
   std::string name_;
   std::shared_ptr<Graph> graph_; // for debugging and for inlining
   bool optimize;
+
+  GraphExecutor& get_executor() {
+    std::call_once(executor_init, [&]{
+      executor = GraphExecutor(graph(), optimize);
+    });
+    return executor;
+  }
+
   GraphExecutor executor; // for execution
   // member_inputs are a list of additional arguments appended to graph that are
   // inputs that come from the members of the Module or its submodules.

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -630,7 +630,8 @@ _compiled_methods_whitelist = {
     '_apply', 'apply', 'cuda', 'cpu', 'type', 'float', 'double', 'half',
     'state_dict', 'load_state_dict', '_load_from_state_dict', 'parameters',
     'named_parameters', '_all_buffers', 'children', 'named_children', 'modules',
-    'named_modules', 'zero_grad', 'share_memory', '_get_name', 'extra_repr'
+    'named_modules', 'zero_grad', 'share_memory', '_get_name', 'extra_repr',
+    '_slow_forward', '_tracing_name'
 }
 
 
@@ -698,9 +699,6 @@ class TracedModule(ScriptModule):
 class TopLevelTracedModule(TracedModule):
     def forward(self, *args, **kwargs):
         return self._get_method('forward')(*args, **kwargs)
-
-    def _slow_forward(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
 
 
 class _ConstModuleList(ScriptModule):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -586,6 +586,8 @@ class ScriptModule(with_metaclass(ScriptMeta, Module, torch._C.ScriptModule)):
                 return functools.wraps(original_method)(script_method)
             else:
                 return self._get_method(attr)
+        if attr == 'graph' and self._has_method('forward'):
+            return self.__getattr__('forward').graph
         return Module.__getattr__(self, attr)
 
     def __setattr__(self, attr, value):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -569,7 +569,7 @@ class ScriptMeta(type(torch._C.ScriptModule)):
         return super(ScriptMeta, cls).__init__(name, bases, attrs)
 
 
-class ScriptModule(with_metaclass(ScriptMeta, Module, torch._C.ScriptModule)):
+class ScriptModule(with_metaclass(ScriptMeta, torch._C.ScriptModule, Module)):
     def __init__(self, optimize=True):
         # must be before Module.init since the field is used in __getattr__
         Module.__init__(self)
@@ -608,9 +608,6 @@ class ScriptModule(with_metaclass(ScriptMeta, Module, torch._C.ScriptModule)):
 
     def __dir__(self):
         return sorted(Module.__dir__(self) + self._method_names())
-
-    def forward(self, *args, **kwargs):
-        return self._forward(*args, **kwargs)
 
     def define(self, lang):
         rcb = createResolutionCallback(frames_up=1)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -652,7 +652,7 @@ class TracedModule(ScriptModule):
     __frozen = False
 
     def __init__(self, orig, id_set=None, optimize=True):
-        super(TracedModule, self).__init__(optimize=True)
+        super(TracedModule, self).__init__(optimize=optimize)
         if id_set is None:
             id_set = set()
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -609,10 +609,8 @@ class ScriptModule(with_metaclass(ScriptMeta, Module, torch._C.ScriptModule)):
     def __dir__(self):
         return sorted(Module.__dir__(self) + self._method_names())
 
-    # Module already has this method defined, so we
-    # need to override it and send it through the ScriptModule lookup
     def forward(self, *args, **kwargs):
-        return self.__getattr__('forward')(*args, **kwargs)
+        return self._forward(*args, **kwargs)
 
     def define(self, lang):
         rcb = createResolutionCallback(frames_up=1)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -304,7 +304,7 @@ def trace(*args, **kwargs):
             orig = func
         else:
             # traced functions become a method on an Empty module
-            orig = ScriptModule()
+            orig = Module()
 
         module = TopLevelTracedModule(orig, **executor_options)
         module._create_method_from_trace('forward', func, args)


### PR DESCRIPTION
Solves https://github.com/pytorch/pytorch/issues/8716 and closes https://github.com/pytorch/pytorch/issues/8867

This makes it so that all of {script, traced} {module, function} create ScriptModules and implements proper inlining between them. This also greatly simplifies things and makes clear that tracing is a way to convert regular Python into a ScriptModule