### PR TITLE
[EASY] Allow passing '0' to ASAN/UBSAN flags

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -71,8 +71,8 @@ except ImportError:
 TEST_MKL = torch.backends.mkl.is_available()
 
 NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1'
-TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', False)
-TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', False)
+TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
+TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 
 
 def skipIfNoLapack(fn):


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/9187, This PR makes setting the `PYTORCH_TEST_WITH_ASAN` and `PYTORCH_TEST_WITH_UBSAN` flags easier internally, by allowing the flags to be set to `0`.