### PR TITLE
Strings lexing, parsing, implementation in print 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -760,6 +760,7 @@ main_sources = [
     "torch/csrc/finalizer.cpp",
     "torch/csrc/jit/batched/BatchTensor.cpp",
     "torch/csrc/jit/init.cpp",
+    "torch/csrc/jit/ivalue.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp",
     "torch/csrc/jit/passes/onnx/peephole.cpp",

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,6 +1,7 @@
 graph(%a : Dynamic) {
-  %1 : string = prim::StringLiteral[string=a\n\tb\n]()
+  %1 : string = prim::Constant[string=a\n\tb\n]()
   %2 : int = prim::Constant[value=2]()
-   = prim::Print(%a, %1, %2)
+  %3 : string = prim::Constant[string=aa]()
+   = prim::Print(%a, %1, %2, %3)
   return (%a);
 }

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,4 +1,8 @@
 graph(%a : Dynamic) {
-   = prim::Print[string_indices=[1], strings=[abc]](%a)
+  %1 : string = prim::StringLiteral[string=a
+	b
+]()
+  %2 : int = prim::Constant[value={2}]()
+   = prim::Print[string=tst](%a, %1, %2)
   return (%a);
 }

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,8 +1,6 @@
 graph(%a : Dynamic) {
-  %1 : string = prim::StringLiteral[string=a
-	b
-]()
-  %2 : int = prim::Constant[value={2}]()
-   = prim::Print[string=tst](%a, %1, %2)
+  %1 : string = prim::StringLiteral[string=a\n\tb\n]()
+  %2 : int = prim::Constant[value=2]()
+   = prim::Print(%a, %1, %2)
   return (%a);
 }

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,0 +1,4 @@
+graph(%a : Dynamic) {
+   = prim::Print[string_indices=[1], strings=[abc]](%a)
+  return (%a);
+}

--- a/test/expect/TestScript.test_string_print-stdout.expect
+++ b/test/expect/TestScript.test_string_print-stdout.expect
@@ -1,3 +1,2 @@
 1
-[ Variable[CPULongType]{} ] abcd a    bcd 1
-[ Variable[CPULongType]{} ]
+[ Variable[CPULongType]{} ] abcd 2 1.5

--- a/test/expect/TestScript.test_string_print-stdout.expect
+++ b/test/expect/TestScript.test_string_print-stdout.expect
@@ -1,2 +1,3 @@
 1
-[ Variable[CPULongType]{} ] abcd a    bcd
+[ Variable[CPULongType]{} ] abcd a    bcd 1
+[ Variable[CPULongType]{} ]

--- a/test/expect/TestScript.test_string_print-stdout.expect
+++ b/test/expect/TestScript.test_string_print-stdout.expect
@@ -1,0 +1,2 @@
+1
+[ Variable[CPULongType]{} ] abcd a    bcd

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1438,6 +1438,16 @@ class TestScript(JitTestCase):
         a = Variable(torch.rand(1))
         self.assertEqual(a, cu.foo(a))
 
+    def test_string_cu(self):
+        cu = torch.jit.CompilationUnit('''
+            def foo(a):
+                print(a, "a" "b" \
+                'c')
+                return a
+        ''')
+        a = Variable(torch.rand(1))
+        self.assertExpected(str(cu.foo.graph))
+
     def test_script_annotation(self):
         @torch.jit.script
         def foo(a):
@@ -1725,6 +1735,15 @@ class TestScript(JitTestCase):
 
     def _make_scalar_vars(self, arr, dtype):
         return [torch.tensor(val, dtype=dtype) for val in arr]
+
+    def test_string_print(self):
+        def func(a):
+            print(a, "a" 'b' '''c''' """d""", "a\
+            b" "c"  # ignored
+                    "d")
+            return a
+        inputs = self._make_scalar_vars([1], torch.int64)
+        self.checkScript(func, inputs, capture_output=True)
 
     def test_while(self):
         def func(a, b, max):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1758,6 +1758,7 @@ a")
         def func(a):
             print(a, "a" 'b' '''c''' """d""", 2, 1.5)
             return a
+
         inputs = self._make_scalar_vars([1], torch.int64)
         self.checkScript(func, inputs, capture_output=True)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1443,7 +1443,8 @@ class TestScript(JitTestCase):
     def test_string_cu(self):
         cu = torch.jit.CompilationUnit('''
             def foo(a):
-                print(a, """a\\n\tb\\n""", 2)
+                print(a, """a\\n\tb\\n""", 2, "a\
+a")
                 return a
         ''')
         self.assertExpected(str(cu.foo.graph))
@@ -1755,13 +1756,10 @@ class TestScript(JitTestCase):
 
     def test_string_print(self):
         def func(a):
-            print(a, "a" 'b' '''c''' """d""", "a\
-            b" "c"  # ignored
-                    "d", a)
+            print(a, "a" 'b' '''c''' """d""", 2, 1.5)
             return a
         inputs = self._make_scalar_vars([1], torch.int64)
-        func(inputs)
-        # self.checkScript(func, inputs, capture_output=True)
+        self.checkScript(func, inputs, capture_output=True)
 
     def test_while(self):
         def func(a, b, max):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1760,7 +1760,8 @@ class TestScript(JitTestCase):
                     "d", a)
             return a
         inputs = self._make_scalar_vars([1], torch.int64)
