### PR TITLE
Change THTensor::size into a std::vector<int64_t>

### DIFF
--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,6 +1,8 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
+  // NB: THTensor doesn't agree with Tensor for scalars, so we
+  // have to construct a fresh IntList
   return IntList(THTensor_getStridePtr(tensor), dim());
 }
 Scalar ${Tensor}::localScalar() {

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,7 +1,7 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
-  return IntList(tensor->stride,dim());
+  return IntList(THTensor_getStridePtr(tensor), dim());
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -31,7 +31,9 @@ const char * ${Tensor}::toString() const {
 }
 
 IntList ${Tensor}::sizes() const {
-  return IntList(tensor->size,dim());
+  // NB: dim in tensor is not synchronized with THTensor, so it's
+  // important to apply dim here
+  return IntList(THTensor_getSizePtr(tensor), dim());
 }
 
 int64_t ${Tensor}::dim() const {

--- a/aten/src/TH/THGeneral.cpp
+++ b/aten/src/TH/THGeneral.cpp
@@ -303,7 +303,11 @@ TH_API void THInferNumThreads(void)
 #endif
 }
 
-TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
+THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim) {
+  return _THSizeDesc(size.data(), ndim);
+}
+
+THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
   const int L = TH_DESC_BUFF_LEN;
   THDescBuff buf;
   char *str = buf.str;

--- a/aten/src/TH/THGeneral.cpp
+++ b/aten/src/TH/THGeneral.cpp
@@ -303,10 +303,6 @@ TH_API void THInferNumThreads(void)
 #endif
 }
 
-THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim) {
-  return _THSizeDesc(size.data(), ndim);
-}
-
 THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
   const int L = TH_DESC_BUFF_LEN;
   THDescBuff buf;

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -21,11 +21,6 @@
 #include <mkl_vsl.h>
 #endif
 
-#ifdef __cplusplus
-#include <ATen/ATenGeneral.h>
-#include <ATen/ArrayRef.h>
-#endif
-
 #cmakedefine USE_BLAS
 #cmakedefine USE_LAPACK
 #cmakedefine BLAS_F2C
@@ -85,10 +80,8 @@ typedef struct {
 TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
-
-
-TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);
 TH_API void THSetDefaultErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -86,13 +86,9 @@ TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
 
-#ifdef __cplusplus
-// Mangled so we can have an overload
-AT_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
-AT_API THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim);
-#endif
 
 TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
+TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);
 TH_API void THSetDefaultErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -21,6 +21,11 @@
 #include <mkl_vsl.h>
 #endif
 
+#ifdef __cplusplus
+#include <ATen/ATenGeneral.h>
+#include <ATen/ArrayRef.h>
+#endif
+
 #cmakedefine USE_BLAS
 #cmakedefine USE_LAPACK
 #cmakedefine BLAS_F2C
@@ -80,7 +85,13 @@ typedef struct {
 TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
-TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+
+#ifdef __cplusplus
+// Mangled so we can have an overload
+AT_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+AT_API THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim);
+#endif
+
 TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -81,10 +81,12 @@ struct THTensor
 #include "THGenerateAllTypes.h"
 
 inline int64_t* THTensor_getSizePtr(THTensor* tensor) {
+  AT_ASSERT(static_cast<int64_t>(tensor->size.size()) == tensor->dim_);
   return tensor->size.data();
 }
 
 inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
+  AT_ASSERT(static_cast<int64_t>(tensor->stride.size()) == tensor->dim_);
   return tensor->stride.data();
 }
 

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -89,11 +89,16 @@ inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
 }
 
 inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
