### PR TITLE
Only set -fvisibility-inlines-hidden when needed

### DIFF
--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -152,10 +152,6 @@ cmake_pop_check_state()
 # ---[ Checks if compiler supports -fvisibility=hidden
 check_cxx_compiler_flag("-fvisibility=hidden" COMPILER_SUPPORTS_HIDDEN_VISIBILITY)
 check_cxx_compiler_flag("-fvisibility-inlines-hidden" COMPILER_SUPPORTS_HIDDEN_INLINE_VISIBILITY)
-if (${COMPILER_SUPPORTS_HIDDEN_INLINE_VISIBILITY})
-  set(CAFFE2_VISIBILITY_FLAG "-fvisibility-inlines-hidden")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CAFFE2_VISIBILITY_FLAG}")
-endif()
 
 # ---[ If we are using msvc, set no warning flags
 # Note(jiayq): if you are going to add a warning flag, check if this is


### PR DESCRIPTION
It's only needed when we link a local copy of protobuf
https://github.com/pytorch/pytorch/blob/edd4e2c5d158e5531ac1fbe5cf8c9a2857756b64/cmake/ProtoBuf.cmake#L33-L35