### PR TITLE
Correct link flag order for GNU ld in utils.cpp_extension.load

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -843,7 +843,7 @@ def _write_ninja_file(path,
             '  command = "{}/link.exe" $in /nologo $ldflags /out:$out'.format(
                 cl_path))
     else:
-        link_rule.append('  command = $cxx $ldflags $in -o $out')
+        link_rule.append('  command = $cxx $in $ldflags -o $out')
 
     # Emit one build rule per source to enable incremental build.
     object_files = []


### PR DESCRIPTION
Any flags linking libraries only take effect on inputs preceding them,
so we have to call `$cxx $in $ldflags -o $out` instead of the other way
around.

This was probably not detected so far since the torch libraries are
already loaded when loading JIT-compiled extensions, so this only has an
effect on third-party libraries.

This also matches our behavior on windows.