### PR TITLE
[docs] Update extension docs, fix Fold/Unfold docs

### DIFF
--- a/aten/src/THCUNN/generic/Col2Im.cu
+++ b/aten/src/THCUNN/generic/Col2Im.cu
@@ -19,18 +19,34 @@ static inline void THNN_(Col2Im_shapeCheck)(
 
   int ndim = THCTensor_(nDimension)(state, input);
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 2 || ndim == 3), 2, input,
-                  "non-empty 2D or 3D input tensor expected but got %s");
+                  "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
-  int batch_dim = (ndim == 4) ? 0 : -1;
-  long nInputPlane  = input->size[batch_dim + 1];
-  long inputLength  = input->size[batch_dim + 2];
+  int batch_dim = (ndim == 3) ? 0 : -1;
+  int64_t nInputPlane  = input->size[batch_dim + 1];
 
-  long nOutputPlane = nInputPlane / (kW * kH);
+  if (nInputPlane % (kW * kH) != 0) {
+    THError("Expected size of input's dimension 1 to be divisible by the "
+            "product of kernel_size, but got input.size(1)=%lld and "
+            "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
+  }
+
+  int64_t inputLength  = input->size[batch_dim + 2];
+  int64_t nBlocksH = 1 + (outputHeight + 2 * padH - dH * (kH - 1) - 1) / sH;
+  int64_t nBlocksW = 1 + ( outputWidth + 2 * padW - dW * (kW - 1) - 1) / sW;
+
+  if (inputLength != (nBlocksH * nBlocksW)) {
+    THError("Given output_size=(%d, %d), kernel_size=(%d, %d), "
+            "dilation=(%d, %d), padding=(%d, %d), stride=(%d, %d), expected "
+            "size of input's dimension 2 to match the calculated number of "
+            "sliding blocks %lld * %lld = %lld, but got input.size(2)=%lld.",
+            outputHeight, outputWidth, kH, kW, dH, dW, padH, padW, sH, sW,
+            (long long) nBlocksH, (long long) nBlocksW,
+            (long long) (nBlocksH * nBlocksW), (long long) inputLength);
+  }
 
   if (outputWidth < 1 || outputHeight < 1) {
-    THError("Given input size: (%lld x %lld). "
-            "Calculated output size: (%lld x %d x %d). Output size is too small",
-            (long long)nInputPlane, (long long)inputLength, (long long)nOutputPlane, outputHeight, outputWidth);
+    THError("Expected output spatial size to be positive, but got: output_size=(%d, %d).",
+            outputHeight, outputWidth);
   }
 }
 
@@ -56,9 +72,9 @@ void THNN_(Col2Im_updateOutput)(
       THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);
   }
 
-  long batchSize = input->size[0];
-  long nInputPlane = input->size[1];
-  long nOutputPlane = nInputPlane / (kW * kH);
+  int64_t batchSize = input->size[0];
+  int64_t nInputPlane = input->size[1];
+  int64_t nOutputPlane = nInputPlane / (kW * kH);
 
   input = THCTensor_(newContiguous)(state, input);
 

