### PR TITLE
change stft to have consistent signature with librosa

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -188,21 +188,19 @@ Tensor irfft(const Tensor& self, const int64_t signal_ndim, const bool normalize
 }
 
 
-Tensor stft(const Tensor& self, const int64_t frame_length,
-                                const int64_t hop, const int64_t fft_size,
-                                const bool normalized, const bool onesided,
-                                const Tensor& window, const int64_t pad_end) {
+Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
+            const int64_t win_length, const Tensor& window,
+            const bool normalized, const bool onesided) {
   #define REPR(SS) \
-    SS << "stft(" << self.type() << self.sizes() << ", frame_length=" \
-       << frame_length << ", hop=" << hop << ", fft_size=" << fft_size \
-       << ", normalized=" << normalized << ", onesided=" << onesided << \
-       ", window="; \
+    SS << "stft(" << self.type() << self.sizes() << ", n_fft=" << n_fft \
+       << ", hop_length=" << hop_length << ", win_length=" << win_length \
+       << ", window="; \
     if (window.defined()) { \
       SS << window.type() << "{" << window.sizes() << "}"; \
     } else { \
       SS << "None"; \
     } \
-    SS << ", pad_end=" << pad_end << ")"
+    SS << ", normalized=" << normalized << ", onesided=" << onesided << ")"
 
   if (!at::isFloatingType(self.type().scalarType()) || self.dim() > 2 || self.dim() < 1) {
     std::ostringstream ss;
@@ -215,82 +213,51 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
   }
   int64_t batch = input.size(0);
   int64_t len = input.size(1);
-  if (pad_end < 0) {
+  if (n_fft <= 0 || n_fft > len) {
     std::ostringstream ss;
-    REPR(ss) << ": expected pad_end >= 0, but got pad_end=" << pad_end;
+    REPR(ss) << ": expected 0 < n_fft < " << len
+             << ", but got n_fft=" << win_length;
     throw std::runtime_error(ss.str());
   }
-  // pad zeros
-  if (pad_end != 0) {
-    Tensor padded_input = at::empty({batch, len + pad_end}, self.options());
-    padded_input.narrow(1, 0, len).copy_(input);
-    padded_input.narrow(1, len, pad_end).zero_();
-    len += pad_end;
-    input = padded_input;
-  }
-  if (frame_length <= 0 || frame_length > len) {
+  if (hop_length <= 0) {
     std::ostringstream ss;
-    REPR(ss) << ": expected 0 < frame_length < " << len
-             << ", but got frame_length=" << frame_length;
+    REPR(ss) << ": expected hop_length > 0, but got hop_length=" << hop_length;
     throw std::runtime_error(ss.str());
   }
-  if (hop <= 0) {
+  if (win_length <= 0 || win_length > n_fft) {
     std::ostringstream ss;
-    REPR(ss) << ": expected hop > 0, but got hop=" << hop;
+    REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
+             << win_length;
     throw std::runtime_error(ss.str());
   }
-  if (fft_size <= 0) {
-    std::ostringstream ss;
-    REPR(ss) << ": expected fft_size > 0, but got fft_size=" << fft_size;
-    throw std::runtime_error(ss.str());
-  }
-  if (window.defined() && (window.dim() != 1 || window.size(0) != frame_length)) {
+  if (window.defined() && (window.dim() != 1 || window.size(0) != win_length)) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D window tensor of size equal to "
-             << "frame_length=" << frame_length
+             << "win_length=" << win_length
              << ", but got window with size " << window.sizes();
     throw std::runtime_error(ss.str());
   }
   #undef REPR
-  // two cases:
-  //   1. frame_length == fft_size
-  //      use fft
-  //   2. frame_length != fft_size
-  //      use conv1d
-  Tensor out;
-  if (frame_length == fft_size) {
-    int64_t n_frames = 1 + (len - frame_length) / hop;
-    input = input.as_strided({batch, n_frames, frame_length}, {input.stride(0), hop * input.stride(1), input.stride(1)});
+  auto window_ = window;
+  if (win_length < n_fft) {
+    // pad center
+    window_ = at::zeros({n_fft}, self.options());
+    auto left = (n_fft - win_length) / 2;
     if (window.defined()) {
-      input = input.mul(window);
+      window_.narrow(0, left, win_length).copy_(window);
+    } else {
+      window_.narrow(0, left, win_length).fill_(1);
     }
-    out = input.rfft(1, normalized, onesided);
-  } else {
-    int64_t return_size = onesided ? infer_ft_real_to_complex_onesided_size(fft_size) : fft_size;
-    // build ft kernel
-    // k[omega, t] = cos (2 pi omega t / N) - j sin (2 pi omega t / N)
-    double N = static_cast<double>(fft_size);
-    auto freq_arange = at::arange(0, return_size, self.options()).mul_(M_PI * 2. / N);
-    auto time_arange = at::arange(0, frame_length, self.options());
-    auto arange_2d = at::ger(freq_arange, time_arange);
-    auto re_kernel = arange_2d.cos();
-    auto im_kernel = arange_2d.sin().neg_();
-    auto kernel = at::cat({re_kernel, im_kernel}, 0);
-    if (window.defined()) {
-      kernel.mul_(window.view({1, -1}));
-    }
-    if (normalized) {
-      double T = static_cast<double>(frame_length);
-      kernel.div_(std::sqrt(T));
-    }
-    // prepare for conv1d
-    input = input.view({batch, 1, len});
-    kernel = kernel.view({return_size * 2, 1, frame_length});
-    // conv is actually correlation, so we are good
-    auto conv_out = at::conv1d(input, kernel, {}, hop).squeeze_(-1);
-    // transpose to [batch x time x freq x (re/im)]
-    out = conv_out.view({batch, 2, return_size, -1}).transpose_(1, -1);
   }
+  int64_t n_frames = 1 + (len - n_fft) / hop_length;
+  input = input.as_strided(
+    {batch, n_frames, n_fft},
+    {input.stride(0), hop_length * input.stride(1), input.stride(1)}
+  );
+  if (window_.defined()) {
+    input = input.mul(window_);
+  }
+  auto out = input.rfft(1, normalized, onesided);
   if (self.dim() == 1) {
     return out.squeeze_(0);
   } else {

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -250,6 +250,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
     }
   }
   int64_t n_frames = 1 + (len - n_fft) / hop_length;
+  // time2col
   input = input.as_strided(
     {batch, n_frames, n_fft},
     {input.stride(0), hop_length * input.stride(1), input.stride(1)}
@@ -257,7 +258,8 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
   if (window_.defined()) {
     input = input.mul(window_);
   }
-  auto out = input.rfft(1, normalized, onesided);
+  // rfft and transpose to get (batch x fft_size x num_frames)
+  auto out = input.rfft(1, normalized, onesided).transpose_(1, 2);
   if (self.dim() == 1) {
     return out.squeeze_(0);
   } else {

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -205,7 +205,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
   if (!at::isFloatingType(self.type().scalarType()) || self.dim() > 2 || self.dim() < 1) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D or 2D tensor of floating types";
-    throw std::runtime_error(ss.str());
+    AT_ERROR(ss.str());
   }
   Tensor input = self;
   if (self.dim() == 1) {
@@ -217,7 +217,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < n_fft < " << len
              << ", but got n_fft=" << win_length;
-    throw std::runtime_error(ss.str());
+    AT_ERROR(ss.str());
   }
   if (hop_length <= 0) {
     std::ostringstream ss;
@@ -228,14 +228,13 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
     std::ostringstream ss;
     REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
              << win_length;
-    throw std::runtime_error(ss.str());
+    AT_ERROR(ss.str());
   }
   if (window.defined() && (window.dim() != 1 || window.size(0) != win_length)) {
     std::ostringstream ss;
-    REPR(ss) << ": expected a 1D window tensor of size equal to "
-             << "win_length=" << win_length
-             << ", but got window with size " << window.sizes();
-    throw std::runtime_error(ss.str());
+    REPR(ss) << ": expected a 1D window tensor of size equal to win_length="
+             << win_length << ", but got window with size " << window.sizes();
+    AT_ERROR(ss.str());
   }
   #undef REPR
   auto window_ = window;

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -215,8 +215,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
   int64_t len = input.size(1);
   if (n_fft <= 0 || n_fft > len) {
     std::ostringstream ss;
-    REPR(ss) << ": expected 0 < n_fft < " << len
-             << ", but got n_fft=" << win_length;
+    REPR(ss) << ": expected 0 < n_fft < " << len << ", but got n_fft=" << n_fft;
     AT_ERROR(ss.str());
   }
   if (hop_length <= 0) {
@@ -224,16 +223,16 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
     REPR(ss) << ": expected hop_length > 0, but got hop_length=" << hop_length;
     throw std::runtime_error(ss.str());
   }
-  if (win_length <= 0 || win_length > n_fft) {
-    std::ostringstream ss;
-    REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
-             << win_length;
-    AT_ERROR(ss.str());
-  }
   if (window.defined() && (window.dim() != 1 || window.size(0) != win_length)) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D window tensor of size equal to win_length="
              << win_length << ", but got window with size " << window.sizes();
+    AT_ERROR(ss.str());
+  }
+  if (win_length <= 0 || win_length > n_fft) {
+    std::ostringstream ss;
+    REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
+             << win_length;
     AT_ERROR(ss.str());
   }
   #undef REPR

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1250,9 +1250,10 @@
 - func: stack_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
 
-- func: stft(Tensor self, int64_t frame_length, int64_t hop, int64_t fft_size, bool normalized=false, bool onesided=true, Tensor? window={}, int64_t pad_end=0) -> Tensor
+- func: stft(Tensor self, int64_t n_fft, int64_t hop_length, int64_t win_length, Tensor? window={}, bool normalized=false, bool onesided=true) -> Tensor
   python_default_init:
-    fft_size: frame_length
+    hop_length: n_fft >> 2
+    win_length: n_fft
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
   device_guard: false

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1250,6 +1250,10 @@
 - func: stack_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
 
+# The signature is designed to be consistent with librosa except that it is
+# missing the `pad_mode` and `center` arguments, which are taken care of at
+# `torch.functional.py`. They shall be moved here once we have mapping between
+# Python strings and C++ Enum in codegen.
 - func: stft(Tensor self, int64_t n_fft, int64_t hop_length, int64_t win_length, Tensor? window={}, bool normalized=false, bool onesided=true) -> Tensor
   python_default_init:
     hop_length: n_fft >> 2

--- a/test/common.py
+++ b/test/common.py
@@ -68,6 +68,12 @@ try:
 except ImportError:
     TEST_SCIPY = False
 
+TEST_LIBROSA = True
+try:
+    import librosa
+except ImportError:
+    TEST_LIBROSA = False
+
 TEST_MKL = torch.backends.mkl.is_available()
 
 NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1'

--- a/test/common.py
+++ b/test/common.py
@@ -56,29 +56,45 @@ PY34 = sys.version_info >= (3, 4)
 IS_WINDOWS = sys.platform == "win32"
 IS_PPC = platform.machine() == "ppc64le"
 
-TEST_NUMPY = True
-try:
-    import numpy
-except ImportError:
-    TEST_NUMPY = False
 
-TEST_SCIPY = True
-try:
-    import scipy
-except ImportError:
-    TEST_SCIPY = False
+def _check_module_exists(name):
+    r"""Returns if a top-level module with :attr:`name` exists *without**
+    importing it. This is generally safer than try-catch block around a
+    `import X`. It avoids third party libraries breaking assumptions of some of
+    our tests, e.g., setting multiprocessing start method when imported
+    (see librosa/#747, torchvision/#544).
+    """
+    if not PY3:  # Python 2
+        import imp
+        try:
+            imp.find_module(name)
+            return True
+        except ImportError:
+            return False
+    elif PY34:  # Python [3, 3.4)
+        import importlib
+        loader = importlib.find_loader(name)
+        return loader is not None
+    else:  # Python >= 3.4
+        import importlib
+        spec = importlib.util.find_spec(name)
+        return spec is not None
 
-TEST_LIBROSA = True
-try:
-    import librosa
-except ImportError:
-    TEST_LIBROSA = False
-
+TEST_NUMPY = _check_module_exists('numpy')
+TEST_SCIPY = _check_module_exists('scipy')
 TEST_MKL = torch.backends.mkl.is_available()
+
+# On Py2, importing librosa 0.6.1 triggers a TypeError (if using newest joblib)
+# see librosa/librosa#729.
+# TODO: allow Py2 when librosa 0.6.2 releases
+TEST_LIBROSA = _check_module_exists('librosa') and PY3
 
 NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1'
 TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
+
+if TEST_NUMPY:
+    import numpy
 
 
 def skipIfNoLapack(fn):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1479,11 +1479,8 @@ class TestCuda(TestCase):
         os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())
 
     def _spawn_method(self, method, arg):
-        try:
-            mp.set_start_method('spawn')
-        except RuntimeError:
-            pass
-        with mp.Pool(1, initializer=self.mute) as pool:
+        ctx = mp.get_context("spawn")
+        with ctx.Pool(1, initializer=self.mute) as pool:
             errors = pool.map(method, [arg])
             for e in errors:
                 if 'device-side assert triggered' not in str(e):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -9,7 +9,7 @@ import time
 import traceback
 import unittest
 import subprocess
-from torch import multiprocessing
+from torch import multiprocessing as mp
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
@@ -24,12 +24,9 @@ TEST_CUDA = torch.cuda.is_available()
 # We need spawn start method for test_manager_unclean_exit, but
 # Python 2.7 doesn't allow it.
 if sys.version_info[0] == 3:
-    # Without the try-catch block, some tests will complain that
-    # context has already been set.
-    try:
-        multiprocessing.set_start_method('spawn')
-    except RuntimeError:
-        pass
+    # Get a multiprocessing context because some test / third party library will
+    # set start_method when imported, and setting again triggers RuntimeError.
+    mp = mp.get_context(method='spawn')
 
 
 JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 6.5
@@ -144,11 +141,11 @@ class TestConcatDataset(TestCase):
 
 # Stores the first encountered exception in .exception.
 # Inspired by https://stackoverflow.com/a/33599967
-class ErrorTrackingProcess(multiprocessing.Process):
+class ErrorTrackingProcess(mp.Process):
 
     def __init__(self, *args, **kwargs):
         super(ErrorTrackingProcess, self).__init__(*args, **kwargs)
-        self._pconn, self._cconn = multiprocessing.Pipe()
+        self._pconn, self._cconn = mp.Pipe()
         self._exception = None
 
     def run(self):
@@ -235,8 +232,8 @@ class SynchronizedSeedDataset(Dataset):
 
     def __init__(self, size, num_workers):
         assert size >= num_workers
-        self.count = multiprocessing.Value('i', 0, lock=True)
-        self.barrier = multiprocessing.Semaphore(0)
+        self.count = mp.Value('i', 0, lock=True)
+        self.barrier = mp.Semaphore(0)
         self.num_workers = num_workers
         self.size = size
 
@@ -532,12 +529,12 @@ class TestDataLoader(TestCase):
     def test_manager_unclean_exit(self):
         '''there might be ConnectionResetError or leaked semaphore warning (due to dirty process exit), \
 but they are all safe to ignore'''
-        worker_pids = multiprocessing.Array('i', [0] * 4)
+        worker_pids = mp.Array('i', [0] * 4)
 
-        manager_exit_event = multiprocessing.Event()
-        mp = multiprocessing.Process(target=TestDataLoader._manager_process,
-                                     args=(self.dataset, worker_pids, manager_exit_event))
-        mp.start()
+        manager_exit_event = mp.Event()
+        p = mp.Process(target=TestDataLoader._manager_process,
+                       args=(self.dataset, worker_pids, manager_exit_event))
+        p.start()
 
         manager_exit_event.wait()
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4510,35 +4510,29 @@ class TestTorch(TestCase):
             if expected_error is None:
                 result = x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end)
                 ref_result = naive_stft(x, frame_length, hop, fft_size, normalized, onesided, window, pad_end)
-                self.assertEqual(result.data, ref_result, 7e-6, 'stft result')
+                self.assertEqual(result, ref_result, 7e-6, 'stft result')
             else:
                 self.assertRaises(expected_error,
                                   lambda: x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end))
 
-        _test((2, 5), 4, 2, pad_end=1)
-        _test((4, 150), 90, 45, pad_end=0)
-        _test((10,), 7, 2, pad_end=0)
-        _test((10, 4000), 1024, 512, pad_end=0)
+        for normalized, onesided in product([True, False], repeat=2):
+            for pad_end in [0, 3]:
+                kwargs = dict(normalized=normalized, onesided=onesided, pad_end=pad_end)
 
-        _test((2, 5), 4, 2, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, **kwargs)
+                _test((4, 150), 90, 45, **kwargs)
+                _test((10,), 7, 2, **kwargs)
+                _test((10, 4000), 1024, 512, **kwargs)
 
-        _test((2, 5), 4, 2, fft_size=5, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, window_sizes=(4,), **kwargs)
+                _test((4, 150), 90, 45, window_sizes=(90,), **kwargs)
+                _test((10,), 7, 2, window_sizes=(7,), **kwargs)
+                _test((10, 4000), 1024, 512, window_sizes=(1024,), **kwargs)
 
-        _test((2, 5), 4, 2, fft_size=5, onesided=False, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, onesided=False, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, onesided=False, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, onesided=False, window_sizes=(1024,), pad_end=0)
-
-        _test((2, 5), 4, 2, fft_size=5, normalized=True, onesided=False, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, normalized=True, onesided=False, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, normalized=True, onesided=False, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, normalized=True, onesided=False, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, fft_size=5, window_sizes=(4,), **kwargs)
+                _test((4, 150), 90, 45, fft_size=100, window_sizes=(90,), **kwargs)
+                _test((10,), 7, 2, fft_size=33, window_sizes=(7,), **kwargs)
+                _test((10, 4000), 1024, 512, fft_size=1500, window_sizes=(1024,), **kwargs)
 
         _test((10, 4, 2), 1, 1, expected_error=RuntimeError)
         _test((10,), 11, 1, expected_error=RuntimeError)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4463,7 +4463,7 @@ class TestTorch(TestCase):
                 x = x.view(1, -1)
             result = []
             for xi in x:
-                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center).T
+                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center)
                 result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
             result = torch.stack(result, 0)
             if input_1d:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5517,7 +5517,7 @@ Arguments:
     normalized (bool, optional): controls whether to return normalized results.
         Default: ``False``
     onesided (bool, optional): controls whether to return half of results to
