### PR TITLE
Fix boolean indexing.

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -451,7 +451,7 @@ class NumpyTests(TestCase):
             self.assertEqual((0,), a[False, True, ...].shape)
         self.assertEqual(torch.ones(1, 2), a[True, [0, 1], True, True, [1], [[2]]])
         if torch._C._use_zero_size_dim():
-            self.assertRaises(lambda: a[False, [0, 1], ...])
+            self.assertRaises(RuntimeError, lambda: a[False, [0, 1], ...])
 
     def test_boolean_indexing_weirdness_tensors(self):
         # Weird boolean indexing things
@@ -464,7 +464,7 @@ class NumpyTests(TestCase):
             self.assertEqual((0,), a[False, True, ...].shape)
         self.assertEqual(torch.ones(1, 2), a[true, [0, 1], true, true, [1], [[2]]])
         if torch._C._use_zero_size_dim():
-            self.assertRaises(lambda: a[false, [0, 1], ...])
+            self.assertRaises(RuntimeError, lambda: a[false, [0, 1], ...])
 
     def test_boolean_indexing_alldims(self):
         true = torch.tensor(True)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -442,6 +442,36 @@ class NumpyTests(TestCase):
                                     [4, 0, 6],
                                     [0, 8, 0]]))
 
+    def test_boolean_indexing_weirdness(self):
+        # Weird boolean indexing things
+        a = torch.ones((2, 3, 4))
+        if torch._C._use_zero_size_dim():
+            self.assertEqual((0, 2, 3, 4), a[False, True, ...].shape)
+        else:
+            self.assertEqual((0,), a[False, True, ...].shape)
+        self.assertEqual(torch.ones(1, 2), a[True, [0, 1], True, True, [1], [[2]]])
+        if torch._C._use_zero_size_dim():
+            self.assertRaises(lambda: a[False, [0, 1], ...])
+
+    def test_boolean_indexing_weirdness_tensors(self):
+        # Weird boolean indexing things
+        false = torch.tensor(False)
+        true = torch.tensor(True)
+        a = torch.ones((2, 3, 4))
+        if torch._C._use_zero_size_dim():
+            self.assertEqual((0, 2, 3, 4), a[False, True, ...].shape)
+        else:
+            self.assertEqual((0,), a[False, True, ...].shape)
+        self.assertEqual(torch.ones(1, 2), a[true, [0, 1], true, true, [1], [[2]]])
+        if torch._C._use_zero_size_dim():
+            self.assertRaises(lambda: a[false, [0, 1], ...])
+
+    def test_boolean_indexing_alldims(self):
+        true = torch.tensor(True)
+        a = torch.ones((2, 3))
+        self.assertEqual((1, 2, 3), a[True, True].shape)
+        self.assertEqual((1, 2, 3), a[true, true].shape)
+
     def test_everything_returns_views(self):
         # Before `...` would return a itself.
         a = tensor([5])

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -122,7 +122,7 @@ static Variable valueToTensor(const Type & type, PyObject* value) {
   throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
 }
 
-static Variable boolToIndexingTensor(const Variable& self, int64_t dim, bool value) {
+static Variable boolToIndexingTensor(const Variable& self, bool value) {
   // booleans add a dimension of size 1. true indexes this dimension as if 0:, false as empty.
   if (value) {
     return at::zeros({1}, self.options().dtype(kLong));
@@ -168,7 +168,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       dim++;
     } else if (PyBool_Check(obj)) {
       result = result.unsqueeze(dim);
-      handle_var(boolToIndexingTensor(result, dim, obj == Py_True));
+      handle_var(boolToIndexingTensor(result, obj == Py_True));
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
       auto scalar_type = var.type().scalarType();
@@ -177,7 +177,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
           result = applySelect(result, dim, THPUtils_unpackLong(obj));
         } else {
           result = result.unsqueeze(dim);
-          handle_var(boolToIndexingTensor(result, dim, var.toCByte() != 0));
+          handle_var(boolToIndexingTensor(result, var.toCByte() != 0));
         }
       } else {
         handle_var(var);

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -52,7 +52,7 @@ static int64_t count_specified_dimensions(PyObject* index) {
       } else {
         count++;
       }
-    } else if (obj != Py_None && obj != Py_Ellipsis) {
+    } else if (obj != Py_None && obj != Py_Ellipsis && obj != Py_True && obj != Py_False) {
       count++;
     }
   }
@@ -122,6 +122,15 @@ static Variable valueToTensor(const Type & type, PyObject* value) {
   throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
 }
 