--- a/aten/src/THCUNN/generic/Im2Col.cu
+++ b/aten/src/THCUNN/generic/Im2Col.cu
@@ -20,7 +20,7 @@ static inline void THNN_(Im2Col_shapeCheck)(
 
   int ndim = THCTensor_(nDimension)(state, input);
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
-                  "non-empty 3D or 4D input tensor expected but got: %s");
+                "Expected non-empty 3D or 4D input tensor, but got input of shape %s");
 
   int dim_batch = 0;
   if (ndim == 3) {
@@ -34,10 +34,13 @@ static inline void THNN_(Im2Col_shapeCheck)(
   int nOutputPlane = nInputPlane * kW * kH;
   int outputLength = outputHeight * outputWidth;
 
-  if (outputWidth < 1 || outputHeight < 1) {
-    THError("Given input size: (%d x %d x %d). "
-            "Calculated output size: (%d x %d). Output size is too small",
-            nInputPlane, inputHeight, inputWidth, nOutputPlane, outputLength);
+  if (outputHeight < 1 || outputWidth < 1) {
+    THError("Given input with spatial size (%d, %d), kernel_size=(%d, %d), "
+            "dilation=(%d, %d), padding=(%d, %d), calculated "
+            "shape of the array of sliding blocks as (%d, %d), which is "
+            "too small (non-positive).",
+            inputHeight, inputHeight, kH, kW, dH, dW, padH, padW,
+            outputHeight, outputWidth);
   }
 }
 

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -126,18 +126,34 @@ static inline void THNN_(Col2Im_shapeCheck)(
 
   int ndim = THTensor_(nDimension)(input);
   THNN_ARGCHECK(!input->is_empty() && (ndim == 2 || ndim == 3), 2, input,
-                "non-empty 2D or 3D input tensor expected but got %s");
+                "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
-  int batch_dim = (ndim == 4) ? 0 : -1;
-  long nInputPlane  = input->size[batch_dim + 1];
-  long inputLength  = input->size[batch_dim + 2];
+  int batch_dim = (ndim == 3) ? 0 : -1;
+  int64_t nInputPlane  = input->size[batch_dim + 1];
 
-  long nOutputPlane = nInputPlane / (kW * kH);
+  if (nInputPlane % (kW * kH) != 0) {
+    THError("Expected size of input's dimension 1 to be divisible by the "
+            "product of kernel_size, but got input.size(1)=%lld and "
+            "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
+  }
+
+  int64_t inputLength  = input->size[batch_dim + 2];
+  int64_t nBlocksH = 1 + (outputHeight + 2 * padH - dH * (kH - 1) - 1) / sH;
+  int64_t nBlocksW = 1 + ( outputWidth + 2 * padW - dW * (kW - 1) - 1) / sW;
+
+  if (inputLength != (nBlocksH * nBlocksW)) {
+    THError("Given output_size=(%d, %d), kernel_size=(%d, %d), "
+            "dilation=(%d, %d), padding=(%d, %d), stride=(%d, %d), expected "
+            "size of input's dimension 2 to match the calculated number of "
+            "sliding blocks %lld * %lld = %lld, but got input.size(2)=%lld.",
+            outputHeight, outputWidth, kH, kW, dH, dW, padH, padW, sH, sW,
+            (long long) nBlocksH, (long long) nBlocksW,
+            (long long) (nBlocksH * nBlocksW), (long long) inputLength);
+  }
 
   if (outputWidth < 1 || outputHeight < 1) {
-    THError("Given input size: (%lld x %lld). "
-            "Calculated output size: (%lld x %d x %d). Output size is too small",
-            (long long)nInputPlane, (long long)inputLength, (long long)nOutputPlane, outputHeight, outputWidth);
+    THError("Expected output spatial size to be positive, but got: output_size=(%d, %d).",
+            outputHeight, outputWidth);
   }
 }
 

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -18,7 +18,7 @@ static inline void THNN_(Im2Col_shapeCheck)(
 
   int ndim = THTensor_(nDimension)(input);
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
-                "non-empty 3D or 4D input tensor expected but got: %s");
+                "Expected non-empty 3D or 4D input tensor, but got input of shape %s");
 
   int dim_batch = 0;
   if (ndim == 3) {
@@ -32,10 +32,13 @@ static inline void THNN_(Im2Col_shapeCheck)(
   int nOutputPlane = nInputPlane * kW * kH;
   int outputLength = outputHeight * outputWidth;
 
-  if (outputWidth < 1 || outputHeight < 1) {
-    THError("Given input size: (%d x %d x %d). "
-            "Calculated output size: (%d x %d). Output size is too small",
-            nInputPlane, inputHeight, inputWidth, nOutputPlane, outputLength);
+  if (outputHeight < 1 || outputWidth < 1) {
+    THError("Given input with spatial size (%d, %d), kernel_size=(%d, %d), "
+            "dilation=(%d, %d), padding=(%d, %d), calculated "
+            "shape of the array of sliding blocks as (%d, %d), which is "
+            "too small (non-positive).",
+            inputHeight, inputHeight, kH, kW, dH, dW, padH, padW,
+            outputHeight, outputWidth);
   }
 }
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -80,16 +80,16 @@ Convolution layers
 .. autoclass:: ConvTranspose3d
     :members:
 
+:hidden:`Unfold`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: Unfold
+    :members:
+
 :hidden:`Fold`
 ~~~~~~~~~~~~~~
 
 .. autoclass:: Fold
-    :members:
-
-:hidden:`Unfold`
-~~~~~~~~~~~~~~~
-
-.. autoclass:: Unfold
     :members:
 
 
@@ -428,7 +428,7 @@ Normalization layers
 .. autoclass:: GroupNorm
     :members:
 
-    :hidden:`InstanceNorm1d`
+:hidden:`InstanceNorm1d`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: InstanceNorm1d
@@ -735,12 +735,12 @@ Utilities
 .. autofunction:: torch.nn.utils.clip_grad_value_
 
 :hidden:`parameters_to_vector`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: torch.nn.utils.parameters_to_vector
 
 :hidden:`vector_to_parameters`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: torch.nn.utils.vector_to_parameters
 
@@ -835,15 +835,15 @@ Convolution functions
 
 .. autofunction:: conv_transpose3d
 
-:hidden:`fold`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: fold
-
 :hidden:`unfold`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: unfold
+
+:hidden:`fold`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: fold
 
 Pooling functions
 ----------------------------------
@@ -1035,7 +1035,7 @@ Non-linear activation functions
 .. autofunction:: softshrink
 
 :hidden:`gumbel_softmax`
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: gumbel_softmax
 

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -19,21 +19,24 @@ methods:
 - :meth:`~Function.forward` - the code that performs the operation. It can take
   as many arguments as you want, with some of them being optional, if you
   specify the default values. All kinds of Python objects are accepted here.
-  :class:`Variable` arguments will be converted to :class:`Tensor` s before the
-  call, and their use will be registered in the graph. Note that this logic won't
-  traverse lists/dicts/any other data structures and will only consider Variables
-  that are direct arguments to the call. You can return either a single
-  :class:`Tensor` output, or a :class:`tuple` of :class:`Tensor` s if there are
-  multiple outputs. Also, please refer to the docs of :class:`Function` to find
-  descriptions of useful methods that can be called only from :meth:`~Function.forward`.
+  :class:`Tensor` arguments that track history (i.e., with
+  ``requires_grad=True``) will be converted to ones that don't track history
+  before the call, and their use will be registered in the graph. Note that this
+  logic won't traverse lists/dicts/any other data structures and will only
+  consider :class:`Tensor` s that are direct arguments to the call. You can
+  return either a single :class:`Tensor` output, or a :class:`tuple` of
+  :class:`Tensor` s if there are multiple outputs. Also, please refer to the
+  docs of :class:`Function` to find descriptions of useful methods that can be
+  called only from :meth:`~Function.forward`.
 - :meth:`~Function.backward` - gradient formula. It will be given
-  as many :class:`Variable` arguments as there were outputs, with each of them
+  as many :class:`Tensor` arguments as there were outputs, with each of them
   representing gradient w.r.t. that output. It should return as many
-  :class:`Variable` s as there were inputs, with each of them containing the
+  :class:`Tensor` s as there were inputs, with each of them containing the
   gradient w.r.t. its corresponding input. If your inputs didn't require
-  gradient (see :attr:`~Variable.needs_input_grad`), or were non-:class:`Variable`
+  gradient (:attr:`~ctx.needs_input_grad` is a tuple of booleans indicating
+  whether each input needs gradient computation), or were non-:class:`Tensor`
   objects, you can return :class:`python:None`. Also, if you have optional
-  arguments to :meth:`~Variable.forward` you can return more gradients than there
+  arguments to :meth:`~Function.forward` you can return more gradients than there
   were inputs, as long as they're all :any:`python:None`.
 
 Below you can find code for a ``Linear`` function from :mod:`torch.nn`, with
@@ -82,7 +85,7 @@ Now, to make it easier to use these custom ops, we recommend aliasing their
     linear = LinearFunction.apply
 
 Here, we give an additional example of a function that is parametrized by
-non-Variable arguments::
+non-Tensor arguments::
 
     class MulConstant(Function):
         @staticmethod
@@ -157,7 +160,7 @@ This is how a ``Linear`` module can be implemented::
             self.input_features = input_features
             self.output_features = output_features
 
-            # nn.Parameter is a special kind of Variable, that will get
+            # nn.Parameter is a special kind of Tensor, that will get
             # automatically registered as Module's parameter once it's assigned
             # as an attribute. Parameters and buffers need to be registered, or
             # they won't appear in .parameters() (doesn't apply to buffers), and
@@ -189,8 +192,18 @@ This is how a ``Linear`` module can be implemented::
             )
 
 
+Writing custom C++ extensions
+-----------------------------
+
+See this
+`PyTorch tutorial <https://pytorch.org/tutorials/advanced/cpp_extension.html>`_
+for a detailed explanation and examples.
+
+Documentations are available at :doc:`../cpp_extension`.
+
+
 Writing custom C extensions
 ---------------------------
 
-Coming soon. For now you can find an example at
-`GitHub <https://github.com/pytorch/extension-ffi>`_.
+Example available at
+`this GitHub repository <https://github.com/pytorch/extension-ffi>`_.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5242,6 +5242,57 @@ class TestNN(NNTestCase):
     def test_grad_conv3d_weight(self):
         self.run_grad_conv_test(F.conv3d, F.grad.conv3d_weight, 3, 'weight')
 
+    def test_fold_invalid_arg(self):
+        # input wrong dimension
+
+        fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 3))
+        with self.assertRaisesRegex(NotImplementedError, r"Only 3D input Tensors are supported"):
+            fold(torch.randn(1, 5))
+
+        # input.size(1) not divisible by \prod(kernel_size)
+
+        fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 3))
+        with self.assertRaisesRegex(RuntimeError, r"be divisible by the product of kernel_size"):
+            fold(torch.randn(1, 5, 9))
+
+        with self.assertRaisesRegex(RuntimeError, r"be divisible by the product of kernel_size"):
+            fold(torch.randn(1, 19, 9))
+
+        # input.size(2) not matching the total number of sliding blocks
+
+        with self.assertRaisesRegex(RuntimeError, r"match the calculated number of sliding blocks"):
+            fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 3))
+            fold(torch.randn(1, 6, 10))
+
+        with self.assertRaisesRegex(RuntimeError, r"match the calculated number of sliding blocks"):
+            fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 3), stride=(2, 2))
+            fold(torch.randn(1, 6, 5))
+
+        with self.assertRaisesRegex(RuntimeError, r"match the calculated number of sliding blocks"):
+            fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 3), stride=(2, 2), dilation=(1, 2), padding=(2, 0))
+            fold(torch.randn(1, 6, 5))  # should be 4 * 1 = 4 sliding blocks
+
+    def test_unfold_invalid_arg(self):
+        # input wrong dimension
+
+        unfold = nn.Unfold(kernel_size=(2, 3))
+        with self.assertRaisesRegex(NotImplementedError, r"Only 4D input Tensors are supported"):
+            unfold(torch.randn(1, 5, 2))
+
+        # calculated output shape is too small
+
+        with self.assertRaisesRegex(RuntimeError, r"too small \(non-positive\)"):
+            unfold = nn.Unfold(kernel_size=(2, 3))
+            unfold(torch.randn(1, 2, 2, 2))
+
+        with self.assertRaisesRegex(RuntimeError, r"too small \(non-positive\)"):
+            unfold = nn.Unfold(kernel_size=(5, 3), padding=(1, 1))
+            unfold(torch.randn(1, 2, 2, 3))
+
+        with self.assertRaisesRegex(RuntimeError, r"too small \(non-positive\)"):
+            unfold = nn.Unfold(kernel_size=(1, 3), padding=(1, 1), dilation=(1, 2))
+            unfold(torch.randn(1, 2, 2, 2))
+
     def test_adaptive_log_softmax(self):
         # args validation
         with self.assertRaises(ValueError):
