### PR TITLE
Implement tensor weak references

### DIFF
--- a/aten/src/ATen/Retainable.h
+++ b/aten/src/ATen/Retainable.h
@@ -13,11 +13,14 @@ struct Retainable {
   }
   void release() {
     if(--refcount == 0) {
-      // Skip releaseResources() when this is the last weak reference.
-      if (weak_refcount > 1) {
+      // If we know that this is the last reference then we can skip
+      // all the decrements and releaseResources().
+      if (weak_refcount == 1) {
+        delete this;
+      } else {
         releaseResources();
+        weakRelease();
       }
-      weakRelease();
     }
   }
   void weakRetain() {

--- a/aten/src/ATen/Retainable.h
+++ b/aten/src/ATen/Retainable.h
@@ -7,21 +7,49 @@ namespace at {
 // base class for refcounted things, allows for collects of generic
 // refcounted objects that include tensors
 struct Retainable {
-  Retainable(): refcount(1) {}
+  Retainable(): refcount(1), weak_refcount(1) {}
   void retain() {
     ++refcount;
   }
   void release() {
     if(--refcount == 0) {
+      // Skip releaseResources() when this is the last weak reference.
+      if (weak_refcount > 1) {
+        releaseResources();
+      }
+      weakRelease();
+    }
+  }
+  void weakRetain() {
+    ++weak_refcount;
+  }
+  void weakRelease() {
+    if (--weak_refcount == 0) {
       delete this;
     }
   }
-  int use_count() const {
+  bool weakLock() {
+    for (;;) {
+      auto current_refcount = refcount.load();
+      if (current_refcount == 0) return false;
+      if (refcount.compare_exchange_strong(current_refcount, current_refcount + 1)) break;
+    }
+    return true;
+  }
+  uint32_t use_count() const {
     return refcount.load();
   }
+  uint32_t weak_use_count() const {
+    return weak_refcount.load();
+  }
+
+  virtual void releaseResources() {};
   virtual ~Retainable() {}
 private:
-  std::atomic<int> refcount;
+  // INVARIANT: once refcount reaches 0 it can never go up
+  // INVARIANT: weak_refcount = number of weak references + (refcount > 0 ? 1 : 0)
+  std::atomic<uint32_t> refcount;
+  std::atomic<uint32_t> weak_refcount;
 };
 
 }

--- a/aten/src/ATen/Retainable.h
+++ b/aten/src/ATen/Retainable.h
@@ -14,24 +14,24 @@ struct Retainable {
   void release() {
     if(--refcount == 0) {
       // If we know that this is the last reference then we can skip
-      // all the decrements and releaseResources().
+      // all the decrements and release_resources().
       if (weak_refcount == 1) {
         delete this;
       } else {
-        releaseResources();
-        weakRelease();
+        release_resources();
+        weak_release();
       }
     }
   }
-  void weakRetain() {
+  void weak_retain() {
     ++weak_refcount;
   }
-  void weakRelease() {
+  void weak_release() {
     if (--weak_refcount == 0) {
       delete this;
     }
   }
-  bool weakLock() {
+  bool weak_lock() {
     for (;;) {
       auto current_refcount = refcount.load();
       if (current_refcount == 0) return false;
@@ -46,7 +46,7 @@ struct Retainable {
     return weak_refcount.load();
   }
 
-  virtual void releaseResources() {};
+  virtual void release_resources() {};
   virtual ~Retainable() {}
 private:
   // INVARIANT: once refcount reaches 0 it can never go up

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -13,6 +13,7 @@
 #include "ATen/Utils.h"
 #include "ATen/Device.h"
 #include "ATen/Layout.h"
+#include "ATen/optional.h"
 
 namespace at {
 struct Type;
@@ -42,6 +43,7 @@ namespace at {
 // Note that Tensor can also be NULL, i.e. it is not associated with any underlying TensorImpl, and
 // special care must be taken to handle this.
 struct Tensor : public detail::TensorBase {
+  using TensorBase = detail::TensorBase;
   Tensor() : TensorBase() {}
   Tensor(TensorImpl * self, bool retain) : TensorBase(self, retain) {}
   Tensor(const TensorBase & rhs) : TensorBase(rhs) {}
@@ -197,6 +199,44 @@ struct Tensor : public detail::TensorBase {
   template <typename F, typename... Args>
   auto m(F func, Args&&... params) const -> decltype(func(*this, std::forward<Args>(params)...)) {
     return func(*this, std::forward<Args>(params)...);
+  }
+
+  friend struct WeakTensor;
+};
+
+struct WeakTensor : public detail::WeakTensorBase {
+  using WeakTensorBase = detail::WeakTensorBase;
+  WeakTensor() : WeakTensorBase() {}
+  WeakTensor(TensorImpl * self, bool retain) : WeakTensorBase(self, retain) {}
+  WeakTensor(const WeakTensor & rhs) = default;
+  WeakTensor(WeakTensor && rhs) noexcept = default;
+  WeakTensor(const Tensor& t) : WeakTensorBase(t.pImpl, true) {}
+
+  // reimplemented from TensorBase so the return type is Tensor rather than TensorBase
+  WeakTensor & operator=(WeakTensor && rhs) & {
+    rhs.swap(*this);
+    return *this;
+  }
+  WeakTensor & operator=(WeakTensor const & rhs) & {
+    //Tensor ctor retains original rhs.pImpl
+    //then rhs.pImpl is swapped with this->pImpl
+    //finally Tensor dtor releases rhs.pImpl, which was originally this->pImpl
+    WeakTensor(rhs).swap(*this);
+    return *this;
+  }
+
+  WeakTensor & operator=(const Tensor& t) {
+    WeakTensor(t.pImpl, true).swap(*this);
+    return *this;
+  }
+
+  // non-retaining
+  TensorImpl * unsafeGetTensorImpl() const {
+    return pImpl;
+  }
+
+  at::optional<Tensor> lock() {
+    return pImpl->weakLock() ? at::optional<Tensor>{Tensor(pImpl, false)} : at::nullopt;
   }
 };
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -235,8 +235,10 @@ struct WeakTensor : public detail::WeakTensorBase {
     return pImpl;
   }
 
-  at::optional<Tensor> lock() {
-    return pImpl->weakLock() ? at::optional<Tensor>{Tensor(pImpl, false)} : at::nullopt;
+  // XXX: this can return undefined tensors
+  // Ideally it would be at::optional<Tensor>, but MSVC is too cool for that
+  Tensor lock() {
+    return pImpl->weakLock() ? Tensor(pImpl, false) : Tensor();
   }
 };
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -212,7 +212,7 @@ struct WeakTensor : public detail::WeakTensorBase {
   WeakTensor(WeakTensor && rhs) noexcept = default;
   WeakTensor(const Tensor& t) : WeakTensorBase(t.pImpl, true) {}
 
-  // reimplemented from TensorBase so the return type is Tensor rather than TensorBase
+  // reimplemented from TensorBase so the return type is WeakTensor rather than TensorBase
   WeakTensor & operator=(WeakTensor && rhs) & {
     rhs.swap(*this);
     return *this;
@@ -237,8 +237,8 @@ struct WeakTensor : public detail::WeakTensorBase {
 
   // XXX: this can return undefined tensors
   // Ideally it would be at::optional<Tensor>, but MSVC is too cool for that
-  Tensor lock() {
-    return pImpl->weakLock() ? Tensor(pImpl, false) : Tensor();
+  Tensor lock() const {
+    return pImpl->weak_lock() ? Tensor(pImpl, false) : Tensor();
   }
 };
 

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -49,7 +49,7 @@ void * ${Tensor}::unsafeGetTH(bool retain) {
   return tensor;
 }
 
-void ${Tensor}::releaseResources() {
+void ${Tensor}::release_resources() {
   ${THTensor}_free(${state,} tensor);
   tensor = nullptr;
 }

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -49,6 +49,11 @@ void * ${Tensor}::unsafeGetTH(bool retain) {
   return tensor;
 }
 
+void ${Tensor}::releaseResources() {
+  ${THTensor}_free(${state,} tensor);
+  tensor = nullptr;
+}
+
 ${TensorDenseOrSparse}
 
 }

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -23,6 +23,7 @@ public:
   virtual Scalar localScalar() override;
   virtual void * unsafeGetTH(bool retain) override;
   virtual std::unique_ptr<Storage> storage() override;
+  virtual void releaseResources() override;
   static const char * typeString();
 
 //TODO(zach): sort of friend permissions later so this

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -23,7 +23,7 @@ public:
   virtual Scalar localScalar() override;
   virtual void * unsafeGetTH(bool retain) override;
   virtual std::unique_ptr<Storage> storage() override;
-  virtual void releaseResources() override;
+  virtual void release_resources() override;
   static const char * typeString();
 
 //TODO(zach): sort of friend permissions later so this

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -18,7 +18,8 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/undefined_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/verify_api_visibility.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/tbb_init_test.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/tbb_init_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/weakref_test.cpp)
 
 list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/integer_divider_test.cu

--- a/aten/src/ATen/test/weakref_test.cpp
+++ b/aten/src/ATen/test/weakref_test.cpp
@@ -15,20 +15,19 @@ TEST_CASE( "Weak pointer tests", "" ) {
     Tensor a = at::ones({2, 2});
     WeakTensor b = a;
     a.reset();
-    REQUIRE_FALSE(b.lock());
+    REQUIRE_FALSE(b.lock().defined());
   }
 
   SECTION("can successfully lock") {
     Tensor a = at::ones({2, 2});
     WeakTensor b = a;
-    auto locked = b.lock();
-    REQUIRE(locked);
-    Tensor & c = *locked;
+    auto c = b.lock();
+    REQUIRE(c.defined());
 
     a.reset();
-    REQUIRE(b.lock());
+    REQUIRE(b.lock().defined());
     c.reset();
-    REQUIRE_FALSE(b.lock());
+    REQUIRE_FALSE(b.lock().defined());
   }
 
   SECTION("updates refcounts correctly") {
@@ -47,7 +46,7 @@ TEST_CASE( "Weak pointer tests", "" ) {
       WeakTensor b = a;
       REQUIRE(ai->use_count() == 1);
       auto locked = b.lock();
-      REQUIRE(locked);
+      REQUIRE(locked.defined());
       REQUIRE(ai->use_count() == 2);
     }
     REQUIRE(ai->use_count() == 1);

--- a/aten/src/ATen/test/weakref_test.cpp
+++ b/aten/src/ATen/test/weakref_test.cpp
@@ -1,0 +1,65 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "ATen/ATen.h"
+
+#include <iostream>
+#include <chrono>
+#include <sstream>
+
+using at::Tensor;
+using at::WeakTensor;
+
+TEST_CASE( "Weak pointer tests", "" ) {
+  SECTION("gets invalidated") {
+    Tensor a = at::ones({2, 2});
+    WeakTensor b = a;
+    a.reset();
+    REQUIRE_FALSE(b.lock());
+  }
+
+  SECTION("can successfully lock") {
+    Tensor a = at::ones({2, 2});
+    WeakTensor b = a;
+    auto locked = b.lock();
+    REQUIRE(locked);
+    Tensor & c = *locked;
+
+    a.reset();
+    REQUIRE(b.lock());
+    c.reset();
+    REQUIRE_FALSE(b.lock());
+  }
+
+  SECTION("updates refcounts correctly") {
+    Tensor a = at::ones({2, 2});
+    auto ai = a.unsafeGetTensorImpl();
+    REQUIRE(ai->use_count() == 1);
+    REQUIRE(ai->weak_use_count() == 1);
+    {
+      WeakTensor b = a;
+      REQUIRE(ai->use_count() == 1);
+      REQUIRE(ai->weak_use_count() == 2);
+    }
+    REQUIRE(ai->use_count() == 1);
+    REQUIRE(ai->weak_use_count() == 1);
+    {
+      WeakTensor b = a;
+      REQUIRE(ai->use_count() == 1);
+      auto locked = b.lock();
+      REQUIRE(locked);
+      REQUIRE(ai->use_count() == 2);
+    }
+    REQUIRE(ai->use_count() == 1);
+    REQUIRE(ai->weak_use_count() == 1);
+    {
+      WeakTensor b = a;
+      REQUIRE(ai->use_count() == 1);
+      REQUIRE(ai->weak_use_count() == 2);
+      a.reset();
+      auto bi = b.unsafeGetTensorImpl();
+      REQUIRE(bi->use_count() == 0);
+      REQUIRE(bi->weak_use_count() == 1);
+    }
+  }
+}

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -136,6 +136,14 @@ void Variable::Impl::set_data(Tensor new_data) {
   data_ = std::move(new_data);
 }
 
+void Variable::Impl::releaseResources() {
+  data_.reset();
+  grad_.reset();
+  grad_fn_.reset();
+  hooks_.clear();
+  tracing_state_.reset();
+}
+
 Variable::ViewImpl::ViewImpl(Variable base, at::Tensor data, Edge gradient_edge)
     : Variable::Impl(std::move(data), false, std::move(gradient_edge)),
       base_(std::move(base)) {
@@ -182,6 +190,11 @@ void Variable::ViewImpl::rebase_history(Edge gradient_edge) {
   get_grad_fn(); // trigger an update to the view's grad_fn
 }
 
+void Variable::ViewImpl::releaseResources() {
+  Variable::Impl::releaseResources();
+  base_.reset();
+}
+
 void Variable::rebase_history(Edge gradient_edge) {
   TORCH_ASSERT(gradient_edge.function != nullptr);
   if (is_view()) {
@@ -200,4 +213,5 @@ void Variable::set_tracing_state(
 jit::tracer::ValueTracingState& Variable::tracing_state() const noexcept {
   return *get()->tracing_state_;
 }
+
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -136,7 +136,7 @@ void Variable::Impl::set_data(Tensor new_data) {
   data_ = std::move(new_data);
 }
 
-void Variable::Impl::releaseResources() {
+void Variable::Impl::release_resources() {
   data_.reset();
   grad_.reset();
   grad_fn_.reset();
@@ -190,8 +190,8 @@ void Variable::ViewImpl::rebase_history(Edge gradient_edge) {
   get_grad_fn(); // trigger an update to the view's grad_fn
 }
 
-void Variable::ViewImpl::releaseResources() {
-  Variable::Impl::releaseResources();
+void Variable::ViewImpl::release_resources() {
+  Variable::Impl::release_resources();
   base_.reset();
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -347,7 +347,7 @@ struct Variable::Impl : public at::TensorImpl {
       bool create_graph) override;
 
   /// Reset all expensive fields to free up resources
-  void releaseResources() override;
+  void release_resources() override;
 
   // Make this field public so we can access it from `Variable`.
   using at::TensorImpl::type_;
@@ -404,7 +404,7 @@ struct Variable::ViewImpl : public Variable::Impl {
   }
 
   /// Reset all expensive fields to free up resources
-  void releaseResources() override;
+  void release_resources() override;
 
   /// Called after in-place modifications. Modifies the grad_fn of the base
   /// Variable.

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -346,6 +346,9 @@ struct Variable::Impl : public at::TensorImpl {
       bool keep_graph,
       bool create_graph) override;
 
+  /// Reset all expensive fields to free up resources
+  void releaseResources() override;
+
   // Make this field public so we can access it from `Variable`.
   using at::TensorImpl::type_;
 
@@ -399,6 +402,9 @@ struct Variable::ViewImpl : public Variable::Impl {
   const Variable& base() const override {
     return base_;
   }
+
+  /// Reset all expensive fields to free up resources
+  void releaseResources() override;
 
   /// Called after in-place modifications. Modifies the grad_fn of the base
   /// Variable.


### PR DESCRIPTION
Add `WeakTensor` - a `Tensor` counterpart which doesn't keep the data (or any other expensive resources) alive. They can be `.lock()`ed and return `at::optional<Tensor>` if they're still alive.