### PR TITLE
Fix standard deviation gradient

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2040,6 +2040,17 @@ class TestAutograd(TestCase):
         run_test((10, 10), torch.zeros(10, 10))
         run_test((10,), 0)
 
+    def test_std_result_zero(self):
+        def run_test(input_size, val):
+            input = torch.full(input_size, val).requires_grad_()
+            input.std().backward()
+            self.assertEqual((input.grad == torch.full(input_size, float('inf'))).all().item(), 1)
+
+        run_test((10,), 0)
+        run_test((10,), 0.5)
+        run_test((10, 10), 0)
+        run_test((10, 10), 0.5)
+
     def test_pinverse(self):
         # Why is pinverse tested this way, and not ordinarily as other linear algebra methods?
         # 1. Pseudo-inverses are not generally continuous, which means that they are not differentiable

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2044,8 +2044,12 @@ class TestAutograd(TestCase):
         def run_test(input_size, val):
             input = torch.full(input_size, val).to(torch.double).requires_grad_()
             input.std().backward()
-            input[0] = input[0] + 1e-09
-            self.assertEqual((input.grad == torch.std(input)).all().item(), 1)
+            with torch.no_grad():
+                eps = 1e-09
+                input[0] = input[0] + eps
+                print(torch.std(input) / eps)
+                num_der = torch.std(input) / eps
+                self.assertEqual(input.grad, torch.full(input_size, num_der.item()))
 
         run_test((10,), 0)
         run_test((10,), 0.5)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2042,14 +2042,13 @@ class TestAutograd(TestCase):
 
     def test_std_result_zero(self):
         def run_test(input_size, val):
-            input = torch.full(input_size, val).requires_grad_()
+            input = torch.full(input_size, val).to(torch.double).requires_grad_()
             input.std().backward()
-            self.assertEqual((input.grad == torch.full(input_size, float('inf'))).all().item(), 1)
+            input[0] = input[0] + 1e-09
+            self.assertEqual((input.grad == torch.std(input)).all().item(), 1)
 
         run_test((10,), 0)
         run_test((10,), 0.5)
-        run_test((10, 10), 0)
-        run_test((10, 10), 0.5)
 
     def test_pinverse(self):
         # Why is pinverse tested this way, and not ordinarily as other linear algebra methods?

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -648,10 +648,10 @@
   self: unsqueeze_to(grad, dim, self.sizes())
 
 - name: std(Tensor self, bool unbiased)
-  self: std_backward(grad, self, result, unbiased)
+  self: var_backward(grad / (2 * result), self, unbiased).masked_fill_(result == 0., INFINITY)
 
 - name: std(Tensor self, int64_t dim, bool unbiased, bool keepdim)
-  self: std_backward(grad, self, result, dim, unbiased, keepdim)
+  self: var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result == 0., INFINITY)
 
 - name: sub(Tensor self, Scalar other, *, Scalar alpha)
   self: grad

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -648,10 +648,10 @@
   self: unsqueeze_to(grad, dim, self.sizes())
 
 - name: std(Tensor self, bool unbiased)
-  self: var_backward(grad / (2 * result), self, unbiased).masked_fill_(result == 0., INFINITY)
+  self: std_backward(grad, self, result, unbiased)
 
 - name: std(Tensor self, int64_t dim, bool unbiased, bool keepdim)
-  self: var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result == 0., INFINITY)
+  self: std_backward(grad, self, result, dim, unbiased, keepdim)
 
 - name: sub(Tensor self, Scalar other, *, Scalar alpha)
   self: grad

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -648,10 +648,10 @@
   self: unsqueeze_to(grad, dim, self.sizes())
 
 - name: std(Tensor self, bool unbiased)
-  self: var_backward(grad / (result * 2), self, unbiased)
+  self: std_backward(grad, self, result, unbiased)
 
 - name: std(Tensor self, int64_t dim, bool unbiased, bool keepdim)
-  self: var_backward(grad / (result * 2), self, dim, unbiased, keepdim)
+  self: std_backward(grad, self, result, dim, unbiased, keepdim)
 
 - name: sub(Tensor self, Scalar other, *, Scalar alpha)
   self: grad

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -575,6 +575,14 @@ Tensor var_backward(Tensor grad, const Tensor & self, int64_t dim, bool unbiased
   return (2.0 / (self.size(dim) - unbiased)) * grad * (self - self.mean(dim, true));
 }
 