@@ -5254,14 +5305,14 @@ class TestNN(NNTestCase):
             _ = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 25], div_value=2.)
 
         # input shapes
-        with self.assertRaisesRegex(RuntimeError, "Input and target should have the same size"):
+        with self.assertRaisesRegex(RuntimeError, r"Input and target should have the same size"):
             asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
             x = torch.randn(2, 16)
             y = torch.tensor([0, 5, 10])
             asfm(x, y)
 
         # out-of-bound targets
-        with self.assertRaisesRegex(RuntimeError, "Target values should be in"):
+        with self.assertRaisesRegex(RuntimeError, r"Target values should be in"):
             asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
             x = torch.randn(2, 16)
             y = torch.tensor([0, 20])

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4752,8 +4752,6 @@ and multiple right-hand sides `b`.
 In particular, solves :math:`AX = b` and assumes `A` is upper-triangular
 with the default keyword arguments.
 
-This method is NOT implemented for CUDA tensors.
-
 Args:
     A (Tensor): the input triangular coefficient matrix
     b (Tensor): multiple right-hand sides. Each column of `b` is a

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -122,10 +122,6 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
 
     Each function object is meant to be used only once (in the forward pass).
 
-    Attributes:
-        requires_grad: Boolean indicating whether the :func:`backward` will
-            ever need to be called.
-
     Examples::
 
         >>> class Exp(Function):
