### PR TITLE
[Caffe2] Setting docker locale to C.UTF-8 to enable py3 tests

### DIFF
--- a/docker/caffe2/jenkins/ubuntu/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu/Dockerfile
@@ -1,6 +1,10 @@
 ARG UBUNTU_VERSION
 FROM ubuntu:${UBUNTU_VERSION}
 
+# Set locale to C.UTF-8
+ENV LANG C.UTF-8  
+ENV LC_ALL C.UTF-8  
+
 # Install required packages to build Caffe2
 ARG EC2
 ARG UBUNTU_VERSION


### PR DESCRIPTION
Testing on python 3 results in
 "RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps."
on caffe2/python/onnx/tests/conversion_test.py::TestConversion::test_caffe2_to_onnx (at least it does for conda https://ci.pytorch.org/jenkins/job/caffe2-builds/job/conda3-ubuntu16.04-test/16/console ). This fixes the problem.

If there are no downsides to this, it should be added to ubuntu-cuda/Dockerfile as well