### PR TITLE
[C++ API] Turn BatchNorm into BatchNorm1d,2d,3d

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -372,11 +372,11 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto batchnorm2d =
-      model->add(BatchNorm(BatchNormOptions(10).stateful(true)), "batchnorm2d");
+      model->add(BatchNorm2d(BatchNormOptions(10).stateful(true)), "batchnorm2d");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto linear1 = model->add(Linear(320, 50), "linear1");
   auto batchnorm1 =
-      model->add(BatchNorm(BatchNormOptions(50).stateful(true)), "batchnorm1");
+      model->add(BatchNorm2d(BatchNormOptions(50).stateful(true)), "batchnorm1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](torch::Tensor x) {

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -247,7 +247,7 @@ TEST_CASE("integration/cartpole") {
   std::vector<float> rewards;
 
   auto forward = [&](torch::Tensor inp) {
-    auto x = linear->forward(inp).clamp_min(0);
+    auto x = linear->forward(inp).relu();
     torch::Tensor actions = policyHead->forward(x);
     torch::Tensor value = valueHead->forward(x);
     return std::make_tuple(torch::softmax(actions, -1), value);
@@ -348,7 +348,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
     x = torch::max_pool2d(x, {2, 2}).relu();
 
     x = x.view({-1, 320});
-    x = linear1->forward(x).clamp_min(0);
+    x = linear1->forward(x).relu();
     x = drop->forward(x);
     x = linear2->forward(x);
     x = torch::log_softmax(x, 1);
@@ -371,12 +371,12 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   torch::manual_seed(0);
   auto model = std::make_shared<torch::SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
-  auto batchnorm2d =
-      model->add(BatchNorm2d(BatchNormOptions(10).stateful(true)), "batchnorm2d");
+  auto batchnorm2d = model->add(
+      BatchNorm2d(BatchNormOptions(10).stateful(true)), "batchnorm2d");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto linear1 = model->add(Linear(320, 50), "linear1");
-  auto batchnorm1 =
-      model->add(BatchNorm2d(BatchNormOptions(50).stateful(true)), "batchnorm1");
+  auto batchnorm1 = model->add(
+      BatchNorm1d(BatchNormOptions(50).stateful(true)), "batchnorm1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](torch::Tensor x) {
@@ -386,7 +386,7 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
     x = torch::max_pool2d(x, {2, 2}).relu();
 
     x = x.view({-1, 320});
-    x = linear1->forward(x).clamp_min(0);
+    x = linear1->forward(x).relu();
     x = batchnorm1->forward(x);
     x = linear2->forward(x);
     x = torch::log_softmax(x, 1);

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -12,6 +12,8 @@
 
 #include <test/cpp/api/util.h>
 
+using Catch::StartsWith;
+
 using namespace torch::nn;
 
 class TestModel : public torch::nn::Module {
@@ -236,6 +238,56 @@ TEST_CASE("modules") {
       auto functional = Functional(torch::elu, /*alpha=*/1, /*scale=*/0);
       REQUIRE(functional(torch::ones({})).toCFloat() == 0);
     }
+  }
+
+  SECTION("batchnorm") {
+    BatchNorm1d bn1d(BatchNormOptions(5).stateful(true));
+    REQUIRE_THROWS_WITH(
+        bn1d->forward(torch::rand({})),
+        StartsWith("Expected 2D or 3D input (got 0D input)"));
+    REQUIRE_THROWS_WITH(
+        bn1d->forward(torch::rand({4})),
+        StartsWith("Expected 2D or 3D input (got 1D input)"));
+    REQUIRE_THROWS_WITH(
+        bn1d->forward(torch::rand({4, 5, 6, 7})),
+        StartsWith("Expected 2D or 3D input (got 4D input)"));
+
+    BatchNorm2d bn2d(BatchNormOptions(5).stateful(true));
+    REQUIRE_THROWS_WITH(
+        bn2d->forward(torch::rand({})),
+        StartsWith("Expected 4D input (got 0D input)"));
+    REQUIRE_THROWS_WITH(
+        bn2d->forward(torch::rand({1})),
+        StartsWith("Expected 4D input (got 1D input)"));
+    REQUIRE_THROWS_WITH(
+        bn2d->forward(torch::rand({1, 2})),
+        StartsWith("Expected 4D input (got 2D input)"));
+    REQUIRE_THROWS_WITH(
+        bn2d->forward(torch::rand({1, 2, 3})),
+        StartsWith("Expected 4D input (got 3D input)"));
+    REQUIRE_THROWS_WITH(
+        bn2d->forward(torch::rand({1, 2, 3, 4, 5})),
+        StartsWith("Expected 4D input (got 5D input)"));
+
+    BatchNorm3d bn3d(BatchNormOptions(5).stateful(true));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({})),
+        StartsWith("Expected 5D input (got 0D input)"));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({1})),
+        StartsWith("Expected 5D input (got 1D input)"));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({1, 2})),
+        StartsWith("Expected 5D input (got 2D input)"));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({1, 2, 3})),
+        StartsWith("Expected 5D input (got 3D input)"));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({1, 2, 3, 4})),
+        StartsWith("Expected 5D input (got 4D input)"));
+    REQUIRE_THROWS_WITH(
+        bn3d->forward(torch::rand({1, 2, 3, 4, 5, 6})),
+        StartsWith("Expected 5D input (got 6D input)"));
   }
 }
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -132,9 +132,9 @@ TEST_CASE("modules") {
     auto l3 = model->add(Linear(5, 100), "l3");
 
     auto x = torch::randn({1000, 10}, torch::requires_grad());
-    x = l1->forward(x).clamp_min(0);
-    x = l2->forward(x).clamp_min(0);
-    x = l3->forward(x).clamp_min(0);
+    x = l1->forward(x).relu();
+    x = l2->forward(x).relu();
+    x = l3->forward(x).relu();
 
     x.backward();
     REQUIRE(x.ndimension() == 2);

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -191,7 +191,7 @@ TEST_CASE("sequential") {
         Linear(10, 3),
         Conv2d(1, 2, 3),
         Dropout(0.5),
-        BatchNorm(5),
+        BatchNorm2d(5),
         Embedding(4, 10),
         LSTM(4, 5));
   }

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -17,9 +17,11 @@ struct BatchNormOptions {
   TORCH_ARG(double, momentum) = 0.1;
 };
 
