### PR TITLE
Add support of is_compatible for old version of onnx

### DIFF
--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -990,7 +990,8 @@ class Caffe2Backend(Backend):
     def is_compatible(cls, model, device='CPU', **kwargs):
         if hasattr(super(Caffe2Backend, cls), 'is_compatible') \
            and callable(super(Caffe2Backend, cls).is_compatible):
-            super(Caffe2Backend, cls).is_compatible(model, device, **kwargs)
+            if not super(Caffe2Backend, cls).is_compatible(model, device, **kwargs):
+              return False
         # TODO: should have an unspported list of operators, be optimistic for now
         return True
 

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -986,6 +986,13 @@ class Caffe2Backend(Backend):
             return workspace.has_gpu_support
         return False
 
+    @classmethod
+    def is_compatible(cls, model, device='CPU', **kwargs):
+        if hasattr(super(Caffe2Backend, cls), 'is_compatible') \
+           and callable(super(Caffe2Backend, cls).is_compatible):
+            super(Caffe2Backend, cls).is_compatible(model, device, **kwargs)
+        # TODO: should have an unspported list of operators, be optimistic for now
+        return True
 
 prepare = Caffe2Backend.prepare
 


### PR DESCRIPTION
Fix the problem if caffe2 works with old version of onnx