### PR TITLE
Allow arbitrary namespaces for Symbols

### DIFF
--- a/test/expect/TestJit.test_alexnet.expect
+++ b/test/expect/TestJit.test_alexnet.expect
@@ -17,17 +17,17 @@ graph(%0 : Double(1, 3, 224, 224)
       %16 : Double(1000)) {
   %17 : Double(1, 64, 55, 55) = aten::_convolution[stride=[4, 4], padding=[2, 2], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %2), scope: AlexNet/Sequential[features]/Conv2d[0]
   %18 : Double(1, 64, 55, 55) = aten::threshold[threshold={0}, value={0}](%17), scope: AlexNet/Sequential[features]/ReLU[1]
-  %19 : Double(1, 64, 27, 27), %20 : Long(1, 64, 27, 27) = aten::max_pool2d[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%18), scope: AlexNet/Sequential[features]/MaxPool2d[2]
+  %19 : Double(1, 64, 27, 27), %20 : Long(1, 64, 27, 27) = aten::max_pool2d_with_indices[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%18), scope: AlexNet/Sequential[features]/MaxPool2d[2]
   %21 : Double(1, 192, 27, 27) = aten::_convolution[stride=[1, 1], padding=[2, 2], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%19, %3, %4), scope: AlexNet/Sequential[features]/Conv2d[3]
   %22 : Double(1, 192, 27, 27) = aten::threshold[threshold={0}, value={0}](%21), scope: AlexNet/Sequential[features]/ReLU[4]
-  %23 : Double(1, 192, 13, 13), %24 : Long(1, 192, 13, 13) = aten::max_pool2d[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%22), scope: AlexNet/Sequential[features]/MaxPool2d[5]
+  %23 : Double(1, 192, 13, 13), %24 : Long(1, 192, 13, 13) = aten::max_pool2d_with_indices[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%22), scope: AlexNet/Sequential[features]/MaxPool2d[5]
   %25 : Double(1, 384, 13, 13) = aten::_convolution[stride=[1, 1], padding=[1, 1], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%23, %5, %6), scope: AlexNet/Sequential[features]/Conv2d[6]
   %26 : Double(1, 384, 13, 13) = aten::threshold[threshold={0}, value={0}](%25), scope: AlexNet/Sequential[features]/ReLU[7]
   %27 : Double(1, 256, 13, 13) = aten::_convolution[stride=[1, 1], padding=[1, 1], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%26, %7, %8), scope: AlexNet/Sequential[features]/Conv2d[8]
   %28 : Double(1, 256, 13, 13) = aten::threshold[threshold={0}, value={0}](%27), scope: AlexNet/Sequential[features]/ReLU[9]
   %29 : Double(1, 256, 13, 13) = aten::_convolution[stride=[1, 1], padding=[1, 1], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%28, %9, %10), scope: AlexNet/Sequential[features]/Conv2d[10]
   %30 : Double(1, 256, 13, 13) = aten::threshold[threshold={0}, value={0}](%29), scope: AlexNet/Sequential[features]/ReLU[11]
-  %31 : Double(1, 256, 6, 6), %32 : Long(1, 256, 6, 6) = aten::max_pool2d[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%30), scope: AlexNet/Sequential[features]/MaxPool2d[12]
+  %31 : Double(1, 256, 6, 6), %32 : Long(1, 256, 6, 6) = aten::max_pool2d_with_indices[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%30), scope: AlexNet/Sequential[features]/MaxPool2d[12]
   %33 : Long() = aten::size[dim=0](%31), scope: AlexNet
   %34 : Long() = prim::Constant[value={9216}](), scope: AlexNet
   %35 : Dynamic = aten::stack[dim=0](%33, %34), scope: AlexNet

--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -7,120 +7,84 @@
 #include "ATen/optional.h"
 #include "torch/csrc/assertions.h"
 #include "torch/csrc/jit/interned_strings.h"
+#include "string.h"
+#include <iostream>
 
 namespace torch { namespace jit {
 
-// TODO: programatically generate this
-inline std::string valid_namespaces_str() {
-  return "'onnx', 'prim', 'aten', 'attr', 'scope'";
-}
-
-// Alas, this is only constexpr in C++14
-const unique_t unique_start =
-  std::max({static_cast<unique_t>(aten::_keys::num_symbols),
-            static_cast<unique_t>(prim::_keys::num_symbols),
-            static_cast<unique_t>(onnx::_keys::num_symbols),
-            static_cast<unique_t>(attr::_keys::num_symbols)});
-
-SymbolNamespace parseNamespace(const std::string & s) {
-  size_t colon_pos = s.find(':');
-  if (colon_pos == std::string::npos) {
-    std::ostringstream ss;
-    ss << "Symbol: illegal unqualified string '" << s << "'; "
-       << "all symbols must be qualified, e.g., 'ns::" << s << "'. "
-       << "Valid namespaces are: " << valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-  if (colon_pos == 0) {
-    std::ostringstream ss;
-    ss << "Symbol: illegal leading colon in '" << s << "'; "
-       << "all symbols must have a non-empty namespace. "
-       << "Valid namespaces are: " << valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-  // attr::x
-  //     ^___ colon_pos
-  //        ^___ s.size()
-  if (colon_pos + 2 > s.size()) {
-    std::ostringstream ss;
-    ss << "Symbol: underlong string '" << s << "'; "
-       << "namespace must be followed by double colon and a "
-       << "non-empty string.";
-    throw std::runtime_error(ss.str());
-  }
-  if (s[colon_pos + 1] != ':') {
-    std::ostringstream ss;
-    ss << "Symbol: invalid use of colons in '" << s << "'; "
-       << "namespace must be followed by double colon, not a"
-       << "single colon.";
-    throw std::runtime_error(ss.str());
-  }
-  auto ns = s.substr(0, colon_pos);
-  if (ns == "aten") {
-    return SymbolNamespace::aten;
-  } else if (ns == "prim") {
-    return SymbolNamespace::prim;
-  } else if (ns == "onnx") {
-    return SymbolNamespace::onnx;
-  } else if (ns == "attr") {
-    return SymbolNamespace::attr;
-  } else if (ns == "scope") {
-    return SymbolNamespace::scope;
-  } else {
-    std::ostringstream ss;
-    ss << "Symbol: invalid namespace in '" << s << "'. "
-       << "Valid namespaces are: " << valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-}
-
 struct InternedStrings {
   InternedStrings()
-  : next_uniq(unique_start) {
-    #define REGISTER_SYMBOL(ns, s) \
-      string_to_sym_[#ns "::" #s] = ns::s; \
-      sym_to_string_[ns::s] = #ns "::" #s;
-    FORALL_BUILTIN_SYMBOLS(REGISTER_SYMBOL)
+  : sym_to_info_(static_cast<size_t>(_keys::num_symbols)) {
+    #define REGISTER_SYMBOL(n, s) \
+      string_to_sym_[#n "::" #s] = n::s; \
+      sym_to_info_[n::s] = {namespaces::n, #n "::" #s, #s};
+
+    FORALL_NS_SYMBOLS(REGISTER_SYMBOL)
     #undef REGISTER_SYMBOL
   }
-  Symbol symbol(const std::string & s, at::optional<SymbolNamespace> known_ns = at::nullopt) {
-    JIT_ASSERT(!known_ns || parseNamespace(s) == known_ns);
+  Symbol symbol(const std::string & s) {
     std::lock_guard<std::mutex> guard(mutex_);
-    auto it = string_to_sym_.find(s);
-    if(it != string_to_sym_.end())
-      return it->second;
-    unique_t uniq = next_uniq++;
-    // TODO: Doing the parsing while we hold the lock is a bit naughty
-    SymbolNamespace ns = known_ns ? *known_ns : parseNamespace(s);
-    Symbol sym(ns, uniq);
-    string_to_sym_[s] = sym;
-    sym_to_string_[sym] = s;
-    return sym;
+    return _symbol(s);
   }
-  const char * string(Symbol sym) {
+  std::pair<const char *, const char *> string(Symbol sym) {
     // Builtin Symbols are also in the maps, but
     // we can bypass the need to acquire a lock
     // to read the map for Builtins because we already
     // know their string value
     switch(sym) {
       #define DEFINE_CASE(ns, s) \
-        case ns::s: return #ns "::" #s;
-      FORALL_BUILTIN_SYMBOLS(DEFINE_CASE)
+        case ns::s: return {#ns "::" #s, #s};
+      FORALL_NS_SYMBOLS(DEFINE_CASE)
       #undef DEFINE_CASE
         default:
           return customString(sym);
     }
   }
+  Symbol ns(Symbol sym) {
+    switch(sym) {
+      #define DEFINE_CASE(ns, s) \
+        case ns::s: return namespaces::ns;
+      FORALL_NS_SYMBOLS(DEFINE_CASE)
+      #undef DEFINE_CASE
+        default: {
+          std::lock_guard<std::mutex> guard(mutex_);
+          return sym_to_info_.at(sym).ns;
+        }
+    }
+  }
 private:
-  const char * customString(Symbol sym) {
+  // prereq - holding mutex_
+  Symbol _symbol(const std::string & s) {
+    auto it = string_to_sym_.find(s);
+    if(it != string_to_sym_.end())
+      return it->second;
+
+    auto pos = s.find("::");
+    if(pos == std::string::npos) {
+      throw std::runtime_error("all symbols must have a namespace, <namespace>::<string>");
+    }
+    Symbol ns = _symbol("namespaces::" + s.substr(0, pos));
+
+    Symbol sym(sym_to_info_.size());
+    string_to_sym_[s] = sym;
+    sym_to_info_.push_back({ns, s, s.substr(pos + strlen("::"))});
+    return sym;
+  }
+
+  std::pair<const char *, const char *> customString(Symbol sym) {
     std::lock_guard<std::mutex> guard(mutex_);
-    auto it = sym_to_string_.find(sym);
-    JIT_ASSERT(it != sym_to_string_.end());
-    return it->second.c_str();
+    SymbolInfo& s = sym_to_info_.at(sym);
+    return {s.qual_name.c_str(), s.unqual_name.c_str()};
   }
   std::unordered_map<std::string, Symbol> string_to_sym_;
-  std::unordered_map<Symbol, std::string> sym_to_string_;
-  unique_t next_uniq;
+
+  struct SymbolInfo {
+    Symbol ns;
+    std::string qual_name;
+    std::string unqual_name;
+  };
+  std::vector<SymbolInfo> sym_to_info_;
+
   std::mutex mutex_;
 };
 
@@ -133,38 +97,12 @@ Symbol Symbol::fromQualString(const std::string & s) {
   return globalStrings().symbol(s);
 }
 
-const char* symbolNamespaceString(SymbolNamespace ns) {
-  switch (ns) {
-    case SymbolNamespace::onnx: return "onnx";
-    case SymbolNamespace::prim: return "prim";
-    case SymbolNamespace::aten: return "aten";
-    case SymbolNamespace::attr: return "attr";
-    case SymbolNamespace::scope: return "scope";
-    // NB: throwing an exception here causes gcc -O3 to produce far worse code
-    default: return "";
-  }
-}
-
-// NB: I really wanted to define this as std::strlen(symbolNamespaceString(ns)),
-// but gcc -O3 doesn't seem to be smart enough to push the std::strlen into
-// the switch statement.
-size_t symbolNamespaceLength(SymbolNamespace ns) {
-  switch (ns) {
-    case SymbolNamespace::onnx: return 4;
-    case SymbolNamespace::prim: return 4;
-    case SymbolNamespace::aten: return 4;
-    case SymbolNamespace::attr: return 4;
-    case SymbolNamespace::scope: return 5;
-    default: return 0;
-  }
-}
-
 const char * Symbol::toUnqualString() const {
-  return globalStrings().string(*this) + symbolNamespaceLength(ns()) + 2 /* double colon */;
+  return globalStrings().string(*this).second;
 }
 
 const char * Symbol::toQualString() const {
-  return globalStrings().string(*this);
+  return globalStrings().string(*this).first;
 }
 
 const char * Symbol::toDisplayString() const {
@@ -172,29 +110,20 @@ const char * Symbol::toDisplayString() const {
   // The trouble is that, for this to be usable in printf-style assert
   // statements, this has to return a const char* (whose lifetime is
   // global), so we can't actually assemble a string on the fly.
-  return globalStrings().string(*this);
+  return toQualString();
+}
+
+Symbol Symbol::ns() const {
+  return globalStrings().ns(*this);
 }
 
 std::string Symbol::domainString() const {
-  return domain_prefix + symbolNamespaceString(ns());
+  return domain_prefix + ns().toUnqualString();
 }
 
 Symbol Symbol::fromDomainAndUnqualString(const std::string & d, const std::string & s) {
   std::string qualString = d.substr(domain_prefix.size()) + "::" + s;
   return fromQualString(qualString);
-}
-
-std::string qualifyString(SymbolNamespace ns, const std::string & s) {
-  std::string qual_s;
-  qual_s.reserve(s.size() + 2 /* double colon */ + symbolNamespaceLength(ns));
-  qual_s.append(symbolNamespaceString(ns));
-  qual_s.append("::");
-  qual_s.append(s);
-  return qual_s;
-}
-
-Symbol::Symbol(SymbolNamespace ns, const std::string & s)
-: value(globalStrings().symbol(qualifyString(ns, s), ns)) {
 }
 
 }}

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -9,27 +9,13 @@
 
 namespace torch { namespace jit {
 
-// Every symbol is classified in a namespace, specifying what kind of symbol it
-// is.  Unsigned char to ensure widening to unique_t (also an unsigned type)
-enum class SymbolNamespace : unsigned char {
-  onnx  = 'o',
-  prim  = 'p',
-  aten  = 't',
-  // NB: ONNX and ATen attributes all live in a unified namespace, as
-  // their interpretation depends on the operator name (which is namespaced)
-  attr  = 'a',
-  // TODO: eliminate me
-  scope = 's'
-};
-
-// Primitive symbols are synthetic operators that occur only in the IR
-// and don't have corresponding implementations in ATen.
-//
-// TODO: We need documentation for all of these symbols.
-//
-// TODO: Consider moving the synthetic onnx operators to their own
-// namespace.
-#define FORALL_PRIM_SYMBOLS(_) \
+#define FORALL_NS_SYMBOLS(_) \
+_(namespaces, prim) \
+_(namespaces, aten) \
+_(namespaces, onnx) \
+_(namespaces, attr) \
+_(namespaces, scope) \
+_(namespaces, namespaces) \
 _(prim, Assign) \
 _(prim, Constant) \
 _(prim, CppOp) \
@@ -62,32 +48,9 @@ _(prim, NumToTensor) \
 _(prim, TensorToNum) \
 _(prim, AutogradAdd) \
 _(prim, GradOf) \
-_(prim, AnyDefined)
-/* end */
-
-// Workaround for some not-yet-defined ATen symbols, see
-//  - __not__: https://github.com/pytorch/pytorch/issues/5495
-//  - ones, zeros: https://github.com/pytorch/pytorch/issues/5496
-
-#define FORALL_ATEN_EXTRA_SYMBOLS(_) \
+_(prim, AnyDefined) \
 _(aten, __not__) \
-/* end */
-
-#define FORALL_ATEN_SYMBOLS(_) \
 FORALL_ATEN_BASE_SYMBOLS(_) \
-FORALL_ATEN_EXTRA_SYMBOLS(_)
-
-// These symbols correspond to ONNX operators.  Their semantics
-// are defined in https://github.com/onnx/onnx/blob/master/docs/Operators.md
-// The particular version we are targeting is specified by '_onnx_opset_version'
-// in torch.onnx.symbolic
-//
-// In general, most ONNX operators won't get an entry here, because they
-// are handled from the Python end.  However, you may occasionally need
-// to intern an ONNX symbol here so that you can conveniently write an
-// optimization on ONNX operations.
-
-#define FORALL_ONNX_SYMBOLS(_) \
 _(onnx, Add) \
 _(onnx, Concat) \
 _(onnx, Constant) \
@@ -109,15 +72,8 @@ _(onnx, Transpose) \
 _(onnx, Unsqueeze) \
 _(onnx, Loop) \
 _(onnx, If) \
-_(onnx, Reshape)
-/* end */
-
-// These symbols are attribute keys.  They are shared between both ONNX and ATen
-// operators (you disambiguate their meaning by looking at the operator itself).
-// In general, you only need to define attribute keys that are used by
-// onnx or prim; ATen attributes are automatically generated in FORALL_ATTR_BASE_SYMBOLS.
-
-#define FORALL_ATTR_EXTRA_SYMBOLS(_) \
+_(onnx, Reshape) \
+FORALL_ATTR_BASE_SYMBOLS(_) \
 _(attr, Subgraph) \
 _(attr, axes) \
 _(attr, axis) \
@@ -133,40 +89,33 @@ _(attr, starts) \
 _(attr, transA) \
 _(attr, transB) \
 _(attr, name)
-/* end */
 
-#define FORALL_ATTR_SYMBOLS(_) \
-FORALL_ATTR_BASE_SYMBOLS(_) \
-FORALL_ATTR_EXTRA_SYMBOLS(_)
+// 'prim' symbols are synthetic operators that occur only in the IR
+// and don't have corresponding implementations in ATen.
 
-#define FORALL_BUILTIN_SYMBOLS(_) \
-  FORALL_ONNX_SYMBOLS(_) \
-  FORALL_ATEN_SYMBOLS(_) \
-  FORALL_ATTR_SYMBOLS(_) \
-  FORALL_PRIM_SYMBOLS(_) \
-  /* end */
+// 'onnx' symbols correspond to ONNX operators.  Their semantics
+// are defined in https://github.com/onnx/onnx/blob/master/docs/Operators.md
+// The particular version we are targeting is specified by '_onnx_opset_version'
+// in torch.onnx.symbolic
+//
+// In general, most ONNX operators won't get an entry here, because they
+// are handled from the Python end.  However, you may occasionally need
+// to intern an ONNX symbol here so that you can conveniently write an
+// optimization on ONNX operations.
+
+// 'attr' symbols are attribute keys.  They are shared between both ONNX and ATen
+// operators (you disambiguate their meaning by looking at the operator itself).
+// In general, you only need to define attribute keys that are used by
+// onnx or prim; ATen attributes are automatically generated in FORALL_ATTR_BASE_SYMBOLS.
 
 // Note [Symbol allocation]
 // ~~~~~~~~~~~~~~~~~~~~~~~~
 //
-//  1. Symbol namespace is split up into namespaces.  The hex structure
-//  of our symbols is TTUUUUUU, where TT is the tag byte and U are the unique
-//  bytes.
+//  1. Symbol namespace is split up into namespaces.
 //
-//  2. We only maintain a single counter for the unique bytes, which means that
-//  we take 256 more space than we would have if we maintained multiple
-//  counters.
-//
-//  3. The first unique_start symbols are reserved for "built-in" symbols.
-//  These symbols are allocated at compile time and get put into the intern
-//  table at process startup time.  Since it's pretty easy to maintain a
-//  distinct counter for every built-in namespace, we let the unique bytes of
-//  built-in symbols to overlap (this is why unique_start is a max)
-//
-//  4. The intended access pattern for built-in symbols is onnx::MatMul
+//  2. The intended access pattern for built-in symbols is onnx::MatMul
 //  in the torch::jit namespace (this is a Symbol).
 //
-// The code here is not very economical but it gets the job done.
 
 
 // Built-in constant definition strategy:
@@ -180,10 +129,6 @@ FORALL_ATTR_EXTRA_SYMBOLS(_)
 
 typedef uint32_t unique_t;
 
-constexpr size_t unique_tag_bits = 8;
-constexpr size_t unique_bits = sizeof(unique_t) * 8 - unique_tag_bits;
-constexpr unique_t unique_mask = (1ULL << unique_bits) - 1;
-
 static const std::string domain_prefix = "org.pytorch.";
 
 // A Symbol is like an interned string, but with a little extra
@@ -191,8 +136,8 @@ static const std::string domain_prefix = "org.pytorch.";
 // intern pointers support efficient namespace testing.
 struct Symbol {
   explicit constexpr Symbol() : value(0) {};
-  explicit constexpr Symbol(SymbolNamespace ns, uint32_t uniq)
-  : value((static_cast<uint32_t>(ns) << unique_bits) | (uniq & unique_mask)) {};
+  explicit constexpr Symbol(unique_t uniq)
+  : value(uniq) {}
 
   // Get a Symbol for a qualified string like "attr::bar"
   static Symbol fromQualString(const std::string & s);
@@ -205,26 +150,24 @@ struct Symbol {
   // argument "foo", and then attempt to intern it.  DO NOT USE THIS
   // with a string literal; attr::foo should be available in that case
   // (and if it's not, you should add it to the built-ins list above.)
-  static Symbol attr(const std::string & s) { return Symbol(SymbolNamespace::attr, s); };
-  static Symbol aten(const std::string & s) { return Symbol(SymbolNamespace::aten, s); };
-  static Symbol onnx(const std::string & s) { return Symbol(SymbolNamespace::onnx, s); };
-  static Symbol prim(const std::string & s) { return Symbol(SymbolNamespace::prim, s); };
+  static Symbol attr(const std::string & s);
+  static Symbol aten(const std::string & s);
+  static Symbol onnx(const std::string & s);
+  static Symbol prim(const std::string & s);
   // TODO: eliminate me
-  static Symbol scope(const std::string & s) { return Symbol(SymbolNamespace::scope, s); };
+  static Symbol scope(const std::string & s);
 
-  constexpr bool is_attr() const { return ns() == SymbolNamespace::attr; };
-  constexpr bool is_aten() const { return ns() == SymbolNamespace::aten; };
-  constexpr bool is_prim() const { return ns() == SymbolNamespace::prim; };
-  constexpr bool is_onnx() const { return ns() == SymbolNamespace::onnx; };
+  bool is_attr() const;
+  bool is_aten() const;
+  bool is_prim() const;
+  bool is_onnx() const;
 
   // So we can switch on this
   constexpr operator unique_t() const {
     return value;
   }
 
-  constexpr SymbolNamespace ns() const {
-    return static_cast<SymbolNamespace>(value >> unique_bits);
-  }
+  Symbol ns() const;
 
   // Give a string corresponding to the unqualified version of this name, e.g.,
   // "mm". Use this in a context where the intended namespace of the string is
@@ -246,7 +189,7 @@ struct Symbol {
   std::string domainString() const;
 
 private:
-  explicit Symbol(SymbolNamespace ns, const std::string & s);
+  explicit Symbol(Symbol ns, const std::string & s);
   unique_t value;
 };
 
@@ -254,24 +197,32 @@ static inline bool operator==(Symbol lhs, Symbol rhs) {
   return static_cast<unique_t>(lhs) == static_cast<unique_t>(rhs);
 }
 
-#define DEFINE_KEY(ns, s) s,
-#define DEFINE_SYMBOL(ns, s) constexpr Symbol s(SymbolNamespace::ns, static_cast<unique_t>(_keys::s));
-#define DEFINE_BUILTINS(ns, forall_symbols) \
-  namespace ns { \
-    enum class _keys : unique_t { \
-      forall_symbols(DEFINE_KEY) \
-      num_symbols \
-    }; \
-    forall_symbols(DEFINE_SYMBOL) \
-  }
+enum class _keys : unique_t {
+    #define DEFINE_KEY(ns, s) ns##_##s,
+    FORALL_NS_SYMBOLS(DEFINE_KEY)
+    #undef DEFINE_KEY
+    num_symbols
+};
 
-DEFINE_BUILTINS(onnx, FORALL_ONNX_SYMBOLS)
-DEFINE_BUILTINS(aten, FORALL_ATEN_SYMBOLS)
-DEFINE_BUILTINS(attr, FORALL_ATTR_SYMBOLS)
-DEFINE_BUILTINS(prim, FORALL_PRIM_SYMBOLS)
+#define DEFINE_SYMBOL(s) \
+  constexpr Symbol s(static_cast<unique_t>(_keys::s));
 
-#undef DEFINE_KEY
 #undef DEFINE_SYMBOL
+
+#define DEFINE_SYMBOL(ns, s) \
+  namespace ns { constexpr Symbol s(static_cast<unique_t>(_keys::ns##_##s)); }
+FORALL_NS_SYMBOLS(DEFINE_SYMBOL)
+#undef DEFINE_SYMBOL
+
+inline Symbol Symbol::attr(const std::string & s) { return Symbol::fromQualString("attr::" + s); }
+inline Symbol Symbol::aten(const std::string & s)  { return Symbol::fromQualString("aten::" + s); }
+inline Symbol Symbol::onnx(const std::string & s)  { return Symbol::fromQualString("onnx::" + s); }
+inline Symbol Symbol::prim(const std::string & s)  { return Symbol::fromQualString("prim::" + s); }
+inline Symbol Symbol::scope(const std::string & s) { return Symbol::fromQualString("scope::" + s); }
+inline bool Symbol::is_attr() const { return ns() == namespaces::attr; }
+inline bool Symbol::is_aten() const { return ns() == namespaces::aten; }
+inline bool Symbol::is_prim() const { return ns() == namespaces::prim; }
+inline bool Symbol::is_onnx() const { return ns() == namespaces::onnx; }
 
 }} // namespace torch::jit
 

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -287,7 +287,7 @@ void internedStringsTests () {
   REQUIRE(Symbol::aten("What2") == symstart+2);
   REQUIRE(Symbol::aten("What") == symstart+1);
   REQUIRE(Symbol::aten("What2") == symstart+2);
-  REQUIRE(Symbol(SymbolNamespace::aten, symstart+2).toUnqualString() == std::string("What2"));
+  REQUIRE(Symbol(symstart+2).toUnqualString() == std::string("What2"));
 }
 
 void fromQualStringTests() {
@@ -296,7 +296,13 @@ void fromQualStringTests() {
   REQUIRE(Symbol::fromQualString("onnx::LSTM") == Symbol::onnx("LSTM"));
   REQUIRE(Symbol::fromQualString("attr::value") == Symbol::attr("value"));
   REQUIRE(Symbol::fromQualString("scope::") == Symbol::scope(""));
-  auto bad_inputs = {"scope", "foo::bar", "prim:Param", "::", ":", ""};
+  REQUIRE(Symbol::fromQualString("::").toUnqualString() == std::string(""));
+  REQUIRE(Symbol::fromQualString("::").ns().toQualString() == std::string("namespaces::"));
+  REQUIRE(Symbol::fromQualString("new_ns::param").toUnqualString() == std::string("param"));
+  REQUIRE(Symbol::fromQualString("new_ns::param").ns().toUnqualString() == std::string("new_ns"));
+  REQUIRE(Symbol::fromQualString("new_ns::param").ns() == Symbol::fromQualString("namespaces::new_ns"));
+
+  auto bad_inputs = {"scope", ":", ""};
   for (auto input : bad_inputs) {
     try {
       Symbol::fromQualString(input);


### PR DESCRIPTION
Context: I am updating jit::FunctionSchema to use `Symbol name;` rather than `std::string name`. Sometimes the name refers to a builtin  thing like `prim::UnpackTuple`, sometimes to an aten operator like `aten::add`, and sometimes just to a raw string, like `my_method_foo` that really doesn't belong in any namespace and should be printed to the user in that form. For this last case, I want the ability to create a raw Symbol again, like was previously possible, that just represents an interned string. This PR enables that use, keeps the other functionality still possible, and simplifies interned_string's implementation a bit. 

This changes how Symbol is implemented. Now the namespace of a symbol
is optional and the namespaces themselves are Symbols.
This allows Symbol to be used with arbitrary namespaces, and allows
you to use Symbol as an simple interned string using via fromQualString
and toQualString without :: in the string. This also simplifies the
implementation. Like with string conversion, builtin primitives go
through a fast path for namespace lookup while registered symbols require
holding a lock and reading an array entry to lookup the namespace.



Note: alexnet expect file update is from a previous commit. It doesn't run in CI because pytorch vision is not installed.
