### PR TITLE
Prepare to stop using attributes in the JIT

### DIFF
--- a/test/expect/TestJit.test_alexnet.expect
+++ b/test/expect/TestJit.test_alexnet.expect
@@ -28,22 +28,23 @@ graph(%0 : Double(1, 3, 224, 224)
   %29 : Double(1, 256, 13, 13) = aten::_convolution[stride=[1, 1], padding=[1, 1], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%28, %9, %10), scope: AlexNet/Sequential[features]/Conv2d[10]
   %30 : Double(1, 256, 13, 13) = aten::threshold[threshold={0}, value={0}](%29), scope: AlexNet/Sequential[features]/ReLU[11]
   %31 : Double(1, 256, 6, 6), %32 : Long(1, 256, 6, 6) = aten::max_pool2d_with_indices[kernel_size=[3, 3], stride=[2, 2], padding=[0, 0], dilation=[1, 1], ceil_mode=0](%30), scope: AlexNet/Sequential[features]/MaxPool2d[12]
-  %33 : Long() = aten::size[dim=0](%31), scope: AlexNet
-  %34 : Long() = prim::Constant[value={9216}](), scope: AlexNet
-  %35 : Dynamic = aten::stack[dim=0](%33, %34), scope: AlexNet
-  %36 : Double(1, 9216) = aten::view(%31, %35), scope: AlexNet
-  %37 : Double(1, 9216) = ^Dropout(0.5, True, False)(%36), scope: AlexNet/Sequential[classifier]/Dropout[0]
-  %38 : Double(9216!, 4096!) = aten::t(%11), scope: AlexNet/Sequential[classifier]/Linear[1]
-  %39 : Double(1, 4096) = aten::expand[size=[1, 4096], implicit=1](%12), scope: AlexNet/Sequential[classifier]/Linear[1]
-  %40 : Double(1, 4096) = aten::addmm[beta={1}, alpha={1}](%39, %37, %38), scope: AlexNet/Sequential[classifier]/Linear[1]
-  %41 : Double(1, 4096) = aten::threshold[threshold={0}, value={0}](%40), scope: AlexNet/Sequential[classifier]/ReLU[2]
-  %42 : Double(1, 4096) = ^Dropout(0.5, True, False)(%41), scope: AlexNet/Sequential[classifier]/Dropout[3]
-  %43 : Double(4096!, 4096!) = aten::t(%13), scope: AlexNet/Sequential[classifier]/Linear[4]
-  %44 : Double(1, 4096) = aten::expand[size=[1, 4096], implicit=1](%14), scope: AlexNet/Sequential[classifier]/Linear[4]
-  %45 : Double(1, 4096) = aten::addmm[beta={1}, alpha={1}](%44, %42, %43), scope: AlexNet/Sequential[classifier]/Linear[4]
-  %46 : Double(1, 4096) = aten::threshold[threshold={0}, value={0}](%45), scope: AlexNet/Sequential[classifier]/ReLU[5]
-  %47 : Double(4096!, 1000!) = aten::t(%15), scope: AlexNet/Sequential[classifier]/Linear[6]
-  %48 : Double(1, 1000) = aten::expand[size=[1, 1000], implicit=1](%16), scope: AlexNet/Sequential[classifier]/Linear[6]
-  %49 : Double(1, 1000) = aten::addmm[beta={1}, alpha={1}](%48, %46, %47), scope: AlexNet/Sequential[classifier]/Linear[6]
-  return (%49);
+  %33 : Long() = prim::Constant[value={0}](), scope: AlexNet
+  %34 : Long() = aten::size(%31, %33), scope: AlexNet
+  %35 : Long() = prim::Constant[value={9216}](), scope: AlexNet
+  %36 : Dynamic = aten::stack[dim=0](%34, %35), scope: AlexNet
+  %37 : Double(1, 9216) = aten::view(%31, %36), scope: AlexNet
+  %38 : Double(1, 9216) = ^Dropout(0.5, True, False)(%37), scope: AlexNet/Sequential[classifier]/Dropout[0]
+  %39 : Double(9216!, 4096!) = aten::t(%11), scope: AlexNet/Sequential[classifier]/Linear[1]
+  %40 : Double(1, 4096) = aten::expand[size=[1, 4096], implicit=1](%12), scope: AlexNet/Sequential[classifier]/Linear[1]
+  %41 : Double(1, 4096) = aten::addmm[beta={1}, alpha={1}](%40, %38, %39), scope: AlexNet/Sequential[classifier]/Linear[1]
+  %42 : Double(1, 4096) = aten::threshold[threshold={0}, value={0}](%41), scope: AlexNet/Sequential[classifier]/ReLU[2]
+  %43 : Double(1, 4096) = ^Dropout(0.5, True, False)(%42), scope: AlexNet/Sequential[classifier]/Dropout[3]
+  %44 : Double(4096!, 4096!) = aten::t(%13), scope: AlexNet/Sequential[classifier]/Linear[4]
+  %45 : Double(1, 4096) = aten::expand[size=[1, 4096], implicit=1](%14), scope: AlexNet/Sequential[classifier]/Linear[4]
+  %46 : Double(1, 4096) = aten::addmm[beta={1}, alpha={1}](%45, %43, %44), scope: AlexNet/Sequential[classifier]/Linear[4]
+  %47 : Double(1, 4096) = aten::threshold[threshold={0}, value={0}](%46), scope: AlexNet/Sequential[classifier]/ReLU[5]
+  %48 : Double(4096!, 1000!) = aten::t(%15), scope: AlexNet/Sequential[classifier]/Linear[6]
+  %49 : Double(1, 1000) = aten::expand[size=[1, 1000], implicit=1](%16), scope: AlexNet/Sequential[classifier]/Linear[6]
+  %50 : Double(1, 1000) = aten::addmm[beta={1}, alpha={1}](%49, %47, %48), scope: AlexNet/Sequential[classifier]/Linear[6]
+  return (%50);
 }

