### PR TITLE
Disable py2-clang3.8-rocmnightly-ubuntu16.04-test in disabled-configs…

### DIFF
--- a/.jenkins/pytorch/disabled-configs.txt
+++ b/.jenkins/pytorch/disabled-configs.txt
@@ -3,3 +3,5 @@
 # fail.  You can use this to temporarily reserve a test name to
 # turn on CI side before PyTorch repository supports it.  This
 # file has the same format as .jenkins/enabled-configs.txt
+
+py2-clang3.8-rocmnightly-ubuntu16.04-test

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -9,11 +9,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch"
 
-if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-  echo "Skipping ROCm tests for now"
-  exit 0
-fi
-
 # JIT C++ extensions require ninja.
 git clone https://github.com/ninja-build/ninja --quiet
 pushd ninja


### PR DESCRIPTION
….txt setting

In the ROCm branches we will experiment with turning this on.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

