### PR TITLE
Install THC/THCGeneral.hpp

### DIFF
--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -59,6 +59,7 @@ set(ATen_CUDA_SRCS ${ATen_CUDA_SRCS}
 INSTALL(FILES
           THC.h
           ${CMAKE_CURRENT_BINARY_DIR}/THCGeneral.h
+          THCGeneral.hpp
           THCBlas.h
           THCSleep.h
           THCStorage.h


### PR DESCRIPTION
This file was added in #9107 but wasn't installed. The libraries in
./torch/lib use the headers from Caffe2/ATen from their temporary
install path at torch/lib/tmp_install, and c10d was not able to find
THC/THCGeneral.hpp before this fix.

