### PR TITLE
Improving THCReduce.cuh's performance on latency-bound non-contiguous reductions

### DIFF
--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -14,6 +14,7 @@
 
 // Threads per thread block
 #define THC_NONCONTIG_REDUCE_BLOCK_SIZE 32 * 16
+#define CHUNKPERBLOCK 256
 
 template <typename IndexType>
 __device__ __forceinline__ IndexType getReduceNoncontigDimSliceIndex() {
@@ -21,99 +22,224 @@ __device__ __forceinline__ IndexType getReduceNoncontigDimSliceIndex() {
   return getLinearBlockId<IndexType>() * THC_NONCONTIG_REDUCE_BLOCK_SIZE + threadIdx.x;
 }
 
-// Kernel that handles an entire reduction of a slice of a tensor per each thread
-template <typename T,
-          typename IndexType,
-          typename AccT,
-          typename ModifyOp,
-          typename ReduceOp,
-          typename FinalizeOp,
-          int ADims, int BDims>
-#if __CUDA_ARCH__ >= 350
-__launch_bounds__(32 * 16, 4)
-#endif
-__global__ void
-kernelReduceNoncontigDim_shared(TensorInfo<T, IndexType> out,
-                         TensorInfo<T, IndexType> in,
-                         IndexType reductionStride,
-                         IndexType reductionSize,
-                         IndexType totalSlices,
-                         AccT init,
-                         ModifyOp modifyOp,
-                         ReduceOp reduceOp,
-                         FinalizeOp finalizeOp) {
+// quick hack to enable two-stage use of reduceChunk
+template <typename T>
+struct SimpleCopyOp
+{
+  __device__ __forceinline__ T operator()(const T val) const 
+  {
+    return val;
+  }
+};
 
-  IndexType sliceIndex  = blockIdx.x * blockDim.x + threadIdx.x;
-  IndexType sliceStride = gridDim.x * blockDim.x;
+__device__ __forceinline__ int lastpow2(int n)
+{
+  int out = 1 << (31 - __clz(n));
+  if(n == out) 
+    out >>= 1;
+  return out;
+}
 
-  __shared__ AccT local_reduce[THC_NONCONTIG_REDUCE_BLOCK_SIZE];
-  AccT* shmem = &local_reduce[threadIdx.x + threadIdx.y * blockDim.x];
+template
+  <typename T,
+   typename U,
+   typename IndexType,
+   typename AccT, 
+   typename ModifyOp,
+   typename ReduceOp,
+   typename FinalizeOp>
+__device__ __forceinline__ void reduceChunk
+  (T* out,
+   U* in,
+   const int& inbounds,
+   const IndexType& reductionStride,
+   const IndexType& reductionSize,
+   const IndexType& inOffset,
+   const IndexType& outOffset,
+   const int& shmem_lim,
+   AccT init,
+   AccT* shmem,
+   ModifyOp modifyOp,
+   ReduceOp reduceOp,
+   FinalizeOp finalizeOp) 
+{
   AccT load_reg[4];
-  AccT local_reg;
-
-  for(;sliceIndex<totalSlices; sliceIndex+=sliceStride) {
-    local_reg = init;
-
-    const IndexType outOffset =
-      IndexToOffset<T, IndexType, ADims>::get(sliceIndex, out);
-    const IndexType inOffset =
-      IndexToOffset<T, IndexType, BDims>::get(sliceIndex, in);
-
-    //Unroll this loop
-    //for(IndexType i=threadIdx.y; i<reductionSize; i+=blockDim.y){
-    //  local_reg += in[inOffset + i * reductionStride];
-    //}
-    for(IndexType i = threadIdx.y; i < reductionSize; i += blockDim.y * 4) {
-      if (i + blockDim.y * 3 < reductionSize) {
-        const AccT val0 = scalar_cast<AccT>(in.data[inOffset + i * reductionStride]);
+  AccT local_reg = init;
+  
+  //Unroll this loop
+  //for(IndexType i=threadIdx.y; i<reductionSize; i+=blockDim.y){
+  //  local_reg += in[inOffset + i*reductionStride];
+  //}
+  if(inbounds)
+    for(IndexType i = threadIdx.y; i < reductionSize; i += blockDim.y*4) 
+    {
+      if (i + blockDim.y*3 < reductionSize) 
+      {
+        const AccT val0 = scalar_cast<AccT>(in[inOffset + i*reductionStride]);
         load_reg[0] = modifyOp(val0);
-        const AccT val1 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y) * reductionStride]);
+        const AccT val1 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y)*reductionStride]);
         load_reg[1] = modifyOp(val1);
-        const AccT val2 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y * 2) * reductionStride]);
+        const AccT val2 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y*2)*reductionStride]);
         load_reg[2] = modifyOp(val2);
