### PR TITLE
[C++ API] Create Sequential::extend

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -213,4 +213,34 @@ TEST_CASE("sequential") {
             .sum()
             .toCFloat() == 10);
   }
+
+  SECTION("extend() pushes modules from other Sequential") {
+    struct A : torch::nn::Module { int forward(int x) { return x; } };
+    struct B : torch::nn::Module { int forward(int x) { return x; } };
+    struct C : torch::nn::Module { int forward(int x) { return x; } };
+    struct D : torch::nn::Module { int forward(int x) { return x; } };
+    Sequential a(A{}, B{});
+    Sequential b(C{}, D{});
+    a.extend(b);
+
+    REQUIRE(a.size() == 4);
+    REQUIRE(a[0]->is<A>());
+    REQUIRE(a[1]->is<B>());
+    REQUIRE(a[2]->is<C>());
+    REQUIRE(a[3]->is<D>());
+
+    REQUIRE(b.size() == 2);
+    REQUIRE(b[0]->is<C>());
+    REQUIRE(b[1]->is<D>());
+
+    std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
+                                         std::make_shared<A>()};
+    b.extend(c);
+
+    REQUIRE(b.size() == 4);
+    REQUIRE(b[0]->is<C>());
+    REQUIRE(b[1]->is<D>());
+    REQUIRE(b[2]->is<A>());
+    REQUIRE(b[3]->is<A>());
+  }
 }

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -23,6 +23,7 @@ namespace nn {
 class Sequential : public Cloneable<Sequential> {
  public:
   using Iterator = std::vector<std::shared_ptr<AnyModule>>::iterator;
+  using ConstIterator = std::vector<std::shared_ptr<AnyModule>>::const_iterator;
 
   /// Constructs the `Sequential` from a pack of modules. Each module can either
   /// be a plain value (e.g. `Linear`) or a boxed value (e.g.
@@ -80,9 +81,7 @@ class Sequential : public Cloneable<Sequential> {
     static_assert(
         torch::detail::has_forward<ModuleType>::value,
         "Can only add modules with a forward() method to Sequential");
-    modules_.push_back(std::make_shared<AnyModule>(std::move(module_ptr)));
-    const auto index = modules_.size() - 1;
-    register_module(std::to_string(index), modules_[index]->ptr());
+    push_back(std::make_shared<AnyModule>(std::move(module_ptr)));
   }
 
   /// Adds a new `Module` to the `Sequential` container, moving or copying it
@@ -105,13 +104,35 @@ class Sequential : public Cloneable<Sequential> {
     push_back(module_holder.get());
   }
 
+  /// Adds a type-erased `AnyModule` to the `Sequential`.
+  void push_back(std::shared_ptr<AnyModule> any_module) {
+    modules_.push_back(std::move(any_module));
+    const auto index = modules_.size() - 1;
+    register_module(std::to_string(index), modules_[index]->ptr());
+  }
+
+  /// Iterates over the container and calls `push_back()` on each iterated
+  /// value.
+  template <typename Container>
+  void extend(const Container& container) {
+    for (const auto& module : container) {
+      push_back(module);
+    }
+  }
+
   /// Returns an iterator to the start of the `Sequential`.
   Iterator begin() {
+    return modules_.begin();
+  }
+  ConstIterator begin() const {
     return modules_.begin();
   }
 
   /// Returns an iterator to the end of the `Sequential`.
   Iterator end() {
+    return modules_.end();
+  }
+  ConstIterator end() const {
     return modules_.end();
   }
 


### PR DESCRIPTION
There is no way to concatenate two `Sequential`s in Python, but it's also easier to do in an immutable fashion by just writing `Sequential(first.modules() + second.modules())`. Concatenating vectors isn't as easy in C++, so I think it's fair to save users some for loops by giving them `Sequential::extend()`.

@apaszke @ebetica @ezyang 

CC @jamespinkerton