### PR TITLE
Delete default copy constructor for Tensor

### DIFF
--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -124,7 +124,7 @@ struct WorkspaceIdInjector {
   void InjectWorkspaceId(Workspace* workspace) {
     if (workspace->HasBlob(NODE_ID)) {
       Blob* node_id_blob = workspace->GetBlob(NODE_ID);
-      TensorCPU node_id_tensor = node_id_blob->template Get<TensorCPU>();
+      const TensorCPU& node_id_tensor = node_id_blob->template Get<TensorCPU>();
       int node_id = node_id_tensor.template data<int32_t>()[0];
       CAFFE_ENFORCE(
           seq_ < (1 << 16),

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -168,6 +168,15 @@ class Tensor {
       return;
     }
     meta_ = src.meta();
+    if (src.size() == -1) {
+      dims_.clear();
+      size_ = -1;
+      data_.reset();
+      shares_data_ = false;
+      capacity_ = 0;
+      reserved_ = false;
+      return;
+    }
     Resize(src.dims());
     if (size() > 0) {
       if (meta_.copy()) {
@@ -680,6 +689,21 @@ class Tensor {
     #endif
     return dims_[i];
   }
+
+  Tensor Clone() const {
+    Tensor x;
+    x.CopyFrom(*this);
+    return x;
+  }
+
+  Tensor(Tensor<Context>&& src) noexcept {
+    swap(src);
+  }
+
+  /**
+   * @brief Delete the copy constructor and use Clone explicitly
+   */
+  Tensor(const Tensor<Context>& src) = delete;
 
  protected:
   vector<TIndex> dims_;

--- a/caffe2/mobile/contrib/ulp2/ulp.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp.cc
@@ -286,7 +286,8 @@ std::unique_ptr<QConvState> create2b1bConvState(Workspace* ws,
 #endif
   };
   if (b) {
-    state->bias = caffe2::make_unique<TensorCPU>(*b);
+    CPUContext context;
+    state->bias = caffe2::make_unique<TensorCPU>(*b, &context);
   }
   return state;
 }

--- a/caffe2/operators/elementwise_op_test.h
+++ b/caffe2/operators/elementwise_op_test.h
@@ -59,7 +59,7 @@ void elementwiseAnd() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), N);
     std::vector<bool> result{true, false, false, false};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -79,7 +79,7 @@ void elementwiseAnd() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), M * N);
     std::vector<bool> result{
         true, false, false, false, true, false, false, false};
@@ -105,7 +105,7 @@ void elementwiseOr() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), N);
     std::vector<bool> result{true, true, true, false};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -125,7 +125,7 @@ void elementwiseOr() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), M * N);
     std::vector<bool> result{true, true, true, false, true, true, true, false};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -150,7 +150,7 @@ void elementwiseXor() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), N);
     std::vector<bool> result{false, true, true, false};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -170,7 +170,7 @@ void elementwiseXor() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), M * N);
     std::vector<bool> result{
         false, true, true, false, false, true, true, false};
