### PR TITLE
Replace max_pool with max_pool_with_indices

### DIFF
--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -41,10 +41,13 @@ std::tuple<Tensor,Tensor> adaptive_max_pool1d(const Tensor & self, IntList outpu
   return std::make_tuple(output.squeeze(2), indices.squeeze(2));
 }
 
-std::tuple<Tensor,Tensor> max_pool1d(
-    const Tensor & self, IntList kernel_size, IntList stride, IntList padding,
-    IntList dilation, bool ceil_mode) {
-
+std::tuple<Tensor, Tensor> max_pool1d_with_indices(
+    const Tensor& self,
+    IntList kernel_size,
+    IntList stride,
+    IntList padding,
+    IntList dilation,
+    bool ceil_mode) {
   if (stride.empty()) {
     stride = kernel_size;
   }
@@ -55,7 +58,7 @@ std::tuple<Tensor,Tensor> max_pool1d(
   check1d("max_pool1d", "dilation", dilation);
 
   Tensor output, indices;
-  std::tie(output, indices) = at::max_pool2d(
+  std::tie(output, indices) = at::max_pool2d_with_indices(
       self.unsqueeze(2),
       {1, kernel_size[0]},
       {1, stride[0]},
@@ -90,6 +93,42 @@ Tensor avg_pool1d(
       count_include_pad);
 
   return output.squeeze(2);
+}
+
+Tensor max_pool1d(
+    const Tensor& self,
+    IntList kernel_size,
+    IntList stride,
+    IntList padding,
+    IntList dilation,
+    bool ceil_mode) {
+  auto output_and_indices = at::max_pool1d_with_indices(
+      self, kernel_size, stride, padding, dilation, ceil_mode);
+  return std::get<0>(output_and_indices);
+}
+
+Tensor max_pool2d(
+    const Tensor& self,
+    IntList kernel_size,
+    IntList stride,
+    IntList padding,
+    IntList dilation,
+    bool ceil_mode) {
+  auto output_and_indices = at::max_pool2d_with_indices(
+      self, kernel_size, stride, padding, dilation, ceil_mode);
+  return std::get<0>(output_and_indices);
+}
+
+Tensor max_pool3d(
+    const Tensor& self,
+    IntList kernel_size,
+    IntList stride,
+    IntList padding,
+    IntList dilation,
+    bool ceil_mode) {
+  auto output_and_indices = at::max_pool3d_with_indices(
+      self, kernel_size, stride, padding, dilation, ceil_mode);
+  return std::get<0>(output_and_indices);
 }
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -817,7 +817,16 @@
 
 - func: max_values(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
 
-- func: max_pool1d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> (Tensor, Tensor)
+- func: max_pool1d_with_indices(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> (Tensor, Tensor)
+  variants: function
+
+- func: max_pool1d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> Tensor
+  variants: function
+
+- func: max_pool2d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> Tensor
+  variants: function
+
+- func: max_pool3d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> Tensor
   variants: function
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -149,12 +149,12 @@
   scalar_check:
     output: 'false'
 
-- name: max_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, IntList[2] dilation=1, bool ceil_mode=false)
+- name: max_pool2d_with_indices(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, IntList[2] dilation=1, bool ceil_mode=false)
   cname: SpatialDilatedMaxPooling
   default_init:
     stride: kernel_size
 
-- name: max_pool3d(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, IntList[3] dilation=1, bool ceil_mode=false)
+- name: max_pool3d_with_indices(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, IntList[3] dilation=1, bool ceil_mode=false)
   cname: VolumetricDilatedMaxPooling
   default_init:
     stride: kernel_size

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -340,10 +340,10 @@ TEST_CASE("integration/mnist", "[cuda]") {
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](torch::Tensor x) {
-    x = std::get<0>(at::max_pool2d(conv1->forward(x), {2, 2})).clamp_min(0);
+    x = at::max_pool2d(conv1->forward(x), {2, 2}).relu();
     x = conv2->forward(x);
     x = drop2d->forward(x);
-    x = std::get<0>(at::max_pool2d(x, {2, 2})).clamp_min(0);
+    x = at::max_pool2d(x, {2, 2}).relu();
 
     x = x.view({-1, 320});
     x = linear1->forward(x).clamp_min(0);
@@ -377,10 +377,10 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](torch::Tensor x) {
-    x = std::get<0>(at::max_pool2d(conv1->forward(x), {2, 2})).clamp_min(0);
+    x = at::max_pool2d(conv1->forward(x), {2, 2}).relu();
     x = batchnorm2d->forward(x);
     x = conv2->forward(x);
-    x = std::get<0>(at::max_pool2d(x, {2, 2})).clamp_min(0);
+    x = at::max_pool2d(x, {2, 2}).relu();
 
     x = x.view({-1, 320});
     x = linear1->forward(x).clamp_min(0);

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -915,11 +915,11 @@
 - name: fractional_max_pool2d_forward(Tensor self, IntList kernel_size, IntList output_size, Tensor random_samples)
   self: fractional_max_pool2d_backward(grad, self, kernel_size, output_size, indices)
 
-- name: max_pool2d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
-  self: max_pool2d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+- name: max_pool2d_with_indices_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+  self: max_pool2d_with_indices_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
 
-- name: max_pool3d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
-  self: max_pool3d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+- name: max_pool3d_with_indices_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+  self: max_pool3d_with_indices_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
 
 - name: max_unpool2d_forward(Tensor self, Tensor indices, IntList output_size)
   self: max_unpool2d_backward(grad, self, indices, output_size)
@@ -1041,11 +1041,11 @@
   grad_output: leaky_relu_backward(grad, self, negative_slope)
   self: zeros_like(grad)
 
-- name: max_pool2d_backward(Tensor grad_output, Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode, Tensor indices)
+- name: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode, Tensor indices)
   grad_output: max_pool_double_backward(grad, indices, 2);
   self: zeros_like(self)
 
-- name: max_pool3d_backward(Tensor grad_output, Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode, Tensor indices)
+- name: max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode, Tensor indices)
   grad_output: max_pool_double_backward(grad, indices, 3);
   self: zeros_like(self)
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -25,7 +25,7 @@ SKIP_PYTHON_BINDINGS = [
     'index',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_sum.*', '_th_prod.*',
-    'arange.*', 'range.*', '_gesv.*', 'slice',
+    'arange.*', 'range.*', '_gesv.*', 'slice', 'max_pool1d', 'max_pool2d', 'max_pool3d'
 ]
 
 PY_VARIABLE_METHOD_VARARGS = CodeTemplate("""\

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -341,7 +341,7 @@ def max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1,
 
     See :class:`~torch.nn.MaxPool1d` for details.
     """
-    ret = torch.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)
+    ret = torch.max_pool1d_with_indices(input, kernel_size, stride, padding, dilation, ceil_mode)
     return ret if return_indices else ret[0]
 
 
@@ -352,7 +352,7 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
 
     See :class:`~torch.nn.MaxPool2d` for details.
     """
-    ret = torch._C._nn.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)
+    ret = torch._C._nn.max_pool2d_with_indices(input, kernel_size, stride, padding, dilation, ceil_mode)
     return ret if return_indices else ret[0]
 
 
@@ -363,7 +363,7 @@ def max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1,
 
     See :class:`~torch.nn.MaxPool3d` for details.
     """
-    ret = torch._C._nn.max_pool3d(input, kernel_size, stride, padding, dilation, ceil_mode)
+    ret = torch._C._nn.max_pool3d_with_indices(input, kernel_size, stride, padding, dilation, ceil_mode)
     return ret if return_indices else ret[0]
 
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -396,11 +396,11 @@ def softplus(g, self, beta, threshold):
     return g.op('Softplus', self)
 
 
-def max_pool1d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
+def max_pool1d_with_indices(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     if ceil_mode:
-        return _unimplemented("max_pool1d", "ceil_mode")
+        return _unimplemented("max_pool1d_with_indices", "ceil_mode")
     if set(_single(dilation)) != {1}:
-        return _unimplemented("max_pool1d", "dilation")
+        return _unimplemented("max_pool1d_with_indices", "dilation")
     if stride is None:
         stride = kernel_size
     r = g.op("MaxPool", input,
@@ -410,11 +410,11 @@ def max_pool1d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     return r, None
 
 
-def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
+def max_pool2d_with_indices(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     if ceil_mode:
-        return _unimplemented("max_pool2d", "ceil_mode")
+        return _unimplemented("max_pool2d_with_indices", "ceil_mode")
     if set(_pair(dilation)) != {1}:
-        return _unimplemented("max_pool2d", "dilation")
+        return _unimplemented("max_pool2d_with_indices", "dilation")
     if not stride:
         stride = kernel_size
     r = g.op("MaxPool", input,
@@ -424,11 +424,11 @@ def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     return r, None
 
 
-def max_pool3d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
+def max_pool3d_with_indices(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     if ceil_mode:
-        return _unimplemented("max_pool3d", "ceil_mode")
+        return _unimplemented("max_pool3d_with_indices", "ceil_mode")
     if set(_triple(dilation)) != {1}:
-        return _unimplemented("max_pool3d", "dilation")
+        return _unimplemented("max_pool3d_with_indices", "dilation")
     if not stride:
         stride = kernel_size
     r = g.op("MaxPool", input,


### PR DESCRIPTION
The ATen max pooling functions currently return the output values (the maxima) and the indices of the maxima in a tuple. This makes it super inconvenient to access either of these things alone, since you have to write e.g. `auto values = std::get<0>(at::max_pool2d(..., {2, 2}))`. The second return value (the indices) is required only in rather niche cases, so it should be easier to get only the values.

This PR does two things:
1. Rename all the existing max pooling functions from `max_poolXd` to `max_poolXd_with_indices`,
2. Create C++ functions (that are not bound to Python) called `max_poolXd` that call `max_poolXd_with_indices` but return only the first value.

This makes the whole business happier to use from C++, without changing anything from Python.

@colesbury @ezyang @SsnL @apaszke 

CC @ebetica 