### PR TITLE
Allocator unification, attempt three!

### DIFF
--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -2,18 +2,13 @@
 
 namespace at {
 
-void deleteNothing(void*) {}
-SupervisorPtr nonOwningSupervisorPtr() {
-  return {nullptr, &deleteNothing};
+static void deleteInefficientStdFunctionContext(void* ptr) {
+  delete static_cast<InefficientStdFunctionContext*>(ptr);
 }
 
-static void deleteInefficientStdFunctionSupervisor(void* ptr) {
-  delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
-}
-
-at::DevicePtr
-InefficientStdFunctionSupervisor::makeDevicePtr(void* ptr, const std::function<void(void*)>& deleter, Device device) {
-  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}, device};
+at::DataPtr
+InefficientStdFunctionContext::makeDataPtr(void* ptr, const std::function<void(void*)>& deleter, Device device) {
+  return {ptr, new InefficientStdFunctionContext({ptr, deleter}), &deleteInefficientStdFunctionContext, device};
 }
 
 } // namespace at

--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -11,8 +11,8 @@ static void deleteInefficientStdFunctionSupervisor(void* ptr) {
   delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
 }
 
-at::SupervisedPtr
-makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter, Device device) {
+at::DevicePtr
+InefficientStdFunctionSupervisor::makeDevicePtr(void* ptr, const std::function<void(void*)>& deleter, Device device) {
   return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}, device};
 }
 

--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -12,8 +12,8 @@ static void deleteInefficientStdFunctionSupervisor(void* ptr) {
 }
 
 at::SupervisedPtr
-makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
-  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter, Device device) {
+  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}, device};
 }
 
 } // namespace at

--- a/aten/src/ATen/Allocator.cpp
+++ b/aten/src/ATen/Allocator.cpp
@@ -1,0 +1,19 @@
+#include <ATen/Allocator.h>
+
+namespace at {
+
+void deleteNothing(void*) {}
+SupervisorPtr nonOwningSupervisorPtr() {
+  return {nullptr, &deleteNothing};
+}
+
+static void deleteInefficientStdFunctionSupervisor(void* ptr) {
+  delete static_cast<InefficientStdFunctionSupervisor*>(ptr);
+}
+
+at::SupervisedPtr
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter) {
+  return {ptr, SupervisorPtr{new InefficientStdFunctionSupervisor({ptr, deleter}), &deleteInefficientStdFunctionSupervisor}};
+}
+
+} // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -3,14 +3,122 @@
 #include <memory>
 #include <stddef.h>
 
-#include "ATen/Retainable.h"
+#include <ATen/Error.h>
+#include <ATen/Retainable.h>
 
 namespace at {
 
+// Note [Supervisor deleter]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~
+// SupervisorPtr solves a common problem for allocators of tensor data, which
+// is that the data pointer (e.g., float*) which you are interested in, is not
+// the same as the metadata pointer (e.g., DLManagedTensor) which you need
+// to actually deallocate the data.  Under a conventional deleter design, you
+// have to store extra context in the deleter (the metadata pointer) so that
+// you can actually delete the right thing.  Implementing this with standard
+// C++ is somewhat error-prone: if you use a std::unique_ptr to manage tensors,
+// the deleter will not be called if the data pointer is nullptr, which can
+// cause a leak if the metadata pointer is non-null (and the deleter is
+// responsible for freeing both the data pointer and the metadata pointer).
+//
+// We take a different approach.  The "metadata supervisor" situation is common
+// enough that we have organized our deleter strategy entirely around it:
+// instead of trying to make the deleter for the data pointer handle all the
+// heavy lifting, the data pointer is *non-owning*, and instead there is a
+// (type-erased) supervisor pointer which actually handles deletion.  For simple
+// cases, the supervisor pointer is the same as the data pointer, but if
+// there is some extra metadata, the supervisor pointer points there.
+//
+// There is something of a pattern to writing these; check THAllocator.{h,cpp}
+// for some examples.
+
+using DeleterFnPtr = void(*)(void*);
+using SupervisorPtr = std::unique_ptr<void, DeleterFnPtr>;
+
+// Does not delete anything
+AT_API void deleteNothing(void*);
+// Mints a SupervisorPtr that doesn't do anything.  You must
+// use this, not a nullptr, when you want a view.
+AT_API SupervisorPtr nonOwningSupervisorPtr();
+
+struct SupervisedPtr {
+  // Lifetime tied to supervisor_
+  void* data_;
+  SupervisorPtr supervisor_;
+  SupervisedPtr() : data_(nullptr), supervisor_(nonOwningSupervisorPtr()) {}
+  SupervisedPtr(void* data, SupervisorPtr&& supervisor)
+    : data_(data), supervisor_(std::move(supervisor)) {}
+  void* operator->() const { return data_; }
+  void* get() const { return data_; }
+  operator bool() { return data_ || supervisor_; }
+  SupervisedPtr& operator=( nullptr_t ) noexcept { data_ = nullptr; supervisor_ = nullptr; return *this; }
+};
+
+inline bool operator==(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
+}
+inline bool operator==(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
+}
+inline bool operator!=(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
+}
+inline bool operator!=(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
+}
+
+// Note [raw_allocate/raw_deallocate and Thrust]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Thrust's support for custom allocators requires us to write something
+// like this:
+//
+//  class ThrustAllocator {
+//    char* allocate(size_t);
+//    void deallocate(char*, size_t);
+//  };
+//
+// This is not good for our unique_ptr based allocator interface, as
+// there is no way to get the deleter from our allocator to the
+// deletion site in Thrust.  Indeed, if every pointer is getting a
+// *fresh* deleter, we truly would have no choice except to maintain
+// a map from pointers to deleters.  This is bad.
+//
+// So, we observe that not *all* deleters actually have lots of
+// different deleters; some of them actually always return the same
+// deleter every time.  In this case, we can support the "raw"
+// allocate and deallocate interface.  This is what
+// maybeGlobalBoundDeleter signifies.  By default, it returns the
+// default (empty) BoundDeleter, which means that the raw interface
+// is not implemented.  Be sure to implement it whenever possible.
+
 struct Allocator {
   virtual ~Allocator() {}
-  virtual void* allocate(size_t n) const = 0;
-  virtual void deallocate(void* ptr) const = 0;
+  virtual at::SupervisedPtr allocate(size_t n) const = 0;
+
+  // If this returns a non nullptr, it means that allocate()
+  // is guaranteed to return a unique_ptr with this deleter attached;
+  // it means the rawAllocate and rawDeallocate APIs are safe to use.
+  // This function MUST always return the same BoundDeleter.
+  virtual DeleterFnPtr raw_deleter() const { return nullptr; }
+  void* raw_allocate(size_t n) {
+    auto sptr = allocate(n);
+    AT_ASSERT(sptr.data_ == sptr.supervisor_.get());
+    return sptr.supervisor_.release();
+  }
+  void raw_deallocate(void* ptr) {
+    auto d = raw_deleter();
+    AT_ASSERT(d);
+    d(ptr);
+  }
 };
+
+struct AT_API InefficientStdFunctionSupervisor {
+  std::unique_ptr<void, std::function<void(void*)>> ptr_;
+  InefficientStdFunctionSupervisor(std::unique_ptr<void, std::function<void(void*)>>&& ptr)
+    : ptr_(std::move(ptr)) {}
+};
+
+AT_API at::SupervisedPtr
+makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter);
 
 }  // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -51,19 +51,19 @@ struct SupervisedPtr {
   void* operator->() const { return data_; }
   void* get() const { return data_; }
   operator bool() { return data_ || supervisor_; }
-  SupervisedPtr& operator=( nullptr_t ) noexcept { data_ = nullptr; supervisor_ = nullptr; return *this; }
+  SupervisedPtr& operator=( std::nullptr_t ) noexcept { data_ = nullptr; supervisor_ = nullptr; return *this; }
 };
 
-inline bool operator==(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+inline bool operator==(const at::SupervisedPtr& sp, std::nullptr_t) noexcept {
   return sp.data_ == nullptr && sp.supervisor_ == nullptr;
 }
-inline bool operator==(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+inline bool operator==(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
   return sp.data_ == nullptr && sp.supervisor_ == nullptr;
 }
-inline bool operator!=(const at::SupervisedPtr& sp, nullptr_t) noexcept {
+inline bool operator!=(const at::SupervisedPtr& sp, std::nullptr_t) noexcept {
   return sp.data_ != nullptr || sp.supervisor_ != nullptr;
 }
-inline bool operator!=(nullptr_t, const at::SupervisedPtr& sp) noexcept {
+inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
   return sp.data_ != nullptr || sp.supervisor_ != nullptr;
 }
 

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -6,103 +6,48 @@
 #include <ATen/Error.h>
 #include <ATen/Retainable.h>
 #include <ATen/Device.h>
+#include <ATen/detail/UniqueVoidPtr.h>
 
 namespace at {
 
-// Note [Supervisor deleter]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~
-// SupervisorPtr solves a common problem for allocators of tensor data, which
-// is that the data pointer (e.g., float*) which you are interested in, is not
-// the same as the metadata pointer (e.g., DLManagedTensor) which you need
-// to actually deallocate the data.  Under a conventional deleter design, you
-// have to store extra context in the deleter (the metadata pointer) so that
-// you can actually delete the right thing.  Implementing this with standard
-// C++ is somewhat error-prone: if you use a std::unique_ptr to manage tensors,
-// the deleter will not be called if the data pointer is nullptr, which can
-// cause a leak if the metadata pointer is non-null (and the deleter is
-// responsible for freeing both the data pointer and the metadata pointer).
+// A DataPtr is a unique pointer (with an attached deleter and some
+// context for the deleter) to some memory, which also records what
+// device is for its data.
 //
-// We take a different approach.  The "metadata supervisor" situation is common
-// enough that we have organized our deleter strategy entirely around it:
-// instead of trying to make the deleter for the data pointer handle all the
-// heavy lifting, the data pointer is *non-owning*, and instead there is a
-// (type-erased) supervisor pointer which actually handles deletion.  For simple
-// cases, the supervisor pointer is the same as the data pointer, but if
-// there is some extra metadata, the supervisor pointer points there.
+// nullptr DataPtrs can still have a nontrivial device; this allows
+// us to treat zero-size allocations uniformly with non-zero allocations.
 //
-// There is something of a pattern to writing these; check THAllocator.{h,cpp}
-// for some examples.
-
-using DeleterFnPtr = void(*)(void*);
-using SupervisorPtr = std::unique_ptr<void, DeleterFnPtr>;
-
-// Does not delete anything
-AT_API void deleteNothing(void*);
-// Mints a SupervisorPtr that doesn't do anything.  You must
-// use this, not a nullptr, when you want a view.  However,
-// this compares equal to nullptr.
-AT_API SupervisorPtr nonOwningSupervisorPtr();
-
-class SupervisedPtr {
+class DataPtr {
 private:
-  // Lifetime tied to supervisor_
-  void* data_;
-  SupervisorPtr supervisor_;
-public:
-  SupervisedPtr() : data_(nullptr), supervisor_(nonOwningSupervisorPtr()) {}
-  SupervisedPtr(void* data, SupervisorPtr&& supervisor)
-    : data_(data), supervisor_(std::move(supervisor)) {}
-  void* operator->() const { return data_; }
-  void* get() const { return data_; }
-  void* get_supervisor() const { return supervisor_.get(); }
-  void* release_supervisor() { return supervisor_.release(); }
-  template <typename T>
-  T* cast_supervisor(DeleterFnPtr expected_deleter) const {
-    if (get_deleter() != expected_deleter) return nullptr;
-    return static_cast<T*>(get_supervisor());
-  }
-  operator bool() const { return data_ || supervisor_; }
-  DeleterFnPtr get_deleter() const { return supervisor_.get_deleter(); }
-};
-
-// A DevicePtr is a SupervisedPtr that also records what device it's memory
-// is stored on.
-
-class DevicePtr {
-private:
-  // Lifetime tied to supervisor_
-  SupervisedPtr sptr_;
+  detail::UniqueVoidPtr ptr_;
   Device device_;
 public:
   // Choice of CPU here is arbitrary; if there's an "undefined" device
   // we could use that too
-  DevicePtr() : sptr_(), device_(kCPU) {}
-  DevicePtr(void* data, SupervisorPtr&& supervisor, Device device)
-    : sptr_(data, std::move(supervisor)), device_(device) {}
-  void* operator->() const { return sptr_.get(); }
-  void* get() const { return sptr_.get(); }
-  void* get_supervisor() const { return sptr_.get_supervisor(); }
-  void* release_supervisor() { return sptr_.release_supervisor(); }
-  operator bool() const { return static_cast<bool>(sptr_); }
+  DataPtr() : ptr_(), device_(kCPU) {}
+  DataPtr(void* data, Device device)
+    : ptr_(data), device_(device) {}
+  DataPtr(void* data, void* ctx, DeleterFnPtr ctx_deleter, Device device)
+    : ptr_(data, ctx, ctx_deleter), device_(device) {}
+  void* operator->() const { return ptr_.get(); }
+  void* get() const { return ptr_.get(); }
+  void* get_context() const { return ptr_.get_context(); }
+  void* release_context() { return ptr_.release_context(); }
+  operator bool() const { return static_cast<bool>(ptr_); }
   template <typename T>
-  T* cast_supervisor(DeleterFnPtr expected_deleter) const {
-    return sptr_.cast_supervisor<T>(expected_deleter);
+  T* cast_context(DeleterFnPtr expected_deleter) const {
+    return ptr_.cast_context<T>(expected_deleter);
   }
   Device device() const { return device_; }
 };
 
-inline bool operator==(const at::SupervisedPtr& sp, std::nullptr_t) noexcept { return !sp; }
-inline bool operator==(std::nullptr_t, const at::SupervisedPtr& sp) noexcept { return !sp; }
-inline bool operator!=(const at::SupervisedPtr& sp, std::nullptr_t) noexcept { return sp; }
-inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept { return sp; }
-
 // NB: Device is NOT tested for here; a CUDA nullptr is as much a nullptr as a
 // CPU nullptr
 
-inline bool operator==(const at::DevicePtr& dp, std::nullptr_t) noexcept { return !dp; }
-inline bool operator==(std::nullptr_t, const at::DevicePtr& dp) noexcept { return !dp; }
-inline bool operator!=(const at::DevicePtr& dp, std::nullptr_t) noexcept { return dp; }
-inline bool operator!=(std::nullptr_t, const at::DevicePtr& dp) noexcept { return dp; }
+inline bool operator==(const at::DataPtr& dp, std::nullptr_t) noexcept { return !dp; }
+inline bool operator==(std::nullptr_t, const at::DataPtr& dp) noexcept { return !dp; }
+inline bool operator!=(const at::DataPtr& dp, std::nullptr_t) noexcept { return dp; }
+inline bool operator!=(std::nullptr_t, const at::DataPtr& dp) noexcept { return dp; }
 
 // Note [raw_allocate/raw_deallocate and Thrust]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,9 +60,9 @@ inline bool operator!=(std::nullptr_t, const at::DevicePtr& dp) noexcept { retur
 //  };
 //
 // This is not good for our unique_ptr based allocator interface, as
-// there is no way to get to the supervisor when we free.
+// there is no way to get to the context when we free.
 //
-// However, in some cases the supervisor is exactly the same as
+// However, in some cases the context is exactly the same as
 // the data pointer.  In this case, we can support the "raw"
 // allocate and deallocate interface.  This is what
 // raw_deleter signifies.  By default, it returns a nullptr, which means that
@@ -126,7 +71,7 @@ inline bool operator!=(std::nullptr_t, const at::DevicePtr& dp) noexcept { retur
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual at::DevicePtr allocate(size_t n) const = 0;
+  virtual at::DataPtr allocate(size_t n) const = 0;
 
   // If this returns a non nullptr, it means that allocate()
   // is guaranteed to return a unique_ptr with this deleter attached;
@@ -135,8 +80,8 @@ struct Allocator {
   virtual DeleterFnPtr raw_deleter() const { return nullptr; }
   void* raw_allocate(size_t n) {
     auto dptr = allocate(n);
-    AT_ASSERT(dptr.get() == dptr.get_supervisor());
-    return dptr.release_supervisor();
+    AT_ASSERT(dptr.get() == dptr.get_context());
+    return dptr.release_context();
   }
   void raw_deallocate(void* ptr) {
     auto d = raw_deleter();
@@ -145,11 +90,11 @@ struct Allocator {
   }
 };
 
-struct AT_API InefficientStdFunctionSupervisor {
+struct AT_API InefficientStdFunctionContext {
   std::unique_ptr<void, std::function<void(void*)>> ptr_;
-  InefficientStdFunctionSupervisor(std::unique_ptr<void, std::function<void(void*)>>&& ptr)
+  InefficientStdFunctionContext(std::unique_ptr<void, std::function<void(void*)>>&& ptr)
     : ptr_(std::move(ptr)) {}
-  static at::DevicePtr makeDevicePtr(void* ptr, const std::function<void(void*)>& deleter, Device device);
+  static at::DataPtr makeDataPtr(void* ptr, const std::function<void(void*)>& deleter, Device device);
 };
 
 }  // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -67,7 +67,8 @@ inline bool operator!=(std::nullptr_t, const at::DataPtr& dp) noexcept { return 
 // allocate and deallocate interface.  This is what
 // raw_deleter signifies.  By default, it returns a nullptr, which means that
 // the raw interface is not implemented.  Be sure to implement it whenever
-// possible.
+// possible, or the raw interface will incorrectly reported as unsupported,
+// when it is actually possible.
 
 struct Allocator {
   virtual ~Allocator() {}

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -39,37 +39,70 @@ using SupervisorPtr = std::unique_ptr<void, DeleterFnPtr>;
 // Does not delete anything
 AT_API void deleteNothing(void*);
 // Mints a SupervisorPtr that doesn't do anything.  You must
-// use this, not a nullptr, when you want a view.
+// use this, not a nullptr, when you want a view.  However,
+// this compares equal to nullptr.
 AT_API SupervisorPtr nonOwningSupervisorPtr();
 
-struct SupervisedPtr {
+class SupervisedPtr {
+private:
   // Lifetime tied to supervisor_
   void* data_;
   SupervisorPtr supervisor_;
-  Device device_;
-  SupervisedPtr() : data_(nullptr), supervisor_(nonOwningSupervisorPtr()), device_(kCPU) {}
-  SupervisedPtr(void* data, SupervisorPtr&& supervisor, Device device)
-    : data_(data), supervisor_(std::move(supervisor)), device_(device) {}
+public:
+  SupervisedPtr() : data_(nullptr), supervisor_(nonOwningSupervisorPtr()) {}
+  SupervisedPtr(void* data, SupervisorPtr&& supervisor)
+    : data_(data), supervisor_(std::move(supervisor)) {}
   void* operator->() const { return data_; }
   void* get() const { return data_; }
-  operator bool() { return data_ || supervisor_; }
+  void* get_supervisor() const { return supervisor_.get(); }
+  void* release_supervisor() { return supervisor_.release(); }
+  template <typename T>
+  T* cast_supervisor(DeleterFnPtr expected_deleter) const {
+    if (get_deleter() != expected_deleter) return nullptr;
+    return static_cast<T*>(get_supervisor());
+  }
+  operator bool() const { return data_ || supervisor_; }
+  DeleterFnPtr get_deleter() const { return supervisor_.get_deleter(); }
 };
+
+// A DevicePtr is a SupervisedPtr that also records what device it's memory
+// is stored on.
+
+class DevicePtr {
+private:
+  // Lifetime tied to supervisor_
+  SupervisedPtr sptr_;
+  Device device_;
+public:
+  // Choice of CPU here is arbitrary; if there's an "undefined" device
+  // we could use that too
+  DevicePtr() : sptr_(), device_(kCPU) {}
+  DevicePtr(void* data, SupervisorPtr&& supervisor, Device device)
+    : sptr_(data, std::move(supervisor)), device_(device) {}
+  void* operator->() const { return sptr_.get(); }
+  void* get() const { return sptr_.get(); }
+  void* get_supervisor() const { return sptr_.get_supervisor(); }
+  void* release_supervisor() { return sptr_.release_supervisor(); }
+  operator bool() const { return static_cast<bool>(sptr_); }
+  template <typename T>
+  T* cast_supervisor(DeleterFnPtr expected_deleter) const {
+    return sptr_.cast_supervisor<T>(expected_deleter);
+  }
+  Device device() const { return device_; }
+};
+
+inline bool operator==(const at::SupervisedPtr& sp, std::nullptr_t) noexcept { return !sp; }
+inline bool operator==(std::nullptr_t, const at::SupervisedPtr& sp) noexcept { return !sp; }
+inline bool operator!=(const at::SupervisedPtr& sp, std::nullptr_t) noexcept { return sp; }
+inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept { return sp; }
 
 // NB: Device is NOT tested for here; a CUDA nullptr is as much a nullptr as a
 // CPU nullptr
 
-inline bool operator==(const at::SupervisedPtr& sp, std::nullptr_t) noexcept {
-  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
-}
-inline bool operator==(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
-  return sp.data_ == nullptr && sp.supervisor_ == nullptr;
-}
-inline bool operator!=(const at::SupervisedPtr& sp, std::nullptr_t) noexcept {
-  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
-}
-inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
-  return sp.data_ != nullptr || sp.supervisor_ != nullptr;
-}
+inline bool operator==(const at::DevicePtr& dp, std::nullptr_t) noexcept { return !dp; }
+inline bool operator==(std::nullptr_t, const at::DevicePtr& dp) noexcept { return !dp; }
+inline bool operator!=(const at::DevicePtr& dp, std::nullptr_t) noexcept { return dp; }
+inline bool operator!=(std::nullptr_t, const at::DevicePtr& dp) noexcept { return dp; }
 
 // Note [raw_allocate/raw_deallocate and Thrust]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -93,7 +126,7 @@ inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual at::SupervisedPtr allocate(size_t n) const = 0;
+  virtual at::DevicePtr allocate(size_t n) const = 0;
 
   // If this returns a non nullptr, it means that allocate()
   // is guaranteed to return a unique_ptr with this deleter attached;
@@ -101,9 +134,9 @@ struct Allocator {
   // This function MUST always return the same BoundDeleter.
   virtual DeleterFnPtr raw_deleter() const { return nullptr; }
   void* raw_allocate(size_t n) {
-    auto sptr = allocate(n);
-    AT_ASSERT(sptr.data_ == sptr.supervisor_.get());
-    return sptr.supervisor_.release();
+    auto dptr = allocate(n);
+    AT_ASSERT(dptr.get() == dptr.get_supervisor());
+    return dptr.release_supervisor();
   }
   void raw_deallocate(void* ptr) {
     auto d = raw_deleter();
@@ -116,9 +149,7 @@ struct AT_API InefficientStdFunctionSupervisor {
   std::unique_ptr<void, std::function<void(void*)>> ptr_;
   InefficientStdFunctionSupervisor(std::unique_ptr<void, std::function<void(void*)>>&& ptr)
     : ptr_(std::move(ptr)) {}
+  static at::DevicePtr makeDevicePtr(void* ptr, const std::function<void(void*)>& deleter, Device device);
 };
-
-AT_API at::SupervisedPtr
-makeInefficientStdFunctionSupervisedPtr(void* ptr, const std::function<void(void*)>& deleter, Device device);
 
 }  // namespace at

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -82,18 +82,14 @@ inline bool operator!=(std::nullptr_t, const at::SupervisedPtr& sp) noexcept {
 //  };
 //
 // This is not good for our unique_ptr based allocator interface, as
-// there is no way to get the deleter from our allocator to the
-// deletion site in Thrust.  Indeed, if every pointer is getting a
-// *fresh* deleter, we truly would have no choice except to maintain
-// a map from pointers to deleters.  This is bad.
+// there is no way to get to the supervisor when we free.
 //
-// So, we observe that not *all* deleters actually have lots of
-// different deleters; some of them actually always return the same
-// deleter every time.  In this case, we can support the "raw"
+// However, in some cases the supervisor is exactly the same as
+// the data pointer.  In this case, we can support the "raw"
 // allocate and deallocate interface.  This is what
-// maybeGlobalBoundDeleter signifies.  By default, it returns the
-// default (empty) BoundDeleter, which means that the raw interface
-// is not implemented.  Be sure to implement it whenever possible.
+// raw_deleter signifies.  By default, it returns a nullptr, which means that
+// the raw interface is not implemented.  Be sure to implement it whenever
+// possible.
 
 struct Allocator {
   virtual ~Allocator() {}

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -58,10 +58,10 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data_ptr = {&one, at::nonOwningSupervisorPtr(), kCPU};
+      storage.data_ptr = {&one, kCPU}; // non-owning
       storage.size = 1;
     } else {
-      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), at::nonOwningSupervisorPtr(), kCPU};
+      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), kCPU}; // non-owning
       storage.size = ref.size();
     }
     storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -58,17 +58,15 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data_ptr = &one;
+      storage.data_ptr = {&one, at::nonOwningSupervisorPtr()};
       storage.size = 1;
     } else {
-      storage.data_ptr = (void*)(ref.data());
+      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), at::nonOwningSupervisorPtr()};
       storage.size = ref.size();
     }
     storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();
     storage.refcount = 0;
     storage.flag = 0;
-    storage.allocatorVoidPtr = nullptr;
-    storage.allocatorContext = nullptr;
   }
 private:
   int64_t one;

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -58,10 +58,10 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data_ptr = {&one, at::nonOwningSupervisorPtr()};
+      storage.data_ptr = {&one, at::nonOwningSupervisorPtr(), kCPU};
       storage.size = 1;
     } else {
-      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), at::nonOwningSupervisorPtr()};
+      storage.data_ptr = {const_cast<void*>(static_cast<const void*>(ref.data())), at::nonOwningSupervisorPtr(), kCPU};
       storage.size = ref.size();
     }
     storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
