### PR TITLE
Install typing for Mac

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -37,6 +37,12 @@ else
     pip install --user pyyaml
   fi
 
+  # Make sure that typing is installed for the codegen of building Aten to work
+  if [[ -n "$(python -c 'import typing' 2>&1)" ]]; then
+    echo "Installing typing with pip at $(which pip)"
+    pip install --user typing
+  fi
+
   # Build protobuf compiler from third_party if configured to do so
   if [ -n "${USE_HOST_PROTOC:-}" ]; then
     echo "USE_HOST_PROTOC is set; building protoc before building Caffe2..."


### PR DESCRIPTION
Breaking this out of #8338 

When BUILD_CAFFE2 and BUILD_ATEN are removed, we need to install typing on Mac. 

cc @orionr 