### PR TITLE
Correctly escape operator documentation

### DIFF
--- a/caffe2/operators/abs_op.cc
+++ b/caffe2/operators/abs_op.cc
@@ -78,7 +78,7 @@ Y: [0.3005476  1.551666   1.3591481  0.39191285 0.21866608]
 </details>
 
 )DOC")
-    .Input(0, "X", "*(type: Tensor<float\\>)* Input tensor.")
+    .Input(0, "X", "*(type: Tensor<float>)* Input tensor.")
     .Output(
         0,
         "Y",

--- a/caffe2/operators/counter_ops.cc
+++ b/caffe2/operators/counter_ops.cc
@@ -74,7 +74,7 @@ print("Initial 'done' value:", workspace.FetchBlob("done"))
 
 
 # Test CountUp operator
-print("\nTesting CountUp operator...")
+print("\\nTesting CountUp operator...")
 for i in range(5):
     workspace.RunOperatorOnce(countup_op)
     print("'previous_count' after CountUp:", workspace.FetchBlob("previous_count"))
@@ -84,11 +84,11 @@ print("'count' value after CountUp test:", workspace.FetchBlob("count"))
 
 
 # Test CountDown operator
-print("\nTesting CountDown operator...")
+print("\\nTesting CountDown operator...")
 for i in range(11):
     workspace.RunOperatorOnce(countdown_op)
     workspace.RunOperatorOnce(retrievecount_op)
-    print("'count' value after CountDown: {}\t'done' value: {}".format(workspace.FetchBlob("count"), workspace.FetchBlob("done")))
+    print("'count' value after CountDown: {}\\t'done' value: {}".format(workspace.FetchBlob("count"), workspace.FetchBlob("done")))
 ```
 
 **Result**

--- a/caffe2/operators/distance_op.cc
+++ b/caffe2/operators/distance_op.cc
@@ -399,7 +399,7 @@ OPERATOR_SCHEMA(L1Distance)
     .SetDoc(R"DOC(
 Computes the row-wise L1 Distance between the two input tensors $X$ and $Y$, which is defined as
 
-$$L1Distance(\mathbf{x},\mathbf{y}) = \sum_{i}\mid x_i - y_i\mid$$
+$$L1Distance(\\mathbf{x},\\mathbf{y}) = \\sum_{i}\mid x_i - y_i\\mid$$
 
 Note, both inputs must either be 1-dimensional or 2-dimensional and both must have the same shape. The output $Z$ will be 1-dimensional regardless and its length will equal the number of rows in the inputs.
 
@@ -425,11 +425,11 @@ op = core.CreateOperator(
 
 # Create X
 X = 5*np.ones((1, 4))
-print("X:\n",X)
+print("X:\\n",X)
 
 # Create Y
 Y = np.ones((1, 4))
-print("Y:\n",Y)
+print("Y:\\n",Y)
 
 # Feed X & Y into workspace
 workspace.FeedBlob("X", X.astype(np.float32))
@@ -439,7 +439,7 @@ workspace.FeedBlob("Y", Y.astype(np.float32))
 workspace.RunOperatorOnce(op)
 
 # Collect Output
-print("Z:\n", workspace.FetchBlob("Z"))
+print("Z:\\n", workspace.FetchBlob("Z"))
 
 ```
 
@@ -502,15 +502,15 @@ Given two vectors $X = [x_0, x_1, x_2]$ and $Y = [y_0, y_1, y_2]$; $Z = [x_0 * y
 
 For 2D inputs:
 Given two matrices:
-$$X = [[x_0^0, x_1^0, x_2^0], \\ [x_0^1, x_1^1, x_2^1], \\ [x_0^2, x_1^2, x_2^2], \\ ..., \\ [x_0^n, x_1^n, x_2^n]]$$
+$$X = [[x_0^0, x_1^0, x_2^0], \\\\ [x_0^1, x_1^1, x_2^1], \\\\ [x_0^2, x_1^2, x_2^2], \\\\ ..., \\\\ [x_0^n, x_1^n, x_2^n]]$$
 
 and
 
-$$Y = [[y_0^0, y_1^0, y_2^0], \\ [y_0^1, y_1^1, y_2^1], \\ [y_0^2, y_1^2, y_2^2], \\ ..., \\ [y_0^n, y_1^n, y_2^n]]$$
+$$Y = [[y_0^0, y_1^0, y_2^0], \\\\ [y_0^1, y_1^1, y_2^1], \\\\ [y_0^2, y_1^2, y_2^2], \\\\ ..., \\\\ [y_0^n, y_1^n, y_2^n]]$$
 
 then
 
-$$Z =  \biggl[\Big((x_0^0 * y_0^0) + (x_1^0 * y_1^0) + (x_2^0 * y_2^0)\Big), \\ \Big((x_0^1 * y_0^1) + (x_1^1 * y_1^1) + (x_2^1 * y_2^1)\Big), \\ \Big((x_0^2 * y_0^2) + (x_1^2 * y_1^2) + (x_2^2 * y_2^2)\Big), \\ ..., \\ \Big((x_0^n * y_0^n) + (x_1^n * y_1^n) + (x_2^n * y_2^n)\Big)\biggr]$$
+$$Z =  \\biggl[\\Big((x_0^0 * y_0^0) + (x_1^0 * y_1^0) + (x_2^0 * y_2^0)\\Big), \\\\ \\Big((x_0^1 * y_0^1) + (x_1^1 * y_1^1) + (x_2^1 * y_2^1)\\Big), \\\\ \\Big((x_0^2 * y_0^2) + (x_1^2 * y_1^2) + (x_2^2 * y_2^2)\\Big), \\\\ ..., \\\\ \\Big((x_0^n * y_0^n) + (x_1^n * y_1^n) + (x_2^n * y_2^n)\\Big)\\biggr]$$
 
 Github Link:
 - https://github.com/pytorch/pytorch/blob/master/caffe2/operators/distance_op.cc
@@ -533,19 +533,19 @@ op = core.CreateOperator(
 
 workspace.FeedBlob("X", np.random.randint(20, size=(5)).astype(np.float32))
 workspace.FeedBlob("Y", np.random.randint(20, size=(5)).astype(np.float32))
-print("X:\n", workspace.FetchBlob("X"))
-print("Y:\n", workspace.FetchBlob("Y"))
+print("X:\\n", workspace.FetchBlob("X"))
+print("Y:\\n", workspace.FetchBlob("Y"))
 workspace.RunOperatorOnce(op)
-print("Z:\n", workspace.FetchBlob("X"))
+print("Z:\\n", workspace.FetchBlob("X"))
 
 
 workspace.ResetWorkspace()
 workspace.FeedBlob("X", np.random.randint(10, size=(3,3)).astype(np.float32))
 workspace.FeedBlob("Y", np.random.randint(10, size=(3,3)).astype(np.float32))
-print("X:\n", workspace.FetchBlob("X"))
-print("Y:\n", workspace.FetchBlob("Y"))
+print("X:\\n", workspace.FetchBlob("X"))
+print("Y:\\n", workspace.FetchBlob("Y"))
 workspace.RunOperatorOnce(op)
-print("Z:\n", workspace.FetchBlob("Z"))
+print("Z:\\n", workspace.FetchBlob("Z"))
 
 ```
 
@@ -609,7 +609,7 @@ OPERATOR_SCHEMA(CosineSimilarity)
     .SetDoc(R"DOC(
 This op takes two input float tensors of the same size, $X$ and $Y$, and produces one output float tensor , $Z$, calculated as the cosine similarity between $X$ and $Y$. Recall, the cosine similarity between two tensors $X$ and $Y$ is defined as:
 
-$$\mathbf{Z}=CosineSimilarity(\mathbf{X},\mathbf{Y}) = \frac{\mathbf{X}\cdot\mathbf{Y}}{\|\mathbf{X}\|\|\mathbf{Y}\|} = \frac{\sum_n^{i=1}X_iY_i}{\sqrt{\sum_n^{i=1}X_i^2}\sqrt{\sum_n^{i=1}Y_i^2}}$$
+$$\\mathbf{Z}=CosineSimilarity(\\mathbf{X},\\mathbf{Y}) = \\frac{\\mathbf{X}\\cdot\\mathbf{Y}}{\\|\\mathbf{X}\\|\\|\\mathbf{Y}\\|} = \\frac{\\sum_n^{i=1}X_iY_i}{\\sqrt{\\sum_n^{i=1}X_i^2}\\sqrt{\\sum_n^{i=1}Y_i^2}}$$
 
 Github Links:
 - https://github.com/pytorch/pytorch/blob/master/caffe2/operators/distance_op.h
@@ -633,11 +633,11 @@ op = core.CreateOperator(
 
 # Create X
 X = np.random.randn(3, 3)
-print("X:\n",X)
+print("X:\\n",X)
 
 # Create Y
 Y = np.random.randn(3, 3)
-print("Y:\n",Y)
+print("Y:\\n",Y)
 
 # Feed X & Y into workspace
 workspace.FeedBlob("X", X.astype(np.float32))
@@ -647,7 +647,7 @@ workspace.FeedBlob("Y", Y.astype(np.float32))
 workspace.RunOperatorOnce(op)
 
 # Collect Output
-print("Z:\n", workspace.FetchBlob("Z"))
+print("Z:\\n", workspace.FetchBlob("Z"))
 
 ```
 

--- a/caffe2/operators/dropout_op.cc
+++ b/caffe2/operators/dropout_op.cc
@@ -84,7 +84,7 @@ with random elements zeroed. The probability that a given element is zeroed is
 determined by the `ratio` argument.
 
 If the `is_test` argument is set to non-zero, the output `Y` is exactly the same as the
-input `X`. Note that outputs are scaled by a factor of $\frac{1}{1-ratio}$ during
+input `X`. Note that outputs are scaled by a factor of $\\frac{1}{1-ratio}$ during
 training, so that during test time, we can simply compute an identity function. This
 scaling is important because we want the output at test time to equal the expected value
 at training time. Dropout has been proven to be an effective regularization technique to
@@ -154,7 +154,7 @@ mask: [[False False False  True  True]
         1,
         "mask",
         "*(type: Tensor`<bool>`)* The output mask containing boolean values for"
-        "each element, signifying which elements are dropped out. If `is_test` is" 
+        "each element, signifying which elements are dropped out. If `is_test` is"
         "nonzero, this output is not filled.")
     .InheritOnnxSchema("Dropout");
 

--- a/caffe2/operators/flatten_op.cc
+++ b/caffe2/operators/flatten_op.cc
@@ -31,7 +31,7 @@ OPERATOR_SCHEMA(Flatten)
     .SetDoc(R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
 $(d_0, d_1, ..., d_n)$ then the output will have shape
-$\bigl((d_0 * d_1 * ... * d_{(axis-1)}), (d_{axis} * d_{(axis+1)} * ... * d_n)\bigr)$.
+$\\bigl((d_0 * d_1 * ... * d_{(axis-1)}), (d_{axis} * d_{(axis+1)} * ... * d_n)\\bigr)$.
 
 Github Links:
 

--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -70,7 +70,7 @@ OPERATOR_SCHEMA(Load)
     .NumOutputs(0, INT_MAX)
     .SetDoc(R"DOC(
 The Load operator loads a set of serialized blobs from a db or multiple dbs. It
-takes $[0, \infty)$ number of inputs and $[0, \infty)$ number of outputs, using
+takes $[0, \\infty)$ number of inputs and $[0, \\infty)$ number of outputs, using
 the db keys to match the db entries with the outputs.
 
 If at least one input is passed, then it is assumed that that input blobs are a
@@ -165,7 +165,7 @@ OPERATOR_SCHEMA(Save)
     .NumInputs(1, INT_MAX)
     .NumOutputs(0)
     .SetDoc(R"DOC(
-Saves a set of blobs to a db. It takes $[1, \infty)$ number of inputs and has
+Saves a set of blobs to a db. It takes $[1, \\infty)$ number of inputs and has
 no output. The contents of the inputs are written into the db using the
 settings specified by the arguments.
 

--- a/caffe2/operators/local_response_normalization_op.cc
+++ b/caffe2/operators/local_response_normalization_op.cc
@@ -309,15 +309,15 @@ OPERATOR_SCHEMA(LRN)
   .SetDoc(R"DOC(
 
 `LRN` applies Local Response Normalization to an input blob. This operation performs
-a kind of "lateral inhibition" by normalizing over local input regions, where 
-normalization is applied across channels. This operator is typically used to 
+a kind of "lateral inhibition" by normalizing over local input regions, where
+normalization is applied across channels. This operator is typically used to
 normalize an unbounded activation (such as ReLU). The output shape is the same as
 the input shape. The `brew` module has a wrapper for this operator for use in a
 `ModelHelper` object.
 
 The formula for LRN is as follows:
 
-$$b_{c} = a_{c}(bias + \frac{\alpha}{n}\sum_{c'=max(0,c-n/2)}^{min(N-1,c+n/2)} a_{c'}^2 )^{-\beta}$$
+$$b_{c} = a_{c}(bias + \\frac{\\alpha}{n}\\sum_{c'=max(0,c-n/2)}^{min(N-1,c+n/2)} a_{c'}^2 )^{-\\beta}$$
 
 
 Github Links:
@@ -346,10 +346,10 @@ op = core.CreateOperator("LRN",
 )
 
 workspace.FeedBlob("X", np.random.randn(1, 6, 6, 1).astype(np.float32)) # NCHW
-print("X:\n", workspace.FetchBlob("X"), "\n")
+print("X:\\n", workspace.FetchBlob("X"), "\\n")
 workspace.RunOperatorOnce(op)
-print("Y:\n", workspace.FetchBlob("Y"))
-print("Y_scale:\n", workspace.FetchBlob("Y_scale"))
+print("Y:\\n", workspace.FetchBlob("Y"))
+print("Y_scale:\\n", workspace.FetchBlob("Y_scale"))
 ```
 
 **Result**
@@ -396,7 +396,7 @@ X:
    [ 0.45961624]
    [-1.0201577 ]
    [ 0.62854475]
-   [-0.6395456 ]]]] 
+   [-0.6395456 ]]]]
 
 Y:
  [[[[ 0.5160766 ]
@@ -494,7 +494,7 @@ Y_scale:
   .Arg("order", "*(type: float; default: 'NCHW')* Order of blob dimensions.")
   .Input(0, "X", "*(type: Tensor`<float>`)* Input data tensor (ReLU output).")
   .Output(0, "Y", "*(type: Tensor`<float>`)* Output tensor.")
-  .Output(1, "Y_scale", "*(type: Tensor`<float>`)* Output scale.") 
+  .Output(1, "Y_scale", "*(type: Tensor`<float>`)* Output scale.")
   .InheritOnnxSchema("LRN");
 OPERATOR_SCHEMA(LRNGradient).NumInputs(3).NumOutputs(1);
 

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -737,7 +737,7 @@ size and downsampling the data into the output blob for further processing. The
 Pooling layers reduce the spatial dimensionality of the input blob. Each of the
 output blob's dimensions will reduce according to:
 
-$$dim_{out}=\frac{dim_{in}-kernel+2*pad}{stride}+1$$
+$$dim_{out}=\\frac{dim_{in}-kernel+2*pad}{stride}+1$$
 
 Github Links:
 
@@ -764,9 +764,9 @@ op = core.CreateOperator(
 )
 
 workspace.FeedBlob("X", np.random.randn(1, 1, 6, 6).astype(np.float32)) # NCHW
-print("X:\n", workspace.FetchBlob("X"), "\n")
+print("X:\\n", workspace.FetchBlob("X"), "\\n")
 workspace.RunOperatorOnce(op)
-print("Y:\n", workspace.FetchBlob("Y"))
+print("Y:\\n", workspace.FetchBlob("Y"))
 ```
 
 **Result**
@@ -806,7 +806,7 @@ size and downsampling the data into the output blob for further processing. The
 Pooling layers reduce the spatial dimensionality of the input blob. Each of the
 output blob's dimensions will reduce according to:
 
-$$dim_{out}=\frac{dim_{in}-kernel+2*pad}{stride}+1$$
+$$dim_{out}=\\frac{dim_{in}-kernel+2*pad}{stride}+1$$
 
 Github Links:
 
@@ -832,9 +832,9 @@ op = core.CreateOperator(
 )
 
 workspace.FeedBlob("X", np.random.randn(1, 1, 6, 6).astype(np.float32)) # NCHW
-print("X:\n", workspace.FetchBlob("X"), "\n")
+print("X:\\n", workspace.FetchBlob("X"), "\\n")
 workspace.RunOperatorOnce(op)
-print("Y:\n", workspace.FetchBlob("Y"))
+print("Y:\\n", workspace.FetchBlob("Y"))
 ```
 
 **Result**

--- a/caffe2/operators/sequence_ops.cc
+++ b/caffe2/operators/sequence_ops.cc
@@ -287,7 +287,7 @@ OPERATOR_SCHEMA(AddPadding)
     .SetDoc(R"DOC(
 Given a partitioned tensor $T<N, D_1, ..., D_n>$, where the partitions are
 defined as ranges on its outer-most (slowest varying) dimension $N$,
-return a tensor $T<(N + 2 * padding\_width), D_1, ..., D_n>$ with paddings
+return a tensor $T<(N + 2 * padding\\_width), D_1, ..., D_n>$ with paddings
 added to the start and end of each range.
 
 Optionally, different paddings can be provided for beginning and end.

--- a/caffe2/operators/sigmoid_op.cc
+++ b/caffe2/operators/sigmoid_op.cc
@@ -29,7 +29,7 @@ Apply the Sigmoid function element-wise to the input tensor. This is often used
 as a non-linear activation function in a neural network. The sigmoid function is
 defined as:
 
-$$Sigmoid(x) = \frac{1}{1+\exp(-x)}$$
+$$Sigmoid(x) = \\frac{1}{1+\\exp(-x)}$$
 
 Github Links:
 

--- a/caffe2/operators/softmax_op.cc
+++ b/caffe2/operators/softmax_op.cc
@@ -84,25 +84,25 @@ OPERATOR_SCHEMA(Softmax)
   .IdenticalTypeAndShape()
   .SetDoc(R"DOC(
 
-Applies the Softmax function to an n-dimensional input Tensor rescaling them so 
-that the elements of the n-dimensional output Tensor lie in the range (0,1) and 
+Applies the Softmax function to an n-dimensional input Tensor rescaling them so
+that the elements of the n-dimensional output Tensor lie in the range (0,1) and
 sum to 1. The softmax operator is typically the last layer in a classifier network,
 as its output can be interpreted as confidence probabilities of an input belonging
-to each class. The input is a 2-D tensor (Tensor) of size (batch_size x 
-input_feature_dimensions). The output tensor has the same shape and contains the 
-softmax normalized values of the corresponding input. The softmax function is 
+to each class. The input is a 2-D tensor (Tensor) of size (batch_size x
+input_feature_dimensions). The output tensor has the same shape and contains the
+softmax normalized values of the corresponding input. The softmax function is
 defined as follows:
 
-$$softmax(x_i) = \frac{\exp(x_i)}{\sum_{j} \exp(x_j)}$$
+$$softmax(x_i) = \\frac{\\exp(x_i)}{\\sum_{j} \\exp(x_j)}$$
 
 The input does not need to explicitly be a 2D vector; rather, it will be coerced
-into one. For an arbitrary n-dimensional tensor `X` in 
-$[a_0, a_1, ..., a_{k-1}, a_k, ..., a_{n-1}]$, where k is the `axis` provided, 
-then `X` will be coerced into a 2-dimensional tensor with dimensions 
+into one. For an arbitrary n-dimensional tensor `X` in
+$[a_0, a_1, ..., a_{k-1}, a_k, ..., a_{n-1}]$, where k is the `axis` provided,
+then `X` will be coerced into a 2-dimensional tensor with dimensions
 $[(a_0 * ... * a_{k-1}), (a_k * ... * a_{n-1})]$. For the default case where
-`axis`=1, the `X` tensor will be coerced into a 2D tensor of dimensions 
+`axis`=1, the `X` tensor will be coerced into a 2D tensor of dimensions
 $[a_0, (a_1 * ... * a_{n-1})]$, where $a_0$ is often the batch size. In this
-situation, we must have $a_0 = N$ and $a_1 * ... * a_{n-1} = D$. Each of these 
+situation, we must have $a_0 = N$ and $a_1 * ... * a_{n-1} = D$. Each of these
 dimensions must be matched correctly, or else the operator will throw errors.
 
 Github Links:

--- a/caffe2/operators/softmax_with_loss_op.cc
+++ b/caffe2/operators/softmax_with_loss_op.cc
@@ -39,11 +39,11 @@ Combined Softmax and Cross-Entropy loss operator. The operator first computes th
 
 Softmax cross-entropy loss function:
 
-$$loss(x, class) = -\log{\biggl(\frac{\exp(x[class])}{\sum_{j} \exp(x[j])}\biggr)} = -x[class] + \log{\biggl(\sum_{j} \exp(x[j])\biggr)}$$
+$$loss(x, class) = -\\log{\\biggl(\\frac{\\exp(x[class])}{\\sum_{j} \\exp(x[j])}\\biggr)} = -x[class] + \\log{\\biggl(\\sum_{j} \\exp(x[j])\\biggr)}$$
 
 or if the `weight_tensor` has been passed:
 
-$$loss(x, class) = weight[class]\biggl(-x[class] + \log{\biggl(\sum_{j} \exp(x[j])\biggr)}\biggr)$$
+$$loss(x, class) = weight[class]\\biggl(-x[class] + \\log{\\biggl(\\sum_{j} \\exp(x[j])\\biggr)}\\biggr)$$
 
 The `logits` input does not need to explicitly be a 2D vector; rather, it will be coerced into one. For an arbitrary n-dimensional tensor `X` in $[a_0, a_1, ..., a_{k-1}, a_k, ..., a_{n-1}]$, where k is the `axis` provided, then `X` will be coerced into a 2-dimensional tensor with dimensions $[(a_0 * ... * a_{k-1}), (a_k * ... * a_{n-1})]$. For the default case where `axis`=1, the `X` tensor will be coerced into a 2D tensor of dimensions $[a_0, (a_1 * ... * a_{n-1})]$, where $a_0$ is often the batch size. In this situation, we must have $a_0 = N$ and $a_1 * ... * a_{n-1} = D$. Each of these dimensions must be matched correctly, or else the operator will throw errors.
 

--- a/caffe2/operators/sqrt_op.cc
+++ b/caffe2/operators/sqrt_op.cc
@@ -19,7 +19,7 @@ OPERATOR_SCHEMA(Sqrt)
     .AllowInplace({{0, 0}})
     .IdenticalTypeAndShape()
     .SetDoc(R"DOC(
-Performs element-wise square-root ($\sqrt{x}$) of input tensor $X$.
+Performs element-wise square-root ($\\sqrt{x}$) of input tensor $X$.
 
 Github Link:
 - https://github.com/pytorch/pytorch/blob/master/caffe2/operators/sqrt_op.cc


### PR DESCRIPTION
Summary: Looks like we didn't doubly-escape the new operator docs. This takes care of that.

Differential Revision: D8678436

cc @goodlux @MatthewInkawhich @inkawhich 