-        const AccT val3 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y * 3) * reductionStride]);
+        const AccT val3 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y*3)*reductionStride]);
         load_reg[3] = modifyOp(val3);
         local_reg = reduceOp(local_reg, load_reg[0]);
         local_reg = reduceOp(local_reg, load_reg[1]);
         local_reg = reduceOp(local_reg, load_reg[2]);
         local_reg = reduceOp(local_reg, load_reg[3]);
-      } else if (i + blockDim.y * 2 < reductionSize) {
-        const AccT val0 = scalar_cast<AccT>(in.data[inOffset + i * reductionStride]);
+      } 
+      else if (i + blockDim.y*2 < reductionSize) 
+      {
+        const AccT val0 = scalar_cast<AccT>(in[inOffset + i*reductionStride]);
         load_reg[0] = modifyOp(val0);
-        const AccT val1 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y) * reductionStride]);
+        const AccT val1 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y)*reductionStride]);
         load_reg[1] = modifyOp(val1);
-        const AccT val2 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y * 2) * reductionStride]);
+        const AccT val2 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y*2)*reductionStride]);
         load_reg[2] = modifyOp(val2);
         local_reg = reduceOp(local_reg, load_reg[0]);
         local_reg = reduceOp(local_reg, load_reg[1]);
         local_reg = reduceOp(local_reg, load_reg[2]);
-      } else if (i + blockDim.y < reductionSize) {
-        const AccT val0 = scalar_cast<AccT>(in.data[inOffset + i * reductionStride]);
+      } 
+      else if (i + blockDim.y < reductionSize) 
+      {
+        const AccT val0 = scalar_cast<AccT>(in[inOffset + i*reductionStride]);
         load_reg[0] = modifyOp(val0);
-        const AccT val1 = scalar_cast<AccT>(in.data[inOffset + (i + blockDim.y) * reductionStride]);
+        const AccT val1 = scalar_cast<AccT>(in[inOffset + (i + blockDim.y)*reductionStride]);
         load_reg[1] = modifyOp(val1);
         local_reg = reduceOp(local_reg, load_reg[0]);
         local_reg = reduceOp(local_reg, load_reg[1]);
-      } else if (i < reductionSize) {
-        const AccT val0 = scalar_cast<AccT>(in.data[inOffset + i * reductionStride]);
+      } 
+      else if (i < reductionSize) 
+      {
+        const AccT val0 = scalar_cast<AccT>(in[inOffset + i*reductionStride]);
         local_reg = reduceOp(local_reg, modifyOp(val0));
       }
     }
+  
+  *shmem = local_reg;
+  for(int i = lastpow2(shmem_lim); i > 0; i >>= 1)
+  {
+    __syncthreads();
+    if(threadIdx.y < i && threadIdx.y + i < shmem_lim) 
+       *shmem = reduceOp(*shmem, *(shmem + i*blockDim.x));
+  }
 
