### PR TITLE
Move nccl scatter and gather to C++

### DIFF
--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -431,7 +431,7 @@ cusparseHandle_t THCState_getDeviceSparseHandle(THCState *state, int device, int
   return res->sparseHandles[handle - 1];
 }
 
-static THCStream* THCState_getStreamOnDevice(THCState* state, int device)
+THCStream* THCState_getStreamOnDevice(THCState* state, int device)
 {
   THCThreadLocal local = state->currentStreams[device];
   THCStream* stream = (THCStream*)THCThreadLocal_get(local);
@@ -443,7 +443,7 @@ static THCStream* THCState_getStreamOnDevice(THCState* state, int device)
   return stream;
 }
 
-static void THCState_setStreamOnDevice(THCState *state, int device, THCStream *stream)
+void THCState_setStreamOnDevice(THCState *state, int device, THCStream *stream)
 {
   THAssert(stream);
   if (stream->device != device) {

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -112,6 +112,8 @@ THC_API cudaStream_t THCState_getCurrentStreamOnDevice(THCState *state, int devi
 THC_API cudaStream_t THCState_getCurrentStream(THCState *state);
 THC_API struct THCStream* THCState_getStream(THCState *state);
 THC_API void THCState_setStream(THCState *state, struct THCStream* stream);
+THC_API THCStream* THCState_getStreamOnDevice(THCState* state, int device);
+THC_API void THCState_setStreamOnDevice(THCState *state, int device, THCStream *stream);
 
 THC_API void THCState_reserveBlasHandles(THCState* state, int numHandles);
 THC_API int THCState_getNumBlasHandles(THCState* state);

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -125,9 +125,7 @@ std::vector<at::Tensor> scatter(
     int64_t dim,
     const at::optional<std::vector<THCStream*>>& streams) {
   std::vector<at::Tensor> chunks;
-  if (!chunk_sizes) {
-    chunks = tensor.chunk(/*chunks=*/devices.size(), /*dim=*/dim);
-  } else {
+  if (chunk_sizes) {
     const int64_t chunk_size_sum =
         std::accumulate(chunk_sizes->begin(), chunk_sizes->end(), 0);
     AT_CHECK(
@@ -144,6 +142,8 @@ std::vector<at::Tensor> scatter(
       chunk_start += chunk_size;
     }
     AT_ASSERT(chunks.size() == chunk_sizes->size());
+  } else {
+    chunks = tensor.chunk(/*chunks=*/devices.size(), /*dim=*/dim);
   }
   auto* thc_state = at::globalContext().lazyInitCUDA();
   for (size_t chunk = 0; chunk < chunks.size(); ++chunk) {

--- a/torch/csrc/cuda/comm.h
+++ b/torch/csrc/cuda/comm.h
@@ -1,7 +1,12 @@
-#include "torch/csrc/assertions.h"
+#pragma once
+
+#include <THC/THC.h>
 
 #include <ATen/ATen.h>
-#include <unordered_map>
+#include <ATen/optional.h>
+
+#include <cstddef>
+#include <vector>
 
 namespace torch { namespace cuda {
 
@@ -11,4 +16,15 @@ std::vector<at::Tensor> broadcast(const at::Tensor& tensor, at::IntList devices)
 tensor_list2d broadcast_coalesced(at::TensorList tensors, at::IntList devices,
                                   size_t buffer_size);
 
+std::vector<at::Tensor> scatter(
+    const at::Tensor& tensor,
+    at::IntList devices,
+    const at::optional<std::vector<int64_t>>& chunk_sizes = at::nullopt,
+    int64_t dim = 0,
+    const at::optional<std::vector<THCStream*>>& streams = at::nullopt);
+
+at::Tensor gather(
+    at::TensorList tensors,
+    int64_t dim,
+    at::optional<int32_t> destination_index);
 }}

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -32,6 +32,7 @@ void initCommMethods(PyObject *module) {
        py::handle handle = *py_streams;
        streams = THPUtils_PySequence_to_THCStreamList(handle.ptr());
      }
+     // Note: We're holding the GIL up to here.
      AutoNoGIL no_gil;
      return scatter(tensor, devices, chunk_sizes, dim, streams);
    },
@@ -39,8 +40,7 @@ void initCommMethods(PyObject *module) {
    py::arg("devices"),
    py::arg("chunk_sizes"),
    py::arg("dim"),
-   py::arg("streams"),
-   py::call_guard<py::gil_scoped_release>())
+   py::arg("streams"))
    .def("_gather", [](
      std::vector<at::Tensor>& tensors,
      int64_t dim,

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -1,10 +1,16 @@
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/cuda/comm.h"
+#include "torch/csrc/cuda/Stream.h"
+#include "torch/csrc/cuda/THCP.h"
 
-#include <chrono>
+#include <ATen/ATen.h>
+
+#include <THC/THC.h>
+
+#include <cstddef>
+#include <vector>
 
 namespace torch { namespace cuda { namespace python {
-
 void initCommMethods(PyObject *module) {
   auto m = py::cast<py::module>(module);
   m.def("_broadcast_coalesced", [](std::vector<at::Tensor>& tensors, std::vector<int64_t> devices, size_t buffer_size) {
@@ -13,7 +19,35 @@ void initCommMethods(PyObject *module) {
       py::call_guard<py::gil_scoped_release>())
    .def("_broadcast", [](at::Tensor& tensor, std::vector<int64_t> devices) {
      return broadcast(tensor, devices);
-   }, py::call_guard<py::gil_scoped_release>());
+   }, py::call_guard<py::gil_scoped_release>())
+   .def("_scatter", [](
+     at::Tensor& tensor,
+     std::vector<int64_t>& devices,
+     at::optional<std::vector<int64_t>> chunk_sizes,
+     int64_t dim,
+     at::optional<py::object> py_streams) {
+     at::optional<std::vector<THCStream*>> streams;
+     if (py_streams) {
+       py::handle handle = *py_streams;
+       streams = THPUtils_PySequence_to_THCStreamList(handle.ptr());
+     }
+     return scatter(tensor, devices, chunk_sizes, dim, streams);
+   },
+   py::arg("tensor"),
+   py::arg("devices"),
+   py::arg("chunk_sizes"),
+   py::arg("dim"),
+   py::arg("streams"),
+   py::call_guard<py::gil_scoped_release>())
+   .def("_gather", [](
+     std::vector<at::Tensor>& tensors,
+     int64_t dim,
+     at::optional<int32_t> destination_index) {
+     return gather(tensors, dim, destination_index);
+   },
+   py::arg("tensors"),
+   py::arg("dim"),
+   py::arg("destination_index"),
+   py::call_guard<py::gil_scoped_release>());
 }
-
 }}}

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -2,6 +2,7 @@
 #include "torch/csrc/cuda/comm.h"
 #include "torch/csrc/cuda/Stream.h"
 #include "torch/csrc/cuda/THCP.h"
+#include "torch/csrc/utils/auto_gil.h"
 
 #include <ATen/ATen.h>
 
@@ -31,6 +32,7 @@ void initCommMethods(PyObject *module) {
        py::handle handle = *py_streams;
        streams = THPUtils_PySequence_to_THCStreamList(handle.ptr());
      }
+     AutoNoGIL no_gil;
      return scatter(tensor, devices, chunk_sizes, dim, streams);
    },
    py::arg("tensor"),

--- a/torch/lib/c10d/private/CUDAUtils.hpp
+++ b/torch/lib/c10d/private/CUDAUtils.hpp
@@ -7,7 +7,7 @@
 #include <cuda_runtime.h>
 
 #include <ATen/ATen.h>
-#include <THCStream.h>
+#include <THC/THCStream.h>
 
 #include "../CUDAUtils.hpp"
 


### PR DESCRIPTION
As I try to replicate DP in C++, I need to move some functions into C++ from Python. This PR ports the scatter and gather primitives from Python in torch/cuda/comm.py to C++ in torch/csrc/cuda/comm.cpp. The basic infrastructure was already there, since @apaszke had rewritten broadcast in C++ already.

I'm not very familiar with this code, so let me know if I'm doing something wrong. I largely just literally translated the code.

I don't know how "public" `torch.cuda.comm` is, but I feel like the `destination_index` parameter for `gather` should be changed from -1 indicating CPU to `None` indicating CPU, and `-1` indicating the default CUDA device. That would make the code clearer IMO.

@apaszke @colesbury @teng-li @pietern 