### PR TITLE
Support n-dimensional empty tensors in TensorShape methods.

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -334,7 +334,7 @@ std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
   if (split_size != 0) {
     // ensuring num_splits if at least 1 makes consistent the case where split_size > dim_size
     // (returns a single split).  We might want to error here, but keep it for BC.
-    num_splits = std::max<int64_t>(dim_size + split_size - 1, 1);
+    num_splits = std::max<int64_t>((dim_size + split_size - 1) / split_size, 1);
   }
   std::vector<Tensor> splits(num_splits);
   int64_t last_split_size = split_size - (split_size * num_splits - dim_size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -41,8 +41,14 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
     AT_ERROR("chunk expects `chunks` to be greater than 0, got: ", chunks);
   }
   int64_t split_size = (self.size(dim) + chunks - 1) / chunks;
-  // ensure this is dispatched through Tensor/Type, rather than the native function directly.
-  return self.split(split_size, dim);
+
+  // We need to call split_with_sizes in the case where split_size and dimension size are 0, because
+  // a call to split would discard the number of chunks (because we can have an arbitrary number of
+  // 0-sized chunks adding up to 0).  So, call split_with_sizes with the correct number of chunks,
+  // and do this for all cases for consistency.
+  std::vector<int64_t> split_sizes(chunks, split_size);
+  split_sizes[chunks - 1] = split_size - (split_size * chunks - self.size(dim));
+  return self.split_with_sizes(split_sizes, dim);
 }
 
 Tensor diagflat(const Tensor& self, int64_t offset) {
@@ -64,13 +70,24 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   // Note that we invert +/- in the second to absorb the negative
   // sign in the offset.
   if (offset >= 0) {
-    diag_size = std::min(self.size(dim1), self.size(dim2)-offset);
+    diag_size = std::max<int64_t>(std::min(self.size(dim1), self.size(dim2)-offset), 0);
+  } else {
+    diag_size = std::max<int64_t>(std::min(self.size(dim1)+offset, self.size(dim2)), 0);
+  }
+#ifndef USE_TH_SIZE_ZERO_DIM
+  AT_CHECK(diag_size > 0, "invalid diagonal offset ", offset); // the diagonal offset was too large in magnitude
+#endif
+
+  // NumPy allows you to specify offsets "off the end"; let's just be careful not to
+  // set a ridiculous storage_offset in that case (technically it shouldn't matter
+  // because there are no elements in the tensor, but let's be kosher).
+  if (diag_size == 0) {
+    // skip
+  } else if (offset >= 0) {
     storage_offset += offset * self.stride(dim2);
   } else {
-    diag_size = std::min(self.size(dim1)+offset, self.size(dim2));
     storage_offset -= offset * self.stride(dim1);
   }
-  AT_CHECK(diag_size > 0, "invalid diagonal offset ", offset); // the diagonal offset was too large in magnitude
 
   // construct new size and stride: we drop dim1 and dim2 (maximum first for not changing the index of the minumum)
   // the new ("joint") dimension is appended to the end of the shape / stride to match numpy semantics
@@ -181,7 +198,9 @@ Tensor repeat(const Tensor& self, IntList repeats) {
   Tensor result = self.type().tensor(target_size);
   Tensor urtensor = result.type().alias(result);
   for (int64_t i = 0; i < xtensor.dim(); ++i) {
-    urtensor = urtensor.unfold(i, xtensor.size(i), xtensor.size(i));
+    // can't unfold with step 0, so make sure step is at least 1
+    // (it doesn't matter what it is in that case, because the size is 0).
+    urtensor = urtensor.unfold(i, xtensor.size(i), std::max<int64_t>(xtensor.size(i), 1));
   }
 
   urtensor.copy_(xtensor.expand_as(urtensor));
@@ -210,6 +229,9 @@ static std::vector<int64_t> infer_size(IntList shape, int64_t numel) {
 
   if (numel == newsize || (infer_dim && newsize > 0 && numel % newsize == 0)) {
     if (infer_dim) {
+      // we have a degree of freedom here to select the dimension size; follow NumPy semantics
+      // and just bail.
+      AT_CHECK(newsize != 0, "cannot reshape tensor of 0 elements into shape ", shape);
       res[*infer_dim] = numel / newsize;
     }
 #ifndef USE_TH_SIZE_ZERO_DIM
@@ -301,17 +323,19 @@ Tensor slice(const Tensor& self, int64_t dim, int64_t start, int64_t end, int64_
 }
 
 std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
-  if (self.dim() == 0) {
-    throw std::runtime_error("split expects at least a 1-dimensional tensor");
-  }
-  if (split_size < 0) {
-    std::ostringstream ss;
-    ss << "split expects split_size be non-negative, but got split_size="
-       << split_size;
-    throw std::runtime_error(ss.str());
-  }
+  AT_CHECK(self.dim() != 0, "split expects at least a 1-dimensional tensor");
+  AT_CHECK(split_size >= 0,  "split expects split_size be non-negative, but got split_size=", split_size);
   int64_t dim_size = self.size(dim);
-  int64_t num_splits = (dim_size + split_size - 1) / split_size;
+  AT_CHECK(split_size > 0 || self.size(dim) == 0,
+           "split_size can only be 0 if dimension size is 0, "
+           "but got dimension size of ", dim_size);
+  // if split_size is 0 and dimension size is 0, there is 1 split.
+  int64_t num_splits = 1;
+  if (split_size != 0) {
+    // ensuring num_splits if at least 1 makes consistent the case where split_size > dim_size
+    // (returns a single split).  We might want to error here, but keep it for BC.
+    num_splits = std::max<int64_t>(dim_size + split_size - 1, 1);
+  }
   std::vector<Tensor> splits(num_splits);
   int64_t last_split_size = split_size - (split_size * num_splits - dim_size);
 
@@ -323,9 +347,7 @@ std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
 }
 
 std::vector<Tensor> split_with_sizes(const Tensor& self, IntList split_sizes, int64_t dim) {
-  if (self.dim() == 0) {
-    throw std::runtime_error("split_with_sizes expects at least a 1-dimensional tensor");
-  }
+  AT_CHECK(self.dim() != 0, "split expects at least a 1-dimensional tensor");
   int64_t dim_size = self.size(dim);
   int64_t num_splits = split_sizes.size();
   std::vector<Tensor> splits(num_splits);
@@ -339,9 +361,6 @@ std::vector<Tensor> split_with_sizes(const Tensor& self, IntList split_sizes, in
       ss << "split_with_sizes expects split_sizes have only non-negative "
          << "entries, but got split_sizes=" << split_sizes;
       throw std::runtime_error(ss.str());
-    }
-    if (start_idx >= dim_size) {
-      break;
     }
     splits[i] = self.narrow(dim, start_idx, length);
     start_idx += length;
@@ -504,10 +523,11 @@ inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >
 inferUnsqueezeGeometry(const Tensor& tensor, int64_t dim) {
+#ifndef USE_TH_SIZE_ZERO_DIM
   if (tensor.numel() == 0) {
     throw std::runtime_error("cannot unsqueeze empty tensor");
   }
-
+#endif
   std::vector<int64_t> sizes(tensor.sizes());
   std::vector<int64_t> strides(tensor.strides());
   int64_t new_stride = dim >= tensor.dim() ? 1 : sizes[dim] * strides[dim];
@@ -586,12 +606,17 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
     return self;
   }
 
+  // We don't want to infer_size on the entire shape, because that can give us an extra degree
+  // of freedom we don't want; for example, consider shape [0, 1, 3, 0], with start_dim=1, end_dim=2.
+  // It's clear we want result shape [0, 3, 0] but passing [0, -1, 0] to infer_size means the -1
+  // can take on any value and satisfy the constraints.
+  auto slice_numel = prod_intlist(self.sizes().slice(start_dim, end_dim - start_dim + 1));
   std::vector<int64_t> shape;
   shape.reserve(self.dim() - end_dim + start_dim);
   for (int64_t i = 0; i < start_dim; i++) {
     shape.push_back(self.size(i));
   }
-  shape.push_back(-1);
+  shape.push_back(slice_numel);
   for (int64_t i = end_dim + 1; i < self.dim(); i++) {
     shape.push_back(self.size(i));
   }

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -466,7 +466,9 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   if(!src)
     src = self;
 
+#ifndef USE_TH_SIZE_ZERO_DIM
   THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
+#endif
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -2826,7 +2826,10 @@ void THTensor_(onesLike)(THTensor *r_, THTensor *input)
 
 void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
 {
-  THArgCheck(!t->is_empty() && (THTensor_(nDimension)(t) == 1 || THTensor_(nDimension)(t) == 2), 1, "non-empty matrix or a vector expected");
+#ifndef USE_TH_SIZE_ZERO_DIM
+  AT_ASSERT(!t->is_empty())
+#endif
+  THArgCheck(THTensor_(nDimension)(t) == 1 || THTensor_(nDimension)(t) == 2, 1, "matrix or a vector expected");
 
   if(THTensor_(nDimension)(t) == 1)
   {

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -456,7 +456,9 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   if(!src)
     src = self;
 
+#ifndef USE_TH_SIZE_ZERO_DIM
   THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
+#endif
   THArgCheck(dimension < src->dim(), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
@@ -468,7 +470,7 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
 
   newSize[self->dim()] = size;
   newStride[self->dim()] = self->stride[dimension];
-  for(d = 0; d < self->_dim(); d++)
+  for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6050,8 +6050,8 @@ class TestTorch(TestCase):
             self.assertEqual((0, 1, 0), torch.select(x, 2, 2).shape)
             # unfold
             self.assertEqual((0, 1, 1, 0, 3), x.unfold(2, 3, 2).shape)
-            z = torch.randn((0, 1, 3), device=device)
-            self.assertEqual((1, 1, 3, 0), z.unfold(0, 0, 4).shape)
+            y = torch.randn((0, 1, 3), device=device)
+            self.assertEqual((1, 1, 3, 0), y.unfold(0, 0, 4).shape)
 
             # repeat, permute
             self.assertEqual((9, 0, 5, 6, 0), x.repeat(9, 7, 5, 2, 3).shape)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6075,21 +6075,21 @@ class TestTorch(TestCase):
             # stack, split, chunk
             self.assertEqual((4, 0, 1, 3, 0), torch.stack((x, x, x, x)).shape)
             self.assertEqual([(0, 1, 3, 0)],
-                             [y.shape for y in torch.chunk(x, 1, dim=0)])
+                             [z.shape for z in torch.chunk(x, 1, dim=0)])
 
-            self.assertEqual([(0, 1, 3, 0), ] * 3, [y.shape for y in torch.chunk(x, 3, dim=0)])
-            self.assertEqual([(0, 1, 1, 0), ] * 3, [y.shape for y in torch.chunk(x, 3, dim=2)])
+            self.assertEqual([(0, 1, 3, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=0)])
+            self.assertEqual([(0, 1, 1, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=2)])
 
             # NOTE: split_with_sizes behaves differently than NumPy in that it
             # takes sizes rather than offsets
             self.assertEqual([(0, 1, 0, 0), (0, 1, 1, 0), (0, 1, 2, 0)],
-                             [x.shape for x in torch.split(x, (0, 1, 2), dim=2)])
+                             [z.shape for z in torch.split(x, (0, 1, 2), dim=2)])
 
             self.assertRaises(RuntimeError, lambda: torch.split(x, 0, dim=1))
             # This is strange because the split size is larger than the dim size, but consistent with
             # how split handles that case generally (when no 0s are involved).
-            self.assertEqual([(0, 1, 3, 0)], [y.shape for y in torch.split(x, 1, dim=0)])
-            self.assertEqual([(0, 1, 3, 0)], [y.shape for y in torch.split(x, 0, dim=0)])
+            self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 1, dim=0)])
+            self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 0, dim=0)])
 
     def test_expand(self):
         tensor = torch.rand(1, 8, 1)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6023,6 +6023,74 @@ class TestTorch(TestCase):
         # should be viewable -- i.e. data_ptr is the same.
         self.assertEqual(x.data_ptr(), x.reshape(1, 0, 6, 1, 1).data_ptr())
 
