### PR TITLE
Unify THAllocator and THCDeviceAllocator with at::Allocator/Deleter

### DIFF
--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -1,0 +1,7 @@
+#include <ATen/Allocator.h>
+
+namespace at {
+
+InefficientStdFunctionDeleter InefficientStdFunctionDeleter::singleton_;
+
+} // namespace at

--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -2,6 +2,11 @@
 
 namespace at {
 
+void deleteNothing(void*) {}
+SupervisorPtr nonOwningSupervisorPtr() {
+  return {nullptr, &deleteNothing};
+}
+
 static void deleteInefficientStdFunctionSupervisor(void* ptr) {
   delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
 }

--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -2,6 +2,13 @@
 
 namespace at {
 
-InefficientStdFunctionDeleter InefficientStdFunctionDeleter::singleton_;
+static void deleteInefficientStdFunctionSupervisor(void* ptr) {
+  delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
+}
+
+at::SupervisedPtr
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
+  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
+}
 
 } // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -51,7 +51,7 @@ struct SupervisedPtr {
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual SupervisedPtr allocate(size_t n) const = 0;
+  virtual at::SupervisedPtr allocate(size_t n) const = 0;
 
   // If this returns a non nullptr, it means that allocate()
   // is guaranteed to return a unique_ptr with this deleter attached;
@@ -80,7 +80,7 @@ static void deleteInefficientStdFunctionSupervisor(void* ptr) {
   delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
 }
 
-AT_API SupervisedPtr
+AT_API at::SupervisedPtr
 makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
   return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
 }

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -30,6 +30,7 @@ struct SupervisedPtr {
     : data_(data), supervisor_(std::move(supervisor)) {}
   void* operator->() const { return data_; }
   void* get() const { return data_; }
+  SupervisedPtr& operator=( nullptr_t ) noexcept { data_ = nullptr; supervisor_ = nullptr; return *this; }
 };
 
 inline bool operator==(const at::SupervisedPtr& sp, nullptr_t) noexcept {

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -15,11 +15,17 @@ namespace at {
 using DeleterFnPtr = void(*)(void*);
 using SupervisorPtr = std::unique_ptr<void, DeleterFnPtr>;
 
+// Does not delete anything
+AT_API void deleteNothing(void*);
+// Mints a SupervisorPtr that doesn't do anything.  You must
+// use this, not a nullptr, when you want a view.
+AT_API SupervisorPtr nonOwningSupervisorPtr();
+
 struct SupervisedPtr {
   // Lifetime tied to supervisor_
   void* data_;
   SupervisorPtr supervisor_;
-  SupervisedPtr() : data_(nullptr), supervisor_(nullptr, nullptr) {}
+  SupervisedPtr() : data_(nullptr), supervisor_(nonOwningSupervisorPtr()) {}
   SupervisedPtr(void* data, SupervisorPtr&& supervisor)
     : data_(data), supervisor_(std::move(supervisor)) {}
   void* operator->() const { return data_; }

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -3,14 +3,127 @@
 #include <memory>
 #include <stddef.h>
 
-#include "ATen/Retainable.h"
+#include <ATen/Error.h>
+#include <ATen/Retainable.h>
 
 namespace at {
 
+// Note [Separated Allocator and Deleter]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Why are Allocator and Deleter put in separate classes?  The key is that
+// an allocator may allocate a distinct context for every deleter.  This is
+// especially important upon reallocation: if we do not allocate a new
+// context, the contexts of the new and old data can clobber each other.
+// Imagine the following sequence of events:
+//
+//  1. Storage has some data and a BoundAllocatorDeleter associated with it.
+//     The context in this case is an owning reference to "IOBuf", an
+//     enclosing struct for the data.
+//
+//  2. A resize occurs on storage.  We call BoundAllocatorDeleter to
+//     allocate some new memory to store the resized data.  To allocate
+//     this new memory, we must allocate a new IOBuf.  But how can
+//     we update the context to replace the old reference with
+//     the new one?  Disaster!
+//
+// Previously, this case was worked around by directly supporting realloc()
+// in the deleter.  But this is bad for different reasons (it assumes the
+// allocator knows how to copy data; not a safe assumption, since allocators
+// don't know what data is actually contained within them.)
+
+struct Deleter {
+  virtual ~Deleter() {}
+  virtual void deallocate(void* ctx, void* ptr) const = 0;
+};
+
+// WARNING: BoundDeleter may LEAK ctx_ if you never actually call it on
+// the pointer it's supposed to delete; e.g., ctx_'s lifetime may be the
+// same as the pointer, and invocation of deallocate() is necessary to
+// ensure that deallocation of ctx_ happens at the same time ptr is
+// deallocated.
+struct BoundDeleter final {
+  at::Deleter* deleter_;
+  void* ctx_;
+  BoundDeleter() : deleter_(nullptr), ctx_(nullptr) {}
+  BoundDeleter(at::Deleter* deleter, void* ctx) : deleter_(deleter), ctx_(ctx) {
+    if (!deleter_) { AT_ASSERT(ctx == nullptr); }
+  }
+  void operator()(void* ptr) {
+    if (deleter_) { deleter_->deallocate(ctx_, ptr); }
+  }
+  operator bool() {
+    return static_cast<bool>(deleter_);
+  }
+};
+
+// Note [raw_allocate/raw_deallocate and Thrust]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Thrust's support for custom allocators requires us to write something
+// like this:
+//
+//  class ThrustAllocator {
+//    char* allocate(size_t);
+//    void deallocate(char*, size_t);
+//  };
+//
+// This is not good for our unique_ptr based allocator interface, as
+// there is no way to get the deleter from our allocator to the
+// deletion site in Thrust.  Indeed, if every pointer is getting a
+// *fresh* deleter, we truly would have no choice except to maintain
+// a map from pointers to deleters.  This is bad.
+//
+// So, we observe that not *all* deleters actually have lots of
+// different deleters; some of them actually always return the same
+// deleter every time.  In this case, we can support the "raw"
+// allocate and deallocate interface.  This is what
+// maybeGlobalBoundDeleter signifies.  By default, it returns the
+// default (empty) BoundDeleter, which means that the raw interface
+// is not implemented.  Be sure to implement it whenever possible.
+
 struct Allocator {
   virtual ~Allocator() {}
-  virtual void* allocate(size_t n) const = 0;
-  virtual void deallocate(void* ptr) const = 0;
+  virtual std::unique_ptr<void, BoundDeleter> allocate(size_t n) const = 0;
+
+  // If this returns a callable deleter, it means that allocate()
+  // is guaranteed to return a unique_ptr with this deleter attached;
+  // it means the rawAllocate and rawDeallocate APIs are safe to use.
+  // This function MUST always return the same BoundDeleter.
+  virtual BoundDeleter maybeGlobalBoundDeleter() const { return {}; }
+  void* raw_allocate(size_t n) {
+    AT_ASSERT(maybeGlobalBoundDeleter());
+    return allocate(n).release();
+  }
+  void raw_deallocate(void* ptr) {
+    auto d = maybeGlobalBoundDeleter();
+    AT_ASSERT(d);
+    d(ptr);
+  }
+
+  // There's a slight inefficiency here.  We are unable to inline
+  // across maybeGlobalBoundDeleter, because it is virtual, but
+  // this inlining might be quite profitable because the deleter
+  // is likely to be quite simple so we might be able to completely
+  // eliminate the BoundDeleter struct.  However, if we virtualized
+  // raw_allocate/raw_deallocate, in principle they could be generated
+  // for every subclass, with maybeGlobalBoundDeleter inlined (because
+  // all subclasses of Allocator ought to be final).  Unfortunately,
+  // doing this is a bit unreadable, so we leave this optimization
+  // to future work.
+};
+
+// An inefficient deleter that stashes a pointer to a dynamically allocated
+// std::function in the context.  This is a "use-at-last-resort" deleter.
+struct InefficientStdFunctionDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    auto* fnptr = static_cast<std::function<void(void*)>*>(ctx);
+    (*fnptr)(ptr);
+    delete fnptr;
+  }
+  static BoundDeleter make(const std::function<void(void*)> & deleter) {
+    return {&singleton_, new std::function<void(void*)>(deleter)};
+  }
+private:
+  static InefficientStdFunctionDeleter singleton_;
 };
 
 }  // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -19,6 +19,7 @@ struct SupervisedPtr {
   // Lifetime tied to supervisor_
   void* data_;
   SupervisorPtr supervisor_;
+  SupervisedPtr() : data_(nullptr), supervisor_(nullptr, nullptr) {}
   SupervisedPtr(void* data, SupervisorPtr&& supervisor)
     : data_(data), supervisor_(std::move(supervisor)) {}
   void* operator->() const { return data_; }
@@ -76,13 +77,7 @@ struct AT_API InefficientStdFunctionSupervisor {
     : ptr_(std::move(ptr)) {}
 };
 
-static void deleteInefficientStdFunctionSupervisor(void* ptr) {
-  delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
-}
-
 AT_API at::SupervisedPtr
-makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
-  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
-}
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter);
 
 }  // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -30,6 +30,7 @@ struct SupervisedPtr {
     : data_(data), supervisor_(std::move(supervisor)) {}
   void* operator->() const { return data_; }
   void* get() const { return data_; }
+  operator bool() { return data_ || supervisor_; }
   SupervisedPtr& operator=( nullptr_t ) noexcept { data_ = nullptr; supervisor_ = nullptr; return *this; }
 };
 

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -32,6 +32,19 @@ struct SupervisedPtr {
   void* get() const { return data_; }
 };
 