@@ -168,14 +164,18 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
 
         This function is to be overridden by all subclasses.
 
-        It must accept a context ctx as the first argument, followed by as many
-        outputs did :func:`forward` return, and it should return as many
+        It must accept a context :attr:`ctx` as the first argument, followed by
+        as many outputs did :func:`forward` return, and it should return as many
         tensors, as there were inputs to :func:`forward`. Each argument is the
         gradient w.r.t the given output, and each returned value should be the
         gradient w.r.t. the corresponding input.
 
         The context can be used to retrieve tensors saved during the forward
-        pass.
+        pass. It also has an attribute :attr:`ctx.needs_input_grad` as a tuple
+        of booleans representing whether each input needs gradient. E.g.,
+        :func:`backward` will have ``ctx.needs_input_grad[0] = True`` if the
+        first input to :func:`forward` needs gradient computated w.r.t. the
+        output.
         """
         raise NotImplementedError
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2235,12 +2235,16 @@ def assert_int_or_pair(arg, arg_name, message):
 
 
 def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
-    r"""Creates array of convolution patches from :math:`(N,C,H,W)`-tensor
+    r"""Extracts sliding local blocks from an batched input tensor.
+
+    .. warning::
+        Currently, only 4-D input tensors (batched image-like tensors) are
+        supported.
 
     See :class:`torch.nn.Unfold` for details
     """
 
-    if input is not None and input.dim() == 4:
+    if input.dim() == 4:
         msg = '{} must be int or 2-tuple for 4D input'
         assert_int_or_pair(kernel_size, 'kernel_size', msg)
         assert_int_or_pair(dilation, 'dilation', msg)
@@ -2250,15 +2254,20 @@ def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
         return Im2Col.apply(input, _pair(kernel_size),
                             _pair(dilation), _pair(padding), _pair(stride))
     else:
-        raise NotImplementedError("Input Error: Only 4D input Tensors supported (got {}D)".format(input.dim()))
+        raise NotImplementedError("Input Error: Only 4D input Tensors are supported (got {}D)".format(input.dim()))
 
 
 def fold(input, output_size, kernel_size, dilation=1, padding=0, stride=1):
