### PR TITLE
fix extra output in generate_code.py

### DIFF
--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -41,7 +41,6 @@ outputs = [
     'torch/csrc/autograd/generated/VariableType.cpp',
     'torch/csrc/autograd/generated/VariableType.h',
     'torch/csrc/jit/generated/register_aten_ops.cpp',
-    'torch/csrc/jit/generated/operator.cpp',
 ]
 
 


### PR DESCRIPTION
operator.cpp is not generated. removing the line prevents generate_code.py from always thinking it is out of date and running.