### PR TITLE
Add random data filler to predictor bench to support production nets

### DIFF
--- a/caffe2/experiments/operators/sparse_funhash_op.h
+++ b/caffe2/experiments/operators/sparse_funhash_op.h
@@ -47,6 +47,9 @@ class SparseFunHashOp : public Operator<Context> {
     adaptive_ = (InputSize() == 5);
   }
 
+  // TODO: enable the filler
+  DISABLE_INPUT_FILLERS(Context)
+
   bool RunOnDevice() override {
     const auto& val = Input(0);
     const auto& key = Input(1);
@@ -150,6 +153,9 @@ class SparseFunHashGradientOp : public Operator<Context> {
         seed_(OperatorBase::GetSingleArgument<uint64_t>("seed", 0)) {
     adaptive_ = (InputSize() == 6);
   }
+
+  // TODO: enable the filler
+  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     const auto& grad_out = Input(0);

--- a/caffe2/experiments/operators/sparse_matrix_reshape_op.h
+++ b/caffe2/experiments/operators/sparse_matrix_reshape_op.h
@@ -91,6 +91,9 @@ class SparseMatrixReshapeOp : public Operator<Context> {
     new_stride_ = new_shape[1];
   }
 
+  // TODO: enable the filler
+  DISABLE_INPUT_FILLERS(Context)
+
   bool RunOnDevice() override {
     auto& old_col = Input(0);
     CAFFE_ENFORCE(old_col.ndim() == 1, "Row index tensor must be 1-D.");

--- a/caffe2/operators/batch_sparse_to_dense_op.h
+++ b/caffe2/operators/batch_sparse_to_dense_op.h
@@ -19,6 +19,9 @@ class BatchSparseToDenseOp : public Operator<Context> {
         OP_SINGLE_ARG(T, "default_value", default_value_, static_cast<T>(0)) {}
   bool RunOnDevice() override;
 
+  // TODO: enable the filler
+  DISABLE_INPUT_FILLERS(Context)
+
  private:
   TIndex dense_last_dim_;
   T default_value_;

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -68,6 +68,8 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     return true;
   }
 
+  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(Context, DATA, INDICES, LENGTHS)
+
  private:
   enum {
     DATA = 0,

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -92,6 +92,8 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
     return true;
   }
 
+  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(CPUContext, DATA, INDICES, LENGTHS)
+
  private:
   enum {
     DATA = 0, // Data input.

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
@@ -87,6 +87,8 @@ class SparseLengths8BitsRowwiseOp : public Operator<Context> {
     return true;
   }
 
+  USE_VALUE_LENGTH_INPUT_FILLERS(Context, DATA, LENGTHS)
+
   enum {
     DATA = 0,
     WEIGHTS = 1,

--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -37,6 +37,9 @@ class SparseToDenseMaskBase : public Operator<Context> {
     }
   }
 
+  // TODO: enable the filler
+  DISABLE_INPUT_FILLERS(Context)
+
  protected:
   const int64_t kMaxDenseSize = 1024 * 128;
 

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -703,6 +703,9 @@ class LengthsToSegmentIdsOp : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(LengthsToSegmentIdsOp);
 
+  // TODO: enable the InputFillers
+  DISABLE_INPUT_FILLERS(Context)
+
   bool RunOnDevice() override {
     auto& input = Input(0);
     auto* output = Output(0);
@@ -757,6 +760,9 @@ class SegmentIdsToLengthsOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(SegmentIdsToLengthsOp);
+
+  // TODO: enable the InputFillers
+  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(0));
@@ -814,6 +820,9 @@ class SegmentIdsToRangesOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(SegmentIdsToRangesOp);
+
+  // TODO: enable the InputFillers
+  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(0));

--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -1,0 +1,126 @@
+#ifndef CAFFE2_FILLER_H_
+#define CAFFE2_FILLER_H_
+
+#include <sstream>
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context_t>
+class TensorFiller {
+ public:
+  template <class Type>
+  void Fill(Tensor<Context_t>* tensor) const {
+    CAFFE_ENFORCE(context_, "context is null");
+    CAFFE_ENFORCE(tensor, "tensor is null");
+    auto min = static_cast<Type>(min_);
+    auto max = static_cast<Type>(max_);
+    CAFFE_ENFORCE_LE(min, max);
+
+    Tensor<Context_t> temp_tensor(shape_);
+    tensor->swap(temp_tensor);
+    Type* data = tensor->template mutable_data<Type>();
+    Context_t* context = static_cast<Context_t*>(context_);
+
+    // TODO: Come up with a good distribution abstraction so that
+    // the users could plug in their own distribution.
+    if (has_fixed_sum_) {
+      auto fixed_sum = static_cast<Type>(fixed_sum_);
+      CAFFE_ENFORCE_LE(min * tensor->size(), fixed_sum);
+      CAFFE_ENFORCE_GE(max * tensor->size(), fixed_sum);
+      math::RandFixedSum<Type, Context_t>(
+          tensor->size(), min, max, fixed_sum_, data, context);
+    } else {
+      math::RandUniform<Type, Context_t>(
+          tensor->size(), min, max, data, context);
+    }
+  }
+
+  template <class Type>
+  TensorFiller& Min(Type min) {
+    min_ = (double)min;
+    return *this;
+  }
+
+  template <class Type>
+  TensorFiller& Max(Type max) {
+    max_ = (double)max;
+    return *this;
+  }
+
+  template <class Type>
+  TensorFiller& FixedSum(Type fixed_sum) {
+    has_fixed_sum_ = true;
+    fixed_sum_ = (double)fixed_sum;
+    return *this;
+  }
+
+  // a helper function to construct the lengths vector for sparse features
+  template <class Type>
+  TensorFiller& SparseLengths(Type total_length) {
+    return FixedSum(total_length).Min(0).Max(total_length);
+  }
+
+  // a helper function to construct the segments vector for sparse features
+  template <class Type>
+  TensorFiller& SparseSegments(Type max_segment) {
+    CAFFE_ENFORCE(!has_fixed_sum_);
+    return Min(0).Max(max_segment);
+  }
+
+  TensorFiller& Shape(const std::vector<TIndex>& shape) {
+    shape_ = shape;
+    return *this;
+  }
+
+  // Use new context so that it is independent from its operator
+  TensorFiller& Context(Context_t* context) {
+    context_ = (void*)context;
+    return *this;
+  }
+
+  template <class Type>
+  TensorFiller(
+      const std::vector<TIndex>& shape,
+      Type fixed_sum,
+      Context_t* context)
+      : shape_(shape),
+        has_fixed_sum_(true),
+        fixed_sum_((double)fixed_sum),
+        context_((void*)context) {}
+
+  TensorFiller(const std::vector<TIndex>& shape, Context_t* context)
+      : shape_(shape),
+        has_fixed_sum_(false),
+        fixed_sum_(0),
+        context_((void*)context) {}
+
+  TensorFiller() : TensorFiller({}, (Context_t*)nullptr) {}
+
+  std::string DebugString() const {
+    std::stringstream stream;
+    stream << "shape = [" << shape_ << "]; min = " << min_
+           << "; max = " << max_;
+    if (has_fixed_sum_) {
+      stream << "; fixed sum = " << fixed_sum_;
+    }
+    return stream.str();
+  }
+
+ private:
+  std::vector<TIndex> shape_;
+  // TODO: type is unknown until a user starts to fill data;
+  // cast everything to double for now.
+  double min_ = 0.0;
+  double max_ = 1.0;
+  bool has_fixed_sum_;
+  double fixed_sum_;
+  void* context_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_FILLER_H_

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -383,6 +383,17 @@ void Set(const size_t N, const T alpha, T* X, Context* context);
 template <typename T, class Context>
 void RandUniform(const size_t n, const T a, const T b, T* r, Context* context);
 
+// Generate n values that sum up to a fixed sum
+// and subject to a restriction a <= x <= b for each x generated
+template <typename T, class Context>
+void RandFixedSum(
+    const size_t n,
+    const T a,
+    const T b,
+    const T sum,
+    T* r,
+    Context* context);
+
 template <typename T, class Context>
 void RandUniformUnique(
     const size_t n,


### PR DESCRIPTION
Summary: Add random data filler to predictor bench to support production nets

Reviewed By: salexspb

Differential Revision: D8712757