-class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
+namespace detail {
+template <typename Derived>
+class BatchNormImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  explicit BatchNormImpl(BatchNormOptions options);
+  explicit BatchNormImplBase(BatchNormOptions options);
 
   void reset() override;
 
@@ -31,9 +33,44 @@ class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
   Tensor bias;
   Tensor running_mean;
   Tensor running_variance;
-};
 
-TORCH_MODULE(BatchNorm);
+ protected:
+  virtual void check_input_dimensions(Tensor input) const = 0;
+};
+} // namespace detail
+
+// Our usual convention is that the name of the option is <class-name> +
+// "Options", so we define these aliases.
+
+using BatchNorm1dOptions = BatchNormOptions;
+class BatchNorm1dImpl : public detail::BatchNormImplBase<BatchNorm1dImpl> {
+ public:
+  using detail::BatchNormImplBase<BatchNorm1dImpl>::BatchNormImplBase;
+
+ private:
+  virtual void check_input_dimensions(Tensor input) const override;
+};
+TORCH_MODULE(BatchNorm1d);
+
+using BatchNorm2dOptions = BatchNormOptions;
+class BatchNorm2dImpl : public detail::BatchNormImplBase<BatchNorm2dImpl> {
+ public:
+  using detail::BatchNormImplBase<BatchNorm2dImpl>::BatchNormImplBase;
+
+ private:
+  virtual void check_input_dimensions(Tensor input) const override;
+};
+TORCH_MODULE(BatchNorm2d);
+
+using BatchNorm3dOptions = BatchNormOptions;
+class BatchNorm3dImpl : public detail::BatchNormImplBase<BatchNorm3dImpl> {
+ public:
+  using detail::BatchNormImplBase<BatchNorm3dImpl>::BatchNormImplBase;
+
+ private:
+  virtual void check_input_dimensions(Tensor input) const override;
+};
+TORCH_MODULE(BatchNorm3d);
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -7,42 +7,46 @@
 
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 namespace torch {
 namespace nn {
 BatchNormOptions::BatchNormOptions(int64_t features) : features_(features) {}
 
-BatchNormImpl::BatchNormImpl(BatchNormOptions options)
+namespace detail {
+template <typename Derived>
+BatchNormImplBase<Derived>::BatchNormImplBase(BatchNormOptions options)
     : options(std::move(options)) {
   reset();
 }
 
-void BatchNormImpl::reset() {
+template <typename Derived>
+void BatchNormImplBase<Derived>::reset() {
   if (options.affine_) {
-    weight = register_parameter(
+    weight = this->register_parameter(
         "weight", torch::empty({options.features_}).uniform_());
-    bias = register_parameter("bias", torch::zeros({options.features_}));
+    bias = this->register_parameter("bias", torch::zeros({options.features_}));
   }
 
   if (options.stateful_) {
-    running_mean =
-        register_buffer("running_mean", torch::zeros({options.features_}));
-    running_variance =
-        register_buffer("running_variance", torch::ones({options.features_}));
+    running_mean = this->register_buffer(
+        "running_mean", torch::zeros({options.features_}));
+    running_variance = this->register_buffer(
+        "running_variance", torch::ones({options.features_}));
   }
 }
 
-Tensor BatchNormImpl::forward(Tensor input) {
-  return pure_forward(input, Tensor(), Tensor());
+template <typename Derived>
+Tensor BatchNormImplBase<Derived>::forward(Tensor input) {
+  return pure_forward(input, this->running_mean, this->running_variance);
 }
 
-Tensor BatchNormImpl::pure_forward(Tensor input, Tensor mean, Tensor variance) {
-  auto& running_mean = options.stateful_ ? this->running_mean : mean;
-  auto& running_variance =
-      options.stateful_ ? this->running_variance : variance;
-
-  if (is_training()) {
+template <typename Derived>
+Tensor BatchNormImplBase<Derived>::pure_forward(
+    Tensor input,
+    Tensor mean,
+    Tensor variance) {
+  check_input_dimensions(input);
+  if (this->is_training()) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
     AT_CHECK(
         input.numel() / num_channels > 1,
@@ -55,10 +59,33 @@ Tensor BatchNormImpl::pure_forward(Tensor input, Tensor mean, Tensor variance) {
       bias,
       running_mean,
       running_variance,
-      is_training(),
+      this->is_training(),
       options.momentum_,
       options.eps_,
       torch::cuda::cudnn_is_available());
+}
+
+template class BatchNormImplBase<BatchNorm1dImpl>;
+template class BatchNormImplBase<BatchNorm2dImpl>;
+template class BatchNormImplBase<BatchNorm3dImpl>;
+} // namespace detail
+
+void BatchNorm1dImpl::check_input_dimensions(Tensor input) const {
+  AT_CHECK(
+      input.dim() == 2 || input.dim() == 3,
+      "Expected 2D or 3D input (got ",
+      input.dim(),
+      "D input)");
+}
+
+void BatchNorm2dImpl::check_input_dimensions(Tensor input) const {
+  AT_CHECK(
+      input.dim() == 4, "Expected 4D input (got ", input.dim(), "D input)");
+}
+
+void BatchNorm3dImpl::check_input_dimensions(Tensor input) const {
+  AT_CHECK(
+      input.dim() == 5, "Expected 5D input (got ", input.dim(), "D input)");
 }
 
 } // namespace nn


### PR DESCRIPTION
@jamespinkerton mentioned that he found it confusing that in the C++ API there is only `BatchNorm`, while in PyTorch we have `BatchNorm{1,2,3}d`. This PR changes this.

It's the same module/function call in the end, but I took the opportunity to add another dimensionality check to every of the BatchNormXd modules, like PyTorch https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/batchnorm.py#L52

@ebetica @apaszke @ezyang 