### PR TITLE
Move non-dimension reduction var/std to native wrappers.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1649,7 +1649,7 @@
     - THTensor* self
 ]]
 [[
-  name: var
+  name: _th_var
   types:
     - floating_point
   backends:
@@ -1667,18 +1667,6 @@
           if_true: 0
           if_false: 1
           default: 0
-]]
-[[
-  name: _th_var
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
-  variants:
-    - method
-    - function
-  options:
     - cname: var
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
@@ -1696,7 +1684,7 @@
           default: "false"
 ]]
 [[
-  name: std
+  name: _th_std
   types:
     - floating_point
   backends:
@@ -1714,18 +1702,6 @@
           if_true: 0
           if_false: 1
           default: 0
-]]
-[[
-  name: _th_std
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
-  variants:
-    - method
-    - function
-  options:
     - cname: std
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -632,6 +632,14 @@ Tensor &any_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
   }
 }
 
+Tensor var(const Tensor& self, bool unbiased) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "var only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "var only supports floating-point dtypes");
+  auto trivial_return = _allreduce_return_trivial(self, std::numeric_limits<double>::quiet_NaN());
+  return trivial_return.has_value() ? trivial_return.value() : at::_th_var(self, unbiased);
+}
+
 Tensor var(const Tensor& self, int64_t dim, bool unbiased, bool keepdim) {
   Tensor result = self.type().tensor();
   return at::native::var_out(result, self, dim, unbiased, keepdim);
@@ -647,6 +655,14 @@ Tensor &var_out(Tensor &result, const Tensor &self, int64_t dim, bool unbiased, 
   } else {
     return at::_th_var_out(result, self, dim, unbiased, keepdim);
   }
+}
+
+Tensor std(const Tensor& self, bool unbiased) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "std only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "std only supports floating-point dtypes");
+  auto trivial_return = _allreduce_return_trivial(self, std::numeric_limits<double>::quiet_NaN());
+  return trivial_return.has_value() ? trivial_return.value() : at::_th_std(self, unbiased);
 }
 
 Tensor std(const Tensor& self, int64_t dim, bool unbiased, bool keepdim) {

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -44,4 +44,12 @@ static bool _dimreduce_return_trivial_no_ident(Tensor &result, const Tensor &sel
   return false;
 }
 
+static at::optional<Tensor> _allreduce_return_trivial(const Tensor &self, Scalar ident) {
+  // Return identity
+  if (self.numel() == 0) {
+    return self.type().scalarTensor(ident);
+  }
+  return at::nullopt;
+}
+
 }}  // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1305,6 +1305,8 @@
     CPU: _sqrt_out_cpu
     CUDA: _sqrt_out_cuda
 
+- func: std(Tensor self, bool unbiased=true) -> Tensor
+
 - func: std(Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
 
 - func: std_out(Tensor result, Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
@@ -1418,6 +1420,8 @@
 
 - func: unsqueeze_(Tensor self, int64_t dim) -> Tensor
   variants: method
+
+- func: var(Tensor self, bool unbiased=true) -> Tensor
 
 - func: var(Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
 


### PR DESCRIPTION
This is to unify the handling of empty tensors in std/var between the dimension reduce and all reduce cases.
Also to avoid triggering ubsan errors around divide by 0.