+  tensor->dim_ = ndim;
+  // NB: This is *truly* a resize; calling code (e.g., squeeze)
+  // assumes that old values are preserved
   tensor->size.resize(ndim);
   tensor->stride.resize(ndim);
 }
 
 inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&& new_size, std::vector<int64_t>&& new_stride) {
+  AT_ASSERT(new_size.size() == new_stride.size());
+  tensor->dim_ = new_size.size();
   tensor->size = std::move(new_size);
   tensor->stride = std::move(new_stride);
 }

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -160,13 +160,12 @@
     elements_equal = 0;                                                 \
   }                                                                     \
   if (elements_equal == 0) {                                            \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
-            "number of elements, but got %d, %d and %d elements respectively", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, \
-            TENSOR1##_n, TENSOR2##_n, TENSOR3##_n);                     \
+    AT_ERROR("inconsistent tensor size, expected ",                     \
+            #TENSOR1, " ", TENSOR1->sizes(), ", ",                      \
+            #TENSOR2, " ", TENSOR2->sizes(), " and ",                   \
+            #TENSOR3, " ", TENSOR3->sizes(), " to have the same "       \
+            "number of elements, but got ", TENSOR1##_n, ", ",          \
+            TENSOR2##_n, " and ", TENSOR3##_n, " elements respectively"); \
   }                                                                     \
                                                                         \
   while(!TH_TENSOR_APPLY_hasFinished) \
@@ -199,11 +198,11 @@
   __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, DIM, 1) \
 \
     if(TENSOR1##_n != TENSOR2##_n) {                                    \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-      THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
-              "number of elements, but got %d and %d elements respectively", \
-              #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, TENSOR1##_n, TENSOR2##_n); \
+      AT_ERROR("inconsistent tensor size, expected ",                   \
+      #TENSOR1, " ", TENSOR1->sizes(), " and ",                         \
+      #TENSOR2, " ", TENSOR2->sizes(),                                  \
+      " to have the same number of elements, but got ",                 \
+      TENSOR1##_n, " and ", TENSOR2##_n, " elements respectively");     \
     }                                                                   \
   while(!TH_TENSOR_APPLY_hasFinished) \
   { \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -23,11 +23,7 @@
     } \
   } \
   if (shape_check_flag == 1) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("Expected %s %s, %s %s and %s %s to have the same size apart from dimension %d", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, DIMENSION); \
+    AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), ", ", #TENSOR2, " ", TENSOR2->sizes(), " and ", #TENSOR3, " ", TENSOR3->sizes(), " to have the same size apart from dimension ", DIMENSION); \
   } \
 }
 
@@ -53,11 +49,7 @@
     same_dims = 0;                                   \
   } \
   if (same_dims == 0) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
-            "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str); \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), ", ", #TENSOR2, " ", TENSOR2->sizes(), " and ", #TENSOR3, " ",TENSOR3->sizes() , " to have the same number of dimensions"); \
   }                                                                     \
   SIZE_CHECK(TENSOR1, TENSOR2, TENSOR3, DIMENSION)                      \
 \
@@ -156,10 +148,7 @@
   if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->dim()) ) \
     THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->_dim()); \
   if( TENSOR1->dim() != TENSOR2->dim() ) {                    \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
-            "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str);        \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same number of dimensions");        \
   }                                                                     \
   TH_UNUSED int shape_check_flag = 0;                                             \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
@@ -167,10 +156,7 @@
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
     if(TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-      THError("Expected %s %s and %s %s to have the same size in dimension %d", \
-              #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, DIMENSION);   \
+      AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size in dimension ", DIMENSION); \
     }                                                                   \
   } \
 \

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -416,7 +416,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
   }
-  self->dim_--;
+  THTensor_resizeDim(self, self->dim_ - 1);
 }
 
 void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dimension2)
@@ -538,7 +538,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }
-    self->dim_--;
+    THTensor_resizeDim(self, self->dim_ - 1);
   }
 }
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -229,7 +229,7 @@ THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size)
   ptrdiff_t numel = THTensor_(nElement)(tensor);
   THTensor *self = THTensor_(new)();
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
+  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
                                         at::IntList(tensor->stride, tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -873,4 +873,11 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   return buf;
 }
 
+THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
+  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
+  THDescBuff buf = THLongStorage_sizeDesc(size);
+  THLongStorage_free(size);
+  return buf;
+}
+
 #endif

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -873,11 +873,4 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   return buf;
 }
 
-THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
-  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
-  THDescBuff buf = THLongStorage_sizeDesc(size);
-  THLongStorage_free(size);
-  return buf;
-}
-
 #endif

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -327,7 +327,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   numel = THLongTensor_nElement(index);
 
   newSize = THLongStorage_newWithSize(src->dim());
-  THLongStorage_rawCopy(newSize,src->size);
+  THLongStorage_rawCopy(newSize, THTensor_getSizePtr(src));
 #ifdef DEBUG
   THAssert(numel <= LONG_MAX);
 #endif
