### PR TITLE
Fix core.Plan.create_from_proto

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2732,6 +2732,8 @@ class Plan(object):
         assert isinstance(plan_proto, caffe2_pb2.PlanDef)
         plan = Plan(plan_proto.name)
         plan._plan.CopyFrom(plan_proto)
+        del plan._plan.network[:]
+        del plan._plan.execution_step[:]
 
         net_obj_dict = {}
         net_proto_dict = {}

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -481,8 +481,11 @@ class TestCreatePlan(test_util.TestCase):
 
         self.assertEqual(len(plan.Steps()), 1)
         self.assertEqual(len(test_plan.Steps()), 1)
+        self.assertEqual(len(plan.Proto().network), 9)
+        self.assertEqual(len(test_plan.Proto().network), 9)
+        self.assertEqual(len(plan.Proto().execution_step), 1)
+        self.assertEqual(len(test_plan.Proto().execution_step), 1)
         self.assertEqual(plan.Steps()[0].Name(), test_plan.Steps()[0].Name())
-
         self.assertEqual(len(plan.Nets()), len(test_plan.Nets()))
         for idx in range(0, len(plan.Nets())):
             # When we create Net for test_plan, we will end up with new Net


### PR DESCRIPTION
Summary:
Current implementation of create_from_proto doesn't work as expected: it
duplicates networks and execution steps by copying original PlanDef first and
adding each step one-by-one later.

Differential Revision: D8850316
