### PR TITLE
Fix l2 normalization when handling zero vector

### DIFF
--- a/caffe2/operators/normalize_op.cc
+++ b/caffe2/operators/normalize_op.cc
@@ -42,7 +42,6 @@ void NormalizeGradientOp<T, Context>::DoNormalize(
       Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>, 0, InnerStride>;
   using ConstStridedVec =
       Eigen::Map<const Eigen::Matrix<T, 1, Eigen::Dynamic>, 0, InnerStride>;
-
   for (int i = 0; i < n; ++i) {
     auto base = (i / sf) * sf * m + (i % sf);
     ConstStridedVec xVec(xData + base, 1, m, InnerStride(sf));
@@ -51,9 +50,11 @@ void NormalizeGradientOp<T, Context>::DoNormalize(
     auto row_sum = xVec.dot(gOutVec);
     auto row_norm = xVec.template lpNorm<2>();
     auto row_norm_3 = pow(row_norm, 3);
+    StridedVec gInVec(gInData + base, 1, m, InnerStride(sf));
     if (row_norm != 0) {
-      StridedVec gInVec(gInData + base, 1, m, InnerStride(sf));
       gInVec = (gOutVec / row_norm) - ((xVec / row_norm_3) * row_sum);
+    } else {
+      gInVec = gOutVec * 0.0;
     }
   }
 };

--- a/caffe2/operators/normalize_ops.cu
+++ b/caffe2/operators/normalize_ops.cu
@@ -70,11 +70,16 @@ __global__ void NormalizeGradientKernel(
       row_norm_3 = pow(row_norm, 3);
     }
     __syncthreads();
+
     for (int j = threadIdx.x; j < N; j += blockDim.x) {
       int index = base + j * SF;
       const float x_ij = in_mat[index];
       const float dy_ij = grad_out_mat[index];
-      grad_mat[index] = (dy_ij / row_norm) - ((x_ij / row_norm_3) * row_sum);
+      if (row_norm != 0) {
+        grad_mat[index] = (dy_ij / row_norm) - ((x_ij / row_norm_3) * row_sum);
+      } else {
+        grad_mat[index] = 0.0;
+      }
     }
   }
 }

--- a/caffe2/python/operator_test/normalize_op_test.py
+++ b/caffe2/python/operator_test/normalize_op_test.py
@@ -9,45 +9,45 @@ from hypothesis import given
 import hypothesis.strategies as st
 from caffe2.python import core
 import caffe2.python.hypothesis_test_util as hu
+import copy
 
 
 class TestNormalizeOp(hu.HypothesisTestCase):
-
-    @given(X=hu.tensor(min_dim=1,
-                       max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
-           **hu.gcs)
+    @given(
+        X=hu.tensor(
+            min_dim=1, max_dim=5, elements=st.floats(min_value=0.5, max_value=1.0)
+        ),
+        **hu.gcs
+    )
     def test_normalize(self, X, gc, dc):
         def ref_normalize(X, axis):
             x_normed = X / (
-                np.sqrt((X**2).sum(axis=axis, keepdims=True)) + np.finfo(X.dtype).tiny)
+                np.sqrt((X ** 2).sum(axis=axis, keepdims=True)) + np.finfo(X.dtype).tiny
+            )
             return (x_normed,)
 
         for axis in range(-X.ndim, X.ndim):
+            x = copy.copy(X)
             op = core.CreateOperator("Normalize", "X", "Y", axis=axis)
             self.assertReferenceChecks(
-                gc,
-                op,
-                [X],
-                functools.partial(ref_normalize, axis=axis))
-            self.assertDeviceChecks(dc, op, [X], [0])
-            self.assertGradientChecks(gc, op, [X], 0, [0])
+                gc, op, [x], functools.partial(ref_normalize, axis=axis)
+            )
+            self.assertDeviceChecks(dc, op, [x], [0])
+            self.assertGradientChecks(gc, op, [x], 0, [0])
 
-    @given(X=hu.tensor(min_dim=1,
-                       max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
-           **hu.gcs)
+    @given(
+        X=hu.tensor(
+            min_dim=1, max_dim=5, elements=st.floats(min_value=0.5, max_value=1.0)
+        ),
+        **hu.gcs
+    )
     def test_normalize_L1(self, X, gc, dc):
         def ref(X, axis):
             norm = abs(X).sum(axis=axis, keepdims=True)
             return (X / norm,)
 
         for axis in range(-X.ndim, X.ndim):
-            print('axis: ', axis)
+            print("axis: ", axis)
             op = core.CreateOperator("NormalizeL1", "X", "Y", axis=axis)
-            self.assertReferenceChecks(
-                gc,
-                op,
-                [X],
-                functools.partial(ref, axis=axis))
+            self.assertReferenceChecks(gc, op, [X], functools.partial(ref, axis=axis))
             self.assertDeviceChecks(dc, op, [X], [0])


### PR DESCRIPTION
Summary:
When the input vector is a zero vector, the previous GPU code will give Nan in backward. We fix this.

Also I noticed that in the backward, it's important to use `if (row_norm > kEps)` rather than `if (row_norm != 0)`, since row_norm may be something like 1e-10 when the input vector is a zero vector. For forward this is not an issue. I guess the reason is that in the input, `xVec / norm` will still yield zero even if norm is something like 1e-10 when the input vector is a zero vector.

Differential Revision: D8849732
