### PR TITLE
[C++ API] nn::Module::as

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -93,21 +93,32 @@ TEST_CASE("module/name") {
   }
 }
 
-TEST_CASE("module/is") {
+TEST_CASE("module/as") {
   Linear module(3, 4);
-  REQUIRE(module->is<Linear>());
-  REQUIRE(module->is<LinearImpl>());
-  REQUIRE(!module->is<AGIUnit>());
+  REQUIRE(module->as<Linear>() == module.get());
+  REQUIRE(module->as<LinearImpl>() == module.get());
+  REQUIRE(module->as<Module>() == module.get());
+  REQUIRE(module->as<AGIUnit>() == nullptr);
 
-  std::shared_ptr<Module> raw = module.get();
-  REQUIRE(raw->is<Linear>());
-  REQUIRE(raw->is<LinearImpl>());
-  REQUIRE(!raw->is<AGIUnit>());
+  std::shared_ptr<Module> raw = module.ptr();
+  REQUIRE(raw->as<Linear>() == module.get());
+  REQUIRE(raw->as<LinearImpl>() == module.get());
+  REQUIRE(raw->as<Module>() == module.get());
+  REQUIRE(raw->as<AGIUnit>() == nullptr);
+
+  Module& raw_ref = *raw.get();
+  REQUIRE(raw_ref.as<Linear>() == module.get());
+  REQUIRE(raw_ref.as<LinearImpl>() == module.get());
+  REQUIRE(raw_ref.as<Module>() == module.get());
+  REQUIRE(raw_ref.as<AGIUnit>() == nullptr);
+  if (auto* linear = raw_ref.as<Linear>()) {
+    REQUIRE(linear->weight.ndimension() == 2);
+  }
 
   AGIUnit unit;
-  REQUIRE(!unit.is<Linear>());
-  REQUIRE(!unit.is<LinearImpl>());
-  REQUIRE(unit.is<AGIUnit>());
+  REQUIRE(unit.as<Linear>() == nullptr);
+  REQUIRE(unit.as<LinearImpl>() == nullptr);
+  REQUIRE(unit.as<AGIUnit>() == &unit);
 }
 
 TEST_CASE("module/conversions", "[cuda]") {

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -224,23 +224,23 @@ TEST_CASE("sequential") {
     a.extend(b);
 
     REQUIRE(a.size() == 4);
-    REQUIRE(a[0]->is<A>());
-    REQUIRE(a[1]->is<B>());
-    REQUIRE(a[2]->is<C>());
-    REQUIRE(a[3]->is<D>());
+    REQUIRE(a[0]->as<A>());
+    REQUIRE(a[1]->as<B>());
+    REQUIRE(a[2]->as<C>());
+    REQUIRE(a[3]->as<D>());
 
     REQUIRE(b.size() == 2);
-    REQUIRE(b[0]->is<C>());
-    REQUIRE(b[1]->is<D>());
+    REQUIRE(b[0]->as<C>());
+    REQUIRE(b[1]->as<D>());
 
     std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
                                          std::make_shared<A>()};
     b.extend(c);
 
     REQUIRE(b.size() == 4);
-    REQUIRE(b[0]->is<C>());
-    REQUIRE(b[1]->is<D>());
-    REQUIRE(b[2]->is<A>());
-    REQUIRE(b[3]->is<A>());
+    REQUIRE(b[0]->as<C>());
+    REQUIRE(b[1]->as<D>());
+    REQUIRE(b[2]->as<A>());
+    REQUIRE(b[3]->as<A>());
   }
 }

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -96,71 +96,44 @@ class Module {
   /// Recursively zeros out the `grad` values of all parameters.
   virtual void zero_grad();
 
+  /// Serializes the `Module`.
   template <class Archive>
-  void save(Archive& ar) const {
-    auto params = parameters();
-    size_t size = params.size();
-    ar(size);
-    for (auto& p : params) {
-      ar(p.key, p.value);
-    }
-  }
+  void save(Archive& ar) const;
 
+  /// Deserializes the `Module`.
   template <class Archive>
-  void load(Archive& ar) {
-    auto params = parameters();
-    size_t size;
-    ar(size);
-    std::string name;
-    for (size_t i = 0; i < size; i++) {
-      ar(name);
-      ar(params[name]);
-    }
-  }
+  void load(Archive& ar);
 
-  /// Returns true if the dynamic type of this module is of the given
-  /// `ModuleType`. Performs a `dynamic_cast` to check this.
+  /// Attempts to cast this `Module` to the given `ModuleType`.
+  template <typename ModuleType>
+  typename ModuleType::ContainedType* as() noexcept;
+
+  /// Attempts to cast this `Module` to the given `ModuleType`.
   template <
       typename ModuleType,
       typename = torch::detail::disable_if_module_holder_t<ModuleType>>
-  bool is() const noexcept {
-    return dynamic_cast<const ModuleType*>(this) != nullptr;
-  }
-
-  /// Returns true if the dynamic type of this module is of the given
-  /// `ModuleType`. Performs a `dynamic_cast` to check this.
-  template <typename ModuleType>
-  torch::enable_if_t<torch::detail::is_module_holder<ModuleType>::value, bool>
-  is() const noexcept {
-    // Use the contained type of the `ModuleHolder`, e.g. `LinearImpl` for
-    // `Linear`, since `LinearImpl` inherits `nn::Module`.
-    return is<typename ModuleType::ContainedType>();
-  }
+  ModuleType* as() noexcept;
 
  protected:
+  /// Registers a parameter with this `Module`.
   Tensor& register_parameter(
       std::string name,
       Tensor tensor,
       bool requires_grad = true);
+  /// Registers a buffer with this `Module`.
   Tensor& register_buffer(std::string name, Tensor tensor);
 
-  template <
-      typename ModuleType,
-      typename = torch::detail::disable_if_module_holder_t<ModuleType>>
+  /// Registers a submodule with this `Module`.
+  template <typename ModuleType>
   std::shared_ptr<ModuleType> register_module(
       std::string name,
-      std::shared_ptr<ModuleType> module) {
-    auto& base_module = children_.insert(std::move(name), std::move(module));
-    return std::static_pointer_cast<ModuleType>(base_module);
-  }
+      std::shared_ptr<ModuleType> module);
 
