### PR TITLE
[C++ API] Make all module members public

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -26,14 +26,11 @@ class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
   Tensor forward(Tensor input);
   Tensor pure_forward(Tensor input, Tensor mean, Tensor variance);
 
-  const BatchNormOptions& options() const noexcept;
-
- private:
-  BatchNormOptions options_;
-  Tensor weight_;
-  Tensor bias_;
-  Tensor running_mean_;
-  Tensor running_variance_;
+  BatchNormOptions options;
+  Tensor weight;
+  Tensor bias;
+  Tensor running_mean;
+  Tensor running_variance;
 };
 
 TORCH_MODULE(BatchNorm);

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -35,12 +35,10 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
   explicit ConvImpl(ConvOptions<D> options);
 
   void reset() override;
-  const ConvOptions<D>& options() const noexcept;
 
- protected:
-  Tensor weight_;
-  Tensor bias_;
-  ConvOptions<D> options_;
+  ConvOptions<D> options;
+  Tensor weight;
+  Tensor bias;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -18,16 +18,13 @@ namespace detail {
 template <typename Derived>
 class DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  explicit DropoutImplBase(DropoutOptions options);
+  explicit DropoutImplBase(DropoutOptions options_);
 
   void reset() override;
   Tensor forward(Tensor input);
-  const DropoutOptions& options() const noexcept;
-
- protected:
   virtual Tensor noise_mask(Tensor input) const = 0;
 
-  DropoutOptions options_;
+  DropoutOptions options;
 };
 } // namespace detail
 

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -22,11 +22,9 @@ class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
 
   void reset() override;
   Tensor forward(Tensor);
-  const EmbeddingOptions& options() const noexcept;
 
