### PR TITLE
Add Feature-wise Linear Modulation layer

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -512,6 +512,12 @@ Linear layers
 .. autoclass:: Bilinear
     :members:
 
+:hidden:`FiLM`
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: FiLM
+    :members:
+
 Dropout layers
 ----------------------------------
 
@@ -1089,6 +1095,11 @@ Linear functions
 ~~~~~~~~~~~~~~~~
 
 .. autofunction:: linear
+
+:hidden:`film`
+~~~~~~~~~~~~~~~~
+
+.. autofunction:: film
 
 Dropout functions
 -----------------

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5052,7 +5052,7 @@ class TestNN(NNTestCase):
 
             output = m(inp, half_ones_half_zeros, half_ones_half_neg_ones)
             self.assertEqual(F.film(inp, half_ones_half_zeros, half_ones_half_neg_ones), output)
-            self.assertEqual(output.sum(), inp[:,:5].sum())
+            self.assertEqual(output.sum(), inp[:, :5].sum())
 
     @staticmethod
     def _test_conv_noncontig_weights(self, device):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1052,6 +1052,17 @@ def bilinear(input1, input2, weight, bias=None):
     return torch.bilinear(input1, input2, weight, bias)
 
 
+def film(input, gammas, betas):
+    r"""Applies Feature-wise Linear Modulation to the incoming data.
+
+    See :class:`~torch.nn.FiLM` for details.
+    """
+    for _ in range(input.dim() - 2):
+        gammas = gammas.unsqueeze(-1)
+        betas = betas.unsqueeze(-1)
+    return gammas * input + betas
+
+
 def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
               scale_grad_by_freq=False, sparse=False):
     r"""A simple lookup table that looks up embeddings in a fixed dictionary and size.

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -1,5 +1,5 @@
 from .module import Module
-from .linear import Linear, Bilinear
+from .linear import Linear, Bilinear, FiLM
 from .conv import Conv1d, Conv2d, Conv3d, \
     ConvTranspose1d, ConvTranspose2d, ConvTranspose3d
 from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
@@ -46,6 +46,6 @@ __all__ = [
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
-    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
+    'ConstantPad3d', 'Bilinear', 'FiLM', 'CosineSimilarity', 'Unfold', 'Fold',
     'AdaptiveLogSoftmaxWithLoss',
 ]

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -119,4 +119,41 @@ class Bilinear(Module):
             self.in1_features, self.in2_features, self.out_features, self.bias is not None
         )
 
+
+class FiLM(Module):
+    r"""Applies Feature-wise Linear Modulation to the incoming data as described in
+    the paper `FiLM: Visual Reasoning with a General Conditioning Layer`_ .
+    
+    .. math::
+        y_{n,c,*} = \gamma_{n,c} * x_{n,c,*} + \beta_{n,c},
+
+    where :math:`\gamma_{n,c}` and :math:`\beta_{n,c}` are scalars and operations are
+    broadcast over any additional dimensions of :math:`x`
+
+    Shape:
+        - Input: :math:`(N, C, *)` where :math:`*` means any number of additional
+          dimensions
+        - Gamma: :math:`(N, C)`
+        - Beta: :math:`(N, C)`
+        - Output: :math:`(N, C, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.FiLM()
+        >>> input = torch.randn(128, 20, 4, 4)
+        >>> gammas = torch.randn(128, 20)
+        >>> betas = torch.randn(128, 20)
+        >>> m(input, gammas, betas)
+        >>> print(output.size())
+        
+    .. _`FiLM: Visual Reasoning with a General Conditioning Layer`:
+        https://arxiv.org/abs/1709.07871
+    """
+    
+    def forward(self, input, gammas, betas):
+        for _ in range(input.dim() - 2):
+            gammas = gammas.unsqueeze(-1)
+            betas = betas.unsqueeze(-1)
+        return gammas * input + betas
+
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -133,8 +133,8 @@ class FiLM(Module):
     Shape:
         - Input: :math:`(N, C, *)` where :math:`*` means any number of additional
           dimensions
-        - Gamma: :math:`(N, C)`
-        - Beta: :math:`(N, C)`
+        - Gammas: :math:`(N, C)`
+        - Betas: :math:`(N, C)`
         - Output: :math:`(N, C, *)`, same shape as the input
 
     Examples::
@@ -143,7 +143,7 @@ class FiLM(Module):
         >>> input = torch.randn(128, 20, 4, 4)
         >>> gammas = torch.randn(128, 20)
         >>> betas = torch.randn(128, 20)
-        >>> m(input, gammas, betas)
+        >>> output = m(input, gammas, betas)
         >>> print(output.size())
 
     .. _`FiLM: Visual Reasoning with a General Conditioning Layer`:
@@ -151,9 +151,6 @@ class FiLM(Module):
     """
 
     def forward(self, input, gammas, betas):
-        for _ in range(input.dim() - 2):
-            gammas = gammas.unsqueeze(-1)
-            betas = betas.unsqueeze(-1)
-        return gammas * input + betas
+        return F.film(input, gammas, betas)
 
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -123,7 +123,7 @@ class Bilinear(Module):
 class FiLM(Module):
     r"""Applies Feature-wise Linear Modulation to the incoming data as described in
     the paper `FiLM: Visual Reasoning with a General Conditioning Layer`_ .
-    
+
     .. math::
         y_{n,c,*} = \gamma_{n,c} * x_{n,c,*} + \beta_{n,c},
 
@@ -145,11 +145,11 @@ class FiLM(Module):
         >>> betas = torch.randn(128, 20)
         >>> m(input, gammas, betas)
         >>> print(output.size())
-        
+
     .. _`FiLM: Visual Reasoning with a General Conditioning Layer`:
         https://arxiv.org/abs/1709.07871
     """
-    
+
     def forward(self, input, gammas, betas):
         for _ in range(input.dim() - 2):
             gammas = gammas.unsqueeze(-1)


### PR DESCRIPTION
This PR adds an implementation for Feature-wise Linear Modulation (FiLM) layers, which scale and shift each feature (map) of a set of activations independently. FiLM is particularly useful for learning from multiple inputs/modalities and for incorporating external conditioning information.

This layer was introduced in "[FiLM: Visual Reasoning with a General Conditioning Layer](https://arxiv.org/abs/1709.07871)" and has since been used in follow-up work such as:
- "[Learning by Asking Questions](https://arxiv.org/abs/1712.01238)"
- "[Learning to Follow Language Instructions with Adversarial Reward Induction](https://arxiv.org/abs/1806.01946)"
- "[A dataset and architecture for visual reasoning with a working memory](https://arxiv.org/abs/1803.06092)"
- "[Guided Feature Transformation (GFT): A Neural
Language Grounding Module for Embodied Agents](https://arxiv.org/abs/1805.08329)"

If placed immediately after a batch norm layer with affine=false, this layer implements Conditional Normalization methods used in [visual question-answering](https://arxiv.org/abs/1707.00683), [image style transfer](https://arxiv.org/abs/1610.07629), and [speech recognition](https://arxiv.org/abs/1707.06065). Conditional Normalization was recently independently proposed as a [feature proposal](https://github.com/pytorch/pytorch/issues/8985) for PyTorch.