### PR TITLE
Fix Eigen issue on OS X with CUDA and nvcc compile

### DIFF
--- a/caffe2/mkl/operators/operator_fallback_mkl.cc
+++ b/caffe2/mkl/operators/operator_fallback_mkl.cc
@@ -15,6 +15,7 @@
 #include "caffe2/operators/roi_align_rotated_op.h"
 #include "caffe2/operators/softmax_op.h"
 #include "caffe2/operators/utility_ops.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 namespace {

--- a/caffe2/mobile/contrib/ulp2/ulp.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp.cc
@@ -1,5 +1,8 @@
 #include "ulp.h"
+
+#include <cstring>
 #include "caffe2/operators/conv_pool_op_base.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "ulp_neon.h"
 
 namespace caffe2 {

--- a/caffe2/mobile/contrib/ulp2/ulp_neon.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_neon.cc
@@ -1,5 +1,6 @@
 #include "ulp_neon.h"
 #include "caffe2/core/timer.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/abs_op.cc
+++ b/caffe2/operators/abs_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/abs_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/acos_op.cc
+++ b/caffe2/operators/acos_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/acos_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/affine_channel_op.cc
+++ b/caffe2/operators/affine_channel_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/affine_channel_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <vector>
 

--- a/caffe2/operators/asin_op.cc
+++ b/caffe2/operators/asin_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/asin_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/atan_op.cc
+++ b/caffe2/operators/atan_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/atan_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/cbrt_op.cc
+++ b/caffe2/operators/cbrt_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/cbrt_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/channel_backprop_stats_op.cc
+++ b/caffe2/operators/channel_backprop_stats_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/channel_backprop_stats_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/channel_stats_op.cc
+++ b/caffe2/operators/channel_stats_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/channel_stats_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/clip_op.cc
+++ b/caffe2/operators/clip_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/clip_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/conv_op_eigen.cc
+++ b/caffe2/operators/conv_op_eigen.cc
@@ -1,4 +1,5 @@
 #include "Eigen/Core"
+#include "caffe2/utils/eigen_utils.h"
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -15,6 +15,7 @@
 #include "caffe2/operators/conv_op_shared.h"
 #include "caffe2/operators/conv_transpose_op_mobile.h"
 #include "caffe2/utils/cpu_neon.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/fixed_divisor.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/operators/cos_op.cc
+++ b/caffe2/operators/cos_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/cos_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/cross_entropy_op.cc
+++ b/caffe2/operators/cross_entropy_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/cross_entropy_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/cube_op.cc
+++ b/caffe2/operators/cube_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/cube_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/distance_op.cc
+++ b/caffe2/operators/distance_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/distance_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/elementwise_div_gradient_op.cc
+++ b/caffe2/operators/elementwise_div_gradient_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/elementwise_div_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/elementwise_ops.cc
+++ b/caffe2/operators/elementwise_ops.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/elementwise_ops.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 

--- a/caffe2/operators/elementwise_ops.h
+++ b/caffe2/operators/elementwise_ops.h
@@ -12,6 +12,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/operators/elementwise_ops_utils.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/elu_op.cc
+++ b/caffe2/operators/elu_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/elu_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/ensure_clipped_op.h
+++ b/caffe2/operators/ensure_clipped_op.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/reducer_functors.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/gather_fused_8bit_rowwise_op.h
+++ b/caffe2/operators/gather_fused_8bit_rowwise_op.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -10,6 +10,7 @@
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
 
+#include <cstring>
 #include <map>
 #include <utility>
 

--- a/caffe2/operators/generate_proposals_op_util_boxes_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_boxes_test.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/generate_proposals_op_util_boxes.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <gtest/gtest.h>
 

--- a/caffe2/operators/generate_proposals_op_util_nms_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_nms_test.cc
@@ -1,3 +1,4 @@
+#include "caffe2/utils/eigen_utils.h"
 #include "generate_proposals_op_util_nms.h"
 
 #include <gtest/gtest.h>

--- a/caffe2/operators/group_norm_op.cc
+++ b/caffe2/operators/group_norm_op.cc
@@ -10,6 +10,7 @@
 
 #include <array>
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/instance_norm_gradient_op.cc
+++ b/caffe2/operators/instance_norm_gradient_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/instance_norm_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/instance_norm_op.cc
+++ b/caffe2/operators/instance_norm_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/instance_norm_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/integral_image_op.cc
+++ b/caffe2/operators/integral_image_op.cc
@@ -1,5 +1,121 @@
 #include "integral_image_op.h"
+#include "caffe2/utils/eigen_utils.h"
+
 namespace caffe2 {
+
+namespace {
+template <typename T>
+using EigenMatrixMapRowMajor = Eigen::Map<
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
+template <typename T>
+using ConstEigenMatrixMapRowMajor = Eigen::Map<
+    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+} // namespace
+
+template <>
+bool IntegralImageOp<float, CPUContext>::RunOnDevice() {
+  const auto& X = Input(0);
+  auto* Y = Output(0);
+  CAFFE_ENFORCE_EQ(X.ndim(), 4, "Only supports 4D tensors for the momement");
+
+  vector<TIndex> out_shape(X.dims());
+  out_shape[2] += 1; // H + 1 output size
+  out_shape[3] += 1; // W + 1 output size
+  Y->Resize(out_shape);
+  const int ind = X.dim32(0);
+  const int chans = X.dim32(1);
+  const int rows_in = X.dim32(2);
+  const int cols_in = X.dim32(3);
+  const int rows_out = Y->dim32(2);
+  const int cols_out = Y->dim32(3);
+
+  const float* input_data = X.template data<float>();
+  float* output_data = Y->template mutable_data<float>();
+
+  const int row_out_pass_size = ind * chans * rows_out;
+  const int row_in_pass_size = ind * chans * rows_in;
+  EigenMatrixMapRowMajor<float> Y_arr(output_data, row_out_pass_size, cols_out);
+  ConstEigenMatrixMapRowMajor<float> X_arr(
+      input_data, row_in_pass_size, cols_in);
+
+  // Row Pass
+  for (int i = 0; i < row_out_pass_size; i++) {
+    int row = i % rows_out;
+    int diff = i / rows_out + 1;
+    Y_arr(i, 0) = 0.;
+    if (row == 0) {
+      for (int j = 1; j < cols_out; ++j) {
+        Y_arr(i, j) = 0.;
+      }
+    } else {
+      for (int j = 1; j < cols_out; ++j) {
+        Y_arr(i, j) = Y_arr(i, j - 1) + X_arr(i - diff, j - 1);
+      }
+    }
+  }
+
+  // Col Pass
+  const int col_out_pass_size = X.dim32(0) * chans * cols_out;
+  for (int i = 0; i < col_out_pass_size; i++) {
+    int col = i % cols_out;
+    int row = i / cols_out;
+    for (int j = row * rows_out + 1; j < (row + 1) * rows_out; ++j) {
+      Y_arr(j, col) += Y_arr(j - 1, col);
+    }
+  }
+  return true;
+}
+
+template <>
+bool IntegralImageGradientOp<float, CPUContext>::RunOnDevice() {
+  auto& X = Input(0); // Original input to "forward" op
+  auto& dY = Input(1); // Gradient of net w.r.t. output of "forward" op
+  // (aka "gradOutput")
+  auto* dX = Output(0); // Gradient of net w.r.t. input to "forward" op
+  // (aka "gradInput")
+
+  dX->ResizeLike(X);
+  const int ind = X.dim32(0);
+  const int chans = X.dim32(1);
+  const int rows_in = dY.dim32(2);
+  const int cols_in = dY.dim32(3);
+  const int rows_out = dX->dim32(2);
+  const int cols_out = dX->dim32(3);
+
+  const float* input_data = dY.template data<float>();
+  float* output_data = dX->template mutable_data<float>();
+
+  const int row_out_pass_size = ind * chans * rows_out;
+  const int row_in_pass_size = ind * chans * rows_in;
+  EigenMatrixMapRowMajor<float> dX_arr(
+      output_data, row_out_pass_size, cols_out);
+  ConstEigenMatrixMapRowMajor<float> dY_arr(
+      input_data, row_in_pass_size, cols_in);
+  Eigen::MatrixXf tmp(row_in_pass_size, cols_out);
+
+  // Row Pass dY(N, C, H+1, W+1) => tmp(N, C, H+1, W)
+  for (int i = 0; i < row_in_pass_size; i++) {
+    tmp(i, 0) = dY_arr(i, 0);
+    for (int j = 1; j < cols_out; ++j) {
+      tmp(i, j) = tmp(i, j - 1) + dY_arr(i, j);
+    }
+  }
+
+  // Col Pass tmp(N, C, H+1, W)=>dX(N, C, H, W)
+  const int col_out_pass_size = X.dim32(0) * chans * cols_out;
+  for (int i = 0; i < col_out_pass_size; i++) {
+    int col = i % cols_out;
+    int row_out_start = (i / cols_out) * rows_out;
+    int row_in_start = (i / cols_out) * rows_in;
+    dX_arr(row_out_start, col) = tmp(row_in_start, col);
+    for (int j = 1; j < rows_out; ++j) {
+      dX_arr(row_out_start + j, col) =
+          dX_arr(row_out_start + j - 1, col) + tmp(row_in_start + j, col);
+    }
+  }
+  return true;
+}
 
 REGISTER_CPU_OPERATOR(IntegralImage, IntegralImageOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(

--- a/caffe2/operators/integral_image_op.h
+++ b/caffe2/operators/integral_image_op.h
@@ -8,16 +8,6 @@
 
 namespace caffe2 {
 
-namespace {
-template <typename T>
-using EigenMatrixMapRowMajor = Eigen::Map<
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-
-template <typename T>
-using ConstEigenMatrixMapRowMajor = Eigen::Map<
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
-} // namespace
-
 template <typename T, class Context>
 class IntegralImageOp final : public Operator<Context> {
  public:
@@ -25,59 +15,7 @@ class IntegralImageOp final : public Operator<Context> {
       : Operator<Context>(operator_def, ws) {}
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  bool RunOnDevice() override {
-    const auto& X = Input(0);
-    auto* Y = Output(0);
-    CAFFE_ENFORCE_EQ(X.ndim(), 4, "Only supports 4D tensors for the momement");
-
-    vector<TIndex> out_shape(X.dims());
-    out_shape[2] += 1; // H + 1 output size
-    out_shape[3] += 1; // W + 1 output size
-    Y->Resize(out_shape);
-    const int ind = X.dim32(0);
-    const int chans = X.dim32(1);
-    const int rows_in = X.dim32(2);
-    const int cols_in = X.dim32(3);
-    const int rows_out = Y->dim32(2);
-    const int cols_out = Y->dim32(3);
-
-    const float* input_data = X.template data<float>();
-    float* output_data = Y->template mutable_data<float>();
-
-    const int row_out_pass_size = ind * chans * rows_out;
-    const int row_in_pass_size = ind * chans * rows_in;
-    EigenMatrixMapRowMajor<float> Y_arr(
-        output_data, row_out_pass_size, cols_out);
-    ConstEigenMatrixMapRowMajor<float> X_arr(
-        input_data, row_in_pass_size, cols_in);
-
-    // Row Pass
-    for (int i = 0; i < row_out_pass_size; i++) {
-      int row = i % rows_out;
-      int diff = i / rows_out + 1;
-      Y_arr(i, 0) = 0.;
-      if (row == 0) {
-        for (int j = 1; j < cols_out; ++j) {
-          Y_arr(i, j) = 0.;
-        }
-      } else {
-        for (int j = 1; j < cols_out; ++j) {
-          Y_arr(i, j) = Y_arr(i, j - 1) + X_arr(i - diff, j - 1);
-        }
-      }
-    }
-
-    // Col Pass
-    const int col_out_pass_size = X.dim32(0) * chans * cols_out;
-    for (int i = 0; i < col_out_pass_size; i++) {
-      int col = i % cols_out;
-      int row = i / cols_out;
-      for (int j = row * rows_out + 1; j < (row + 1) * rows_out; ++j) {
-        Y_arr(j, col) += Y_arr(j - 1, col);
-      }
-    }
-    return true;
-  }
+  bool RunOnDevice() override;
 };
 
 template <typename T, class Context>
@@ -87,54 +25,7 @@ class IntegralImageGradientOp final : public Operator<Context> {
       : Operator<Context>(def, ws) {}
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  bool RunOnDevice() override {
-    auto& X = Input(0); // Original input to "forward" op
-    auto& dY = Input(1); // Gradient of net w.r.t. output of "forward" op
-    // (aka "gradOutput")
-    auto* dX = Output(0); // Gradient of net w.r.t. input to "forward" op
-    // (aka "gradInput")
-
-    dX->ResizeLike(X);
-    const int ind = X.dim32(0);
-    const int chans = X.dim32(1);
-    const int rows_in = dY.dim32(2);
-    const int cols_in = dY.dim32(3);
-    const int rows_out = dX->dim32(2);
-    const int cols_out = dX->dim32(3);
-
-    const float* input_data = dY.template data<float>();
-    float* output_data = dX->template mutable_data<float>();
-
-    const int row_out_pass_size = ind * chans * rows_out;
-    const int row_in_pass_size = ind * chans * rows_in;
-    EigenMatrixMapRowMajor<float> dX_arr(
-        output_data, row_out_pass_size, cols_out);
-    ConstEigenMatrixMapRowMajor<float> dY_arr(
-        input_data, row_in_pass_size, cols_in);
-    Eigen::MatrixXf tmp(row_in_pass_size, cols_out);
-
-    // Row Pass dY(N, C, H+1, W+1) => tmp(N, C, H+1, W)
-    for (int i = 0; i < row_in_pass_size; i++) {
-      tmp(i, 0) = dY_arr(i, 0);
-      for (int j = 1; j < cols_out; ++j) {
-        tmp(i, j) = tmp(i, j - 1) + dY_arr(i, j);
-      }
-    }
-
-    // Col Pass tmp(N, C, H+1, W)=>dX(N, C, H, W)
-    const int col_out_pass_size = X.dim32(0) * chans * cols_out;
-    for (int i = 0; i < col_out_pass_size; i++) {
-      int col = i % cols_out;
-      int row_out_start = (i / cols_out) * rows_out;
-      int row_in_start = (i / cols_out) * rows_in;
-      dX_arr(row_out_start, col) = tmp(row_in_start, col);
-      for (int j = 1; j < rows_out; ++j) {
-        dX_arr(row_out_start + j, col) =
-            dX_arr(row_out_start + j - 1, col) + tmp(row_in_start + j, col);
-      }
-    }
-    return true;
-  }
+  bool RunOnDevice() override;
 
  protected:
   Tensor<Context> row_pass_buffer_;

--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/layer_norm_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/leaky_relu_op.cc
+++ b/caffe2/operators/leaky_relu_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/leaky_relu_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
@@ -8,6 +8,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/reducer_functors.h"
 #include "caffe2/perfkernels/embedding_lookup.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/listwise_l2r_op.cc
+++ b/caffe2/operators/listwise_l2r_op.cc
@@ -1,6 +1,7 @@
 #include "caffe2/operators/listwise_l2r_op.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/logit_op.cc
+++ b/caffe2/operators/logit_op.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "caffe2/operators/elementwise_ops.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/lpnorm_op.cc
+++ b/caffe2/operators/lpnorm_op.cc
@@ -2,6 +2,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/minmax_gradient_ops.cc
+++ b/caffe2/operators/minmax_gradient_ops.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/minmax_ops.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/minmax_ops.cc
+++ b/caffe2/operators/minmax_ops.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/minmax_ops.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/norm_planar_yuv_op.cc
+++ b/caffe2/operators/norm_planar_yuv_op.cc
@@ -1,5 +1,6 @@
 #include <array>
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/normalize_l1_op.cc
+++ b/caffe2/operators/normalize_l1_op.cc
@@ -1,6 +1,7 @@
 #include "caffe2/operators/normalize_l1_op.h"
 
 #include "caffe2/core/tensor.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/normalize_op.cc
+++ b/caffe2/operators/normalize_op.cc
@@ -1,6 +1,7 @@
 #include "caffe2/operators/normalize_op.h"
 
 #include "caffe2/core/tensor.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/pool_gradient_op.cc
+++ b/caffe2/operators/pool_gradient_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/pool_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -1,6 +1,7 @@
 // TODO(ataei): reduce the apparent redundancy of all the code below.
 #include "caffe2/operators/pool_op.h"
 #include "caffe2/utils/cpu_neon.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/pow_op.cc
+++ b/caffe2/operators/pow_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/pow_op.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 // definition of NumericTypes and SameTypeAsInput is in below header file
 //#include "caffe2/operators/elementwise_op.h"

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/prelu_op.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 #include "caffe2/core/types.h"

--- a/caffe2/operators/reducer_functors.h
+++ b/caffe2/operators/reducer_functors.h
@@ -6,6 +6,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 #include "caffe2/utils/proto_utils.h"
 

--- a/caffe2/operators/relu_n_op.cc
+++ b/caffe2/operators/relu_n_op.cc
@@ -16,6 +16,7 @@
 
 #include "caffe2/operators/relu_n_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/relu_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/roi_align_op_gpu_test.cc
+++ b/caffe2/operators/roi_align_op_gpu_test.cc
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/flags.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 #include "gtest/gtest.h"
 

--- a/caffe2/operators/rsqrt_op.cc
+++ b/caffe2/operators/rsqrt_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/rsqrt_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 #include <algorithm>
 #include <functional>
 #include <string>

--- a/caffe2/operators/selu_op.cc
+++ b/caffe2/operators/selu_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/selu_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/sigmoid_gradient_op.cc
+++ b/caffe2/operators/sigmoid_gradient_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/sigmoid_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 #include <algorithm>
 #include <functional>
 #include <string>

--- a/caffe2/operators/sigmoid_op.cc
+++ b/caffe2/operators/sigmoid_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/sigmoid_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 namespace caffe2 {
 
 template <>

--- a/caffe2/operators/sin_op.cc
+++ b/caffe2/operators/sin_op.cc
@@ -1,4 +1,5 @@
 #include "caffe2/operators/sin_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
 #include <algorithm>
 #include <functional>

--- a/caffe2/operators/sinusoid_position_encoding_op.h
+++ b/caffe2/operators/sinusoid_position_encoding_op.h
@@ -9,6 +9,7 @@
 #include "caffe2/core/operator.h"
 
 #include "Eigen/Core"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/softplus_op.cc
+++ b/caffe2/operators/softplus_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/softplus_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/softsign_op.cc
+++ b/caffe2/operators/softsign_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/softsign_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 #include <algorithm>
 #include <functional>
 

--- a/caffe2/operators/sparse_normalize_op.cc
+++ b/caffe2/operators/sparse_normalize_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/sparse_normalize_op.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/spatial_batch_norm_gradient_op.cc
+++ b/caffe2/operators/spatial_batch_norm_gradient_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/spatial_batch_norm_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 namespace caffe2 {
 
 template <>

--- a/caffe2/operators/spatial_batch_norm_op.cc
+++ b/caffe2/operators/spatial_batch_norm_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/spatial_batch_norm_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 namespace caffe2 {
 
 template <>

--- a/caffe2/operators/swish_op.cc
+++ b/caffe2/operators/swish_op.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "caffe2/core/types.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/tan_op.cc
+++ b/caffe2/operators/tan_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/tan_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 #include <algorithm>
 #include <functional>
 

--- a/caffe2/operators/tanh_gradient_op.cc
+++ b/caffe2/operators/tanh_gradient_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/tanh_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 #include <algorithm>
 #include <functional>
 #include <string>

--- a/caffe2/operators/tanh_op.cc
+++ b/caffe2/operators/tanh_op.cc
@@ -1,5 +1,7 @@
 #include "caffe2/operators/tanh_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
+
 namespace caffe2 {
 
 template <>

--- a/caffe2/operators/thresholded_relu_op.cc
+++ b/caffe2/operators/thresholded_relu_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/thresholded_relu_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/tt_linear_op.h
+++ b/caffe2/operators/tt_linear_op.h
@@ -9,6 +9,7 @@
 #include "Eigen/Dense"
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/operators/utility_ops.cc
+++ b/caffe2/operators/utility_ops.cc
@@ -1,6 +1,6 @@
 #include "caffe2/operators/utility_ops.h"
-
 #include <cmath>
+#include "caffe2/utils/eigen_utils.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/variable_length_sequence_padding.h
+++ b/caffe2/operators/variable_length_sequence_padding.h
@@ -2,6 +2,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/perfkernels/embedding_lookup.cc
+++ b/caffe2/perfkernels/embedding_lookup.cc
@@ -4,6 +4,7 @@
 #include "caffe2/perfkernels/common.h"
 #include "caffe2/perfkernels/typed_axpy.h"
 #include "caffe2/utils/cpuid.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/perfkernels/fused_8bit_rowwise_embedding_lookup.cc
+++ b/caffe2/perfkernels/fused_8bit_rowwise_embedding_lookup.cc
@@ -4,6 +4,7 @@
 #include "caffe2/perfkernels/common.h"
 #include "caffe2/perfkernels/typed_axpy.h"
 #include "caffe2/utils/cpuid.h"
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/sgd/lars_op.cc
+++ b/caffe2/sgd/lars_op.cc
@@ -1,5 +1,6 @@
 #include "caffe2/sgd/lars_op.h"
 #include <math.h>
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/sgd/rmsprop_op.cc
+++ b/caffe2/sgd/rmsprop_op.cc
@@ -1,5 +1,6 @@
 #include "rmsprop_op.h"
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/utils/eigen_utils.h
+++ b/caffe2/utils/eigen_utils.h
@@ -9,6 +9,30 @@
 
 namespace caffe2 {
 
+// Common Eigen types that we will often use
+template <typename T>
+using EigenMatrixMap =
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using EigenArrayMap =
+    Eigen::Map<Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using EigenVectorMap = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+template <typename T>
+using EigenVectorArrayMap = Eigen::Map<Eigen::Array<T, Eigen::Dynamic, 1>>;
+template <typename T>
+using ConstEigenMatrixMap =
+    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using ConstEigenArrayMap =
+    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using ConstEigenVectorMap =
+    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+template <typename T>
+using ConstEigenVectorArrayMap =
+    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, 1>>;
+
 // 1-d array
 template <typename T>
 using EArrXt = Eigen::Array<T, Eigen::Dynamic, 1>;

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -17,9 +17,6 @@ extern "C" {
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math_utils.h"
 
-#include "Eigen/Core"
-#include "Eigen/Dense"
-
 namespace caffe2 {
 
 template <class Context>
@@ -28,30 +25,6 @@ class Tensor;
 // An empty class as a placeholder for a math function that has no specific
 // engine specified.
 class DefaultEngine {};
-
-// Common Eigen types that we will often use
-template <typename T>
-using EigenMatrixMap =
-    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
-template <typename T>
-using EigenArrayMap =
-    Eigen::Map<Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
-template <typename T>
-using EigenVectorMap = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
-template <typename T>
-using EigenVectorArrayMap = Eigen::Map<Eigen::Array<T, Eigen::Dynamic, 1>>;
-template <typename T>
-using ConstEigenMatrixMap =
-    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
-template <typename T>
-using ConstEigenArrayMap =
-    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
-template <typename T>
-using ConstEigenVectorMap =
-    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>;
-template <typename T>
-using ConstEigenVectorArrayMap =
-    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, 1>>;
 
 namespace math {
 

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -11,6 +11,7 @@
 //     platforms, it allows one to quickly port Caffe2 to different platforms
 //     where BLAS may not be present.
 
+#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
 #include <algorithm>

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -2,6 +2,7 @@
 
 #include "caffe2/utils/math.h"
 
+#include <cstring>
 #include <limits>
 #include <numeric>
 #include <vector>


### PR DESCRIPTION
Summary:
Re-apply #9270

Breaking this out of #8338

This takes care of the Eigen failure we saw on Mac CUDA builds when BUILD_CAFFE2 and BUILD_ATEN were removed. Fix is to isolate Eigen from headers included by cu files and processed by nvcc. This was worked on with smessmer.

Differential Revision: D8794431
