### PR TITLE
document torch.utils.dlpack

### DIFF
--- a/docs/source/dlpack.rst
+++ b/docs/source/dlpack.rst
@@ -1,0 +1,8 @@
+torch.utils.dlpack
+==================
+
+.. currentmodule:: torch.utils.dlpack
+
+.. autofunction:: from_dlpack
+.. autofunction:: to_dlpack
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    checkpoint
    cpp_extension
    data
+   dlpack
    ffi
    model_zoo
    onnx

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -2,3 +2,26 @@ import torch
 
 from torch._C import _from_dlpack as from_dlpack
 from torch._C import _to_dlpack as to_dlpack
+
+torch._C._add_docstr(from_dlpack, r"""from_dlpack(dlpack) -> Tensor
+
+Decodes a DLPack to a tensor.
+
+Arguments::
+    dlpack - a PyCapsule object with the dltensor
+
+The tensor will share the memory with the object represented
+in the dlpack.
+Note that each dlpack can only be consumed once.
+""")
+
+torch._C._add_docstr(to_dlpack, r"""to_dlpack(tensor) -> PyCapsule
+
+Returns a DLPack representing the tensor.
+
+Arguments::
+    tensor - a tensor to be exported
+
+The dlpack shares the tensors memory.
+Note that each dlpack can only be consumed once.
+""")


### PR DESCRIPTION
dlpacks deserve documentation. :)

I wonder whether it might make sense to merge the various small torch.utils pages (and include a link for the larger ones, e.g. data) to enhance the structure in the docs.