+inline bool operator==(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
+}
+inline bool operator==(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
+}
+inline bool operator!=(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
+}
+inline bool operator!=(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
+}
+
 // Note [raw_allocate/raw_deallocate and Thrust]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Thrust's support for custom allocators requires us to write something

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -8,89 +8,21 @@
 
 namespace at {
 
-// Note [Separated Allocator and Deleter]
+// Note [Supervisor deleter]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// A Deleter knows how to delete a void* pointer, freeing it back to the
-// system.  Every storage needs a deleter, so that we know how to free
-// the memory.
-//
-// An Allocator, given a size, knows how to allocate memory of that size.
-// Generally, you don't care too much about how a given piece of memory
-// is allocated, but if you need to *reallocate* some memory, it's good
-// to know how to reallocate something "in the same way", and that means
-// you have to know what the allocator is.
-//
-// Below, Allocator and Deleter are split into two separate classes.  You
-// might wonder, why is that?  In the common case, an allocator is in
-// one-to-one correspondence with a deleter, in the same way malloc() is
-// paired with free().
-//
-// However, there is a major exception to this case: when we write
-// Allocators/Deleters for "externally" managed memory.  In this case,
-// we may need an extra, externally provided pointer to some enclosing
-// struct if we want to free this memory, and this pointer is *different* for
-// every allocated void* pointer.
-//
-// To see what can go wrong, let's suppose that we had put Allocator and Deleter
-// together with the context, in a single "Allocator" class:
-//
-//    struct Allocator {
-//        void* ctx_;
-//        Allocator* allocator_;
-//        Deleter* deleter_;
-//    }
-//
-// Here, ctx_ stores the pointer to the enclosing struct.  Imagine the following
-// sequence of events:
-//
-//  1. Storage has some data and a Allocator associated with it.
-//     The context in the Allocator is an owning reference to "IOBuf", an
-//     enclosing struct for the data; the function to free an IOBuf
-//     is freeIOBuf(IOBuf*), NOT freeIOBuf(void*).
-//
-//  2. A resize occurs on storage.  We call Allocator to
-//     allocate some new memory to store the resized data.  To allocate
-//     this new memory, we must allocate a new IOBuf.  Now we have a
-//     problem: the classic API for an allocator is void*(void* ctx, size_t size).
-//     Where are we going to put the freshly allocated IOBuf?  We can't write it
-//     into the context directly, because that will clobber the old
-//     IOBuf (which we need to keep live until we copy the data out.)
-//
-// Instead, the allocator should *return* a new context for the deleter,
-// and this is what we have done below.  (We have further simplified matters
-// by saying that an allocator never has a context; we haven't seen any cases
-// where this is necessary, but it is a possible future extension).
-//
-// By the way, previously, this case was worked around by directly supporting
-// realloc() in the deleter.  But this is bad for different reasons (it assumes
-// the allocator knows how to copy data; not a safe assumption, since allocators
-// don't know the type of the data is actually contained within them; if the
-// data has a non-trivial copy constructor, there's no way to do a resize safely
-// in this case.)
+// TODO WRITE ME
 
-struct Deleter {
-  virtual ~Deleter() {}
-  virtual void deallocate(void* ctx, void* ptr) const = 0;
-};
+using DeleterFnPtr = void(*)(void*);
+using SupervisorPtr = std::unique_ptr<void, DeleterFnPtr>;
 
-// WARNING: A common pattern when writing BoundDeleter is to set things
-// up so that the lifetime of ctx_ is the same as pointer.  In this case,
-// you will LEAK ctx_ if you never actually call it on the pointer it's
-// supposed to delete.  Use the deleter that comes with a pointer to
-// deallocate it; don't do it some out-of-band way!
-struct BoundDeleter final {
-  at::Deleter* deleter_;
-  void* ctx_;
-  BoundDeleter() : deleter_(nullptr), ctx_(nullptr) {}
-  BoundDeleter(at::Deleter* deleter, void* ctx) : deleter_(deleter), ctx_(ctx) {
-    if (!deleter_) { AT_ASSERT(ctx == nullptr); }
-  }
-  void operator()(void* ptr) {
-    if (deleter_) { deleter_->deallocate(ctx_, ptr); }
-  }
-  operator bool() {
-    return static_cast<bool>(deleter_);
-  }
+struct SupervisedPtr {
+  // Lifetime tied to supervisor_
+  void* data_;
+  SupervisorPtr supervisor_;
+  SupervisedPtr(void* data, SupervisorPtr&& supervisor)
+    : data_(data), supervisor_(std::move(supervisor)) {}
+  void* operator->() const { return data_; }
+  void* get() const { return data_; }
 };
 
 // Note [raw_allocate/raw_deallocate and Thrust]
@@ -119,48 +51,38 @@ struct BoundDeleter final {
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual std::unique_ptr<void, BoundDeleter> allocate(size_t n) const = 0;
+  virtual SupervisedPtr allocate(size_t n) const = 0;
 
-  // If this returns a callable deleter, it means that allocate()
+  // If this returns a non nullptr, it means that allocate()
   // is guaranteed to return a unique_ptr with this deleter attached;
   // it means the rawAllocate and rawDeallocate APIs are safe to use.
   // This function MUST always return the same BoundDeleter.
-  virtual BoundDeleter maybeGlobalBoundDeleter() const { return {}; }
+  virtual DeleterFnPtr raw_deleter() const { return nullptr; }
   void* raw_allocate(size_t n) {
-    AT_ASSERT(maybeGlobalBoundDeleter());
-    return allocate(n).release();
+    auto sptr = allocate(n);
+    AT_ASSERT(sptr.data_ == sptr.supervisor_.get());
+    return sptr.supervisor_.release();
   }
   void raw_deallocate(void* ptr) {
-    auto d = maybeGlobalBoundDeleter();
+    auto d = raw_deleter();
     AT_ASSERT(d);
     d(ptr);
   }
-
-  // There's a slight inefficiency here.  We are unable to inline
-  // across maybeGlobalBoundDeleter, because it is virtual, but
-  // this inlining might be quite profitable because the deleter
-  // is likely to be quite simple so we might be able to completely
-  // eliminate the BoundDeleter struct.  However, if we virtualized
-  // raw_allocate/raw_deallocate, in principle they could be generated
-  // for every subclass, with maybeGlobalBoundDeleter inlined (because
-  // all subclasses of Allocator ought to be final).  Unfortunately,
-  // doing this is a bit unreadable, so we leave this optimization
-  // to future work.
 };
 
-// An inefficient deleter that stashes a pointer to a dynamically allocated
-// std::function in the context.  This is a "use-at-last-resort" deleter.
-struct InefficientStdFunctionDeleter : public at::Deleter {
-  void deallocate(void* ctx, void* ptr) const override {
-    auto* fnptr = static_cast<std::function<void(void*)>*>(ctx);
-    (*fnptr)(ptr);
-    delete fnptr;
-  }
-  static BoundDeleter make(const std::function<void(void*)> & deleter) {
-    return {&singleton_, new std::function<void(void*)>(deleter)};
-  }
-private:
-  static InefficientStdFunctionDeleter singleton_;
+struct AT_API InefficientStdFunctionSupervisor {
+  std::unique_ptr<void, std::function<void(void*)>> ptr_;
+  InefficientStdFunctionSupervisor(std::unique_ptr<void, std::function<void(void*)>>&& ptr)
+    : ptr_(std::move(ptr)) {}
 };
+
+static void deleteInefficientStdFunctionSupervisor(void* ptr) {
+  delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
+}
+
+AT_API SupervisedPtr
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
+  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
+}
 
 }  // namespace at

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -58,17 +58,15 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data_ptr = &one;
+      storage.data_ptr = {&one, BoundDeleter{}};
       storage.size = 1;
     } else {
-      storage.data_ptr = (void*)(ref.data());
+      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), BoundDeleter{}};
       storage.size = ref.size();
     }
     storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();
     storage.refcount = 0;
     storage.flag = 0;
-    storage.allocatorVoidPtr = nullptr;
-    storage.allocatorContext = nullptr;
   }
 private:
   int64_t one;

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -58,10 +58,10 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data_ptr = {&one, BoundDeleter{}};
+      storage.data_ptr = {&one, at::nonOwningSupervisorPtr()};
       storage.size = 1;
     } else {
-      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), BoundDeleter{}};
+      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), at::nonOwningSupervisorPtr()};
       storage.size = ref.size();
     }
     storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
