### PR TITLE
Accumulate MSELoss reduce=True into accreal instead of real

### DIFF
--- a/aten/src/THNN/generic/MSECriterion.c
+++ b/aten/src/THNN/generic/MSECriterion.c
@@ -14,17 +14,17 @@ void THNN_(MSECriterion_updateOutput)(
   if (reduction != Reduction::None) {
     THTensor_(resize1d)(output, 1);
 
-    real sum = 0;
+    accreal sum = 0;
 
     TH_TENSOR_APPLY2(real, input, real, target,
-      real z = (*input_data - *target_data);
+      accreal z = (*input_data - *target_data);
       sum += z*z;
     );
 
     if (reduction == Reduction::ElementwiseMean)
       sum /= THTensor_(nElement)(input);
 
-    THTensor_(set1d)(output, 0, sum);
+    THTensor_(set1d)(output, 0, (real)sum);
     return;
   }
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1087,6 +1087,7 @@ class CriterionTest(TestBase):
     def __init__(self, *args, **kwargs):
         super(CriterionTest, self).__init__(*args, **kwargs)
         self.should_test_cuda = kwargs.get('test_cuda', True)
+        self.check_forward_only = kwargs.get('check_forward_only', True)
 
     def _get_target(self):
         return self._get_arg('target', True)
@@ -1108,6 +1109,9 @@ class CriterionTest(TestBase):
             if isinstance(expected_out, torch.Tensor):
                 expected_out = expected_out.item()
             test_case.assertEqual(out, expected_out)
+
+        if self.check_forward_only:
+            return
 
         test_case.check_criterion_jacobian(module, input, target)
         self._do_extra_tests(test_case, module, input, target)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5934,6 +5934,15 @@ new_criterion_tests = [
         desc='scalar'
     ),
     dict(
+        module_name='MSELoss',
+        input_fn=lambda: torch.ones(5, 68, 64, 64, dtype=torch.float) / 10,
+        target_fn=lambda: torch.zeros(5, 68, 64, 64, dtype=torch.float),
+        reference_fn=lambda i, t, m: ((i - t).abs().pow(2).sum() /
+                                      (i.numel() if get_reduction(m) == 'elementwise_mean' else 1)),
+        check_forward_only=True,
+        desc='prec',
+    ),
+    dict(
         module_name='BCELoss',
         constructor_args_fn=lambda: (torch.rand(()),),
         input_fn=lambda: torch.rand(()).clamp_(1e-2, 1 - 1e-2),


### PR DESCRIPTION
THNN was accumulating the result of reduction loss functions
into real instead of accreal. This was causing precision issues with
MSELoss.

This patch only fixes MSELoss. Some of the other losses exhibit bad precision as well (because they accumulate into real instead of accreal) and require more investigation. I will open an issue for those (#9286)

Fixes #8710

cc @li-roy @SsnL 