### PR TITLE
Move easy THCStorage functions out of generic

### DIFF
--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -17,17 +17,16 @@
 void THStorage_free(THStorage *storage) {
   AT_ASSERT(storage->backend == at::kCPU);
 
-  if(!storage)
+  if (!storage) {
     return;
+  }
 
-  if((storage->flag & TH_STORAGE_REFCOUNTED) && (storage->refcount.load() > 0))
-  {
-    if(--storage->refcount == 0)
-    {
-      if(storage->flag & TH_STORAGE_FREEMEM) {
+  if ((storage->flag & TH_STORAGE_REFCOUNTED) && (storage->refcount.load() > 0)) {
+    if (--storage->refcount == 0) {
+      if (storage->flag & TH_STORAGE_FREEMEM) {
         static_cast<THAllocator*>(storage->allocatorVoidPtr)->free(storage->allocatorContext, storage->data_ptr);
       }
-      if(storage->flag & TH_STORAGE_VIEW) {
+      if (storage->flag & TH_STORAGE_VIEW) {
         THStorage_free(storage->view);
       }
       storage->refcount.~atomic<int>();
@@ -115,8 +114,9 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
                                                   &THMapAllocator,
                                                   ctx);
 
-  if(size <= 0)
+  if (size <= 0) {
     storage->size = THMapAllocatorContext_size(ctx)/THStorage_elementSize(storage);
+  }
 
   THStorage_clearFlag(storage, TH_STORAGE_RESIZABLE);
 
@@ -135,8 +135,9 @@ void THStorage_clearFlag(THStorage *storage, const char flag)
 
 void THStorage_retain(THStorage *storage)
 {
-  if(storage && (storage->flag & TH_STORAGE_REFCOUNTED))
+  if (storage && (storage->flag & TH_STORAGE_REFCOUNTED)) {
     ++storage->refcount;
+  }
 }
 
 int THStorage_retainIfLive(THStorage *storage)
@@ -181,9 +182,9 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 
   auto* th_allocator = static_cast<THAllocator*>(storage->allocatorVoidPtr);
 
-  if(storage->flag & TH_STORAGE_RESIZABLE)
+  if (storage->flag & TH_STORAGE_RESIZABLE)
   {
-    if(th_allocator->realloc == nullptr) {
+    if (th_allocator->realloc == nullptr) {
       /* case when the allocator does not have a realloc defined */
       void *old_data = storage->data_ptr;
       ptrdiff_t old_size = storage->size;
@@ -219,15 +220,7 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 
 void THStorage_swap(THStorage *storage1, THStorage *storage2)
 {
-#define SWAP(val) { val = storage1->val; storage1->val = storage2->val; storage2->val = val; }
-    void *data_ptr;
-    ptrdiff_t size;
-    char flag;
-    void *allocatorVoidPtr;
-    void *allocatorContext;
-    struct THStorage *view;
-    int device;
-
+#define SWAP(val) { std::swap(storage1->val, storage2->val); }
     SWAP(data_ptr);
     SWAP(size);
     SWAP(flag);

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -96,3 +96,145 @@ THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size
   storage->device = INT_MIN;  // device is not meaningful on CPU
   return storage;
 }
+
+ptrdiff_t THStorage_size(const THStorage *self)
+{
+  return self->size;
+}
+
+size_t THStorage_elementSize(const THStorage *self)
+{
+  return at::elementSize(self->scalar_type);
+}
+
+THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *filename, ptrdiff_t size, int flags)
+{
+  THMapAllocatorContext *ctx = THMapAllocatorContext_new(filename, flags);
+
+  THStorage *storage = THStorage_newWithAllocator(scalar_type, size,
+                                                  &THMapAllocator,
+                                                  ctx);
+
+  if(size <= 0)
+    storage->size = THMapAllocatorContext_size(ctx)/THStorage_elementSize(storage);
+
+  THStorage_clearFlag(storage, TH_STORAGE_RESIZABLE);
+
+  return storage;
+}
+
+void THStorage_setFlag(THStorage *storage, const char flag)
+{
+  storage->flag |= flag;
+}
+
+void THStorage_clearFlag(THStorage *storage, const char flag)
+{
+  storage->flag &= ~flag;
+}
+
+void THStorage_retain(THStorage *storage)
+{
+  if(storage && (storage->flag & TH_STORAGE_REFCOUNTED))
+    ++storage->refcount;
+}
+
+int THStorage_retainIfLive(THStorage *storage)
+{
+  // TODO: Check if TH_STORAGE_REFCOUNTED?
+  int refcount = storage->refcount.load();
+  while (refcount > 0) {
+    if (storage->refcount.compare_exchange_strong(refcount, refcount + 1)) {
+      return 1;
+    }
+    refcount = storage->refcount.load();
+  }
+  return 0;
+}
+
+THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size)
+{
+  return THStorage_newWithDataAndAllocator(scalar_type, data, size,
+                                           &THDefaultAllocator, NULL);
+}
+
+THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
+                                             void* data, ptrdiff_t size,
+                                             THAllocator* allocator,
+                                             void* allocatorContext) {
+  THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
+  storage->backend = at::kCPU;
+  storage->scalar_type = scalar_type;
+  storage->data_ptr = data;
+  storage->size = size;
+  storage->refcount = 1;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
+  storage->allocatorVoidPtr = allocator;
+  storage->allocatorContext = allocatorContext;
+  storage->device = 0;
+  return storage;
+}
+
+void THStorage_resize(THStorage *storage, ptrdiff_t size)
+{
+  AT_ASSERT(storage->backend == at::kCPU);
+
+  auto* th_allocator = static_cast<THAllocator*>(storage->allocatorVoidPtr);
+
+  if(storage->flag & TH_STORAGE_RESIZABLE)
+  {
+    if(th_allocator->realloc == nullptr) {
+      /* case when the allocator does not have a realloc defined */
+      void *old_data = storage->data_ptr;
+      ptrdiff_t old_size = storage->size;
+      if (size == 0) {
+        storage->data_ptr = nullptr;
+      } else {
+        storage->data_ptr = th_allocator->malloc(
+            storage->allocatorContext,
+            at::elementSize(storage->scalar_type)*size);
+      }
+      storage->size = size;
+      if (old_data != nullptr) {
+        ptrdiff_t copy_size = old_size;
+        if (storage->size < copy_size) {
+          copy_size = storage->size;
+        }
+        if (copy_size > 0) {
+          memcpy(storage->data_ptr, old_data, at::elementSize(storage->scalar_type)*copy_size);
+        }
+        th_allocator->free(storage->allocatorContext, old_data);
+      }
+    } else {
+      storage->data_ptr = th_allocator->realloc(
+              storage->allocatorContext,
+              storage->data_ptr,
+              at::elementSize(storage->scalar_type)*size);
+      storage->size = size;
+    }
+  } else {
+    THError("Trying to resize storage that is not resizable");
+  }
+}
+
+void THStorage_swap(THStorage *storage1, THStorage *storage2)
+{
+#define SWAP(val) { val = storage1->val; storage1->val = storage2->val; storage2->val = val; }
+    void *data_ptr;
+    ptrdiff_t size;
+    char flag;
+    void *allocatorVoidPtr;
+    void *allocatorContext;
+    struct THStorage *view;
+    int device;
+
+    SWAP(data_ptr);
+    SWAP(size);
+    SWAP(flag);
+    // don't swap refcount!
+    SWAP(allocatorVoidPtr);
+    SWAP(allocatorContext);
+    SWAP(view);
+    SWAP(device);
+#undef SWAP
+}

--- a/aten/src/TH/THStorage.h
+++ b/aten/src/TH/THStorage.h
@@ -1,5 +1,4 @@
-#ifndef TH_STORAGE_INC
-#define TH_STORAGE_INC
+#pragma once
 
 #include "THGeneral.h"
 #include "THAllocator.h"
@@ -23,5 +22,3 @@ TH_API void THStorage_free(THStorage *storage);
 
 TH_API THDescBuff THLongStorage_sizeDesc(const THLongStorage *size);
 TH_API THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElement);
-
-#endif

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -44,3 +44,18 @@ TH_API THStorage* THStorage_newWithSize(at::ScalarType scalar_type, ptrdiff_t si
 TH_API THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size,
                                              THAllocator *allocator,
                                              void *allocatorContext);
+
+ptrdiff_t THStorage_size(const THStorage *self);
+size_t THStorage_elementSize();
+THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *filename, ptrdiff_t size, int flags);
+void THStorage_setFlag(THStorage *storage, const char flag);
+void THStorage_clearFlag(THStorage *storage, const char flag);
+void THStorage_retain(THStorage *storage);
+int THStorage_retainIfLive(THStorage *storage);
+THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
+THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
+                                             void* data, ptrdiff_t size,
+                                             THAllocator* allocator,
+                                             void* allocatorContext);
+void THStorage_resize(THStorage *storage, ptrdiff_t size);
+void THStorage_swap(THStorage *storage1, THStorage *storage2);

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -11,7 +11,7 @@ real* THStorage_(data)(const THStorage *self)
 
 ptrdiff_t THStorage_(size)(const THStorage *self)
 {
-  return self->size;
+  return THStorage_size(self);
 }
 
 size_t THStorage_(elementSize)()
@@ -39,18 +39,7 @@ THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
 
 THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int flags)
 {
-  THMapAllocatorContext *ctx = THMapAllocatorContext_new(filename, flags);
-
-  THStorage *storage = THStorage_(newWithAllocator)(size,
-                                                    &THMapAllocator,
-                                                    ctx);
-
-  if(size <= 0)
-    storage->size = THMapAllocatorContext_size(ctx)/sizeof(real);
-
-  THStorage_(clearFlag)(storage, TH_STORAGE_RESIZABLE);
-
-  return storage;
+  return THStorage_newWithMapping(at::CTypeToScalarType<th::from_type<real>>::to(), filename, size, flags);
 }
 
 THStorage* THStorage_(newWithSize1)(real data0)
@@ -93,31 +82,22 @@ THStorage* THStorage_(newWithSize4)(real data0, real data1, real data2, real dat
 
 void THStorage_(setFlag)(THStorage *storage, const char flag)
 {
-  storage->flag |= flag;
+  THStorage_setFlag(storage, flag);
 }
 
 void THStorage_(clearFlag)(THStorage *storage, const char flag)
 {
-  storage->flag &= ~flag;
+  THStorage_clearFlag(storage, flag);
 }
 
 void THStorage_(retain)(THStorage *storage)
 {
-  if(storage && (storage->flag & TH_STORAGE_REFCOUNTED))
-    ++storage->refcount;
+  THStorage_retain(storage);
 }
 
 int THStorage_(retainIfLive)(THStorage *storage)
 {
-  // TODO: Check if TH_STORAGE_REFCOUNTED?
-  int refcount = storage->refcount.load();
-  while (refcount > 0) {
-    if (storage->refcount.compare_exchange_strong(refcount, refcount + 1)) {
-      return 1;
-    }
-    refcount = storage->refcount.load();
-  }
-  return 0;
+  return THStorage_retainIfLive(storage);
 }
 
 void THStorage_(free)(THStorage *storage)
@@ -127,66 +107,18 @@ void THStorage_(free)(THStorage *storage)
 
 THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 {
-  return THStorage_(newWithDataAndAllocator)(data, size,
-                                             &THDefaultAllocator, NULL);
+  return THStorage_newWithData(at::CTypeToScalarType<th::from_type<real>>::to(), data, size);
 }
 
 THStorage* THStorage_(newWithDataAndAllocator)(real* data, ptrdiff_t size,
                                                THAllocator* allocator,
                                                void* allocatorContext) {
-  THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
-  storage->backend = at::kCPU;
-  storage->scalar_type = at::CTypeToScalarType<th::from_type<real>>::to();
-  storage->data_ptr = data;
-  storage->size = size;
-  storage->refcount = 1;
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
-  storage->device = 0;
-  return storage;
+  return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), data, size, allocator, allocatorContext);
 }
 
 void THStorage_(resize)(THStorage *storage, ptrdiff_t size)
 {
-  AT_ASSERT(storage->backend == at::kCPU);
-
-  auto* th_allocator = static_cast<THAllocator*>(storage->allocatorVoidPtr);
-
-  if(storage->flag & TH_STORAGE_RESIZABLE)
-  {
-    if(th_allocator->realloc == NULL) {
-      /* case when the allocator does not have a realloc defined */
-      real *old_data = THStorage_(data)(storage);
-      ptrdiff_t old_size = storage->size;
-      if (size == 0) {
-        storage->data_ptr = NULL;
-      } else {
-        storage->data_ptr = th_allocator->malloc(
-            storage->allocatorContext,
-            sizeof(real)*size);
-      }
-      storage->size = size;
-      if (old_data != NULL) {
-        ptrdiff_t copy_size = old_size;
-        if (storage->size < copy_size) {
-          copy_size = storage->size;
-        }
-        if (copy_size > 0) {
-          memcpy(THStorage_(data)(storage), old_data, sizeof(real)*copy_size);
-        }
-        th_allocator->free(storage->allocatorContext, old_data);
-      }
-    } else {
-      storage->data_ptr = th_allocator->realloc(
-              storage->allocatorContext,
-              THStorage_(data)(storage),
-              sizeof(real)*size);
-      storage->size = size;
-    }
-  } else {
-    THError("Trying to resize storage that is not resizable");
-  }
+  return THStorage_resize(storage, size);
 }
 
 void THStorage_(fill)(THStorage *storage, real value)
@@ -210,24 +142,7 @@ real THStorage_(get)(const THStorage *self, ptrdiff_t idx)
 
 void THStorage_(swap)(THStorage *storage1, THStorage *storage2)
 {
-#define SWAP(val) { val = storage1->val; storage1->val = storage2->val; storage2->val = val; }
-    void *data_ptr;
-    ptrdiff_t size;
-    char flag;
-    void *allocatorVoidPtr;
-    void *allocatorContext;
-    struct THStorage *view;
-    int device;
-
-    SWAP(data_ptr);
-    SWAP(size);
-    SWAP(flag);
-    // don't swap refcount!
-    SWAP(allocatorVoidPtr);
-    SWAP(allocatorContext);
-    SWAP(view);
-    SWAP(device);
-#undef SWAP
+  THStorage_swap(storage1, storage2);
 }
 
 #endif

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -33,3 +33,8 @@ THC_API void THCStorage_free(THCState *state, THCStorage *self);
 
 THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
+
+THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
+THC_API THCStorage* THCStorage_newWithDataAndAllocator(
+  THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size,
+  THCDeviceAllocator *allocator, void *allocatorContext);

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -187,7 +187,7 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
     if(storage)
     {
       self->storage = storage;
-      THCStorage_retain(state, self->storage);
+      THStorage_retain(self->storage);
     }
     else
       self->storage = THCStorage_new(state, scalar_type);

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -9,7 +9,7 @@ real* THCStorage_(data)(THCState *state, const THCStorage *self)
 
 ptrdiff_t THCStorage_(size)(THCState *state, const THCStorage *self)
 {
-  return self->size;
+  return THStorage_size(self);
 }
 
 int THCStorage_(elementSize)(THCState *state)
@@ -98,62 +98,33 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
 
 THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size)
 {
-  return THCStorage_(newWithDataAndAllocator)(state, data, size,
-                                              state->cudaDeviceAllocator,
-                                              state->cudaDeviceAllocator->state);
+  return THCStorage_newWithData(state, at::CTypeToScalarType<real>::to(), data, size);
 }
 
 THCStorage* THCStorage_(newWithDataAndAllocator)(
   THCState *state, real *data, ptrdiff_t size,
   THCDeviceAllocator *allocator, void *allocatorContext) {
-  THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
-  memset(storage, 0, sizeof(THCStorage));
-  storage->backend = at::kCUDA;
-  storage->scalar_type = at::CTypeToScalarType<real>::to();
-  storage->data_ptr = data;
-  storage->size = size;
-  storage->refcount = 1;
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
-  int device;
-  if (data) {
-    struct cudaPointerAttributes attr;
-    THCudaCheck(cudaPointerGetAttributes(&attr, data));
-    device = attr.device;
-  } else {
-    THCudaCheck(cudaGetDevice(&device));
-  }
-  storage->device = device;
-  return storage;
+  return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), data, size, allocator, allocatorContext);
 }
 
 void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag)
 {
-  storage->flag |= flag;
+  THStorage_setFlag(storage, flag);
 }
 
 void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag)
 {
-  storage->flag &= ~flag;
+  THStorage_clearFlag(storage, flag);
 }
 
 void THCStorage_(retain)(THCState *state, THCStorage *self)
 {
-  THCStorage_retain(state, self);
+  THStorage_retain(self);
 }
 
 int THCStorage_(retainIfLive)(THCState *state, THCStorage *storage)
 {
-  // TODO: Check if THC_STORAGE_REFCOUNTED?
-  int refcount = storage->refcount.load();
-  while (refcount > 0) {
-    if (storage->refcount.compare_exchange_strong(refcount, refcount + 1)) {
-      return 1;
-    }
-    refcount = storage->refcount.load();
-  }
-  return 0;
+  return THStorage_retainIfLive(storage);
 }
 
 void THCStorage_(free)(THCState *state, THCStorage *self)


### PR DESCRIPTION
Some functions are exactly implemented in THStorage_; in that case,
we called those functions directly.

Stacked on #9135