### PR TITLE
[c10d] Fix link order for building C++ tests

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -77,8 +77,8 @@ set(C10D_SRCS
 
 set(C10D_LIBS
   caffe2_gpu
-  ${Gloo_NATIVE_LIBRARY}
   ${Gloo_LIBRARY}
+  ${Gloo_NATIVE_LIBRARY}
   )
 
 if(DISTRIBUTED_NCCL_FOUND)


### PR DESCRIPTION
List dependency on gloo_cuda before dependency on gloo such that
unresolved symbols in gloo_cuda are correctly resolved (since the linker
resolves from left to right).

This fixes building c10d C++ tests on GCC 4.8.