@@ -424,7 +424,7 @@ void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTens
 }
 
 static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) {
-  int64_t *size = tensor->size;
+  auto size = tensor->sizes();
   int64_t *stride = tensor->stride;
   int nDim = tensor->_dim();
   ptrdiff_t dataOffset = 0;
@@ -445,7 +445,7 @@ static inline int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t nu
 
 void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
 {
-  THTensor_(resizeNd)(r_, index->dim(), index->size, NULL);
+  THTensor_(resizeNd)(r_, index->dim(), THTensor_getSizePtr(index), NULL);
   THTensor* dst = THTensor_(newContiguous)(r_);
 
   index = THLongTensor_newContiguous(index);
@@ -3739,25 +3739,25 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb)
 #define TENSOR_IMPLEMENT_LOGICAL(NAME,OP)				\
   void THTensor_(NAME##Value)(THByteTensor *r_, THTensor* t, real value)	\
   {									\
-    THByteTensor_resizeNd(r_, t->dim(), t->size, NULL);		\
+    THByteTensor_resizeNd(r_, t->dim(), THTensor_getSizePtr(t), NULL);		\
     TH_TENSOR_APPLY2(unsigned char, r_, real, t,			\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##ValueT)(THTensor* r_, THTensor* t, real value)	\
   {									\
-    THTensor_(resizeNd)(r_, t->dim(), t->size, NULL);		\
+    THTensor_(resizeNd)(r_, t->dim(), THTensor_getSizePtr(t), NULL);		\
     TH_TENSOR_APPLY2(real, r_, real, t,					\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##Tensor)(THByteTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THByteTensor_resizeNd(r_, ta->dim(), ta->size, NULL);		\
+    THByteTensor_resizeNd(r_, ta->dim(), THTensor_getSizePtr(ta), NULL);		\
     TH_TENSOR_APPLY3(unsigned char, r_, real, ta, real, tb,		\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##TensorT)(THTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THTensor_(resizeNd)(r_, ta->dim(), ta->size, NULL);		\
+    THTensor_(resizeNd)(r_, ta->dim(), THTensor_getSizePtr(ta), NULL);		\
     TH_TENSOR_APPLY3(real, r_, real, ta, real, tb,			\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -425,7 +425,7 @@ void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTens
 
 static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) {
   auto size = tensor->sizes();
-  int64_t *stride = tensor->stride;
+  auto stride = tensor->strides();
   int nDim = tensor->_dim();
   ptrdiff_t dataOffset = 0;
   for (int i = nDim - 1; i >= 0; i--) {

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -109,10 +109,7 @@
 #define TH_CHECK_SAME_SIZE(TENSOR1, TENSOR2) \
 { \
   if(!THTensor_(isSameSizeAs)(TENSOR1, TENSOR2)) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
-    THError("inconsistent tensor size, expected %s %s and %s %s to have the same size", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str); \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size"); \
   } \
 }
 
@@ -141,11 +138,7 @@
     } \
   } \
   if (shape_check_flag == 1) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->_dim()); \
-    THError("Expected %s %s to be smaller size than %s %s and to be smaller than %s %s apart from dimension %d", \
-            #TENSOR3, T3buff.str, #TENSOR2, T2buff.str, #TENSOR1, T1buff.str, DIMENSION); \
+    AT_ERROR("Expected ", #TENSOR3, " ", TENSOR3->sizes(), " to be smaller size than ", #TENSOR2, " ", TENSOR2->sizes(), " and to be smaller than ", #TENSOR1, " ", TENSOR1->sizes(), " apart from dimension ", DIMENSION); \
   } \
 }
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -79,7 +79,7 @@ void THTensor_(iBernoulli_generate_copy)(THTensor *self, THGenerator *_generator
 #endif
   } else {
     intTensor = THIntTensor_new();
-    THIntTensor_resizeNd(intTensor, self->dim(), self->size, NULL);
+    THIntTensor_resizeNd(intTensor, self->dim(), THTensor_getSizePtr(self), nullptr);
     tmp = THIntTensor_data(intTensor);
   }
 

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -128,8 +128,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
 
   if(nDimension != self->dim())
   {
-    THTensor_resizeSize(self, nDimension);
-    self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*nDimension);
+    THTensor_resizeDim(self, nDimension);
     self->dim_ = nDimension;
   }
 
@@ -170,7 +169,7 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
                            src->storageOffset,
                            src->dim(),
                            THTensor_getSizePtr(src),
-                           src->stride);
+                           THTensor_getStridePtr(src));
 }
 
 void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)
@@ -242,8 +241,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THCTensor_set(state, self, src);
 
-  THTensor_resizeSize(self, self->dim() + 1);
-  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->dim()+1));
+  THTensor_resizeDim(self, self->dim() + 1);
   self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -28,7 +28,7 @@ int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim) {
 }
 THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self) {
   THLongStorage *size = THLongStorage_newWithSize(self->dim());
-  THLongStorage_rawCopy(size, self->size);
+  THLongStorage_rawCopy(size, THTensor_getSizePtr(self));
   return size;
 }
 
@@ -82,7 +82,7 @@ void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
   }
 
   if(!isSame)
