### PR TITLE
Fix TestCollectEnv flakiness

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -637,7 +637,7 @@ class TestCollectEnv(TestCase):
 
     def _preprocess_info_for_test(self, info_output):
         # Remove the version hash
-        version_hash_regex = re.compile(r'(a\d+)\+.......')
+        version_hash_regex = re.compile(r'(a\d+)\+\w+')
         result = re.sub(version_hash_regex, r'\1', info_output).strip()
 
         # Substitutions to lower the specificity of the versions listed


### PR DESCRIPTION
The problem was a bad regex; the version hash match used to match 6
wildcards. This PR changes it to match \w+, which is sufficient for the
test because the version hash is always followed by either whitespace or
a right-paren.

Fixes #8981

Test Plan:
wait for CI

cc @ezyang thank you for the catch!

