### PR TITLE
[C++ API] Fix Module::zero_grad

### DIFF
--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -119,7 +119,11 @@ void Module::zero_grad() {
     child.value->zero_grad();
   }
   for (auto& parameter : parameters_) {
-    parameter->grad().zero_();
+    auto& grad = parameter->grad();
+    if (grad.defined()) {
+      grad = grad.detach();
+      grad.zero_();
+    }
   }
 }
 


### PR DESCRIPTION
`nn::Module::zero_grad` did not respect undefined `grad()` variables. This is fixed (the code now replicates PyTorch).

@ebetica @ezyang @apaszke 