### PR TITLE
make coalesceInsertedDataDependencies foolproof (with 2 fixes)

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
@@ -65,9 +65,9 @@ class BasicBlock {
     assert(hasInstruction(instr2) && "Instruction not in basic block.");
     auto it1 =
         std::find(std::begin(Instructions), std::end(Instructions), instr1);
+    Instructions.erase(it1);
     auto it2 =
         std::find(std::begin(Instructions), std::end(Instructions), instr2);
-    Instructions.erase(it1);
     Instructions.insert(it2, instr1);
   }
 

--- a/caffe2/opt/converter_nomigraph_test.cc
+++ b/caffe2/opt/converter_nomigraph_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace nom::repr;
+
 #define ADD_ARG(_op, _name, _type, _val)                                       \
 {                                                                            \
   caffe2::Argument *arg = _op->add_arg();                                    \
@@ -46,6 +48,78 @@ TEST(Converter, UnknownType) {
       caffe2::to_string(rand() % 2));
   auto nn = caffe2::convertToNNModule(net);
   auto new_netdef = caffe2::convertToCaffe2Proto(nn);
+}
+
+TEST(Converter, AddNewOpChain) {
+  caffe2::NetDef net;
+  // create net of Op1->Op2
+  caffe2::OperatorDef* def = net.add_op();
+  def->set_type("Op1");
+  def->add_input("X");
+  def->add_output("Y");
+
+  def = net.add_op();
+  def->set_type("Op2");
+  def->add_input("Y");
+  def->add_output("Z");
+  auto nn = caffe2::convertToNNModule(net);
+  auto& dfg = nn.dataFlow;
+  auto& cfg = nn.controlFlow;
+  for (auto data_pair : nn::dataIterator<NeuralNetData>(dfg)) {
+    NNGraph::NodeRef node;
+    NeuralNetData* node_data;
+    std::tie(node_data, node) = data_pair;
+    if (node_data->getName() != "X") {
+      continue;
+    }
+    // insert two new ops so the correct op order should be
+    // Softmax -> Relu -> Op1 -> Op2
+    auto consumers = nn::getConsumers(node);
+    ASSERT_EQ(consumers.size(), 1);
+    NNGraph::NodeRef op1_node = consumers.front();
+    auto outputs = nn::getOutputs(op1_node);
+    ASSERT_EQ(outputs.size(), 1);
+    consumers = nn::getConsumers(outputs.front());
+    ASSERT_EQ(consumers.size(), 1);
+    NNGraph::NodeRef op2_node = consumers.front();
+
+    dfg.deleteEdge(dfg.getEdge(node, op1_node));
+    auto softmax_output = dfg.createNode(
+        nom::util::make_unique<nom::repr::Tensor>("softmax_output"));
+    auto relu_output = dfg.createNode(
+        nom::util::make_unique<nom::repr::Tensor>("relu_output"));
+    auto softmax_node = dfg.createNode(nom::util::make_unique<Softmax>());
+    auto relu_node = dfg.createNode(nom::util::make_unique<Relu>());
+    dfg.createEdge(node, softmax_node);
+    dfg.createEdge(softmax_node, softmax_output);
+    dfg.createEdge(softmax_output, relu_node);
+    dfg.createEdge(relu_node, relu_output);
+    dfg.createEdge(relu_output, op1_node);
+    nn::coalesceInsertedDataDependencies(&nn);
+    // change the op order in cfg to be
+    // Op1 -> Op2 -> Softmax -> Relu
+    for (auto& bbNode : cfg.getMutableNodes()) {
+      auto bb = bbNode->mutableData()->get();
+      if (bb->getInstructions().empty()) {
+        continue;
+      }
+      ASSERT_EQ(bb->getInstructions().size(), 4);
+      bb->moveInstructionBefore(op1_node, softmax_node);
+      bb->moveInstructionBefore(op2_node, softmax_node);
+      break;
+    }
+    break;
+  }
+  auto new_netdef = caffe2::convertToCaffe2Proto(nn);
+  std::vector<std::string> ops;
+  for (auto op : new_netdef.op()) {
+    ops.emplace_back(op.type());
+  }
+  std::vector<std::string> result = {"Softmax", "Relu", "Op1", "Op2"};
+  ASSERT_EQ(ops.size(), result.size());
+  for (auto idx = 0; idx < result.size(); ++idx) {
+    ASSERT_EQ(ops.at(idx), result.at(idx));
+  }
 }
 
 /* Temporarily disabled While conversion tests


### PR DESCRIPTION
Summary:
1.Currently in coalesceInsertedDataDependencies, the op order correction part might fail for complex cases where a chain of the ops have incorrect order.

E.g:
if the correct order is op1->op2->op3->op4,
but the op order in the cfg is op3, op4, op1, op2,
then after running coalesceInsertedDataDependencies(), the resulting op order will be op2, op3, op4, op1, which is still not correct.

This blocks complex graph changes e.g. int8 conversion using backend_cutting.

This diff works by using a full topological sort to sort the ops in each basicblock, to make sure that the op orders are indeed correct. For basicblocks where the number of ops are equal or less than 1, the sorting is skipped.

2.Also a fix for moveInstructionBefore. Previously the function moveInstructionBefore() needs instr1 to be after instr2 to correctly work. This is due to the iterator invalidation rule for vector erase operation: Invalidates iterators and references at or after the point of the erase. The change get rid of potential vector iterator invalidation issue.

Differential Revision: D8860056