-    THCTensor_resizeNd(state, self, src->dim(), src->size, NULL);
+    THCTensor_resizeNd(state, self, src->dim(), THTensor_getSizePtr(src), NULL);
 }
 
 void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_t *size, int64_t *stride)
@@ -128,7 +128,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
 
   if(nDimension != self->dim())
   {
-    self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*nDimension);
+    THTensor_resizeSize(self, nDimension);
     self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*nDimension);
     self->dim_ = nDimension;
   }
@@ -169,7 +169,7 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
                            src->storage,
                            src->storageOffset,
                            src->dim(),
-                           src->size,
+                           THTensor_getSizePtr(src),
                            src->stride);
 }
 
@@ -242,7 +242,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THCTensor_set(state, self, src);
 
-  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->dim()+1));
+  THTensor_resizeSize(self, self->dim() + 1);
   self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->dim()+1));
   self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -129,7 +129,6 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
   if(nDimension != self->dim())
   {
     THTensor_resizeDim(self, nDimension);
-    self->dim_ = nDimension;
   }
 
   totalSize = 1;
@@ -242,7 +241,6 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
   THCTensor_set(state, self, src);
 
   THTensor_resizeDim(self, self->dim() + 1);
-  self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];
     self->stride[d] = self->stride[d-1];

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -222,7 +222,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }
-    self->dim_--;
+    THTensor_resizeDim(self, self->dim_ - 1);
   }
 }
 

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -218,8 +218,8 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
-                                        at::IntList(THTensor_getStridePtr(tensor), tensor->dim()),
+  auto stride = THTensor_compute_stride(tensor->sizes(),
+                                        tensor->strides(),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "
     "not compatible with input tensor's size and stride (at least one dimension spans "
@@ -464,7 +464,6 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   }
 
   THTensor_setSizesAndStrides(self, std::move(newSize), std::move(newStride));
-  self->dim_++;
 }
 
 /* we have to handle the case where the result is a number */
@@ -499,7 +498,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
     self->stride[0] = 1;
     ndim = 1;
   }
-  self->dim_ = ndim;
+  THTensor_resizeDim(self, ndim);
 }
 #endif
 

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -218,7 +218,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
+  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
                                         at::IntList(tensor->stride, tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -402,7 +402,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
   }
-  self->dim_--;
+  THTensor_resizeDim(self, self->dim_ - 1);
 }
 
 void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int dimension1, int dimension2)

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -70,7 +70,7 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
                            tensor->storage,
                            tensor->storageOffset,
                            tensor->dim(),
-                           tensor->size,
+                           THTensor_getSizePtr(tensor),
                            tensor->stride);
   return self;
 }
@@ -218,7 +218,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(at::IntList(tensor->size, tensor->dim()),
+  auto stride = THTensor_compute_stride(tensor->sizes(),
                                         at::IntList(tensor->stride, tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "
@@ -430,8 +430,6 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
 
 void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int dimension, int64_t size, int64_t step)
 {
-  int64_t *newSize;
-  int64_t *newStride;
   int d;
 
   if(!src)
@@ -446,7 +444,9 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
 
   THCTensor_(set)(state, self, src);
 
-  newSize = (int64_t*)THAlloc(sizeof(int64_t)*(self->dim()+1));
+  std::vector<int64_t> newSize(/* size */ self->dim() + 1);
+
+  int64_t *newStride;
   newStride = (int64_t*)THAlloc(sizeof(int64_t)*(self->dim()+1));
 
   newSize[self->dim()] = size;
@@ -465,10 +465,9 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
     }
   }
 
-  THFree(self->size);
   THFree(self->stride);
 
-  self->size = newSize;
+  THTensor_setSize(self, std::move(newSize));
   self->stride = newStride;
   self->dim_++;
 }

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -41,7 +41,7 @@ THLongStorage *THCTensor_(newSizeOf)(THCState *state, THCTensor *self)
 THLongStorage *THCTensor_(newStrideOf)(THCState *state, THCTensor *self)
 {
   THLongStorage *stride = THLongStorage_newWithSize(self->dim());
-  THLongStorage_rawCopy(stride, self->stride);
+  THLongStorage_rawCopy(stride, THTensor_getStridePtr(self));
   return stride;
 }
 
@@ -71,7 +71,7 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
                            tensor->storageOffset,
                            tensor->dim(),
                            THTensor_getSizePtr(tensor),
-                           tensor->stride);
+                           THTensor_getStridePtr(tensor));
   return self;
 }
 
@@ -219,7 +219,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
   auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
