### PR TITLE
Use high priority CUDA streams

### DIFF
--- a/torch/lib/c10d/CUDAUtils.cpp
+++ b/torch/lib/c10d/CUDAUtils.cpp
@@ -18,7 +18,9 @@ CUDAEvent::~CUDAEvent() {
 
 CUDAStream CUDAStream::create() {
   CUDAStream stream;
-  stream.stream_ = THCStream_new(cudaStreamNonBlocking);
+  int loPri, hiPri;
+  C10D_CUDA_CHECK(cudaDeviceGetStreamPriorityRange(&loPri, &hiPri));
+  stream.stream_ = THCStream_newWithPriority(cudaStreamNonBlocking, hiPri);
   return stream;
 }
 


### PR DESCRIPTION
Summary:
There is no significant change in performance for your run of the mill
multi node ResNet-101 trainer, but there a 1% difference when
comparing to the low priority stream. All processes should run their
c10d related kernels ASAP to keep cross process jitter low, so there
is no harm in being explicit about stream priority.

Differential Revision: D8817945
