### PR TITLE
Skip the count_include_pad in average pool for now

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -35,6 +35,7 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_operator_repeat.*'  # Tile is not compliant with ONNX yet
                      '|test_.*pool_.*same.*'  # Does not support pool same.
                      '|test_convtranspose.*'  # ConvTranspose needs some more complicated translation
+                     '|test_averagepool.*count_include_pad.*'  # Waiting for the support in Caffe2 onnx backend.
                      ')')
 
 # Quick patch to unbreak master CI, is working on the debugging.


### PR DESCRIPTION
Will create a bootcamp task. 