### PR TITLE
[WIP] add mul_ / mul(S, D) and sparse_mul_ / sparse_mul(S, D) in ATen

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -71,7 +71,12 @@ Tensor& mul_out(Tensor& result, const Tensor& self, const Tensor& other) {
     if (!result.defined()) {
       result = self.type().tensor();
     }
-    return at::_sparse_mul_out(result, self, other);
+    if (self.is_sparse() && other.is_sparse()) {
+      return at::_sparse_mul_out(result, self, other);
+    }
+    else {
+      return at::_sparse_dense_mul_out(result, self, other);
+    }
   }
   auto iter = TensorIterator::binary_op(result, self, other);
   mul_stub(iter->device_type(), *iter);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -92,6 +92,15 @@ Tensor& mul_(Tensor& self, const Tensor& other) {
   return native::mul_out(self, self, other);
 }
 
+Tensor sparse_mul(const Tensor& self, const Tensor& dense) {
+  Tensor result;
+  return native::mul_out(result, self, dense);
+}
+
+Tensor& sparse_mul_(Tensor& self, const Tensor& dense) {
+  return native::mul_out(self, self, dense);
+}
+
 Tensor& sub_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   if (other.is_sparse()) {
     if (!result.defined()) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1860,6 +1860,12 @@
 - func: sub_(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
   variants: method
 
+- func: s_native_sparse_dense_mul_(Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    SparseCPU: s_mul_sparse_dense_cpu_
+    SparseCUDA: s_mul_sparse_dense_cuda_
+
 - func: s_native_addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1523,6 +1523,12 @@
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
 
+- func: _sparse_dense_mul_out(Tensor result, Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    SparseCPU: mul_out_sparse_dense_cpu
+    SparseCUDA: mul_out_sparse_dense_cuda
+
 - func: split(Tensor self, int64_t split_size, int64_t dim=0) -> TensorList
 
 - func: split_with_sizes(Tensor self, IntList split_sizes, int64_t dim=0) -> TensorList
@@ -1859,12 +1865,6 @@
 - func: sub(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
 - func: sub_(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
   variants: method
-
-- func: s_native_sparse_dense_mul_(Tensor self, Tensor other) -> Tensor
-  variants: function
-  dispatch:
-    SparseCPU: s_mul_sparse_dense_cpu_
-    SparseCUDA: s_mul_sparse_dense_cuda_
 
 - func: s_native_addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1198,6 +1198,11 @@
 - func: sparse_mul_(Tensor self, Tensor other) -> Tensor
   variants: method, function
 
+- func: sparse_mul(Tensor self, Scalar other) -> Tensor
+  variants: method, function
+- func: sparse_mul_(Tensor self, Scalar other) -> Tensor
+  variants: method, function
+
 - func: mv(Tensor self, Tensor vec) -> Tensor
 
 - func: mv_out(Tensor result, Tensor self, Tensor vec) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1193,6 +1193,11 @@
 - func: mul_(Tensor self, Scalar other) -> Tensor
   variants: method
 
+- func: sparse_mul(Tensor self, Tensor other) -> Tensor
+  variants: method, function
+- func: sparse_mul_(Tensor self, Tensor other) -> Tensor
+  variants: method, function
+
 - func: mv(Tensor self, Tensor vec) -> Tensor
 
 - func: mv_out(Tensor result, Tensor self, Tensor vec) -> Tensor

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -317,6 +317,9 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
   return dst;
 }
 
+// --------------------------------------------------------------------
+// _sparse_mask(Tensor, SparseTensor) -> SparseTensor
+// --------------------------------------------------------------------
 SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const SparseTensor& mask) {
   AT_CHECK(mask.is_coalesced(), "sparse_mask: mask is uncoalesced");
   AT_CHECK(mask.sizes().equals(t.sizes()), "sparse_mask: operands have incompatible sizes; self has size ",

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -510,8 +510,8 @@ SparseTensor& mul_out_sparse_dense_cpu(SparseTensor& r, const SparseTensor& t, c
   );
 
   r.resize_as_(t);
-  _get_sparse_impl(r)->set_indices_and_values(r_indices, r_values);
-  _get_sparse_impl(r)->set_nnz(t_nnz);
+  _get_sparse_impl(r)->set_indices_and_values_unsafe(r_indices, r_values);
+  _get_sparse_impl(r)->set_nnz_and_narrow(t_nnz);
   _get_sparse_impl(r)->set_coalesced(true);
 
   return r;

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -355,8 +355,6 @@ SparseTensor& mul_out_sparse_cpu(SparseTensor& r, const Tensor& t_, const Tensor
   AT_CHECK(!r.is_cuda(), "mul: expected 'out' to be CPU tensor, but got CUDA tensor");
   AT_CHECK(!src_.is_cuda(), "mul: expected 'other' to be a CPU tensor, but got a CUDA tensor");
 
-  AT_CHECK(t_.sizes().equals(src_.sizes()), "mul: expected 'self' and 'other' to have same sizes, but ", t_.sizes(), " != ", src_.sizes());
-
   if (src_._nnz() == 0 || t_._nnz() == 0) {
     return r.zero_();
   }
@@ -439,6 +437,78 @@ SparseTensor& mul_out_sparse_cpu(SparseTensor& r, const Tensor& t_, const Tensor
   _get_sparse_impl(r)->set_coalesced(true);
 
   return r;
+}
+
+// --------------------------------------------------------------------
+// mul(SparseTensor, DenseTensor) -> SparseTensor
+// --------------------------------------------------------------------
+
+SparseTensor& s_mul_out_sparse_dense_cpu(SparseTensor& r, const SparseTensor& t_, const Tensor& dense) {
+  AT_CHECK(t_.sizes().equals(dense.sizes()), "mul: expected 'self' and 'other' to have same sizes, but ", t_.sizes(), " != ", dense.sizes());
+  AT_ASSERT(!t_.is_cuda()); // dispatch argument
+  AT_CHECK(!r.is_cuda(), "mul: expected 'out' to be CPU tensor, but got CUDA tensor");
+  AT_CHECK(!dense.is_cuda(), "mul: expected 'other' to be a CPU tensor, but got a CUDA tensor");
+  AT_CHECK(t_._values().dim() == 1, "only support mul(result, sparse, dense) with sparse._values() dim = 1, but found ", t_._values().dim());
+
+  if (dense.numel() == 0 || t_._nnz() == 0) {
+    return r.zero_();
+  }
+
+  SparseTensor t = t_.coalesce();
+
+  int64_t sparseDims = t._sparseDims();
+  auto strides = dense.strides();
+  int64_t t_nnz = t._nnz();
+  LongTensor t_indices = t._indices();
+  Tensor t_values = t._values();
+  LongTensor r_indices = t_indices.type().tensor({sparseDims, t_nnz});
+  Tensor r_values = _new_values_with_size_of(t_values, t_nnz).zero_();
+  r.resize_as_(t);
+  _get_sparse_impl(r)->set_indices_and_values(r_indices, r_values);
+
+  int64_t r_i = 0;
+  auto t_indices_accessor = t_indices.accessor<int64_t, 2>();
+  auto r_indices_accessor = r_indices.accessor<int64_t, 2>();
+
+  AT_DISPATCH_ALL_TYPES(
+      r_values.type(), "mul_out_sparse", [&] {
+        auto r_accessor = r_values.accessor<scalar_t, 1>();
+        auto t_accessor = t_values.accessor<scalar_t, 1>();
+        auto dense_ptr = dense.data<scalar_t>();
+
+        for (int64_t i = 0; i < t_nnz; i++) {
+          // compute index of dense wrt sparse indices
+          int64_t dense_i = 0;
+          for (int64_t j = 0; j < sparseDims; j++) {
+            dense_i += t_indices_accessor[j][i] * strides[j];
+          }
+
+          scalar_t dense_val = dense_ptr[dense_i];
+          if (static_cast<double>(dense_val) == 0.0) continue;
+
+          r_accessor[r_i] = t_accessor[i] * dense_val;
+          for (int64_t k = 0; k < sparseDims; k++) {
+            r_indices_accessor[k][r_i] = t_indices_accessor[k][i];
+          }
+          r_i ++;
+        }
+      }
+  );
+
+  _get_sparse_impl(r)->set_nnz(r_i);
+  _get_sparse_impl(r)->set_coalesced(true);
+
+  return r;
+}
+
+SparseTensor s_mul_sparse_dense_cpu(const SparseTensor& t, const Tensor& dense) {
+  SparseTensor r = t.type().tensor();
+  s_mul_out_sparse_dense_cpu(r, t, dense);
+  return r;
+}
+
+SparseTensor& s_mul_sparse_dense_cpu_(SparseTensor& t, const Tensor& dense) {
+  return s_mul_out_sparse_dense_cpu(t, t, dense);
 }
 
 // --------------------------------------------------------------------
@@ -652,7 +722,7 @@ SparseTensor hspmm_sparse_cpu(const SparseTensor& sparse, const Tensor& dense) {
 }
 
 // --------------------------------------------------------------------
-// sspaddmm
+// sspaddmm(SparseTensor, SparseTensor, DenseTensor, Scalar, Scalar)
 // --------------------------------------------------------------------
 
 SparseTensor& _sspaddmm_out_cpu(

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
@@ -5,6 +5,9 @@
 
 namespace at { namespace native {
 
+// --------------------------------------------------------------------
+// _sparse_mask(Tensor, SparseTensor) -> SparseTensor
+// --------------------------------------------------------------------
 SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const SparseTensor& mask) {
   AT_CHECK(mask.is_coalesced(), "sparse_mask: mask is uncoalesced");
   AT_CHECK(mask.sizes().equals(t.sizes()), "sparse_mask: operands have incompatible sizes; self has size ",

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -483,73 +483,71 @@ SparseTensor& mul_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t_, cons
 // mul(SparseTensor, DenseTensor) -> SparseTensor
 // --------------------------------------------------------------------
 
-SparseTensor& s_mul_out_sparse_dense_cuda(SparseTensor& r_, const SparseTensor& t_, const Tensor& dense) {
+SparseTensor& mul_out_sparse_dense_cuda(SparseTensor& r, const SparseTensor& t_, const Tensor& dense) {
 #ifndef __HIP_PLATFORM_HCC__
   AT_ASSERT(t_.is_cuda()); // dispatch argument
   AT_CHECK(dense.is_cuda(), "mul: expected 'other' to be CUDA, but got CPU");
-  AT_CHECK(r_.is_cuda(), "mul: expected 'out' to be CUDA, but got CPU");
+  AT_CHECK(r.is_cuda(), "mul: expected 'out' to be CUDA, but got CPU");
 
-  AT_CHECK(_check_device({r_, t_, dense})); // check if all tensors are in the same device
+  AT_CHECK(_check_device({r, t_, dense})); // check if all tensors are in the same device
   AT_CHECK(t_.sizes().equals(dense.sizes()), "mul: expected 'self' and 'other' to have same size, but ", t_.sizes(), " != ", dense.sizes());
   AT_CHECK(t_._values().dim() == 1, "only support mul(result, sparse, dense) with sparse._values() dim = 1, but found ", t_._values().dim());
 
   SparseTensor t = t_.coalesce();
 
   if (dense.numel() == 0 || t_._nnz() == 0) {
-    return r_.zero_();
+    return r.zero_();
   }
 
   // saving those because they can be overwritten when doing in-place operations
   int64_t t_nnz = t._nnz();
   int64_t sparseDims = t._sparseDims();
-  LongTensor t_indices_ = t._indices();
-  Tensor t_values_ = t._values();
-  LongTensor r_indices_ = t_indices_.type().tensor({sparseDims, t_nnz});
-  Tensor r_values_ = _new_values_with_size_of(t_values_, t_nnz).zero_();
-  r_.resize_as_(t);
-  _get_sparse_impl(r_)->set_indices_and_values(r_indices_, r_values_);
+  LongTensor r_indices = t._indices().clone();
+  Tensor r_values = t._values().clone();
+  r.resize_as_(t);
+  _get_sparse_impl(r)->set_indices_and_values(r_indices, r_values);
 
   int64_t valueSize = t_values_.stride(0);
   const dim3 block = dim3(std::min(static_cast<int64_t>(cuda::getApplyBlock().x), valueSize));
   dim3 grid;
   int curDevice = -1;
   cudaGetDevice(&curDevice);
-  cudaStream_t stream = globalContext().getCurrentCUDAStreamOnDevice(curDevice);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStreamOnDevice(curDevice);
   AT_CHECK(cuda::getApplyGrid(valueSize, grid, curDevice), "mul: Argument #0: tensor too large or too many dimensions");
 
-  LongTensor result_nnz = at::empty({1}, CUDA(kLong));
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      t_values_.type(), "s_mul_out_sparse_cuda", [&] {
+    values.type(), "add_out_dense_sparse_cuda", [&] {
+      apply::sparseDenseElementwiseKernel<TensorMulOp<scalar_t>, uint64_t, scalar_t>
+        <<<grid, block, 0, stream>>>(
+          TensorMulOp<scalar_t>(),
+          I_INFO(r_indices),
+          V_INFO(r_values),
+          V_INFO(dense),
+          static_cast<uint64_t>(t_nnz)
+        );
+    }
+  );
 
-        apply::sparseAndDenseIntersectionKernel<TensorMulOp<scalar_t>, uint64_t, scalar_t>
-          <<<grid, block, 0, stream>>>(
-            TensorMulOp<scalar_t>(),
-            I_INFO(r_indices_),
-            I_INFO(t_indices_),
-            V_INFO(r_values_),
-            V_INFO(t_values_),
-            V_INFO(dense),
-            static_cast<uint64_t>(t_nnz),
-            reinterpret_cast<uint64_t*>(result_nnz.data_ptr()));
-      });
+  // AT_DISPATCH_ALL_TYPES_AND_HALF(
+  //   t_values_.type(), "mul_out_sparse_cuda", [&] {
+  //     apply::sparseAndDenseIntersectionKernel<TensorMulOp<scalar_t>, uint64_t, scalar_t>
+  //       <<<grid, block, 0, stream>>>(
+  //         TensorMulOp<scalar_t>(),
+  //         I_INFO(t_indices_),
+  //         V_INFO(t_values_),
+  //         V_INFO(r_values_),
+  //         V_INFO(dense),
+  //         static_cast<uint64_t>(t_nnz));
+  //   }
+  // );
 
-  _get_sparse_impl(r_)->set_nnz(result_nnz.toType(CPU(kLong)).accessor<int64_t, 1>()[0]);
-  _get_sparse_impl(r_)->set_coalesced(true);
+  _get_sparse_impl(r)->set_nnz(t_nnz);
+  _get_sparse_impl(r)->set_coalesced(true);
 
-  return r_;
-#else
-  AT_ERROR("s_mul_out_sparse_dense_cuda: HIP not supported");
-#endif
-}
-
-SparseTensor s_mul_sparse_dense_cuda(const SparseTensor& t, const Tensor& dense) {
-  SparseTensor r = t.type().tensor();
-  s_mul_out_sparse_dense_cuda(r, t, dense);
   return r;
-}
-
-SparseTensor& s_mul_sparse_dense_cuda_(SparseTensor& t, const Tensor& dense) {
-  return s_mul_out_sparse_dense_cuda(t, t, dense);
+#else
+  AT_ERROR("mul_out_sparse_dense_cuda: HIP not supported");
+#endif
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -529,8 +529,8 @@ SparseTensor& mul_out_sparse_dense_cuda(SparseTensor& r, const SparseTensor& t, 
   );
 
   r.resize_as_(t);
-  _get_sparse_impl(r)->set_indices_and_values(r_indices, r_values);
-  _get_sparse_impl(r)->set_nnz(t_nnz);
+  _get_sparse_impl(r)->set_indices_and_values_unsafe(r_indices, r_values);
+  _get_sparse_impl(r)->set_nnz_and_narrow(t_nnz);
   _get_sparse_impl(r)->set_coalesced(true);
 
   return r;

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -110,6 +110,8 @@ An empty sparse tensor can be constructed by specifying its size:
     .. method:: mm
     .. method:: mul
     .. method:: mul_
+    .. automethod:: sparse_mul
+    .. automethod:: sparse_mul_
     .. method:: resizeAs_
     .. method:: size
     .. method:: spadd

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -462,6 +462,13 @@ class TestSparse(TestCase):
         self.assertEqual(s.grad.to_dense(), input.mul(s_ones).to_dense())
         self.assertEqual(s2.grad.to_dense(), input.mul(s2_ones).to_dense())
 
+        # autograd for sparse_mul(Sparse, Scalar)
+        scalar = 5
+        y = s.sparse_mul(scalar)
+        y.backward(input)
+        self.assertTrue(s.grad.is_sparse)
+        self.assertEqual(s.grad.to_dense(), input.mul(s_ones).to_dense() * scalar)
+
     @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -424,26 +424,26 @@ class TestSparse(TestCase):
         test_shape(4, [3, 17, 19, 5])
         test_shape(2, [3, 17, 19, 5])
 
-    def test_mul_autograd(self):
-        if self.is_cuda:
-            i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]]).cuda()
-            v = torch.DoubleTensor([3, 3, 4, 1, 2]).cuda()
-            sparse_mat = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
-            dense_mat = torch.ones(3, 3).cuda()
-            x = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
-        else:
-            i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])
-            v = torch.DoubleTensor([3, 3, 4, 1, 2])
-            sparse_mat = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
-            dense_mat = torch.ones(3, 3)
-            x = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
-
-        sparse_var = sparse_mat.requires_grad_()
-        dense_var = dense_mat.requires_grad_()
-
-        y = torch.mul(sparse_var, dense_var)
-        y.backward(x)
-        self.assertEqual(sparse_var.grad.to_dense(), x.to_dense())
+    # def test_mul_autograd(self):
+    #     if self.is_cuda:
+    #         i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]]).cuda()
+    #         v = torch.DoubleTensor([3, 3, 4, 1, 2]).cuda()
+    #         sparse_mat = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+    #         dense_mat = torch.ones(3, 3).cuda()
+    #         x = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+    #     else:
+    #         i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])
+    #         v = torch.DoubleTensor([3, 3, 4, 1, 2])
+    #         sparse_mat = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+    #         dense_mat = torch.ones(3, 3)
+    #         x = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+    #
+    #     sparse_var = sparse_mat.requires_grad_()
+    #     dense_var = dense_mat.requires_grad_()
+    #
+    #     y = torch.mul(sparse_var, dense_var)
+    #     y.backward(x)
+    #     self.assertEqual(sparse_var.grad.to_dense(), x.to_dense())
 
     @cpu_only
     def test_mm(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -424,6 +424,27 @@ class TestSparse(TestCase):
         test_shape(4, [3, 17, 19, 5])
         test_shape(2, [3, 17, 19, 5])
 
+    def test_mul_autograd(self):
+        if self.is_cuda:
+            i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]]).cuda()
+            v = torch.DoubleTensor([3, 3, 4, 1, 2]).cuda()
+            sparse_mat = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+            dense_mat = torch.ones(3, 3).cuda()
+            x = torch.cuda.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+        else:
+            i = torch.LongTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])
+            v = torch.DoubleTensor([3, 3, 4, 1, 2])
+            sparse_mat = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+            dense_mat = torch.ones(3, 3)
+            x = torch.sparse.DoubleTensor(i, v, torch.Size([3, 3]))
+
+        sparse_var = sparse_mat.requires_grad_()
+        dense_var = dense_mat.requires_grad_()
+
+        y = torch.mul(sparse_var, dense_var)
+        y.backward(x)
+        self.assertEqual(sparse_var.grad.to_dense(), x.to_dense())
+
     @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk):
@@ -866,6 +887,9 @@ class TestSparse(TestCase):
             ('addmm_', lambda sp, de: de.addmm(sp, de), True),
             ('mm', lambda sp, de: torch.mm(sp, de), True),
             ('mm_out', lambda sp, de: torch.mm(sp, de, out=de), True),
+            ('mul', lambda sp, de: sp.mul(de), True),
+            ('mul_', lambda sp, de: sp.mul_(de), True),
+            ('mul_out', lambda sp, de: torch.mul(sp, de, out=sp), True),
         ]
 
         i = self.IndexTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -470,14 +470,9 @@
   self: index_select_backward(grad, dim, result1, self.sizes(), keepdim)
 
 - name: mul(Tensor self, Tensor other)