-  template <typename ModuleHolderType>
-  ModuleHolderType register_module(
+  /// Registers a submodule with this `Module`.
+  template <typename ModuleType>
+  std::shared_ptr<ModuleType> register_module(
       std::string name,
-      ModuleHolderType module_holder) {
-    register_module(std::move(name), module_holder.get());
-    return module_holder;
-  }
+      ModuleHolder<ModuleType> module_holder);
 
  private:
   template <typename T>
@@ -173,22 +146,9 @@ class Module {
 
   virtual void clone_(Module& other);
 
-  /// The implementation of the various `to()`.
+  /// The implementation of the various `to()` methods.
   template <typename... Ts>
-  void to_impl(Ts&&... ts) {
-    // First call `to()` on every child module.
-    for (auto& child : children_) {
-      child.value->to(ts...);
-    }
-    // Then move every parameter to the new dtype/device.
-    for (auto& parameter : parameters_) {
-      at::detail::set_data(*parameter, parameter->data().to(ts...));
-    }
-    // Then move every buffer to the new dtype/device.
-    for (auto& buffer : buffers_) {
-      at::detail::set_data(*buffer, buffer->data().to(ts...));
-    }
-  }
+  void to_impl(Ts&&... ts);
 
   OrderedDict<Tensor> parameters_;
   OrderedDict<Tensor> buffers_;
@@ -200,5 +160,73 @@ class Module {
   /// Whether the module is in training mode.
   bool is_training_{true};
 };
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ nn::Module ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <class Archive>
+void Module::save(Archive& ar) const {
+  auto params = parameters();
+  size_t size = params.size();
+  ar(size);
+  for (auto& p : params) {
+    ar(p.key, p.value);
+  }
+}
+
+template <class Archive>
+void Module::load(Archive& ar) {
+  auto params = parameters();
+  size_t size;
+  ar(size);
+  std::string name;
+  for (size_t i = 0; i < size; i++) {
+    ar(name);
+    ar(params[name]);
+  }
+}
+
+template <typename ModuleType>
+typename ModuleType::ContainedType* Module::as() noexcept {
+  // Use the contained type of the `ModuleHolder`, e.g. `LinearImpl` for
+  // `Linear`, since `LinearImpl` inherits `nn::Module`.
+  return as<typename ModuleType::ContainedType>();
+}
+
+template <typename ModuleType, typename>
+ModuleType* Module::as() noexcept {
+  return dynamic_cast<ModuleType*>(this);
+}
+
+template <typename ModuleType>
+std::shared_ptr<ModuleType> Module::register_module(
+    std::string name,
+    std::shared_ptr<ModuleType> module) {
+  auto& base_module = children_.insert(std::move(name), std::move(module));
+  return std::static_pointer_cast<ModuleType>(base_module);
+}
+
+template <typename ModuleType>
+std::shared_ptr<ModuleType> Module::register_module(
+    std::string name,
+    ModuleHolder<ModuleType> module_holder) {
+  return register_module(std::move(name), module_holder.ptr());
+}
+
+template <typename... Ts>
+void Module::to_impl(Ts&&... ts) {
+  // First call `to()` on every child module.
+  for (auto& child : children_) {
+    child.value->to(ts...);
+  }
+  // Then move every parameter to the new dtype/device.
+  for (auto& parameter : parameters_) {
+    at::detail::set_data(*parameter, parameter->data().to(ts...));
+  }
+  // Then move every buffer to the new dtype/device.
+  for (auto& buffer : buffers_) {
+    at::detail::set_data(*buffer, buffer->data().to(ts...));
+  }
+}
+
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -313,7 +313,7 @@ AnyModule::AnyModule(ModuleType&& module)
 
 template <typename ModuleType>
 AnyModule::AnyModule(const ModuleHolder<ModuleType>& module_holder)
-    : AnyModule(module_holder.get()) {}
+    : AnyModule(module_holder.ptr()) {}
 
 template <typename ModuleType>
 AnyModule& AnyModule::operator=(std::shared_ptr<ModuleType> module) {

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -101,7 +101,7 @@ class Sequential : public Cloneable<Sequential> {
   /// `Sequential`.
   template <typename M>
   void push_back(const ModuleHolder<M>& module_holder) {
-    push_back(module_holder.get());
+    push_back(module_holder.ptr());
   }
 
   /// Adds a type-erased `AnyModule` to the `Sequential`.

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -54,7 +54,7 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 
   /// Constructs the `ModuleHolder` from a pointer to the contained type.
   /// Example: `Linear(std::make_shared<LinearImpl>(...))`.
-  explicit ModuleHolder(std::shared_ptr<Contained> module)
+  /* implicit */ ModuleHolder(std::shared_ptr<Contained> module)
       : impl_(std::move(module)) {}
 
   /// Returns true if the `ModuleHolder` contains a module, or false if it is
@@ -81,10 +81,22 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
     return (*impl_)(std::forward<Args>(args)...);
   }
 
-  /// Returns the underlying module.
-  const std::shared_ptr<Contained>& get() const {
+  /// Returns a shared pointer to the underlying module.
+  const std::shared_ptr<Contained>& ptr() const {
     AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
     return impl_;
+  }
+
+  /// Returns a pointer to the underlying module.
+  Contained* get() {
+    AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
+    return impl_.get();
+  }
+
+  /// Returns a pointer to the underlying module.
+  const Contained* get() const {
+    AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
+    return impl_.get();
   }
 
   /// Returns true if the `ModuleHolder` does not contain a module.
@@ -119,11 +131,6 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   class Name : public torch::nn::ModuleHolder<Impl> {  \
    public:                                             \
     using torch::nn::ModuleHolder<Impl>::ModuleHolder; \
-    using torch::nn::ModuleHolder<Impl>::operator->;   \
-    using torch::nn::ModuleHolder<Impl>::get;          \
-                                                       \
-   protected:                                          \
-    using torch::nn::ModuleHolder<Impl>::impl_;        \
   }
 
 /// Like `TORCH_MODULE_IMPL`, but defaults the `Impl` name to `<Name>Impl`.

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -28,14 +28,6 @@ struct RMSpropOptions {
 
 class RMSprop : public Optimizer {
  public:
-  RMSprop(std::shared_ptr<nn::Module> model, const RMSpropOptions& options);
-
-  template <typename ModuleType>
-  RMSprop(
-      nn::ModuleHolder<ModuleType> module_holder,
-      const RMSpropOptions& options)
-      : RMSprop(module_holder.get(), options) {}
-
   template <typename ParameterContainer>
   explicit RMSprop(
       ParameterContainer&& parameters,


### PR DESCRIPTION
Added a way to `dynamic_cast` an `nn::Module` and get a pointer to it. `nn::Module::is<T>` just checked if the return value of the `dynamic_cast` was nullptr, so I got rid of `is<T>` since it's equivalent to `as<T> != nullptr`(or just `as<T>` due to boolean conversion).

We're now at

```
if (auto* conv = module.as<nn::Conv2d>()) {
  conv->weight.data().normal_(0.0, 0.02);
} else if (auto* bn = module.as<nn::BatchNorm>()) {
  bn->weight.data().normal_(1.0, 0.02);
  bn->bias.data().fill_(0);
}
```

@ezyang @apaszke @ebetica 