-        self.checkScript(func, inputs, capture_output=True)
+        func(inputs)
+        # self.checkScript(func, inputs, capture_output=True)
 
     def test_while(self):
         def func(a, b, max):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1438,15 +1438,32 @@ class TestScript(JitTestCase):
         a = Variable(torch.rand(1))
         self.assertEqual(a, cu.foo(a))
 
+    # because the compilation unit ingests python strings
+    # to use an escape sequence escape the backslash (\\n = \n)
     def test_string_cu(self):
         cu = torch.jit.CompilationUnit('''
             def foo(a):
-                print(a, "a" "b" \
-                'c')
+                print(a, """a\\n\tb\\n""", 2)
                 return a
         ''')
-        a = Variable(torch.rand(1))
         self.assertExpected(str(cu.foo.graph))
+
+    def test_string_new_line(self):
+        with self.assertRaisesRegex(RuntimeError, "expected a valid token*"):
+            torch.jit.CompilationUnit('''
+            def test_while(a):
+                print("
+                    a")
+                return a
+            ''')
+
+    def test_string_single_escape(self):
+        with self.assertRaisesRegex(RuntimeError, "expected a valid token*"):
+            torch.jit.CompilationUnit('''
+            def test_while(a):
+                print("\\")
+                return a
+            ''')
 
     def test_script_annotation(self):
         @torch.jit.script
@@ -1740,7 +1757,7 @@ class TestScript(JitTestCase):
         def func(a):
             print(a, "a" 'b' '''c''' """d""", "a\
             b" "c"  # ignored
-                    "d")
+                    "d", a)
             return a
         inputs = self._make_scalar_vars([1], torch.int64)
         self.checkScript(func, inputs, capture_output=True)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -134,6 +134,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/interpreter.cpp
   ${TORCH_SRC_DIR}/csrc/jit/constants.cpp
   ${TORCH_SRC_DIR}/csrc/jit/ir.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/ivalue.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -29,6 +29,9 @@ Value* insertConstant(
       return autograd::Variable(t).data();
     }));
     n->output()->setType(ListType::ofTensors());
+  } else if(val.isString()) {
+    n->s_(attr::string, val.toString()->string());
+    n->output()->setType(StringType::get());
   } else {
     throw std::runtime_error("Unsupported value kind: " + val.tagKind());
   }
