### PR TITLE
[Caffe2] Enable channel shuffle op on IDEEP device with openomp optimization

### DIFF
--- a/caffe2/ideep/CMakeLists.txt
+++ b/caffe2/ideep/CMakeLists.txt
@@ -9,7 +9,7 @@ if(USE_MKL AND USE_IDEEP AND CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
 
   add_library(Caffe2_ideep_operators OBJECT ${avx2_srcs})
   add_dependencies(Caffe2_ideep_operators Caffe_PROTO Caffe2_PROTO)
-  set_target_properties(Caffe2_ideep_operators PROPERTIES COMPILE_FLAGS "-mavx2")
+  set_target_properties(Caffe2_ideep_operators PROPERTIES COMPILE_FLAGS "-mavx2 -fopenmp")
 
   # ---[ Send the lists to the parent scope.
   set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS}

--- a/caffe2/ideep/operators/channel_shuffle_op.cc
+++ b/caffe2/ideep/operators/channel_shuffle_op.cc
@@ -1,0 +1,53 @@
+#include <caffe2/ideep/operators/conv_pool_base_op.h>
+
+namespace caffe2 {
+
+class ChannelShuffleOp final : public IDEEPConvPoolOpBase {
+ public:
+  USE_IDEEP_DEF_ALIASES();
+  USE_IDEEP_CONV_POOL_BASE_FUNCTIONS();
+
+  ChannelShuffleOp(const OperatorDef& operator_def, Workspace* ws)
+      : IDEEPConvPoolOpBase(operator_def, ws) {}
+
+  bool RunOnDeviceWithOrderNCHW() override {
+    const auto& X = Input(INPUT);
+    auto* Y = Output(OUTPUT);
+
+    ideep::channel_shuffle_forward::compute(X, *Y, group_);
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(INPUT);
+  OUTPUT_TAGS(OUTPUT);
+};
+
+class ChannelShuffleGradientOp final : public IDEEPConvPoolOpBase {
+ public:
+  USE_IDEEP_DEF_ALIASES();
+  USE_IDEEP_CONV_POOL_BASE_FUNCTIONS();
+
+  ChannelShuffleGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : IDEEPConvPoolOpBase(operator_def, ws) {}
+
+  bool RunOnDeviceWithOrderNCHW() override {
+    const auto& dY = Input(OUTPUT_GRAD);
+    auto* dX = Output(INPUT_GRAD);
+
+    ideep::channel_shuffle_backward::compute(dY, *dX, group_);
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(OUTPUT_GRAD);
+  OUTPUT_TAGS(INPUT_GRAD);
+};
+
+
+REGISTER_IDEEP_OPERATOR(ChannelShuffle, ChannelShuffleOp);
+REGISTER_IDEEP_OPERATOR(ChannelShuffleGradient, ChannelShuffleGradientOp);
+
+} // namespace caffe2

--- a/caffe2/ideep/operators/operator_fallback_ideep.cc
+++ b/caffe2/ideep/operators/operator_fallback_ideep.cc
@@ -3,7 +3,6 @@
 
 #include <caffe2/operators/bbox_transform_op.h>
 #include <caffe2/operators/box_with_nms_limit_op.h>
-#include <caffe2/operators/channel_shuffle_op.h>
 #include <caffe2/operators/collect_and_distribute_fpn_rpn_proposals_op.h>
 #include <caffe2/operators/conv_transpose_op.h>
 #include <caffe2/operators/cross_entropy_op.h>
@@ -41,9 +40,6 @@ struct SigmoidCPUFunctor {
 } // namespace
 
 REGISTER_IDEEP_OPERATOR(Softmax, IDEEPFallbackOp<SoftmaxOp<float, CPUContext>>);
-REGISTER_IDEEP_OPERATOR(
-    ChannelShuffle,
-    IDEEPFallbackOp<ChannelShuffleOp<CPUContext>>);
 REGISTER_IDEEP_OPERATOR(
     LabelCrossEntropy,
     IDEEPFallbackOp<LabelCrossEntropyOp<float, CPUContext>>);

--- a/caffe2/python/ideep/channel_shuffle_op_test.py
+++ b/caffe2/python/ideep/channel_shuffle_op_test.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import hypothesis.strategies as st
+from hypothesis import given
+import numpy as np
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.ideep_test_util as mu
+
+@unittest.skipIf(not workspace.C.use_ideep, "No IDEEP support.")
+class ChannelShuffleTest(hu.HypothesisTestCase):
+    @given(size=st.integers(8, 10),
+           input_channels=st.integers(1, 3),
+           batch_size=st.integers(1, 32),
+           group=st.integers(2, 4),
+           stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           kernel=st.integers(3, 5),
+           **mu.gcs)
+    def test_channel_shuffle(self, size, input_channels, batch_size, group, stride, pad, kernel, gc, dc):
+        op = core.CreateOperator(
+            "ChannelShuffle",
+            ["X"],
+            ["Y"],
+            group = group,
+            stride = stride,
+            pad = pad,
+            kernel = kernel,
+        )
+        X = np.random.rand(
+            batch_size, input_channels * group, size, size).astype(np.float32) - 0.5
+
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+        self.assertGradientChecks(gc, op, [X], 0, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Enable channel shuffle op on IDEEP device
2. Optimize channel shuffle by openmp
3. Add channel shuffle test case