--- a/test/expect/TestJit.test_trace_size.expect
+++ b/test/expect/TestJit.test_trace_size.expect
@@ -1,9 +1,11 @@
 graph(%0 : Double(5, 2, 4)) {
-  %1 : Long() = aten::size[dim=1](%0)
-  %2 : Long() = aten::mul[other={2}](%1)
-  %3 : Long() = aten::size[dim=0](%0)
-  %4 : Long() = prim::Constant[value={2}]()
-  %5 : Dynamic = aten::stack[dim=0](%2, %3, %4)
-  %6 : Double(4, 5, 2) = aten::view(%0, %5)
-  return (%6);
+  %1 : Long() = prim::Constant[value={1}]()
+  %2 : Long() = aten::size(%0, %1)
+  %3 : Long() = aten::mul[other={2}](%2)
+  %4 : Long() = prim::Constant[value={0}]()
+  %5 : Long() = aten::size(%0, %4)
+  %6 : Long() = prim::Constant[value={2}]()
+  %7 : Dynamic = aten::stack[dim=0](%3, %5, %6)
+  %8 : Double(4, 5, 2) = aten::view(%0, %7)
+  return (%8);
 }

--- a/test/expect/TestJit.test_trace_size_with_grad.expect
+++ b/test/expect/TestJit.test_trace_size_with_grad.expect
@@ -1,9 +1,11 @@
 graph(%0 : Double(5, 2, 4)) {
-  %1 : Long() = aten::size[dim=1](%0)
-  %2 : Long() = aten::mul[other={2}](%1)
-  %3 : Long() = aten::size[dim=0](%0)
-  %4 : Long() = prim::Constant[value={2}]()
-  %5 : Dynamic = aten::stack[dim=0](%2, %3, %4)
-  %6 : Double(4, 5, 2) = aten::view(%0, %5)
-  return (%6);
+  %1 : Long() = prim::Constant[value={1}]()
+  %2 : Long() = aten::size(%0, %1)
+  %3 : Long() = aten::mul[other={2}](%2)
+  %4 : Long() = prim::Constant[value={0}]()
+  %5 : Long() = aten::size(%0, %4)
+  %6 : Long() = prim::Constant[value={2}]()
+  %7 : Dynamic = aten::stack[dim=0](%3, %5, %6)
+  %8 : Double(4, 5, 2) = aten::view(%0, %7)
+  return (%8);
 }

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -127,6 +127,7 @@ const auto options = TensorOptions()
 auto result = torch::${name}(${args}, options);
 """)
 
+# TODO (apaszke): remove the attributed codepath once we remove them
 CONSTRUCTOR = CodeTemplate("""\
 [](Node *node) {
   ${kw_assignments}

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -11,8 +11,10 @@ namespace torch { namespace jit {
 using value_map = std::unordered_map<Value*, Value*>;
 using value_set = std::unordered_set<Value*>;
 
-bool hasOneValuedAttribute(Node *n, torch::jit::Symbol name) {
-  return n->hasAttribute(name) && at::Scalar(n->t(name)).toDouble() == 1.0;
+bool hasOneValuedInput(Node *n, torch::jit::Symbol name) {
+  auto maybe_t = n->get<at::Tensor>(name);
+  if (!maybe_t) return false;
+  return at::Scalar(*maybe_t).toDouble() == 1.0;
 }
 
 bool isDifferentiable(Node * n) {
@@ -28,7 +30,7 @@ bool isDifferentiable(Node * n) {
   if (n->kind() == aten::addmm) {
     if (n->inputs().size() > 3)
       return false;
-    if (!hasOneValuedAttribute(n, attr::alpha) || !hasOneValuedAttribute(n, attr::beta))
+    if (!hasOneValuedInput(n, attr::alpha) || !hasOneValuedInput(n, attr::beta))
       return false;
   }
   if (n->kind() == aten::type_as && !n->inputs().at(1)->isTensor()) {
@@ -65,7 +67,8 @@ bool outputRequiresGrad(Node* node, std::function<bool(Value*)> requires_grad) {
     case aten::eq:
       return false;
     case aten::type_as:
-    //type_as has two inputs, the second of which (setting type) might require grad, but it still won't affect the output of type_as requiring grad.
+      // type_as has two inputs, the second of which (setting type) might require grad,
+      // but it still won't affect the output of type_as requiring grad.
       return requires_grad(node->inputs().at(0));
     default:
       return std::any_of(node->inputs().begin(), node->inputs().end(), requires_grad);
@@ -80,23 +83,30 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
     auto outputs = fmap<SymbolicVariable>(node->outputs());
     switch(node->kind()) {
       case aten::add:
-        // o = a - alpha*other
-        if(inputs.size() == 1)
+        // TODO (apaszke): remove formulas for attributed nodes once they are removed
+        // o = self + alpha*other
+        if(inputs.size() == 1) {
           return { grads.at(0) };
-          // o = a + alpha*b
-        return {grads.at(0), grads.at(0) * at::Scalar(node->t(attr::alpha)) };
+        } else if (node->hasAttribute(attr::alpha)) {
+          return {grads.at(0), grads.at(0) * at::Scalar(node->t(attr::alpha))};
+        } else {
+          return {grads.at(0), nullptr, grads.at(0) * node->getValue(attr::alpha)};
+        }
       case aten::sub:
-        // o = a - alpha*other
-        if(inputs.size() == 1)
+        // o = self - alpha*other
+        if(inputs.size() == 1) {
           return {grads.at(0)};
-        // o = a - alpha*b
-        return {grads.at(0), -grads.at(0) * at::Scalar(node->t(attr::alpha))};
+        } else if (node->hasAttribute(attr::alpha)) {
+          return {grads.at(0), -grads.at(0) * at::Scalar(node->t(attr::alpha))};
+        } else {
+          return {grads.at(0), nullptr, grads.at(0) * node->getValue(attr::alpha)};
+        }
       case aten::mul:
-        // o = a * other
+        // o = self * other
         if(inputs.size() == 1)
           return {grads.at(0) * at::Scalar(node->t(attr::other))};
-        // o = a * b
-        return {grads.at(0) * inputs.at(1), grads.at(0) * inputs.at(0)};
+        else
+          return {grads.at(0) * inputs.at(1), grads.at(0) * inputs.at(0)};
       case prim::Constant:
         return {};
       case aten::sigmoid:
@@ -109,17 +119,18 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         return {grads.at(0) * (outputs.at(0))};
       case aten::chunk:
       case aten::split:
-        return {SymbolicVariable::cat(grads, node->i(attr::dim))};
+        return {SymbolicVariable::cat(grads, node->getValue(attr::dim))};
       case aten::t:
         return {grads.at(0).t()};
       case aten::neg:
         return {-grads.at(0)};
       case aten::view:
+        // TODO: if sizes are not available statically, add an operator that reutrns them as a tuple
         return {grads.at(0).view(inputs.at(0).sizes())};
       case aten::type_as:
         return {grads.at(0).type_as(inputs.at(0))};
       case aten::unsqueeze:
-        return {grads.at(0).squeeze(node->i(attr::dim))};
+        return {grads.at(0).squeeze(node->getValue(attr::dim))};
       case aten::mm: {
         SymbolicVariable dmat1, dmat2;
         if (auto type = inputs.at(0).value()->type()->cast<TensorType>()) {
@@ -148,7 +159,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         const auto& input_sizes = inputs.at(0).sizes();
         if (input_sizes.size() == 0)
           return {grads.at(0).sum()};
-        auto grad_sizes = node->is(attr::size);
+        auto grad_sizes = node->get<std::vector<int64_t>>(attr::size).value();
         auto grad = grads.at(0);
         while (grad_sizes.size() > input_sizes.size()) {
           grad = grad.sum(0, false);
@@ -163,6 +174,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       }
       case aten::squeeze: {
         const auto& sizes = inputs.at(0).sizes();
+        // TODO (apaszke): need to select the right overload here
         if (node->hasAttribute(attr::dim)) {
           int dim = node->i(attr::dim);
           return {sizes.at(dim) > 1 ? grads.at(0) : grads.at(0).unsqueeze(dim)};
@@ -179,11 +191,12 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         }
       }
       case aten::cat: {
-        int dim = node->i(attr::dim);
+        int dim = node->get<int64_t>(attr::dim).value();
         const auto& first_sizes = inputs.at(0).sizes();
         const auto has_first_sizes = [&first_sizes](SymbolicVariable var) {
           return var.sizes() == first_sizes;
         };
+        // TODO (apaszke): This will need an adjustment for the dim argument
         // NB: this is a specialization for the common case where all inputs are
         // of equal sizes. We can use a single split operation to handle that.
         if (std::all_of(inputs.begin(), inputs.end(), has_first_sizes)) {
@@ -339,6 +352,8 @@ static ReverseDetails addReverseInline(Gradient& grad_desc,
     value_list grad_inputs = linearGradientForNode(node, fmap(node->outputs(), get_grad));
     JIT_ASSERT(grad_inputs.size() == node->inputs().size());
     for (size_t i = 0, num_inputs = grad_inputs.size(); i < num_inputs; ++i) {
+      if (!requires_grad(inputs[i])) continue;
+      JIT_ASSERT(grad_inputs[i]);
       set_grad(inputs[i], grad_inputs[i]);
     }
   }

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ATen/ATen.h"
-#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/type.h"
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -170,7 +170,7 @@ size_t ${tensor}_dimIndex${d} = ${tensor}_linearIndex ${mod_sizes};
 ${tensor}_offset += ${tensor}_dimIndex${d} ${times_stride};
 )");
 
-void emitIndexingFor(std::ostream & out, const std::string & tensor, int ndim, bool last_is_cont) {
+static void emitIndexingFor(std::ostream & out, const std::string & tensor, int ndim, bool last_is_cont) {
   TemplateEnv env;
   env.s("tensor",tensor);
   out << format("IndexType ${tensor}_offset = 0;\n",env);
@@ -187,20 +187,11 @@ void emitIndexingFor(std::ostream & out, const std::string & tensor, int ndim, b
   }
 }
 
-std::string valueName(Value * n) {
+static std::string valueName(Value * n) {
   return "n" + std::to_string(n->unique());
 }
 
-std::string valueNameOrConstant(Value * n) {
-  if (auto value = constant_as<double>(n)) {
-    std::ostringstream s;
-    s << std::scientific << *value;
-    return s.str();
-  }
-  return "n" + std::to_string(n->unique());
-}
-
- std::string scalarValue(const at::Tensor & t) {
+static std::string scalarValue(const at::Tensor & t) {
   auto s =  at::Scalar(t);
   if (s.isIntegral()){
     return std::to_string(s.toLong());
@@ -211,7 +202,7 @@ std::string valueNameOrConstant(Value * n) {
   }
 }
 
-const char * scalarTypeName(at::ScalarType type) {
+static const char * scalarTypeName(at::ScalarType type) {
   if (type == at::ScalarType::Half) {
     return "half";
   }
@@ -301,7 +292,7 @@ std::string encodeRHS(Node * n) {
   TemplateEnv env;
   size_t i = 0;
   for(auto in : n->inputs()) {
-    env.s(std::to_string(i++), valueNameOrConstant(in));
+    env.s(std::to_string(i++), valueName(in));
   }
   // TODO (apaszke): remove once we get rid of attributes
   // ops like div have a / b or a / 2 with the constant having the attribute other

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/python_arg_flatten.h"
 #include "torch/csrc/jit/export.h"
 #include "torch/csrc/jit/argument_spec.h"
+#include "torch/csrc/jit/passes/remove_expands.h"
 #include "torch/csrc/jit/passes/graph_fuser.h"
 #include "torch/csrc/jit/passes/onnx.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
@@ -68,6 +69,7 @@ void initJITBindings(PyObject *module) {
      auto tensor_inputs = createVariableTensorList(inputs);
      PropagateInputShapes(graph, ArgumentSpec(with_grad, tensor_inputs));
    })
+   .def("_jit_pass_remove_expands", RemoveExpands)
    .def("_jit_pass_erase_number_types", EraseNumberTypes)
    .def("_jit_pass_loop_unrolling", UnrollLoops)
    .def("_jit_run_cpp_tests", [] {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -578,6 +578,13 @@ Value* Graph::insertConstant(T value) {
   return n->output();
 }
 
+// This is necessary, because integral literals are of type int by default,
+// and will dispatch to this function.
+template<>
+Value * Graph::insertConstant(int value) {
+  return insertConstant(static_cast<int64_t>(value));
+}
+
 template Value* Graph::insertConstant(int64_t value);
 template Value* Graph::insertConstant(double value);
 template Value* Graph::insertConstant(at::Tensor value);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -596,22 +596,10 @@ template<>
 double getattr<double>(Node *n, Symbol name) { return n->f(name); }
 
 template<>
-std::string getattr<std::string>(Node *n, Symbol name) { return n->s(name); }
-
-template<>
 at::Tensor getattr<at::Tensor>(Node *n, Symbol name) { return n->t(name); }
 
 template<>
 std::vector<int64_t> getattr<std::vector<int64_t>>(Node *n, Symbol name) { return n->is(name); }
-
-template<>
-std::vector<double> getattr<std::vector<double>>(Node *n, Symbol name) { return n->fs(name); }
-
-template<>
-std::vector<std::string> getattr<std::vector<std::string>>(Node *n, Symbol name) { return n->ss(name); }
-
-template<>
-std::vector<at::Tensor> getattr<std::vector<at::Tensor>>(Node *n, Symbol name) { return n->ts(name); }
 
 } // anonymous namespace
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -6,6 +6,8 @@
 #include "torch/csrc/jit/interned_strings.h"
 #include "torch/csrc/jit/resource_guard.h"
 #include "torch/csrc/jit/source_location.h"
+#include "torch/csrc/jit/function_schema.h"
+#include "torch/csrc/jit/ivalue.h"
 #include "torch/csrc/jit/type.h"
 
 #include "torch/csrc/utils/disallow_copy.h"
@@ -287,6 +289,11 @@ private:
   std::shared_ptr<SourceLocation> source_location_;
   size_t stage_;
   Scope* scope_;
+  // Assumes FunctionSchemas are persistent, so we don't manage their lifetime.
+  // This field is effective a cache that's populated on attribute lookups and
+  // invalidated every time we perform an operation that could potentially change
+  // the schema.
+  const FunctionSchema* schema_;
 protected:
   Node(Graph * graph_, NodeKind kind_); //defined after graph
 public:
@@ -370,7 +377,7 @@ public:
       outputs()[i]->replaceAllUsesWith(n->outputs()[i]);
     }
   }
-  // lots of things like chunk have a single input or singel output, so we have a
+  // lots of things like chunk have a single input or single output, so we have a
   // helper to make accessing it easier
   Value * input() {
     JIT_ASSERT(inputs_.size() == 1);
@@ -391,6 +398,11 @@ public:
   const Value * input(size_t i) const {
     return inputs_.at(i);
   }
+
+  template<typename T>
+  at::optional<T> get(Symbol name);
+
+  at::optional<IValue> get(Symbol name);
 
   // Graphs
 
@@ -414,6 +426,7 @@ public:
   // Result:  %3 = f(%1, %2, %4)
   Value* addInput(Value * node) {
     JIT_ASSERT(graph_ == node->owningGraph());
+    schema_ = nullptr;
     node->uses_.emplace_back(this, inputs_.size());
     inputs_.push_back(node);
     return node;
@@ -423,6 +436,7 @@ public:
   // arguments. Returns the added node for ease of chaining.
   Value* insertInput(size_t i, Value* node) {
     JIT_ASSERT(graph_ == node->owningGraph());
+    schema_ = nullptr;
     // First we update the offsets for all existing inputs that will reside
     // after the one we're inserting. Concretely, these are the inputs at
     // indices [i, # input). Since we're inserting one input before all of
@@ -447,6 +461,7 @@ public:
   // Result:  %3 = f(%1, %4)
   Value * replaceInput(size_t i, Value * newValue) {
     JIT_ASSERT(newValue->owningGraph() == graph_);
+    schema_ = nullptr;
     Value * old = dropInput(i);
     inputs_[i] = newValue;
     newValue->uses_.emplace_back(this, i);
@@ -462,6 +477,7 @@ public:
   void replaceInputWith(Value * from, Value * to) {
     JIT_ASSERT(from->owningGraph() == graph_);
     JIT_ASSERT(to->owningGraph() == graph_);
+    schema_ = nullptr;
     size_t i = 0;
     for(auto input : inputs()) {
       if(input == from)
@@ -472,10 +488,12 @@ public:
 
   Value* addOutput() {
     outputs_.push_back(new Value(this, outputs_.size()));
+    schema_ = nullptr;
     return outputs_.back();
   }
 
   Value* insertOutput(size_t i) {
+    schema_ = nullptr;
     outputs_.insert(outputs_.begin() + i, new Value(this, i));
     for (size_t itr = i + 1; itr < outputs_.size(); ++itr) {
       outputs_[itr]->setOffset(outputs_[itr]->offset() + 1);
@@ -585,6 +603,7 @@ public:
   // Execute: %3.removeInput(1)
   // Result: %3 = f(%1)
   void removeInput(size_t i) {
+    schema_ = nullptr;
     dropInput(i);
     // everything after this input shifts left,
     // so we need to update their use offsets to match
@@ -601,6 +620,7 @@ public:
   // Execute: %3.removeAllInputs()
   // Result: %3 = f()
   void removeAllInputs() {
+    schema_ = nullptr;
     for(size_t i = 0; i < inputs().size(); ++i)
       dropInput(i);
     inputs_.clear();
@@ -643,6 +663,8 @@ public:
 
   virtual ~Node() {}
 private:
+  at::optional<std::pair<Value*, const Argument&>> findConstInput(Symbol name);
+  void findSchema();
   // Lookup iterator in use list of _input i_ that corresponds to its use of _this_
   use_list::iterator findUseForInput(size_t i) {
     auto & input_uses = inputs_[i]->uses_;
@@ -1142,13 +1164,15 @@ inline Node::Node(Graph * graph_, NodeKind kind_) :
   graph_(graph_),
   owning_block_(nullptr),
   stage_(graph_->new_node_stage_),
-  scope_(graph_->current_scope_) {
+  scope_(graph_->current_scope_),
+  schema_(nullptr) {
   graph_->all_nodes.emplace(this);
 }
 
 inline void Node::eraseOutput(size_t i) {
   JIT_ASSERT(i < outputs_.size());
   JIT_ASSERT(outputs_[i]->uses().size() == 0);
+  schema_ = nullptr;
   Value * n = outputs_[i];
   outputs_.erase(outputs_.begin() + i);
   owningGraph()->freeValue(n);
@@ -1158,12 +1182,14 @@ inline void Node::eraseOutput(size_t i) {
 }
 
 inline Block * Node::addBlock() {
+  schema_ = nullptr;
   blocks_.push_back(new Block(owningGraph(), this));
   return blocks_.back();
 }
 
 inline void Node::eraseBlock(size_t i) {
   JIT_ASSERT(i < blocks_.size());
+  schema_ = nullptr;
   Block * n = blocks_[i];
   blocks_.erase(blocks_.begin() + i);
   n->destroy();

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -178,11 +178,7 @@ private:
   std::string unique_name_;
   TypePtr type_;
 public:
-  Value* setType(const TypePtr type) {
-    JIT_ASSERT(type);
-    type_ = type;
-    return this;
-  }
+  Value* setType(const TypePtr type);
   void inferTypeFrom(const at::Tensor& output) {
     setType(std::make_shared<TensorType>(output));
   }
@@ -1138,6 +1134,15 @@ inline Value::Value(Node * node_, size_t offset_)
   stage_(node_->graph_->new_node_stage_),
   type_(DynamicType::get()) {
   node_->graph_->all_values.emplace(this);
+}
+
+Value* Value::setType(const TypePtr type) {
+  JIT_ASSERT(type);
+  type_ = type;
+  for (Use & use : uses_) {
+    use.user->schema_ = nullptr;
+  }
+  return this;
 }
 
 inline Graph * Value::owningGraph() {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1136,7 +1136,7 @@ inline Value::Value(Node * node_, size_t offset_)
   node_->graph_->all_values.emplace(this);
 }
 
-Value* Value::setType(const TypePtr type) {
+inline Value* Value::setType(const TypePtr type) {
   JIT_ASSERT(type);
   type_ = type;
   for (Use & use : uses_) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -401,8 +401,8 @@ public:
 
   template<typename T>
   at::optional<T> get(Symbol name);
-
   at::optional<IValue> get(Symbol name);
+  Value* getValue(Symbol name);
 
   // Graphs
 
@@ -663,7 +663,7 @@ public:
 
   virtual ~Node() {}
 private:
-  at::optional<std::pair<Value*, const Argument&>> findConstInput(Symbol name);
+  std::pair<Value*, const Argument&> findInput(Symbol name);
   void findSchema();
   // Lookup iterator in use list of _input i_ that corresponds to its use of _this_
   use_list::iterator findUseForInput(size_t i) {
@@ -1017,6 +1017,9 @@ public:
     }
     return r;
   }
+
+  template<typename T>
+  Value * insertConstant(T value);
 
   Node * appendNode(Node * n) {
     return block_->appendNode(n);

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -87,21 +87,15 @@ struct EqualNodeCSE {
     if (lhs == nullptr && rhs == nullptr) return true;
     if (lhs == nullptr || rhs == nullptr) return false;
 
-    // Check whether two nodes are the same kind.
     if (lhs->kind() != rhs->kind()) return false;
-
-    // Check the stage.
     if (lhs->stage() != rhs->stage()) return false;
 
     // Check whether the inputs are the same.
     auto lhs_inputs = lhs->inputs();
     auto rhs_inputs = rhs->inputs();
-
     if (lhs_inputs.size() != rhs_inputs.size()) return false;
-
     if (!std::equal(lhs_inputs.begin(), lhs_inputs.end(), rhs_inputs.begin())) return false;
 
-    // Check the attributes.
     if (!attributesEqualCSE(lhs, rhs)) return false;
 
     return true;
@@ -117,7 +111,7 @@ void EliminateCommonSubexpression(Block * block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end(); ++ it) {
     auto node = *it;
     if (node->kind() == prim::PythonOp
-        || node->kind() == prim::Eval
+        || node->kind() == prim::Print
         || node->blocks().size() > 0
        ) {
       // Do NOT have enough information to do CSE on these nodes.

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -5,7 +5,7 @@
 
 #ifdef USE_CUDA
   #include "cuda.h" // for CUDA_VERSION
-#endif 
+#endif
 
 namespace torch { namespace jit {
 
@@ -136,13 +136,13 @@ struct GraphFuser {
       #ifdef USE_CUDA
         // Checks for half tensor on GPU
         // const auto device = tt->device();
-        if (tt->device() != kCPUDevice 
+        if (tt->device() != kCPUDevice
           && CUDA_VERSION >= 9
           && tt->scalarType() == at::ScalarType::Half) {
           return true;
         }
-      #endif 
-    } 
+      #endif
+    }
 
     return false;
   }
@@ -204,8 +204,9 @@ struct GraphFuser {
     if(isFusable(node))
       return true;
     // this concat fusion only works when all the inputs are the same size
+    // and we can statically infer the dimension along which we should concat
     // otherwise they cannot partipate in the same map
-    if(node->kind() == aten::cat && allOutputsHaveSameSize(node))
+    if(node->kind() == aten::cat && node->get<int64_t>(attr::dim) && allOutputsHaveSameSize(node))
       return true;
 
     return false;

--- a/torch/csrc/jit/passes/remove_expands.cpp
+++ b/torch/csrc/jit/passes/remove_expands.cpp
@@ -7,7 +7,7 @@ static void RemoveExpands(Block* block) {
        ++it) {
     for (auto sub : it->blocks())
       RemoveExpands(sub);
-    if (it->kind() == aten::expand && it->hasAttribute(attr::implicit) && it->i(attr::implicit)) {
+    if (it->kind() == aten::expand && it->get<int64_t>(attr::implicit) != static_cast<int64_t>(0)) {
       it->output()->replaceAllUsesWith(it->input());
       it.destroyCurrent();
     }

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -52,6 +52,11 @@ struct SymbolicVariable {
       return (int64_t) i == s.toLong();
     }
   }
+  // TODO (apaszke): Use this instead of attribute setters
+  template<typename T>
+  SymbolicVariable insertConstant(T value) const {
+    return v->owningGraph()->insertConstant(std::move(value));
+  }
   SymbolicVariable operator*(const SymbolicVariable rhs) const {
     return create(aten::mul, {*this, rhs})[0].typeLike(*this);
   }
@@ -165,6 +170,13 @@ struct SymbolicVariable {
      ->i_(a("length"), length);
     return r;
   }
+  static SymbolicVariable cat(ArrayRef<SymbolicVariable> inputs, Value* dim) {
+    Node* n;
+    std::vector<SymbolicVariable> all_inputs = inputs;
+    all_inputs.push_back(dim);
+    auto r = create(aten::cat, all_inputs, 1, &n)[0];
+    return r;
+  }
   static SymbolicVariable cat(ArrayRef<SymbolicVariable> inputs, int32_t dim) {
     Node* n;
     auto r = create(aten::cat, inputs, 1, &n)[0];
@@ -186,6 +198,11 @@ struct SymbolicVariable {
     auto r = create(t("sum"), {*this}, 1, &n)[0];
     n->is_(a("dim"), {dim})
      ->i_(a("keepdim"), keepdim);
+    return r;
+  }
+  SymbolicVariable squeeze(Value* dim) const {
+    Node * n;
+    auto r = create(t("squeeze"), {*this, dim}, 1, &n)[0];
     return r;
   }
   SymbolicVariable squeeze(int dim) const {

--- a/torch/csrc/jit/tensor_conversions.h
+++ b/torch/csrc/jit/tensor_conversions.h
@@ -15,7 +15,7 @@ struct tensor_conversion_error : public std::runtime_error {
 };
 
 template<typename T>
-inline T tensor_as(at::Tensor&& t);
+inline T tensor_as(at::Tensor t);
 
 namespace detail {
 
@@ -79,7 +79,7 @@ struct tensor_as_impl<at::Scalar> {
 }
 
 template<typename T>
-inline T tensor_as(at::Tensor&& t) {
+inline T tensor_as(at::Tensor t) {
   return detail::tensor_as_impl<T>()(std::move(t));
 }
 
@@ -107,6 +107,10 @@ inline at::Tensor as_tensor(at::IntList l) {
 
 inline at::Tensor as_tensor(const at::Scalar& s) {
   return s.toTensor();
+}
+
+inline at::Tensor as_tensor(at::Tensor t) {
+  return t;
 }
 
 template<size_t N>

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -62,10 +62,9 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
 
   auto size_var = autograd::make_variable(at::Scalar(var.size(dim)).toTensor());
   auto* value = getValueTrace(var);
-  auto* node = graph->create(aten::size, {value})
-                    ->i_(attr::dim, dim);
+  WithInsertPoint ipoint { graph->block() };
+  auto* node = graph->insertNode(graph->create(aten::size, {value, graph->insertConstant(dim)}));
   node->output()->inferTypeFrom(size_var);
-  graph->appendNode(node);
   setValueTrace(size_var, node->output());
 
   return size_var;

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -259,7 +259,9 @@ def embedding_bag(g,
 
 def size(g, self, dim):
     if _is_value(dim):
-        raise RuntimeError("ONNX export only supports constant dim values in .size()")
+        if dim.node().kind() != 'onnx::Constant':
+            raise RuntimeError("ONNX export only supports constant dim values in .size()")
+        dim = int(dim.node().t('value'))
     full_shape = g.op("Shape", self)
     return select(g, full_shape, dim=0, index=dim)
 


### PR DESCRIPTION
This PR adds machinery to cache the schema in an IR node, and allows lookups of (possibly) constant inputs by their names (instead of position). The new methods are:

- `at::optional<T> get<T>(Symbol name)` - if the argument called name is a constant, then casts it to type `T` and returns it. If it's not constant returns `nullopt`. Raises an error if there's no argument with that name.
- `at::optional<IValue> get<T>(Symbol name)` - like above, but packs the result in an IValue
- `Value* getValue(Symbol name)` - retrieves a `Value*` for an argument (no need to know its position).

All above functions currently inspect the attributes as well, but that's only so that I could start using them in other places in the JIT without disrupting our current functionality. I wanted this diff to be a preparation that doesn't change the semantics too much, and so both the tracer and script create nodes with attributes. The next PR will put that to a stop, and hopefully the changes we need to make to other components will be simpler thanks to what I did here.

One more thing I'd like to do before actually stopping creating the non-attributed nodes is to have a convenient way of creating a schema programmatically, matching nodes against it, and creating them without having to pack inputs into flat argument lists (which is quite error prone).

@zdevito 