### PR TITLE
Add log1p for sparse tensor

### DIFF
--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -156,7 +156,6 @@ Tensor& add_(Tensor& self, const Tensor& other, Scalar alpha) {
   }
 }
 
-
 Tensor& sub_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   if (_has_native(self)) {
     Tensor b_self, b_other;

--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -156,6 +156,7 @@ Tensor& add_(Tensor& self, const Tensor& other, Scalar alpha) {
   }
 }
 
+
 Tensor& sub_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   if (_has_native(self)) {
     Tensor b_self, b_other;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -754,12 +754,16 @@
   dispatch:
     CPU: _log1p__cpu
     CUDA: _log1p__cuda
+    SparseCPU: log1p_sparse_
+    SparseCUDA: log1p_sparse_
 
 - func: log1p_out(Tensor result, Tensor self) -> Tensor
   variants: function
   dispatch:
     CPU: _log1p_out_cpu
     CUDA: _log1p_out_cuda
+    SparseCPU: log1p_out_sparse
+    SparseCUDA: log1p_out_sparse
 
 - func: log2(Tensor self) -> Tensor
 
@@ -1420,8 +1424,6 @@
     SparseCUDA: zero_sparse_
 
 - func: zero_(Tensor self) -> Tensor
-
-
 
 - func: s_native_add_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   variants: function

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -6,6 +6,8 @@
 
 #include <TH/THBlasUtils.h>
 
+#include <torch/csrc/variable_tensor_functions.h>
+
 namespace at { namespace native {
 
 // --------------------------------------------------------------------
@@ -92,6 +94,27 @@ SparseTensor mul_sparse_scalar(const SparseTensor& t, Scalar value) {
 
 SparseTensor& mul_sparse_scalar_(SparseTensor& t, Scalar v) {
   return mul_out_sparse_scalar(t, t, v);
+}
+
+// --------------------------------------------------------------------
+// log1p(SparseTensor)
+// --------------------------------------------------------------------
+
+SparseTensor& log1p_out_sparse(SparseTensor& r, const SparseTensor& t) {
+  AT_ASSERT(r.is_sparse());
+  AT_ASSERT(t.is_sparse());
+
+  if (isSameTensor(r, t)) {
+    r._values().log1p_();
+  } else {
+    r = raw_copy_sparse_(r, t);
+    r._values().log1p_();
+  }
+  return r;
+}
+
+SparseTensor& log1p_sparse_(SparseTensor& t) {
+  return log1p_out_sparse(t, t);
 }
 
 // --------------------------------------------------------------------

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -105,8 +105,8 @@ SparseTensor& log1p_out_sparse(SparseTensor& r, const SparseTensor& t) {
   AT_ASSERT(t.is_sparse());
 
   if (isSameTensor(r, t)) {
-    // don't have in-place log1p because coalesce() is not in-place
-    AT_CHECK(r.is_coalesced(), "log1p only applies to coalesced sparse tensor!");
+    // don't have in-place log1p for uncoalesced input because coalesce() is not in-place
+    AT_CHECK(r.is_coalesced(), "in-place log1p on uncoalesced tensors is not supported yet!");
   }
   else {
     r = raw_copy_sparse_(r, t.coalesce());
@@ -116,7 +116,7 @@ SparseTensor& log1p_out_sparse(SparseTensor& r, const SparseTensor& t) {
 }
 
 SparseTensor& log1p_sparse_(SparseTensor& t) {
-  AT_CHECK(t.is_coalesced(), "log1p only applies to coalesced sparse tensor!");
+  AT_CHECK(t.is_coalesced(), "in-place log1p on uncoalesced tensors is not supported yet!");
   return log1p_out_sparse(t, t);
 }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -106,7 +106,8 @@ SparseTensor& log1p_out_sparse(SparseTensor& r, const SparseTensor& t) {
 
   if (isSameTensor(r, t)) {
     // don't have in-place log1p for uncoalesced input because coalesce() is not in-place
-    AT_CHECK(r.is_coalesced(), "in-place log1p on uncoalesced tensors is not supported yet!");
+    AT_CHECK(
+      r.is_coalesced(), "in-place log1p on uncoalesced tensors is not supported yet!");
   }
   else {
     r = raw_copy_sparse_(r, t.coalesce());

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -98,20 +98,25 @@ SparseTensor& mul_sparse_scalar_(SparseTensor& t, Scalar v) {
 // log1p(SparseTensor)
 // --------------------------------------------------------------------
 
+// TODO: add in-place variant
+
 SparseTensor& log1p_out_sparse(SparseTensor& r, const SparseTensor& t) {
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());
 
   if (isSameTensor(r, t)) {
-    r._values().log1p_();
-  } else {
-    r = raw_copy_sparse_(r, t);
-    r._values().log1p_();
+    // don't have in-place log1p because coalesce() is not in-place
+    AT_CHECK(r.is_coalesced(), "log1p only applies to coalesced sparse tensor!");
   }
+  else {
+    r = raw_copy_sparse_(r, t.coalesce());
+  }
+  r._values().log1p_();
   return r;
 }
 
 SparseTensor& log1p_sparse_(SparseTensor& t) {
+  AT_CHECK(t.is_coalesced(), "log1p only applies to coalesced sparse tensor!");
   return log1p_out_sparse(t, t);
 }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -6,8 +6,6 @@
 
 #include <TH/THBlasUtils.h>
 
-#include <torch/csrc/variable_tensor_functions.h>
-
 namespace at { namespace native {
 
 // --------------------------------------------------------------------

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -660,8 +660,6 @@ class TestSparse(TestCase):
             self.assertEqual(out._denseDims(), 0)
 
     def test_log1p(self):
-        import math
-
         if self.is_cuda:
             input = torch.cuda.sparse.DoubleTensor(
                 torch.LongTensor([[0], [1], [2]]).transpose(1, 0).cuda(),
@@ -673,13 +671,13 @@ class TestSparse(TestCase):
                 torch.FloatTensor([3, 4, 5]),
                 torch.Size([3]))
 
-        expected_output = torch.tensor([math.log(3 + 1), math.log(4 + 1), math.log(5 + 1)])
+        expected_output = torch.tensor([3., 4., 5.]).log1p_()
         self.assertEqual(expected_output, input.log1p().to_dense())
         self.assertEqual(expected_output, input.coalesce().log1p_().to_dense())
 
         # test in-place op on uncoalesced input
         with self.assertRaisesRegex(RuntimeError,
-                                    "log1p only applies to coalesced sparse tensor!"):
+                                    "in-place log1p on uncoalesced tensors is not supported yet!"):
             input.log1p_()
 
         input.requires_grad_()

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -371,7 +371,7 @@
   self: grad / (self * 2.3025850929940456)
 
 - name: log1p(Tensor self)
-  self: grad / (self + 1)
+  self: log1p_backward(grad, self)
 
 - name: log2(Tensor self)
   self: grad / (self * 0.6931471805599453)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1863,7 +1863,8 @@ std::tuple<Tensor, Tensor, Tensor> _trilinear_backward(const Tensor& grad_out, c
 
 Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
   if (self.is_sparse()) {
-    AT_ERROR("log1p of a sparse tensor is made to be non-differentiable since ",
+    AT_ERROR(
+      "log1p of a sparse tensor is made to be non-differentiable since ",
       "local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. ",
       "Use a different mathematical operation which preserves sparsity of gradients, ",
       "or report a bug if you think this is an error.");

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1861,6 +1861,14 @@ std::tuple<Tensor, Tensor, Tensor> _trilinear_backward(const Tensor& grad_out, c
   return std::tuple<Tensor, Tensor, Tensor>(grad_i1, grad_i2, grad_i3);
 }
 
+Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
+  if (self.is_sparse()) {
+    AT_ERROR("log1p of a sparse tensor is made to be non-differentiable since ",
+      "local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense");
+  }
+  return grad / (self + 1);
+}
+
 } // anonymous namespace
 
 ${autograd_function_definitions}

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1864,7 +1864,9 @@ std::tuple<Tensor, Tensor, Tensor> _trilinear_backward(const Tensor& grad_out, c
 Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
   if (self.is_sparse()) {
     AT_ERROR("log1p of a sparse tensor is made to be non-differentiable since ",
-      "local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense");
+      "local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. ",
+      "Use a different mathematical operation which preserves sparsity of gradients, ",
+      "or report a bug if you think this is an error.");
   }
   return grad / (self + 1);
 }


### PR DESCRIPTION
## summary
- fixes log1p at #8853
- added log1p of sparse tensor in ATen
- make log1p of sparse tensor non-differentiable and raise error, because local derivate of log1p for zero element is 1 / (0 + 1) = 1 and make tensor dense