@@ -9,20 +9,9 @@
 
 namespace at { namespace cuda {
 
-void* PinnedMemoryAllocator::allocate(size_t n) const {
+at::Allocator* getPinnedMemoryAllocator() {
   auto state = globalContext().lazyInitCUDA();
-  return state->cudaHostAllocator->malloc(nullptr, n);
-}
-
-void PinnedMemoryAllocator::deallocate(void* ptr) const {
-  auto state = globalContext().lazyInitCUDA();
-  return state->cudaHostAllocator->free(nullptr, ptr);
-}
-
-// No risk of static initialization order fiasco
-static PinnedMemoryAllocator r;
-PinnedMemoryAllocator* getPinnedMemoryAllocator() {
-  return &r;
+  return state->cudaHostAllocator;
 }
 
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.h
@@ -4,11 +4,6 @@
 
 namespace at { namespace cuda {
 
-struct PinnedMemoryAllocator final : public Allocator {
-  void* allocate(size_t n) const override;
-  void deallocate(void* ptr) const override;
-};
-
-PinnedMemoryAllocator* getPinnedMemoryAllocator();
+at::Allocator* getPinnedMemoryAllocator();
 
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -87,8 +87,9 @@ DynamicCUDAInterfaceSetter _;
 // let's not if we don't need to!)
 std::unique_ptr<THCState, void (*)(THCState*)> CUDAHooks::initCUDA() const {
   THCState* thc_state = THCState_alloc();
+  // Caching allocator has no context
   THCState_setDeviceAllocator(thc_state, THCCachingAllocator_get());
-  thc_state->cudaHostAllocator = &THCCachingHostAllocator;
+  thc_state->cudaHostAllocator = getTHCCachingHostAllocator();
   THCudaInit(thc_state);
   return std::unique_ptr<THCState, void (*)(THCState*)>(
       thc_state, [](THCState* p) {

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -349,7 +349,7 @@ BenchmarkCache<cudnnConvolutionBwdFilterAlgo_t> bwd_filter_algos;
 // tensor instead.
 struct Workspace {
   Workspace(size_t size) : size(size), data(NULL) {
-    AT_CUDA_CHECK(THCudaMalloc(globalContext().lazyInitCUDA(), &data, size));
+    data = THCudaMalloc(globalContext().lazyInitCUDA(), size);
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
@@ -692,11 +692,10 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   }
   cache.insert(args.params, *algo);
 
-  // These two lines frees the cached blocks in our caching allocator. They are
+  // Free the cached blocks in our caching allocator. They are
   // needed here because the above benchmarking uses a huge amount of memory,
   // e.g. a few GBs.
-  THCDeviceAllocator* allocator = THCCachingAllocator_get();
-  AT_CUDA_CHECK(allocator->emptyCache(allocator->state));
+  THCCachingAllocator_emptyCache();
 }
 
 template<typename algo_t>

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -29,7 +29,7 @@ ${Storage}::${Storage}(Context* context, size_t size, Allocator* allocator)
 ${Storage}::${Storage}(Context* context,
   void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
-     {data, InefficientStdFunctionDeleter::make(deleter)}, size,
+     makeInefficientStdFunctionSupervisedPtr(data, deleter), size,
      /* allocator */ nullptr
     )),
     context(context) {

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -19,76 +19,18 @@ ${Storage}::${Storage}(Context* context, THStorage* storage):
 ${Storage}::${Storage}(Context* context, size_t storage_size)
   : storage(${THStorage}_newWithSize(${state,} storage_size)), context(context) {}
 
-#if ${isCUDA}
-static cudaError_t call_deleter(void * ctx, void * data) {
-  auto fnptr = (std::function<void(void*)>*) ctx;
-  (*fnptr)(data);
-  delete fnptr;
-  return cudaSuccess;
-}
-static THCDeviceAllocator storage_deleter = {
-  nullptr,
-  nullptr,
-  call_deleter,
-  nullptr,
-  nullptr,
-};
-static cudaError_t wrapped_alloc(void * ctx, void** result, size_t size, cudaStream_t stream) {
-  auto ac = static_cast<Allocator*>(ctx);
-  *result = ac->allocate(size);
-  return cudaSuccess;
-}
-static cudaError_t wrapped_free(void * ctx, void * data) {
-  auto ac = static_cast<Allocator*>(ctx);
-  ac->deallocate(data);
-  return cudaSuccess;
-}
-static THCDeviceAllocator wrapped_allocator = {
-  wrapped_alloc,
-  nullptr,
-  wrapped_free,
-  nullptr,
-  nullptr,
-};
-#else
-static void call_deleter(void * ctx, void * data) {
-  auto fnptr = (std::function<void(void*)>*) ctx;
-  (*fnptr)(data);
-  delete fnptr;
-}
-static THAllocator storage_deleter = {
-  nullptr,
-  nullptr,
-  call_deleter,
-};
-static void* wrapped_alloc(void * ctx, ptrdiff_t size) {
-  auto ac = static_cast<Allocator*>(ctx);
-  return ac->allocate(size);
-}
-static void wrapped_free(void * ctx, void * data) {
-  auto ac = static_cast<Allocator*>(ctx);
-  ac->deallocate(data);
-}
-static THAllocator wrapped_allocator = {
-  wrapped_alloc,
-  nullptr,
-  wrapped_free,
-};
-#endif
-
 ${Storage}::${Storage}(Context* context, size_t size, Allocator* allocator)
   : storage(nullptr),
     context(context) {
-  storage = ${THStorage}_newWithAllocator(${state,} size, &wrapped_allocator, allocator);
+  storage = ${THStorage}_newWithAllocator(${state,} size, allocator);
   ${THStorage}_clearFlag(${state,} storage, TH_STORAGE_RESIZABLE);
 }
 
 ${Storage}::${Storage}(Context* context,
   void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
-     static_cast<${THScalarType}*>(data), size,
-     &storage_deleter,
-     new std::function<void(void*)>(deleter)
+     {data, InefficientStdFunctionDeleter::make(deleter)}, size,
+     /* allocator */ nullptr
     )),
     context(context) {
     ${THStorage}_clearFlag(${state,} storage, TH_STORAGE_RESIZABLE);
@@ -107,11 +49,11 @@ size_t ${Storage}::size() const {
 }
 
 void* ${Storage}::data() {
-  return storage->data_ptr;
+  return storage->data_ptr.get();
 }
 
 const void* ${Storage}::data() const {
-  return storage->data_ptr;
+  return storage->data_ptr.get();
 }
 
 auto ${Storage}::retain() -> ${Storage}& {

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -100,6 +100,9 @@ TEST_CASE( "atest", "[]" ) {
     REQUIRE(isgone == 1);
   }
 
+  /*
+  // Commented out hotfix: deleters don't get called on unique_ptr if they're
+  // nullptr! We might have to fix this.
   if(at::hasCUDA()) {
     int isgone = 0;
     {
@@ -109,4 +112,5 @@ TEST_CASE( "atest", "[]" ) {
     }
     REQUIRE(isgone==1);
   }
+  */
 }

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -20,7 +20,7 @@
 /* end of stuff for mapped files */
 
 struct THDefaultAllocator final : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     auto* ptr = THAlloc(size);
     return {ptr, {ptr, THFree}};
   }
@@ -520,22 +520,22 @@ static void deleteTHRefcountedMapAllocator(void* ptr) {
   delete static_cast<THRefcountedMapAllocator*>(ptr);
 }
 
-THMapAllocator* THMapAllocator::fromSupervisedPtr(const SupervisedPtr& sptr) {
+THMapAllocator* THMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
   if (sptr.supervisor_.get_deleter() != &deleteTHMapAllocator) return nullptr;
   return static_cast<THMapAllocator*>(sptr.supervisor_.get());
 }
 
-THRefcountedMapAllocator* THRefcountedMapAllocator::fromSupervisedPtr(const SupervisedPtr& sptr) {
+THRefcountedMapAllocator* THRefcountedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
   if (sptr.supervisor_.get_deleter() != &deleteTHRefcountedMapAllocator) return nullptr;
   return static_cast<THRefcountedMapAllocator*>(sptr.supervisor_.get());
 }
 
-SupervisedPtr makeSupervisedPtr(std::unique_ptr<THMapAllocator>&& supervisor_) {
+at::SupervisedPtr THMapAllocator::makeSupervisedPtr(std::unique_ptr<THMapAllocator>&& supervisor_) {
   auto* supervisor = supervisor_.release();
   return {supervisor->data(), {supervisor, &deleteTHMapAllocator}};
 }
 
-SupervisedPtr makeSupervisedPtr(std::unique_ptr<THRefcountedMapAllocator>&& supervisor_) {
+at::SupervisedPtr THRefcountedMapAllocator::makeSupervisedPtr(std::unique_ptr<THRefcountedMapAllocator>&& supervisor_) {
   auto* supervisor = supervisor_.release();
   return {static_cast<void*>(static_cast<char*>(supervisor->data()) + TH_ALLOC_ALIGNMENT),
           {supervisor, &deleteTHRefcountedMapAllocator}};

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -47,7 +47,10 @@ public:
 #endif
   }
   ptrdiff_t size() const { return size_; }
-  void* data() const { return data_; }
+  // Return a pointer to the actual data for this allocator
+  // (in the case of the refcounted allocator, this is offset
+  // from the base pointer.)
+  virtual void* data() const { return base_ptr_; }
 
   static THMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
   static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
@@ -64,7 +67,7 @@ protected:
 #else
   int fd_ = -1;
 #endif
-  void *data_ = nullptr;
+  void *base_ptr_ = nullptr;
 };
 
 // Base-from-member idiom
@@ -81,6 +84,8 @@ public:
   static THRefcountedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
   static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
   static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+
+  void* data() const override;
 
   void incref();
   int decref();

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -28,7 +28,7 @@ typedef struct at_THAllocator THAllocator;
  */
 TH_API THAllocator* getTHDefaultAllocator();
 #ifdef __cplusplus
-struct THDefaultDeleter final : public at::Deleter {
+struct TH_API THDefaultDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override {
     THFree(ptr);
   }
@@ -56,7 +56,7 @@ TH_API void THMapAllocatorContext_free(THMapAllocatorContext *ctx);
 AT_API std::unique_ptr<void, at::BoundDeleter> THMapAllocatorContext_alloc(THMapAllocatorContext *ctx, ptrdiff_t size);
 AT_API std::unique_ptr<void, at::BoundDeleter> THRefcountedMapAllocator_alloc(void *_ctx, ptrdiff_t size);
 
-struct THMapDeleter final : public at::Deleter {
+struct TH_API THMapDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override;
   static at::BoundDeleter make(THMapAllocatorContext* ctx) {
     return {&singleton_, ctx};
@@ -69,7 +69,7 @@ private:
   static THMapDeleter singleton_;
 };
 
-struct THRefcountedMapDeleter final : public at::Deleter {
+struct TH_API THRefcountedMapDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override;
   static at::BoundDeleter make(THMapAllocatorContext* ctx) {
     return {&singleton_, ctx};

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -38,7 +38,7 @@ public:
   THMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
   virtual ~THMapAllocator();
 
-  char* filename() const { return filename_.c_str(); }
+  const char* filename() const { return filename_.c_str(); }
   int fd() const {
 #ifdef _WIN32
     AT_ERROR("THMapAllocator::fd() is unsupported on Windows");
@@ -50,6 +50,7 @@ public:
   void* data() const { return data_; }
 
   static THMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THMapAllocator>&&);
 
 private:
   std::string filename_;
@@ -77,6 +78,7 @@ public:
   virtual ~THRefcountedMapAllocator();
 
   static THRefcountedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THRefcountedMapAllocator>&&);
 
   void incref();
   int decref();
@@ -84,8 +86,5 @@ private:
   void checkFlags();
   void initializeAlloc();
 };
-
-AT_API at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THMapAllocator>&&);
-AT_API at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THRefcountedMapAllocator>&&);
 
 #endif // __cplusplus

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -50,9 +50,10 @@ public:
   void* data() const { return data_; }
 
   static THMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
-  static at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THMapAllocator>&&);
+  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
-private:
+protected:
   std::string filename_;
   int flags_ = 0;
   ptrdiff_t size_; /* mapped size */
@@ -78,11 +79,12 @@ public:
   virtual ~THRefcountedMapAllocator();
 
   static THRefcountedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
-  static at::SupervisedPtr makeSupervisedPtr(std::unique_ptr<THRefcountedMapAllocator>&&);
+  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
   void incref();
   int decref();
-private:
+protected:
   void checkFlags();
   void initializeAlloc();
 };

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -28,7 +28,7 @@ typedef struct at_THAllocator THAllocator;
  */
 TH_API THAllocator* getTHDefaultAllocator();
 #ifdef __cplusplus
-struct TH_API THDefaultDeleter final : public at::Deleter {
+struct AT_API THDefaultDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override {
     THFree(ptr);
   }
@@ -56,7 +56,7 @@ TH_API void THMapAllocatorContext_free(THMapAllocatorContext *ctx);
 AT_API std::unique_ptr<void, at::BoundDeleter> THMapAllocatorContext_alloc(THMapAllocatorContext *ctx, ptrdiff_t size);
 AT_API std::unique_ptr<void, at::BoundDeleter> THRefcountedMapAllocator_alloc(void *_ctx, ptrdiff_t size);
 
-struct TH_API THMapDeleter final : public at::Deleter {
+struct AT_API THMapDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override;
   static at::BoundDeleter make(THMapAllocatorContext* ctx) {
     return {&singleton_, ctx};
@@ -69,7 +69,7 @@ private:
   static THMapDeleter singleton_;
 };
 
-struct TH_API THRefcountedMapDeleter final : public at::Deleter {
+struct AT_API THRefcountedMapDeleter final : public at::Deleter {
   void deallocate(void* ctx, void* ptr) const override;
   static at::BoundDeleter make(THMapAllocatorContext* ctx) {
     return {&singleton_, ctx};

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -112,7 +112,7 @@ THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  new (&storage->data_ptr) SupervisedPtr(allocator->allocate(at::elementSize(scalar_type)*size));
+  new (&storage->data_ptr) at::SupervisedPtr(allocator->allocate(at::elementSize(scalar_type)*size));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
@@ -178,12 +178,12 @@ THStorage* THStorage_newWithData(at::ScalarType scalar_type, std::unique_ptr<at:
 */
 
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             SupervisedPtr&& data, ptrdiff_t size,
+                                             at::SupervisedPtr&& data, ptrdiff_t size,
                                              THAllocator* allocator) {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  new (&storage->data_ptr) SupervisedPtr(std::move(data));
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
@@ -201,7 +201,7 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
   if (storage->flag & TH_STORAGE_RESIZABLE)
   {
     /* case when the allocator does not have a realloc defined */
-    SupervisedPtr old_data;
+    at::SupervisedPtr old_data;
     std::swap(old_data, storage->data_ptr);
     ptrdiff_t old_size = storage->size;
     if (size != 0) {

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -28,9 +28,7 @@ void THStorage_free(THStorage *storage) {
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      if (storage->flag & TH_STORAGE_FREEMEM) {
-        static_cast<THAllocator*>(storage->allocatorVoidPtr)->free(storage->allocatorContext, storage->data_ptr);
-      }
+      storage->data_ptr.~unique_ptr<void, at::BoundDeleter>();
       if (storage->flag & TH_STORAGE_VIEW) {
         THStorage_free(storage->view);
       }
@@ -105,24 +103,22 @@ THStorage* THStorage_new(at::ScalarType scalar_type)
 
 THStorage* THStorage_newWithSize(at::ScalarType scalar_type, ptrdiff_t size)
 {
-  return THStorage_newWithAllocator(scalar_type, size, &THDefaultAllocator, nullptr);
+  return THStorage_newWithAllocator(scalar_type, size, getTHDefaultAllocator());
 }
 
 THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size,
-                                      THAllocator *allocator,
-                                      void *allocatorContext)
+                                      at::Allocator *allocator)
 {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = allocator->malloc(allocatorContext, at::elementSize(scalar_type)*size);
+  new (&storage->data_ptr) std::unique_ptr<void, at::BoundDeleter>(allocator->allocate(at::elementSize(scalar_type)*size));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   storage->device = INT_MIN;  // device is not meaningful on CPU
   return storage;
 }
@@ -141,9 +137,10 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
 {
   THMapAllocatorContext *ctx = THMapAllocatorContext_new(filename, flags);
 
-  THStorage *storage = THStorage_newWithAllocator(scalar_type, size,
-                                                  &THMapAllocator,
-                                                  ctx);
+  THStorage *storage = THStorage_newWithDataAndAllocator(scalar_type,
+                                                         THMapAllocatorContext_alloc(ctx, size * at::elementSize(scalar_type)),
+                                                         size,
+                                                         /* allocator */ nullptr);
 
   if (size <= 0) {
     storage->size = THMapAllocatorContext_size(ctx)/THStorage_elementSize(storage);
@@ -171,28 +168,29 @@ void THStorage_retain(THStorage *storage)
   }
 }
 
-THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size)
+/*
+// I don't think you should ever call this
+THStorage* THStorage_newWithData(at::ScalarType scalar_type, std::unique_ptr<at::BoundDeleter> data, ptrdiff_t size)
 {
   return THStorage_newWithDataAndAllocator(scalar_type, data, size,
-                                           &THDefaultAllocator, NULL);
+                                           getTHDefaultAllocator());
 }
+*/
 
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             void* data, ptrdiff_t size,
-                                             THAllocator* allocator,
-                                             void* allocatorContext) {
+                                             std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+                                             THAllocator* allocator) {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = data;
+  new (&storage->data_ptr) std::unique_ptr<void, at::BoundDeleter>(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
-  storage->device = 0;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
+  storage->device = INT_MIN;  // device is not meaningful on CPU
   return storage;
 }
 
@@ -200,38 +198,24 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 {
   AT_ASSERT(storage->backend == at::kCPU);
 
-  auto* th_allocator = static_cast<THAllocator*>(storage->allocatorVoidPtr);
-
   if (storage->flag & TH_STORAGE_RESIZABLE)
   {
-    if (th_allocator->realloc == nullptr) {
-      /* case when the allocator does not have a realloc defined */
-      void *old_data = storage->data_ptr;
-      ptrdiff_t old_size = storage->size;
-      if (size == 0) {
-        storage->data_ptr = nullptr;
-      } else {
-        storage->data_ptr = th_allocator->malloc(
-            storage->allocatorContext,
-            at::elementSize(storage->scalar_type)*size);
+    /* case when the allocator does not have a realloc defined */
+    std::unique_ptr<void, at::BoundDeleter> old_data;
+    std::swap(old_data, storage->data_ptr);
+    ptrdiff_t old_size = storage->size;
+    if (size != 0) {
+      storage->data_ptr = storage->allocator->allocate(at::elementSize(storage->scalar_type)*size);
+    }
+    storage->size = size;
+    if (old_data != nullptr) {
+      ptrdiff_t copy_size = old_size;
+      if (storage->size < copy_size) {
+        copy_size = storage->size;
       }
-      storage->size = size;
-      if (old_data != nullptr) {
-        ptrdiff_t copy_size = old_size;
-        if (storage->size < copy_size) {
-          copy_size = storage->size;
-        }
-        if (copy_size > 0) {
-          memcpy(storage->data_ptr, old_data, at::elementSize(storage->scalar_type)*copy_size);
-        }
-        th_allocator->free(storage->allocatorContext, old_data);
+      if (copy_size > 0) {
+        memcpy(storage->data_ptr.get(), old_data.get(), at::elementSize(storage->scalar_type)*copy_size);
       }
-    } else {
-      storage->data_ptr = th_allocator->realloc(
-              storage->allocatorContext,
-              storage->data_ptr,
-              at::elementSize(storage->scalar_type)*size);
-      storage->size = size;
     }
   } else {
     THError("Trying to resize storage that is not resizable");
@@ -241,12 +225,13 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 void THStorage_swap(THStorage *storage1, THStorage *storage2)
 {
 #define SWAP(val) { std::swap(storage1->val, storage2->val); }
+    SWAP(backend);
+    SWAP(scalar_type);
     SWAP(data_ptr);
     SWAP(size);
-    SWAP(flag);
     // don't swap refcount!
-    SWAP(allocatorVoidPtr);
-    SWAP(allocatorContext);
+    SWAP(flag);
+    SWAP(allocator);
     SWAP(finalizer);
     SWAP(view);
     SWAP(device);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -41,7 +41,7 @@ typedef struct THStorage
 {
     at::Backend backend; // kCPU or kCUDA only
     at::ScalarType scalar_type;
-    std::unique_ptr<void, at::BoundDeleter> data_ptr;
+    at::SupervisedPtr data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     std::atomic<int> weakcount;
@@ -80,7 +80,7 @@ void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
 // THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+                                             SupervisedPtr&& data, ptrdiff_t size,
                                              at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -80,7 +80,7 @@ void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
 // THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             SupervisedPtr&& data, ptrdiff_t size,
+                                             at::SupervisedPtr&& data, ptrdiff_t size,
                                              at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -41,13 +41,12 @@ typedef struct THStorage
 {
     at::Backend backend; // kCPU or kCUDA only
     at::ScalarType scalar_type;
-    void *data_ptr;
+    std::unique_ptr<void, at::BoundDeleter> data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     std::atomic<int> weakcount;
     char flag;
-    void *allocatorVoidPtr; // Either THDeviceAllocator or THCDeviceAllocator
-    void *allocatorContext;
+    at::Allocator *allocator;
     std::unique_ptr<THFinalizer> finalizer;
     struct THStorage *view;
     int device;
@@ -64,15 +63,14 @@ typedef struct THStorage
 
     template <typename T>
     inline T * unsafe_data() const {
-      return static_cast<T*>(this->data_ptr);
+      return static_cast<T*>(this->data_ptr.get());
     }
 } THStorage;
 
 TH_API THStorage* THStorage_new(at::ScalarType scalar_type);
 TH_API THStorage* THStorage_newWithSize(at::ScalarType scalar_type, ptrdiff_t size);
 TH_API THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size,
-                                             THAllocator *allocator,
-                                             void *allocatorContext);
+                                             at::Allocator *allocator);
 
 ptrdiff_t THStorage_size(const THStorage *self);
 size_t THStorage_elementSize();
@@ -80,11 +78,10 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
 void THStorage_setFlag(THStorage *storage, const char flag);
 void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
-THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
+// THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             void* data, ptrdiff_t size,
-                                             THAllocator* allocator,
-                                             void* allocatorContext);
+                                             std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+                                             at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);
 

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -106,7 +106,7 @@ THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 }
 */
 
-THStorage* THStorage_(newWithDataAndAllocator)(SupervisedPtr&& data, ptrdiff_t size,
+THStorage* THStorage_(newWithDataAndAllocator)(at::SupervisedPtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -106,7 +106,7 @@ THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 }
 */
 
-THStorage* THStorage_(newWithDataAndAllocator)(std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+THStorage* THStorage_(newWithDataAndAllocator)(SupervisedPtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -30,10 +30,9 @@ THStorage* THStorage_(newWithSize)(ptrdiff_t size)
 }
 
 THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
-                                        THAllocator *allocator,
-                                        void *allocatorContext)
+                                        at::Allocator *allocator)
 {
-  return THStorage_newWithAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), size, allocator, allocatorContext);
+  return THStorage_newWithAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), size, allocator);
 }
 
 
@@ -100,15 +99,16 @@ void THStorage_(free)(THStorage *storage)
   THStorage_free(storage);
 }
 
+/*
 THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 {
   return THStorage_newWithData(at::CTypeToScalarType<th::from_type<real>>::to(), data, size);
 }
+*/
 
-THStorage* THStorage_(newWithDataAndAllocator)(real* data, ptrdiff_t size,
-                                               THAllocator* allocator,
-                                               void* allocatorContext) {
-  return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), data, size, allocator, allocatorContext);
+THStorage* THStorage_(newWithDataAndAllocator)(std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+                                               at::Allocator* allocator) {
+  return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }
 
 void THStorage_(resize)(THStorage *storage, ptrdiff_t size)

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -58,7 +58,7 @@ TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                                THAllocator* allocator);
 #ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size, at::Allocator* allocator);
+    SupervisedPtr&& data, ptrdiff_t size, at::Allocator* allocator);
 #endif
 
 /* should not differ with API */

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -2,6 +2,10 @@
 #define TH_GENERIC_FILE "generic/THStorage.h"
 #else
 
+#ifdef __cplusplus
+#include <ATen/Allocator.h>
+#endif
+
 /* on pourrait avoir un liste chainee
    qui initialise math, lab structures (or more).
    mouais -- complique.
@@ -18,7 +22,6 @@
 
 #define TH_STORAGE_REFCOUNTED 1
 #define TH_STORAGE_RESIZABLE  2
-#define TH_STORAGE_FREEMEM    4
 #define TH_STORAGE_VIEW       8
 
 // Struct definition is moved to THStorage.hpp (so this file stays C compatible)
@@ -51,14 +54,12 @@ TH_API THStorage* THStorage_(newWithSize3)(real, real, real);
 TH_API THStorage* THStorage_(newWithSize4)(real, real, real, real);
 TH_API THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int flags);
 
-/* takes ownership of data */
-TH_API THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size);
-
 TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
-                                               THAllocator* allocator,
-                                               void *allocatorContext);
+                                               THAllocator* allocator);
+#ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    real* data, ptrdiff_t size, THAllocator* allocator, void *allocatorContext);
+    std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size, at::Allocator* allocator);
+#endif
 
 /* should not differ with API */
 TH_API void THStorage_(setFlag)(THStorage *storage, const char flag);

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -58,7 +58,7 @@ TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                                THAllocator* allocator);
 #ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    SupervisedPtr&& data, ptrdiff_t size, at::Allocator* allocator);
+    at::SupervisedPtr&& data, ptrdiff_t size, at::Allocator* allocator);
 #endif
 
 /* should not differ with API */

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -1,80 +1,43 @@
 #include "THCAllocator.h"
 
