### PR TITLE
Fix out-of-range error for test_neg

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1072,7 +1072,7 @@ class TestTorch(TestCase):
             if t in float_types:
                 a = cast(torch.randn(100, 90).type(t))
             else:
-                a = cast(torch.Tensor(100, 90).type(t).random_())
+                a = cast(torch.Tensor(100, 90).type(t).random_(-128, 128))
             zeros = cast(torch.Tensor().type(t)).resize_as_(a).zero_()
 
             if t == 'torch.ByteTensor':


### PR DESCRIPTION
`test_neg` sometimes fails internally because `random_()` can generate an out-of-range value for CharTensor. This PR fixes it.