### PR TITLE
LARS implementation --option 2

### DIFF
--- a/caffe2/sgd/lars_op.cc
+++ b/caffe2/sgd/lars_op.cc
@@ -9,6 +9,7 @@ void LarsOp<float, CPUContext>::Compute(
     TIndex N,
     const float* X_data,
     const float* dX_data,
+    const float* wd,
     float offset,
     float* lr_rescale_data) {
   *lr_rescale_data = 1.0;
@@ -19,33 +20,34 @@ void LarsOp<float, CPUContext>::Compute(
   if (X_norm > 0) {
     float dX_norm =
         sqrtf((ConstEigenVectorMap<float>(dX_data, N).array()).square().sum());
-    *lr_rescale_data /= (dX_norm / X_norm + offset);
+    *lr_rescale_data /= (dX_norm / X_norm + (*wd) + offset);
   }
 }
 
 REGISTER_CPU_OPERATOR(Lars, LarsOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(Lars)
-    .NumInputs(2)
+    .NumInputs(3)
     .NumOutputs(1)
     .SetDoc(R"DOC(
 Implement Layer-wise Adaptive Rate Scaling (LARS) as in
-https://arxiv.org/abs/1708.03888. Without weight decay, given a global
+https://arxiv.org/abs/1708.03888. Before adding weight decay, given a global
 learning rate lr, parameter tensor X and its gradient dX, the local learning
 rate for X will be
 
-    local_lr = lr * norm(X) / ( norm(dX) + offset * norm(X) )
+    local_lr = lr * norm(X) / ( norm(dX) + wd * norm(X) + offset * norm(X) )
 
-             = lr  / ( norm(dX) / norm(X) + offset ),
+            = lr  / ( norm(dX) / norm(X) + wd + offset ),
 
 where offset is a preset hyper-parameter to avoid numerical issue.
 In this implementation, we uses l2 norm and output the rescaling factor
 
-    1 / ( norm(dX) / norm(X) + offset ).
+    1 / ( norm(dX) / norm(X) + wd + offset ).
 
 )DOC")
     .Input(0, "X", "Parameter tensor")
     .Input(1, "dX", "Gradient tensor")
+    .Input(2, "wd", "Weight decay")
     .Output(0, "lr_rescale", "Local learning rate rescaling factor")
     .Arg("offset", "rescaling offset parameter");
 

--- a/caffe2/sgd/lars_op.h
+++ b/caffe2/sgd/lars_op.h
@@ -22,6 +22,7 @@ class LarsOp final : public Operator<Context> {
         dX.size() == X.size(), "Gradient size doesn't match parameter size.");
     CAFFE_ENFORCE_GE(offset_, 0);
 
+    auto& wd = Input(2);
     auto* lr_rescale = Output(0);
     lr_rescale->Resize(vector<TIndex>{1});
 
@@ -29,6 +30,7 @@ class LarsOp final : public Operator<Context> {
         dX.size(),
         X.template data<T>(),
         dX.template data<T>(),
+        wd.template data<T>(),
         offset_,
         lr_rescale->template mutable_data<T>());
 
@@ -40,6 +42,7 @@ class LarsOp final : public Operator<Context> {
       TIndex N,
       const T* X_data,
       const T* dX_data,
+      const T* wd,
       T offset,
       T* lr_rescale_data);
 


### PR DESCRIPTION
Summary: Option 2 of LARS implementation: apply LARS first, then add weight decay

Differential Revision: D8794928