-static void *THCudaHostAllocator_malloc(void* ctx, ptrdiff_t size) {
-  void* ptr;
+THCudaHostDeleter THCudaHostDeleter::singleton_;
 
-  if (size < 0) THError("Invalid memory size: %ld", size);
-
-  if (size == 0) return NULL;
-
-  THCudaCheck(cudaMallocHost(&ptr, size));
-
-  return ptr;
-}
-
-static void THCudaHostAllocator_free(void* ctx, void* ptr) {
-  if (!ptr) return;
-
-  THCudaCheck(cudaFreeHost(ptr));
-}
-
-THAllocator THCudaHostAllocator = {
-  &THCudaHostAllocator_malloc,
-  NULL,
-  &THCudaHostAllocator_free
+struct THCudaHostAllocator : public at::Allocator {
+  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+    if (size == 0) return nullptr;
+    void* ptr;
+    THCudaCheck(cudaMallocHost(&ptr, size));
+    return {ptr, THCudaHostDeleter::make()};
+  }
+  at::BoundDeleter maybeGlobalBoundDeleter() const override {
+    return THCudaHostDeleter::make();
+  }
 };
 
-static cudaError_t THCIpcAllocator_malloc(void* ctx, void** devPtr, size_t size, cudaStream_t stream)
-{
-  THError("THCIpcAllocator.malloc() not supported");
-  return cudaSuccess;
+static THCudaHostAllocator th_cuda_host_allocator;
+at::Allocator* getTHCudaHostAllocator() {
+  return &th_cuda_host_allocator;
 }
 
-static cudaError_t THCIpcAllocator_free(void* ctx, void* devPtr)
-{
-  cudaError_t err;
-  int prev_device;
-  int device = (int)(int64_t)ctx;
+THCIpcDeleter THCIpcDeleter::singleton_;
+THCUVADeleter THCUVADeleter::singleton_;
 
-  err = cudaGetDevice(&prev_device);
-  if (err != cudaSuccess) { return err; }
+struct THCUVAAllocator : public at::Allocator {
+  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+    if (size == 0) return nullptr;
 
-  err = cudaSetDevice(device);
-  if (err != cudaSuccess) { return err; }
-
-  err = cudaIpcCloseMemHandle(devPtr);
-
-  cudaSetDevice(prev_device);
-  return err;
-}
-
-THCDeviceAllocator THCIpcAllocator = {
-  &THCIpcAllocator_malloc,
-  NULL,
-  &THCIpcAllocator_free,
-  NULL,
-  NULL
+    // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules
+    // on various compute capabilities.
+    void* ptr;
+    THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
+    return {ptr, THCUVADeleter::make()};
+  }
+  at::BoundDeleter maybeGlobalBoundDeleter() const override {
+    return THCUVADeleter::make();
+  }
 };
 
-static void *THCUVAAllocator_alloc(void* ctx, ptrdiff_t size) {
-  if (size < 0) THError("Invalid memory size: %ld", size);
-
-  if (size == 0) return NULL;
-
-  // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules
-  // on various compute capabilities.
-  void* ptr;
-  THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
-  return ptr;
+static THCUVAAllocator thc_uva_allocator;
+at::Allocator* getTHCUVAAllocator() {
+  return &thc_uva_allocator;
 }
-
-static void THCUVAAllocator_free(void* ctx, void* ptr) {
-  if (!ptr) return;
-  THCudaCheck(cudaFree(ptr));
-}
-
-THAllocator THCUVAAllocator = {
-  &THCUVAAllocator_alloc,
-  NULL,
-  &THCUVAAllocator_free
-};

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -3,7 +3,7 @@
 THCudaHostDeleter THCudaHostDeleter::singleton_;
 
 struct THCudaHostAllocator : public at::Allocator {
-  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+  SupervisedPtr allocate(size_t size) const override {
     if (size == 0) return nullptr;
     void* ptr;
     THCudaCheck(cudaMallocHost(&ptr, size));
@@ -23,7 +23,7 @@ THCIpcDeleter THCIpcDeleter::singleton_;
 THCUVADeleter THCUVADeleter::singleton_;
 
 struct THCUVAAllocator : public at::Allocator {
-  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+  SupervisedPtr allocate(size_t size) const override {
     if (size == 0) return nullptr;
 
     // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -12,7 +12,7 @@ struct THCudaHostAllocator : public at::Allocator {
     }
     return {ptr, {ptr, &THCudaHostDeleter}};
   }
-  DeleterFnPtr raw_deleter() const override {
+  at::DeleterFnPtr raw_deleter() const override {
     return &THCudaHostDeleter;
   }
 };
@@ -36,7 +36,7 @@ struct THCUVAAllocator : public at::Allocator {
     }
     return {ptr, {ptr, &THCUVADeleter}};
   }
-  at::BoundDeleter raw_deleter() const override {
+  at::DeleterFnPtr raw_deleter() const override {
     return &THCUVADeleter;
   }
 };

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -3,7 +3,7 @@
 THCudaHostDeleter THCudaHostDeleter::singleton_;
 
 struct THCudaHostAllocator : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     if (size == 0) return nullptr;
     void* ptr;
     THCudaCheck(cudaMallocHost(&ptr, size));
@@ -23,7 +23,7 @@ THCIpcDeleter THCIpcDeleter::singleton_;
 THCUVADeleter THCUVADeleter::singleton_;
 
 struct THCUVAAllocator : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     if (size == 0) return nullptr;
 
     // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -3,8 +3,54 @@
 
 #include "THCGeneral.h"
 
-extern THAllocator THCudaHostAllocator;
-extern THAllocator THCUVAAllocator;
-THC_API THCDeviceAllocator THCIpcAllocator;
+THC_API THAllocator* getTHCudaHostAllocator();
+THC_API THAllocator* getTHCUVAAllocator();
+// IPC doesn't support (re)allocation
+
+#ifdef __cplusplus
+struct THCudaHostDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    if (!ptr) return;
+
+    THCudaCheck(cudaFreeHost(ptr));
+  }
+  static at::BoundDeleter make() {
+    return {&singleton_, nullptr};
+  }
+private:
+  static THCudaHostDeleter singleton_;
+};
+
+struct THCIpcDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    int prev_device;
+    int device = (int)(int64_t)ctx;
+
+    THCudaCheck(cudaGetDevice(&prev_device));
+    THCudaCheck(cudaSetDevice(device));
+    THCudaCheck(cudaIpcCloseMemHandle(ptr));
+    THCudaCheck(cudaSetDevice(prev_device));
+  }
+
+  static at::BoundDeleter make(int device) {
+    // TODO: Do this properly with intptr_t (but is it portable enough?)
+    return {&singleton_, (void*)(int64_t)device};
+  }
+private:
+  static THCIpcDeleter singleton_;
+};
+
+struct THCUVADeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    if (!ptr) return;
+    THCudaCheck(cudaFree(ptr));
+  }
+  static at::BoundDeleter make() {
+    return {&singleton_, nullptr};
+  }
+private:
+  static THCUVADeleter singleton_;
+};
+#endif
 
 #endif

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -510,7 +510,7 @@ CudaCachingDeleter CudaCachingDeleter::singleton_;
 // has a lot more methods and it wasn't altogether clear that they should
 // actually be publically exposed
 struct CudaCachingAllocator : public at::Allocator {
-  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+  SupervisedPtr allocate(size_t size) const override {
     int device;
     THCudaCheck(cudaGetDevice(&device));
     void* r;

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -510,7 +510,7 @@ CudaCachingDeleter CudaCachingDeleter::singleton_;
 // has a lot more methods and it wasn't altogether clear that they should
 // actually be publically exposed
 struct CudaCachingAllocator : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     int device;
     THCudaCheck(cudaGetDevice(&device));
     void* r;

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -1,5 +1,8 @@
 #include "THCCachingAllocator.h"
 
+#include <ATen/Context.h>
+#include <ATen/cudnn/Exceptions.h>
+
 #include <cuda_runtime_api.h>
 #include <algorithm>
 #include <deque>
@@ -489,44 +492,49 @@ struct THCCachingAllocator
   }
 };
 
