### PR TITLE
Updated WeightedRandomSampler to fit usage of other samplers

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -101,6 +101,7 @@ class WeightedRandomSampler(Sampler):
 
     def __next__(self):
         if (self.current_iter > len(self.weights)):
+            self.current_iter = 1
             raise StopIteration
         else:
             self.current_iter += 1

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -94,7 +94,7 @@ class WeightedRandomSampler(Sampler):
         self.weights = torch.tensor(weights, dtype=torch.double)
         self.num_samples = num_samples
         self.replacement = replacement
-        self.current_iter = 1 # To keep track of iterations
+        self.current_iter = 1  # To keep track of iterations
 
     def __iter__(self):
         return self
@@ -109,6 +109,7 @@ class WeightedRandomSampler(Sampler):
 
     def __len__(self):
         return len(self.weights) * self.num_samples
+
 
 class BatchSampler(Sampler):
     r"""Wraps another sampler to yield a mini-batch of indices.
@@ -146,9 +147,9 @@ class BatchSampler(Sampler):
         batch = []
         for idx in self.sampler:
             try:
-                batch.extend(idx) # If num_samples>1 are drawn using WeightedRandomSampler
+                batch.extend(idx)  # If num_samples>1 are drawn using WeightedRandomSampler
             except TypeError:
-                batch.append(idx) # For all other samplers
+                batch.append(idx)  # For all other samplers
             if len(batch) == self.batch_size:
                 yield batch
                 batch = []


### PR DESCRIPTION
Commit to address #9171 

It does not break functioning of `BatchSampler()` or any of the other samplers, tested with the following code. It should also make it easy to dynamically change sampling weights in every call of the iterator of `WeightedRandomSampler`

```python
import torch
from torchvision import datasets, transforms
from torch._six import int_classes as _int_classes


mnist_dataset = datasets.MNIST(
    "../data",
    train=False,
    download=True,
    transform=transforms.Compose([transforms.ToTensor()]),
)
test_loader_no_sampler = torch.utils.data.DataLoader(
    mnist_dataset, batch_size=1, shuffle=True
)
test_loader_random = torch.utils.data.DataLoader(
    mnist_dataset, sampler=torch.utils.data.sampler.RandomSampler(mnist_dataset)
)
test_loader_subsetrandom = torch.utils.data.DataLoader(
    mnist_dataset, sampler=torch.utils.data.sampler.SubsetRandomSampler(range(10000))
)
test_loader_subsetrandom_2 = torch.utils.data.DataLoader(
    mnist_dataset,
    batch_size=100,
    num_workers=4,
    sampler=torch.utils.data.sampler.SubsetRandomSampler(range(10000)),
)
test_loader_weightedrandom = torch.utils.data.DataLoader(
    mnist_dataset,
    sampler=torch.utils.data.sampler.WeightedRandomSampler(weights=[1] * 10000),
)
test_loader_weightedrandom_2 = torch.utils.data.DataLoader(
    mnist_dataset,
    batch_size=100,
    num_workers=4,
    sampler=torch.utils.data.sampler.WeightedRandomSampler(
        weights=[1] * 10000, num_samples=2
    ),
)

for iter_no, (data, label) in enumerate(test_loader_no_sampler):
    continue
print("No sampler: ", iter_no)

for iter_no, (data, label) in enumerate(test_loader_random):
    continue
print("Random sampler: ", iter_no)

for iter_no, (data, label) in enumerate(test_loader_subsetrandom):
    continue
print("Subset Random sampler: ", iter_no)

for iter_no, (data, label) in enumerate(test_loader_subsetrandom_2):
    continue
print("Subset Random sampler with batch size 100: ", iter_no)

for iter_no, (data, label) in enumerate(test_loader_weightedrandom):
    continue
print("Weighted Random sampler: ", iter_no)

for iter_no, (data, label) in enumerate(test_loader_weightedrandom_2):
    continue
print("Weighted Random sampler 100 batch size and 2 samples every draw: ", iter_no)

```

Output:
```
No sampler:  9999
Random sampler:  9999
Subset Random sampler:  9999
Subset Random sampler with batch size 100:  99
Weighted Random sampler:  9999
Weighted Random sampler 100 batch size and 2 samples every draw:  199
```