### PR TITLE
Fix Mac CUDA issues

### DIFF
--- a/caffe2/operators/sparse_normalize_op.cc
+++ b/caffe2/operators/sparse_normalize_op.cc
@@ -4,6 +4,16 @@
 namespace caffe2 {
 
 template <>
+bool SparseNormalizeOp<float, CPUContext>::RunOnDevice() {
+  CAFFE_ENFORCE_EQ(
+     Input(PARAM).size_from_dim(1),
+     Input(GRAD).size_from_dim(Input(INDICES).ndim()));
+
+  return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+     this, Input(INDICES));
+}
+
+template <>
 template <typename SIndex>
 bool SparseNormalizeOp<float, CPUContext>::DoRunWithType() {
   const auto* indices = Input(INDICES).template data<SIndex>();

--- a/caffe2/operators/sparse_normalize_op.h
+++ b/caffe2/operators/sparse_normalize_op.h
@@ -17,14 +17,7 @@ class SparseNormalizeOp final : public Operator<Context> {
     CAFFE_ENFORCE_GE(norm_, 0, "norm should be bigger than 0");
   }
 
-  bool RunOnDevice() override {
-    CAFFE_ENFORCE_EQ(
-        Input(PARAM).size_from_dim(1),
-        Input(GRAD).size_from_dim(Input(INDICES).ndim()));
-
-    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
-        this, Input(INDICES));
-  }
+  bool RunOnDevice() override;
 
   template <typename SIndex>
   bool DoRunWithType();

--- a/caffe2/utils/IdWrapper.h
+++ b/caffe2/utils/IdWrapper.h
@@ -35,7 +35,9 @@ protected:
     }
 
 private:
-    friend struct std::hash<ConcreteType>;
+    friend size_t hash_value(const concrete_type& v) {
+        return std::hash<underlying_type>()(v.id_);
+    }
 
     // TODO Making operator== noexcept if underlying type is noexcept equality comparable doesn't work with GCC 4.8.
     //      Fix this once we don't need GCC 4.8 anymore.
@@ -59,7 +61,7 @@ private:
   template <>                                                \
   struct hash<ClassName> {                                   \
     size_t operator()(ClassName x) const {                   \
-      return std::hash<ClassName::underlying_type>()(x.id_); \
+      return hash_value(x);                                  \
     }                                                        \
   };                                                         \
   }


### PR DESCRIPTION
Breaking this out of #8338

This takes care of failures we saw on Mac CUDA builds when BUILD_CAFFE2 and BUILD_ATEN were removed. Specifically, @smessmer fixed `std::hash` being handled in a weird way by nvcc and I fixed an nvcc template issue by moving `SparseNormalizeOp::RunOnDevice` implementation into the cc file.

cc @mingzhe09088 @smessmer