### PR TITLE
Use std::random_device for generating storage handle

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -21,7 +21,6 @@ from functools import reduce
 from torch import multiprocessing as mp
 from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3
-import io
 from multiprocessing.reduction import ForkingPickler
 
 if TEST_NUMPY:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -21,6 +21,8 @@ from functools import reduce
 from torch import multiprocessing as mp
 from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3
+import io
+from multiprocessing.reduction import ForkingPickler
 
 if TEST_NUMPY:
     import numpy as np
@@ -4551,6 +4553,18 @@ class TestTorch(TestCase):
         _ = torch.rand(100000)
         forked_value = torch.rand(1000, generator=gen)
         self.assertEqual(target_value, forked_value, 0, "RNG has not forked correctly.")
+
+    def test_RNG_after_pickle(self):
+        torch.random.manual_seed(100)
+        before = torch.rand(10)
+
+        torch.random.manual_seed(100)
+        buf = io.BytesIO()
+        tensor = torch.Tensor([1, 2, 3])
+        ForkingPickler(buf, pickle.HIGHEST_PROTOCOL).dump(tensor)
+        after = torch.rand(10)
+
+        self.assertEqual(before, after, 0)
 
     def test_boxMullerState(self):
         torch.manual_seed(123)

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -3,6 +3,7 @@
 #include <cuda_runtime.h>
 #endif
 
+#include <random>
 
 static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
 {
@@ -58,6 +59,7 @@ static PyObject * THPStorage_(newTHView)(THWStorage *base, ptrdiff_t offset, siz
 #ifndef THC_GENERIC_FILE
 // TODO: move this somewhere - we only need one version
 static std::string THPStorage_(__newHandle)() {
+  std::random_device rd;
   std::string handle = "/torch_";
 #ifdef _MSC_VER
   handle += std::to_string(GetCurrentProcessId());
@@ -65,7 +67,7 @@ static std::string THPStorage_(__newHandle)() {
   handle += std::to_string(getpid());
 #endif
   handle += "_";
-  handle += std::to_string(THRandom_random(THPGenerator_TH_CData(THPDefaultGenerator)));
+  handle += std::to_string(rd());
   return handle;
 }
 


### PR DESCRIPTION
Currently the `test_RNG_after_pickle` in the PR would fail because pickling a tensor changes the RNG state. This PR aims to fix it.

This will also fix https://github.com/pytorch/pytorch/issues/8651.