### PR TITLE
Add clang-format check to travis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,7 +37,6 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
@@ -68,7 +67,7 @@ PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 2000000
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,13 @@ matrix:
         python: "3.6"
         install: pip install mypy mypy-extensions
         script: mypy @mypy-files.txt
+      - env: CLANG_FORMAT_CHECK
+        install:
+          - sudo apt-get install -y clang-format-3.9 expect-dev
+          - sudo ln -s /usr/bin/clang-format-3.9 /usr/bin/clang-format
+          - wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format -O git-clang-format.py
+        script:
+          - unbuffer python git-clang-format.py --verbose --diff master | tee output
+          - grep -E 'clang-format did not modify any files|no modified files to format' output
+    allow_failures:
+      - env: CLANG_FORMAT_CHECK


### PR DESCRIPTION
This PR adds a clang-format check to Travis CI.

It uses LLVM/clang's own `git-clang-format` utility, which runs clang format on the latest changes as determined by git, i.e. only what is different from the base revision (master).

I also updated our clang-format to be 100% identical to fbcode, otherwise we'll run into inconsistencies sooner or later.

For now, I have configured it such that it is allowed to fail, meaning it won't mark the CI job as failed.

Unfortunately there is no good middle way between failing the CI job and just showing that this particular check failed in a user-visible way. Right now, you really have to explicitly click on the CI job and see that it failed on Travis (even though it didn't fail CI since it's allowed to fail).

Thoughts?