-static cudaError_t THCCachingAllocator_malloc(void* ctx, void** ptr, size_t size, cudaStream_t stream)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->malloc(ptr, size, stream);
-}
+THCCachingAllocator caching_allocator;
 
-static cudaError_t THCCachingAllocator_free(void* ctx, void* ptr)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->free(ptr);
-}
+struct CudaCachingDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    AT_CUDA_CHECK(caching_allocator.free(ptr));
+  }
+  static at::BoundDeleter make() {
+    return {&singleton_, nullptr};
+  }
+private:
+  static CudaCachingDeleter singleton_;
+};
+CudaCachingDeleter CudaCachingDeleter::singleton_;
 
-static cudaError_t THCCachingAllocator_emptyCache(void* ctx)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->emptyCache();
-}
-
-static cudaError_t THCCachingAllocator_cacheInfo(void* ctx, int dev_id, size_t* cachedAndFree, size_t* largestBlock)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  a->cacheInfo(dev_id, cachedAndFree, largestBlock);
-  return cudaSuccess;
-}
-
-static THCCachingAllocator caching_allocator;
-static THCDeviceAllocator device_allocator = {
-  &THCCachingAllocator_malloc,
-  NULL,
-  &THCCachingAllocator_free,
-  &THCCachingAllocator_emptyCache,
-  &THCCachingAllocator_cacheInfo,
-  &caching_allocator
+// NB: I decided not to fold this into THCCachingAllocator, because the latter
+// has a lot more methods and it wasn't altogether clear that they should
+// actually be publically exposed
+struct CudaCachingAllocator : public at::Allocator {
+  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+    int device;
+    THCudaCheck(cudaGetDevice(&device));
+    void* r;
+    AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
+    return {r, CudaCachingDeleter::make()};
+  }
+  at::BoundDeleter maybeGlobalBoundDeleter() const override {
+    return CudaCachingDeleter::make();
+  }
 };
 
-THC_API THCDeviceAllocator* THCCachingAllocator_get(void)
+CudaCachingAllocator device_allocator;
+
+THC_API at::Allocator* THCCachingAllocator_get(void)
 {
   return &device_allocator;
+}
+
+THC_API void THCCachingAllocator_emptyCache(void) {
+  AT_CUDA_CHECK(caching_allocator.emptyCache());
+}
+
+THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock) {
+  caching_allocator.cacheInfo(dev_id, cachedAndFree, largestBlock);
 }
 
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size)

--- a/aten/src/THC/THCCachingAllocator.h
+++ b/aten/src/THC/THCCachingAllocator.h
@@ -9,6 +9,8 @@
 #include "THCStream.h"
 
 THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
+THC_API void THCCachingAllocator_emptyCache(void);
+THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
 THC_API void THCCachingAllocator_recordStream(void *ptr, THCStream* stream);
 THC_API uint64_t THCCachingAllocator_currentMemoryAllocated(int device);

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -250,19 +250,6 @@ struct HostAllocator
 
 static HostAllocator allocator;
 
-static void* THCCachingHostAllocator_malloc(void* ctx, ptrdiff_t size)
-{
-  THAssert(size >= 0);
-  void *ptr;
-  THCudaCheck(allocator.malloc(&ptr, size));
-  return ptr;
-}
-
-static void THCCachingHostAllocator_free(void* ctx, void* ptr)
-{
-  allocator.free(ptr);
-}
-
 cudaError_t THCCachingHostAllocator_recordEvent(void *ptr, THCStream *stream)
 {
   return allocator.recordEvent(ptr, stream);
@@ -273,8 +260,31 @@ void THCCachingHostAllocator_emptyCache()
   allocator.emptyCache();
 }
 
-THAllocator THCCachingHostAllocator = {
-  &THCCachingHostAllocator_malloc,
-  NULL,
-  &THCCachingHostAllocator_free,
+struct THCCachingHostDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* ptr) const override {
+    allocator.free(ptr);
+  }
+  static at::BoundDeleter make() {
+    return {&singleton_, nullptr};
+  }
+private:
+  static THCCachingHostDeleter singleton_;
 };
+THCCachingHostDeleter THCCachingHostDeleter::singleton_;
+
+struct THCCachingHostAllocator final : public at::Allocator {
+  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+    THAssert(size >= 0);
+    void *ptr;
+    THCudaCheck(allocator.malloc(&ptr, size));
+    return {ptr, THCCachingHostDeleter::make()};
+  }
+  at::BoundDeleter maybeGlobalBoundDeleter() {
+    return THCCachingHostDeleter::make();
+  }
+};
+
+static THCCachingHostAllocator thc_caching_host_allocator;
+at::Allocator* getTHCCachingHostAllocator() {
+  return &thc_caching_host_allocator;
+}

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -273,7 +273,7 @@ private:
 THCCachingHostDeleter THCCachingHostDeleter::singleton_;
 
 struct THCCachingHostAllocator final : public at::Allocator {
-  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+  SupervisedPtr allocate(size_t size) const override {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -273,7 +273,7 @@ private:
 THCCachingHostDeleter THCCachingHostDeleter::singleton_;
 
 struct THCCachingHostAllocator final : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));

--- a/aten/src/THC/THCCachingHostAllocator.h
+++ b/aten/src/THC/THCCachingHostAllocator.h
@@ -19,7 +19,7 @@
 // Note that this allocator does not split larger allocations into smaller
 // blocks, unlike the caching device allocator.
 //
