### PR TITLE
Make GroupNorm arg order consistent with BN and IN

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2138,7 +2138,7 @@ class TestNN(NNTestCase):
             c = shape[1]
 
             # test that GN normalizes to mean 0 and stddev 1
-            gn = nn.GroupNorm(g, c, eps=0).to(device, dtype)
+            gn = nn.GroupNorm(c, g, eps=0).to(device, dtype)
             gn.weight.data.fill_(1)
             gn.bias.data.fill_(0)
             output = gn(x)
@@ -2169,14 +2169,14 @@ class TestNN(NNTestCase):
             (2, 6, 4, 2, 2): 4,
         }
         for shape, g in bad_shape_g.items():
-            gn = nn.GroupNorm(g, shape[1])
+            gn = nn.GroupNorm(shape[1], g)
             input = torch.empty(*shape, device=device, dtype=dtype).uniform_(0, 10)
             self.assertRaises(RuntimeError, lambda: gn(input))
 
     def _test_GroupNorm_cuda_half(self):
         input = Variable(torch.empty(2, 3, 3, 2).to("cuda", torch.half).random_(1, 10), requires_grad=True)
         input = torch.zeros(2, 4, 3, 2, requires_grad=True).cuda().half().random_(1, 10)
-        m = nn.GroupNorm(2, 4).to("cuda", torch.half)
+        m = nn.GroupNorm(4, 2).to("cuda", torch.half)
         output = m(input)
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
@@ -6658,7 +6658,7 @@ new_module_tests = [
     ),
     dict(
         module_name='GroupNorm',
-        constructor_args=(3, 6, 1e-3),
+        constructor_args=(6, 3, 1e-3),
         input_size=(4, 6, 5),
         cudnn=True,
         check_eval=True,
@@ -6674,7 +6674,7 @@ new_module_tests = [
     ),
     dict(
         module_name='GroupNorm',
-        constructor_args=(1, 5, 1e-3, False),
+        constructor_args=(5, 1, 1e-3, False),
         input_size=(4, 5, 5),
         cudnn=True,
         check_eval=True,
@@ -6682,7 +6682,7 @@ new_module_tests = [
     ),
     dict(
         module_name='GroupNorm',
-        constructor_args=(3, 6, 1e-3),
+        constructor_args=(6, 3, 1e-3),
         input_size=(4, 6, 2, 3),
         cudnn=True,
         check_eval=True,
@@ -6698,7 +6698,7 @@ new_module_tests = [
     ),
     dict(
         module_name='GroupNorm',
-        constructor_args=(1, 3, 1e-3, False),
+        constructor_args=(3, 1, 1e-3, False),
         input_size=(4, 3, 2, 3),
         cudnn=True,
         check_eval=True,

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -168,8 +168,8 @@ class GroupNorm(Module):
     evaluation modes.
 
     Args:
-        num_groups (int): number of groups to separate the channels into
         num_channels (int): number of channels expected in input
+        num_groups (int): number of groups to separate the channels into
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         affine: a boolean value that when set to ``True``, this module
             has learnable per-channel affine parameters. Default: ``True``
@@ -182,20 +182,20 @@ class GroupNorm(Module):
 
         >>> input = torch.randn(20, 6, 10, 10)
         >>> # Separate 6 channels into 3 groups
-        >>> m = nn.GroupNorm(3, 6)
+        >>> m = nn.GroupNorm(6, 3)
         >>> # Separate 6 channels into 6 groups (equivalent with InstanceNorm)
         >>> m = nn.GroupNorm(6, 6)
         >>> # Put all 6 channels into a single group (equivalent with LayerNorm)
-        >>> m = nn.GroupNorm(1, 6)
+        >>> m = nn.GroupNorm(6, 1)
         >>> # Activating the module
         >>> output = m(input)
 
     .. _`Group Normalization`: https://arxiv.org/abs/1803.08494
     """
-    def __init__(self, num_groups, num_channels, eps=1e-5, affine=True):
+    def __init__(self, num_channels, num_groups, eps=1e-5, affine=True):
         super(GroupNorm, self).__init__()
-        self.num_groups = num_groups
         self.num_channels = num_channels
+        self.num_groups = num_groups
         self.eps = eps
         self.affine = affine
         if self.affine:
@@ -216,7 +216,7 @@ class GroupNorm(Module):
             input, self.num_groups, self.weight, self.bias, self.eps)
 
     def extra_repr(self):
-        return '{num_groups}, {num_channels}, eps={eps}, ' \
+        return '{num_channels}, {num_groups}, eps={eps}, ' \
             'affine={affine}'.format(**self.__dict__)
 
 


### PR DESCRIPTION
Now GroupNorm has `GroupNorm(num_groups, num_channels)`. But for IN and BN, the first arg is `num_channels`. Since GN hasn't been a release yet, I propose to make `num_channels` the first arg.

The functional form doesn't have such issue.