### PR TITLE
Add angle normalization for rotated boxes

### DIFF
--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -42,6 +42,18 @@ Transform proposal bounding boxes to target bounding box using bounding box
         "bool (default false). If true, then boxes (rois and deltas) include "
         "angle info to handle rotation. The format will be "
         "[ctr_x, ctr_y, width, height, angle (in degrees)].")
+    .Arg(
+        "angle_bound_on",
+        "bool (default true). If set, for rotated boxes, angle is "
+        "normalized to be within [angle_bound_lo, angle_bound_hi].")
+    .Arg(
+        "angle_bound_lo",
+        "int (default -90 degrees). If set, for rotated boxes, angle is "
+        "normalized to be within [angle_bound_lo, angle_bound_hi].")
+    .Arg(
+        "angle_bound_hi",
+        "int (default 90 degrees). If set, for rotated boxes, angle is "
+        "normalized to be within [angle_bound_lo, angle_bound_hi].")
     .Input(
         0,
         "rois",
@@ -152,7 +164,10 @@ bool BBoxTransformOp<float, CPUContext>::RunOnDevice() {
           cur_deltas,
           weights_,
           utils::BBOX_XFORM_CLIP_DEFAULT,
-          correct_transform_coords_);
+          correct_transform_coords_,
+          angle_bound_on_,
+          angle_bound_lo_,
+          angle_bound_hi_);
       EArrXXf clip_boxes = utils::clip_boxes(trans_boxes, img_h, img_w);
       // Do not apply scale for angle in rotated boxes
       clip_boxes.leftCols(4) *= scale_after;

