### PR TITLE
[codemod] Remove virtual+override anti-pattern

### DIFF
--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -9,14 +9,13 @@ public:
   static inline UndefinedTensor * singleton() {
     return &_singleton;
   }
-  virtual ~UndefinedTensor() {}
-  virtual const char * toString() const override;
-  virtual IntList sizes() const override;
-  virtual IntList strides() const override;
-  virtual int64_t dim() const override;
-  virtual Scalar localScalar() override;
-  virtual void * unsafeGetTH(bool retain) override;
-  virtual std::unique_ptr<Storage> storage() override;
+  const char * toString() const override;
+  IntList sizes() const override;
+  IntList strides() const override;
+  int64_t dim() const override;
+  Scalar localScalar() override;
+  void * unsafeGetTH(bool retain) override;
+  std::unique_ptr<Storage> storage() override;
   static const char * typeString();
 private:
   UndefinedTensor();

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -25,7 +25,7 @@ struct ${op} : public ${superclass} {
 
 WILL_RELEASE_VARIABLES = CodeTemplate("""\
 bool retain_variables = true;
-virtual void will_release_variables() override {
+void will_release_variables() override {
   retain_variables = false;
 }
 """)

--- a/torch/csrc/assertions.h
+++ b/torch/csrc/assertions.h
@@ -9,7 +9,7 @@ namespace torch {
 struct assert_error final : public std::exception {
   const std::string msg;
   explicit assert_error(const std::string& msg) : msg(msg) {}
-  virtual const char* what() const noexcept { return msg.c_str(); }
+  const char* what() const noexcept override { return msg.c_str(); }
 };
 
 [[noreturn]]

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -8,7 +8,7 @@ namespace torch { namespace autograd {
 struct AccumulateGrad : public Function {
   explicit AccumulateGrad(Variable variable);
 
-  virtual variable_list apply(variable_list&& inputs) override;
+  variable_list apply(variable_list&& inputs) override;
 
   Variable variable;
 };

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -18,7 +18,7 @@ struct Error : public Function {
   Error(std::string msg)
     : msg(std::move(msg)) {}
 
-  virtual variable_list apply(variable_list&& inputs) override;
+  variable_list apply(variable_list&& inputs) override;
 
   std::string msg;
 };
@@ -28,7 +28,7 @@ struct DelayedError : public Function {
   DelayedError(std::string msg)
     : msg(std::move(msg)) {};
 
-  virtual variable_list apply(variable_list&& inputs) override;
+  variable_list apply(variable_list&& inputs) override;
 
   std::string msg;
 };
@@ -38,7 +38,7 @@ struct GraphRoot : public Function {
       : Function(std::move(functions)),
         outputs(std::move(inputs)) {}
 
-  virtual variable_list apply(variable_list&& inputs) {
+  variable_list apply(variable_list&& inputs) override {
     return outputs;
   }
 

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -13,7 +13,7 @@
 namespace torch { namespace autograd {
 
 struct CopyBackwards : public Function {
-  virtual variable_list apply(variable_list&& inputs) override;
+  variable_list apply(variable_list&& inputs) override;
 
   at::Type *src_type;
   int32_t src_device = -1;
@@ -25,8 +25,8 @@ struct CopyBackwards : public Function {
 struct CopySlices : public Function {
   CopySlices(const Variable& base, at::TensorGeometry view, std::shared_ptr<Function> fn);
 
-  virtual variable_list apply(variable_list&& grads) override;
-  virtual void release_variables() override;
+  variable_list apply(variable_list&& grads) override;
+  void release_variables() override;
 
   at::TensorGeometry base;
   at::TensorGeometry view;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -285,7 +285,7 @@ struct Variable::Impl : public at::TensorImpl {
       bool requires_grad = false,
       Edge edge = Edge());
 
-  virtual ~Impl();
+  ~Impl() override;
 
   const char* toString() const override;
   at::IntList sizes() const override;
@@ -394,7 +394,7 @@ struct Variable::ViewImpl : public Variable::Impl {
   /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
   /// re-create the grad_fn to express the up-to-date view relationship between
   /// this and the base Variable.
-  virtual std::shared_ptr<Function>& get_grad_fn() override;
+  std::shared_ptr<Function>& get_grad_fn() override;
 
   const Variable& base() const override {
     return base_;

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -40,10 +40,10 @@ struct ScalarAttributeValue : public AttributeValue {
   ValueType & value() {
     return value_;
   }
-  virtual Ptr clone() const override {
+  Ptr clone() const override {
     return Ptr(new ScalarAttributeValue(name, value_));
   }
-  virtual AttributeKind kind() const override { return Kind; }
+  AttributeKind kind() const override { return Kind; }
 private:
   ValueType value_;
 };
@@ -57,8 +57,8 @@ struct VectorAttributeValue : public AttributeValue {
   ValueType & value() {
     return value_;
   }
-  virtual AttributeKind kind() const override { return Kind; }
-  virtual std::unique_ptr<AttributeValue> clone() const override {
+  AttributeKind kind() const override { return Kind; }
+  std::unique_ptr<AttributeValue> clone() const override {
     auto copy = value_;
     return Ptr(new VectorAttributeValue(name, std::move(copy)));
   }
@@ -88,7 +88,7 @@ struct AttributeError : public std::exception {
     }
     msg = ss.str();
   }
-  virtual const char* what() const noexcept override  {
+  const char* what() const noexcept override  {
     return msg.c_str();
   }
 private:

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1283,8 +1283,8 @@ struct PythonOp : public Node {
   std::vector<THPObjectPtr> scalar_args;
   virtual std::string name() const = 0;
   virtual void writeScalars(std::ostream& out) const = 0;
-  virtual void cloneFrom(Node * other_) override = 0;
-  virtual Node * allocNewInstance(Graph * g) override = 0;
+  void cloneFrom(Node * other_) override = 0;
+  Node * allocNewInstance(Graph * g) override = 0;
   // recover the autograd.Function instance, if this PythonOp's function
   // was originally SomeFunction.apply
   // used in ONNX for discovering symbolics
@@ -1305,7 +1305,6 @@ inline Node* Graph::createPythonOp(
       cconv,
       std::move(scalar_args));
 }
-
 
 inline graph_node_list_iterator Node::iterator() {
   return graph_node_list_iterator(this, 0);

--- a/torch/csrc/jit/source_location.h
+++ b/torch/csrc/jit/source_location.h
@@ -35,7 +35,7 @@ inline std::ostream& operator<<(std::ostream& out, const SourceLocation& sl) {
 struct StringSourceLocation : public SourceLocation {
   StringSourceLocation(std::string context)
   : context(std::move(context)) {}
-  virtual void highlight(std::ostream & out) const override {
+  void highlight(std::ostream & out) const override {
     out << context;
   }
 private:

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -92,10 +92,10 @@ inline bool operator!=(const Type & lhs, const Type & rhs) {
 struct DynamicType : public Type {
   DynamicType()
   : Type(TypeKind::DynamicType) {}
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     return "Tensor";
   }
   static const TypeKind Kind = TypeKind::DynamicType;
@@ -151,7 +151,7 @@ struct TensorType : public Type {
     return t;
   }
 
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     if(rhs.kind() != kind())
       return false;
     auto rt = rhs.expect<TensorType>();
@@ -160,10 +160,10 @@ struct TensorType : public Type {
            strides() == rt->strides() &&
            device() == rt->device();
   }
-  virtual bool isSubtypeOf(const Type& rhs) const override {
+  bool isSubtypeOf(const Type& rhs) const override {
     return *this == rhs || rhs.kind() == TypeKind::DynamicType;
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     // str is used for user-facing error messages, where we
     // don't want to reveal underlying size information.
     return "Tensor";
@@ -190,13 +190,13 @@ struct ListType : public Type {
   static const TypeKind Kind = TypeKind::ListType;
   ListType(TypePtr elem)
   : Type(TypeKind::ListType), elem(elem) {}
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     if(auto rhs_ = rhs.cast<ListType>()) {
       return *getElementType() == *rhs_->getElementType();
     }
     return false;
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     std::stringstream ss;
     ss << getElementType()->str() << "[]";
     return ss.str();
@@ -220,12 +220,12 @@ struct TupleType : public Type {
   at::ArrayRef<TypePtr> elements() const {
     return elements_;
   }
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     return compare(rhs, [](const Type& a, const Type& b) {
       return a == b;
     });
   }
-  virtual bool isSubtypeOf(const Type& rhs) const override {
+  bool isSubtypeOf(const Type& rhs) const override {
     // e.g. (Tensor, Tensor, Tensor) <: List[Tensor]
     if(auto lt = rhs.cast<ListType>()) {
       for(auto e : elements()) {
@@ -239,7 +239,7 @@ struct TupleType : public Type {
       return a.isSubtypeOf(b);
     });
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     std::stringstream ss;
     ss << "(";
     for(size_t i = 0; i < elements().size(); ++i) {
@@ -271,10 +271,10 @@ private:
 struct NumberType : public Type {
   NumberType()
   : Type(TypeKind::NumberType) {}
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     return "Scalar"; // match what PythonArgParser says for clarity
   }
   static const TypeKind Kind = TypeKind::NumberType;
@@ -286,13 +286,13 @@ struct NumberType : public Type {
 struct FloatType : public Type {
   FloatType()
   : Type(TypeKind::FloatType) {}
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     return "float";
   }
-  virtual bool isSubtypeOf(const Type& rhs) const override {
+  bool isSubtypeOf(const Type& rhs) const override {
     return *this == rhs || rhs.kind() == TypeKind::NumberType;
   }
   static const TypeKind Kind = TypeKind::FloatType;
@@ -304,13 +304,13 @@ struct FloatType : public Type {
 struct IntType : public Type {
   IntType()
   : Type(TypeKind::IntType) {}
-  virtual bool operator==(const Type& rhs) const override {
+  bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
-  virtual std::string str() const override {
+  std::string str() const override {
     return "int";
   }
-  virtual bool isSubtypeOf(const Type& rhs) const override {
+  bool isSubtypeOf(const Type& rhs) const override {
     return *this == rhs || rhs.kind() == TypeKind::NumberType;
   }
   static const TypeKind Kind = TypeKind::IntType;


### PR DESCRIPTION
I'm cramming through clang tidy emitted warnings. This PR addresses the `hi-cpp-override` check which warns that `virtual` + `override` is redundant, since `override` already  signifies that a function is overriding and thus virtual.

Where there was `virtual` + `override` I removed the `virtual`, where there was `virtual` and no `override` I removed `virtual` and added `override`.

@ezyang @apaszke 