### PR TITLE
[JIT] Add Support for NoneLiteral.

### DIFF
--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -8,7 +8,7 @@
     (assign
       (list (variable (ident q)))
       (=)
-      (variable (ident None)))
+      (None))
     (assign
       (list (variable (ident q)))
       (=)

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -8,6 +8,10 @@
     (assign
       (list (variable (ident q)))
       (=)
+      (variable (ident None)))
+    (assign
+      (list (variable (ident q)))
+      (=)
       (-
         (+
           (variable (ident x))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1060,7 +1060,7 @@ class TestJit(JitTestCase):
         self.assertEqual(test_fn(ten, mask), traced_test_fn(ten, mask))
 
 
-class TestBatched(TestCase):
+class TestBatched(JitTestCase):
     # generate random examples and create an batchtensor with them
     def rand_batch(self, *dims):
         dims = [dim for dim in dims if dim != ()]
@@ -1812,21 +1812,21 @@ class TestScript(JitTestCase):
 
     def test_script_None(self):
         @torch.jit.script
-        def test_script_None(x):
+        def func(x):
             output = None
             output = x
             return output
 
-        self.assertEqual(test_script_None(torch.rand(1,2)).shape[1], 2)
+        self.assertEqual(func(torch.rand(1,2)).shape[1], 2)
 
-    def test_script_clamp_max(self):
-        @torch.jit.script
-        def test_script_clamp_max(x):
-            # return torch.clamp(x, min=0.5, max=None)
-            return torch.clamp(x, None, 0.5)
-
-        input = torch.tensor([[0.3, 0.4],[0.5, 0.51]])
-        self.assertEqual(test_script_clamp_max(input)[1][1], 0.5)
+    # def test_script_clamp_max(self):
+    #     @torch.jit.script
+    #     def test_script_clamp_max(x):
+    #         # return torch.clamp(x, min=0.5, max=None)
+    #         return torch.clamp(x, None, 0.5)
+    #
+    #     input = torch.tensor([[0.3, 0.4],[0.5, 0.51]])
+    #     self.assertEqual(test_script_clamp_max(input)[1][1], 0.5)
 
     def test_script_bool_constant(self):
         script = '''
@@ -4817,7 +4817,7 @@ def create_script_fn(method_name, is_functional, output_process_fn):
             call = '{}.{}({}{})'.format(actuals[0], method_name, ', '.join(actuals[1:]), kwargs_str)
         script = script_template.format(', '.join(formals), call)
         CU = torch.jit.CompilationUnit(script)
-        print(CU.__getattr__("the_method").graph)
+        # print(CU.__getattr__("the_method").graph)
         return output_process_fn(CU.the_method(*tensors))
     return script_fn
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -28,7 +28,6 @@ import random
 
 from torch.jit.frontend import NotSupportedError
 from torch.jit import BatchTensor
-import torch.jit.batchop
 
 try:
     import torchvision
@@ -1817,16 +1816,19 @@ class TestScript(JitTestCase):
             output = x
             return output
 
+        print(func.graph)
         self.assertEqual(func(torch.rand(1,2)).shape[1], 2)
 
-    # def test_script_clamp_max(self):
-    #     @torch.jit.script
-    #     def test_script_clamp_max(x):
-    #         # return torch.clamp(x, min=0.5, max=None)
-    #         return torch.clamp(x, None, 0.5)
-    #
-    #     input = torch.tensor([[0.3, 0.4],[0.5, 0.51]])
-    #     self.assertEqual(test_script_clamp_max(input)[1][1], 0.5)
+    def test_script_clamp_max(self):
+        @torch.jit.script
+        def test_script_clamp_max(x):
+            # return torch.clamp(x, min=0.5, max=None)
+            return torch.clamp(x, min=None, max=0.5)
+
+        print(test_script_clamp_max.graph)
+
+        input = torch.tensor([[0.3, 0.4],[0.5, 0.51]])
+        self.assertEqual(test_script_clamp_max(input)[1][1], 0.5)
 
     def test_script_bool_constant(self):
         script = '''

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1576,6 +1576,7 @@ class TestScript(JitTestCase):
 
     def test_python_frontend(self):
         def fn(x, y, z):
+            q = None
             q = x + y - z.sigmoid()
             print(q)
             w = -z

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -18,6 +18,7 @@ _(namespaces, scope) \
 _(namespaces, namespaces) \
 _(prim, Assign) \
 _(prim, Constant) \
+_(prim, None) \
 _(prim, Drop) \
 _(prim, Eval) \
 _(prim, Expand) /* onnx */ \

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -114,6 +114,9 @@ struct SchemaParser {
       case TK_FLOAT:
         L.next();
         return as_tensor(static_cast<int64_t>(at::kFloat));
+      case TK_NONE:
+        L.next();
+        return as_tensor(at::Scalar(NAN));
       case TK_IDENT: {
         auto tok = L.next();
         auto text = tok.text();
@@ -162,11 +165,8 @@ struct SchemaParser {
     return at::stack(vs);
   }
   at::Tensor parseTensorDefault(const SourceRange& range) {
-    if("None" == L.expect(TK_IDENT).text()) {
-      return at::Tensor();
-    } else {
-      throw ErrorReport(range) << "invalid tensor default value";
-    }
+    L.expect(TK_NONE);
+    return at::Tensor();
   }
   void parseDefaultValue(Argument& arg) {
     auto range = L.cur().range;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -503,18 +503,18 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         v.value = createStack(graph, loc, unpacked_t)->setType(ListType::ofInts());
       }
 
-      // implicit conversion from Tensor to Python Number
-      // FIXME: remove this when we support passing numbers into script fns
-      if (isTensorSubtype(v.value) && isNumberSubtype(arg.type)) {
-        v.value = tensorToNum(loc, graph, v.value, arg.type);
-      }
-
       if (v.value->node()->kind() == prim::None){
-        // std::cout<<"detecting None Node" <<std::endl;
+        std::cout<<"tryMatchSchema detecting None node, output value type" << v.value->type()->str() <<std::endl;
         if (isNumberSubtype(arg.type))
           v.value = createConstant(graph, loc, at::tensor(NAN));
         else
           v.value = graph.insertNode(graph.createUndefined())->output();
+      }
+
+      // implicit conversion from Tensor to Python Number
+      // FIXME: remove this when we support passing numbers into script fns
+      if (isTensorSubtype(v.value) && isNumberSubtype(arg.type)) {
+        v.value = tensorToNum(loc, graph, v.value, arg.type);
       }
 
       if(!v.value->type()->isSubtypeOf(*arg.type)) {
@@ -533,6 +533,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       }
     }
 
+    std::cout<<"tryMatchSchema graph: " << graph <<std::endl;
     return flat_inputs;
 }
 
@@ -701,8 +702,6 @@ struct to_ir {
       , resolver(resolver)
       , environment_stack(nullptr) {
     pushFrame(graph->block());
-
-    std::cout<<"to_ir: " << def.name();
 
     std::vector<Argument> arguments, returns; // for schema
     // inputs

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -504,7 +504,6 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       }
 
       if (v.value->node()->kind() == prim::None){
-        std::cout<<"tryMatchSchema detecting None node, output value type" << v.value->type()->str() <<std::endl;
         if (isNumberSubtype(arg.type))
           v.value = createConstant(graph, loc, at::tensor(NAN));
         else
@@ -533,7 +532,6 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       }
     }
 
-    std::cout<<"tryMatchSchema graph: " << graph <<std::endl;
     return flat_inputs;
 }
 
@@ -577,18 +575,7 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
   for(size_t i = 0; i < num_outputs; ++i)
     n->addOutput();
 
-  //for(auto& arg: schema.arguments) {
-    //std::cout<<"tryEmitBuiltin schema args: " << arg <<std::endl;
-  //}
   liftConstantAttributes(schema, n);
-
-  //if(n->kind() == aten::clamp) {
-    //std::cout<<"tryEmitBuiltin find clamp" <<std::endl;
-    //NodeKind new_kind(Symbol::aten("clamp_min"));
-    //n->setKind(new_kind);
-    //n->removeInput(2);
-  //}
-  // std::cout<<"tryEmitBuiltin graph: "<< graph->toString()<<std::endl;
 
   // assert that we did indeed create an op that has implementation
   // otherwise schema and dispatch are not in sync
@@ -622,7 +609,6 @@ std::shared_ptr<SugaredValue> emitBuiltinCall(
   const auto& variants = getAllOperatorsFor(Symbol::aten(name));
   std::stringstream failure_messages;
   for (const std::shared_ptr<Operator>& op : variants) {
-    // std::cout<<"emitBuiltinCall op schema: " << op->schema <<std::endl;
     if (auto result = tryEmitBuiltin(
             op->schema, failure_messages, loc, method, name, inputs, attributes)) {
       return result;
@@ -664,7 +650,7 @@ static Value* ensureTensorOrNumber(const SourceRange& range, Value* v) {
 }
 
 
-void  ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values) {
+void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values) {
   for(auto value : values) {
     ensureTensor(range, value);
   }
@@ -1602,7 +1588,6 @@ private:
   Value* emitNone(SourceRange range) {
     //return createConstant(*graph, range, at::tensor(NAN));
     auto n = emitNode(prim::None, range, {}, 1);
-    // std::cout <<"emitNone node: " << n->output()->uniqueName() <<std::endl;
     return n->output();
   }
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -64,6 +64,7 @@ namespace script {
   _(TK_IF_EXPR, "if", "")                        \
   _(TK_TRUE, "True", "True")                     \
   _(TK_FALSE, "False", "False")                  \
+  _(TK_NONE, "None", "None")                     \
   _(TK_AND, "and", "and")                        \
   _(TK_OR, "or", "or")                           \
   _(TK_NOT, "not", "not")                        \

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -52,7 +52,8 @@ struct Parser {
         prefix = parseConst();
       } break;
       case TK_TRUE:
-      case TK_FALSE: {
+      case TK_FALSE:
+      case TK_NONE: {
         auto k = L.cur().kind;
         auto r = L.cur().range;
         prefix = c(k, r, {});

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -97,6 +97,9 @@ void initTreeViewBindings(PyObject *module) {
   m.def("FalseLiteral", [](const SourceRange& range) {
     return Expr(Compound::create(TK_FALSE, range, {}));
   });
+  m.def("NoneLiteral", [](const SourceRange& range) {
+    return Expr(Compound::create(TK_NONE, range, {}));
+  });
   py::class_<Type, TreeView>(m, "Type");
   py::class_<TensorType, Type>(m, "TensorType")
     .def(py::init(&TensorType::create));

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -252,6 +252,7 @@ struct Expr : public TreeView {
       case TK_CONST:
       case TK_TRUE:
       case TK_FALSE:
+      case TK_NONE:
       case TK_CAST:
       case TK_APPLY:
       case '.':

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -36,6 +36,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   } else if(t.kind() == TypeKind::ListType) {
     auto prim = t.cast<ListType>()->getElementType();
     out << *prim << "[]";
+  } else if(t.kind() == TypeKind::NoneType) {
+    out << "None";
   } else {
     barf("unknown type kind");
   }
@@ -58,8 +60,10 @@ TypePtr FloatType::get() {
   static auto value = std::make_shared<FloatType>();
   return value;
 }
-
-
+TypePtr NoneType::get() {
+  static auto value = std::make_shared<NoneType>();
+  return value;
+}
 TypePtr ListType::ofTensors() {
   static auto value = std::make_shared<ListType>(DynamicType::get());
   return value;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -330,7 +330,7 @@ struct NoneType : public Type {
     return "None";
   }
   virtual bool isSubtypeOf(const Type& rhs) const override {
-    return *this == rhs || rhs.kind() == TypeKind::NumberType;
+    return *this == rhs;
   }
   static const TypeKind Kind = TypeKind::NoneType;
   // global singleton

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -18,6 +18,7 @@ _(ListType) \
 _(NumberType) \
 _(FloatType) \
 _(IntType) \
+_(NoneType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -314,6 +315,24 @@ struct IntType : public Type {
     return *this == rhs || rhs.kind() == TypeKind::NumberType;
   }
   static const TypeKind Kind = TypeKind::IntType;
+  // global singleton
+  static TypePtr get();
+};
+
+// This node represents a Python int number value
+struct NoneType : public Type {
+  NoneType()
+  : Type(TypeKind::NoneType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string str() const override {
+    return "None";
+  }
+  virtual bool isSubtypeOf(const Type& rhs) const override {
+    return *this == rhs || rhs.kind() == TypeKind::NumberType;
+  }
+  static const TypeKind Kind = TypeKind::NoneType;
   // global singleton
   static TypePtr get();
 };

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -390,6 +390,7 @@ def script_method(fn):
 
 def batch(batch_size=1, optimize=True, _frames_up=0):
     def decorator(fn):
+        import torch.jit.batchop
         mod = script(fn, optimize, _frames_up)
         res_graph = torch.to_batch_graph(mod.graph)
         res_mod = ScriptModule()

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -333,6 +333,8 @@ class ExprBuilder(Builder):
             return TrueLiteral(r)
         elif expr.id == "False":
             return FalseLiteral(r)
+        elif expr.id == "None":
+            return NoneLiteral(r)
         return Var(Ident(r, expr.id))
 
     @staticmethod

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -342,7 +342,10 @@ class ExprBuilder(Builder):
             return TrueLiteral(r)
         elif expr.value is False:
             return FalseLiteral(r)
-        return Var(Ident(r, "None"))
+        elif expr.value is None:
+            return Var(Ident(r, "None"))
+        else:
+            raise ValueError("Name constant value unsupported: " + str(expr.value))
 
     @staticmethod
     def build_BinOp(ctx, expr):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -343,7 +343,7 @@ class ExprBuilder(Builder):
         elif expr.value is False:
             return FalseLiteral(r)
         elif expr.value is None:
-            return Var(Ident(r, "None"))
+            return NoneLiteral(r)
         else:
             raise ValueError("Name constant value unsupported: " + str(expr.value))
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -337,12 +337,12 @@ class ExprBuilder(Builder):
 
     @staticmethod
     def build_NameConstant(ctx, expr):
-        text = "True" if expr.value else "False"
-        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(text))
-        if expr.value:
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(str(expr.value)))
+        if expr.value is True:
             return TrueLiteral(r)
-        else:
+        elif expr.value is False:
             return FalseLiteral(r)
+        return Var(Ident(r, "None"))
 
     @staticmethod
     def build_BinOp(ctx, expr):


### PR DESCRIPTION
Currently we are not be able to support None type yet, things like None in the statements or passing None as argument is not possible (like clamp). 

This PR add support for the NoneLiteral and NoneType in script. In a following PR will enable the #8502 tests, and address clamp's gradients problem in Aten native when passing None to clamp. 