### PR TITLE
Modify arguments for random_

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3353,15 +3353,15 @@
         - arg: THGenerator* generator
           default: nullptr
           kwarg_only: True
-        - int64_t to
+        - int64_t max
     - cname: clampedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: nullptr
           kwarg_only: True
-        - int64_t from
-        - int64_t to
+        - int64_t min
+        - int64_t max
 ]]
 [[
   name: multinomial

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3353,15 +3353,15 @@
         - arg: THGenerator* generator
           default: nullptr
           kwarg_only: True
-        - int64_t max
+        - int64_t to
     - cname: clampedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: nullptr
           kwarg_only: True
-        - int64_t min
-        - int64_t max
+        - int64_t start
+        - int64_t to
 ]]
 [[
   name: multinomial

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -551,10 +551,10 @@
 - name: qr(Tensor self)
   self: not_implemented("qr")
 
-- name: random_(Tensor self, int64_t from, int64_t to, Generator generator)
+- name: random_(Tensor self, int64_t min, int64_t max, Generator generator)
   self: zeros_like(grad)
 
-- name: random_(Tensor self, int64_t to, Generator generator)
+- name: random_(Tensor self, int64_t max, Generator generator)
   self: zeros_like(grad)
 
 - name: random_(Tensor self, Generator generator)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -551,10 +551,10 @@
 - name: qr(Tensor self)
   self: not_implemented("qr")
 
-- name: random_(Tensor self, int64_t min, int64_t max, Generator generator)
+- name: random_(Tensor self, int64_t start, int64_t to, Generator generator)
   self: zeros_like(grad)
 
-- name: random_(Tensor self, int64_t max, Generator generator)
+- name: random_(Tensor self, int64_t to, Generator generator)
   self: zeros_like(grad)
 
 - name: random_(Tensor self, Generator generator)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1527,7 +1527,7 @@ See :func:`torch.qr`
 
 add_docstr_all('random_',
                r"""
-random_(from=0, to=None, *, generator=None) -> Tensor
+random_(min=0, max=None, *, generator=None) -> Tensor
 
 Fills :attr:`self` tensor with numbers sampled from the discrete uniform
 distribution over ``[from, to - 1]``. If not specified, the values are usually

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1527,10 +1527,10 @@ See :func:`torch.qr`
 
 add_docstr_all('random_',
                r"""
-random_(min=0, max=None, *, generator=None) -> Tensor
+random_(start=0, to=None, *, generator=None) -> Tensor
 
 Fills :attr:`self` tensor with numbers sampled from the discrete uniform
-distribution over ``[from, to - 1]``. If not specified, the values are usually
+distribution over ``[start, to - 1]``. If not specified, the values are usually
 only bounded by :attr:`self` tensor's data type. However, for floating point
 types, if unspecified, range will be ``[0, 2^mantissa]`` to ensure that every
 value is representable. For example, `torch.tensor(1, dtype=torch.double).random_()`


### PR DESCRIPTION
This fixes #4574 . Arguments have been changed from `from` and `to` to `min` and `max` respectively.