### PR TITLE
Implement calling of c10 ops from c2

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -14,6 +14,8 @@
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 
+#include "caffe2/core/operator_c10wrapper.h"
+
 CAFFE2_DEFINE_int(
     caffe2_operator_max_engine_name_length,
     10,
@@ -75,8 +77,10 @@ GlobalEnginePrefType& g_global_engine_pref() {
   return *g_global_engine_pref_;
 }
 
-unique_ptr<OperatorBase> TryCreateOperator(
-    const string& key, const OperatorDef& operator_def, Workspace* ws) {
+unique_ptr<OperatorBase> TryCreateC2Operator(
+    const string& key,
+    const OperatorDef& operator_def,
+    Workspace* ws) {
   const auto& type = operator_def.device_option().device_type();
   CAFFE_ENFORCE(
       gDeviceTypeRegistry()->count(type),
@@ -93,6 +97,24 @@ unique_ptr<OperatorBase> TryCreateOperator(
                  << err.what()
                  << ". Proto is: " << ProtoDebugString(operator_def);
     return nullptr;
+  }
+}
+
+unique_ptr<OperatorBase> TryCreateC10Operator(
+    const string& key,
+    const OperatorDef& operator_def,
+    Workspace* ws) {
+  return C10OperatorRegistry()->Create(key, operator_def, ws);
+}
+
+unique_ptr<OperatorBase> TryCreateOperator(
+    const string& key,
+    const OperatorDef& operator_def,
+    Workspace* ws) {
+  if (auto op = TryCreateC10Operator(key, operator_def, ws)) {
+    return op;
+  } else {
+    return TryCreateC2Operator(key, operator_def, ws);
   }
 }
 
@@ -656,8 +678,14 @@ std::set<std::string> GetRegisteredOperators() {
   for (const auto& name : CUDAOperatorRegistry()->Keys()) {
     all_keys.emplace(name);
   }
+
   // HIP operators
   for (const auto& name : HIPOperatorRegistry()->Keys()) {
+    all_keys.emplace(name);
+  }
+
+  // C10 operators
+  for (const auto& name : C10OperatorRegistry()->Keys()) {
     all_keys.emplace(name);
   }
 

--- a/caffe2/core/operator_c10wrapper.cc
+++ b/caffe2/core/operator_c10wrapper.cc
@@ -1,0 +1,10 @@
+#include "caffe2/core/operator_c10wrapper.h"
+
+namespace caffe2 {
+
+CAFFE_DEFINE_REGISTRY(
+    C10OperatorRegistry,
+    OperatorBase,
+    const OperatorDef&,
+    Workspace*);
+}

--- a/caffe2/core/operator_c10wrapper.h
+++ b/caffe2/core/operator_c10wrapper.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "caffe2/core/dispatch/Dispatcher.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+/**
+ * To make a c10 operator "C10Add" callable from caffe2 as "C2MyAddOpName", just
+ * write
+ *
+ *     REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(C10Add, C2MyAddOpName)
+ *
+ * Note: This wrapper currently only supports C10 ops that have exactly one
+ * output and take that in the last parameter as "Tensor* output".
+ * TODO: Figure out a better way to handle output parameters
+ */
+
+template <class OpSchemaDef, class Context>
+class C10OperatorWrapper final : public Operator<Context> {
+  using Schema = c10::OpSchema<OpSchemaDef>;
+
+ public:
+  C10OperatorWrapper(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws) {}
+
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  bool RunOnDevice() override {
+    RunOnDevice_(
+        c10::guts::make_index_sequence<Schema::signature::num_args - 1>());
+    return true;
+  }
+
+ private:
+  template <size_t... InputIndex>
+  void RunOnDevice_(c10::guts::index_sequence<InputIndex...>) {
+    c10::Dispatcher<OpSchemaDef>::call(Input(InputIndex)..., Output(0));
+  }
+};
+
+CAFFE_DECLARE_REGISTRY(
+    C10OperatorRegistry,
+    OperatorBase,
+    const OperatorDef&,
+    Workspace*);
+
+// TODO Currently we only register the CPU variant. This is going to be fixed
+//      once the tensor detemplatization lands.
+#define REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(OpSchemaDef, Name) \
+  CAFFE_REGISTER_CLASS(                                              \
+      C10OperatorRegistry, Name, C10OperatorWrapper<OpSchemaDef, CPUContext>)
+
+} // namespace caffe2

--- a/caffe2/operators/c10_sigmoid_op.cc
+++ b/caffe2/operators/c10_sigmoid_op.cc
@@ -1,0 +1,14 @@
+#include "c10_sigmoid_op.h"
+#include "caffe2/core/dispatch/OpSchemaRegistration.h"
+#include "caffe2/core/operator_c10wrapper.h"
+
+using caffe2::CPUContext;
+using caffe2::Tensor;
+
+C10_DEFINE_OP_SCHEMA(caffe2::SigmoidOp);
+
+namespace caffe2 {
+REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH(
+    SigmoidOp,
+    C10Sigmoid_DontUseThisOpYet)
+}

--- a/caffe2/operators/c10_sigmoid_op.h
+++ b/caffe2/operators/c10_sigmoid_op.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "caffe2/core/tensor.h"
+#include "caffe2/utils/Array.h"
+
+namespace caffe2 {
+
+struct SigmoidOp final {
+  static constexpr const char* name = "sigmoid";
+
+  using Signature = void(const Tensor& input, Tensor* output);
+
+  static constexpr c10::guts::array<const char*, 2> parameter_names = {
+      {"input", "output"}};
+};
+
+} // namespace caffe2

--- a/caffe2/operators/c10_sigmoid_op_cpu.cc
+++ b/caffe2/operators/c10_sigmoid_op_cpu.cc
@@ -1,0 +1,29 @@
+#include "c10_sigmoid_op.h"
+#include "caffe2/core/dispatch/KernelRegistration.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+using caffe2::CPUContext;
+using caffe2::Tensor;
+
+namespace {
+template <class DataType>
+void sigmoid_op_cpu_impl(
+    const Tensor& input,
+    Tensor* output) {
+  output->ResizeLike(input);
+
+  caffe2::ConstEigenVectorArrayMap<DataType> xM(
+      input.data<DataType>(), input.size());
+  caffe2::EigenVectorArrayMap<DataType>(
+      output->mutable_data<DataType>(), input.size()) = 1. / (1. + (-xM).exp());
+}
+} // namespace
+
+namespace c10 {
+C10_REGISTER_KERNEL(caffe2::SigmoidOp)
+    .kernel(&sigmoid_op_cpu_impl<float>)
+    .dispatchKey({DeviceTypeId::CPU,
+                  LayoutId(0),
+                  caffe2::TypeMeta::Id<float>()});
+} // namespace c10

--- a/caffe2/utils/flat_hash_map/flat_hash_map.h
+++ b/caffe2/utils/flat_hash_map/flat_hash_map.h
@@ -72,37 +72,37 @@ namespace ska
             }
         };
         template<typename key_type, typename value_type, typename hasher>
-        struct KeyOrValueHasher : functor_storage<size_t, hasher>
+        struct KeyOrValueHasher : functor_storage<uint64_t, hasher>
         {
-            typedef functor_storage<size_t, hasher> hasher_storage;
+            typedef functor_storage<uint64_t, hasher> hasher_storage;
             KeyOrValueHasher() = default;
             KeyOrValueHasher(const hasher & hash)
                     : hasher_storage(hash)
             {
             }
-            size_t operator()(const key_type & key)
+            uint64_t operator()(const key_type & key)
             {
                 return static_cast<hasher_storage &>(*this)(key);
             }
-            size_t operator()(const key_type & key) const
+            uint64_t operator()(const key_type & key) const
             {
                 return static_cast<const hasher_storage &>(*this)(key);
             }
-            size_t operator()(const value_type & value)
+            uint64_t operator()(const value_type & value)
             {
                 return static_cast<hasher_storage &>(*this)(value.first);
             }
-            size_t operator()(const value_type & value) const
+            uint64_t operator()(const value_type & value) const
             {
                 return static_cast<const hasher_storage &>(*this)(value.first);
             }
             template<typename F, typename S>
-            size_t operator()(const std::pair<F, S> & value)
+            uint64_t operator()(const std::pair<F, S> & value)
             {
                 return static_cast<hasher_storage &>(*this)(value.first);
             }
             template<typename F, typename S>
-            size_t operator()(const std::pair<F, S> & value) const
+            uint64_t operator()(const std::pair<F, S> & value) const
             {
                 return static_cast<const hasher_storage &>(*this)(value.first);
             }
@@ -228,7 +228,7 @@ namespace ska
         template<typename T>
         constexpr std::array<const sherwood_v3_entry_constexpr<T>, min_lookups> EntryDefaultTable<T>::table;
 
-        inline int8_t log2(size_t value)
+        inline int8_t log2(uint64_t value)
         {
             static constexpr int8_t table[64] =
                     {
@@ -274,7 +274,7 @@ namespace ska
             }
         };
 
-        inline size_t next_power_of_two(size_t i)
+        inline uint64_t next_power_of_two(uint64_t i)
         {
             --i;
             i |= i >> 1;
@@ -314,7 +314,7 @@ namespace ska
         public:
 
             using value_type = T;
-            using size_type = size_t;
+            using uint64_type = uint64_t;
             using difference_type = std::ptrdiff_t;
             using hasher = ArgumentHash;
             using key_equal = ArgumentEqual;
@@ -327,16 +327,16 @@ namespace ska
             sherwood_v3_table()
             {
             }
-            explicit sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
+            explicit sherwood_v3_table(uint64_type bucket_count, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
                     : EntryAlloc(alloc), Hasher(hash), Equal(equal)
             {
                 rehash(bucket_count);
             }
-            sherwood_v3_table(size_type bucket_count, const ArgumentAlloc & alloc)
+            sherwood_v3_table(uint64_type bucket_count, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
             {
             }
-            sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
+            sherwood_v3_table(uint64_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(bucket_count, hash, ArgumentEqual(), alloc)
             {
             }
@@ -345,33 +345,33 @@ namespace ska
             {
             }
             template<typename It>
-            sherwood_v3_table(It first, It last, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
+            sherwood_v3_table(It first, It last, uint64_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
                     : sherwood_v3_table(bucket_count, hash, equal, alloc)
             {
                 insert(first, last);
             }
             template<typename It>
-            sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentAlloc & alloc)
+            sherwood_v3_table(It first, It last, uint64_type bucket_count, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(first, last, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
             {
             }
             template<typename It>
-            sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
+            sherwood_v3_table(It first, It last, uint64_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(first, last, bucket_count, hash, ArgumentEqual(), alloc)
             {
             }
-            sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
+            sherwood_v3_table(std::initializer_list<T> il, uint64_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
                     : sherwood_v3_table(bucket_count, hash, equal, alloc)
             {
                 if (bucket_count == 0)
                     rehash(il.size());
                 insert(il.begin(), il.end());
             }
-            sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentAlloc & alloc)
+            sherwood_v3_table(std::initializer_list<T> il, uint64_type bucket_count, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(il, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
             {
             }
-            sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
+            sherwood_v3_table(std::initializer_list<T> il, uint64_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
                     : sherwood_v3_table(il, bucket_count, hash, ArgumentEqual(), alloc)
             {
             }
@@ -563,7 +563,7 @@ namespace ska
 
             iterator find(const FindKey & key)
             {
-                size_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+                uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
                 EntryPointer it = entries + ptrdiff_t(index);
                 for (int8_t distance = 0; it->distance_from_desired >= distance; ++distance, ++it)
                 {
@@ -576,7 +576,7 @@ namespace ska
             {
                 return const_cast<sherwood_v3_table *>(this)->find(key);
             }
-            size_t count(const FindKey & key) const
+            uint64_t count(const FindKey & key) const
             {
                 return find(key) == end() ? 0 : 1;
             }
@@ -600,7 +600,7 @@ namespace ska
             template<typename Key, typename... Args>
             std::pair<iterator, bool> emplace(Key && key, Args &&... args)
             {
-                size_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+                uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
                 EntryPointer current_entry = entries + ptrdiff_t(index);
                 int8_t distance_from_desired = 0;
                 for (; current_entry->distance_from_desired >= distance_from_desired; ++current_entry, ++distance_from_desired)
@@ -646,9 +646,9 @@ namespace ska
                 insert(il.begin(), il.end());
             }
 
-            void rehash(size_t num_buckets)
+            void rehash(uint64_t num_buckets)
             {
-                num_buckets = std::max(num_buckets, static_cast<size_t>(std::ceil(num_elements / static_cast<double>(_max_load_factor))));
+                num_buckets = std::max(num_buckets, static_cast<uint64_t>(std::ceil(num_elements / static_cast<double>(_max_load_factor))));
                 if (num_buckets == 0)
                 {
                     reset_to_empty_state();
@@ -682,9 +682,9 @@ namespace ska
                 deallocate_data(new_buckets, num_buckets, old_max_lookups);
             }
 
-            void reserve(size_t num_elements)
+            void reserve(uint64_t num_elements)
             {
-                size_t required_buckets = num_buckets_for_reserve(num_elements);
+                uint64_t required_buckets = num_buckets_for_reserve(num_elements);
                 if (required_buckets > bucket_count())
                     rehash(required_buckets);
             }
@@ -731,7 +731,7 @@ namespace ska
                 return iterator(to_return);
             }
 
-            size_t erase(const FindKey & key)
+            uint64_t erase(const FindKey & key)
             {
                 auto found = find(key);
                 if (found == end())
@@ -768,29 +768,29 @@ namespace ska
                     swap(static_cast<EntryAlloc &>(*this), static_cast<EntryAlloc &>(other));
             }
 
-            size_t size() const
+            uint64_t size() const
             {
                 return num_elements;
             }
-            size_t max_size() const
+            uint64_t max_size() const
             {
                 return (AllocatorTraits::max_size(*this)) / sizeof(Entry);
             }
-            size_t bucket_count() const
+            uint64_t bucket_count() const
             {
                 return num_slots_minus_one + 1;
             }
-            size_type max_bucket_count() const
+            uint64_type max_bucket_count() const
             {
                 return (AllocatorTraits::max_size(*this) - min_lookups) / sizeof(Entry);
             }
-            size_t bucket(const FindKey & key) const
+            uint64_t bucket(const FindKey & key) const
             {
                 return hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
             }
             float load_factor() const
             {
-                size_t buckets = bucket_count();
+                uint64_t buckets = bucket_count();
                 if (buckets)
                     return static_cast<float>(num_elements) / bucket_count();
                 else
@@ -813,21 +813,21 @@ namespace ska
         private:
             using DefaultTable = detailv3::EntryDefaultTable<T>;
             EntryPointer entries = const_cast<Entry *>(reinterpret_cast<const Entry *>(DefaultTable::table.data()));
-            size_t num_slots_minus_one = 0;
+            uint64_t num_slots_minus_one = 0;
             typename HashPolicySelector<ArgumentHash>::type hash_policy;
             int8_t max_lookups = detailv3::min_lookups - 1;
             float _max_load_factor = 0.5f;
-            size_t num_elements = 0;
+            uint64_t num_elements = 0;
 
-            static int8_t compute_max_lookups(size_t num_buckets)
+            static int8_t compute_max_lookups(uint64_t num_buckets)
             {
                 int8_t desired = detailv3::log2(num_buckets);
                 return std::max(detailv3::min_lookups, desired);
             }
 
-            size_t num_buckets_for_reserve(size_t num_elements) const
+            uint64_t num_buckets_for_reserve(uint64_t num_elements) const
             {
-                return static_cast<size_t>(std::ceil(num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
+                return static_cast<uint64_t>(std::ceil(num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
             }
             void rehash_for_other_container(const sherwood_v3_table & other)
             {
@@ -893,10 +893,10 @@ namespace ska
 
             void grow()
             {
-                rehash(std::max(size_t(4), 2 * bucket_count()));
+                rehash(std::max(uint64_t(4), 2 * bucket_count()));
             }
 
-            void deallocate_data(EntryPointer begin, size_t num_slots_minus_one, int8_t max_lookups)
+            void deallocate_data(EntryPointer begin, uint64_t num_slots_minus_one, int8_t max_lookups)
             {
                 if (begin != const_cast<Entry *>(reinterpret_cast<const Entry *>(DefaultTable::table.data())))
                 {
@@ -914,12 +914,12 @@ namespace ska
             }
 
             template<typename U>
-            size_t hash_object(const U & key)
+            uint64_t hash_object(const U & key)
             {
                 return static_cast<Hasher &>(*this)(key);
             }
             template<typename U>
-            size_t hash_object(const U & key) const
+            uint64_t hash_object(const U & key) const
             {
                 return static_cast<const Hasher &>(*this)(key);
             }
@@ -954,197 +954,197 @@ namespace ska
 
     struct prime_number_hash_policy
     {
-        static size_t mod0(size_t) { return 0llu; }
-        static size_t mod2(size_t hash) { return hash % 2llu; }
-        static size_t mod3(size_t hash) { return hash % 3llu; }
-        static size_t mod5(size_t hash) { return hash % 5llu; }
-        static size_t mod7(size_t hash) { return hash % 7llu; }
-        static size_t mod11(size_t hash) { return hash % 11llu; }
-        static size_t mod13(size_t hash) { return hash % 13llu; }
-        static size_t mod17(size_t hash) { return hash % 17llu; }
-        static size_t mod23(size_t hash) { return hash % 23llu; }
-        static size_t mod29(size_t hash) { return hash % 29llu; }
-        static size_t mod37(size_t hash) { return hash % 37llu; }
-        static size_t mod47(size_t hash) { return hash % 47llu; }
-        static size_t mod59(size_t hash) { return hash % 59llu; }
-        static size_t mod73(size_t hash) { return hash % 73llu; }
-        static size_t mod97(size_t hash) { return hash % 97llu; }
-        static size_t mod127(size_t hash) { return hash % 127llu; }
-        static size_t mod151(size_t hash) { return hash % 151llu; }
-        static size_t mod197(size_t hash) { return hash % 197llu; }
-        static size_t mod251(size_t hash) { return hash % 251llu; }
-        static size_t mod313(size_t hash) { return hash % 313llu; }
-        static size_t mod397(size_t hash) { return hash % 397llu; }
-        static size_t mod499(size_t hash) { return hash % 499llu; }
-        static size_t mod631(size_t hash) { return hash % 631llu; }
-        static size_t mod797(size_t hash) { return hash % 797llu; }
-        static size_t mod1009(size_t hash) { return hash % 1009llu; }
-        static size_t mod1259(size_t hash) { return hash % 1259llu; }
-        static size_t mod1597(size_t hash) { return hash % 1597llu; }
-        static size_t mod2011(size_t hash) { return hash % 2011llu; }
-        static size_t mod2539(size_t hash) { return hash % 2539llu; }
-        static size_t mod3203(size_t hash) { return hash % 3203llu; }
-        static size_t mod4027(size_t hash) { return hash % 4027llu; }
-        static size_t mod5087(size_t hash) { return hash % 5087llu; }
-        static size_t mod6421(size_t hash) { return hash % 6421llu; }
-        static size_t mod8089(size_t hash) { return hash % 8089llu; }
-        static size_t mod10193(size_t hash) { return hash % 10193llu; }
-        static size_t mod12853(size_t hash) { return hash % 12853llu; }
-        static size_t mod16193(size_t hash) { return hash % 16193llu; }
-        static size_t mod20399(size_t hash) { return hash % 20399llu; }
-        static size_t mod25717(size_t hash) { return hash % 25717llu; }
-        static size_t mod32401(size_t hash) { return hash % 32401llu; }
-        static size_t mod40823(size_t hash) { return hash % 40823llu; }
-        static size_t mod51437(size_t hash) { return hash % 51437llu; }
-        static size_t mod64811(size_t hash) { return hash % 64811llu; }
-        static size_t mod81649(size_t hash) { return hash % 81649llu; }
-        static size_t mod102877(size_t hash) { return hash % 102877llu; }
-        static size_t mod129607(size_t hash) { return hash % 129607llu; }
-        static size_t mod163307(size_t hash) { return hash % 163307llu; }
-        static size_t mod205759(size_t hash) { return hash % 205759llu; }
-        static size_t mod259229(size_t hash) { return hash % 259229llu; }
-        static size_t mod326617(size_t hash) { return hash % 326617llu; }
-        static size_t mod411527(size_t hash) { return hash % 411527llu; }
-        static size_t mod518509(size_t hash) { return hash % 518509llu; }
-        static size_t mod653267(size_t hash) { return hash % 653267llu; }
-        static size_t mod823117(size_t hash) { return hash % 823117llu; }
-        static size_t mod1037059(size_t hash) { return hash % 1037059llu; }
-        static size_t mod1306601(size_t hash) { return hash % 1306601llu; }
-        static size_t mod1646237(size_t hash) { return hash % 1646237llu; }
-        static size_t mod2074129(size_t hash) { return hash % 2074129llu; }
-        static size_t mod2613229(size_t hash) { return hash % 2613229llu; }
-        static size_t mod3292489(size_t hash) { return hash % 3292489llu; }
-        static size_t mod4148279(size_t hash) { return hash % 4148279llu; }
-        static size_t mod5226491(size_t hash) { return hash % 5226491llu; }
-        static size_t mod6584983(size_t hash) { return hash % 6584983llu; }
-        static size_t mod8296553(size_t hash) { return hash % 8296553llu; }
-        static size_t mod10453007(size_t hash) { return hash % 10453007llu; }
-        static size_t mod13169977(size_t hash) { return hash % 13169977llu; }
-        static size_t mod16593127(size_t hash) { return hash % 16593127llu; }
-        static size_t mod20906033(size_t hash) { return hash % 20906033llu; }
-        static size_t mod26339969(size_t hash) { return hash % 26339969llu; }
-        static size_t mod33186281(size_t hash) { return hash % 33186281llu; }
-        static size_t mod41812097(size_t hash) { return hash % 41812097llu; }
-        static size_t mod52679969(size_t hash) { return hash % 52679969llu; }
-        static size_t mod66372617(size_t hash) { return hash % 66372617llu; }
-        static size_t mod83624237(size_t hash) { return hash % 83624237llu; }
-        static size_t mod105359939(size_t hash) { return hash % 105359939llu; }
-        static size_t mod132745199(size_t hash) { return hash % 132745199llu; }
-        static size_t mod167248483(size_t hash) { return hash % 167248483llu; }
-        static size_t mod210719881(size_t hash) { return hash % 210719881llu; }
-        static size_t mod265490441(size_t hash) { return hash % 265490441llu; }
-        static size_t mod334496971(size_t hash) { return hash % 334496971llu; }
-        static size_t mod421439783(size_t hash) { return hash % 421439783llu; }
-        static size_t mod530980861(size_t hash) { return hash % 530980861llu; }
-        static size_t mod668993977(size_t hash) { return hash % 668993977llu; }
-        static size_t mod842879579(size_t hash) { return hash % 842879579llu; }
-        static size_t mod1061961721(size_t hash) { return hash % 1061961721llu; }
-        static size_t mod1337987929(size_t hash) { return hash % 1337987929llu; }
-        static size_t mod1685759167(size_t hash) { return hash % 1685759167llu; }
-        static size_t mod2123923447(size_t hash) { return hash % 2123923447llu; }
-        static size_t mod2675975881(size_t hash) { return hash % 2675975881llu; }
-        static size_t mod3371518343(size_t hash) { return hash % 3371518343llu; }
-        static size_t mod4247846927(size_t hash) { return hash % 4247846927llu; }
-        static size_t mod5351951779(size_t hash) { return hash % 5351951779llu; }
-        static size_t mod6743036717(size_t hash) { return hash % 6743036717llu; }
-        static size_t mod8495693897(size_t hash) { return hash % 8495693897llu; }
-        static size_t mod10703903591(size_t hash) { return hash % 10703903591llu; }
-        static size_t mod13486073473(size_t hash) { return hash % 13486073473llu; }
-        static size_t mod16991387857(size_t hash) { return hash % 16991387857llu; }
-        static size_t mod21407807219(size_t hash) { return hash % 21407807219llu; }
-        static size_t mod26972146961(size_t hash) { return hash % 26972146961llu; }
-        static size_t mod33982775741(size_t hash) { return hash % 33982775741llu; }
-        static size_t mod42815614441(size_t hash) { return hash % 42815614441llu; }
-        static size_t mod53944293929(size_t hash) { return hash % 53944293929llu; }
-        static size_t mod67965551447(size_t hash) { return hash % 67965551447llu; }
-        static size_t mod85631228929(size_t hash) { return hash % 85631228929llu; }
-        static size_t mod107888587883(size_t hash) { return hash % 107888587883llu; }
-        static size_t mod135931102921(size_t hash) { return hash % 135931102921llu; }
-        static size_t mod171262457903(size_t hash) { return hash % 171262457903llu; }
-        static size_t mod215777175787(size_t hash) { return hash % 215777175787llu; }
-        static size_t mod271862205833(size_t hash) { return hash % 271862205833llu; }
-        static size_t mod342524915839(size_t hash) { return hash % 342524915839llu; }
-        static size_t mod431554351609(size_t hash) { return hash % 431554351609llu; }
-        static size_t mod543724411781(size_t hash) { return hash % 543724411781llu; }
-        static size_t mod685049831731(size_t hash) { return hash % 685049831731llu; }
-        static size_t mod863108703229(size_t hash) { return hash % 863108703229llu; }
-        static size_t mod1087448823553(size_t hash) { return hash % 1087448823553llu; }
-        static size_t mod1370099663459(size_t hash) { return hash % 1370099663459llu; }
-        static size_t mod1726217406467(size_t hash) { return hash % 1726217406467llu; }
-        static size_t mod2174897647073(size_t hash) { return hash % 2174897647073llu; }
-        static size_t mod2740199326961(size_t hash) { return hash % 2740199326961llu; }
-        static size_t mod3452434812973(size_t hash) { return hash % 3452434812973llu; }
-        static size_t mod4349795294267(size_t hash) { return hash % 4349795294267llu; }
-        static size_t mod5480398654009(size_t hash) { return hash % 5480398654009llu; }
-        static size_t mod6904869625999(size_t hash) { return hash % 6904869625999llu; }
-        static size_t mod8699590588571(size_t hash) { return hash % 8699590588571llu; }
-        static size_t mod10960797308051(size_t hash) { return hash % 10960797308051llu; }
-        static size_t mod13809739252051(size_t hash) { return hash % 13809739252051llu; }
-        static size_t mod17399181177241(size_t hash) { return hash % 17399181177241llu; }
-        static size_t mod21921594616111(size_t hash) { return hash % 21921594616111llu; }
-        static size_t mod27619478504183(size_t hash) { return hash % 27619478504183llu; }
-        static size_t mod34798362354533(size_t hash) { return hash % 34798362354533llu; }
-        static size_t mod43843189232363(size_t hash) { return hash % 43843189232363llu; }
-        static size_t mod55238957008387(size_t hash) { return hash % 55238957008387llu; }
-        static size_t mod69596724709081(size_t hash) { return hash % 69596724709081llu; }
-        static size_t mod87686378464759(size_t hash) { return hash % 87686378464759llu; }
-        static size_t mod110477914016779(size_t hash) { return hash % 110477914016779llu; }
-        static size_t mod139193449418173(size_t hash) { return hash % 139193449418173llu; }
-        static size_t mod175372756929481(size_t hash) { return hash % 175372756929481llu; }
-        static size_t mod220955828033581(size_t hash) { return hash % 220955828033581llu; }
-        static size_t mod278386898836457(size_t hash) { return hash % 278386898836457llu; }
-        static size_t mod350745513859007(size_t hash) { return hash % 350745513859007llu; }
-        static size_t mod441911656067171(size_t hash) { return hash % 441911656067171llu; }
-        static size_t mod556773797672909(size_t hash) { return hash % 556773797672909llu; }
-        static size_t mod701491027718027(size_t hash) { return hash % 701491027718027llu; }
-        static size_t mod883823312134381(size_t hash) { return hash % 883823312134381llu; }
-        static size_t mod1113547595345903(size_t hash) { return hash % 1113547595345903llu; }
-        static size_t mod1402982055436147(size_t hash) { return hash % 1402982055436147llu; }
-        static size_t mod1767646624268779(size_t hash) { return hash % 1767646624268779llu; }
-        static size_t mod2227095190691797(size_t hash) { return hash % 2227095190691797llu; }
-        static size_t mod2805964110872297(size_t hash) { return hash % 2805964110872297llu; }
-        static size_t mod3535293248537579(size_t hash) { return hash % 3535293248537579llu; }
-        static size_t mod4454190381383713(size_t hash) { return hash % 4454190381383713llu; }
-        static size_t mod5611928221744609(size_t hash) { return hash % 5611928221744609llu; }
-        static size_t mod7070586497075177(size_t hash) { return hash % 7070586497075177llu; }
-        static size_t mod8908380762767489(size_t hash) { return hash % 8908380762767489llu; }
-        static size_t mod11223856443489329(size_t hash) { return hash % 11223856443489329llu; }
-        static size_t mod14141172994150357(size_t hash) { return hash % 14141172994150357llu; }
-        static size_t mod17816761525534927(size_t hash) { return hash % 17816761525534927llu; }
-        static size_t mod22447712886978529(size_t hash) { return hash % 22447712886978529llu; }
-        static size_t mod28282345988300791(size_t hash) { return hash % 28282345988300791llu; }
-        static size_t mod35633523051069991(size_t hash) { return hash % 35633523051069991llu; }
-        static size_t mod44895425773957261(size_t hash) { return hash % 44895425773957261llu; }
-        static size_t mod56564691976601587(size_t hash) { return hash % 56564691976601587llu; }
-        static size_t mod71267046102139967(size_t hash) { return hash % 71267046102139967llu; }
-        static size_t mod89790851547914507(size_t hash) { return hash % 89790851547914507llu; }
-        static size_t mod113129383953203213(size_t hash) { return hash % 113129383953203213llu; }
-        static size_t mod142534092204280003(size_t hash) { return hash % 142534092204280003llu; }
-        static size_t mod179581703095829107(size_t hash) { return hash % 179581703095829107llu; }
-        static size_t mod226258767906406483(size_t hash) { return hash % 226258767906406483llu; }
-        static size_t mod285068184408560057(size_t hash) { return hash % 285068184408560057llu; }
-        static size_t mod359163406191658253(size_t hash) { return hash % 359163406191658253llu; }
-        static size_t mod452517535812813007(size_t hash) { return hash % 452517535812813007llu; }
-        static size_t mod570136368817120201(size_t hash) { return hash % 570136368817120201llu; }
-        static size_t mod718326812383316683(size_t hash) { return hash % 718326812383316683llu; }
-        static size_t mod905035071625626043(size_t hash) { return hash % 905035071625626043llu; }
-        static size_t mod1140272737634240411(size_t hash) { return hash % 1140272737634240411llu; }
-        static size_t mod1436653624766633509(size_t hash) { return hash % 1436653624766633509llu; }
-        static size_t mod1810070143251252131(size_t hash) { return hash % 1810070143251252131llu; }
-        static size_t mod2280545475268481167(size_t hash) { return hash % 2280545475268481167llu; }
-        static size_t mod2873307249533267101(size_t hash) { return hash % 2873307249533267101llu; }
-        static size_t mod3620140286502504283(size_t hash) { return hash % 3620140286502504283llu; }
-        static size_t mod4561090950536962147(size_t hash) { return hash % 4561090950536962147llu; }
-        static size_t mod5746614499066534157(size_t hash) { return hash % 5746614499066534157llu; }
-        static size_t mod7240280573005008577(size_t hash) { return hash % 7240280573005008577llu; }
-        static size_t mod9122181901073924329(size_t hash) { return hash % 9122181901073924329llu; }
-        static size_t mod11493228998133068689(size_t hash) { return hash % 11493228998133068689llu; }
-        static size_t mod14480561146010017169(size_t hash) { return hash % 14480561146010017169llu; }
-        static size_t mod18446744073709551557(size_t hash) { return hash % 18446744073709551557llu; }
+        static uint64_t mod0(uint64_t) { return 0llu; }
+        static uint64_t mod2(uint64_t hash) { return hash % 2llu; }
+        static uint64_t mod3(uint64_t hash) { return hash % 3llu; }
+        static uint64_t mod5(uint64_t hash) { return hash % 5llu; }
+        static uint64_t mod7(uint64_t hash) { return hash % 7llu; }
+        static uint64_t mod11(uint64_t hash) { return hash % 11llu; }
+        static uint64_t mod13(uint64_t hash) { return hash % 13llu; }
+        static uint64_t mod17(uint64_t hash) { return hash % 17llu; }
+        static uint64_t mod23(uint64_t hash) { return hash % 23llu; }
+        static uint64_t mod29(uint64_t hash) { return hash % 29llu; }
+        static uint64_t mod37(uint64_t hash) { return hash % 37llu; }
+        static uint64_t mod47(uint64_t hash) { return hash % 47llu; }
+        static uint64_t mod59(uint64_t hash) { return hash % 59llu; }
+        static uint64_t mod73(uint64_t hash) { return hash % 73llu; }
+        static uint64_t mod97(uint64_t hash) { return hash % 97llu; }
+        static uint64_t mod127(uint64_t hash) { return hash % 127llu; }
+        static uint64_t mod151(uint64_t hash) { return hash % 151llu; }
+        static uint64_t mod197(uint64_t hash) { return hash % 197llu; }
+        static uint64_t mod251(uint64_t hash) { return hash % 251llu; }
+        static uint64_t mod313(uint64_t hash) { return hash % 313llu; }
+        static uint64_t mod397(uint64_t hash) { return hash % 397llu; }
+        static uint64_t mod499(uint64_t hash) { return hash % 499llu; }
+        static uint64_t mod631(uint64_t hash) { return hash % 631llu; }
+        static uint64_t mod797(uint64_t hash) { return hash % 797llu; }
+        static uint64_t mod1009(uint64_t hash) { return hash % 1009llu; }
+        static uint64_t mod1259(uint64_t hash) { return hash % 1259llu; }
+        static uint64_t mod1597(uint64_t hash) { return hash % 1597llu; }
+        static uint64_t mod2011(uint64_t hash) { return hash % 2011llu; }
+        static uint64_t mod2539(uint64_t hash) { return hash % 2539llu; }
+        static uint64_t mod3203(uint64_t hash) { return hash % 3203llu; }
+        static uint64_t mod4027(uint64_t hash) { return hash % 4027llu; }
+        static uint64_t mod5087(uint64_t hash) { return hash % 5087llu; }
+        static uint64_t mod6421(uint64_t hash) { return hash % 6421llu; }
+        static uint64_t mod8089(uint64_t hash) { return hash % 8089llu; }
+        static uint64_t mod10193(uint64_t hash) { return hash % 10193llu; }
+        static uint64_t mod12853(uint64_t hash) { return hash % 12853llu; }
+        static uint64_t mod16193(uint64_t hash) { return hash % 16193llu; }
+        static uint64_t mod20399(uint64_t hash) { return hash % 20399llu; }
+        static uint64_t mod25717(uint64_t hash) { return hash % 25717llu; }
+        static uint64_t mod32401(uint64_t hash) { return hash % 32401llu; }
+        static uint64_t mod40823(uint64_t hash) { return hash % 40823llu; }
+        static uint64_t mod51437(uint64_t hash) { return hash % 51437llu; }
+        static uint64_t mod64811(uint64_t hash) { return hash % 64811llu; }
+        static uint64_t mod81649(uint64_t hash) { return hash % 81649llu; }
+        static uint64_t mod102877(uint64_t hash) { return hash % 102877llu; }
+        static uint64_t mod129607(uint64_t hash) { return hash % 129607llu; }
+        static uint64_t mod163307(uint64_t hash) { return hash % 163307llu; }
+        static uint64_t mod205759(uint64_t hash) { return hash % 205759llu; }
+        static uint64_t mod259229(uint64_t hash) { return hash % 259229llu; }
+        static uint64_t mod326617(uint64_t hash) { return hash % 326617llu; }
+        static uint64_t mod411527(uint64_t hash) { return hash % 411527llu; }
+        static uint64_t mod518509(uint64_t hash) { return hash % 518509llu; }
+        static uint64_t mod653267(uint64_t hash) { return hash % 653267llu; }
+        static uint64_t mod823117(uint64_t hash) { return hash % 823117llu; }
+        static uint64_t mod1037059(uint64_t hash) { return hash % 1037059llu; }
+        static uint64_t mod1306601(uint64_t hash) { return hash % 1306601llu; }
+        static uint64_t mod1646237(uint64_t hash) { return hash % 1646237llu; }
+        static uint64_t mod2074129(uint64_t hash) { return hash % 2074129llu; }
+        static uint64_t mod2613229(uint64_t hash) { return hash % 2613229llu; }
+        static uint64_t mod3292489(uint64_t hash) { return hash % 3292489llu; }
+        static uint64_t mod4148279(uint64_t hash) { return hash % 4148279llu; }
+        static uint64_t mod5226491(uint64_t hash) { return hash % 5226491llu; }
+        static uint64_t mod6584983(uint64_t hash) { return hash % 6584983llu; }
+        static uint64_t mod8296553(uint64_t hash) { return hash % 8296553llu; }
+        static uint64_t mod10453007(uint64_t hash) { return hash % 10453007llu; }
+        static uint64_t mod13169977(uint64_t hash) { return hash % 13169977llu; }
+        static uint64_t mod16593127(uint64_t hash) { return hash % 16593127llu; }
+        static uint64_t mod20906033(uint64_t hash) { return hash % 20906033llu; }
+        static uint64_t mod26339969(uint64_t hash) { return hash % 26339969llu; }
+        static uint64_t mod33186281(uint64_t hash) { return hash % 33186281llu; }
+        static uint64_t mod41812097(uint64_t hash) { return hash % 41812097llu; }
+        static uint64_t mod52679969(uint64_t hash) { return hash % 52679969llu; }
+        static uint64_t mod66372617(uint64_t hash) { return hash % 66372617llu; }
+        static uint64_t mod83624237(uint64_t hash) { return hash % 83624237llu; }
+        static uint64_t mod105359939(uint64_t hash) { return hash % 105359939llu; }
+        static uint64_t mod132745199(uint64_t hash) { return hash % 132745199llu; }
+        static uint64_t mod167248483(uint64_t hash) { return hash % 167248483llu; }
+        static uint64_t mod210719881(uint64_t hash) { return hash % 210719881llu; }
+        static uint64_t mod265490441(uint64_t hash) { return hash % 265490441llu; }
+        static uint64_t mod334496971(uint64_t hash) { return hash % 334496971llu; }
+        static uint64_t mod421439783(uint64_t hash) { return hash % 421439783llu; }
+        static uint64_t mod530980861(uint64_t hash) { return hash % 530980861llu; }
+        static uint64_t mod668993977(uint64_t hash) { return hash % 668993977llu; }
+        static uint64_t mod842879579(uint64_t hash) { return hash % 842879579llu; }
+        static uint64_t mod1061961721(uint64_t hash) { return hash % 1061961721llu; }
+        static uint64_t mod1337987929(uint64_t hash) { return hash % 1337987929llu; }
+        static uint64_t mod1685759167(uint64_t hash) { return hash % 1685759167llu; }
+        static uint64_t mod2123923447(uint64_t hash) { return hash % 2123923447llu; }
+        static uint64_t mod2675975881(uint64_t hash) { return hash % 2675975881llu; }
+        static uint64_t mod3371518343(uint64_t hash) { return hash % 3371518343llu; }
+        static uint64_t mod4247846927(uint64_t hash) { return hash % 4247846927llu; }
+        static uint64_t mod5351951779(uint64_t hash) { return hash % 5351951779llu; }
+        static uint64_t mod6743036717(uint64_t hash) { return hash % 6743036717llu; }
+        static uint64_t mod8495693897(uint64_t hash) { return hash % 8495693897llu; }
+        static uint64_t mod10703903591(uint64_t hash) { return hash % 10703903591llu; }
+        static uint64_t mod13486073473(uint64_t hash) { return hash % 13486073473llu; }
+        static uint64_t mod16991387857(uint64_t hash) { return hash % 16991387857llu; }
+        static uint64_t mod21407807219(uint64_t hash) { return hash % 21407807219llu; }
+        static uint64_t mod26972146961(uint64_t hash) { return hash % 26972146961llu; }
+        static uint64_t mod33982775741(uint64_t hash) { return hash % 33982775741llu; }
+        static uint64_t mod42815614441(uint64_t hash) { return hash % 42815614441llu; }
+        static uint64_t mod53944293929(uint64_t hash) { return hash % 53944293929llu; }
+        static uint64_t mod67965551447(uint64_t hash) { return hash % 67965551447llu; }
+        static uint64_t mod85631228929(uint64_t hash) { return hash % 85631228929llu; }
+        static uint64_t mod107888587883(uint64_t hash) { return hash % 107888587883llu; }
+        static uint64_t mod135931102921(uint64_t hash) { return hash % 135931102921llu; }
+        static uint64_t mod171262457903(uint64_t hash) { return hash % 171262457903llu; }
+        static uint64_t mod215777175787(uint64_t hash) { return hash % 215777175787llu; }
+        static uint64_t mod271862205833(uint64_t hash) { return hash % 271862205833llu; }
+        static uint64_t mod342524915839(uint64_t hash) { return hash % 342524915839llu; }
+        static uint64_t mod431554351609(uint64_t hash) { return hash % 431554351609llu; }
+        static uint64_t mod543724411781(uint64_t hash) { return hash % 543724411781llu; }
+        static uint64_t mod685049831731(uint64_t hash) { return hash % 685049831731llu; }
+        static uint64_t mod863108703229(uint64_t hash) { return hash % 863108703229llu; }
+        static uint64_t mod1087448823553(uint64_t hash) { return hash % 1087448823553llu; }
+        static uint64_t mod1370099663459(uint64_t hash) { return hash % 1370099663459llu; }
+        static uint64_t mod1726217406467(uint64_t hash) { return hash % 1726217406467llu; }
+        static uint64_t mod2174897647073(uint64_t hash) { return hash % 2174897647073llu; }
+        static uint64_t mod2740199326961(uint64_t hash) { return hash % 2740199326961llu; }
+        static uint64_t mod3452434812973(uint64_t hash) { return hash % 3452434812973llu; }
+        static uint64_t mod4349795294267(uint64_t hash) { return hash % 4349795294267llu; }
+        static uint64_t mod5480398654009(uint64_t hash) { return hash % 5480398654009llu; }
+        static uint64_t mod6904869625999(uint64_t hash) { return hash % 6904869625999llu; }
+        static uint64_t mod8699590588571(uint64_t hash) { return hash % 8699590588571llu; }
+        static uint64_t mod10960797308051(uint64_t hash) { return hash % 10960797308051llu; }
+        static uint64_t mod13809739252051(uint64_t hash) { return hash % 13809739252051llu; }
+        static uint64_t mod17399181177241(uint64_t hash) { return hash % 17399181177241llu; }
+        static uint64_t mod21921594616111(uint64_t hash) { return hash % 21921594616111llu; }
+        static uint64_t mod27619478504183(uint64_t hash) { return hash % 27619478504183llu; }
+        static uint64_t mod34798362354533(uint64_t hash) { return hash % 34798362354533llu; }
+        static uint64_t mod43843189232363(uint64_t hash) { return hash % 43843189232363llu; }
+        static uint64_t mod55238957008387(uint64_t hash) { return hash % 55238957008387llu; }
+        static uint64_t mod69596724709081(uint64_t hash) { return hash % 69596724709081llu; }
+        static uint64_t mod87686378464759(uint64_t hash) { return hash % 87686378464759llu; }
+        static uint64_t mod110477914016779(uint64_t hash) { return hash % 110477914016779llu; }
+        static uint64_t mod139193449418173(uint64_t hash) { return hash % 139193449418173llu; }
+        static uint64_t mod175372756929481(uint64_t hash) { return hash % 175372756929481llu; }
+        static uint64_t mod220955828033581(uint64_t hash) { return hash % 220955828033581llu; }
+        static uint64_t mod278386898836457(uint64_t hash) { return hash % 278386898836457llu; }
+        static uint64_t mod350745513859007(uint64_t hash) { return hash % 350745513859007llu; }
+        static uint64_t mod441911656067171(uint64_t hash) { return hash % 441911656067171llu; }
+        static uint64_t mod556773797672909(uint64_t hash) { return hash % 556773797672909llu; }
+        static uint64_t mod701491027718027(uint64_t hash) { return hash % 701491027718027llu; }
+        static uint64_t mod883823312134381(uint64_t hash) { return hash % 883823312134381llu; }
+        static uint64_t mod1113547595345903(uint64_t hash) { return hash % 1113547595345903llu; }
+        static uint64_t mod1402982055436147(uint64_t hash) { return hash % 1402982055436147llu; }
+        static uint64_t mod1767646624268779(uint64_t hash) { return hash % 1767646624268779llu; }
+        static uint64_t mod2227095190691797(uint64_t hash) { return hash % 2227095190691797llu; }
+        static uint64_t mod2805964110872297(uint64_t hash) { return hash % 2805964110872297llu; }
+        static uint64_t mod3535293248537579(uint64_t hash) { return hash % 3535293248537579llu; }
+        static uint64_t mod4454190381383713(uint64_t hash) { return hash % 4454190381383713llu; }
+        static uint64_t mod5611928221744609(uint64_t hash) { return hash % 5611928221744609llu; }
+        static uint64_t mod7070586497075177(uint64_t hash) { return hash % 7070586497075177llu; }
+        static uint64_t mod8908380762767489(uint64_t hash) { return hash % 8908380762767489llu; }
+        static uint64_t mod11223856443489329(uint64_t hash) { return hash % 11223856443489329llu; }
+        static uint64_t mod14141172994150357(uint64_t hash) { return hash % 14141172994150357llu; }
+        static uint64_t mod17816761525534927(uint64_t hash) { return hash % 17816761525534927llu; }
+        static uint64_t mod22447712886978529(uint64_t hash) { return hash % 22447712886978529llu; }
+        static uint64_t mod28282345988300791(uint64_t hash) { return hash % 28282345988300791llu; }
+        static uint64_t mod35633523051069991(uint64_t hash) { return hash % 35633523051069991llu; }
+        static uint64_t mod44895425773957261(uint64_t hash) { return hash % 44895425773957261llu; }
+        static uint64_t mod56564691976601587(uint64_t hash) { return hash % 56564691976601587llu; }
+        static uint64_t mod71267046102139967(uint64_t hash) { return hash % 71267046102139967llu; }
+        static uint64_t mod89790851547914507(uint64_t hash) { return hash % 89790851547914507llu; }
+        static uint64_t mod113129383953203213(uint64_t hash) { return hash % 113129383953203213llu; }
+        static uint64_t mod142534092204280003(uint64_t hash) { return hash % 142534092204280003llu; }
+        static uint64_t mod179581703095829107(uint64_t hash) { return hash % 179581703095829107llu; }
+        static uint64_t mod226258767906406483(uint64_t hash) { return hash % 226258767906406483llu; }
+        static uint64_t mod285068184408560057(uint64_t hash) { return hash % 285068184408560057llu; }
+        static uint64_t mod359163406191658253(uint64_t hash) { return hash % 359163406191658253llu; }
+        static uint64_t mod452517535812813007(uint64_t hash) { return hash % 452517535812813007llu; }
+        static uint64_t mod570136368817120201(uint64_t hash) { return hash % 570136368817120201llu; }
+        static uint64_t mod718326812383316683(uint64_t hash) { return hash % 718326812383316683llu; }
+        static uint64_t mod905035071625626043(uint64_t hash) { return hash % 905035071625626043llu; }
+        static uint64_t mod1140272737634240411(uint64_t hash) { return hash % 1140272737634240411llu; }
+        static uint64_t mod1436653624766633509(uint64_t hash) { return hash % 1436653624766633509llu; }
+        static uint64_t mod1810070143251252131(uint64_t hash) { return hash % 1810070143251252131llu; }
+        static uint64_t mod2280545475268481167(uint64_t hash) { return hash % 2280545475268481167llu; }
+        static uint64_t mod2873307249533267101(uint64_t hash) { return hash % 2873307249533267101llu; }
+        static uint64_t mod3620140286502504283(uint64_t hash) { return hash % 3620140286502504283llu; }
+        static uint64_t mod4561090950536962147(uint64_t hash) { return hash % 4561090950536962147llu; }
+        static uint64_t mod5746614499066534157(uint64_t hash) { return hash % 5746614499066534157llu; }
+        static uint64_t mod7240280573005008577(uint64_t hash) { return hash % 7240280573005008577llu; }
+        static uint64_t mod9122181901073924329(uint64_t hash) { return hash % 9122181901073924329llu; }
+        static uint64_t mod11493228998133068689(uint64_t hash) { return hash % 11493228998133068689llu; }
+        static uint64_t mod14480561146010017169(uint64_t hash) { return hash % 14480561146010017169llu; }
+        static uint64_t mod18446744073709551557(uint64_t hash) { return hash % 18446744073709551557llu; }
 
-        size_t index_for_hash(size_t hash, size_t /*num_slots_minus_one*/) const
+        uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/) const
         {
-            static constexpr size_t (* const mod_functions[])(size_t) =
+            static constexpr uint64_t (* const mod_functions[])(uint64_t) =
                     {
                             &mod0, &mod2, &mod3, &mod5, &mod7, &mod11, &mod13, &mod17, &mod23, &mod29, &mod37,
                             &mod47, &mod59, &mod73, &mod97, &mod127, &mod151, &mod197, &mod251, &mod313, &mod397,
@@ -1188,7 +1188,7 @@ namespace ska
                     };
             return mod_functions[prime_index](hash);
         }
-        uint8_t next_size_over(size_t & size) const
+        uint8_t next_size_over(uint64_t & size) const
         {
             // prime numbers generated by the following method:
             // 1. start with a prime p = 2
@@ -1197,7 +1197,7 @@ namespace ska
             // you now have large gaps which you would hit if somebody called reserve() with an unlucky number.
             // 4. to fill the gaps for every prime p go to wolfram alpha and get ClosestPrime(p * 2^(1/3)) and ClosestPrime(p * 2^(2/3)) and put those in the gaps
             // 5. get PrevPrime(2^64) and put it at the end
-            static constexpr const size_t prime_list[] =
+            static constexpr const uint64_t prime_list[] =
                     {
                             2llu, 3llu, 5llu, 7llu, 11llu, 13llu, 17llu, 23llu, 29llu, 37llu, 47llu,
                             59llu, 73llu, 97llu, 127llu, 151llu, 197llu, 251llu, 313llu, 397llu,
@@ -1242,7 +1242,7 @@ namespace ska
                             5746614499066534157llu, 7240280573005008577llu, 9122181901073924329llu,
                             11493228998133068689llu, 14480561146010017169llu, 18446744073709551557llu
                     };
-            const size_t * found = std::lower_bound(std::begin(prime_list), std::end(prime_list) - 1, size);
+            const uint64_t * found = std::lower_bound(std::begin(prime_list), std::end(prime_list) - 1, size);
             size = *found;
             return static_cast<uint8_t>(1 + found - prime_list);
         }
@@ -1261,11 +1261,11 @@ namespace ska
 
     struct power_of_two_hash_policy
     {
-        size_t index_for_hash(size_t hash, size_t num_slots_minus_one) const
+        uint64_t index_for_hash(uint64_t hash, uint64_t num_slots_minus_one) const
         {
             return hash & num_slots_minus_one;
         }
-        int8_t next_size_over(size_t & size) const
+        int8_t next_size_over(uint64_t & size) const
         {
             size = detailv3::next_power_of_two(size);
             return 0;
@@ -1379,7 +1379,7 @@ namespace ska
                             T,
                             T,
                             H,
-                            detailv3::functor_storage<size_t, H>,
+                            detailv3::functor_storage<uint64_t, H>,
                             E,
                             detailv3::functor_storage<bool, E>,
                             A,
@@ -1391,7 +1391,7 @@ namespace ska
                         T,
                         T,
                         H,
-                        detailv3::functor_storage<size_t, H>,
+                        detailv3::functor_storage<uint64_t, H>,
                         E,
                         detailv3::functor_storage<bool, E>,
                         A,


### PR DESCRIPTION
Summary:
This adds the capability for caffe2 to call c10 operators and adds a dummy c10 sigmoid op as a proof of concept.

I used this test script to make sure it works:

    from caffe2.python import workspace, model_helper
    import numpy as np

    data1 = np.random.rand(16, 100).astype(np.float32)
    workspace.FeedBlob("data1", data1)
    m = model_helper.ModelHelper(name="my net")
    sigmoid1 = m.net.C10Sigmoid_DontUseThisOpYet("data1", "sigmoid1")
    sigmoid2 = m.net.Sigmoid("data1", "sigmoid2")

    workspace.RunNetOnce(m.param_init_net)
    workspace.CreateNet(m.net)
    data1 = np.random.rand(16, 100).astype(np.float32)
    workspace.FeedBlob("data1", data1)
    workspace.RunNet(m.name, 1)

    print(workspace.FetchBlob("data1"))
    print(workspace.FetchBlob("sigmoid1"))
    print(workspace.FetchBlob("sigmoid2"))

(and check that both sigmoid outputs are the same)

Differential Revision: D8814669
