### PR TITLE
Skip timed out tests in Sandcastle

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -55,6 +55,7 @@ PY34 = sys.version_info >= (3, 4)
 
 IS_WINDOWS = sys.platform == "win32"
 IS_PPC = platform.machine() == "ppc64le"
+IN_SANDCASTLE = 'IN_SANDCASTLE' in os.environ
 
 TEST_NUMPY = True
 try:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -14,7 +14,8 @@ import torch.cuda.comm as comm
 from torch import multiprocessing as mp
 
 from test_torch import TestTorch
-from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, IS_WINDOWS
+from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, PY3, \
+    IS_WINDOWS, IN_SANDCASTLE
 
 # We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,
 # because if we do that, the TEST_CUDNN line from common_cuda will be executed
@@ -1468,6 +1469,7 @@ class TestCuda(TestCase):
         except RuntimeError as e:
             return e
 
+    @unittest.skipIf(IN_SANDCASTLE, "timed out in Sandcastle")
     @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
     @unittest.skipIf(not PY3,
                      "spawn start method is not supported in Python 2, \

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -20,7 +20,8 @@ from itertools import product, combinations
 from functools import reduce
 from torch import multiprocessing as mp
 from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
-    run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3
+    run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3, \
+    IN_SANDCASTLE
 from multiprocessing.reduction import ForkingPickler
 
 if TEST_NUMPY:
@@ -2389,6 +2390,7 @@ class TestTorch(TestCase):
         except RuntimeError as e:
             return 'invalid multinomial distribution' in str(e)
 
+    @unittest.skipIf(IN_SANDCASTLE, "timed out in Sandcastle")
     @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
     @unittest.skipIf(not PY3,
                      "spawn start method is not supported in Python 2, \


### PR DESCRIPTION
Because the Sandcastle tests are run as a bundle, disabling individual test cases doesn't have an effect on whether those tests will be run in the test suite (e.g. `test_type_casts` is disabled 3 days ago, but `caffe2/test:nn_3 - main` still runs it and fails in GreenWarden). Instead we probably need a way in the code to mark whether a test should be skipped in Sandcastle.