-                                        at::IntList(tensor->stride, tensor->dim()),
+                                        at::IntList(THTensor_getStridePtr(tensor), tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "
     "not compatible with input tensor's size and stride (at least one dimension spans "
@@ -445,9 +445,7 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   THCTensor_(set)(state, self, src);
 
   std::vector<int64_t> newSize(/* size */ self->dim() + 1);
-
-  int64_t *newStride;
-  newStride = (int64_t*)THAlloc(sizeof(int64_t)*(self->dim()+1));
+  std::vector<int64_t> newStride(/* size */ self->dim() + 1);
 
   newSize[self->dim()] = size;
   newStride[self->dim()] = self->stride[dimension];
@@ -465,10 +463,7 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
     }
   }
 
-  THFree(self->stride);
-
-  THTensor_setSize(self, std::move(newSize));
-  self->stride = newStride;
+  THTensor_setSizesAndStrides(self, std::move(newSize), std::move(newStride));
   self->dim_++;
 }
 

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -444,8 +444,8 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
 
   THCTensor_(set)(state, self, src);
 
-  std::vector<int64_t> newSize(/* size */ self->dim() + 1);
-  std::vector<int64_t> newStride(/* size */ self->dim() + 1);
+  std::vector<int64_t> newSize(self->dim() + 1);
+  std::vector<int64_t> newStride(self->dim() + 1);
 
   newSize[self->dim()] = size;
   newStride[self->dim()] = self->stride[dimension];

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -224,7 +224,7 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THArgCheck(!(THCTensor_(_nDimension)(state, src) == 0 && THCudaLongTensor__nDimension(state, index) != 0), 2,
              "tried to take from an empty tensor");
 
-  THCTensor_(resizeNd)(state, dst, index->dim(), index->size, NULL);
+  THCTensor_(resizeNd)(state, dst, index->dim(), THTensor_getSizePtr(index), NULL);
 
   // dispatchTakePut only handles non-empty tensors;
   if (index->_dim() > 0) {

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -434,7 +434,7 @@ THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 
   // input
   THCTensor *input = THCTensor_(newColumnMajor)(state, a, a);
-  THCTensor_(resizeNd)(state, ra_, 2, input->size, input->stride);
+  THCTensor_(resizeNd)(state, ra_, 2, THTensor_getSizePtr(input), THTensor_getStridePtr(input));
 
   real *matrices1[1] = { THCTensor_(data)(state, input) };
   real *matrices2[1] = { THCTensor_(data)(state, ra_) };

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -83,15 +83,13 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   iheight = input->size[dimh];
   iwidth = input->size[dimw];
 
-  THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_l < iwidth && pad_r < iwidth,
+           "Argument #4: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_l, ", ", pad_r, ") at dimension ", dimw, " of input ", input->sizes());
 
-  THArgCheck(pad_t < iheight && pad_b < iheight, 6,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_t < iheight && pad_b < iheight,
+           "Argument #6: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_t, ", ", pad_b, ") at dimension ", dimh, " of input ", input->sizes());
 
   /* output sizes */
   oheight = iheight + pad_t + pad_b;

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -64,10 +64,9 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   nslices = input->size[dimslices];
   iwidth = input->size[dimw];
 
-  THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_l < iwidth && pad_r < iwidth,
+           "Argument #4: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_l, ", ", pad_r, ") at dimension ", dimw, " of input ", input->sizes());
 
   /* output size */
   owidth  = iwidth + pad_l + pad_r;


### PR DESCRIPTION
This patch was very carefully constructed to avoid having to modify
too many files; there are some obvious follow ups which I will
be hitting later.

- ~~I didn't do stride.  But the change for stride should look
  very similar.~~ I did stride.

- I did NOT rename the field in question, so that direct
  accesses of the form foo->size[n] keep working.  I intend
  to do a codemod to fix all of these shortly.

- Anywhere a "public" API function made use of a int64_t*
  of sizes, I opted to just finagle it out of the tensor using
  THTensor_getSizePtr rather than try to rewrite all of these
  sites to use ArrayRef.  They should use ArrayRef eventually,
  but not yet.

- _THSizeDesc got an overload that understands ArrayRef (which
  a vector size is convertible to).  Eventually we should get
  rid of all of these functions (because ArrayRef is printable
  via the AT_ERROR macros), but not today.

- I ran into something very subtle in the implementation of sizes()
  for TensorDerived: I MUST use the dim as per Tensor::dim() (which
  correctly is zero for scalars), otherwise I'll give a nonsense
  sizes().  We can fix this eventually once Scalar is turned on
  internally.

- I added two new functions THTensor_resizeSize and THTensor_setSize.
  Maybe these are eventually worth deifying as methods in the Tensor class, but
  for now I'm keeping them out-of-line just in case.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>