- private:
-  EmbeddingOptions options_;
-  Tensor table_;
+  EmbeddingOptions options;
+  Tensor table;
 };
 
 TORCH_MODULE(Embedding);

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -23,12 +23,10 @@ class LinearImpl : public Cloneable<LinearImpl> {
 
   void reset() override;
   Tensor forward(Tensor);
-  const LinearOptions& options() const noexcept;
 
- private:
-  Tensor weight_;
-  Tensor bias_;
-  LinearOptions options_;
+  LinearOptions options;
+  Tensor weight;
+  Tensor bias;
 };
 
 TORCH_MODULE(Linear);

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -41,7 +41,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   enum class CuDNNMode { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
   RNNImplBase(
-      RNNOptionsBase options,
+      RNNOptionsBase options_,
       at::optional<CuDNNMode> cudnn_mode = at::nullopt,
       int64_t number_of_gates = 1,
       bool has_cell_state = false);
@@ -60,7 +60,19 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   /// Recursively moves all parameters to the given device.
   void to(torch::Device device, bool non_blocking = false) override;
 
+  /// Fills the internal flattened parameter buffers passed to cuDNN. Call this
+  /// method if you mess around with the variable storages and want to use
+  /// cuDNN.
   void flatten_parameters_for_cudnn();
+
+  RNNOptionsBase options;
+
+  std::vector<Tensor> w_ih;
+  std::vector<Tensor> w_hh;
+  std::vector<Tensor> b_ih;
+  std::vector<Tensor> b_hh;
+
+  Dropout dropout;
 
  protected:
   virtual Tensor cell_forward(Tensor input, Tensor state, int64_t layer) = 0;
@@ -72,17 +84,9 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   bool use_cudnn(Tensor sample) const;
   Tensor create_dropout_state(Tensor input) const;
 
-  RNNOptionsBase options_;
-
-  std::vector<Tensor> ihw_;
-  std::vector<Tensor> ihb_;
-  std::vector<Tensor> hhw_;
-  std::vector<Tensor> hhb_;
-
   int64_t number_of_gates_;
   bool has_cell_state_;
   at::optional<CuDNNMode> cudnn_mode_;
-  Dropout dropout_module_;
 
   // This is copied from pytorch, to determine whether weights are flat for the
   // fast CUDNN route. Otherwise, we have to use non flattened weights, which
@@ -119,12 +123,10 @@ class RNNImpl : public detail::RNNImplBase<RNNImpl> {
  public:
   explicit RNNImpl(RNNOptions options);
 
-  const RNNOptions& options() const noexcept;
+  RNNOptions options;
 
  private:
   Tensor cell_forward(Tensor input, Tensor state, int64_t layer) override;
-
-  RNNOptions options_;
   std::function<Tensor(Tensor)> activation_function_;
 };
 
@@ -137,8 +139,6 @@ using LSTMOptions = detail::RNNOptionsBase;
 class LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
  public:
   explicit LSTMImpl(LSTMOptions options);
-
-  const LSTMOptions& options() const noexcept;
 
  private:
   Tensor cell_forward(Tensor input, Tensor state, int64_t layer) override;
@@ -153,8 +153,6 @@ using GRUOptions = detail::RNNOptionsBase;
 class GRUImpl : public detail::RNNImplBase<GRUImpl> {
  public:
   explicit GRUImpl(GRUOptions options);
-
-  const GRUOptions& options() const noexcept;
 
  private:
   Tensor cell_forward(Tensor input, Tensor state, int64_t layer) override;

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -21,43 +21,43 @@ ConvOptions<D>::ConvOptions(
 
 template <size_t D, typename Derived>
 ConvImpl<D, Derived>::ConvImpl(ConvOptions<D> options)
-    : options_(std::move(options)) {
+    : options(std::move(options)) {
   reset();
 }
 
 template <size_t D, typename Derived>
 void ConvImpl<D, Derived>::reset() {
-  if (!options_.transposed_) {
-    for (auto pad : *options_.output_padding_) {
+  if (!options.transposed_) {
+    for (auto pad : *options.output_padding_) {
       AT_CHECK(
           pad == 0, "Only transposed convolutions support output padding!");
     }
   }
 
   std::vector<int64_t> weights_size;
-  if (options_.transposed_) {
-    weights_size.push_back(options_.input_channels_);
-    weights_size.push_back(options_.output_channels_ / options_.groups_);
+  if (options.transposed_) {
+    weights_size.push_back(options.input_channels_);
+    weights_size.push_back(options.output_channels_ / options.groups_);
   } else {
-    weights_size.push_back(options_.output_channels_);
-    weights_size.push_back(options_.input_channels_ / options_.groups_);
+    weights_size.push_back(options.output_channels_);
+    weights_size.push_back(options.input_channels_ / options.groups_);
   }
   weights_size.insert(
       weights_size.end(),
-      options_.kernel_size_->begin(),
-      options_.kernel_size_->end());
-  AT_ASSERT(weights_size.size() == 2 + options_.kernel_size_->size());
+      options.kernel_size_->begin(),
+      options.kernel_size_->end());
+  AT_ASSERT(weights_size.size() == 2 + options.kernel_size_->size());
 
-  weight_ = this->register_parameter("weight", torch::empty(weights_size));
-  if (options_.with_bias_) {
-    bias_ = this->register_parameter(
-        "bias", torch::empty(options_.output_channels_));
+  weight = this->register_parameter("weight", torch::empty(weights_size));
+  if (options.with_bias_) {
+    bias = this->register_parameter(
+        "bias", torch::empty(options.output_channels_));
   }
 
   const auto number_of_features = std::accumulate(
-      options_.kernel_size_->begin(),
-      options_.kernel_size_->end(),
-      options_.input_channels_,
+      options.kernel_size_->begin(),
+      options.kernel_size_->end(),
+      options.input_channels_,
       std::multiplies<int64_t>{});
   const auto stdv = 1.0 / std::sqrt(number_of_features);
   for (auto& p : this->parameters()) {
@@ -65,81 +65,76 @@ void ConvImpl<D, Derived>::reset() {
   }
 }
 
-template <size_t D, typename Derived>
-const ConvOptions<D>& ConvImpl<D, Derived>::options() const noexcept {
-  return options_;
-}
-
 Tensor Conv1dImpl::forward(Tensor input) {
   AT_ASSERT(input.ndimension() == 3);
 
-  if (options_.transposed_) {
+  if (options.transposed_) {
     return torch::conv_transpose1d(
         input,
-        weight_,
-        bias_,
-        options_.stride_,
-        options_.padding_,
-        options_.output_padding_,
-        options_.groups_,
-        options_.dilation_);
+        weight,
+        bias,
+        options.stride_,
+        options.padding_,
+        options.output_padding_,
+        options.groups_,
+        options.dilation_);
   }
   return torch::conv1d(
       input,
-      weight_,
-      bias_,
-      options_.stride_,
-      options_.padding_,
-      options_.dilation_,
-      options_.groups_);
+      weight,
+      bias,
+      options.stride_,
+      options.padding_,
+      options.dilation_,
+      options.groups_);
 }
 
 Tensor Conv2dImpl::forward(Tensor input) {
   AT_ASSERT(input.ndimension() == 4);
 
-  if (options_.transposed_) {
+  if (options.transposed_) {
     return torch::conv_transpose2d(
         input,
-        weight_,
-        bias_,
-        options_.stride_,
-        options_.padding_,
-        options_.output_padding_,
-        options_.groups_,
-        options_.dilation_);
+        weight,
+        bias,
+        options.stride_,
+        options.padding_,
+        options.output_padding_,
+        options.groups_,
+        options.dilation_);
   }
   return torch::conv2d(
       input,
-      weight_,
-      bias_,
-      options_.stride_,
-      options_.padding_,
-      options_.dilation_,
-      options_.groups_);
+      weight,
+      bias,
+      options.stride_,
+      options.padding_,
+      options.dilation_,
+      options.groups_);
 }
 
 Tensor Conv3dImpl::forward(Tensor input) {
   AT_ASSERT(input.ndimension() == 5);
 
-  if (options_.transposed_) {
+  if (options.transposed_) {
     return torch::conv_transpose3d(
         input,
-        weight_,
-        bias_,
-        options_.stride_,
-        options_.padding_,
-        options_.output_padding_,
-        options_.groups_,
-        options_.dilation_);
+        weight,
+        bias,
+        options.stride_,
+        options.padding_,
+        options.output_padding_,
+        options.groups_,
+        options.dilation_);
   } else {
     return torch::conv3d(
         input,
-        weight_,
-        bias_,
-        options_.stride_,
-        options_.padding_,
-        options_.dilation_,
-        options_.groups_);
+        weight,
+        bias,
+        options.stride_,
+        options.padding_,
+        options.dilation_,
+        options.groups_);
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -11,10 +11,10 @@ namespace torch {
 namespace nn {
 namespace detail {
 template <typename Derived>
-DropoutImplBase<Derived>::DropoutImplBase(DropoutOptions options)
-    : options_(options) {
-  AT_CHECK(options_.rate_ >= 0, "Dropout rate must not be less than zero");
-  AT_CHECK(options_.rate_ <= 1, "Dropout rate must not be greater than one");
+DropoutImplBase<Derived>::DropoutImplBase(DropoutOptions options_)
+    : options(options_) {
+  AT_CHECK(options.rate_ >= 0, "Dropout rate must not be less than zero");
+  AT_CHECK(options.rate_ <= 1, "Dropout rate must not be greater than one");
 }
 
 template <typename Derived>
@@ -22,20 +22,15 @@ void DropoutImplBase<Derived>::reset() {}
 
 template <typename Derived>
 Tensor DropoutImplBase<Derived>::forward(Tensor input) {
-  if (options_.rate_ == 0 || !this->is_training()) {
+  if (options.rate_ == 0 || !this->is_training()) {
     return input;
   }
 
-  auto scale = 1.0f / (1.0f - options_.rate_);
-  auto boolean_mask = noise_mask(input).uniform_(0, 1) > options_.rate_;
+  auto scale = 1.0f / (1.0f - options.rate_);
+  auto boolean_mask = noise_mask(input).uniform_(0, 1) > options.rate_;
   auto noise = boolean_mask.to(input.dtype()).mul_(scale);
 
   return input * noise;
-}
-
-template <typename Derived>
-const DropoutOptions& DropoutImplBase<Derived>::options() const noexcept {
-  return options_;
 }
 
 template class DropoutImplBase<DropoutImpl>;

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -13,23 +13,18 @@ EmbeddingOptions::EmbeddingOptions(int64_t count, int64_t dimension)
     : count_(count), dimension_(dimension) {}
 
 EmbeddingImpl::EmbeddingImpl(EmbeddingOptions options)
-    : options_(std::move(options)) {
+    : options(std::move(options)) {
   reset();
 }
 
 void EmbeddingImpl::reset() {
-  table_ = register_parameter(
-      "table", torch::empty({options_.count_, options_.dimension_}));
-  table_.data().normal_(0, 1);
+  table = register_parameter(
+      "table", torch::empty({options.count_, options.dimension_}));
+  table.data().normal_(0, 1);
 }
 
 Tensor EmbeddingImpl::forward(Tensor input) {
-  return torch::embedding(table_, /*indices=*/input);
+  return torch::embedding(table, /*indices=*/input);
 }
-
-const EmbeddingOptions& EmbeddingImpl::options() const noexcept {
-  return options_;
-}
-
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -9,39 +9,35 @@ namespace torch {
 namespace nn {
 LinearOptions::LinearOptions(int64_t in, int64_t out) : in_(in), out_(out) {}
 
-LinearImpl::LinearImpl(LinearOptions options) : options_(std::move(options)) {
+LinearImpl::LinearImpl(LinearOptions options) : options(std::move(options)) {
   reset();
 }
 
 void LinearImpl::reset() {
-  weight_ =
-      register_parameter("weight", torch::empty({options_.out_, options_.in_}));
-  if (options_.with_bias_) {
-    bias_ = register_parameter("bias", torch::empty(options_.out_));
+  weight =
+      register_parameter("weight", torch::empty({options.out_, options.in_}));
+  if (options.with_bias_) {
+    bias = register_parameter("bias", torch::empty(options.out_));
   }
 
-  const auto stdv = 1.0 / std::sqrt(weight_.size(1));
+  const auto stdv = 1.0 / std::sqrt(weight.size(1));
   for (auto& p : parameters()) {
     p->data().uniform_(-stdv, stdv);
   }
 }
 
 Tensor LinearImpl::forward(Tensor input) {
-  if (input.ndimension() == 2 && options_.with_bias_) {
+  if (input.ndimension() == 2 && options.with_bias_) {
     // Fused op is marginally faster
-    AT_ASSERT(input.size(1) == weight_.size(1));
-    return {torch::addmm(bias_, input, weight_.t())};
+    AT_ASSERT(input.size(1) == weight.size(1));
+    return {torch::addmm(bias, input, weight.t())};
   }
 
-  auto output = input.matmul(weight_.t());
-  if (options_.with_bias_) {
-    output += bias_;
+  auto output = input.matmul(weight.t());
+  if (options.with_bias_) {
+    output += bias;
   }
   return output;
-}
-
-const LinearOptions& LinearImpl::options() const noexcept {
-  return options_;
 }
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -47,11 +47,11 @@ RNNOptionsBase::RNNOptionsBase(int64_t input_size, int64_t hidden_size)
 
 template <typename Derived>
 RNNImplBase<Derived>::RNNImplBase(
-    RNNOptionsBase options,
+    RNNOptionsBase options_,
     at::optional<CuDNNMode> cudnn_mode,
     int64_t number_of_gates,
     bool has_cell_state)
-    : options_(options),
+    : options(options_),
       number_of_gates_(number_of_gates),
       has_cell_state_(has_cell_state),
       cudnn_mode_(cudnn_mode) {
@@ -60,36 +60,36 @@ RNNImplBase<Derived>::RNNImplBase(
 
 template <typename Derived>
 void RNNImplBase<Derived>::reset() {
-  if (options_.dropout_ > 0.0) {
-    dropout_module_ = Dropout(options_.dropout_);
+  if (options.dropout_ > 0.0) {
+    dropout = Dropout(options.dropout_);
   }
 
-  ihw_.resize(options_.layers_);
-  hhw_.resize(options_.layers_);
-  ihb_.resize(options_.layers_);
-  hhb_.resize(options_.layers_);
+  w_ih.resize(options.layers_);
+  w_hh.resize(options.layers_);
+  b_ih.resize(options.layers_);
+  b_hh.resize(options.layers_);
 
-  const int64_t gate_size = options_.hidden_size_ * number_of_gates_;
+  const int64_t gate_size = options.hidden_size_ * number_of_gates_;
 
-  for (int64_t layer = 0; layer < options_.layers_; ++layer) {
+  for (int64_t layer = 0; layer < options.layers_; ++layer) {
     const int64_t input_size =
-        (layer == 0) ? options_.input_size_ : options_.hidden_size_;
-    ihw_[layer] = this->register_parameter(
+        (layer == 0) ? options.input_size_ : options.hidden_size_;
+    w_ih[layer] = this->register_parameter(
         "weight_ih_l" + std::to_string(layer),
         torch::empty({gate_size, input_size}));
-    hhw_[layer] = this->register_parameter(
+    w_hh[layer] = this->register_parameter(
         "weight_hh_l" + std::to_string(layer),
-        torch::empty({gate_size, options_.hidden_size_}));
+        torch::empty({gate_size, options.hidden_size_}));
 
-    if (options_.with_bias_) {
-      ihb_[layer] = this->register_parameter(
+    if (options.with_bias_) {
+      b_ih[layer] = this->register_parameter(
           "bias_ih_l" + std::to_string(layer), torch::empty({gate_size}));
-      hhb_[layer] = this->register_parameter(
+      b_hh[layer] = this->register_parameter(
           "bias_hh_l" + std::to_string(layer), torch::empty({gate_size}));
     }
   }
 
-  const auto stdv = 1.0 / std::sqrt(options_.hidden_size_);
+  const auto stdv = 1.0 / std::sqrt(options.hidden_size_);
   for (auto& p : this->parameters()) {
     p->data().uniform_(-stdv, stdv);
   }
@@ -107,12 +107,12 @@ RNNOutput RNNImplBase<Derived>::forward(Tensor input, Tensor state) {
 template <typename Derived>
 std::vector<Tensor> RNNImplBase<Derived>::flat_weights() const {
   std::vector<Tensor> flat;
-  for (int64_t layer = 0; layer < options_.layers_; layer++) {
-    flat.push_back(ihw_[layer]);
-    flat.push_back(hhw_[layer]);
-    if (options_.with_bias_) {
-      flat.push_back(ihb_[layer]);
-      flat.push_back(hhb_[layer]);
+  for (int64_t layer = 0; layer < options.layers_; layer++) {
+    flat.push_back(w_ih[layer]);
+    flat.push_back(w_hh[layer]);
+    if (options.with_bias_) {
+      flat.push_back(b_ih[layer]);
+      flat.push_back(b_hh[layer]);
     }
   }
   return flat;
@@ -128,11 +128,11 @@ template <typename Derived>
 Tensor RNNImplBase<Derived>::create_dropout_state(Tensor input) const {
   static const int64_t dropout_seed =
       torch::ones({}, torch::kInt64).random_().toCLong();
-  if (options_.dropout_ > 0) {
+  if (options.dropout_ > 0) {
     torch::DeviceGuard guard(input.device());
     return torch::_cudnn_init_dropout_state(
         input.type().toScalarType(torch::kUInt8),
-        options_.dropout_,
+        options.dropout_,
         this->is_training(),
         dropout_seed);
   }
@@ -144,16 +144,16 @@ RNNOutput RNNImplBase<Derived>::autograd_forward(Tensor input, Tensor state) {
   std::vector<Tensor> new_state;
   auto has_hidden = state.defined();
   auto layer_dimension = has_hidden ? state.ndimension() - 3 : -1;
-  for (int64_t layer = 0; layer < options_.layers_; layer++) {
+  for (int64_t layer = 0; layer < options.layers_; layer++) {
     new_state.push_back(
         has_hidden ? state.select(layer_dimension, layer) : Tensor());
   }
 
   auto output = torch::zeros(
-      {input.size(0), input.size(1), options_.hidden_size_}, input.options());
+      {input.size(0), input.size(1), options.hidden_size_}, input.options());
   for (int64_t t = 0; t < input.size(0); t++) {
     auto x = input.select(0, t);
-    for (int64_t i = 0; i < options_.layers_; i++) {
+    for (int64_t i = 0; i < options.layers_; i++) {
       // cell_forward() returns a stacked tensor of one or more cell states.
       auto layer_output = cell_forward(x, new_state[i], i);
       // If there are multiple cell states, keep all. If there is only one,
@@ -162,8 +162,8 @@ RNNOutput RNNImplBase<Derived>::autograd_forward(Tensor input, Tensor state) {
       // x should always be the hidden cell state h, assumed to be the zero-th.
       x = layer_output[0];
       output.select(0, t).copy_(x);
-      if (options_.dropout_ > 0 && i != options_.layers_ - 1) {
-        x = dropout_module_->forward(x);
+      if (options.dropout_ > 0 && i != options.layers_ - 1) {
+        x = dropout->forward(x);
       }
     }
   }
@@ -178,8 +178,8 @@ RNNOutput RNNImplBase<Derived>::autograd_forward(Tensor input, Tensor state) {
 template <typename Derived>
 void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
   data_ptrs_.clear();
-  const auto any_parameter = ihw_.at(0);
-  if (!use_cudnn(/*sample=*/ihw_.at(0))) {
+  const auto any_parameter = w_ih.at(0);
+  if (!use_cudnn(/*sample=*/w_ih.at(0))) {
     return;
   }
   std::unordered_set<void*> unique_data_ptrs;
@@ -200,11 +200,11 @@ void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
     NoGradGuard guard;
     flat_weights_ = torch::_cudnn_rnn_flatten_weight(
         TensorListView(flat_weights()),
-        /*weight_stride=*/options_.with_bias_ ? 4 : 2,
-        options_.input_size_,
+        /*weight_stride=*/options.with_bias_ ? 4 : 2,
+        options.input_size_,
         static_cast<int64_t>(*cudnn_mode_),
-        options_.hidden_size_,
-        options_.layers_,
+        options.hidden_size_,
+        options.layers_,
         /*batch_first=*/false,
         /*bidirectional=*/false);
   }
@@ -225,11 +225,11 @@ RNNOutput RNNImplBase<Derived>::CUDNN_forward(Tensor input, Tensor state) {
     }
   } else {
     hx = torch::zeros(
-        {options_.layers_, input.size(1), options_.hidden_size_},
+        {options.layers_, input.size(1), options.hidden_size_},
         input.options());
     if (has_cell_state_) {
       cx = torch::zeros(
-          {options_.layers_, input.size(1), options_.hidden_size_},
+          {options.layers_, input.size(1), options.hidden_size_},
           input.options());
     }
   }
@@ -248,15 +248,15 @@ RNNOutput RNNImplBase<Derived>::CUDNN_forward(Tensor input, Tensor state) {
   auto cudnn_output = torch::_cudnn_rnn(
       /*input=*/input,
       /*weight=*/TensorListView(flat_weights()),
-      /*weight_stride0=*/options_.with_bias_ ? 4 : 2,
+      /*weight_stride0=*/options.with_bias_ ? 4 : 2,
       /*weight_buf=*/flat_weights_,
       /*hx=*/hx,
       /*cx=*/cx,
       /*mode=*/static_cast<int64_t>(*cudnn_mode_),
-      /*hidden_size=*/options_.hidden_size_,
-      /*num_layers=*/options_.layers_,
+      /*hidden_size=*/options.hidden_size_,
+      /*num_layers=*/options.layers_,
       /*batch_first=*/false,
-      /*dropout=*/options_.dropout_,
+      /*dropout=*/options.dropout_,
       /*train=*/this->is_training(),
       /*bidirectional=*/false,
       /*batch_sizes=*/{},
@@ -318,8 +318,8 @@ RNNImpl::RNNImpl(RNNOptions options)
               .with_bias(options.with_bias_)
               .dropout(options.dropout_),
           /*cudnn_mode=*/static_cast<CuDNNMode>(options.activation_)),
-      options_(options) {
-  switch (options_.activation_) {
+      options(options) {
+  switch (options.activation_) {
     case RNNActivation::ReLU: {
       activation_function_ = torch::relu;
       break;
@@ -334,16 +334,12 @@ RNNImpl::RNNImpl(RNNOptions options)
 Tensor RNNImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   auto hx = state.defined()
       ? state
-      : torch::zeros({input.size(0), options_.hidden_size_}, input.options());
+      : torch::zeros({input.size(0), options.hidden_size_}, input.options());
 
-  auto h = linear(input, ihw_[layer], ihb_[layer]) +
-      linear(hx, hhw_[layer], hhb_[layer]);
+  auto h = linear(input, w_ih[layer], b_ih[layer]) +
+      linear(hx, w_hh[layer], b_hh[layer]);
 
   return torch::stack(activation_function_(h));
-}
-
-const RNNOptions& RNNImpl::options() const noexcept {
-  return options_;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -358,13 +354,12 @@ LSTMImpl::LSTMImpl(LSTMOptions options)
 Tensor LSTMImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   auto hid = state.defined()
       ? state
-      : torch::zeros(
-            {2, input.size(0), options_.hidden_size_}, input.options());
+      : torch::zeros({2, input.size(0), options.hidden_size_}, input.options());
   auto hx = hid[0];
   auto cx = hid[1];
 
-  auto gates = linear(input, ihw_[layer], ihb_[layer]) +
-      linear(hx, hhw_[layer], hhb_[layer]);
+  auto gates = linear(input, w_ih[layer], b_ih[layer]) +
+      linear(hx, w_hh[layer], b_hh[layer]);
 
   auto chunked = gates.chunk(4, 1);
   auto in_gate = chunked[0].sigmoid();
@@ -378,10 +373,6 @@ Tensor LSTMImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   return torch::stack(TensorListView{hy, cy}, 0);
 }
 
-const LSTMOptions& LSTMImpl::options() const noexcept {
-  return options_;
-}
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 GRUImpl::GRUImpl(GRUOptions options)
@@ -393,10 +384,10 @@ GRUImpl::GRUImpl(GRUOptions options)
 Tensor GRUImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   auto hx = state.defined()
       ? state
-      : torch::zeros({input.size(0), options_.hidden_size_}, input.options());
+      : torch::zeros({input.size(0), options.hidden_size_}, input.options());
 
-  auto gi = linear(input, ihw_[layer], ihb_[layer]);
-  auto gh = linear(input, hhw_[layer], hhb_[layer]);
+  auto gi = linear(input, w_ih[layer], b_ih[layer]);
+  auto gh = linear(input, w_hh[layer], b_hh[layer]);
   auto gic = gi.chunk(3, 1);
   auto ghc = gh.chunk(3, 1);
 
@@ -406,10 +397,6 @@ Tensor GRUImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   auto hy = new_gate + input_gate * (hx - new_gate);
 
   return torch::stack(TensorListView(hy));
-}
-
-const GRUOptions& GRUImpl::options() const noexcept {
-  return options_;
 }
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
Having circulated the C++ API a bit, I found that it would make it easier for folks to access module parameters directly than through the `parameters()` map. So here I make all variables/submodules and also the configuration options for every module public.

For RNNs, I also updated the names of parameters to match PyTorch, e.g. `hhw` -> `w_hh`. This should make it easier to transition from Python.

@apaszke @ebetica 