-    *shmem = local_reg;
-    int dimy = blockDim.y;
-    while (dimy > 1) {
-      __syncthreads();
-      if (threadIdx.y == 0 && (dimy % 2 != 0) ) {
-        *shmem = reduceOp(*shmem, *(shmem + (dimy - 1) * blockDim.x));
-      }
-      if (threadIdx.y < dimy / 2) {
-        *shmem = reduceOp(*shmem, *(shmem + (dimy / 2) * blockDim.x));
-      }
-      dimy /= 2;
+  if(threadIdx.y == 0 && inbounds)
+    out[outOffset] = scalar_cast<T>(finalizeOp(*shmem));
+}
+
+// Kernel that handles an entire reduction of a slice of a tensor per each thread
+template 
+  <typename T,
+   typename IndexType,
+   typename AccT,
+   typename ModifyOp,
+   typename ReduceOp,
+   typename FinalizeOp,
+   int ADims, int BDims>
+#if __CUDA_ARCH__ >= 350
+__launch_bounds__(32 * 16, 4)
+#endif
+__global__ void kernelReduceNoncontigDim_shared
+  (TensorInfo<T, IndexType> out,
+   TensorInfo<T, IndexType> in,
+   IndexType reductionStride,
+   IndexType reductionSize,
+   IndexType totalSlices,
+   AccT init,
+   ModifyOp modifyOp,
+   ReduceOp reduceOp,
+   FinalizeOp finalizeOp,
+   volatile AccT* stagingData,
+   int* semaphores)
+{
+  IndexType sliceIndex  = blockIdx.x*blockDim.x + threadIdx.x;
+
+  __shared__ int isLastBlockDone;
+  __shared__ AccT local_reduce[THC_NONCONTIG_REDUCE_BLOCK_SIZE];
+  AccT* shmem = &local_reduce[threadIdx.x + threadIdx.y*blockDim.x];
+
+  // This kernel is intended for the latency-bound case, so we want to launch enough blocks
+  // to cover the entire output.  This means we don't need grid-stride loops.
+  const IndexType outOffset =
+    IndexToOffset<T, IndexType, ADims>::get(sliceIndex, out);
+  const IndexType inOffset =
+    IndexToOffset<T, IndexType, BDims>::get(sliceIndex, in);
+  const int inbounds = (sliceIndex < totalSlices);
+
+  if(gridDim.y == 1)
+    reduceChunk
+      (out.data,
+       in.data, 
+       inbounds,
+       reductionStride,
+       reductionSize,
+       inOffset,
+       outOffset,
+       reductionSize < blockDim.y ? reductionSize : blockDim.y,
+       init,
+       shmem,
+       modifyOp,
+       reduceOp,
+       finalizeOp);
+  else
+  { 
+    int* semaphore = semaphores + blockIdx.x;
+  
+    const IndexType chunkStart = blockIdx.y*CHUNKPERBLOCK;
+    const IndexType chunkSize = reductionSize - chunkStart < CHUNKPERBLOCK ? 
+                                reductionSize - chunkStart : CHUNKPERBLOCK;
+    const IndexType reductionStrideStaging = totalSlices;
+    const IndexType stagingOffset = sliceIndex;
+
+    reduceChunk
+      (stagingData,
+       in.data, 
+       inbounds,
+       reductionStride,
+       chunkSize,
+       inOffset + chunkStart*reductionStride,
+       stagingOffset + blockIdx.y*reductionStrideStaging,
+       chunkSize < blockDim.y ? chunkSize : blockDim.y, 
+       init,
+       shmem,
+       modifyOp,
+       reduceOp,
+       SimpleCopyOp<AccT>());
+  
+    __threadfence(); // make sure writes are globally visible
+    __syncthreads(); // if multiple warps in this block wrote to staging, make sure they're all done
+  
+    if(threadIdx.x == 0 && threadIdx.y == 0)
+    {
+      int old = atomicAdd(semaphore, 1);
+      isLastBlockDone = (old == gridDim.y - 1);
     }
-    if (threadIdx.y == 0)
-      out.data[outOffset] = scalar_cast<T>(finalizeOp(*shmem));
+  
+    __syncthreads();
+ 
+    // The staging area contains gridDim.y elements along each slice.  The final reduction
+    // begins by treating the first blockDim.y elements as "init" values. 
+    if(isLastBlockDone)
+    {
+      if(threadIdx.y < gridDim.y)
+        init = stagingData[stagingOffset + threadIdx.y*reductionStrideStaging];
+      IndexType remaining = gridDim.y < blockDim.y ? 0 : gridDim.y - blockDim.y;
+      reduceChunk
+        (out.data,
+         stagingData, 
+         inbounds,
+         reductionStrideStaging,
+         remaining, // if 0, loop in reduceChunk is skipped, otherwise...
+         stagingOffset + blockDim.y*reductionStrideStaging, // ...loop begins at blockDim+1th element
+         outOffset,
+         gridDim.y < blockDim.y ? gridDim.y : blockDim.y, 
+         init,
+         shmem,
+         SimpleCopyOp<AccT>(),
+         reduceOp,
+         finalizeOp);
+    }
   }
 }
 
