### PR TITLE
Privatize values for vec256

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -23,8 +23,10 @@ namespace {
 // emulates vectorized types
 template <class T>
 struct Vec256 {
-  static constexpr int size = 32 / sizeof(T);
+private:
   T values[32 / sizeof(T)] = {0};
+public:
+  static constexpr int size = 32 / sizeof(T);
   Vec256() {}
   Vec256(T val) {
     for (int i = 0; i != size; i++) {
@@ -37,9 +39,9 @@ struct Vec256 {
     Vec256 vec;
     for (int64_t i = 0; i < size; i++) {
       if (mask & 0x01) {
-        vec.values[i] = b[i];
+        vec[i] = b[i];
       } else {
-        vec.values[i] = a[i];
+        vec[i] = a[i];
       }
       mask = mask >> 1;
     }
@@ -49,9 +51,9 @@ struct Vec256 {
     Vec256 vec;
     for (int64_t i = 0; i < size; i++) {
       if (i < count) {
-        vec.values[i] = b.values[i];
+        vec[i] = b[i];
       } else {
-        vec.values[i] = a.values[i];
+        vec[i] = a[i];
       }
     }
     return vec;
@@ -69,17 +71,23 @@ struct Vec256 {
   void store(void* ptr, int count = size) const {
     std::memcpy(ptr, values, count * sizeof(T));
   }
+  const T& operator[](int idx) const {
+    return values[idx];
+  }
+  T& operator[](int idx) {
+    return values[idx];
+  }
   Vec256<T> map(T (*f)(T)) const {
     Vec256<T> ret;
     for (int64_t i = 0; i != size; i++) {
-      ret.values[i] = f(values[i]);
+      ret[i] = f(values[i]);
     }
     return ret;
   }
   Vec256<T> abs() const {
     Vec256<T> ret;
     for (int64_t i = 0; i < size; i++) {
-      ret.values[i] = values[i] < 0 ? -values[i] : values[i];
+      ret[i] = values[i] < 0 ? -values[i] : values[i];
     }
     return ret;
   }
@@ -160,7 +168,7 @@ struct Vec256 {
 template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] + b.values[i];
+    c[i] = a[i] + b[i];
   }
   return c;
 }
@@ -168,7 +176,7 @@ template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] - b.values[i];
+    c[i] = a[i] - b[i];
   }
   return c;
 }
@@ -176,7 +184,7 @@ template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] * b.values[i];
+    c[i] = a[i] * b[i];
   }
   return c;
 }
@@ -184,7 +192,7 @@ template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) __ubsan_ignore_float_divide_by_zero__ {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] / b.values[i];
+    c[i] = a[i] / b[i];
   }
   return c;
 }
@@ -192,7 +200,7 @@ template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) _
 template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = std::max(a.values[i], b.values[i]);
+    c[i] = std::max(a[i], b[i]);
   }
   return c;
 }

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -13,9 +13,10 @@ namespace {
 #if defined(__AVX__) && !defined(_MSC_VER)
 
 template <> class Vec256<double> {
+private:
+  __m256d values;
 public:
   static constexpr int size = 4;
-  __m256d values;
   Vec256() {}
   Vec256(__m256d v) : values(v) {}
   Vec256(double val) {
@@ -61,6 +62,8 @@ public:
       std::memcpy(ptr, tmp_values, count * sizeof(double));
     }
   }
+  const double& operator[](int idx) const  = delete;
+  double& operator[](int idx) = delete;
   Vec256<double> map(double (*f)(double)) const {
     __at_align32__ double tmp[4];
     store(tmp);

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -13,9 +13,10 @@ namespace {
 #if defined(__AVX__) && !defined(_MSC_VER)
 
 template <> class Vec256<float> {
+private:
+  __m256 values;
 public:
   static constexpr int64_t size = 8;
-  __m256 values;
   Vec256() {}
   Vec256(__m256 v) : values(v) {}
   Vec256(float val) {
@@ -66,6 +67,8 @@ public:
       std::memcpy(ptr, tmp_values, count * sizeof(float));
     }
   }
+  const float& operator[](int idx) const  = delete;
+  float& operator[](int idx) = delete;
   Vec256<float> map(float (*f)(float)) const {
     __at_align32__ float tmp[8];
     store(tmp);

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -10,7 +10,9 @@ namespace {
 #ifdef __AVX2__
 
 struct Vec256i {
+protected:
   __m256i values;
+public:
   Vec256i() {}
   Vec256i(__m256i v) : values(v) {}
   operator __m256i() const {
@@ -69,6 +71,8 @@ struct Vec256<int64_t> : public Vec256i {
       std::memcpy(ptr, tmp_values, count * sizeof(int64_t));
     }
   }
+  const int64_t& operator[](int idx) const  = delete;
+  int64_t& operator[](int idx)  = delete;
   Vec256<int64_t> abs() const {
     auto zero = _mm256_set1_epi64x(0);
     auto is_larger = _mm256_cmpgt_epi64(zero, values);
@@ -126,6 +130,8 @@ struct Vec256<int32_t> : public Vec256i {
       std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
     }
   }
+  const int32_t& operator[](int idx) const  = delete;
+  int32_t& operator[](int idx)  = delete;
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
   }
@@ -230,6 +236,8 @@ struct Vec256<int16_t> : public Vec256i {
       std::memcpy(ptr, tmp_values, count * sizeof(int16_t));
     }
   }
+  const int16_t& operator[](int idx) const  = delete;
+  int16_t& operator[](int idx)  = delete;
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
   }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -30,8 +30,8 @@ int64_t _sigmoid(float* x, float* y, int64_t size) {
     ret = ret.neg();
     ret2 = ret2.neg();
 #if defined(__AVX2__) && !defined(_MSC_VER)
-    ret.values = exp256_ps(ret.values);
-    ret2.values = exp256_ps(ret2.values);
+    ret = exp256_ps(ret);
+    ret2 = exp256_ps(ret2);
 #else
     ret = ret.exp();
     ret2 = ret2.exp();


### PR DESCRIPTION
Helps prevent calling functions of the base case on float/double/int subclasses that aren't supported.