### PR TITLE
Add support for .norm() pytorch onnx export and ReduceL1/ReduceL2 caffe2 operators

### DIFF
--- a/caffe2/operators/reduce_ops.h
+++ b/caffe2/operators/reduce_ops.h
@@ -277,6 +277,68 @@ struct MeanReducer {
   }
 };
 
+template <class Context>
+struct L1Reducer {
+  template <typename T>
+  bool Forward(
+      const std::vector<int>& dims,
+      const std::vector<int>& axes,
+      const T* X_data,
+      T* Y_data,
+      Context* context) const {
+    math::ReduceL1<T, Context>(
+        dims.size(),
+        dims.data(),
+        axes.size(),
+        axes.data(),
+        X_data,
+        Y_data,
+        context);
+    return true;
+  }
+
+  template <typename T>
+  bool Backward(
+      const std::vector<int>& dY_dims,
+      const std::vector<int>& dX_dims,
+      const T* dY_data,
+      const T* X_data,
+      const T* Y_data,
+      T* dX_data,
+      Context* context) const;
+};
+
+template <class Context>
+struct L2Reducer {
+  template <typename T>
+  bool Forward(
+      const std::vector<int>& dims,
+      const std::vector<int>& axes,
+      const T* X_data,
+      T* Y_data,
+      Context* context) const {
+    math::ReduceL2<T, Context>(
+        dims.size(),
+        dims.data(),
+        axes.size(),
+        axes.data(),
+        X_data,
+        Y_data,
+        context);
+    return true;
+  }
+
+  template <typename T>
+  bool Backward(
+      const std::vector<int>& dY_dims,
+      const std::vector<int>& dX_dims,
+      const T* dY_data,
+      const T* X_data,
+      const T* Y_data,
+      T* dX_data,
+      Context* context) const;
+};
+
 } // namespace caffe2
 
 #endif // CAFFE2_OPERATORS_REDUCE_OPS_H_

--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -90,6 +90,34 @@ class TestReduceOps(hu.HypothesisTestCase):
         self.run_reduce_op_test(
             "ReduceMean", X, keepdims, num_axes, np.mean, gc, dc)
 
+    @given(n=st.integers(1, 3), m=st.integers(1, 3), k=st.integers(1, 3),
+           keepdims=st.booleans(), num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
+    def test_reduce_l1(self, n, m, k, keepdims, num_axes, gc, dc):
+        X = np.arange(n * m * k, dtype=np.float32) - 0.5
+        np.random.shuffle(X)
+        X = X.reshape((m, n, k))
+        self.run_reduce_op_test(
+            "ReduceL1", X, keepdims, num_axes, getNorm(1), gc, dc)
+
+    @given(n=st.integers(1, 5), m=st.integers(1, 5), k=st.integers(1, 5),
+           keepdims=st.booleans(), num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
+    def test_reduce_l2(self, n, m, k, keepdims, num_axes, gc, dc):
+        X = np.random.randn(n, m, k).astype(np.float32)
+        self.run_reduce_op_test(
+            "ReduceL2", X, keepdims, num_axes, getNorm(2), gc, dc)
+
+
+def getNorm(p):
+    if p == 1:
+        def norm(X, axis, keepdims):
+            return np.sum(np.abs(X), axis=axis, keepdims=keepdims)
+    elif p == 2:
+        def norm(X, axis, keepdims):
+            return np.sqrt(np.sum(np.power(X, 2), axis=axis, keepdims=keepdims))
+    else:
+        raise RuntimeError("Only L1 and L2 norms supported")
+    return norm
+
 
 class TestReduceFrontReductions(hu.HypothesisTestCase):
     def grad_variant_input_test(self, grad_op_name, X, ref, num_reduce_dim):

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -219,6 +219,26 @@ void ReduceMean(
     T* Y,
     Context* context);
 
+template <typename T, class Context>
+void ReduceL1(
+    const int num_dims,
+    const int* dims,
+    const int num_axes,
+    const int* axes,
+    const T* X,
+    T* Y,
+    Context* context);
+
+template <typename T, class Context>
+void ReduceL2(
+    const int num_dims,
+    const int* dims,
+    const int num_axes,
+    const int* axes,
+    const T* X,
+    T* Y,
+    Context* context);
+
 // Broadcasts X with X_dims to Y with Y_dims.
 template <typename T, class Context>
 void Broadcast(

--- a/test/onnx/expect/TestOperators.test_norm.expect
+++ b/test/onnx/expect/TestOperators.test_norm.expect
@@ -1,0 +1,65 @@
+ir_version: 3
+producer_name: "pytorch"
+producer_version: "0.3"
+graph {
+  node {
+    input: "0"
+    output: "1"
+    op_type: "ReduceL2"
+    attribute {
+      name: "axes"
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  name: "torch-jit-export"
+  input {
+    name: "0"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}

--- a/test/onnx/test_caffe2.py
+++ b/test/onnx/test_caffe2.py
@@ -615,6 +615,13 @@ class TestCaffe2Backend(unittest.TestCase):
         model = nn.AvgPool2d(5)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
+    def test_weight_norm(self):
+        model = nn.utils.weight_norm(nn.Conv1d(1, 1, 3))
+        input = Variable(torch.randn(1, 1, 5), requires_grad=True)
+        self.run_model_test(
+            model, train=True, batch_size=0, input=input, use_gpu=False
+        )
+
     def test_mnist(self):
         model = MNIST()
         input = Variable(torch.randn(BATCH_SIZE, 1, 28, 28))

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -374,6 +374,10 @@ class TestOperators(TestCase):
         x = Variable(torch.randn(1, 2), requires_grad=True)
         self.assertONNX(lambda x: x.repeat(1, 2, 3, 4), x)
 
+    def test_norm(self):
+        x = Variable(torch.randn(1, 2, 3, 4), requires_grad=True)
+        self.assertONNX(lambda x: x.norm(dim=2), (x))
+
     def test_symbolic_override(self):
         """Lifted from fast-neural-style: custom implementation of instance norm
         to be mapped to ONNX operator"""

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -688,6 +688,16 @@ def exp(g, self):
     return g.op("Exp", self)
 
 
+def norm(g, self, p, dim, keepdim):
+    if p == 1:
+        f = _reduce_op_symbolic("ReduceL1")
+    elif p == 2:
+        f = _reduce_op_symbolic("ReduceL2")
+    else:
+        raise RuntimeError("ONNX export only p-norms with p of 1 or 2")
+    return f(g, self, dim=dim, keepdim=keepdim)
+
+
 def conv_tbc(g, input, weight, bias, pad):
     return g.op("ATen", input, weight, bias, operator_s="conv_tbc", pad_i=pad)
 


### PR DESCRIPTION
Onnx has ReduceL1 and ReduceL2 operators that would facilitate this, so allow pytorch to export those and allow caffe2 to run them.

I only implemented this on CPU so far.
