### PR TITLE
Stop making dynamic allocations of PinnedMemoryAllocator.

### DIFF
--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -13,22 +13,4 @@ struct Allocator {
   virtual void deallocate(void* ptr) const = 0;
 };
 
-namespace detail {
-
-struct AllocatorRetainable : public Retainable {
-  AllocatorRetainable(std::unique_ptr<Allocator> allocator)
-    : allocator(std::move(allocator)) {}
-
-  void* allocate(size_t n) {
-    return allocator->allocate(n);
-  }
-  void deallocate(void* ptr) {
-    return allocator->deallocate(ptr);
-  }
-private:
-  std::unique_ptr<Allocator> allocator;
-};
-
-}  // namespace at::detail
-
 }  // namespace at

--- a/aten/src/ATen/UndefinedType.cpp
+++ b/aten/src/ATen/UndefinedType.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<Storage> UndefinedType::storageFromBlob(void * data, int64_t siz
 std::unique_ptr<Storage> UndefinedType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   AT_ERROR("unsafeStorageFromTH not defined for UndefinedType");
 }
-std::unique_ptr<Storage> UndefinedType::storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const {
+std::unique_ptr<Storage> UndefinedType::storageWithAllocator(int64_t size, Allocator* allocator) const {
   AT_ERROR("storageWithAllocator not defined for UndefinedType");
 }
 Tensor UndefinedType::unsafeTensorFromTH(void * th_pointer, bool retain) const {

--- a/aten/src/ATen/UndefinedType.h
+++ b/aten/src/ATen/UndefinedType.h
@@ -22,7 +22,7 @@ struct UndefinedType final : public Type {
   virtual std::unique_ptr<Storage> storage() const override;
   virtual std::unique_ptr<Storage> storage(size_t size) const override;
   virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const override;
+  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
   virtual size_t elementSizeInBytes() const override;

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
@@ -18,4 +18,10 @@ void PinnedMemoryAllocator::deallocate(void* ptr) const {
   return state->cudaHostAllocator->free(nullptr, ptr);
 }
 
+// No risk of static initialization order fiasco
+static PinnedMemoryAllocator r;
+PinnedMemoryAllocator* getPinnedMemoryAllocator() {
+  return &r;
+}
+
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.h
@@ -9,4 +9,6 @@ struct PinnedMemoryAllocator final : public Allocator {
   void deallocate(void* ptr) const override;
 };
 
+PinnedMemoryAllocator* getPinnedMemoryAllocator();
+
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -128,8 +128,8 @@ int64_t CUDAHooks::current_device() const {
   return -1;
 }
 
-std::unique_ptr<Allocator> CUDAHooks::newPinnedMemoryAllocator() const {
-  return std::unique_ptr<Allocator>(new PinnedMemoryAllocator());
+Allocator* CUDAHooks::getPinnedMemoryAllocator() const {
+  return at::cuda::getPinnedMemoryAllocator();
 }
 
 void CUDAHooks::registerCUDATypes(Context* context) const {

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -22,7 +22,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   struct cudaDeviceProp* getCurrentDeviceProperties(THCState*) const override;
   struct cudaDeviceProp* getDeviceProperties(THCState*, int device) const override;
   int64_t current_device() const override;
-  std::unique_ptr<Allocator> newPinnedMemoryAllocator() const override;
+  Allocator* getPinnedMemoryAllocator() const override;
   void registerCUDATypes(Context*) const override;
   bool compiledWithCuDNN() const override;
   bool supportsDilatedConvolutionWithCuDNN() const override;

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -105,7 +105,7 @@ struct AT_API CUDAHooksInterface {
     return -1;
   }
 
-  virtual std::unique_ptr<Allocator> newPinnedMemoryAllocator() const {
+  virtual Allocator* getPinnedMemoryAllocator() const {
     AT_ERROR("pinned memory requires CUDA");
   }
 

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -10,8 +10,8 @@ Tensor pin_memory(const Tensor& self) {
   if (self.type().backend() != kCPU) {
     AT_ERROR("cannot pin '", self.type().toString(), "' only CPU memory can be pinned");
   }
-  auto allocator = detail::getCUDAHooks().newPinnedMemoryAllocator();
-  auto tensor = self.type().tensorWithAllocator(self.sizes(), self.strides(), std::move(allocator));
+  auto* allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
+  auto tensor = self.type().tensorWithAllocator(self.sizes(), self.strides(), allocator);
   tensor.copy_(self);
   return tensor;
 }

--- a/aten/src/ATen/native/cuda/Gesv.cu
+++ b/aten/src/ATen/native/cuda/Gesv.cu
@@ -73,9 +73,9 @@ static inline magma_int_t magma_int_cast(int64_t value, const char* varname) {
 template<class T>
 static inline std::unique_ptr<Storage> pin_memory(int64_t size, Tensor dummy) {
   int64_t adjusted_size = size * sizeof(T);
-  auto allocator = std::unique_ptr<Allocator>(new cuda::PinnedMemoryAllocator());
+  auto* allocator = cuda::getPinnedMemoryAllocator();
   auto& backend = dummy.type().toBackend(kCPU).toScalarType(kByte);
-  return backend.storageWithAllocator(adjusted_size, std::move(allocator));
+  return backend.storageWithAllocator(adjusted_size, allocator);
 }
 
 #define ALLOCATE_ARRAY(name, type, size, dummy_tensor) \

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<Storage> ${Type}::storage(size_t size) const {
 std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
   AT_ERROR("storage not supported on sparse");
 }
-std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const {
+std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
   AT_ERROR("storage not supported on sparse");
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {

--- a/aten/src/ATen/templates/StorageDerived.h
+++ b/aten/src/ATen/templates/StorageDerived.h
@@ -18,7 +18,7 @@ public:
   explicit ${Storage}(Context* context);
   ${Storage}(Context* context, ${THStorage} *wrapped);
   ${Storage}(Context* context, size_t size);
-  ${Storage}(Context* context, size_t size, std::unique_ptr<Allocator> allocator);
+  ${Storage}(Context* context, size_t size, Allocator* allocator);
   ${Storage}(Context* context,
     void * data, size_t size, const std::function<void(void*)> & deleter);
   virtual ~${Storage}();

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -83,10 +83,10 @@ Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides, const s
   auto storage = storageFromBlob(data, computeStorageSize(sizes, strides), deleter);
   return tensor(*storage, 0, sizes, strides);
 }
-Tensor Type::tensorWithAllocator(IntList sizes, std::unique_ptr<Allocator> allocator) const {
+Tensor Type::tensorWithAllocator(IntList sizes, Allocator* allocator) const {
   return tensorWithAllocator(sizes, defaultStrides(sizes), std::move(allocator));
 }
-Tensor Type::tensorWithAllocator(IntList sizes, IntList strides, std::unique_ptr<Allocator> allocator) const {
+Tensor Type::tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const {
   auto storage = storageWithAllocator(computeStorageSize(sizes, strides), std::move(allocator));
   return tensor(*storage, 0, sizes, strides);
 }

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -58,7 +58,7 @@ struct AT_API Type {
   virtual std::unique_ptr<Storage> storage() const = 0;
   virtual std::unique_ptr<Storage> storage(size_t size) const = 0;
   virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const = 0;
+  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const = 0;
   virtual std::unique_ptr<Generator> generator() const = 0;
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
   virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
@@ -85,8 +85,8 @@ struct AT_API Type {
 
   Tensor tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter=noop_deleter) const;
   Tensor tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter=noop_deleter) const;
-  Tensor tensorWithAllocator(IntList sizes, std::unique_ptr<Allocator> allocator) const;
-  Tensor tensorWithAllocator(IntList sizes, IntList strides, std::unique_ptr<Allocator> allocator) const;
+  Tensor tensorWithAllocator(IntList sizes, Allocator* allocator) const;
+  Tensor tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const;
   Tensor scalarTensor(Scalar s) const;
 
   bool operator==(const Type& other) const;

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -53,9 +53,9 @@ std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, con
     return std::unique_ptr<Storage>(
       new ${Storage}(context,data,size,deleter));
 }
-std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const {
+std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
     return std::unique_ptr<Storage>(
-        new ${Storage}(context, size, std::move(allocator)));
+        new ${Storage}(context, size, allocator));
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   if (retain)

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -25,7 +25,7 @@ struct ${Type} final : public Type {
   virtual std::unique_ptr<Storage> storage() const override;
   virtual std::unique_ptr<Storage> storage(size_t size) const override;
   virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const override;
+  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
   virtual size_t elementSizeInBytes() const override;

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -125,8 +125,8 @@ std::unique_ptr<Storage> VariableType::storageFromBlob(void * data, int64_t size
 std::unique_ptr<Storage> VariableType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   return baseType->unsafeStorageFromTH(th_pointer, retain);
 }
-std::unique_ptr<Storage> VariableType::storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const {
-  return baseType->storageWithAllocator(size, std::move(allocator));
+std::unique_ptr<Storage> VariableType::storageWithAllocator(int64_t size, Allocator* allocator) const {
+  return baseType->storageWithAllocator(size, allocator);
 }
 Tensor VariableType::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   return make_variable(baseType->unsafeTensorFromTH(th_pointer, retain), /*requires_grad=*/false);

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -38,7 +38,7 @@ struct VariableType final : public at::Type {
   virtual std::unique_ptr<at::Storage> storage() const override;
   virtual std::unique_ptr<at::Storage> storage(size_t size) const override;
   virtual std::unique_ptr<at::Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<at::Allocator> allocator) const override;
+  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, at::Allocator* allocator) const override;
   virtual std::unique_ptr<at::Generator> generator() const override;
   virtual const char * toString() const override;
   virtual at::TypeID ID() const override;


### PR DESCRIPTION
There is no relevant state in PinnedMemoryAllocator, so we
can have a single allocator with static lifetime.

Furthermore, this is the only use case of `std::unique_ptr<Allocator>`, so we revert it to `Allocator*`.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @colesbury 
