### PR TITLE
[codemod] Add explicit to conversions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,36 +3,38 @@
 Checks: '
   *
   ,modernize-*
-  ,clang-analyzer-*
-  ,-clang-diagnostic-*
-  ,-hicpp-no-array-decay
-  ,-fuchsia-*
-  ,-google-readability-namespace-comments
-  ,-llvm-namespace-comment
-  ,-google-readability-todo
-  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
-  ,-cert-err60-cpp
-  ,-llvm-header-guard
-  ,-cppcoreguidelines-special-member-functions
-  ,-misc-unused-parameters
-  ,-hicpp-braces-around-statements
-  ,-hicpp-special-member-functions
-  ,-readability-braces-around-statements
-  ,-modernize-use-default-member-init
-  ,-google-runtime-references
-  ,-cppcoreguidelines-pro-type-vararg
-  ,-google-readability-braces-around-statements
-  ,-google-build-using-namespace
-  ,-hicpp-vararg
-  ,-hicpp-explicit-conversions
-  ,-performance-unnecessary-value-param
-  ,-google-runtime-references
-  ,-cppcoreguidelines-pro-type-static-cast-downcast
-  ,-cppcoreguidelines-pro-bounds-constant-array-index
   ,-cert-err58-cpp
-  ,-modernize-make-unique
+  ,-cert-err60-cpp
+  ,-clang-diagnostic-*
   ,-cppcoreguidelines-owning-memory
+  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
+  ,-cppcoreguidelines-pro-bounds-constant-array-index
+  ,-cppcoreguidelines-pro-type-static-cast-downcast
+  ,-cppcoreguidelines-pro-type-vararg
+  ,-cppcoreguidelines-special-member-functions
+  ,-fuchsia-*
+  ,-google-build-using-namespace
+  ,-google-explicit-constructor
+  ,-google-readability-braces-around-statements
+  ,-google-readability-namespace-comments
+  ,-google-readability-todo
+  ,-google-runtime-references
+  ,-google-runtime-references
+  ,-hicpp-braces-around-statements
+  ,-hicpp-explicit-conversions
+  ,-hicpp-no-array-decay
+  ,-hicpp-special-member-functions
+  ,-hicpp-vararg
+  ,-llvm-header-guard
+  ,-llvm-namespace-comment
+  ,-misc-unused-parameters
+  ,-modernize-make-unique
+  ,-modernize-use-default-member-init
+  ,-performance-unnecessary-value-param
+  ,-readability-braces-around-statements
+  ,-readability-else-after-return
   ,-readability-named-parameter
+  ,clang-analyzer-*
   '
 WarningsAsErrors: ''
 HeaderFilterRegex: 'torch/csrc/'

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -33,7 +33,7 @@ using value_list = std::vector<Value*>;
 // Terminology: vjp = vector-jacobian product
 
 struct Gradient {
-  operator bool() const {
+  explicit operator bool() const {
     return df != nullptr;
   }
   std::shared_ptr<Graph> f;

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -39,7 +39,7 @@ struct GraphExecutor {
   // note: if not specified, symbolically_differentiable is computed from the graph.
   GraphExecutor(std::shared_ptr<Graph> graph, bool optimize, bool symbolically_differentiable);
   variable_tensor_list run(variable_tensor_list && inputs);
-  operator bool() const {
+  explicit operator bool() const {
     return pImpl != nullptr;
   }
   std::shared_ptr<Graph> graph() const;

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -29,7 +29,7 @@ struct Code {
   // Returns pointers to GraphExecutors created to run GraphExecutor nodes in the given graph.
   const std::vector<GraphExecutor*>& executors();
 
-  operator bool() const {
+  explicit operator bool() const {
     return pImpl != nullptr;
   }
 

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -119,7 +119,7 @@ struct TreeToken {
     return token;
   }
 
-  operator bool() {
+  explicit operator bool() {
     return is_root;
   }
 

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -17,7 +17,7 @@ public:
   THPPointer& operator =(T *new_ptr) { free(); ptr = new_ptr; return *this; }
   THPPointer& operator =(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; return *this; }
   T * operator ->() { return ptr; }
-  operator bool() const { return ptr != nullptr; }
+  explicit operator bool() const { return ptr != nullptr; }
 
 private:
   void free();


### PR DESCRIPTION
Another code-mod for clang-tidy: Conversion operators should be marked explicit so that they don't cause unwanted implicit conversions. This is especially important for `operator bool()`, see https://stackoverflow.com/questions/39995573/when-can-i-use-explicit-operator-bool-without-a-cast

@ezyang @apaszke 