### PR TITLE
Deduplicate THTensor and THCTensor.

### DIFF
--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -4,6 +4,8 @@
 
 /* a la lua? dim, storageoffset, ...  et les methodes ? */
 
+#define THCTensor THTensor
+
 // Struct definition moved to THTensor.hpp
 typedef struct THTensor THTensor;
 

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -48,16 +48,7 @@ THCStorage* THCStorage_newWithAllocator(THCState *state,
 
 void THCStorage_free(THCState *state, THCStorage *storage)
 {
-  if (storage->flag & TH_STORAGE_REFCOUNTED) {
-    if (--storage->refcount == 0) {
-      if (storage->finalizer) {
-        (*storage->finalizer)();
-      }
-      storage->finalizer.~unique_ptr<THFinalizer>();
-      storage->data_ptr.~DataPtr();
-      THStorage_weakFree(storage);
-    }
-  }
+  THStorage_free(storage);
 }
 
 void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -303,18 +303,7 @@ void THCTensor_retain(THCState *state, THCTensor *self) {
 
 
 void THCTensor_free(THCState *state, THCTensor *self) {
-  if(!self)
-    return;
-
-  if(--self->refcount == 0)
-  {
-    THFree(self->size);
-    THFree(self->stride);
-    if(self->storage)
-      THCStorage_free(state, self->storage);
-    self->refcount.~atomic<int>();
-    THFree(self);
-  }
+  THTensor_free(self);
 }
 
 int THCTensor_getDevice(THCState* state, const THCTensor* tensor) {

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -10,52 +10,6 @@
 #include <atomic>
 #include <ATen/ATen.h>
 
-typedef struct THCTensor
-{
-    int64_t *size;
-    int64_t *stride;
-    int64_t dim_;
-
-    THCStorage *storage;
-    ptrdiff_t storageOffset;
-    std::atomic<int> refcount;
-
-    template <typename T>
-    inline T * data() const {
-      return storage->data<T>() + storageOffset;
-    }
-
-    template <typename T>
-    inline T * unsafe_data() const {
-      return storage->unsafe_data<T>() + storageOffset;
-    }
-
-    // [NOTE: _dim() vs dim()]
-    // _dim() returns the "old" TH dimension view where no dimensions represents an empty tensor.
-    // dim()  returns the ATen view of the dimensionality, i.e. 0-sized dimensions are supported.
-    inline int64_t _dim() const {
-      return is_empty() ? 0: dim_;
-    }
-
-    inline int64_t dim() const {
-      return dim_;
-    }
-
-    // represents that numel() == 0.
-    inline bool is_empty() const {
-      for (int64_t i = 0; i < dim_; ++i) {
-        if (size[i] == 0) {
-          return true;  
-        }
-      }
-      return false;
-    }
-
-    inline at::IntList sizes() {
-      return at::IntList(size, dim_);
-    }
-} THCTensor;
-
 // See [NOTE: _dim() vs dim()]; _nDimension corresponds to _dim(), nDimension corresponds to dim().
 THC_API int THCTensor_nDimension(THCState *state, const THCTensor *self);
 THC_API int THCTensor__nDimension(THCState *state, const THCTensor *self);

--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -34,10 +34,4 @@ std::vector <THCStream*> THPUtils_PySequence_to_THCStreamList(PyObject *obj) {
   return streams;
 }
 
-template<>
-void THPPointer<THCTensor>::free() {
-  if (ptr)
-    THCTensor_free(LIBRARY_STATE ptr);
-}
-
 #endif

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -230,6 +230,7 @@ bool maybeThrowBackCompatKeepdimWarn(char *func) {
 
 template<>
 void THPPointer<THTensor>::free() {
-  if (ptr)
+  if (ptr) {
     THTensor_free(LIBRARY_STATE ptr);
+  }
 }


### PR DESCRIPTION
Stacked on #9494

```
commit fc24fae89b66a4d21dc3d0c78e29379d9db2e571 (HEAD -> pytorch-tmp, ezyang/pr/merge-thtensor-thctensor)
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Jul 17 08:17:35 2018 -0700

    Deduplicate THTensor and THCTensor.
    
    This is enabled by the allocator patch; previously we could not
    deduplicate THStorage_free/THCStorage_free; now we can.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```