### PR TITLE
Ensure that domain starts with domain_prefix before extracting substring

### DIFF
--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -180,6 +180,12 @@ std::string Symbol::domainString() const {
 }
 
 Symbol Symbol::fromDomainAndUnqualString(const std::string & d, const std::string & s) {
+  if (d.compare(0, domain_prefix.size(), domain_prefix) != 0) {
+    std::ostringstream ss;
+    ss << "Symbol: domain string is expected to be prefixed with '"
+       << domain_prefix << "', e.g. 'org.pytorch.aten'";
+    throw std::runtime_error(ss.str());
+  }
   std::string qualString = d.substr(domain_prefix.size()) + "::" + s;
   return fromQualString(qualString);
 }


### PR DESCRIPTION
Fixes #9049.
When provided with a domain string that lacks proper prefix, i.e. `org.pytorch.`, an exception is thrown.