### PR TITLE
[c10d] No default device for ProcessGroupGloo

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -214,7 +214,7 @@ ProcessGroupGloo::ProcessGroupGloo(
       cacheNumAlgorithmEntries_(options.cacheNumAlgorithmEntries) {
   auto& devices = options.devices;
   if (devices.empty()) {
-    devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
+    throw std::runtime_error("No device(s) specified");
   }
 
   for (auto& device : options.devices) {


### PR DESCRIPTION
This should be set by the code that instantiates it, be it the Python
bindings or other C++ code. Defaulting to use localhost is not useful
beyond tests. Instead of keeping multiple default paths around we can
punt on it here and require it to be initialized elsewhere.

