### PR TITLE
Use torch.save in _StorageBase.__reduce__

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -1,3 +1,5 @@
+import io
+
 import torch
 from ._utils import _type, _cuda
 
@@ -28,7 +30,9 @@ class _StorageBase(object):
         return new_storage
 
     def __reduce__(self):
-        return type(self), (self.tolist(),)
+        b = io.BytesIO()
+        torch.save(self, b)
+        return (_load_from_bytes, (b.getvalue(),))
 
     def __sizeof__(self):
         return super(_StorageBase, self).__sizeof__() + self.element_size() * self.size()
@@ -114,6 +118,10 @@ class _StorageBase(object):
             return cls._new_using_filename(size)
         else:
             return cls._new_using_fd(size)
+
+
+def _load_from_bytes(b):
+    return torch.load(io.BytesIO(b))
 
 
 _StorageBase.type = _type


### PR DESCRIPTION
Previously this used the ``.toliist`` method, which converted the
storage object into a list of Python objects, and then sent those to
pickle.  For storage objects of non-trivial size, this was very slow.

Now we reuse the logic of the ``torch.save`` function to efficiently
turn the Storage object into bytes, and send those instead.  This
reduces the semantic information (it's harder to interpret the bytes)
but should be orders of magnitude more efficient when serializing data
with the pickle protocol or with copy

For future work it would be nice to develop a mechanism to get a buffer
of bytes out of a Storage object, and use that alongside the current
``from_buffer`` method.

See #9168 for context

