### PR TITLE
Make _C depend on csrc-no-python

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -536,7 +536,7 @@ std::shared_ptr<Graph> Graph::copy() {
   return new_g;
 }
 
-inline Value* Value::setUniqueName(const std::string & name) {
+Value* Value::setUniqueName(const std::string & name) {
   if (name.size() > 0 && name.find_first_not_of("0123456789") == std::string::npos) {
     throw std::runtime_error("names may not be integers: " + name);
   }


### PR DESCRIPTION
Summary:
Make the `_C` target depend on the `csrc-no-python` target. Also removes the `csrc` target and the with-python version of autogradpp (which is not used). Let me know if we should pick better names here.

I also ran into a nasty linker issue with only one symbol being undefined. It turns out had been given inline linkage in the `.cpp` file, which I believe is an error.

Reviewed By: orionr

Differential Revision: D8705750