@@ -319,23 +445,37 @@ bool THC_reduceDim(THCState* state,
 
     block = getNoncontigReduceBlock();
 
-    if(outElements <= 4096){
-        //x dim does different columns
-        //y dim helps with the same reduction
-        //If we only have 8 loops, don't bother sharing work across ydim
-        uint64_t ydim = THCCeilDiv(reductionSize, (int64_t) 8L);
+    if(outElements <= 4096)
+    {
+      // gridDim.x and blockDim.x parallelize work across slices.
+      // blockDim.y enables some intra-block reduction within slices.
+      // gridDim.y enables inter-block reduction within slices.
 
-        //don't want y dim any bigger than 16, leaving min x dim to 32
-        ydim = min((uint64_t) 16, ydim);
+      // Each block covers 32 output elements.
+      int blockdimx = 32;
+      int griddimx = THCCeilDiv((int64_t)outElements, (int64_t)blockdimx);
 
-        block = dim3(THC_NONCONTIG_REDUCE_BLOCK_SIZE, 1, 1);
-        while(ydim > 1){
-          block.x /= 2;
-          block.y *= 2;
-          ydim /= 2;
-        }
-        THC_getGridFromTiles(THCCeilDiv((int64_t)outElements, (int64_t)block.x), grid);
+      // Each warp reduces at most 4 slices.  This heuristic can be tuned, 
+      // but locking blockdimy to 16 is robust and reasonably performant.
+      int blockdimy = 16;
 
+      int griddimy = 1;
+      bool coop = false;
+      // Rough heuristics to decide if using cooperating blocks is worthwhile
+      if(                      outElements <=   32 && reductionSize >= 4096) coop = true;
+      if(  32 < outElements && outElements <=   64 && reductionSize >= 4096) coop = true;
+      if(  64 < outElements && outElements <=  128 && reductionSize >= 4096) coop = true;
+      if( 128 < outElements && outElements <=  256 && reductionSize >= 4096) coop = true;
+      if( 256 < outElements && outElements <=  512 && reductionSize >= 4096) coop = true;
+      if( 512 < outElements && outElements <= 1024 && reductionSize >= 4096) coop = true;
+      if(1024 < outElements && outElements <= 2048 && reductionSize >= 2048) coop = true;
+      if(2048 < outElements && outElements <= 4096 && reductionSize >= 2048) coop = true;
+      // Each block reduces at most CHUNKPERBLOCK (currently 256) slices.
+      if(coop) 
+        griddimy = THCCeilDiv((int64_t)reductionSize, (int64_t)CHUNKPERBLOCK);
+
+      grid = dim3(griddimx, griddimy, 1); 
+      block = dim3(blockdimx, blockdimy, 1);
     }
   }
 
@@ -376,16 +516,51 @@ bool THC_reduceDim(THCState* state,
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>          \
         (outInfo, inInfo, reductionStride, reductionSize,               \
         (TYPE) outElements, init, modifyOp, reduceOp, finalizeOp);      \
-    }else{                                                              \
-        kernelReduceNoncontigDim_shared<                                \
-                          ScalarType,                                   \
-                          TYPE, AccT, ModifyOp, ReduceOp, FinalizeOp,   \
-                          OUT, IN>                                      \
-        <<<grid, block, 0, THCState_getCurrentStream(state)>>>          \
-        (outInfo, inInfo, reductionStride, reductionSize,               \
-        (TYPE) outElements, init, modifyOp, reduceOp, finalizeOp);      \
     }                                                                   \
-  }                                                                     \
+    else                                                                \
+    {                                                                        \
+        void* stagingData;                                                   \
+        void* semaphores;                                                    \
+                                                                             \
+        if(grid.y > 1)                                                       \
+        {                                                                    \
+          THCudaCheck(THCudaMalloc                                           \
+            (state,                                                          \
+             &stagingData,                                                   \
+             sizeof(AccT)*outElements*grid.y));                              \
+          THCudaCheck(THCudaMalloc                                           \
+            (state,                                                          \
+             &semaphores,                                                    \
+             sizeof(int)*grid.x));                                           \
+          THCudaCheck(cudaMemsetAsync                                        \
+            (semaphores,                                                     \
+             0,                                                              \
+             sizeof(int)*grid.x,                                             \
+             THCState_getCurrentStream(state)));                             \
+        }                                                                    \
+                                                                             \
+        kernelReduceNoncontigDim_shared                                      \
+          <ScalarType, TYPE, AccT, ModifyOp, ReduceOp, FinalizeOp,  OUT, IN> \
+          <<<grid, block, 0, THCState_getCurrentStream(state)>>>             \
+          (outInfo,                                                          \
+           inInfo,                                                           \
+           reductionStride,                                                  \
+           reductionSize,                                                    \
+           (TYPE) outElements,                                               \
+           init,                                                             \
+           modifyOp,                                                         \
+           reduceOp,                                                         \
+           finalizeOp,                                                       \
+           (volatile AccT*)stagingData,                                      \
+           (int*)semaphores);                                                \
+                                                                             \
+        if(grid.y > 1)                                                       \
+        {                                                                    \
+          THCudaCheck(THCudaFree(state, stagingData));                       \
+          THCudaCheck(THCudaFree(state, semaphores));                        \
+        }                                                                    \
+    }                                                                        \
+  }                                                                    
 
 #define HANDLE_IN_CASE(TYPE, OUT, IN)                     \
   {                                                       \
@@ -417,8 +592,9 @@ bool THC_reduceDim(THCState* state,
     }                                                     \
   }
 
