### PR TITLE
Delete flag from THTensor.

### DIFF
--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -43,17 +43,14 @@ void THTensor_free(THTensor *self)
   if(!self)
     return;
 
-  if(self->flag & TH_TENSOR_REFCOUNTED)
+  if(--self->refcount == 0)
   {
-    if(--self->refcount == 0)
-    {
-      THFree(self->size);
-      THFree(self->stride);
-      if(self->storage)
-        THStorage_free(self->storage);
-      self->refcount.~atomic<int>();
-      THFree(self);
-    }
+    THFree(self->size);
+    THFree(self->stride);
+    if(self->storage)
+      THStorage_free(self->storage);
+    self->refcount.~atomic<int>();
+    THFree(self);
   }
 }
 

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -21,8 +21,6 @@ typedef struct THTensor
     ptrdiff_t storageOffset;
     std::atomic<int> refcount;
 
-    char flag;
-
     template <typename T>
     inline T * data() const {
       return storage->data<T>() + storageOffset;

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -61,16 +61,6 @@ real *THTensor_(data)(const THTensor *self)
     return NULL;
 }
 
-void THTensor_(setFlag)(THTensor *self, const char flag)
-{
-  self->flag |= flag;
-}
-
-void THTensor_(clearFlag)(THTensor *self, const char flag)
-{
-  self->flag &= ~flag;
-}
-
 /**** creation methods ****/
 
 static void THTensor_(rawInit)(THTensor *self);
@@ -697,8 +687,7 @@ ptrdiff_t THTensor_(nElement)(const THTensor *self)
 
 void THTensor_(retain)(THTensor *self)
 {
-  if(self->flag & TH_TENSOR_REFCOUNTED)
-    ++self->refcount;
+  ++self->refcount;
 }
 
 void THTensor_(free)(THTensor *self)
@@ -726,7 +715,6 @@ static void THTensor_(rawInit)(THTensor *self)
   self->size[0] = 0;
   self->stride[0] = 1;
   self->dim_ = 1;
-  self->flag = TH_TENSOR_REFCOUNTED;
 }
 
 void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -4,8 +4,6 @@
 
 /* a la lua? dim, storageoffset, ...  et les methodes ? */
 
-#define TH_TENSOR_REFCOUNTED 1
-
 // Struct definition moved to THTensor.hpp
 typedef struct THTensor THTensor;
 
@@ -32,9 +30,6 @@ TH_API int64_t THTensor_(stride)(const THTensor *self, int dim);
 TH_API THLongStorage *THTensor_(newSizeOf)(THTensor *self);
 TH_API THLongStorage *THTensor_(newStrideOf)(THTensor *self);
 TH_API real *THTensor_(data)(const THTensor *self);
-
-TH_API void THTensor_(setFlag)(THTensor *self, const char flag);
-TH_API void THTensor_(clearFlag)(THTensor *self, const char flag);
 
 
 /**** creation methods ****/

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -298,8 +298,7 @@ ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self) {
 }
 
 void THCTensor_retain(THCState *state, THCTensor *self) {
-  if(self->flag & TH_TENSOR_REFCOUNTED)
-    self->refcount++;
+  self->refcount++;
 }
 
 
@@ -307,17 +306,14 @@ void THCTensor_free(THCState *state, THCTensor *self) {
   if(!self)
     return;
 
-  if(self->flag & TH_TENSOR_REFCOUNTED)
+  if(--self->refcount == 0)
   {
-    if(--self->refcount == 0)
-    {
-      THFree(self->size);
-      THFree(self->stride);
-      if(self->storage)
-        THCStorage_free(state, self->storage);
-      self->refcount.~atomic<int>();
-      THFree(self);
-    }
+    THFree(self->size);
+    THFree(self->stride);
+    if(self->storage)
+      THCStorage_free(state, self->storage);
+    self->refcount.~atomic<int>();
+    THFree(self);
   }
 }
 

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -20,8 +20,6 @@ typedef struct THCTensor
     ptrdiff_t storageOffset;
     std::atomic<int> refcount;
 
-    char flag;
-
     template <typename T>
     inline T * data() const {
       return storage->data<T>() + storageOffset;

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -622,7 +622,6 @@ static void THCTensor_(rawInit)(THCState *state, THCTensor *self)
   self->size[0] = 0;
   self->stride[0] = 1;
   self->dim_ = 1;
-  self->flag = TH_TENSOR_REFCOUNTED;
 }
 
 void THCTensor_(setStorageNd)(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -53,16 +53,6 @@ real *THCTensor_(data)(THCState *state, const THCTensor *self)
     return NULL;
 }
 
-void THCTensor_(setFlag)(THCState *state, THCTensor *self, const char flag)
-{
-  self->flag |= flag;
-}
-
-void THCTensor_(clearFlag)(THCState *state, THCTensor *self, const char flag)
-{
-  self->flag &= ~flag;
-}
-
 /**** creation methods ****/
 
 static void THCTensor_(rawInit)(THCState *state, THCTensor *self);

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -2,8 +2,6 @@
 #define THC_GENERIC_FILE "generic/THCTensor.h"
 #else
 
-#define TH_TENSOR_REFCOUNTED 1
-
 typedef struct THCTensor THCTensor;
 
 // These used to be distinct types; for some measure of backwards compatibility and documentation

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -826,8 +826,7 @@ ptrdiff_t THDTensor_(nElement)(const THDTensor *self) {
 }
 
 void THDTensor_(retain)(THDTensor *tensor) {
-  if (tensor->flag & TH_TENSOR_REFCOUNTED)
-    tensor->refcount++;
+  tensor->refcount++;
 }
 
 void THDTensor_(free)(THDTensor *tensor) {

--- a/torch/lib/THD/master_worker/master/generic/THDTensorMeta.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensorMeta.cpp
@@ -141,7 +141,6 @@ static THDTensor *THDTensor_(_alloc)() {
   new_tensor->storageOffset = 0;
 
   new_tensor->refcount = 1;
-  new_tensor->flag = TH_TENSOR_REFCOUNTED;
 
   new_tensor->tensor_id = THDState::s_nextId++;
   return new_tensor;


### PR DESCRIPTION
It was only used to toggle refcounting, but we ALWAYS
refcount tensors.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