-THC_API THAllocator THCCachingHostAllocator;
+THC_API THAllocator* getTHCCachingHostAllocator();
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -51,7 +51,7 @@ private:
 };
 
 struct THDefaultDeviceAllocator final : public at::Allocator {
-  std::unique_ptr<void, at::BoundDeleter> allocate(size_t size) const override {
+  SupervisedPtr allocate(size_t size) const override {
     void* p;
     THCudaCheck(cudaMalloc(&p, size));
     return {p, THDefaultDeviceDeleter::make()};
@@ -686,7 +686,7 @@ void THCudaFree(THCState *state, void* ptr) {
   state->cudaDeviceAllocator->raw_deallocate(ptr);
 }
 
-std::unique_ptr<void, at::BoundDeleter> THCudaHostAlloc(THCState *state, size_t size)
+SupervisedPtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
   THAllocator* allocator = state->cudaHostAllocator;

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -51,7 +51,7 @@ private:
 };
 
 struct THDefaultDeviceAllocator final : public at::Allocator {
-  SupervisedPtr allocate(size_t size) const override {
+  at::SupervisedPtr allocate(size_t size) const override {
     void* p;
     THCudaCheck(cudaMalloc(&p, size));
     return {p, THDefaultDeviceDeleter::make()};
@@ -686,7 +686,7 @@ void THCudaFree(THCState *state, void* ptr) {
   state->cudaDeviceAllocator->raw_deallocate(ptr);
 }
 
-SupervisedPtr THCudaHostAlloc(THCState *state, size_t size)
+at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
   THAllocator* allocator = state->cudaHostAllocator;

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -144,7 +144,7 @@ THC_API void* THCudaMalloc(THCState *state, size_t size);
 THC_API void THCudaFree(THCState *state, void* ptr);
 
 #ifdef __cplusplus
-std::unique_ptr<void, at::BoundDeleter> THCudaHostAlloc(THCState *state, size_t size);
+SupervisedPtr THCudaHostAlloc(THCState *state, size_t size);
 #endif
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -49,14 +49,7 @@ typedef struct CUDAStreamInternals THCStream;
 typedef struct THCState THCState;
 struct THCState;
 
-typedef struct _THCDeviceAllocator {
-   cudaError_t (*malloc)( void*, void**, size_t,         cudaStream_t);
-   cudaError_t (*realloc)(void*, void**, size_t, size_t, cudaStream_t);
-   cudaError_t (*free)(void*, void*);
-   cudaError_t (*emptyCache)(void*);
-   cudaError_t  (*cacheInfo)(void*, int, size_t*, size_t*);
-   void* state;
-} THCDeviceAllocator;
+typedef THAllocator THCDeviceAllocator;
 
 typedef struct _THCCudaResourcesPerDevice {
   /* Number of materialized cuBLAS handles */
@@ -147,10 +140,13 @@ THC_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line
 THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
 THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
 
-THC_API cudaError_t THCudaMalloc(THCState *state, void **ptr, size_t size);
-THC_API cudaError_t THCudaFree(THCState *state, void *ptr);
-THC_API void* THCudaHostAlloc(THCState *state, size_t size);
-THC_API void THCudaHostFree(THCState *state, void *ptr);
+THC_API void* THCudaMalloc(THCState *state, size_t size);
+THC_API void THCudaFree(THCState *state, void* ptr);
+
+#ifdef __cplusplus
+std::unique_ptr<void, at::BoundDeleter> THCudaHostAlloc(THCState *state, size_t size);
+#endif
+
 THC_API void THCudaHostRecord(THCState *state, void *ptr);
 
 THC_API cudaError_t THCudaMemGetInfo(THCState *state, size_t* freeBytes, size_t* totalBytes);

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -144,7 +144,7 @@ THC_API void* THCudaMalloc(THCState *state, size_t size);
 THC_API void THCudaFree(THCState *state, void* ptr);
 
 #ifdef __cplusplus
-SupervisedPtr THCudaHostAlloc(THCState *state, size_t size);
+at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size);
 #endif
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);

--- a/aten/src/THC/THCGeneral.hpp
+++ b/aten/src/THC/THCGeneral.hpp
@@ -17,9 +17,13 @@ struct THCState {
   int numUserSparseHandles;
 
   /* Allocator using cudaMallocHost. */
-  THAllocator* cudaHostAllocator;
-  THAllocator* cudaUVAAllocator;
-  THCDeviceAllocator* cudaDeviceAllocator;
+  // NB: These allocators (specifically, cudaHostAllocator) MUST implement
+  // maybeGlobalBoundDeleter, because we have a few use-cases where we need to
+  // do raw allocations with them (for Thrust).
+  // TODO: Make this statically obvious
+  at::Allocator* cudaHostAllocator;
+  at::Allocator* cudaUVAAllocator;
+  at::Allocator* cudaDeviceAllocator;
 
   /* Index of the current selected BLAS handle. The actual BLAS handle used
      depends on the current device. */

--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -186,8 +186,7 @@ void callReduceAll(THCState* state,
   dim3 block;
 
   if (isTwoPassReductionSize(totalElements)) {
-    void* scratchSpace;
-    THCudaCheck(THCudaMalloc(state, &scratchSpace, THCState_getCurrentDeviceScratchSpaceSize(state)));
+    void* scratchSpace = THCudaMalloc(state, THCState_getCurrentDeviceScratchSpaceSize(state));
 
     getPass1ReduceBlockGrid<AccT>(state, totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -206,7 +205,7 @@ void callReduceAll(THCState* state,
         numPass1Blocks, init, reduceOp,
         (AccT*) scratchSpace, devOut);
 
-    THCudaCheck(THCudaFree(state, scratchSpace));
+    THCudaFree(state, scratchSpace);
   } else {
     getSinglePassReduceBlockGrid(totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -248,7 +247,7 @@ bool THC_reduceAll(THCState* state,
   if (!outOnDevice) {
     // Use the stream-specific scratch space for the reduction kernel
     // to write out its value
-    THCudaCheck(THCudaMalloc(state, (void**)&devOut,
+    devOut = static_cast<AccT*>(THCudaMalloc(state,
         THCState_getCurrentDeviceScratchSpaceSize(state)));
     freeDevOut = true;
   }
@@ -320,7 +319,7 @@ bool THC_reduceAll(THCState* state,
   }
 
   if (freeDevOut) {
-    THCudaCheck(THCudaFree(state, devOut));
+    THCudaFree(state, devOut);
   }
 
   return true;

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -65,7 +65,7 @@ void THCStorage_free(THCState *state, THCStorage *storage)
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      storage->data_ptr.~unique_ptr<void, at::BoundDeleter>();
+      storage->data_ptr.~SupervisedPtr();
       if (storage->flag & TH_STORAGE_VIEW) {
         THCStorage_free(state, storage->view);
       }

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -41,7 +41,7 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
   storage->size = size;
   storage->device = device;
 
-  at::SupervisedPtr ptr = nullptr;
+  at::SupervisedPtr ptr;
   if (size > 0) {
     // update heap *before* attempting malloc, to free space for the malloc
     try {

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -17,15 +17,13 @@ THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scalar_type, 
 {
   return THCStorage_newWithAllocator(
     state, scalar_type, size,
-    state->cudaDeviceAllocator,
-    state->cudaDeviceAllocator->state);
+    state->cudaDeviceAllocator);
 }
 
 THCStorage* THCStorage_newWithAllocator(THCState *state,
                                         at::ScalarType scalar_type,
                                         ptrdiff_t size,
-                                        THCDeviceAllocator* allocator,
-                                        void* allocatorContext)
+                                        at::Allocator* allocator)
 {
   THArgCheck(size >= 0, 2, "invalid size");
   int device;
@@ -38,27 +36,22 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
   storage->backend = at::kCUDA;
   storage->scalar_type = scalar_type;
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   storage->size = size;
   storage->device = device;
 
-  if(size > 0)
-  {
+  std::unique_ptr<void, at::BoundDeleter> ptr = nullptr;
+  if (size > 0) {
     // update heap *before* attempting malloc, to free space for the malloc
-    cudaError_t err =
-      (*allocator->malloc)(allocatorContext,
-                           (void**)&(storage->data_ptr),
-                           size * at::elementSize(scalar_type),
-                           THCState_getCurrentStreamOnDevice(state, device));
-    if(err != cudaSuccess){
+    try {
+      ptr = allocator->allocate(size * at::elementSize(scalar_type));
+    } catch(...) {
       free(storage);
+      throw;
     }
-    THCudaCheck(err);
-  } else {
-    storage->data_ptr = NULL;
   }
+  new (&storage->data_ptr) std::unique_ptr<void, at::BoundDeleter>(std::move(ptr));
   return storage;
 }
 
@@ -72,10 +65,7 @@ void THCStorage_free(THCState *state, THCStorage *storage)
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      if (storage->flag & TH_STORAGE_FREEMEM) {
-        auto* thc_device_allocator = static_cast<THCDeviceAllocator*>(storage->allocatorVoidPtr);
-        THCudaCheck((*thc_device_allocator->free)(storage->allocatorContext, storage->data_ptr));
-      }
+      storage->data_ptr.~unique_ptr<void, at::BoundDeleter>();
       if (storage->flag & TH_STORAGE_VIEW) {
         THCStorage_free(state, storage->view);
       }
@@ -89,7 +79,7 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
   AT_ASSERT(self->backend == at::kCUDA);
 
   THArgCheck(size >= 0, 2, "invalid size");
-  THAssert(self->allocatorVoidPtr != NULL);
+  THAssert(self->allocator != nullptr);
   int device;
   THCudaCheck(cudaGetDevice(&device));
 
@@ -98,59 +88,30 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
 
   size_t elementSize = at::elementSize(self->scalar_type);
 
-  auto* thc_device_allocator = static_cast<THCDeviceAllocator*>(self->allocatorVoidPtr);
-
-  if (thc_device_allocator->realloc) {
-    void * data_ptr = self->data_ptr;
-    cudaError_t err = (*thc_device_allocator->realloc)(
-      self->allocatorContext,
-      (void**)&(data_ptr),
-      self->size * elementSize,
-      size * elementSize, THCState_getCurrentStreamOnDevice(state, device));
-    if (err != cudaSuccess) {
-      THCudaCheck(err);
-    }
-    self->size = size;
-    self->device = device;
-    return;
-  }
-
   if(size == 0)
   {
-    if(self->flag & TH_STORAGE_FREEMEM) {
-      THCudaCheck(
-        (*thc_device_allocator->free)(self->allocatorContext, self->data_ptr));
-    }
-    self->data_ptr = NULL;
+    self->data_ptr = nullptr;
     self->size = 0;
     self->device = device;
   }
   else
   {
-    void *data = NULL;
-    cudaError_t err =
-      (*thc_device_allocator->malloc)(self->allocatorContext,
-                                 (void**)&(data),
-                                 size * elementSize,
-                                 THCState_getCurrentStreamOnDevice(state, device));
-    THCudaCheck(err);
+    std::unique_ptr<void, at::BoundDeleter> data =
+      self->allocator->allocate(size * elementSize);
 
     if (self->data_ptr) {
       // Enable p2p access when the memcpy is across devices
       THCState_getPeerToPeerAccess(state, device, self->device);
 
-      THCudaCheck(cudaMemcpyAsync(data,
-                                  self->data_ptr,
+      THCudaCheck(cudaMemcpyAsync(data.get(),
+                                  self->data_ptr.get(),
                                   THMin(self->size, size) * elementSize,
                                   cudaMemcpyDeviceToDevice,
                                   THCState_getCurrentStream(state)));
-      if(self->flag & TH_STORAGE_FREEMEM) {
-        THCudaCheck(
-          (*thc_device_allocator->free)(self->allocatorContext, self->data_ptr));
-      }
     }
 
-    self->data_ptr = data;
+    // Destructively overwrite data_ptr
+    self->data_ptr = std::move(data);
     self->size = size;
     self->device = device;
   }
@@ -160,32 +121,24 @@ int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
   return storage->device;
 }
 
-THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size)
-{
-  return THCStorage_newWithDataAndAllocator(state, scalar_type, data, size,
-                                            state->cudaDeviceAllocator,
-                                            state->cudaDeviceAllocator->state);
-}
-
 THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext) {
+  THCState *state, at::ScalarType scalar_type, std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  at::Allocator *allocator) {
   THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
   memset(storage, 0, sizeof(THCStorage));
   storage->backend = at::kCUDA;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = data;
+  new (&storage->data_ptr) std::unique_ptr<void, at::BoundDeleter>(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1);
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   int device;
-  if (data) {
+  if (storage->data_ptr) {
     struct cudaPointerAttributes attr;
-    THCudaCheck(cudaPointerGetAttributes(&attr, data));
+    THCudaCheck(cudaPointerGetAttributes(&attr, storage->data_ptr.get()));
     device = attr.device;
   } else {
     THCudaCheck(cudaGetDevice(&device));

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -41,7 +41,7 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
   storage->size = size;
   storage->device = device;
 
-  SupervisedPtr ptr = nullptr;
+  at::SupervisedPtr ptr = nullptr;
   if (size > 0) {
     // update heap *before* attempting malloc, to free space for the malloc
     try {
@@ -51,7 +51,7 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
       throw;
     }
   }
-  new (&storage->data_ptr) SupervisedPtr(std::move(ptr));
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(ptr));
   return storage;
 }
 
@@ -96,7 +96,7 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
   }
   else
   {
-    SupervisedPtr data =
+    at::SupervisedPtr data =
       self->allocator->allocate(size * elementSize);
 
     if (self->data_ptr) {
@@ -122,13 +122,13 @@ int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
 }
 
 THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type, SupervisedPtr&& data, ptrdiff_t size,
+  THCState *state, at::ScalarType scalar_type, at::SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator *allocator) {
   THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
   memset(storage, 0, sizeof(THCStorage));
   storage->backend = at::kCUDA;
   storage->scalar_type = scalar_type;
-  new (&storage->data_ptr) SupervisedPtr(std::move(data));
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1);

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -23,8 +23,7 @@ THC_API THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scala
 THC_API THCStorage* THCStorage_newWithAllocator(THCState *state,
                                         at::ScalarType scalar_type,
                                         ptrdiff_t size,
-                                        THCDeviceAllocator* allocator,
-                                        void* allocatorContext);
+                                        at::Allocator* allocator);
 
 THC_API void THCStorage_retain(THCState *state, THCStorage *storage);
 
@@ -34,7 +33,8 @@ THC_API void THCStorage_free(THCState *state, THCStorage *self);
 THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
-THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
+//THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext);
+  THCState *state, at::ScalarType scalar_type,
+  std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  at::Allocator* allocator);

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -36,5 +36,5 @@ THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 //THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
   THCState *state, at::ScalarType scalar_type,
-  std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -36,5 +36,5 @@ THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 //THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
   THCState *state, at::ScalarType scalar_type,
-  SupervisedPtr&& data, ptrdiff_t size,
+  at::SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);

--- a/aten/src/THC/THCTensorRandom.cpp
+++ b/aten/src/THC/THCTensorRandom.cpp
@@ -15,12 +15,12 @@ void destroyGenerator(THCState *state, THCGenerator* gen)
   std::lock_guard<std::mutex> lock(gen->mutex);
   if (gen->state.gen_states)
   {
-    THCudaCheck(THCudaFree(state, gen->state.gen_states));
+    THCudaFree(state, gen->state.gen_states);
     gen->state.gen_states = NULL;
   }
   if (gen->state.kernel_params)
   {
-    THCudaCheck(THCudaFree(state, gen->state.kernel_params));
+    THCudaFree(state, gen->state.kernel_params);
     gen->state.kernel_params = NULL;
   }
 }

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -22,8 +22,8 @@ THCGenerator* THCRandom_getGenerator(THCState* state);
 /* Sets up generator. Allocates but does not create the generator states. Not thread-safe. */
 __host__ void initializeGenerator(THCState *state, THCGenerator* gen)
 {
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.gen_states, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.kernel_params, sizeof(mtgp32_kernel_params)));
+  gen->state.gen_states = static_cast<struct curandStateMtgp32*>(THCudaMalloc(state, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
+  gen->state.kernel_params = static_cast<mtgp32_kernel_params*>(THCudaMalloc(state, sizeof(mtgp32_kernel_params)));
 }
 
 /* Creates a new generator state given the seed. Not thread-safe. */

--- a/aten/src/THC/THCThrustAllocator.cuh
+++ b/aten/src/THC/THCThrustAllocator.cuh
@@ -17,13 +17,11 @@ class THCThrustAllocator {
   }
 
   char* allocate(std::ptrdiff_t size) {
-    char* out = NULL;
-    THCudaCheck(THCudaMalloc(state_, (void**) &out, size));
-    return out;
+    return static_cast<char*>(THCudaMalloc(state_, size));
   }
 
   void deallocate(char* p, size_t size) {
-    THCudaCheck(THCudaFree(state_, p));
+    THCudaFree(state_, p);
   }
 
  private:

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -49,11 +49,10 @@ THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 }
 
 THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
-                                          THCDeviceAllocator* allocator,
-                                          void* allocatorContext)
+                                          at::Allocator* allocator)
 {
   return THCStorage_newWithAllocator(state, at::CTypeToScalarType<real>::to(),
-                                     size, allocator, allocatorContext);
+                                     size, allocator);
 }
 
 THCStorage* THCStorage_(newWithSize1)(THCState *state, real data0)
@@ -96,15 +95,10 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
   return NULL;
 }
 
-THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size)
-{
-  return THCStorage_newWithData(state, at::CTypeToScalarType<real>::to(), data, size);
-}
-
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, real *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext) {
-  return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), data, size, allocator, allocatorContext);
+  THCState *state, std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  at::Allocator *allocator) {
+  return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }
 
 void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag)

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -96,7 +96,7 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
 }
 
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  THCState *state, SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator *allocator) {
   return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -96,7 +96,7 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
 }
 
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, SupervisedPtr&& data, ptrdiff_t size,
+  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator *allocator) {
   return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -4,7 +4,6 @@
 
 #define TH_STORAGE_REFCOUNTED 1
 #define TH_STORAGE_RESIZABLE  2
-#define TH_STORAGE_FREEMEM    4
 
 #define THCStorage THStorage
 
@@ -37,17 +36,14 @@ THC_API THCStorage* THCStorage_(newWithSize3)(THCState *state, real, real, real)
 THC_API THCStorage* THCStorage_(newWithSize4)(THCState *state, real, real, real, real);
 THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, ptrdiff_t size, int shared);
 
-/* takes ownership of data */
-THC_API THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size);
-
+#ifdef __cplusplus
 THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
-  THCDeviceAllocator* allocator,
-  void *allocatorContext);
+  at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, real* data, ptrdiff_t size,
-  THCDeviceAllocator* allocator,
-  void *allocatorContext);
+  THCState *state, std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  at::Allocator* allocator);
+#endif
 
 THC_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
 THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -41,7 +41,7 @@ THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, SupervisedPtr&& data, ptrdiff_t size,
+  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
 #endif
 

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -41,7 +41,7 @@ THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, std::unique_ptr<void, at::BoundDeleter>&& data, ptrdiff_t size,
+  THCState *state, SupervisedPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
 #endif
 

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -575,11 +575,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   size_t matrices_size = num_batches * sizeof(real*);
 
 //   Copy pointers to device.
-  const real **d_matrices1, **d_matrices2;
-  real **d_result_matrices;
-  THCudaCheck(THCudaMalloc(state, (void**)&d_matrices1, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_matrices2, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result_matrices, matrices_size));
+  auto d_matrices1 = static_cast<const real**>(THCudaMalloc(state, matrices_size));
+  auto d_matrices2 = static_cast<const real**>(THCudaMalloc(state, matrices_size));
+  auto d_result_matrices = static_cast<real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;
@@ -786,9 +784,8 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
   int *info_gpu = THCudaIntTensor_data(state, rinfo_);
 
   // Copy pointers to device.
