### PR TITLE
Convert at::Tensor to torch::Tensor in AnyModule

### DIFF
--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -225,6 +225,42 @@ TEST_CASE("any-module") {
     REQUIRE(any.get<MImpl>().value == 5);
     REQUIRE(any.get<M>()->value == 5);
   }
+  SECTION("converts at::Tensor to torch::Tensor correctly") {
+    struct M : torch::nn::Module {
+      torch::Tensor forward(torch::Tensor input) {
+        return input;
+      }
+    };
+    struct N : torch::nn::Module {
+      at::Tensor forward(at::Tensor input) {
+        return input;
+      }
+    };
+    {
+      // When you get an at::Tensor by performing an operation on a
+      // torch::Tensor, the tensor should be converted back to torch::Tensor
+      // before being passed to the function (to avoid a type mismatch).
+      AnyModule any(M{});
+      at::Tensor tensor_that_is_actually_a_variable = torch::ones(5) * 2;
+      REQUIRE(
+          any.forward(tensor_that_is_actually_a_variable)
+              .get<torch::Tensor>()
+              .sum()
+              .toCFloat() == 10);
+      // But tensors that are really tensors should just error.
+      REQUIRE_THROWS_WITH(
+          any.forward(at::ones(5)),
+          StartsWith(
+              "Expected argument #0 to be of type torch::autograd::Variable, "
+              "but received value of type at::Tensor"));
+    }
+    {
+      // If the function does really accept an `at::Tensor`, this should still
+      // work.
+      AnyModule any(N{});
+      REQUIRE(any.forward(at::ones(5)).get<at::Tensor>().sum().toCFloat() == 5);
+    }
+  }
 }
 
 namespace torch {

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -193,4 +193,22 @@ TEST_CASE("sequential") {
         Embedding(4, 10),
         LSTM(4, 5));
   }
+
+  SECTION("converts at::Tensor to torch::Tensor correctly") {
+    struct M : torch::nn::Module {
+      torch::Tensor forward(torch::Tensor input) {
+        return input;
+      }
+    };
+
+    Sequential sequential(M{});
+    torch::Tensor variable = torch::ones(5);
+    REQUIRE(sequential.forward(variable).sum().toCFloat() == 5);
+
+    at::Tensor tensor_that_is_actually_a_variable = variable * 2;
+    REQUIRE(
+        sequential.forward(tensor_that_is_actually_a_variable)
+            .sum()
+            .toCFloat() == 10);
+  }
 }

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -185,10 +185,22 @@ class AnyModule::Value {
   friend class TestValue;
 
   /// Constructs the `Value` from value type.
-  template <typename T>
+  template <
+      typename T,
+      typename = torch::disable_if_t<std::is_same<at::Tensor, T>::value>>
   explicit Value(T&& value)
       : content_(
             torch::make_unique<Holder<decay_t<T>>>(std::forward<T>(value))) {}
+
+  /// Constructs the `Value`, but converts an `at::Tensor` to a `torch::Tensor`
+  /// implicitly if the `at::Tensor` is really a `torch::Tensor` (a variable).
+  explicit Value(at::Tensor tensor) {
+    if (tensor.is_variable()) {
+      content_ = torch::make_unique<Holder<torch::Tensor>>(std::move(tensor));
+    } else {
+      content_ = torch::make_unique<Holder<at::Tensor>>(std::move(tensor));
+    }
+  }
 
   /// The static type of the object we store in the `Value`, which erases the
   /// actual object's type, allowing us only to check the `type_info` of the


### PR DESCRIPTION
Operations on `Variable`s (or `torch::Tensor`) usually return `at::Tensor`. This is usually fine, but the `AnyModule` used in the implementation of `torch::Sequential` is very picky about types, and does not understand implicit conversions like this. This means that `sequential.forward(at_tensor_that_is_actually_a_variable)` will fail unless you wrap `at_tensor_that_is_actually_a_variable` with `torch::Tensor`.

This PR adds a special case to `AnyModule` that will convert an `at::Tensor` to `torch::Tensor` when the tensor is really a variable, and else just pass the `at::Tensor`. This is a nice little usability improvement for the often-used `Sequential` class.

@ebetica @ezyang @apaszke 