-  self: grad * other
-  other: grad * self
+  self, other: mul_backward(grad, self, other)
 
 - name: mul(Tensor self, Scalar other)
-
-- name: s_native_sparse_dense_mul(Tensor self, Tensor other)
-  self: grad * other
-  other: grad * self
 
 - name: mv(Tensor self, Tensor vec)
   self: grad.ger(vec)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -472,6 +472,9 @@
 - name: mul(Tensor self, Tensor other)
   self, other: mul_backward(grad, self, other)
 
+# - name: sparse_mul(Tensor self, Tensor other)
+#   self, other: sparse_mul_backward(grad, self, other)
+
 - name: mul(Tensor self, Scalar other)
 
 - name: mv(Tensor self, Tensor vec)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -472,10 +472,12 @@
 - name: mul(Tensor self, Tensor other)
   self, other: mul_backward(grad, self, other)
 
-# - name: sparse_mul(Tensor self, Tensor other)
-#   self, other: sparse_mul_backward(grad, self, other)
-
 - name: mul(Tensor self, Scalar other)
+
+- name: sparse_mul(Tensor self, Tensor other)
+  self, other: sparse_mul_backward(grad, self, other)
+
+- name: sparse_mul(Tensor self, Scalar other)
 
 - name: mv(Tensor self, Tensor vec)
   self: grad.ger(vec)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -473,11 +473,13 @@
   self, other: mul_backward(grad, self, other)
 
 - name: mul(Tensor self, Scalar other)