-  real **d_result;
   size_t matrices_size = num_batches * sizeof(real*);
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result, matrices_size));
+  auto d_result = static_cast<real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;
@@ -899,10 +896,8 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   size_t matrices_size = num_batches * sizeof(real*);
 
   // Copy pointers to device.
-  real **d_result;
-  const real **d_atf;
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_atf, matrices_size));
+  auto d_result = static_cast<real**>(THCudaMalloc(state, matrices_size));
+  auto d_atf = static_cast<const real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -241,8 +241,7 @@ PyObject * THCPModule_cudaUnlockMutex(PyObject *module)
 PyObject * THCPModule_emptyCache(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  auto device_allocator = THCState_getDeviceAllocator(state);
-  THCudaCheck(device_allocator->emptyCache(device_allocator->state));
+  THCCachingAllocator_emptyCache();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -119,7 +119,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
     real *data_ptr = THWStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
     // TODO: Hmmmm
-    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, {}}, size, nullptr));
+    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr()}, size, nullptr));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THWStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -214,7 +214,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THWStorage_(data)(LIBRARY_STATE self->cdata);
-    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), {}}, slicelength, nullptr));
+    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr()}, slicelength, nullptr));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THWStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/lib/THD/base/data_channels/GlooCache.hpp
+++ b/torch/lib/THD/base/data_channels/GlooCache.hpp
@@ -143,8 +143,7 @@ struct GlooCache {
                                           std::default_delete<char[]>());
 #ifdef USE_CUDA
     } else if (device == DeviceType::CUDA) {
-      buffer_type *buf;
-      THCudaCheck(THCudaMalloc(THDGetCudaState(), (void**)&buf, bytes));
+      buffer_type *buf = static_cast<buffer_type*>(THCudaMalloc(THDGetCudaState(), bytes));
       return std::shared_ptr<buffer_type>(buf, [](char* ptr) { THCudaFree(THDGetCudaState(), ptr); });
 #endif
     } else {

--- a/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
@@ -12,7 +12,7 @@ static THDStorage* THDStorage_(_alloc)() {
   new (&new_storage->refcount) std::atomic<int>(1);
   new_storage->storage_id = THDState::s_nextId++;
   new_storage->node_id = THDState::s_current_worker;
-  new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
+  new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
   return new_storage;
 }
 

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -117,7 +117,7 @@ void libshm_free(void *_ctx, void *data) {
 
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
-SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
+at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
   // TODO: unlock GIL when contacting the manager
   auto *ctx = (libshm_context*)_ctx;
   try {

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -117,7 +117,7 @@ void libshm_free(void *_ctx, void *data) {
 
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
-std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size) {
+SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
   // TODO: unlock GIL when contacting the manager
   auto *ctx = (libshm_context*)_ctx;
   try {

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -10,26 +10,17 @@
 std::unordered_map<std::string, ClientSocket> managers;
 std::string manager_executable_path;
 
-void libshm_init(const char *manager_exec_path) {
-  manager_executable_path = std::string(manager_exec_path);
-}
-
-libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags) {
-  libshm_context *ctx = new libshm_context();
-  if (!manager_handle) {
-    ctx->manager_handle = nullptr;
-  } else {
-    size_t handle_length = std::strlen(manager_handle);
-    ctx->manager_handle = new char[handle_length+1];
-    memcpy(ctx->manager_handle, manager_handle, handle_length+1);
+AllocInfo get_alloc_info(THManagedMapAllocator *ctx) {
+  AllocInfo info = {0};
+  info.pid = getpid();
+  info.free = false;
+  const char *filename = ctx->filename();
+  size_t len = strlen(filename);
+  if (len >= sizeof(info.filename)) {
+    throw std::runtime_error("THMapAllocatorContext_filename too long");
   }
-  ctx->th_context = THMapAllocatorContext_new(filename, flags);
-  return ctx;
-}
-
-void libshm_context_free(libshm_context *ctx) {
-  delete[] ctx->manager_handle;
-  delete ctx;
+  memcpy(info.filename, filename, len + 1);
+  return info;
 }
 
 void start_manager() {
@@ -73,74 +64,65 @@ void start_manager() {
   managers.emplace(std::move(handle), std::move(manager));
 }
 
-ClientSocket& get_manager_socket(char *manager_handle) {
-  std::string str_handle(manager_handle);
-  auto it = managers.find(str_handle);
+ClientSocket& get_manager_socket(const std::string& manager_handle) {
+  auto it = managers.find(manager_handle);
   if (it == managers.end()) {
-    auto socket = ClientSocket(str_handle);
-    auto result = managers.emplace(std::move(str_handle), std::move(socket));
+    auto socket = ClientSocket(manager_handle);
+    auto result = managers.emplace(manager_handle, std::move(socket));
     return result.first->second;
   } else {
     return it->second;
   }
 }
 
-char * copy_handle(const std::string &handle) {
-  char *new_handle = new char[handle.length()+1];
-  memcpy(new_handle, handle.c_str(), handle.length() + 1);
-  return new_handle;
+void libshm_init(const char *manager_exec_path) {
+  manager_executable_path = std::string(manager_exec_path);
 }
 
-AllocInfo get_alloc_info(libshm_context *ctx) {
-  AllocInfo info = {0};
-  info.pid = getpid();
-  info.free = false;
-  const char *filename = THMapAllocatorContext_filename(ctx->th_context);
-  size_t len = strlen(filename);
-  if (len >= sizeof(info.filename)) {
-    throw std::runtime_error("THMapAllocatorContext_filename too long");
-  }
-  memcpy(info.filename, filename, len + 1);
-  return info;
-}
+THManagedMapAllocator::THManagedMapAllocator(const char *manager_handle, const char *filename, int flags, ptrdiff_t size)
+  : THRefcountedMapAllocator(filename, flags, size)
+  // TODO: Perhaps it should be an at::optional<std::string>?
+  , manager_handle_(manager_handle ? manager_handle : "") {
 
-void libshm_free(void *_ctx, void *data) {
-  auto *ctx = (libshm_context*)_ctx;
-  AllocInfo info = get_alloc_info(ctx);
-  info.free = true;
-  ClientSocket &socket = get_manager_socket(ctx->manager_handle);
-  ctx->th_deleter(data);
-  // NB: No need to clear th_context; it was stolen by th_deleter
-  libshm_context_free(ctx);
-  socket.register_deallocation(info);
-}
-
-THManagedSharedDeleter THManagedSharedDeleter::singleton_;
-
-at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
   // TODO: unlock GIL when contacting the manager
-  auto *ctx = (libshm_context*)_ctx;
   try {
-    THMapAllocatorContext *th_context = ctx->th_context;
     ClientSocket *socket;
-    if (ctx->manager_handle) {
-      socket = &get_manager_socket(ctx->manager_handle);
+    if (!manager_handle_.empty()) {
+      socket = &get_manager_socket(manager_handle_);
     } else {
-      if (managers.size() == 0)
-          start_manager();
+      if (managers.size() == 0) {
+        start_manager();
+      }
       const auto &manager = managers.begin();
-      ctx->manager_handle = copy_handle(manager->first);
+      manager_handle_ = manager->first;
       socket = &manager->second;
     }
-    AllocInfo info = get_alloc_info(ctx);
+    AllocInfo info = get_alloc_info(this);
     socket->register_allocation(info);
   } catch(std::exception &e) {
     THError(e.what());
   }
-  auto ptr = THRefcountedMapAllocator_alloc(ctx->th_context, size);
-  return {ptr.release(), THManagedSharedDeleter::make(ctx, ptr.get_deleter())};
 }
 
-void THManagedSharedDeleter::deallocate(void* ctx, void* data) const {
-  return libshm_free(ctx, data);
+THManagedMapAllocator::~THManagedMapAllocator() {
+  AllocInfo info = get_alloc_info(this);
+  info.free = true;
+  ClientSocket &socket = get_manager_socket(manager_handle_);
+  // TODO: I think its OK to register deallocation before we actually
+  // deallocate; I hope so!
+  socket.register_deallocation(info);
+}
+
+static void deleteTHManagedMapAllocator(void* ptr) {
+  delete static_cast<THManagedMapAllocator*>(ptr);
+}
+
+at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+  auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
+}
+
+THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
+  if (sptr.supervisor_.get_deleter() != &deleteTHManagedMapAllocator) return nullptr;
+  return static_cast<THManagedMapAllocator*>(sptr.supervisor_.get());
 }

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -1,38 +1,26 @@
-#ifndef LIBSHM_H
-#define LIBSHM_H
+#pragma once
 
 #include <TH/TH.h>
 
 #ifdef __cplusplus
-#define EXPORT_API extern "C"
-#else
-#define EXPORT_API
-#endif
 
-typedef struct {
-  char *manager_handle;
-  // NB: th_context is a temporary field
-  THMapAllocatorContext *th_context;
-  at::BoundDeleter th_deleter;
-} libshm_context;
+void libshm_init(const char *manager_exec_path);
 
-EXPORT_API void libshm_init(const char *manager_exec_path);
-EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-EXPORT_API at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
-EXPORT_API void libshm_context_free(libshm_context *context);
+// Like a THRefcountedMapAllocator, but it also makes use of an external
+// shared memory manager process to ensure that shared memory regions actually
+// get freed in the end (even if processes lose the memory).
+class THManagedMapAllocator : public THRefcountedMapAllocator {
+public:
+  THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  virtual ~THManagedMapAllocator();
 
-struct EXPORT_API THManagedSharedDeleter : public at::Deleter {
-  void deallocate(void* ctx, void* data) const override;
-  static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
-    ctx->th_deleter = deleter;
-    return {&singleton_, ctx};
-  }
-  static libshm_context * getContext(at::BoundDeleter bd) {
-    if (bd.deleter_ != &singleton_) return nullptr;
-    return static_cast<libshm_context*>(bd.ctx_);
-  }
-private:
-  static THManagedSharedDeleter singleton_;
+  static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+
+  const char* manager_handle() const { return manager_handle_.c_str(); }
+
+protected:
+  std::string manager_handle_;
 };
 
 #endif

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -18,7 +18,7 @@ typedef struct {
 
 EXPORT_API void libshm_init(const char *manager_exec_path);
 EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-EXPORT_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
+EXPORT_API SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
 EXPORT_API void libshm_context_free(libshm_context *context);
 
 struct EXPORT_API THManagedSharedDeleter : public at::Deleter {

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -21,7 +21,7 @@ EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const
 EXPORT_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
 EXPORT_API void libshm_context_free(libshm_context *context);
 
-struct THManagedSharedDeleter : public at::Deleter {
+struct EXPORT_API THManagedSharedDeleter : public at::Deleter {
   void deallocate(void* ctx, void* data) const override;
   static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
     ctx->th_deleter = deleter;

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -11,13 +11,28 @@
 
 typedef struct {
   char *manager_handle;
+  // NB: th_context is a temporary field
   THMapAllocatorContext *th_context;
+  at::BoundDeleter th_deleter;
 } libshm_context;
 
 EXPORT_API void libshm_init(const char *manager_exec_path);
 EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
+EXPORT_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
 EXPORT_API void libshm_context_free(libshm_context *context);
 
-extern THAllocator THManagedSharedAllocator;
+struct THManagedSharedDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* data) const override;
+  static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
+    ctx->th_deleter = deleter;
+    return {&singleton_, ctx};
+  }
+  static libshm_context * getContext(at::BoundDeleter bd) {
+    if (bd.deleter_ != &singleton_) return nullptr;
+    return static_cast<libshm_context*>(bd.ctx_);
+  }
+private:
+  static THManagedSharedDeleter singleton_;
+};
 
 #endif

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -18,7 +18,7 @@ typedef struct {
 
 EXPORT_API void libshm_init(const char *manager_exec_path);
 EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-EXPORT_API SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
+EXPORT_API at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
 EXPORT_API void libshm_context_free(libshm_context *context);
 
 struct EXPORT_API THManagedSharedDeleter : public at::Deleter {

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -12,14 +12,17 @@ void libshm_init(const char *manager_exec_path);
 class THManagedMapAllocator : public THRefcountedMapAllocator {
 public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  THManagedMapAllocator(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
   virtual ~THManagedMapAllocator();
 
   static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
   static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
 
   const char* manager_handle() const { return manager_handle_.c_str(); }
 
 protected:
+  void initializeManager();
   std::string manager_handle_;
 };
 

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -23,7 +23,7 @@ void libshm_context_free(libshm_context *ctx) {
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
 
-SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
+at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
   auto *ctx = (libshm_context*)_ctx;
   return THRefcountedMapAllocator_alloc(ctx->th_context, size);
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -23,7 +23,7 @@ void libshm_context_free(libshm_context *ctx) {
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
 
-std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size) {
+SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
   auto *ctx = (libshm_context*)_ctx;
   return THRefcountedMapAllocator_alloc(ctx->th_context, size);
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -22,6 +22,13 @@ void libshm_context_free(libshm_context *ctx) {
 
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
+
+std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size) {
+  auto *ctx = (libshm_context*)_ctx;
+  return THRefcountedMapAllocator_alloc(ctx->th_context, size);
+}
+
+
 void THManagedSharedDeleter::deallocate(void* _ctx, void* data) const {
   auto *ctx = (libshm_context*)_ctx;
   ctx->th_deleter(data);

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -20,32 +20,8 @@ void libshm_context_free(libshm_context *ctx) {
   delete ctx;
 }
 
-void * libshm_alloc(void *_ctx, ptrdiff_t size) {
-  auto *ctx = (libshm_context*)_ctx;
-  return getTHRefcountedMapAllocator()->allocate(ctx->th_context, size);
-}
+THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
-void * libshm_realloc(void *_ctx, void *data, ptrdiff_t size) {
-  THError("cannot realloc shared memory");
-  return NULL;
-}
-
-void libshm_free(void *_ctx, void *data) {
-  auto *ctx = (libshm_context*)_ctx;
-  getTHRefcountedMapAllocator()->deallocate(ctx->th_context, data);
-  libshm_context_free(ctx);
-}
-
-struct THManagedSharedAllocator : public at::Allocator {
-  void* allocate(void* ctx, size_t size) const override {
-    return libshm_alloc(ctx, size);
-  }
-  void deallocate(void* ctx, void* data) const override {
-    return libshm_free(ctx, data);
-  }
-};
-
-static THManagedSharedAllocator th_managed_shared_allocator;
-at::Allocator* getTHManagedSharedAllocator() {
-  return &th_managed_shared_allocator;
+void THManagedSharedDeleter::deallocate(void* ctx, void* data) const {
+  return libshm_free(ctx, data);
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -22,6 +22,8 @@ void libshm_context_free(libshm_context *ctx) {
 
 THManagedSharedDeleter THManagedSharedDeleter::singleton_;
 
-void THManagedSharedDeleter::deallocate(void* ctx, void* data) const {
-  return libshm_free(ctx, data);
+void THManagedSharedDeleter::deallocate(void* _ctx, void* data) const {
+  auto *ctx = (libshm_context*)_ctx;
+  ctx->th_deleter(data);
+  return libshm_context_free(ctx);
 }

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -24,6 +24,6 @@ SHM_API void libshm_init(const char *manager_exec_path);
 SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
 SHM_API void libshm_context_free(libshm_context *context);
 
-SHM_API THAllocator THManagedSharedAllocator;
+SHM_API at::Allocator* getTHManagedSharedAllocator();
 
 #endif

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -15,6 +15,12 @@
 # define SHM_API SHM_EXTERNC __declspec(dllimport)
 #endif
 
+#ifdef SHM_EXPORTS
+# define SHM_API_NOEXTERNC __declspec(dllexport)
+#else
+# define SHM_API_NOEXTERNC __declspec(dllimport)
+#endif
+
 typedef struct {
   char *manager_handle;
   // NB: th_context is a temporary field
@@ -27,7 +33,7 @@ SHM_API libshm_context * libshm_context_new(const char *manager_handle, const ch
 SHM_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
-struct SHM_API THManagedSharedDeleter : public at::Deleter {
+struct SHM_API_NOEXTERNC THManagedSharedDeleter : public at::Deleter {
   void deallocate(void* ctx, void* data) const override;
   static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
     ctx->th_deleter = deleter;

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -27,7 +27,7 @@ SHM_API libshm_context * libshm_context_new(const char *manager_handle, const ch
 SHM_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
-struct THManagedSharedDeleter : public at::Deleter {
+struct SHM_API THManagedSharedDeleter : public at::Deleter {
   void deallocate(void* ctx, void* data) const override;
   static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
     ctx->th_deleter = deleter;

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -30,7 +30,7 @@ typedef struct {
 
 SHM_API void libshm_init(const char *manager_exec_path);
 SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-SHM_API SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
+SHM_API at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
 struct SHM_API_NOEXTERNC THManagedSharedDeleter : public at::Deleter {

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -30,7 +30,7 @@ typedef struct {
 
 SHM_API void libshm_init(const char *manager_exec_path);
 SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-SHM_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
+SHM_API SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
 struct SHM_API_NOEXTERNC THManagedSharedDeleter : public at::Deleter {

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -17,13 +17,28 @@
 
 typedef struct {
   char *manager_handle;
+  // NB: th_context is a temporary field
   THMapAllocatorContext *th_context;
+  at::BoundDeleter th_deleter;
 } libshm_context;
 
 SHM_API void libshm_init(const char *manager_exec_path);
 SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
+SHM_API std::unique_ptr<void, at::BoundDeleter> libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
-SHM_API at::Allocator* getTHManagedSharedAllocator();
+struct THManagedSharedDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* data) const override;
+  static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
+    ctx->th_deleter = deleter;
+    return {&singleton_, ctx};
+  }
+  static libshm_context * getContext(at::BoundDeleter bd) {
+    if (bd.deleter_ != &singleton_) return nullptr;
+    return static_cast<libshm_context*>(bd.ctx_);
+  }
+private:
+  static THManagedSharedDeleter singleton_;
+};
 
 #endif


### PR DESCRIPTION
Stacked on #9148

```
The design might look a little strange, but there were a lot of
constraints feeding into it:

- It must support the reallocation usage-pattern, where, given
  an existing Storage, we allocate a new region of memory,
  copy the existing data to it, and then deallocate the old
  region of memory.

- Creation of a deleter for memory MUST avoid dynamic allocations
  in the common case.  We've done some benchmarking in Caffe2
  where dynamic allocation for deleters is ruinously expensive,
  and it's really hard to avoid these performance tarpits in
  very general function wrappers like std::function or
  folly::Function (while benchmarking this, we discovered that
  folly::Function's move constructor was way more expensive
  than it should be).

- We need to be able to deallocate data that comes from external
  sources, e.g., dlpack and numpy tensors.  Most notably,
  you often cannot deallocate these with merely the void*
  data pointer; you need some extra, out-of-band information
  (e.g., the managing struct) to deallocate it.  Sometimes,
  you may even want to resize data living in an external source!

- The "core" allocators need to support being wrapped in a Thrust
  allocator, so you need to be implement the following two functions:

    char* allocate(size_t);
    void deallocate(char*, size_t);

- We need to support tensors which contain non-POD, non-trivially
  copyable data; specifically tensors of std::string.  This is
  an upcoming requirement from Caffe2.  It's dirty AF, but
  it's really useful.

Here is the billing of changes:

- Built-in support for realloc() has been DROPPED ENTIRELY.
  Instead, you're expected to allocate and then copy from
  the old memory to the new memory if you want to do a
  reallocation.  This is what you'd generally have expected
  to occur; and axing realloc() from the design lets us avoid
  some tricky correctness issues with std::realloc(), namely
  the fact that we must refuse the realloc if the type of the
  elements are not trivially copyeable.  If it really matters,
  we can add this back, but there really needs to be a good
  explanation WHY you need fast resizing reallocations (by in
  large, people don't resize their storages, and it should
  be acceptable to have a performance degradation when they
  do).

- TH_STORAGE_FREEMEM is no more; instead, if you want a
  storage which doesn't free its result, you just give it
  an empty deleter.

- What we used to call an "allocator" has been split into two
  concepts, an allocator and a deleter.  True to their names,
  allocators know how to allocate, and deleters know how to
  delete the things allocators produce.

  This is NOT just a simple split of the previous
  THAllocator/THCAllocator design:

    - Unlike previously, where the "context" of an THAllocator
      was allocate prior to even allocating, and then used
      for the entire lifetime of the storage (even if a
      reallocation happens), the notion of context has been
      isolated to the Deleter (a Deleter plus a context is
      a BoundDeleter); this context is *freshly manufactured*
      when you do an allocation with an Allocator.

    - We definitely need some sort of context for deleters,
      because sometimes we need more information than the data
      pointer itself to properly deallocate.  A simple example
      is a dlpack tensor; to free the data, we need an
      enclosing struct which contains the actual function pointer
      to perform deletion.

      Allocation of the deleter at *allocation* time allows
      us to support some resizing use-cases in the absence of
      built-in support for realloc().  If a context lifetime
      is tied to a storage, there's no where to put a second
      context for temporary memory before you perform a copy
      from old to new.

    - By default, allocators don't support "raw" allocations
      and deallocations with raw pointers.  This is because
      some allocations may return a different context every
      time, in which case you need to reconstruct the context
      at delete time (because all you got was a void*, not
      a unique_ptr that carries the deleter).

- THCDeviceAllocator has a few more changes.

    - It used to return a cudaError_t.  Now, allocators
      are expected to check the error status immediately and throw
      an exception if there was an error.  It turns out that this
      is what was immediately done after all occurrences of
      allocate/release, so it wasn't a big deal (although some
      subsidiary interfaces had to themselves be converted to
      not return cudaError_t).

      There is one notable exception to this, and it is how
      we handle CUDA OOM: if this occurs, we attempt to return
      unused memory to the system and try again.  This is now
      handled by a catch-all try-catch block.  The cost of
      catching the exception is probably the least of your worries
      if you're about to OOM.

    - It used to take the CUDA stream to perform the allocation
      on as an argument.  However, it turned out that all call
      sites, this stream was the stream for the current device.
      So we can push this into the allocator (and the choice,
      in the future, could be made explicitly by twiddling
      thread local state.)

    - It held two extra methods, emptyCache and cacheInfo, specifically
      for interacting with some state in THCCachingAllocator.
      But this "generality" was a lie, since THCCachingAllocator
      was the only allocator that actually implemented these
      methods, and there is actually a bunch of code in THC
      which assumes that it is the caching allocator that is
      the underlying allocator for CUDA allocations.  So I
      folded these two methods into this interface as
      THCCachingAllocator_emptyCache and THCCachingAllocator_cacheInfo.

    - It held its context directly inside the THCDeviceAllocator
      struct.  This context has been moved out into whatever
      is holding the at::Allocator*.

- The APIs for getting at allocators/deleters is now a little different.

    - Previously there were a bunch of static variables you could get
      the address of (e.g., &THDefaultAllocator); now there is a
      function getTHDefaultAllocator().

    - Some "allocators" didn't actually know how to allocate (e.g.,
      the IPC "allocator").  These have been deleted; you only have
      deleters for these allocators now.

    - Deleters have a convention that there is a make() static
      method, which will construct an appropriate at::BoundDeleter
      for that method (they take as arguments any context they need).

- Storage sharing was a lot of work to wrangle, but I think I've
  tamed the beast.

    - Deleters for storage sharing (and some other deleters) follow
      the convention that their context is dynamically allocated memory
      whose lifetime is tied to the data in question.  So many
      invocations of Deleter::make(ctx) actually *steal* the ctx
      in question; however, we can't write this as an actual
      unique_ptr because we want deallocation to be handled externally.

    - Sometimes, we need to pull out the file descriptor from a
      tensor.  Previously, it was pulled out of the allocator context.
      We still do morally the same thing, pulling out this information
      from the deleter context; however, there is a nice static
      method getContext() which checks if the conversion is valid
      before pulling it out for you.  The returned pointer is NON-owning.

- I renamed the std::function deleter into
  InefficientStdFunctionDeleter, to emphasize the fact that it does
  a dynamic allocation to save the std::function deleter.

TODO:

- Windows libshm is in shambles and needs to be fixed.

Perhaps for the future:

- newFromFd is now unconditionally calling cudaPointerGetAttributes
  even though this is unnecessary, because we know what the device
  is from higher up in the callstack.  We can fix this by making
  newWithDataAndAllocator also take an explicit device argument.

- Consider statically distinguishing between allocators that
  support raw_allocate/raw_deallocate, and those which don't.
  The Thrust constraint applies only to the CUDA device allocator;
  you never need to allocate CPU memory this way

- Really want to get rid of storage views. Ugh.

Nontrivial bugs I noticed when preparing this patch:

- I forgot to placement-new unique pointers and attempted to
  assign them directly on uninitialized memory; very bad!  Sam
  Gross has encouraged me to replace this with a proper constructor
  but I keep putting it off, because once everything goes in
  StorageImpl there really will be a proper constructor.

- I rewrote a number of APIs to use newWithDataAndAllocator
  instead of newWithAllocator, calling the allocator at the
  call site (because they required "allocation context" which
  we no longer give to "allocators").  When I did this, I forgot
  to insert the multiplication with sizeof(real) to scale from
  numels to number of bytes.

- The implementation of swap on storages was missing it for
  scalarType and backend.  It was benign (because the only case
  we call swap is when these are the same), but I fixed it anyway.

- I accidentally returned a nullptr unique_ptr with no deleter,
  even though there was a legitimate one.  This matters, because
  some code still shoves its hands in the deleter context to
  get extra metadata about the function.

- I used std::move() on a unique_ptr, and then did a boolean
  test on the pointer aftewards (always false!)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```