### PR TITLE
Reenable multiprocessing preserve sharing tests on ASAN.

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -249,8 +249,6 @@ class TestMultiprocessing(TestCase):
         self._test_sharing(repeat=TEST_REPEATS)
 
     @unittest.skipIf(platform == 'darwin', "file descriptor strategy is not supported on macOS")
-    @unittest.skipIf(TEST_WITH_ASAN,
-                     "test_fd_preserve_sharing is known buggy, see https://github.com/pytorch/pytorch/issues/5311")
     def test_fd_preserve_sharing(self):
         self._test_preserve_sharing(repeat=TEST_REPEATS)
 
@@ -264,8 +262,6 @@ class TestMultiprocessing(TestCase):
         with fs_sharing():
             self._test_sharing(repeat=TEST_REPEATS)
 
-    @unittest.skipIf(TEST_WITH_ASAN,
-                     "test_fs_preserve_sharing is known buggy, see https://github.com/pytorch/pytorch/issues/5311")
     def test_fs_preserve_sharing(self):
         with fs_sharing():
             self._test_preserve_sharing(repeat=TEST_REPEATS)


### PR DESCRIPTION
This issue was fixed in 976f9253a5425918eda7cf865b097cf42b5da8d7

Fixes #5311.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