+  self: mul_scalar_backward(grad, self, other)
 
 - name: sparse_mul(Tensor self, Tensor other)
   self, other: sparse_mul_backward(grad, self, other)
 
 - name: sparse_mul(Tensor self, Scalar other)
+  self: sparse_mul_scalar_backward(grad, self, other)
 
 - name: mv(Tensor self, Tensor vec)
   self: grad.ger(vec)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -474,7 +474,10 @@
   other: grad * self
 
 - name: mul(Tensor self, Scalar other)
+
+- name: s_native_sparse_dense_mul(Tensor self, Tensor other)
   self: grad * other
+  other: grad * self
 
 - name: mv(Tensor self, Tensor vec)
   self: grad.ger(vec)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -22,10 +22,9 @@ SKIP_PYTHON_BINDINGS = [
     '.*_forward_out', '_unsafe_view', 'tensor',
     'sparse_coo_tensor', 'th_sparse_coo_tensor', 'native_sparse_coo_tensor',
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
-    '_sparse_add.*', '_sparse_div.*', '_sparse_mul.*', '_sparse_sub.*',
-    'index',
-    '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
-    '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',
+    '_sparse_add.*', '_sparse_div.*', '_sparse_mul.*', '_sparse_dense_mul.*',
+    '_sparse_sub.*', 'index', '_indexCopy_', 'max_values', 'min_values', 'argmax',
+    'argmin', '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',
     'arange.*', 'range.*', '_gesv.*', '_getri.*', 'slice',
     '_local_scalar', '_local_scalar_dense',
     'max_pool1d', 'max_pool2d', 'max_pool3d'

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -36,6 +36,7 @@ SKIP_PYTHON_BINDINGS_SIGNATURES = [
     'add(Tensor, Scalar, Scalar)', 'add_(Tensor, Scalar, Scalar)',
     'sub(Tensor, Scalar, Scalar)', 'sub_(Tensor, Scalar, Scalar)',
     'mul(Tensor, Scalar)', 'mul_(Tensor, Scalar)',
+    'sparse_mul(Tensor, Scalar)', 'sparse_mul_(Tensor, Scalar)',
     'div(Tensor, Scalar)', 'div_(Tensor, Scalar)',
 ]
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1961,6 +1961,18 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
   return grad / (self + 1);
 }
 
