### PR TITLE
[C++ API] Make Sequential ref-counted

### DIFF
--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -201,13 +201,6 @@ TEST_CASE("any-module") {
     REQUIRE(!any.is_empty());
     REQUIRE(any.forward(5.0f).get<int>() == 8);
   }
-  SECTION("has reference semantics") {
-    Sequential first(Linear(2, 3), Linear(4, 4), Linear(4, 5));
-    Sequential second(first);
-
-    REQUIRE(first.size() == second.size());
-    REQUIRE(std::equal(first.begin(), first.end(), second.begin()));
-  }
   SECTION("constructs from ModuleHolder") {
     struct MImpl : torch::nn::Module {
       explicit MImpl(int value_) : torch::nn::Module("M"), value(value_) {}

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -202,7 +202,7 @@ TEST_CASE("module/clone") {
         buffer = register_buffer("buf", torch::ones({2, 2}));
       }
 
-      Linear l1, l2, l3;
+      Linear l1{nullptr}, l2{nullptr}, l3{nullptr};
       torch::Tensor buffer;
     };
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -16,22 +16,20 @@ using namespace torch::nn;
 
 class TestModel : public torch::nn::Module {
  public:
-  TestModel() {
-    l1 = register_module("l1", Linear(10, 3));
-    l2 = register_module("l2", Linear(3, 5));
-    l3 = register_module("l3", Linear(5, 100));
-  }
+  TestModel()
+      : l1(register_module("l1", Linear(10, 3))),
+        l2(register_module("l2", Linear(3, 5))),
+        l3(register_module("l3", Linear(5, 100))) {}
 
   Linear l1, l2, l3;
 };
 
 class NestedModel : public torch::nn::Module {
  public:
-  NestedModel() {
-    l1 = register_module("l1", Linear(5, 20));
-    t = register_module("test", std::make_shared<TestModel>());
-    param_ = register_parameter("param", torch::empty({3, 2, 21}));
-  }
+  NestedModel()
+      : l1(register_module("l1", Linear(5, 20))),
+        t(register_module("test", std::make_shared<TestModel>())),
+        param_(register_parameter("param", torch::empty({3, 2, 21}))) {}
 
   torch::Tensor param_;
   Linear l1;

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -35,7 +35,7 @@ bool test_optimizer_xor(Options options) {
   const int64_t kBatchSize = 4;
   const int64_t kMaximumNumberOfEpochs = 3000;
 
-  auto optimizer = OptimizerClass(model.parameters(), options);
+  auto optimizer = OptimizerClass(model->parameters(), options);
 
   float running_loss = 1;
   int epoch = 0;
@@ -48,7 +48,7 @@ bool test_optimizer_xor(Options options) {
     }
     inputs.set_requires_grad(true);
     optimizer.zero_grad();
-    auto x = model.forward(inputs);
+    auto x = model->forward(inputs);
     torch::Tensor loss = torch::binary_cross_entropy(x, labels);
     loss.backward();
 
@@ -91,10 +91,10 @@ void check_exact_values(
       Linear(3, 1),
       Functional(torch::sigmoid));
 
-  model.to(torch::kFloat64);
+  model->to(torch::kFloat64);
 
   // Use exact input values because matching random values is hard.
-  auto parameters = model.parameters();
+  auto parameters = model->parameters();
   assign_parameter(
       parameters,
       "0.weight",
@@ -111,7 +111,7 @@ void check_exact_values(
 
   for (size_t i = 0; i < kIterations; ++i) {
     optimizer.zero_grad();
-    auto output = model.forward(input);
+    auto output = model->forward(input);
     auto loss = output.sum();
     loss.backward();
 

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -239,24 +239,24 @@ TEST_CASE("sequential") {
     a->extend(*b);
 
     REQUIRE(a->size() == 4);
-    REQUIRE(a[0]->is<A>());
-    REQUIRE(a[1]->is<B>());
-    REQUIRE(a[2]->is<C>());
-    REQUIRE(a[3]->is<D>());
+    REQUIRE(a[0]->as<A>());
+    REQUIRE(a[1]->as<B>());
+    REQUIRE(a[2]->as<C>());
+    REQUIRE(a[3]->as<D>());
 
     REQUIRE(b->size() == 2);
-    REQUIRE(b[0]->is<C>());
-    REQUIRE(b[1]->is<D>());
+    REQUIRE(b[0]->as<C>());
+    REQUIRE(b[1]->as<D>());
 
     std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
                                          std::make_shared<A>()};
     b->extend(c);
 
     REQUIRE(b->size() == 4);
-    REQUIRE(b[0]->is<C>());
-    REQUIRE(b[1]->is<D>());
-    REQUIRE(b[2]->is<A>());
-    REQUIRE(b[3]->is<A>());
+    REQUIRE(b[0]->as<C>());
+    REQUIRE(b[1]->as<D>());
+    REQUIRE(b[2]->as<A>());
+    REQUIRE(b[3]->as<A>());
   }
   SECTION("has reference semantics") {
     Sequential first(Linear(2, 3), Linear(4, 4), Linear(4, 5));

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -24,7 +24,7 @@ TEST_CASE("sequential") {
     };
     Sequential sequential(
         std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3));
-    REQUIRE(sequential.size() == 3);
+    REQUIRE(sequential->size() == 3);
   }
   SECTION("construction from concrete type") {
     struct M : torch::nn::Module {
@@ -36,7 +36,7 @@ TEST_CASE("sequential") {
     };
 
     Sequential sequential(M(1), M(2), M(3));
-    REQUIRE(sequential.size() == 3);
+    REQUIRE(sequential->size() == 3);
   }
   SECTION("construction from module holders") {
     struct MImpl : torch::nn::Module {
@@ -53,7 +53,7 @@ TEST_CASE("sequential") {
     };
 
     Sequential sequential(M(1), M(2), M(3));
-    REQUIRE(sequential.size() == 3);
+    REQUIRE(sequential->size() == 3);
   }
   SECTION("push_back") {
     struct M : torch::nn::Module {
@@ -64,14 +64,14 @@ TEST_CASE("sequential") {
       int value;
     };
     Sequential sequential;
-    REQUIRE(sequential.size() == 0);
-    REQUIRE(sequential.is_empty());
-    sequential.push_back(Linear(3, 4));
-    REQUIRE(sequential.size() == 1);
-    sequential.push_back(std::make_shared<M>(1));
-    REQUIRE(sequential.size() == 2);
-    sequential.push_back(M(2));
-    REQUIRE(sequential.size() == 3);
+    REQUIRE(sequential->size() == 0);
+    REQUIRE(sequential->is_empty());
+    sequential->push_back(Linear(3, 4));
+    REQUIRE(sequential->size() == 1);
+    sequential->push_back(std::make_shared<M>(1));
+    REQUIRE(sequential->size() == 2);
+    sequential->push_back(M(2));
+    REQUIRE(sequential->size() == 3);
   }
   SECTION("access") {
     struct M : torch::nn::Module {
@@ -86,22 +86,22 @@ TEST_CASE("sequential") {
 
     Sequential sequential;
     for (auto& module : modules) {
-      sequential.push_back(module);
+      sequential->push_back(module);
     }
-    REQUIRE(sequential.size() == 3);
+    REQUIRE(sequential->size() == 3);
 
     SECTION("at()") {
       SECTION("returns the correct module for a given index") {
         for (size_t i = 0; i < modules.size(); ++i) {
-          REQUIRE(&sequential.at<M>(i) == modules[i].get());
+          REQUIRE(&sequential->at<M>(i) == modules[i].get());
         }
       }
       SECTION("throws for a bad index") {
         REQUIRE_THROWS_WITH(
-            sequential.at<M>(modules.size() + 1),
+            sequential->at<M>(modules.size() + 1),
             StartsWith("Index out of range"));
         REQUIRE_THROWS_WITH(
-            sequential.at<M>(modules.size() + 1000000),
+            sequential->at<M>(modules.size() + 1000000),
             StartsWith("Index out of range"));
       }
     }
@@ -109,17 +109,17 @@ TEST_CASE("sequential") {
     SECTION("ptr()") {
       SECTION("returns the correct module for a given index") {
         for (size_t i = 0; i < modules.size(); ++i) {
-          REQUIRE(sequential.ptr(i).get() == modules[i].get());
+          REQUIRE(sequential->ptr(i).get() == modules[i].get());
           REQUIRE(sequential[i].get() == modules[i].get());
-          REQUIRE(sequential.ptr<M>(i).get() == modules[i].get());
+          REQUIRE(sequential->ptr<M>(i).get() == modules[i].get());
         }
       }
       SECTION("throws for a bad index") {
         REQUIRE_THROWS_WITH(
-            sequential.ptr(modules.size() + 1),
+            sequential->ptr(modules.size() + 1),
             StartsWith("Index out of range"));
         REQUIRE_THROWS_WITH(
-            sequential.ptr(modules.size() + 1000000),
+            sequential->ptr(modules.size() + 1000000),
             StartsWith("Index out of range"));
       }
     }
@@ -128,7 +128,7 @@ TEST_CASE("sequential") {
     SECTION("calling forward() on an empty sequential is disallowed") {
       Sequential empty;
       REQUIRE_THROWS_WITH(
-          empty.forward<int>(),
+          empty->forward<int>(),
           StartsWith("Cannot call forward() on an empty Sequential"));
     }
 
@@ -144,7 +144,7 @@ TEST_CASE("sequential") {
 
       Sequential sequential(MockModule{1}, MockModule{2}, MockModule{3});
 
-      REQUIRE(sequential.forward<int>(1) == 4);
+      REQUIRE(sequential->forward<int>(1) == 4);
     }
 
     SECTION("calling forward() with the wrong return type throws") {
@@ -155,9 +155,9 @@ TEST_CASE("sequential") {
       };
 
       Sequential sequential(M{});
-      REQUIRE(sequential.forward<int>() == 5);
+      REQUIRE(sequential->forward<int>() == 5);
       REQUIRE_THROWS_WITH(
-          sequential.forward<float>(),
+          sequential->forward<float>(),
           StartsWith("The type of the return value "
                      "is int, but you asked for type float"));
     }
@@ -171,7 +171,7 @@ TEST_CASE("sequential") {
 
       Sequential sequential(M{});
       auto variable = torch::ones({3, 3}, torch::requires_grad());
-      REQUIRE(sequential.forward(variable).equal(variable));
+      REQUIRE(sequential->forward(variable).equal(variable));
     }
   }
 
@@ -180,7 +180,7 @@ TEST_CASE("sequential") {
     Sequential sequential(Linear(10, 3), Linear(3, 5), Linear(5, 100));
 
     auto x = torch::randn({1000, 10}, torch::requires_grad());
-    auto y = sequential.forward(x);
+    auto y = sequential->forward(x);
     REQUIRE(y.ndimension() == 2);
     REQUIRE(y.size(0) == 1000);
     REQUIRE(y.size(1) == 100);
@@ -205,42 +205,71 @@ TEST_CASE("sequential") {
 
     Sequential sequential(M{});
     torch::Tensor variable = torch::ones(5);
-    REQUIRE(sequential.forward(variable).sum().toCFloat() == 5);
+    REQUIRE(sequential->forward(variable).sum().toCFloat() == 5);
 
     at::Tensor tensor_that_is_actually_a_variable = variable * 2;
     REQUIRE(
-        sequential.forward(tensor_that_is_actually_a_variable)
+        sequential->forward(tensor_that_is_actually_a_variable)
             .sum()
             .toCFloat() == 10);
   }
-
   SECTION("extend() pushes modules from other Sequential") {
-    struct A : torch::nn::Module { int forward(int x) { return x; } };
-    struct B : torch::nn::Module { int forward(int x) { return x; } };
-    struct C : torch::nn::Module { int forward(int x) { return x; } };
-    struct D : torch::nn::Module { int forward(int x) { return x; } };
+    struct A : torch::nn::Module {
+      int forward(int x) {
+        return x;
+      }
+    };
+    struct B : torch::nn::Module {
+      int forward(int x) {
+        return x;
+      }
+    };
+    struct C : torch::nn::Module {
+      int forward(int x) {
+        return x;
+      }
+    };
+    struct D : torch::nn::Module {
+      int forward(int x) {
+        return x;
+      }
+    };
     Sequential a(A{}, B{});
     Sequential b(C{}, D{});
-    a.extend(b);
+    a->extend(*b);
 
-    REQUIRE(a.size() == 4);
-    REQUIRE(a[0]->as<A>());
-    REQUIRE(a[1]->as<B>());
-    REQUIRE(a[2]->as<C>());
-    REQUIRE(a[3]->as<D>());
+    REQUIRE(a->size() == 4);
+    REQUIRE(a[0]->is<A>());
+    REQUIRE(a[1]->is<B>());
+    REQUIRE(a[2]->is<C>());
+    REQUIRE(a[3]->is<D>());
 
-    REQUIRE(b.size() == 2);
-    REQUIRE(b[0]->as<C>());
-    REQUIRE(b[1]->as<D>());
+    REQUIRE(b->size() == 2);
+    REQUIRE(b[0]->is<C>());
+    REQUIRE(b[1]->is<D>());
 
     std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
                                          std::make_shared<A>()};
-    b.extend(c);
+    b->extend(c);
 
-    REQUIRE(b.size() == 4);
-    REQUIRE(b[0]->as<C>());
-    REQUIRE(b[1]->as<D>());
-    REQUIRE(b[2]->as<A>());
-    REQUIRE(b[3]->as<A>());
+    REQUIRE(b->size() == 4);
+    REQUIRE(b[0]->is<C>());
+    REQUIRE(b[1]->is<D>());
+    REQUIRE(b[2]->is<A>());
+    REQUIRE(b[3]->is<A>());
+  }
+  SECTION("has reference semantics") {
+    Sequential first(Linear(2, 3), Linear(4, 4), Linear(4, 5));
+    Sequential second(first);
+
+    REQUIRE(first.get() == second.get());
+    REQUIRE(first->size() == second->size());
+    REQUIRE(std::equal(
+        first->begin(),
+        first->end(),
+        second->begin(),
+        [](const AnyModule& first, const AnyModule& second) {
+          return &first == &second;
+        }));
   }
 }

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -21,8 +21,8 @@
 using namespace torch::nn;
 
 namespace {
-std::shared_ptr<Sequential> xor_model() {
-  return std::make_shared<Sequential>(
+Sequential xor_model() {
+  return Sequential(
       Linear(2, 8),
       Functional(at::sigmoid),
       Linear(8, 1),
@@ -174,7 +174,7 @@ TEST_CASE("serialization") {
 
   SECTION("xor") {
     // We better be able to save and load a XOR model!
-    auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t batch_size) {
+    auto getLoss = [](Sequential model, uint32_t batch_size) {
       auto inputs = torch::empty({batch_size, 2});
       auto labels = torch::empty({batch_size});
       for (size_t i = 0; i < batch_size; i++) {
@@ -279,7 +279,7 @@ TEST_CASE("serialization") {
 TEST_CASE("serialization_cuda", "[cuda]") {
   torch::manual_seed(0);
   // We better be able to save and load a XOR model!
-  auto getLoss = [](std::shared_ptr<Sequential> model, uint32_t batch_size) {
+  auto getLoss = [](Sequential model, uint32_t batch_size) {
     auto inputs = torch::empty({batch_size, 2});
     auto labels = torch::empty({batch_size});
     for (size_t i = 0; i < batch_size; i++) {

--- a/test/cpp/api/static.cpp
+++ b/test/cpp/api/static.cpp
@@ -39,7 +39,7 @@ TEST_CASE("static") {
     REQUIRE(torch::any_of<true, true, false>::value == true);
   }
   SECTION("enable_if_module_t") {
-    REQUIRE(f(torch::nn::LinearImpl({1, 2})) == true);
+    REQUIRE(f(torch::nn::LinearImpl(1, 2)) == true);
     REQUIRE(f(5) == false);
   }
   SECTION("check_not_lvalue_references") {

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -19,6 +19,9 @@ struct BatchNormOptions {
 
 class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
  public:
+  template <typename... Ts>
+  explicit BatchNormImpl(Ts&&... ts)
+      : BatchNormImpl(BatchNormOptions(std::forward<Ts>(ts)...)) {}
   explicit BatchNormImpl(BatchNormOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -32,6 +32,9 @@ struct ConvOptions {
 template <size_t D, typename Derived>
 class ConvImpl : public torch::nn::Cloneable<Derived> {
  public:
+  template <typename... Ts>
+  explicit ConvImpl(Ts&&... ts)
+      : ConvImpl(ConvOptions<D>(std::forward<Ts>(ts)...)) {}
   explicit ConvImpl(ConvOptions<D> options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -18,6 +18,9 @@ namespace detail {
 template <typename Derived>
 class DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
+  template <typename... Ts>
+  explicit DropoutImplBase(Ts&&... ts)
+      : DropoutImplBase(DropoutOptions(std::forward<Ts>(ts)...)) {}
   explicit DropoutImplBase(DropoutOptions options_);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -18,6 +18,9 @@ struct EmbeddingOptions {
 
 class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
  public:
+  template <typename... Ts>
+  explicit EmbeddingImpl(Ts&&... ts)
+      : EmbeddingImpl(EmbeddingOptions(std::forward<Ts>(ts)...)) {}
   explicit EmbeddingImpl(EmbeddingOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/functional.h
@@ -16,33 +16,22 @@ class FunctionalImpl : public torch::nn::Cloneable<FunctionalImpl> {
  public:
   using Function = std::function<Tensor(Tensor)>;
 
-  /// A small type that is used only in the constructor of `FunctionalImpl`,
-  /// that allows constructing it with a function with more than one argument,
-  /// and binding all but the first parameter to specific values. It is
-  /// necessary due to interaction with the `ModuleHolder` class, which expects
-  /// to construct a module with `Module({...})` when there is more than one
-  /// argument. It also deals with argument binding.
-  struct BoundFunction {
-    template <
-        typename AnyFunction,
-        typename... Args,
-        typename = torch::enable_if_t<(sizeof...(Args) > 0)>>
-    /* implicit */ BoundFunction(AnyFunction original_function, Args&&... args)
-        : function_(std::bind(
-              original_function,
-              /*input=*/std::placeholders::_1,
-              std::forward<Args>(args)...)) {
-      // std::bind is normally evil, but (1) gcc is broken w.r.t. handling
-      // parameter pack expansion in lambdas and (2) moving parameter packs into
-      // a lambda only works with C++14, so std::bind is the more move-aware
-      // solution here.
-    }
-
-    Function function_;
-  };
-
   explicit FunctionalImpl(Function function);
-  explicit FunctionalImpl(BoundFunction bound_function);
+
+  template <
+      typename SomeFunction,
+      typename... Args,
+      typename = torch::enable_if_t<(sizeof...(Args) > 0)>>
+  explicit FunctionalImpl(SomeFunction original_function, Args&&... args)
+      : function_(std::bind(
+            original_function,
+            /*input=*/std::placeholders::_1,
+            std::forward<Args>(args)...)) {
+    // std::bind is normally evil, but (1) gcc is broken w.r.t. handling
+    // parameter pack expansion in lambdas and (2) moving parameter packs into
+    // a lambda only works with C++14, so std::bind is the more move-aware
+    // solution here.
+  }
 
   void reset() override;
   Tensor forward(Tensor input);

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -19,6 +19,9 @@ struct LinearOptions {
 
 class LinearImpl : public Cloneable<LinearImpl> {
  public:
+  template <typename... Ts>
+  explicit LinearImpl(Ts&&... ts)
+      : LinearImpl(LinearOptions(std::forward<Ts>(ts)...)) {}
   explicit LinearImpl(LinearOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -121,6 +121,8 @@ struct RNNOptions {
 
 class RNNImpl : public detail::RNNImplBase<RNNImpl> {
  public:
+  template <typename... Ts>
+  explicit RNNImpl(Ts&&... ts) : RNNImpl(RNNOptions(std::forward<Ts>(ts)...)) {}
   explicit RNNImpl(RNNOptions options);
 
   RNNOptions options;
@@ -138,6 +140,9 @@ using LSTMOptions = detail::RNNOptionsBase;
 
 class LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
  public:
+  template <typename... Ts>
+  explicit LSTMImpl(Ts&&... ts)
+      : LSTMImpl(LSTMOptions(std::forward<Ts>(ts)...)) {}
   explicit LSTMImpl(LSTMOptions options);
 
  private:
@@ -152,6 +157,8 @@ using GRUOptions = detail::RNNOptionsBase;
 
 class GRUImpl : public detail::RNNImplBase<GRUImpl> {
  public:
+  template <typename... Ts>
+  explicit GRUImpl(Ts&&... ts) : GRUImpl(GRUOptions(std::forward<Ts>(ts)...)) {}
   explicit GRUImpl(GRUOptions options);
 
  private:

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -20,19 +20,17 @@ namespace nn {
 /// A `Sequential` module is a container for any number of other modules. Its
 /// `forward()` method chains outputs to inputs and returns the final output.
 /// The `Sequential` class reference semantics.
-class Sequential : public Cloneable<Sequential> {
+class SequentialImpl : public Cloneable<SequentialImpl> {
  public:
-  using Iterator = std::vector<std::shared_ptr<AnyModule>>::iterator;
-  using ConstIterator = std::vector<std::shared_ptr<AnyModule>>::const_iterator;
+  using Iterator = std::vector<AnyModule>::iterator;
+  using ConstIterator = std::vector<AnyModule>::const_iterator;
 
   /// Constructs the `Sequential` from a pack of modules. Each module can either
   /// be a plain value (e.g. `Linear`) or a boxed value (e.g.
   /// `shared_ptr<Linear>`). Unboxed modules will be moved into `shared_ptr`s
   /// internally.
-  template <
-      typename... Modules,
-      typename = disable_if_contains_t<Sequential, Modules...>>
-  explicit Sequential(Modules&&... modules) {
+  template <typename... Modules>
+  explicit SequentialImpl(Modules&&... modules) {
     modules_.reserve(sizeof...(Modules));
     push_back(std::forward<Modules>(modules)...);
   }
@@ -48,11 +46,10 @@ class Sequential : public Cloneable<Sequential> {
     AT_CHECK(!is_empty(), "Cannot call forward() on an empty Sequential");
 
     auto iterator = modules_.begin();
-    auto input =
-        (*iterator)->forward(std::forward<ArgumentTypes>(arguments)...);
+    auto input = iterator->forward(std::forward<ArgumentTypes>(arguments)...);
 
     for (++iterator; iterator != modules_.end(); ++iterator) {
-      input = (*iterator)->forward(std::move(input));
+      input = iterator->forward(std::move(input));
     }
 
     // Check the return value and give a nice error message if the requsted
@@ -73,7 +70,7 @@ class Sequential : public Cloneable<Sequential> {
     // Nesting Sequential doesn't work because `forward()`'s return type is
     // templatized, so it'll give a nasty compiler error.
     static_assert(
-        !std::is_same<Sequential, ModuleType>::value,
+        !std::is_same<SequentialImpl, ModuleType>::value,
         "Sequential is not nestable");
     static_assert(
         torch::detail::is_module<ModuleType>::value,
@@ -81,7 +78,7 @@ class Sequential : public Cloneable<Sequential> {
     static_assert(
         torch::detail::has_forward<ModuleType>::value,
         "Can only add modules with a forward() method to Sequential");
-    push_back(std::make_shared<AnyModule>(std::move(module_ptr)));
+    push_back(AnyModule(std::move(module_ptr)));
   }
 
   /// Adds a new `Module` to the `Sequential` container, moving or copying it
@@ -89,7 +86,7 @@ class Sequential : public Cloneable<Sequential> {
   /// and letting the container deal with the boxing. This means you can write
   /// `Sequential(Module(3, 4))` instead of
   /// `Sequential(std::make_shared<Module>(3, 4))`.
-  template <typename M, typename = torch::detail::disable_if_module_holder_t<M>>
+  template <typename M, typename = torch::detail::enable_if_module_t<M>>
   void push_back(M&& module) {
     // Need to get rid of any reference components for make_unique.
     using Type = typename std::remove_reference<M>::type;
@@ -104,15 +101,7 @@ class Sequential : public Cloneable<Sequential> {
     push_back(module_holder.ptr());
   }
 
-  /// Adds a type-erased `AnyModule` to the `Sequential`.
-  void push_back(std::shared_ptr<AnyModule> any_module) {
-    modules_.push_back(std::move(any_module));
-    const auto index = modules_.size() - 1;
-    register_module(std::to_string(index), modules_[index]->ptr());
-  }
-
-  /// Iterates over the container and calls `push_back()` on each iterated
-  /// value.
+  /// Iterates over the container and calls `push_back()` on each value.
   template <typename Container>
   void extend(const Container& container) {
     for (const auto& module : container) {
@@ -145,7 +134,7 @@ class Sequential : public Cloneable<Sequential> {
         torch::detail::is_module<T>::value,
         "Can only call Sequential::at with an nn::Module type");
     AT_CHECK(index < size(), "Index out of range");
-    return modules_[index]->get<T>();
+    return modules_[index].get<T>();
   }
 
   /// Attempts to return the module at the given index as the requested type.
@@ -157,7 +146,7 @@ class Sequential : public Cloneable<Sequential> {
         torch::detail::is_module<T>::value,
         "Can only call Sequential::at with an nn::Module type");
     AT_CHECK(index < size(), "Index out of range");
-    return modules_[index]->get<T>();
+    return modules_[index].get<T>();
   }
 
   /// Attempts to return a `std::shared_ptr` whose dynamic type is that of the
@@ -165,7 +154,7 @@ class Sequential : public Cloneable<Sequential> {
   /// out of bounds.
   std::shared_ptr<Module> ptr(size_t index) const {
     AT_CHECK(index < size(), "Index out of range");
-    return modules_[index]->ptr();
+    return modules_[index].ptr();
   }
 
   /// Attempts to return a `std::shared_ptr` whose type is the one provided.
@@ -177,7 +166,7 @@ class Sequential : public Cloneable<Sequential> {
         torch::detail::is_module<T>::value,
         "Can only call Sequential::ptr with an nn::Module type");
     AT_CHECK(index < size(), "Index out of range");
-    return modules_[index]->ptr<T>();
+    return modules_[index].ptr<T>();
   }
 
   /// Like `ptr(index)`.
@@ -209,13 +198,22 @@ class Sequential : public Cloneable<Sequential> {
     push_back(std::forward<Second>(second), std::forward<Rest>(rest)...);
   }
 
+  /// Adds a type-erased `AnyModule` to the `Sequential`.
+  void push_back(AnyModule any_module) {
+    modules_.push_back(std::move(any_module));
+    const auto index = modules_.size() - 1;
+    register_module(std::to_string(index), modules_[index].ptr());
+  }
+
   /// The base case, when the list of modules is empty.
   void push_back() {}
 
   // Box the AnyModules to give Sequential reference semantics, like the rest of
   // the API. Note that this is not required otherwise, this could just be a
   // `vector<AnyModule>`.
-  std::vector<std::shared_ptr<AnyModule>> modules_;
+  std::vector<AnyModule> modules_;
 };
+
+TORCH_MODULE(Sequential);
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -19,8 +19,7 @@ template <typename T>
 using is_module_holder = std::is_base_of<ModuleHolderIndicator, decay_t<T>>;
 
 template <typename T>
-using disable_if_module_holder_t =
-    disable_if_t<std::is_base_of<ModuleHolderIndicator, decay_t<T>>::value>;
+using disable_if_module_holder_t = disable_if_t<is_module_holder<T>::value>;
 } // namespace detail
 
 namespace nn {
@@ -30,31 +29,29 @@ namespace nn {
 /// the kind of constructions we want to allow for our modules.
 template <typename Contained>
 class ModuleHolder : torch::detail::ModuleHolderIndicator {
+ protected:
+  /// The module pointer this class wraps.
+  /// NOTE: Must be placed at the top of the class so that we can use it with
+  /// trailing return types below.
+  std::shared_ptr<Contained> impl_;
+
  public:
   using ContainedType = Contained;
 
-  /// Constructs the `ModuleHolder` with an empty contained value.
-  ModuleHolder() = default;
+  /// Constructs the `ModuleHolder` with an empty contained value. Access to
+  /// the underlying module is not permitted and will throw an exception, until
+  /// a value is assigned.
+  explicit ModuleHolder(std::nullptr_t) : impl_(nullptr) {}
 
-  /// Single argument constructor of the underlying type.
-  /// Example: `Linear(4)` or `Linear(LinearOptions(4))`.
-  template <typename T>
-  explicit ModuleHolder(T&& t)
-      : impl_(std::make_shared<Contained>(std::forward<T>(t))) {}
-
-  /// Multi-argument constructor. This constructor is special in that the
-  /// expectation is that the constructor of the contained type takes an object
-  /// that can be constructed with the given arguments. For our modules, this is
-  /// always the `Options` struct. For this reason, the arguments are forwarded
-  /// inside braces, as to construct the constructor argument.
-  /// Example: `Linear(3, 4)`, equivalent to `Linear(LinearOptions(3, 4))`.
-  template <typename T, typename... Ts>
-  explicit ModuleHolder(T&& t, Ts&&... ts)
-      : impl_(new Contained({std::forward<T>(t), std::forward<Ts>(ts)...})) {}
+  /// Constructs the `ModuleHolder` with a contained module, forwarding all
+  /// arguments to its constructor.
+  template <typename... Ts>
+  explicit ModuleHolder(Ts&&... ts)
+      : impl_(new Contained(std::forward<Ts>(ts)...)) {}
 
   /// Constructs the `ModuleHolder` from a pointer to the contained type.
   /// Example: `Linear(std::make_shared<LinearImpl>(...))`.
-  /* implicit */ ModuleHolder(std::shared_ptr<Contained> module)
+  explicit ModuleHolder(std::shared_ptr<Contained> module)
       : impl_(std::move(module)) {}
 
   /// Returns true if the `ModuleHolder` contains a module, or false if it is
@@ -77,36 +74,39 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 
   /// Forwards to the call operator of the contained module.
   template <typename... Args>
-  Tensor operator()(Args&&... args) {
+  auto operator()(Args&&... args)
+      -> decltype((*impl_)(std::forward<Args>(args)...)) {
     return (*impl_)(std::forward<Args>(args)...);
   }
 
-  /// Returns a shared pointer to the underlying module.
-  const std::shared_ptr<Contained>& ptr() const {
+  /// Forwards to the call operator of the contained module.
+  template <typename Arg>
+  auto operator[](Arg&& arg) -> decltype((*impl_)[std::forward<Arg>(arg)]) {
+    return (*impl_)[std::forward<Arg>(arg)];
+  }
+
+  /// Returns the underlying module.
+  const std::shared_ptr<Contained>& get() const {
     AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
     return impl_;
   }
 
-  /// Returns a pointer to the underlying module.
-  Contained* get() {
+  /// Returns a reference to the contained module.
+  Contained& operator*() {
     AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
-    return impl_.get();
+    return *impl_;
   }
 
-  /// Returns a pointer to the underlying module.
-  const Contained* get() const {
+  /// Returns a const reference to the contained module.
+  const Contained& operator*() const {
     AT_CHECK(!is_empty(), "Accessing empty ModuleHolder");
-    return impl_.get();
+    return *impl_;
   }
 
   /// Returns true if the `ModuleHolder` does not contain a module.
   bool is_empty() const noexcept {
     return impl_ == nullptr;
   }
-
- protected:
-  /// The module pointer this class wraps.
-  std::shared_ptr<Contained> impl_;
 };
 } // namespace nn
 } // namespace torch
@@ -127,10 +127,15 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 
 /// Defines a class `Name` which inherits from `nn::ModuleHolder` to provide a
 /// wrapper over a `std::shared_ptr<Impl>`.
-#define TORCH_MODULE_IMPL(Name, Impl)                  \
-  class Name : public torch::nn::ModuleHolder<Impl> {  \
-   public:                                             \
-    using torch::nn::ModuleHolder<Impl>::ModuleHolder; \
+#define TORCH_MODULE_IMPL(Name, Impl)                            \
+  class Name : public torch::nn::ModuleHolder<Impl> {            \
+   public:                                                       \
+    using torch::nn::ModuleHolder<Impl>::ModuleHolder;           \
+    Name(const Name&) = default;                                 \
+    Name(Name&&) = default;                                      \
+    Name(Name& other) : Name(static_cast<const Name&>(other)) {} \
+    Name& operator=(const Name&) = default;                      \
+    Name& operator=(Name&&) = default;                           \
   }
 
 /// Like `TORCH_MODULE_IMPL`, but defaults the `Impl` name to `<Name>Impl`.

--- a/torch/csrc/api/src/nn/modules/functional.cpp
+++ b/torch/csrc/api/src/nn/modules/functional.cpp
@@ -10,9 +10,6 @@ namespace nn {
 FunctionalImpl::FunctionalImpl(std::function<Tensor(Tensor)> function)
     : function_(std::move(function)) {}
 
-FunctionalImpl::FunctionalImpl(BoundFunction bound_function)
-    : function_(std::move(bound_function.function_)) {}
-
 void FunctionalImpl::reset() {}
 
 Tensor FunctionalImpl::forward(Tensor input) {

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -52,6 +52,7 @@ RNNImplBase<Derived>::RNNImplBase(
     int64_t number_of_gates,
     bool has_cell_state)
     : options(options_),
+      dropout(nullptr),
       number_of_gates_(number_of_gates),
       has_cell_state_(has_cell_state),
       cudnn_mode_(cudnn_mode) {


### PR DESCRIPTION
In the C++ API, `Sequential` currently was not refcounted itself, but stored `shared_ptr<AnyModule>` to get the reference semantics. This is unfortunate because most modules in the API are accessed via `->`, e.g. `Linear l(1, 2); l->forward(...);`. `Sequential` was different in that it had value semantics itself, thus was accessed via `.`.

This PR makes `Sequential` store `AnyModule` (without extra indirection), and uses the same pImpl mechanism we use for all other modules to make `Sequential` have reference semantics itself. This makes it consistent with the rest of the library. It also removes one level of indirection inside of `Sequential`, which is cool.

One thing I had to change was that the `ModuleHolder` with which the whole pImpl thing is implemented previously did some tricks to make `Linear(3, 4)` actually construct `Linear(LinearOptions(3, 4))`. This doesn't work well with `Sequential` since it takes a variadic parameter pack. Instead, I made `ModuleHolder` forward all arguments to the underlying module, and then further pushed the trick to forward parameters to modules' options types into the actual Modules. This adds one constructor per Module in the library. This is not something user modules have to do (unless they want this nice forwarding themselves). It makes the code simpler overall.

@ezyang @ebetica @apaszke 