### PR TITLE
Dataloader shutdown hangs

### DIFF
--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -30,9 +30,10 @@ __all__ += multiprocessing.__all__
 if sys.version_info < (3, 3):
     """Override basic classes in Python 2.7 and Python 3.3 to use ForkingPickler
     for serialization. Later versions of Python already use ForkingPickler."""
-    from .queue import Queue, SimpleQueue
+    from .queue import SimpleQueue
     from .pool import Pool
 
+from .queue import Queue
 
 if sys.platform == 'darwin' or sys.platform == 'win32':
     _sharing_strategy = 'file_system'

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -58,7 +58,7 @@ class Queue(multiprocessing.queues.Queue):
     def shutdown(self):
         with self.sig_shutdown.get_lock():
             with self.put_lock and self.get_lock:
-                self.shutdown.value = 1
+                self.sig_shutdown.value = 1
 
     def is_shutdown(self):
         with self.sig_shutdown.get_lock():

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -365,9 +365,7 @@ class _DataLoaderIter(object):
                 self.shutdown = True
                 for q in self.index_queues:
                     q.shutdown()
-                    q.put(None)
                 self.worker_result_queue.shutdown()
-                self.worker_result_queue.put(None)
         finally:
             # removes pids no matter what
             if self.worker_pids_set:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -250,9 +250,9 @@ class _DataLoaderIter(object):
 
         if self.num_workers > 0:
             self.worker_init_fn = loader.worker_init_fn
-            self.index_queues = [multiprocessing.Queue() for _ in range(self.num_workers)]
+            self.index_queues = [multiprocessing.queue.Queue() for _ in range(self.num_workers)]
             self.worker_queue_idx = 0
-            self.worker_result_queue = multiprocessing.SimpleQueue()
+            self.worker_result_queue = multiprocessing.queue.Queue()
             self.batches_outstanding = 0
             self.worker_pids_set = False
             self.shutdown = False


### PR DESCRIPTION
So for dataloader, there's a main thread, manager thread, and worker threads. (Horrible names fyi)
Main thread does 2 things: Puts indices in a queue that gets sent to workers to process
Worker thread: reads the data and send it through the collate function and puts it to a results queue
Manager thread: Reads from the result queue, puts it on pinned memory if necessary, puts it on an output queue

Currently to shutdown dataloader processes the Main thread puts a None in the index queues, tries to empty the results queue, and then puts a None on the results queue. The manager thread / worker processes are supposed to read the None's in the queue and quit.

2 issues can cause a hang... 
1) https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L377-L378
Calling is_empty and then a get is not guaranteed to get an actual entry. Since manager thread is trying to get on this queue it could empty it in between is_empty and get and then main thread is hung on shutdown.

2) Worker threads are still running as everything goes on until they hit a None, but they may have work to do. Main thread/manager thread can quit while workers are finishing up. Main thread/manager may free queue resources and then workers will put. Since the pipes can be broken this can result in a hang on the worker threads.

I have added an extended multiprocessing queue that has a shutdown signal with guards around get/put. This will prevent attempting to communicate across the queue in any way once shutdown is triggered. It will also make sure that shutdown does not happen during a get/put. I haven't seen any more processes hang on cleanup with these modifications.