--- a/caffe2/operators/bbox_transform_op.h
+++ b/caffe2/operators/bbox_transform_op.h
@@ -23,7 +23,13 @@ class BBoxTransformOp final : public Operator<Context> {
         correct_transform_coords_(OperatorBase::GetSingleArgument<bool>(
             "correct_transform_coords",
             false)),
-        rotated_(OperatorBase::GetSingleArgument<bool>("rotated", false)) {
+        rotated_(OperatorBase::GetSingleArgument<bool>("rotated", false)),
+        angle_bound_on_(
+            OperatorBase::GetSingleArgument<bool>("angle_bound_on", true)),
+        angle_bound_lo_(
+            OperatorBase::GetSingleArgument<int>("angle_bound_lo", -90)),
+        angle_bound_hi_(
+            OperatorBase::GetSingleArgument<int>("angle_bound_hi", 90)) {
     CAFFE_ENFORCE_EQ(
         weights_.size(),
         4,
@@ -48,6 +54,11 @@ class BBoxTransformOp final : public Operator<Context> {
   // Set for RRPN case to handle rotated boxes. Inputs should be in format
   // [ctr_x, ctr_y, width, height, angle (in degrees)].
   bool rotated_{false};
+  // If set, for rotated boxes in RRPN, output angles are normalized to be
+  // within [angle_bound_lo, angle_bound_hi].
+  bool angle_bound_on_{true};
+  int angle_bound_lo_{-90};
+  int angle_bound_hi_{90};
 };
 
 } // namespace caffe2

--- a/caffe2/operators/box_with_nms_limit_op.h
+++ b/caffe2/operators/box_with_nms_limit_op.h
@@ -29,7 +29,8 @@ class BoxWithNMSLimitOp final : public Operator<Context> {
             OperatorBase::GetSingleArgument<float>("soft_nms_sigma", 0.5)),
         soft_nms_min_score_thres_(OperatorBase::GetSingleArgument<float>(
             "soft_nms_min_score_thres",
-            0.001)) {
+            0.001)),
+        rotated_(OperatorBase::GetSingleArgument<bool>("rotated", false)) {
     CAFFE_ENFORCE(
         soft_nms_method_str_ == "linear" || soft_nms_method_str_ == "gaussian",
         "Unexpected soft_nms_method");
@@ -56,6 +57,9 @@ class BoxWithNMSLimitOp final : public Operator<Context> {
   float soft_nms_sigma_ = 0.5;
   // Lower-bound on updated scores to discard boxes
   float soft_nms_min_score_thres_ = 0.001;
+  // Set for RRPN case to handle rotated boxes. Inputs should be in format
+  // [ctr_x, ctr_y, width, height, angle (in degrees)].
+  bool rotated_{false};
 };
 
 } // namespace caffe2

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -59,36 +59,51 @@ ERMatXf ComputeAllAnchors(
     float feat_stride) {
   const auto K = height * width;
   const auto A = anchors.dim(0);
+  const auto box_dim = anchors.dim(1);
+  CAFFE_ENFORCE(box_dim == 4 || box_dim == 5);
 
   ERMatXf shift_x = (ERVecXf::LinSpaced(width, 0.0, width - 1.0) * feat_stride)
                         .replicate(height, 1);
   ERMatXf shift_y = (EVecXf::LinSpaced(height, 0.0, height - 1.0) * feat_stride)
                         .replicate(1, width);
-  Eigen::MatrixXf shifts(K, 4);
-  shifts << ConstEigenVectorMap<float>(shift_x.data(), shift_x.size()),
-      ConstEigenVectorMap<float>(shift_y.data(), shift_y.size()),
-      ConstEigenVectorMap<float>(shift_x.data(), shift_x.size()),
-      ConstEigenVectorMap<float>(shift_y.data(), shift_y.size());
+  Eigen::MatrixXf shifts(K, box_dim);
+  if (box_dim == 4) {
+    // Upright boxes in [x1, y1, x2, y2] format
+    shifts << ConstEigenVectorMap<float>(shift_x.data(), shift_x.size()),
+        ConstEigenVectorMap<float>(shift_y.data(), shift_y.size()),
+        ConstEigenVectorMap<float>(shift_x.data(), shift_x.size()),
+        ConstEigenVectorMap<float>(shift_y.data(), shift_y.size());
+  } else {
+    // Rotated boxes in [ctr_x, ctr_y, w, h, angle] format.
+    // Zero shift for width, height and angle.
+    ERMatXf shift_zero = ERMatXf::Constant(height, width, 0.0);
+    shifts << ConstEigenVectorMap<float>(shift_x.data(), shift_x.size()),
+        ConstEigenVectorMap<float>(shift_y.data(), shift_y.size()),
+        ConstEigenVectorMap<float>(shift_zero.data(), shift_zero.size()),
+        ConstEigenVectorMap<float>(shift_zero.data(), shift_zero.size()),
+        ConstEigenVectorMap<float>(shift_zero.data(), shift_zero.size());
+  }
 
   // Broacast anchors over shifts to enumerate all anchors at all positions
   // in the (H, W) grid:
-  //   - add A anchors of shape (1, A, 4) to
-  //   - K shifts of shape (K, 1, 4) to get
-  //   - all shifted anchors of shape (K, A, 4)
-  //   - reshape to (K*A, 4) shifted anchors
+  //   - add A anchors of shape (1, A, box_dim) to
+  //   - K shifts of shape (K, 1, box_dim) to get
+  //   - all shifted anchors of shape (K, A, box_dim)
+  //   - reshape to (K*A, box_dim) shifted anchors
   ConstEigenMatrixMap<float> anchors_vec(
-      anchors.template data<float>(), 1, A * 4);
+      anchors.template data<float>(), 1, A * box_dim);
   // equivalent to python code
   //  all_anchors = (
-  //        self._model.anchors.reshape((1, A, 4)) +
-  //        shifts.reshape((1, K, 4)).transpose((1, 0, 2)))
-  //    all_anchors = all_anchors.reshape((K * A, 4))
-  // all_anchors_vec: (K, A * 4)
+  //        self._model.anchors.reshape((1, A, box_dim)) +
+  //        shifts.reshape((1, K, box_dim)).transpose((1, 0, 2)))
+  //    all_anchors = all_anchors.reshape((K * A, box_dim))
+  // all_anchors_vec: (K, A * box_dim)
   ERMatXf all_anchors_vec =
       anchors_vec.replicate(K, 1) + shifts.rowwise().replicate(A);
 
-  // use the following to reshape to (K * A, 4)
-  // Eigen::Map<const ERMatXf> all_anchors(all_anchors_vec.data(), K * A, 4);
+  // use the following to reshape to (K * A, box_dim)
+  // Eigen::Map<const ERMatXf> all_anchors(
+  //            all_anchors_vec.data(), K * A, box_dim);
 
   return all_anchors_vec;
 }
@@ -106,23 +121,25 @@ void GenerateProposalsOp<CPUContext>::ProposalsForOneImage(
   const auto& post_nms_topN = rpn_post_nms_topN_;
   const auto& nms_thresh = rpn_nms_thresh_;
   const auto& min_size = rpn_min_size_;
+  const int box_dim = static_cast<int>(all_anchors.cols());
+  CAFFE_ENFORCE(box_dim == 4 || box_dim == 5);
 
   // Transpose and reshape predicted bbox transformations to get them
   // into the same order as the anchors:
-  //   - bbox deltas will be (4 * A, H, W) format from conv output
-  //   - transpose to (H, W, 4 * A)
-  //   - reshape to (H * W * A, 4) where rows are ordered by (H, W, A)
+  //   - bbox deltas will be (box_dim * A, H, W) format from conv output
+  //   - transpose to (H, W, box_dim * A)
+  //   - reshape to (H * W * A, box_dim) where rows are ordered by (H, W, A)
   //     in slowest to fastest order to match the enumerated anchors
   CAFFE_ENFORCE_EQ(bbox_deltas_tensor.ndim(), 3);
-  CAFFE_ENFORCE_EQ(bbox_deltas_tensor.dim(0) % 4, 0);
-  auto A = bbox_deltas_tensor.dim(0) / 4;
+  CAFFE_ENFORCE_EQ(bbox_deltas_tensor.dim(0) % box_dim, 0);
+  auto A = bbox_deltas_tensor.dim(0) / box_dim;
   auto H = bbox_deltas_tensor.dim(1);
   auto W = bbox_deltas_tensor.dim(2);
   // equivalent to python code
-  //  bbox_deltas = bbox_deltas.transpose((1, 2, 0)).reshape((-1, 4))
-  ERArrXXf bbox_deltas(H * W * A, 4);
-  Eigen::Map<ERMatXf>(bbox_deltas.data(), H * W, 4 * A) =
-      Eigen::Map<const ERMatXf>(bbox_deltas_tensor.data(), A * 4, H * W)
+  //  bbox_deltas = bbox_deltas.transpose((1, 2, 0)).reshape((-1, box_dim))
+  ERArrXXf bbox_deltas(H * W * A, box_dim);
+  Eigen::Map<ERMatXf>(bbox_deltas.data(), H * W, box_dim * A) =
+      Eigen::Map<const ERMatXf>(bbox_deltas_tensor.data(), A * box_dim, H * W)
           .transpose();
   CAFFE_ENFORCE_EQ(bbox_deltas.rows(), all_anchors.rows());
 
@@ -177,6 +194,7 @@ void GenerateProposalsOp<CPUContext>::ProposalsForOneImage(
 
   // 2. clip proposals to image (may result in proposals with zero area
   // that will be removed in the next step)
+  // TODO (viswanath): Should we clip rotated boxes as well?
   proposals = utils::clip_boxes(proposals, im_info[0], im_info[1]);
 
   // 3. remove predicted boxes with either height or width < min_size
@@ -214,31 +232,34 @@ bool GenerateProposalsOp<CPUContext>::RunOnDevice() {
   const auto height = scores.dim(2);
   const auto width = scores.dim(3);
   const auto K = height * width;
+  const auto box_dim = anchors.dim(1);
+  CAFFE_ENFORCE(box_dim == 4 || box_dim == 5);
 
-  // bbox_deltas: (num_images, A * 4, H, W)
+  // bbox_deltas: (num_images, A * box_dim, H, W)
   CAFFE_ENFORCE_EQ(
-      bbox_deltas.dims(), (vector<TIndex>{num_images, 4 * A, height, width}));
+      bbox_deltas.dims(),
+      (vector<TIndex>{num_images, box_dim * A, height, width}));
 
   // im_info_tensor: (num_images, 3), format [height, width, scale; ...]
   CAFFE_ENFORCE_EQ(im_info_tensor.dims(), (vector<TIndex>{num_images, 3}));
   CAFFE_ENFORCE(
       im_info_tensor.template IsType<float>(), im_info_tensor.meta().name());
 
-  // anchors: (A, 4)
-  CAFFE_ENFORCE_EQ(anchors.dims(), (vector<TIndex>{A, 4}));
+  // anchors: (A, box_dim)
+  CAFFE_ENFORCE_EQ(anchors.dims(), (vector<TIndex>{A, box_dim}));
   CAFFE_ENFORCE(anchors.template IsType<float>(), anchors.meta().name());
 
   // Broadcast the anchors to all pixels
   auto all_anchors_vec =
       utils::ComputeAllAnchors(anchors, height, width, feat_stride_);
-  Eigen::Map<const ERMatXf> all_anchors(all_anchors_vec.data(), K * A, 4);
+  Eigen::Map<const ERMatXf> all_anchors(all_anchors_vec.data(), K * A, box_dim);
 
   Eigen::Map<const ERArrXXf> im_info(
       im_info_tensor.data<float>(),
       im_info_tensor.dim(0),
       im_info_tensor.dim(1));
 
-  const int roi_col_count = 5;
+  const int roi_col_count = box_dim + 1;
   out_rois->Resize(0, roi_col_count);
   out_rois_probs->Resize(0);
 
@@ -274,9 +295,9 @@ bool GenerateProposalsOp<CPUContext>::RunOnDevice() {
     int csz = im_i_boxes.rows();
 
     // write rois
-    Eigen::Map<ERArrXXf> cur_rois(out_rois_ptr, csz, 5);
+    Eigen::Map<ERArrXXf> cur_rois(out_rois_ptr, csz, roi_col_count);
     cur_rois.col(0).setConstant(i);
-    cur_rois.block(0, 1, csz, 4) = im_i_boxes;
+    cur_rois.block(0, 1, csz, box_dim) = im_i_boxes;
 
     // write rois_probs
     Eigen::Map<EArrXf>(out_rois_probs_ptr, csz) = im_i_probs;

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -190,7 +190,10 @@ void GenerateProposalsOp<CPUContext>::ProposalsForOneImage(
       bbox_deltas_sorted,
       bbox_weights,
       utils::BBOX_XFORM_CLIP_DEFAULT,
-      correct_transform_coords_);
+      correct_transform_coords_,
+      angle_bound_on_,
+      angle_bound_lo_,
+      angle_bound_hi_);
 
   // 2. clip proposals to image (may result in proposals with zero area
   // that will be removed in the next step)

--- a/caffe2/operators/generate_proposals_op.h
+++ b/caffe2/operators/generate_proposals_op.h
@@ -78,7 +78,13 @@ class GenerateProposalsOp final : public Operator<Context> {
         rpn_min_size_(OperatorBase::GetSingleArgument<float>("min_size", 16)),
         correct_transform_coords_(OperatorBase::GetSingleArgument<bool>(
             "correct_transform_coords",
-            false)) {}
+            false)),
+        angle_bound_on_(
+            OperatorBase::GetSingleArgument<bool>("angle_bound_on", true)),
+        angle_bound_lo_(
+            OperatorBase::GetSingleArgument<int>("angle_bound_lo", -90)),
+        angle_bound_hi_(
+            OperatorBase::GetSingleArgument<int>("angle_bound_hi", 90)) {}
 
   ~GenerateProposalsOp() {}
 
@@ -116,6 +122,11 @@ class GenerateProposalsOp final : public Operator<Context> {
   // Set to true to match the detectron code, set to false for backward
   // compatibility
   bool correct_transform_coords_{false};
+  // If set, for rotated boxes in RRPN, output angles are normalized to be
+  // within [angle_bound_lo, angle_bound_hi].
+  bool angle_bound_on_{true};
+  int angle_bound_lo_{-90};
+  int angle_bound_hi_{90};
 };
 
 } // namespace caffe2

--- a/caffe2/operators/generate_proposals_op_test.cc
+++ b/caffe2/operators/generate_proposals_op_test.cc
@@ -87,6 +87,70 @@ TEST(GenerateProposalsTest, TestComputeAllAnchors) {
   EXPECT_EQ((all_anchors_result - all_anchors_gt).norm(), 0);
 }
 
+namespace {
+
+template <class Derived>
+ERMatXf boxes_xyxy_to_xywh(const Eigen::MatrixBase<Derived>& boxes) {
+  CAFFE_ENFORCE_EQ(boxes.cols(), 4);
+  ERMatXf res(boxes.rows(), 4);
+  auto ones = ERMatXf::Constant(boxes.rows(), 1, 1.0);
+  res.col(0) = (boxes.col(0) + boxes.col(2)) / 2.0; // ctr_x = (x1 + x2)/2
+  res.col(1) = (boxes.col(1) + boxes.col(3)) / 2.0; // ctr_y = (y1 + y2)/2
+  res.col(2) = boxes.col(2) - boxes.col(0) + ones; // w = x2 - x1 + 1
+  res.col(3) = boxes.col(3) - boxes.col(1) + ones; // h = y2 - y1 + 1
+  return res;
+}
+
+} // namespace
+
+TEST(GenerateProposalsTest, TestComputeAllAnchorsRotated) {
+  // Similar to TestComputeAllAnchors but for rotated boxes with angle info.
+  ERMatXf anchors_xyxy(3, 4);
+  anchors_xyxy << -38, -16, 53, 31, -84, -40, 99, 55, -176, -88, 191, 103;
+
+  // Convert to RRPN format and add angles
+  ERMatXf anchors(3, 5);
+  anchors.block(0, 0, 3, 4) = boxes_xyxy_to_xywh(anchors_xyxy);
+  std::vector<float> angles{0.0, 45.0, -120.0};
+  for (int i = 0; i < anchors.rows(); ++i) {
+    anchors(i, 4) = angles[i % angles.size()];
+  }
+
+  int height = 4;
+  int width = 3;
+  float feat_stride = 16;
+  ERMatXf all_anchors_gt_xyxy(36, 4);
+  all_anchors_gt_xyxy << -38, -16, 53, 31, -84, -40, 99, 55, -176, -88, 191,
+      103, -22, -16, 69, 31, -68, -40, 115, 55, -160, -88, 207, 103, -6, -16,
+      85, 31, -52, -40, 131, 55, -144, -88, 223, 103, -38, 0, 53, 47, -84, -24,
+      99, 71, -176, -72, 191, 119, -22, 0, 69, 47, -68, -24, 115, 71, -160, -72,
+      207, 119, -6, 0, 85, 47, -52, -24, 131, 71, -144, -72, 223, 119, -38, 16,
+      53, 63, -84, -8, 99, 87, -176, -56, 191, 135, -22, 16, 69, 63, -68, -8,
+      115, 87, -160, -56, 207, 135, -6, 16, 85, 63, -52, -8, 131, 87, -144, -56,
+      223, 135, -38, 32, 53, 79, -84, 8, 99, 103, -176, -40, 191, 151, -22, 32,
+      69, 79, -68, 8, 115, 103, -160, -40, 207, 151, -6, 32, 85, 79, -52, 8,
+      131, 103, -144, -40, 223, 151;
+
+  // Convert gt to RRPN format and add angles
+  ERMatXf all_anchors_gt(36, 5);
+  all_anchors_gt.block(0, 0, 36, 4) = boxes_xyxy_to_xywh(all_anchors_gt_xyxy);
+  for (int i = 0; i < all_anchors_gt.rows(); ++i) {
+    all_anchors_gt(i, 4) = angles[i % angles.size()];
+  }
+
+  TensorCPU anchors_tensor(vector<TIndex>{anchors.rows(), anchors.cols()});
+  Eigen::Map<ERMatXf>(
+      anchors_tensor.mutable_data<float>(), anchors.rows(), anchors.cols()) =
+      anchors;
+
+  auto result =
+      utils::ComputeAllAnchors(anchors_tensor, height, width, feat_stride);
+  Eigen::Map<const ERMatXf> all_anchors_result(
+      result.data(), height * width * anchors.rows(), 5);
+
+  EXPECT_EQ((all_anchors_result - all_anchors_gt).norm(), 0);
+}
+
 TEST(GenerateProposalsTest, TestEmpty) {
   Workspace ws;
   OperatorDef def;
@@ -196,11 +260,11 @@ TEST(GenerateProposalsTest, TestRealDownSampled) {
   vector<float> anchors{-38, -16, 53, 31, -120, -120, 135, 135};
 
   ERMatXf rois_gt(9, 5);
-  rois_gt << 0, 0, 0, 79, 59, 0, 0, 5.0005703f, 52.63237f, 43.69501495f, 0,
-      24.13628387f, 7.51243401f, 79, 46.06628418f, 0, 0, 7.50924301f,
-      68.47792816f, 46.03357315f, 0, 0, 23.09477997f, 51.61448669f, 59, 0, 0,
-      39.52141571f, 52.44710541f, 59, 0, 23.57396317f, 29.98791885f, 79, 59, 0,
-      0, 41.90219116f, 79, 59, 0, 0, 23.30098343f, 79, 59;
+  rois_gt << 0, 0, 0, 79, 59, 0, 0, 5.0005703f, 51.6324f, 42.6950f, 0,
+      24.13628387f, 7.51243401f, 79, 45.0663f, 0, 0, 7.50924301f, 67.4779f,
+      45.0336, 0, 0, 23.09477997f, 50.61448669f, 59, 0, 0, 39.52141571f,
+      51.44710541f, 59, 0, 23.57396317f, 29.98791885f, 79, 59, 0, 0,
+      41.90219116f, 79, 59, 0, 0, 23.30098343f, 78.2413f, 58.7287f;
   vector<float> rois_probs_gt{2.66913995e-02f,
                               5.44218998e-03f,
                               1.20544003e-03f,
@@ -221,6 +285,7 @@ TEST(GenerateProposalsTest, TestRealDownSampled) {
   def.add_arg()->CopyFrom(MakeArgument("post_nms_topN", 300));
   def.add_arg()->CopyFrom(MakeArgument("nms_thresh", 0.7f));
   def.add_arg()->CopyFrom(MakeArgument("min_size", 16.0f));
+  def.add_arg()->CopyFrom(MakeArgument("correct_transform_coords", true));
 
   unique_ptr<OperatorBase> op(CreateOperator(def, &ws));
   EXPECT_NE(nullptr, op.get());
@@ -249,5 +314,296 @@ TEST(GenerateProposalsTest, TestRealDownSampled) {
       0,
       1e-4);
 }
+
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+TEST(GenerateProposalsTest, TestRealDownSampledRotatedAngle0) {
+  // Similar to TestRealDownSampled but for rotated boxes with angle info.
+  float angle = 0;
+  float delta_angle = 0;
+
+  Workspace ws;
+  OperatorDef def;
+  def.set_name("test");
+  def.set_type("GenerateProposals");
+  def.add_input("scores");
+  def.add_input("bbox_deltas");
+  def.add_input("im_info");
+  def.add_input("anchors");
+  def.add_output("rois");
+  def.add_output("rois_probs");
+  const int img_count = 1;
+  const int A = 2;
+  const int H = 4;
+  const int W = 5;
+
+  vector<float> scores{
+      5.44218998e-03f, 1.19207997e-03f, 1.12379994e-03f, 1.17181998e-03f,
+      1.20544003e-03f, 6.17993006e-04f, 1.05261997e-05f, 8.91025957e-06f,
+      9.29536981e-09f, 6.09605013e-05f, 4.72735002e-04f, 1.13482002e-10f,
+      1.50015003e-05f, 4.45032993e-06f, 3.21612994e-08f, 8.02662980e-04f,
+      1.40488002e-04f, 3.12508007e-07f, 3.02616991e-06f, 1.97759000e-08f,
+      2.66913995e-02f, 5.26766013e-03f, 5.05053019e-03f, 5.62100019e-03f,
+      5.37420018e-03f, 5.26280981e-03f, 2.48894998e-04f, 1.06842002e-04f,
+      3.92931997e-06f, 1.79388002e-03f, 4.79440019e-03f, 3.41609990e-07f,
+      5.20430971e-04f, 3.34090000e-05f, 2.19159006e-07f, 2.28786003e-03f,
+      5.16703985e-05f, 4.04523007e-06f, 1.79227004e-06f, 5.32449000e-08f};
+  vector<float> bbx{
+      -1.65040009e-02f, -1.84051003e-02f, -1.85930002e-02f, -2.08263006e-02f,
+      -1.83814000e-02f, -2.89172009e-02f, -3.89706008e-02f, -7.52277970e-02f,
+      -1.54091999e-01f, -2.55433004e-02f, -1.77490003e-02f, -1.10340998e-01f,
+      -4.20190990e-02f, -2.71421000e-02f, 6.89801015e-03f,  5.71171008e-02f,
+      -1.75665006e-01f, 2.30021998e-02f,  3.08554992e-02f,  -1.39333997e-02f,
+      3.40579003e-01f,  3.91070992e-01f,  3.91624004e-01f,  3.92527014e-01f,
+      3.91445011e-01f,  3.79328012e-01f,  4.26631987e-01f,  3.64892989e-01f,
+      2.76894987e-01f,  5.13985991e-01f,  3.79999995e-01f,  1.80457994e-01f,
+      4.37402993e-01f,  4.18545991e-01f,  2.51549989e-01f,  4.48318988e-01f,
+      1.68564007e-01f,  4.65440989e-01f,  4.21891987e-01f,  4.45928007e-01f,
+      3.27155995e-03f,  3.71480011e-03f,  3.60032008e-03f,  4.27092984e-03f,
+      3.74579988e-03f,  5.95752988e-03f,  -3.14473989e-03f, 3.52022005e-03f,
+      -1.88564006e-02f, 1.65188999e-03f,  1.73791999e-03f,  -3.56074013e-02f,
+      -1.66615995e-04f, 3.14146001e-03f,  -1.11830998e-02f, -5.35363983e-03f,
+      6.49790000e-03f,  -9.27671045e-03f, -2.83346009e-02f, -1.61233004e-02f,
+      -2.15505004e-01f, -2.19910994e-01f, -2.20872998e-01f, -2.12831005e-01f,
+      -2.19145000e-01f, -2.27687001e-01f, -3.43973994e-01f, -2.75869995e-01f,
+      -3.19516987e-01f, -2.50418007e-01f, -2.48537004e-01f, -5.08224010e-01f,
+      -2.28724003e-01f, -2.82402009e-01f, -3.75815988e-01f, -2.86352992e-01f,
+      -5.28333001e-02f, -4.43836004e-01f, -4.55134988e-01f, -4.34897989e-01f,
+      -5.65053988e-03f, -9.25739005e-04f, -1.06790999e-03f, -2.37016007e-03f,
+      -9.71166010e-04f, -8.90910998e-03f, -1.17592998e-02f, -2.08992008e-02f,
+      -4.94231991e-02f, 6.63906988e-03f,  3.20469006e-03f,  -6.44695014e-02f,
+      -3.11607006e-03f, 2.02738005e-03f,  1.48096997e-02f,  4.39785011e-02f,
+      -8.28424022e-02f, 3.62076014e-02f,  2.71668993e-02f,  1.38250999e-02f,
+      6.76669031e-02f,  1.03252999e-01f,  1.03255004e-01f,  9.89722982e-02f,
+      1.03646003e-01f,  4.79663983e-02f,  1.11014001e-01f,  9.31736007e-02f,
+      1.15768999e-01f,  1.04014002e-01f,  -8.90677981e-03f, 1.13103002e-01f,
+      1.33085996e-01f,  1.25405997e-01f,  1.50051996e-01f,  -1.13038003e-01f,
+      7.01059997e-02f,  1.79651007e-01f,  1.41055003e-01f,  1.62841007e-01f,
+      -1.00247003e-02f, -8.17587040e-03f, -8.32176022e-03f, -8.90108012e-03f,
+      -8.13035015e-03f, -1.77263003e-02f, -3.69572006e-02f, -3.51580009e-02f,
+      -5.92143014e-02f, -1.80795006e-02f, -5.46086021e-03f, -4.10550982e-02f,
+      -1.83081999e-02f, -2.15411000e-02f, -1.17953997e-02f, 3.33894007e-02f,
+      -5.29635996e-02f, -6.97528012e-03f, -3.15250992e-03f, -3.27355005e-02f,
+      1.29676998e-01f,  1.16080999e-01f,  1.15947001e-01f,  1.21797003e-01f,
+      1.16089001e-01f,  1.44875005e-01f,  1.15617000e-01f,  1.31586999e-01f,
+      1.74735002e-02f,  1.21973999e-01f,  1.31596997e-01f,  2.48907991e-02f,
+      6.18605018e-02f,  1.12855002e-01f,  -6.99798986e-02f, 9.58312973e-02f,
+      1.53593004e-01f,  -8.75087008e-02f, -4.92327996e-02f, -3.32239009e-02f};
+
+  // Add angle in bbox deltas
+  int num_boxes = scores.size();
+  CHECK_EQ(bbx.size() / 4, num_boxes);
+  vector<float> bbx_with_angle(num_boxes * 5);
+  // bbx (deltas) is in shape (A * 4, H, W). Insert angle delta
+  // at each spatial location for each anchor.
+  int i = 0, j = 0;
+  for (int a = 0; a < A; ++a) {
+    for (int k = 0; k < 4 * H * W; ++k) {
+      bbx_with_angle[i++] = bbx[j++];
+    }
+    for (int k = 0; k < H * W; ++k) {
+      bbx_with_angle[i++] = delta_angle;
+    }
+  }
+
+  vector<float> im_info{60, 80, 0.166667f};
+  // vector<float> anchors{-38, -16, 53, 31, -120, -120, 135, 135};
+  vector<float> anchors{8, 8, 92, 48, angle, 8, 8, 256, 256, angle};
+
+  // Although angle == 0, the results aren't exactly the same as
+  // TestRealDownSampled because because clip_boxes() is not performed
+  // for RRPN style boxes.
+  ERMatXf rois_gt(13, 6);
+  rois_gt << 0, 6.55346, 25.3227, 253.447, 291.446, 0, 0, 55.3932, 33.3369,
+      253.731, 289.158, 0, 0, 6.48163, 24.3478, 92.3015, 38.6944, 0, 0, 70.3089,
+      26.7894, 92.3453, 38.5539, 0, 0, 22.3067, 26.7714, 92.3424, 38.5243, 0, 0,
+      054.084, 26.8413, 92.3938, 38.798, 0, 0, 5.33962, 42.2077, 92.5497,
+      38.2259, 0, 0, 6.36709, 58.24, 92.16, 37.4372, 0, 0, 69.65, 48.6713,
+      92.1521, 37.3668, 0, 0, 20.4147, 44.4783, 91.7111, 34.0295, 0, 0, 033.079,
+      41.5149, 92.3244, 36.4278, 0, 0, 41.8235, 037.291, 90.2815, 034.872, 0, 0,
+      13.8486, 48.662, 88.7818, 28.875, 0;
+  vector<float> rois_probs_gt{0.0266914,
+                              0.005621,
+                              0.00544219,
+                              0.00120544,
+                              0.00119208,
+                              0.00117182,
+                              0.000617993,
+                              0.000472735,
+                              6.09605e-05,
+                              1.05262e-05,
+                              8.91026e-06,
+                              9.29537e-09,
+                              1.13482e-10};
+
+  AddInput(vector<TIndex>{img_count, A, H, W}, scores, "scores", &ws);
+  AddInput(
+      vector<TIndex>{img_count, 5 * A, H, W},
+      bbx_with_angle,
+      "bbox_deltas",
+      &ws);
+  AddInput(vector<TIndex>{img_count, 3}, im_info, "im_info", &ws);
+  AddInput(vector<TIndex>{A, 5}, anchors, "anchors", &ws);
+
+  def.add_arg()->CopyFrom(MakeArgument("spatial_scale", 1.0f / 16.0f));
+  def.add_arg()->CopyFrom(MakeArgument("pre_nms_topN", 6000));
+  def.add_arg()->CopyFrom(MakeArgument("post_nms_topN", 300));
+  def.add_arg()->CopyFrom(MakeArgument("nms_thresh", 0.7f));
+  def.add_arg()->CopyFrom(MakeArgument("min_size", 16.0f));
+  def.add_arg()->CopyFrom(MakeArgument("correct_transform_coords", true));
+
+  unique_ptr<OperatorBase> op(CreateOperator(def, &ws));
+  EXPECT_NE(nullptr, op.get());
+  EXPECT_TRUE(op->Run());
+
+  // test rois
+  Blob* rois_blob = ws.GetBlob("rois");
+  EXPECT_NE(nullptr, rois_blob);
+  auto& rois = rois_blob->Get<TensorCPU>();
+  EXPECT_EQ(rois.dims(), (vector<TIndex>{rois_gt.rows(), rois_gt.cols()}));
+  auto rois_data =
+      Eigen::Map<const ERMatXf>(rois.data<float>(), rois.dim(0), rois.dim(1));
+  EXPECT_NEAR((rois_data.matrix() - rois_gt).cwiseAbs().maxCoeff(), 0, 1e-3);
+
+  // test rois_probs
+  Blob* rois_probs_blob = ws.GetBlob("rois_probs");
+  EXPECT_NE(nullptr, rois_probs_blob);
+  auto& rois_probs = rois_probs_blob->Get<TensorCPU>();
+  EXPECT_EQ(rois_probs.dims(), (vector<TIndex>{TIndex(rois_probs_gt.size())}));
+  auto rois_probs_data =
+      ConstEigenVectorArrayMap<float>(rois_probs.data<float>(), rois.dim(0));
+  EXPECT_NEAR(
+      (rois_probs_data.matrix() - utils::AsEArrXt(rois_probs_gt).matrix())
+          .cwiseAbs()
+          .maxCoeff(),
+      0,
+      1e-4);
+}
+
+TEST(GenerateProposalsTest, TestRealDownSampledRotated) {
+  // Similar to TestRealDownSampled but for rotated boxes with angle info.
+  float angle = 45.0;
+  float delta_angle = 0.174533; // 0.174533 radians -> 10 degrees
+  float expected_angle = 55.0;
+
+  Workspace ws;
+  OperatorDef def;
+  def.set_name("test");
+  def.set_type("GenerateProposals");
+  def.add_input("scores");
+  def.add_input("bbox_deltas");
+  def.add_input("im_info");
+  def.add_input("anchors");
+  def.add_output("rois");
+  def.add_output("rois_probs");
+  const int img_count = 1;
+  const int A = 2;
+  const int H = 4;
+  const int W = 5;
+
+  vector<float> scores{
+      5.44218998e-03f, 1.19207997e-03f, 1.12379994e-03f, 1.17181998e-03f,
+      1.20544003e-03f, 6.17993006e-04f, 1.05261997e-05f, 8.91025957e-06f,
+      9.29536981e-09f, 6.09605013e-05f, 4.72735002e-04f, 1.13482002e-10f,
+      1.50015003e-05f, 4.45032993e-06f, 3.21612994e-08f, 8.02662980e-04f,
+      1.40488002e-04f, 3.12508007e-07f, 3.02616991e-06f, 1.97759000e-08f,
+      2.66913995e-02f, 5.26766013e-03f, 5.05053019e-03f, 5.62100019e-03f,
+      5.37420018e-03f, 5.26280981e-03f, 2.48894998e-04f, 1.06842002e-04f,
+      3.92931997e-06f, 1.79388002e-03f, 4.79440019e-03f, 3.41609990e-07f,
+      5.20430971e-04f, 3.34090000e-05f, 2.19159006e-07f, 2.28786003e-03f,
+      5.16703985e-05f, 4.04523007e-06f, 1.79227004e-06f, 5.32449000e-08f};
+  vector<float> bbx{
+      -1.65040009e-02f, -1.84051003e-02f, -1.85930002e-02f, -2.08263006e-02f,
+      -1.83814000e-02f, -2.89172009e-02f, -3.89706008e-02f, -7.52277970e-02f,
+      -1.54091999e-01f, -2.55433004e-02f, -1.77490003e-02f, -1.10340998e-01f,
+      -4.20190990e-02f, -2.71421000e-02f, 6.89801015e-03f,  5.71171008e-02f,
+      -1.75665006e-01f, 2.30021998e-02f,  3.08554992e-02f,  -1.39333997e-02f,
+      3.40579003e-01f,  3.91070992e-01f,  3.91624004e-01f,  3.92527014e-01f,
+      3.91445011e-01f,  3.79328012e-01f,  4.26631987e-01f,  3.64892989e-01f,
+      2.76894987e-01f,  5.13985991e-01f,  3.79999995e-01f,  1.80457994e-01f,
+      4.37402993e-01f,  4.18545991e-01f,  2.51549989e-01f,  4.48318988e-01f,
+      1.68564007e-01f,  4.65440989e-01f,  4.21891987e-01f,  4.45928007e-01f,
+      3.27155995e-03f,  3.71480011e-03f,  3.60032008e-03f,  4.27092984e-03f,
+      3.74579988e-03f,  5.95752988e-03f,  -3.14473989e-03f, 3.52022005e-03f,
+      -1.88564006e-02f, 1.65188999e-03f,  1.73791999e-03f,  -3.56074013e-02f,
+      -1.66615995e-04f, 3.14146001e-03f,  -1.11830998e-02f, -5.35363983e-03f,
+      6.49790000e-03f,  -9.27671045e-03f, -2.83346009e-02f, -1.61233004e-02f,
+      -2.15505004e-01f, -2.19910994e-01f, -2.20872998e-01f, -2.12831005e-01f,
+      -2.19145000e-01f, -2.27687001e-01f, -3.43973994e-01f, -2.75869995e-01f,
+      -3.19516987e-01f, -2.50418007e-01f, -2.48537004e-01f, -5.08224010e-01f,
+      -2.28724003e-01f, -2.82402009e-01f, -3.75815988e-01f, -2.86352992e-01f,
+      -5.28333001e-02f, -4.43836004e-01f, -4.55134988e-01f, -4.34897989e-01f,
+      -5.65053988e-03f, -9.25739005e-04f, -1.06790999e-03f, -2.37016007e-03f,
+      -9.71166010e-04f, -8.90910998e-03f, -1.17592998e-02f, -2.08992008e-02f,
+      -4.94231991e-02f, 6.63906988e-03f,  3.20469006e-03f,  -6.44695014e-02f,
+      -3.11607006e-03f, 2.02738005e-03f,  1.48096997e-02f,  4.39785011e-02f,
+      -8.28424022e-02f, 3.62076014e-02f,  2.71668993e-02f,  1.38250999e-02f,
+      6.76669031e-02f,  1.03252999e-01f,  1.03255004e-01f,  9.89722982e-02f,
+      1.03646003e-01f,  4.79663983e-02f,  1.11014001e-01f,  9.31736007e-02f,
+      1.15768999e-01f,  1.04014002e-01f,  -8.90677981e-03f, 1.13103002e-01f,
+      1.33085996e-01f,  1.25405997e-01f,  1.50051996e-01f,  -1.13038003e-01f,
+      7.01059997e-02f,  1.79651007e-01f,  1.41055003e-01f,  1.62841007e-01f,
+      -1.00247003e-02f, -8.17587040e-03f, -8.32176022e-03f, -8.90108012e-03f,
+      -8.13035015e-03f, -1.77263003e-02f, -3.69572006e-02f, -3.51580009e-02f,
+      -5.92143014e-02f, -1.80795006e-02f, -5.46086021e-03f, -4.10550982e-02f,
+      -1.83081999e-02f, -2.15411000e-02f, -1.17953997e-02f, 3.33894007e-02f,
+      -5.29635996e-02f, -6.97528012e-03f, -3.15250992e-03f, -3.27355005e-02f,
+      1.29676998e-01f,  1.16080999e-01f,  1.15947001e-01f,  1.21797003e-01f,
+      1.16089001e-01f,  1.44875005e-01f,  1.15617000e-01f,  1.31586999e-01f,
+      1.74735002e-02f,  1.21973999e-01f,  1.31596997e-01f,  2.48907991e-02f,
+      6.18605018e-02f,  1.12855002e-01f,  -6.99798986e-02f, 9.58312973e-02f,
+      1.53593004e-01f,  -8.75087008e-02f, -4.92327996e-02f, -3.32239009e-02f};
+
+  // Add angle in bbox deltas
+  int num_boxes = scores.size();
+  CHECK_EQ(bbx.size() / 4, num_boxes);
+  vector<float> bbx_with_angle(num_boxes * 5);
+  // bbx (deltas) is in shape (A * 4, H, W). Insert angle delta
+  // at each spatial location for each anchor.
+  int i = 0, j = 0;
+  for (int a = 0; a < A; ++a) {
+    for (int k = 0; k < 4 * H * W; ++k) {
+      bbx_with_angle[i++] = bbx[j++];
+    }
+    for (int k = 0; k < H * W; ++k) {
+      bbx_with_angle[i++] = delta_angle;
+    }
+  }
+
+  vector<float> im_info{60, 80, 0.166667f};
+  // vector<float> anchors{-38, -16, 53, 31, -120, -120, 135, 135};
+  vector<float> anchors{8, 8, 92, 48, angle, 8, 8, 256, 256, angle};
+
+  AddInput(vector<TIndex>{img_count, A, H, W}, scores, "scores", &ws);
+  AddInput(
+      vector<TIndex>{img_count, 5 * A, H, W},
+      bbx_with_angle,
+      "bbox_deltas",
+      &ws);
+  AddInput(vector<TIndex>{img_count, 3}, im_info, "im_info", &ws);
+  AddInput(vector<TIndex>{A, 5}, anchors, "anchors", &ws);
+
+  def.add_arg()->CopyFrom(MakeArgument("spatial_scale", 1.0f / 16.0f));
+  def.add_arg()->CopyFrom(MakeArgument("pre_nms_topN", 6000));
+  def.add_arg()->CopyFrom(MakeArgument("post_nms_topN", 300));
+  def.add_arg()->CopyFrom(MakeArgument("nms_thresh", 0.7f));
+  def.add_arg()->CopyFrom(MakeArgument("min_size", 16.0f));
+  def.add_arg()->CopyFrom(MakeArgument("correct_transform_coords", true));
+
+  unique_ptr<OperatorBase> op(CreateOperator(def, &ws));
+  EXPECT_NE(nullptr, op.get());
+  EXPECT_TRUE(op->Run());
+
+  // Verify that the resulting angles are correct
+  Blob* rois_blob = ws.GetBlob("rois");
+  EXPECT_NE(nullptr, rois_blob);
+  auto& rois = rois_blob->Get<TensorCPU>();
+  EXPECT_GT(rois.dim(0), 0);
+  auto rois_data =
+      Eigen::Map<const ERMatXf>(rois.data<float>(), rois.dim(0), rois.dim(1));
+  for (int i = 0; i < rois.dim(0); ++i) {
+    EXPECT_LE(std::abs(rois_data(i, 5) - expected_angle), 1e-4);
+  }
+}
+#endif // CV_MAJOR_VERSION >= 3
 
 } // namespace caffe2

--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -177,6 +177,8 @@ clip_boxes(const Eigen::ArrayBase<Derived>& boxes, int height, int width) {
   CAFFE_ENFORCE(boxes.cols() == 4 || boxes.cols() == 5);
   if (boxes.cols() == 5) {
     // No clipping for rotated boxes.
+    // TODO (viswanath): Should this be implemented for backward compatibility
+    // with angle=0 case?
     return boxes;
   }
 

--- a/caffe2/operators/generate_proposals_op_util_boxes_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_boxes_test.cc
@@ -36,12 +36,13 @@ TEST(UtilsBoxesTest, TestBboxTransformRandom) {
 }
 
 TEST(UtilsBoxesTest, TestBboxTransformRotated) {
+  // Test rotated bbox transform w/o angle normalization
   using EMatXf = Eigen::MatrixXf;
 
   EMatXf bbox(5, 5);
   bbox << 214.986, 88.4628, 78.7317, 135.104, 0.0, 199.553, 55.4367, 60.6142,
       101.169, 45.0, 187.829, 207.427, 0012.11, 15.1967, 90.0, 235.777, 209.518,
-      122.828, 45.5215, -60.0, 79.6505, 150.914, 113.838, 117.777, 170.0;
+      122.828, 45.5215, -60.0, 79.6505, 150.914, 113.838, 117.777, 170.5;
 
   EMatXf deltas(5, 5);
   // 0.174533 radians -> 10 degrees
@@ -55,14 +56,51 @@ TEST(UtilsBoxesTest, TestBboxTransformRotated) {
   result_gt << 252.668, 107.367, 91.4381, 276.165, 0.0, 217.686, 19.3551,
       147.631, 205.397, 55.0, 187.363, 214.185, 19.865, 31.0368, 100.0, 270.234,
       210.513, 235.963, 130.163, -50.0, 36.1956, 140.863, 62.2665, 259.645,
-      180.0;
+      180.5;
 
   const float BBOX_XFORM_CLIP = log(1000.0 / 16.0);
   auto result = utils::bbox_transform(
       bbox.array(),
       deltas.array(),
       std::vector<float>{1.0, 1.0, 1.0, 1.0},
-      BBOX_XFORM_CLIP);
+      BBOX_XFORM_CLIP,
+      true, /* correct_transform_coords */
+      false /* angle_bound_on */);
+  EXPECT_NEAR((result.matrix() - result_gt).norm(), 0.0, 1e-2);
+}
+
+TEST(UtilsBoxesTest, TestBboxTransformRotatedNormalized) {
+  // Test rotated bbox transform with angle normalization
+  using EMatXf = Eigen::MatrixXf;
+
+  EMatXf bbox(5, 5);
+  bbox << 214.986, 88.4628, 78.7317, 135.104, 0.0, 199.553, 55.4367, 60.6142,
+      101.169, 45.0, 187.829, 207.427, 0012.11, 15.1967, 90.0, 235.777, 209.518,
+      122.828, 45.5215, -60.0, 79.6505, 150.914, 113.838, 117.777, 170.5;
+
+  EMatXf deltas(5, 5);
+  // 0.174533 radians -> 10 degrees
+  deltas << 0.47861834, 0.13992102, 0.14961673, 0.71495209, 0.0, 0.29915856,
+      -0.35664671, 0.89018666, 0.70815367, 0.174533, -0.03852064, 0.44466892,
+      0.49492538, 0.71409376, 0.174533, 0.28052918, 0.02184832, 0.65289006,
+      1.05060139, 0.174533, -0.38172557, -0.08533806, -0.60335309, 0.79052375,
+      0.174533;
+
+  EMatXf result_gt(5, 5);
+  result_gt << 252.668, 107.367, 91.4381, 276.165, 0.0, 217.686, 19.3551,
+      147.631, 205.397, 55.0, 187.363, 214.185, 19.865, 31.0368, -80.0, 270.234,
+      210.513, 235.963, 130.163, -50.0, 36.1956, 140.863, 62.2665, 259.645, 0.5;
+
+  const float BBOX_XFORM_CLIP = log(1000.0 / 16.0);
+  auto result = utils::bbox_transform(
+      bbox.array(),
+      deltas.array(),
+      std::vector<float>{1.0, 1.0, 1.0, 1.0},
+      BBOX_XFORM_CLIP,
+      true, /* correct_transform_coords */
+      true, /* angle_bound_on */
+      -90, /* angle_bound_lo */
+      90 /* angle_bound_hi */);
   EXPECT_NEAR((result.matrix() - result_gt).norm(), 0.0, 1e-2);
 }
 

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -1,13 +1,15 @@
 #ifndef CAFFE2_OPERATORS_UTILS_NMS_H_
 #define CAFFE2_OPERATORS_UTILS_NMS_H_
 
-#include <list>
 #include <vector>
 
-#include "caffe2/utils/eigen_utils.h"
-
 #include "caffe2/core/logging.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
+
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+#include <opencv2/opencv.hpp>
+#endif // CV_MAJOR_VERSION >= 3
 
 namespace caffe2 {
 namespace utils {
@@ -23,7 +25,7 @@ namespace utils {
 // sorted_indices: indices that sorts the scores from high to low
 // return: row indices of the selected proposals
 template <class Derived1, class Derived2>
-std::vector<int> nms_cpu(
+std::vector<int> nms_cpu_upright(
     const Eigen::ArrayBase<Derived1>& proposals,
     const Eigen::ArrayBase<Derived2>& scores,
     const std::vector<int>& sorted_indices,
@@ -45,7 +47,6 @@ std::vector<int> nms_cpu(
 
   EArrXi order = AsEArrXt(sorted_indices);
   std::vector<int> keep;
-  int ci = 0;
   while (order.size() > 0) {
     // exit if already enough proposals
     if (topN >= 0 && keep.size() >= topN) {
@@ -74,36 +75,13 @@ std::vector<int> nms_cpu(
   return keep;
 }
 
-// Greedy non-maximum suppression for proposed bounding boxes
-// Reject a bounding box if its region has an intersection-overunion (IoU)
-//    overlap with a higher scoring selected bounding box larger than a
-//    threshold.
-// Reference: detectron/lib/utils/cython_nms.pyx
-// proposals: pixel coordinates of proposed bounding boxes,
-//    size: (M, 4), format: [x1; y1; x2; y2]
-// scores: scores for each bounding box, size: (M, 1)
-// return: row indices of the selected proposals
-template <class Derived1, class Derived2>
-std::vector<int> nms_cpu(
-    const Eigen::ArrayBase<Derived1>& proposals,
-    const Eigen::ArrayBase<Derived2>& scores,
-    float thres) {
-  std::vector<int> indices(proposals.rows());
-  std::iota(indices.begin(), indices.end(), 0);
-  std::sort(
-      indices.data(),
-      indices.data() + indices.size(),
-      [&scores](int lhs, int rhs) { return scores(lhs) > scores(rhs); });
-
-  return nms_cpu(proposals, scores, indices, thres);
-}
-
 /**
  * Soft-NMS implementation as outlined in https://arxiv.org/abs/1704.04503.
  * Reference: detectron/lib/utils/cython_nms.pyx
  * out_scores: Output updated scores after applying Soft-NMS
  * proposals: pixel coordinates of proposed bounding boxes,
  *    size: (M, 4), format: [x1; y1; x2; y2]
+ *    size: (M, 5), format: [ctr_x; ctr_y; w; h; angle (degrees)] for RRPN
  * scores: scores for each bounding box, size: (M, 1)
  * indices: Indices to consider within proposals and scores. Can be used
  *     to pre-filter proposals/scores based on some threshold.
@@ -114,7 +92,7 @@ std::vector<int> nms_cpu(
  * return: row indices of the selected proposals
  */
 template <class Derived1, class Derived2, class Derived3>
-std::vector<int> soft_nms_cpu(
+std::vector<int> soft_nms_cpu_upright(
     Eigen::ArrayBase<Derived3>* out_scores,
     const Eigen::ArrayBase<Derived1>& proposals,
     const Eigen::ArrayBase<Derived2>& scores,
@@ -192,6 +170,332 @@ std::vector<int> soft_nms_cpu(
   }
 
   return keep;
+}
+
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+namespace {
+
+template <class Derived>
+cv::RotatedRect bbox_to_rotated_rect(const Eigen::ArrayBase<Derived>& box) {
+  CAFFE_ENFORCE_EQ(box.size(), 5);
+  // cv::RotatedRect takes angle to mean clockwise rotation, but RRPN bbox
+  // representation means counter-clockwise rotation.
+  return cv::RotatedRect(
+      cv::Point2f(box[0], box[1]), cv::Size2f(box[2], box[3]), -box[4]);
+}
+
+/**
+ * Returns the intersection area of two rotated rectangles.
+ */
+double rotated_rect_intersection(
+    const cv::RotatedRect& rect1,
+    const cv::RotatedRect& rect2) {
+  std::vector<cv::Point2f> intersectPts, orderedPts;
+
+  // Find points of intersection
+  auto ret = cv::rotatedRectangleIntersection(rect1, rect2, intersectPts);
+  if (intersectPts.size() <= 2) {
+    return 0.0;
+  }
+
+  // If one rectangle is fully enclosed within another, return the area
+  // of the smaller one early.
+  if (ret == cv::INTERSECT_FULL) {
+    return std::min(rect1.size.area(), rect2.size.area());
+  }
+
+  // Convex Hull to order the intersection points in clockwise or
+  // counter-clockwise order and find the countour area.
+  cv::convexHull(intersectPts, orderedPts);
+  return cv::contourArea(orderedPts);
+}
+
+} // namespace
+
+/**
+ * Find the intersection area of two rotated boxes represented in format
+ * [ctr_x, ctr_y, width, height, angle].
+ * `angle` represents counter-clockwise rotation in degrees.
+ */
+template <class Derived1, class Derived2>
+double bbox_intersection_rotated(
+    const Eigen::ArrayBase<Derived1>& box1,
+    const Eigen::ArrayBase<Derived2>& box2) {
+  CAFFE_ENFORCE(box1.size() == 5 && box2.size() == 5);
+  const auto& rect1 = bbox_to_rotated_rect(box1);
+  const auto& rect2 = bbox_to_rotated_rect(box2);
+  return rotated_rect_intersection(rect1, rect2);
+}
+
+/**
+ * Similar to `bbox_overlaps()` in detectron/utils/cython_bbox.pyx,
+ * but handles rotated boxes represented in format
+ * [ctr_x, ctr_y, width, height, angle].
+ * `angle` represents counter-clockwise rotation in degrees.
+ */
+template <class Derived1, class Derived2>
+Eigen::ArrayXXf bbox_overlaps_rotated(
+    const Eigen::ArrayBase<Derived1>& boxes,
+    const Eigen::ArrayBase<Derived2>& query_boxes) {
+  CAFFE_ENFORCE(boxes.cols() == 5 && query_boxes.cols() == 5);
+
+  const auto& boxes_areas = boxes.col(2) * boxes.col(3);
+  const auto& query_boxes_areas = query_boxes.col(2) * query_boxes.col(3);
+
+  Eigen::ArrayXXf overlaps(boxes.rows(), query_boxes.rows());
+  for (int i = 0; i < boxes.rows(); ++i) {
+    for (int j = 0; j < query_boxes.rows(); ++j) {
+      auto inter = bbox_intersection_rotated(boxes.row(i), query_boxes.row(j));
+      overlaps(i, j) = (inter == 0.0)
+          ? 0.0
+          : inter / (boxes_areas[i] + query_boxes_areas[j] - inter);
+    }
+  }
+  return overlaps;
+}
+
+// Similar to nms_cpu_upright, but handles rotated proposal boxes
+// in the format:
+//   size (M, 5), format [ctr_x; ctr_y; width; height; angle (in degrees)].
+//
+// For now, we only consider IoU as the metric for suppression. No angle info
+// is used yet.
+template <class Derived1, class Derived2>
+std::vector<int> nms_cpu_rotated(
+    const Eigen::ArrayBase<Derived1>& proposals,
+    const Eigen::ArrayBase<Derived2>& scores,
+    const std::vector<int>& sorted_indices,
+    float thresh,
+    int topN = -1) {
+  CAFFE_ENFORCE_EQ(proposals.rows(), scores.rows());
+  CAFFE_ENFORCE_EQ(proposals.cols(), 5);
+  CAFFE_ENFORCE_EQ(scores.cols(), 1);
+  CAFFE_ENFORCE_LE(sorted_indices.size(), proposals.rows());
+
+  using EArrX = EArrXt<typename Derived1::Scalar>;
+
+  auto widths = proposals.col(2);
+  auto heights = proposals.col(3);
+  EArrX areas = widths * heights;
+
+  std::vector<cv::RotatedRect> rotated_rects(proposals.rows());
+  for (int i = 0; i < proposals.rows(); ++i) {
+    rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
+  }
+
+  EArrXi order = AsEArrXt(sorted_indices);
+  std::vector<int> keep;
+  while (order.size() > 0) {
+    // exit if already enough proposals
+    if (topN >= 0 && keep.size() >= topN) {
+      break;
+    }
+
+    int i = order[0];
+    keep.push_back(i);
+    ConstEigenVectorArrayMap<int> rest_indices(
+        order.data() + 1, order.size() - 1);
+
+    EArrX inter(rest_indices.size());
+    for (int j = 0; j < rest_indices.size(); ++j) {
+      inter[j] = rotated_rect_intersection(
+          rotated_rects[i], rotated_rects[rest_indices[j]]);
+    }
+    EArrX ovr = inter / (areas[i] + GetSubArray(areas, rest_indices) - inter);
+
+    // indices for sub array order[1:n].
+    // TODO (viswanath): Should angle info be included as well while filtering?
+    auto inds = GetArrayIndices(ovr <= thresh);
+    order = GetSubArray(order, AsEArrXt(inds) + 1);
+  }
+
+  return keep;
+}
+
+// Similar to soft_nms_cpu_upright, but handles rotated proposal boxes
+// in the format:
+//   size (M, 5), format [ctr_x; ctr_y; width; height; angle (in degrees)].
+//
+// For now, we only consider IoU as the metric for suppression. No angle info
+// is used yet.
+template <class Derived1, class Derived2, class Derived3>
+std::vector<int> soft_nms_cpu_rotated(
+    Eigen::ArrayBase<Derived3>* out_scores,
+    const Eigen::ArrayBase<Derived1>& proposals,
+    const Eigen::ArrayBase<Derived2>& scores,
+    const std::vector<int>& indices,
+    float sigma = 0.5,
+    float overlap_thresh = 0.3,
+    float score_thresh = 0.001,
+    unsigned int method = 1,
+    int topN = -1) {
+  CAFFE_ENFORCE_EQ(proposals.rows(), scores.rows());
+  CAFFE_ENFORCE_EQ(proposals.cols(), 5);
+  CAFFE_ENFORCE_EQ(scores.cols(), 1);
+
+  using EArrX = EArrXt<typename Derived1::Scalar>;
+
+  auto widths = proposals.col(2);
+  auto heights = proposals.col(3);
+  EArrX areas = widths * heights;
+
+  std::vector<cv::RotatedRect> rotated_rects(proposals.rows());
+  for (int i = 0; i < proposals.rows(); ++i) {
+    rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
+  }
+
+  // Initialize out_scores with original scores. Will be iteratively updated
+  // as Soft-NMS is applied.
+  *out_scores = scores;
+
+  std::vector<int> keep;
+  EArrXi pending = AsEArrXt(indices);
+  while (pending.size() > 0) {
+    // Exit if already enough proposals
+    if (topN >= 0 && keep.size() >= topN) {
+      break;
+    }
+
+    // Find proposal with max score among remaining proposals
+    int max_pos;
+    auto max_score = GetSubArray(*out_scores, pending).maxCoeff(&max_pos);
+    int i = pending[max_pos];
+    keep.push_back(i);
+
+    // Compute IoU of the remaining boxes with the identified max box
+    std::swap(pending(0), pending(max_pos));
+    const auto& rest_indices = pending.tail(pending.size() - 1);
+    EArrX inter(rest_indices.size());
+    for (int j = 0; j < rest_indices.size(); ++j) {
+      inter[j] = rotated_rect_intersection(
+          rotated_rects[i], rotated_rects[rest_indices[j]]);
+    }
+    EArrX ovr = inter / (areas[i] + GetSubArray(areas, rest_indices) - inter);
+
+    // Update scores based on computed IoU, overlap threshold and NMS method
+    // TODO (viswanath): Should angle info be included as well while filtering?
+    for (int j = 0; j < rest_indices.size(); ++j) {
+      typename Derived2::Scalar weight;
+      switch (method) {
+        case 1: // Linear
+          weight = (ovr(j) > overlap_thresh) ? (1.0 - ovr(j)) : 1.0;
+          break;
+        case 2: // Gaussian
+          weight = std::exp(-1.0 * ovr(j) * ovr(j) / sigma);
+          break;
+        default: // Original NMS
+          weight = (ovr(j) > overlap_thresh) ? 0.0 : 1.0;
+      }
+      (*out_scores)(rest_indices[j]) *= weight;
+    }
+
+    // Discard boxes with new scores below min threshold and update pending
+    // indices
+    const auto& rest_scores = GetSubArray(*out_scores, rest_indices);
+    const auto& inds = GetArrayIndices(rest_scores >= score_thresh);
+    pending = GetSubArray(rest_indices, AsEArrXt(inds));
+  }
+
+  return keep;
+}
+#endif // CV_MAJOR_VERSION >= 3
+
+template <class Derived1, class Derived2>
+std::vector<int> nms_cpu(
+    const Eigen::ArrayBase<Derived1>& proposals,
+    const Eigen::ArrayBase<Derived2>& scores,
+    const std::vector<int>& sorted_indices,
+    float thresh,
+    int topN = -1) {
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+  CAFFE_ENFORCE(proposals.cols() == 4 || proposals.cols() == 5);
+  if (proposals.cols() == 4) {
+    // Upright boxes
+    return nms_cpu_upright(proposals, scores, sorted_indices, thresh, topN);
+  } else {
+    // Rotated boxes with angle info
+    return nms_cpu_rotated(proposals, scores, sorted_indices, thresh, topN);
+  }
+#else
+  return nms_cpu_upright(proposals, scores, sorted_indices, thresh, topN);
+#endif // CV_MAJOR_VERSION >= 3
+}
+
+// Greedy non-maximum suppression for proposed bounding boxes
+// Reject a bounding box if its region has an intersection-overunion (IoU)
+//    overlap with a higher scoring selected bounding box larger than a
+//    threshold.
+// Reference: detectron/lib/utils/cython_nms.pyx
+// proposals: pixel coordinates of proposed bounding boxes,
+//    size: (M, 4), format: [x1; y1; x2; y2]
+//    size: (M, 5), format: [ctr_x; ctr_y; w; h; angle (degrees)] for RRPN
+// scores: scores for each bounding box, size: (M, 1)
+// return: row indices of the selected proposals
+template <class Derived1, class Derived2>
+std::vector<int> nms_cpu(
+    const Eigen::ArrayBase<Derived1>& proposals,
+    const Eigen::ArrayBase<Derived2>& scores,
+    float thres) {
+  std::vector<int> indices(proposals.rows());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::sort(
+      indices.data(),
+      indices.data() + indices.size(),
+      [&scores](int lhs, int rhs) { return scores(lhs) > scores(rhs); });
+
+  return nms_cpu(proposals, scores, indices, thres);
+}
+
+template <class Derived1, class Derived2, class Derived3>
+std::vector<int> soft_nms_cpu(
+    Eigen::ArrayBase<Derived3>* out_scores,
+    const Eigen::ArrayBase<Derived1>& proposals,
+    const Eigen::ArrayBase<Derived2>& scores,
+    const std::vector<int>& indices,
+    float sigma = 0.5,
+    float overlap_thresh = 0.3,
+    float score_thresh = 0.001,
+    unsigned int method = 1,
+    int topN = -1) {
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+  CAFFE_ENFORCE(proposals.cols() == 4 || proposals.cols() == 5);
+  if (proposals.cols() == 4) {
+    // Upright boxes
+    return soft_nms_cpu_upright(
+        out_scores,
+        proposals,
+        scores,
+        indices,
+        sigma,
+        overlap_thresh,
+        score_thresh,
+        method,
+        topN);
+  } else {
+    // Rotated boxes with angle info
+    return soft_nms_cpu_rotated(
+        out_scores,
+        proposals,
+        scores,
+        indices,
+        sigma,
+        overlap_thresh,
+        score_thresh,
+        method,
+        topN);
+  }
+#else
+  return soft_nms_cpu_upright(
+      out_scores,
+      proposals,
+      scores,
+      indices,
+      sigma,
+      overlap_thresh,
+      score_thresh,
+      method,
+      topN);
+#endif // CV_MAJOR_VERSION >= 3
 }
 
 template <class Derived1, class Derived2, class Derived3>

--- a/caffe2/operators/generate_proposals_op_util_nms_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_nms_test.cc
@@ -8,6 +8,7 @@ TEST(UtilsNMSTest, TestNMS) {
   Eigen::ArrayXXf input(5, 5);
   input << 10, 10, 50, 60, 0.5, 11, 12, 48, 60, 0.7, 8, 9, 40, 50, 0.6, 100,
       100, 150, 140, 0.9, 99, 110, 155, 139, 0.8;
+
   std::vector<float> input_thresh{0.1f, 0.3f, 0.5f, 0.8f, 0.9f};
   // ground truth generated based on detection.caffe2/lib/nms/py_cpu_nms.py
   std::vector<std::vector<int>> output_gt{
@@ -158,5 +159,231 @@ TEST(UtilsNMSTest, TestSoftNMS) {
     }
   }
 }
+
+#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+TEST(UtilsNMSTest, TestNMSRotatedAngle0) {
+  // Same inputs as TestNMS, but in RRPN format with angle 0 for testing
+  // nms_cpu_rotated
+  Eigen::ArrayXXf input(5, 5);
+  input << 10, 10, 50, 60, 0.5, 11, 12, 48, 60, 0.7, 8, 9, 40, 50, 0.6, 100,
+      100, 150, 140, 0.9, 99, 110, 155, 139, 0.8;
+
+  std::vector<float> input_thresh{0.1f, 0.3f, 0.5f, 0.8f, 0.9f};
+  // ground truth generated based on detection.caffe2/lib/nms/py_cpu_nms.py
+  std::vector<std::vector<int>> output_gt{
+      {3, 1}, {3, 1}, {3, 1}, {3, 4, 1, 2}, {3, 4, 1, 2, 0}};
+
+  // test utils::nms_cpu without indices input.
+  // Add additional dim for angle and convert from
+  // [x1, y1, x2, y1] to [ctr_x, ctr_y, w, h] format.
+  Eigen::ArrayXXf proposals = Eigen::ArrayXXf::Zero(input.rows(), 5);
+  proposals.col(0) = (input.col(0) + input.col(2)) / 2.0; // ctr_x = (x1 + x2)/2
+  proposals.col(1) = (input.col(1) + input.col(3)) / 2.0; // ctr_y = (y1 + y2)/2
+  proposals.col(2) = input.col(2) - input.col(0) + 1.0; // w = x2 - x1 + 1
+  proposals.col(3) = input.col(3) - input.col(1) + 1.0; // h = y2 - y1 + 1
+
+  auto scores = input.col(4);
+  for (int i = 0; i < input_thresh.size(); i++) {
+    auto cur_out = utils::nms_cpu(proposals, scores, input_thresh[i]);
+    EXPECT_EQ(output_gt[i], cur_out);
+  }
+
+  // test utils::nms_cpu with indices
+  std::vector<int> indices(proposals.rows());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::sort(
+      indices.data(),
+      indices.data() + indices.size(),
+      [&scores](int lhs, int rhs) { return scores(lhs) > scores(rhs); });
+  for (int i = 0; i < input_thresh.size(); i++) {
+    auto cur_out = utils::nms_cpu(proposals, scores, indices, input_thresh[i]);
+    EXPECT_EQ(output_gt[i], cur_out);
+  }
+
+  // test utils::nms_cpu with topN
+  std::vector<int> top_n = {1, 1, 2, 2, 3};
+  auto gt_out = output_gt;
+  for (int i = 0; i < input_thresh.size(); i++) {
+    auto cur_out =
+        utils::nms_cpu(proposals, scores, indices, input_thresh[i], top_n[i]);
+    gt_out[i].resize(top_n[i]);
+    EXPECT_EQ(gt_out[i], cur_out);
+  }
+}
+
+TEST(UtilsNMSTest, TestSoftNMSRotatedAngle0) {
+  // Same inputs as TestSoftNMS, but in RRPN format with angle 0 for testing
+  // nms_cpu_rotated
+  Eigen::ArrayXXf input(5, 5);
+  input.row(0) << 5.18349426e+02, 1.77783920e+02, 9.06085266e+02,
+      2.59163239e+02, 8.17906916e-01;
+  input.row(1) << 2.11392624e+02, 1.76144958e+02, 6.14215149e+02,
+      2.48934662e+02, 9.52467501e-01;
+  input.row(2) << 4.65724518e+02, 1.83594269e+02, 9.39000000e+02,
+      2.55136627e+02, 6.73921347e-01;
+  input.row(3) << 6.07164246e+02, 2.60230377e+02, 8.32768127e+02,
+      3.39919891e+02, 9.99834776e-01;
+  input.row(4) << 3.23936859e+02, 3.43427063e+02, 6.20561157e+02,
+      3.98286072e+02, 9.99737203e-01;
+
+  // Add additional dim for angle and convert from
+  // [x1, y1, x2, y1] to [ctr_x, ctr_y, w, h] format.
+  Eigen::ArrayXXf proposals = Eigen::ArrayXXf::Zero(input.rows(), 5);
+  proposals.col(0) = (input.col(0) + input.col(2)) / 2.0; // ctr_x = (x1 + x2)/2
+  proposals.col(1) = (input.col(1) + input.col(3)) / 2.0; // ctr_y = (y1 + y2)/2
+  proposals.col(2) = input.col(2) - input.col(0) + 1.0; // w = x2 - x1 + 1
+  proposals.col(3) = input.col(3) - input.col(1) + 1.0; // h = y2 - y1 + 1
+
+  const auto& scores = input.col(4);
+
+  vector<int> method{1, 1, 2, 2};
+  vector<float> overlap_thresh{0.1f, 0.3f, 0.1f, 0.3f};
+
+  // Ground truth generated based on
+  //   detectron/lib/utils/cython_nms.pyx
+  std::vector<int> keep_gt{3, 4, 1, 0, 2};
+
+  // Explicitly use colmajor order to match scores
+  Eigen::ArrayXXf scores_gt(5, 4);
+  // Linear, overlap_thresh=0.1
+  scores_gt.col(0) << 7.13657320e-01, 9.52467501e-01, 1.44501388e-01,
+      9.99834776e-01, 9.99737203e-01;
+  // Linear, overlap_thresh=0.3
+  scores_gt.col(1) << 8.17906916e-01, 9.52467501e-01, 1.76800430e-01,
+      9.99834776e-01, 9.99737203e-01;
+  // Gaussian, overlap_thresh=0.1
+  scores_gt.col(2) << 7.91758895e-01, 9.52467501e-01, 2.12320581e-01,
+      9.99834776e-01, 9.99737203e-01;
+  // Gaussian, overlap_thresh=0.3
+  scores_gt.col(3) << 7.91758895e-01, 9.52467501e-01, 2.12320581e-01,
+      9.99834776e-01, 9.99737203e-01;
+
+  Eigen::ArrayXf out_scores;
+  for (int i = 0; i < method.size(); ++i) {
+    LOG(INFO) << "Testing SoftNMS with method=" << method[i]
+              << ", overlap_thresh=" << overlap_thresh[i];
+    const auto& expected_scores = scores_gt.col(i);
+
+    auto keep = utils::soft_nms_cpu(
+        &out_scores,
+        proposals,
+        scores,
+        0.5,
+        overlap_thresh[i],
+        0.0001,
+        method[i]);
+    EXPECT_EQ(keep, keep_gt);
+    {
+      auto diff = expected_scores - out_scores;
+      EXPECT_TRUE((diff.abs() < 1e-6).all());
+    }
+
+    // Test with topN
+    for (int topN = 1; topN <= 3; ++topN) {
+      keep = utils::soft_nms_cpu(
+          &out_scores,
+          proposals,
+          scores,
+          0.5,
+          overlap_thresh[i],
+          0.0001,
+          method[i],
+          topN);
+      std::vector<int> expected_keep(keep_gt.begin(), keep_gt.begin() + topN);
+      EXPECT_EQ(expected_keep, keep);
+    }
+
+    // Test with filtered indices
+    auto indices = utils::GetArrayIndices(scores >= 0.9);
+    keep = utils::soft_nms_cpu(
+        &out_scores,
+        proposals,
+        scores,
+        indices,
+        0.5,
+        overlap_thresh[i],
+        0.0001,
+        method[i]);
+    std::sort(keep.begin(), keep.end());
+    EXPECT_EQ(indices, keep);
+    {
+      const auto& expected = utils::GetSubArray(expected_scores, indices);
+      const auto& actual = utils::GetSubArray(out_scores, indices);
+      EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+    }
+
+    // Test with high score_thresh
+    float score_thresh = 0.9;
+    keep = utils::soft_nms_cpu(
+        &out_scores,
+        proposals,
+        scores,
+        0.5,
+        overlap_thresh[i],
+        score_thresh,
+        method[i]);
+    {
+      auto expected_keep =
+          utils::GetArrayIndices(expected_scores >= score_thresh);
+      std::sort(keep.begin(), keep.end());
+      EXPECT_EQ(expected_keep, keep);
+
+      const auto& expected = utils::GetSubArray(expected_scores, expected_keep);
+      const auto& actual = utils::GetSubArray(out_scores, expected_keep);
+      EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+    }
+  }
+}
+
+TEST(UtilsNMSTest, RotatedBBoxOverlaps) {
+  {
+    // Simple case with angle 0 (upright boxes)
+    Eigen::ArrayXXf boxes(2, 5);
+    boxes << 10.5, 15.5, 21, 31, 0, 14.0, 17, 4, 10, 0;
+
+    Eigen::ArrayXXf query_boxes(3, 5);
+    query_boxes << 30.5, 10.5, 41, 1, 0, 13.5, 21.5, 5, 21, 0, 10.5, 15.5, 21,
+        31, 0;
+
+    Eigen::ArrayXXf expected(2, 3);
+    expected << 0.0161527172, 0.152439028, 1., 0., 0.38095239, 0.0614439324;
+
+    auto actual = utils::bbox_overlaps_rotated(boxes, query_boxes);
+    EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+  }
+
+  {
+    // Angle 45
+    Eigen::ArrayXXf boxes(1, 5);
+    boxes << 0, 0, 2.0 * std::sqrt(2), 2.0 * std::sqrt(2), 45;
+
+    Eigen::ArrayXXf query_boxes(1, 5);
+    query_boxes << 1, 1, 2, 2, 0;
+
+    Eigen::ArrayXXf expected(1, 1);
+    expected << 0.2;
+
+    auto actual = utils::bbox_overlaps_rotated(boxes, query_boxes);
+    EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+  }
+
+  {
+    Eigen::ArrayXXf boxes(2, 5);
+    boxes << 60.0, 60.0, 100.0, 100.0, 0.0, 50.0, 50.0, 100.0, 100.0, 135.0;
+
+    Eigen::ArrayXXf query_boxes(6, 5);
+    query_boxes << 60.0, 60.0, 100.0, 100.0, 180.0, 50.0, 50.0, 100.0, 100.0,
+        45.0, 80.0, 50.0, 100.0, 100.0, 0.0, 50.0, 50.0, 200.0, 50.0, 45.0,
+        200.0, 200.0, 100.0, 100.0, 0, 60.0, 60.0, 100.0, 100.0, 1.0;
+
+    Eigen::ArrayXXf expected(2, 6);
+    expected << 1., 0.6507467031, 0.5625, 0.3718426526, 0., 0.9829941392,
+        0.6507467628, 1., 0.4893216789, 0.3333334029, 0., 0.6508141756;
+
+    auto actual = utils::bbox_overlaps_rotated(boxes, query_boxes);
+    EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+  }
+}
+#endif // CV_MAJOR_VERSION >= 3
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Updates bbox_transform for rotated boxes with angle info to normalize the
predicted angle to be within [angle_bound_lo, angle_bound_hi] range.

Differential Revision: D8706240