-    r"""Combines array of convolution patches to :math:`(N,C,H,W)`-tensor
+    r"""Combines an array of sliding local blocks into a large containing
+    tensor.
+
+    .. warning::
+        Currently, only 4-D output tensors (batched image-like tensors) are
+        supported.
 
     See :class:`torch.nn.Fold` for details
     """
-    if input is not None and input.dim() == 3:
+    if input.dim() == 3:
         msg = '{} must be int or 2-tuple for 3D input'
         assert_int_or_pair(output_size, 'output_size', msg)
         assert_int_or_pair(kernel_size, 'kernel_size', msg)
@@ -2269,4 +2278,4 @@ def fold(input, output_size, kernel_size, dilation=1, padding=0, stride=1):
         return Col2Im.apply(input, _pair(output_size), _pair(kernel_size),
                             _pair(dilation), _pair(padding), _pair(stride))
     else:
-        raise NotImplementedError("Input Error: Only 3D input Tensors supported (got {}D)".format(input.dim()))
+        raise NotImplementedError("Input Error: Only 3D input Tensors are supported (got {}D)".format(input.dim()))

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -532,7 +532,8 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
         - Output: :math:`(N, C_{out}, L_{out})` where
 
           .. math::
-              L_{out} = (L_{in} - 1) \times \text{stride} - 2 \times \text{padding} + \text{kernel_size} + \text{output_padding}
+              L_{out} = (L_{in} - 1) \times \text{stride} - 2 \times \text{padding}
+                    + \text{kernel_size} + \text{output_padding}
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -139,8 +139,8 @@ class Conv1d(_ConvNd):
         - Output: :math:`(N, C_{out}, L_{out})` where
 
           .. math::
-              L_{out} = \left\lfloor\frac{L_{in} + 2 * \text{padding} - \text{dilation}
-                        * (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\right\rfloor
+              L_{out} = \left\lfloor\frac{L_{in} + 2 \times \text{padding} - \text{dilation}
+                        \times (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -257,11 +257,11 @@ class Conv2d(_ConvNd):
         - Output: :math:`(N, C_{out}, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \left\lfloor\frac{H_{in}  + 2 * \text{padding}[0] - \text{dilation}[0]
-                        * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
+              H_{out} = \left\lfloor\frac{H_{in}  + 2 \times \text{padding}[0] - \text{dilation}[0]
+                        \times (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              W_{out} = \left\lfloor\frac{W_{in}  + 2 * \text{padding}[1] - \text{dilation}[1]
-                        * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
+              W_{out} = \left\lfloor\frac{W_{in}  + 2 \times \text{padding}[1] - \text{dilation}[1]
+                        \times (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -376,14 +376,14 @@ class Conv3d(_ConvNd):
         - Output: :math:`(N, C_{out}, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[0] - \text{dilation}[0]
-                    * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
+              D_{out} = \left\lfloor\frac{D_{in} + 2 \times \text{padding}[0] - \text{dilation}[0]
+                    \times (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              H_{out} = \left\lfloor\frac{H_{in} + 2 * \text{padding}[1] - \text{dilation}[1]
-                    * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
+              H_{out} = \left\lfloor\frac{H_{in} + 2 \times \text{padding}[1] - \text{dilation}[1]
+                    \times (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
-              W_{out} = \left\lfloor\frac{W_{in} + 2 * \text{padding}[2] - \text{dilation}[2]
-                    * (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\right\rfloor
+              W_{out} = \left\lfloor\frac{W_{in} + 2 \times \text{padding}[2] - \text{dilation}[2]
+                    \times (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -532,7 +532,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
         - Output: :math:`(N, C_{out}, L_{out})` where
 
           .. math::
-              L_{out} = (L_{in} - 1) * \text{stride} - 2 * \text{padding} + \text{kernel_size} + \text{output_padding}
+              L_{out} = (L_{in} - 1) \times \text{stride} - 2 \times \text{padding} + \text{kernel_size} + \text{output_padding}
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -635,10 +635,10 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
         - Output: :math:`(N, C_{out}, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = (H_{in} - 1) * \text{stride}[0] - 2 * \text{padding}[0]
+              H_{out} = (H_{in} - 1) \times \text{stride}[0] - 2 \times \text{padding}[0]
                     + \text{kernel_size}[0] + \text{output_padding}[0]
 
-              W_{out} = (W_{in} - 1) * \text{stride}[1] - 2 * \text{padding}[1]
+              W_{out} = (W_{in} - 1) \times \text{stride}[1] - 2 \times \text{padding}[1]
                     + \text{kernel_size}[1] + \text{output_padding}[1]
 
     Attributes:
@@ -769,13 +769,13 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         - Output: :math:`(N, C_{out}, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = (D_{in} - 1) * \text{stride}[0] - 2 * \text{padding}[0]
+              D_{out} = (D_{in} - 1) \times \text{stride}[0] - 2 \times \text{padding}[0]
                     + \text{kernel_size}[0] + \text{output_padding}[0]
 
-              H_{out} = (H_{in} - 1) * \text{stride}[1] - 2 * \text{padding}[1]
+              H_{out} = (H_{in} - 1) \times \text{stride}[1] - 2 \times \text{padding}[1]
                     + \text{kernel_size}[1] + \text{output_padding}[1]
 
-              W_{out} = (W_{in} - 1) * \text{stride}[2] - 2 * \text{padding}[2]
+              W_{out} = (W_{in} - 1) \times \text{stride}[2] - 2 \times \text{padding}[2]
                     + \text{kernel_size}[2] + \text{output_padding}[2]
 
     Attributes:

--- a/torch/nn/modules/fold.py
+++ b/torch/nn/modules/fold.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from .module import Module
 from .. import functional as F
 

--- a/torch/nn/modules/fold.py
+++ b/torch/nn/modules/fold.py
@@ -3,28 +3,46 @@ from .. import functional as F
 
 
 class Fold(Module):
-    """
-    De-interleaves vectors of length :math:`\prod(kernel\_size)` from the "channel"
-    dimension of the input tensor to generate blocks of size :math:`kernel\_size`
-    of the output.  These blocks populate the "spatial" dimensions [2:]
-    of the output via a sliding window with positions determined by the
-    padding, stride and dilation values.  The "channel" dimension 1 of the output
-    is determined by the vectors interleaevd position in the "channel" dimension
-    of the input.
+    r"""Combines an array of sliding local blocks into a large containing
+    tensor.
 
-    Each element of the output batch dimension 0 has :math:`C / \prod(kernel\_size)`
-    channels (dimension 1) and spatial dimensions [2:] of shape :math:`output\_size`.
+    Consider a batched :attr:`input` tensor containing sliding local blocks,
+    e.g., patches of images, of shape :math:`(N, C \times  \prod(\text{kernel_size}), L)`,
+    where :math:`N` is batch dimension, :math:`C \times \prod(\text{kernel_size})`
+    is the number of values with in a block (a block has :math:`\prod(\text{kernel_size})`
+    spatial locations each containing a :math:`C`-channeled vector), and
+    :math:`L` is the total number of blocks. (This is exacly the
+    same specification as the output shape of :class:`~torch.nn.Unfold`.) This
+    operation combines these local blocks into the large :attr:`output` tensor
+    of shape :math:`(N, C, \text{output_size}[0], \text{output_size}[1], \dots)`.
+    Similar to :class:`~torch.nn.Unfold`, the arguments must satisfy
 
-    | If :attr:`padding` is non-zero, then the input is implicitly
-    zero-padded on both sides by :attr:`padding` number of points
-    | :attr:`dilation` controls the intenal spacing between the kernel points in the output.
-    It is harder to describe, but this `link`_ has a nice visualization of what
-    dilation does.
+    .. math::
+        L = \prod_d \left\lfloor\frac{\text{output_size}[d] + 2 \times \text{padding}[d] \
+            - \text{dilation}[d] \times (\text{kernel_size}[d] - 1) - 1}{\text{stride}[d]} + 1\right\rfloor,
+
+    where :math:`d` is over all spatial dimensions.
+
+    * :attr:`output_size` describes the spatial shape of the large containing
+      tensor of the sliding local blocks. It is useful to resolve the ambiguity
+      when multiple input shapes map to same number of sliding blocks, e.g.,
+      with ``stride > 0``.
+
+    The :attr:`padding`, :attr:`stride` and :attr:`dilation` arguments specify
+    how the sliding blocks are retrieved.
+
+    * :attr:`stride` controls the stride for the sliding blocks.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension before
+      reshaping.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+      It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
 
     Args:
         output_size (int or tuple): the shape of the spatial dimensions [2:] of the output
-        kernel_size (int or tuple): the size of the sliding blocks to convert
-                                    to columns.
+        kernel_size (int or tuple): the size of the sliding blocks
         stride (int or tuple): the stride of the sliding blocks in the input
                                spatial dimensions. Default: 1
         padding (int or tuple, optional): implicit zero padding to be added on
@@ -33,23 +51,27 @@ class Fold(Module):
                                            stride of elements within the
                                            neighborhood. Default: 1
 
-    | If :attr:`output_size`, :attr:`kernel_size`, :attr:`dilation`,
-    :attr:`padding` or :attr:`stride` is of length 1 then
-    their value will be replicated across all spatial dimensions
+    * If :attr:`output_size`, :attr:`kernel_size`, :attr:`dilation`,
+      :attr:`padding` or :attr:`stride` is an int or a tuple of length 1 then
+      their values will be replicated across all spatial dimensions.
 
-    | For the case of two output spatial dimensions this operation is sometimes called col2im
+    * For the case of two output spatial dimensions this operation is sometimes
+      called ``col2im``.
+
+    .. warning::
+        Currently, only 4-D output tensors (batched image-like tensors) are
+        supported.
 
     Shape:
-        - Input: :math:`(N, C, L_{in})`
-        - Output: :math:`(N * C * \prod(kernel\_size), L_{out},)` where
-          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel\_size - 1) - 1) / stride + 1)`
+        - Input: :math:`(N, C \times \prod(\text{kernel_size}), L)`
+        - Output: :math:`(N, C, \text{output_size}[0], \text{output_size}[1], \dots)` as described above
 
     Examples::
 
-        >>> # output_size (3, 3) kernel_size (2, 2), dilation (1, 1), padding (0, 0), stride (1, 1)
-        >>> fold = nn.Fold((3, 3), (2, 2), (1, 1), (0, 0), (1, 1))
-        >>> input = torch.randn(1, 4, 10, 12)
+        >>> fold = nn.Fold(output_size=(4, 5), kernel_size=(2, 2))
+        >>> input = torch.randn(1, 3 * 2 * 2, 1)
         >>> output = fold(input)
+        >>> output.size()
 
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md
@@ -76,27 +98,44 @@ class Fold(Module):
 
 
 class Unfold(Module):
-    """
+    r"""Extracts sliding local blocks from a batched input tensor.
 
-    Converts each sliding :math:`kernel\_size` block of the "spatial" dimensions [2:]
-    of the input tensor into a column of the output. These columns are interleaved
-    with the "channel" dimension 1 such that in the output the channel dimension combines
-    both the spatial position of the block within the input and the original
-    channel position. We denote size of the "batch" dimension 0 as :math:`N`.
+    Consider an batched :attr:`input` tensor of shape :math:`(N, C, *)`,
+    where :math:`N` is the batch dimension, :math:`C` is the channel dimension,
+    and :math:`*` represent arbitrary spatial dimensions. This operation flattens
+    each sliding :attr:`kernel_size`-sized block within the spatial dimensions
+    of :attr:`input` into a column (i.e., last dimension) of a 3-D :attr:`output`
+    tensor of shape :math:`(N, C \times \prod(\text{kernel_size}), L)`, where
+    :math:`C \times \prod(\text{kernel_size})` is the total number of values
+    with in each block (a block has :math:`\prod(\text{kernel_size})` spatial
+    locations each containing a :math:`C`-channeled vector), and :math:`L` is
+    the total number of such blocks:
 
-    Each element of the output batch dimension 0 has :math:`C * \prod(kernel\_size)`
-    rows and contains as many columns as there are :math:`kernel\_size` neighborhoods
-    of the input according to the padding, stride and dilation values.
+    .. math::
+        L = \prod_d \left\lfloor\frac{\text{input_spatial_size}[d] + 2 \times \text{padding}[d] \
+            - \text{dilation}[d] \times (\text{kernel_size}[d] - 1) - 1}{\text{stride}[d]} + 1\right\rfloor,
 
-    | If :attr:`padding` is non-zero, then the input is implicitly
-    zero-padded on both sides by :attr:`padding` number of points before reshaping
-    | :attr:`dilation` controls the internal spacing between the kernel points.
-    It is harder to describe, but this `link`_ has a nice visualization of what
-    dilation does.
+    where :math:`\text{input_spatial_size}` is formed by the spatial dimensions
+    of :attr:`input` (:math:`*` above), and :math:`d` is over all spatial
+    dimensions.
+
+    Therefore, indexing :attr:`output` at the last dimension (column dimension)
+    gives all values within a certain block.
+
+    The :attr:`padding`, :attr:`stride` and :attr:`dilation` arguments specify
+    how the sliding blocks are retrieved.
+
+    * :attr:`stride` controls the stride for the sliding blocks.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension before
+      reshaping.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+      It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
 
     Args:
-        kernel_size (int or tuple): the size of the sliding blocks to convert
-                                    to columns.
+        kernel_size (int or tuple): the size of the sliding blocks
         stride (int or tuple, optional): the stride of the sliding blocks in the input
                                          spatial dimensions. Default: 1
         padding (int or tuple, optional): implicit zero padding to be added on
@@ -105,30 +144,41 @@ class Unfold(Module):
                                            stride of elements within the
                                            neighborhood. Default: 1
 
-    | If :attr:`kernel_size`, :attr:`dilation`, :attr:`padding` or :attr:`stride`
-    is of length 1 then their value will be replicated across all spatial dimensions
+    * If :attr:`kernel_size`, :attr:`dilation`, :attr:`padding` or
+      :attr:`stride` is an int or a tuple of length 1, their values will be
+      replicated across all spatial dimensions.
 
-    | For the case of two input spatial dimensions this operation is sometimes called im2col
+    * For the case of two input spatial dimensions this operation is sometimes
+      called ``im2col``.
+
+    .. warning::
+        Currently, only 4-D input tensors (batched image-like tensors) are
+        supported.
 
     Shape:
-        - Input: :math:`(N, C, L_{in})`
-        - Output: :math:`(N, C * \prod(kernel\_size), L_{out},)` where
-          :math:`L_{out} = floor((L_{in} + 2 * padding - dilation * (kernel\_size - 1) - 1) / stride + 1)`
+        - Input: :math:`(N, C, *)`
+        - Output: :math:`(N, C \times \prod(\text{kernel_size}), L)` as described above
 
     Examples::
 
-        >>> # kernel_size (2, 2), dilation (1, 1), padding (0, 0), stride (1, 1)
-        >>> unfold = nn.Unfold((3, 3), (1, 1), (0, 0), (1, 1))
-        >>> input = torch.randn(2, 4, 3, 3)
+        >>> unfold = nn.Unfold(kernel_size=(2, 3))
+        >>> input = torch.randn(2, 5, 3, 4)
         >>> output = unfold(input)
+        >>> # each patch contains 30 values (2x3=6 vectors, each of 5 channels)
+        >>> # 4 blocks (2x3 kernels) in total in the 3x4 input
+        >>> output.size()
+        torch.Size([2, 30, 4])
 
-        >>> inp = torch.arange(1*3*10*12.0).view(1,3,10,12)
-        >>> w = torch.randn(2,3,4,5)
-        >>> inp_unf = torch.nn.functional.unfold(inp, (4,5))
-        >>> out_unf = torch.nn.functional.linear(inp_unf.transpose(1,2), w.view(w.size(0),-1)).transpose(1,2)
-        >>> out = torch.nn.functional.fold(out_unf, (7,8), (1, 1))
-        >>> (torch.nn.functional.conv2d(inp, w)-out).abs().max().item()
-        0.0
+        >>> # Convolution is equivalent with Unfold + Matrix Multiplication + Fold (or view to output shape)
+        >>> inp = torch.randn(1, 3, 10, 12)
+        >>> w = torch.randn(2, 3, 4, 5)
+        >>> inp_unf = torch.nn.functional.unfold(inp, (4, 5))
+        >>> out_unf = inp_unf.transpose(1, 2).matmul(w.view(w.size(0), -1).t()).transpose(1, 2)
+        >>> out = torch.nn.functional.fold(out_unf, (7, 8), (1, 1))
+        >>> # or equivalently (and avoiding a copy),
+        >>> # out = out_unf.view(1, 2, 7, 8)
+        >>> (torch.nn.functional.conv2d(inp, w) - out).abs().max()
+        tensor(1.9073e-06)
 
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -513,6 +513,7 @@ class BCEWithLogitsLoss(_Loss):
 
     It's possible to trade off recall and precision by adding weights to positive examples.
     In this case the loss can be described as:
+
     .. math::
         \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
         l_n = - w_n \left[ p_n t_n \cdot \log \sigma(x_n)
@@ -577,7 +578,7 @@ class HingeEmbeddingLoss(_Loss):
     containing values (`1` or `-1`).
     This is usually used for measuring whether two inputs are similar or
     dissimilar, e.g. using the L1 pairwise distance as `x`, and is typically
-    used for learning nonlinear embeddings or semi-supervised learning::
+    used for learning nonlinear embeddings or semi-supervised learning.
 
     The loss function for :math:`n`-th sample in the mini-batch is
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -96,6 +96,7 @@ class LayerNorm(Module):
             .. math::
                 [* \times \text{normalized_shape}[0] \times \text{normalized_shape}[1]
                     \times \ldots \times \text{normalized_shape}[-1]]
+
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
         eps: a value added to the denominator for numerical stability. Default: 1e-5

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -100,13 +100,15 @@ class Tensor(torch._C._TensorBase):
 
             hook(grad) -> Tensor or None
 
+
         The hook should not modify its argument, but it can optionally return
         a new gradient which will be used in place of :attr:`grad`.
 
         This function returns a handle with a method ``handle.remove()``
         that removes the hook from the module.
 
-        Example:
+        Example::
+
             >>> v = torch.tensor([0., 0., 0.], requires_grad=True)
             >>> h = v.register_hook(lambda grad: grad * 2)  # double the gradient
             >>> v.backward(torch.tensor([1., 2., 3.]))


### PR DESCRIPTION
Commits: 
1. In extension doc, get rid of all references of `Variable` s (Closes #6947 )
    + also add minor improvements 
    + also added a section with links to cpp extension :) @goldsborough 
    + removed mentions of `autograd.Function.requires_grad` as it's not used anywhere and hardcoded to `return_Py_True`.
2. Fix several sphinx warnings
3. Change `*` in equations in `module/conv.py` to `\times`
4. Fix docs for `Fold` and `Unfold`. 
    + Added better shape check for `Fold` (it previously may give bogus result when there are not enough blocks). Added test for the checks.
5. Fix doc saying `trtrs` not available for CUDA (#9247 )
