### PR TITLE
Don't run test_torch in test_cuda and test_sparse

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1911,6 +1911,7 @@ def generate_tests():
 
                 setattr(TestCuda, test_name, test_fn)
 
+
 TestTorch.__bases__ = (object, )
 
 if __name__ == '__main__':

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1911,22 +1911,11 @@ def generate_tests():
 
                 setattr(TestCuda, test_name, test_fn)
 
+TestTorch.__bases__ = (object, )
 
 if __name__ == '__main__':
     if TEST_CUDA:
         load_ignore_file()
         generate_tests()
-
-    # skip TestTorch tests
-    # hide in __name__ == '__main__' because we don't want this to be run when
-    # someone imports test_cuda
-    def load_tests(loader, tests, pattern):
-        test_suite = unittest.TestSuite()
-        for test_group in tests:
-            for test in test_group:
-                if test.__class__.__name__ == 'TestTorch':
-                    continue
-                test_suite.addTest(test)
-        return test_suite
 
     run_tests()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1035,5 +1035,7 @@ class TestCudaUncoalescedSparse(TestCudaSparse):
         super(TestCudaUncoalescedSparse, self).setUp()
         self.is_uncoalesced = True
 
+TestTorch.__bases__ = (object, )
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1035,6 +1035,7 @@ class TestCudaUncoalescedSparse(TestCudaSparse):
         super(TestCudaUncoalescedSparse, self).setUp()
         self.is_uncoalesced = True
 
+
 TestTorch.__bases__ = (object, )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sandcastle doesn't run tests with `__name__ == '__main__'`, and we need a different way to skip `TestTorch` tests in `test_cuda` and `test_sparse`.