### PR TITLE
Fix TestAutograd.test_as_strided

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3692,38 +3692,6 @@
 ]]
 
 [[
-  name: as_strided
-  variants: [method,function]
-  cpu_half: True
-  return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-    - THSize* size
-    - THStride* stride
-    - arg: int64_t storage_offset
-  aten_custom_call: |
-    ${THTensor}_setStorage(${state,}result_->tensor, self_->tensor->storage, storage_offset, size_, stride_);
-    result_->maybeScalar(size.size() == 0);
-]]
-
-[[
-  name: as_strided_
-  variants: [method]
-  cpu_half: True
-  return: argument 0
-  arguments:
-    - THTensor* self
-    - THSize* size
-    - THStride* stride
-    - arg: int64_t storage_offset
-  aten_custom_call: |
-    ${THTensor}_setStorage(${state,}self_->tensor, self_->tensor->storage, storage_offset, size_, stride_);
-    self_->maybeScalar(size.size() == 0);
-]]
-
-[[
   name: _cat
   cname: catArray
   variants: [function]

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -135,12 +135,20 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
   return self.expand(other.sizes());
 }
 
+Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
+  return self.type().tensor().set_(*self.storage(), storage_offset, size, stride);
+}
+
+Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
+  return self.set_(*self.storage(), storage_offset, size, stride);
+}
+
 Tensor as_strided(const Tensor& self, IntList size, IntList stride) {
-  return self.as_strided(size, stride, self.storage_offset());
+  return at::native::as_strided(self, size, stride, self.storage_offset());
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
-  return self.as_strided_(size, stride, self.storage_offset());
+  return at::native::as_strided_(self, size, stride, self.storage_offset());
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -144,11 +144,11 @@ Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride) {
-  return at::native::as_strided(self, size, stride, self.storage_offset());
+  return at::as_strided(self, size, stride, self.storage_offset());
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
-  return at::native::as_strided_(self, size, stride, self.storage_offset());
+  return at::as_strided_(self, size, stride, self.storage_offset());
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -162,7 +162,16 @@
 # The actual implementations live in Declarations.cwrap. These are just to
 # provide default values for storage_offset=self.storage_offset()
 - func: as_strided(Tensor self, IntList size, IntList stride) -> Tensor
+
 - func: as_strided_(Tensor self, IntList size, IntList stride) -> Tensor
+
+- func: as_strided(Tensor self, IntList size, IntList stride, int64_t storage_offset) -> Tensor
+  python_default_init:
+    storage_offset: self.storage_offset()
+
+- func: as_strided_(Tensor self, IntList size, IntList stride, int64_t storage_offset) -> Tensor
+  python_default_init:
+    storage_offset: self.storage_offset()
 
 - func: asin(Tensor self) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -159,8 +159,6 @@
 - func: argmin(Tensor self) -> Tensor
 - func: _argmin(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
 
-# The actual implementations live in Declarations.cwrap. These are just to
-# provide default values for storage_offset=self.storage_offset()
 - func: as_strided(Tensor self, IntList size, IntList stride) -> Tensor
 
 - func: as_strided_(Tensor self, IntList size, IntList stride) -> Tensor

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2105,8 +2105,10 @@ class TestAutograd(TestCase):
             self.assertTrue(hasattr(x, key))
 
     def test_as_strided(self):
+        # The test cases in this function should **not** resize storage because
+        # it may include nan in input and cause numerical Jacobian to have NaN.
 
-        def test(x, repro_fn, *args):
+        def test(x, repro_fn, size, strides, offset=None):
             def closure(x):
                 if repro_fn is not None:
                     x = repro_fn(x)
@@ -2120,7 +2122,7 @@ class TestAutograd(TestCase):
         test(torch.arange(0, 25), lambda x: x.view(5, 5), [3, 3], [6, 2], 2)
 
         # test crazy stride at dim with size 1 case
-        test(torch.randn(10), None, [1, 2, 1, 5], [0, 5, 100, 1], 2)
+        test(torch.randn(12), None, [1, 2, 1, 5], [0, 5, 100, 1], 2)
 
         # test expand case
         test(torch.randn(5), None, [3, 3, 3], [0, 1, 0], 2)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -30,7 +30,7 @@ SKIP_PYTHON_BINDINGS = [
 ]
 
 PY_VARIABLE_METHOD_VARARGS = CodeTemplate("""\
-static PyObject * ${pycname}(PyObject* self, PyObject* args, PyObject* kwargs)
+static PyObject * ${pycname}(PyObject* self_, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
@@ -46,7 +46,7 @@ static PyObject * ${pycname}(PyObject* self, PyObject* args, PyObject* kwargs)
 """)
 
 PY_VARIABLE_METHOD_NOARGS = CodeTemplate("""\
-static PyObject * ${pycname}(PyObject* self, PyObject* args)
+static PyObject * ${pycname}(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
   ${unpack_self}
@@ -99,7 +99,7 @@ inline ${return_type} ${dispatch_name}(${formal_args}) {
 PY_VARIABLE_METHOD_DEF = CodeTemplate("""\
 {"${name}", (PyCFunction)${pycname}, ${flags}, NULL},""")
 
-UNPACK_SELF = "auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;"
+UNPACK_SELF = "auto& self = reinterpret_cast<THPVariable*>(self_)->cdata;"
 
 PYTHON_FUNCTION_SIGNATURE = CodeTemplate("""\
 ${name}(${py_formal_args})""")
@@ -330,7 +330,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 continue
             if has_self and arg['name'] == 'self':
                 formal_args.append('Tensor & self')
-                actuals.append('self_')
+                actuals.append('self')
                 continue
             append_actuals_formals(*parse_arg(arg, arg_idx, unpack))
             arg_idx += 1
@@ -583,7 +583,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
 
         if len(declarations) == 1 and len(declarations[0]['args']) == 1 and has_self:
             tmpl = PY_VARIABLE_METHOD_NOARGS
-            env['actuals'] = ['self_']
+            env['actuals'] = ['self']
             env['flags'] = 'METH_NOARGS'
         else:
             tmpl = PY_VARIABLE_METHOD_VARARGS


### PR DESCRIPTION
0. Fixes #9479 
1. rewrites `as_strided` as a native function. This is fine because `set_` does the scalar check.
2. allow using `self` in `python_default_init`. Previously `python_variable_methods.cpp` has `self` as an input `PyObject *`, and use `self_` as the unpacked tensor. But `python_torch_functions.cpp` just use `self` as the unpacked tensor, making it impossible to use `self` in `python_default_init`.