+Tensor std_backward(const Tensor & grad, const Tensor & self, Tensor result, bool unbiased) {
+  return var_backward(grad / (2 * result), self, unbiased).masked_fill_(result == 0., INFINITY);
+}
+
+Tensor std_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim, bool unbiased, bool keepdim) {
+  return var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result == 0., INFINITY);
+}
+
 Tensor masked_scatter_backward(const Tensor & grad, const Tensor & mask, IntList sizes) {
   int64_t numel = 1;
   for (auto size : sizes) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -580,7 +580,7 @@ Tensor std_backward(const Tensor & grad, const Tensor & self, Tensor result, boo
   if (result_zero_mask.any().toCByte()) {
     auto N = self.numel();
     double grad_zero_squared = unbiased ? 1 / N : (N - 1) / (N * N);
-    Scalar grad_zero = Scalar(grad_zero_squared).sqrt();
+    Scalar grad_zero = Scalar(grad_zero_squared).pow(0.5);
     return var_backward(grad / (2 * result), self, unbiased).masked_fill_(result_zero_mask, grad_zero);
   }
   return var_backward(grad / (2 * result), self, unbiased);
@@ -591,8 +591,8 @@ Tensor std_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim
   if (result_zero_mask.any().toCByte()) {
     auto N = self.size(dim);
     double grad_zero_squared = unbiased ? 1 / N : (N - 1) / (N * N);
-    Scalar grad_zero = Scalar(grad_zero_squared).sqrt();
-    return var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result == 0., grad_zero);
+    Scalar grad_zero = Scalar(grad_zero_squared).pow(0.5);
+    return var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result_zero_mask, grad_zero);
   }
   return var_backward(grad / (2 * result), self, dim, unbiased, keepdim);
 }

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -575,14 +575,6 @@ Tensor var_backward(Tensor grad, const Tensor & self, int64_t dim, bool unbiased
   return (2.0 / (self.size(dim) - unbiased)) * grad * (self - self.mean(dim, true));
 }
 
-Tensor std_backward(const Tensor & grad, const Tensor & self, Tensor result, bool unbiased) {
-  return var_backward(grad / (2 * result), self, unbiased).masked_fill_(result == 0., INFINITY);
-}
-
-Tensor std_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim, bool unbiased, bool keepdim) {
-  return var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result == 0., INFINITY);
-}
-
 Tensor masked_scatter_backward(const Tensor & grad, const Tensor & mask, IntList sizes) {
   int64_t numel = 1;
   for (auto size : sizes) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -578,9 +578,9 @@ Tensor var_backward(Tensor grad, const Tensor & self, int64_t dim, bool unbiased
 Tensor std_backward(const Tensor & grad, const Tensor & self, Tensor result, bool unbiased) {
   Tensor result_zero_mask = (result == 0.);
   if (result_zero_mask.any().toCByte()) {
-    auto N = self.numel();
-    double grad_zero_squared = unbiased ? 1 / N : (N - 1) / (N * N);
-    Scalar grad_zero = Scalar(grad_zero_squared).pow(0.5);
+    auto N = self.numel();  
+    double grad_zero_squared = unbiased ? (1. / N) : (N - 1.) / (N * N);
+    Scalar grad_zero = Scalar(sqrt(grad_zero_squared));
     return var_backward(grad / (2 * result), self, unbiased).masked_fill_(result_zero_mask, grad_zero);
   }
   return var_backward(grad / (2 * result), self, unbiased);
@@ -590,8 +590,8 @@ Tensor std_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim
   Tensor result_zero_mask = (result == 0.);
   if (result_zero_mask.any().toCByte()) {
     auto N = self.size(dim);
-    double grad_zero_squared = unbiased ? 1 / N : (N - 1) / (N * N);
-    Scalar grad_zero = Scalar(grad_zero_squared).pow(0.5);
+    double grad_zero_squared = unbiased ? 1. / N : (N - 1.) / (N * N);
+    Scalar grad_zero = Scalar(sqrt(grad_zero_squared));
     return var_backward(grad / (2 * result), self, dim, unbiased, keepdim).masked_fill_(result_zero_mask, grad_zero);
   }
   return var_backward(grad / (2 * result), self, dim, unbiased, keepdim);

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4219,6 +4219,12 @@ Returns the standard-deviation of all elements in the :attr:`input` tensor.
 If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated
 via the biased estimator. Otherwise, Bessel's correction will be used.
 
+.. note::
+    If the standard deviation is zero, then the derivative for the standard deviation with
+    respect to the elements of the tensor is considered to be
+    :math:`\displaystyle \sqrt{\frac{n-1}{nN}}` where :math:`n` is the number of elements and
+    :math:`N = n - 1` if :attr:`unbiased` is ``True`` and :math:`N = n` otherwise.
+
 Args:
     input (Tensor): the input tensor
     unbiased (bool): whether to use the unbiased estimation or not


### PR DESCRIPTION
Defined the subgradient of `std` when `result = 0` to be `inf`.

1. Added tests in test_autograd
2. New method std_backward() for computing backward in Functions.cpp

Fixes #4320 .

