### PR TITLE
Add FTRL Optimizer with Group Lasso regularizer (#8918)

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -584,6 +584,74 @@ class TestOperators(hu.HypothesisTestCase):
             gc, op, [var, nz, grad],
             partial(self._dense_ftrl, alpha, beta, lambda1, lambda2))
 
+    # Reference
+    @staticmethod
+    def _dense_gftrl(alpha, beta, lambda1, lambda2, w, nz, g):
+        if isinstance(alpha, np.ndarray):
+            alpha = np.asscalar(alpha)
+
+        old_shape = g.shape
+
+        n = np.take(nz, 0, axis=-1)
+        z = np.take(nz, 1, axis=-1)
+
+        output_dim = g.shape[0]
+
+        w = w.reshape(output_dim, -1)
+        g = g.reshape(output_dim, -1)
+
+        n = n.reshape(output_dim, -1)
+        z = z.reshape(output_dim, -1)
+
+        input_dim = g.shape[1]
+
+        g2 = g * g
+        sigma = (np.sqrt(n + g2) - np.sqrt(n)) / alpha
+        z += g - sigma * w
+        n += g2
+
+        z_norms = np.linalg.norm(z, 2, axis=0)
+
+        z_norms = z_norms + 1e-6
+        w = z * ((lambda1 * np.sqrt(output_dim)) / z_norms - 1) / \
+                    ((beta + np.sqrt(n)) / alpha + lambda2)
+        for i in range(input_dim):
+            if z_norms[i] <= lambda1 * np.sqrt(output_dim):
+                w[:, i] = 0
+
+        w = w.reshape(old_shape)
+        n = n.reshape(old_shape)
+        z = z.reshape(old_shape)
+        return (w, np.stack([n, z], axis=-1))
+
+    @given(inputs=hu.tensors(n=4),
+           in_place=st.booleans(),
+           alpha=st.floats(min_value=0.01, max_value=0.1),
+           beta=st.floats(min_value=0.1, max_value=0.9),
+           lambda1=st.floats(min_value=0.001, max_value=0.1),
+           lambda2=st.floats(min_value=0.001, max_value=0.1),
+           engine=st.sampled_from([None]),
+           **hu.gcs_cpu_only)
+    def test_gftrl_sgd(self, inputs, in_place, alpha, beta, lambda1, lambda2,
+                      engine, gc, dc):
+        var, n, z, grad = inputs
+        n = np.abs(n)
+        nz = np.stack([n, z], axis=-1)
+        op = core.CreateOperator(
+            "GFtrl",
+            ["var", "nz", "grad"],
+            ["var" if in_place else "var_o",
+             "nz" if in_place else "nz_o"],
+            alpha=alpha, beta=beta, lambda1=lambda1, lambda2=lambda2,
+            engine=engine,
+            device_option=gc)
+        self.assertDeviceChecks(
+            dc, op, [var, nz, grad], [0])
+
+        self.assertReferenceChecks(
+            gc, op, [var, nz, grad],
+            partial(self._dense_gftrl, alpha, beta, lambda1, lambda2))
+
     @given(inputs=hu.tensors(n=4),
            alpha=st.floats(min_value=0.01, max_value=0.1),
            beta=st.floats(min_value=0.1, max_value=0.9),

--- a/caffe2/python/optimizer_test.py
+++ b/caffe2/python/optimizer_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from caffe2.proto import caffe2_pb2
 import caffe2.python.optimizer as optimizer
 from caffe2.python.optimizer import (
-    build_sgd, build_multi_precision_sgd, build_ftrl, build_adagrad,
+    build_sgd, build_multi_precision_sgd, build_ftrl, build_gftrl, build_adagrad,
     build_adam, build_yellowfin, build_rms_prop, add_weight_decay, SgdOptimizer)
 from caffe2.python.optimizer_context import UseOptimizer
 from caffe2.python.optimizer_test_util import (
@@ -85,6 +85,29 @@ class TestFtrl(OptimizerTestBase, TestCase):
     def build_optimizer(self, model, **kwargs):
         self._skip_gpu = True
         return build_ftrl(
+            model,
+            engine=None,
+            alpha=1.0,
+            beta=0.1,
+            lambda1=0.0,
+            lambda2=0.0,
+            **kwargs
+        )
+
+    def check_optimizer(self, optimizer):
+        self.assertFalse(optimizer.get_auxiliary_parameters().shared)
+        self.assertTrue(optimizer.get_auxiliary_parameters().local)
+        for param in optimizer.get_auxiliary_parameters().local:
+            workspace.FetchBlob(param)
+
+
+class TestGFtrl(OptimizerTestBase, TestCase):
+    def testSparse(self):
+        raise unittest.SkipTest("no sparse support")
+
+    def build_optimizer(self, model, **kwargs):
+        self._skip_gpu = True
+        return build_gftrl(
             model,
             engine=None,
             alpha=1.0,

--- a/caffe2/sgd/gftrl_op.cc
+++ b/caffe2/sgd/gftrl_op.cc
@@ -1,0 +1,104 @@
+#include "gftrl_op.h"
+
+namespace caffe2 {
+
+// Computes one coordinate
+template <typename T>
+
+inline void gftrl_compute(
+    const T& w,
+    const T& n,
+    const T& z,
+    const T& g,
+    T& nw,
+    T& nn,
+    T& nz,
+    const T& z_norm,
+    const int OutputDim,
+    const GFtrlParams<T>& params) {
+  auto new_n = n + g * g;
+  auto sigma = (sqrt(new_n) - sqrt(n)) * params.alphaInv;
+  nn = new_n;
+  nz = z + g - sigma * w;
+  // update the weight
+  if (z_norm > params.lambda1 * std::sqrt(OutputDim)) {
+    nw = nz * (params.lambda1 * std::sqrt(OutputDim) / z_norm - 1) /
+        ((params.beta + sqrt(new_n)) * params.alphaInv + params.lambda2);
+  } else {
+    nw = 0.0;
+  }
+}
+
+template <typename Context, typename T>
+void gftrl_update(
+    int OutputDim, // # of output nodes
+    int InputDim, // # of input features
+    const T* w,
+    const T* nz,
+    const T* g,
+    T* new_w,
+    T* new_nz,
+    const GFtrlParams<T>& params,
+    Context* /*context*/) {
+  for (auto j = 0; j < InputDim; ++j) {
+    T z_norm = 0.0;
+    for (auto i = 0; i < OutputDim; ++i) {
+      int idx = i * InputDim + j;
+      auto new_n = nz[idx * 2] + g[idx] * g[idx];
+      auto sigma = (sqrt(new_n) - sqrt(nz[idx * 2])) * params.alphaInv;
+      auto new_z = nz[idx * 2 + 1] + g[idx] - sigma * w[idx];
+      z_norm = z_norm + new_z * new_z;
+    }
+
+    z_norm = sqrt(z_norm);
+    for (auto i = 0; i < OutputDim; ++i) {
+      int idx = i * InputDim + j;
+      gftrl_compute(
+          w[idx],
+          nz[idx * 2],
+          nz[idx * 2 + 1],
+          g[idx],
+          new_w[idx],
+          new_nz[idx * 2],
+          new_nz[idx * 2 + 1],
+          z_norm,
+          OutputDim,
+          params);
+    }
+  }
+}
+
+template <typename T, typename Context>
+bool GFtrlOp<T, Context>::RunOnDevice() {
+  // run time learning rate override
+  if (ALPHA < InputSize()) {
+    CAFFE_ENFORCE_EQ(Input(ALPHA).size(), 1, "alpha should be real-valued");
+    params_.alphaInv = 1.0 / *(Input(ALPHA).template data<T>());
+  }
+
+  CAFFE_ENFORCE_EQ(Input(GRAD).size(), Input(VAR).size());
+  CAFFE_ENFORCE_EQ(Input(GRAD).size() * 2, Input(N_Z).size());
+  Output(OUTPUT_VAR)->ResizeLike(Input(VAR));
+  Output(OUTPUT_N_Z)->ResizeLike(Input(N_Z));
+  gftrl_update<Context>(
+      Input(GRAD).dim(0), // # of output nodes
+      Input(GRAD).size() / Input(GRAD).dim(0), // # of input features
+      Input(VAR).template data<T>(),
+      Input(N_Z).template data<T>(),
+      Input(GRAD).template data<T>(),
+      Output(OUTPUT_VAR)->template mutable_data<T>(),
+      Output(OUTPUT_N_Z)->template mutable_data<T>(),
+      params_,
+      &context_);
+  return true;
+}
+
+namespace {
+REGISTER_CPU_OPERATOR(GFtrl, GFtrlOp<float, CPUContext>);
+OPERATOR_SCHEMA(GFtrl).NumInputs(3, 4).NumOutputs(2).AllowInplace({{0, 0},
+                                                                   {1, 1}});
+SHOULD_NOT_DO_GRADIENT(GFtrl);
+
+} // namespace
+
+} // namespace caffe2

--- a/caffe2/sgd/gftrl_op.h
+++ b/caffe2/sgd/gftrl_op.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+template <typename T>
+struct GFtrlParams {
+  explicit GFtrlParams(OperatorBase* op)
+      : alphaInv(1.0 / op->GetSingleArgument<float>("alpha", 0.005f)),
+        beta(op->GetSingleArgument<float>("beta", 1.0f)),
+        lambda1(op->GetSingleArgument<float>("lambda1", 0.001f)),
+        lambda2(op->GetSingleArgument<float>("lambda2", 0.001f)) {}
+  T alphaInv;
+  T beta;
+  T lambda1;
+  T lambda2;
+};
+
+template <typename T, class Context>
+class GFtrlOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  GFtrlOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws), params_(this) {
+    CAFFE_ENFORCE(
+        !HasArgument("alpha") || ALPHA >= InputSize(),
+        "Cannot specify alpha by both input and argument");
+  }
+  bool RunOnDevice() override;
+
+ protected:
+  GFtrlParams<T> params_;
+  INPUT_TAGS(VAR, N_Z, GRAD, ALPHA);
+  OUTPUT_TAGS(OUTPUT_VAR, OUTPUT_N_Z);
+};
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Closes https://github.com/pytorch/pytorch/pull/8918

Implement an optimizer which support Group Lasso regularizer based on FTRL Optimizer.

The relevant paper list for this optimizer:
1. About the FTRL Optimizer: https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/41159.pdf,
2. About the group lasso regularizer solver: http://www.cse.cuhk.edu.hk/~king/PUB/ICML2010-Yang-473.pdf

Differential Revision: D8623146
