### PR TITLE
detach spectral norm calculated weight in eval mode

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1484,6 +1484,12 @@ class TestNN(NNTestCase):
         x2 = m(inp)
         self.assertEqual(x0, x1)
         self.assertEqual(x0, x2)
+        # test that we can backward several times without running into problems
+        x1 = m(inp)
+        x1.sum().backward()
+        x1 = m(inp)
+        x1.sum().backward()
+        # test removing
         m = torch.nn.utils.remove_spectral_norm(m)
         x3 = m(inp)
         self.assertEqual(x0, x3)

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -51,6 +51,8 @@ class SpectralNorm(object):
             weight, u = self.compute_weight(module)
             setattr(module, self.name, weight)
             setattr(module, self.name + '_u', u)
+        else:
+            getattr(module, self.name).detach_()
 
     @staticmethod
     def apply(module, name, n_power_iterations, dim, eps):

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -52,7 +52,8 @@ class SpectralNorm(object):
             setattr(module, self.name, weight)
             setattr(module, self.name + '_u', u)
         else:
-            getattr(module, self.name).detach_()
+            r_g = getattr(module, self.name + '_orig').requires_grad
+            getattr(module, self.name).detach_().requires_grad_(r_g)
 
     @staticmethod
     def apply(module, name, n_power_iterations, dim, eps):


### PR DESCRIPTION
As we left weight to be the last calculated weight in eval mode, we need to detach it from the computation in order to facilitate using backward.
The typical use case is in GANs when the discriminator has spectral norm, is in eval mode and we want to backprop through the discriminator to get weight gradients for the generator.
