### PR TITLE
by default, donot throw image decoding error

### DIFF
--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -206,7 +206,7 @@ ImageInputOp<Context>::ImageInputOp(
           {-1, -1})),
       max_decode_error_ratio_(OperatorBase::template GetSingleArgument<float>(
           "max_decode_error_ratio",
-          0.0)) {
+          1.0)) {
   if ((random_scale_[0] == -1) || (random_scale_[1] == -1)) {
     random_scaling_ = false;
   } else {


### PR DESCRIPTION
Summary: Change default value of max decode error rate to 1.0 which means we don't throw such runtime error by default

Differential Revision: D8665640
