### PR TITLE
[C++ API] Set random seed at the start of C++ tests

### DIFF
--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -1,7 +1,7 @@
 #include <catch.hpp>
 
 #include <torch/torch.h>
-
+#include <torch/utils.h>
 #include <torch/nn/modules/any.h>
 
 #include <algorithm>
@@ -14,6 +14,7 @@ using Catch::Contains;
 using Catch::StartsWith;
 
 TEST_CASE("any-module") {
+  torch::manual_seed(0);
   SECTION("int()") {
     struct M : torch::nn::Module {
       int forward() {
@@ -245,6 +246,7 @@ AnyModule::Value make_value(T&& value) {
 } // namespace torch
 
 TEST_CASE("any-value") {
+  torch::manual_seed(0);
   SECTION("gets the correct value for the right type") {
     SECTION("int") {
       auto value = make_value(5);

--- a/test/cpp/api/cursor.cpp
+++ b/test/cpp/api/cursor.cpp
@@ -3,6 +3,7 @@
 #include <torch/nn/cursor.h>
 #include <torch/nn/module.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 #include <iostream>
 #include <iterator>
@@ -58,6 +59,7 @@ struct Container : public torch::nn::Module {
 };
 
 TEST_CASE("cursor/module") {
+  torch::manual_seed(0);
   SECTION("Works for flat models (depth = 1)") {
     Container model(TestModule(1), TestModule(2), TestModule(3));
     auto cursor = model.modules();
@@ -250,6 +252,7 @@ TEST_CASE("cursor/module") {
 }
 
 TEST_CASE("cursor/parameter") {
+  torch::manual_seed(0);
   SECTION("Works for single models") {
     TestModule model(1);
     auto cursor = model.parameters();
@@ -357,6 +360,7 @@ TEST_CASE("cursor/parameter") {
 }
 
 TEST_CASE("cursor/non-const-to-const-conversion") {
+  torch::manual_seed(0);
   auto first = std::make_shared<TestModule>(1);
   auto second = std::make_shared<TestModule>(2);
   Container model(first, second);
@@ -385,6 +389,7 @@ TEST_CASE("cursor/non-const-to-const-conversion") {
 }
 
 TEST_CASE("cursor/can-invoke-const-method-on-const-cursor") {
+  torch::manual_seed(0);
   TestModule model(1);
 
   /// This will only compile if `Cursor` has the appropriate const methods.

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -233,6 +233,7 @@ bool test_mnist(
 }
 
 TEST_CASE("integration/cartpole") {
+  torch::manual_seed(0);
   std::cerr << "Training episodic policy gradient with a critic for up to 3000"
                " episodes, rest your eyes for a bit!\n";
   auto model = std::make_shared<torch::SimpleContainer>();
@@ -331,6 +332,7 @@ TEST_CASE("integration/cartpole") {
 }
 
 TEST_CASE("integration/mnist", "[cuda]") {
+  torch::manual_seed(0);
   auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
@@ -366,6 +368,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
 }
 
 TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
+  torch::manual_seed(0);
   auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto batchnorm2d =

--- a/test/cpp/api/main.cpp
+++ b/test/cpp/api/main.cpp
@@ -2,7 +2,6 @@
 #include <catch.hpp>
 
 #include <torch/cuda.h>
-#include <torch/utils.h>
 
 #include <iostream>
 
@@ -22,9 +21,6 @@ int main(int argc, char* argv[]) {
     // ~ disables the [cuda] tag.
     session.configData().testsOrTags.emplace_back("~[cuda]");
   }
-
-  // Set a deterministic random seed for all tests.
-  torch::manual_seed(0);
 
   return session.run();
 }

--- a/test/cpp/api/main.cpp
+++ b/test/cpp/api/main.cpp
@@ -2,6 +2,7 @@
 #include <catch.hpp>
 
 #include <torch/cuda.h>
+#include <torch/utils.h>
 
 #include <iostream>
 
@@ -21,6 +22,9 @@ int main(int argc, char* argv[]) {
     // ~ disables the [cuda] tag.
     session.configData().testsOrTags.emplace_back("~[cuda]");
   }
+
+  // Set a deterministic random seed for all tests.
+  torch::manual_seed(0);
 
   return session.run();
 }

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -17,41 +17,15 @@ using OrderedDict = torch::detail::OrderedDict<std::string, T>;
 
 using Catch::StartsWith;
 
-TEST_CASE("misc") {
-  SECTION("no_grad") {
-    torch::NoGradGuard guard;
-    Linear model(5, 2);
-    auto x = torch::randn({10, 5}, torch::requires_grad());
-    auto y = model->forward(x);
-    torch::Tensor s = y.sum();
+TEST_CASE("NoGrad") {
+  torch::NoGradGuard guard;
+  Linear model(5, 2);
+  auto x = torch::randn({10, 5}, torch::requires_grad());
+  auto y = model->forward(x);
+  torch::Tensor s = y.sum();
 
-    s.backward();
-    REQUIRE(!model->parameters()["weight"].grad().defined());
-  }
-
-  SECTION("CPU random seed") {
-    int size = 100;
-    torch::manual_seed(7);
-    auto x1 = torch::randn({size});
-    torch::manual_seed(7);
-    auto x2 = torch::randn({size});
-
-    auto l_inf = (x1.data() - x2.data()).abs().max().toCFloat();
-    REQUIRE(l_inf < 1e-10);
-  }
-}
-
-TEST_CASE("misc_cuda", "[cuda]") {
-  SECTION("CUDA random seed") {
-    int size = 100;
-    torch::manual_seed(7);
-    auto x1 = torch::randn({size}, torch::kCUDA);
-    torch::manual_seed(7);
-    auto x2 = torch::randn({size}, torch::kCUDA);
-
-    auto l_inf = (x1.data() - x2.data()).abs().max().toCFloat();
-    REQUIRE(l_inf < 1e-10);
-  }
+  s.backward();
+  REQUIRE(!model->parameters()["weight"].grad().defined());
 }
 
 TEST_CASE("autograd") {

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -18,6 +18,7 @@ using OrderedDict = torch::detail::OrderedDict<std::string, T>;
 using Catch::StartsWith;
 
 TEST_CASE("NoGrad") {
+  torch::manual_seed(0);
   torch::NoGradGuard guard;
   Linear model(5, 2);
   auto x = torch::randn({10, 5}, torch::requires_grad());
@@ -29,6 +30,7 @@ TEST_CASE("NoGrad") {
 }
 
 TEST_CASE("autograd") {
+  torch::manual_seed(0);
   auto x = torch::randn({3, 3}, torch::requires_grad());
   auto y = torch::randn({3, 3});
   auto z = x * y;
@@ -48,6 +50,7 @@ TEST_CASE("autograd") {
 }
 
 TEST_CASE("expanding-array") {
+  torch::manual_seed(0);
   SECTION("successful construction") {
     SECTION("initializer_list") {
       torch::ExpandingArray<5> e({1, 2, 3, 4, 5});

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -4,6 +4,7 @@
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/rnn.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 using namespace torch::nn;
 
@@ -23,6 +24,7 @@ bool pointer_equal(torch::Tensor first, torch::Tensor second) {
 }
 
 TEST_CASE("module/training-mode") {
+  torch::manual_seed(0);
   Linear module(3, 4);
   REQUIRE(module->is_training());
   SECTION("Enable eval mode") {
@@ -36,6 +38,7 @@ TEST_CASE("module/training-mode") {
 }
 
 TEST_CASE("module/zero-grad") {
+  torch::manual_seed(0);
   Linear module(3, 4);
   auto weight = torch::ones({8, 3}, torch::requires_grad());
   auto loss = module->forward(weight).sum();
@@ -67,6 +70,7 @@ TEST_CASE("module/name") {
 }
 
 TEST_CASE("module/conversions", "[cuda]") {
+  torch::manual_seed(0);
   Linear module(128, 64);
   SECTION("starts as float on CPU") {
     for (auto& parameter : module->parameters()) {
@@ -117,6 +121,7 @@ TEST_CASE("module/conversions", "[cuda]") {
 }
 
 TEST_CASE("module/clone") {
+  torch::manual_seed(0);
   SECTION(
       "a module that does not override clone() throws when clone() is called") {
     struct UnCloneable : Module {};
@@ -232,6 +237,7 @@ TEST_CASE("module/clone") {
 }
 
 TEST_CASE("module/parameters") {
+  torch::manual_seed(0);
   struct TestModule : Module {
     TestModule() {
       a = register_parameter("a", torch::zeros({2, 2}));
@@ -257,6 +263,7 @@ TEST_CASE("module/parameters") {
 }
 
 TEST_CASE("module/buffers") {
+  torch::manual_seed(0);
   struct TestModule : Module {
     TestModule() {
       a = register_buffer("a", torch::zeros({2, 2}));

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -180,10 +180,8 @@ TEST_CASE("modules") {
     y.backward();
     REQUIRE(y.ndimension() == 1);
     REQUIRE(y.size(0) == 100);
-    // TODO: These two tests are flaky
-    // https://github.com/pytorch/pytorch/issues/7286
-    // REQUIRE(y.sum().toCFloat() < 130); // Probably
-    // REQUIRE(y.sum().toCFloat() > 70); // Probably
+    REQUIRE(y.sum().toCFloat() < 130); // Probably
+    REQUIRE(y.sum().toCFloat() > 70); // Probably
 
     dropout->eval();
     y = dropout->forward(x);

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -8,6 +8,7 @@
 #include <torch/nn/modules/functional.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 #include <test/cpp/api/util.h>
 
@@ -38,6 +39,7 @@ class NestedModel : public torch::nn::Module {
 };
 
 TEST_CASE("modules") {
+  torch::manual_seed(0);
   SECTION("conv") {
     SECTION("1d") {
       Conv1d model(Conv1dOptions(3, 2, 3).stride(2));
@@ -238,6 +240,7 @@ TEST_CASE("modules") {
 }
 
 TEST_CASE("modules_cuda", "[cuda]") {
+  torch::manual_seed(0);
   SECTION("1") {
     Linear model(5, 2);
     model->cuda();

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -31,7 +31,7 @@ bool test_optimizer_xor(Optimizer&& optimizer, Sequential& model) {
     auto inputs = torch::empty({kBatchSize, 2});
     auto labels = torch::empty({kBatchSize});
     for (size_t i = 0; i < kBatchSize; i++) {
-      inputs[i] = (torch::rand({2}) >= 0.5).to(torch::kInt64);
+      inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
     }
     inputs.set_requires_grad(true);

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -4,6 +4,7 @@
 #include <torch/nn/modules/rnn.h>
 #include <torch/optim/adam.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 #include <test/cpp/api/util.h>
 
@@ -11,6 +12,8 @@ using namespace torch::nn;
 
 template <typename R, typename Func>
 bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
+  torch::manual_seed(0);
+
   auto nhid = 32;
   auto model = std::make_shared<torch::SimpleContainer>();
   auto l1 = model->add(Linear(1, nhid), "l1");
@@ -81,84 +84,83 @@ void check_lstm_sizes(RNNOutput output) {
 }
 
 TEST_CASE("rnn") {
-  SECTION("lstm") {
-    SECTION("sizes") {
-      LSTM model(LSTMOptions(128, 64).layers(3).dropout(0.2));
-      auto x = torch::randn({10, 16, 128}, torch::requires_grad());
-      auto output = model->forward(x);
-      auto y = x.mean();
+  torch::manual_seed(0);
+  SECTION("sizes") {
+    LSTM model(LSTMOptions(128, 64).layers(3).dropout(0.2));
+    auto x = torch::randn({10, 16, 128}, torch::requires_grad());
+    auto output = model->forward(x);
+    auto y = x.mean();
 
-      y.backward();
-      check_lstm_sizes(output);
+    y.backward();
+    check_lstm_sizes(output);
 
-      auto next = model->forward(x, output.state);
+    auto next = model->forward(x, output.state);
 
-      check_lstm_sizes(next);
+    check_lstm_sizes(next);
 
-      torch::Tensor diff = next.state - output.state;
+    torch::Tensor diff = next.state - output.state;
 
-      // Hiddens changed
-      REQUIRE(diff.data().abs().sum().toCFloat() > 1e-3);
+    // Hiddens changed
+    REQUIRE(diff.data().abs().sum().toCFloat() > 1e-3);
+  }
+
+  SECTION("outputs") {
+    // Make sure the outputs match pytorch outputs
+    LSTM model(2, 2);
+    for (auto& v : model->parameters()) {
+      float size = v->numel();
+      auto p = static_cast<float*>(v->data().storage()->data());
+      for (size_t i = 0; i < size; i++) {
+        p[i] = i / size;
+      }
     }
 
-    SECTION("outputs") {
-      // Make sure the outputs match pytorch outputs
-      LSTM model(2, 2);
-      for (auto& v : model->parameters()) {
-        float size = v->numel();
-        auto p = static_cast<float*>(v->data().storage()->data());
-        for (size_t i = 0; i < size; i++) {
-          p[i] = i / size;
-        }
-      }
+    auto x = torch::empty({3, 4, 2}, torch::requires_grad());
+    float size = x.data().numel();
+    auto p = static_cast<float*>(x.data().storage()->data());
+    for (size_t i = 0; i < size; i++) {
+      p[i] = (size - i) / size;
+    }
 
-      auto x = torch::empty({3, 4, 2}, torch::requires_grad());
-      float size = x.data().numel();
-      auto p = static_cast<float*>(x.data().storage()->data());
-      for (size_t i = 0; i < size; i++) {
-        p[i] = (size - i) / size;
-      }
+    auto out = model->forward(x);
+    REQUIRE(out.output.ndimension() == 3);
+    REQUIRE(out.output.size(0) == 3);
+    REQUIRE(out.output.size(1) == 4);
+    REQUIRE(out.output.size(2) == 2);
 
-      auto out = model->forward(x);
-      REQUIRE(out.output.ndimension() == 3);
-      REQUIRE(out.output.size(0) == 3);
-      REQUIRE(out.output.size(1) == 4);
-      REQUIRE(out.output.size(2) == 2);
+    auto flat = out.output.data().view(3 * 4 * 2);
+    float c_out[] = {0.4391, 0.5402, 0.4330, 0.5324, 0.4261, 0.5239,
+                     0.4183, 0.5147, 0.6822, 0.8064, 0.6726, 0.7968,
+                     0.6620, 0.7860, 0.6501, 0.7741, 0.7889, 0.9003,
+                     0.7769, 0.8905, 0.7635, 0.8794, 0.7484, 0.8666};
+    for (size_t i = 0; i < 3 * 4 * 2; i++) {
+      REQUIRE(std::abs(flat[i].toCFloat() - c_out[i]) < 1e-3);
+    }
 
-      auto flat = out.output.data().view(3 * 4 * 2);
-      float c_out[] = {0.4391, 0.5402, 0.4330, 0.5324, 0.4261, 0.5239,
-                       0.4183, 0.5147, 0.6822, 0.8064, 0.6726, 0.7968,
-                       0.6620, 0.7860, 0.6501, 0.7741, 0.7889, 0.9003,
-                       0.7769, 0.8905, 0.7635, 0.8794, 0.7484, 0.8666};
-      for (size_t i = 0; i < 3 * 4 * 2; i++) {
-        REQUIRE(std::abs(flat[i].toCFloat() - c_out[i]) < 1e-3);
-      }
-
-      REQUIRE(out.state.ndimension() == 4); // (hx, cx) x layers x B x 2
-      REQUIRE(out.state.size(0) == 2);
-      REQUIRE(out.state.size(1) == 1);
-      REQUIRE(out.state.size(2) == 4);
-      REQUIRE(out.state.size(3) == 2);
-      flat = out.state.data().view(16);
-      float h_out[] = {0.7889,
-                       0.9003,
-                       0.7769,
-                       0.8905,
-                       0.7635,
-                       0.8794,
-                       0.7484,
-                       0.8666,
-                       1.1647,
-                       1.6106,
-                       1.1425,
-                       1.5726,
-                       1.1187,
-                       1.5329,
-                       1.0931,
-                       1.4911};
-      for (size_t i = 0; i < 16; i++) {
-        REQUIRE(std::abs(flat[i].toCFloat() - h_out[i]) < 1e-3);
-      }
+    REQUIRE(out.state.ndimension() == 4); // (hx, cx) x layers x B x 2
+    REQUIRE(out.state.size(0) == 2);
+    REQUIRE(out.state.size(1) == 1);
+    REQUIRE(out.state.size(2) == 4);
+    REQUIRE(out.state.size(3) == 2);
+    flat = out.state.data().view(16);
+    float h_out[] = {0.7889,
+                     0.9003,
+                     0.7769,
+                     0.8905,
+                     0.7635,
+                     0.8794,
+                     0.7484,
+                     0.8666,
+                     1.1647,
+                     1.6106,
+                     1.1425,
+                     1.5726,
+                     1.1187,
+                     1.5329,
+                     1.0931,
+                     1.4911};
+    for (size_t i = 0; i < 16; i++) {
+      REQUIRE(std::abs(flat[i].toCFloat() - h_out[i]) < 1e-3);
     }
   }
 }
@@ -186,6 +188,7 @@ TEST_CASE("rnn/integration/RNN") {
 
 TEST_CASE("rnn_cuda", "[cuda]") {
   SECTION("sizes") {
+    torch::manual_seed(0);
     LSTM model(LSTMOptions(128, 64).layers(3).dropout(0.2));
     model->cuda();
     auto x = torch::randn(

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -4,6 +4,7 @@
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/sequential.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 #include <memory>
 #include <vector>
@@ -175,6 +176,7 @@ TEST_CASE("sequential") {
   }
 
   SECTION("returns the last value") {
+    torch::manual_seed(0);
     Sequential sequential(Linear(10, 3), Linear(3, 5), Linear(5, 100));
 
     auto x = torch::randn({1000, 10}, torch::requires_grad());

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -7,6 +7,7 @@
 #include <torch/optim/sgd.h>
 #include <torch/serialization.h>
 #include <torch/tensor.h>
+#include <torch/utils.h>
 
 #include <test/cpp/api/util.h>
 
@@ -30,6 +31,7 @@ std::shared_ptr<Sequential> xor_model() {
 } // namespace
 
 TEST_CASE("serialization") {
+  torch::manual_seed(0);
   SECTION("undefined") {
     auto x = torch::Tensor();
 
@@ -275,6 +277,7 @@ TEST_CASE("serialization") {
 }
 
 TEST_CASE("serialization_cuda", "[cuda]") {
+  torch::manual_seed(0);
   // We better be able to save and load a XOR model!
   auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t batch_size) {
     auto inputs = torch::empty({batch_size, 2});

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -176,7 +176,7 @@ TEST_CASE("serialization") {
       auto inputs = torch::empty({batch_size, 2});
       auto labels = torch::empty({batch_size});
       for (size_t i = 0; i < batch_size; i++) {
-        inputs[i] = (torch::rand({2}) >= 0.5).to(torch::kInt64);
+        inputs[i] = torch::randint(2, {2}, torch::kInt64);
         labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
       }
       auto x = model->forward<torch::Tensor>(inputs);
@@ -280,7 +280,7 @@ TEST_CASE("serialization_cuda", "[cuda]") {
     auto inputs = torch::empty({batch_size, 2});
     auto labels = torch::empty({batch_size});
     for (size_t i = 0; i < batch_size; i++) {
-      inputs[i] = (torch::rand({2}) >= 0.5).to(torch::kInt64);
+      inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
     }
     auto x = model->forward<torch::Tensor>(inputs);

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -172,21 +172,15 @@ TEST_CASE("serialization") {
 
   SECTION("xor") {
     // We better be able to save and load a XOR model!
-    auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t bs) {
-      auto inp = torch::empty({bs, 2});
-      auto lab = torch::empty({bs});
-      for (auto i = 0U; i < bs; i++) {
-        auto a = std::rand() % 2;
-        auto b = std::rand() % 2;
-        auto c = a ^ b;
-        inp[i][0] = a;
-        inp[i][1] = b;
-        lab[i] = c;
+    auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t batch_size) {
+      auto inputs = torch::empty({batch_size, 2});
+      auto labels = torch::empty({batch_size});
+      for (size_t i = 0; i < batch_size; i++) {
+        inputs[i] = (torch::rand({2}) >= 0.5).to(torch::kInt64);
+        labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
       }
-
-      // forward
-      auto x = model->forward<torch::Tensor>(inp);
-      return torch::binary_cross_entropy(x, lab);
+      auto x = model->forward<torch::Tensor>(inputs);
+      return torch::binary_cross_entropy(x, labels);
     };
 
     auto model = xor_model();
@@ -282,21 +276,15 @@ TEST_CASE("serialization") {
 
 TEST_CASE("serialization_cuda", "[cuda]") {
   // We better be able to save and load a XOR model!
-  auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t bs) {
-    auto inp = torch::empty({bs, 2});
-    auto lab = torch::empty({bs});
-    for (auto i = 0U; i < bs; i++) {
-      auto a = std::rand() % 2;
-      auto b = std::rand() % 2;
-      auto c = a ^ b;
-      inp[i][0] = a;
-      inp[i][1] = b;
-      lab[i] = c;
+  auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t batch_size) {
+    auto inputs = torch::empty({batch_size, 2});
+    auto labels = torch::empty({batch_size});
+    for (size_t i = 0; i < batch_size; i++) {
+      inputs[i] = (torch::rand({2}) >= 0.5).to(torch::kInt64);
+      labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
     }
-
-    // forward
-    auto x = model->forward<torch::Tensor>(inp);
-    return torch::binary_cross_entropy(x, lab);
+    auto x = model->forward<torch::Tensor>(inputs);
+    return torch::binary_cross_entropy(x, labels);
   };
 
   auto model = xor_model();

--- a/torch/csrc/api/include/torch/nn.h
+++ b/torch/csrc/api/include/torch/nn.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <torch/nn/cloneable.h>
+#include <torch/nn/cursor.h>
+#include <torch/nn/module.h>
+#include <torch/nn/modules.h>
+#include <torch/nn/pimpl.h>

--- a/torch/csrc/api/include/torch/nn/modules.h
+++ b/torch/csrc/api/include/torch/nn/modules.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/nn/modules/any.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>
 #include <torch/nn/modules/dropout.h>

--- a/torch/csrc/api/include/torch/torch.h
+++ b/torch/csrc/api/include/torch/torch.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <torch/nn/module.h>
-#include <torch/nn/modules.h>
+#include <torch/cuda.h>
+#include <torch/nn.h>
 #include <torch/optim.h>
 #include <torch/serialization.h>
 #include <torch/tensor.h>
+#include <torch/tensor_list_view.h>
+#include <torch/utils.h>


### PR DESCRIPTION
Sets the random seed at the start of C++ tests so that everything is super deterministic.

I made sure we only generate random values from torch instead of `std::`, so that this seed always applies. I.e. I do:

```
torch::randint(2, {2}, at::kInt64)
```

instead of

```
std::rand() % 2
```

Also got rid of the tests that test the random seeding, since it would interfere here. And the test is not useful since we just use ATen's seeding mechanism, which should work.

Fixes  #7288 #7286 #7289

@ebetica @ezyang 