### PR TITLE
Remove ScalarConvert and cast_wrapper in favor of static_cast

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -46,7 +46,7 @@ void poisson_cuda_kernel(
             blockIdx.x * blockDim.x + threadIdx.x,
             seeds.second,
             &state);
-        ret_val = scalar_cast<scalar_t>(curand_poisson(&state, scalar_cast<float>(lambda)));
+        ret_val = static_cast<scalar_t>(curand_poisson(&state, lambda));
       });
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ATen/cuda/detail/TensorInfo.cuh>
-#include <THC/THCNumerics.cuh>
 
 namespace at { namespace native {
 
@@ -262,12 +261,12 @@ __global__ void indexSparseIntersectionKernel(
 //       long seg = chunk / chunksPerSeg;
 //       auto begin = segment_offsets[seg];
 //       auto end = (seg < newNnz - 1) ? segment_offsets[seg + 1] : nnz;
-//       Acctype valSum = ScalarConvert<float, Acctype>::to(0);
+//       Acctype valSum = static_cast<Acctype>::to(0);
 //       for (long valIdx = begin; valIdx < end; valIdx++) {
 //         const long valRow = value_indices[valIdx] * stride;
-//         valSum += ScalarConvert<Dtype, Acctype>::to(valFeat[valRow]);
+//         valSum += static_cast<Acctype>::to(valFeat[valRow]);
 //       }
-//       newValues[seg * stride + featureDim] = ScalarConvert<Acctype, Dtype>::to(valSum);
+//       newValues[seg * stride + featureDim] = static_cast<Dtype>::to(valSum);
 //     }
 //   }
 // }
@@ -291,7 +290,7 @@ __global__ void coalesceValuesKernel(
     Acctype tmp[SZ];
     #pragma unroll
     for (int ii = 0; ii < SZ; ii++) {
-      tmp[ii] = ScalarConvert<float, Acctype>::to(0);
+      tmp[ii] = 0;
     }
     for (int row = begin; row < end; row++) {
       const int valueRow = ((int) value_indices[row]) * stride;
@@ -303,7 +302,7 @@ __global__ void coalesceValuesKernel(
         int featureDim = startFeature + ii * WARP_SIZE;
         if (featureDim < stride)
         {
-          tmp[ii] += ScalarConvert<Dtype, Acctype>::to(values[valueRow + featureDim]);
+          tmp[ii] += static_cast<Acctype>(values[valueRow + featureDim]);
         }
       }
     }
@@ -313,7 +312,7 @@ __global__ void coalesceValuesKernel(
       int featureDim = startFeature + ii * WARP_SIZE;
       if (featureDim < stride)
       {
-        newValues[newValueRow + featureDim] = ScalarConvert<Acctype, Dtype>::to(tmp[ii]);
+        newValues[newValueRow + featureDim] = static_cast<Dtype>(tmp[ii]);
       }
     }
   }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -8,7 +8,6 @@
 
 #include <THC/THCTensorMathPointwise.cuh>
 #include <THC/THCThrustAllocator.cuh>
-#include <THC/THCNumerics.cuh>
 #include <thrust/device_ptr.h>
 #include <thrust/sequence.h>
 #include <thrust/system/cuda/execution_policy.h>
@@ -89,7 +88,7 @@ Tensor& s_addmm_out_sparse_dense_cuda(Tensor& r_, const Tensor& t, const SparseT
         scalar_t cast_alpha = alpha.to<scalar_t>();
         if (cast_beta == 0) {
           r_.zero_();
-        } else if (cast_beta == ScalarConvert<int, scalar_t>::to(1)) {
+        } else if (cast_beta == 1) {
           if (!isSameTensor(t, r_)) {
             r_.copy_(t);
           }
@@ -314,7 +313,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorR
     // NB: Purposely not inplace!
     AT_DISPATCH_ALL_TYPES_AND_HALF(
         values.type(), "add_out_dense_sparse_cuda", [&] {
-          if (value.to<scalar_t>() != ScalarConvert<int, scalar_t>::to(1)) {
+          if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
             values = values.mul(value);
           }
         });
@@ -383,7 +382,7 @@ SparseTensor& s_add_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t, con
 
   AT_DISPATCH_ALL_TYPES_AND_HALF(
       s_values_.type(), "s_add_out_sparse_cuda", [&] {
-        if (value.to<scalar_t>() != ScalarConvert<int, scalar_t>::to(1)) {
+        if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
           s_values_ = s_values_.mul(value);
         }
       });
@@ -429,7 +428,7 @@ SparseTensor& s_sub_out_sparse_cuda(SparseTensor& r, const SparseTensor& t, cons
   AT_DISPATCH_ALL_TYPES(
       t.type(), "sub_sparse", [&] {
         scalar_t cast_value = value.to<scalar_t>();
-        s_add_out_sparse_cuda(r, t, src, ScalarNegate<scalar_t>::to(cast_value));
+        s_add_out_sparse_cuda(r, t, src, -cast_value);
       }
   );
   return r;


### PR DESCRIPTION
While talking to @mruberry, I noticed a few places that use
special cast wrappers that are no longer necessary.