### PR TITLE
[C++ API] Fix Sequential::clone()

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -14,6 +14,7 @@
 #include <test/cpp/api/util.h>
 
 using namespace torch::nn;
+using namespace torch::test;
 
 #include <cmath>
 #include <iostream>
@@ -236,7 +237,7 @@ TEST_CASE("integration/cartpole") {
   torch::manual_seed(0);
   std::cerr << "Training episodic policy gradient with a critic for up to 3000"
                " episodes, rest your eyes for a bit!\n";
-  auto model = std::make_shared<torch::SimpleContainer>();
+  auto model = std::make_shared<SimpleContainer>();
   auto linear = model->add(Linear(4, 128), "linear");
   auto policyHead = model->add(Linear(128, 2), "policy");
   auto valueHead = model->add(Linear(128, 1), "action");
@@ -333,7 +334,7 @@ TEST_CASE("integration/cartpole") {
 
 TEST_CASE("integration/mnist", "[cuda]") {
   torch::manual_seed(0);
-  auto model = std::make_shared<torch::SimpleContainer>();
+  auto model = std::make_shared<SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto drop = Dropout(0.3);
@@ -369,7 +370,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
 
 TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   torch::manual_seed(0);
-  auto model = std::make_shared<torch::SimpleContainer>();
+  auto model = std::make_shared<SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto batchnorm2d =
       model->add(BatchNorm(BatchNormOptions(10).stateful(true)), "batchnorm2d");

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -194,6 +194,9 @@ TEST_CASE("module/clone") {
 
   SECTION("Cloning creates distinct parameters") {
     struct TestModule : public Cloneable<TestModule> {
+      TestModule() {
+        reset();
+      }
       void reset() override {
         l1 = register_module("l1", Linear(10, 3));
         l2 = register_module("l2", Linear(3, 5));
@@ -237,6 +240,9 @@ TEST_CASE("module/clone") {
 
   SECTION("Cloning preserves external references") {
     struct TestModule : public Cloneable<TestModule> {
+      TestModule() {
+        reset();
+      }
       void reset() override {
         weight = register_parameter("weight", torch::ones({4, 4}));
       }
@@ -258,6 +264,9 @@ TEST_CASE("module/clone") {
 
   SECTION("Cloning copies the values of variables of submodules") {
     struct TestModule : public Cloneable<TestModule> {
+      TestModule() {
+        reset();
+      }
       void reset() override {
         weight = register_parameter("weight", torch::ones({4, 4}));
       }
@@ -266,6 +275,9 @@ TEST_CASE("module/clone") {
       int value = 0;
     };
     struct NestedModule : public Cloneable<NestedModule> {
+      NestedModule() {
+        reset();
+      }
       void reset() override {
         module = register_module("module", std::make_shared<TestModule>());
       }

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -6,7 +6,10 @@
 #include <torch/tensor.h>
 #include <torch/utils.h>
 
+#include <test/cpp/api/util.h>
+
 using namespace torch::nn;
+using namespace torch::test;
 
 using Catch::StartsWith;
 
@@ -18,10 +21,6 @@ struct AGIUnit2 : torch::nn::Module {
   AGIUnit2() : torch::nn::Module("Foo") {}
 };
 } // namespace test
-
-bool pointer_equal(torch::Tensor first, torch::Tensor second) {
-  return first.data().data<float>() == second.data().data<float>();
-}
 
 TEST_CASE("module/training-mode") {
   torch::manual_seed(0);
@@ -206,7 +205,7 @@ TEST_CASE("module/clone") {
       torch::Tensor buffer;
     };
 
-    auto module = TestModule().build();
+    auto module = std::make_shared<TestModule>();
 
     auto module2 = module->clone();
     auto params1 = module->parameters();
@@ -216,7 +215,7 @@ TEST_CASE("module/clone") {
     for (auto& param : params1) {
       REQUIRE(!pointer_equal(param.value, params2[param.key]));
       REQUIRE(param->allclose(params2[param.key]));
-      param->data().mul_(2);
+      param->data().add_(2);
     }
     for (auto& param : params1) {
       REQUIRE(!param->allclose(params2[param.key]));
@@ -229,7 +228,7 @@ TEST_CASE("module/clone") {
     for (auto& buffer : buffers1) {
       REQUIRE(!pointer_equal(buffer.value, buffers2[buffer.key]));
       REQUIRE(buffer->allclose(buffers2[buffer.key]));
-      buffer->data().mul_(2);
+      buffer->data().add_(2);
     }
     for (auto& buffer : buffers1) {
       REQUIRE(!buffer->allclose(buffers2[buffer.key]));
@@ -243,7 +242,7 @@ TEST_CASE("module/clone") {
       }
       torch::Tensor weight;
     };
-    auto module = TestModule().build();
+    auto module = std::make_shared<TestModule>();
     module->weight.data() += 1;
     REQUIRE(pointer_equal(module->weight, module->parameters()["weight"]));
     REQUIRE(module->weight.allclose(module->parameters()["weight"]));
@@ -268,12 +267,12 @@ TEST_CASE("module/clone") {
     };
     struct NestedModule : public Cloneable<NestedModule> {
       void reset() override {
-        module = register_module("module", TestModule().build());
+        module = register_module("module", std::make_shared<TestModule>());
       }
       std::shared_ptr<TestModule> module;
     };
 
-    auto a = NestedModule().build();
+    auto a = std::make_shared<NestedModule>();
     a->module->weight.data() += 1;
     a->module->value = 123;
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -13,6 +13,7 @@
 #include <test/cpp/api/util.h>
 
 using namespace torch::nn;
+using namespace torch::test;
 
 class TestModel : public torch::nn::Module {
  public:
@@ -122,7 +123,7 @@ TEST_CASE("modules") {
   }
 
   SECTION("simple") {
-    auto model = std::make_shared<torch::SimpleContainer>();
+    auto model = std::make_shared<SimpleContainer>();
     auto l1 = model->add(Linear(10, 3), "l1");
     auto l2 = model->add(Linear(3, 5), "l2");
     auto l3 = model->add(Linear(5, 100), "l3");

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -9,13 +9,14 @@
 #include <test/cpp/api/util.h>
 
 using namespace torch::nn;
+using namespace torch::test;
 
 template <typename R, typename Func>
 bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
   torch::manual_seed(0);
 
   auto nhid = 32;
-  auto model = std::make_shared<torch::SimpleContainer>();
+  auto model = std::make_shared<SimpleContainer>();
   auto l1 = model->add(Linear(1, nhid), "l1");
   auto rnn = model->add(model_maker(nhid), "rnn");
   auto lo = model->add(Linear(nhid, 1), "lo");

--- a/test/cpp/api/util.h
+++ b/test/cpp/api/util.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 namespace torch {
+namespace test {
 
 // Lets you use a container without making a new class,
 // for experimental implementations
@@ -20,4 +21,9 @@ class SimpleContainer : public nn::Cloneable<SimpleContainer> {
     return Module::register_module(std::move(name), module_holder);
   }
 };
+
+inline bool pointer_equal(torch::Tensor first, torch::Tensor second) {
+  return first.data().data<float>() == second.data().data<float>();
+}
+} // namespace test
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -26,13 +26,6 @@ class Cloneable : public Module {
   /// semantics, most importantly parameters, buffers and submodules.
   virtual void reset() = 0;
 
-  /// Moves the `Module` into a `shared_ptr` and calls `reset()` on it.
-  std::shared_ptr<Derived> build() {
-    auto module = std::make_shared<Derived>(static_cast<Derived&&>(*this));
-    module->reset();
-    return module;
-  }
-
   /// Performs a recursive "deep copy" of the `Module`, such that all parameters
   /// and submodules in the cloned module are different from those in the
   /// original module.
@@ -43,12 +36,30 @@ class Cloneable : public Module {
     copy->buffers_.clear();
     copy->children_.clear();
     copy->reset();
+    AT_CHECK(
+        copy->parameters_.size() == parameters_.size(),
+        "The cloned module does not have the same number of "
+        "parameters as the original module after calling reset(). "
+        "Are you sure you called register_parameter() inside reset() "
+        "and not the constructor?");
     for (const auto& parameter : parameters_) {
       copy->parameters_[parameter.key].data().copy_(parameter->data());
     }
+    AT_CHECK(
+        copy->buffers_.size() == buffers_.size(),
+        "The cloned module does not have the same number of "
+        "buffers as the original module after calling reset(). "
+        "Are you sure you called register_buffer() inside reset() "
+        "and not the constructor?");
     for (const auto& buffer : buffers_) {
       copy->buffers_[buffer.key].data().copy_(buffer->data());
     }
+    AT_CHECK(
+        copy->children_.size() == children_.size(),
+        "The cloned module does not have the same number of "
+        "child modules as the original module after calling reset(). "
+        "Are you sure you called register_module() inside reset() "
+        "and not the constructor?");
     for (const auto& child : children_) {
       copy->children_[child.key]->clone_(*child.value);
     }

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -48,9 +48,13 @@ class AnyModule {
   AnyModule(AnyModule&&) = default;
   AnyModule& operator=(AnyModule&&) = default;
 
-  /// Creates a copy of an `AnyModule`.
+  /// Creates a shallow copy of an `AnyModule`.
   AnyModule(const AnyModule& other);
   AnyModule& operator=(const AnyModule& other);
+
+  /// Creates a deep copy of an `AnyModule` if it contains a module, else an
+  /// empty `AnyModule` if it is empty.
+  AnyModule clone() const;
 
   /// Assigns a module to the `AnyModule` (to circumvent the explicit
   /// constructor).
@@ -238,7 +242,10 @@ struct AnyModule::Placeholder : public AnyModule::Value::Placeholder {
   /// Returns std::shared_ptr<Module> pointing to the erased module.
   virtual std::shared_ptr<Module> ptr() = 0;
 
-  /// Returns a `Placeholder` with a copy of this `AnyModule`.
+  /// Returns a `Placeholder` with a shallow copy of this `AnyModule`.
+  virtual std::unique_ptr<Placeholder> copy() const = 0;
+
+  /// Returns a `Placeholder` with a deep copy of this `AnyModule`.
   virtual std::unique_ptr<Placeholder> clone() const = 0;
 };
 
@@ -297,8 +304,13 @@ struct AnyModule::Holder : public AnyModule::Placeholder {
     return module;
   }
 
-  std::unique_ptr<Placeholder> clone() const override {
+  std::unique_ptr<Placeholder> copy() const override {
     return torch::make_unique<Holder>(*this);
+  }
+
+  std::unique_ptr<Placeholder> clone() const override {
+    return torch::make_unique<Holder>(
+        std::static_pointer_cast<ModuleType>(module->clone()));
   }
 
   /// The actual concrete module instance.
@@ -323,13 +335,19 @@ AnyModule::AnyModule(const ModuleHolder<ModuleType>& module_holder)
     : AnyModule(module_holder.ptr()) {}
 
 inline AnyModule::AnyModule(const AnyModule& other)
-    : content_(other.content_ ? other.content_->clone() : nullptr) {}
+    : content_(other.content_ ? other.content_->copy() : nullptr) {}
 
 inline AnyModule& AnyModule::operator=(const AnyModule& other) {
   if (this != &other) {
-    content_ = other.content_ ? other.content_->clone() : nullptr;
+    content_ = other.content_ ? other.content_->copy() : nullptr;
   }
   return *this;
+}
+
+inline AnyModule AnyModule::clone() const {
+  AnyModule clone;
+  clone.content_ = content_ ? content_->clone() : nullptr;
+  return clone;
 }
 
 template <typename ModuleType>

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -35,8 +35,18 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     push_back(std::forward<Modules>(modules)...);
   }
 
-  /// reset() is empty for `Sequential`, since it does not have parameter of its
-  /// own.
+  /// Special cloning function for `Sequential` because it does not use
+  /// `reset()`.
+  std::shared_ptr<Module> clone() const override {
+    auto clone = std::make_shared<SequentialImpl>();
+    for (const auto& module : modules_) {
+      clone->push_back(module.clone());
+    }
+    return clone;
+  }
+
+  /// `reset()` is empty for `Sequential`, since it does not have parameter of
+  /// its own.
   void reset() override {}
 
   /// Feeds the `inputs` to the first module, then chains the output of each


### PR DESCRIPTION
I noticed that `Sequential::clone()` does not work. This is because `Sequential` does not use `reset()` which is normally where modules have to initialize and register its submodules. Further, this is because of the way `Sequential` allows its modules to be passed in the constructor, which doesn't work with `reset()` (since it does "late" initialization).

I've added some better error messages inside `Cloneable::clone()` which makes this kind of mistake clearer for other users, and tests for `Sequential::clone()`.

I also had to give `AnyModule` a deep `clone()` method.

@ebetica @ezyang 