### PR TITLE
[JIT] Make builtin call outputs to match the schema return types

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1861,11 +1861,10 @@ class TestScript(JitTestCase):
         self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
 
     def test_script_torch_size(self):
-        @torch.jit.script
         def func(x):
-            return torch.rand((x.size(0), 1))
+            return torch.zeros((x.size(0), 1))
 
-        self.assertEqual(func(torch.rand(2, 3)).shape[0], 2)
+        self.checkScript(func, [torch.rand(2, 3)], optimize=True)
 
     def test_script_bool_constant(self):
         script = '''

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1860,6 +1860,13 @@ class TestScript(JitTestCase):
 
         self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
 
+    def test_script_torch_size(self):
+        @torch.jit.script
+        def func(x):
+            return torch.rand((x.size(0), 1))
+
+        self.assertEqual(func(torch.rand(2, 3)).shape[0], 2)
+
     def test_script_bool_constant(self):
         script = '''
         def test_script_bool_constant():

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -97,7 +97,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
 
   out << schema.name;
   emitList(schema.arguments);
-  if(schema.returns.size() > 1) {
+  if(schema.returns.size() > 0) {
     out << " -> ";
     emitList(schema.returns);
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -565,8 +565,14 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
     num_outputs = *value;
   }
 
-  for(size_t i = 0; i < num_outputs; ++i)
-    n->addOutput();
+  for(size_t i = 0; i < num_outputs; ++i) {
+    if (n->kind() == aten::chunk) {
+      // special case for chunk as the schema return only have one Tensor[] type
+      n->addOutput()->setType(DynamicType::get());
+    } else {
+      n->addOutput()->setType(schema.returns[i].type);
+    }
+  }
 
   liftConstantAttributes(schema, n);
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -555,8 +555,8 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
   size_t num_outputs = schema.returns.size();
 
   // special case for chunk when the chunks=<const> is known
-  // DO NOT ADD MORE SPECIAL CASES HERE, REFACTOR INTO A FUNCTION IF
-  // NEEDED
+  // DO NOT ADD MORE SPECIAL CASES HERE, REFACTOR INTO A FUNCTION IF NEEDED
+  // TODO: fix the special case after we have list supported
   if(n->kind() == aten::chunk) {
     auto value = constant_as<int64_t>((*flat_inputs)[1]);
     if(!value) {


### PR DESCRIPTION
This PR fixes #8769 , currently when we emit built in calls, we only add the outputs and assume all outputs are dynamic type, where it should not be the case since some builtin calls return int and other types instead (e.g. torch.size(0)), the PR fix this by setting the type to match the schema return types when we add the outputs. 