### PR TITLE
Optimize LeakyReLU and PReLU 'forward' functions on the CPU

### DIFF
--- a/aten/src/THNN/generic/LeakyReLU.c
+++ b/aten/src/THNN/generic/LeakyReLU.c
@@ -22,7 +22,8 @@ void THNN_(LeakyReLU_updateOutput)(
   {
     THTensor_(resizeAs)(output, input);
     TH_TENSOR_APPLY2(real, output, real, input,
-      *output_data = *input_data > 0 ? *input_data : *input_data * negval;
+      const real r = (*input_data > 0) ? 1 : negval;
+      *output_data = *input_data * r;
     );
   }
 }

--- a/aten/src/THNN/generic/PReLU.c
+++ b/aten/src/THNN/generic/PReLU.c
@@ -16,7 +16,8 @@ void THNN_(PReLU_updateOutput)(
     // handle shared parameter case
     real w = *THTensor_(data)(weight);
     TH_TENSOR_APPLY2(real, output, real, input,
-      *output_data = (*input_data > 0) ? *input_data : w*(*input_data);
+          const real r = (*input_data > 0) ? 1 : w;
+          *output_data = *input_data * r;
     );
     return;
   }


### PR DESCRIPTION
This looks like a totally cosmetic change, but for some reason it reduces the runtime by ~50% running in a single CPU thread.

```
import os
os.environ['OMP_NUM_THREADS']='1'  #Use one CPU thread
import torch, torch.nn as nn, time
def test_net(net,offset):
    net.eval()
    total=0
    with torch.no_grad():
        for _ in range(100):
            x = torch.randn(100,100,100)+offset
            start_time = time.time()
            y = net(x)
            total+=time.time()-start_time
    print(net, total*10, 'ms')

for offset in [-1,0,+1]:
    test_net(nn.LeakyReLU(),offset) 
    test_net(nn.PReLU(),offset) 
```