### PR TITLE
Added HardTanh support for ONNX

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -360,7 +360,6 @@ def leaky_relu(g, input, negative_slope, inplace=False):
 
 
 def hardtanh(g, self, min_val, max_val, inplace=False):
-    # See Note [Export inplace]
     return g.op("Clip", self, min_f=_scalar(min_val), max_f=_scalar(max_val))
 
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -359,6 +359,11 @@ def leaky_relu(g, input, negative_slope, inplace=False):
     return g.op("LeakyRelu", input, alpha_f=_scalar(negative_slope))
 
 
+def hardtanh(g, self, min_val, max_val, inplace=False):
+    # See Note [Export inplace]
+    return g.op("Clip", self, min_f=_scalar(min_val), max_f=_scalar(max_val))
+
+
 def glu(g, input, dim):
     assert input.type().sizes()[dim] % 2 == 0
 


### PR DESCRIPTION
I added a function to __symbolic.py__, implementing the ``Hardtanh`` function with the ONNX [``Clip``](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Clip) function, [which does basically the same](https://github.com/onnx/onnx/issues/141).

I don't know if there is anything else that needs to be done for this PR to be accepted?  
Let me know if that is the case.

I tested my changes on a network with a ReLu6, and it indeed exported to an ONNX model with a Clip function with min=0 and max=6, so it seems to be working okay I guess?  
I read the ONNX model with [Netron](https://github.com/lutzroeder/Netron) as validation.