### PR TITLE
N-dimensional empty tensors: indexing, factories, reductions.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -888,7 +888,6 @@
         - arg: bool keepdim
           default: "false"
 ]]
-
 [[
   name: _th_kthvalue
   backends:

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -888,6 +888,7 @@
         - arg: bool keepdim
           default: "false"
 ]]
+
 [[
   name: _th_kthvalue
   backends:
@@ -1018,6 +1019,18 @@
       return: real
       arguments:
         - THTensor* self
+]]
+[[
+  name: _th_all
+  types:
+    - Byte
+  variants:
+    - method
+    - function
+  backends:
+    - CPU
+    - CUDA
+  options:
     - cname: logicalAnd
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
@@ -1045,6 +1058,18 @@
       return: real
       arguments:
         - THTensor* self
+]]
+[[
+  name: _th_any
+  types:
+    - Byte
+  variants:
+    - method
+    - function
+  backends:
+    - CPU
+    - CUDA
+  options:
     - cname: logicalAny
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
@@ -1641,6 +1666,18 @@
           if_true: 0
           if_false: 1
           default: 0
+]]
+[[
+  name: _th_var
+  types:
+    - floating_point
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  options:
     - cname: var
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
@@ -1676,6 +1713,18 @@
           if_true: 0
           if_false: 1
           default: 0
+]]
+[[
+  name: _th_std
+  types:
+    - floating_point
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  options:
     - cname: std
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
@@ -1711,7 +1760,7 @@
           default: AS_REAL(2)
 ]]
 [[
-  name: norm
+  name: _th_norm
   types:
     - floating_point
   backends:

--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -21,7 +21,8 @@ std::vector<int64_t> infer_size(IntList a, IntList b) {
         ") must match the size of tensor b (", sizeB,
         ") at non-singleton dimension ", i);
 
-    expandedSizes[i] = std::max(sizeA, sizeB);
+      // 1s map to the other size (even 0).
+      expandedSizes[i] = sizeA == 1 ? sizeB : sizeA;
   }
 
   return expandedSizes;

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -5,6 +5,6 @@
 namespace at { namespace native {
 
 Tensor pairwise_distance(const Tensor& x1, const Tensor& x2, double p, double eps, bool keepdim) {
-  return norm(x1 - x2 + eps, p, 1, keepdim);
+  return at::native::norm(x1 - x2 + eps, p, 1, keepdim);
 }
 }}  // namespace at::native

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -5,6 +5,6 @@
 namespace at { namespace native {
 
 Tensor pairwise_distance(const Tensor& x1, const Tensor& x2, double p, double eps, bool keepdim) {
-  return at::native::norm(x1 - x2 + eps, p, 1, keepdim);
+  return at::norm(x1 - x2 + eps, p, 1, keepdim);
 }
 }}  // namespace at::native

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -71,6 +71,7 @@ Tensor embedding_sparse_backward(
 
   // check if all our grad come from padding_idx
   if (grad.numel() == 0) {
+    // FIXME: USE_TH_SIZE_ZERO_DIM
     return sparse_type._sparse_coo_tensor_unsafe(indices_.type().tensor(),
                                          dense_type.tensor(), weight_size);
   }

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -69,8 +69,19 @@ static std::vector<Tensor> expandByteTensors(const Tensor & self, TensorList ind
       }
       // Replace with nonzeros
       auto nonzero = index.nonzero();
+#ifndef USE_TH_SIZE_ZERO_DIM
+      auto special_empty = nonzero.numel() == 0;
+#else
+      auto special_empty = false;
+#endif
       for (int64_t j = 0; j < index.dim(); j++) {
-        result.emplace_back(nonzero.select(1, j));
+        if (special_empty) {
+          // We can't call select on an empty tensor so we just create an empty
+          // tensor.
+          result.emplace_back(nonzero.type().tensor());
+        } else {
+          result.emplace_back(nonzero.select(1, j));
+        }
       }
     } else {
       result.emplace_back(index);
@@ -203,10 +214,26 @@ static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
   return linearIndex;
 }
 
+#ifndef USE_TH_SIZE_ZERO_DIM
+static bool hasEmptyTensor(TensorList tensors) {
+  for (auto& tensor : tensors) {
+    if (tensor.defined() && tensor.numel() == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif
+
 static std::tuple<Tensor, Tensor> makeLinearIndex(Tensor self, TensorList orig) {
   checkIndexTensorTypes(orig);
   // first expand ByteTensor (boolean masks) into 1 or more LongTensors
   auto indices = expandByteTensors(self, orig);
+#ifndef USE_TH_SIZE_ZERO_DIM
+  if (hasEmptyTensor(indices)) {
+    return std::make_tuple(self, self.type().toScalarType(kLong).tensor());
+  }
+#endif
   // next broadcast all index tensors together
   indices = expand_outplace(indices);
   // add missing null Tensors so that it matches self.dim()

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -96,10 +96,12 @@ static inline Tensor mean(const Tensor &self, optional<ScalarType> dtype) {
       "Can only calculate the mean of floating types. Got ",
       at::toString(scalarType),
       " instead.");
-  Tensor result = at::native::sum(self);
-  if (self.numel() > 0)
-    result.div_(self.numel());
-  return result;
+  if (self.numel() > 0) {
+    Tensor result = at::native::sum(self);
+    return result.div_(self.numel());
+  } else {
+    return self.type().scalarTensor(std::numeric_limits<double>::quiet_NaN());
+  }
 }
 
 Tensor mean(const Tensor &self, ScalarType dtype) {
@@ -168,7 +170,12 @@ static inline Tensor &mean_out(Tensor &result, const Tensor &self, int64_t dim,
       result, self.toType(result.type().scalarType()), dim, keepdim);
   if (result.numel() > 0 && self.ndimension() > 0) {
     int64_t numel = self.size(dim);
-    result.div_(numel);
+    if (numel > 0) {
+      result.div_(numel);
+    } else {
+      // NumPy equivalent
+      result.fill_(std::numeric_limits<double>::quiet_NaN());
+    }
   }
   return result;
 }
@@ -270,7 +277,12 @@ static inline Tensor mean(const Tensor &self, int64_t dim, bool keepdim, optiona
   Tensor result = at::native::sum(self, dim, keepdim);
   if (result.numel() > 0 && self.ndimension() > 0) {
     int64_t numel = self.size(dim);
-    result.div_(numel);
+    if (numel > 0) {
+      result.div_(numel);
+    } else {
+      // NumPy equivalent
+      result.fill_(std::numeric_limits<double>::quiet_NaN());
+    }
   }
   return result;
 }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -610,7 +610,7 @@ Tensor any(const Tensor& self, int64_t dim, bool keepdim) {
 
 Tensor &any_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
-           "all only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+           "any only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   AT_CHECK(self.type().scalarType() == at::ScalarType::Byte, "any only supports torch.uint8 dtype");
   dim = maybe_wrap_dim(dim, self.dim());
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -4,10 +4,12 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/WrapDimUtils.h"
 #include "ATen/WrapDimUtilsMulti.h"
+#include "ReduceOpsUtils.h"
 #include "cpu/ReduceOpsKernel.h"
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <vector>
 #include <map>
@@ -154,32 +156,6 @@ Tensor _prod_cpu(const Tensor &self) {
 
 // DIM REDUCE #################################################################
 
-static bool _dimreduce_return_trivial(Tensor &result, const Tensor &self,
-                                      int64_t ident) {
-  if (self.numel() == 1 && self.ndimension() == 0) {
-    result.resize_({});
-    result.fill_(self);
-    return true;
-  }
-  // Return identity
-  if (self.numel() == 0 && self.ndimension() == 1) {
-    result.resize_({0});
-    result.fill_(ident);
-    return true;
-  }
-  return false;
-}
-
-static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
-                                int64_t dim) {
-  IntList self_sizes = self.sizes();
-  std::vector<int64_t> result_sizes;
-  result_sizes.insert(result_sizes.end(), self_sizes.begin(), self_sizes.end());
-  result_sizes[dim] = 1;
-  result.resize_(result_sizes);
-  return result;
-}
-
 static inline Tensor &mean_out(Tensor &result, const Tensor &self, int64_t dim,
                  bool keepdim, optional<ScalarType> dtype) {
   ScalarType scalarType = result.type().scalarType();
@@ -235,7 +211,7 @@ Tensor& sum_out(Tensor& result, const Tensor& self, IntList dim, ScalarType dtyp
 Tensor &_sum_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
                      bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
-  if (_dimreduce_return_trivial(result, self, 0))
+  if (_dimreduce_return_trivial(result, self, 0, dim, keepdim))
     return result;
   if (self.is_contiguous() && result.is_contiguous()) {
     _dimreduce_setup(result, self, dim);
@@ -273,7 +249,7 @@ Tensor& prod_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dty
 Tensor &_prod_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
                       bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
-  if (_dimreduce_return_trivial(result, self, 1))
+  if (_dimreduce_return_trivial(result, self, 1, dim, keepdim))
     return result;
   if (self.is_contiguous() && result.is_contiguous()) {
     _dimreduce_setup(result, self, dim);
@@ -357,10 +333,15 @@ Tensor _prod(const Tensor &self, int64_t dim_, bool keepdim) {
 
 Tensor& logsumexp_out(Tensor& result, const Tensor &self, int64_t dim_, bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
-  auto maxes = at::max_values(self, dim, true);
-  result = at::where((maxes == INFINITY).__or__(maxes == -INFINITY),
-		     maxes,
-		     maxes + at::log(at::sum(at::exp(self - maxes), dim, true)));
+  // can't take max of empty tensor.
+  if (self.numel() != 0) {
+    auto maxes = at::max_values(self, dim, true);
+    result = at::where((maxes == INFINITY).__or__(maxes == -INFINITY),
+                       maxes,
+                       maxes + at::log(at::sum(at::exp(self - maxes), dim, true)));
+  } else {
+    result = at::log(at::sum(at::exp(self), dim, true));
+  }
   if (! keepdim)
     result.squeeze_(dim);
   return result;
@@ -586,6 +567,91 @@ Tensor _sum(const Tensor &self, IntList dims, bool keepdim) {
 Tensor& _sum_out(Tensor &result, const Tensor &self, IntList dims, bool keepdim)
 {
   return reduce_multi_associative_out<_sum, _sum_out>(result, self, dims, keepdim);
+}
+
+Tensor norm(const Tensor& self, Scalar p, int64_t dim, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::norm_out(result, self, p, dim, keepdim);
+}
+
+Tensor &norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool keepdim) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "norm only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
+  dim = maybe_wrap_dim(dim, self.dim());
+  if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_norm_out(result, self, p, dim, keepdim);
+  }
+}
+
+Tensor all(const Tensor& self, int64_t dim, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::all_out(result, self, dim, keepdim);
+}
+
+Tensor &all_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "all only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte, "all only supports torch.uint8 dtype");
+  dim = maybe_wrap_dim(dim, self.dim());
+  if (_dimreduce_return_trivial(result, self, 1, dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_all_out(result, self, dim, keepdim);
+  }
+}
+
+Tensor any(const Tensor& self, int64_t dim, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::any_out(result, self, dim, keepdim);
+}
+
+Tensor &any_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "all only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte, "any only supports torch.uint8 dtype");
+  dim = maybe_wrap_dim(dim, self.dim());
+  if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_any_out(result, self, dim, keepdim);
+  }
+}
+
+Tensor var(const Tensor& self, int64_t dim, bool unbiased, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::var_out(result, self, dim, unbiased, keepdim);
+}
+
+Tensor &var_out(Tensor &result, const Tensor &self, int64_t dim, bool unbiased, bool keepdim) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "var only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "var only supports floating-point dtypes");
+  dim = maybe_wrap_dim(dim, self.dim());
+  if (_dimreduce_return_trivial(result, self, std::numeric_limits<double>::quiet_NaN(), dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_var_out(result, self, dim, unbiased, keepdim);
+  }
+}
+
+Tensor std(const Tensor& self, int64_t dim, bool unbiased, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::std_out(result, self, dim, unbiased, keepdim);
+}
+
+Tensor &std_out(Tensor &result, const Tensor &self, int64_t dim, bool unbiased, bool keepdim) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "std only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "std only supports floating-point dtypes");
+  dim = maybe_wrap_dim(dim, self.dim());
+  if (_dimreduce_return_trivial(result, self, std::numeric_limits<double>::quiet_NaN(), dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_std_out(result, self, dim, unbiased, keepdim);
+  }
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -1,0 +1,47 @@
+#pragma once
+
+namespace at { namespace native {
+
+static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
+                                int64_t dim) {
+  IntList self_sizes = self.sizes();
+  std::vector<int64_t> result_sizes;
+  result_sizes.insert(result_sizes.end(), self_sizes.begin(), self_sizes.end());
+  result_sizes[dim] = 1;
+  result.resize_(result_sizes);
+  return result;
+}
+
+static bool _dimreduce_return_trivial(Tensor &result, const Tensor &self,
+                                      int64_t ident, int64_t dim, bool keepdim) {
+  if (self.numel() == 1 && self.ndimension() == 0) {
+    result.resize_({});
+    result.fill_(self);
+    return true;
+  }
+  // Return identity
+  if (self.numel() == 0) {
+    _dimreduce_setup(result, self, dim);
+    result.fill_(ident);
+    if (!keepdim) result.squeeze_(dim);
+    return true;
+  }
+  return false;
+}
+
+static bool _dimreduce_return_trivial_no_ident(Tensor &result, const Tensor &self,
+                                               int64_t dim, bool keepdim, const char *fn_name) {
+  if (self.numel() == 1 && self.ndimension() == 0) {
+    result.resize_({});
+    result.fill_(self);
+    return true;
+  }
+
+  if (self.numel() == 0) {
+    AT_ERROR("cannot perform reduction function ", fn_name,
+             " on tensor with no elements because the operation does not have an identity");
+  }
+  return false;
+}
+
+}}  // at::native

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -13,7 +13,7 @@ static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
 }
 
 static bool _dimreduce_return_trivial(Tensor &result, const Tensor &self,
-                                      int64_t ident, int64_t dim, bool keepdim) {
+                                      Scalar ident, int64_t dim, bool keepdim) {
   if (self.numel() == 1 && self.ndimension() == 0) {
     result.resize_({});
     result.fill_(self);

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -4,6 +4,7 @@
 #include "ATen/Error.h"
 #include "ATen/ExpandUtils.h"
 #include "ATen/NativeFunctions.h"
+#include "ReduceOpsUtils.h"
 
 namespace {
 template <typename scalar_t>
@@ -96,7 +97,13 @@ std::tuple<Tensor &,Tensor &> kthvalue_out(Tensor& values, Tensor& indices,
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "kthvalue only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   dim = maybe_wrap_dim(dim, self.dim());
-  return at::_th_kthvalue_out(values, indices, self, k, dim, keepdim);
+  if (_dimreduce_return_trivial_no_ident(values, self, dim, keepdim, "kthvalue")) {
+    AT_ASSERT(values.dim() == 0);
+    indices.resize_({}).fill_(0);
+    return std::forward_as_tuple(values, indices);
+  } else {
+    return at::_th_kthvalue_out(values, indices, self, k, dim, keepdim);
+  }
 }
 
 std::tuple<Tensor, Tensor> median(const Tensor& self, int64_t dim, bool keepdim) {
@@ -110,7 +117,13 @@ std::tuple<Tensor &,Tensor &> median_out(Tensor& values, Tensor& indices,
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "median only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   dim = maybe_wrap_dim(dim, self.dim());
-  return at::_th_median_out(values, indices, self, dim, keepdim);
+  if (_dimreduce_return_trivial_no_ident(values, self, dim, keepdim, "median")) {
+    AT_ASSERT(values.dim() == 0);
+    indices.resize_({}).fill_(0);
+    return std::forward_as_tuple(values, indices);
+  } else {
+    return at::_th_median_out(values, indices, self, dim, keepdim);
+  }
 }
 
 std::tuple<Tensor, Tensor> mode(const Tensor& self, int64_t dim, bool keepdim) {
@@ -124,7 +137,13 @@ std::tuple<Tensor &,Tensor &> mode_out(Tensor& values, Tensor& indices,
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "mode only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   dim = maybe_wrap_dim(dim, self.dim());
-  return at::_th_mode_out(values, indices, self, dim, keepdim);
+  if (_dimreduce_return_trivial_no_ident(values, self, dim, keepdim, "mode")) {
+    AT_ASSERT(values.dim() == 0);
+    indices.resize_({}).fill_(0);
+    return std::forward_as_tuple(values, indices);
+  } else {
+    return at::_th_mode_out(values, indices, self, dim, keepdim);
+  }
 }
 
 std::tuple<Tensor, Tensor> max(const Tensor& self, int64_t dim, bool keepdim) {
@@ -138,7 +157,13 @@ std::tuple<Tensor &,Tensor &> max_out(Tensor& max, Tensor& max_indices,
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "max only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   dim = maybe_wrap_dim(dim, self.dim());
-  return at::_th_max_out(max, max_indices, self, dim, keepdim);
+  if (_dimreduce_return_trivial_no_ident(max, self, dim, keepdim, "max")) {
+    AT_ASSERT(max.dim() == 0);
+    max_indices.resize_({}).fill_(0);
+    return std::forward_as_tuple(max, max_indices);
+  } else {
+    return at::_th_max_out(max, max_indices, self, dim, keepdim);
+  }
 }
 
 Tensor max_values(const Tensor& self, int64_t dim, bool keepdim) {
@@ -156,7 +181,13 @@ std::tuple<Tensor &,Tensor &> min_out(Tensor& min, Tensor& min_indices,
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "min only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   dim = maybe_wrap_dim(dim, self.dim());
-  return at::_th_min_out(min, min_indices, self, dim, keepdim);
+  if (_dimreduce_return_trivial_no_ident(min, self, dim, keepdim, "min")) {
+    AT_ASSERT(min.dim() == 0);
+    min_indices.resize_({}).fill_(0);
+    return std::forward_as_tuple(min, min_indices);
+  } else {
+    return at::_th_min_out(min, min_indices, self, dim, keepdim);
+  }
 }
 
 Tensor min_values(const Tensor& self, int64_t dim, bool keepdim) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -37,9 +37,9 @@ void window_function_checks(
       " expects floating point dtypes, got: ",
       options.type().toString());
   AT_CHECK(
-      window_length > 0,
+      window_length >= 0,
       function_name,
-      " requires positive window_length, got window_length=%lld",
+      " requires non-negative window_length, got window_length=",
       window_length);
 }
 } // namespace
@@ -141,8 +141,17 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n) {
 }
 
 Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
-  AT_CHECK(n > 0, "n must be greater than 0, got", n);
+#ifndef USE_TH_SIZE_ZERO_DIM
+  AT_CHECK(n > 0, "n must be greater than 0, got ", n);
+#else
+  AT_CHECK(n >= 0, "n must be greater or equal to 0, got ", n);
+#endif
+
+#ifndef USE_TH_SIZE_ZERO_DIM
   if(m <= 0) {
+#else
+  if(m < 0) {
+#endif
     m = n;
   }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -212,12 +212,14 @@ static std::vector<int64_t> infer_size(IntList shape, int64_t numel) {
     if (infer_dim) {
       res[*infer_dim] = numel / newsize;
     }
+#ifndef USE_TH_SIZE_ZERO_DIM
     if (numel == 0) {
       // Collapse zero-element shapes into one dimension because TH handles zeros
       // in sizes strangely: x.resize_(1, 0) has shape (1,). TODO: remove this
       // once we have multi-dimensional empty tensors.
       return {0};
     }
+#endif
     return res;
   }
 

--- a/aten/src/ATen/native/cuda/CUDAReduceOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAReduceOps.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include "ATen/native/ReduceOpsUtils.h"
 
 namespace at { namespace native {
 
@@ -8,12 +9,20 @@ Tensor _prod_cuda(const Tensor &self_) { return self_._prodall(); }
 
 Tensor &_sum_out_cuda(Tensor &result, const Tensor &self, int64_t dim,
                       bool keepdim) {
-  return at::_th_sum_out(result, self, dim, keepdim);
+  if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_sum_out(result, self, dim, keepdim);
+  }
 }
 
 Tensor &_prod_out_cuda(Tensor &result, const Tensor &self, int64_t dim,
                        bool keepdim) {
-  return at::_th_prod_out(result, self, dim, keepdim);
+  if (_dimreduce_return_trivial(result, self, 1, dim, keepdim)) {
+    return result;
+  } else {
+    return at::_th_prod_out(result, self, dim, keepdim);
+  }
 }
 
 

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -20,8 +20,17 @@ Tensor& eye_out_cuda(Tensor& result, int64_t n) {
 }
 
 Tensor& eye_out_cuda(Tensor& result, int64_t n, int64_t m) {
-  AT_CHECK(n > 0, "n must be greater than zero, got", n);
+#ifndef USE_TH_SIZE_ZERO_DIM
+  AT_CHECK(n > 0, "n must be greater than 0, got ", n);
+#else
+  AT_CHECK(n >= 0, "n must be greater or equal to 0, got ", n);
+#endif
+
+#ifndef USE_TH_SIZE_ZERO_DIM
   if(m <= 0) {
+#else
+  if(m < 0) {
+#endif
     m = n;
   }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -102,6 +102,16 @@
 - func: addr_out(Tensor result, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
 
+- func: all(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
+
+- func: all_out(Tensor result, Tensor self, int64_t dim, bool keepdim=false) -> Tensor
+  variants: function
+
+- func: any(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
+
+- func: any_out(Tensor result, Tensor self, int64_t dim, bool keepdim=false) -> Tensor
+  variants: function
+
 - func: arange(Scalar start, Scalar end, TensorOptions options={}) -> Tensor
   variants: function
 
@@ -1266,6 +1276,11 @@
     CPU: _sqrt_out_cpu
     CUDA: _sqrt_out_cuda
 
+- func: std(Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
+
+- func: std_out(Tensor result, Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
+  variants: function
+
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: prod(Tensor self, *, ScalarType dtype) -> Tensor
 
@@ -1375,6 +1390,11 @@
 - func: unsqueeze_(Tensor self, int64_t dim) -> Tensor
   variants: method
 
+- func: var(Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
+
+- func: var_out(Tensor result, Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
+  variants: function
+
 - func: view_as(Tensor self, Tensor other) -> Tensor
   variants: method
 
@@ -1430,6 +1450,15 @@
 
 - func: norm(Tensor self, Scalar p=2) -> Tensor
   variants: method, function
+
+- func: norm(Tensor self, Scalar p, int64_t dim, bool keepdim=false) -> Tensor
+  python_default_init:
+    p: 2
+
+- func: norm_out(Tensor result, Tensor self, Scalar p, int64_t dim, bool keepdim=false) -> Tensor
+  variants: function
+  python_default_init:
+    p: 2
 
 - func: native_clone(Tensor self) -> Tensor
   variants: function

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -132,9 +132,7 @@ void test(Type &T) {
     if (t.numel() != 0) {
       REQUIRE(t.sum(0).dim() == std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      if (!T.is_cuda()) { // FIXME: out of range exception in CUDA
-        REQUIRE(t.sum(0).equal(at::empty({0}, T)));
-      }
+      REQUIRE(t.sum(0).equal(at::zeros({}, T)));
     }
 
     // reduce (with dimension argument and with 2 return arguments)
@@ -143,7 +141,6 @@ void test(Type &T) {
       REQUIRE(std::get<0>(ret).dim() == std::max<int64_t>(t.dim() - 1, 0));
       REQUIRE(std::get<1>(ret).dim() == std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      // FIXME: you should be able to reduce over size {0}
       REQUIRE_THROWS(t.min(0));
     }
 
@@ -156,8 +153,8 @@ void test(Type &T) {
 
     // fill_ (argument to fill_ can only be a 0-dim tensor)
     TRY_CATCH_ELSE(t.fill_(t.sum(0)),
-                   REQUIRE((t.numel() == 0 || t.dim() > 1)),
-                   { REQUIRE(t.numel() > 0); REQUIRE(t.dim() <= 1); });
+                   REQUIRE(t.dim() > 1),
+                   REQUIRE(t.dim() <= 1));
   }
 
   for (auto lhs_it = sizes.begin(); lhs_it != sizes.end(); ++lhs_it) {

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "wrapdim test", "[]" ) {
 
   SECTION( "empty tensor" ) {
     auto a = randn(0, T);
-    REQUIRE(a.prod(0).equal(at::empty({0}, T)));
+    REQUIRE(a.prod(0).equal(at::ones({}, T)));
   }
 
   SECTION( "scalar vs 1-dim, 1-size" ) {

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -617,9 +617,10 @@ int THTensor_(isTransposed)(const THTensor *self)
 
 int THTensor_(isContiguous)(const THTensor *self)
 {
+  if (self->is_empty()) return 1;
   int64_t z = 1;
   int d;
-  for(d = self->_dim()-1; d >= 0; d--)
+  for(d = self->dim()-1; d >= 0; d--)
   {
     if(self->size[d] != 1)
     {

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -4366,13 +4366,15 @@ void THTensor_(linspace)(THTensor *r_, real a, real b, int64_t n)
 {
   real i = 0;
 
-  THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
+  // NumPy allows you to pass different points even if n <= 1 -- should we?
+  THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
 
   if (THTensor_(nElement)(r_) != n) {
     THTensor_(resize1d)(r_, n);
   }
 
-  if(n == 1) {
+  if (n == 0) {
+  } else if (n == 1) {
     THTensor_(set1d)(r_, 0, a);
   } else {
      TH_TENSOR_APPLY(real, r_,
@@ -4386,13 +4388,15 @@ void THTensor_(logspace)(THTensor *r_, real a, real b, int64_t n)
 {
   real i = 0;
 
-  THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
+  // NumPy allows you to pass different points even if n <= 1 -- should we?
+  THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
 
   if (THTensor_(nElement)(r_) != n) {
     THTensor_(resize1d)(r_, n);
   }
 
-  if(n == 1) {
+  if (n == 0) {
+  } else if (n == 1) {
     THTensor_(set1d)(r_, 0, TH_MATH_NAME(pow)(10.0, a));
   } else {
     TH_TENSOR_APPLY(real, r_,

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -4344,7 +4344,6 @@ accreal THTensor_(dist)(THTensor *tensor, THTensor *src, real value)
 
 accreal THTensor_(meanall)(THTensor *tensor)
 {
-  THArgCheck(tensor->_dim() > 0, 1, "empty Tensor");
   return THTensor_(sumall)(tensor)/THTensor_(nElement)(tensor);
 }
 
@@ -4353,7 +4352,7 @@ accreal THTensor_(varall)(THTensor *tensor, int biased)
   accreal mean = THTensor_(meanall)(tensor);
   accreal sum = 0;
   TH_TENSOR_APPLY(real, tensor, sum += (*tensor_data - mean)*(*tensor_data - mean););
-  sum /= THTensor_(nElement)(tensor) - (biased ? 0 : 1);
+  sum /= std::max<int64_t>(0, THTensor_(nElement)(tensor) - (biased ? 0 : 1));
   return sum;
 }
 

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -68,10 +68,10 @@ void THCTensor_resize(THCState *state, THCTensor *self, THLongStorage *size, THL
 void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
   int isSame = 0;
   int d;
-  if(self->_dim() == src->_dim())
+  if(self->dim() == src->dim())
   {
     isSame = 1;
-    for(d = 0; d < self->_dim(); d++)
+    for(d = 0; d < self->dim(); d++)
     {
       if(self->size[d] != src->size[d])
       {
@@ -258,9 +258,10 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 }
 
 bool THCTensor_isContiguous(THCState *state, const THCTensor *self) {
+  if (self->is_empty()) return true;
   int64_t z = 1;
   int d;
-  for(d = self->_dim()-1; d >= 0; d--)
+  for(d = self->dim()-1; d >= 0; d--)
   {
     if(self->size[d] != 1)
     {

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -396,9 +396,11 @@ accreal THCTensor_(trace)(THCState *state, THCTensor *src_) {
 
 void THCTensor_(linspace)(THCState *state, THCTensor *r_, real a, real b, int64_t n) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
+  // NumPy allows you to pass different points even if n <= 1 -- should we?
+  THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
   if (THCTensor_(nElement)(state, r_) != n) THCTensor_(resize1d)(state, r_, n);
-  if (n == 1) THCTensor_(fill)(state, r_, a);
+  if (n == 0) {
+  } else if (n == 1) THCTensor_(fill)(state, r_, a);
   else {
     THCTensor *r = THCTensor_(isContiguous)(state, r_)
                    ? r_ // if r_ is contiguous we can direct work on it
@@ -417,9 +419,11 @@ void THCTensor_(linspace)(THCState *state, THCTensor *r_, real a, real b, int64_
 
 void THCTensor_(logspace)(THCState *state, THCTensor *r_, real a, real b, int64_t n) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
+  // NumPy allows you to pass different points even if n <= 1 -- should we?
+  THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
   if (THCTensor_(nElement)(state, r_) != n) THCTensor_(resize1d)(state, r_, n);
-  if (n == 1) THCTensor_(fill)(state, r_, THCNumerics<real>::exp10(a));
+  if (n == 0) {
+  } else if (n == 1) THCTensor_(fill)(state, r_, THCNumerics<real>::exp10(a));
   else {
     THCTensor *r = THCTensor_(isContiguous)(state, r_)
                    ? r_

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -400,6 +400,7 @@ void THCTensor_(linspace)(THCState *state, THCTensor *r_, real a, real b, int64_
   THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
   if (THCTensor_(nElement)(state, r_) != n) THCTensor_(resize1d)(state, r_, n);
   if (n == 0) {
+    // skip
   } else if (n == 1) THCTensor_(fill)(state, r_, a);
   else {
     THCTensor *r = THCTensor_(isContiguous)(state, r_)
@@ -423,6 +424,7 @@ void THCTensor_(logspace)(THCState *state, THCTensor *r_, real a, real b, int64_
   THArgCheck(n > 1 || ((n == 0 || n == 1) && (a == b)), 3, "invalid number of points");
   if (THCTensor_(nElement)(state, r_) != n) THCTensor_(resize1d)(state, r_, n);
   if (n == 0) {
+    // skip
   } else if (n == 1) THCTensor_(fill)(state, r_, THCNumerics<real>::exp10(a));
   else {
     THCTensor *r = THCTensor_(isContiguous)(state, r_)

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -167,7 +167,7 @@ THCTensor_(varall)(THCState *state, THCTensor *self, int biased)
 
   val = THCNumerics<accreal>::div(
     val,
-    scalar_cast<accreal>(THCTensor_(nElement)(state, self) - (biased ? 0 : 1))
+    scalar_cast<accreal>(std::max<int64_t>(0, THCTensor_(nElement)(state, self) - (biased ? 0 : 1)))
   );
 
   THCudaCheck(cudaGetLastError());
@@ -329,7 +329,6 @@ THC_API accreal
 THCTensor_(meanall)(THCState *state, THCTensor *self)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
-  THArgCheck(self->_dim() > 0, 1, "empty Tensor");
   return THCTensor_(sumall)(state, self)/THCTensor_(nElement)(state, self);
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3557,7 +3557,7 @@ class TestTorch(TestCase):
         self.assertEqual(res1, res2)
 
     def test_slice(self):
-        empty = torch.Tensor()
+        empty = torch.empty(0, 4) if torch._C._use_zero_size_dim() else torch.Tensor()
         x = torch.arange(0., 16).view(4, 4)
         self.assertEqual(x[:], x)
         self.assertEqual(x[:4], x)
@@ -6005,8 +6005,12 @@ class TestTorch(TestCase):
         self.assertEqual(empty, empty.reshape(-1))
         self.assertEqual(empty, empty.reshape([0]))
         # TODO: fix these once we have multi-dimensional empty tensors
-        self.assertEqual(empty.reshape([0, 1]).shape, (0,))
-        self.assertEqual(empty.reshape([1, -1]).shape, (0,))
+        if torch._C._use_zero_size_dim():
+            self.assertEqual(empty.reshape([0, 1]).shape, (0, 1))
+            self.assertEqual(empty.reshape([1, -1]).shape, (1, 0))
+        else:
+            self.assertEqual(empty.reshape([0, 1]).shape, (0,))
+            self.assertEqual(empty.reshape([1, -1]).shape, (0,))
         self.assertRaises(RuntimeError, lambda: empty.reshape(1))
 
     @skipIfNoZeroSize

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2194,8 +2194,8 @@ class TestTorch(TestCase):
             self.assertEqual((0,), torch.bartlett_window(0, device=device).shape)
             self.assertEqual((0,), torch.hamming_window(0, device=device).shape)
             self.assertEqual((0,), torch.hann_window(0, device=device).shape)
-            self.assertEqual((1, 1, 0), torch.tensor([[[]]]).shape)
-            self.assertEqual((1, 1, 0), torch.as_tensor([[[]]]).shape)
+            self.assertEqual((1, 1, 0), torch.tensor([[[]]], device=device).shape)
+            self.assertEqual((1, 1, 0), torch.as_tensor([[[]]], device=device).shape)
 
     def test_new_tensor(self):
         expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
@@ -6010,7 +6010,7 @@ class TestTorch(TestCase):
     def test_empty_reshape(self):
         x = torch.randn(0, 6)
         self.assertEqual((1, 0, 6, 1, 1), x.reshape(1, 0, 6, 1, 1).shape)
-        # should have been viewable.
+        # should be viewable -- i.e. data_ptr is the same.
         self.assertEqual(x.data_ptr(), x.reshape(1, 0, 6, 1, 1).data_ptr())
 
     def test_expand(self):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -24,7 +24,7 @@ SKIP_PYTHON_BINDINGS = [
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
     'index',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
-    '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_*',
+    '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',
     'arange.*', 'range.*', '_gesv.*', 'slice', 'max_pool1d', 'max_pool2d', 'max_pool3d'
 ]
 

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -154,6 +154,14 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       result = applySelect(result, dim, THPUtils_unpackLong(obj));
     } else if (PySlice_Check(obj)) {
       result = applySlice(result, dim, obj);
+#ifndef USE_TH_SIZE_ZERO_DIM
+      if (result.numel() == 0) {
+        // TODO: currently we don't have support for 0-sized dims, so slicing a dim
+        // to size 0 will return a size 0 tensor. for now, just shortcircuit slicing
+        // and return that size 0 tensor.
+        return result;
+      }
+#endif
       dim++;
     } else if (obj == Py_Ellipsis) {
       dim += self.dim() - specified_dims;

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -154,12 +154,6 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       result = applySelect(result, dim, THPUtils_unpackLong(obj));
     } else if (PySlice_Check(obj)) {
       result = applySlice(result, dim, obj);
-      if (result.numel() == 0) {
-        // TODO: currently we don't have support for 0-sized dims, so slicing a dim
-        // to size 0 will return a size 0 tensor. for now, just shortcircuit slicing
-        // and return that size 0 tensor.
-        return result;
-      }
       dim++;
     } else if (obj == Py_Ellipsis) {
       dim += self.dim() - specified_dims;


### PR DESCRIPTION
This PR implements and tests N-dimensional empty tensors for indexing, factories, and reductions if compiled with -DUSE_TH_SIZE_ZERO_DIM.

Still remaining to add:
1) TensorShape functions
2) Simple linear algebra functions (matrix multiply variants)
3) Other functions that operate over a dimension (but don't reduce).

