### PR TITLE
[EASY] Allow passing '0' to NO_MULTIPROCESSING_SPAWN

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -70,7 +70,7 @@ except ImportError:
 
 TEST_MKL = torch.backends.mkl.is_available()
 
-NO_MULTIPROCESSING_SPAWN = 'NO_MULTIPROCESSING_SPAWN' in os.environ
+NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1'
 
 
 def skipIfNoLapack(fn):


### PR DESCRIPTION
This PR makes setting the `NO_MULTIPROCESSING_SPAWN` easier internally, by allowing the flag to be set to `0`.