### PR TITLE
loss plugin: Fix indexing into a scalar

### DIFF
--- a/torch/utils/trainer/plugins/loss.py
+++ b/torch/utils/trainer/plugins/loss.py
@@ -5,4 +5,4 @@ class LossMonitor(Monitor):
     stat_name = 'loss'
 
     def _get_value(self, iteration, input, target, output, loss):
-        return loss[0]
+        return loss.item()


### PR DESCRIPTION
The loss plugin was using the old-style loss[0] access, which in PyTorch 0.4 and
later is an attempt to index into a scalar, generating a warning.
Replaced that with loss.item().

This fixes
https://github.com/pytorch/pytorch/issues/9142

