### PR TITLE
Fix select backward when wrap dim

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3045,6 +3045,7 @@ method_tests = [
     ('permute', (1, 2, 3, 4), (0, -2, -1, 1), 'neg_dim'),
     ('permute', (), (dont_convert(()),), 'scalar'),
     ('select', (S, S, S), (1, 2), 'dim', [0]),
+    ('select', (S, S, S), (1, -1), 'wrap_dim', [0]),
     ('select', (S,), (0, 2), '1d'),
     ('narrow', (S, S, S), (1, 2, 2), 'dim', [0]),
     ('narrow', (S, S, S), (1, 0, 0), 'empty_dim', [0], [skipIfNoZeroSize]),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -603,7 +603,7 @@
   src: grad.gather(dim, index)
 
 - name: select(Tensor self, int64_t dim, int64_t index)
-  self: slice_backward(grad.unsqueeze(dim), self.sizes(), dim, index, index + 1, 1)
+  self: select_backward(grad, self.sizes(), dim, index)
 
 - name: sigmoid(Tensor self)
   self: _sigmoid_backward(grad, result)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -521,8 +521,14 @@ Tensor index_select_backward(Tensor grad, int64_t dim, Tensor indices, IntList s
 }
 
 Tensor slice_backward(Tensor grad, IntList input_sizes, int64_t dim, int64_t start, int64_t end, int64_t step) {
-  auto grad_input = at::zeros(input_sizes, grad.type());
+  auto grad_input = at::zeros(input_sizes, grad.options());
   grad_input.slice(dim, start, end, step).copy_(grad);
+  return grad_input;
+}
+
+Tensor select_backward(Tensor grad, IntList input_sizes, int64_t dim, int64_t index) {
+  auto grad_input = at::zeros(input_sizes, grad.options());
+  grad_input.select(dim, index).copy_(grad);
   return grad_input;
 }
 


### PR DESCRIPTION
Previous backward was broken when `index=-1` because slicing `[-1:0]` gives empty tensor/list/array.

Added a test.

cc @goldsborough 