### PR TITLE
Use at::DeviceGuard everywhere

### DIFF
--- a/torch/lib/c10d/CUDAUtils.cpp
+++ b/torch/lib/c10d/CUDAUtils.cpp
@@ -4,27 +4,6 @@
 
 namespace c10d {
 
-CUDADevice::CUDADevice(int device) {
-  setDevice(device);
-}
-
-CUDADevice::~CUDADevice() {
-  setDevice(originalDevice_);
-}
-
-void CUDADevice::setDevice(int device) {
-  if (device >= 0) {
-    if (originalDevice_ == -1) {
-      C10D_CUDA_CHECK(cudaGetDevice(&originalDevice_));
-      if (device != originalDevice_) {
-        C10D_CUDA_CHECK(cudaSetDevice(device));
-      }
-    } else {
-      C10D_CUDA_CHECK(cudaSetDevice(device));
-    }
-  }
-}
-
 CUDAEvent CUDAEvent::create(unsigned int flags) {
   CUDAEvent event;
   C10D_CUDA_CHECK(cudaEventCreateWithFlags(&event.event_, flags));

--- a/torch/lib/c10d/CUDAUtils.hpp
+++ b/torch/lib/c10d/CUDAUtils.hpp
@@ -9,21 +9,6 @@ typedef struct CUDAStreamInternals THCStream;
 
 namespace c10d {
 
-// RAII wrapper for current CUDA device.
-class CUDADevice {
- public:
-  CUDADevice(int device);
-
-  CUDADevice() {}
-
-  ~CUDADevice();
-
-  void setDevice(int device);
-
- protected:
-  int originalDevice_ = -1;
-};
-
 // RAII wrapper for CUDA events.
 class CUDAEvent {
  public:

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -40,23 +40,24 @@ ncclDataType_t getNcclDataType(at::ScalarType type) {
 }
 
 // Get the deviceList String from the list of devices
-std::string getKeyFromDevices(const std::vector<int>& devices) {
+std::string getKeyFromDevices(const std::vector<at::Device>& devices) {
   std::string deviceList;
-  for (auto device : devices) {
+  for (auto& device : devices) {
     if (deviceList.empty()) {
-      deviceList = std::to_string(device);
+      deviceList = std::to_string(device.index());
     } else {
-      deviceList += "," + std::to_string(device);
+      deviceList += "," + std::to_string(device.index());
     }
   }
   return deviceList;
 }
 
 // Get the list of devices from list of tensors
-std::vector<int> getDevicesOfTensors(const std::vector<at::Tensor>& tensors) {
-  std::vector<int> res;
+std::vector<at::Device> getDevices(const std::vector<at::Tensor>& tensors) {
+  std::vector<at::Device> res;
+  res.reserve(tensors.size());
   for (auto& tensor : tensors) {
-    res.push_back(tensor.get_device());
+    res.push_back(tensor.device());
   }
   return res;
 }
@@ -64,14 +65,14 @@ std::vector<int> getDevicesOfTensors(const std::vector<at::Tensor>& tensors) {
 // Helper that lets the input ncclStreams to wait for the THC stream
 void syncStreams(
     THCState* thcState,
-    const std::vector<int>& devices,
+    const std::vector<at::Device>& devices,
     std::vector<CUDAEvent>& ncclEvents,
     std::vector<CUDAStream>& ncclStreams) {
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
   for (size_t i = 0; i < devices.size(); ++i) {
-    gpuGuard.setDevice(devices[i]);
+    gpuGuard.set_index(devices[i].index());
     auto currentThcStream =
-        THCState_getCurrentStreamOnDevice(thcState, devices[i]);
+        THCState_getCurrentStreamOnDevice(thcState, devices[i].index());
     CUDAStream& ncclStream = ncclStreams[i];
     CUDAEvent& ncclEvent = ncclEvents[i];
 
@@ -83,13 +84,13 @@ void syncStreams(
 
 } // namespace
 
-ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<int>& devices)
+ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<at::Device>& devices)
     : devices_(devices) {
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
   cudaEvents_.resize(devices.size());
   // Now create the CUDA events
   for (size_t i = 0; i < devices.size(); ++i) {
-    gpuGuard.setDevice(devices[i]);
+    gpuGuard.set_index(devices[i].index());
     cudaEvents_[i] = CUDAEvent::create(cudaEventDisableTiming);
   }
 }
@@ -103,9 +104,9 @@ bool ProcessGroupNCCL::WorkNCCL::isCompleted() const {
 
 // Helper that checks if the NCCL kernels are completed on the GPUs
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecution() const {
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
   for (size_t i = 0; i < devices_.size(); ++i) {
-    gpuGuard.setDevice(devices_[i]);
+    gpuGuard.set_index(devices_[i].index());
     auto& cudaEvent = cudaEvents_[i];
     // Checking the work's corresponding CUDA events' status
     auto ret = cudaEventQuery(cudaEvent.getEvent());
@@ -128,10 +129,11 @@ bool ProcessGroupNCCL::WorkNCCL::wait() {
 // Waiting on the work's corresponding CUDA events
 void ProcessGroupNCCL::WorkNCCL::synchronize() {
   auto thcState = ::at::globalContext().lazyInitCUDA();
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
   for (size_t i = 0; i < devices_.size(); ++i) {
-    gpuGuard.setDevice(devices_[i]);
-    auto thcStream = THCState_getCurrentStreamOnDevice(thcState, devices_[i]);
+    gpuGuard.set_index(devices_[i].index());
+    auto thcStream =
+        THCState_getCurrentStreamOnDevice(thcState, devices_[i].index());
     auto& cudaEvent = cudaEvents_[i];
     // Let THC stream wait for the NCCL stream
     C10D_CUDA_CHECK(cudaStreamWaitEvent(thcStream, cudaEvent.getEvent(), 0));
@@ -209,7 +211,7 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
 
 std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     const std::string& devicesKey,
-    const std::vector<int>& devices) {
+    const std::vector<at::Device>& devices) {
   // Sanity check
   if (devicesKey.empty()) {
     throw std::runtime_error(
@@ -234,7 +236,7 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
   // Broadcast so that each process can have a unique NCCL ID
   broadcastUniqueNCCLID(&ncclID);
 
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
 
   std::vector<CUDAEvent> eventVal;
   std::vector<CUDAStream> streamVal;
@@ -250,7 +252,7 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     int numRanks = getSize() * devices.size();
     int rank = getRank() * devices.size() + i;
 
-    gpuGuard.setDevice(devices[i]);
+    gpuGuard.set_index(devices[i].index());
     ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID);
 
     // Also create the NCCL streams and events
@@ -354,7 +356,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
     const AllreduceOptions& opts) {
   tensorCheckHelper(tensors, tensors);
 
-  auto devices = getDevicesOfTensors(tensors);
+  auto devices = getDevices(tensors);
   auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices);
 
@@ -364,7 +366,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
   // Work itself will create the CUDA events on all GPUs of tensors
   auto work = std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices);
 
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
 
   std::unique_lock<std::mutex> cudaFreeMutexLock(
       *(THCCachingAllocator_getCudaFreeMutex()));
@@ -372,7 +374,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
   C10D_NCCL_CHECK(ncclGroupStart());
 
   for (size_t i = 0; i < tensors.size(); ++i) {
-    gpuGuard.setDevice(devices[i]);
+    gpuGuard.set_index(devices[i].index());
     CUDAStream& ncclStream = ncclStreams_[key][i];
 
     C10D_NCCL_CHECK(ncclAllReduce(
@@ -404,7 +406,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
     const BroadcastOptions& opts) {
   tensorCheckHelper(tensors, tensors);
 
-  auto devices = getDevicesOfTensors(tensors);
+  auto devices = getDevices(tensors);
   auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices);
 
@@ -414,7 +416,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
   // Work itself will create the CUDA events on all GPUs of tensors
   auto work = std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices);
 
-  CUDADevice gpuGuard;
+  at::DeviceGuard gpuGuard;
 
   std::unique_lock<std::mutex> cudaFreeMutexLock(
       *(THCCachingAllocator_getCudaFreeMutex()));
@@ -422,7 +424,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
   C10D_NCCL_CHECK(ncclGroupStart());
 
   for (size_t i = 0; i < tensors.size(); ++i) {
-    gpuGuard.setDevice(devices[i]);
+    gpuGuard.set_index(devices[i].index());
     CUDAStream& ncclStream = ncclStreams_[key][i];
     // root rank of the the GPU
     int root = opts.rootRank * tensors.size() + opts.rootTensor;

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -60,7 +60,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   class WorkNCCL : public ProcessGroup::Work {
    public:
     // Constructor takes a list of CUDA devices
-    WorkNCCL(const std::vector<int>& devices);
+    WorkNCCL(const std::vector<at::Device>& devices);
     virtual ~WorkNCCL();
 
     // Checks if request has completed. In this specific case of NCCL, it checks
@@ -88,9 +88,9 @@ class ProcessGroupNCCL : public ProcessGroup {
 
    protected:
     // The cached list of CUDA devices to operate on
-    std::vector<int> devices_;
-    // The CUDA events that are used to track this workitem on
-    // multiple CUDA devices
+    std::vector<at::Device> devices_;
+
+    // The CUDA events tracking this work item on multiple CUDA devices
     std::vector<CUDAEvent> cudaEvents_;
 
     friend class ProcessGroupNCCL;
@@ -117,7 +117,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   // a new set of NCCL communicators as a cache entry
   std::vector<std::shared_ptr<NCCLComm>>& getNCCLComm(
       const std::string& devicesKey,
-      const std::vector<int>& devices);
+      const std::vector<at::Device>& devices);
 
   // Tensor checker helper
   void tensorCheckHelper(

--- a/torch/lib/c10d/private/CUDAUtils.hpp
+++ b/torch/lib/c10d/private/CUDAUtils.hpp
@@ -37,7 +37,7 @@ class THCStreamGuard {
  public:
   explicit THCStreamGuard(THCState* state, CUDAStream& stream)
       : device_(THCStream_device(stream.getTHCStream())), state_(state) {
-    CUDADevice device(device_);
+    at::DeviceGuard deviceGuard(device_);
     original_ = THCState_getStream(state_);
     THCStream_retain(original_);
     THCState_setStream(state_, stream.getTHCStream());
@@ -51,7 +51,7 @@ class THCStreamGuard {
 
   ~THCStreamGuard() {
     if (original_ != nullptr) {
-      CUDADevice device(device_);
+      at::DeviceGuard deviceGuard(device_);
       THCState_setStream(state_, original_);
       THCStream_free(original_);
     }

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -18,8 +18,6 @@
 
 using namespace c10d::test;
 
-using c10d::CUDADevice;
-
 class SignalTest {
  public:
   SignalTest(const std::string& path) : path_(path) {}
@@ -202,8 +200,11 @@ void testBroadcast(const std::string& path, const at::Backend b) {
       // Initialize inputs
       for (auto k = 0; k < size; k++) {
         inputs[k].resize(stride);
+        at::DeviceGuard deviceGuard;
         for (auto l = 0; l < stride; l++) {
-          CUDADevice device(type.is_cuda() ? l : -1);
+          if (type.is_cuda()) {
+            deviceGuard.set_index(l);
+          }
           inputs[k][l] = at::ones(type, {16, 16}) * (k * stride + l);
         }
       }

--- a/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
@@ -10,7 +10,6 @@
 
 using namespace c10d::test;
 
-using c10d::CUDADevice;
 using c10d::CUDAStream;
 using c10d::ProcessGroup;
 using c10d::THCStreamGuard;
@@ -50,8 +49,9 @@ class NCCLTest : public NCCLTestBase {
 
     // Each device has a single tensor to perf the NCCL op
     inputs_.resize(numDevices_);
+    at::DeviceGuard deviceGuard;
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       inputs_[i] = type.tensor({3, 3});
     }
 
@@ -64,7 +64,7 @@ class NCCLTest : public NCCLTestBase {
     //
     streams_.resize(numDevices_);
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       streams_[i] = CUDAStream::create();
     }
   }
@@ -117,14 +117,15 @@ class AllreduceNCCLTest : public NCCLTest {
     auto guards = createStreamGuard();
 
     // Launch sleep on every device
+    at::DeviceGuard deviceGuard;
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       cudaSleep(streams_[i], 2000 * 1000 * 1000);
     }
 
     // Launch value initialization for every tensor
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       inputs_[i].fill_(pg_->getRank() * numDevices_ + i);
     }
 
@@ -141,14 +142,15 @@ class BroadcastNCCLTest : public NCCLTest {
     auto guards = createStreamGuard();
 
     // Launch sleep on every device
+    at::DeviceGuard deviceGuard;
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       cudaSleep(streams_[i], 2000 * 1000 * 1000);
     }
 
     // Launch value initialization for every tensor
     for (auto i = 0; i < numDevices_; i++) {
-      CUDADevice device(i);
+      deviceGuard.set_index(i);
       inputs_[i].fill_(pg_->getRank() * numDevices_ + i);
     }
 


### PR DESCRIPTION
Summary: The custom and local CUDADevice RAII wrapper has been superseded by at::DeviceGuard so it doesn't make sense to keep it around.

Differential Revision: D8824200
