### PR TITLE
Make localScalar error message more intuitive

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -43,7 +43,7 @@ int64_t SparseTensorImpl::dim() const {
 }
 Scalar SparseTensorImpl::localScalar() {
   int64_t n = numel();
-  AT_CHECK(n == 1, "localScalar() called on a Tensor with ", n, " elements");
+  AT_CHECK(n == 1, "a Tensor with ", n, " elements cannot be converted to Scalar");
   if (nnz_ == 0) return Scalar(0);
   if (coalesced_) return values_.pImpl->localScalar();
   // You have a non-coalesced scalar sparse tensor?!  Wow!  Have

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -5,7 +5,7 @@ IntList ${Tensor}::strides() const {
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
-  AT_CHECK(numel == 1,"localScalar() called on Tensor with ", numel, " elements");
+  AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
   return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storageOffset)));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {


### PR DESCRIPTION
Fixes: #9419

This assumes that anyone who knows localScalar can also grep for the
error message or get a traceback.

