### PR TITLE
Add Support for count_include_pad in AveragePool in Caffe2 ONNX Backend

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -340,8 +340,8 @@ Caffe2Backend::get_special_operators() const {
               {"Cast", &Caffe2Backend::CreateCast},
               {"Constant", &Caffe2Backend::CreateConstant},
               {"Conv", &Caffe2Backend::CreateConvPoolOpBase},
-              {"AveragePool", &Caffe2Backend::CreateConvPoolOpBase},
-              {"GlobalAveragePool", &Caffe2Backend::CreateConvPoolOpBase},
+              {"AveragePool", &Caffe2Backend::CreatePadPool},
+              {"GlobalAveragePool", &Caffe2Backend::CreatePadPool},
               {"GlobalMaxPool", &Caffe2Backend::CreateConvPoolOpBase},
               {"MaxPool", &Caffe2Backend::CreateConvPoolOpBase},
               {"Reshape", &Caffe2Backend::CreateReshape},
@@ -513,6 +513,63 @@ Caffe2Ops Caffe2Backend::CreateConvPoolOpBase(
   }
 
   return CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
+}
+
+Caffe2Ops Caffe2Backend::CreatePadPool(OnnxNode* onnx_node, int opset_version) {
+  auto& node = onnx_node->node;
+  auto& attributes = onnx_node->attributes;
+  Caffe2Ops ret;
+  // Pad
+  bool padding = false;
+  const std::string pad_name = opset_version < 2 ? "paddings" : "pads";
+  const auto pad_input = dummy_->NewDummyName();
+  if (attributes.HasAttribute("count_include_pad") &&
+      attributes.HasAttribute(pad_name)) {
+    auto count_include_pad = attributes.get<int64_t>("count_include_pad", 0L);
+    ::google::protobuf::RepeatedField<::google::protobuf::int64> pads;
+    pads =
+        attributes
+            .get<::google::protobuf::RepeatedField<::google::protobuf::int64>>(
+                pad_name);
+    if (count_include_pad == 1 && pads.size() == 4 &&
+        !(pads.Get(0) == 0 && pads.Get(1) == 0 && pads.Get(2) == 0 &&
+          pads.Get(3) == 0)) {
+      padding = true;
+      attributes.remove(pad_name);
+      caffe2::Argument arg_pads;
+      arg_pads.add_ints(pads.Get(0));
+      arg_pads.add_ints(pads.Get(1));
+      arg_pads.add_ints(pads.Get(2));
+      arg_pads.add_ints(pads.Get(3));
+      arg_pads.set_name("pads");
+      auto* c2_op = ret.ops.Add();
+      BuildOperator(
+          c2_op, "PadImage", {node.input(0)}, {pad_input}, {arg_pads});
+    } else if (count_include_pad == 1) {
+      std::string str;
+      bool pads_flag = false;
+      str += "[";
+      for (const auto& i : pads) {
+        str += caffe2::to_string(i) + ",";
+        pads_flag = pads_flag || i > 0;
+      }
+      str += "]";
+      if (pads_flag == true) {
+        CAFFE_THROW(
+            "Caffe2 only supports padding 2D Tensor, whereas padding is ", str);
+      }
+    }
+  }
+  // Pool
+  auto c2_ops = Caffe2Backend::CreateConvPoolOpBase(onnx_node, opset_version);
+  auto* pool_op = c2_ops.ops.Mutable(0);
+  if (padding) {
+    pool_op->set_input(0, pad_input);
+  }
+  auto* c2_op = ret.ops.Add();
+  c2_op->CopyFrom(*pool_op);
+
+  return ret;
 }
 
 Caffe2Ops Caffe2Backend::CreateReshape(OnnxNode* onnx_node, int opset_version) {

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -168,6 +168,8 @@ class Caffe2Backend {
 
   Caffe2Ops CreateConvPoolOpBase(OnnxNode* onnx_node, int opset_version);
 
+  Caffe2Ops CreatePadPool(OnnxNode* onnx_node, int opset_version);
+
   Caffe2Ops CreateReshape(OnnxNode* onnx_node, int opset_version);
 
   Caffe2Ops CreateGather(OnnxNode* onnx_node, int opset_version);

--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -35,7 +35,6 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_operator_repeat.*'  # Tile is not compliant with ONNX yet
                      '|test_.*pool_.*same.*'  # Does not support pool same.
                      '|test_convtranspose.*'  # ConvTranspose needs some more complicated translation
-                     '|test_averagepool.*count_include_pad.*'  # Waiting for the support in Caffe2 onnx backend.
                      ')')
 
 # Quick patch to unbreak master CI, is working on the debugging.


### PR DESCRIPTION
Summary:
The goal is to support count_include_pad in Caffe2 ONNX backend. This commit contains the first step - support 4-D tensor cases.
AveragePool with count_include_pad can be expressed as PadImage + AveragePool.

Differential Revision: D8852180
