### PR TITLE
[C++ API] Create nn::Module::is

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -66,6 +66,23 @@ TEST_CASE("module/name") {
   }
 }
 
+TEST_CASE("module/is") {
+  Linear module(3, 4);
+  REQUIRE(module->is<Linear>());
+  REQUIRE(module->is<LinearImpl>());
+  REQUIRE(!module->is<AGIUnit>());
+
+  std::shared_ptr<Module> raw = module.get();
+  REQUIRE(raw->is<Linear>());
+  REQUIRE(raw->is<LinearImpl>());
+  REQUIRE(!raw->is<AGIUnit>());
+
+  AGIUnit unit;
+  REQUIRE(!unit.is<Linear>());
+  REQUIRE(!unit.is<LinearImpl>());
+  REQUIRE(unit.is<AGIUnit>());
+}
+
 TEST_CASE("module/conversions", "[cuda]") {
   Linear module(128, 64);
   SECTION("starts as float on CPU") {

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -128,6 +128,25 @@ class Module {
     }
   }
 
+  /// Returns true if the dynamic type of this module is of the given
+  /// `ModuleType`. Performs a `dynamic_cast` to check this.
+  template <
+      typename ModuleType,
+      typename = torch::detail::disable_if_module_holder_t<ModuleType>>
+  bool is() const noexcept {
+    return dynamic_cast<const ModuleType*>(this) != nullptr;
+  }
+
+  /// Returns true if the dynamic type of this module is of the given
+  /// `ModuleType`. Performs a `dynamic_cast` to check this.
+  template <typename ModuleType>
+  torch::enable_if_t<torch::detail::is_module_holder<ModuleType>::value, bool>
+  is() const noexcept {
+    // Use the contained type of the `ModuleHolder`, e.g. `LinearImpl` for
+    // `Linear`, since `LinearImpl` inherits `nn::Module`.
+    return is<typename ModuleType::ContainedType>();
+  }
+
  protected:
   Tensor& register_parameter(
       std::string name,

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -16,6 +16,9 @@ namespace detail {
 struct ModuleHolderIndicator {};
 
 template <typename T>
+using is_module_holder = std::is_base_of<ModuleHolderIndicator, decay_t<T>>;
+
+template <typename T>
 using disable_if_module_holder_t =
     disable_if_t<std::is_base_of<ModuleHolderIndicator, decay_t<T>>::value>;
 } // namespace detail


### PR DESCRIPTION
When initializing weights for my C++ model, I had to write

```cpp
void initialize_weights(nn::Module& module) {
  if (module.name().find("Conv2d") != std::string::npos) {
    module.parameters()["weight"].data().normal_(0.0, 0.02);
  } else if (module.name().find("BatchNorm") != std::string::npos) {
    auto parameters = module.parameters();
    parameters["weight"].data().normal_(1.0, 0.02);
    parameters["bias"].data().fill_(0);
  }
}
```

The string-based module determination is not very nice, and not very C++-y. So I created `nn::Module::is<T>` which does a `dynamic_cast` inside. It also handles the `ModuleHolder` vs. `Module` distinction.

It now becomes

```cpp
if (module.is<nn::Conv2d>()) {
    module.parameters()["weight"].data().normal_(0.0, 0.02);
  } else if (module.is<nn::BatchNorm>()) {
    auto parameters = module.parameters();
    parameters["weight"].data().normal_(1.0, 0.02);
    parameters["bias"].data().fill_(0);
  }
```

@ebetica @ezyang @apaszke 