+        # match NumPy semantics -- don't infer the size of dimension with a degree of freedom
+        self.assertRaises(RuntimeError, lambda: x.reshape(0, -1))
+
+    @skipIfNoZeroSize
+    def test_tensor_shape_empty(self):
+        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        for device in devices:
+            x = torch.randn((0, 1, 3, 0), device=device)
+            # flatten
+            self.assertEqual((0,), torch.flatten(x, 0, 3).shape)
+            self.assertEqual((0, 0), torch.flatten(x, 0, 2).shape)
+            self.assertEqual((0, 3, 0), torch.flatten(x, 1, 2).shape)
+
+            # squeeze, unsqueeze
+            self.assertEqual((0, 1, 1, 3, 0), torch.unsqueeze(x, 1).shape)
+            self.assertEqual((0, 3, 0), torch.squeeze(x, 1).shape)
+            self.assertEqual((0, 3, 0), torch.squeeze(x).shape)
+
+            # transpose, t
+            self.assertEqual((0, 0, 3, 1), torch.transpose(x, 1, 3).shape)
+            y = torch.randn((5, 0), device=device)
+            self.assertEqual((0, 5), y.t().shape)
+
+            # select
+            self.assertEqual((0, 1, 0), torch.select(x, 2, 2).shape)
+            # unfold
+            self.assertEqual((0, 1, 1, 0, 3), x.unfold(2, 3, 2).shape)
+            z = torch.randn((0, 1, 3), device=device)
+            self.assertEqual((1, 1, 3, 0), z.unfold(0, 0, 4).shape)
+
+            # repeat, permute
+            self.assertEqual((9, 0, 5, 6, 0), x.repeat(9, 7, 5, 2, 3).shape)
+            self.assertEqual((3, 0, 0, 1), x.permute(2, 3, 0, 1).shape)
+
+            # diagonal, diagflat
+            self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device)).shape)
+            self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device)).shape)
+            # off the end offsets are valid
+            self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device), offset=1).shape)
+            self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device), offset=1).shape)
+            # check non-zero sized offsets off the end
+            self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=45252).shape)
+            self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=-45252).shape)
+
+            self.assertEqual((0, 0), torch.diagflat(torch.tensor([], device=device)).shape)
+            self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([], device=device), offset=1))
+            self.assertEqual((0, 0), torch.diagflat(torch.tensor([[]], device=device)).shape)
+            self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([[]], device=device), offset=1))
+
+            # stack, split, chunk
+            self.assertEqual((4, 0, 1, 3, 0), torch.stack((x, x, x, x)).shape)
+            self.assertEqual([(0, 1, 3, 0)],
+                             [y.shape for y in torch.chunk(x, 1, dim=0)])
+
+            self.assertEqual([(0, 1, 3, 0), ] * 3, [y.shape for y in torch.chunk(x, 3, dim=0)])
+            self.assertEqual([(0, 1, 1, 0), ] * 3, [y.shape for y in torch.chunk(x, 3, dim=2)])
+
+            # NOTE: split_with_sizes behaves differently than NumPy in that it
+            # takes sizes rather than offsets
+            self.assertEqual([(0, 1, 0, 0), (0, 1, 1, 0), (0, 1, 2, 0)],
+                             [x.shape for x in torch.split(x, (0, 1, 2), dim=2)])
+
+            self.assertRaises(RuntimeError, lambda: torch.split(x, 0, dim=1))
+            # This is strange because the split size is larger than the dim size, but consistent with
+            # how split handles that case generally (when no 0s are involved).
+            self.assertEqual([(0, 1, 3, 0)], [y.shape for y in torch.split(x, 1, dim=0)])
+            self.assertEqual([(0, 1, 3, 0)], [y.shape for y in torch.split(x, 0, dim=0)])
+
     def test_expand(self):
         tensor = torch.rand(1, 8, 1)
         tensor2 = torch.rand(5)


### PR DESCRIPTION
This includes either bug fixes or NumPy semantics changes for the following methods:
chunk, diagonal, unfold, repeat, flatten, reshape, split, unsqueeze.

The n-dimensional empty tensor feature is still hidden behind a feature flag.