@@ -77,6 +80,12 @@ RegisterOperators reg({
           });
           return [ts](Stack& stack) {
             push(stack, ts);
+            return 0;
+          };
+        } else if (type == StringType::get()) {
+          auto s = node->s(attr::string);
+          return [s](Stack& stack) {
+            push(stack, s);
             return 0;
           };
         } else {

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -90,7 +90,9 @@ _(attr, sizes) \
 _(attr, starts) \
 _(attr, transA) \
 _(attr, transB) \
-_(attr, name)
+_(attr, name) \
+_(attr, string)
+
 
 // 'prim' symbols are synthetic operators that occur only in the IR
 // and don't have corresponding implementations in ATen.

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -83,14 +83,13 @@ void printPrimList(std::ostream & out, const std::vector<T> & items) {
   out << "]";
 }
 
-std::string formatWhitespace(std::string s) {
+std::string escapeString(std::string s) {
   std::vector<char> search = {'\n', '\t', '\v'};
   std::vector<std::string> replace = {"\\n", "\\t", "\\v"};
   for (size_t i = 0; i < search.size(); i++) {
     size_t pos = s.find(search[i]);
     while(pos != std::string::npos) {
-      s.erase(pos, 1);
-      s.insert(pos, replace[i]);
+      s.replace(pos, 1, replace[i]);
       pos = s.find(search[i], pos + 1);
     }
   }
@@ -125,7 +124,7 @@ void printAttributes(std::ostream & out, const Node * n, bool ignore_subgraph=fa
         printPrimList(out,n->is(name));
         break;
       case AttributeKind::s:
-        out << formatWhitespace(n->s(name));
+        out << escapeString(n->s(name));
         break;
       case AttributeKind::ss:
         printPrimList(out,n->ss(name));

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -82,6 +82,21 @@ void printPrimList(std::ostream & out, const std::vector<T> & items) {
   }
   out << "]";
 }
+
+std::string formatWhitespace(std::string s) {
+  std::vector<char> search = {'\n', '\t', '\v'};
+  std::vector<std::string> replace = {"\\n", "\\t", "\\v"};
+  for (size_t i = 0; i < search.size(); i++) {
+    size_t pos = s.find(search[i]);
+    while(pos != std::string::npos) {
+      s.erase(pos, 1);
+      s.insert(pos, replace[i]);
+      pos = s.find(search[i], pos + 1);
+    }
+  }
+  return s;
+}
+
 void printAttributes(std::ostream & out, const Node * n, bool ignore_subgraph=false) {
   out << "[";
   auto names = n->attributeNames();
@@ -110,7 +125,7 @@ void printAttributes(std::ostream & out, const Node * n, bool ignore_subgraph=fa
         printPrimList(out,n->is(name));
         break;
       case AttributeKind::s:
-        out << n->s(name);
+        out << formatWhitespace(n->s(name));
         break;
       case AttributeKind::ss:
         printPrimList(out,n->ss(name));

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -985,12 +985,6 @@ public:
   Node * createUndefined() {
     return create(prim::Undefined);
   }
-  Node * createString(const std::string& str) {
-    auto n = create(prim::StringLiteral);
-    n->s_(attr::string, std::move(str));
-    n->output()->setType(StringType::get());
-    return n;
-  }
   Node * createFusionGroup(int device) {
     auto n = create(prim::FusionGroup, 0);
     n->g_(attr::Subgraph,std::make_shared<Graph>(scope_root_));

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -985,7 +985,12 @@ public:
   Node * createUndefined() {
     return create(prim::Undefined);
   }
-
+  Node * createString(const std::string& str) {
+    auto n = create(prim::StringLiteral);
+    n->s_(attr::string, std::move(str));
+    n->output()->setType(StringType::get());
+    return n;
+  }
   Node * createFusionGroup(int device) {
     auto n = create(prim::FusionGroup, 0);
     n->g_(attr::Subgraph,std::make_shared<Graph>(scope_root_));

--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -8,7 +8,7 @@
 namespace torch { namespace jit {
 std::ostream& operator<<(std::ostream & out, const IValue & v) {
   switch(v.tag) {
-    #define DEFINE_CASE(x) case v.Tag::x: return v.format ## x(out);
+    #define DEFINE_CASE(x) case IValue::Tag::x: return v.format ## x(out);
     TORCH_FORALL_TAGS(DEFINE_CASE)
     #undef DEFINE_CASE
   }

--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String)
+  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
 
 namespace torch { namespace jit {
 std::ostream& operator<<(std::ostream & out, const IValue & v) {

--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -1,0 +1,20 @@
+#include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/ivalue.h"
+#include <ATen/ATen.h>
+
+#define TORCH_FORALL_TAGS(_) \
+  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String)
+
+namespace torch { namespace jit {
+std::ostream& operator<<(std::ostream & out, const IValue & v) {
+  switch(v.tag) {
+    #define DEFINE_CASE(x) case v.Tag::x: return v.format ## x(out);
+    TORCH_FORALL_TAGS(DEFINE_CASE)
+    #undef DEFINE_CASE
+  }
+  AT_ERROR("Tag not found\n");
+}
+
+#undef TORCH_FORALL_TAGS
+
+}}

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -254,7 +254,6 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
       }
       return;
     }
-    case prim::StringLiteral:
     case prim::PythonOp:
     case prim::Print:
     case prim::Undefined: {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -254,6 +254,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
       }
       return;
     }
+    case prim::StringLiteral:
     case prim::PythonOp:
     case prim::Print:
     case prim::Undefined: {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -20,9 +20,10 @@ inline Stack createStack(const py::tuple& tuple, at::ArrayRef<Value*> inputs, si
         return py::cast<int64_t>(obj);
       case TypeKind::NoneType:
         return {};
+      case TypeKind::StringType:
       case TypeKind::ListType:
       case TypeKind::TupleType:
-        throw std::runtime_error("Lists and tuples are not supported yet");
+        throw std::runtime_error("Lists tuples and strings are not supported yet");
       case TypeKind::NumberType:
         throw std::runtime_error("Insufficient type information to convert input");
     }
@@ -52,9 +53,10 @@ inline py::object wrapStack(Stack&& outputs, at::ArrayRef<Value*> output_vals) {
         return py::cast(ivalue.toInt());
       case TypeKind::NoneType:
         return py::none();
+      case TypeKind::StringType:
       case TypeKind::ListType:
       case TypeKind::TupleType:
-        throw std::runtime_error("Lists and tuples are not supported yet");
+        throw std::runtime_error("Lists tuples and strings are not supported yet");
       case TypeKind::NumberType:
         throw std::runtime_error("Insufficient type information to convert input");
     }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -96,19 +96,11 @@ RegisterOperators reg({
           size_t num_inputs = node->inputs().size();
           return [num_inputs](Stack& stack) {
             bool first = true;
-            for (const IValue& i_ : last(stack, num_inputs)) {
-              auto i = i_.toTensor();
+            for (const IValue& i : last(stack, num_inputs)) {
               if (!first)
                 std::cout << " ";
               first = false;
-              if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
-                std::cout << at::Tensor(tensor_impl, true);
-              } else if (!i.defined()) {
-                std::cout << "<undefined tensor>";
-              } else {
-                auto& r = *i.get();
-                std::cout << "<" << typeid(r).name() << " at " << i << ">";
-              }
+              std::cout << i;
             }
             drop(stack, num_inputs);
             std::cout << std::endl;
@@ -118,8 +110,9 @@ RegisterOperators reg({
     Operator(
         prim::StringLiteral,
         [](Node* node) {
-          return [](Stack& stack) {
-            stack.push_back(at::Tensor());
+          std::string s = node->s(attr::string);
+          return [s](Stack& stack) {
+            stack.push_back(IValue(s));
             return 0;
           };
         }),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -91,38 +91,30 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::None,
-        [](Node* node) {
-          return [](Stack& stack) {
-            stack.push_back(IValue());
-            return 0;
-          };
-        }),
-    Operator(
-        prim::Print,
-        [](Node* node) {
-          size_t num_inputs = node->inputs().size();
-          return [num_inputs](Stack& stack) {
-            bool first = true;
-            for (const IValue& i_ : last(stack, num_inputs)) {
-              auto i = i_.toTensor();
-              if (!first)
-                std::cout << " ";
-              first = false;
-              if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
-                std::cout << at::Tensor(tensor_impl, true);
-              } else if (!i.defined()) {
-                std::cout << "<undefined tensor>";
-              } else {
-                auto& r = *i.get();
-                std::cout << "<" << typeid(r).name() << " at " << i << ">";
-              }
+      prim::Print,
+      [](Node* node) {
+        size_t num_inputs = node->inputs().size();
+        return [num_inputs](Stack& stack) {
+          bool first = true;
+          for (const IValue& i_ : last(stack, num_inputs)) {
+            auto i = i_.toTensor();
+            if (!first)
+              std::cout << " ";
+            first = false;
+            if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
+              std::cout << at::Tensor(tensor_impl, true);
+            } else if (!i.defined()) {
+              std::cout << "<undefined tensor>";
+            } else {
+              auto& r = *i.get();
+              std::cout << "<" << typeid(r).name() << " at " << i << ">";
             }
-            drop(stack, num_inputs);
-            std::cout << std::endl;
-            return 0;
-          };
-        }),
+          }
+          drop(stack, num_inputs);
+          std::cout << std::endl;
+          return 0;
+        };
+      }),
     // Load x, y
     // loads values from registers onto the stack, the actual callback does
     // nothing since the stack manipulation is already encoded in inst.inputs

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -107,15 +107,6 @@ RegisterOperators reg({
             return 0;
           };
         }),
-    Operator(
-        prim::StringLiteral,
-        [](Node* node) {
-          std::string s = node->s(attr::string);
-          return [s](Stack& stack) {
-            stack.push_back(IValue(s));
-            return 0;
-          };
-        }),
     // Load x, y
     // loads values from registers onto the stack, the actual callback does
     // nothing since the stack manipulation is already encoded in inst.inputs

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -91,30 +91,38 @@ RegisterOperators reg({
           };
         }),
     Operator(
-      prim::Print,
-      [](Node* node) {
-        size_t num_inputs = node->inputs().size();
-        return [num_inputs](Stack& stack) {
-          bool first = true;
-          for (const IValue& i_ : last(stack, num_inputs)) {
-            auto i = i_.toTensor();
-            if (!first)
-              std::cout << " ";
-            first = false;
-            if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
-              std::cout << at::Tensor(tensor_impl, true);
-            } else if (!i.defined()) {
-              std::cout << "<undefined tensor>";
-            } else {
-              auto& r = *i.get();
-              std::cout << "<" << typeid(r).name() << " at " << i << ">";
+        prim::Print,
+        [](Node* node) {
+          size_t num_inputs = node->inputs().size();
+          return [num_inputs](Stack& stack) {
+            bool first = true;
+            for (const IValue& i_ : last(stack, num_inputs)) {
+              auto i = i_.toTensor();
+              if (!first)
+                std::cout << " ";
+              first = false;
+              if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
+                std::cout << at::Tensor(tensor_impl, true);
+              } else if (!i.defined()) {
+                std::cout << "<undefined tensor>";
+              } else {
+                auto& r = *i.get();
+                std::cout << "<" << typeid(r).name() << " at " << i << ">";
+              }
             }
-          }
-          drop(stack, num_inputs);
-          std::cout << std::endl;
-          return 0;
-        };
-      }),
+            drop(stack, num_inputs);
+            std::cout << std::endl;
+            return 0;
+          };
+        }),
+    Operator(
+        prim::StringLiteral,
+        [](Node* node) {
+          return [](Stack& stack) {
+            stack.push_back(at::Tensor());
+            return 0;
+          };
+        }),
     // Load x, y
     // loads values from registers onto the stack, the actual callback does
     // nothing since the stack manipulation is already encoded in inst.inputs

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -350,10 +350,6 @@ Value* createNumber(Graph& g, const SourceRange& loc, const at::Tensor& val) {
   return output;
 }
 
-Value* createStringLiteral(Graph& g, const SourceRange& loc, const std::string& str) {
-  return insertConstant(g, str, loc);
-}
-
 Value* createStack(Graph& g, const SourceRange& loc, at::ArrayRef<Value*> inputs) {
   // bake in constant propagation for the all-constant case because it is
   // common to see constant lists like [1, 2] passed to attributes
@@ -1413,7 +1409,7 @@ private:
   }
 
   Value* emitStringLiteral(const StringLiteral& c) {
-    return createStringLiteral(*graph, c.range(), c.text());
+    return insertConstant(*graph, c.text(), c.range());
   }
 
   // Desugars slice syntactic sugar tensor[begin:end] -> tensor.slice(begin,

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -351,9 +351,7 @@ Value* createNumber(Graph& g, const SourceRange& loc, const at::Tensor& val) {
 }
 
 Value* createStringLiteral(Graph& g, const SourceRange& loc, const std::string& str) {
-  auto n = g.createString(str);
-  n->setSourceLocation(std::make_shared<SourceRange>(loc));
-  return g.insertNode(n)->output();
+  return insertConstant(g, str, loc);
 }
 
 Value* createStack(Graph& g, const SourceRange& loc, at::ArrayRef<Value*> inputs) {

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -216,7 +216,10 @@ struct SharedParserData {
       }
       end++;
     }
+    //set length equal to the complete string including quotations
     *len = end - start + quote_len;
+    //if end finished without going past the last character of the string than
+    //there is a match
     return end < str.size();
   }
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -195,19 +195,22 @@ struct SharedParserData {
 
   // python conconcatenates all adjacent strings "a" "b" == "ab"
   // strings can be enclosed with 1 or 3 single or double quotes
-  // if enclosed 3 quotes newlines are valid
+  // if enclosed with 3 quotes newlines are valid
   // as elsewhere, backslash and new line should be ignored
   bool isString(const std::string& str, size_t start, size_t* len) {
     char quote = str[start];
     if (quote != '\"' && quote != '\'')
       return false;
     int quote_len = isCharCount(quote, str, start, 3) ? 3 : 1;
+
+    //end is now set past the opening quotation marks
     size_t end = start + quote_len;
     while(end < str.size() && !isCharCount(quote, str, end, quote_len)) {
       if (str[end] == '\n' && quote_len != 3) {
         return false;
       }
-      //handle escaped characters
+      //handle escaped characters. advances past escaped quotation marks,
+      //escaped newlines and escaped backslashes
       if (str[end] == '\\') {
         end++;
       }

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -189,8 +189,8 @@ struct SharedParserData {
   }
 
   bool isCharCount(char c, const std::string& str, size_t start, int len) {
-    //count checks from [start, start + len) 
-    return start + len <= str.size() && std::count(str.begin() + start, str.begin() + start + len, c) == len; 
+    //count checks from [start, start + len)
+    return start + len <= str.size() && std::count(str.begin() + start, str.begin() + start + len, c) == len;
   }
 
   // python conconcatenates all adjacent strings "a" "b" == "ab"
@@ -201,30 +201,20 @@ struct SharedParserData {
     char quote = str[start];
     if (quote != '\"' && quote != '\'')
       return false;
-    int quote_len = isCharCount(quote, str, start, 3) ? 3 : 1; 
-    size_t end = start + quote_len; 
+    int quote_len = isCharCount(quote, str, start, 3) ? 3 : 1;
+    size_t end = start + quote_len;
     while(end < str.size() && !isCharCount(quote, str, end, quote_len)) {
       if (str[end] == '\n' && quote_len != 3) {
         return false;
       }
+      //handle escaped characters
       if (str[end] == '\\') {
         end++;
       }
       end++;
     }
-    *len = end - start + quote_len; 
-    if (end == str.size()) {
-      return false;
-    }
-    int kind;
-    size_t next_start = end + 1;
-    size_t next_len;
-    //finding adjacent strings
-    match(str, end + 1, true, false, &kind, &next_start, &next_len);
-    if (kind == TK_STRINGLITERAL) {
-      *len = (next_start + next_len - start);
-    }
-    return true;
+    *len = end - start + quote_len;
+    return end < str.size();
   }
 
   bool isblank(int n) {
@@ -284,7 +274,7 @@ struct SharedParserData {
       *kind = TK_NUMBER;
       return true;
     }
-    // check for string 
+    // check for string
     if (isString(str, pos, len)) {
       *kind = TK_STRINGLITERAL;
       return true;

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -34,6 +34,7 @@ namespace script {
   _(TK_EQUIVALENT, "equivalent", "<=>")          \
   _(TK_IDENT, "ident", "")                       \
   _(TK_STRING, "string", "")                     \
+  _(TK_STRINGLITERAL, "string_literal", "")      \
   _(TK_CONST, "const", "")                       \
   _(TK_LIST, "list", "")                         \
   _(TK_OPTION, "option", "")                     \
@@ -186,6 +187,46 @@ struct SharedParserData {
     *len = endptr - startptr;
     return *len > 0;
   }
+
+  bool isCharCount(char c, const std::string& str, size_t start, int len) {
+    //count checks from [start, start + len) 
+    return start + len <= str.size() && std::count(str.begin() + start, str.begin() + start + len, c) == len; 
+  }
+
+  // python conconcatenates all adjacent strings "a" "b" == "ab"
+  // strings can be enclosed with 1 or 3 single or double quotes
+  // if enclosed 3 quotes newlines are valid
+  // as elsewhere, backslash and new line should be ignored
+  bool isString(const std::string& str, size_t start, size_t* len) {
+    char quote = str[start];
+    if (quote != '\"' && quote != '\'')
+      return false;
+    int quote_len = isCharCount(quote, str, start, 3) ? 3 : 1; 
+    size_t end = start + quote_len; 
+    while(end < str.size() && !isCharCount(quote, str, end, quote_len)) {
+      if (str[end] == '\n' && quote_len != 3) {
+        return false;
+      }
+      if (str[end] == '\\') {
+        end++;
+      }
+      end++;
+    }
+    *len = end - start + quote_len; 
+    if (end == str.size()) {
+      return false;
+    }
+    int kind;
+    size_t next_start = end + 1;
+    size_t next_len;
+    //finding adjacent strings
+    match(str, end + 1, true, false, &kind, &next_start, &next_len);
+    if (kind == TK_STRINGLITERAL) {
+      *len = (next_start + next_len - start);
+    }
+    return true;
+  }
+
   bool isblank(int n) {
     return isspace(n) && n != '\n';
   }
@@ -243,6 +284,12 @@ struct SharedParserData {
       *kind = TK_NUMBER;
       return true;
     }
+    // check for string 
+    if (isString(str, pos, len)) {
+      *kind = TK_STRINGLITERAL;
+      return true;
+    }
+
     // check for either an ident or a token
     // ident tracks whether what we have scanned so far could be an identifier
     // matched indicates if we have found any match.

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -193,7 +193,7 @@ struct Parser {
     auto ret_str = str.substr(quote_len, str.size() - quote_len * 2);
     size_t pos = ret_str.find('\\');
     while(pos != std::string::npos) {
-      //invariant: backslash cannot be the last character
+      //invariant: pos has to escape a character because it is a valid string
       char c = ret_str[pos + 1];
       switch (ret_str[pos + 1]) {
         case '\\':
@@ -219,8 +219,7 @@ struct Parser {
         default:
           throw ErrorReport(range) << " octal and hex escaped sequences are not supported";
       }
-      ret_str.erase(pos, 2);
-      ret_str.insert(pos, 1, c);
+      ret_str.replace(pos, /* num to erase */ 2, /* num copies */ 1, c);
       pos = ret_str.find('\\', pos + 1);
     }
     return ret_str;

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -174,6 +174,10 @@ void initTreeViewBindings(PyObject *module) {
     .def(py::init([](const SourceRange& range, std::string value) {
       return Const::create(range, value);
     }));
+  py::class_<StringLiteral, Expr>(m, "StringLiteral")
+    .def(py::init([](const SourceRange& range, std::string value) {
+      return StringLiteral::create(range, value);
+    }));
   py::class_<Apply, Expr>(m, "Apply")
     .def(py::init([](const Expr& expr, std::vector<Expr> args, std::vector<Attribute> kwargs) {
       auto r = expr.range();

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -245,6 +245,7 @@ struct Expr : public TreeView {
       case '/':
       case TK_NOT:
       case TK_CONST:
+      case TK_STRINGLITERAL:
       case TK_TRUE:
       case TK_FALSE:
       case TK_NONE:
@@ -559,6 +560,18 @@ struct Const : public Expr {
   }
   static Const create(const SourceRange& range, const std::string& value) {
     return Const(Compound::create(TK_CONST, range, {String::create(value)}));
+  }
+};
+
+struct StringLiteral : public Expr {
+  explicit StringLiteral(const TreeRef& tree) : Expr(tree) {
+    tree_->matchNumSubtrees(TK_STRINGLITERAL, 1);
+  }
+  const std::string& text() const {
+    return subtree(0)->stringValue();
+  }
+  static StringLiteral create(const SourceRange& range, const std::string& value) {
+    return StringLiteral(Compound::create(TK_STRINGLITERAL, range, {String::create(value)}));
   }
 };
 

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -69,7 +69,7 @@ NoneTypePtr NoneType::get() {
   return value;
 }
 StringTypePtr StringType::get() {
-  static auto value = std::make_shared<StringType>();
+  static auto value = StringType::create();
   return value;
 }
 ListTypePtr ListType::ofTensors() {

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -40,6 +40,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << *prim << "[]";
   } else if(t.kind() == TypeKind::NoneType) {
     out << "None";
+  } else if(t.kind() == TypeKind::StringType) {
+    out << "string";
   } else {
     AT_ERROR("unknown type kind");
   }
@@ -64,6 +66,10 @@ FloatTypePtr FloatType::get() {
 }
 NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
+  return value;
+}
+StringTypePtr StringType::get() {
+  static auto value = std::make_shared<StringType>();
   return value;
 }
 ListTypePtr ListType::ofTensors() {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -384,7 +384,7 @@ private:
 };
 
 struct StringType;
-using StringTypePtr = std::shared_ptr<IntType>;
+using StringTypePtr = std::shared_ptr<StringType>;
 // This node represents a Python string value
 struct TORCH_API StringType : public Type {
   template<typename ... T>

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -21,6 +21,7 @@ _(NumberType) \
 _(FloatType) \
 _(IntType) \
 _(NoneType) \
+_(StringType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -380,6 +381,31 @@ struct TORCH_API IntType : public Type {
 private:
   IntType()
   : Type(TypeKind::IntType) {}
+};
+
+struct StringType;
+using StringTypePtr = std::shared_ptr<IntType>;
+// This node represents a Python string value
+struct TORCH_API StringType : public Type {
+  template<typename ... T>
+  static StringTypePtr create( T&& ... all ) {
+    return StringTypePtr(new StringType( std::forward<T>(all)... ));
+  }
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return "string";
+  }
+  bool isSubtypeOf(const TypePtr rhs) const override {
+    return *this == *rhs;
+  }
+  static const TypeKind Kind = TypeKind::StringType;
+  // global singleton
+  static TypePtr get();
+private:
+  StringType()
+  : Type(TypeKind::StringType) {}
 };
 
 struct NoneType;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -402,7 +402,7 @@ struct TORCH_API StringType : public Type {
   }
   static const TypeKind Kind = TypeKind::StringType;
   // global singleton
-  static TypePtr get();
+  static StringTypePtr get();
 private:
   StringType()
   : Type(TypeKind::StringType) {}

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -447,7 +447,7 @@ class ExprBuilder(Builder):
     @staticmethod
     def build_Str(ctx, expr):
         value = str(expr.s)
-        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(value))
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1)
         return StringLiteral(r, value)
 
     @staticmethod

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -445,6 +445,12 @@ class ExprBuilder(Builder):
         return Const(r, value)
 
     @staticmethod
+    def build_Str(ctx, expr):
+        value = str(expr.s)
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(value))
+        return StringLiteral(r, value)
+
+    @staticmethod
     def build_Starred(ctx, expr):
         r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1)
         return Starred(r, build_expr(ctx, expr.value))


### PR DESCRIPTION
This PR adds strings to the ast and implements them for print statements. Strings are lifted as attributes to the print node. They must be arguments to print itself, not as an argument for an object that is passed to print.  If they are encountered elsewhere a NYI exception will be thrown. 