+std::tuple<Tensor, Tensor> mul_backward(const Tensor& grad, const Tensor self, const Tensor other) {
+  if (self.is_sparse()) {
+    AT_ERROR(
+      "mul(Sparse, Dense) is made to be non-differentiable since ",
+      "local gradient of non-nnz at the sparse tensor are all 1s ",
+      "and it makes the tensor dense. Use a sparse_mul() operation ",
+      "which preserves sparsity of gradients, or report a bug if you "
+      "think this is an error.");
+  }
+  return std::tuple<Tensor, Tensor>(grad * other, grad * self);
+}
+
 } // anonymous namespace
 
 ${autograd_function_definitions}

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1352,6 +1352,26 @@ mul_(value)
 In-place version of :meth:`~Tensor.mul`
 """)
 
+add_docstr_all('sparse_mul',
+               r"""
+sparse_mul(input, value) -> SparseTensor
+
+Pointwise multiplication between a sparse tensor :attr:`input` and :attr:`value`,
+and return a sparse tensor. Shape of :attr:`input` and :attr:`value` must match.
+This op supports autograd with sparse gradient, as opposed to :meth`~Tensor.mul`.
+
+Args:
+    input (SparseTensor): a sparse Tensor
+    value (Number...): a real or integer, a dense tesnor, or a sparse tensor
+""")
+
+add_docstr_all('sparse_mul_',
+               r"""
+sparse_mul_(input, value)
+
+In-place version of :meth:`~Tensor.sparse_mul`
+""")
+
 add_docstr_all('multinomial',
                r"""
 multinomial(num_samples, replacement=False, *, generator=None) -> Tensor

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -42,6 +42,7 @@ static bool should_allow_numbers_as_tensors(const std::string& name) {
     "add", "add_", "add_out",
     "div", "div_", "div_out",
     "mul", "mul_", "mul_out",
+    "sparse_mul", "sparse_mul_",
     "sub", "sub_", "sub_out",
   };
   return allowed.find(name) != allowed.end();


### PR DESCRIPTION
- fixes https://github.com/pytorch/pytorch/issues/4456 and mul_ / mul(S, D) at #8853
- add `mul_ / mul(S, D) -> S` without autograd support because of dense local gradient during backward
- add `sparse_mul_ / sparse_mul(S ,D) -> S`,  `sparse_mul_ / sparse_mul(S ,S) -> S` and `sparse_mul_ / sparse_mul(S, alpha) -> S` with autograd support. Gradient of non-nnz elements will be zeroed out during backward