### PR TITLE
[Caffe2] Fix TensorRT tests

### DIFF
--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
@@ -380,7 +380,7 @@ NetDef TensorRTTransformer::SubnetToTrtOp(
 
   // Debug stuff
   if (debug_builder_) {
-    DumpModel(onnx_model, "debug.onnx");
+    DumpModel(onnx_model, "debug.onnxtxt");
   }
 
   // Convert weights to initializing tensors if we are building serializable trt

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
@@ -42,21 +42,9 @@ std::unordered_map<std::string, TensorShape> InferShapes(
 
 void DumpModel(const ::ONNX_NAMESPACE::ModelProto& model, const std::string& fname) {
   std::ofstream ff(fname);
-  for (const auto& t : model.graph().initializer()) {
-    ff << "tensor: " << t.name() << std::endl;
-    ff << "  dims: ";
-    for (auto i : t.dims()) {
-      ff << i << " ";
-    }
-    ff << std::endl;
-    int i = 0;
-    for (auto i : t.float_data()) {
-      ff << "    " << i << std::endl;
-      if (++i > 10) {
-        break;
-      }
-    }
-  }
+  std::string body;
+  ::google::protobuf::TextFormat::PrintToString(model.graph(), &body);
+  ff << body << std::endl;
   ff.close();
 }
 
@@ -390,16 +378,16 @@ NetDef TensorRTTransformer::SubnetToTrtOp(
     onnx_model.mutable_graph()->add_input()->CopyFrom(i);
   }
 
+  // Debug stuff
+  if (debug_builder_) {
+    DumpModel(onnx_model, "debug.onnx");
+  }
+
   // Convert weights to initializing tensors if we are building serializable trt
   // op or defer it to construction time of trt op
   if (build_serializable_op_) {
     BuildInitializationList(
         ws, onnx_model.mutable_graph(), &initialization_list);
-  }
-
-  // Debug stuff
-  if (debug_builder_) {
-    DumpModel(onnx_model, "debug.onnx");
   }
 
   // Onnx model is ready. Call onnx-trt to convert to one trt c2 op

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.h
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.h
@@ -26,12 +26,12 @@ class TensorRTTransformer {
       size_t max_workspace_size,
       int verbosity,
       bool debug_builder,
-      bool build_serializable_op = true)
-      : max_batch_size_(max_batch_size),
+      bool build_serializable_op = false)
+      : build_serializable_op_(build_serializable_op),
+        max_batch_size_(max_batch_size),
         max_workspace_size_(max_workspace_size),
         verbosity_(verbosity),
-        debug_builder_(debug_builder),
-        build_serializable_op_(build_serializable_op) {}
+        debug_builder_(debug_builder) {}
 
   OperatorDef BuildTrtOp(
       const std::string& onnx_model_str,
@@ -79,7 +79,8 @@ class TensorRTTransformer {
   // Input mapping
   std::unordered_map<std::string, std::string> input_mapping_;
 
-  // Generate serializable trt op or defer the onnx->trt process to ctor of the Trt op
+  // Generate serializable trt op or defer the onnx->trt process to ctor of the
+  // Trt op
   bool build_serializable_op_{true};
 
   // TensorRT params

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -825,7 +825,8 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
       "Gemm",
       {x, w, b},
       {gemm_y_output},
-      {MakeAttribute("transB", 1L)},
+      {MakeAttribute("transB", 1L),
+       MakeAttribute("broadcast", legacy_mode_ ? 1 : 0)},
       def.name()));
 
   if (has_axis) {

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -821,12 +821,15 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
   }
 
   auto gemm_y_output = (has_axis) ? dummy_->NewDummyName() : y;
+  std::vector<AttributeProto> attrs = {MakeAttribute("transB", 1L)};
+  if (legacy_mode_) {
+    attrs.emplace_back(MakeAttribute("broadcast", 1));
+  }
   nodes.emplace_back(MakeNode(
       "Gemm",
       {x, w, b},
       {gemm_y_output},
-      {MakeAttribute("transB", 1L),
-       MakeAttribute("broadcast", legacy_mode_ ? 1 : 0)},
+      attrs,
       def.name()));
 
   if (has_axis) {

--- a/caffe2/python/trt/test_trt.py
+++ b/caffe2/python/trt/test_trt.py
@@ -287,8 +287,11 @@ class TensorRTTransformTest(TestCase):
         start = time.time()
         pred_net_cut = transform_caffe2_net(pred_net,
                                             {input_name: input_blob_dims},
-                                            build_serializable_op=True)
+                                            build_serializable_op=False)
         del init_net, pred_net
+        pred_net_cut.device_option.CopyFrom(device_option)
+        for op in pred_net_cut.op:
+            op.device_option.CopyFrom(device_option)
         #_print_net(pred_net_cut)
 
         Y_trt = None


### PR DESCRIPTION
ONNX-TensorRT is still using old opset (<7). Patch it for now. 

Future fix would be expose versioning in onnx exporter. 