### PR TITLE
Fix the build break for python3.7 PyUnicode_AsUTF8AndSize() prototype changing

### DIFF
--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -197,7 +197,7 @@ class TensorFeeder : public BlobFeederBase {
                 PyBytes_AsStringAndSize(input[i], &str, &strSize) != -1,
                 "Had a PyBytes object but cannot convert it to a string.");
           } else if (PyUnicode_Check(input[i])) { // string
-            str = PyUnicode_AsUTF8AndSize(input[i], &strSize);
+            str = const_cast<char*>(PyUnicode_AsUTF8AndSize(input[i], &strSize));
             CAFFE_ENFORCE(
                 str,
                 "Had a PyUnicode object but cannot convert it to a string.");


### PR DESCRIPTION
https://docs.python.org/3.7/c-api/unicode.html#c.PyUnicode_AsUTF8AndSize
The return type changes from "char*" to "const char*".

