### PR TITLE
Ensure pending tasks are finished in case of failure

### DIFF
--- a/caffe2/core/net_test.cc
+++ b/caffe2/core/net_test.cc
@@ -769,4 +769,50 @@ TEST(NetTest, NoTypeNet) {
   }
 }
 
+class NotFinishingOp final : public Operator<CPUContext> {
+ public:
+  NotFinishingOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // never calls SetFinished
+    return true;
+  }
+
+  bool HasAsyncPart() const override {
+    return true;
+  }
+};
+
+REGISTER_CPU_OPERATOR(NotFinishingOp, NotFinishingOp);
+
+OPERATOR_SCHEMA(NotFinishingOp);
+
+TEST(NetTest, PendingOpsAndNetFailure) {
+  const auto spec = R"DOC(
+        name: "example"
+        type: "async_scheduling"
+        op {
+          type: "NotFinishingOp"
+        }
+        op {
+          type: "NetTestDummy"
+          arg {
+            name: "fail"
+            i: 1
+          }
+        }
+)DOC";
+
+  NetDef net_def;
+  CAFFE_ENFORCE(
+      ::google::protobuf::TextFormat::ParseFromString(spec, &net_def));
+
+  Workspace ws;
+  std::unique_ptr<NetBase> net(CreateNet(net_def, &ws));
+
+  // net is not stuck and returns false
+  ASSERT_FALSE(net->Run());
+}
+
 } // namespace caffe2


### PR DESCRIPTION
Summary: Ensure pending tasks (e.g. network ops) are finished when net fails

Differential Revision: D8777230