-        avoid redundancy Default: ``True``
+        avoid redundancy. Default: ``True``
 
 Returns:
     Tensor: A tensor containing the real-to-complex Fourier transform result

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3782,11 +3782,11 @@ Args:
     end (Number): the ending value for the set of points
     step (Number): the gap between each pair of adjacent points. Default: ``1``.
     {out}
-    {dtype}
-        If `dtype` is not given, infer the data type from the other input arguments.
-        If any of `start`, `end`, or `stop` are floating-point,
-        the `dtype` is inferred to be the default dtype, see :meth:`~torch.get_default_dtype`.
-        Otherwise, the `dtype` is inferred to be `torch.int64`.
+    {dtype} If `dtype` is not given, infer the data type from the other input
+        arguments. If any of `start`, `end`, or `stop` are floating-point, the
+        `dtype` is inferred to be the default dtype, see
+        :meth:`~torch.get_default_dtype`. Otherwise, the `dtype` is inferred to
+        be `torch.int64`.
     {layout}
     {device}
     {requires_grad}
@@ -5107,58 +5107,6 @@ Args:
     {device}
     {requires_grad}
 """.format(**factory_like_common_args))
-
-add_docstr(torch.stft,
-           r"""
-stft(signal, frame_length, hop, fft_size=None, normalized=False, onesided=True, window=None, pad_end=0) -> Tensor
-
-Short-time Fourier transform (STFT).
-
-Ignoring the batch dimension, this method computes the following expression:
-
-.. math::
-    X[m, \omega] = \sum_{k = 0}^{\text{frame_length}}%
-                        window[k]\ signal[m \times hop + k]\ e^{- j \frac{2 \pi \cdot \omega k}{\text{frame_length}}},
-
-where :math:`m` is the index of the sliding window, and :math:`\omega` is
-the frequency that :math:`0 \leq \omega <` :attr:`fft_size`. When
-:attr:`return_onsesided` is the default value ``True``, only values for
-:math:`\omega` in range :math:`\left[0, 1, 2, \dots, \left\lfloor \frac{\text{fft_size}}{2} \right\rfloor + 1\right]`
-are returned because the real-to-complex transform satisfies the Hermitian
-symmetry, i.e., :math:`X[m, \omega] = X[m, \text{fft_size} - \omega]^*`.
-
-The input :attr:`signal` must be 1-D sequence :math:`(T)` or 2-D a batch of
-sequences :math:`(N \times T)`. If :attr:`fft_size` is ``None``, it is
-default to same value as  :attr:`frame_length`. :attr:`window` can be a
-1-D tensor of size :attr:`frame_length`, e.g., see
-:meth:`torch.hann_window`. If :attr:`window` is the default value ``None``,
-it is treated as if having :math:`1` everywhere in the frame.
-:attr:`pad_end` indicates the amount of zero padding at the end of
-:attr:`signal` before STFT. If :attr:`normalized` is set to ``True``, the
-function returns the normalized STFT results, i.e., multiplied by
-:math:`(frame\_length)^{-0.5}`.
-
-Returns the real and the imaginary parts together as one tensor of size
-:math:`(* \times N \times 2)`, where :math:`*` is the shape of input :attr:`signal`,
-:math:`N` is the number of :math:`\omega` s considered depending on
-:attr:`fft_size` and :attr:`return_onesided`, and each pair in the last
-dimension represents a complex number as real part and imaginary part.
-
-Arguments:
-    signal (Tensor): the input tensor
-    frame_length (int): the size of window frame and STFT filter
-    hop (int): the distance between neighboring sliding window frames
-    fft_size (int, optional): size of Fourier transform. Default: ``None``
-    normalized (bool, optional): controls whether to return the normalized STFT results
-         Default: ``False``
-    onesided (bool, optional): controls whether to return half of results to
-        avoid redundancy Default: ``True``
-    window (Tensor, optional): the optional window function. Default: ``None``
-    pad_end (int, optional): implicit zero padding at the end of :attr:`signal`. Default: 0
-
-Returns:
-    Tensor: A tensor containing the STFT result
-""")
 
 add_docstr(torch.det,
            r"""

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -163,16 +163,17 @@ def stft(input, n_fft, hop_length=None, win_length=None, window='hann',
       :attr:`n_fft`. :attr:`win_length` must be less than or equal to
       :attr:`n_fft`.
 
-    * :attr:`window` can be a string, a 1-D window tensor, or ``None`` (default).
+    * :attr:`window` can be a string, a 1-D window tensor, or ``None``. Default
+      is ``"hann"``.
 
         * If :attr:`window` is a string, it is the name of the window function
           used and must be one of ``"bartlett"``, ``"blackman"``, ``"hamming"``,
-          and ``"hann"``. The window will be created with length
+          and ``"hann"``. (default) The window will be created with length
           :attr:`win_length`.
 
         * If :attr:`window` is a tensor, it must have length :attr:`win_length`.
 
-        * If :attr:`window` is ``None`` (default), no window is applied, i.e.,
+        * If :attr:`window` is ``None``, no window is applied in STFT, i.e.,
           it is equivalent with having :math:`1` everywhere in the window.
 
       If size of :attr:`window` is less than :attr:`n_fft`, :attr:`window`
@@ -214,7 +215,7 @@ def stft(input, n_fft, hop_length=None, win_length=None, window='hann',
         win_length (int): the size of window frame and STFT filter.
             Default: ``None``  (treated as equal to :attr:`n_fft`)
         window (string or Tensor, optional): the optional window function.
-            Default: ``None`` (treated as window of all :math:`1`s)
+            Default: ``"hann"``
         center (bool, optional): whether to pad :attr:`input` on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop_length}`.
             Default: ``True``

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -3,6 +3,7 @@ import torch.nn.functional as F
 from operator import mul
 from functools import reduce
 import math
+from ._six import string_classes as _string_classes
 
 __all__ = [
     'argmax',
@@ -137,7 +138,7 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
     return P, L, U
 
 
-def stft(input, n_fft, hop_length=None, win_length=None, window=None,
+def stft(input, n_fft, hop_length=None, win_length=None, window='hann',
          center=True, pad_mode='reflect', normalized=False, onesided=True):
     r"""Short-time Fourier transform (STFT).
 
@@ -149,9 +150,8 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
                             window[k]\ input[m \times hop_length + k]\ %
                             e^{- j \frac{2 \pi \cdot \omega k}{\text{win_length}}},
 
-    where :math:`m` is the index of the sliding window, and :math:`\omega` is
-    the frequency that :math:`0 \leq \omega < \text{n_fft}`. When
-    :attr:`onesided` is the default value ``True``,
+    where :math:`m` is the index of the sliding window, and :math:`\omega` is a
+    frequency satisfying :math:`0 \leq \omega < \text{n_fft}`.
 
     * :attr:`input` must be either a 1-D time sequenceor 2-D a batch of time
       sequences.
@@ -160,13 +160,23 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
       ``floor(n_fft / 4)``.
 
     * If :attr:`win_length` is ``None`` (default), it is treated as equal to
+      :attr:`n_fft`. :attr:`win_length` must be less than or equal to
       :attr:`n_fft`.
 
-    * :attr:`window` can be a 1-D tensor of size :attr:`win_length`, e.g., from
-      :meth:`torch.hann_window`. If :attr:`window` is ``None`` (default), it is
-      treated as if having :math:`1` everywhere in the window. If
-      :math:`\text{win_length} < \text{n_fft}`, :attr:`window` will be padded on
-      both sides to length :attr:`n_fft` before being applied.
+    * :attr:`window` can be a string, a 1-D window tensor, or ``None`` (default).
+
+        * If :attr:`window` is a string, it is the name of the window function
+          used and must be one of ``"bartlett"``, ``"blackman"``, ``"hamming"``,
+          and ``"hann"``. The window will be created with length
+          :attr:`win_length`.
+
+        * If :attr:`window` is a tensor, it must have length :attr:`win_length`.
+
+        * If :attr:`window` is ``None`` (default), no window is applied, i.e.,
+          it is equivalent with having :math:`1` everywhere in the window.
+
+      If size of :attr:`window` is less than :attr:`n_fft`, :attr:`window`
+      will be padded on both sides to length :attr:`n_fft` before being applied.
 
     * If :attr:`center` is ``True`` (default), :attr:`input` will be padded on
       both sides so that the :math:`t`-th frame is centered at time
@@ -203,7 +213,7 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
             frames. Default: ``None`` (treated as equal to ``floor(n_fft / 4)``)
         win_length (int): the size of window frame and STFT filter.
             Default: ``None``  (treated as equal to :attr:`n_fft`)
-        window (Tensor, optional): the optional window function.
+        window (string or Tensor, optional): the optional window function.
             Default: ``None`` (treated as window of all :math:`1`s)
         center (bool, optional): whether to pad :attr:`input` on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop_length}`.
@@ -221,6 +231,24 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
     """
     # TODO: after having proper ways to map Python strings to ATen Enum, move
     #       this and F.pad to ATen.
+    if win_length is None:
+        win_length = n_fft
+    if isinstance(window, _string_classes):
+        if window == 'bartlett':
+            window = torch.bartlett_window(win_length, device=input.device, dtype=input.dtype)
+        elif window == 'blackman':
+            window = torch.blackman_window(win_length, device=input.device, dtype=input.dtype)
+        elif window == 'hamming':
+            window = torch.hamming_window(win_length, device=input.device, dtype=input.dtype)
+        elif window == 'hann':
+            window = torch.hann_window(win_length, device=input.device, dtype=input.dtype)
+        else:
+            raise RuntimeError(
+                "stft: unsupported window type {}".format(repr(window)))
+    elif not isinstance(window, torch.Tensor):
+        raise RuntimeError(
+            "stft: expects window to be one of allowed strings or a tensor, "
+            "but got window={}".format(window))
     if center:
         signal_dim = input.dim()
         extended_shape = [1] * (3 - signal_dim) + list(input.size())

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -260,7 +260,7 @@ class Tensor(torch._C._TensorBase):
         else:
             return super(Tensor, self).btrifact(pivot=pivot)
 
-    def stft(self, n_fft, hop_length=None, win_length=None, window=None,
+    def stft(self, n_fft, hop_length=None, win_length=None, window='hann',
              center=True, pad_mode='reflect', normalized=False, onesided=True):
         r"""See :func:`torch.stft`
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -260,6 +260,13 @@ class Tensor(torch._C._TensorBase):
         else:
             return super(Tensor, self).btrifact(pivot=pivot)
 
+    def stft(self, n_fft, hop_length=None, win_length=None, window=None,
+             center=True, pad_mode='reflect', normalized=False, onesided=True):
+        r"""See :func:`torch.stft`
+        """
+        return torch.stft(self, n_fft, hop_length, win_length, window, center,
+                          pad_mode, normalized, onesided)
+
     def resize(self, *sizes):
         warnings.warn("non-inplace resize is deprecated")
         from torch.autograd._functions import Resize

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -263,6 +263,10 @@ class Tensor(torch._C._TensorBase):
     def stft(self, n_fft, hop_length=None, win_length=None, window=None,
              center=True, pad_mode='reflect', normalized=False, onesided=True):
         r"""See :func:`torch.stft`
+
+        .. warning::
+          This function changed signature at version 0.4.1. Calling with
+          the previous signature may cause error or return incorrect result.
         """
         return torch.stft(self, n_fft, hop_length, win_length, window, center,
                           pad_mode, normalized, onesided)


### PR DESCRIPTION
Fixes #7883 by using `rfft`.

It's worth noting that this is BC breaking. And it's impossible to detect the change because the two signatures before and after this change supports a common subset of calling patterns, e.g., `stft(Tensor, int, int)`. (some other calling patterns will raise error). 

@soumith and I plan to change the current `stft` interface because it is a bit messy and non-standard. @rafaelvalle suggested us that `librosa` is a good reference API to align with. After discussing with @soumith and @ezyang , and given that `stft` is only out for 1 release, I decide to go with directly changing the signature. Also, my understanding is that most researchers in this field will welcome this change as `librosa` seems to be the golden-standard here. (it doesn't yet support all `pad_mode` but those will become available if added to `F.pad`.)