### PR TITLE
Add some missing error checks in sparse.

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -62,9 +62,9 @@ void SparseTensorImpl::set_indices_and_values(const Tensor& indices, const Tenso
   // dimensions at the moment
   bool empty = values.numel() == 0;
   AT_CHECK(values.type().toSparse() == type(), "values type must match sparse tensor type");
-  AT_CHECK(indices.type().scalarType() == kLong);
-  AT_CHECK(indices.type().backend() == values.type().backend());
-  AT_CHECK(!indices.is_cuda() || indices.get_device() == values.get_device());
+  AT_CHECK(indices.type().scalarType() == kLong, "indices must be an int64 tensor");
+  AT_CHECK(indices.type().backend() == values.type().backend(), "backend of indices (", indices.type().backend(), ") must match backend of values (", values.type().backend(), ")");
+  AT_CHECK(!indices.is_cuda() || indices.get_device() == values.get_device(), "device of indices (", indices.get_device(), ") must match device of values (", values.get_device(), ")");
   if (!empty) {
     AT_CHECK(indices.dim() == 2, "indices must be nDim x nnz");
     AT_CHECK(indices.size(1) == values.size(0), "indices and values must have same nnz");

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -330,6 +330,9 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
   AT_CHECK(mask.is_coalesced(), "sparse_mask: mask is uncoalesced");
   AT_CHECK(mask.sizes().equals(t.sizes()), "sparse_mask: operands have incompatible sizes; self has size ",
       t.sizes(), " but mask has size ", mask.sizes());
+  AT_ASSERT(!t.is_cuda()); // we were supposed to have dispatched on this
+  AT_CHECK(!r.is_cuda(), "sparse_mask: expected 'out' to be CPU, but got CUDA");
+  AT_CHECK(!mask.is_cuda(), "sparse_mask: expected 'mask' to be CPU, but got CUDA");
   resize_as_sparse_(r, mask);
   if (mask._nnz() == 0) {
     r.zero_();

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
@@ -9,6 +9,9 @@ SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const Spars
   AT_CHECK(mask.is_coalesced(), "sparse_mask: mask is uncoalesced");
   AT_CHECK(mask.sizes().equals(t.sizes()), "sparse_mask: operands have incompatible sizes; self has size ",
       t.sizes(), " but mask has size ", mask.sizes());
+  AT_ASSERT(t.is_cuda()); // dispatch argument
+  AT_CHECK(mask.is_cuda(), "sparse_mask: expected 'mask' to be CUDA, but got CPU");
+  AT_CHECK(r.is_cuda(), "sparse_mask: expected 'out' to be CUDA, but got CPU");
   AT_CHECK(_check_device({r, t, mask}),
       "sparse_mask: arguments are located on different devices; self is on device ", t.get_device(),
       ", mask is on device ", mask.get_device(), ", out is on device ", r.get_device());

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -268,7 +268,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorR
     r_.resize_as_(dense);
     r_.copy_(dense);
   } else {
-    AT_CHECK(r_.is_contiguous(), "add: CUDA dense-sparse addition does not work; shout if you need it");
+    AT_CHECK(r_.is_contiguous(), "add: CUDA dense-sparse addition with a non-contiguous output tensor does not work; shout if you need it (see https://github.com/pytorch/pytorch/issues/1521 )");
     r = r_.contiguous();
   }
 

--- a/test/expect/TestCudaSparse.test_add_dense_sparse_mismatch.expect
+++ b/test/expect/TestCudaSparse.test_add_dense_sparse_mismatch.expect
@@ -1,0 +1,1 @@
+add: expected 'self' and 'other' to have same size, but self has size [3, 4] while other has size [3, 4, 4] (FYI: dense-sparse addition does not currently support broadcasting)

--- a/test/expect/TestCudaSparse.test_log1p-backward.expect
+++ b/test/expect/TestCudaSparse.test_log1p-backward.expect
@@ -1,0 +1,1 @@
+log1p of a sparse tensor is made to be non-differentiable since local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. Use a different mathematical operation which preserves sparsity of gradients, or report a bug if you think this is an error.

--- a/test/expect/TestCudaSparse.test_log1p-uncoalesced.expect
+++ b/test/expect/TestCudaSparse.test_log1p-uncoalesced.expect
@@ -1,0 +1,1 @@
+log1p: in-place on uncoalesced tensors is not supported yet!

--- a/test/expect/TestCudaUncoalescedSparse.test_add_dense_sparse_mismatch.expect
+++ b/test/expect/TestCudaUncoalescedSparse.test_add_dense_sparse_mismatch.expect
@@ -1,0 +1,1 @@
+add: expected 'self' and 'other' to have same size, but self has size [3, 4] while other has size [3, 4, 4] (FYI: dense-sparse addition does not currently support broadcasting)

--- a/test/expect/TestCudaUncoalescedSparse.test_log1p-backward.expect
+++ b/test/expect/TestCudaUncoalescedSparse.test_log1p-backward.expect
@@ -1,0 +1,1 @@
+log1p of a sparse tensor is made to be non-differentiable since local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. Use a different mathematical operation which preserves sparsity of gradients, or report a bug if you think this is an error.

--- a/test/expect/TestCudaUncoalescedSparse.test_log1p-uncoalesced.expect
+++ b/test/expect/TestCudaUncoalescedSparse.test_log1p-uncoalesced.expect
@@ -1,0 +1,1 @@
+log1p: in-place on uncoalesced tensors is not supported yet!

--- a/test/expect/TestSparse.test_add_dense_sparse_mismatch.expect
+++ b/test/expect/TestSparse.test_add_dense_sparse_mismatch.expect
@@ -1,0 +1,1 @@
+add: expected 'self' and 'other' to have same size, but self has size [3, 4] while other has size [3, 4, 4] (FYI: dense-sparse addition does not currently support broadcasting)

--- a/test/expect/TestSparse.test_log1p-backward.expect
+++ b/test/expect/TestSparse.test_log1p-backward.expect
@@ -1,0 +1,1 @@
+log1p of a sparse tensor is made to be non-differentiable since local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. Use a different mathematical operation which preserves sparsity of gradients, or report a bug if you think this is an error.

--- a/test/expect/TestSparse.test_log1p-uncoalesced.expect
+++ b/test/expect/TestSparse.test_log1p-uncoalesced.expect
@@ -1,0 +1,1 @@
+log1p: in-place on uncoalesced tensors is not supported yet!

--- a/test/expect/TestSparseOneOff.test_cuda_from_cpu.expect
+++ b/test/expect/TestSparseOneOff.test_cuda_from_cpu.expect
@@ -1,0 +1,1 @@
+backend of indices (CUDA) must match backend of values (CPU)

--- a/test/expect/TestSparseOneOff.test_cuda_sparse_cpu_dense_add.expect
+++ b/test/expect/TestSparseOneOff.test_cuda_sparse_cpu_dense_add.expect
@@ -1,0 +1,1 @@
+add: expected 'other' to be a CPU tensor, but got a CUDA tensor

--- a/test/expect/TestUncoalescedSparse.test_add_dense_sparse_mismatch.expect
+++ b/test/expect/TestUncoalescedSparse.test_add_dense_sparse_mismatch.expect
@@ -1,0 +1,1 @@
+add: expected 'self' and 'other' to have same size, but self has size [3, 4] while other has size [3, 4, 4] (FYI: dense-sparse addition does not currently support broadcasting)

--- a/test/expect/TestUncoalescedSparse.test_log1p-backward.expect
+++ b/test/expect/TestUncoalescedSparse.test_log1p-backward.expect
@@ -1,0 +1,1 @@
+log1p of a sparse tensor is made to be non-differentiable since local gradient of zero is 1 / (0 + 1) = 1 and it makes the tensor dense. Use a different mathematical operation which preserves sparsity of gradients, or report a bug if you think this is an error.

--- a/test/expect/TestUncoalescedSparse.test_log1p-uncoalesced.expect
+++ b/test/expect/TestUncoalescedSparse.test_log1p-uncoalesced.expect
@@ -1,0 +1,1 @@
+log1p: in-place on uncoalesced tensors is not supported yet!

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1089,15 +1089,18 @@ class TestCudaUncoalescedSparse(TestCudaSparse):
 class TestSparseOneOff(TestCase):
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_cuda_from_cpu(self):
-        self.assertExpectedRaises(RuntimeError,
-            lambda: torch.sparse.FloatTensor(torch.zeros(1,4).long().cuda(),
-                                             torch.randn(4,4,4),
-                                             [3,4,4]))
+        self.assertExpectedRaises(
+            RuntimeError,
+            lambda: torch.sparse.FloatTensor(torch.zeros(1, 4).long().cuda(),
+                                             torch.randn(4, 4, 4),
+                                             [3, 4, 4]))
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_cuda_sparse_cpu_dense_add(self):
-        x = torch.zeros(3,4,4)
-        sparse_y = torch.cuda.sparse.FloatTensor(torch.zeros(1,4).long().cuda(), torch.randn(4,4,4).cuda(), [3,4,4])
+        x = torch.zeros(3, 4, 4)
+        sparse_y = torch.cuda.sparse.FloatTensor(torch.zeros(1, 4).long().cuda(),
+                                                 torch.randn(4, 4, 4).cuda(),
+                                                 [3, 4, 4])
         self.assertExpectedRaises(RuntimeError, lambda: x + sparse_y)
 
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -685,9 +685,7 @@ class TestSparse(TestCase):
         self.assertEqual(expected_output, input.coalesce().log1p_().to_dense())
 
         # test in-place op on uncoalesced input
-        with self.assertRaisesRegex(RuntimeError,
-                                    "in-place log1p on uncoalesced tensors is not supported yet!"):
-            input.log1p_()
+        self.assertExpectedRaises(RuntimeError, lambda: input.log1p_(), subname="uncoalesced")
 
         input.requires_grad_()
         self.assertTrue(input.requires_grad)
@@ -695,9 +693,7 @@ class TestSparse(TestCase):
         # test autograd
         x = input.clone()
         y = input.log1p()
-        with self.assertRaisesRegex(RuntimeError,
-                                    "log1p of a sparse tensor is made to be non-differentiable since.*"):
-            y.backward(x)
+        self.assertExpectedRaises(RuntimeError, lambda: y.backward(x), subname="backward")
 
         # test uncoalesced input
         input_uncoalesced = torch.sparse.DoubleTensor(


### PR DESCRIPTION
- There were missing error messages for AT_CHECK in SparseTensorImpl::set_indices_and_values
- We have to check that the backends of all our inputs line up,
  since native does not do it for us.
- Some math operations were missing shape tests.

Fixes #9110

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

