### PR TITLE
[Caffe2] Fix issues in IDEEP fallback ops and enable Detectron on IDEEP device

### DIFF
--- a/caffe2/ideep/operators/operator_fallback_ideep.cc
+++ b/caffe2/ideep/operators/operator_fallback_ideep.cc
@@ -23,6 +23,8 @@
 #include <caffe2/operators/softmax_op.h>
 #include <caffe2/operators/transpose_op.h>
 #include <caffe2/operators/utility_ops.h>
+#include <caffe2/operators/affine_channel_op.h>
+#include <caffe2/operators/stop_gradient.h>
 
 // can add more non-IDEEP operators if needed
 namespace caffe2 {
@@ -104,6 +106,12 @@ REGISTER_IDEEP_OPERATOR(
 REGISTER_IDEEP_OPERATOR(
     BBoxTransform,
     IDEEPFallbackOp<BBoxTransformOp<float, CPUContext>>);
+REGISTER_IDEEP_OPERATOR(
+    AffineChannel,
+    IDEEPFallbackOp<AffineChannelOp<float, CPUContext>>);
+REGISTER_IDEEP_OPERATOR(
+    StopGradient,
+    IDEEPFallbackOp<StopGradientOp<CPUContext>>);
 
 REGISTER_IDEEP_OPERATOR(
     PadImage,

--- a/caffe2/python/ideep/operator_fallback_op_test.py
+++ b/caffe2/python/ideep/operator_fallback_op_test.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given
+import numpy as np
+from caffe2.python import core, workspace
+from caffe2.proto import caffe2_pb2
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.ideep_test_util as mu
+
+
+@unittest.skipIf(not workspace.C.use_ideep, "No IDEEP support.")
+class TestFallbackOps(hu.HypothesisTestCase):
+    @given(stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           kernel=st.integers(3, 5),
+           size=st.integers(8, 10),
+           input_channels=st.integers(1, 3),
+           output_channels=st.integers(1, 5),
+           batch_size=st.integers(1, 3),
+           use_bias=st.booleans(),
+           **mu.gcs)
+    def test_in_place(self, stride, pad, kernel, size,
+                             input_channels, output_channels,
+                             batch_size, use_bias, gc, dc):
+        # To expose fallback in-place potential issue, the fallback op
+        # following ideep op must be run at least two iterations.
+        conv = core.CreateOperator(
+            "Conv",
+            ["X", "w", "b"] if use_bias else ["X", "w"],
+            ["Y"],
+            stride=stride,
+            pad=pad,
+            kernel=kernel,
+            device_option=dc[0]
+        )
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32) - 0.5
+        w = np.random.rand(output_channels, input_channels, kernel, kernel) \
+            .astype(np.float32) - 0.5
+        b = np.random.rand(output_channels).astype(np.float32) - 0.5
+
+        old_ws_name = workspace.CurrentWorkspace()
+        workspace.SwitchWorkspace("_device_check_", True)
+        workspace.FeedBlob('X', X, dc[0])
+        workspace.FeedBlob('w', w, dc[0])
+        workspace.FeedBlob('b', b, dc[0])
+        workspace.RunOperatorOnce(conv)
+        Y = workspace.FetchBlob('Y')
+
+        scale = np.random.randn(Y.shape[1]).astype(np.float32)
+        bias = np.random.randn(Y.shape[1]).astype(np.float32)
+        ac = core.CreateOperator(
+            "AffineChannel",
+            ["Y", "scale", "bias"],
+            ["Y"],
+            is_learnable=False,
+            device_option=dc[0]
+        )
+        workspace.FeedBlob('scale', scale, dc[0])
+        workspace.FeedBlob('bias', bias, dc[0])
+        workspace.RunOperatorOnce(ac)
+        workspace.RunOperatorOnce(conv)
+        workspace.RunOperatorOnce(ac)
+        Y0 = workspace.FetchBlob('Y')
+
+        workspace.ResetWorkspace()
+        dev_net = caffe2_pb2.NetDef()
+        conv_dev = caffe2_pb2.OperatorDef()
+        conv_dev.CopyFrom(conv)
+        conv_dev.device_option.CopyFrom(dc[1])
+        ac_dev = caffe2_pb2.OperatorDef()
+        ac_dev.CopyFrom(ac)
+        ac_dev.device_option.CopyFrom(dc[1])
+        dev_net.op.extend([conv_dev, ac_dev])
+        workspace.FeedBlob('X', X, dc[1])
+        workspace.FeedBlob('w', w, dc[1])
+        workspace.FeedBlob('b', b, dc[1])
+        workspace.FeedBlob('scale', scale, dc[1])
+        workspace.FeedBlob('bias', bias, dc[1])
+        workspace.RunNetOnce(dev_net)
+        workspace.RunNetOnce(dev_net)
+        Y1 = workspace.FetchBlob('Y')
+
+        if not np.allclose(Y0, Y1, atol=0.01, rtol=0.01):
+            print(Y1.flatten())
+            print(Y0.flatten())
+            print(np.max(np.abs(Y1 - Y0)))
+            self.assertTrue(False)
+
+        workspace.SwitchWorkspace(old_ws_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/caffe2/python/pybind_state_ideep.cc
+++ b/caffe2/python/pybind_state_ideep.cc
@@ -9,6 +9,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "caffe2/ideep/operators/operator_fallback_ideep.h"
 #include <caffe2/ideep/ideep_utils.h>
 
 namespace caffe2 {
@@ -19,42 +20,42 @@ USE_IDEEP_DEF_ALIASES();
 class IDeepFetcher;
 class IDeepFeeder;
 
-REGISTER_BLOB_FETCHER((TypeMeta::Id<itensor>()),IDeepFetcher);
+REGISTER_IDEEP_OPERATOR(Python, IDEEPFallbackOp<PythonOp<CPUContext, false>>);
+
+REGISTER_BLOB_FETCHER((TypeMeta::Id<itensor>()), IDeepFetcher);
 REGISTER_BLOB_FEEDER(IDEEP, IDeepFeeder);
 
 class IDeepFetcher : public BlobFetcherBase {
   TypeMeta type_transform(const itensor &atensor) {
-    switch(atensor.get_data_type()) {
-      case itensor::data_type::f32:
-        return TypeMeta::Make<float>();
-      case itensor::data_type::s16:
-        return TypeMeta::Make<float16>();
-      case itensor::data_type::s32:
-        return TypeMeta::Make<int>();
-      case itensor::data_type::s8:
-        return TypeMeta::Make<int8_t>();
-      case itensor::data_type::u8:
-        return TypeMeta::Make<uint8_t>();
-      default:
-        // Should we throw exception?
-        return TypeMeta();
+    switch (atensor.get_data_type()) {
+    case itensor::data_type::f32:
+      return TypeMeta::Make<float>();
+    case itensor::data_type::s32:
+      return TypeMeta::Make<int>();
+    case itensor::data_type::s8:
+      return TypeMeta::Make<int8_t>();
+    case itensor::data_type::u8:
+      return TypeMeta::Make<uint8_t>();
+    default:
+      // Should we throw exception?
+      return TypeMeta();
     }
   }
 
- public:
-  pybind11::object Fetch(const Blob& blob) override {
+public:
+  pybind11::object Fetch(const Blob &blob) override {
     try {
       return FetchTensor(blob.Get<itensor>(), true).obj;
-    } catch (ideep::error& e) {
-      VLOG(1) << "IDEEP error: " << e.message;
+    } catch (ideep::error &e) {
+      LOG(ERROR) << "IDEEP error: " << e.message;
       throw;
     }
   }
 
-  FetchedBlob FetchTensor(const itensor& atensor, bool force_copy) {
+  FetchedBlob FetchTensor(const itensor &atensor, bool force_copy) {
     FetchedBlob result;
     CAFFE_ENFORCE(atensor.materialized(),
-        "Trying to fetch uninitialized tensor");
+                  "Trying to fetch uninitialized tensor");
     const int numpy_type = CaffeToNumpyType(type_transform(atensor));
     CAFFE_ENFORCE(
         numpy_type != -1,
@@ -64,17 +65,16 @@ class IDeepFetcher : public BlobFetcherBase {
     std::vector<npy_intp> npy_dims(dims.begin(), dims.end());
 
     result.copied = force_copy || atensor.need_reorder();
-    void* outPtr;
+    void *outPtr;
     if (result.copied) {
       result.obj = py::reinterpret_steal<py::object>(
           PyArray_SimpleNew(atensor.ndims(), npy_dims.data(), numpy_type));
       outPtr = static_cast<void *>(
-          PyArray_DATA(reinterpret_cast<PyArrayObject*>(result.obj.ptr())));
+          PyArray_DATA(reinterpret_cast<PyArrayObject *>(result.obj.ptr())));
     } else {
       outPtr = atensor.get_data_handle();
-      result.obj = py::reinterpret_steal<py::object>(
-          PyArray_SimpleNewFromData(
-            atensor.ndims(), npy_dims.data(), numpy_type, outPtr));
+      result.obj = py::reinterpret_steal<py::object>(PyArray_SimpleNewFromData(
+          atensor.ndims(), npy_dims.data(), numpy_type, outPtr));
     }
 
     if (numpy_type == NPY_OBJECT) {
@@ -95,8 +95,6 @@ class IDeepFeeder : public BlobFeederBase {
       return itensor::data_type::f32;
     else if (meta == TypeMeta::Make<int>())
       return itensor::data_type::s32;
-    else if (meta == TypeMeta::Make<float16>())
-      return itensor::data_type::s16;
     else if (meta == TypeMeta::Make<int8_t>())
       return itensor::data_type::s8;
     else if (meta == TypeMeta::Make<uint8_t>())
@@ -105,53 +103,63 @@ class IDeepFeeder : public BlobFeederBase {
       return itensor::data_type::data_undef;
   }
 
- public:
-   void FeedTensor(
-       const DeviceOption& option,
-       PyArrayObject *original_array,
-       itensor *tensor) {
-     PyArrayObject *array = PyArray_GETCONTIGUOUS(original_array);
-     auto g = MakeGuard([&]() {Py_XDECREF(array); });
+public:
+  void FeedTensor(const DeviceOption &option, PyArrayObject *original_array,
+                  itensor *tensor) {
+    PyArrayObject *array = PyArray_GETCONTIGUOUS(original_array);
+    auto g = MakeGuard([&]() { Py_XDECREF(array); });
+    const auto npy_type = PyArray_TYPE(array);
+    const TypeMeta &meta = NumpyTypeToCaffe(npy_type);
+    CAFFE_ENFORCE(meta.id() != CaffeTypeId::uninitialized(),
+                  "This numpy data type is not supported: ",
+                  PyArray_TYPE(array), ".");
 
-     const auto npy_type = PyArray_TYPE(array);
-     const TypeMeta& meta = NumpyTypeToCaffe(npy_type);
-     CAFFE_ENFORCE(
-        meta.id() != CaffeTypeId::uninitialized(),
-        "This numpy data type is not supported: ",
-        PyArray_TYPE(array),
-        ".");
+    int ndim = PyArray_NDIM(array);
+    npy_intp *npy_dims = PyArray_DIMS(array);
 
-     int ndim = PyArray_NDIM(array);
-     npy_intp* npy_dims = PyArray_DIMS(array);
+    itensor::dims adims;
+    for (int i = 0; i < ndim; i++) {
+      adims.push_back(static_cast<itensor::dims::value_type>(npy_dims[i]));
+    }
 
-     itensor::dims adims;
-     for (int i = 0; i < ndim; i++) {
-       adims.push_back(static_cast<itensor::dims::value_type>(
-             npy_dims[i]));
-     }
-
-     switch (npy_type) {
-      case NPY_OBJECT:
-      case NPY_UNICODE:
-        CAFFE_THROW("IDeep doesn't support string");
-        break;
-      default:
-        auto type = type_transform(meta);
+    switch (npy_type) {
+    case NPY_OBJECT:
+    case NPY_UNICODE:
+      CAFFE_THROW("IDeep doesn't support string");
+      break;
+    default:
+      auto type = type_transform(meta);
+      if (tensor->get_dims() != adims || type != tensor->get_data_type()) {
         tensor->resize(adims, type);
-        tensor->reorder_from(adims, type,
-            static_cast<void *>(PyArray_DATA(array)));
-     }
-   }
-
-   void Feed(const DeviceOption& option, PyArrayObject* original_array,
-       Blob* blob) {
-      try {
-        FeedTensor(option, original_array, blob->GetMutable<itensor>());
-      } catch (ideep::error& e) {
-        VLOG(1) << "IDEEP error: " << e.message;
-        throw;
       }
-   }
+      tensor->reorder_from(adims, type,
+                           static_cast<void *>(PyArray_DATA(array)));
+    }
+  }
+
+  void Feed(const DeviceOption &option, PyArrayObject *original_array,
+            Blob *blob) {
+    try {
+      PyArrayObject *array = PyArray_GETCONTIGUOUS(original_array);
+      auto g = MakeGuard([&]() { Py_XDECREF(array); });
+
+      const auto npy_type = PyArray_TYPE(array);
+      const TypeMeta &meta = NumpyTypeToCaffe(npy_type);
+      // TODO: if necessary, use dispatcher.
+      if (meta.Match<float>()) {
+        FeedTensor(option, original_array, blob->GetMutable<itensor>());
+      } else {
+        DeviceOption cpu_option(option);
+        cpu_option.set_device_type(DeviceType::CPU);
+        TensorFeeder<CPUContext> cpu_tensor_feeder;
+        cpu_tensor_feeder.FeedTensor(cpu_option, original_array,
+                                     blob->GetMutable<TensorCPU>());
+      }
+    } catch (ideep::error &e) {
+      LOG(ERROR) << "IDEEP error: " << e.message;
+      throw;
+    }
+  }
 };
 
 } // namespace python

--- a/modules/detectron/CMakeLists.txt
+++ b/modules/detectron/CMakeLists.txt
@@ -11,4 +11,8 @@ if (USE_CUDA)
 
   target_link_libraries(caffe2_detectron_ops_gpu caffe2_gpu)
   install(TARGETS caffe2_detectron_ops_gpu DESTINATION lib)
+elseif(NOT IOS_PLATFORM)
+  add_library(caffe2_detectron_ops SHARED ${Detectron_CPU_SRCS})
+  target_link_libraries(caffe2_detectron_ops caffe2)
+  install(TARGETS caffe2_detectron_ops DESTINATION lib)
 endif()

--- a/modules/detectron/batch_permutation_op.cc
+++ b/modules/detectron/batch_permutation_op.cc
@@ -15,8 +15,18 @@
  */
 
 #include "batch_permutation_op.h"
+#ifdef CAFFE2_USE_IDEEP
+#include <caffe2/ideep/operators/operator_fallback_ideep.h>
+#include <caffe2/ideep/utils/ideep_operator.h>
+#endif
 
 namespace caffe2 {
+
+#ifdef CAFFE2_USE_IDEEP
+REGISTER_IDEEP_OPERATOR(
+    BatchPermutation,
+    IDEEPFallbackOp<BatchPermutationOp<float, CPUContext>>);
+#endif
 
 REGISTER_CPU_OPERATOR(BatchPermutation, BatchPermutationOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(

--- a/modules/detectron/upsample_nearest_op.cc
+++ b/modules/detectron/upsample_nearest_op.cc
@@ -15,8 +15,17 @@
  */
 
 #include "upsample_nearest_op.h"
+#ifdef CAFFE2_USE_IDEEP
+#include <caffe2/ideep/operators/operator_fallback_ideep.h>
+#include <caffe2/ideep/utils/ideep_operator.h>
+#endif
 
 namespace caffe2 {
+#ifdef CAFFE2_USE_IDEEP
+REGISTER_IDEEP_OPERATOR(
+    UpsampleNearest,
+    IDEEPFallbackOp<UpsampleNearestOp<float, CPUContext>>);
+#endif
 
 REGISTER_CPU_OPERATOR(UpsampleNearest, UpsampleNearestOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(

--- a/modules/detectron/upsample_nearest_op.h
+++ b/modules/detectron/upsample_nearest_op.h
@@ -35,8 +35,54 @@ class UpsampleNearestOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
   bool RunOnDevice() override {
-    // No CPU implementation for now
-    CAFFE_NOT_IMPLEMENTED;
+    auto translate_idx = [](int ii, int d1, int d2, int d3, int scale_factor) {
+      int x, y, z, w;
+      w = ii % d3;
+      ii = ii/d3;
+      z = ii % d2;
+      ii = ii/d2;
+      y = ii % d1;
+      ii = ii/d1;
+      x = ii;
+      w = w/scale_factor;
+      z = z/scale_factor;
+      d2 /= scale_factor;
+      d3 /= scale_factor;
+      return (((x*d1+y)*d2)+z)*d3+w;
+    };
+
+    auto& X = Input(0);
+    auto* Y = Output(0);
+
+    vector<TIndex> out_shape;
+    for (int i = 0; i < X.ndim(); ++i) {
+      out_shape.push_back(X.dim32(i));
+    }
+    out_shape[X.ndim() - 1] *= scale_;
+    out_shape[X.ndim() - 2] *= scale_;
+    Y->Resize(out_shape);
+
+    int d1;
+    int d2;
+    int d3;
+    if (X.ndim() == 3) {
+      d1 = Y->dim32(0);
+      d2 = Y->dim32(1);
+      d3 = Y->dim32(2);
+    } else {
+      d1 = Y->dim32(1);
+      d2 = Y->dim32(2);
+      d3 = Y->dim32(3);
+    }
+
+    const float *input_data = X.template data<T>();
+    float *output_data = Y->template mutable_data<T>();
+
+    for (int ii = 0; ii < Y->size(); ii++) {
+      int ipidx = translate_idx(ii, d1, d2, d3, scale_);
+      output_data[ii] = input_data[ipidx];
+    }
+    return true;
   }
 
  protected:


### PR DESCRIPTION
Fix issues in IDEEP fallback ops and enable Detectron on IDEEP device

Fix the correctness issue in fallback op implementation when the fallback op is in-place and its upstream op is with IDEEP device. The reorder would happen incorrectly from the same buffer then.
Support Mask-RCNN model from the Detectron, added all the fallbacks needed, e.g. Python op and other related ops. And also support feeding blobs with integer types using TensorCPU.