### PR TITLE
Speed-up multidim sum

### DIFF
--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -46,11 +46,18 @@ static inline int64_t maybe_wrap_dim(int64_t dim, const std::vector<std::vector<
 }
 
 // wrap negative dims in to_transform_dims
-static inline void maybe_wrap_dims(std::vector<int64_t>& to_transform_dims, int64_t tensor_total_dims) {
-  for (size_t i = 0; i < to_transform_dims.size(); i++) {
-    if (to_transform_dims[i] < 0) {
-      to_transform_dims[i] = (tensor_total_dims + (to_transform_dims[i] % tensor_total_dims)) % tensor_total_dims;
-    }
+static inline void maybe_wrap_dims(std::vector<int64_t>& dims, int64_t dim_post_expr) {
+  if (dim_post_expr <= 0) {
+    dim_post_expr = 1; // this will make range [-1, 0]
+  }
+  int64_t min = -dim_post_expr;
+  int64_t max = dim_post_expr - 1;
+  for (auto& dim : dims) {
+    AT_CHECK(
+        dim >= min && dim <= max,
+        "Dimension out of range (expected to be in range of [",
+        min, ", ", max, "], but got ", dim, ")");
+    if (dim < 0) dim += dim_post_expr;
   }
 }
 

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -45,6 +45,15 @@ static inline int64_t maybe_wrap_dim(int64_t dim, const std::vector<std::vector<
   return maybe_wrap_dim(dim, tensor_sizes[0].size());
 }
 
+// wrap negative dims in to_transform_dims
+static inline void maybe_wrap_dims(std::vector<int64_t>& to_transform_dims, int64_t tensor_total_dims) {
+  for (size_t i = 0; i < to_transform_dims.size(); i++) {
+    if (to_transform_dims[i] < 0) {
+      to_transform_dims[i] = (tensor_total_dims + (to_transform_dims[i] % tensor_total_dims)) % tensor_total_dims;
+    }
+  }
+}
+
 // previously, size [0] tensors were the only possible empty tensors; thus, it wasn't possible
 // to cat empty tensors unless all the other tensors were 1-dimensional, so we allowed these tensors
 // to be "skipped" (both for wrap dimension behavior and dimension size checking).

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -45,7 +45,7 @@ static inline int64_t maybe_wrap_dim(int64_t dim, const std::vector<std::vector<
   return maybe_wrap_dim(dim, tensor_sizes[0].size());
 }
 
-// wrap negative dims in to_transform_dims
+// wrap each of dims basing on dim_post_expr
 static inline void maybe_wrap_dims(std::vector<int64_t>& dims, int64_t dim_post_expr) {
   if (dim_post_expr <= 0) {
     dim_post_expr = 1; // this will make range [-1, 0]

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -454,6 +454,9 @@ Tensor logsumexp(const Tensor &self, int64_t dim_, bool keepdim) {
 //              (after reduction)
 //                buffer:        [ {output of 3rd it}, {output of 2nd it}]
 //            Return {output of 3rd it}.
+//
+// TODO: If two or more reduced dimensions are contiguous, reduce as if they are
+//       a large dimension.
 template <Tensor (reduce_1)(const Tensor &, int64_t, bool),
     Tensor& (reduce_1_out)(Tensor& result, const Tensor &, int64_t, bool)>
 inline Tensor reduce_multi_associative(const Tensor &self, IntList dims_, bool keepdim) {


### PR DESCRIPTION
1. Instead of using non `_out` variant, we allocate a buffer and use `_out` variant to write the intermediate results into the buffer.
2. Reduce dimensions in order of decreasing sizes.

Benchmark:
Sum a randn tensor of shape `[200, 1, 30, 40, 20, 1, 50]` along dimensions `[4, 6, 3, 0, 2, 5]`. Averaged across 1000 times:
```
before patch:
CPU: 0.0441 s
CUDA: 0.0273 s

after patch:
CPU: 0.0234 s
CUDA: 0.0047 s
```