### PR TITLE
Dummy CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7-node-browsers
+    steps:
+      - run: echo "hello world"


### PR DESCRIPTION
The purpose of this config is to make sure that CircleCI builds
don't fail when I turn them on for pytorch/pytorch.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

