### PR TITLE
In Gloo backend create one context per device

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -250,7 +250,14 @@ class ProcessGroupGloo : public ProcessGroup {
   using WorkType = std::tuple<AlgorithmEntry*, std::shared_ptr<WorkGloo>>;
 
   std::unique_ptr<::gloo::rendezvous::Store> store_;
+
+  // Every Gloo context represents a set of connections to its peers.
+  // In order to use more than one device (or allow for parallelism on
+  // a single device), you need multiple contexts. They are used in a
+  // round robin fashion, assuming that results in reasonable balance.
   std::vector<std::shared_ptr<::gloo::Context>> contexts_;
+  size_t contextIndex_;
+
   std::vector<std::thread> threads_;
   bool stop_;
 


### PR DESCRIPTION
Summary:
Every context is uses a dedicated Gloo device object. Every device has a single I/O thread.
In order to use multiple physical devices in single process group you can create it with
multiple devices and it will load balance algorithms across them.

This is also useful if you want to maximize throughput on machines with NICs faster
than 25GbE (or so). Emperical evidence shows that a single core can sustain about
25Gbit of RX traffic without fancy zero copy tricks. Therefore, in order to efficiently
use a 40GbE or even 100GbE NIC you need multiple I/O threads.

Differential Revision: D8817730
