### PR TITLE
Fix RoIAlignOp GPU implementation for RoIs without batch index

### DIFF
--- a/caffe2/operators/roi_align_op.cu
+++ b/caffe2/operators/roi_align_op.cu
@@ -76,6 +76,7 @@ __global__ void RoIAlignForward(
     const int pooled_width,
     const int sampling_ratio,
     const T* bottom_rois,
+    int roi_cols,
     T* top_data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
@@ -84,18 +85,23 @@ __global__ void RoIAlignForward(
     int c = (index / pooled_width / pooled_height) % channels;
     int n = index / pooled_width / pooled_height / channels;
 
-    const T* offset_bottom_rois = bottom_rois + n * 5;
-    int roi_batch_ind = offset_bottom_rois[0];
+    // RoI could have 4 or 5 columns
+    const T* offset_bottom_rois = bottom_rois + n * roi_cols;
+    int roi_batch_ind = 0;
+    if (roi_cols == 5) {
+      roi_batch_ind = offset_bottom_rois[0];
+      offset_bottom_rois++;
+    }
 
     // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_bottom_rois[1] * spatial_scale;
-    T roi_start_h = offset_bottom_rois[2] * spatial_scale;
-    T roi_end_w = offset_bottom_rois[3] * spatial_scale;
-    T roi_end_h = offset_bottom_rois[4] * spatial_scale;
-    // T roi_start_w = roundf(offset_bottom_rois[1] * spatial_scale);
-    // T roi_start_h = roundf(offset_bottom_rois[2] * spatial_scale);
-    // T roi_end_w = roundf(offset_bottom_rois[3] * spatial_scale);
-    // T roi_end_h = roundf(offset_bottom_rois[4] * spatial_scale);
+    T roi_start_w = offset_bottom_rois[0] * spatial_scale;
+    T roi_start_h = offset_bottom_rois[1] * spatial_scale;
+    T roi_end_w = offset_bottom_rois[2] * spatial_scale;
+    T roi_end_h = offset_bottom_rois[3] * spatial_scale;
+    // T roi_start_w = roundf(offset_bottom_rois[0] * spatial_scale);
+    // T roi_start_h = roundf(offset_bottom_rois[1] * spatial_scale);
+    // T roi_end_w = roundf(offset_bottom_rois[2] * spatial_scale);
+    // T roi_end_h = roundf(offset_bottom_rois[3] * spatial_scale);
 
     // Force malformed ROIs to be 1x1
     T roi_width = max(roi_end_w - roi_start_w, (T)1.);
@@ -173,6 +179,7 @@ bool RoIAlignOp<float, CUDAContext>::RunOnDevice() {
           pooled_width_,
           sampling_ratio_,
           R.data<float>(),
+          R.dim32(1),
           Y->mutable_data<float>());
   return true;
 }


### PR DESCRIPTION
Summary: Fix RoIAlignOp GPU implementation for RoIs without batch index
According to https://caffe2.ai/docs/operators-catalogue.html#roialign, RoIs is "2D input of shape (R, 4 or 5)"
Pass RoIs 2nd dimension as kernel parameter and adjust kernel accordingly