+static Variable boolToIndexingTensor(const Variable& self, int64_t dim, bool value) {
+  // booleans add a dimension of size 1. true indexes this dimension as if 0:, false as empty.
+  if (value) {
+    return at::zeros({1}, self.options().dtype(kLong));
+  } else {
+    return at::empty({0}, self.options().dtype(kLong));
+  }
+}
+
 static Variable applySlicing(const Variable& self, PyObject* index, variable_list& outIndices) {
   int64_t size = PyTuple_GET_SIZE(index);
   int64_t dim = 0;
@@ -157,11 +166,19 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (obj == Py_None) {
       result = result.unsqueeze(dim);
       dim++;
+    } else if (PyBool_Check(obj)) {
+      result = result.unsqueeze(dim);
+      handle_var(boolToIndexingTensor(result, dim, obj == Py_True));
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
       auto scalar_type = var.type().scalarType();
-      if (var.dim() == 0 && at::isIntegralType(scalar_type) && scalar_type != at::kByte) {
-        result = applySelect(result, dim, THPUtils_unpackLong(obj));
+      if (var.dim() == 0 && at::isIntegralType(scalar_type)) {
+        if (scalar_type != at::kByte) {
+          result = applySelect(result, dim, THPUtils_unpackLong(obj));
+        } else {
+          result = result.unsqueeze(dim);
+          handle_var(boolToIndexingTensor(result, dim, var.toCByte() != 0));
+        }
       } else {
         handle_var(var);
       }
@@ -259,18 +276,6 @@ static THPObjectPtr wrapTuple(PyObject* index) {
   return res;
 }
 
-static bool isSingleBoolScalar(const variable_list& vars) {
-  return vars.size() == 1 && vars[0].type().scalarType() == ScalarType::Byte && vars[0].dim() == 0;
-}
-
-static PyObject* applyBoolGetitem(const Variable& self, bool index) {
-  if (index) {
-    return wrap(self.type().copy(self.unsqueeze(0)));
-  } else {
-    return wrap(at::empty({0}, self.options()));
-  }
-}
-
 PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
@@ -283,8 +288,6 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
     return wrap(at::alias(self_));
   } else if (THPUtils_checkLong(index)) {
     return wrap(applySelect(self_, 0, THPUtils_unpackLong(index)));
-  } else if (PyBool_Check(index)) {
-    return applyBoolGetitem(self_, index == Py_True);
   } else if (PySlice_Check(index)) {
     return wrap(applySlice(self_, 0, index, true));
   }
@@ -301,9 +304,6 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
     }
     return wrap(sliced);
   }
-  if (isSingleBoolScalar(variableIndices)) {
-    return applyBoolGetitem(self_, variableIndices[0].toCByte());
-  }
 
   // indexing by tensors ("advanced" indexing)
   return wrap(dispatch_index(sliced, variableIndices));
@@ -311,22 +311,25 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   END_HANDLE_TH_ERRORS
 }
 
-static void copy_to(Variable dst, const Variable& src) {
-  Tensor b_src;
-  // To match numpy semantics:
-  // As a special case for backwards compatibility,
-  // strip away unit dimensions from the left of 'src'
-  auto src_sizes = src.sizes();
-  size_t first_nonzero_src = src_sizes.size();
-  for (size_t i = 0; i < src_sizes.size(); ++i) {
-    if (src_sizes[i] != 1) {
-      first_nonzero_src = i;
+// To match numpy semantics:
+// As a special case for backwards compatibility,
+// strip away unit dimensions from the left of 'src'
+static IntList slicePrefix1sSize(IntList sizes) {
+  size_t first_non1_src = sizes.size();
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    if (sizes[i] != 1) {
+      first_non1_src = i;
       break;
     }
   }
 
-  src_sizes = src_sizes.slice(first_nonzero_src);
-  std::tie(b_src) = expand_inplace(dst, src.view(src_sizes), "setitem");
+  return sizes.slice(first_non1_src);
+}
+
+static void copy_to(Variable dst, const Variable& src) {
+  Tensor b_src;
+  IntList sliced_src_sizes = slicePrefix1sSize(src.sizes());
+  std::tie(b_src) = expand_inplace(dst, src.view(sliced_src_sizes), "setitem");
   dst.copy_(b_src);
 }
 
@@ -364,15 +367,10 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
     copy_to(sliced, value);
     return 0;
   }
-  if (isSingleBoolScalar(variableIndices)) {
-    if (variableIndices[0].toCByte()) {
-      copy_to(self_.unsqueeze(0), value);
-    }
-    return 0;
-  }
 
-  // indexing by tensors ("advanced" indexing)
-  dispatch_index_put_(sliced, variableIndices, value);
+  IntList slicedValueSizes = slicePrefix1sSize(value.sizes());
+  auto valuesSliced = value.view(slicedValueSizes);
+  dispatch_index_put_(sliced, variableIndices, valuesSliced);
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }


### PR DESCRIPTION
Booleaning indexing was special cased to handle a single boolean value, but didn't generally work given multiple booleans.
This PR unifies the behavior with slicing.  Note that only 'True' and torch.tensor(True) behave like NumPy due to the lack of n-dimensional empty tensors.
The corresponding tests for false values have been added, but are guarded behind a flag until we add n-dimensional empty tensors.