@@ -9,20 +9,9 @@
 
 namespace at { namespace cuda {
 
-void* PinnedMemoryAllocator::allocate(size_t n) const {
+at::Allocator* getPinnedMemoryAllocator() {
   auto state = globalContext().lazyInitCUDA();
-  return state->cudaHostAllocator->malloc(nullptr, n);
-}
-
-void PinnedMemoryAllocator::deallocate(void* ptr) const {
-  auto state = globalContext().lazyInitCUDA();
-  return state->cudaHostAllocator->free(nullptr, ptr);
-}
-
-// No risk of static initialization order fiasco
-static PinnedMemoryAllocator r;
-PinnedMemoryAllocator* getPinnedMemoryAllocator() {
-  return &r;
+  return state->cudaHostAllocator;
 }
 
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.h
@@ -4,11 +4,6 @@
 
 namespace at { namespace cuda {
 
-struct PinnedMemoryAllocator final : public Allocator {
-  void* allocate(size_t n) const override;
-  void deallocate(void* ptr) const override;
-};
-
-PinnedMemoryAllocator* getPinnedMemoryAllocator();
+at::Allocator* getPinnedMemoryAllocator();
 
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -87,8 +87,9 @@ DynamicCUDAInterfaceSetter _;
 // let's not if we don't need to!)
 std::unique_ptr<THCState, void (*)(THCState*)> CUDAHooks::initCUDA() const {
   THCState* thc_state = THCState_alloc();
+  // Caching allocator has no context
   THCState_setDeviceAllocator(thc_state, THCCachingAllocator_get());
-  thc_state->cudaHostAllocator = &THCCachingHostAllocator;
+  thc_state->cudaHostAllocator = getTHCCachingHostAllocator();
   THCudaInit(thc_state);
   return std::unique_ptr<THCState, void (*)(THCState*)>(
       thc_state, [](THCState* p) {

--- a/aten/src/ATen/detail/UniqueVoidPtr.cpp
+++ b/aten/src/ATen/detail/UniqueVoidPtr.cpp
@@ -1,0 +1,7 @@
+#include <ATen/detail/UniqueVoidPtr.h>
+
+namespace at { namespace detail {
+
+void deleteNothing(void*) {}
+
+}} // namespace at

--- a/aten/src/ATen/detail/UniqueVoidPtr.h
+++ b/aten/src/ATen/detail/UniqueVoidPtr.h
@@ -19,7 +19,12 @@ AT_API void deleteNothing(void*);
 //    2) It is specialized for a function pointer deleter
 //       void(void* ctx); i.e., the deleter doesn't take a
 //       reference to the data, just to a context pointer
-//       (erased as void*)
+//       (erased as void*).  In fact, internally, this pointer
+//       is implemented as having an owning reference to
+//       context, and a non-owning reference to data; this is why
+//       you release_context(), not release() (the conventional
+//       API for release() wouldn't give you enough information
+//       to properly dispose of the object later.)
 //
 //    3) The deleter is guaranteed to be called when the unique
 //       pointer is destructed and the context is non-null; this is different

--- a/aten/src/ATen/detail/UniqueVoidPtr.h
+++ b/aten/src/ATen/detail/UniqueVoidPtr.h
@@ -1,0 +1,79 @@
+#include <memory>
+
+#include <ATen/ATenGeneral.h>
+
+namespace at {
+
+using DeleterFnPtr = void(*)(void*);
+
+namespace detail {
+
+// Does not delete anything
+AT_API void deleteNothing(void*);
+
+// A detail::UniqueVoidPtr is an owning smart pointer like unique_ptr, but
+// with three major differences:
+//
+//    1) It is specialized to void
+//
+//    2) It is specialized for a function pointer deleter
+//       void(void* ctx); i.e., the deleter doesn't take a
+//       reference to the data, just to a context pointer
+//       (erased as void*)
+//
+//    3) The deleter is guaranteed to be called when the unique
+//       pointer is destructed and the context is non-null; this is different
+//       from std::unique_ptr where the deleter is not called if the
+//       data pointer is null.
+//
+// Some of the methods have slightly different types than std::unique_ptr
+// to reflect this.
+//
+class UniqueVoidPtr {
+private:
+  // Lifetime tied to ctx_
+  void* data_;
+  std::unique_ptr<void, DeleterFnPtr> ctx_;
+public:
+  UniqueVoidPtr() : data_(nullptr), ctx_(nullptr, &deleteNothing) {}
+  explicit UniqueVoidPtr(void* data) : data_(data), ctx_(nullptr, &deleteNothing) {}
+  UniqueVoidPtr(void* data, void* ctx, DeleterFnPtr ctx_deleter)
+    : data_(data), ctx_(ctx, ctx_deleter ? ctx_deleter : &deleteNothing) {}
+  void* operator->() const { return data_; }
+  void* get() const { return data_; }
+  void* get_context() const { return ctx_.get(); }
+  void* release_context() { return ctx_.release(); }
+  template <typename T>
+  T* cast_context(DeleterFnPtr expected_deleter) const {
+    if (get_deleter() != expected_deleter) return nullptr;
+    return static_cast<T*>(get_context());
+  }
+  operator bool() const { return data_ || ctx_; }
+  DeleterFnPtr get_deleter() const { return ctx_.get_deleter(); }
+};
+
+
+// Note [How UniqueVoidPtr is implemented]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// UniqueVoidPtr solves a common problem for allocators of tensor data, which
+// is that the data pointer (e.g., float*) which you are interested in, is not
+// the same as the context pointer (e.g., DLManagedTensor) which you need
+// to actually deallocate the data.  Under a conventional deleter design, you
+// have to store extra context in the deleter itself so that you can actually
+// delete the right thing.  Implementing this with standard C++ is somewhat
+// error-prone: if you use a std::unique_ptr to manage tensors, the deleter will
+// not be called if the data pointer is nullptr, which can cause a leak if the
+// context pointer is non-null (and the deleter is responsible for freeing both
+// the data pointer and the context pointer).
+//
+// So, in our reimplementation of unique_ptr, which just store the context
+// directly in the unique pointer, and attach the deleter to the context
+// pointer itself.  In simple cases, the context pointer is just the pointer
+// itself.
+
+inline bool operator==(const UniqueVoidPtr& sp, std::nullptr_t) noexcept { return !sp; }
+inline bool operator==(std::nullptr_t, const UniqueVoidPtr& sp) noexcept { return !sp; }
+inline bool operator!=(const UniqueVoidPtr& sp, std::nullptr_t) noexcept { return sp; }
+inline bool operator!=(std::nullptr_t, const UniqueVoidPtr& sp) noexcept { return sp; }
+
+}} // namespace at::detail

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -349,7 +349,7 @@ BenchmarkCache<cudnnConvolutionBwdFilterAlgo_t> bwd_filter_algos;
 // tensor instead.
 struct Workspace {
   Workspace(size_t size) : size(size), data(NULL) {
-    AT_CUDA_CHECK(THCudaMalloc(globalContext().lazyInitCUDA(), &data, size));
+    data = THCudaMalloc(globalContext().lazyInitCUDA(), size);
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
@@ -692,11 +692,10 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   }
   cache.insert(args.params, *algo);
 
-  // These two lines frees the cached blocks in our caching allocator. They are
+  // Free the cached blocks in our caching allocator. They are
   // needed here because the above benchmarking uses a huge amount of memory,
   // e.g. a few GBs.
-  THCDeviceAllocator* allocator = THCCachingAllocator_get();
-  AT_CUDA_CHECK(allocator->emptyCache(allocator->state));
+  THCCachingAllocator_emptyCache();
 }
 
 template<typename algo_t>

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -39,7 +39,7 @@ static int getPointerDevice(void* ptr) {
 ${Storage}::${Storage}(Context* context,
   void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
-      InefficientStdFunctionSupervisor::makeDevicePtr(data, deleter,
+      InefficientStdFunctionContext::makeDataPtr(data, deleter,
 #if ${isCUDA}
       Device(kCUDA, getPointerDevice(data))
 #else

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -19,76 +19,18 @@ ${Storage}::${Storage}(Context* context, THStorage* storage):
 ${Storage}::${Storage}(Context* context, size_t storage_size)
   : storage(${THStorage}_newWithSize(${state,} storage_size)), context(context) {}
 
-#if ${isCUDA}
-static cudaError_t call_deleter(void * ctx, void * data) {
-  auto fnptr = (std::function<void(void*)>*) ctx;
-  (*fnptr)(data);
-  delete fnptr;
-  return cudaSuccess;
-}
-static THCDeviceAllocator storage_deleter = {
-  nullptr,
-  nullptr,
-  call_deleter,
-  nullptr,
-  nullptr,
-};
-static cudaError_t wrapped_alloc(void * ctx, void** result, size_t size, cudaStream_t stream) {
-  auto ac = static_cast<Allocator*>(ctx);
-  *result = ac->allocate(size);
-  return cudaSuccess;
-}
-static cudaError_t wrapped_free(void * ctx, void * data) {
-  auto ac = static_cast<Allocator*>(ctx);
-  ac->deallocate(data);
-  return cudaSuccess;
-}
-static THCDeviceAllocator wrapped_allocator = {
-  wrapped_alloc,
-  nullptr,
-  wrapped_free,
-  nullptr,
-  nullptr,
-};
-#else
-static void call_deleter(void * ctx, void * data) {
-  auto fnptr = (std::function<void(void*)>*) ctx;
-  (*fnptr)(data);
-  delete fnptr;
-}
-static THAllocator storage_deleter = {
-  nullptr,
-  nullptr,
-  call_deleter,
-};
-static void* wrapped_alloc(void * ctx, ptrdiff_t size) {
-  auto ac = static_cast<Allocator*>(ctx);
-  return ac->allocate(size);
-}
-static void wrapped_free(void * ctx, void * data) {
-  auto ac = static_cast<Allocator*>(ctx);
-  ac->deallocate(data);
-}
-static THAllocator wrapped_allocator = {
-  wrapped_alloc,
-  nullptr,
-  wrapped_free,
-};
-#endif
-
 ${Storage}::${Storage}(Context* context, size_t size, Allocator* allocator)
   : storage(nullptr),
     context(context) {
-  storage = ${THStorage}_newWithAllocator(${state,} size, &wrapped_allocator, allocator);
+  storage = ${THStorage}_newWithAllocator(${state,} size, allocator);
   ${THStorage}_clearFlag(${state,} storage, TH_STORAGE_RESIZABLE);
 }
 
 ${Storage}::${Storage}(Context* context,
   void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
-     static_cast<${THScalarType}*>(data), size,
-     &storage_deleter,
-     new std::function<void(void*)>(deleter)
+     makeInefficientStdFunctionSupervisedPtr(data, deleter), size,
+     /* allocator */ nullptr
     )),
     context(context) {
     ${THStorage}_clearFlag(${state,} storage, TH_STORAGE_RESIZABLE);
@@ -107,11 +49,11 @@ size_t ${Storage}::size() const {
 }
 
 void* ${Storage}::data() {
-  return storage->data_ptr;
+  return storage->data_ptr.get();
 }
 
 const void* ${Storage}::data() const {
-  return storage->data_ptr;
+  return storage->data_ptr.get();
 }
 
 auto ${Storage}::retain() -> ${Storage}& {

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -39,7 +39,7 @@ static int getPointerDevice(void* ptr) {
 ${Storage}::${Storage}(Context* context,
   void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
-     makeInefficientStdFunctionSupervisedPtr(data, deleter,
+      InefficientStdFunctionSupervisor::makeDevicePtr(data, deleter,
 #if ${isCUDA}
       Device(kCUDA, getPointerDevice(data))
 #else
@@ -128,7 +128,7 @@ void ${Storage}::clear_flag(char flag) {
 }
 
 int ${Storage}::getDevice() const {
-  return storage->data_ptr.device_.index();
+  return storage->data_ptr.device().index();
 }
 
 Type& ${Storage}::type() const {

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -103,7 +103,8 @@ TEST_CASE( "atest", "[]" ) {
   if(at::hasCUDA()) {
     int isgone = 0;
     {
-      auto f2 = CUDA(kFloat).tensorFromBlob(nullptr, {1,2,3}, [&](void*) {
+      auto base = CUDA(kFloat).tensor({1,2,3});
+      auto f2 = CUDA(kFloat).tensorFromBlob(base.data_ptr(), {1,2,3}, [&](void*) {
         isgone++;
       });
     }

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -5,11 +5,6 @@
 #define TH_ATOMIC_IPC_REFCOUNT 1
 #endif
 
-/* stuff for mapped files */
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #if HAVE_MMAP
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -49,7 +49,7 @@ THMapAllocator::THMapAllocator(WithFd, const char *filename, int fd, int flags, 
 #ifdef _WIN32
   , handle_(INVALID_HANDLE_VALUE) // to be filled later
   , event_(INVALID_HANDLE_VALUE) // to be filled later
-  , eventname_(filename ? filename + "_event" : unknown_eventname)
+  , eventname_(filename ? std::string(filename) + "_event" : unknown_eventname)
 #else
   , fd_(fd)
 #endif
@@ -78,16 +78,16 @@ THMapAllocator::THMapAllocator(WithFd, const char *filename, int fd, int flags, 
 #ifdef _WIN32
   if (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM) {
     // Shadowing
-    char *filename;
-    char *eventname;
+    const char *filename;
+    const char *eventname;
     LARGE_INTEGER hfilesz;
 
     if (filename_[0] == '/') {
       filename = filename_.c_str() + 1;
       eventname = eventname_.c_str() + 1;
     } else {
-      filename = filename_;
-      eventname = eventname_;
+      filename = filename_.c_str();
+      eventname = eventname_.c_str();
     }
 
     hfilesz.QuadPart = size;

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -19,38 +19,22 @@
 #endif
 /* end of stuff for mapped files */
 
-static void *THDefaultAllocator_alloc(void* ctx, ptrdiff_t size) {
-  return THAlloc(size);
-}
-
-static void *THDefaultAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
-  return THRealloc(ptr, size);
-}
-
-static void THDefaultAllocator_free(void* ctx, void* ptr) {
-  THFree(ptr);
-}
-
-THAllocator THDefaultAllocator = {
-  &THDefaultAllocator_alloc,
-  &THDefaultAllocator_realloc,
-  &THDefaultAllocator_free
+struct THDefaultAllocator final : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    auto* ptr = THAlloc(size);
+    return {ptr, {ptr, THFree}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &THFree;
+  }
 };
+
+static THDefaultAllocator th_default_allocator;
+at::Allocator* getTHDefaultAllocator() {
+  return &th_default_allocator;
+}
 
 #if defined(_WIN32) || defined(HAVE_MMAP)
-
-struct THMapAllocatorContext_ {
-  char *filename; /* file name */
-  int flags;
-  ptrdiff_t size; /* mapped size */
-#ifdef _WIN32
-  HANDLE handle;
-  HANDLE event;
-  char *eventname;
-#else
-  int fd;
-#endif
-};
 
 #define TH_ALLOC_ALIGNMENT 64
 
@@ -63,85 +47,286 @@ const char * unknown_filename = "filename not specified";
 const char * unknown_eventname = "eventname not specified";
 #endif
 
-THMapAllocatorContext *THMapAllocatorContext_new(const char *filename, int flags)
+THMapAllocator::THMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size)
+  : filename_(filename ? filename : unknown_filename)
+  , flags_(0) // to be filled later
+  , size_(0) // to be filled later
+#ifdef _WIN32
+  , handle_(INVALID_HANDLE_VALUE) // to be filled later
+  , event_(INVALID_HANDLE_VALUE) // to be filled later
+  , eventname_(filename ? filename + "_event" : unknown_eventname)
+#else
+  , fd_(fd)
+#endif
+  , base_ptr_(nullptr)
 {
-  THMapAllocatorContext *ctx = static_cast<THMapAllocatorContext*>(THAlloc(sizeof(THMapAllocatorContext)));
 
-  if (!(flags & TH_ALLOCATOR_MAPPED_SHARED) && !(flags & TH_ALLOCATOR_MAPPED_SHAREDMEM))
+  if (!(flags & TH_ALLOCATOR_MAPPED_SHARED) && !(flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)) {
     flags &= ~TH_ALLOCATOR_MAPPED_NOCREATE;
-  if ((flags ^ TH_ALLOCATOR_MAPPED_EXCLUSIVE) == 0)
-    THError("TH_ALLOCATOR_MAPPED_EXCLUSIVE flag requires opening the file "
-        "in shared mode");
-
-  if (!filename) {
-    filename = unknown_filename;
   }
-  ctx->filename = static_cast<char*>(THAlloc(strlen(filename)+1));
-  strcpy(ctx->filename, filename);
+  if ((flags ^ TH_ALLOCATOR_MAPPED_EXCLUSIVE) == 0) {
+    AT_ERROR("TH_ALLOCATOR_MAPPED_EXCLUSIVE flag requires opening the file in shared mode");
+  }
 #ifdef _WIN32
-  if (filename == unknown_filename) {
-    size_t namelen = strlen(unknown_eventname)+1;
-    ctx->eventname = static_cast<char*>(THAlloc(namelen));
-    strcpy(ctx->eventname, unknown_eventname);
+  if (fd != -1) {
+    AT_ERROR("THMapAllocator_newWithFd is unsupported on Windows");
+  }
+#endif
+  flags_ = flags;
+
+  // OK, now do the allocation
+
+  if (size == 0) {
+    return;
+  }
+
+#ifdef _WIN32
+  if (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM) {
+    // Shadowing
+    char *filename;
+    char *eventname;
+    LARGE_INTEGER hfilesz;
+
+    if (filename_[0] == '/') {
+      filename = filename_.c_str() + 1;
+      eventname = eventname_.c_str() + 1;
+    } else {
+      filename = filename_;
+      eventname = eventname_;
+    }
+
+    hfilesz.QuadPart = size;
+
+    if (flags_ & TH_ALLOCATOR_MAPPED_EXCLUSIVE) {
+      handle_ = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, hfilesz.HighPart, hfilesz.LowPart, filename);
+      event_ = CreateEvent(nullptr, FALSE, FALSE, eventname);
+    } else if (flags_ & TH_ALLOCATOR_MAPPED_NOCREATE) {
+      handle_ = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, filename);
+      event_ = OpenEvent(EVENT_ALL_ACCESS, FALSE, eventname);
+    } else {
+      AT_ERROR("Expected either TH_ALLOCATOR_MAPPED_EXCLUSIVE or TH_ALLOCATOR_MAPPED_NOCREATE");
+    }
+
+    if (event_ == nullptr) {
+      AT_ERROR("Couldn't open shared event: <", eventname, ">, error code: <", GetLastError(), ">");
+    }
+
+    if (handle_ == nullptr) {
+      AT_ERROR("Couldn't open shared file mapping: <", filename, ">, error code: <", GetLastError(), ">");
+    }
+
+    size_ = size;
+    base_ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size);
+    if (!base_ptr_) {
+      AT_ERROR("Couldn't map view of shared file <", filename, ">, error code: <", GetLastError(), ">");
+    }
   } else {
-    const char *suffixname = "_event";
-    size_t namelen = strlen(filename)+1+strlen(suffixname);
-    ctx->eventname = static_cast<char*>(THAlloc(namelen));
-    strcpy(ctx->eventname, ctx->filename);
-    strcat(ctx->eventname, suffixname);
+
+    HANDLE hfile;
+    HANDLE hmfile;
+    LARGE_INTEGER hfilesz;
+
+    if (flags_ & TH_ALLOCATOR_MAPPED_EXCLUSIVE) {
+      AT_ERROR("exclusive file mapping is not supported on Windows");
+    }
+    if (flags_ & TH_ALLOCATOR_MAPPED_NOCREATE) {
+      AT_ERROR("file mapping without creation is not supported on Windows");
+    }
+    if (flags_ & TH_ALLOCATOR_MAPPED_KEEPFD) {
+      AT_ERROR("TH_ALLOCATOR_MAPPED_KEEPFD not supported on Windows");
+    }
+    if (flags_ & TH_ALLOCATOR_MAPPED_FROMFD) {
+      AT_ERROR("TH_ALLOCATOR_MAPPED_FROMFD not supported on Windows");
+    }
+
+    /* open file */
+    /* FILE_FLAG_RANDOM_ACCESS ? */
+    if (flags_) {
+      hfile = CreateFileA(filename_.c_str(), GENERIC_READ|GENERIC_WRITE, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
+      if (hfile == INVALID_HANDLE_VALUE) {
+        AT_ERROR("could not open file <", filename_, "> in read-write mode; error code: <", GetLastError(), ">");
+      }
+    } else {
+      hfile = CreateFileA(filename_.c_str(), GENERIC_READ, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+      if (hfile == INVALID_HANDLE_VALUE) {
+        AT_ERROR("could not open file <", filename_, "> in read-only mode; error code: <", GetLastError(), ">");
+      }
+    }
+
+    if (GetFileSizeEx(hfile, &hfilesz) == 0) {
+      AT_ERROR("could not get file size: <", filename_, ">; error code: <", GetLastError(), ">");
+    }
+
+    if (size > 0) {
+      if (size > hfilesz.QuadPart) {
+        if (flags_) {
+          hfilesz.QuadPart = size;
+          if (SetFilePointerEx(hfile, hfilesz, NULL, FILE_BEGIN) == 0) {
+            CloseHandle(hfile);
+            AT_ERROR("unable to stretch file <", filename_, "> to the right size; error code: <", GetLastError(), ">", filename_);
+          }
+          if (SetEndOfFile(hfile) == 0) {
+            CloseHandle(hfile);
+            AT_ERROR("unable to write to file <", filename_, ">; error code: <", GetLastError(), ">");
+          }
+        } else {
+          CloseHandle(hfile);
+          AT_ERROR("file <", filename_, "> size is smaller than the required mapping size <", size, ">; error code: <", GetLastError(), ">");
+        }
+      }
+    } else {
+      size = hfilesz.QuadPart;
+    }
+
+    size_ = size; /* if we are here, it must be the right size */
+
+    hfilesz.QuadPart = size_;
+
+    /* get map handle */
+    if (flags_) {
+      if ( (hmfile = CreateFileMapping(hfile, NULL, PAGE_READWRITE, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL ) {
+        AT_ERROR("could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
+      }
+    } else {
+      if ( (hmfile = CreateFileMapping(hfile, NULL, PAGE_WRITECOPY, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL ) {
+        AT_ERROR("could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
+      }
+    }
+
+    /* map the stuff */
+    if(flags_) {
+      base_ptr_ = MapViewOfFile(hmfile, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+    } else {
+      base_ptr_ = MapViewOfFile(hmfile, FILE_MAP_COPY, 0, 0, 0);
+    }
+
+    CloseHandle(hfile);
+    CloseHandle(hmfile);
+  }
+#else /* _WIN32 */
+  {
+    /* open file */
+    int fd;
+    int flags; // shadow
+    struct stat file_stat;
+
+    if (flags_ & (TH_ALLOCATOR_MAPPED_SHARED | TH_ALLOCATOR_MAPPED_SHAREDMEM)) {
+      flags = O_RDWR | O_CREAT;
+    } else {
+      flags = O_RDONLY;
+    }
+
+    if (flags_ & TH_ALLOCATOR_MAPPED_EXCLUSIVE) {
+      flags |= O_EXCL;
+    }
+    if (flags_ & TH_ALLOCATOR_MAPPED_NOCREATE) {
+      flags &= ~O_CREAT;
+    }
+
+    if (!(flags_ & TH_ALLOCATOR_MAPPED_FROMFD)) {
+      if (flags_ & TH_ALLOCATOR_MAPPED_SHARED) {
+        if ((fd = open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
+          AT_ERROR("unable to open file <", filename_, "> in read-write mode");
+        }
+      } else if (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM) {
+#ifdef HAVE_SHM_OPEN
+        if((fd = shm_open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
+          AT_ERROR("unable to open shared memory object <", filename_, "> in read-write mode");
+        }
+#else
+        AT_ERROR("unable to open file <", filename_, "> in sharedmem mode, shm_open unavailable on this platform");
+#endif
+      } else {
+        if ((fd = open(filename_.c_str(), O_RDONLY)) == -1) {
+          AT_ERROR("unable to open file <", filename_, "> in read-only mode");
+        }
+      }
+    } else {
+      fd = fd_;
+    }
+
+    if (fstat(fd, &file_stat) == -1) {
+      if (!(flags_ & TH_ALLOCATOR_MAPPED_FROMFD)) {
+        close(fd);
+      }
+      AT_ERROR("unable to stat the file <", filename_, ">");
+    }
+
+    if (size > 0) {
+      if (size > file_stat.st_size) {
+        if (flags_) {
+          if (ftruncate(fd, size) == -1) {
+            AT_ERROR("unable to resize file <", filename_, "> to the right size");
+          }
+          if (fstat(fd, &file_stat) == -1 || file_stat.st_size < size) {
+            close(fd);
+            AT_ERROR("unable to stretch file <", filename_, "> to the right size");
+          }
+/* on macOS write returns with errno 45 (Opperation not supported) when used
+ * with a file descriptor obtained via shm_open
+ */
+#ifndef __APPLE__
+          if ((write(fd, "", 1)) != 1) /* note that the string "" contains the '\0' byte ... */ {
+            close(fd);
+            AT_ERROR("unable to write to file <", filename_, ">");
+          }
+#endif
+        } else {
+          close(fd);
+          AT_ERROR("file <", filename_, "> size is smaller than the required mapping size <", size, ">");
+        }
+      }
+    } else {
+      size = file_stat.st_size;
+    }
+
+    size_ = size; /* if we are here, it must be the right size */
+
+    /* map it */
+    if (flags_ & (TH_ALLOCATOR_MAPPED_SHARED | TH_ALLOCATOR_MAPPED_SHAREDMEM)) {
+      base_ptr_ = mmap(nullptr, size_, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+    } else {
+      base_ptr_ = mmap(nullptr, size_, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
+    }
+
+    if (base_ptr_ == MAP_FAILED) {
+      base_ptr_ = nullptr; /* let's be sure it is NULL */
+    }
+
+    if (flags_ & TH_ALLOCATOR_MAPPED_KEEPFD) {
+      fd_ = fd;
+    } else {
+      if (close(fd) == -1) {
+        AT_ERROR("Error closing file <", filename_, ">");
+      }
+      fd_ = -1;
+    }
+
+    if (flags_ & TH_ALLOCATOR_MAPPED_UNLINK) {
+      if (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM) {
+#ifdef HAVE_SHM_UNLINK
+        if (shm_unlink(filename_.c_str()) == -1) {
+          AT_ERROR("could not unlink the shared memory file ", filename_);
+        }
+#else
+        AT_ERROR("could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
+#endif
+      } else {
+        if (unlink(filename_.c_str()) == -1)
+          AT_ERROR("could not unlink file %s", filename_);
+      }
+    }
+
+    if (base_ptr_ == MAP_FAILED) {
+      AT_ERROR("$ Torch: unable to mmap memory: you tried to mmap ", size_/1073741824, " GB.");
+    }
   }
 #endif
-
-  ctx->flags = flags;
-  ctx->size = 0;
-#ifdef _WIN32
-  ctx->handle = INVALID_HANDLE_VALUE;
-#else
-  ctx->fd = -1;
-#endif
-
-  return ctx;
 }
 
-THMapAllocatorContext *THMapAllocatorContext_newWithFd(const char *filename, int fd, int flags)
-{
-#ifdef _WIN32
-  THError("THMapAllocatorContext_newWithFd is unsupported on Windows");
-#else
-  THMapAllocatorContext *ctx = THMapAllocatorContext_new(filename, flags);
-  ctx->fd = fd;
-
-  return ctx;
-#endif
-}
-
-char * THMapAllocatorContext_filename(THMapAllocatorContext *ctx)
-{
-  return ctx->filename;
-}
-
-int THMapAllocatorContext_fd(THMapAllocatorContext *ctx)
-{
-#ifdef _WIN32
-  THError("THMapAllocatorContext_fd is unsupported on Windows");
-#else
-  return ctx->fd;
-#endif
-}
-
-ptrdiff_t THMapAllocatorContext_size(THMapAllocatorContext *ctx)
-{
-  return ctx->size;
-}
-
-void THMapAllocatorContext_free(THMapAllocatorContext *ctx)
-{
-  THFree(ctx->filename);
-#ifdef _WIN32
-  THFree(ctx->eventname);
-#endif
-  THFree(ctx);
-}
+THMapAllocator::THMapAllocator(const char *filename, int flags, size_t size)
+  : THMapAllocator(WITH_FD, filename, -1, flags, size)
+{}
 
 #ifdef _WIN32
 typedef struct{
@@ -165,464 +350,210 @@ static VOID CALLBACK WaitForReleaseHandle(PVOID lpParam, BOOLEAN TimerOrWaitFire
 }
 #endif
 
-static void *_map_alloc(void* ctx_, ptrdiff_t size)
-{
-  if (size == 0)
-    return NULL;
-
-  THMapAllocatorContext *ctx = static_cast<THMapAllocatorContext*>(ctx_);
-  void *data = NULL;
-
-#ifdef _WIN32
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)
-  {
-    char *filename;
-    char *eventname;
-    LARGE_INTEGER hfilesz;
-
-    if (ctx->filename[0] == '/') {
-      filename = ctx->filename + 1;
-      eventname = ctx->eventname + 1;
-    }
-    else {
-      filename = ctx->filename;
-      eventname = ctx->eventname;
-    }
-
-    hfilesz.QuadPart = size;
-
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_EXCLUSIVE)
-    {
-      ctx->handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, hfilesz.HighPart, hfilesz.LowPart, filename);
-      ctx->event = CreateEvent(NULL, FALSE, FALSE, eventname);
-    }
-    else if (ctx->flags & TH_ALLOCATOR_MAPPED_NOCREATE)
-    {
-      ctx->handle = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, filename);
-      ctx->event = OpenEvent(EVENT_ALL_ACCESS, FALSE, eventname);
-    }
-    else
-    {
-      THError("Expected either TH_ALLOCATOR_MAPPED_EXCLUSIVE or TH_ALLOCATOR_MAPPED_NOCREATE");
-    }
-
-    if (ctx->event == NULL)
-      THError("Couldn't open shared event: <%s>, error code: <%d>", eventname, GetLastError());
-
-    if (ctx->handle == NULL)
-      THError("Couldn't open shared file mapping: <%s>, error code: <%d>", filename, GetLastError());
-
-    ctx->size = size;
-    data = MapViewOfFile(ctx->handle, FILE_MAP_ALL_ACCESS, 0, 0, size);
-    if (!data)
-      THError("Couldn't map view of shared file <%s>, error code: <%d>", filename, GetLastError());
-  }
-  else
-  {
-
-    HANDLE hfile;
-    HANDLE hmfile;
-    LARGE_INTEGER hfilesz;
-
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_EXCLUSIVE)
-      THError("exclusive file mapping is not supported on Windows");
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_NOCREATE)
-      THError("file mapping without creation is not supported on Windows");
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_KEEPFD)
-      THError("TH_ALLOCATOR_MAPPED_KEEPFD not supported on Windows");
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_FROMFD)
-      THError("TH_ALLOCATOR_MAPPED_FROMFD not supported on Windows");
-
-    /* open file */
-    /* FILE_FLAG_RANDOM_ACCESS ? */
-    if(ctx->flags)
-    {
-      hfile = CreateFileA(ctx->filename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
-      if (hfile == INVALID_HANDLE_VALUE)
-        THError("could not open file <%s> in read-write mode; error code: <%d>", ctx->filename, GetLastError());
-    }
-    else
-    {
-      hfile = CreateFileA(ctx->filename, GENERIC_READ, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-      if (hfile == INVALID_HANDLE_VALUE)
-        THError("could not open file <%s> in read-only mode; error code: <%d>", ctx->filename, GetLastError());
-    }
-
-    if (GetFileSizeEx(hfile, &hfilesz) == 0)
-      THError("could not get file size: <%s>; error code: <%d>", ctx->filename, GetLastError());
-
-    if(size > 0)
-    {
-      if(size > hfilesz.QuadPart)
-      {
-        if(ctx->flags)
-        {
-          hfilesz.QuadPart = size;
-          if(SetFilePointerEx(hfile, hfilesz, NULL, FILE_BEGIN) == 0)
-          {
-            CloseHandle(hfile);
-            THError("unable to stretch file <%s> to the right size; error code: <%d>", ctx->filename, GetLastError());
-          }
-          if(SetEndOfFile(hfile) == 0)
-          {
-            CloseHandle(hfile);
-            THError("unable to write to file <%s>; error code: <%d>", ctx->filename, GetLastError());
-          }
-        }
-        else
-        {
-          CloseHandle(hfile);
-          THError("file <%s> size is smaller than the required mapping size <%ld>; error code: <%d>", ctx->filename, size, GetLastError());
-        }
-      }
-    }
-    else
-      size = hfilesz.QuadPart;
-
-    ctx->size = size; /* if we are here, it must be the right size */
-
-    hfilesz.QuadPart = ctx->size;
-
-    /* get map handle */
-    if(ctx->flags)
-    {
-      if( (hmfile = CreateFileMapping(hfile, NULL, PAGE_READWRITE, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL )
-        THError("could not create a map on file <%s>; error code: <%d>", ctx->filename, GetLastError());
-    }
-    else
-    {
-      if( (hmfile = CreateFileMapping(hfile, NULL, PAGE_WRITECOPY, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL )
-        THError("could not create a map on file <%s>; error code: <%d>", ctx->filename, GetLastError());
-    }
-
-    /* map the stuff */
-    if(ctx->flags)
-      data = MapViewOfFile(hmfile, FILE_MAP_ALL_ACCESS, 0, 0, 0);
-    else
-      data = MapViewOfFile(hmfile, FILE_MAP_COPY, 0, 0, 0);
-
-    CloseHandle(hfile);
-    CloseHandle(hmfile);
-  }
-#else /* _WIN32 */
-  {
-    /* open file */
-    int fd;
-    int flags;
-    struct stat file_stat;
-
-    if (ctx->flags & (TH_ALLOCATOR_MAPPED_SHARED | TH_ALLOCATOR_MAPPED_SHAREDMEM))
-      flags = O_RDWR | O_CREAT;
-    else
-      flags = O_RDONLY;
-
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_EXCLUSIVE)
-      flags |= O_EXCL;
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_NOCREATE)
-      flags &= ~O_CREAT;
-
-    if (!(ctx->flags & TH_ALLOCATOR_MAPPED_FROMFD)) {
-      if(ctx->flags & TH_ALLOCATOR_MAPPED_SHARED)
-      {
-        if((fd = open(ctx->filename, flags, (mode_t)0600)) == -1)
-          THError("unable to open file <%s> in read-write mode", ctx->filename);
-      }
-      else if (ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)
-      {
-#ifdef HAVE_SHM_OPEN
-        if((fd = shm_open(ctx->filename, flags, (mode_t)0600)) == -1)
-          THError("unable to open shared memory object <%s> in read-write mode", ctx->filename);
-#else
-        THError("unable to open file <%s> in sharedmem mode, shm_open unavailable on this platform", ctx->filename);
-#endif
-      }
-      else
-      {
-        if((fd = open(ctx->filename, O_RDONLY)) == -1)
-          THError("unable to open file <%s> in read-only mode", ctx->filename);
-      }
-    } else {
-      fd = ctx->fd;
-    }
-
-    if(fstat(fd, &file_stat) == -1)
-    {
-      if (!(ctx->flags & TH_ALLOCATOR_MAPPED_FROMFD))
-        close(fd);
-      THError("unable to stat the file <%s>", ctx->filename);
-    }
-
-    if(size > 0)
-    {
-      if(size > file_stat.st_size)
-      {
-        if(ctx->flags)
-        {
-          if(ftruncate(fd, size) == -1)
-            THError("unable to resize file <%s> to the right size", ctx->filename);
-          if(fstat(fd, &file_stat) == -1 || file_stat.st_size < size)
-          {
-            close(fd);
-            THError("unable to stretch file <%s> to the right size", ctx->filename);
-          }
-/* on macOS write returns with errno 45 (Opperation not supported) when used
- * with a file descriptor obtained via shm_open
- */
-#ifndef __APPLE__
-          if((write(fd, "", 1)) != 1) /* note that the string "" contains the '\0' byte ... */
-          {
-            close(fd);
-            THError("unable to write to file <%s>", ctx->filename);
-          }
-#endif
-        }
-        else
-        {
-          close(fd);
-          THError("file <%s> size is smaller than the required mapping size <%ld>", ctx->filename, size);
-        }
-      }
-    }
-    else
-      size = file_stat.st_size;
-
-    ctx->size = size; /* if we are here, it must be the right size */
-
-    /* map it */
-    if (ctx->flags & (TH_ALLOCATOR_MAPPED_SHARED | TH_ALLOCATOR_MAPPED_SHAREDMEM))
-      data = mmap(NULL, ctx->size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
-    else
-      data = mmap(NULL, ctx->size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
-
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_KEEPFD) {
-      ctx->fd = fd;
-    } else {
-      if(close(fd) == -1)
-        THError("Error closing file <%s>", ctx->filename);
-      ctx->fd = -1;
-    }
-
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_UNLINK) {
-      if (ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)
-      {
-#ifdef HAVE_SHM_UNLINK
-        if (shm_unlink(ctx->filename) == -1)
-          THError("could not unlink the shared memory file %s", ctx->filename);
-#else
-        THError("could not unlink the shared memory file %s, shm_unlink not available on platform", ctx->filename);
-#endif
-      }
-      else
-      {
-        if (unlink(ctx->filename) == -1)
-          THError("could not unlink file %s", ctx->filename);
-      }
-    }
-
-    if(data == MAP_FAILED)
-    {
-      data = NULL; /* let's be sure it is NULL */
-      THError("$ Torch: unable to mmap memory: you tried to mmap %dGB.", ctx->size/1073741824);
-    }
-  }
-#endif
-
-  return data;
-}
-
-static void * THMapAllocator_alloc(void *ctx, ptrdiff_t size) {
-  return _map_alloc(ctx, size);
-}
-
-static void *THMapAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
-  THError("cannot realloc mapped data");
-  return NULL;
-}
-
-static void THMapAllocator_free(void* ctx_, void* data) {
-  if (data == NULL)
+THMapAllocator::~THMapAllocator() {
+  if (base_ptr_ == nullptr) {
     return;
-
-  THMapAllocatorContext *ctx = static_cast<THMapAllocatorContext *>(ctx_);
-
-#ifdef _WIN32
-  if ((ctx->flags & TH_ALLOCATOR_MAPPED_KEEPFD) || (ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM))
-    CloseHandle(ctx->handle);
-  if(UnmapViewOfFile(data) == 0)
-    THError("could not unmap the shared memory file");
-#else /* _WIN32 */
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_KEEPFD) {
-    if (close(ctx->fd) == -1)
-      THError("could not close file descriptor %d", ctx->fd);
   }
 
-  if (munmap(data, ctx->size))
-    THError("could not unmap the shared memory file");
+#ifdef _WIN32
+  if ((flags_ & TH_ALLOCATOR_MAPPED_KEEPFD) || (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM))
+    CloseHandle(handle_);
+  if(UnmapViewOfFile(base_ptr_) == 0)
+    AT_ERROR("could not unmap the shared memory file");
+#else /* _WIN32 */
+  if (flags_ & TH_ALLOCATOR_MAPPED_KEEPFD) {
+    if (close(fd_) == -1) {
+      AT_ERROR("could not close file descriptor ", fd_);
+    }
+  }
 
-  if (!(ctx->flags & (TH_ALLOCATOR_MAPPED_FROMFD | TH_ALLOCATOR_MAPPED_UNLINK)))
-  {
-    if (ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)
-    {
+  if (munmap(base_ptr_, size_)) {
+    AT_ERROR("could not unmap the shared memory file");
+  }
+
+  if (!(flags_ & (TH_ALLOCATOR_MAPPED_FROMFD | TH_ALLOCATOR_MAPPED_UNLINK))) {
+    if (flags_ & TH_ALLOCATOR_MAPPED_SHAREDMEM) {
 #ifdef HAVE_SHM_UNLINK
-      if (shm_unlink(ctx->filename) == -1)
-        THError("could not unlink the shared memory file %s", ctx->filename);
+      if (shm_unlink(filename_.c_str()) == -1) {
+        AT_ERROR("could not unlink the shared memory file ", filename_);
+      }
 #else
-      THError("could not unlink the shared memory file %s, shm_unlink not available on platform", ctx->filename);
+      AT_ERROR("could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
 #endif
     }
   }
 #endif /* _WIN32 */
-
-  THMapAllocatorContext_free(ctx);
 }
 
-#else
+#else /* defined(_WIN32) || defined(HAVE_MMAP) */
 
-THMapAllocatorContext *THMapAllocatorContext_new(const char *filename, int flags) {
-  THError("file mapping not supported on your system");
-  return NULL;
+THMapAllocator::THMapAllocator(const char *filename, int flags, size_t size) {
+  AT_ERROR("file mapping not supported on your system");
 }
 
-void THMapAllocatorContext_free(THMapAllocatorContext *ctx) {
-  THError("file mapping not supported on your system");
+THMapAllocator::THMapAllocator(WithFd, const char *filename, int fd, int flags) {
+  AT_ERROR("file mapping not supported on your system");
 }
 
-static void *THMapAllocator_alloc(void* ctx_, ptrdiff_t size) {
-  THError("file mapping not supported on your system");
-  return NULL;
-}
-
-static void *THMapAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
-  THError("file mapping not supported on your system");
-  return NULL;
-}
-
-static void THMapAllocator_free(void* ctx, void* data) {
-  THError("file mapping not supported on your system");
-}
+THMapAllocator::~THMapAllocator(THMapAllocator* ctx) {}
 
 #endif
 
 #if (defined(_WIN32) || defined(HAVE_MMAP)) && defined(TH_ATOMIC_IPC_REFCOUNT)
 
-static void * THRefcountedMapAllocator_alloc(void *_ctx, ptrdiff_t size) {
-  THMapAllocatorContext *ctx = static_cast<THMapAllocatorContext *>(_ctx);
+THRefcountedMapAllocatorArgCheck::THRefcountedMapAllocatorArgCheck(int flags) {
+  if (flags & TH_ALLOCATOR_MAPPED_FROMFD) {
+    AT_ERROR("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_FROMFD flag");
+  }
+  if (flags & TH_ALLOCATOR_MAPPED_KEEPFD) {
+    AT_ERROR("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_KEEPFD flag");
+  }
+  if (flags & TH_ALLOCATOR_MAPPED_UNLINK) {
+    AT_ERROR("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_UNLINK flag");
+  }
+  if (!(flags & TH_ALLOCATOR_MAPPED_SHAREDMEM)) {
+    AT_ERROR("THRefcountedMapAllocator requires TH_ALLOCATOR_MAPPED_SHAREDMEM flag");
+  }
+}
 
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_FROMFD)
-    THError("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_FROMFD flag");
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_KEEPFD)
-    THError("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_KEEPFD flag");
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_UNLINK)
-    THError("THRefcountedMapAllocator doesn't support TH_ALLOCATOR_MAPPED_UNLINK flag");
-  if (!(ctx->flags & TH_ALLOCATOR_MAPPED_SHAREDMEM))
-    THError("THRefcountedMapAllocator requires TH_ALLOCATOR_MAPPED_SHAREDMEM flag");
+THRefcountedMapAllocator::THRefcountedMapAllocator(const char *filename, int flags, size_t size)
+  : THRefcountedMapAllocatorArgCheck(flags)
+  , THMapAllocator(filename, flags, size + TH_ALLOC_ALIGNMENT) {
 
-  size = size + TH_ALLOC_ALIGNMENT;
-  void *ptr = _map_alloc(ctx, size);
-  char *data = ((char*)ptr) + TH_ALLOC_ALIGNMENT;
-  THMapInfo *map_info = (THMapInfo*)ptr;
+    initializeAlloc();
+}
+THRefcountedMapAllocator::THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size)
+  : THRefcountedMapAllocatorArgCheck(flags)
+  , THMapAllocator(WITH_FD, filename, flags, fd, size + TH_ALLOC_ALIGNMENT) {
+
+    initializeAlloc();
+}
+
+void THRefcountedMapAllocator::initializeAlloc() {
+  char *data = ((char*)base_ptr_) + TH_ALLOC_ALIGNMENT;
+  THMapInfo *map_info = (THMapInfo*)base_ptr_;
 
 #ifdef _WIN32
   ReleaseContext* r_ctx = (ReleaseContext *) THAlloc(sizeof(ReleaseContext));
-  r_ctx->handle = ctx->handle;
-  r_ctx->event = ctx->event;
+  r_ctx->handle = handle_;
+  r_ctx->event = event_;
   r_ctx->wait = NULL;
-  BOOL can_wait = RegisterWaitForSingleObject(&r_ctx->wait, ctx->event, WaitForReleaseHandle, (PVOID)r_ctx, INFINITE, WT_EXECUTEONLYONCE);
+  BOOL can_wait = RegisterWaitForSingleObject(&r_ctx->wait, event_, WaitForReleaseHandle, (PVOID)r_ctx, INFINITE, WT_EXECUTEONLYONCE);
   if (!can_wait) {
-    THError("Couldn't register wait on event, error code: <%d>", GetLastError());
+    AT_ERROR("Couldn't register wait on event, error code: <", GetLastError(), ">");
   }
 #endif
 
-  if (ctx->flags & TH_ALLOCATOR_MAPPED_EXCLUSIVE)
-    map_info->refcount = 1;
-  else
+  if (flags_ & TH_ALLOCATOR_MAPPED_EXCLUSIVE) {
+    new (&map_info->refcount) std::atomic<int>(1);
+  } else {
     map_info->refcount++;
-
-  return (void*)data;
+  }
 }
 
-static void *THRefcountedMapAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
-  THError("cannot realloc mapped data");
-  return NULL;
-}
-
-static void THRefcountedMapAllocator_free(void* ctx_, void* data) {
-  THMapAllocatorContext *ctx = static_cast<THMapAllocatorContext *>(ctx_);
+THRefcountedMapAllocator::~THRefcountedMapAllocator() {
+  // Prevent the parent destructor from running
+  void* data = base_ptr_;
+  base_ptr_ = nullptr;
 
 #ifdef _WIN32
-  THMapInfo *info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
+  THMapInfo *info = (THMapInfo*)data;
   if (--info->refcount == 0) {
-    SetEvent(ctx->event);
+    SetEvent(event_);
   }
-  if(UnmapViewOfFile(((char*)data) - TH_ALLOC_ALIGNMENT) == 0)
-    THError("could not unmap the shared memory file");
+  if(UnmapViewOfFile(data) == 0) {
+    AT_ERROR("could not unmap the shared memory file");
+  }
 #else /* _WIN32 */
 
-  THMapInfo *info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
+  THMapInfo *info = (THMapInfo*)(data);
   if (--info->refcount == 0) {
 #ifdef HAVE_SHM_UNLINK
-    if (shm_unlink(ctx->filename) == -1)
-      THError("could not unlink the shared memory file %s", ctx->filename);
+    if (shm_unlink(filename_.c_str()) == -1) {
+      AT_ERROR("could not unlink the shared memory file ", filename_);
+    }
 #else
-    THError("could not unlink the shared memory file %s, shm_unlink not available on platform", ctx->filename);
+    AT_ERROR("could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
 #endif /* HAVE_SHM_UNLINK */
   }
-  if (munmap(info, ctx->size))
-    THError("could not unmap the shared memory file %s", ctx->filename);
+  if (munmap(info, size_)) {
+    AT_ERROR("could not unmap the shared memory file ", filename_);
+  }
 #endif /* _WIN32 */
-
-  THMapAllocatorContext_free(ctx);
 }
 
-void THRefcountedMapAllocator_incref(THMapAllocatorContext *ctx, void *data)
+void THRefcountedMapAllocator::incref()
 {
-  THMapInfo *map_info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
+  THMapInfo *map_info = static_cast<THMapInfo*>(base_ptr_);
   ++map_info->refcount;
 }
 
-int THRefcountedMapAllocator_decref(THMapAllocatorContext *ctx, void *data)
+int THRefcountedMapAllocator::decref()
 {
-  THMapInfo *map_info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
+  THMapInfo *map_info = static_cast<THMapInfo*>(base_ptr_);
   return --map_info->refcount == 0;
 }
 
 #else
 
-static void * THRefcountedMapAllocator_alloc(void *ctx, ptrdiff_t size) {
-  THError("refcounted file mapping not supported on your system");
-  return NULL;
+
+THRefcountedMapAllocatorArgCheck::THRefcountedMapAllocatorArgCheck(int flags) {}
+
+THRefcountedMapAllocator::THRefcountedMapAllocator(const char *filename, int flags, size_t size) {
+  AT_ERROR("refcounted file mapping not supported on your system");
 }
 
-static void *THRefcountedMapAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
-  THError("refcounted file mapping not supported on your system");
-  return NULL;
+THRefcountedMapAllocator::THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size) {
+  AT_ERROR("refcounted file mapping not supported on your system");
 }
 
-static void THRefcountedMapAllocator_free(void* ctx_, void* data) {
-  THError("refcounted file mapping not supported on your system");
-}
-
-void THRefcountedMapAllocator_incref(THMapAllocatorContext *ctx, void *data)
-{
-  THError("refcounted file mapping not supported on your system");
-}
-
-int THRefcountedMapAllocator_decref(THMapAllocatorContext *ctx, void *data)
-{
-  THError("refcounted file mapping not supported on your system");
-  return 0;
-}
+void THRefcountedMapAllocator::initializeAlloc() {}
+THRefcountedMapAllocator::~THRefcountedMapAllocator() {}
 
 #endif
 
-THAllocator THMapAllocator = {
-  &THMapAllocator_alloc,
-  &THMapAllocator_realloc,
-  &THMapAllocator_free
-};
+static void deleteTHMapAllocator(void* ptr) {
+  delete static_cast<THMapAllocator*>(ptr);
+}
 
-THAllocator THRefcountedMapAllocator = {
-  &THRefcountedMapAllocator_alloc,
-  &THRefcountedMapAllocator_realloc,
-  &THRefcountedMapAllocator_free
-};
+static void deleteTHRefcountedMapAllocator(void* ptr) {
+  delete static_cast<THRefcountedMapAllocator*>(ptr);
+}
+
+THMapAllocator* THMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
+  if (sptr.supervisor_.get_deleter() != &deleteTHMapAllocator) return nullptr;
+  return static_cast<THMapAllocator*>(sptr.supervisor_.get());
+}
+
+THRefcountedMapAllocator* THRefcountedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
+  if (sptr.supervisor_.get_deleter() != &deleteTHRefcountedMapAllocator) return nullptr;
+  return static_cast<THRefcountedMapAllocator*>(sptr.supervisor_.get());
+}
+
+at::SupervisedPtr THMapAllocator::makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
+  auto* supervisor = new THMapAllocator(filename, flags, size);
+  if (actual_size_out) *actual_size_out = supervisor->size();
+  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}};
+}
+
+at::SupervisedPtr THMapAllocator::makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
+  auto* supervisor = new THMapAllocator(WITH_FD, filename, fd, flags, size);
+  if (actual_size_out) *actual_size_out = supervisor->size();
+  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}};
+}
+
+at::SupervisedPtr THRefcountedMapAllocator::makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
+  auto* supervisor = new THRefcountedMapAllocator(filename, flags, size);
+  if (actual_size_out) *actual_size_out = supervisor->size() - TH_ALLOC_ALIGNMENT;
+  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}};
+}
+
+at::SupervisedPtr THRefcountedMapAllocator::makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
+  auto* supervisor = new THRefcountedMapAllocator(WITH_FD, filename, fd, flags, size);
+  if (actual_size_out) *actual_size_out = supervisor->size() - TH_ALLOC_ALIGNMENT;
+  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}};
+}
+
+void* THRefcountedMapAllocator::data() const {
+  return static_cast<void*>(static_cast<char*>(base_ptr_) + TH_ALLOC_ALIGNMENT);
+}

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -383,10 +383,6 @@ void THMapAllocator::close() {
 #endif /* _WIN32 */
 }
 
-THMapAllocator::~THMapAllocator() {
-  close();
-}
-
 #else /* defined(_WIN32) || defined(HAVE_MMAP) */
 
 THMapAllocator::THMapAllocator(const char *filename, int flags, size_t size) {

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -1,5 +1,10 @@
 #include "THAllocator.h"
 
+/* stuff for mapped files */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <atomic>
 #if ATOMIC_INT_LOCK_FREE == 2
 #define TH_ATOMIC_IPC_REFCOUNT 1

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -22,7 +22,7 @@
 struct THDefaultAllocator final : public at::Allocator {
   at::SupervisedPtr allocate(size_t size) const override {
     auto* ptr = THAlloc(size);
-    return {ptr, {ptr, THFree}};
+    return {ptr, {ptr, THFree}, at::kCPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THFree;
@@ -539,25 +539,25 @@ THRefcountedMapAllocator* THRefcountedMapAllocator::fromSupervisedPtr(const at::
 at::SupervisedPtr THMapAllocator::makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
   auto* supervisor = new THMapAllocator(filename, flags, size);
   if (actual_size_out) *actual_size_out = supervisor->size();
-  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}, at::kCPU};
 }
 
 at::SupervisedPtr THMapAllocator::makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
   auto* supervisor = new THMapAllocator(WITH_FD, filename, fd, flags, size);
   if (actual_size_out) *actual_size_out = supervisor->size();
-  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHMapAllocator}, at::kCPU};
 }
 
 at::SupervisedPtr THRefcountedMapAllocator::makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
   auto* supervisor = new THRefcountedMapAllocator(filename, flags, size);
   if (actual_size_out) *actual_size_out = supervisor->size() - TH_ALLOC_ALIGNMENT;
-  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}, at::kCPU};
 }
 
 at::SupervisedPtr THRefcountedMapAllocator::makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
   auto* supervisor = new THRefcountedMapAllocator(WITH_FD, filename, fd, flags, size);
   if (actual_size_out) *actual_size_out = supervisor->size() - TH_ALLOC_ALIGNMENT;
-  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHRefcountedMapAllocator}, at::kCPU};
 }
 
 void* THRefcountedMapAllocator::data() const {

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -45,7 +45,6 @@ public:
   THMapAllocator& operator=(const THMapAllocator&) = delete;
   THMapAllocator(THMapAllocator&&) = delete;
   THMapAllocator& operator=(THMapAllocator&&) = delete;
-  virtual ~THMapAllocator();
 
   const char* filename() const { return filename_.c_str(); }
   int fd() const {
@@ -67,6 +66,10 @@ public:
 
   // Closes the data.  Helps us avoid destructor shenanigans
   virtual void close();
+
+  // This is very dangerous.  You have to redefine this destructor for each
+  // subclass
+  virtual ~THMapAllocator() { close(); }
 
 protected:
   bool closed_ = false;
@@ -102,6 +105,9 @@ public:
   void incref();
   int decref();
   void close() override;
+
+  virtual ~THRefcountedMapAllocator() { close(); }
+
 protected:
   void checkFlags();
   void initializeAlloc();

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -6,6 +6,11 @@
 #include <ATen/Allocator.h>
 #endif
 
+/* stuff for mapped files */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #define TH_ALLOCATOR_MAPPED_SHARED 1
 #define TH_ALLOCATOR_MAPPED_SHAREDMEM 2
 #define TH_ALLOCATOR_MAPPED_EXCLUSIVE 4

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -55,9 +55,9 @@ public:
   // from the base pointer.)
   virtual void* data() const { return base_ptr_; }
 
-  static THMapAllocator* fromDevicePtr(const at::DevicePtr&);
-  static at::DevicePtr makeDevicePtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
-  static at::DevicePtr makeDevicePtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static THMapAllocator* fromDataPtr(const at::DataPtr&);
+  static at::DataPtr makeDataPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
   // Closes the data.  Helps us avoid destructor shenanigans
   virtual void close();
@@ -91,9 +91,9 @@ public:
   THRefcountedMapAllocator(const char *filename, int flags, size_t size);
   THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
 
-  static THRefcountedMapAllocator* fromDevicePtr(const at::DevicePtr&);
-  static at::DevicePtr makeDevicePtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
-  static at::DevicePtr makeDevicePtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static THRefcountedMapAllocator* fromDataPtr(const at::DataPtr&);
+  static at::DataPtr makeDataPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
   void* data() const override;
 

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -1,7 +1,10 @@
-#ifndef TH_ALLOCATOR_INC
-#define TH_ALLOCATOR_INC
+#pragma once
 
 #include "THGeneral.h"
+
+#ifdef __cplusplus
+#include <ATen/Allocator.h>
+#endif
 
 #define TH_ALLOCATOR_MAPPED_SHARED 1
 #define TH_ALLOCATOR_MAPPED_SHAREDMEM 2
@@ -11,33 +14,84 @@
 #define TH_ALLOCATOR_MAPPED_FROMFD 32
 #define TH_ALLOCATOR_MAPPED_UNLINK 64
 
-/* Custom allocator
- */
-typedef struct THAllocator {
-  void* (*malloc)(void*, ptrdiff_t);
-  void* (*realloc)(void*, void*, ptrdiff_t);
-  void (*free)(void*, void*);
-} THAllocator;
+#ifdef __cplusplus
+using THAllocator = at::Allocator;
+#else
+// struct at_THAllocator doesn't and will never exist, but we cannot name
+// the actual struct because it's a namespaced C++ thing
+typedef struct at_THAllocator THAllocator;
+#endif
 
 /* default malloc/free allocator. malloc and realloc raise an error (using
  * THError) on allocation failure.
  */
-TH_API THAllocator THDefaultAllocator;
+TH_API THAllocator* getTHDefaultAllocator();
 
-/* file map allocator
- */
-typedef struct THMapAllocatorContext_  THMapAllocatorContext;
-TH_API THMapAllocatorContext *THMapAllocatorContext_new(const char *filename, int flags);
-TH_API THMapAllocatorContext *THMapAllocatorContext_newWithFd(const char *filename,
-    int fd, int flags);
-TH_API char * THMapAllocatorContext_filename(THMapAllocatorContext *ctx);
-TH_API int THMapAllocatorContext_fd(THMapAllocatorContext *ctx);
-TH_API ptrdiff_t THMapAllocatorContext_size(THMapAllocatorContext *ctx);
-TH_API void THMapAllocatorContext_free(THMapAllocatorContext *ctx);
-TH_API void THRefcountedMapAllocator_incref(THMapAllocatorContext *ctx, void *data);
-TH_API int THRefcountedMapAllocator_decref(THMapAllocatorContext *ctx, void *data);
+#ifdef __cplusplus
+// Sentinel value/type to help distinguish the file descriptor constructor from
+// the non-file descriptor constructor
+enum WithFd { WITH_FD };
 
-TH_API THAllocator THMapAllocator;
-TH_API THAllocator THRefcountedMapAllocator;
+class AT_API THMapAllocator {
+public:
+  THMapAllocator(const char *filename, int flags, size_t size);
+  THMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
+  virtual ~THMapAllocator();
 
+  const char* filename() const { return filename_.c_str(); }
+  int fd() const {
+#ifdef _WIN32
+    AT_ERROR("THMapAllocator::fd() is unsupported on Windows");
+#else
+    return fd_;
 #endif
+  }
+  ptrdiff_t size() const { return size_; }
+  // Return a pointer to the actual data for this allocator
+  // (in the case of the refcounted allocator, this is offset
+  // from the base pointer.)
+  virtual void* data() const { return base_ptr_; }
+
+  static THMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+
+protected:
+  std::string filename_;
+  int flags_ = 0;
+  ptrdiff_t size_; /* mapped size */
+#ifdef _WIN32
+  HANDLE handle_;
+  HANDLE event_;
+  std::string eventname_;
+#else
+  int fd_ = -1;
+#endif
+  void *base_ptr_ = nullptr;
+};
+
+// Base-from-member idiom
+struct AT_API THRefcountedMapAllocatorArgCheck {
+  THRefcountedMapAllocatorArgCheck(int flags);
+};
+
+class AT_API THRefcountedMapAllocator : private THRefcountedMapAllocatorArgCheck, public THMapAllocator {
+public:
+  THRefcountedMapAllocator(const char *filename, int flags, size_t size);
+  THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
+  virtual ~THRefcountedMapAllocator();
+
+  static THRefcountedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+
+  void* data() const override;
+
+  void incref();
+  int decref();
+protected:
+  void checkFlags();
+  void initializeAlloc();
+};
+
+#endif // __cplusplus

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -55,9 +55,9 @@ public:
   // from the base pointer.)
   virtual void* data() const { return base_ptr_; }
 
-  static THMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
-  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
-  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static THMapAllocator* fromDevicePtr(const at::DevicePtr&);
+  static at::DevicePtr makeDevicePtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::DevicePtr makeDevicePtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
   // Closes the data.  Helps us avoid destructor shenanigans
   virtual void close();
@@ -91,9 +91,9 @@ public:
   THRefcountedMapAllocator(const char *filename, int flags, size_t size);
   THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
 
-  static THRefcountedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
-  static at::SupervisedPtr makeSupervisedPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
-  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static THRefcountedMapAllocator* fromDevicePtr(const at::DevicePtr&);
+  static at::DevicePtr makeDevicePtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
+  static at::DevicePtr makeDevicePtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
 
   void* data() const override;
 

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -6,11 +6,6 @@
 #include <ATen/Allocator.h>
 #endif
 
-/* stuff for mapped files */
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #define TH_ALLOCATOR_MAPPED_SHARED 1
 #define TH_ALLOCATOR_MAPPED_SHAREDMEM 2
 #define TH_ALLOCATOR_MAPPED_EXCLUSIVE 4
@@ -77,8 +72,8 @@ protected:
   int flags_ = 0;
   ptrdiff_t size_; /* mapped size */
 #ifdef _WIN32
-  HANDLE handle_;
-  HANDLE event_;
+  void* handle_;
+  void* event_;
   std::string eventname_;
 #else
   int fd_ = -1;

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -26,7 +26,7 @@ void THStorage_free(THStorage *storage) {
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      storage->data_ptr.~DevicePtr();
+      storage->data_ptr.~DataPtr();
       if (storage->flag & TH_STORAGE_VIEW) {
         THStorage_free(storage->view);
       }
@@ -109,7 +109,7 @@ THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size
 {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->scalar_type = scalar_type;
-  new (&storage->data_ptr) at::DevicePtr(allocator->allocate(at::elementSize(scalar_type)*size));
+  new (&storage->data_ptr) at::DataPtr(allocator->allocate(at::elementSize(scalar_type)*size));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
@@ -133,7 +133,7 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
 {
   size_t actual_size = -1;
   THStorage *storage = THStorage_newWithDataAndAllocator(scalar_type,
-                                                         THMapAllocator::makeDevicePtr(
+                                                         THMapAllocator::makeDataPtr(
                                                             filename,
                                                             flags,
                                                             size * at::elementSize(scalar_type),
@@ -177,11 +177,11 @@ THStorage* THStorage_newWithData(at::ScalarType scalar_type, std::unique_ptr<at:
 */
 
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             at::DevicePtr&& data, ptrdiff_t size,
+                                             at::DataPtr&& data, ptrdiff_t size,
                                              THAllocator* allocator) {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->scalar_type = scalar_type;
-  new (&storage->data_ptr) at::DevicePtr(std::move(data));
+  new (&storage->data_ptr) at::DataPtr(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
@@ -196,7 +196,7 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
   if (storage->flag & TH_STORAGE_RESIZABLE)
   {
     /* case when the allocator does not have a realloc defined */
-    at::DevicePtr old_data;
+    at::DataPtr old_data;
     std::swap(old_data, storage->data_ptr);
     ptrdiff_t old_size = storage->size;
     if (size != 0) {

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -28,9 +28,7 @@ void THStorage_free(THStorage *storage) {
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      if (storage->flag & TH_STORAGE_FREEMEM) {
-        static_cast<THAllocator*>(storage->allocatorVoidPtr)->free(storage->allocatorContext, storage->data_ptr);
-      }
+      storage->data_ptr.~SupervisedPtr();
       if (storage->flag & TH_STORAGE_VIEW) {
         THStorage_free(storage->view);
       }
@@ -105,24 +103,22 @@ THStorage* THStorage_new(at::ScalarType scalar_type)
 
 THStorage* THStorage_newWithSize(at::ScalarType scalar_type, ptrdiff_t size)
 {
-  return THStorage_newWithAllocator(scalar_type, size, &THDefaultAllocator, nullptr);
+  return THStorage_newWithAllocator(scalar_type, size, getTHDefaultAllocator());
 }
 
 THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size,
-                                      THAllocator *allocator,
-                                      void *allocatorContext)
+                                      at::Allocator *allocator)
 {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = allocator->malloc(allocatorContext, at::elementSize(scalar_type)*size);
+  new (&storage->data_ptr) at::SupervisedPtr(allocator->allocate(at::elementSize(scalar_type)*size));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   storage->device = INT_MIN;  // device is not meaningful on CPU
   return storage;
 }
@@ -139,14 +135,18 @@ size_t THStorage_elementSize(const THStorage *self)
 
 THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *filename, ptrdiff_t size, int flags)
 {
-  THMapAllocatorContext *ctx = THMapAllocatorContext_new(filename, flags);
-
-  THStorage *storage = THStorage_newWithAllocator(scalar_type, size,
-                                                  &THMapAllocator,
-                                                  ctx);
+  size_t actual_size = -1;
+  THStorage *storage = THStorage_newWithDataAndAllocator(scalar_type,
+                                                         THMapAllocator::makeSupervisedPtr(
+                                                            filename,
+                                                            flags,
+                                                            size * at::elementSize(scalar_type),
+                                                            &actual_size),
+                                                         size,
+                                                         /* allocator */ nullptr);
 
   if (size <= 0) {
-    storage->size = THMapAllocatorContext_size(ctx)/THStorage_elementSize(storage);
+    storage->size = actual_size/THStorage_elementSize(storage);
   }
 
   THStorage_clearFlag(storage, TH_STORAGE_RESIZABLE);
@@ -171,28 +171,29 @@ void THStorage_retain(THStorage *storage)
   }
 }
 
-THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size)
+/*
+// I don't think you should ever call this
+THStorage* THStorage_newWithData(at::ScalarType scalar_type, std::unique_ptr<at::BoundDeleter> data, ptrdiff_t size)
 {
   return THStorage_newWithDataAndAllocator(scalar_type, data, size,
-                                           &THDefaultAllocator, NULL);
+                                           getTHDefaultAllocator());
 }
+*/
 
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             void* data, ptrdiff_t size,
-                                             THAllocator* allocator,
-                                             void* allocatorContext) {
+                                             at::SupervisedPtr&& data, ptrdiff_t size,
+                                             THAllocator* allocator) {
   THStorage *storage = static_cast<THStorage*>(THAlloc(sizeof(THStorage)));
   storage->backend = at::kCPU;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = data;
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1); // from the strong reference
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
-  storage->device = 0;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
+  storage->device = INT_MIN;  // device is not meaningful on CPU
   return storage;
 }
 
@@ -200,38 +201,24 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 {
   AT_ASSERT(storage->backend == at::kCPU);
 
-  auto* th_allocator = static_cast<THAllocator*>(storage->allocatorVoidPtr);
-
   if (storage->flag & TH_STORAGE_RESIZABLE)
   {
-    if (th_allocator->realloc == nullptr) {
-      /* case when the allocator does not have a realloc defined */
-      void *old_data = storage->data_ptr;
-      ptrdiff_t old_size = storage->size;
-      if (size == 0) {
-        storage->data_ptr = nullptr;
-      } else {
-        storage->data_ptr = th_allocator->malloc(
-            storage->allocatorContext,
-            at::elementSize(storage->scalar_type)*size);
+    /* case when the allocator does not have a realloc defined */
+    at::SupervisedPtr old_data;
+    std::swap(old_data, storage->data_ptr);
+    ptrdiff_t old_size = storage->size;
+    if (size != 0) {
+      storage->data_ptr = storage->allocator->allocate(at::elementSize(storage->scalar_type)*size);
+    }
+    storage->size = size;
+    if (old_data != nullptr) {
+      ptrdiff_t copy_size = old_size;
+      if (storage->size < copy_size) {
+        copy_size = storage->size;
       }
-      storage->size = size;
-      if (old_data != nullptr) {
-        ptrdiff_t copy_size = old_size;
-        if (storage->size < copy_size) {
-          copy_size = storage->size;
-        }
-        if (copy_size > 0) {
-          memcpy(storage->data_ptr, old_data, at::elementSize(storage->scalar_type)*copy_size);
-        }
-        th_allocator->free(storage->allocatorContext, old_data);
+      if (copy_size > 0) {
+        memcpy(storage->data_ptr.get(), old_data.get(), at::elementSize(storage->scalar_type)*copy_size);
       }
-    } else {
-      storage->data_ptr = th_allocator->realloc(
-              storage->allocatorContext,
-              storage->data_ptr,
-              at::elementSize(storage->scalar_type)*size);
-      storage->size = size;
     }
   } else {
     THError("Trying to resize storage that is not resizable");
@@ -241,12 +228,13 @@ void THStorage_resize(THStorage *storage, ptrdiff_t size)
 void THStorage_swap(THStorage *storage1, THStorage *storage2)
 {
 #define SWAP(val) { std::swap(storage1->val, storage2->val); }
+    SWAP(backend);
+    SWAP(scalar_type);
     SWAP(data_ptr);
     SWAP(size);
-    SWAP(flag);
     // don't swap refcount!
-    SWAP(allocatorVoidPtr);
-    SWAP(allocatorContext);
+    SWAP(flag);
+    SWAP(allocator);
     SWAP(finalizer);
     SWAP(view);
     SWAP(device);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -39,7 +39,6 @@ struct THFinalizer {
 
 typedef struct THStorage
 {
-    at::Backend backend; // kCPU or kCUDA only
     at::ScalarType scalar_type;
     at::SupervisedPtr data_ptr;
     ptrdiff_t size;
@@ -49,7 +48,6 @@ typedef struct THStorage
     at::Allocator *allocator;
     std::unique_ptr<THFinalizer> finalizer;
     struct THStorage *view;
-    int device;
 
     template <typename T>
     inline T * data() const {

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -40,7 +40,7 @@ struct THFinalizer {
 typedef struct THStorage
 {
     at::ScalarType scalar_type;
-    at::DevicePtr data_ptr;
+    at::DataPtr data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     std::atomic<int> weakcount;
@@ -77,7 +77,7 @@ void THStorage_setFlag(THStorage *storage, const char flag);
 void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             at::DevicePtr&& data, ptrdiff_t size,
+                                             at::DataPtr&& data, ptrdiff_t size,
                                              at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -40,7 +40,7 @@ struct THFinalizer {
 typedef struct THStorage
 {
     at::ScalarType scalar_type;
-    at::SupervisedPtr data_ptr;
+    at::DevicePtr data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     std::atomic<int> weakcount;
@@ -78,7 +78,7 @@ void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
 // THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             at::SupervisedPtr&& data, ptrdiff_t size,
+                                             at::DevicePtr&& data, ptrdiff_t size,
                                              at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -76,7 +76,6 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
 void THStorage_setFlag(THStorage *storage, const char flag);
 void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
-// THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
                                              at::DevicePtr&& data, ptrdiff_t size,
                                              at::Allocator* allocator);

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -41,13 +41,12 @@ typedef struct THStorage
 {
     at::Backend backend; // kCPU or kCUDA only
     at::ScalarType scalar_type;
-    void *data_ptr;
+    at::SupervisedPtr data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     std::atomic<int> weakcount;
     char flag;
-    void *allocatorVoidPtr; // Either THDeviceAllocator or THCDeviceAllocator
-    void *allocatorContext;
+    at::Allocator *allocator;
     std::unique_ptr<THFinalizer> finalizer;
     struct THStorage *view;
     int device;
@@ -64,15 +63,14 @@ typedef struct THStorage
 
     template <typename T>
     inline T * unsafe_data() const {
-      return static_cast<T*>(this->data_ptr);
+      return static_cast<T*>(this->data_ptr.get());
     }
 } THStorage;
 
 TH_API THStorage* THStorage_new(at::ScalarType scalar_type);
 TH_API THStorage* THStorage_newWithSize(at::ScalarType scalar_type, ptrdiff_t size);
 TH_API THStorage* THStorage_newWithAllocator(at::ScalarType scalar_type, ptrdiff_t size,
-                                             THAllocator *allocator,
-                                             void *allocatorContext);
+                                             at::Allocator *allocator);
 
 ptrdiff_t THStorage_size(const THStorage *self);
 size_t THStorage_elementSize();
@@ -80,11 +78,10 @@ THStorage* THStorage_newWithMapping(at::ScalarType scalar_type, const char *file
 void THStorage_setFlag(THStorage *storage, const char flag);
 void THStorage_clearFlag(THStorage *storage, const char flag);
 void THStorage_retain(THStorage *storage);
-THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
+// THStorage* THStorage_newWithData(at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THStorage* THStorage_newWithDataAndAllocator(at::ScalarType scalar_type,
-                                             void* data, ptrdiff_t size,
-                                             THAllocator* allocator,
-                                             void* allocatorContext);
+                                             at::SupervisedPtr&& data, ptrdiff_t size,
+                                             at::Allocator* allocator);
 void THStorage_resize(THStorage *storage, ptrdiff_t size);
 void THStorage_swap(THStorage *storage1, THStorage *storage2);
 

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -30,10 +30,9 @@ THStorage* THStorage_(newWithSize)(ptrdiff_t size)
 }
 
 THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
-                                        THAllocator *allocator,
-                                        void *allocatorContext)
+                                        at::Allocator *allocator)
 {
-  return THStorage_newWithAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), size, allocator, allocatorContext);
+  return THStorage_newWithAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), size, allocator);
 }
 
 
@@ -100,15 +99,16 @@ void THStorage_(free)(THStorage *storage)
   THStorage_free(storage);
 }
 
+/*
 THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 {
   return THStorage_newWithData(at::CTypeToScalarType<th::from_type<real>>::to(), data, size);
 }
+*/
 
-THStorage* THStorage_(newWithDataAndAllocator)(real* data, ptrdiff_t size,
-                                               THAllocator* allocator,
-                                               void* allocatorContext) {
-  return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), data, size, allocator, allocatorContext);
+THStorage* THStorage_(newWithDataAndAllocator)(at::SupervisedPtr&& data, ptrdiff_t size,
+                                               at::Allocator* allocator) {
+  return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }
 
 void THStorage_(resize)(THStorage *storage, ptrdiff_t size)

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -99,13 +99,6 @@ void THStorage_(free)(THStorage *storage)
   THStorage_free(storage);
 }
 
-/*
-THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
-{
-  return THStorage_newWithData(at::CTypeToScalarType<th::from_type<real>>::to(), data, size);
-}
-*/
-
 THStorage* THStorage_(newWithDataAndAllocator)(at::DevicePtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -106,7 +106,7 @@ THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size)
 }
 */
 
-THStorage* THStorage_(newWithDataAndAllocator)(at::SupervisedPtr&& data, ptrdiff_t size,
+THStorage* THStorage_(newWithDataAndAllocator)(at::DevicePtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -99,7 +99,7 @@ void THStorage_(free)(THStorage *storage)
   THStorage_free(storage);
 }
 
-THStorage* THStorage_(newWithDataAndAllocator)(at::DevicePtr&& data, ptrdiff_t size,
+THStorage* THStorage_(newWithDataAndAllocator)(at::DataPtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   return THStorage_newWithDataAndAllocator(at::CTypeToScalarType<th::from_type<real>>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -2,6 +2,10 @@
 #define TH_GENERIC_FILE "generic/THStorage.h"
 #else
 
+#ifdef __cplusplus
+#include <ATen/Allocator.h>
+#endif
+
 /* on pourrait avoir un liste chainee
    qui initialise math, lab structures (or more).
    mouais -- complique.
@@ -18,7 +22,6 @@
 
 #define TH_STORAGE_REFCOUNTED 1
 #define TH_STORAGE_RESIZABLE  2
-#define TH_STORAGE_FREEMEM    4
 #define TH_STORAGE_VIEW       8
 
 // Struct definition is moved to THStorage.hpp (so this file stays C compatible)
@@ -51,14 +54,12 @@ TH_API THStorage* THStorage_(newWithSize3)(real, real, real);
 TH_API THStorage* THStorage_(newWithSize4)(real, real, real, real);
 TH_API THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int flags);
 
-/* takes ownership of data */
-TH_API THStorage* THStorage_(newWithData)(real *data, ptrdiff_t size);
-
 TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
-                                               THAllocator* allocator,
-                                               void *allocatorContext);
+                                               THAllocator* allocator);
+#ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    real* data, ptrdiff_t size, THAllocator* allocator, void *allocatorContext);
+    at::SupervisedPtr&& data, ptrdiff_t size, at::Allocator* allocator);
+#endif
 
 /* should not differ with API */
 TH_API void THStorage_(setFlag)(THStorage *storage, const char flag);

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -58,7 +58,7 @@ TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                                THAllocator* allocator);
 #ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    at::SupervisedPtr&& data, ptrdiff_t size, at::Allocator* allocator);
+    at::DevicePtr&& data, ptrdiff_t size, at::Allocator* allocator);
 #endif
 
 /* should not differ with API */

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -58,7 +58,7 @@ TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                                THAllocator* allocator);
 #ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
-    at::DevicePtr&& data, ptrdiff_t size, at::Allocator* allocator);
+    at::DataPtr&& data, ptrdiff_t size, at::Allocator* allocator);
 #endif
 
 /* should not differ with API */

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -34,9 +34,7 @@ struct THCUVAAllocator : public at::Allocator {
     if (size != 0) {
       THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
     }
-    int device;
-    THCudaCheck(cudaGetDevice(&device));
-    return {ptr, {ptr, &THCUVADeleter}, at::Device(at::kCUDA, device)};
+    return {ptr, {ptr, &THCUVADeleter}, at::kCPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCUVADeleter;
@@ -63,6 +61,8 @@ void deleteTHCIpcDeleter(void* ptr) {
 
 at::SupervisedPtr THCIpcDeleter::makeSupervisedPtr(void* data, int device) {
   // The dynamic allocation here is a bit unfortunate
+  int cur_device;
+  THCudaCheck(cudaGetDevice(&cur_device));
   auto* supervisor = new THCIpcDeleter(data, device);
-  return {data, {supervisor, &deleteTHCIpcDeleter}, at::Device(at::kCUDA, device)};
+  return {data, {supervisor, &deleteTHCIpcDeleter}, at::Device(at::kCUDA, cur_device)};
 }

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -1,80 +1,66 @@
 #include "THCAllocator.h"
 
-static void *THCudaHostAllocator_malloc(void* ctx, ptrdiff_t size) {
-  void* ptr;
-
-  if (size < 0) THError("Invalid memory size: %ld", size);
-
-  if (size == 0) return NULL;
-
-  THCudaCheck(cudaMallocHost(&ptr, size));
-
-  return ptr;
-}
-
-static void THCudaHostAllocator_free(void* ctx, void* ptr) {
-  if (!ptr) return;
-
+static void THCudaHostDeleter(void* ptr) {
   THCudaCheck(cudaFreeHost(ptr));
 }
 
-THAllocator THCudaHostAllocator = {
-  &THCudaHostAllocator_malloc,
-  NULL,
-  &THCudaHostAllocator_free
+struct THCudaHostAllocator : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    void* ptr = nullptr;
+    if (size != 0) {
+      THCudaCheck(cudaMallocHost(&ptr, size));
+    }
+    return {ptr, {ptr, &THCudaHostDeleter}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &THCudaHostDeleter;
+  }
 };
 
-static cudaError_t THCIpcAllocator_malloc(void* ctx, void** devPtr, size_t size, cudaStream_t stream)
-{
-  THError("THCIpcAllocator.malloc() not supported");
-  return cudaSuccess;
+static THCudaHostAllocator th_cuda_host_allocator;
+at::Allocator* getTHCudaHostAllocator() {
+  return &th_cuda_host_allocator;
 }
 
-static cudaError_t THCIpcAllocator_free(void* ctx, void* devPtr)
-{
-  cudaError_t err;
-  int prev_device;
-  int device = (int)(int64_t)ctx;
-
-  err = cudaGetDevice(&prev_device);
-  if (err != cudaSuccess) { return err; }
-
-  err = cudaSetDevice(device);
-  if (err != cudaSuccess) { return err; }
-
-  err = cudaIpcCloseMemHandle(devPtr);
-
-  cudaSetDevice(prev_device);
-  return err;
-}
-
-THCDeviceAllocator THCIpcAllocator = {
-  &THCIpcAllocator_malloc,
-  NULL,
-  &THCIpcAllocator_free,
-  NULL,
-  NULL
-};
-
-static void *THCUVAAllocator_alloc(void* ctx, ptrdiff_t size) {
-  if (size < 0) THError("Invalid memory size: %ld", size);
-
-  if (size == 0) return NULL;
-
-  // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules
-  // on various compute capabilities.
-  void* ptr;
-  THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
-  return ptr;
-}
-
-static void THCUVAAllocator_free(void* ctx, void* ptr) {
-  if (!ptr) return;
+static void THCUVADeleter(void* ptr) {
   THCudaCheck(cudaFree(ptr));
 }
 
-THAllocator THCUVAAllocator = {
-  &THCUVAAllocator_alloc,
-  NULL,
-  &THCUVAAllocator_free
+struct THCUVAAllocator : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules
+    // on various compute capabilities.
+    void* ptr = nullptr;
+    if (size != 0) {
+      THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
+    }
+    return {ptr, {ptr, &THCUVADeleter}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &THCUVADeleter;
+  }
 };
+
+static THCUVAAllocator thc_uva_allocator;
+at::Allocator* getTHCUVAAllocator() {
+  return &thc_uva_allocator;
+}
+
+
+THCIpcDeleter::~THCIpcDeleter() {
+  int prev_device;
+  THCudaCheck(cudaGetDevice(&prev_device));
+  THCudaCheck(cudaSetDevice(device_));
+  THCudaCheck(cudaIpcCloseMemHandle(data_));
+  THCudaCheck(cudaSetDevice(prev_device));
+}
+
+void deleteTHCIpcDeleter(void* ptr) {
+  delete static_cast<THCIpcDeleter*>(ptr);
+}
+
+at::SupervisedPtr THCIpcDeleter::makeSupervisedPtr(void* data, int device) {
+  // The dynamic allocation here is a bit unfortunate
+  auto* supervisor = new THCIpcDeleter(data, device);
+  return {data, {supervisor, &deleteTHCIpcDeleter}};
+}

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -5,7 +5,7 @@ static void THCudaHostDeleter(void* ptr) {
 }
 
 struct THCudaHostAllocator : public at::Allocator {
-  at::SupervisedPtr allocate(size_t size) const override {
+  at::DevicePtr allocate(size_t size) const override {
     void* ptr = nullptr;
     if (size != 0) {
       THCudaCheck(cudaMallocHost(&ptr, size));
@@ -27,7 +27,7 @@ static void THCUVADeleter(void* ptr) {
 }
 
 struct THCUVAAllocator : public at::Allocator {
-  at::SupervisedPtr allocate(size_t size) const override {
+  at::DevicePtr allocate(size_t size) const override {
     // See J.1.1 of the CUDA_C_Programming_Guide.pdf for UVA and coherence rules
     // on various compute capabilities.
     void* ptr = nullptr;
@@ -59,7 +59,7 @@ void deleteTHCIpcDeleter(void* ptr) {
   delete static_cast<THCIpcDeleter*>(ptr);
 }
 
-at::SupervisedPtr THCIpcDeleter::makeSupervisedPtr(void* data, int device) {
+at::DevicePtr THCIpcDeleter::makeDevicePtr(void* data, int device) {
   // The dynamic allocation here is a bit unfortunate
   int cur_device;
   THCudaCheck(cudaGetDevice(&cur_device));

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -12,7 +12,7 @@ class AT_API THCIpcDeleter {
 public:
   THCIpcDeleter(void* data, int device) : data_(data), device_(device) {};
   ~THCIpcDeleter();
-  static at::SupervisedPtr makeSupervisedPtr(void* data, int device);
+  static at::DevicePtr makeDevicePtr(void* data, int device);
 private:
   void* data_;
   int device_;

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -3,8 +3,20 @@
 
 #include "THCGeneral.h"
 
-extern THAllocator THCudaHostAllocator;
-extern THAllocator THCUVAAllocator;
-THC_API THCDeviceAllocator THCIpcAllocator;
+THC_API THAllocator* getTHCudaHostAllocator();
+THC_API THAllocator* getTHCUVAAllocator();
+// IPC doesn't support (re)allocation
+
+#ifdef __cplusplus
+class AT_API THCIpcDeleter {
+public:
+  THCIpcDeleter(void* data, int device) : data_(data), device_(device) {};
+  ~THCIpcDeleter();
+  static at::SupervisedPtr makeSupervisedPtr(void* data, int device);
+private:
+  void* data_;
+  int device_;
+};
+#endif
 
 #endif

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -12,7 +12,7 @@ class AT_API THCIpcDeleter {
 public:
   THCIpcDeleter(void* data, int device) : data_(data), device_(device) {};
   ~THCIpcDeleter();
-  static at::DevicePtr makeDevicePtr(void* data, int device);
+  static at::DataPtr makeDataPtr(void* data, int device);
 private:
   void* data_;
   int device_;

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -507,7 +507,7 @@ struct CudaCachingAllocator : public at::Allocator {
     THCudaCheck(cudaGetDevice(&device));
     void* r;
     AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
-    return {r, {r, &CudaCachingDeleter}};
+    return {r, {r, &CudaCachingDeleter}, at::Device(at::kCUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &CudaCachingDeleter;

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -505,8 +505,10 @@ struct CudaCachingAllocator : public at::Allocator {
   at::SupervisedPtr allocate(size_t size) const override {
     int device;
     THCudaCheck(cudaGetDevice(&device));
-    void* r;
-    AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
+    void* r = nullptr;
+    if (size != 0) {
+      AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
+    }
     return {r, {r, &CudaCachingDeleter}, at::Device(at::kCUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -502,14 +502,14 @@ static void CudaCachingDeleter(void* ptr) {
 // has a lot more methods and it wasn't altogether clear that they should
 // actually be publically exposed
 struct CudaCachingAllocator : public at::Allocator {
-  at::DevicePtr allocate(size_t size) const override {
+  at::DataPtr allocate(size_t size) const override {
     int device;
     THCudaCheck(cudaGetDevice(&device));
     void* r = nullptr;
     if (size != 0) {
       AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
     }
-    return {r, {r, &CudaCachingDeleter}, at::Device(at::kCUDA, device)};
+    return {r, r, &CudaCachingDeleter, at::Device(at::kCUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &CudaCachingDeleter;

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -1,5 +1,8 @@
 #include "THCCachingAllocator.h"
 
+#include <ATen/Context.h>
+#include <ATen/cudnn/Exceptions.h>
+
 #include <cuda_runtime_api.h>
 #include <algorithm>
 #include <deque>
@@ -489,44 +492,41 @@ struct THCCachingAllocator
   }
 };
 
-static cudaError_t THCCachingAllocator_malloc(void* ctx, void** ptr, size_t size, cudaStream_t stream)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->malloc(ptr, size, stream);
+THCCachingAllocator caching_allocator;
+
+static void CudaCachingDeleter(void* ptr) {
+  AT_CUDA_CHECK(caching_allocator.free(ptr));
 }
 
-static cudaError_t THCCachingAllocator_free(void* ctx, void* ptr)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->free(ptr);
-}
-
-static cudaError_t THCCachingAllocator_emptyCache(void* ctx)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  return a->emptyCache();
-}
-
-static cudaError_t THCCachingAllocator_cacheInfo(void* ctx, int dev_id, size_t* cachedAndFree, size_t* largestBlock)
-{
-  THCCachingAllocator* a = (THCCachingAllocator*) ctx;
-  a->cacheInfo(dev_id, cachedAndFree, largestBlock);
-  return cudaSuccess;
-}
-
-static THCCachingAllocator caching_allocator;
-static THCDeviceAllocator device_allocator = {
-  &THCCachingAllocator_malloc,
-  NULL,
-  &THCCachingAllocator_free,
-  &THCCachingAllocator_emptyCache,
-  &THCCachingAllocator_cacheInfo,
-  &caching_allocator
+// NB: I decided not to fold this into THCCachingAllocator, because the latter
+// has a lot more methods and it wasn't altogether clear that they should
+// actually be publically exposed
+struct CudaCachingAllocator : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    int device;
+    THCudaCheck(cudaGetDevice(&device));
+    void* r;
+    AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::globalContext().getCurrentCUDAStreamOnDevice(device)));
+    return {r, {r, &CudaCachingDeleter}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &CudaCachingDeleter;
+  }
 };
 
-THC_API THCDeviceAllocator* THCCachingAllocator_get(void)
+CudaCachingAllocator device_allocator;
+
+THC_API at::Allocator* THCCachingAllocator_get(void)
 {
   return &device_allocator;
+}
+
+THC_API void THCCachingAllocator_emptyCache(void) {
+  AT_CUDA_CHECK(caching_allocator.emptyCache());
+}
+
+THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock) {
+  caching_allocator.cacheInfo(dev_id, cachedAndFree, largestBlock);
 }
 
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size)

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -502,7 +502,7 @@ static void CudaCachingDeleter(void* ptr) {
 // has a lot more methods and it wasn't altogether clear that they should
 // actually be publically exposed
 struct CudaCachingAllocator : public at::Allocator {
-  at::SupervisedPtr allocate(size_t size) const override {
+  at::DevicePtr allocate(size_t size) const override {
     int device;
     THCudaCheck(cudaGetDevice(&device));
     void* r = nullptr;

--- a/aten/src/THC/THCCachingAllocator.h
+++ b/aten/src/THC/THCCachingAllocator.h
@@ -9,6 +9,8 @@
 #include "THCStream.h"
 
 THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
+THC_API void THCCachingAllocator_emptyCache(void);
+THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
 THC_API void THCCachingAllocator_recordStream(void *ptr, THCStream* stream);
 THC_API uint64_t THCCachingAllocator_currentMemoryAllocated(int device);

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -265,11 +265,11 @@ static void THCCachingHostDeleter(void* ptr) {
 }
 
 struct THCCachingHostAllocator final : public at::Allocator {
-  at::DevicePtr allocate(size_t size) const override {
+  at::DataPtr allocate(size_t size) const override {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
-    return {ptr, {ptr, &THCCachingHostDeleter}, at::kCPU};
+    return {ptr, ptr, &THCCachingHostDeleter, at::kCPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCCachingHostDeleter;

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -250,19 +250,6 @@ struct HostAllocator
 
 static HostAllocator allocator;
 
-static void* THCCachingHostAllocator_malloc(void* ctx, ptrdiff_t size)
-{
-  THAssert(size >= 0);
-  void *ptr;
-  THCudaCheck(allocator.malloc(&ptr, size));
-  return ptr;
-}
-
-static void THCCachingHostAllocator_free(void* ctx, void* ptr)
-{
-  allocator.free(ptr);
-}
-
 cudaError_t THCCachingHostAllocator_recordEvent(void *ptr, THCStream *stream)
 {
   return allocator.recordEvent(ptr, stream);
@@ -273,8 +260,23 @@ void THCCachingHostAllocator_emptyCache()
   allocator.emptyCache();
 }
 
-THAllocator THCCachingHostAllocator = {
-  &THCCachingHostAllocator_malloc,
-  NULL,
-  &THCCachingHostAllocator_free,
+static void THCCachingHostDeleter(void* ptr) {
+  allocator.free(ptr);
+}
+
+struct THCCachingHostAllocator final : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    THAssert(size >= 0);
+    void *ptr;
+    THCudaCheck(allocator.malloc(&ptr, size));
+    return {ptr, {ptr, &THCCachingHostDeleter}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &THCCachingHostDeleter;
+  }
 };
+
+static THCCachingHostAllocator thc_caching_host_allocator;
+at::Allocator* getTHCCachingHostAllocator() {
+  return &thc_caching_host_allocator;
+}

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -265,7 +265,7 @@ static void THCCachingHostDeleter(void* ptr) {
 }
 
 struct THCCachingHostAllocator final : public at::Allocator {
-  at::SupervisedPtr allocate(size_t size) const override {
+  at::DevicePtr allocate(size_t size) const override {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -269,7 +269,9 @@ struct THCCachingHostAllocator final : public at::Allocator {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
-    return {ptr, {ptr, &THCCachingHostDeleter}};
+    int device;
+    THCudaCheck(cudaGetDevice(&device));
+    return {ptr, {ptr, &THCCachingHostDeleter}, at::kCPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCCachingHostDeleter;

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -269,8 +269,6 @@ struct THCCachingHostAllocator final : public at::Allocator {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
-    int device;
-    THCudaCheck(cudaGetDevice(&device));
     return {ptr, {ptr, &THCCachingHostDeleter}, at::kCPU};
   }
   at::DeleterFnPtr raw_deleter() const override {

--- a/aten/src/THC/THCCachingHostAllocator.h
+++ b/aten/src/THC/THCCachingHostAllocator.h
@@ -19,7 +19,7 @@
 // Note that this allocator does not split larger allocations into smaller
 // blocks, unlike the caching device allocator.
 //
-THC_API THAllocator THCCachingHostAllocator;
+THC_API THAllocator* getTHCCachingHostAllocator();
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -45,8 +45,8 @@ static void THDefaultDeviceDeleter(void* ptr) {
 
 struct THDefaultDeviceAllocator final : public at::Allocator {
   at::SupervisedPtr allocate(size_t size) const override {
-    void* p;
-    THCudaCheck(cudaMalloc(&p, size));
+    void* p = nullptr;
+    if (size != 0) THCudaCheck(cudaMalloc(&p, size));
     int device;
     THCudaCheck(cudaGetDevice(&device));
     return {p, {p, &THDefaultDeviceDeleter}, at::Device(at::kCUDA, device)};

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -44,12 +44,12 @@ static void THDefaultDeviceDeleter(void* ptr) {
 }
 
 struct THDefaultDeviceAllocator final : public at::Allocator {
-  at::DevicePtr allocate(size_t size) const override {
+  at::DataPtr allocate(size_t size) const override {
     void* p = nullptr;
     if (size != 0) THCudaCheck(cudaMalloc(&p, size));
     int device;
     THCudaCheck(cudaGetDevice(&device));
-    return {p, {p, &THDefaultDeviceDeleter}, at::Device(at::kCUDA, device)};
+    return {p, p, &THDefaultDeviceDeleter, at::Device(at::kCUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THDefaultDeviceDeleter;
@@ -679,7 +679,7 @@ void THCudaFree(THCState *state, void* ptr) {
   state->cudaDeviceAllocator->raw_deallocate(ptr);
 }
 
-at::DevicePtr THCudaHostAlloc(THCState *state, size_t size)
+at::DataPtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
   THAllocator* allocator = state->cudaHostAllocator;

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -47,7 +47,9 @@ struct THDefaultDeviceAllocator final : public at::Allocator {
   at::SupervisedPtr allocate(size_t size) const override {
     void* p;
     THCudaCheck(cudaMalloc(&p, size));
-    return {p, {p, &THDefaultDeviceDeleter}};
+    int device;
+    THCudaCheck(cudaGetDevice(&device));
+    return {p, {p, &THDefaultDeviceDeleter}, at::Device(at::kCUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THDefaultDeviceDeleter;

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -44,7 +44,7 @@ static void THDefaultDeviceDeleter(void* ptr) {
 }
 
 struct THDefaultDeviceAllocator final : public at::Allocator {
-  at::SupervisedPtr allocate(size_t size) const override {
+  at::DevicePtr allocate(size_t size) const override {
     void* p = nullptr;
     if (size != 0) THCudaCheck(cudaMalloc(&p, size));
     int device;
@@ -679,7 +679,7 @@ void THCudaFree(THCState *state, void* ptr) {
   state->cudaDeviceAllocator->raw_deallocate(ptr);
 }
 
-at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size)
+at::DevicePtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
   THAllocator* allocator = state->cudaHostAllocator;

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -8,6 +8,7 @@
 
 #include "ATen/CUDAStream.h"
 
+#include "THCCachingAllocator.h"
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -23,6 +24,11 @@
  * enabled in groups of 8). */
 #define THC_CUDA_MAX_PEER_SIZE 8
 
+void THCState_free(THCState* state)
+{
+  free(state);
+}
+
 THCCudaResourcesPerDevice* THCState_getDeviceResourcePtr(
   THCState *state, int device);
 
@@ -33,29 +39,22 @@ THCState* THCState_alloc(void)
   return state;
 }
 
-void THCState_free(THCState* state)
-{
-  free(state);
+static void THDefaultDeviceDeleter(void* ptr) {
+  THCudaCheck(cudaFree(ptr));
 }
 
-static cudaError_t cudaMallocWrapper(void* ctx, void** devPtr, size_t size, cudaStream_t stream)
-{
-  return cudaMalloc(devPtr, size);
-}
-
-static cudaError_t cudaFreeWrapper(void* ctx, void* devPtr)
-{
-  return cudaFree(devPtr);
-}
-
-static THCDeviceAllocator defaultDeviceAllocator = {
-  &cudaMallocWrapper,
-  NULL,
-  &cudaFreeWrapper,
-  NULL,
-  NULL,
-  NULL
+struct THDefaultDeviceAllocator final : public at::Allocator {
+  at::SupervisedPtr allocate(size_t size) const override {
+    void* p;
+    THCudaCheck(cudaMalloc(&p, size));
+    return {p, {p, &THDefaultDeviceDeleter}};
+  }
+  at::DeleterFnPtr raw_deleter() const override {
+    return &THDefaultDeviceDeleter;
+  }
 };
+
+static THDefaultDeviceAllocator defaultDeviceAllocator;
 
 void THCudaInit(THCState* state)
 {
@@ -63,10 +62,10 @@ void THCudaInit(THCState* state)
     state->cudaDeviceAllocator = &defaultDeviceAllocator;
   }
   if (!state->cudaHostAllocator) {
-    state->cudaHostAllocator = &THCudaHostAllocator;
+    state->cudaHostAllocator = getTHCudaHostAllocator();
   }
   if (!state->cudaUVAAllocator) {
-    state->cudaUVAAllocator = &THCUVAAllocator;
+    state->cudaUVAAllocator = getTHCUVAAllocator();
   }
 
   int numDevices = 0;
@@ -178,10 +177,10 @@ void THCudaShutdown(THCState* state)
     free(res->sparseHandles);
   }
   free(state->resourcesPerDevice);
-  if (state->cudaDeviceAllocator->emptyCache) {
-    state->cudaDeviceAllocator->emptyCache(state->cudaDeviceAllocator->state);
+  if (state->cudaDeviceAllocator == THCCachingAllocator_get()) {
+    THCCachingAllocator_emptyCache();
   }
-  if (state->cudaHostAllocator == &THCCachingHostAllocator) {
+  if (state->cudaHostAllocator == getTHCCachingHostAllocator()) {
     THCCachingHostAllocator_emptyCache();
   }
   THCThreadLocal_free(state->currentPerDeviceBlasHandle);
@@ -306,7 +305,7 @@ void THCState_setDeviceAllocator(THCState* state, THCDeviceAllocator* allocator)
 }
 
 int THCState_isCachingAllocatorEnabled(THCState* state) {
-  return state->cudaHostAllocator == &THCCachingHostAllocator;
+  return state->cudaHostAllocator == getTHCCachingHostAllocator();
 }
 
 int THCState_getNumDevices(THCState *state)
@@ -657,41 +656,36 @@ void THCSetGCHandler(THCState *state, void (*cutorchGCFunction_)(void *data), vo
   state->cutorchGCData = data;
 }
 
-cudaError_t THCudaMalloc(THCState *state, void** ptr, size_t size)
+void* THCudaMalloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
-  cudaStream_t stream = THCState_getCurrentStream(state);
   THCDeviceAllocator* allocator = state->cudaDeviceAllocator;
-  cudaError_t err = allocator->malloc(allocator->state, ptr, size, stream);
-  if (state->cutorchGCFunction != NULL && err != cudaSuccess) {
-    cudaGetLastError(); // reset OOM error
-    (state->cutorchGCFunction)(state->cutorchGCData);
-    err = allocator->malloc(allocator->state, ptr, size, stream);
+  if (state->cutorchGCFunction != nullptr) {
+    try {
+      return allocator->raw_allocate(size);
+    } catch (...) {
+      cudaGetLastError(); // reset OOM error
+      (state->cutorchGCFunction)(state->cutorchGCData);
+      return allocator->raw_allocate(size);
+    }
+  } else {
+    return allocator->raw_allocate(size);
   }
-  return err;
 }
 
-cudaError_t THCudaFree(THCState *state, void *ptr)
-{
-  THCDeviceAllocator* allocator = state->cudaDeviceAllocator;
-  return allocator->free(allocator->state, ptr);
+void THCudaFree(THCState *state, void* ptr) {
+  state->cudaDeviceAllocator->raw_deallocate(ptr);
 }
 
-void* THCudaHostAlloc(THCState *state, size_t size)
+at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
   THAllocator* allocator = state->cudaHostAllocator;
-  return allocator->malloc(NULL, size);
-}
-
-void THCudaHostFree(THCState *state, void *ptr)
-{
-  THAllocator* allocator = state->cudaHostAllocator;
-  return allocator->free(NULL, ptr);
+  return allocator->allocate(size);
 }
 
 void THCudaHostRecord(THCState *state, void *ptr) {
-  if (state->cudaHostAllocator == &THCCachingHostAllocator) {
+  if (state->cudaHostAllocator == getTHCCachingHostAllocator()) {
     THCStream* stream = THCState_getStream(state);
     THCCachingHostAllocator_recordEvent(ptr, stream);
   }
@@ -722,8 +716,9 @@ cudaError_t THCudaMemGetInfoCached(THCState *state,  size_t* freeBytes, size_t* 
   /* not always true - our optimistic guess here */
   *largestBlock = *freeBytes;
 
-  if (allocator->cacheInfo != NULL)
-    allocator->cacheInfo(allocator->state, device, &cachedBytes, largestBlock);
+  if (allocator == THCCachingAllocator_get()) {
+    THCCachingAllocator_cacheInfo(device, &cachedBytes, largestBlock);
+  }
 
   /* Adjust resulting free bytes number. largesBlock unused for now */
   *freeBytes += cachedBytes;

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -49,14 +49,7 @@ typedef struct CUDAStreamInternals THCStream;
 typedef struct THCState THCState;
 struct THCState;
 
-typedef struct _THCDeviceAllocator {
-   cudaError_t (*malloc)( void*, void**, size_t,         cudaStream_t);
-   cudaError_t (*realloc)(void*, void**, size_t, size_t, cudaStream_t);
-   cudaError_t (*free)(void*, void*);
-   cudaError_t (*emptyCache)(void*);
-   cudaError_t  (*cacheInfo)(void*, int, size_t*, size_t*);
-   void* state;
-} THCDeviceAllocator;
+typedef THAllocator THCDeviceAllocator;
 
 typedef struct _THCCudaResourcesPerDevice {
   /* Number of materialized cuBLAS handles */
@@ -147,10 +140,13 @@ THC_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line
 THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
 THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
 
-THC_API cudaError_t THCudaMalloc(THCState *state, void **ptr, size_t size);
-THC_API cudaError_t THCudaFree(THCState *state, void *ptr);
-THC_API void* THCudaHostAlloc(THCState *state, size_t size);
-THC_API void THCudaHostFree(THCState *state, void *ptr);
+THC_API void* THCudaMalloc(THCState *state, size_t size);
+THC_API void THCudaFree(THCState *state, void* ptr);
+
+#ifdef __cplusplus
+at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size);
+#endif
+
 THC_API void THCudaHostRecord(THCState *state, void *ptr);
 
 THC_API cudaError_t THCudaMemGetInfo(THCState *state, size_t* freeBytes, size_t* totalBytes);

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -144,7 +144,7 @@ THC_API void* THCudaMalloc(THCState *state, size_t size);
 THC_API void THCudaFree(THCState *state, void* ptr);
 
 #ifdef __cplusplus
-at::DevicePtr THCudaHostAlloc(THCState *state, size_t size);
+at::DataPtr THCudaHostAlloc(THCState *state, size_t size);
 #endif
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -144,7 +144,7 @@ THC_API void* THCudaMalloc(THCState *state, size_t size);
 THC_API void THCudaFree(THCState *state, void* ptr);
 
 #ifdef __cplusplus
-at::SupervisedPtr THCudaHostAlloc(THCState *state, size_t size);
+at::DevicePtr THCudaHostAlloc(THCState *state, size_t size);
 #endif
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);

--- a/aten/src/THC/THCGeneral.hpp
+++ b/aten/src/THC/THCGeneral.hpp
@@ -17,9 +17,13 @@ struct THCState {
   int numUserSparseHandles;
 
   /* Allocator using cudaMallocHost. */
-  THAllocator* cudaHostAllocator;
-  THAllocator* cudaUVAAllocator;
-  THCDeviceAllocator* cudaDeviceAllocator;
+  // NB: These allocators (specifically, cudaHostAllocator) MUST implement
+  // maybeGlobalBoundDeleter, because we have a few use-cases where we need to
+  // do raw allocations with them (for Thrust).
+  // TODO: Make this statically obvious
+  at::Allocator* cudaHostAllocator;
+  at::Allocator* cudaUVAAllocator;
+  at::Allocator* cudaDeviceAllocator;
 
   /* Index of the current selected BLAS handle. The actual BLAS handle used
      depends on the current device. */

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -524,14 +524,8 @@ bool THC_reduceDim(THCState* state,
                                                                              \
         if(grid.y > 1)                                                       \
         {                                                                    \
-          THCudaCheck(THCudaMalloc                                           \
-            (state,                                                          \
-             &stagingData,                                                   \
-             sizeof(AccT)*outElements*grid.y));                              \
-          THCudaCheck(THCudaMalloc                                           \
-            (state,                                                          \
-             &semaphores,                                                    \
-             sizeof(int)*grid.x));                                           \
+          stagingData = THCudaMalloc(state, sizeof(AccT)*outElements*grid.y);\
+          semaphores = THCudaMalloc(state, sizeof(int)*grid.x);              \
           THCudaCheck(cudaMemsetAsync                                        \
             (semaphores,                                                     \
              0,                                                              \
@@ -556,8 +550,8 @@ bool THC_reduceDim(THCState* state,
                                                                              \
         if(grid.y > 1)                                                       \
         {                                                                    \
-          THCudaCheck(THCudaFree(state, stagingData));                       \
-          THCudaCheck(THCudaFree(state, semaphores));                        \
+          THCudaFree(state, stagingData);                                    \
+          THCudaFree(state, semaphores);                                     \
         }                                                                    \
     }                                                                        \
   }                                                                    

--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -186,8 +186,7 @@ void callReduceAll(THCState* state,
   dim3 block;
 
   if (isTwoPassReductionSize(totalElements)) {
-    void* scratchSpace;
-    THCudaCheck(THCudaMalloc(state, &scratchSpace, THCState_getCurrentDeviceScratchSpaceSize(state)));
+    void* scratchSpace = THCudaMalloc(state, THCState_getCurrentDeviceScratchSpaceSize(state));
 
     getPass1ReduceBlockGrid<AccT>(state, totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -206,7 +205,7 @@ void callReduceAll(THCState* state,
         numPass1Blocks, init, reduceOp,
         (AccT*) scratchSpace, devOut);
 
-    THCudaCheck(THCudaFree(state, scratchSpace));
+    THCudaFree(state, scratchSpace);
   } else {
     getSinglePassReduceBlockGrid(totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -248,7 +247,7 @@ bool THC_reduceAll(THCState* state,
   if (!outOnDevice) {
     // Use the stream-specific scratch space for the reduction kernel
     // to write out its value
-    THCudaCheck(THCudaMalloc(state, (void**)&devOut,
+    devOut = static_cast<AccT*>(THCudaMalloc(state,
         THCState_getCurrentDeviceScratchSpaceSize(state)));
     freeDevOut = true;
   }
@@ -320,7 +319,7 @@ bool THC_reduceAll(THCState* state,
   }
 
   if (freeDevOut) {
-    THCudaCheck(THCudaFree(state, devOut));
+    THCudaFree(state, devOut);
   }
 
   return true;

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -136,7 +136,7 @@ THCStorage* THCStorage_newWithDataAndAllocator(
   storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
   storage->allocator = allocator;
   int device;
-  if (storage->data_ptr) {
+  if (storage->data_ptr.get()) {
     struct cudaPointerAttributes attr;
     THCudaCheck(cudaPointerGetAttributes(&attr, storage->data_ptr.get()));
     device = attr.device;

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -17,15 +17,13 @@ THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scalar_type, 
 {
   return THCStorage_newWithAllocator(
     state, scalar_type, size,
-    state->cudaDeviceAllocator,
-    state->cudaDeviceAllocator->state);
+    state->cudaDeviceAllocator);
 }
 
 THCStorage* THCStorage_newWithAllocator(THCState *state,
                                         at::ScalarType scalar_type,
                                         ptrdiff_t size,
-                                        THCDeviceAllocator* allocator,
-                                        void* allocatorContext)
+                                        at::Allocator* allocator)
 {
   THArgCheck(size >= 0, 2, "invalid size");
   int device;
@@ -38,27 +36,22 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
   storage->backend = at::kCUDA;
   storage->scalar_type = scalar_type;
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   storage->size = size;
   storage->device = device;
 
-  if(size > 0)
-  {
+  at::SupervisedPtr ptr;
+  if (size > 0) {
     // update heap *before* attempting malloc, to free space for the malloc
-    cudaError_t err =
-      (*allocator->malloc)(allocatorContext,
-                           (void**)&(storage->data_ptr),
-                           size * at::elementSize(scalar_type),
-                           THCState_getCurrentStreamOnDevice(state, device));
-    if(err != cudaSuccess){
+    try {
+      ptr = allocator->allocate(size * at::elementSize(scalar_type));
+    } catch(...) {
       free(storage);
+      throw;
     }
-    THCudaCheck(err);
-  } else {
-    storage->data_ptr = NULL;
   }
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(ptr));
   return storage;
 }
 
@@ -72,10 +65,7 @@ void THCStorage_free(THCState *state, THCStorage *storage)
         (*storage->finalizer)();
       }
       storage->finalizer.~unique_ptr<THFinalizer>();
-      if (storage->flag & TH_STORAGE_FREEMEM) {
-        auto* thc_device_allocator = static_cast<THCDeviceAllocator*>(storage->allocatorVoidPtr);
-        THCudaCheck((*thc_device_allocator->free)(storage->allocatorContext, storage->data_ptr));
-      }
+      storage->data_ptr.~SupervisedPtr();
       if (storage->flag & TH_STORAGE_VIEW) {
         THCStorage_free(state, storage->view);
       }
@@ -89,7 +79,7 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
   AT_ASSERT(self->backend == at::kCUDA);
 
   THArgCheck(size >= 0, 2, "invalid size");
-  THAssert(self->allocatorVoidPtr != NULL);
+  THAssert(self->allocator != nullptr);
   int device;
   THCudaCheck(cudaGetDevice(&device));
 
@@ -98,59 +88,30 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
 
   size_t elementSize = at::elementSize(self->scalar_type);
 
-  auto* thc_device_allocator = static_cast<THCDeviceAllocator*>(self->allocatorVoidPtr);
-
-  if (thc_device_allocator->realloc) {
-    void * data_ptr = self->data_ptr;
-    cudaError_t err = (*thc_device_allocator->realloc)(
-      self->allocatorContext,
-      (void**)&(data_ptr),
-      self->size * elementSize,
-      size * elementSize, THCState_getCurrentStreamOnDevice(state, device));
-    if (err != cudaSuccess) {
-      THCudaCheck(err);
-    }
-    self->size = size;
-    self->device = device;
-    return;
-  }
-
   if(size == 0)
   {
-    if(self->flag & TH_STORAGE_FREEMEM) {
-      THCudaCheck(
-        (*thc_device_allocator->free)(self->allocatorContext, self->data_ptr));
-    }
-    self->data_ptr = NULL;
+    self->data_ptr = nullptr;
     self->size = 0;
     self->device = device;
   }
   else
   {
-    void *data = NULL;
-    cudaError_t err =
-      (*thc_device_allocator->malloc)(self->allocatorContext,
-                                 (void**)&(data),
-                                 size * elementSize,
-                                 THCState_getCurrentStreamOnDevice(state, device));
-    THCudaCheck(err);
+    at::SupervisedPtr data =
+      self->allocator->allocate(size * elementSize);
 
     if (self->data_ptr) {
       // Enable p2p access when the memcpy is across devices
       THCState_getPeerToPeerAccess(state, device, self->device);
 
-      THCudaCheck(cudaMemcpyAsync(data,
-                                  self->data_ptr,
+      THCudaCheck(cudaMemcpyAsync(data.get(),
+                                  self->data_ptr.get(),
                                   THMin(self->size, size) * elementSize,
                                   cudaMemcpyDeviceToDevice,
                                   THCState_getCurrentStream(state)));
-      if(self->flag & TH_STORAGE_FREEMEM) {
-        THCudaCheck(
-          (*thc_device_allocator->free)(self->allocatorContext, self->data_ptr));
-      }
     }
 
-    self->data_ptr = data;
+    // Destructively overwrite data_ptr
+    self->data_ptr = std::move(data);
     self->size = size;
     self->device = device;
   }
@@ -160,32 +121,24 @@ int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
   return storage->device;
 }
 
-THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size)
-{
-  return THCStorage_newWithDataAndAllocator(state, scalar_type, data, size,
-                                            state->cudaDeviceAllocator,
-                                            state->cudaDeviceAllocator->state);
-}
-
 THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext) {
+  THCState *state, at::ScalarType scalar_type, at::SupervisedPtr&& data, ptrdiff_t size,
+  at::Allocator *allocator) {
   THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
   memset(storage, 0, sizeof(THCStorage));
   storage->backend = at::kCUDA;
   storage->scalar_type = scalar_type;
-  storage->data_ptr = data;
+  new (&storage->data_ptr) at::SupervisedPtr(std::move(data));
   storage->size = size;
   new (&storage->refcount) std::atomic<int>(1);
   new (&storage->weakcount) std::atomic<int>(1);
   new (&storage->finalizer) std::unique_ptr<THFinalizer>(nullptr);
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocatorVoidPtr = allocator;
-  storage->allocatorContext = allocatorContext;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
+  storage->allocator = allocator;
   int device;
-  if (data) {
+  if (storage->data_ptr) {
     struct cudaPointerAttributes attr;
-    THCudaCheck(cudaPointerGetAttributes(&attr, data));
+    THCudaCheck(cudaPointerGetAttributes(&attr, storage->data_ptr.get()));
     device = attr.device;
   } else {
     THCudaCheck(cudaGetDevice(&device));

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -36,14 +36,11 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
   storage->size = size;
 
   at::SupervisedPtr ptr;
-  if (size > 0) {
-    // update heap *before* attempting malloc, to free space for the malloc
-    try {
-      ptr = allocator->allocate(size * at::elementSize(scalar_type));
-    } catch(...) {
-      free(storage);
-      throw;
-    }
+  try {
+    ptr = allocator->allocate(size * at::elementSize(scalar_type));
+  } catch(...) {
+    free(storage);
+    throw;
   }
   new (&storage->data_ptr) at::SupervisedPtr(std::move(ptr));
   return storage;

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -33,7 +33,6 @@ THC_API void THCStorage_free(THCState *state, THCStorage *self);
 THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
-//THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
   THCState *state, at::ScalarType scalar_type,
   at::DevicePtr&& data, ptrdiff_t size,

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -35,5 +35,5 @@ THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
   THCState *state, at::ScalarType scalar_type,
-  at::DevicePtr&& data, ptrdiff_t size,
+  at::DataPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -23,8 +23,7 @@ THC_API THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scala
 THC_API THCStorage* THCStorage_newWithAllocator(THCState *state,
                                         at::ScalarType scalar_type,
                                         ptrdiff_t size,
-                                        THCDeviceAllocator* allocator,
-                                        void* allocatorContext);
+                                        at::Allocator* allocator);
 
 THC_API void THCStorage_retain(THCState *state, THCStorage *storage);
 
@@ -34,7 +33,8 @@ THC_API void THCStorage_free(THCState *state, THCStorage *self);
 THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
-THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
+//THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext);
+  THCState *state, at::ScalarType scalar_type,
+  at::SupervisedPtr&& data, ptrdiff_t size,
+  at::Allocator* allocator);

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -36,5 +36,5 @@ THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 //THC_API THCStorage* THCStorage_newWithData(THCState *state, at::ScalarType scalar_type, void *data, ptrdiff_t size);
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
   THCState *state, at::ScalarType scalar_type,
-  at::SupervisedPtr&& data, ptrdiff_t size,
+  at::DevicePtr&& data, ptrdiff_t size,
   at::Allocator* allocator);

--- a/aten/src/THC/THCTensorRandom.cpp
+++ b/aten/src/THC/THCTensorRandom.cpp
@@ -15,12 +15,12 @@ void destroyGenerator(THCState *state, THCGenerator* gen)
   std::lock_guard<std::mutex> lock(gen->mutex);
   if (gen->state.gen_states)
   {
-    THCudaCheck(THCudaFree(state, gen->state.gen_states));
+    THCudaFree(state, gen->state.gen_states);
     gen->state.gen_states = NULL;
   }
   if (gen->state.kernel_params)
   {
-    THCudaCheck(THCudaFree(state, gen->state.kernel_params));
+    THCudaFree(state, gen->state.kernel_params);
     gen->state.kernel_params = NULL;
   }
 }

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -22,8 +22,8 @@ THCGenerator* THCRandom_getGenerator(THCState* state);
 /* Sets up generator. Allocates but does not create the generator states. Not thread-safe. */
 __host__ void initializeGenerator(THCState *state, THCGenerator* gen)
 {
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.gen_states, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.kernel_params, sizeof(mtgp32_kernel_params)));
+  gen->state.gen_states = static_cast<struct curandStateMtgp32*>(THCudaMalloc(state, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
+  gen->state.kernel_params = static_cast<mtgp32_kernel_params*>(THCudaMalloc(state, sizeof(mtgp32_kernel_params)));
 }
 
 /* Creates a new generator state given the seed. Not thread-safe. */

--- a/aten/src/THC/THCThrustAllocator.cuh
+++ b/aten/src/THC/THCThrustAllocator.cuh
@@ -17,13 +17,11 @@ class THCThrustAllocator {
   }
 
   char* allocate(std::ptrdiff_t size) {
-    char* out = NULL;
-    THCudaCheck(THCudaMalloc(state_, (void**) &out, size));
-    return out;
+    return static_cast<char*>(THCudaMalloc(state_, size));
   }
 
   void deallocate(char* p, size_t size) {
-    THCudaCheck(THCudaFree(state_, p));
+    THCudaFree(state_, p);
   }
 
  private:

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -49,11 +49,10 @@ THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 }
 
 THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
-                                          THCDeviceAllocator* allocator,
-                                          void* allocatorContext)
+                                          at::Allocator* allocator)
 {
   return THCStorage_newWithAllocator(state, at::CTypeToScalarType<real>::to(),
-                                     size, allocator, allocatorContext);
+                                     size, allocator);
 }
 
 THCStorage* THCStorage_(newWithSize1)(THCState *state, real data0)
@@ -96,15 +95,10 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
   return NULL;
 }
 
-THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size)
-{
-  return THCStorage_newWithData(state, at::CTypeToScalarType<real>::to(), data, size);
-}
-
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, real *data, ptrdiff_t size,
-  THCDeviceAllocator *allocator, void *allocatorContext) {
-  return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), data, size, allocator, allocatorContext);
+  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
+  at::Allocator *allocator) {
+  return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }
 
 void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag)

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -96,7 +96,7 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
 }
 
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
+  THCState *state, at::DevicePtr&& data, ptrdiff_t size,
   at::Allocator *allocator) {
   return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -96,7 +96,7 @@ THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fileName, p
 }
 
 THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, at::DevicePtr&& data, ptrdiff_t size,
+  THCState *state, at::DataPtr&& data, ptrdiff_t size,
   at::Allocator *allocator) {
   return THCStorage_newWithDataAndAllocator(state, at::CTypeToScalarType<real>::to(), std::move(data), size, allocator);
 }

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -41,7 +41,7 @@ THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
+  THCState *state, at::DevicePtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
 #endif
 

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -4,7 +4,6 @@
 
 #define TH_STORAGE_REFCOUNTED 1
 #define TH_STORAGE_RESIZABLE  2
-#define TH_STORAGE_FREEMEM    4
 
 #define THCStorage THStorage
 
@@ -37,17 +36,14 @@ THC_API THCStorage* THCStorage_(newWithSize3)(THCState *state, real, real, real)
 THC_API THCStorage* THCStorage_(newWithSize4)(THCState *state, real, real, real, real);
 THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, ptrdiff_t size, int shared);
 
-/* takes ownership of data */
-THC_API THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size);
-
+#ifdef __cplusplus
 THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
-  THCDeviceAllocator* allocator,
-  void *allocatorContext);
+  at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, real* data, ptrdiff_t size,
-  THCDeviceAllocator* allocator,
-  void *allocatorContext);
+  THCState *state, at::SupervisedPtr&& data, ptrdiff_t size,
+  at::Allocator* allocator);
+#endif
 
 THC_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
 THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -41,7 +41,7 @@ THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-  THCState *state, at::DevicePtr&& data, ptrdiff_t size,
+  THCState *state, at::DataPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
 #endif
 

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -575,11 +575,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   size_t matrices_size = num_batches * sizeof(real*);
 
 //   Copy pointers to device.
-  const real **d_matrices1, **d_matrices2;
-  real **d_result_matrices;
-  THCudaCheck(THCudaMalloc(state, (void**)&d_matrices1, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_matrices2, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result_matrices, matrices_size));
+  auto d_matrices1 = static_cast<const real**>(THCudaMalloc(state, matrices_size));
+  auto d_matrices2 = static_cast<const real**>(THCudaMalloc(state, matrices_size));
+  auto d_result_matrices = static_cast<real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;
@@ -786,9 +784,8 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
   int *info_gpu = THCudaIntTensor_data(state, rinfo_);
 
   // Copy pointers to device.
-  real **d_result;
   size_t matrices_size = num_batches * sizeof(real*);
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result, matrices_size));
+  auto d_result = static_cast<real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;
@@ -899,10 +896,8 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   size_t matrices_size = num_batches * sizeof(real*);
 
   // Copy pointers to device.
-  real **d_result;
-  const real **d_atf;
-  THCudaCheck(THCudaMalloc(state, (void**)&d_result, matrices_size));
-  THCudaCheck(THCudaMalloc(state, (void**)&d_atf, matrices_size));
+  auto d_result = static_cast<real**>(THCudaMalloc(state, matrices_size));
+  auto d_atf = static_cast<const real**>(THCudaMalloc(state, matrices_size));
 
   const int64_t block = 512;
   const int64_t grid = (num_batches + block - 1) / block;

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -34,10 +34,10 @@
 template<>
 void THPPointer<THStorage>::free() {
   if (ptr) {
-    if (ptr->data_ptr.device_.is_cpu()) {
+    if (ptr->data_ptr.device().is_cpu()) {
       THStorage_free(ptr);
     } else {
-      AT_ASSERT(ptr->data_ptr.device_.is_cuda());
+      AT_ASSERT(ptr->data_ptr.device().is_cuda());
 #ifdef USE_CUDA
       THCStorage_free(at::globalContext().lazyInitCUDA(), ptr);
 #else

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -34,10 +34,10 @@
 template<>
 void THPPointer<THStorage>::free() {
   if (ptr) {
-    if (ptr->backend == at::kCPU) {
+    if (ptr->data_ptr.device_.is_cpu()) {
       THStorage_free(ptr);
     } else {
-      AT_ASSERT(ptr->backend == at::kCUDA);
+      AT_ASSERT(ptr->data_ptr.device_.is_cuda());
 #ifdef USE_CUDA
       THCStorage_free(at::globalContext().lazyInitCUDA(), ptr);
 #else

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -241,8 +241,7 @@ PyObject * THCPModule_cudaUnlockMutex(PyObject *module)
 PyObject * THCPModule_emptyCache(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  auto device_allocator = THCState_getDeviceAllocator(state);
-  THCudaCheck(device_allocator->emptyCache(device_allocator->state));
+  THCCachingAllocator_emptyCache();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -119,7 +119,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
     real *data_ptr = THWStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
     // TODO: Hmmmm
-    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr(), storage_arg->cdata->data_ptr.device_}, size, nullptr));
+    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr(), storage_arg->cdata->data_ptr.device()}, size, nullptr));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THWStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -214,7 +214,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THWStorage_(data)(LIBRARY_STATE self->cdata);
-    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr(), self->cdata->data_ptr.device_}, slicelength, nullptr));
+    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr(), self->cdata->data_ptr.device()}, slicelength, nullptr));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THWStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -119,7 +119,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
     real *data_ptr = THWStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
     // TODO: Hmmmm
-    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr()}, size, nullptr));
+    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr(), storage_arg->cdata->data_ptr.device_}, size, nullptr));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THWStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -214,7 +214,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THWStorage_(data)(LIBRARY_STATE self->cdata);
-    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr()}, slicelength, nullptr));
+    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr(), self->cdata->data_ptr.device_}, slicelength, nullptr));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THWStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -119,7 +119,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
     real *data_ptr = THWStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
     // TODO: Hmmmm
-    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr(), storage_arg->cdata->data_ptr.device()}, size, nullptr));
+    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, storage_arg->cdata->data_ptr.device()} /* non-owning */, size, nullptr));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THWStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -214,7 +214,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THWStorage_(data)(LIBRARY_STATE self->cdata);
-    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr(), self->cdata->data_ptr.device()}, slicelength, nullptr));
+    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), self->cdata->data_ptr.device()} /* non-owning */, slicelength, nullptr));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THWStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -23,13 +23,13 @@ static void THPStorage_(dealloc)(THPStorage* self)
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-static THWStorage* THPStorage_(newWithAllocator)(int64_t size, THAllocator* allocator)
+static THWStorage* THPStorage_(newWithAllocator)(int64_t size, at::Allocator* allocator)
 {
 #if defined(THC_GENERIC_FILE) || defined(THD_GENERIC_FILE)
   THPUtils_setError(THPStorageStr " does not support custom allocators");
   return NULL;
 #else
-  return THWStorage_(newWithAllocator)(LIBRARY_STATE size, allocator, NULL);
+  return THWStorage_(newWithAllocator)(LIBRARY_STATE size, allocator);
 #endif
 }
 
@@ -118,7 +118,8 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         size, numel - offset, offset);
 
     real *data_ptr = THWStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
-    THWStoragePtr storage(THWStorage_(newWithData)(LIBRARY_STATE data_ptr, size));
+    // TODO: Hmmmm
+    THWStoragePtr storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data_ptr, at::nonOwningSupervisorPtr()}, size, nullptr));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THWStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -213,7 +214,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THWStorage_(data)(LIBRARY_STATE self->cdata);
-    THWStoragePtr new_storage(THWStorage_(newWithData)(LIBRARY_STATE data + start, slicelength));
+    THWStoragePtr new_storage(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {static_cast<void*>(data + start), at::nonOwningSupervisorPtr()}, slicelength, nullptr));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THWStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -10,7 +10,7 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
   THWStorage *storage = self->cdata;
-  THManagedMapAllocator *ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+  THManagedMapAllocator *ctx = THManagedMapAllocator::fromDevicePtr(storage->data_ptr);
   if (ctx) {
     ctx->decref();
   }
@@ -25,7 +25,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
   THWStorage *storage = self->cdata;
-  THManagedMapAllocator *ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+  THManagedMapAllocator *ctx = THManagedMapAllocator::fromDevicePtr(storage->data_ptr);
   if (ctx) {
     ctx->incref();
   }
@@ -37,7 +37,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
 static PyObject * THPStorage_(newTHView)(THWStorage *base, ptrdiff_t offset, size_t size)
 {
   void *data = (char*)base->data<real>() + offset;
-  THWStoragePtr view(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data, at::nonOwningSupervisorPtr(), base->data_ptr.device_}, size, nullptr));
+  THWStoragePtr view(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data, at::nonOwningSupervisorPtr(), base->data_ptr.device()}, size, nullptr));
   view->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
   view->view = base;
   THWStorage_(retain)(LIBRARY_STATE base);
@@ -64,7 +64,7 @@ static THWStorage* THPStorage_(newFilenameStorage)(ptrdiff_t size)
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM | TH_ALLOCATOR_MAPPED_EXCLUSIVE;
   std::string handle = THPStorage_(__newHandle)();
   return THWStorage_(newWithDataAndAllocator)(
-      THManagedMapAllocator::makeSupervisedPtr("", handle.c_str(), flags, size * sizeof(real)), size, /* allocator */ nullptr);
+      THManagedMapAllocator::makeDevicePtr("", handle.c_str(), flags, size * sizeof(real)), size, /* allocator */ nullptr);
 }
 
 static PyObject * THPStorage_(pyNewFilenameStorage)(PyObject *_unused, PyObject *args)
@@ -84,7 +84,7 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self)
   THWStorage *storage = self->cdata;
   THManagedMapAllocator *ctx;
   // Storage is already in shared memory, just return a handle
-  if ((ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr))) {
+  if ((ctx = THManagedMapAllocator::fromDevicePtr(storage->data_ptr))) {
     // done
   } else {
     // TODO: retry on collision
@@ -92,7 +92,7 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self)
     THWStoragePtr new_storage(THPStorage_(newFilenameStorage)(storage->size));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
-    ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+    ctx = THManagedMapAllocator::fromDevicePtr(storage->data_ptr);
     AT_ASSERT(ctx);
   }
 
@@ -131,7 +131,7 @@ static PyObject * THPStorage_(newSharedFilename)(PyObject *_unused, PyObject *ar
               TH_ALLOCATOR_MAPPED_NOCREATE;
   return THPStorage_(New)(
           THWStorage_(newWithDataAndAllocator)(
-            THManagedMapAllocator::makeSupervisedPtr(manager_handle, object_handle, flags, size * sizeof(real)),
+            THManagedMapAllocator::makeDevicePtr(manager_handle, object_handle, flags, size * sizeof(real)),
             size,
             /* allocator */ nullptr));
   END_HANDLE_TH_ERRORS
@@ -144,7 +144,7 @@ static THWStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
               TH_ALLOCATOR_MAPPED_KEEPFD |
               TH_ALLOCATOR_MAPPED_UNLINK;
   std::string handle = THPStorage_(__newHandle)();
-  auto sptr = THMapAllocator::makeSupervisedPtr(handle.c_str(), flags, size * sizeof(real), nullptr);
+  auto sptr = THMapAllocator::makeDevicePtr(handle.c_str(), flags, size * sizeof(real), nullptr);
   return THWStorage_(newWithDataAndAllocator)(std::move(sptr), size, /* allocator */ nullptr);
 }
 
@@ -165,13 +165,13 @@ static PyObject * THPStorage_(shareFd)(THPStorage *self)
   THWStorage *storage = self->cdata;
   THMapAllocator *ctx;
   // Storage is already in shared memory, just return a handle
-  if ((ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr))) {
+  if ((ctx = THMapAllocator::fromDevicePtr(storage->data_ptr))) {
     // done
   } else {
     THWStoragePtr new_storage(THPStorage_(newFdStorage)(storage->size));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
-    ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr);
+    ctx = THMapAllocator::fromDevicePtr(storage->data_ptr);
     AT_ASSERT(ctx);
   }
 
@@ -214,7 +214,7 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
   return THPStorage_(New)(
           THWStorage_(newWithDataAndAllocator)(
             // TODO: Maybe we should read out the real size and use it for size
-            THMapAllocator::makeSupervisedPtr(WITH_FD, nullptr, fd, flags, size * sizeof(real), nullptr),
+            THMapAllocator::makeDevicePtr(WITH_FD, nullptr, fd, flags, size * sizeof(real), nullptr),
             size, /* allocator */ nullptr));
   END_HANDLE_TH_ERRORS
 }
@@ -225,9 +225,9 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
-  at::DeviceGuard device_guard(storage->data_ptr.device_.index());
+  at::DeviceGuard device_guard(storage->data_ptr.device().index());
   THPObjectPtr tuple(PyTuple_New(5));
-  THPObjectPtr device(PyLong_FromLong(storage->data_ptr.device_.index()));
+  THPObjectPtr device(PyLong_FromLong(storage->data_ptr.device().index()));
   THPObjectPtr _handle(Py_None);
   Py_INCREF(Py_None);
   THPObjectPtr size(PyLong_FromLong(storage->size));
@@ -294,7 +294,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 
   THWStoragePtr base(THWStorage_(newWithDataAndAllocator)(
       LIBRARY_STATE
-      THCIpcDeleter::makeSupervisedPtr(devPtr, device),
+      THCIpcDeleter::makeDevicePtr(devPtr, device),
       storage_size, /* allocator */ nullptr));
   base->flag = TH_STORAGE_REFCOUNTED;
 
@@ -379,7 +379,7 @@ PyObject * THPStorage_(sharedFd)(THPStorage *self)
   THMapAllocator *ctx = nullptr;
 #ifndef THC_GENERIC_FILE
   THWStorage *storage = self->cdata;
-  ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr);
+  ctx = THMapAllocator::fromDevicePtr(storage->data_ptr);
 #endif
 
   THPUtils_assert(ctx, "couldn't retrieve a shared file descriptor");
@@ -406,8 +406,8 @@ PyObject * THPStorage_(isShared)(THPStorage *self)
 #ifdef THC_GENERIC_FILE
   Py_RETURN_TRUE;
 #else
-  if (THMapAllocator::fromSupervisedPtr(self->cdata->data_ptr) ||
-      THManagedMapAllocator::fromSupervisedPtr(self->cdata->data_ptr)) {
+  if (THMapAllocator::fromDevicePtr(self->cdata->data_ptr) ||
+      THManagedMapAllocator::fromDevicePtr(self->cdata->data_ptr)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -9,13 +9,11 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
-  libshm_context *ctx = NULL;
   THWStorage *storage = self->cdata;
-  if (storage->allocatorVoidPtr == &THManagedSharedAllocator) {
-    ctx = (libshm_context*)storage->allocatorContext;
+  THManagedMapAllocator *ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+  if (ctx) {
+    ctx->decref();
   }
-  if (ctx)
-    THRefcountedMapAllocator_decref(ctx->th_context, THWStorage_(data)(storage));
 #endif
   Py_INCREF(self);
   return (PyObject *)self;
@@ -26,13 +24,11 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
-  libshm_context *ctx = NULL;
   THWStorage *storage = self->cdata;
-  if (storage->allocatorVoidPtr == &THManagedSharedAllocator) {
-    ctx = (libshm_context*)storage->allocatorContext;
+  THManagedMapAllocator *ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+  if (ctx) {
+    ctx->incref();
   }
-  if (ctx)
-    THRefcountedMapAllocator_incref(ctx->th_context, THWStorage_(data)(storage));
 #endif
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -41,7 +37,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
 static PyObject * THPStorage_(newTHView)(THWStorage *base, ptrdiff_t offset, size_t size)
 {
   void *data = (char*)base->data<real>() + offset;
-  THWStoragePtr view(THWStorage_(newWithData)(LIBRARY_STATE (real*)data, size));
+  THWStoragePtr view(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data, at::nonOwningSupervisorPtr()}, size, nullptr));
   view->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
   view->view = base;
   THWStorage_(retain)(LIBRARY_STATE base);
@@ -67,8 +63,8 @@ static THWStorage* THPStorage_(newFilenameStorage)(ptrdiff_t size)
 {
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM | TH_ALLOCATOR_MAPPED_EXCLUSIVE;
   std::string handle = THPStorage_(__newHandle)();
-  auto ctx = libshm_context_new(NULL, handle.c_str(), flags);
-  return THWStorage_(newWithAllocator)(size, &THManagedSharedAllocator, (void*)ctx);
+  return THWStorage_(newWithDataAndAllocator)(
+      THManagedMapAllocator::makeSupervisedPtr("", handle.c_str(), flags, size * sizeof(real)), size, /* allocator */ nullptr);
 }
 
 static PyObject * THPStorage_(pyNewFilenameStorage)(PyObject *_unused, PyObject *args)
@@ -86,23 +82,23 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
-  libshm_context *ctx;
+  THManagedMapAllocator *ctx;
   // Storage is already in shared memory, just return a handle
-  if (storage->allocatorVoidPtr == &THManagedSharedAllocator) {
-    ctx = (libshm_context*)storage->allocatorContext;
+  if ((ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr))) {
+    // done
   } else {
     // TODO: retry on collision
     // TODO: free GIL - but remember to reacquire it when an exception is thrown
     THWStoragePtr new_storage(THPStorage_(newFilenameStorage)(storage->size));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
-    ctx = (libshm_context*)storage->allocatorContext;
+    ctx = THManagedMapAllocator::fromSupervisedPtr(storage->data_ptr);
+    AT_ASSERT(ctx);
   }
 
-  THPObjectPtr manager_handle(PyBytes_FromString(ctx->manager_handle));
+  THPObjectPtr manager_handle(PyBytes_FromString(ctx->manager_handle()));
   if (!manager_handle) return NULL;
-  THPObjectPtr storage_handle(
-    PyBytes_FromString(THMapAllocatorContext_filename(ctx->th_context)));
+  THPObjectPtr storage_handle(PyBytes_FromString(ctx->filename()));
   if (!storage_handle) return NULL;
   THPObjectPtr size(PyLong_FromLong(storage->size));
   if (!size) return NULL;
@@ -133,9 +129,11 @@ static PyObject * THPStorage_(newSharedFilename)(PyObject *_unused, PyObject *ar
   int64_t size = THPUtils_unpackLong(_size);
   int flags = TH_ALLOCATOR_MAPPED_SHAREDMEM |
               TH_ALLOCATOR_MAPPED_NOCREATE;
-  libshm_context *ctx = libshm_context_new(manager_handle, object_handle, flags);
-  return THPStorage_(New)(THWStorage_(newWithAllocator)(size,
-      &THManagedSharedAllocator, (void*)ctx));
+  return THPStorage_(New)(
+          THWStorage_(newWithDataAndAllocator)(
+            THManagedMapAllocator::makeSupervisedPtr(manager_handle, object_handle, flags, size * sizeof(real)),
+            size,
+            /* allocator */ nullptr));
   END_HANDLE_TH_ERRORS
 }
 
@@ -146,8 +144,8 @@ static THWStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
               TH_ALLOCATOR_MAPPED_KEEPFD |
               TH_ALLOCATOR_MAPPED_UNLINK;
   std::string handle = THPStorage_(__newHandle)();
-  auto ctx = THMapAllocatorContext_new(handle.c_str(), flags);
-  return THWStorage_(newWithAllocator)(size, &THMapAllocator, (void*)ctx);
+  auto sptr = THMapAllocator::makeSupervisedPtr(handle.c_str(), flags, size * sizeof(real), nullptr);
+  return THWStorage_(newWithDataAndAllocator)(std::move(sptr), size, /* allocator */ nullptr);
 }
 
 static PyObject * THPStorage_(pyNewFdStorage)(PyObject *_unused, PyObject *args)
@@ -165,18 +163,19 @@ static PyObject * THPStorage_(shareFd)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
-  THMapAllocatorContext *ctx;
+  THMapAllocator *ctx;
   // Storage is already in shared memory, just return a handle
-  if (storage->allocatorVoidPtr == &THMapAllocator) {
-    ctx = (THMapAllocatorContext*)storage->allocatorContext;
+  if ((ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr))) {
+    // done
   } else {
     THWStoragePtr new_storage(THPStorage_(newFdStorage)(storage->size));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
-    ctx = (THMapAllocatorContext*)storage->allocatorContext;
+    ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr);
+    AT_ASSERT(ctx);
   }
 
-  THPObjectPtr storage_handle(PyLong_FromLong(THMapAllocatorContext_fd(ctx)));
+  THPObjectPtr storage_handle(PyLong_FromLong(ctx->fd()));
   if (!storage_handle) return NULL;
   THPObjectPtr size(PyLong_FromLong(storage->size));
   if (!size) return NULL;
@@ -212,9 +211,11 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
               TH_ALLOCATOR_MAPPED_NOCREATE |
               TH_ALLOCATOR_MAPPED_KEEPFD |
               TH_ALLOCATOR_MAPPED_FROMFD;
-  THMapAllocatorContext *ctx = THMapAllocatorContext_newWithFd(NULL, fd, flags);
-  return THPStorage_(New)(THWStorage_(newWithAllocator)(size, &THMapAllocator,
-      (void*)ctx));
+  return THPStorage_(New)(
+          THWStorage_(newWithDataAndAllocator)(
+            // TODO: Maybe we should read out the real size and use it for size
+            THMapAllocator::makeSupervisedPtr(WITH_FD, nullptr, fd, flags, size * sizeof(real), nullptr),
+            size, /* allocator */ nullptr));
   END_HANDLE_TH_ERRORS
 }
 
@@ -292,8 +293,10 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   THCudaCheck(cudaIpcOpenMemHandle(&devPtr, handle, cudaIpcMemLazyEnablePeerAccess));
 
   THWStoragePtr base(THWStorage_(newWithDataAndAllocator)(
-      LIBRARY_STATE (real*)devPtr, storage_size, &THCIpcAllocator, (void*)device));
-  base->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_FREEMEM;
+      LIBRARY_STATE
+      THCIpcDeleter::makeSupervisedPtr(devPtr, device),
+      storage_size, /* allocator */ nullptr));
+  base->flag = TH_STORAGE_REFCOUNTED;
 
   if (offset != 0 || view_size != storage_size) {
     return THPStorage_(newTHView)(base.get(), offset, view_size);
@@ -373,16 +376,14 @@ PyObject * THPStorage_(freeWeakRef)(PyObject *_unused, PyObject *arg)
 PyObject * THPStorage_(sharedFd)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THMapAllocatorContext *ctx = NULL;
+  THMapAllocator *ctx = nullptr;
 #ifndef THC_GENERIC_FILE
   THWStorage *storage = self->cdata;
-  if (storage->allocatorVoidPtr == &THMapAllocator) {
-    ctx = (THMapAllocatorContext*)storage->allocatorContext;
-  }
+  ctx = THMapAllocator::fromSupervisedPtr(storage->data_ptr);
 #endif
 
   THPUtils_assert(ctx, "couldn't retrieve a shared file descriptor");
-  return PyLong_FromLong(THMapAllocatorContext_fd(ctx));
+  return PyLong_FromLong(ctx->fd());
   END_HANDLE_TH_ERRORS
 }
 
@@ -405,9 +406,8 @@ PyObject * THPStorage_(isShared)(THPStorage *self)
 #ifdef THC_GENERIC_FILE
   Py_RETURN_TRUE;
 #else
-  void *allocator = self->cdata->allocatorVoidPtr;
-  if (allocator == &THMapAllocator ||
-      allocator == &THManagedSharedAllocator) {
+  if (THMapAllocator::fromSupervisedPtr(self->cdata->data_ptr) ||
+      THManagedMapAllocator::fromSupervisedPtr(self->cdata->data_ptr)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -37,7 +37,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
 static PyObject * THPStorage_(newTHView)(THWStorage *base, ptrdiff_t offset, size_t size)
 {
   void *data = (char*)base->data<real>() + offset;
-  THWStoragePtr view(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data, at::nonOwningSupervisorPtr()}, size, nullptr));
+  THWStoragePtr view(THWStorage_(newWithDataAndAllocator)(LIBRARY_STATE {data, at::nonOwningSupervisorPtr(), base->data_ptr.device_}, size, nullptr));
   view->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
   view->view = base;
   THWStorage_(retain)(LIBRARY_STATE base);
@@ -225,9 +225,9 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
-  at::DeviceGuard device_guard(storage->device);
+  at::DeviceGuard device_guard(storage->data_ptr.device_.index());
   THPObjectPtr tuple(PyTuple_New(5));
-  THPObjectPtr device(PyLong_FromLong(storage->device));
+  THPObjectPtr device(PyLong_FromLong(storage->data_ptr.device_.index()));
   THPObjectPtr _handle(Py_None);
   Py_INCREF(Py_None);
   THPObjectPtr size(PyLong_FromLong(storage->size));

--- a/torch/lib/THD/base/data_channels/GlooCache.hpp
+++ b/torch/lib/THD/base/data_channels/GlooCache.hpp
@@ -143,8 +143,7 @@ struct GlooCache {
                                           std::default_delete<char[]>());
 #ifdef USE_CUDA
     } else if (device == DeviceType::CUDA) {
-      buffer_type *buf;
-      THCudaCheck(THCudaMalloc(THDGetCudaState(), (void**)&buf, bytes));
+      buffer_type *buf = static_cast<buffer_type*>(THCudaMalloc(THDGetCudaState(), bytes));
       return std::shared_ptr<buffer_type>(buf, [](char* ptr) { THCudaFree(THDGetCudaState(), ptr); });
 #endif
     } else {

--- a/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
@@ -12,7 +12,7 @@ static THDStorage* THDStorage_(_alloc)() {
   new (&new_storage->refcount) std::atomic<int>(1);
   new_storage->storage_id = THDState::s_nextId++;
   new_storage->node_id = THDState::s_current_worker;
-  new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
+  new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE;
   return new_storage;
 }
 

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -108,13 +108,6 @@ THManagedMapAllocator::THManagedMapAllocator(const char *manager_handle, const c
     initializeManager();
 }
 
-THManagedMapAllocator::THManagedMapAllocator(WithFd, const char *manager_handle, const char *filename, int fd, int flags, ptrdiff_t size)
-  : THRefcountedMapAllocator(WITH_FD, filename, fd, flags, size)
-  , manager_handle_(manager_handle ? manager_handle : "") {
-
-    initializeManager();
-}
-
 THManagedMapAllocator::~THManagedMapAllocator() {
   AllocInfo info = get_alloc_info(this);
   info.free = true;
@@ -130,11 +123,6 @@ static void deleteTHManagedMapAllocator(void* ptr) {
 
 at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
-}
-
-at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size) {
-  auto* supervisor = new THManagedMapAllocator(WITH_FD, manager_handle, filename, fd, flags, size);
   return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
 }
 

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -10,26 +10,17 @@
 std::unordered_map<std::string, ClientSocket> managers;
 std::string manager_executable_path;
 
-void libshm_init(const char *manager_exec_path) {
-  manager_executable_path = std::string(manager_exec_path);
-}
-
-libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags) {
-  libshm_context *ctx = new libshm_context();
-  if (!manager_handle) {
-    ctx->manager_handle = nullptr;
-  } else {
-    size_t handle_length = std::strlen(manager_handle);
-    ctx->manager_handle = new char[handle_length+1];
-    memcpy(ctx->manager_handle, manager_handle, handle_length+1);
+AllocInfo get_alloc_info(THManagedMapAllocator *ctx) {
+  AllocInfo info = {0};
+  info.pid = getpid();
+  info.free = false;
+  const char *filename = ctx->filename();
+  size_t len = strlen(filename);
+  if (len >= sizeof(info.filename)) {
+    throw std::runtime_error("THMapAllocatorContext_filename too long");
   }
-  ctx->th_context = THMapAllocatorContext_new(filename, flags);
-  return ctx;
-}
-
-void libshm_context_free(libshm_context *ctx) {
-  delete[] ctx->manager_handle;
-  delete ctx;
+  memcpy(info.filename, filename, len + 1);
+  return info;
 }
 
 void start_manager() {
@@ -73,77 +64,81 @@ void start_manager() {
   managers.emplace(std::move(handle), std::move(manager));
 }
 
-ClientSocket& get_manager_socket(char *manager_handle) {
-  std::string str_handle(manager_handle);
-  auto it = managers.find(str_handle);
+ClientSocket& get_manager_socket(const std::string& manager_handle) {
+  auto it = managers.find(manager_handle);
   if (it == managers.end()) {
-    auto socket = ClientSocket(str_handle);
-    auto result = managers.emplace(std::move(str_handle), std::move(socket));
+    auto socket = ClientSocket(manager_handle);
+    auto result = managers.emplace(manager_handle, std::move(socket));
     return result.first->second;
   } else {
     return it->second;
   }
 }
 
-char * copy_handle(const std::string &handle) {
-  char *new_handle = new char[handle.length()+1];
-  memcpy(new_handle, handle.c_str(), handle.length() + 1);
-  return new_handle;
+void libshm_init(const char *manager_exec_path) {
+  manager_executable_path = std::string(manager_exec_path);
 }
 
-AllocInfo get_alloc_info(libshm_context *ctx) {
-  AllocInfo info = {0};
-  info.pid = getpid();
-  info.free = false;
-  const char *filename = THMapAllocatorContext_filename(ctx->th_context);
-  size_t len = strlen(filename);
-  if (len >= sizeof(info.filename)) {
-    throw std::runtime_error("THMapAllocatorContext_filename too long");
-  }
-  memcpy(info.filename, filename, len + 1);
-  return info;
-}
-
-void * libshm_alloc(void *_ctx, ptrdiff_t size) {
+void THManagedMapAllocator::initializeManager() {
   // TODO: unlock GIL when contacting the manager
-  auto *ctx = (libshm_context*)_ctx;
   try {
-    THMapAllocatorContext *th_context = ctx->th_context;
     ClientSocket *socket;
-    if (ctx->manager_handle) {
-      socket = &get_manager_socket(ctx->manager_handle);
+    if (!manager_handle_.empty()) {
+      socket = &get_manager_socket(manager_handle_);
     } else {
-      if (managers.size() == 0)
-          start_manager();
+      if (managers.size() == 0) {
+        start_manager();
+      }
       const auto &manager = managers.begin();
-      ctx->manager_handle = copy_handle(manager->first);
+      manager_handle_ = manager->first;
       socket = &manager->second;
     }
-    AllocInfo info = get_alloc_info(ctx);
+    AllocInfo info = get_alloc_info(this);
     socket->register_allocation(info);
   } catch(std::exception &e) {
     THError(e.what());
   }
-  return THRefcountedMapAllocator.malloc(ctx->th_context, size);
 }
 
-void * libshm_realloc(void *_ctx, void *data, ptrdiff_t size) {
-  THError("cannot realloc shared memory");
-  return NULL;
+THManagedMapAllocator::THManagedMapAllocator(const char *manager_handle, const char *filename, int flags, ptrdiff_t size)
+  : THRefcountedMapAllocator(filename, flags, size)
+  // TODO: Perhaps it should be an at::optional<std::string>?
+  , manager_handle_(manager_handle ? manager_handle : "") {
+
+    initializeManager();
 }
 
-void libshm_free(void *_ctx, void *data) {
-  auto *ctx = (libshm_context*)_ctx;
-  AllocInfo info = get_alloc_info(ctx);
+THManagedMapAllocator::THManagedMapAllocator(WithFd, const char *manager_handle, const char *filename, int fd, int flags, ptrdiff_t size)
+  : THRefcountedMapAllocator(WITH_FD, filename, fd, flags, size)
+  , manager_handle_(manager_handle ? manager_handle : "") {
+
+    initializeManager();
+}
+
+THManagedMapAllocator::~THManagedMapAllocator() {
+  AllocInfo info = get_alloc_info(this);
   info.free = true;
-  ClientSocket &socket = get_manager_socket(ctx->manager_handle);
-  THRefcountedMapAllocator.free(ctx->th_context, data);
-  libshm_context_free(ctx);
+  ClientSocket &socket = get_manager_socket(manager_handle_);
+  // TODO: I think its OK to register deallocation before we actually
+  // deallocate; I hope so!
   socket.register_deallocation(info);
 }
 
-THAllocator THManagedSharedAllocator = {
-  libshm_alloc,
-  libshm_realloc,
-  libshm_free,
-};
+static void deleteTHManagedMapAllocator(void* ptr) {
+  delete static_cast<THManagedMapAllocator*>(ptr);
+}
+
+at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+  auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
+}
+
+at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size) {
+  auto* supervisor = new THManagedMapAllocator(WITH_FD, manager_handle, filename, fd, flags, size);
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
+}
+
+THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
+  if (sptr.supervisor_.get_deleter() != &deleteTHManagedMapAllocator) return nullptr;
+  return static_cast<THManagedMapAllocator*>(sptr.supervisor_.get());
+}

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -108,12 +108,12 @@ THManagedMapAllocator::THManagedMapAllocator(const char *manager_handle, const c
     initializeManager();
 }
 
-THManagedMapAllocator::~THManagedMapAllocator() {
+void THManagedMapAllocator::close() {
+  if (closed_) return;
   AllocInfo info = get_alloc_info(this);
   info.free = true;
   ClientSocket &socket = get_manager_socket(manager_handle_);
-  // TODO: I think its OK to register deallocation before we actually
-  // deallocate; I hope so!
+  THRefcountedMapAllocator::close();
   socket.register_deallocation(info);
 }
 

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -116,11 +116,11 @@ static void deleteTHManagedMapAllocator(void* ptr) {
   delete static_cast<THManagedMapAllocator*>(ptr);
 }
 
-at::DevicePtr THManagedMapAllocator::makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
-  auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
+at::DataPtr THManagedMapAllocator::makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+  auto* context = new THManagedMapAllocator(manager_handle, filename, flags, size);
+  return {context->data(), context, &deleteTHManagedMapAllocator, at::kCPU};
 }
 
-THManagedMapAllocator* THManagedMapAllocator::fromDevicePtr(const at::DevicePtr& dptr) {
-  return dptr.cast_supervisor<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
+THManagedMapAllocator* THManagedMapAllocator::fromDataPtr(const at::DataPtr& dptr) {
+  return dptr.cast_context<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
 }

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -118,7 +118,7 @@ static void deleteTHManagedMapAllocator(void* ptr) {
 
 at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
 }
 
 THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -116,12 +116,11 @@ static void deleteTHManagedMapAllocator(void* ptr) {
   delete static_cast<THManagedMapAllocator*>(ptr);
 }
 
-at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+at::DevicePtr THManagedMapAllocator::makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
   return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
 }
 
-THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
-  if (sptr.supervisor_.get_deleter() != &deleteTHManagedMapAllocator) return nullptr;
-  return static_cast<THManagedMapAllocator*>(sptr.supervisor_.get());
+THManagedMapAllocator* THManagedMapAllocator::fromDevicePtr(const at::DevicePtr& dptr) {
+  return dptr.cast_supervisor<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
 }

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -24,8 +24,8 @@ public:
 
   ~THManagedMapAllocator() { close(); }
 
-  static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::DevicePtr makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromDevicePtr(const at::DevicePtr&);
 
   const char* manager_handle() const { return manager_handle_.c_str(); }
 };

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -1,23 +1,29 @@
-#ifndef LIBSHM_H
-#define LIBSHM_H
+#pragma once
 
 #include <TH/TH.h>
 
 #ifdef __cplusplus
-#define EXPORT_API extern "C"
-#else
-#define EXPORT_API
-#endif
 
-typedef struct {
-  char *manager_handle;
-  THMapAllocatorContext *th_context;
-} libshm_context;
+void libshm_init(const char *manager_exec_path);
 
-EXPORT_API void libshm_init(const char *manager_exec_path);
-EXPORT_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-EXPORT_API void libshm_context_free(libshm_context *context);
+// Like a THRefcountedMapAllocator, but it also makes use of an external
+// shared memory manager process to ensure that shared memory regions actually
+// get freed in the end (even if processes lose the memory).
+class THManagedMapAllocator : public THRefcountedMapAllocator {
+public:
+  THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  THManagedMapAllocator(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
+  virtual ~THManagedMapAllocator();
 
-extern THAllocator THManagedSharedAllocator;
+  static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+
+  const char* manager_handle() const { return manager_handle_.c_str(); }
+
+protected:
+  void initializeManager();
+  std::string manager_handle_;
+};
 
 #endif

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -12,7 +12,8 @@ void libshm_init(const char *manager_exec_path);
 class THManagedMapAllocator : public THRefcountedMapAllocator {
 public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  virtual ~THManagedMapAllocator();
+
+  void close() override;
 
   static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
   static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -12,11 +12,9 @@ void libshm_init(const char *manager_exec_path);
 class THManagedMapAllocator : public THRefcountedMapAllocator {
 public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  THManagedMapAllocator(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
   virtual ~THManagedMapAllocator();
 
   static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  static at::SupervisedPtr makeSupervisedPtr(WithFd, const char* manager_handle, const char* filename, int fd, int flags, ptrdiff_t size);
   static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
 
   const char* manager_handle() const { return manager_handle_.c_str(); }

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -6,23 +6,28 @@
 
 void libshm_init(const char *manager_exec_path);
 
+// Superclass to run a constructor before THRefcountedMapAllocator
+class THManagedMapAllocatorInit {
+protected:
+  THManagedMapAllocatorInit(const char* manager_handle, const char* filename);
+  std::string manager_handle_;
+};
+
 // Like a THRefcountedMapAllocator, but it also makes use of an external
 // shared memory manager process to ensure that shared memory regions actually
 // get freed in the end (even if processes lose the memory).
-class THManagedMapAllocator : public THRefcountedMapAllocator {
+class THManagedMapAllocator : private THManagedMapAllocatorInit, public THRefcountedMapAllocator {
 public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
 
   void close() override;
 
+  ~THManagedMapAllocator() { close(); }
+
   static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
   static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
 
   const char* manager_handle() const { return manager_handle_.c_str(); }
-
-protected:
-  void initializeManager();
-  std::string manager_handle_;
 };
 
 #endif

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -24,8 +24,8 @@ public:
 
   ~THManagedMapAllocator() { close(); }
 
-  static at::DevicePtr makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  static THManagedMapAllocator* fromDevicePtr(const at::DevicePtr&);
+  static at::DataPtr makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromDataPtr(const at::DataPtr&);
 
   const char* manager_handle() const { return manager_handle_.c_str(); }
 };

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -13,12 +13,11 @@ static void deleteTHManagedMapAllocator(void* ptr) {
   delete static_cast<THManagedMapAllocator*>(ptr);
 }
 
-at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+at::DevicePtr THManagedMapAllocator::makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
   return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
 }
 
-THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
-  if (sptr.supervisor_.get_deleter() != &deleteTHManagedMapAllocator) return nullptr;
-  return static_cast<THManagedMapAllocator*>(sptr.supervisor_.get());
+THManagedMapAllocator* THManagedMapAllocator::fromDevicePtr(const at::DevicePtr& dptr) {
+  return dptr.cast_supervisor<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -15,7 +15,7 @@ static void deleteTHManagedMapAllocator(void* ptr) {
 
 at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
 }
 
 THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -9,28 +9,16 @@
 void libshm_init(const char *manager_exec_path) {
 }
 
-libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags) {
-  libshm_context *ctx = new libshm_context();
-  ctx->manager_handle = "no_manager";
-  ctx->th_context = THMapAllocatorContext_new(filename, flags);
-  return ctx;
+static void deleteTHManagedMapAllocator(void* ptr) {
+  delete static_cast<THManagedMapAllocator*>(ptr);
 }
 
-void libshm_context_free(libshm_context *ctx) {
-  delete ctx;
+at::SupervisedPtr THManagedMapAllocator::makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+  auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
+  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}};
 }
 
-THManagedSharedDeleter THManagedSharedDeleter::singleton_;
-
-
-at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size) {
-  auto *ctx = (libshm_context*)_ctx;
-  return THRefcountedMapAllocator_alloc(ctx->th_context, size);
-}
-
-
-void THManagedSharedDeleter::deallocate(void* _ctx, void* data) const {
-  auto *ctx = (libshm_context*)_ctx;
-  ctx->th_deleter(data);
-  return libshm_context_free(ctx);
+THManagedMapAllocator* THManagedMapAllocator::fromSupervisedPtr(const at::SupervisedPtr& sptr) {
+  if (sptr.supervisor_.get_deleter() != &deleteTHManagedMapAllocator) return nullptr;
+  return static_cast<THManagedMapAllocator*>(sptr.supervisor_.get());
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -13,11 +13,11 @@ static void deleteTHManagedMapAllocator(void* ptr) {
   delete static_cast<THManagedMapAllocator*>(ptr);
 }
 
-at::DevicePtr THManagedMapAllocator::makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
-  auto* supervisor = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {supervisor->data(), {supervisor, &deleteTHManagedMapAllocator}, at::kCPU};
+at::DataPtr THManagedMapAllocator::makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
+  auto* context = new THManagedMapAllocator(manager_handle, filename, flags, size);
+  return {context->data(), {context, &deleteTHManagedMapAllocator}, at::kCPU};
 }
 
-THManagedMapAllocator* THManagedMapAllocator::fromDevicePtr(const at::DevicePtr& dptr) {
-  return dptr.cast_supervisor<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
+THManagedMapAllocator* THManagedMapAllocator::fromDataPtr(const at::DataPtr& dptr) {
+  return dptr.cast_context<THManagedMapAllocator>(&deleteTHManagedMapAllocator);
 }

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -15,7 +15,7 @@ static void deleteTHManagedMapAllocator(void* ptr) {
 
 at::DataPtr THManagedMapAllocator::makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* context = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {context->data(), {context, &deleteTHManagedMapAllocator}, at::kCPU};
+  return {context->data(), context, &deleteTHManagedMapAllocator, at::kCPU};
 }
 
 THManagedMapAllocator* THManagedMapAllocator::fromDataPtr(const at::DataPtr& dptr) {

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -15,15 +15,36 @@
 # define SHM_API SHM_EXTERNC __declspec(dllimport)
 #endif
 
+#ifdef SHM_EXPORTS
+# define SHM_API_NOEXTERNC __declspec(dllexport)
+#else
+# define SHM_API_NOEXTERNC __declspec(dllimport)
+#endif
+
 typedef struct {
   char *manager_handle;
+  // NB: th_context is a temporary field
   THMapAllocatorContext *th_context;
+  at::BoundDeleter th_deleter;
 } libshm_context;
 
 SHM_API void libshm_init(const char *manager_exec_path);
 SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
+SHM_API at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
 SHM_API void libshm_context_free(libshm_context *context);
 
-SHM_API THAllocator THManagedSharedAllocator;
+struct SHM_API_NOEXTERNC THManagedSharedDeleter : public at::Deleter {
+  void deallocate(void* ctx, void* data) const override;
+  static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
+    ctx->th_deleter = deleter;
+    return {&singleton_, ctx};
+  }
+  static libshm_context * getContext(at::BoundDeleter bd) {
+    if (bd.deleter_ != &singleton_) return nullptr;
+    return static_cast<libshm_context*>(bd.ctx_);
+  }
+private:
+  static THManagedSharedDeleter singleton_;
+};
 
 #endif

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -17,8 +17,8 @@ public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size)
     : THRefcountedMapAllocator(filename, flags, size) {}
 
-  static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+  static at::DevicePtr makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromDevicePtr(const at::DevicePtr&);
 
   const char* manager_handle() const { return "no_manager"; }
 };

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -17,8 +17,8 @@ public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size)
     : THRefcountedMapAllocator(filename, flags, size) {}
 
-  static at::DevicePtr makeDevicePtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
-  static THManagedMapAllocator* fromDevicePtr(const at::DevicePtr&);
+  static at::DataPtr makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromDataPtr(const at::DataPtr&);
 
   const char* manager_handle() const { return "no_manager"; }
 };

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -12,10 +12,10 @@
 
 SHM_API void libshm_init(const char *manager_exec_path);
 
-class THManagedMapAllocator : public THRefcountedMapAllocator {
+class SHM_API THManagedMapAllocator : public THRefcountedMapAllocator {
 public:
   THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size)
-    : THRefcountedMapAllocator(filename, flags, size);
+    : THRefcountedMapAllocator(filename, flags, size) {}
 
   static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
   static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -1,50 +1,26 @@
-#ifndef LIBSHM_H
-#define LIBSHM_H
+#pragma once
 
 #include <TH/TH.h>
 
 #ifdef __cplusplus
-#define SHM_EXTERNC extern "C"
-#else
-#define SHM_EXTERNC
-#endif
 
 #ifdef SHM_EXPORTS
-# define SHM_API SHM_EXTERNC __declspec(dllexport)
+# define SHM_API __declspec(dllexport)
 #else
-# define SHM_API SHM_EXTERNC __declspec(dllimport)
+# define SHM_API __declspec(dllimport)
 #endif
-
-#ifdef SHM_EXPORTS
-# define SHM_API_NOEXTERNC __declspec(dllexport)
-#else
-# define SHM_API_NOEXTERNC __declspec(dllimport)
-#endif
-
-typedef struct {
-  char *manager_handle;
-  // NB: th_context is a temporary field
-  THMapAllocatorContext *th_context;
-  at::BoundDeleter th_deleter;
-} libshm_context;
 
 SHM_API void libshm_init(const char *manager_exec_path);
-SHM_API libshm_context * libshm_context_new(const char *manager_handle, const char *filename, int flags);
-SHM_API at::SupervisedPtr libshm_alloc(void *_ctx, ptrdiff_t size);
-SHM_API void libshm_context_free(libshm_context *context);
 
-struct SHM_API_NOEXTERNC THManagedSharedDeleter : public at::Deleter {
-  void deallocate(void* ctx, void* data) const override;
-  static at::BoundDeleter make(libshm_context* ctx, at::BoundDeleter deleter) {
-    ctx->th_deleter = deleter;
-    return {&singleton_, ctx};
-  }
-  static libshm_context * getContext(at::BoundDeleter bd) {
-    if (bd.deleter_ != &singleton_) return nullptr;
-    return static_cast<libshm_context*>(bd.ctx_);
-  }
-private:
-  static THManagedSharedDeleter singleton_;
+class THManagedMapAllocator : public THRefcountedMapAllocator {
+public:
+  THManagedMapAllocator(const char* manager_handle, const char* filename, int flags, ptrdiff_t size)
+    : THRefcountedMapAllocator(filename, flags, size);
+
+  static at::SupervisedPtr makeSupervisedPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size);
+  static THManagedMapAllocator* fromSupervisedPtr(const at::SupervisedPtr&);
+
+  const char* manager_handle() const { return "no_manager"; }
 };
 
 #endif


### PR DESCRIPTION
```
Introduce SupervisedPtr, delete THAllocator and THCDeviceAllocator

See Note [Supervisor deleter] for how SupervisedPtr works.
This design is not the obvious one, but there were a lot of
constraints feeding into it:

- It must support the reallocation usage-pattern, where, given
  an existing Storage, we allocate a new region of memory,
  copy the existing data to it, and then deallocate the old
  region of memory.

- Creation of a deleter for memory MUST avoid dynamic allocations
  in the common case.  We've done some benchmarking in Caffe2
  where dynamic allocation for deleters is ruinously expensive,
  and it's really hard to avoid these performance tarpits in
  very general function wrappers like std::function or
  folly::Function (while benchmarking this, we discovered that
  folly::Function's move constructor was way more expensive
  than it should be).

- We need to be able to deallocate data that comes from external
  sources, e.g., dlpack and numpy tensors.  Most notably,
  you often cannot deallocate these with merely the void*
  data pointer; you need some extra, out-of-band information
  (e.g., the managing struct) to deallocate it.  Sometimes,
  you may even want to resize data living in an external source!

- The "core" allocators need to support being wrapped in a Thrust
  allocator, so you need to be implement the following two functions:

    char* allocate(size_t);
    void deallocate(char*, size_t);

- We need to support tensors which contain non-POD, non-trivially
  copyable data; specifically tensors of std::string.  This is
  an upcoming requirement from Caffe2.  It's dirty AF, but
  it's really useful.

- It should use C++ standard library types like std::unique_ptr
  (which is hugely problematic because std::unique_ptr doesn't
  call the deleter when the pointer is null.)

Here is the billing of changes:

- Built-in support for realloc() has been DROPPED ENTIRELY.
  Instead, you're expected to allocate and then copy from
  the old memory to the new memory if you want to do a
  reallocation.  This is what you'd generally have expected
  to occur; and axing realloc() from the design lets us avoid
  some tricky correctness issues with std::realloc(), namely
  the fact that we must refuse the realloc if the type of the
  elements are not trivially copyeable.  If it really matters,
  we can add this back, but there really needs to be a good
  explanation WHY you need fast resizing reallocations (by in
  large, people don't resize their storages, and it should
  be acceptable to have a performance degradation when they
  do).

- TH_STORAGE_FREEMEM is no more; instead, if you want a
  storage which doesn't free its result, you just give it
  an empty deleter.

- What we used to call an "allocator" (really, a combined
  object for allocating/deleting) has been split into two
  concepts, an allocator, and a smart pointer (SupervisedPtr)
  which knows how to delete data.

    - Unlike previously, where THAllocator/THCDeviceAllocator
      could have a per-tensor context storing extra information
      (e.g., a pointer to the metadata you need to actually
      free the tensor), there is no context in the allocator or
      the deleter of the smart pointer; instead, the smart
      pointer directly holds an owning reference to the
      metadata necessary to free the data.  This metadata
      is *freshly manufactured* upon every allocation, which
      permits us to resize tensors even in the absence of
      built-in support for realloc().

    - By default, allocators don't support "raw" allocations
      and deallocations with raw pointers.  This is because
      some allocations may return a different context every
      time, in which case you need to reconstruct the context
      at delete time (because all you got was a void*, not
      a unique_ptr that carries the deleter).

- The diff between at::Allocator and THCDeviceAllocator is a
  bit larger:

    - It used to return a cudaError_t.  Now, allocators
      are expected to check the error status immediately and throw
      an exception if there was an error.  It turns out that this
      is what was immediately done after all occurrences of
      allocate/release, so it wasn't a big deal (although some
      subsidiary interfaces had to themselves be converted to
      not return cudaError_t).

      There is one notable exception to this, and it is how
      we handle CUDA OOM: if this occurs, we attempt to return
      unused memory to the system and try again.  This is now
      handled by a catch-all try-catch block.  The cost of
      catching the exception is probably the least of your worries
      if you're about to OOM.

    - It used to take the CUDA stream to perform the allocation
      on as an argument.  However, it turned out that all call
      sites, this stream was the stream for the current device.
      So we can push this into the allocator (and the choice,
      in the future, could be made explicitly by twiddling
      thread local state.)

    - It held two extra methods, emptyCache and cacheInfo, specifically
      for interacting with some state in THCCachingAllocator.
      But this "generality" was a lie, since THCCachingAllocator
      was the only allocator that actually implemented these
      methods, and there is actually a bunch of code in THC
      which assumes that it is the caching allocator that is
      the underlying allocator for CUDA allocations.  So I
      folded these two methods into this interface as
      THCCachingAllocator_emptyCache and THCCachingAllocator_cacheInfo.

    - It held its context directly inside the THCDeviceAllocator
      struct.  This context has been moved out into whatever
      is holding the at::Allocator*.

- The APIs for getting at allocators/deleters is now a little different.

    - Previously there were a bunch of static variables you could get
      the address of (e.g., &THDefaultAllocator); now there is a
      function getTHDefaultAllocator().

    - Some "allocators" didn't actually know how to allocate (e.g.,
      the IPC "allocator").  These have been deleted; instead, you
      can wrap the produced pointers into SupervisedPtr using
      an appropriate makeSupervisedPtr() static method.

- Storage sharing was a lot of work to wrangle, but I think I've
  tamed the beast.

    - THMapAllocator and its "subclasses" have been refactored to
      be proper, honest to goodness C++ classes.  I used the enum
      argument trick to get "named" constructors.  We use inheritance
      to add refcounting and management (in libshm).  What we previously
      called the "Context" class (Context has been dropped from the name)
      is now the supervisor for the data.

    - Sometimes, we need to pull out the file descriptor from a
      tensor.  Previously, it was pulled out of the allocator context.
      Now, we pull it out of the supervisor of the SupervisorPtr,
      using the static method fromSupervisedPtr(), which uses the
      deleter as the typeid, and refines the type if it matches.

- I renamed the std::function deleter into
  InefficientStdFunctionSupervisor, to emphasize the fact that it does
  a dynamic allocation to save the std::function deleter.

TODO:

- Windows libshm is in shambles and needs to be fixed.

Perhaps for the future:

- newFromFd is now unconditionally calling cudaPointerGetAttributes
  even though this is unnecessary, because we know what the device
  is from higher up in the callstack.  We can fix this by making
  newWithDataAndAllocator also take an explicit device argument.

- Consider statically distinguishing between allocators that
  support raw_allocate/raw_deallocate, and those which don't.
  The Thrust constraint applies only to the CUDA device allocator;
  you never need to allocate CPU memory this way

- Really want to get rid of storage views. Ugh.

Nontrivial bugs I noticed when preparing this patch:

- I forgot to placement-new unique pointers and attempted to
  assign them directly on uninitialized memory; very bad!  Sam
  Gross has encouraged me to replace this with a proper constructor
  but I keep putting it off, because once everything goes in
  StorageImpl there really will be a proper constructor.

- I rewrote a number of APIs to use newWithDataAndAllocator
  instead of newWithAllocator, calling the allocator at the
  call site (because they required "allocation context" which
  we no longer give to "allocators").  When I did this, I forgot
  to insert the multiplication with sizeof(real) to scale from
  numels to number of bytes.

- The implementation of swap on storages was missing it for
  scalarType and backend.  It was benign (because the only case
  we call swap is when these are the same), but I fixed it anyway.

- I accidentally returned a nullptr unique_ptr with no deleter,
  even though there was a legitimate one.  This matters, because
  some code still shoves its hands in the deleter context to
  get extra metadata about the function.

- I used std::move() on a unique_ptr, and then did a boolean
  test on the pointer aftewards (always false!)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```