### PR TITLE
Expose CAFFE2_USE_OPENCV preprocessor flag

### DIFF
--- a/caffe2/operators/generate_proposals_op_test.cc
+++ b/caffe2/operators/generate_proposals_op_test.cc
@@ -2,6 +2,11 @@
 
 #include <gtest/gtest.h>
 #include "caffe2/core/flags.h"
+#include "caffe2/core/macros.h"
+
+#ifdef CAFFE2_USE_OPENCV
+#include <opencv2/opencv.hpp>
+#endif // CAFFE2_USE_OPENCV
 
 namespace caffe2 {
 

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -4,12 +4,13 @@
 #include <vector>
 
 #include "caffe2/core/logging.h"
+#include "caffe2/core/macros.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 
-#if defined(CV_MAJOR_VERSION) && (CV_MAJOR_VERSION >= 3)
+#ifdef CAFFE2_USE_OPENCV
 #include <opencv2/opencv.hpp>
-#endif // CV_MAJOR_VERSION >= 3
+#endif // CAFFE2_USE_OPENCV
 
 namespace caffe2 {
 namespace utils {


### PR DESCRIPTION
Summary:
generate_proposals_op_util_nms.h conditionally requires OpenCV in some cases,
and earlier this was checking just CV_MAJOR_VERSION macro, but that is
undefined unless opencv.hpp is included. Adding `-DCAFFE2_USE_OPENCV` to
TARGETS when opencv is included in external_deps to check for this correctly.
Thanks jinghuang for flagging this issue!

Differential Revision: D8880401