@@ -195,7 +195,7 @@ void elementwiseNot() {
   EXPECT_TRUE(op->Run());
   auto* blob = ws.GetBlob("Y");
   EXPECT_NE(nullptr, blob);
-  caffe2::TensorCPU Y(blob->Get<caffe2::Tensor<Context>>());
+  const auto& Y = blob->Get<caffe2::Tensor<Context>>();
   EXPECT_EQ(Y.size(), N);
   std::vector<bool> result{false, true};
   for (size_t i = 0; i < Y.size(); ++i) {
@@ -217,7 +217,7 @@ void elementwiseEQ() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), N);
     std::vector<bool> result{false, true, false, true};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -234,7 +234,7 @@ void elementwiseEQ() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), N);
     std::vector<bool> result{true, true, false, false};
     for (size_t i = 0; i < Z.size(); ++i) {
@@ -253,7 +253,7 @@ void elementwiseEQ() {
     EXPECT_TRUE(op->Run());
     auto* blob = ws.GetBlob("Z");
     EXPECT_NE(nullptr, blob);
-    caffe2::TensorCPU Z(blob->Get<caffe2::Tensor<Context>>());
+    const auto& Z = blob->Get<caffe2::Tensor<Context>>();
     EXPECT_EQ(Z.size(), M * N);
     std::vector<bool> result{
         true, false, false, true, false, true, true, false};

--- a/caffe2/operators/reduction_ops.cc
+++ b/caffe2/operators/reduction_ops.cc
@@ -296,13 +296,14 @@ bool SumElementsGradientOp<T, Context>::RunOnDevice()
 #endif
 {
   auto& X = Input(0);
-  TensorCPU sum_grad = TensorCPU(Input(1));
+  const auto& sum_grad = Input(1);
   auto* dX = Output(0);
   dX->ResizeLike(X);
   DCHECK_EQ(sum_grad.size(), 1);
   math::Set<T, Context>(
       dX->size(),
-      static_cast<T>(sum_grad.data<T>()[0] * (average_ ? 1.0 / X.size() : 1)),
+      static_cast<T>(
+          sum_grad.template data<T>()[0] * (average_ ? 1.0 / X.size() : 1)),
       dX->template mutable_data<T>(),
       &context_);
   return true;

--- a/caffe2/python/pybind_state_int8.cc
+++ b/caffe2/python/pybind_state_int8.cc
@@ -32,7 +32,7 @@ namespace python {
 class Int8TensorFetcher : public BlobFetcherBase {
  public:
   pybind11::object Fetch(const Blob& blob) override {
-    const caffe2::int8::Int8TensorCPU src =
+    const caffe2::int8::Int8TensorCPU& src =
         blob.template Get<caffe2::int8::Int8TensorCPU>();
     const int numpy_type = CaffeToNumpyType(src.t.meta());
     CAFFE_ENFORCE(numpy_type != -1, "Int8Tensor contains unknown type data");

--- a/caffe2/queue/rebatching_queue.cc
+++ b/caffe2/queue/rebatching_queue.cc
@@ -163,7 +163,7 @@ bool RebatchingQueue::enqueueOne(
   auto& tensorVector = splittedInputs.back();
   tensorVector.reserve(inputs.size());
   for (const auto* tensorPtr : inputs) {
-    tensorVector.push_back(*tensorPtr);
+    tensorVector.push_back(tensorPtr->Clone());
   }
 
   return enqueue(std::move(splittedInputs));

--- a/caffe2/sgd/yellowfin_op.h
+++ b/caffe2/sgd/yellowfin_op.h
@@ -111,19 +111,19 @@ class YellowFinOp final : public Operator<Context> {
   bool RunOnDevice() override {
 // Iter live on the CPU
 
-#define CAFFE2_YF_READ_INPUT(INPUT_NAME, VAR_NAME)  \
-  const auto VAR_NAME##_tensor = Input(INPUT_NAME); \
+#define CAFFE2_YF_READ_INPUT(INPUT_NAME, VAR_NAME)   \
+  const auto& VAR_NAME##_tensor = Input(INPUT_NAME); \
   VAR_NAME##_ = VAR_NAME##_tensor.template data<T>();
 
-    CAFFE2_YF_READ_INPUT(PARAM, param)
-    CAFFE2_YF_READ_INPUT(MOMENT, moment)
-    CAFFE2_YF_READ_INPUT(LR_AVG, lr_avg)
-    CAFFE2_YF_READ_INPUT(MU_AVG, mu_avg)
-    CAFFE2_YF_READ_INPUT(CURV_WIN, curv_win)
-    CAFFE2_YF_READ_INPUT(G_AVG, g_avg)
-    CAFFE2_YF_READ_INPUT(G2_AVG, g2_avg)
-    CAFFE2_YF_READ_INPUT(SCALARS_MEMORY, scalars_memory)
-    CAFFE2_YF_READ_INPUT(GRAD, grad)
+CAFFE2_YF_READ_INPUT(PARAM, param)
+CAFFE2_YF_READ_INPUT(MOMENT, moment)
+CAFFE2_YF_READ_INPUT(LR_AVG, lr_avg)
+CAFFE2_YF_READ_INPUT(MU_AVG, mu_avg)
+CAFFE2_YF_READ_INPUT(CURV_WIN, curv_win)
+CAFFE2_YF_READ_INPUT(G_AVG, g_avg)
+CAFFE2_YF_READ_INPUT(G2_AVG, g2_avg)
+CAFFE2_YF_READ_INPUT(SCALARS_MEMORY, scalars_memory)
+CAFFE2_YF_READ_INPUT(GRAD, grad)
 #undef CAFFE2_YF_READ_OUTPUT
 
     CAFFE_ENFORCE(OperatorBase::InputIsType<TensorCPU>(ITER));


### PR DESCRIPTION
Summary:
Current Tensor has a constructor that looks like a copy constructor but actually is not, instead we have a
generated default copy constructor which results in aliasing behavior for Tensor, this might cause some
unexpected behavior. We'd like to remove the default copy constructor and have people use Clone or the
move constructor instead.

Reviewed By: dzhulgakov

Differential Revision: D8556056