-  if (THCTensor_canUse32BitIndexMath(state, out) &&
-      THCTensor_canUse32BitIndexMath(state, in)) {
+  if(THCTensor_canUse32BitIndexMath(state, out) &&
+     THCTensor_canUse32BitIndexMath(state, in)) 
+  {
     TensorInfo<ScalarType,
                unsigned int> outInfo =
       getTensorInfo<ScalarType, TensorType, unsigned int>(state, out);
@@ -430,7 +606,9 @@ bool THC_reduceDim(THCState* state,
     inInfo.reduceDim(dim);
     inInfo.collapseDims();
     HANDLE_OUT_CASE(unsigned int, outInfo.dims, inInfo.dims);
-  } else {
+  } 
+  else 
+  {
     TensorInfo<ScalarType,
                uint64_t> outInfo =
       getTensorInfo<ScalarType, TensorType, uint64_t>(state, out);
@@ -464,5 +642,6 @@ bool THC_reduceDim(THCState* state,
 }
 
 #undef THC_NONCONTIG_REDUCE_BLOCK_SIZE
+#undef CHUNKPERBLOCK
 
 #endif // THC_REDUCE_INC


### PR DESCRIPTION
This PR improves perfomance of (formerly) latency-bound non-contig-dim reduction kernels by up to 20X, while maintaining determinism.

Currently, reducing across a non-contiguous dimension uses the parallelism exposed across the number of output elements.  This means that performance suffers if the number of output elements is small.  Example:
```
a = torch.cuda.FloatTensor(32768, 32)
a.sum(dim=0)
```
Before this PR, `a.sum`'s kernel (kernelReduceNoncontigDim_shared) took 138 microseconds on my machine.  The speed-of-light estimate (based on a bandwidth of 700 GB/s) should be around 6 microseconds.  After this PR's changes, `a.sum(dim=0)`'s kernel takes 6.9 microseconds on my machine. 

Christian implemented some nice logic to squeeze out better performance for cases like `a.sum` using intra-block and instruction-level parallelism across the dimension being reduced, but his kernel still only launched one block for every 32 output elements.  This was insufficient to saturate the device in many cases, like `a.sum` here (where only one block is launched).

My PR adds block cooperation across the dimension being reduced.  Many blocks, instead of one block, help to reduce into each 32 output elements.  Internally, each block leverages all of Christian's nice logic to compute a partial reduction into a per-block staging buffer, then the last block to finish combines the results to compute the final output. 

Block cooperation does require THCudaMalloc-ing staging and semaphore buffers, so it's not always worthwhile.  I included a set of rough heuristics to decide when the kernel should choose to use block cooperation.  These heuristics are based on Python-side timings of calling sum() many times in a loop, and comparing to the old implementation.

 I tested a wide range of sizes (to determine heuristics) and as long as the number of output elements is greater than 16ish, I don't think there are any remaining pathological sizes where users will encounter unexpectedly poor performance.