### PR TITLE
allow empty batch for spatialBN

### DIFF
--- a/caffe2/operators/spatial_batch_norm_gradient_op.cc
+++ b/caffe2/operators/spatial_batch_norm_gradient_op.cc
@@ -63,7 +63,9 @@ bool SpatialBNGradientOp<CPUContext>::RunOnDevice() {
       EigenArrayMap<float> dX_arr(
           dX->mutable_data<float>(), sample_size, N * C);
       dX_arr.setZero();
-
+      if (N == 0) {
+        return true;
+      }
       if (num_batches_ == 1) {
         for (int nc = 0; nc < N * C; ++nc) {
           int c = nc % C;
@@ -92,6 +94,9 @@ bool SpatialBNGradientOp<CPUContext>::RunOnDevice() {
       EigenArrayMap<float> dX_arr(
           dX->mutable_data<float>(), C, N * sample_size);
       dX_arr.setZero();
+      if (N == 0) {
+        return true;
+      }
 
       const auto dYRowSum = dY_arr.rowwise().sum();
       const auto XMinusMean = X_arr.colwise() - mean_arr;

--- a/caffe2/python/operator_test/spatial_bn_op_test.py
+++ b/caffe2/python/operator_test/spatial_bn_op_test.py
@@ -17,7 +17,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(min_value=1e-5, max_value=1e-2),
@@ -42,6 +42,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
                 bias = bias[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
                 mean = mean[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
                 var = var[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
+
             return ((X - mean) / np.sqrt(var + epsilon) * scale + bias,)
 
         np.random.seed(1701)
@@ -61,7 +62,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(min_value=1e-5, max_value=1e-2),
@@ -103,7 +104,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(min_value=1e-5, max_value=1e-2),
@@ -148,7 +149,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(1e-5, 1e-2),
@@ -184,7 +185,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(min_value=1e-5, max_value=1e-2),
@@ -218,7 +219,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            order=st.sampled_from(["NCHW", "NHWC"]),
            epsilon=st.floats(min_value=1e-5, max_value=1e-2),
@@ -251,7 +252,7 @@ class TestSpatialBN(hu.HypothesisTestCase):
 
     @given(size=st.integers(7, 10),
            input_channels=st.integers(1, 10),
-           batch_size=st.integers(1, 3),
+           batch_size=st.integers(0, 3),
            seed=st.integers(0, 65535),
            epsilon=st.floats(1e-5, 1e-2),
            engine=st.sampled_from(["", "CUDNN"]),


### PR DESCRIPTION
Summary:
spatialBN implementation cannot deal with empty batch, this diff tries to enable zero batch setting:

during training, when batch_size = 0:
in forward, output's saved_mean and saved_var are zeros.
in backward, the gradient for SCALE_GRAD and BIAS_GRAD are zeros.

Differential Revision: D8644699
