### PR TITLE
Removing extraneous main function to fix buck test detection

### DIFF
--- a/caffe2/core/dispatch/OpSchema_test.cpp
+++ b/caffe2/core/dispatch/OpSchema_test.cpp
@@ -22,8 +22,3 @@ static_assert(6 == OpSchema<SchemaDef>::signature::num_args, "test num_dispatch_
 static_assert(3 == OpSchema<SchemaDef>::signature::num_tensor_args, "test num_dispatch_args");
 static_assert(std::is_same<bool, typename OpSchema<SchemaDef>::signature::return_type>::value, "test num_dispatch_args");
 static_assert(std::is_same<guts::typelist::typelist<int, Tensor<CPUContext>, float, Tensor<CPUContext>, Tensor<CPUContext>, unsigned int>, typename OpSchema<SchemaDef>::signature::parameter_types>::value, "test num_dispatch_args");
-
-int main() {
-  return 0;
-}
-


### PR DESCRIPTION
Summary: This main function causes 'buck test caffe2_test_cpu' to run 0 tests

Differential Revision: D8719343
