### PR TITLE
Eliminate direct access to size/strides of THTensor; replace them with std::vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-overflow")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
   # These flags are not available in GCC-4.8.5. Set only when using clang.

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,6 +1,8 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
+  // NB: THTensor doesn't agree with Tensor for scalars, so we
+  // have to construct a fresh IntList
   return IntList(THTensor_getStridePtr(tensor), dim());
 }
 Scalar ${Tensor}::localScalar() {

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,7 +1,7 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {
-  return IntList(tensor->stride,dim());
+  return IntList(THTensor_getStridePtr(tensor), dim());
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -31,7 +31,9 @@ const char * ${Tensor}::toString() const {
 }
 
 IntList ${Tensor}::sizes() const {
-  return IntList(tensor->size,dim());
+  // NB: dim in tensor is not synchronized with THTensor, so it's
+  // important to apply dim here
+  return IntList(THTensor_getSizePtr(tensor), dim());
 }
 
 int64_t ${Tensor}::dim() const {

--- a/aten/src/README.md
+++ b/aten/src/README.md
@@ -75,7 +75,7 @@ under some conditions you have to have to call, e.g., `newContiguous`, to get
 it into the correct form:
 
 ```
-  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size[3])) {
+  if (!(k_->stride(3) == 1) || !(k_->stride[2] == k_->size(3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);

--- a/aten/src/TH/THGeneral.cpp
+++ b/aten/src/TH/THGeneral.cpp
@@ -303,7 +303,11 @@ TH_API void THInferNumThreads(void)
 #endif
 }
 
-TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
+THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim) {
+  return _THSizeDesc(size.data(), ndim);
+}
+
+THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
   const int L = TH_DESC_BUFF_LEN;
   THDescBuff buf;
   char *str = buf.str;

--- a/aten/src/TH/THGeneral.cpp
+++ b/aten/src/TH/THGeneral.cpp
@@ -303,10 +303,6 @@ TH_API void THInferNumThreads(void)
 #endif
 }
 
-THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim) {
-  return _THSizeDesc(size.data(), ndim);
-}
-
 THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim) {
   const int L = TH_DESC_BUFF_LEN;
   THDescBuff buf;

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -21,11 +21,6 @@
 #include <mkl_vsl.h>
 #endif
 
-#ifdef __cplusplus
-#include <ATen/ATenGeneral.h>
-#include <ATen/ArrayRef.h>
-#endif
-
 #cmakedefine USE_BLAS
 #cmakedefine USE_LAPACK
 #cmakedefine BLAS_F2C
@@ -85,10 +80,8 @@ typedef struct {
 TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
-
-
-TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);
 TH_API void THSetDefaultErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -86,13 +86,9 @@ TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
 
-#ifdef __cplusplus
-// Mangled so we can have an overload
-AT_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
-AT_API THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim);
-#endif
 
 TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
+TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);
 TH_API void THSetDefaultErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -21,6 +21,11 @@
 #include <mkl_vsl.h>
 #endif
 
+#ifdef __cplusplus
+#include <ATen/ATenGeneral.h>
+#include <ATen/ArrayRef.h>
+#endif
+
 #cmakedefine USE_BLAS
 #cmakedefine USE_LAPACK
 #cmakedefine BLAS_F2C
@@ -80,7 +85,13 @@ typedef struct {
 TH_API double THLog1p(const double x);
 TH_API double THLog2(const double x);
 TH_API double THExpm1(const double x);
-TH_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+
+#ifdef __cplusplus
+// Mangled so we can have an overload
+AT_API THDescBuff _THSizeDesc(const int64_t *size, const int64_t ndim);
+AT_API THDescBuff _THSizeDesc(at::ArrayRef<int64_t> size, const int64_t ndim);
+#endif
+
 TH_API TH_NO_RETURN void _THError(const char *file, const int line, const char *fmt, ...);
 TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler(THErrorHandlerFunction new_handler, void *data);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -68,8 +68,9 @@ struct THTensor
       return false;
     }
 
-    int64_t size(int64_t dim) const {
-      return sizes_[dim];
+    int64_t size(int64_t d) const {
+      d = at::maybe_wrap_dim(d, dim(), false);
+      return sizes_[d];
     }
 
     inline at::IntList sizes() {

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -15,7 +15,7 @@ struct THTensor
       : refcount(1)
       , storage(storage)
       , storageOffset(0)
-      , size{0}
+      , sizes_{0}
       , stride{1}
       , dim_(1)
       {}
@@ -33,7 +33,7 @@ struct THTensor
     THStorage *storage;
     ptrdiff_t storageOffset;
 
-    std::vector<int64_t> size;
+    std::vector<int64_t> sizes_;
     std::vector<int64_t> stride;
     int64_t dim_;
 
@@ -61,15 +61,19 @@ struct THTensor
     // represents that numel() == 0.
     inline bool is_empty() const {
       for (int64_t i = 0; i < dim_; ++i) {
-        if (size[i] == 0) {
+        if (sizes_[i] == 0) {
           return true;
         }
       }
       return false;
     }
 
+    int64_t size(int64_t dim) const {
+      return sizes_[dim];
+    }
+
     inline at::IntList sizes() {
-      return size;
+      return sizes_;
     }
 
     inline at::IntList strides() {
@@ -81,8 +85,8 @@ struct THTensor
 #include "THGenerateAllTypes.h"
 
 inline int64_t* THTensor_getSizePtr(THTensor* tensor) {
-  AT_ASSERT(static_cast<int64_t>(tensor->size.size()) == tensor->dim_);
-  return tensor->size.data();
+  AT_ASSERT(static_cast<int64_t>(tensor->sizes_.size()) == tensor->dim_);
+  return tensor->sizes_.data();
 }
 
 inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
@@ -94,19 +98,19 @@ inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
   tensor->dim_ = ndim;
   // NB: This is *truly* a resize; calling code (e.g., squeeze)
   // assumes that old values are preserved
-  tensor->size.resize(ndim);
+  tensor->sizes_.resize(ndim);
   tensor->stride.resize(ndim);
 }
 
 inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&& new_size, std::vector<int64_t>&& new_stride) {
   AT_ASSERT(new_size.size() == new_stride.size());
   tensor->dim_ = new_size.size();
-  tensor->size = std::move(new_size);
+  tensor->sizes_ = std::move(new_size);
   tensor->stride = std::move(new_stride);
 }
 
 inline void THTensor_setSizeAtDim(THTensor* tensor, int dim, int64_t new_size) {
-  tensor->size[dim] = new_size;
+  tensor->sizes_[dim] = new_size;
 }
 
 inline void THTensor_setStrideAtDim(THTensor* tensor, int dim, int64_t new_stride) {

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -91,12 +91,10 @@ struct THTensor
 #include "THGenerateAllTypes.h"
 
 inline int64_t* THTensor_getSizePtr(THTensor* tensor) {
-  AT_ASSERT(static_cast<int64_t>(tensor->sizes_.size()) == tensor->dim_);
   return tensor->sizes_.data();
 }
 
 inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
-  AT_ASSERT(static_cast<int64_t>(tensor->strides_.size()) == tensor->dim_);
   return tensor->strides_.data();
 }
 
@@ -109,7 +107,6 @@ inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
 }
 
 inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&& new_size, std::vector<int64_t>&& new_stride) {
-  AT_ASSERT(new_size.size() == new_stride.size());
   tensor->dim_ = new_size.size();
   tensor->sizes_ = std::move(new_size);
   tensor->strides_ = std::move(new_stride);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -109,6 +109,10 @@ inline void THTensor_setSizeAtDim(THTensor* tensor, int dim, int64_t new_size) {
   tensor->size[dim] = new_size;
 }
 
+inline void THTensor_setStrideAtDim(THTensor* tensor, int dim, int64_t new_stride) {
+  tensor->stride[dim] = new_stride;
+}
+
 TH_API void THTensor_free(THTensor *self);
 at::optional<std::vector<int64_t>> THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride,
                                                            at::IntList newshape);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -81,10 +81,12 @@ struct THTensor
 #include "THGenerateAllTypes.h"
 
 inline int64_t* THTensor_getSizePtr(THTensor* tensor) {
+  AT_ASSERT(static_cast<int64_t>(tensor->size.size()) == tensor->dim_);
   return tensor->size.data();
 }
 
 inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
+  AT_ASSERT(static_cast<int64_t>(tensor->stride.size()) == tensor->dim_);
   return tensor->stride.data();
 }
 

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -105,6 +105,10 @@ inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&&
   tensor->stride = std::move(new_stride);
 }
 
+inline void THTensor_setSizeAtDim(THTensor* tensor, int dim, int64_t new_size) {
+  tensor->size[dim] = new_size;
+}
+
 TH_API void THTensor_free(THTensor *self);
 at::optional<std::vector<int64_t>> THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride,
                                                            at::IntList newshape);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -89,11 +89,16 @@ inline int64_t* THTensor_getStridePtr(THTensor* tensor) {
 }
 
 inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
+  tensor->dim_ = ndim;
+  // NB: This is *truly* a resize; calling code (e.g., squeeze)
+  // assumes that old values are preserved
   tensor->size.resize(ndim);
   tensor->stride.resize(ndim);
 }
 
 inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&& new_size, std::vector<int64_t>&& new_stride) {
+  AT_ASSERT(new_size.size() == new_stride.size());
+  tensor->dim_ = new_size.size();
   tensor->size = std::move(new_size);
   tensor->stride = std::move(new_stride);
 }

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -160,13 +160,12 @@
     elements_equal = 0;                                                 \
   }                                                                     \
   if (elements_equal == 0) {                                            \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
-            "number of elements, but got %d, %d and %d elements respectively", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, \
-            TENSOR1##_n, TENSOR2##_n, TENSOR3##_n);                     \
+    AT_ERROR("inconsistent tensor size, expected ",                     \
+            #TENSOR1, " ", TENSOR1->sizes(), ", ",                      \
+            #TENSOR2, " ", TENSOR2->sizes(), " and ",                   \
+            #TENSOR3, " ", TENSOR3->sizes(), " to have the same "       \
+            "number of elements, but got ", TENSOR1##_n, ", ",          \
+            TENSOR2##_n, " and ", TENSOR3##_n, " elements respectively"); \
   }                                                                     \
                                                                         \
   while(!TH_TENSOR_APPLY_hasFinished) \
@@ -199,11 +198,11 @@
   __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, DIM, 1) \
 \
     if(TENSOR1##_n != TENSOR2##_n) {                                    \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-      THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
-              "number of elements, but got %d and %d elements respectively", \
-              #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, TENSOR1##_n, TENSOR2##_n); \
+      AT_ERROR("inconsistent tensor size, expected ",                   \
+      #TENSOR1, " ", TENSOR1->sizes(), " and ",                         \
+      #TENSOR2, " ", TENSOR2->sizes(),                                  \
+      " to have the same number of elements, but got ",                 \
+      TENSOR1##_n, " and ", TENSOR2##_n, " elements respectively");     \
     }                                                                   \
   while(!TH_TENSOR_APPLY_hasFinished) \
   { \

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -37,7 +37,7 @@
   int TENSOR##_contiguous = ALLOW_CONTIGUOUS && DIM < 0; \
   TENSOR##_n = 1; \
   for(TENSOR##_i = 0; TENSOR##_i < TENSOR->dim(); TENSOR##_i++) \
-    TENSOR##_n *= TENSOR->size[TENSOR##_i]; \
+    TENSOR##_n *= TENSOR->size(TENSOR##_i); \
 \
   if(TENSOR->is_empty()) \
     TH_TENSOR_APPLY_hasFinished = 1; \
@@ -47,9 +47,9 @@
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
     for(TENSOR##_i = TENSOR->_dim()-1; TENSOR##_i >= 0; TENSOR##_i--) { \
-      if(TENSOR->size[TENSOR##_i] != 1) { \
+      if(TENSOR->size(TENSOR##_i) != 1) { \
         if(TENSOR->stride[TENSOR##_i] == TENSOR##_size && TENSOR##_i != DIM) \
-          TENSOR##_size *= TENSOR->size[TENSOR##_i]; \
+          TENSOR##_size *= TENSOR->size(TENSOR##_i); \
         else{ \
           TENSOR##_contiguous = 0; \
           break; \
@@ -61,7 +61,7 @@
       TENSOR##_dim = 1; \
       for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; TENSOR##_i--) \
       { \
-        if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
+        if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size(TENSOR##_i+1) || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
           TENSOR##_dim++; \
       } \
       /* Allocate an array of 3*dim elements, where dim is the number of contiguous sections */ \
@@ -70,7 +70,7 @@
       TENSOR##_strides = TENSOR##_counter + 2*TENSOR##_dim; \
       TH_TENSOR_dim_index = TENSOR##_dim-1; \
       TENSOR##_dimOffset = (DIM == TENSOR->_dim()-1) ? &TENSOR##_i : &TENSOR##_counter[DIM]; \
-      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR->_dim()-1]; \
+      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR->_dim()-1); \
       TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->_dim()-1]; \
       /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
       /* storage is given by storage_offset + (i * j), where i is the stride */ \
@@ -79,13 +79,13 @@
         TENSOR##_counter[TENSOR##_i] = 0; \
       } \
       for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; --TENSOR##_i) { \
-        if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
-          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i] * TENSOR##_sizes[TH_TENSOR_dim_index]; \
+        if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size(TENSOR##_i+1) && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i) * TENSOR##_sizes[TH_TENSOR_dim_index]; \
           if (DIM != TENSOR->_dim()-1 && TENSOR##_i < DIM) \
             TENSOR##_dimOffset--; \
         } else { \
           --TH_TENSOR_dim_index; \
-          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i]; \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i); \
           TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR##_i]; \
         } \
       } \

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -48,7 +48,7 @@
     TENSOR##_stride = 1; \
     for(TENSOR##_i = TENSOR->_dim()-1; TENSOR##_i >= 0; TENSOR##_i--) { \
       if(TENSOR->size(TENSOR##_i) != 1) { \
-        if(TENSOR->stride[TENSOR##_i] == TENSOR##_size && TENSOR##_i != DIM) \
+        if(TENSOR->stride(TENSOR##_i) == TENSOR##_size && TENSOR##_i != DIM) \
           TENSOR##_size *= TENSOR->size(TENSOR##_i); \
         else{ \
           TENSOR##_contiguous = 0; \
@@ -61,7 +61,7 @@
       TENSOR##_dim = 1; \
       for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; TENSOR##_i--) \
       { \
-        if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size(TENSOR##_i+1) || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
+        if(TENSOR->stride(TENSOR##_i) != TENSOR->stride(TENSOR##_i+1) * TENSOR->size(TENSOR##_i+1) || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
           TENSOR##_dim++; \
       } \
       /* Allocate an array of 3*dim elements, where dim is the number of contiguous sections */ \
@@ -71,7 +71,7 @@
       TH_TENSOR_dim_index = TENSOR##_dim-1; \
       TENSOR##_dimOffset = (DIM == TENSOR->_dim()-1) ? &TENSOR##_i : &TENSOR##_counter[DIM]; \
       TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR->_dim()-1); \
-      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->_dim()-1]; \
+      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride(TENSOR->_dim()-1); \
       /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
       /* storage is given by storage_offset + (i * j), where i is the stride */ \
       /* vector and j is tensor_counter vector. This sets the starting position for the loop. */ \
@@ -79,14 +79,14 @@
         TENSOR##_counter[TENSOR##_i] = 0; \
       } \
       for(TENSOR##_i = TENSOR->_dim()-2; TENSOR##_i >= 0; --TENSOR##_i) { \
-        if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size(TENSOR##_i+1) && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
+        if (TENSOR->stride(TENSOR##_i) == TENSOR->stride(TENSOR##_i+1) * TENSOR->size(TENSOR##_i+1) && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
           TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i) * TENSOR##_sizes[TH_TENSOR_dim_index]; \
           if (DIM != TENSOR->_dim()-1 && TENSOR##_i < DIM) \
             TENSOR##_dimOffset--; \
         } else { \
           --TH_TENSOR_dim_index; \
           TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i); \
-          TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR##_i]; \
+          TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride(TENSOR##_i); \
         } \
       } \
       /* Size of the inner most section */ \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -61,15 +61,15 @@
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
-  TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
+  TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
   TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
-  TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
+  TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
   TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storageOffset; \
-  TENSOR3##_stride = (TENSOR3)->stride[DIMENSION]; \
+  TENSOR3##_stride = (TENSOR3)->stride(DIMENSION); \
   TENSOR3##_size = TENSOR3->size(DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
@@ -92,9 +92,9 @@
       } \
 \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR1##_data += TENSOR1->stride[TH_TENSOR_DIM_APPLY_i]; \
-      TENSOR2##_data += TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
-      TENSOR3##_data += TENSOR3->stride[TH_TENSOR_DIM_APPLY_i]; \
+      TENSOR1##_data += TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR2##_data += TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR3##_data += TENSOR3->stride(TH_TENSOR_DIM_APPLY_i); \
 \
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
@@ -105,9 +105,9 @@
         } \
         else \
         { \
-          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride[TH_TENSOR_DIM_APPLY_i]; \
-          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
-          TENSOR3##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR3->stride[TH_TENSOR_DIM_APPLY_i]; \
+          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR3##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR3->stride(TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \
@@ -168,11 +168,11 @@
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
-  TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
+  TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
   TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
-  TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
+  TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
@@ -195,8 +195,8 @@
       } \
 \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR1##_data += TENSOR1->stride[TH_TENSOR_DIM_APPLY_i]; \
-      TENSOR2##_data += TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
+      TENSOR1##_data += TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR2##_data += TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
 \
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
@@ -207,8 +207,8 @@
         } \
         else \
         { \
-          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride[TH_TENSOR_DIM_APPLY_i]; \
-          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
+          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \
@@ -270,7 +270,7 @@
     THError("invalid dimension"); \
 \
   TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storageOffset; \
-  TENSOR##_stride = (TENSOR)->stride[DIMENSION]; \
+  TENSOR##_stride = (TENSOR)->stride(DIMENSION); \
   TENSOR##_size = TENSOR->size(DIMENSION); \
   /* Counter stores the indices into the Tensor at any time */ \
   TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR->_dim())); \
@@ -302,7 +302,7 @@
 \
       /* Bump the counter at this index, update the pointer */ \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR##_data += TENSOR->stride[TH_TENSOR_DIM_APPLY_i]; \
+      TENSOR##_data += TENSOR->stride(TH_TENSOR_DIM_APPLY_i); \
 \
       if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
@@ -315,7 +315,7 @@
         else \
         { \
           /* Reset the counter, and the pointer to the beginning of the storage for this combination of indices */ \
-          TENSOR##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR->stride[TH_TENSOR_DIM_APPLY_i]; \
+          TENSOR##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR->stride(TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -23,11 +23,7 @@
     } \
   } \
   if (shape_check_flag == 1) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("Expected %s %s, %s %s and %s %s to have the same size apart from dimension %d", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str, DIMENSION); \
+    AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), ", ", #TENSOR2, " ", TENSOR2->sizes(), " and ", #TENSOR3, " ", TENSOR3->sizes(), " to have the same size apart from dimension ", DIMENSION); \
   } \
 }
 
@@ -53,11 +49,7 @@
     same_dims = 0;                                   \
   } \
   if (same_dims == 0) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->dim()); \
-    THError("inconsistent tensor size, expected %s %s, %s %s and %s %s to have the same " \
-            "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, #TENSOR3, T3buff.str); \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), ", ", #TENSOR2, " ", TENSOR2->sizes(), " and ", #TENSOR3, " ",TENSOR3->sizes() , " to have the same number of dimensions"); \
   }                                                                     \
   SIZE_CHECK(TENSOR1, TENSOR2, TENSOR3, DIMENSION)                      \
 \
@@ -156,10 +148,7 @@
   if( (DIMENSION < 0) || (DIMENSION >= TENSOR1->dim()) ) \
     THError("invalid dimension %d (expected to be 0 <= dim < %d)", DIMENSION, TENSOR1->_dim()); \
   if( TENSOR1->dim() != TENSOR2->dim() ) {                    \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-    THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
-            "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str);        \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same number of dimensions");        \
   }                                                                     \
   TH_UNUSED int shape_check_flag = 0;                                             \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
@@ -167,10 +156,7 @@
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
     if(TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
-      THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->dim()); \
-      THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->dim()); \
-      THError("Expected %s %s and %s %s to have the same size in dimension %d", \
-              #TENSOR1, T1buff.str, #TENSOR2, T2buff.str, DIMENSION);   \
+      AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size in dimension ", DIMENSION); \
     }                                                                   \
   } \
 \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -13,11 +13,11 @@
   { \
     if (TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
-    if (TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
+    if (TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \
-    if(TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR3->size[TH_TENSOR_DIM_APPLY_i]) { \
+    if(TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR3->size(TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \
@@ -62,15 +62,15 @@
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
   TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
-  TENSOR1##_size = TENSOR1->size[DIMENSION]; \
+  TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
   TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
   TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
-  TENSOR2##_size = TENSOR2->size[DIMENSION]; \
+  TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
   TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storageOffset; \
   TENSOR3##_stride = (TENSOR3)->stride[DIMENSION]; \
-  TENSOR3##_size = TENSOR3->size[DIMENSION]; \
+  TENSOR3##_size = TENSOR3->size(DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
   { \
@@ -96,7 +96,7 @@
       TENSOR2##_data += TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
       TENSOR3##_data += TENSOR3->stride[TH_TENSOR_DIM_APPLY_i]; \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size[TH_TENSOR_DIM_APPLY_i]) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
         if(TH_TENSOR_DIM_APPLY_i == TENSOR1->dim()-1) \
         { \
@@ -155,7 +155,7 @@
   { \
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
-    if(TENSOR1->size[TH_TENSOR_DIM_APPLY_i] != TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
+    if(TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
       AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size in dimension ", DIMENSION); \
     }                                                                   \
   } \
@@ -169,11 +169,11 @@
 \
   TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
   TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
-  TENSOR1##_size = TENSOR1->size[DIMENSION]; \
+  TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
   TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
   TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
-  TENSOR2##_size = TENSOR2->size[DIMENSION]; \
+  TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
   { \
@@ -198,7 +198,7 @@
       TENSOR1##_data += TENSOR1->stride[TH_TENSOR_DIM_APPLY_i]; \
       TENSOR2##_data += TENSOR2->stride[TH_TENSOR_DIM_APPLY_i]; \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size[TH_TENSOR_DIM_APPLY_i]) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
         if(TH_TENSOR_DIM_APPLY_i == TENSOR1->dim()-1) \
         { \
@@ -271,7 +271,7 @@
 \
   TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storageOffset; \
   TENSOR##_stride = (TENSOR)->stride[DIMENSION]; \
-  TENSOR##_size = TENSOR->size[DIMENSION]; \
+  TENSOR##_size = TENSOR->size(DIMENSION); \
   /* Counter stores the indices into the Tensor at any time */ \
   TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(TENSOR->_dim())); \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR->_dim(); TH_TENSOR_DIM_APPLY_i++) \
@@ -304,7 +304,7 @@
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
       TENSOR##_data += TENSOR->stride[TH_TENSOR_DIM_APPLY_i]; \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR->size[TH_TENSOR_DIM_APPLY_i]) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR->size(TH_TENSOR_DIM_APPLY_i)) \
       { \
         /* Handled TENSOR_size(dim) iterations for DIM_APPLY_i. If this is the last dimension, exit */ \
         if(TH_TENSOR_DIM_APPLY_i == TENSOR->_dim()-1) \

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -416,7 +416,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
   }
-  self->dim_--;
+  THTensor_resizeDim(self, self->dim_ - 1);
 }
 
 void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dimension2)
@@ -538,7 +538,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }
-    self->dim_--;
+    THTensor_resizeDim(self, self->dim_ - 1);
   }
 }
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -389,7 +389,7 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, int64_t fir
   if(firstIndex > 0)
     self->storageOffset += firstIndex*self->stride[dimension];
 
-  self->size[dimension] = size;
+  THTensor_setSizeAtDim(self, dimension, size);
 }
 
 void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sliceIndex)
@@ -413,7 +413,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   THTensor_(narrow)(self, NULL, dimension, sliceIndex, 1);
   for(d = dimension; d < self->dim()-1; d++)
   {
-    self->size[d] = self->size[d+1];
+    THTensor_setSizeAtDim(self, d, self->size[d+1]);
     self->stride[d] = self->stride[d+1];
   }
   THTensor_resizeDim(self, self->dim_ - 1);
@@ -438,8 +438,8 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
   self->stride[dimension1] = self->stride[dimension2];
   self->stride[dimension2] = z;
   z = self->size[dimension1];
-  self->size[dimension1] = self->size[dimension2];
-  self->size[dimension2] = z;
+  THTensor_setSizeAtDim(self, dimension1, self->size[dimension2]);
+  THTensor_setSizeAtDim(self, dimension2, z);
 }
 
 void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t size, int64_t step)
@@ -497,7 +497,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
     {
       if(d != ndim)
       {
-        self->size[ndim] = src->size[d];
+        THTensor_setSizeAtDim(self, ndim, src->size[d]);
         self->stride[ndim] = src->stride[d];
       }
       ndim++;
@@ -508,7 +508,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
   /* right now, we do not handle 0-dimension tensors */
   if(ndim == 0 && src->dim() > 0)
   {
-    self->size[0] = 1;
+    THTensor_setSizeAtDim(self, 0, 1);
     self->stride[0] = 1;
     ndim = 1;
   }
@@ -535,7 +535,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
   {
     for(d = dimension; d < self->dim()-1; d++)
     {
-      self->size[d] = self->size[d+1];
+      THTensor_setSizeAtDim(self, d, self->size[d+1]);
       self->stride[d] = self->stride[d+1];
     }
     THTensor_resizeDim(self, self->dim_ - 1);
@@ -558,7 +558,7 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
 
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
-    self->size[d] = self->size[d-1];
+    THTensor_setSizeAtDim(self, d, self->size[d-1]);
     self->stride[d] = self->stride[d-1];
   }
   if (dimension+1 < self->dim()) {
@@ -566,7 +566,7 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
   } else {
     self->stride[dimension] = 1;
   }
-  self->size[dimension] = 1;
+  THTensor_setSizeAtDim(self, dimension, 1);
 }
 
 int THTensor_(isTransposed)(const THTensor *self)
@@ -766,7 +766,7 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
   totalSize = 1;
   for(d = nDimension-1; d >= 0; d--)
   {
-    self->size[d] = size[d];
+    THTensor_setSizeAtDim(self, d, size[d]);
     if(stride && (stride[d] >= 0) ) {
       self->stride[d] = stride[d];
     } else {

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -229,7 +229,7 @@ THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size)
   ptrdiff_t numel = THTensor_(nElement)(tensor);
   THTensor *self = THTensor_(new)();
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
+  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
                                         at::IntList(tensor->stride, tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -873,4 +873,11 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   return buf;
 }
 
+THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
+  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
+  THDescBuff buf = THLongStorage_sizeDesc(size);
+  THLongStorage_free(size);
+  return buf;
+}
+
 #endif

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -36,7 +36,7 @@ int64_t THTensor_(stride)(const THTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->dim()), 2, "dimension %d out of range of %dD tensor",
       dim+TH_INDEX_BASE, THTensor_(nDimension)(self));
-  return self->stride[dim];
+  return self->stride(dim);
 }
 
 THLongStorage *THTensor_(newSizeOf)(THTensor *self)
@@ -387,7 +387,7 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, int64_t fir
   THTensor_(set)(self, src);
 
   if(firstIndex > 0)
-    self->storageOffset += firstIndex*self->stride[dimension];
+    self->storageOffset += firstIndex*self->stride(dimension);
 
   THTensor_setSizeAtDim(self, dimension, size);
 }
@@ -414,7 +414,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   for(d = dimension; d < self->dim()-1; d++)
   {
     THTensor_setSizeAtDim(self, d, self->size(d+1));
-    THTensor_setStrideAtDim(self, d, self->stride[d+1]);
+    THTensor_setStrideAtDim(self, d, self->stride(d+1));
   }
   THTensor_resizeDim(self, self->dim_ - 1);
 }
@@ -434,8 +434,8 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
   if(dimension1 == dimension2)
     return;
 
-  z = self->stride[dimension1];
-  THTensor_setStrideAtDim(self, dimension1, self->stride[dimension2]);
+  z = self->stride(dimension1);
+  THTensor_setStrideAtDim(self, dimension1, self->stride(dimension2));
   THTensor_setStrideAtDim(self, dimension2, z);
   z = self->size(dimension1);
   THTensor_setSizeAtDim(self, dimension1, self->size(dimension2));
@@ -462,18 +462,18 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   std::vector<int64_t> newStride(/* size */ self->dim()+1);
 
   newSize[self->dim()] = size;
-  newStride[self->dim()] = self->stride[dimension];
+  newStride[self->dim()] = self->stride(dimension);
   for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {
       newSize[d] = (self->size(d) - size) / step + 1;
-      newStride[d] = step*self->stride[d];
+      newStride[d] = step*self->stride(d);
     }
     else
     {
       newSize[d] = self->size(d);
-      newStride[d] = self->stride[d];
+      newStride[d] = self->stride(d);
     }
   }
 
@@ -498,7 +498,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
       if(d != ndim)
       {
         THTensor_setSizeAtDim(self, ndim, src->size(d));
-        THTensor_setStrideAtDim(self, ndim, src->stride[d]);
+        THTensor_setStrideAtDim(self, ndim, src->stride(d));
       }
       ndim++;
     }
@@ -536,7 +536,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
     for(d = dimension; d < self->dim()-1; d++)
     {
       THTensor_setSizeAtDim(self, d, self->size(d+1));
-      THTensor_setStrideAtDim(self, d, self->stride[d+1]);
+      THTensor_setStrideAtDim(self, d, self->stride(d+1));
     }
     THTensor_resizeDim(self, self->dim_ - 1);
   }
@@ -559,10 +559,10 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
     THTensor_setSizeAtDim(self, d, self->size(d-1));
-    THTensor_setStrideAtDim(self, d, self->stride[d-1]);
+    THTensor_setStrideAtDim(self, d, self->stride(d-1));
   }
   if (dimension+1 < self->dim()) {
-    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride[dimension+1]);
+    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride(dimension+1));
   } else {
     THTensor_setStrideAtDim(self, dimension, 1);
   }
@@ -579,10 +579,10 @@ int THTensor_(isTransposed)(const THTensor *self)
   int64_t z = 1;
   int d;
   for (d = 0; d < self->_dim(); ++d) {
-    if (self->stride[d] == 0 && self->size(d) != 1)
+    if (self->stride(d) == 0 && self->size(d) != 1)
       return 0;
-    if (self->stride[d] > max_stride) {
-      max_stride = self->stride[d];
+    if (self->stride(d) > max_stride) {
+      max_stride = self->stride(d);
       size_max_stride = self->size(d);
     }
     z *= self->size(d);
@@ -602,7 +602,7 @@ int THTensor_(isContiguous)(const THTensor *self)
   {
     if(self->size(d) != 1)
     {
-      if(self->stride[d] == z)
+      if(self->stride(d) == z)
         z *= self->size(d);
       else
         return 0;
@@ -649,7 +649,7 @@ int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
     int d;
     for (d = 0; d < self->_dim(); ++d)
     {
-      if (self->size(d) != src->size(d) || self->stride[d] != src->stride[d])
+      if (self->size(d) != src->size(d) || self->stride(d) != src->stride(d))
         return 0;
     }
     return 1;
@@ -745,7 +745,7 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
     }
 
     // NB: this used to test that stride[d] was >= 0
-    if((self->dim() > d) && stride && (stride[d] != self->stride[d])) {
+    if((self->dim() > d) && stride && (stride[d] != self->stride(d))) {
       hascorrectsize = false;
     }
   }
@@ -774,10 +774,10 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
         THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1), 1)*self->stride[d+1]);
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1), 1)*self->stride(d+1));
       }
     }
-    totalSize += (self->size(d)-1)*self->stride[d];
+    totalSize += (self->size(d)-1)*self->stride(d);
   }
 
   if(totalSize+self->storageOffset > 0)
@@ -795,56 +795,56 @@ void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)
 {
   THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
+  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0), value);
 }
 
 real THTensor_(get1d)(const THTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]);
+  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0));
 }
 
 void THTensor_(set2d)(THTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
+  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1), value);
 }
 
 real THTensor_(get2d)(const THTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]);
+  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1));
 }
 
 void THTensor_(set3d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
+  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
 }
 
 real THTensor_(get3d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]);
+  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
 }
 
 void THTensor_(set4d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
+  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
 }
 
 real THTensor_(get4d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3]);
+  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
 }
 
 THDescBuff THTensor_(desc)(const THTensor *tensor) {

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -873,11 +873,4 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   return buf;
 }
 
-THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
-  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
-  THDescBuff buf = THLongStorage_sizeDesc(size);
-  THLongStorage_free(size);
-  return buf;
-}
-
 #endif

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -414,7 +414,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   for(d = dimension; d < self->dim()-1; d++)
   {
     THTensor_setSizeAtDim(self, d, self->size[d+1]);
-    self->stride[d] = self->stride[d+1];
+    THTensor_setStrideAtDim(self, d, self->stride[d+1]);
   }
   THTensor_resizeDim(self, self->dim_ - 1);
 }
@@ -435,8 +435,8 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
     return;
 
   z = self->stride[dimension1];
-  self->stride[dimension1] = self->stride[dimension2];
-  self->stride[dimension2] = z;
+  THTensor_setStrideAtDim(self, dimension1, self->stride[dimension2]);
+  THTensor_setStrideAtDim(self, dimension2, z);
   z = self->size[dimension1];
   THTensor_setSizeAtDim(self, dimension1, self->size[dimension2]);
   THTensor_setSizeAtDim(self, dimension2, z);
@@ -498,7 +498,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
       if(d != ndim)
       {
         THTensor_setSizeAtDim(self, ndim, src->size[d]);
-        self->stride[ndim] = src->stride[d];
+        THTensor_setStrideAtDim(self, ndim, src->stride[d]);
       }
       ndim++;
     }
@@ -509,7 +509,7 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
   if(ndim == 0 && src->dim() > 0)
   {
     THTensor_setSizeAtDim(self, 0, 1);
-    self->stride[0] = 1;
+    THTensor_setStrideAtDim(self, 0, 1);
     ndim = 1;
   }
 #endif
@@ -536,7 +536,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
     for(d = dimension; d < self->dim()-1; d++)
     {
       THTensor_setSizeAtDim(self, d, self->size[d+1]);
-      self->stride[d] = self->stride[d+1];
+      THTensor_setStrideAtDim(self, d, self->stride[d+1]);
     }
     THTensor_resizeDim(self, self->dim_ - 1);
   }
@@ -559,12 +559,12 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
     THTensor_setSizeAtDim(self, d, self->size[d-1]);
-    self->stride[d] = self->stride[d-1];
+    THTensor_setStrideAtDim(self, d, self->stride[d-1]);
   }
   if (dimension+1 < self->dim()) {
-    self->stride[dimension] = self->size[dimension+1] * self->stride[dimension+1];
+    THTensor_setStrideAtDim(self, dimension, self->size[dimension+1] * self->stride[dimension+1]);
   } else {
-    self->stride[dimension] = 1;
+    THTensor_setStrideAtDim(self, dimension, 1);
   }
   THTensor_setSizeAtDim(self, dimension, 1);
 }
@@ -768,13 +768,13 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
   {
     THTensor_setSizeAtDim(self, d, size[d]);
     if(stride && (stride[d] >= 0) ) {
-      self->stride[d] = stride[d];
+      THTensor_setStrideAtDim(self, d, stride[d]);
     } else {
       if(d == nDimension-1) {
-        self->stride[d] = 1;
+        THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        self->stride[d] = std::max<int64_t>(self->size[d+1], 1)*self->stride[d+1];
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size[d+1], 1)*self->stride[d+1]);
       }
     }
     totalSize += (self->size[d]-1)*self->stride[d];

--- a/aten/src/TH/generic/THTensorConv.cpp
+++ b/aten/src/TH/generic/THTensorConv.cpp
@@ -600,15 +600,15 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
 
   kstride0 = kernel->stride[0];
-  nKernelPlane = kernel->size[0];
-  nKernelRows = kernel->size[1];
-  nKernelCols = kernel->size[2];
+  nKernelPlane = kernel->size(0);
+  nKernelRows = kernel->size(1);
+  nKernelCols = kernel->size(2);
 
   THArgCheck(nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "covn2DRevger : Input image is smaller than kernel");
 
@@ -627,7 +627,7 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
     /*THTensor_(zero)(r_);*/
 
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -639,7 +639,7 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -708,19 +708,19 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
 
   istride0    = input->stride[0];
   istride1    = input->stride[1];
-  nbatch      = input->size[0];
-  nInputPlane = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nbatch      = input->size(0);
+  nInputPlane = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0 = kernel->stride[0];
   kstride1 = kernel->stride[1];
-  nKernelPlane = kernel->size[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
+  nKernelPlane = kernel->size(1);
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
 
   THArgCheck(nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "conv2DRevger : Input image is smaller than kernel");
-  THArgCheck(kernel->size[0] == input->size[0] , 2, "conv2DRevger : Input batch and kernel batch is not same size");
+  THArgCheck(kernel->size(0) == input->size(0) , 2, "conv2DRevger : Input batch and kernel batch is not same size");
 
   nOutputRows = nInputRows - (nKernelRows - 1) * srow;
   nOutputCols = nInputCols - (nKernelCols - 1) * scol;
@@ -737,7 +737,7 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
     /*THTensor_(zero)(r_);*/
 
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -749,7 +749,7 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -820,15 +820,15 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
 
   kstride0 = kernel->stride[0];
-  nKernelPlane = kernel->size[0];
-  nKernelRows = kernel->size[1];
-  nKernelCols = kernel->size[2];
+  nKernelPlane = kernel->size(0);
+  nKernelRows = kernel->size(1);
+  nKernelCols = kernel->size(2);
 
   THArgCheck((nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dger : Input image is smaller than kernel");
 
@@ -851,7 +851,7 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -863,7 +863,7 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]*r_->size[1]; k++)
+    for (k = 0; k < r_->size(0)*r_->size(1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -949,24 +949,24 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size[3])) {
+  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size(3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
 
   kstride0    = kernel->stride[0];
   kstride1    = kernel->stride[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
-  nOutputPlane = kernel->size[0];
-  THArgCheck(kernel->size[1] == nInputPlane, 2, "invalid number of input planes");
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
+  nOutputPlane = kernel->size(0);
+  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmv : Input image is smaller than kernel");
 
@@ -989,7 +989,7 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]; k++)
+    for (k = 0; k < r_->size(0); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -1001,7 +1001,7 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size[0]; k++)
+    for (k = 0; k < r_->size(0); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -1087,24 +1087,24 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size[3])) {
+  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size(3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nbatch = input->size[0];
-  nInputPlane = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nbatch = input->size(0);
+  nInputPlane = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0    = kernel->stride[0];
   kstride1    = kernel->stride[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
-  nOutputPlane = kernel->size[0];
-  THArgCheck(kernel->size[1] == nInputPlane, 2, "invalid number of input planes");
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
+  nOutputPlane = kernel->size(0);
+  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmv : Input image is smaller than kernel");
 
@@ -1127,10 +1127,10 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(p)
-    for (p=0; p < r_->size[0]; p++)
+    for (p=0; p < r_->size(0); p++)
     {
       int64_t k;
-      for (k = 0; k < r_->size[1]; k++)
+      for (k = 0; k < r_->size(1); k++)
       {
         real* ptr_output = output_data + p*nOutputPlane*nOutputRows*nOutputCols + k*nOutputCols*nOutputRows;
         int64_t l;
@@ -1143,10 +1143,10 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(p)
-    for(p=0; p < r_->size[0]; p++)
+    for(p=0; p < r_->size(0); p++)
     {
       int64_t k;
-      for (k = 0; k < r_->size[1]; k++)
+      for (k = 0; k < r_->size(1); k++)
       {
         real* ptr_output = output_data + p*nOutputPlane*nOutputRows*nOutputCols + k*nOutputCols*nOutputRows;
         int64_t l;
@@ -1236,10 +1236,10 @@ void THTensor_(conv2Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputRows  = input->size[0];
-  nInputCols  = input->size[1];
-  nKernelRows = kernel->size[0];
-  nKernelCols = kernel->size[1];
+  nInputRows  = input->size(0);
+  nInputCols  = input->size(1);
+  nKernelRows = kernel->size(0);
+  nKernelCols = kernel->size(1);
 
   THArgCheck((nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmul : Input image is smaller than kernel");
 
@@ -1296,14 +1296,14 @@ void THTensor_(conv2Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   kernel = THTensor_(newContiguous)(k_);
 
   istride0    = input->stride[0];
-  nInputPlane = input->size[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
+  nInputPlane = input->size(0);
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
 
   kstride0    = kernel->stride[0];
-  nOutputPlane = kernel->size[0];
-  nKernelRows = kernel->size[1];
-  nKernelCols = kernel->size[2];
+  nOutputPlane = kernel->size(0);
+  nKernelRows = kernel->size(1);
+  nKernelCols = kernel->size(2);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dcmul : Input image is smaller than kernel");
@@ -1375,14 +1375,14 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   kernel = THTensor_(newContiguous)(k_);
 
   istride0    = input->stride[0];
-  nInputPlane = input->size[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
+  nInputPlane = input->size(0);
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
 
   kstride0    = kernel->stride[0];
-  nOutputPlane = kernel->size[0];
-  nKernelRows = kernel->size[1];
-  nKernelCols = kernel->size[2];
+  nOutputPlane = kernel->size(0);
+  nKernelRows = kernel->size(1);
+  nKernelCols = kernel->size(2);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols)
@@ -1405,7 +1405,7 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   weight_data = THTensor_(data)(kernel);
   output_data = THTensor_(data)(r_);
 
-  nmaps = map->size[0];
+  nmaps = map->size(0);
 
   for(k = 0; k < nmaps; k++)
   {
@@ -1462,17 +1462,17 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputDepth = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nInputDepth = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0 = kernel->stride[0];
-  nKernelPlane = kernel->size[0];
-  nKernelDepth= kernel->size[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
+  nKernelPlane = kernel->size(0);
+  nKernelDepth= kernel->size(1);
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
 
   THArgCheck(nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "conv3DRevger : Input image is smaller than kernel");
 
@@ -1550,17 +1550,17 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputDepth = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nInputDepth = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0     = kernel->stride[0];
-  nKernelPlane = kernel->size[0];
-  nKernelDepth = kernel->size[1];
-  nKernelRows  = kernel->size[2];
-  nKernelCols  = kernel->size[3];
+  nKernelPlane = kernel->size(0);
+  nKernelDepth = kernel->size(1);
+  nKernelRows  = kernel->size(2);
+  nKernelCols  = kernel->size(3);
 
   THArgCheck((nInputDepth >= nKernelDepth
               && nInputRows >= nKernelRows
@@ -1639,26 +1639,26 @@ void THTensor_(conv3Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 8, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[4] == 1) || !(k_->stride[3] == k_->size[4])) {
+  if (!(k_->stride[4] == 1) || !(k_->stride[3] == k_->size(4))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nInputPlane = input->size[0];
+  nInputPlane = input->size(0);
   istride0    = input->stride[0];
-  nInputDepth = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nInputDepth = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0    = kernel->stride[0];
   kstride1    = kernel->stride[1];
-  nKernelDepth = kernel->size[2];
-  nKernelRows = kernel->size[3];
-  nKernelCols = kernel->size[4];
-  nOutputPlane = kernel->size[0];
-  THArgCheck(kernel->size[1] == nInputPlane, 2, "invalid number of input planes");
+  nKernelDepth = kernel->size(2);
+  nKernelRows = kernel->size(3);
+  nKernelCols = kernel->size(4);
+  nOutputPlane = kernel->size(0);
+  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dmv : Input image is smaller than kernel");
 
@@ -1736,12 +1736,12 @@ void THTensor_(conv3Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputDepth = input->size[0];
-  nInputRows  = input->size[1];
-  nInputCols  = input->size[2];
-  nKernelDepth = kernel->size[0];
-  nKernelRows = kernel->size[1];
-  nKernelCols = kernel->size[2];
+  nInputDepth = input->size(0);
+  nInputRows  = input->size(1);
+  nInputCols  = input->size(2);
+  nKernelDepth = kernel->size(0);
+  nKernelRows = kernel->size(1);
+  nKernelCols = kernel->size(2);
 
   THArgCheck((nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dmul : Input image is smaller than kernel");
 
@@ -1803,16 +1803,16 @@ void THTensor_(conv3Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   kernel = THTensor_(newContiguous)(k_);
 
   istride0    = input->stride[0];
-  nInputPlane = input->size[0];
-  nInputDepth = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nInputPlane = input->size(0);
+  nInputDepth = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0    = kernel->stride[0];
-  nOutputPlane = kernel->size[0];
-  nKernelDepth = kernel->size[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
+  nOutputPlane = kernel->size(0);
+  nKernelDepth = kernel->size(1);
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dcmul : Input image is smaller than kernel");
@@ -1890,16 +1890,16 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   kernel = THTensor_(newContiguous)(k_);
 
   istride0    = input->stride[0];
-  nInputPlane = input->size[0];
-  nInputDepth = input->size[1];
-  nInputRows  = input->size[2];
-  nInputCols  = input->size[3];
+  nInputPlane = input->size(0);
+  nInputDepth = input->size(1);
+  nInputRows  = input->size(2);
+  nInputCols  = input->size(3);
 
   kstride0    = kernel->stride[0];
-  nOutputPlane = kernel->size[0];
-  nKernelDepth = kernel->size[1];
-  nKernelRows = kernel->size[2];
-  nKernelCols = kernel->size[3];
+  nOutputPlane = kernel->size(0);
+  nKernelDepth = kernel->size(1);
+  nKernelRows = kernel->size(2);
+  nKernelCols = kernel->size(3);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck((nInputDepth >= nKernelDepth
@@ -1925,7 +1925,7 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   weight_data = THTensor_(data)(kernel);
   output_data = THTensor_(data)(r_);
 
-  nmaps = map->size[0];
+  nmaps = map->size(0);
 
   for(k = 0; k < nmaps; k++)
   {

--- a/aten/src/TH/generic/THTensorConv.cpp
+++ b/aten/src/TH/generic/THTensorConv.cpp
@@ -601,11 +601,11 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   kernel = THTensor_(newContiguous)(k_);
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputRows  = input->size(1);
   nInputCols  = input->size(2);
 
-  kstride0 = kernel->stride[0];
+  kstride0 = kernel->stride(0);
   nKernelPlane = kernel->size(0);
   nKernelRows = kernel->size(1);
   nKernelCols = kernel->size(2);
@@ -706,15 +706,15 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride[0];
-  istride1    = input->stride[1];
+  istride0    = input->stride(0);
+  istride1    = input->stride(1);
   nbatch      = input->size(0);
   nInputPlane = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0 = kernel->stride[0];
-  kstride1 = kernel->stride[1];
+  kstride0 = kernel->stride(0);
+  kstride1 = kernel->stride(1);
   nKernelPlane = kernel->size(1);
   nKernelRows = kernel->size(2);
   nKernelCols = kernel->size(3);
@@ -821,11 +821,11 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   kernel = THTensor_(newContiguous)(k_);
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputRows  = input->size(1);
   nInputCols  = input->size(2);
 
-  kstride0 = kernel->stride[0];
+  kstride0 = kernel->stride(0);
   nKernelPlane = kernel->size(0);
   nKernelRows = kernel->size(1);
   nKernelCols = kernel->size(2);
@@ -949,7 +949,7 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size(3))) {
+  if (!(k_->stride(3) == 1) || !(k_->stride(2) == k_->size(3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
@@ -957,12 +957,12 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   }
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputRows  = input->size(1);
   nInputCols  = input->size(2);
 
-  kstride0    = kernel->stride[0];
-  kstride1    = kernel->stride[1];
+  kstride0    = kernel->stride(0);
+  kstride1    = kernel->stride(1);
   nKernelRows = kernel->size(2);
   nKernelCols = kernel->size(3);
   nOutputPlane = kernel->size(0);
@@ -1087,7 +1087,7 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[3] == 1) || !(k_->stride[2] == k_->size(3))) {
+  if (!(k_->stride(3) == 1) || !(k_->stride(2) == k_->size(3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
@@ -1099,8 +1099,8 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0    = kernel->stride[0];
-  kstride1    = kernel->stride[1];
+  kstride0    = kernel->stride(0);
+  kstride1    = kernel->stride(1);
   nKernelRows = kernel->size(2);
   nKernelCols = kernel->size(3);
   nOutputPlane = kernel->size(0);
@@ -1295,12 +1295,12 @@ void THTensor_(conv2Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputPlane = input->size(0);
   nInputRows  = input->size(1);
   nInputCols  = input->size(2);
 
-  kstride0    = kernel->stride[0];
+  kstride0    = kernel->stride(0);
   nOutputPlane = kernel->size(0);
   nKernelRows = kernel->size(1);
   nKernelCols = kernel->size(2);
@@ -1374,12 +1374,12 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputPlane = input->size(0);
   nInputRows  = input->size(1);
   nInputCols  = input->size(2);
 
-  kstride0    = kernel->stride[0];
+  kstride0    = kernel->stride(0);
   nOutputPlane = kernel->size(0);
   nKernelRows = kernel->size(1);
   nKernelCols = kernel->size(2);
@@ -1463,12 +1463,12 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   kernel = THTensor_(newContiguous)(k_);
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputDepth = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0 = kernel->stride[0];
+  kstride0 = kernel->stride(0);
   nKernelPlane = kernel->size(0);
   nKernelDepth= kernel->size(1);
   nKernelRows = kernel->size(2);
@@ -1551,12 +1551,12 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   kernel = THTensor_(newContiguous)(k_);
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputDepth = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0     = kernel->stride[0];
+  kstride0     = kernel->stride(0);
   nKernelPlane = kernel->size(0);
   nKernelDepth = kernel->size(1);
   nKernelRows  = kernel->size(2);
@@ -1639,7 +1639,7 @@ void THTensor_(conv3Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 8, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride[4] == 1) || !(k_->stride[3] == k_->size(4))) {
+  if (!(k_->stride(4) == 1) || !(k_->stride(3) == k_->size(4))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
@@ -1647,13 +1647,13 @@ void THTensor_(conv3Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   }
 
   nInputPlane = input->size(0);
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputDepth = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0    = kernel->stride[0];
-  kstride1    = kernel->stride[1];
+  kstride0    = kernel->stride(0);
+  kstride1    = kernel->stride(1);
   nKernelDepth = kernel->size(2);
   nKernelRows = kernel->size(3);
   nKernelCols = kernel->size(4);
@@ -1802,13 +1802,13 @@ void THTensor_(conv3Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputPlane = input->size(0);
   nInputDepth = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0    = kernel->stride[0];
+  kstride0    = kernel->stride(0);
   nOutputPlane = kernel->size(0);
   nKernelDepth = kernel->size(1);
   nKernelRows = kernel->size(2);
@@ -1889,13 +1889,13 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride[0];
+  istride0    = input->stride(0);
   nInputPlane = input->size(0);
   nInputDepth = input->size(1);
   nInputRows  = input->size(2);
   nInputCols  = input->size(3);
 
-  kstride0    = kernel->stride[0];
+  kstride0    = kernel->stride(0);
   nOutputPlane = kernel->size(0);
   nKernelDepth = kernel->size(1);
   nKernelRows = kernel->size(2);

--- a/aten/src/TH/generic/THTensorFastGetSet.hpp
+++ b/aten/src/TH/generic/THTensorFastGetSet.hpp
@@ -3,43 +3,43 @@
 #else
 
 static inline real THTensor_(fastGet1d)(THTensor *self, int64_t x0) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]];
+  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)];
 }
 
 static inline real THTensor_(fastGet2d)(THTensor *self, int64_t x0, int64_t x1) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]];
+  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)];
 }
 
 static inline real THTensor_(fastGet3d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]];
+  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)];
 }
 
 static inline real THTensor_(fastGet4d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]+(x3)*self->stride[3]];
+  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)];
 }
 
 static inline real THTensor_(fastGet5d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, int64_t x4) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]+(x3)*self->stride[3]+(x4)*self->stride[4]];
+  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)];
 }
 
 static inline void THTensor_(fastSet1d)(THTensor *self, int64_t x0, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]] = value;
+  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)] = value;
 }
 
 static inline void THTensor_(fastSet2d)(THTensor *self, int64_t x0, int64_t x1, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]] = value;
+  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)] = value;
 }
 
 static inline void THTensor_(fastSet3d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]] = value;
+  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)] = value;
 }
 
 static inline void THTensor_(fastSet4d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]+(x3)*self->stride[3]] = value;
+  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)] = value;
 }
 
 static inline void THTensor_(fastSet5d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, int64_t x4, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride[0]+(x1)*self->stride[1]+(x2)*self->stride[2]+(x3)*self->stride[3]+(x4)*self->stride[4]] = value;
+  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)] = value;
 }
 
 #endif

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -7,7 +7,7 @@ Check if self is transpose of a contiguous matrix
 */
 static int THTensor_(isTransposedContiguous)(THTensor *self)
 {
-  return self->stride[0] == 1 && self->stride[1] == self->size(0);
+  return self->stride(0) == 1 && self->stride(1) == self->size(0);
 }
 /*
 If a matrix is a regular contiguous matrix, make sure it is transposed
@@ -119,7 +119,7 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 
   if (b->dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
-            b->stride[0], 1, 0);
+            b->stride(0), 1, 0);
     free_b = 1;
   }
 
@@ -172,7 +172,7 @@ void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,
 
   if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
-            b->stride[0], 1, 0);
+            b->stride(0), 1, 0);
     free_b = 1;
   }
 
@@ -222,7 +222,7 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 
   if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
-            b->stride[0], 1, 0);
+            b->stride(0), 1, 0);
     free_b = 1;
   }
 
@@ -645,7 +645,7 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
 
   if (b->_dim() == 1) {
     b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
-            b->stride[0], 1, 0);
+            b->stride(0), 1, 0);
     free_b = 1;
   }
 
@@ -977,9 +977,9 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
   THTensor *ra__;
   int lda;
 
-  if (ra_->stride[1] == 1) {
+  if (ra_->stride(1) == 1) {
     // column ordered, what BLAS wants
-    lda = ra_->stride[2];
+    lda = ra_->stride(2);
     ra__ = ra_;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -987,7 +987,7 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
     ra__ = THTensor_(newClone)(transp_r_);
     THTensor_(free)(transp_r_);
     THTensor_(transpose)(ra__, NULL, 1, 2);
-    lda = ra__->stride[2];
+    lda = ra__->stride(2);
   }
 
   THTensor *ai = THTensor_(new)();
@@ -1058,9 +1058,9 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
   THTensor *rb__;
 
   // correct ordering of A
-  if (atf->stride[1] == 1) {
+  if (atf->stride(1) == 1) {
     // column ordered, what BLAS wants
-    lda = atf->stride[2];
+    lda = atf->stride(2);
     atf_ = atf;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -1071,16 +1071,16 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
     atf_ = THTensor_(newClone)(transp_r_);
     THTensor_(free)(transp_r_);
     THTensor_(transpose)(atf_, NULL, 1, 2);
-    lda = atf_->stride[2];
+    lda = atf_->stride(2);
   }
 
   // correct ordering of B
-  if (rb_->stride[1] == 1) {
+  if (rb_->stride(1) == 1) {
     // column ordered
     if (rb_->_dim() == 2 || rb_->size(2) == 1) {
       ldb = n;
     } else {
-      ldb = rb_->stride[2];
+      ldb = rb_->stride(2);
     }
     rb__ = rb_;
   } else {
@@ -1090,7 +1090,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
       rb__ = THTensor_(newClone)(transp_r_);
       THTensor_(free)(transp_r_);
       THTensor_(transpose)(rb__, NULL, 1, 2);
-      ldb = rb__->stride[2];
+      ldb = rb__->stride(2);
     } else {
       rb__ = THTensor_(newClone)(rb_);
       ldb = n;

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -7,7 +7,7 @@ Check if self is transpose of a contiguous matrix
 */
 static int THTensor_(isTransposedContiguous)(THTensor *self)
 {
-  return self->stride[0] == 1 && self->stride[1] == self->size[0];
+  return self->stride[0] == 1 && self->stride[1] == self->size(0);
 }
 /*
 If a matrix is a regular contiguous matrix, make sure it is transposed
@@ -53,7 +53,7 @@ input space, like underdetermined gels.
 static THTensor *THTensor_(checkLapackClone)(THTensor *result, THTensor *src, int nrows)
 {
   /* check if user wants to reuse src and if it is correct shape/size */
-  if (src == result && THTensor_(isTransposedContiguous)(src) && src->size[1] == nrows)
+  if (src == result && THTensor_(isTransposedContiguous)(src) && src->size(1) == nrows)
     THTensor_(retain)(result);
   else if(src == result || result == NULL) /* in this case, user wants reuse of src, but its structure is not OK */
     result = THTensor_(new)();
@@ -77,14 +77,14 @@ static THTensor *THTensor_(cloneColumnMajorNrows)(THTensor *self, THTensor *src,
   if (src == result)
     return result;
 
-  THTensor_(resize2d)(result, src->size[1], nrows);
+  THTensor_(resize2d)(result, src->size(1), nrows);
   THTensor_(checkTransposed)(result);
 
-  if (src->size[0] == nrows)
+  if (src->size(0) == nrows)
     THTensor_(copy)(result, src);
   else
   {
-    view = THTensor_(newNarrow)(result, 0, 0, src->size[0]);
+    view = THTensor_(newNarrow)(result, 0, 0, src->size(0));
     THTensor_(copy)(view, src);
     THTensor_(free)(view);
   }
@@ -98,7 +98,7 @@ freed by calling function.
 */
 static THTensor *THTensor_(cloneColumnMajor)(THTensor *self, THTensor *src)
 {
-  return THTensor_(cloneColumnMajorNrows)(self, src, src->size[0]);
+  return THTensor_(cloneColumnMajorNrows)(self, src, src->size(0));
 }
 
 void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
@@ -112,13 +112,13 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   THArgCheck(b->dim() == 1 || b->dim() == 2, 1, "B should have 1 or 2 "
       "dimensions, but has %d", b->dim());
   THArgCheck(!b->is_empty(), 2, "B should not be empty");
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
-      a->size[0], a->size[1]);
-  THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
-      "rows, B has %ld", a->size[0], b->size[0]);
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square, but is %ldx%ld",
+      a->size(0), a->size(1));
+  THArgCheck(a->size(0) == b->size(0), 2, "A,B size incompatible - A has %ld "
+      "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
+    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
             b->stride[0], 1, 0);
     free_b = 1;
   }
@@ -131,8 +131,8 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
   rb__ = THTensor_(cloneColumnMajor)(rb_, b);
 
-  n    = (int)ra__->size[0];
-  nrhs = (int)rb__->size[1];
+  n    = (int)ra__->size(0);
+  nrhs = (int)rb__->size(1);
   lda  = n;
   ldb  = n;
 
@@ -165,13 +165,13 @@ void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,
       a->_dim());
   THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
       "dimensions, but has %d", b->_dim());
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
-      a->size[0], a->size[1]);
-  THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
-      "rows, B has %ld", a->size[0], b->size[0]);
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square, but is %ldx%ld",
+      a->size(0), a->size(1));
+  THArgCheck(a->size(0) == b->size(0), 2, "A,B size incompatible - A has %ld "
+      "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
+    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
             b->stride[0], 1, 0);
     free_b = 1;
   }
@@ -183,8 +183,8 @@ void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
   rb__ = THTensor_(cloneColumnMajor)(rb_, b);
 
-  n    = (int)ra__->size[0];
-  nrhs = (int)rb__->size[1];
+  n    = (int)ra__->size(0);
+  nrhs = (int)rb__->size(1);
   lda  = n;
   ldb  = n;
 
@@ -217,11 +217,11 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   THArgCheck(b->dim() == 1 || b->dim() == 2, 1, "B should have 1 or 2 "
       "dimensions, but has %d", b->dim());
   THArgCheck(!b->is_empty(), 1, "B should not be empty");
-  THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
-      "rows, B has %ld", a->size[0], b->size[0]);
+  THArgCheck(a->size(0) == b->size(0), 2, "A,B size incompatible - A has %ld "
+      "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
+    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
             b->stride[0], 1, 0);
     free_b = 1;
   }
@@ -235,14 +235,14 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  m = ra__->size[0];
-  n = ra__->size[1];
+  m = ra__->size(0);
+  n = ra__->size(1);
   lda = m;
   ldb = (m > n) ? m : n;
 
   rb__ = THTensor_(cloneColumnMajorNrows)(rb_, b, ldb);
 
-  nrhs = rb__->size[1];
+  nrhs = rb__->size(1);
   info = 0;
 
 
@@ -290,12 +290,12 @@ void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *job
   THTensor *rv__ = NULL;
 
   THArgCheck(a_->dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a_->size[0] == a_->size[1], 1,"A should be square");
+  THArgCheck(a_->size(0) == a_->size(1), 1,"A should be square");
 
   /* we want to definitely clone a_ for geev*/
   a = THTensor_(cloneColumnMajor)(NULL, a_);
 
-  n = a->size[0];
+  n = a->size(0);
   lda = n;
 
   wi = THTensor_(newWithSize1d)(n);
@@ -362,7 +362,7 @@ void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz
 {
   if (a == NULL) a = rv_;
   THArgCheck(a->dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1,"A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1,"A should be square");
 
   int n, lda, lwork, info;
   THTensor *work = nullptr;
@@ -373,7 +373,7 @@ void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz
 
   rv__ = THTensor_(cloneColumnMajor)(rv_, a);
 
-  n = rv__->size[0];
+  n = rv__->size(0);
   lda = n;
 
   THTensor_(resize1d)(re_,n);
@@ -430,8 +430,8 @@ void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  m = ra__->size[0];
-  n = ra__->size[1];
+  m = ra__->size(0);
+  n = ra__->size(1);
   k = (m < n ? m : n);
 
   lda = m;
@@ -499,7 +499,7 @@ void THTensor_(getri)(THTensor *ra_, THTensor *a)
 {
   if (a == NULL) a = ra_;
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int m, n, lda, info, lwork;
   real wkopt;
@@ -509,8 +509,8 @@ void THTensor_(getri)(THTensor *ra_, THTensor *a)
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  m = ra__->size[0];
-  n = ra__->size[1];
+  m = ra__->size(0);
+  n = ra__->size(1);
   lda = m;
   ipiv = THIntTensor_newWithSize1d((int64_t)m);
 
@@ -542,9 +542,9 @@ void THTensor_(getri)(THTensor *ra_, THTensor *a)
 void THTensor_(clearUpLoTriangle)(THTensor *a, const char *uplo)
 {
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
-  int n = a->size[0];
+  int n = a->size(0);
 
   /* Build full matrix */
   real *p = THTensor_(data)(a);
@@ -575,9 +575,9 @@ void THTensor_(clearUpLoTriangle)(THTensor *a, const char *uplo)
 void THTensor_(copyUpLoTriangle)(THTensor *a, const char *uplo)
 {
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
-  int n = a->size[0];
+  int n = a->size(0);
 
   /* Build full matrix */
   real *p = THTensor_(data)(a);
@@ -609,14 +609,14 @@ void THTensor_(potrf)(THTensor *ra_, THTensor *a, const char *uplo)
 {
   if (a == NULL) a = ra_;
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int n, lda, info;
   THTensor *ra__ = NULL;
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  n = ra__->size[0];
+  n = ra__->size(0);
   lda = n;
 
   /* Run Factorization */
@@ -638,13 +638,13 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
       a->_dim());
   THArgCheck(b->_dim() == 1 || b->_dim() == 2, 1, "B should have 1 or 2 "
       "dimensions, but has %d", b->_dim());
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square, but is %ldx%ld",
-      a->size[0], a->size[1]);
-  THArgCheck(a->size[0] == b->size[0], 2, "A,B size incompatible - A has %ld "
-      "rows, B has %ld", a->size[0], b->size[0]);
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square, but is %ldx%ld",
+      a->size(0), a->size(1));
+  THArgCheck(a->size(0) == b->size(0), 2, "A,B size incompatible - A has %ld "
+      "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size[0],
+    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
             b->stride[0], 1, 0);
     free_b = 1;
   }
@@ -656,8 +656,8 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
   ra__ = THTensor_(cloneColumnMajor)(NULL, a);
   rb__ = THTensor_(cloneColumnMajor)(rb_, b);
 
-  n    = (int)ra__->size[0];
-  nrhs = (int)rb__->size[1];
+  n    = (int)ra__->size(0);
+  nrhs = (int)rb__->size(1);
   lda  = n;
   ldb  = n;
 
@@ -681,14 +681,14 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, const char *uplo)
 {
   if (a == NULL) a = ra_;
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int n, lda, info;
   THTensor *ra__ = NULL;
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  n = ra__->size[0];
+  n = ra__->size(0);
   lda = n;
 
   /* Run inverse */
@@ -719,9 +719,9 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, const char *uplo)
  */
 void THTensor_(pstrf)(THTensor *ra_, THIntTensor *rpiv_, THTensor *a, const char *uplo, real tol) {
   THArgCheck(a->_dim() == 2, 1, "A should be 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 1, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
-  int n = a->size[0];
+  int n = a->size(0);
 
   THTensor *ra__ = THTensor_(cloneColumnMajor)(ra_, a);
   THIntTensor_resize1d(rpiv_, n);
@@ -766,17 +766,17 @@ void THTensor_(pstrf)(THTensor *ra_, THIntTensor *rpiv_, THTensor *a, const char
 */
 void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a)
 {
-  int m = a->size[0];
-  int n = a->size[1];
+  int m = a->size(0);
+  int n = a->size(1);
   int k = (m < n ? m : n);
   THTensor *ra_ = THTensor_(new)();
   THTensor *rtau_ = THTensor_(new)();
   THTensor *rr__ = THTensor_(new)();
   THTensor_(geqrf)(ra_, rtau_, a);
-  THTensor_(resize2d)(rr__, k, ra_->size[1]);
+  THTensor_(resize2d)(rr__, k, ra_->size(1));
   THTensor_(narrow)(rr__, ra_, 0, 0, k);
   THTensor_(triu)(rr_, rr__, 0);
-  THTensor_(resize2d)(rq_, ra_->size[0], k);
+  THTensor_(resize2d)(rq_, ra_->size(0), k);
   THTensor_(orgqr)(rq_, ra_, rtau_);
   THTensor_(narrow)(rq_, rq_, 1, 0, k);
   THTensor_(free)(ra_);
@@ -812,8 +812,8 @@ void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
   /* Prepare the input for LAPACK, making a copy if necessary. */
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  int m = ra__->size[0];
-  int n = ra__->size[1];
+  int m = ra__->size(0);
+  int n = ra__->size(1);
   int k = (m < n ? m : n);
   int lda = m;
   THTensor_(resize1d)(rtau_, k);
@@ -866,8 +866,8 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  int m = ra__->size[0];
-  int k = tau->size[0];
+  int m = ra__->size(0);
+  int k = tau->size(0);
   int lda = m;
 
   /* Dry-run to query the suggested size of the workspace. */
@@ -919,9 +919,9 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, co
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, c);
 
-  int m = c->size[0];
-  int n = c->size[1];
-  int k = tau->size[0];
+  int m = c->size(0);
+  int n = c->size(1);
+  int k = tau->size(0);
   int lda;
   if (*side == 'L')
   {
@@ -968,8 +968,8 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
     THTensor_(copy)(ra_, a);
   }
 
-  int m = a->size[1];
-  int n = a->size[2];
+  int m = a->size(1);
+  int n = a->size(2);
   if (m != n) {
     THError("btrifact is only implemented for square matrices");
   }
@@ -1049,9 +1049,9 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
     THTensor_(copy)(rb_, b);
   }
 
-  int64_t num_batches = atf->size[0];
-  int64_t n = atf->size[1];
-  int nrhs = rb_->_dim() > 2 ? rb_->size[2] : 1;
+  int64_t num_batches = atf->size(0);
+  int64_t n = atf->size(1);
+  int nrhs = rb_->_dim() > 2 ? rb_->size(2) : 1;
 
   int lda, ldb;
   THTensor *atf_;
@@ -1077,7 +1077,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
   // correct ordering of B
   if (rb_->stride[1] == 1) {
     // column ordered
-    if (rb_->_dim() == 2 || rb_->size[2] == 1) {
+    if (rb_->_dim() == 2 || rb_->size(2) == 1) {
       ldb = n;
     } else {
       ldb = rb_->stride[2];

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -1976,28 +1976,28 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(mat->stride[0] == 1 && LDA_COND(mat->size(0), mat->size(1), mat->stride[1]))
+  if(mat->stride(0) == 1 && LDA_COND(mat->size(0), mat->size(1), mat->stride(1)))
   {
     THBlas_(gemv)('n', mat->size(0), mat->size(1),
-                  alpha, THTensor_(data)(mat), mat->stride[1],
-                  THTensor_(data)(vec), vec->stride[0],
-                  beta, THTensor_(data)(r_), r_->stride[0]);
+                  alpha, THTensor_(data)(mat), mat->stride(1),
+                  THTensor_(data)(vec), vec->stride(0),
+                  beta, THTensor_(data)(r_), r_->stride(0));
   }
-  else if(mat->stride[1] == 1 && LDA_COND(mat->size(1), mat->size(0), mat->stride[0]))
+  else if(mat->stride(1) == 1 && LDA_COND(mat->size(1), mat->size(0), mat->stride(0)))
   {
     THBlas_(gemv)('t',  mat->size(1), mat->size(0),
-                  alpha, THTensor_(data)(mat), mat->stride[0],
-                  THTensor_(data)(vec), vec->stride[0],
-                  beta, THTensor_(data)(r_), r_->stride[0]);
+                  alpha, THTensor_(data)(mat), mat->stride(0),
+                  THTensor_(data)(vec), vec->stride(0),
+                  beta, THTensor_(data)(r_), r_->stride(0));
   }
   else
   {
     THTensor *cmat = THTensor_(newContiguous)(mat);
 
     THBlas_(gemv)('t',  mat->size(1), mat->size(0),
-                  alpha, THTensor_(data)(cmat), cmat->stride[0],
-                  THTensor_(data)(vec), vec->stride[0],
-                  beta, THTensor_(data)(r_), r_->stride[0]);
+                  alpha, THTensor_(data)(cmat), cmat->stride(0),
+                  THTensor_(data)(vec), vec->stride(0),
+                  beta, THTensor_(data)(r_), r_->stride(0));
 
     THTensor_(free)(cmat);
   }
@@ -2085,14 +2085,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   #define LDC_COND(M, N, LDC) ((N) == 1 || (LDC) >= THMax(1, M))
 
   /* r_ */
-  if(r_->stride[0] == 1 &&
-     LDC_COND(r_->size(0), r_->size(1), r_->stride[1]))
+  if(r_->stride(0) == 1 &&
+     LDC_COND(r_->size(0), r_->size(1), r_->stride(1)))
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride[1] == 1 &&
-          LDC_COND(r_->size(1), r_->size(0), r_->stride[0]))
+  else if(r_->stride(1) == 1 &&
+          LDC_COND(r_->size(1), r_->size(0), r_->stride(0)))
   {
     THTensor *swap = m2;
     m2 = m1;
@@ -2115,18 +2115,18 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   int64_t m = r__->size((transpose_r == 'n' ? 0 : 1));
   int64_t n = r__->size((transpose_r == 'n' ? 1 : 0));
   int64_t k = m1->size((transpose_r == 'n' ? 1 : 0));
-  int64_t ldr__ = r__->stride[(transpose_r == 'n' ? 1 : 0)];
+  int64_t ldr__ = r__->stride((transpose_r == 'n' ? 1 : 0));
 
   /* m1 */
   /* Need ldm1_ >= max(1, (transpose_m1 == 'n' ? m : k)) */
-  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
-     m1->stride[(transpose_r == 'n' ? 1 : 0)] >= THMax(1, m))
+  if(m1->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
+     m1->stride((transpose_r == 'n' ? 1 : 0)) >= THMax(1, m))
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
-          m1->stride[(transpose_r == 'n' ? 0 : 1)] >= THMax(1, k))
+  else if(m1->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
+          m1->stride((transpose_r == 'n' ? 0 : 1)) >= THMax(1, k))
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -2140,14 +2140,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   /* m2 */
   /* Need ldm2_ >= max(1, (transpose_m2 == 'n' ? k : n)) */
-  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
-     m2->stride[(transpose_r == 'n' ? 1 : 0)] >= THMax(1, k))
+  if(m2->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
+     m2->stride((transpose_r == 'n' ? 1 : 0)) >= THMax(1, k))
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
-          m2->stride[(transpose_r == 'n' ? 0 : 1)] >= THMax(1, n))
+  else if(m2->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
+          m2->stride((transpose_r == 'n' ? 0 : 1)) >= THMax(1, n))
   {
     transpose_m2 = 't';
     m2_ = m2;
@@ -2159,8 +2159,8 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     free_m2 = 1;
   }
 
-  int64_t ldm1_ = (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]);
-  int64_t ldm2_ = (transpose_m2 == 'n' ? m2_->stride[(transpose_r == 'n' ? 1 : 0)] : m2_->stride[(transpose_r == 'n' ? 0 : 1)]);
+  int64_t ldm1_ = (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1)));
+  int64_t ldm2_ = (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1)));
 
 #pragma omp critical(blasgemm)
   /* do the operation */
@@ -2220,28 +2220,28 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(r_->stride[0] == 1 && LDA_COND(vec1->size(0), vec2->size(0), r_->stride[1]))
+  if(r_->stride(0) == 1 && LDA_COND(vec1->size(0), vec2->size(0), r_->stride(1)))
   {
     THBlas_(ger)(vec1->size(0), vec2->size(0),
-                 alpha, THTensor_(data)(vec1), vec1->stride[0],
-                 THTensor_(data)(vec2), vec2->stride[0],
-                 THTensor_(data)(r_), r_->stride[1]);
+                 alpha, THTensor_(data)(vec1), vec1->stride(0),
+                 THTensor_(data)(vec2), vec2->stride(0),
+                 THTensor_(data)(r_), r_->stride(1));
   }
-  else if(r_->stride[1] == 1 && LDA_COND(vec2->size(0), vec1->size(0), r_->stride[0]))
+  else if(r_->stride(1) == 1 && LDA_COND(vec2->size(0), vec1->size(0), r_->stride(0)))
   {
     THBlas_(ger)(vec2->size(0), vec1->size(0),
-                 alpha, THTensor_(data)(vec2), vec2->stride[0],
-                 THTensor_(data)(vec1), vec1->stride[0],
-                 THTensor_(data)(r_), r_->stride[0]);
+                 alpha, THTensor_(data)(vec2), vec2->stride(0),
+                 THTensor_(data)(vec1), vec1->stride(0),
+                 THTensor_(data)(r_), r_->stride(0));
   }
   else
   {
     THTensor *cr = THTensor_(newClone)(r_);
 
     THBlas_(ger)(vec2->size(0), vec1->size(0),
-                 alpha, THTensor_(data)(vec2), vec2->stride[0],
-                 THTensor_(data)(vec1), vec1->stride[0],
-                 THTensor_(data)(cr), cr->stride[0]);
+                 alpha, THTensor_(data)(vec2), vec2->stride(0),
+                 THTensor_(data)(vec1), vec1->stride(0),
+                 THTensor_(data)(cr), cr->stride(0));
 
     THTensor_(freeCopyTo)(cr, r_);
   }
@@ -2374,7 +2374,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
-  if (t->stride[dimension] == 1) {
+  if (t->stride(dimension) == 1) {
     real theMax;
     real value;
     int64_t theIndex;
@@ -2458,7 +2458,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
-  if (t->stride[dimension] == 1) {
+  if (t->stride(dimension) == 1) {
     real theMax;
     real value;
     int64_t theIndex;
@@ -2560,16 +2560,16 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride[j];
-            rem = rem%r_->stride[j];
-            tBasicIndex += quot*t->stride[j];
+            quot = rem/r_->stride(j);
+            rem = rem%r_->stride(j);
+            tBasicIndex += quot*t->stride(j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
         for(j=0; j < t->size(dimension); ++j) {
-          *r__data += *(t_data + j*t->stride[dimension]);
+          *r__data += *(t_data + j*t->stride(dimension));
         }
       }
     } else {
@@ -2581,7 +2581,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 #endif
   if (serial_path) {
     // two implementations optimized for data locality
-    if (t->stride[dimension] == 1) {
+    if (t->stride(dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal sum = 0;
                            int64_t i;
@@ -2640,16 +2640,16 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride[j];
-            rem = rem%r_->stride[j];
-            tBasicIndex += quot*t->stride[j];
+            quot = rem/r_->stride(j);
+            rem = rem%r_->stride(j);
+            tBasicIndex += quot*t->stride(j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
         for(j=0; j < t->size(dimension); ++j) {
-          *r__data *= *(t_data + j*t->stride[dimension]);
+          *r__data *= *(t_data + j*t->stride(dimension));
         }
       }
     } else {
@@ -2662,7 +2662,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
   if(serial_path) {
     // two implementations optimized for data locality
-    if (t->stride[dimension] == 1) {
+    if (t->stride(dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal prod = 1;
                            int64_t i;
@@ -2910,7 +2910,7 @@ void THTensor_(eye)(THTensor *r_, int64_t n, int64_t m)
   r__data = THTensor_(data)(r_);
   sz = THMin(THTensor_(size)(r_, 0), THTensor_(size)(r_, 1));
   for(i = 0; i < sz; i++)
-    r__data[i*(r_->stride[0]+r_->stride[1])] = 1;
+    r__data[i*(r_->stride(0)+r_->stride(1))] = 1;
 }
 
 
@@ -3951,16 +3951,16 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride[j];
-            rem = rem%r_->stride[j];
-            tBasicIndex += quot*t->stride[j];
+            quot = rem/r_->stride(j);
+            rem = rem%r_->stride(j);
+            tBasicIndex += quot*t->stride(j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
         for(j=0; j < t->size(dimension); ++j) {
-          *r__data = *r__data && *(t_data + j*t->stride[dimension]);
+          *r__data = *r__data && *(t_data + j*t->stride(dimension));
         }
       }
     } else {
@@ -3973,7 +3973,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
   if(serial_path) {
     // two implementations optimized for data locality
-    if (t->stride[dimension] == 1) {
+    if (t->stride(dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal prod = 1;
                            int64_t i;
@@ -4031,16 +4031,16 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride[j];
-            rem = rem%r_->stride[j];
-            tBasicIndex += quot*t->stride[j];
+            quot = rem/r_->stride(j);
+            rem = rem%r_->stride(j);
+            tBasicIndex += quot*t->stride(j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
         for(j=0; j < t->size(dimension); ++j) {
-          *r__data = *r__data || *(t_data + j*t->stride[dimension]);
+          *r__data = *r__data || *(t_data + j*t->stride(dimension));
         }
       }
     } else {
@@ -4052,7 +4052,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
 #endif
   if (serial_path) {
     // two implementations optimized for data locality
-    if (t->stride[dimension] == 1) {
+    if (t->stride(dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal sum = 0;
                            int64_t i;

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -4313,7 +4313,6 @@ accreal THTensor_(normall)(THTensor *tensor, real value)
 
 void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, real maxnorm)
 {
-  int i;
   THTensor *rowR, *rowS;
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(src), 3, "invalid dimension %d",
@@ -4327,7 +4326,7 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
 
   THTensor_(resizeAs)(res, src);
 
-  for (i=0; i<src->size(dimension); i++)
+  for (int64_t i = 0; i < src->size(dimension); i++)
   {
     real norm = 0;
     real new_norm;

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -327,7 +327,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   numel = THLongTensor_nElement(index);
 
   newSize = THLongStorage_newWithSize(src->dim());
-  THLongStorage_rawCopy(newSize,src->size);
+  THLongStorage_rawCopy(newSize, THTensor_getSizePtr(src));
 #ifdef DEBUG
   THAssert(numel <= LONG_MAX);
 #endif
@@ -424,7 +424,7 @@ void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTens
 }
 
 static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) {
-  int64_t *size = tensor->size;
+  auto size = tensor->sizes();
   int64_t *stride = tensor->stride;
   int nDim = tensor->_dim();
   ptrdiff_t dataOffset = 0;
@@ -445,7 +445,7 @@ static inline int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t nu
 
 void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
 {
-  THTensor_(resizeNd)(r_, index->dim(), index->size, NULL);
+  THTensor_(resizeNd)(r_, index->dim(), THTensor_getSizePtr(index), NULL);
   THTensor* dst = THTensor_(newContiguous)(r_);
 
   index = THLongTensor_newContiguous(index);
@@ -3739,25 +3739,25 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb)
 #define TENSOR_IMPLEMENT_LOGICAL(NAME,OP)				\
   void THTensor_(NAME##Value)(THByteTensor *r_, THTensor* t, real value)	\
   {									\
-    THByteTensor_resizeNd(r_, t->dim(), t->size, NULL);		\
+    THByteTensor_resizeNd(r_, t->dim(), THTensor_getSizePtr(t), NULL);		\
     TH_TENSOR_APPLY2(unsigned char, r_, real, t,			\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##ValueT)(THTensor* r_, THTensor* t, real value)	\
   {									\
-    THTensor_(resizeNd)(r_, t->dim(), t->size, NULL);		\
+    THTensor_(resizeNd)(r_, t->dim(), THTensor_getSizePtr(t), NULL);		\
     TH_TENSOR_APPLY2(real, r_, real, t,					\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##Tensor)(THByteTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THByteTensor_resizeNd(r_, ta->dim(), ta->size, NULL);		\
+    THByteTensor_resizeNd(r_, ta->dim(), THTensor_getSizePtr(ta), NULL);		\
     TH_TENSOR_APPLY3(unsigned char, r_, real, ta, real, tb,		\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\
   void THTensor_(NAME##TensorT)(THTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
-    THTensor_(resizeNd)(r_, ta->dim(), ta->size, NULL);		\
+    THTensor_(resizeNd)(r_, ta->dim(), THTensor_getSizePtr(ta), NULL);		\
     TH_TENSOR_APPLY3(real, r_, real, ta, real, tb,			\
 		     *r__data = (*ta_data OP *tb_data) ? 1 : 0;); \
   }									\

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -425,7 +425,7 @@ void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTens
 
 static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) {
   auto size = tensor->sizes();
-  int64_t *stride = tensor->stride;
+  auto stride = tensor->strides();
   int nDim = tensor->_dim();
   ptrdiff_t dataOffset = 0;
   for (int i = nDim - 1; i >= 0; i--) {

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -2417,12 +2417,12 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    tempValues_->size[dimension] = t->size[dimension];
+    THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
     tempValues_->stride[dimension] = 0;
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    tempIndices_->size[dimension] = t->size[dimension];
+    THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
     tempIndices_->stride[dimension] = 0;
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -2501,12 +2501,12 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    tempValues_->size[dimension] = t->size[dimension];
+    THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
     tempValues_->stride[dimension] = 0;
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    tempIndices_->size[dimension] = t->size[dimension];
+    THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
     tempIndices_->stride[dimension] = 0;
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -2592,7 +2592,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      temp_->size[dimension] = t->size[dimension];
+      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
       temp_->stride[dimension] = 0;
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
@@ -2673,7 +2673,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      temp_->size[dimension] = t->size[dimension];
+      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
       temp_->stride[dimension] = 0;
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
@@ -3984,7 +3984,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      temp_->size[dimension] = t->size[dimension];
+      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
       temp_->stride[dimension] = 0;
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data && *t_data;);
@@ -4063,7 +4063,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      temp_->size[dimension] = t->size[dimension];
+      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
       temp_->stride[dimension] = 0;
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data || *t_data;);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -118,21 +118,21 @@
 //         TENSOR2 is src
 //         TENSOR3 is index
 // Tests:
-//   1. index->size[d] <= src->size[d] for all d
-//   2. index->size[d] <= real->size[d] for all d != dim
+//   1. index->size(d) <= src->size(d) for all d
+//   2. index->size(d) <= real->size(d) for all d != dim
 #define TH_TENSOR_DIM_APPLY3_SIZE_SCATTER(TENSOR1, TENSOR2, TENSOR3, DIMENSION) \
 { \
   int shape_check_flag = 0; \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->_dim(); TH_TENSOR_DIM_APPLY_i++) \
   { \
-    int64_t TENSOR3##_dim_size = TENSOR3->size[TH_TENSOR_DIM_APPLY_i]; \
+    int64_t TENSOR3##_dim_size = TENSOR3->size(TH_TENSOR_DIM_APPLY_i); \
     if (TH_TENSOR_DIM_APPLY_i != DIMENSION) { \
-      if (TENSOR3##_dim_size > TENSOR1->size[TH_TENSOR_DIM_APPLY_i]) { \
+      if (TENSOR3##_dim_size > TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) { \
         shape_check_flag = 1; \
         break; \
       } \
     } \
-    if (TENSOR3##_dim_size > TENSOR2->size[TH_TENSOR_DIM_APPLY_i]) { \
+    if (TENSOR3##_dim_size > TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \
@@ -290,8 +290,8 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
                     div = 1;
 
                     for (dim = tensor->dim() - 1; dim >= 0; dim--) {
-                      *(subscript_data + dim) = (i/div) % tensor->size[dim];
-                      div *= tensor->size[dim];
+                      *(subscript_data + dim) = (i/div) % tensor->size(dim);
+                      div *= tensor->size(dim);
                     }
 
                     subscript_data += tensor->dim();
@@ -335,10 +335,10 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   {
     tensor_data = THTensor_(data)(tensor);
     src_data = THTensor_(data)(src);
-    ptrdiff_t rowsize = src->size[0] == 0 ? 1: THTensor_(nElement)(src) / src->size[0];
+    ptrdiff_t rowsize = src->size(0) == 0 ? 1: THTensor_(nElement)(src) / src->size(0);
 
     // check that the indices are within range
-    int64_t max = src->size[0] - 1 + TH_INDEX_BASE;
+    int64_t max = src->size(0) - 1 + TH_INDEX_BASE;
     for (i=0; i<numel; i++) {
       if (index_data[i] < TH_INDEX_BASE || index_data[i] > max) {
         THLongTensor_free(index);
@@ -519,7 +519,7 @@ void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTenso
   THArgCheck(index->dim() == 1, 3, "Index is supposed to be a vector");
   THArgCheck(dim < src->dim(), 4,"Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
 #endif
-  THArgCheck(numel == src->size[dim],4,"Number of indices should be equal to source:size(dim)");
+  THArgCheck(numel == src->size(dim),4,"Number of indices should be equal to source:size(dim)");
 
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
@@ -1952,7 +1952,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     THError("matrix and vector expected, got %dD, %dD",
       mat->dim(), vec->dim());
 
-  if( mat->size[1] != vec->size[0] ) {
+  if( mat->size(1) != vec->size(0) ) {
     THDescBuff bm = THTensor_(sizeDesc)(mat);
     THDescBuff bv = THTensor_(sizeDesc)(vec);
     THError("size mismatch, %s, %s", bm.str, bv.str);
@@ -1961,7 +1961,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if(t->dim() != 1)
     THError("vector expected, got t: %dD", t->dim());
 
-  if(t->size[0] != mat->size[0]) {
+  if(t->size(0) != mat->size(0)) {
     THDescBuff bt = THTensor_(sizeDesc)(t);
     THDescBuff bm = THTensor_(sizeDesc)(mat);
     THError("size mismatch, t: %s, mat: %s", bt.str, bm.str);
@@ -1976,16 +1976,16 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(mat->stride[0] == 1 && LDA_COND(mat->size[0], mat->size[1], mat->stride[1]))
+  if(mat->stride[0] == 1 && LDA_COND(mat->size(0), mat->size(1), mat->stride[1]))
   {
-    THBlas_(gemv)('n', mat->size[0], mat->size[1],
+    THBlas_(gemv)('n', mat->size(0), mat->size(1),
                   alpha, THTensor_(data)(mat), mat->stride[1],
                   THTensor_(data)(vec), vec->stride[0],
                   beta, THTensor_(data)(r_), r_->stride[0]);
   }
-  else if(mat->stride[1] == 1 && LDA_COND(mat->size[1], mat->size[0], mat->stride[0]))
+  else if(mat->stride[1] == 1 && LDA_COND(mat->size(1), mat->size(0), mat->stride[0]))
   {
-    THBlas_(gemv)('t',  mat->size[1], mat->size[0],
+    THBlas_(gemv)('t',  mat->size(1), mat->size(0),
                   alpha, THTensor_(data)(mat), mat->stride[0],
                   THTensor_(data)(vec), vec->stride[0],
                   beta, THTensor_(data)(r_), r_->stride[0]);
@@ -1994,7 +1994,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   {
     THTensor *cmat = THTensor_(newContiguous)(mat);
 
-    THBlas_(gemv)('t',  mat->size[1], mat->size[0],
+    THBlas_(gemv)('t',  mat->size(1), mat->size(0),
                   alpha, THTensor_(data)(cmat), cmat->stride[0],
                   THTensor_(data)(vec), vec->stride[0],
                   beta, THTensor_(data)(r_), r_->stride[0]);
@@ -2007,8 +2007,8 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
 void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
 {
-  int64_t N1 = m1->size[0];
-  int64_t N2 = m2->size[0];
+  int64_t N1 = m1->size(0);
+  int64_t N2 = m2->size(0);
   int64_t dim;
   real *m1_p;
   real *m2_p;
@@ -2023,8 +2023,8 @@ void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
   THTensor_(resize2d)(m1, N1, THTensor_(nElement)(m1) / N1);
   THTensor_(resize2d)(m2, N2, THTensor_(nElement)(m2) / N2);
 
-  dim = m1->size[1];
-  THArgCheck(m1->size[1] == m2->size[1], 3, "m1 and m2 must have the same inner vector dim");
+  dim = m1->size(1);
+  THArgCheck(m1->size(1) == m2->size(1), 3, "m1 and m2 must have the same inner vector dim");
 
   m1_p = THTensor_(data)(m1);
   m2_p = THTensor_(data)(m2);
@@ -2057,7 +2057,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if( (m1->dim() != 2) || (m2->dim() != 2))
     THError("matrices expected, got %dD, %dD tensors", m1->dim(), m2->dim());
 
-  if(m1->size[1] != m2->size[0]) {
+  if(m1->size(1) != m2->size(0)) {
     THDescBuff bm1 = THTensor_(sizeDesc)(m1);
     THDescBuff bm2 = THTensor_(sizeDesc)(m2);
     THError("size mismatch, m1: %s, m2: %s", bm1.str, bm2.str);
@@ -2066,7 +2066,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if( t->dim() != 2 )
     THError("matrix expected, got %dD tensor for t", t->dim());
 
-  if( (t->size[0] != m1->size[0]) || (t->size[1] != m2->size[1]) ) {
+  if( (t->size(0) != m1->size(0)) || (t->size(1) != m2->size(1)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
     THDescBuff bm1 = THTensor_(sizeDesc)(m1);
     THDescBuff bm2 = THTensor_(sizeDesc)(m2);
@@ -2086,13 +2086,13 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   /* r_ */
   if(r_->stride[0] == 1 &&
-     LDC_COND(r_->size[0], r_->size[1], r_->stride[1]))
+     LDC_COND(r_->size(0), r_->size(1), r_->stride[1]))
   {
     transpose_r = 'n';
     r__ = r_;
   }
   else if(r_->stride[1] == 1 &&
-          LDC_COND(r_->size[1], r_->size[0], r_->stride[0]))
+          LDC_COND(r_->size(1), r_->size(0), r_->stride[0]))
   {
     THTensor *swap = m2;
     m2 = m1;
@@ -2112,9 +2112,9 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   #undef LDC_COND
 
-  int64_t m = r__->size[(transpose_r == 'n' ? 0 : 1)];
-  int64_t n = r__->size[(transpose_r == 'n' ? 1 : 0)];
-  int64_t k = m1->size[(transpose_r == 'n' ? 1 : 0)];
+  int64_t m = r__->size((transpose_r == 'n' ? 0 : 1));
+  int64_t n = r__->size((transpose_r == 'n' ? 1 : 0));
+  int64_t k = m1->size((transpose_r == 'n' ? 1 : 0));
   int64_t ldr__ = r__->stride[(transpose_r == 'n' ? 1 : 0)];
 
   /* m1 */
@@ -2198,7 +2198,7 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   if(t->dim() != 2)
     THError("expected matrix, got %dD tensor for t", t->dim());
 
-  if( (t->size[0] != vec1->size[0]) || (t->size[1] != vec2->size[0]) ) {
+  if( (t->size(0) != vec1->size(0)) || (t->size(1) != vec2->size(0)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
     THDescBuff bv1 = THTensor_(sizeDesc)(vec1);
     THDescBuff bv2 = THTensor_(sizeDesc)(vec2);
@@ -2220,16 +2220,16 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(r_->stride[0] == 1 && LDA_COND(vec1->size[0], vec2->size[0], r_->stride[1]))
+  if(r_->stride[0] == 1 && LDA_COND(vec1->size(0), vec2->size(0), r_->stride[1]))
   {
-    THBlas_(ger)(vec1->size[0], vec2->size[0],
+    THBlas_(ger)(vec1->size(0), vec2->size(0),
                  alpha, THTensor_(data)(vec1), vec1->stride[0],
                  THTensor_(data)(vec2), vec2->stride[0],
                  THTensor_(data)(r_), r_->stride[1]);
   }
-  else if(r_->stride[1] == 1 && LDA_COND(vec2->size[0], vec1->size[0], r_->stride[0]))
+  else if(r_->stride[1] == 1 && LDA_COND(vec2->size(0), vec1->size(0), r_->stride[0]))
   {
-    THBlas_(ger)(vec2->size[0], vec1->size[0],
+    THBlas_(ger)(vec2->size(0), vec1->size(0),
                  alpha, THTensor_(data)(vec2), vec2->stride[0],
                  THTensor_(data)(vec1), vec1->stride[0],
                  THTensor_(data)(r_), r_->stride[0]);
@@ -2238,7 +2238,7 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   {
     THTensor *cr = THTensor_(newClone)(r_);
 
-    THBlas_(ger)(vec2->size[0], vec1->size[0],
+    THBlas_(ger)(vec2->size(0), vec1->size(0),
                  alpha, THTensor_(data)(vec2), vec2->stride[0],
                  THTensor_(data)(vec1), vec1->stride[0],
                  THTensor_(data)(cr), cr->stride[0]);
@@ -2407,7 +2407,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     }
     THLongTensor_zero(indices_);
 
-    if(t->size[dimension] == 1) {
+    if(t->size(dimension) == 1) {
       if (!keepdim) {
         THTensor_(squeeze1d)(values_, values_, dimension);
         THLongTensor_squeeze1d(indices_, indices_, dimension);
@@ -2417,12 +2417,12 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
+    THTensor_setSizeAtDim(tempValues_, dimension, t->size(dimension));
     THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
+    THTensor_setSizeAtDim(tempIndices_, dimension, t->size(dimension));
     THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -2491,7 +2491,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     }
     THLongTensor_zero(indices_);
 
-    if(t->size[dimension] == 1) {
+    if(t->size(dimension) == 1) {
       if (!keepdim) {
         THTensor_(squeeze1d)(values_, values_, dimension);
         THLongTensor_squeeze1d(indices_, indices_, dimension);
@@ -2501,12 +2501,12 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
+    THTensor_setSizeAtDim(tempValues_, dimension, t->size(dimension));
     THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
+    THTensor_setSizeAtDim(tempIndices_, dimension, t->size(dimension));
     THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -2568,7 +2568,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
-        for(j=0; j < t->size[dimension]; ++j) {
+        for(j=0; j < t->size(dimension); ++j) {
           *r__data += *(t_data + j*t->stride[dimension]);
         }
       }
@@ -2592,7 +2592,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
+      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
@@ -2648,7 +2648,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
-        for(j=0; j < t->size[dimension]; ++j) {
+        for(j=0; j < t->size(dimension); ++j) {
           *r__data *= *(t_data + j*t->stride[dimension]);
         }
       }
@@ -2673,7 +2673,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
+      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
@@ -3393,7 +3393,7 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   int64_t t_size_dim;
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(_nDimension)(t), 3, "dimension out of range");
-  THArgCheck(k > 0 && k <= t->size[dimension], 2, "selected index out of range");
+  THArgCheck(k > 0 && k <= t->size(dimension), 2, "selected index out of range");
 
   int in_dims = THTensor_(_nDimension)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
@@ -3602,8 +3602,8 @@ inline void THTensor_(check_shape_except_dim)(THTensor *first, THTensor *second,
     if (dim == dimension) {
       continue;
     }
-    int64_t first_dim_size = first->size[dim];
-    int64_t second_dim_size = second->size[dim];
+    int64_t first_dim_size = first->size(dim);
+    int64_t second_dim_size = second->size(dim);
     THArgCheck(first_dim_size == second_dim_size, 0,
         "Sizes of tensors must match except in dimension %d. Got %lld and %lld in dimension %d",
         dimension, (long long)first_dim_size, (long long)second_dim_size, dim);
@@ -3647,13 +3647,13 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
       continue;
     }
     THTensor_(check_shape_except_dim)(notSkippedTensor, tensor, dimension);
-    cat_dim_size += tensor->size[dimension];
+    cat_dim_size += tensor->size(dimension);
   }
 
   // Compute the size of the result
   THLongStorage *size = THLongStorage_newWithSize(nDims);
   for (int dim = 0; dim < nDims; dim++) {
-    int64_t result_dim_size = notSkippedTensor->size[dim];
+    int64_t result_dim_size = notSkippedTensor->size(dim);
     if (dim == dimension) {
       result_dim_size = cat_dim_size;
     }
@@ -3692,7 +3692,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
     offset = 0;
     for (int j = 0; j < numInputs; j++) {
       if (!should_skip(inputs[j])) {
-        int64_t dimSize = inputs[j]->size[dimension];
+        int64_t dimSize = inputs[j]->size(dimension);
         THTensor *nt = THTensor_(newWithTensor)(result);
         THTensor_(narrow)(nt, NULL, dimension, offset, dimSize);
         THTensor_(copy)(nt, inputs[j]);
@@ -3959,7 +3959,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
-        for(j=0; j < t->size[dimension]; ++j) {
+        for(j=0; j < t->size(dimension); ++j) {
           *r__data = *r__data && *(t_data + j*t->stride[dimension]);
         }
       }
@@ -3984,7 +3984,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
+      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data && *t_data;);
@@ -4039,7 +4039,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
-        for(j=0; j < t->size[dimension]; ++j) {
+        for(j=0; j < t->size(dimension); ++j) {
           *r__data = *r__data || *(t_data + j*t->stride[dimension]);
         }
       }
@@ -4063,7 +4063,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
+      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data || *t_data;);
@@ -4148,7 +4148,7 @@ void THTensor_(mean)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       dimension + TH_INDEX_BASE);
 
   THTensor_(sum)(r_, t, dimension, keepdim);
-  THTensor_(div)(r_, r_, t->size[dimension]);
+  THTensor_(div)(r_, r_, t->size(dimension));
 }
 
 void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim)
@@ -4327,7 +4327,7 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
 
   THTensor_(resizeAs)(res, src);
 
-  for (i=0; i<src->size[dimension]; i++)
+  for (i=0; i<src->size(dimension); i++)
   {
     real norm = 0;
     real new_norm;
@@ -4479,7 +4479,7 @@ void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, real min
   real minval;
   real maxval;
 
-  THTensor_(resize2d)(hist, tensor->size[0], nbins);
+  THTensor_(resize2d)(hist, tensor->size(0), nbins);
   THTensor_(zero)(hist);
 
   minval = minvalue;

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -2418,12 +2418,12 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
     THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
-    tempValues_->stride[dimension] = 0;
+    THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
     THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
-    tempIndices_->stride[dimension] = 0;
+    THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
                           if(!(*t_data <= *tempValues__data) && !th_isnan(*tempValues__data)) {
@@ -2502,12 +2502,12 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
     THTensor_setSizeAtDim(tempValues_, dimension, t->size[dimension]);
-    tempValues_->stride[dimension] = 0;
+    THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
     THTensor_setSizeAtDim(tempIndices_, dimension, t->size[dimension]);
-    tempIndices_->stride[dimension] = 0;
+    THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
                           if(!(*t_data >= *tempValues__data) && !th_isnan(*tempValues__data)) {
@@ -2593,7 +2593,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
       THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
-      temp_->stride[dimension] = 0;
+      THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
       THTensor_(free)(temp_);
@@ -2674,7 +2674,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
       THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
-      temp_->stride[dimension] = 0;
+      THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
       THTensor_(free)(temp_);
@@ -3985,7 +3985,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
       THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
-      temp_->stride[dimension] = 0;
+      THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data && *t_data;);
       THTensor_(free)(temp_);
@@ -4064,7 +4064,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
       THTensor_setSizeAtDim(temp_, dimension, t->size[dimension]);
-      temp_->stride[dimension] = 0;
+      THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data || *t_data;);
       THTensor_(free)(temp_);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -109,10 +109,7 @@
 #define TH_CHECK_SAME_SIZE(TENSOR1, TENSOR2) \
 { \
   if(!THTensor_(isSameSizeAs)(TENSOR1, TENSOR2)) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
-    THError("inconsistent tensor size, expected %s %s and %s %s to have the same size", \
-            #TENSOR1, T1buff.str, #TENSOR2, T2buff.str); \
+    AT_ERROR("inconsistent tensor size, expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size"); \
   } \
 }
 
@@ -141,11 +138,7 @@
     } \
   } \
   if (shape_check_flag == 1) { \
-    THDescBuff T1buff = _THSizeDesc(TENSOR1->size, TENSOR1->_dim()); \
-    THDescBuff T2buff = _THSizeDesc(TENSOR2->size, TENSOR2->_dim()); \
-    THDescBuff T3buff = _THSizeDesc(TENSOR3->size, TENSOR3->_dim()); \
-    THError("Expected %s %s to be smaller size than %s %s and to be smaller than %s %s apart from dimension %d", \
-            #TENSOR3, T3buff.str, #TENSOR2, T2buff.str, #TENSOR1, T1buff.str, DIMENSION); \
+    AT_ERROR("Expected ", #TENSOR3, " ", TENSOR3->sizes(), " to be smaller size than ", #TENSOR2, " ", TENSOR2->sizes(), " and to be smaller than ", #TENSOR1, " ", TENSOR1->sizes(), " apart from dimension ", DIMENSION); \
   } \
 }
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -79,7 +79,7 @@ void THTensor_(iBernoulli_generate_copy)(THTensor *self, THGenerator *_generator
 #endif
   } else {
     intTensor = THIntTensor_new();
-    THIntTensor_resizeNd(intTensor, self->dim(), self->size, NULL);
+    THIntTensor_resizeNd(intTensor, self->dim(), THTensor_getSizePtr(self), nullptr);
     tmp = THIntTensor_data(intTensor);
   }
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -284,9 +284,9 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
       small = THLongTensor_fastGet1d(smaller, small_c-1);
 
       THLongTensor_fastSet1d(J, small, large);
-      q_data[large * q->stride[0]] -= 1.0 - THTensor_(fastGet1d)(q, small);
+      q_data[large * q->stride(0)] -= 1.0 - THTensor_(fastGet1d)(q, small);
 
-      if(q_data[large * q->stride[0]] < 1.0)
+      if(q_data[large * q->stride(0)] < 1.0)
         {
           THLongTensor_fastSet1d(smaller, small_c-1, large);
           large_c -= 1;
@@ -317,7 +317,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     {
       for (i=0; i < inputsize; i++)
         {
-          q_data[i*q->stride[0]] /= q_max;
+          q_data[i*q->stride(0)] /= q_max;
         }
     }
   for (i=0; i < inputsize; i++)
@@ -399,7 +399,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
     {
       val = THStorage_(get)( \
         prob_dist->storage, \
-        prob_dist->storageOffset+i*prob_dist->stride[0]+j*prob_dist->stride[1] \
+        prob_dist->storageOffset+i*prob_dist->stride(0)+j*prob_dist->stride(1) \
       );
       THArgCheckWithCleanup((val >= 0),
                             THCleanup(THDoubleTensor_free(cum_dist); if (start_dim == 1) THTensor_(squeeze1d)(prob_dist, prob_dist, 0);),
@@ -412,7 +412,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
       sum += val;
       THDoubleStorage_set(
         cum_dist->storage, \
-        cum_dist->storageOffset+j*cum_dist->stride[0], \
+        cum_dist->storageOffset+j*cum_dist->stride(0), \
         sum \
       );
     }
@@ -426,7 +426,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
     {
       for (j=0; j<n_categories; j++)
       {
-        THDoubleTensor_data(cum_dist)[j*cum_dist->stride[0]] /= sum;
+        THDoubleTensor_data(cum_dist)[j*cum_dist->stride(0)] /= sum;
       }
     }
 
@@ -442,14 +442,14 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
       double cum_prob;
       int sample_idx;
       /* Make sure the last cumulative distribution bucket sums to 1 */
-      THDoubleTensor_data(cum_dist)[(n_categories-1)*cum_dist->stride[0]] = 1;
+      THDoubleTensor_data(cum_dist)[(n_categories-1)*cum_dist->stride(0)] = 1;
 
       while(right_pointer - left_pointer > 0)
       {
           mid_pointer = left_pointer + (right_pointer - left_pointer) / 2;
           cum_prob = THDoubleStorage_get( \
             cum_dist->storage, \
-            cum_dist->storageOffset+mid_pointer*cum_dist->stride[0] \
+            cum_dist->storageOffset+mid_pointer*cum_dist->stride(0) \
           );
           if (cum_prob < uniform_sample)
           {
@@ -465,7 +465,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
        /* store in result tensor (will be incremented for lua compat by wrapper) */
       THLongStorage_set( \
         self->storage, \
-        self->storageOffset+i*self->stride[0]+j*self->stride[1], \
+        self->storageOffset+i*self->stride(0)+j*self->stride(1), \
         sample_idx \
       );
 
@@ -481,13 +481,13 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
         {
           new_val = THDoubleStorage_get( \
             cum_dist->storage, \
-            cum_dist->storageOffset+(sample_idx-1)*cum_dist->stride[0] \
+            cum_dist->storageOffset+(sample_idx-1)*cum_dist->stride(0) \
           );
         }
         /* marginal cumulative mass (i.e. original probability) of sample */
         diff = THDoubleStorage_get( \
           cum_dist->storage, \
-          cum_dist->storageOffset+sample_idx*cum_dist->stride[0] \
+          cum_dist->storageOffset+sample_idx*cum_dist->stride(0) \
         ) - new_val;
         /* new sum of marginals is not one anymore... */
         sum = 1.0 - diff;
@@ -495,7 +495,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
         {
           new_val = THDoubleStorage_get( \
             cum_dist->storage, \
-            cum_dist->storageOffset+k*cum_dist->stride[0] \
+            cum_dist->storageOffset+k*cum_dist->stride(0) \
           );
           if (k >= sample_idx)
           {
@@ -506,7 +506,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
           new_val /= sum;
           THDoubleStorage_set( \
             cum_dist->storage, \
-            cum_dist->storageOffset+k*cum_dist->stride[0], \
+            cum_dist->storageOffset+k*cum_dist->stride(0), \
             new_val \
           );
         }

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -24,7 +24,7 @@ int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim) {
 
 int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim) {
   THArgCheck((dim >= 0) && (dim < self->dim()), 2, "out of range");
-  return self->stride[dim];
+  return self->stride(dim);
 }
 THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self) {
   THLongStorage *size = THLongStorage_newWithSize(self->dim());
@@ -113,7 +113,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
     }
 
     // NB: this used to test that stride[d] was >= 0
-    if((self->dim() > d) && stride && (stride[d] != self->stride[d])) {
+    if((self->dim() > d) && stride && (stride[d] != self->stride(d))) {
       hascorrectsize = false;
     }
   }
@@ -142,10 +142,10 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
         THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1),1)*self->stride[d+1]);
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1),1)*self->stride(d+1));
       }
     }
-    totalSize += (self->size(d)-1)*self->stride[d];
+    totalSize += (self->size(d)-1)*self->stride(d);
   }
 
   if(totalSize+self->storageOffset > 0)
@@ -220,7 +220,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
     for(d = dimension; d < self->dim()-1; d++)
     {
       THTensor_setSizeAtDim(self, d, self->size(d+1));
-      THTensor_setStrideAtDim(self, d, self->stride[d+1]);
+      THTensor_setStrideAtDim(self, d, self->stride(d+1));
     }
     THTensor_resizeDim(self, self->dim_ - 1);
   }
@@ -243,10 +243,10 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
     THTensor_setSizeAtDim(self, d, self->size(d-1));
-    THTensor_setStrideAtDim(self, d, self->stride[d-1]);
+    THTensor_setStrideAtDim(self, d, self->stride(d-1));
   }
   if (dimension+1 < self->dim()) {
-    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride[dimension+1]);
+    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride(dimension+1));
   } else {
     THTensor_setStrideAtDim(self, dimension, 1);
   }
@@ -261,7 +261,7 @@ bool THCTensor_isContiguous(THCState *state, const THCTensor *self) {
   {
     if(self->size(d) != 1)
     {
-      if(self->stride[d] == z)
+      if(self->stride(d) == z)
         z *= self->size(d);
       else
         return false;

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -19,7 +19,7 @@ int THCTensor__nDimension(THCState *state, const THCTensor *self) {
 
 int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim) {
   THArgCheck((dim >= 0) && (dim < self->dim()), 2, "out of range");
-  return self->size[dim];
+  return self->size(dim);
 }
 
 int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim) {
@@ -73,7 +73,7 @@ void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
     isSame = 1;
     for(d = 0; d < self->dim(); d++)
     {
-      if(self->size[d] != src->size[d])
+      if(self->size(d) != src->size(d))
       {
         isSame = 0;
         break;
@@ -108,7 +108,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
       AT_CHECK(size[d] > 0, "sizes must be non-negative");
     }
 #endif
-    if((self->dim() > d) && (size[d] != self->size[d])) {
+    if((self->dim() > d) && (size[d] != self->size(d))) {
       hascorrectsize = false;
     }
 
@@ -142,10 +142,10 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
         THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size[d+1],1)*self->stride[d+1]);
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1),1)*self->stride[d+1]);
       }
     }
-    totalSize += (self->size[d]-1)*self->stride[d];
+    totalSize += (self->size(d)-1)*self->stride[d];
   }
 
   if(totalSize+self->storageOffset > 0)
@@ -212,14 +212,14 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
   THCTensor_set(state, self, src);
 
 #ifdef TH_SCALAR
-  if(src->size[dimension] == 1)
+  if(src->size(dimension) == 1)
 #else
-  if(src->size[dimension] == 1 && src->dim() > 1)
+  if(src->size(dimension) == 1 && src->dim() > 1)
 #endif
   {
     for(d = dimension; d < self->dim()-1; d++)
     {
-      THTensor_setSizeAtDim(self, d, self->size[d+1]);
+      THTensor_setSizeAtDim(self, d, self->size(d+1));
       THTensor_setStrideAtDim(self, d, self->stride[d+1]);
     }
     THTensor_resizeDim(self, self->dim_ - 1);
@@ -242,11 +242,11 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
-    THTensor_setSizeAtDim(self, d, self->size[d-1]);
+    THTensor_setSizeAtDim(self, d, self->size(d-1));
     THTensor_setStrideAtDim(self, d, self->stride[d-1]);
   }
   if (dimension+1 < self->dim()) {
-    THTensor_setStrideAtDim(self, dimension, self->size[dimension+1] * self->stride[dimension+1]);
+    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride[dimension+1]);
   } else {
     THTensor_setStrideAtDim(self, dimension, 1);
   }
@@ -259,10 +259,10 @@ bool THCTensor_isContiguous(THCState *state, const THCTensor *self) {
   int d;
   for(d = self->dim()-1; d >= 0; d--)
   {
-    if(self->size[d] != 1)
+    if(self->size(d) != 1)
     {
       if(self->stride[d] == z)
-        z *= self->size[d];
+        z *= self->size(d);
       else
         return false;
     }
@@ -288,7 +288,7 @@ ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self) {
     ptrdiff_t nElement = 1;
     int d;
     for(d = 0; d < self->_dim(); d++)
-      nElement *= self->size[d];
+      nElement *= self->size(d);
     return nElement;
   }
 }

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -128,8 +128,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
 
   if(nDimension != self->dim())
   {
-    THTensor_resizeSize(self, nDimension);
-    self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*nDimension);
+    THTensor_resizeDim(self, nDimension);
     self->dim_ = nDimension;
   }
 
@@ -170,7 +169,7 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
                            src->storageOffset,
                            src->dim(),
                            THTensor_getSizePtr(src),
-                           src->stride);
+                           THTensor_getStridePtr(src));
 }
 
 void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)
@@ -242,8 +241,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THCTensor_set(state, self, src);
 
-  THTensor_resizeSize(self, self->dim() + 1);
-  self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->dim()+1));
+  THTensor_resizeDim(self, self->dim() + 1);
   self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -134,7 +134,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
   totalSize = 1;
   for(d = nDimension-1; d >= 0; d--)
   {
-    self->size[d] = size[d];
+    THTensor_setSizeAtDim(self, d, size[d]);
     if(stride && (stride[d] >= 0) ) {
       self->stride[d] = stride[d];
     } else {
@@ -219,7 +219,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
   {
     for(d = dimension; d < self->dim()-1; d++)
     {
-      self->size[d] = self->size[d+1];
+      THTensor_setSizeAtDim(self, d, self->size[d+1]);
       self->stride[d] = self->stride[d+1];
     }
     THTensor_resizeDim(self, self->dim_ - 1);
@@ -242,7 +242,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
-    self->size[d] = self->size[d-1];
+    THTensor_setSizeAtDim(self, d, self->size[d-1]);
     self->stride[d] = self->stride[d-1];
   }
   if (dimension+1 < self->dim()) {
@@ -250,7 +250,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
   } else {
     self->stride[dimension] = 1;
   }
-  self->size[dimension] = 1;
+  THTensor_setSizeAtDim(self, dimension, 1);
 }
 
 bool THCTensor_isContiguous(THCState *state, const THCTensor *self) {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -28,7 +28,7 @@ int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim) {
 }
 THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self) {
   THLongStorage *size = THLongStorage_newWithSize(self->dim());
-  THLongStorage_rawCopy(size, self->size);
+  THLongStorage_rawCopy(size, THTensor_getSizePtr(self));
   return size;
 }
 
@@ -82,7 +82,7 @@ void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
   }
 
   if(!isSame)
-    THCTensor_resizeNd(state, self, src->dim(), src->size, NULL);
+    THCTensor_resizeNd(state, self, src->dim(), THTensor_getSizePtr(src), NULL);
 }
 
 void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_t *size, int64_t *stride)
@@ -128,7 +128,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
 
   if(nDimension != self->dim())
   {
-    self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*nDimension);
+    THTensor_resizeSize(self, nDimension);
     self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*nDimension);
     self->dim_ = nDimension;
   }
@@ -169,7 +169,7 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
                            src->storage,
                            src->storageOffset,
                            src->dim(),
-                           src->size,
+                           THTensor_getSizePtr(src),
                            src->stride);
 }
 
@@ -242,7 +242,7 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
 
   THCTensor_set(state, self, src);
 
-  self->size = (int64_t*)THRealloc(self->size, sizeof(int64_t)*(self->dim()+1));
+  THTensor_resizeSize(self, self->dim() + 1);
   self->stride = (int64_t*)THRealloc(self->stride, sizeof(int64_t)*(self->dim()+1));
   self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -129,7 +129,6 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
   if(nDimension != self->dim())
   {
     THTensor_resizeDim(self, nDimension);
-    self->dim_ = nDimension;
   }
 
   totalSize = 1;
@@ -242,7 +241,6 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
   THCTensor_set(state, self, src);
 
   THTensor_resizeDim(self, self->dim() + 1);
-  self->dim_++;
   for (d = self->dim()-1; d > dimension; d--) {
     self->size[d] = self->size[d-1];
     self->stride[d] = self->stride[d-1];

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -136,13 +136,13 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
   {
     THTensor_setSizeAtDim(self, d, size[d]);
     if(stride && (stride[d] >= 0) ) {
-      self->stride[d] = stride[d];
+      THTensor_setStrideAtDim(self, d, stride[d]);
     } else {
       if(d == nDimension-1) {
-        self->stride[d] = 1;
+        THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        self->stride[d] = std::max<int64_t>(self->size[d+1],1)*self->stride[d+1];
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size[d+1],1)*self->stride[d+1]);
       }
     }
     totalSize += (self->size[d]-1)*self->stride[d];
@@ -220,7 +220,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
     for(d = dimension; d < self->dim()-1; d++)
     {
       THTensor_setSizeAtDim(self, d, self->size[d+1]);
-      self->stride[d] = self->stride[d+1];
+      THTensor_setStrideAtDim(self, d, self->stride[d+1]);
     }
     THTensor_resizeDim(self, self->dim_ - 1);
   }
@@ -243,12 +243,12 @@ void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
     THTensor_setSizeAtDim(self, d, self->size[d-1]);
-    self->stride[d] = self->stride[d-1];
+    THTensor_setStrideAtDim(self, d, self->stride[d-1]);
   }
   if (dimension+1 < self->dim()) {
-    self->stride[dimension] = self->size[dimension+1] * self->stride[dimension+1];
+    THTensor_setStrideAtDim(self, dimension, self->size[dimension+1] * self->stride[dimension+1]);
   } else {
-    self->stride[dimension] = 1;
+    THTensor_setStrideAtDim(self, dimension, 1);
   }
   THTensor_setSizeAtDim(self, dimension, 1);
 }

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -222,7 +222,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }
-    self->dim_--;
+    THTensor_resizeDim(self, self->dim_ - 1);
   }
 }
 

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -160,8 +160,8 @@ sampleMultinomialOnce(int64_t* dest,
                       int categories,
                       T* sampled,
                       T* dist,
-                      int stride_dist,        // dist->stride[0]
-                      int stride_categories   // dist->stride[1]
+                      int stride_dist,        // dist->stride(0)
+                      int stride_categories   // dist->stride(1)
                       ) {
   extern __shared__  unsigned char my_smem[];
   __shared__ bool found;

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -448,8 +448,8 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
 
   THCTensor_(set)(state, self, src);
 
-  std::vector<int64_t> newSize(/* size */ self->dim() + 1);
-  std::vector<int64_t> newStride(/* size */ self->dim() + 1);
+  std::vector<int64_t> newSize(self->dim() + 1);
+  std::vector<int64_t> newStride(self->dim() + 1);
 
   newSize[self->dim()] = size;
   newStride[self->dim()] = self->stride[dimension];

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -218,8 +218,8 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
-                                        at::IntList(THTensor_getStridePtr(tensor), tensor->dim()),
+  auto stride = THTensor_compute_stride(tensor->sizes(),
+                                        tensor->strides(),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "
     "not compatible with input tensor's size and stride (at least one dimension spans "
@@ -468,7 +468,6 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   }
 
   THTensor_setSizesAndStrides(self, std::move(newSize), std::move(newStride));
-  self->dim_++;
 }
 
 /* we have to handle the case where the result is a number */
@@ -503,7 +502,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
     self->stride[0] = 1;
     ndim = 1;
   }
-  self->dim_ = ndim;
+  THTensor_resizeDim(self, ndim);
 }
 #endif
 

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -406,7 +406,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
     self->size[d] = self->size[d+1];
     self->stride[d] = self->stride[d+1];
   }
-  self->dim_--;
+  THTensor_resizeDim(self, self->dim_ - 1);
 }
 
 void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int dimension1, int dimension2)

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -218,7 +218,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
   THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
+  auto stride = THTensor_compute_stride(at::IntList(THTensor_getSizePtr(tensor), tensor->dim()),
                                         at::IntList(tensor->stride, tensor->dim()),
                                         at::IntList(inferred_size->data<int64_t>(), inferred_size->size));
   THArgCheck(stride.has_value(), 2, "view size is "

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -404,7 +404,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
   for(d = dimension; d < self->dim()-1; d++)
   {
     THTensor_setSizeAtDim(self, d, self->size[d+1]);
-    self->stride[d] = self->stride[d+1];
+    THTensor_setStrideAtDim(self, d, self->stride[d+1]);
   }
   THTensor_resizeDim(self, self->dim_ - 1);
 }
@@ -425,8 +425,8 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
     return;
 
   z = self->stride[dimension1];
-  self->stride[dimension1] = self->stride[dimension2];
-  self->stride[dimension2] = z;
+  THTensor_setStrideAtDim(self, dimension1, self->stride[dimension2]);
+  THTensor_setStrideAtDim(self, dimension2, z);
   z = self->size[dimension1];
   THTensor_setSizeAtDim(self, dimension1, self->size[dimension2]);
   THTensor_setSizeAtDim(self, dimension2, z);
@@ -488,7 +488,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
       if(d != ndim)
       {
         THTensor_setSizeAtDim(self, ndim, src->size[d]);
-        self->stride[ndim] = src->stride[d];
+        THTensor_setStrideAtDim(self, ndim, src->stride[d]);
       }
       ndim++;
     }
@@ -499,7 +499,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
   if(ndim == 0 && src->dim() > 0)
   {
     THTensor_setSizeAtDim(self, 0, 1);
-    self->stride[0] = 1;
+    THTensor_setStrideAtDim(self, 0, 1);
     ndim = 1;
   }
   THTensor_resizeDim(self, ndim);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -377,7 +377,7 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
   THCTensor_(set)(state, self, src);
 
   if(firstIndex > 0)
-    self->storageOffset += firstIndex*self->stride[dimension];
+    self->storageOffset += firstIndex*self->stride(dimension);
 
   THTensor_setSizeAtDim(self, dimension, size);
 }
@@ -404,7 +404,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
   for(d = dimension; d < self->dim()-1; d++)
   {
     THTensor_setSizeAtDim(self, d, self->size(d+1));
-    THTensor_setStrideAtDim(self, d, self->stride[d+1]);
+    THTensor_setStrideAtDim(self, d, self->stride(d+1));
   }
   THTensor_resizeDim(self, self->dim_ - 1);
 }
@@ -424,8 +424,8 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
   if(dimension1 == dimension2)
     return;
 
-  z = self->stride[dimension1];
-  THTensor_setStrideAtDim(self, dimension1, self->stride[dimension2]);
+  z = self->stride(dimension1);
+  THTensor_setStrideAtDim(self, dimension1, self->stride(dimension2));
   THTensor_setStrideAtDim(self, dimension2, z);
   z = self->size(dimension1);
   THTensor_setSizeAtDim(self, dimension1, self->size(dimension2));
@@ -452,18 +452,18 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   std::vector<int64_t> newStride(self->dim() + 1);
 
   newSize[self->dim()] = size;
-  newStride[self->dim()] = self->stride[dimension];
+  newStride[self->dim()] = self->stride(dimension);
   for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {
       newSize[d] = (self->size(d) - size) / step + 1;
-      newStride[d] = step*self->stride[d];
+      newStride[d] = step*self->stride(d);
     }
     else
     {
       newSize[d] = self->size(d);
-      newStride[d] = self->stride[d];
+      newStride[d] = self->stride(d);
     }
   }
 
@@ -488,7 +488,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
       if(d != ndim)
       {
         THTensor_setSizeAtDim(self, ndim, src->size(d));
-        THTensor_setStrideAtDim(self, ndim, src->stride[d]);
+        THTensor_setStrideAtDim(self, ndim, src->stride(d));
       }
       ndim++;
     }
@@ -544,7 +544,7 @@ int THCTensor_(isSetTo)(THCState *state, const THCTensor *self, const THCTensor 
     int d;
     for (d = 0; d < self->dim(); ++d)
     {
-      if (self->size(d) != src->size(d) || self->stride[d] != src->stride[d])
+      if (self->size(d) != src->size(d) || self->stride(d) != src->stride(d))
         return 0;
     }
     return 1;
@@ -604,56 +604,56 @@ void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real valu
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
+  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0), value);
 }
 
 real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]);
+  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0));
 }
 
 void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
+  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1), value);
 }
 
 real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]);
+  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1));
 }
 
 void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
+  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
 }
 
 real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]);
+  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
 }
 
 void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
+  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
 }
 
 real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3]);
+  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
 }
 
 int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...)

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -372,7 +372,7 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
 #else
   THArgCheck( size > 0, 5, "out of range");
 #endif
-  THArgCheck(firstIndex+size <= src->size[dimension], 5, "out of range");
+  THArgCheck(firstIndex+size <= src->size(dimension), 5, "out of range");
 
   THCTensor_(set)(state, self, src);
 
@@ -397,13 +397,13 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
 #endif
 #endif
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 3, "out of range");
-  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 4, "out of range");
+  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size(dimension)), 4, "out of range");
 
   THCTensor_(set)(state, self, src);
   THCTensor_(narrow)(state, self, NULL, dimension, sliceIndex, 1);
   for(d = dimension; d < self->dim()-1; d++)
   {
-    THTensor_setSizeAtDim(self, d, self->size[d+1]);
+    THTensor_setSizeAtDim(self, d, self->size(d+1));
     THTensor_setStrideAtDim(self, d, self->stride[d+1]);
   }
   THTensor_resizeDim(self, self->dim_ - 1);
@@ -427,8 +427,8 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
   z = self->stride[dimension1];
   THTensor_setStrideAtDim(self, dimension1, self->stride[dimension2]);
   THTensor_setStrideAtDim(self, dimension2, z);
-  z = self->size[dimension1];
-  THTensor_setSizeAtDim(self, dimension1, self->size[dimension2]);
+  z = self->size(dimension1);
+  THTensor_setSizeAtDim(self, dimension1, self->size(dimension2));
   THTensor_setSizeAtDim(self, dimension2, z);
 }
 
@@ -443,7 +443,7 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
 #endif
   THArgCheck(dimension < src->dim(), 2, "out of range");
-  THArgCheck(size <= src->size[dimension], 3, "out of range");
+  THArgCheck(size <= src->size(dimension), 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THCTensor_(set)(state, self, src);
@@ -457,12 +457,12 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   {
     if(d == dimension)
     {
-      newSize[d] = (self->size[d] - size) / step + 1;
+      newSize[d] = (self->size(d) - size) / step + 1;
       newStride[d] = step*self->stride[d];
     }
     else
     {
-      newSize[d] = self->size[d];
+      newSize[d] = self->size(d);
       newStride[d] = self->stride[d];
     }
   }
@@ -483,11 +483,11 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
 
   for(d = 0; d < src->dim(); d++)
   {
-    if(src->size[d] != 1)
+    if(src->size(d) != 1)
     {
       if(d != ndim)
       {
-        THTensor_setSizeAtDim(self, ndim, src->size[d]);
+        THTensor_setSizeAtDim(self, ndim, src->size(d));
         THTensor_setStrideAtDim(self, ndim, src->stride[d]);
       }
       ndim++;
@@ -529,7 +529,7 @@ int THCTensor_(isSize)(THCState *state, const THCTensor *self, const THLongStora
 
   for (d = 0; d < self->dim(); ++d)
   {
-    if (self->size[d] != THLongStorage_data(dims)[d])
+    if (self->size(d) != THLongStorage_data(dims)[d])
       return 0;
   }
   return 1;
@@ -544,7 +544,7 @@ int THCTensor_(isSetTo)(THCState *state, const THCTensor *self, const THCTensor 
     int d;
     for (d = 0; d < self->dim(); ++d)
     {
-      if (self->size[d] != src->size[d] || self->stride[d] != src->stride[d])
+      if (self->size(d) != src->size(d) || self->stride[d] != src->stride[d])
         return 0;
     }
     return 1;
@@ -559,7 +559,7 @@ int THCTensor_(isSameSizeAs)(THCState *state, const THCTensor *self, const THCTe
     return 0;
   for(d = 0; d < self->dim(); ++d)
   {
-    if(self->size[d] != src->size[d])
+    if(self->size(d) != src->size(d))
       return 0;
   }
   return 1;
@@ -603,56 +603,56 @@ void THCTensor_(resizeNd)(THCState *state, THCTensor *self, int nDimension, int6
 void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real value)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
+  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
 }
 
 real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
+  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]);
 }
 
 void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
+  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
 }
 
 real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
+  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]);
 }
 
 void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
+  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
 }
 
 real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
+  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]);
 }
 
 void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");
+  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
 }
 
 real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");
+  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3]);
 }
 
@@ -712,7 +712,7 @@ THCDescBuff THCTensor_(sizeDesc)(THCState *state, const THCTensor *tensor) {
   int i;
   for(i = 0; i < tensor->dim(); i++) {
     if(n >= L) break;
-    n += snprintf(str+n, L-n, "%" PRId64, tensor->size[i]);
+    n += snprintf(str+n, L-n, "%" PRId64, tensor->size(i));
     if(i < tensor->dim()-1) {
       n += snprintf(str+n, L-n, " x ");
     }

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -379,7 +379,7 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
   if(firstIndex > 0)
     self->storageOffset += firstIndex*self->stride[dimension];
 
-  self->size[dimension] = size;
+  THTensor_setSizeAtDim(self, dimension, size);
 }
 
 void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int dimension, int64_t sliceIndex)
@@ -403,7 +403,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
   THCTensor_(narrow)(state, self, NULL, dimension, sliceIndex, 1);
   for(d = dimension; d < self->dim()-1; d++)
   {
-    self->size[d] = self->size[d+1];
+    THTensor_setSizeAtDim(self, d, self->size[d+1]);
     self->stride[d] = self->stride[d+1];
   }
   THTensor_resizeDim(self, self->dim_ - 1);
@@ -428,8 +428,8 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
   self->stride[dimension1] = self->stride[dimension2];
   self->stride[dimension2] = z;
   z = self->size[dimension1];
-  self->size[dimension1] = self->size[dimension2];
-  self->size[dimension2] = z;
+  THTensor_setSizeAtDim(self, dimension1, self->size[dimension2]);
+  THTensor_setSizeAtDim(self, dimension2, z);
 }
 
 void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int dimension, int64_t size, int64_t step)
@@ -487,7 +487,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
     {
       if(d != ndim)
       {
-        self->size[ndim] = src->size[d];
+        THTensor_setSizeAtDim(self, ndim, src->size[d]);
         self->stride[ndim] = src->stride[d];
       }
       ndim++;
@@ -498,7 +498,7 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
   /* right now, we do not handle 0-dimension tensors */
   if(ndim == 0 && src->dim() > 0)
   {
-    self->size[0] = 1;
+    THTensor_setSizeAtDim(self, 0, 1);
     self->stride[0] = 1;
     ndim = 1;
   }

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -224,7 +224,7 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THArgCheck(!(THCTensor_(_nDimension)(state, src) == 0 && THCudaLongTensor__nDimension(state, index) != 0), 2,
              "tried to take from an empty tensor");
 
-  THCTensor_(resizeNd)(state, dst, index->dim(), index->size, NULL);
+  THCTensor_(resizeNd)(state, dst, index->dim(), THTensor_getSizePtr(index), NULL);
 
   // dispatchTakePut only handles non-empty tensors;
   if (index->_dim() > 0) {

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -19,14 +19,14 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
   ptrdiff_t dstSliceSize = 1;
   for (int d = 0; d < dstDims; d++) {
     if (d != dim) {
-      dstSliceSize *= dst->size[d];
+      dstSliceSize *= dst->size(d);
     }
   }
 
   if (src == nullptr) return dstSliceSize;
 
   THArgCheck(dim < srcDims, 3, "Indexing dim is out of bounds");
-  THArgCheck(THCudaLongTensor_nElement(state, index) == src->size[dim], 4,
+  THArgCheck(THCudaLongTensor_nElement(state, index) == src->size(dim), 4,
              "length of src.size[dim] is not equal to length of indices");
 
   ptrdiff_t srcSliceSize = 1;
@@ -36,8 +36,8 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
 
   for (int d = 0; d < srcDims; d++) {
     if (d != dim) {
-      srcSliceSize *= src->size[d];
-      if (!mismatch && dst->size[d] != src->size[d]) mismatch = true;
+      srcSliceSize *= src->size(d);
+      if (!mismatch && dst->size(d) != src->size(d)) mismatch = true;
     }
   }
 

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -314,9 +314,9 @@ void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor,
       strided_tensor.begin(),
       strided_tensor.end(),
       stride_dim.begin(),
-      idx_functor(div, self->size[dim])
+      idx_functor(div, self->size(dim))
     );
-    div *= self->size[dim];
+    div *= self->size(dim);
   }
 
   THCudaLongTensor_resize2d(state, tensor, num_nonzeros, num_dim);

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -52,13 +52,13 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   if( (mat->dim() != 2) || (vec->dim() != 1) )
     THError("matrix and vector expected");
 
-  if( mat->size[1] != vec->size[0] )
+  if( mat->size(1) != vec->size(0) )
     THError("size mismatch");
 
   if(t->dim() != 1)
     THError("size mismatch");
 
-  if(t->size[0] != mat->size[0])
+  if(t->size(0) != mat->size(0))
     THError("size mismatch");
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
@@ -71,12 +71,12 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   if(mat->stride[0] == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 'n', mat->size[0], mat->size[1],
+    THCudaBlas_Sgemv(state, 'n', mat->size(0), mat->size(1),
                     alpha, THCTensor_(data)(state, mat), mat->stride[1],
                     THCTensor_(data)(state, vec), vec->stride[0],
                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 'n', mat->size[0], mat->size[1],
+    THCudaBlas_Dgemv(state, 'n', mat->size(0), mat->size(1),
                     alpha, THCTensor_(data)(state, mat), mat->stride[1],
                     THCTensor_(data)(state, vec), vec->stride[0],
                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
@@ -85,12 +85,12 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   else if(mat->stride[1] == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 't',  mat->size[1], mat->size[0],
+    THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
                     alpha, THCTensor_(data)(state, mat), mat->stride[0],
                     THCTensor_(data)(state, vec), vec->stride[0],
                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 't',  mat->size[1], mat->size[0],
+    THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
                      alpha, THCTensor_(data)(state, mat), mat->stride[0],
                      THCTensor_(data)(state, vec), vec->stride[0],
                      beta, THCTensor_(data)(state, r_), r_->stride[0]);
@@ -101,12 +101,12 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THCTensor *cmat = THCTensor_(newContiguous)(state, mat);
 
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 't',  mat->size[1], mat->size[0],
+    THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
                     alpha, THCTensor_(data)(state, cmat), cmat->stride[0],
                     THCTensor_(data)(state, vec), vec->stride[0],
                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 't',  mat->size[1], mat->size[0],
+    THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
                     alpha, THCTensor_(data)(state, cmat), cmat->stride[0],
                     THCTensor_(data)(state, vec), vec->stride[0],
                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
@@ -128,15 +128,15 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 #elif defined(THC_REAL_IS_HALF)
     // Currently no Hgemv/SgemvEx in Cublas
     THCTensor *vecAsMatrix = THCTensor_(newWithTensor)(state, vec);
-    THCTensor_(resize2d)(state, vecAsMatrix, vecAsMatrix->size[0], 1);
+    THCTensor_(resize2d)(state, vecAsMatrix, vecAsMatrix->size(0), 1);
 
     THCTensor *tAsMatrix = THCTensor_(newWithTensor)(state, t);
-    THCTensor_(resize2d)(state, tAsMatrix, tAsMatrix->size[0], 1);
+    THCTensor_(resize2d)(state, tAsMatrix, tAsMatrix->size(0), 1);
 
     THCTensor_(addmm)(state, r_, beta, tAsMatrix, alpha, mat, vecAsMatrix);
 
     // r_ will have answer as matrix, need to return a vector
-    THCTensor_(resize1d)(state, r_, r_->size[0]);
+    THCTensor_(resize1d)(state, r_, r_->size(0));
     THCTensor_(free)(state, vecAsMatrix);
     THCTensor_(free)(state, tAsMatrix);
 #endif
@@ -158,7 +158,7 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THError("size mismatch");
   }
 
-  if ( (t->size[0] != vec1->size[0]) || (t->size[1] != vec2->size[0]) ) {
+  if ( (t->size(0) != vec1->size(0)) || (t->size(1) != vec2->size(0)) ) {
     THError("size mismatch");
   }
 
@@ -177,12 +177,12 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
   if(r_->stride[0] == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec1->size[0], vec2->size[0],
+    THCudaBlas_Sger(state, vec1->size(0), vec2->size(0),
                    alpha, THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, r_), r_->stride[1]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec1->size[0], vec2->size[0],
+    THCudaBlas_Dger(state, vec1->size(0), vec2->size(0),
                    alpha, THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, r_), r_->stride[1]);
@@ -191,12 +191,12 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
   else if(r_->stride[1] == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec2->size[0], vec1->size[0],
+    THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
                    alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, r_), r_->stride[0]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec2->size[0], vec1->size[0],
+    THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
                    alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, r_), r_->stride[0]);
@@ -207,12 +207,12 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THCTensor *cr = THCTensor_(newClone)(state, r_);
 
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec2->size[0], vec1->size[0],
+    THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
                    alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, cr), cr->stride[0]);
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec2->size[0], vec1->size[0],
+    THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
                    alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
                    THCTensor_(data)(state, vec1), vec1->stride[0],
                    THCTensor_(data)(state, cr), cr->stride[0]);
@@ -223,11 +223,11 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
 #elif defined(THC_REAL_IS_HALF)
   // currently no Hger/SgerEx in Cublas.
   THCTensor *vec2T = THCTensor_(newWithTensor)(state, vec2);
-  THCTensor_(resize2d)(state, vec2T, vec2T->size[0], 1);
+  THCTensor_(resize2d)(state, vec2T, vec2T->size(0), 1);
   THCTensor_(transpose)(state, vec2T, NULL, 0, 1);
 
   THCTensor *vec1M = THCTensor_(newWithTensor)(state, vec1);
-  THCTensor_(resize2d)(state, vec1M, vec1M->size[0], 1);
+  THCTensor_(resize2d)(state, vec1M, vec1M->size(0), 1);
 
   THCTensor_(addmm)(state, r_, beta, t, alpha, vec1M, vec2T);
   THCTensor_(free)(state, vec2T);
@@ -253,13 +253,13 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   if(t->dim() != 2)
     THError("matrix expected, got %dD tensor for t", t->dim());
 
-  if(m1->size[1] != m2->size[0]) {
+  if(m1->size(1) != m2->size(0)) {
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
     THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
     THError("size mismatch, m1: %s, m2: %s", bm1.str, bm2.str);
   }
 
-  if( (t->size[0] != m1->size[0]) || (t->size[1] != m2->size[1]) ) {
+  if( (t->size(0) != m1->size(0)) || (t->size(1) != m2->size(1)) ) {
     THCDescBuff bt  = THCTensor_(sizeDesc)(state, t);
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
     THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
@@ -342,9 +342,9 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCudaBlas_Hgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size[(transpose_r == 'n' ? 0 : 1)],
-                   r__->size[(transpose_r == 'n' ? 1 : 0)],
-                   m1_->size[(transpose_r == 'n' ? 1 : 0)],
+                   r__->size((transpose_r == 'n' ? 0 : 1)),
+                   r__->size((transpose_r == 'n' ? 1 : 0)),
+                   m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
                    (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
@@ -357,9 +357,9 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCudaBlas_Sgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size[(transpose_r == 'n' ? 0 : 1)],
-                   r__->size[(transpose_r == 'n' ? 1 : 0)],
-                   m1_->size[(transpose_r == 'n' ? 1 : 0)],
+                   r__->size((transpose_r == 'n' ? 0 : 1)),
+                   r__->size((transpose_r == 'n' ? 1 : 0)),
+                   m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
                    (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
@@ -372,9 +372,9 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCudaBlas_Dgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size[(transpose_r == 'n' ? 0 : 1)],
-                   r__->size[(transpose_r == 'n' ? 1 : 0)],
-                   m1_->size[(transpose_r == 'n' ? 1 : 0)],
+                   r__->size((transpose_r == 'n' ? 0 : 1)),
+                   r__->size((transpose_r == 'n' ? 1 : 0)),
+                   m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
                    (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
@@ -577,7 +577,7 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     }
     ldb = batch2_->stride[1];
   }
-  int64_t num_batches = result_->size[0];
+  int64_t num_batches = result_->size(0);
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   // Compute pointers to matrices in each batch.
@@ -602,9 +602,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size[transpose_result ? 2 : 1],
-      result_->size[transpose_result ? 1 : 2],
-      batch1_->size[transpose_result ? 1 : 2],
+      result_->size(transpose_result ? 2 : 1),
+      result_->size(transpose_result ? 1 : 2),
+      batch1_->size(transpose_result ? 1 : 2),
       alpha,
       d_matrices1, lda,
       d_matrices2, ldb,
@@ -616,9 +616,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size[transpose_result ? 2 : 1],
-      result_->size[transpose_result ? 1 : 2],
-      batch1_->size[transpose_result ? 1 : 2],
+      result_->size(transpose_result ? 2 : 1),
+      result_->size(transpose_result ? 1 : 2),
+      batch1_->size(transpose_result ? 1 : 2),
       alpha,
       d_matrices1, lda,
       d_matrices2, ldb,
@@ -637,9 +637,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size[transpose_result ? 2 : 1],
-      result_->size[transpose_result ? 1 : 2],
-      batch1_->size[transpose_result ? 1 : 2],
+      result_->size(transpose_result ? 2 : 1),
+      result_->size(transpose_result ? 1 : 2),
+      batch1_->size(transpose_result ? 1 : 2),
       alpha,
       THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
       THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
@@ -651,9 +651,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size[transpose_result ? 2 : 1],
-      result_->size[transpose_result ? 1 : 2],
-      batch1_->size[transpose_result ? 1 : 2],
+      result_->size(transpose_result ? 2 : 1),
+      result_->size(transpose_result ? 1 : 2),
+      batch1_->size(transpose_result ? 1 : 2),
       alpha,
       THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
       THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
@@ -672,9 +672,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         state,
         transpose_batch1,
         transpose_batch2,
-        result_->size[transpose_result ? 2 : 1],
-        result_->size[transpose_result ? 1 : 2],
-        batch1_->size[transpose_result ? 1 : 2],
+        result_->size(transpose_result ? 2 : 1),
+        result_->size(transpose_result ? 1 : 2),
+        batch1_->size(transpose_result ? 1 : 2),
         alpha,
         THCTensor_(data)(state, batch1_) + i * batch1_->stride[0], lda,
         THCTensor_(data)(state, batch2_) + i * batch2_->stride[0], ldb,
@@ -689,9 +689,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size[transpose_result ? 2 : 1],
-      result_->size[transpose_result ? 1 : 2],
-      batch1_->size[transpose_result ? 1 : 2],
+      result_->size(transpose_result ? 2 : 1),
+      result_->size(transpose_result ? 1 : 2),
+      batch1_->size(transpose_result ? 1 : 2),
       alpha,
       THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
       THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
@@ -704,9 +704,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         state,
         transpose_batch1,
         transpose_batch2,
-        result_->size[transpose_result ? 2 : 1],
-        result_->size[transpose_result ? 1 : 2],
-        batch1_->size[transpose_result ? 1 : 2],
+        result_->size(transpose_result ? 2 : 1),
+        result_->size(transpose_result ? 1 : 2),
+        batch1_->size(transpose_result ? 1 : 2),
         alpha,
         THCTensor_(data)(state, batch1_) + i * batch1_->stride[0], lda,
         THCTensor_(data)(state, batch2_) + i * batch2_->stride[0], ldb,
@@ -751,7 +751,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
   }
 
 
-  int n = a->size[1];
+  int n = a->size(1);
   int lda;
   THCTensor *ra__;
 
@@ -768,7 +768,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
     lda = ra__->stride[2];
   }
 
-  int64_t num_batches = ra__->size[0];
+  int64_t num_batches = ra__->size(0);
 
   if (!pivot) {
     THCudaIntTensor *t = THCudaIntTensor_new(state);
@@ -859,8 +859,8 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   }
 
 
-  int n = atf->size[1];
-  int nrhs = rb_->_dim() > 2 ? rb_->size[2] : 1;
+  int n = atf->size(1);
+  int nrhs = rb_->_dim() > 2 ? rb_->size(2) : 1;
   THCTensor *atf_;
   THCTensor *rb__;
   int lda, ldb;
@@ -885,7 +885,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   // correct ordering of B
   if (rb_->stride[1] == 1) {
     // column ordered
-    if (rb_->_dim() == 2 || rb_->size[2] == 1) {
+    if (rb_->_dim() == 2 || rb_->size(2) == 1) {
       ldb = n;
     } else {
       ldb = rb_->stride[2];
@@ -905,7 +905,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
     }
   }
 
-  int64_t num_batches = rb_->size[0];
+  int64_t num_batches = rb_->size(0);
   size_t matrices_size = num_batches * sizeof(real*);
 
   // Copy pointers to device.

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -68,32 +68,32 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THCTensor_(copy)(state, r_, t);
   }
 
-  if(mat->stride[0] == 1)
+  if(mat->stride(0) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sgemv(state, 'n', mat->size(0), mat->size(1),
-                    alpha, THCTensor_(data)(state, mat), mat->stride[1],
-                    THCTensor_(data)(state, vec), vec->stride[0],
-                    beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                    alpha, THCTensor_(data)(state, mat), mat->stride(1),
+                    THCTensor_(data)(state, vec), vec->stride(0),
+                    beta, THCTensor_(data)(state, r_), r_->stride(0));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dgemv(state, 'n', mat->size(0), mat->size(1),
-                    alpha, THCTensor_(data)(state, mat), mat->stride[1],
-                    THCTensor_(data)(state, vec), vec->stride[0],
-                    beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                    alpha, THCTensor_(data)(state, mat), mat->stride(1),
+                    THCTensor_(data)(state, vec), vec->stride(0),
+                    beta, THCTensor_(data)(state, r_), r_->stride(0));
 #endif
   }
-  else if(mat->stride[1] == 1)
+  else if(mat->stride(1) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, mat), mat->stride[0],
-                    THCTensor_(data)(state, vec), vec->stride[0],
-                    beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                    alpha, THCTensor_(data)(state, mat), mat->stride(0),
+                    THCTensor_(data)(state, vec), vec->stride(0),
+                    beta, THCTensor_(data)(state, r_), r_->stride(0));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
-                     alpha, THCTensor_(data)(state, mat), mat->stride[0],
-                     THCTensor_(data)(state, vec), vec->stride[0],
-                     beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                     alpha, THCTensor_(data)(state, mat), mat->stride(0),
+                     THCTensor_(data)(state, vec), vec->stride(0),
+                     beta, THCTensor_(data)(state, r_), r_->stride(0));
 #endif
   }
   else
@@ -102,14 +102,14 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, cmat), cmat->stride[0],
-                    THCTensor_(data)(state, vec), vec->stride[0],
-                    beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                    alpha, THCTensor_(data)(state, cmat), cmat->stride(0),
+                    THCTensor_(data)(state, vec), vec->stride(0),
+                    beta, THCTensor_(data)(state, r_), r_->stride(0));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, cmat), cmat->stride[0],
-                    THCTensor_(data)(state, vec), vec->stride[0],
-                    beta, THCTensor_(data)(state, r_), r_->stride[0]);
+                    alpha, THCTensor_(data)(state, cmat), cmat->stride(0),
+                    THCTensor_(data)(state, vec), vec->stride(0),
+                    beta, THCTensor_(data)(state, r_), r_->stride(0));
 #endif
 
     THCTensor_(free)(state, cmat);
@@ -174,32 +174,32 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THCTensor_(mul)(state, r_, r_, beta);
   }
 
-  if(r_->stride[0] == 1)
+  if(r_->stride(0) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sger(state, vec1->size(0), vec2->size(0),
-                   alpha, THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, r_), r_->stride[1]);
+                   alpha, THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, r_), r_->stride(1));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dger(state, vec1->size(0), vec2->size(0),
-                   alpha, THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, r_), r_->stride[1]);
+                   alpha, THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, r_), r_->stride(1));
 #endif
   }
-  else if(r_->stride[1] == 1)
+  else if(r_->stride(1) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, r_), r_->stride[0]);
+                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, r_), r_->stride(0));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, r_), r_->stride[0]);
+                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, r_), r_->stride(0));
 #endif
   }
   else
@@ -208,14 +208,14 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
 
 #ifdef THC_REAL_IS_FLOAT
     THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, cr), cr->stride[0]);
+                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, cr), cr->stride(0));
 #elif defined(THC_REAL_IS_DOUBLE)
     THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride[0],
-                   THCTensor_(data)(state, vec1), vec1->stride[0],
-                   THCTensor_(data)(state, cr), cr->stride[0]);
+                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
+                   THCTensor_(data)(state, vec1), vec1->stride(0),
+                   THCTensor_(data)(state, cr), cr->stride(0));
 #endif
 
     THCTensor_(freeCopyTo)(state, cr, r_);
@@ -275,14 +275,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* r_ */
-  if(r_->stride[0] == 1 &&
-     r_->stride[1] != 0)
+  if(r_->stride(0) == 1 &&
+     r_->stride(1) != 0)
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride[1] == 1 &&
-          r_->stride[0] != 0)
+  else if(r_->stride(1) == 1 &&
+          r_->stride(0) != 0)
   {
     THCTensor *swap = m2;
     m2 = m1;
@@ -301,14 +301,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* m1 */
-  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
-     m1->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
+  if(m1->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
+     m1->stride((transpose_r == 'n' ? 1 : 0)) != 0)
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
-          m1->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
+  else if(m1->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
+          m1->stride((transpose_r == 'n' ? 0 : 1)) != 0)
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -320,14 +320,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* m2 */
-  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
-     m2->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
+  if(m2->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
+     m2->stride((transpose_r == 'n' ? 1 : 0)) != 0)
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
-          m2->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
+  else if(m2->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
+          m2->stride((transpose_r == 'n' ? 0 : 1)) != 0)
   {
     transpose_m2 = 't';
     m2_ = m2;
@@ -347,12 +347,12 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
                    m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride[(transpose_r == 'n' ? 1 : 0)] : m2_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride[(transpose_r == 'n' ? 1 : 0)]);
+                   r__->stride((transpose_r == 'n' ? 1 : 0)));
 #elif defined(THC_REAL_IS_FLOAT)
   THCudaBlas_Sgemm(state,
                    transpose_m1,
@@ -362,12 +362,12 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
                    m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride[(transpose_r == 'n' ? 1 : 0)] : m2_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride[(transpose_r == 'n' ? 1 : 0)]);
+                   r__->stride((transpose_r == 'n' ? 1 : 0)));
 #elif defined(THC_REAL_IS_DOUBLE)
   THCudaBlas_Dgemm(state,
                    transpose_m1,
@@ -377,12 +377,12 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
                    m1_->size((transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride[(transpose_r == 'n' ? 1 : 0)] : m1_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride[(transpose_r == 'n' ? 1 : 0)] : m2_->stride[(transpose_r == 'n' ? 0 : 1)]),
+                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride[(transpose_r == 'n' ? 1 : 0)]);
+                   r__->stride((transpose_r == 'n' ? 1 : 0)));
 #endif
 
   /* free intermediate variables */
@@ -497,13 +497,13 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   char transpose_batch1, transpose_batch2;
   int64_t lda, ldb, ldc;
   THCTensor *result_, *batch1_, *batch2_;
-  if (result->stride[1] == 1)
+  if (result->stride(1) == 1)
   {
     transpose_result = false;
     result_ = result;
-    ldc = result_->stride[2];
+    ldc = result_->stride(2);
   }
-  else if (result->stride[2] == 1)
+  else if (result->stride(2) == 1)
   {
     transpose_result = true;
 
@@ -512,7 +512,7 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     batch1 = swap;
 
     result_ = result;
-    ldc = result_->stride[1];
+    ldc = result_->stride(1);
   }
   else
   {
@@ -523,22 +523,22 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, result_, NULL, 1, 2);
 
-    ldc = result_->stride[2];
+    ldc = result_->stride(2);
   }
 
-  if (batch1->stride[transpose_result ? 2 : 1] == 1 &&
-   batch1->stride[transpose_result ? 1 : 2] != 0)
+  if (batch1->stride(transpose_result ? 2 : 1) == 1 &&
+   batch1->stride(transpose_result ? 1 : 2) != 0)
   {
     transpose_batch1 = 'n';
     batch1_ = batch1;
-    lda = batch1_->stride[transpose_result ? 1 : 2];
+    lda = batch1_->stride(transpose_result ? 1 : 2);
   }
-  else if (batch1->stride[transpose_result ? 1 : 2] == 1 &&
-   batch1->stride[transpose_result ? 2 : 1] != 0)
+  else if (batch1->stride(transpose_result ? 1 : 2) == 1 &&
+   batch1->stride(transpose_result ? 2 : 1) != 0)
   {
     transpose_batch1 = 't';
     batch1_ = batch1;
-    lda = batch1_->stride[transpose_result ? 2 : 1];
+    lda = batch1_->stride(transpose_result ? 2 : 1);
   }
   else
   {
@@ -549,22 +549,22 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     } else {
       batch1_ = THCTensor_(newContiguous)(state, batch1);
     }
-    lda = batch1_->stride[1];
+    lda = batch1_->stride(1);
   }
 
-  if (batch2->stride[transpose_result ? 2 : 1] == 1 &&
-   batch2->stride[transpose_result ? 1 : 2] != 0)
+  if (batch2->stride(transpose_result ? 2 : 1) == 1 &&
+   batch2->stride(transpose_result ? 1 : 2) != 0)
   {
     transpose_batch2 = 'n';
     batch2_ = batch2;
-    ldb = batch2_->stride[transpose_result ? 1 : 2];
+    ldb = batch2_->stride(transpose_result ? 1 : 2);
   }
-  else if (batch2->stride[transpose_result ? 1 : 2] == 1 &&
-   batch2->stride[transpose_result ? 2 : 1] != 0)
+  else if (batch2->stride(transpose_result ? 1 : 2) == 1 &&
+   batch2->stride(transpose_result ? 2 : 1) != 0)
   {
     transpose_batch2 = 't';
     batch2_ = batch2;
-    ldb = batch2_->stride[transpose_result ? 2 : 1];
+    ldb = batch2_->stride(transpose_result ? 2 : 1);
   }
   else
   {
@@ -575,7 +575,7 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     } else {
       batch2_ = THCTensor_(newContiguous)(state, batch2);
     }
-    ldb = batch2_->stride[1];
+    ldb = batch2_->stride(1);
   }
   int64_t num_batches = result_->size(0);
 
@@ -595,7 +595,7 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   createBatchGemmBuffer3<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     d_matrices1, d_matrices2, (const real**)d_result_matrices, THCTensor_(data)(state, batch1_),
     THCTensor_(data)(state, batch2_), THCTensor_(data)(state, result_),
-    batch1_->stride[0], batch2_->stride[0], result_->stride[0], num_batches);
+    batch1_->stride(0), batch2_->stride(0), result_->stride(0), num_batches);
 
 #ifdef THC_REAL_IS_FLOAT
   THCudaBlas_SgemmBatched(
@@ -641,10 +641,10 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       result_->size(transpose_result ? 1 : 2),
       batch1_->size(transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
+      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
+      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride[0],
+      THCTensor_(data)(state, result_), ldc, result_->stride(0),
       num_batches);
 #elif defined(THC_REAL_IS_DOUBLE)
   THCudaBlas_DgemmStridedBatched(
@@ -655,10 +655,10 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       result_->size(transpose_result ? 1 : 2),
       batch1_->size(transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
+      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
+      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride[0],
+      THCTensor_(data)(state, result_), ldc, result_->stride(0),
       num_batches);
 #endif //THC_REAL
 #endif //CUDA_VERSION
@@ -676,10 +676,10 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         result_->size(transpose_result ? 1 : 2),
         batch1_->size(transpose_result ? 1 : 2),
         alpha,
-        THCTensor_(data)(state, batch1_) + i * batch1_->stride[0], lda,
-        THCTensor_(data)(state, batch2_) + i * batch2_->stride[0], ldb,
+        THCTensor_(data)(state, batch1_) + i * batch1_->stride(0), lda,
+        THCTensor_(data)(state, batch2_) + i * batch2_->stride(0), ldb,
         beta,
-        THCTensor_(data)(state, result_) + i * result_->stride[0], ldc);
+        THCTensor_(data)(state, result_) + i * result_->stride(0), ldc);
   }
 #else
   cudaDeviceProp* prop = THCState_getCurrentDeviceProperties(state);
@@ -693,10 +693,10 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       result_->size(transpose_result ? 1 : 2),
       batch1_->size(transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride[0],
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride[0],
+      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
+      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride[0],
+      THCTensor_(data)(state, result_), ldc, result_->stride(0),
       num_batches);
    } else {
       for (int64_t i = 0; i < num_batches; ++i) {
@@ -708,10 +708,10 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         result_->size(transpose_result ? 1 : 2),
         batch1_->size(transpose_result ? 1 : 2),
         alpha,
-        THCTensor_(data)(state, batch1_) + i * batch1_->stride[0], lda,
-        THCTensor_(data)(state, batch2_) + i * batch2_->stride[0], ldb,
+        THCTensor_(data)(state, batch1_) + i * batch1_->stride(0), lda,
+        THCTensor_(data)(state, batch2_) + i * batch2_->stride(0), ldb,
         beta,
-        THCTensor_(data)(state, result_) + i * result_->stride[0], ldc);
+        THCTensor_(data)(state, result_) + i * result_->stride(0), ldc);
       }
    }
 
@@ -744,7 +744,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
 
   if (ra_ != a) {
     THCTensor_(resizeAs)(state, ra_, a);
-    if (ra_->stride[2] == 1) {
+    if (ra_->stride(2) == 1) {
       THCTensor_(transpose)(state, ra_, NULL, 1, 2);
     }
     THCTensor_(copy)(state, ra_, a);
@@ -755,9 +755,9 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
   int lda;
   THCTensor *ra__;
 
-  if (ra_->stride[1] == 1) {
+  if (ra_->stride(1) == 1) {
     // column ordered, what BLAS wants
-    lda = ra_->stride[2];
+    lda = ra_->stride(2);
     ra__ = ra_;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -765,7 +765,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
     ra__ = THCTensor_(newClone)(state, transp_r_);
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, ra__, NULL, 1, 2);
-    lda = ra__->stride[2];
+    lda = ra__->stride(2);
   }
 
   int64_t num_batches = ra__->size(0);
@@ -799,7 +799,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
     const int64_t grid = (num_batches + block - 1) / block;
     createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
       (const real**)d_result, THCTensor_(data)(state, ra__),
-      ra__->stride[0], num_batches);
+      ra__->stride(0), num_batches);
   }
 
   int *pivots_gpu = NULL;
@@ -866,9 +866,9 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   int lda, ldb;
 
   // correct ordering of A_tf
-  if (atf->stride[1] == 1) {
+  if (atf->stride(1) == 1) {
     // column ordered, what BLAS wants
-    lda = atf->stride[2];
+    lda = atf->stride(2);
     atf_ = atf;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -879,16 +879,16 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
     atf_ = THCTensor_(newClone)(state, transp_r_);
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, atf_, NULL, 1, 2);
-    lda = atf_->stride[2];
+    lda = atf_->stride(2);
   }
 
   // correct ordering of B
-  if (rb_->stride[1] == 1) {
+  if (rb_->stride(1) == 1) {
     // column ordered
     if (rb_->_dim() == 2 || rb_->size(2) == 1) {
       ldb = n;
     } else {
-      ldb = rb_->stride[2];
+      ldb = rb_->stride(2);
     }
     rb__ = rb_;
   } else {
@@ -898,7 +898,7 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
       rb__ = THCTensor_(newClone)(state, transp_r_);
       THCTensor_(free)(state, transp_r_);
       THCTensor_(transpose)(state, rb__, NULL, 1, 2);
-      ldb = rb__->stride[2];
+      ldb = rb__->stride(2);
     } else {
       rb__ = THCTensor_(newClone)(state, rb_);
       ldb = n;
@@ -916,10 +916,10 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   const int64_t grid = (num_batches + block - 1) / block;
   createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     (const real**)d_result, THCTensor_(data)(state, rb__),
-    rb__->stride[0], num_batches);
+    rb__->stride(0), num_batches);
   createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     d_atf, THCTensor_(data)(state, atf_),
-    atf_->stride[0], num_batches);
+    atf_->stride(0), num_batches);
 
   if (!THCudaIntTensor_isContiguous(state, pivots)) {
       THError("Error: pivots is not contiguous.");

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -117,7 +117,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 
   // cublasSgemv, cublasDgemv have a bug where (x,0).mv(0) does not
   // handle beta, whereas cublasSgemm, cublasDgemm do for case where (x,0).mm(0,y).
-  if (vec->size[0] == 0 && mat->size[0] != 0) {
+  if (vec->size(0) == 0 && mat->size(0) != 0) {
     if(THCNumerics<real>::eq(beta, ScalarConvert<int, real>::to(0))) {
       THCTensor_(zero)(state, r_);
     } else if(THCNumerics<real>::ne(beta, ScalarConvert<int, real>::to(1))) {

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -434,7 +434,7 @@ THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 
   // input
   THCTensor *input = THCTensor_(newColumnMajor)(state, a, a);
-  THCTensor_(resizeNd)(state, ra_, 2, input->size, input->stride);
+  THCTensor_(resizeNd)(state, ra_, 2, THTensor_getSizePtr(input), THTensor_getStridePtr(input));
 
   real *matrices1[1] = { THCTensor_(data)(state, input) };
   real *matrices2[1] = { THCTensor_(data)(state, ra_) };

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -40,7 +40,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
 static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, THCTensor *src)
 {
   THAssert(src->_dim() == 2);
-  if (self == src && self->stride[0] == 1 && self->stride[1] == self->size(0))
+  if (self == src && self->stride(0) == 1 && self->stride(1) == self->size(0))
   {
     THCTensor_(retain)(state, self);
     return self;

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -40,7 +40,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
 static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, THCTensor *src)
 {
   THAssert(src->_dim() == 2);
-  if (self == src && self->stride[0] == 1 && self->stride[1] == self->size[0])
+  if (self == src && self->stride[0] == 1 && self->stride[1] == self->size(0))
   {
     THCTensor_(retain)(state, self);
     return self;
@@ -51,8 +51,8 @@ static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, T
   else
     THCTensor_(retain)(state, self);
 
-  int64_t size[2] = { src->size[0], src->size[1] };
-  int64_t stride[2] = { 1, src->size[0] };
+  int64_t size[2] = { src->size(0), src->size(1) };
+  int64_t stride[2] = { 1, src->size(0) };
 
   THCTensor_(resizeNd)(state, self, 2, size, stride);
   THCTensor_(copy)(state, self, src);
@@ -65,11 +65,11 @@ THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 2, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size[0] == a_->size[1], 1, "A should be square");
-  THArgCheck(b_->size[0] == a_->size[0], 2, "A,b size incompatible");
+  THArgCheck(a_->size(0) == a_->size(1), 1, "A should be square");
+  THArgCheck(b_->size(0) == a_->size(0), 2, "A,b size incompatible");
 
-  int64_t n = a_->size[0];
-  int64_t nrhs = b_->size[1];
+  int64_t n = a_->size(0);
+  int64_t nrhs = b_->size(1);
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
   THCTensor *b = THCTensor_(newColumnMajor)(state, rb_, b_);
@@ -104,8 +104,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 2, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size[0] == a_->size[1], 1, "A should be square");
-  THArgCheck(b_->size[0] == a_->size[0], 2, "A,b size incompatible");
+  THArgCheck(a_->size(0) == a_->size(1), 1, "A should be square");
+  THArgCheck(b_->size(0) == a_->size(0), 2, "A,b size incompatible");
 
   magma_side_t sz = MagmaLeft;
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
@@ -114,8 +114,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
 
   real alpha = 1;
 
-  int64_t n = a_->size[0];
-  int64_t nrhs = b_->size[1];
+  int64_t n = a_->size(0);
+  int64_t nrhs = b_->size(1);
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
   THCTensor *b = THCTensor_(newColumnMajor)(state, rb_, b_);
@@ -140,9 +140,9 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 1, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size[0] == b_->size[0], 2, "Expected A and b to have same size "
+  THArgCheck(a_->size(0) == b_->size(0), 2, "Expected A and b to have same size "
       "at dim 0, but they have incompatible sizes");
-  THArgCheck(a_->size[0] >= a_->size[1], 2, "Expected A with shape (m x n) to have "
+  THArgCheck(a_->size(0) >= a_->size(1), 2, "Expected A with shape (m x n) to have "
       "m >= n. The case for m < n is not implemented yet.");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
@@ -150,9 +150,9 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
   real *a_data = THCTensor_(data)(state, a);
   real *b_data = THCTensor_(data)(state, b);
 
-  int64_t m = a->size[0];
-  int64_t n = a->size[1];
-  int64_t nrhs = b->size[1];
+  int64_t m = a->size(0);
+  int64_t n = a->size(1);
+  int64_t nrhs = b->size(1);
   real wkopt;
 
   int info;
@@ -185,7 +185,7 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a, const char *jobzs, const char *uplos)
 {
 #ifdef USE_MAGMA
-  int64_t n = a->size[0];
+  int64_t n = a->size(0);
   int64_t lda = n;
 
   magma_uplo_t uplo = uplos[0] == 'U' ?  MagmaUpper : MagmaLower;
@@ -244,10 +244,10 @@ THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
 {
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 3, "A should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size[0] == a_->size[1], 3, "A should be square");
+  THArgCheck(a_->size(0) == a_->size(1), 3, "A should be square");
 
   magma_vec_t jobvr = jobvrs[0] == 'N' ? MagmaNoVec : MagmaVec;
-  int64_t n = a_->size[0];
+  int64_t n = a_->size(0);
 
   real *a_data = th_magma_malloc_pinned<real>(n * n);
   THCTensor_(copyTensor2d)(state, a_data, a_);
@@ -328,8 +328,8 @@ THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_,
   magma_vec_t jobz = jobus[0] == 'A' ? MagmaAllVec : jobus[0] == 'S' ? MagmaSomeVec : jobus[0] == 'O' ? MagmaOverwriteVec : MagmaNoVec;
 
   int iunused[1];
-  int64_t m = a->size[0];
-  int64_t n = a->size[1];
+  int64_t m = a->size(0);
+  int64_t n = a->size(1);
   int64_t k = m < n ? m : n;
   int64_t j = (jobz == MagmaAllVec) ? m : k;
   int64_t jv = (jobz == MagmaAllVec) ? n : k;
@@ -387,11 +387,11 @@ THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_,
 THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 {
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be non-empty 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
 
 #ifdef USE_MAGMA
   int info;
-  int64_t n = a->size[0];
+  int64_t n = a->size(0);
   int lwork = n * magma_get_sgetri_nb(n);
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -430,7 +430,7 @@ THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
   magma_free_pinned(ipiv);
   THCTensor_(freeCopyTo)(state, input, ra_);
 #else
-  int64_t n = a->size[0];
+  int64_t n = a->size(0);
 
   // input
   THCTensor *input = THCTensor_(newColumnMajor)(state, a, a);
@@ -516,9 +516,9 @@ THC_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, co
 {
 #ifdef USE_MAGMA
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be non-empty 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
 
-  int64_t n = a->size[0];
+  int64_t n = a->size(0);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -556,9 +556,9 @@ THC_API void THCTensor_(potrf)(THCState *state, THCTensor *ra_, THCTensor *a, co
 {
 #ifdef USE_MAGMA
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be (non-empty) 2 dimensional");
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
 
-  int64_t n = a->size[0];
+  int64_t n = a->size(0);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -591,10 +591,10 @@ THC_API void THCTensor_(potrf)(THCState *state, THCTensor *ra_, THCTensor *a, co
 THC_API void THCTensor_(potrs)(THCState *state, THCTensor *rb_, THCTensor *b, THCTensor *a, const char *uplo)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
+  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
 
-  int64_t n = a->size[0];
-  int64_t nrhs = b->size[1];
+  int64_t n = a->size(0);
+  int64_t nrhs = b->size(1);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *b_ = THCTensor_(newColumnMajor)(state, rb_, b);
@@ -626,8 +626,8 @@ THC_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 2, "A should be non-empty 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
-  int64_t m = a->size[0];
-  int64_t n = a->size[1];
+  int64_t m = a->size(0);
+  int64_t n = a->size(1);
   int64_t k = (m < n ? m : n);
 
 #if defined(THC_REAL_IS_FLOAT)
@@ -663,8 +663,8 @@ THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THC
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 2, "A should be non-empty 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, rr_, a_);
-  int64_t m = a->size[0];
-  int64_t n = a->size[1];
+  int64_t m = a->size(0);
+  int64_t n = a->size(1);
   int64_t k = (m < n ? m : n);
 
 #if defined(THC_REAL_IS_FLOAT)

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -196,8 +196,8 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = self_->stride[0];
-  int64_t stride1 = self_->stride[1];
+  int64_t stride0 = self_->stride(0);
+  int64_t stride1 = self_->stride(1);
   real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 0> op(start, stride0, stride1, k);
@@ -225,8 +225,8 @@ void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = self_->stride[0];
-  int64_t stride1 = self_->stride[1];
+  int64_t stride0 = self_->stride(0);
+  int64_t stride1 = self_->stride(1);
   real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 1> op(start, stride0, stride1, k);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -61,13 +61,13 @@ THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, real value,
   THCTensor *self_;
   THCTensor *src_ = THCTensor_(newTranspose)(state, src, dimension, 0);
   THCTensor *data = THCTensor_(newClone)(state, src_);
-  ptrdiff_t size = THCTensor_(nElement)(state, data)/data->size[0];
+  ptrdiff_t size = THCTensor_(nElement)(state, data)/data->size(0);
 
   THArgCheck(dimension >= 0 && dimension < THCTensor_(_nDimension)(state, src), 3, "invalid dimension");
   THArgCheck(THCNumerics<real>::gt(value, scalar_cast<real>(0)), 2, "non-positive-norm not supported");
   THArgCheck(THCTensor_(_nDimension)(state, src) > 1, 1, "need at least 2 dimensions");
 
-  dim3 grid(data->size[0]);
+  dim3 grid(data->size(0));
   dim3 threads(32);
 
   THCTensor_kernel_renorm<real, accreal>

--- a/aten/src/THCUNN/generic/BatchNormalization.cu
+++ b/aten/src/THCUNN/generic/BatchNormalization.cu
@@ -21,11 +21,11 @@ static THCDeviceTensor<real, Dim> THNN_(devicetensor)(THCState *state, THCTensor
   int size[Dim];
   for (int i = 0; i < Dim || i < inDim; ++i) {
     if (i < Dim && i < inDim) {
-      size[i] = t->size[i];
+      size[i] = t->size(i);
     } else if (i < Dim) {
       size[i] = 1;
     } else {
-      size[Dim - 1] *= t->size[i];
+      size[Dim - 1] *= t->size(i);
     }
   }
   return THCDeviceTensor<real, Dim>(t->data<real>(), size);

--- a/aten/src/THCUNN/generic/Col2Im.cu
+++ b/aten/src/THCUNN/generic/Col2Im.cu
@@ -22,7 +22,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
                   "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
   int batch_dim = (ndim == 3) ? 0 : -1;
-  int64_t nInputPlane  = input->size[batch_dim + 1];
+  int64_t nInputPlane  = input->size(batch_dim + 1);
 
   if (nInputPlane % (kW * kH) != 0) {
     THError("Expected size of input's dimension 1 to be divisible by the "
@@ -30,7 +30,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
             "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
   }
 
-  int64_t inputLength  = input->size[batch_dim + 2];
+  int64_t inputLength  = input->size(batch_dim + 2);
   int64_t nBlocksH = 1 + (outputHeight + 2 * padH - dH * (kH - 1) - 1) / sH;
   int64_t nBlocksW = 1 + ( outputWidth + 2 * padW - dW * (kW - 1) - 1) / sW;
 
@@ -69,11 +69,11 @@ void THNN_(Col2Im_updateOutput)(
   if (input->dim() == 2) {
       // Force batch
       batched_input = false;
-      THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);
+      THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
   }
 
-  int64_t batchSize = input->size[0];
-  int64_t nInputPlane = input->size[1];
+  int64_t batchSize = input->size(0);
+  int64_t nInputPlane = input->size(1);
   int64_t nOutputPlane = nInputPlane / (kW * kH);
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/Im2Col.cu
+++ b/aten/src/THCUNN/generic/Im2Col.cu
@@ -59,7 +59,7 @@ void THNN_(Im2Col_updateOutput)(
   bool batched_input = true;
   if (input->dim() == 3) {
     batched_input = false;
-    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
+    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
   }
 
   int64_t batchSize    = THCTensor_(size)(state, input, 0);

--- a/aten/src/THCUNN/generic/IndexLinear.cu
+++ b/aten/src/THCUNN/generic/IndexLinear.cu
@@ -44,7 +44,7 @@ void THNN_(IndexLinear_updateOutput)(
     int64_t batchSize = sizes->size(0);
     int64_t outDim = bias->size(0);
     int64_t wDim = weight->size(1);
-    int64_t weightStride = weight->stride[0];
+    int64_t weightStride = weight->stride(0);
     int maxNormalize = wDim - outDim;
     int64_t keysSize = keys->size(0);
     int64_t nnzPerRow = divup(keysSize, batchSize);
@@ -137,7 +137,7 @@ void THNN_(IndexLinear_accGradParameters)(
     real *gradOutputData  = THCTensor_(data)      (state, gradOutput);
     real *gradBiasData    = THCTensor_(data)      (state, gradBias);
     real *gradWeightData  = THCTensor_(data)      (state, gradWeight);
-    int64_t gradWeightStride = gradWeight->stride[0];
+    int64_t gradWeightStride = gradWeight->stride(0);
 
     cudaStream_t stream = THCState_getCurrentStream(state);
     dim3 threads(THREADS_X, THREADS_Y);
@@ -194,7 +194,7 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
     real *valuesData       = THCTensor_(data)      (state, values);
     int64_t *keysData         = THCudaLongTensor_data (state, keys);
     int64_t *cumSumSizesData  = THCudaLongTensor_data (state, cumSumSizes);
-    int64_t weightStride = weight->stride[0];
+    int64_t weightStride = weight->stride(0);
 
     cudaStream_t stream = THCState_getCurrentStream(state);
     dim3 threads(THREADS_X, THREADS_Y);
@@ -248,8 +248,8 @@ void THNN_(IndexLinear_updateParameters)(
     int64_t batchSize = cumSumSizes->size(0);
 
     THCTensor_(cadd)(state, bias, bias, -learningRate, gradBias);
-    int64_t gradWeightStride = gradWeight->stride[0];
-    int64_t weightStride = weight->stride[0];
+    int64_t gradWeightStride = gradWeight->stride(0);
+    int64_t weightStride = weight->stride(0);
 
     int64_t *keysData        = THCudaLongTensor_data (state, runningKeys);
     int64_t *cumSumSizesData = THCudaLongTensor_data (state, cumSumSizes);

--- a/aten/src/THCUNN/generic/IndexLinear.cu
+++ b/aten/src/THCUNN/generic/IndexLinear.cu
@@ -41,12 +41,12 @@ void THNN_(IndexLinear_updateOutput)(
     THArgCheck(THNN_(checkKeysValues)(state, keys, values), 1,
                "Keys and values should have the same number of elements");
 
-    int64_t batchSize = sizes->size[0];
-    int64_t outDim = bias->size[0];
-    int64_t wDim = weight->size[1];
+    int64_t batchSize = sizes->size(0);
+    int64_t outDim = bias->size(0);
+    int64_t wDim = weight->size(1);
     int64_t weightStride = weight->stride[0];
     int maxNormalize = wDim - outDim;
-    int64_t keysSize = keys->size[0];
+    int64_t keysSize = keys->size(0);
     int64_t nnzPerRow = divup(keysSize, batchSize);
 
     THCTensor_(resize2d)(state, output, batchSize, outDim);
@@ -100,10 +100,10 @@ void THNN_(IndexLinear_accGradParameters)(
     accreal weightDecay,
     accreal scale)
 {
-    int64_t keysSize = keys->size[0];
-    int64_t batchSize = sizes->size[0];
-    int64_t outDim = bias->size[0];
-    int64_t wDim = weight->size[1];
+    int64_t keysSize = keys->size(0);
+    int64_t batchSize = sizes->size(0);
+    int64_t outDim = bias->size(0);
+    int64_t wDim = weight->size(1);
     int maxNormalize = wDim - outDim;
 
     // Make sure these inputs are contiguous to accelerate computations
@@ -182,10 +182,10 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
     THArgCheck(THNN_(checkKeysValues)(state, keys, values), 1,
                "Keys and values should have the same number of elements");
 
-    int64_t batchSize = sizes->size[0];
-    int64_t outDim = bias->size[0];
-    int64_t keysSize = keys->size[0];
-    int64_t wDim = weight->size[1];
+    int64_t batchSize = sizes->size(0);
+    int64_t outDim = bias->size(0);
+    int64_t keysSize = keys->size(0);
+    int64_t wDim = weight->size(1);
     int maxNormalize = wDim - outDim;
 
     real *biasData         = THCTensor_(data)      (state, bias);
@@ -241,11 +241,11 @@ void THNN_(IndexLinear_updateParameters)(
     THArgCheck(THCudaLongTensor_isContiguous(state, cumSumSizes), 6,
                "cumSumSizes vector must be contiguous");
 
-    int64_t outDim = bias->size[0];
-    int64_t wDim = weight->size[1];
+    int64_t outDim = bias->size(0);
+    int64_t wDim = weight->size(1);
     int maxNormalize = wDim - outDim;
-    int64_t keysSize = runningKeys->size[0];
-    int64_t batchSize = cumSumSizes->size[0];
+    int64_t keysSize = runningKeys->size(0);
+    int64_t batchSize = cumSumSizes->size(0);
 
     THCTensor_(cadd)(state, bias, bias, -learningRate, gradBias);
     int64_t gradWeightStride = gradWeight->stride[0];

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -18,8 +18,8 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
 
   if(input->dim() == 1)
   {
-    int dim = input->size[0];
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size[0] == dim), 3,
+    int dim = input->size(0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim), 3,
         "inconsistent target size");
     THCTensor_(resize1d)(state, output, 1);
 
@@ -39,17 +39,17 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   }
   else if(input->dim() == 2)
   {
-    int nframe = input->size[0];
-    int dim = input->size[1];
-    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size[0] == nframe)
-               && (target->size[1] == dim), 3, "inconsistent target size");
+    int nframe = input->size(0);
+    int dim = input->size(1);
+    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
+               && (target->size(1) == dim), 3, "inconsistent target size");
 
-    dim3 blocks(input->size[0]);
+    dim3 blocks(input->size(0));
     dim3 threads(MULTILABELMARGIN_THREADS);
 
     if (reduction != Reduction::None)
     {
-      THCTensor *output_tmp = THCTensor_(newWithSize1d)(state, input->size[0]);
+      THCTensor *output_tmp = THCTensor_(newWithSize1d)(state, input->size(0));
       THCTensor_(resize1d)(state, output, 1);
 
       cunn_MultiLabelMarginCriterion_updateOutput_kernel<real, accreal>
@@ -67,7 +67,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
     }
     else
     {
-    THCTensor_(resize1d)(state, output, input->size[0]);
+    THCTensor_(resize1d)(state, output, input->size(0));
 
     cunn_MultiLabelMarginCriterion_updateOutput_kernel<real, accreal>
       <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
@@ -106,10 +106,10 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
 
   if(gradInput->dim() == 1)
   {
-    int dim = gradInput->size[0];
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size[0] == dim), 3,
+    int dim = gradInput->size(0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim), 3,
                "inconsistent target size");
-    THArgCheck(!istarget->is_empty() && (istarget->dim() == 1) && (istarget->size[0] == dim), 3,
+    THArgCheck(!istarget->is_empty() && (istarget->dim() == 1) && (istarget->size(0) == dim), 3,
                "inconsistent isTarget size");
     dim3 blocks(1);
     dim3 threads(MULTILABELMARGIN_THREADS);
@@ -121,20 +121,20 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         THCTensor_(data)(state, istarget),
-        1, gradInput->size[0],
+        1, gradInput->size(0),
         reduction == Reduction::ElementwiseMean,
         reduction != Reduction::None);
 
   }
   else if(gradInput->dim() == 2)
   {
-    int nframe = gradInput->size[0];
-    int dim = gradInput->size[1];
-    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size[0] == nframe)
-               && (target->size[1] == dim), 3, "inconsistent target size");
-    THArgCheck(!istarget->is_empty() && (istarget->dim() == 2) && (istarget->size[0] == nframe)
-               && (istarget->size[1] == dim), 3, "inconsistent isTarget size");
-    dim3 blocks(gradInput->size[0]);
+    int nframe = gradInput->size(0);
+    int dim = gradInput->size(1);
+    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
+               && (target->size(1) == dim), 3, "inconsistent target size");
+    THArgCheck(!istarget->is_empty() && (istarget->dim() == 2) && (istarget->size(0) == nframe)
+               && (istarget->size(1) == dim), 3, "inconsistent isTarget size");
+    dim3 blocks(gradInput->size(0));
     dim3 threads(MULTILABELMARGIN_THREADS);
 
     cunn_MultiLabelMarginCriterion_updateGradInput_kernel<real, accreal>
@@ -144,7 +144,7 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         THCTensor_(data)(state, istarget),
-        gradInput->size[0], gradInput->size[1],
+        gradInput->size(0), gradInput->size(1),
         reduction == Reduction::ElementwiseMean,
         reduction != Reduction::None);
   }

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -30,7 +30,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, input->size[0],
+        1, input->size(0),
         reduction == Reduction::ElementwiseMean,
         margin
       );
@@ -42,7 +42,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, input->size[0],
+        1, input->size(0),
         reduction == Reduction::ElementwiseMean,
         margin
       );
@@ -51,15 +51,15 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   }
   else if (input->dim() == 2)
   {
-    int nframe = input->size[0];
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe), 3,
+    int nframe = input->size(0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe), 3,
                "inconsistent target size");
-    dim3 blocks(input->size[0]);
+    dim3 blocks(input->size(0));
     dim3 threads(MULTIMARGIN_THREADS);
 
     if (reduction == Reduction::None)
     {
-      THCTensor_(resize1d)(state, output, input->size[0]);
+      THCTensor_(resize1d)(state, output, input->size(0));
       if (p == 1)
       {
         cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
@@ -67,7 +67,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size[1],
+          nframe, input->size(1),
           false,
           margin
         );
@@ -79,7 +79,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size[1],
+          nframe, input->size(1),
           false,
           margin
         );
@@ -89,7 +89,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
     else
     {
       THCTensor_(resize1d)(state, output, 1);
-      THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size[0]);  // tmp output buffer
+      THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size(0));  // tmp output buffer
       if (p == 1)
       {
         cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
@@ -97,7 +97,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size[1],
+          nframe, input->size(1),
           reduction == Reduction::ElementwiseMean,
           margin
         );
@@ -109,7 +109,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          input->size[0], input->size[1],
+          input->size(0), input->size(1),
           reduction == Reduction::ElementwiseMean,
           margin
         );
@@ -162,7 +162,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, gradInput->size[0],
+        1, gradInput->size(0),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -176,7 +176,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, gradInput->size[0],
+        1, gradInput->size(0),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -186,10 +186,10 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   }
   else if (input->dim() == 2)
   {
-    int nframe = gradInput->size[0];
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe), 3,
+    int nframe = gradInput->size(0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe), 3,
                "inconsistent target size");
-    dim3 blocks(gradInput->size[0]);
+    dim3 blocks(gradInput->size(0));
     dim3 threads(MULTIMARGIN_THREADS);
 
     if (p == 1)
@@ -200,7 +200,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        nframe, gradInput->size[1],
+        nframe, gradInput->size(1),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -214,7 +214,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        nframe, gradInput->size[1],
+        nframe, gradInput->size(1),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None

--- a/aten/src/THCUNN/generic/PReLU.cu
+++ b/aten/src/THCUNN/generic/PReLU.cu
@@ -24,12 +24,12 @@ void THNN_(PReLU_updateOutput)(
     input = THCTensor_(newContiguous)(state, input);
 
     int n = THCTensor_(nElement)(state, input);
-    if (input->size[ndim > 1] != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[ndim > 1]);
+    if (input->size(ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(ndim > 1));
 
     int mapSize = 1;
     for (int d = 2; d < ndim; d++) {
-      mapSize *= input->size[d];
+      mapSize *= input->size(d);
     }
     int nElemsPerSample = nOutputPlane * mapSize;
     preluForward<<<GET_BLOCKS(n), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
@@ -69,12 +69,12 @@ void THNN_(PReLU_updateGradInput)(
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
     int n = THCTensor_(nElement)(state, input);
-    if (input->size[ndim > 1] != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[ndim > 1]);
+    if (input->size(ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(ndim > 1));
 
     int mapSize = 1;
     for (int d = 2; d < ndim; d++) {
-      mapSize *= input->size[d];
+      mapSize *= input->size(d);
     }
     int nElemsPerSample = nOutputPlane * mapSize;
     preluBackward<<<GET_BLOCKS(n), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
@@ -142,10 +142,10 @@ void THNN_(PReLU_accGradParameters)(
         THCTensor *buffer = THCTensor_(newContiguous)(state, gradInput);
         int64_t size3 = 1;
         for (int d = 2; d < ndim; d++) {
-          size3 *= input->size[d];
+          size3 *= input->size(d);
         }
-        THCTensor_(resize3d)(state, buffer, input->size[0], nOutputPlane, size3);
-        THCTensor_(resize2d)(state, sumbuf, input->size[0], nOutputPlane);
+        THCTensor_(resize3d)(state, buffer, input->size(0), nOutputPlane, size3);
+        THCTensor_(resize2d)(state, sumbuf, input->size(0), nOutputPlane);
         THCTensor_(sum)(state, sumbuf, buffer, 2, 1);
         THCTensor_(sum)(state, gradWeightBuf, sumbuf, 0, 1);
         THCTensor_(cadd)(state, gradWeight, gradWeight, scale, gradWeightBuf);

--- a/aten/src/THCUNN/generic/SparseLinear.cu
+++ b/aten/src/THCUNN/generic/SparseLinear.cu
@@ -4,17 +4,17 @@
 
 static bool THNN_(checkInput)(THCTensor* t)
 {
-  return !t->is_empty() && t->_dim() == 2 && t->size[1] == 3;
+  return !t->is_empty() && t->_dim() == 2 && t->size(1) == 3;
 }
 
 static bool THNN_(checkSize2D)(THCTensor* t, int64_t size0, int64_t size1)
 {
-  return !t->is_empty() && t->_dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
+  return !t->is_empty() && t->_dim() == 2 && t->size(0) == size0 && t->size(1) == size1;
 }
 
 static bool THNN_(checkSize1D)(THCTensor* t, int64_t size0)
 {
-  return !t->is_empty() && t->_dim() == 1 && t->size[0] == size0;
+  return !t->is_empty() && t->_dim() == 1 && t->size(0) == size0;
 }
 
 static inline void THNN_(copyCudaFloatingType)(THCState *state, THCudaIntTensor *buf, THCTensor *t) {

--- a/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
@@ -22,9 +22,9 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size[0];
-    int64_t isizeH = input->size[1];
-    int64_t isizeW = input->size[2];
+    int64_t sizeD  = input->size(0);
+    int64_t isizeH = input->size(1);
+    int64_t isizeW = input->size(2);
 
     int64_t istrideD = input->stride[0];
     int64_t istrideH = input->stride[1];
@@ -49,10 +49,10 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
 
   } else {
     input = THCTensor_(newContiguous)(state, input);
-    int64_t sizeB  = input->size[0];
-    int64_t sizeD  = input->size[1];
-    int64_t isizeH = input->size[2];
-    int64_t isizeW = input->size[3];
+    int64_t sizeB  = input->size(0);
+    int64_t sizeD  = input->size(1);
+    int64_t isizeH = input->size(2);
+    int64_t isizeW = input->size(3);
 
     int64_t istrideD = input->stride[1];
     int64_t istrideH = input->stride[2];
@@ -95,12 +95,12 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size[0];
-    int64_t isizeH = input->size[1];
-    int64_t isizeW = input->size[2];
+    int64_t sizeD  = input->size(0);
+    int64_t isizeH = input->size(1);
+    int64_t isizeW = input->size(2);
 
-    int64_t osizeH = gradOutput->size[1];
-    int64_t osizeW = gradOutput->size[2];
+    int64_t osizeH = gradOutput->size(1);
+    int64_t osizeW = gradOutput->size(2);
 
     //bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 
@@ -129,13 +129,13 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t sizeB  = input->size[0];
-    int64_t sizeD  = input->size[1];
-    int64_t isizeH = input->size[2];
-    int64_t isizeW = input->size[3];
+    int64_t sizeB  = input->size(0);
+    int64_t sizeD  = input->size(1);
+    int64_t isizeH = input->size(2);
+    int64_t isizeW = input->size(3);
 
-    int64_t osizeH = gradOutput->size[2];
-    int64_t osizeW = gradOutput->size[3];
+    int64_t osizeH = gradOutput->size(2);
+    int64_t osizeW = gradOutput->size(3);
 
     //bool atomic = //(isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 

--- a/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
@@ -26,9 +26,9 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
     int64_t isizeH = input->size(1);
     int64_t isizeW = input->size(2);
 
-    int64_t istrideD = input->stride[0];
-    int64_t istrideH = input->stride[1];
-    int64_t istrideW = input->stride[2];
+    int64_t istrideD = input->stride(0);
+    int64_t istrideH = input->stride(1);
+    int64_t istrideW = input->stride(2);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -54,9 +54,9 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
     int64_t isizeH = input->size(2);
     int64_t isizeW = input->size(3);
 
-    int64_t istrideD = input->stride[1];
-    int64_t istrideH = input->stride[2];
-    int64_t istrideW = input->stride[3];
+    int64_t istrideD = input->stride(1);
+    int64_t istrideH = input->stride(2);
+    int64_t istrideW = input->stride(3);
 
     input_data = THCTensor_(data)(state, input);
 

--- a/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -28,9 +28,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     int64_t isizeH = input->size(1);
     int64_t isizeW = input->size(2);
 
-    int64_t istrideD = input->stride[0];
-    int64_t istrideH = input->stride[1];
-    int64_t istrideW = input->stride[2];
+    int64_t istrideD = input->stride(0);
+    int64_t istrideH = input->stride(1);
+    int64_t istrideW = input->stride(2);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -60,9 +60,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     int64_t isizeH = input->size(2);
     int64_t isizeW = input->size(3);
 
-    int64_t istrideD = input->stride[1];
-    int64_t istrideH = input->stride[2];
-    int64_t istrideW = input->stride[3];
+    int64_t istrideD = input->stride(1);
+    int64_t istrideH = input->stride(2);
+    int64_t istrideW = input->stride(3);
 
     input_data = THCTensor_(data)(state, input);
 

--- a/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -24,9 +24,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size[0];
-    int64_t isizeH = input->size[1];
-    int64_t isizeW = input->size[2];
+    int64_t sizeD  = input->size(0);
+    int64_t isizeH = input->size(1);
+    int64_t isizeW = input->size(2);
 
     int64_t istrideD = input->stride[0];
     int64_t istrideH = input->stride[1];
@@ -55,10 +55,10 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
   } else {
     input = THCTensor_(newContiguous)(state, input);
-    int64_t sizeB  = input->size[0];
-    int64_t sizeD  = input->size[1];
-    int64_t isizeH = input->size[2];
-    int64_t isizeW = input->size[3];
+    int64_t sizeB  = input->size(0);
+    int64_t sizeD  = input->size(1);
+    int64_t isizeH = input->size(2);
+    int64_t isizeW = input->size(3);
 
     int64_t istrideD = input->stride[1];
     int64_t istrideH = input->stride[2];
@@ -107,12 +107,12 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size[0];
-    int64_t isizeH = input->size[1];
-    int64_t isizeW = input->size[2];
+    int64_t sizeD  = input->size(0);
+    int64_t isizeH = input->size(1);
+    int64_t isizeW = input->size(2);
 
-    int64_t osizeH = gradOutput->size[1];
-    int64_t osizeW = gradOutput->size[2];
+    int64_t osizeH = gradOutput->size(1);
+    int64_t osizeW = gradOutput->size(2);
 
     //bool atomic = (isizeH%osizeH != 0) || (isizeW%osizeW != 0);
 
@@ -145,13 +145,13 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t sizeB  = input->size[0];
-    int64_t sizeD  = input->size[1];
-    int64_t isizeH = input->size[2];
-    int64_t isizeW = input->size[3];
+    int64_t sizeB  = input->size(0);
+    int64_t sizeD  = input->size(1);
+    int64_t isizeH = input->size(2);
+    int64_t isizeW = input->size(3);
 
-    int64_t osizeH = gradOutput->size[2];
-    int64_t osizeW = gradOutput->size[3];
+    int64_t osizeH = gradOutput->size(2);
+    int64_t osizeW = gradOutput->size(3);
 
     //bool atomic = (isizeH%osizeH != 0) || (isizeW%osizeW != 0);
 

--- a/aten/src/THCUNN/generic/SpatialAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAveragePooling.cu
@@ -32,9 +32,9 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
              "padW = %d, padH = %d, kW = %d, kH = %d",
              padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size[dimh-1];
-  int64_t nInputRows = input->size[dimh];
-  int64_t nInputCols = input->size[dimw];
+  int64_t nInputPlane = input->size(dimh-1);
+  int64_t nInputRows = input->size(dimh);
+  int64_t nInputCols = input->size(dimw);
   int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
@@ -88,17 +88,17 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   int64_t nOutputCols, nOutputRows;
 
   if (input->dim() == 3) {
-    nInputCols = input->size[2];
-    nInputRows = input->size[1];
-    nInputPlane = input->size[0];
+    nInputCols = input->size(2);
+    nInputRows = input->size(1);
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size[3];
-    nInputRows = input->size[2];
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputCols = input->size(3);
+    nInputRows = input->size(2);
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
 
   if(ceil_mode) {
@@ -174,18 +174,18 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
   int dimRow = 1;
 
   if (input->dim() == 3) {
-    nInputPlane = input->size[0];
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
     dimCol = 3;
     dimRow = 2;
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
-  nInputCols = input->size[dimCol];
-  nInputRows = input->size[dimRow];
+  nInputCols = input->size(dimCol);
+  nInputRows = input->size(dimRow);
 
   if(ceil_mode) {
     nOutputCols = ceil(float(nInputCols - kW + 2*padW) / float(dW)) + 1;

--- a/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -30,8 +30,8 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
                   "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane = weight->size[2] / (kH * kW);
-  int64_t nOutputPlane = weight->size[1];
+  int64_t nInputPlane = weight->size(2) / (kH * kW);
+  int64_t nOutputPlane = weight->size(1);
 
   if (bias != NULL) {
    THCUNN_check_dim_size(state, bias, 3, 0, nOutputPlane);
@@ -56,9 +56,9 @@ static THCTensor* THNN_(view_weight_local)(
   AT_CHECK(!weight->is_empty() && (weight->dim() == 3 || weight->dim() == 6), 4,
            "weight tensor should be (non-empty) 3D or 6D - got size: ", weight->sizes());
   if (weight->dim() == 6) {
-    int64_t s1 = weight->size[0] * weight->size[1];
-    int64_t s2 = weight->size[2];
-    int64_t s3 = weight->size[3] * weight->size[4] * weight->size[5];
+    int64_t s1 = weight->size(0) * weight->size(1);
+    int64_t s2 = weight->size(2);
+    int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
     THCTensor *old_weight = weight;
     weight = THCTensor_(newWithStorage3d)(state,
                           weight->storage,
@@ -105,7 +105,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize4d)(state, output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -219,7 +219,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize4d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -339,7 +339,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Helpers
   THCTensor *input_n = THCTensor_(new)(state);

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -17,7 +17,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THCUNN_argCheck(state, !weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                     "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
+      THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -37,8 +37,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
                   "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
 
   int64_t exactInputHeight = inputHeight + 2 * padH;
   int64_t exactInputWidth = inputWidth + 2 * padW;
@@ -59,7 +59,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[1];
+    int64_t nInputPlane = weight->size(1);
     if (weight->dim() == 2) {
       nInputPlane /= (kH * kW);
     }
@@ -68,10 +68,10 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[0];
+      int64_t nOutputPlane = weight->size(0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
@@ -103,12 +103,12 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   int freeWeight = 0;
 
   // Params:
-  int nInputPlane = weight->dim() == 2 ? weight->size[1]/(kH*kW) : weight->size[1];
-  int nOutputPlane = weight->size[0];
+  int nInputPlane = weight->dim() == 2 ? weight->size(1)/(kH*kW) : weight->size(1);
+  int nOutputPlane = weight->size(0);
 
   if (weight->dim() == 4) {
-    int64_t s1 = weight->size[0];
-    int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
+    int64_t s1 = weight->size(0);
+    int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
     freeWeight = 1;
   }
@@ -121,16 +121,16 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
+    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize4d)(state, output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -141,7 +141,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -199,7 +199,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nOutputPlane;
-    int64_t n = columns->size[1];
+    int64_t n = columns->size(1);
     int64_t k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -257,13 +257,13 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
        (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, 0);
 
   // Params
-  int nInputPlane = weight->dim() == 2 ? weight->size[1]/(kW*kH) : weight->size[1];
-  int nOutputPlane = weight->size[0];
+  int nInputPlane = weight->dim() == 2 ? weight->size(1)/(kW*kH) : weight->size(1);
+  int nOutputPlane = weight->size(0);
 
   int freeWeight = 0;
   if (weight->dim() == 4) {
-    int64_t s1 = weight->size[0];
-    int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
+    int64_t s1 = weight->size(0);
+    int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
     freeWeight = 1;
   }
@@ -275,17 +275,17 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
+    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize4d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -306,7 +306,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nInputPlane*kW*kH;
-    int64_t n = gradColumns->size[1];
+    int64_t n = gradColumns->size(1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -387,31 +387,31 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
+    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
   }
 
-  int64_t nInputPlane = input->size[1];
-  int64_t nOutputPlane = gradOutput->size[1];
+  int64_t nInputPlane = input->size(1);
+  int64_t nOutputPlane = gradOutput->size(1);
 
   int freeWeight = 0;
   if (gradWeight && gradWeight->dim() == 4) {
-    int64_t s1 = gradWeight->size[0];
-    int64_t s2 = gradWeight->size[1] * gradWeight->size[2] * gradWeight->size[3];
+    int64_t s1 = gradWeight->size(0);
+    int64_t s2 = gradWeight->size(1) * gradWeight->size(2) * gradWeight->size(3);
     gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storageOffset, s1, -1, s2, -1);
     freeWeight = 1;
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -448,7 +448,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kW*kH;
-      int64_t k = columns->size[1];
+      int64_t k = columns->size(1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       #ifdef THC_REAL_IS_FLOAT

--- a/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
+++ b/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
@@ -19,16 +19,16 @@ void THNN_(LRNforward)(THCState* state, THCTensor* input, THCTensor* output,
 
   if (input->dim() == 3) {
     batchSize = 1;
-    nInputPlane = input->size[0];
-    imsize_h = input->size[1];
-    imsize_w = input->size[2];
+    nInputPlane = input->size(0);
+    imsize_h = input->size(1);
+    imsize_w = input->size(2);
   }
   else
   {
-    batchSize = input->size[0];
-    nInputPlane = input->size[1];
-    imsize_h = input->size[2];
-    imsize_w = input->size[3];
+    batchSize = input->size(0);
+    nInputPlane = input->size(1);
+    imsize_h = input->size(2);
+    imsize_w = input->size(3);
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -64,16 +64,16 @@ void THNN_(LRNbackward)(THCState* state, THCTensor* input, THCTensor* output,
 
   if (input->dim() == 3) {
     batchSize = 1;
-    nInputPlane = input->size[0];
-    imsize_h = input->size[1];
-    imsize_w = input->size[2];
+    nInputPlane = input->size(0);
+    imsize_h = input->size(1);
+    imsize_w = input->size(2);
   }
   else
   {
-    batchSize = input->size[0];
-    nInputPlane = input->size[1];
-    imsize_h = input->size[2];
-    imsize_w = input->size[3];
+    batchSize = input->size(0);
+    nInputPlane = input->size(1);
+    imsize_h = input->size(2);
+    imsize_w = input->size(3);
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -23,15 +23,15 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   // the caller, so we verify that here to some extent
 
   // Weight Tensor is shape (output_channels, 1, kH, kW)
-  THAssert(weight->size[1] == 1);
+  THAssert(weight->size(1) == 1);
 
   // Input Tensor is shape (N, input_channels, H, W)
   // We verify that the # of output_channels is a multiple of input_channels
-  THAssert(weight->size[0] % input->size[1] == 0);
+  THAssert(weight->size(0) % input->size(1) == 0);
 
   // Bias has same # of channels as output
   if (bias) {
-    THAssert(bias->size[0] == weight->size[0]);
+    THAssert(bias->size(0) == weight->size(0));
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -41,12 +41,12 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   // Following the behvaior of other THCUNN functions, we shape the output
   // Tensor ourselves
 
-  int batchSize = input->size[0];
-  int height = input->size[2];
-  int width = input->size[3];
+  int batchSize = input->size(0);
+  int height = input->size(2);
+  int width = input->size(3);
   int outputHeight = (height + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int outputWidth = (width + 2 * padW - (dilationW * (kW - 1) + 1)) / dW + 1;
-  int outputChannels = weight->size[0];
+  int outputChannels = weight->size(0);
 
   THCTensor_(resize4d)(state, output, batchSize, outputChannels, outputHeight, outputWidth);
 
@@ -61,7 +61,7 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
     dBias = toDeviceTensor<real, 1>(state, bias);
   }
 
-  int inputChannels = input->size[1];
+  int inputChannels = input->size(1);
   int depthwiseMultiplier = outputChannels / inputChannels;
 
   // One thread per output value
@@ -113,20 +113,20 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
 
   // Minimal shape checking, as above
   // Same # of elements in batch
-  THAssert(input->size[0] == gradOutput->size[0]);
+  THAssert(input->size(0) == gradOutput->size(0));
   // Same # of filters as outputChannels
-  THAssert(weight->size[0] == gradOutput->size[1]);
+  THAssert(weight->size(0) == gradOutput->size(1));
 
   // Resize GradInput
   THCTensor_(resizeAs)(state, gradInput, input);
 
-  int inputChannels = input->size[1];
-  int height = input->size[2];
-  int width = input->size[3];
+  int inputChannels = input->size(1);
+  int height = input->size(2);
+  int width = input->size(3);
 
-  int outputChannels = gradOutput->size[1];
-  int outputHeight = gradOutput->size[2];
-  int outputWidth = gradOutput->size[3];
+  int outputChannels = gradOutput->size(1);
+  int outputHeight = gradOutput->size(2);
+  int outputWidth = gradOutput->size(3);
 
   int depthwiseMultiplier = outputChannels / inputChannels;
 
@@ -210,18 +210,18 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
 
   // Minimal shape checking as above
   // Same # of elements in batch
-  THAssert(input->size[0] == gradOutput->size[0]);
+  THAssert(input->size(0) == gradOutput->size(0));
   // Same # of filters as outputChannels
-  THAssert(gradWeight->size[0] == gradOutput->size[1]);
+  THAssert(gradWeight->size(0) == gradOutput->size(1));
 
-  int batchSize = input->size[0];
-  int inputChannels = input->size[1];
-  int height = input->size[2];
-  int width = input->size[3];
+  int batchSize = input->size(0);
+  int inputChannels = input->size(1);
+  int height = input->size(2);
+  int width = input->size(3);
 
-  int outputChannels = gradOutput->size[1];
-  int outputHeight = gradOutput->size[2];
-  int outputWidth = gradOutput->size[3];
+  int outputChannels = gradOutput->size(1);
+  int outputHeight = gradOutput->size(2);
+  int outputWidth = gradOutput->size(3);
 
   int depthwiseMultiplier = outputChannels / inputChannels;
 

--- a/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -25,7 +25,7 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
   int batchSize = 1;
 
   if (ndim == 4) {
-    batchSize = input->size[0];
+    batchSize = input->size(0);
     dimf++;
     dimh++;
     dimw++;
@@ -38,9 +38,9 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
              "padW = %d, padH = %d, kW = %d, kH = %d",
              padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size[dimh-1];
-  int64_t nInputRows = input->size[dimh];
-  int64_t nInputCols = input->size[dimw];
+  int64_t nInputPlane = input->size(dimh-1);
+  int64_t nInputRows = input->size(dimh);
+  int64_t nInputCols = input->size(dimw);
   int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
@@ -102,17 +102,17 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   int64_t nOutputCols, nOutputRows;
 
   if (input->dim() == 3) {
-    nInputCols = input->size[2];
-    nInputRows = input->size[1];
-    nInputPlane = input->size[0];
+    nInputCols = input->size(2);
+    nInputRows = input->size(1);
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size[3];
-    nInputRows = input->size[2];
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputCols = input->size(3);
+    nInputRows = input->size(2);
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
 
   if(ceil_mode) {
@@ -181,17 +181,17 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   int64_t nOutputCols, nOutputRows;
 
   if (input->_dim() == 3) {
-    nInputCols = input->size[2];
-    nInputRows = input->size[1];
-    nInputPlane = input->size[0];
+    nInputCols = input->size(2);
+    nInputRows = input->size(1);
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size[3];
-    nInputRows = input->size[2];
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputCols = input->size(3);
+    nInputRows = input->size(2);
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
 
   if(ceil_mode) {

--- a/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
@@ -17,17 +17,17 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
 
   if (input->dim() == 3) {
-    nInputCols = input->size[2];
-    nInputRows = input->size[1];
-    nInputPlane = input->size[0];
+    nInputCols = input->size(2);
+    nInputRows = input->size(1);
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size[3];
-    nInputRows = input->size[2];
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputCols = input->size(3);
+    nInputRows = input->size(2);
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -65,22 +65,22 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   int dimh = 1;
 
   if (input->dim() == 3) {
-    nInputPlane = input->size[0];
+    nInputPlane = input->size(0);
     batchSize = 1;
   }
   else
   {
     ++dimw;
     ++dimh;
-    nInputPlane = input->size[1];
-    batchSize = input->size[0];
+    nInputPlane = input->size(1);
+    batchSize = input->size(0);
   }
-  nInputCols = input->size[dimw];
-  nInputRows = input->size[dimh];
+  nInputCols = input->size(dimw);
+  nInputRows = input->size(dimh);
 
-  if(owidth!=gradOutput->size[dimw] || oheight!=gradOutput->size[dimh]){
+  if(owidth!=gradOutput->size(dimw) || oheight!=gradOutput->size(dimh)){
      THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
-             oheight, owidth,gradOutput->size[dimh],gradOutput->size[dimw]);
+             oheight, owidth,gradOutput->size(dimh),gradOutput->size(dimw));
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
@@ -97,8 +97,8 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(
     dimh++;
     dimw++;
   }
-  int iheight = input->size[dimh];
-  int iwidth = input->size[dimw];
+  int iheight = input->size(dimh);
+  int iwidth = input->size(dimw);
   int oheight = iheight + padT + padB;
   int owidth  = iwidth + padL + padR;
 

--- a/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
@@ -87,8 +87,8 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(
     dimh++;
     dimw++;
   }
-  int iheight = input->size[dimh];
-  int iwidth = input->size[dimw];
+  int iheight = input->size(dimh);
+  int iwidth = input->size(dimw);
   int oheight = iheight + padT + padB;
   int owidth  = iwidth + padL + padR;
 

--- a/aten/src/THCUNN/generic/SpatialSubSampling.cu
+++ b/aten/src/THCUNN/generic/SpatialSubSampling.cu
@@ -242,8 +242,8 @@ void THNN_(SpatialSubSampling_accGradParameters)(
     int64_t sl;
     for (sl=0; sl<nbatch; sl++) {
       subgradweight<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
-        input_data + sl*input->stride[0],
-        gradOutput_data + sl*gradOutput->stride[0],
+        input_data + sl*input->stride(0),
+        gradOutput_data + sl*gradOutput->stride(0),
         gradWeight_data, gradBias_data,
         nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW, scale);
     }

--- a/aten/src/THCUNN/generic/SpatialSubSampling.cu
+++ b/aten/src/THCUNN/generic/SpatialSubSampling.cu
@@ -25,9 +25,9 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
     dimp++;
   }
 
-  int64_t nInputCols = input->size[dimc];
-  int64_t nInputRows = input->size[dimr];
-  THArgCheck(input->size[dimp] == nInputPlane, 2, "invalid number of input planes");
+  int64_t nInputCols = input->size(dimc);
+  int64_t nInputRows = input->size(dimr);
+  THArgCheck(input->size(dimp) == nInputPlane, 2, "invalid number of input planes");
   THArgCheck(nInputCols >= kW && nInputRows >= kH, 2, "input image smaller than kernel size");
 }
 
@@ -51,8 +51,8 @@ void THNN_(SpatialSubSampling_updateOutput)(
   THNN_(SpatialSubSampling_shapeCheck)(state, input, NULL, weight, kW, kH);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size[2];
-    int64_t nInputRows = input->size[1];
+    int64_t nInputCols = input->size(2);
+    int64_t nInputRows = input->size(1);
     int64_t nOutputCols = (nInputCols - kW) / dW + 1;
     int64_t nOutputRows = (nInputRows - kH) / dH + 1;
 
@@ -74,9 +74,9 @@ void THNN_(SpatialSubSampling_updateOutput)(
       nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW);
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size[3];
-    int64_t nInputRows = input->size[2];
-    int64_t nbatch = input->size[0];
+    int64_t nInputCols = input->size(3);
+    int64_t nInputRows = input->size(2);
+    int64_t nbatch = input->size(0);
     int64_t nOutputCols = (nInputCols - kW) / dW + 1;
     int64_t nOutputRows = (nInputRows - kH) / dH + 1;
 
@@ -119,8 +119,8 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   int nInputPlane = THCTensor_(size)(state, weight, 0);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size[2];
-    int64_t nInputRows = input->size[1];
+    int64_t nInputCols = input->size(2);
+    int64_t nInputRows = input->size(1);
 
     real *weight_data = THCTensor_(data)(state, weight);
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -149,9 +149,9 @@ void THNN_(SpatialSubSampling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size[3];
-    int64_t nInputRows = input->size[2];
-    int64_t nbatch = input->size[0];
+    int64_t nInputCols = input->size(3);
+    int64_t nInputRows = input->size(2);
+    int64_t nbatch = input->size(0);
 
     real *weight_data = THCTensor_(data)(state, weight);
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -199,8 +199,8 @@ void THNN_(SpatialSubSampling_accGradParameters)(
   int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size[2];
-    int64_t nInputRows = input->size[1];
+    int64_t nInputCols = input->size(2);
+    int64_t nInputRows = input->size(1);
 
     real *gradWeight_data = THCTensor_(data)(state, gradWeight);
     real *gradBias_data = THCTensor_(data)(state, gradBias);
@@ -221,9 +221,9 @@ void THNN_(SpatialSubSampling_accGradParameters)(
       nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW, scale);
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size[3];
-    int64_t nInputRows = input->size[2];
-    int64_t nbatch = input->size[0];
+    int64_t nInputCols = input->size(3);
+    int64_t nInputRows = input->size(2);
+    int64_t nbatch = input->size(0);
 
     real *gradWeight_data = THCTensor_(data)(state, gradWeight);
     real *gradBias_data = THCTensor_(data)(state, gradBias);

--- a/aten/src/THCUNN/generic/TemporalConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalConvolution.cu
@@ -25,13 +25,13 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck(input->size[dimF] == *inputFrameSize, 2,
+    THArgCheck(input->size(dimF) == *inputFrameSize, 2,
                "invalid input frame size. Got: %d, Expected: %d",
-               input->size[dimF], *inputFrameSize);
+               input->size(dimF), *inputFrameSize);
   }
-  THArgCheck(input->size[dimS] >= kW, 2,
+  THArgCheck(input->size(dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size[dimS], kW);
+             input->size(dimS), kW);
 }
 
 void THNN_(TemporalConvolution_updateOutput)(
@@ -65,7 +65,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   outputWindow = THCTensor_(new)(state);
   inputWindow = THCTensor_(new)(state);
 
-  nInputFrame = input->size[dimS];
+  nInputFrame = input->size(dimS);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (input->dim() == 2)
@@ -91,14 +91,14 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size[1],
-                              nFrame, inputFrameStride*input->size[1],
-                              kW*input->size[1], 1);
+                              input->storageOffset+k*dW*input->size(1),
+                              nFrame, inputFrameStride*input->size(1),
+                              kW*input->size(1), 1);
 
       THCTensor_(setStorage2d)(state, outputWindow, output->storage,
-                              output->storageOffset + k*output->size[1],
-                              nFrame, outputFrameStride*output->size[1],
-                              output->size[1], 1);
+                              output->storageOffset + k*output->size(1),
+                              nFrame, outputFrameStride*output->size(1),
+                              output->size(1), 1);
 
       THCTensor *tweight = THCTensor_(new)(state);
       THCTensor_(transpose)(state, tweight, weight, 0, 1);
@@ -110,7 +110,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   {
     THCTensor *outputSample = THCTensor_(new)(state);
     THCTensor *inputSample = THCTensor_(new)(state);
-    int nBatchFrame = input->size[0];
+    int nBatchFrame = input->size(0);
 
     THCTensor_(resize3d)(state, output,
                           nBatchFrame,
@@ -139,14 +139,14 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size[1],
-                                nFrame, inputFrameStride*inputSample->size[1],
-                                kW*inputSample->size[1], 1);
+                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                nFrame, inputFrameStride*inputSample->size(1),
+                                kW*inputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, outputWindow, outputSample->storage,
-                                outputSample->storageOffset + k*outputSample->size[1],
-                                nFrame, outputFrameStride*outputSample->size[1],
-                                outputSample->size[1], 1);
+                                outputSample->storageOffset + k*outputSample->size(1),
+                                nFrame, outputFrameStride*outputSample->size(1),
+                                outputSample->size(1), 1);
 
         THCTensor *tweight = THCTensor_(new)(state);
         THCTensor_(transpose)(state, tweight, weight, 0, 1);
@@ -194,8 +194,8 @@ void THNN_(TemporalConvolution_updateGradInput)(
     dimS = 1;
   }
 
-  nInputFrame = input->size[dimS];
-  nOutputFrame = gradOutput->size[dimS];
+  nInputFrame = input->size(dimS);
+  nOutputFrame = gradOutput->size(dimS);
 
 
   /* Not necessary with partial backprop: */
@@ -216,14 +216,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size[1],
-                              nFrame, outputFrameStride*gradOutput->size[1],
-                              gradOutput->size[1], 1);
+                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              nFrame, outputFrameStride*gradOutput->size(1),
+                              gradOutput->size(1), 1);
 
       THCTensor_(setStorage2d)(state, gradInputWindow, gradInput->storage,
-                              gradInput->storageOffset+k*dW*gradInput->size[1],
-                              nFrame, inputFrameStride*gradInput->size[1],
-                              kW*gradInput->size[1], 1);
+                              gradInput->storageOffset+k*dW*gradInput->size(1),
+                              nFrame, inputFrameStride*gradInput->size(1),
+                              kW*gradInput->size(1), 1);
 
       THCTensor_(addmm)(state, gradInputWindow, ScalarConvert<int, real>::to(1), gradInputWindow, ScalarConvert<int, real>::to(1), gradOutputWindow, weight);
     }
@@ -232,7 +232,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   {
     THCTensor *gradOutputSample = THCTensor_(new)(state);
     THCTensor *gradInputSample = THCTensor_(new)(state);
-    int64_t nBatchFrame = input->size[0];
+    int64_t nBatchFrame = input->size(0);
     for(i = 0; i < nBatchFrame; i++)
     {
       THCTensor_(select)(state, gradOutputSample, gradOutput, 0, i);
@@ -248,14 +248,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size[1],
-                                nFrame, outputFrameStride*gradOutputSample->size[1],
-                                gradOutputSample->size[1], 1);
+                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                nFrame, outputFrameStride*gradOutputSample->size(1),
+                                gradOutputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, gradInputWindow, gradInputSample->storage,
-                                gradInputSample->storageOffset+k*dW*gradInputSample->size[1],
-                                nFrame, inputFrameStride*gradInputSample->size[1],
-                                kW*gradInputSample->size[1], 1);
+                                gradInputSample->storageOffset+k*dW*gradInputSample->size(1),
+                                nFrame, inputFrameStride*gradInputSample->size(1),
+                                kW*gradInputSample->size(1), 1);
 
         THCTensor_(addmm)(state, gradInputWindow, ScalarConvert<int, real>::to(1), gradInputWindow, ScalarConvert<int, real>::to(1), gradOutputWindow, weight);
       }
@@ -298,8 +298,8 @@ void THNN_(TemporalConvolution_accGradParameters)(
     dimS = 1;
   }
 
-  nInputFrame = input->size[dimS];
-  nOutputFrame = gradOutput->size[dimS];
+  nInputFrame = input->size(dimS);
+  nOutputFrame = gradOutput->size(dimS);
 
   /* Not necessary with partial backprop: */
   input = THCTensor_(newContiguous)(state, input);
@@ -325,14 +325,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size[1],
-                              nFrame, inputFrameStride*input->size[1],
-                              kW*input->size[1], 1);
+                              input->storageOffset+k*dW*input->size(1),
+                              nFrame, inputFrameStride*input->size(1),
+                              kW*input->size(1), 1);
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size[1],
-                              nFrame, outputFrameStride*gradOutput->size[1],
-                              gradOutput->size[1], 1);
+                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              nFrame, outputFrameStride*gradOutput->size(1),
+                              gradOutput->size(1), 1);
 
       THCTensor *tgradOutputWindow = THCTensor_(new)(state);
       THCTensor_(transpose)(state, tgradOutputWindow, gradOutputWindow, 0, 1);
@@ -344,7 +344,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   {
     THCTensor *gradOutputSample = THCTensor_(new)(state);
     THCTensor *inputSample = THCTensor_(new)(state);
-    int64_t nBatchFrame = input->size[0];
+    int64_t nBatchFrame = input->size(0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -368,14 +368,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size[1],
-                                nFrame, inputFrameStride*inputSample->size[1],
-                                kW*inputSample->size[1], 1);
+                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                nFrame, inputFrameStride*inputSample->size(1),
+                                kW*inputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size[1],
-                                nFrame, outputFrameStride*gradOutputSample->size[1],
-                                gradOutputSample->size[1], 1);
+                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                nFrame, outputFrameStride*gradOutputSample->size(1),
+                                gradOutputSample->size(1), 1);
 
         THCTensor *tgradOutputWindow = THCTensor_(new)(state);
         THCTensor_(transpose)(state, tgradOutputWindow, gradOutputWindow, 0, 1);

--- a/aten/src/THCUNN/generic/TemporalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/TemporalMaxPooling.cu
@@ -27,12 +27,12 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   THCUNN_argCheck(state, !input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
-  THArgCheck(input->size[dimT] >= kW, 2,
+  THArgCheck(input->size(dimT) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size[dimT], kW);
+             input->size(dimT), kW);
 
-  input_w = input->size[dimT];
-  input_n = input->size[dimF];
+  input_w = input->size(dimT);
+  input_n = input->size(dimF);
   output_w = (input_w - kW) / dW + 1;
 
   if (gradOutput != NULL) {
@@ -71,23 +71,23 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   {
     dimT = 1;
     dimF = 2;
-    batch = input->size[0];
+    batch = input->size(0);
   }
   input = THCTensor_(newContiguous)(state, input);
 
-  input_w = input->size[dimT];
-  input_n = input->size[dimF];
+  input_w = input->size(dimT);
+  input_n = input->size(dimF);
   output_w = (input_w - kW) / dW + 1;
 
   if (input->dim() == 2)
   {
-    THCTensor_(resize2d)(state, output, output_w, input->size[dimF]);
-    THCIndexTensor_(resize2d)(state, indices, output_w, input->size[dimF]);
+    THCTensor_(resize2d)(state, output, output_w, input->size(dimF));
+    THCIndexTensor_(resize2d)(state, indices, output_w, input->size(dimF));
   }
   else
   {
-    THCTensor_(resize3d)(state, output, batch, output_w, input->size[dimF]);
-    THCIndexTensor_(resize3d)(state, indices, batch, output_w, input->size[dimF]);
+    THCTensor_(resize3d)(state, output, batch, output_w, input->size(dimF));
+    THCIndexTensor_(resize3d)(state, indices, batch, output_w, input->size(dimF));
   }
 
   input_data = THCTensor_(data)(state, input);
@@ -146,12 +146,12 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   {
     dimT = 1;
     dimF = 2;
-    batch = input->size[0];
+    batch = input->size(0);
   }
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  input_w = input->size[dimT];
-  input_n = input->size[dimF];
+  input_w = input->size(dimT);
+  input_n = input->size(dimF);
   output_w = (input_w - kW) / dW + 1;
 
   gradInput_data = THCTensor_(data)(state, gradInput);

--- a/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
@@ -84,7 +84,7 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(
     planeDim++;
     dimw++;
   }
-  int iwidth = input->size[dimw];
+  int iwidth = input->size(dimw);
   int owidth  = iwidth + padL + padR;
 
   THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,

--- a/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
@@ -79,7 +79,7 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(
     planeDim++;
     dimw++;
   }
-  int iwidth = input->size[dimw];
+  int iwidth = input->size(dimw);
   int owidth  = iwidth + padL + padR;
 
   THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,

--- a/aten/src/THCUNN/generic/TemporalRowConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalRowConvolution.cu
@@ -14,7 +14,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
                   weight, "non-empty 2D or 3D weight tensor expected, but got: %s");
 
   if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
+    THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
   }
 
   int ndim = input->dim();
@@ -29,8 +29,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 2 || ndim == 3), 1, input,
                   "non-empty 2D or 3D (batch mode) input tensor expected, but got :%s");
 
-  int64_t inputFrameSize = weight->size[0];
-  int64_t nInputFrame = input->size[dimS];
+  int64_t inputFrameSize = weight->size(0);
+  int64_t nInputFrame = input->size(dimS);
   int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
   if (nOutputFrame < 1) {
@@ -84,16 +84,16 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);
+    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
   }
 
   // Params:
-  int64_t inputFrameSize = weight->size[0];
-  int64_t nInputFrame = input->size[2];
+  int64_t inputFrameSize = weight->size(0);
+  int64_t nInputFrame = input->size(2);
   int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
   // Batch size
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize3d)(state, output, batchSize, inputFrameSize, nOutputFrame);
@@ -104,7 +104,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever
   // gets increased and always contains ones.
-  if (ones->dim() != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
+  if (ones->dim() != 2 || ones->size(0) * ones->size(1) < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -218,18 +218,18 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);
-    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size[0],
-                         gradOutput->size[1]);
+    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
+    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size(0),
+                         gradOutput->size(1));
   }
 
   // Params:
-  int64_t inputFrameSize = weight->size[0];
-  int64_t nInputFrame = input->size[2];
-  int64_t nOutputFrame = gradOutput->size[2];
+  int64_t inputFrameSize = weight->size(0);
+  int64_t nInputFrame = input->size(2);
+  int64_t nOutputFrame = gradOutput->size(2);
 
   // Batch size
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize3d)(state, gradInput, batchSize, inputFrameSize,
@@ -331,21 +331,21 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size[0], input->size[1]);
-    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size[0],
-                         gradOutput->size[1]);
+    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
+    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size(0),
+                         gradOutput->size(1));
   }
 
   // Params:
-  int64_t inputFrameSize = gradWeight->size[0];
-  int64_t nInputFrame = input->size[2];
-  int64_t nOutputFrame = gradOutput->size[2];
+  int64_t inputFrameSize = gradWeight->size(0);
+  int64_t nInputFrame = input->size(2);
+  int64_t nOutputFrame = gradOutput->size(2);
 
   // Batch size
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size[0] * ones->size[1] < nOutputFrame) {
+  if (ones->dim() != 2 || ones->size(0) * ones->size(1) < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
@@ -28,10 +28,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size[0];
-    isizeT = input->size[1];
-    isizeH = input->size[2];
-    isizeW = input->size[3];
+    sizeD = input->size(0);
+    isizeT = input->size(1);
+    isizeH = input->size(2);
+    isizeW = input->size(3);
 
     istrideD = input->stride[0];
     istrideT = input->stride[1];
@@ -44,11 +44,11 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   } else {
     input = THCTensor_(newContiguous)(state, input);
 
-    int64_t sizeB = input->size[0];
-    sizeD = input->size[1];
-    isizeT = input->size[2];
-    isizeH = input->size[3];
-    isizeW = input->size[4];
+    int64_t sizeB = input->size(0);
+    sizeD = input->size(1);
+    isizeT = input->size(2);
+    isizeH = input->size(3);
+    isizeW = input->size(4);
 
     istrideD = input->stride[1];
     istrideT = input->stride[2];
@@ -107,23 +107,23 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size[0];
-    isizeT = input->size[1];
-    isizeH = input->size[2];
-    isizeW = input->size[3];
+    sizeD = input->size(0);
+    isizeT = input->size(1);
+    isizeH = input->size(2);
+    isizeW = input->size(3);
 
-    osizeT = gradOutput->size[1];
-    osizeH = gradOutput->size[2];
-    osizeW = gradOutput->size[3];
+    osizeT = gradOutput->size(1);
+    osizeH = gradOutput->size(2);
+    osizeW = gradOutput->size(3);
   } else {
-    sizeD = input->size[1];
-    isizeT = input->size[2];
-    isizeH = input->size[3];
-    isizeW = input->size[4];
+    sizeD = input->size(1);
+    isizeT = input->size(2);
+    isizeH = input->size(3);
+    isizeW = input->size(4);
 
-    osizeT = gradOutput->size[2];
-    osizeH = gradOutput->size[3];
-    osizeW = gradOutput->size[4];
+    osizeT = gradOutput->size(2);
+    osizeH = gradOutput->size(3);
+    osizeW = gradOutput->size(4);
   }
 
   // somehow nonatomic is passing all test for volumetric case.
@@ -132,7 +132,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   if (input->dim() == 4) {
     totalZ = atomic ? sizeD * osizeT : sizeD * isizeT;
   } else {
-    int sizeB = input->size[0];
+    int sizeB = input->size(0);
     totalZ = atomic ? sizeB * sizeD * osizeT : sizeB * sizeD * isizeT;
   }
 

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
@@ -33,10 +33,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
     isizeH = input->size(2);
     isizeW = input->size(3);
 
-    istrideD = input->stride[0];
-    istrideT = input->stride[1];
-    istrideH = input->stride[2];
-    istrideW = input->stride[3];
+    istrideD = input->stride(0);
+    istrideT = input->stride(1);
+    istrideH = input->stride(2);
+    istrideW = input->stride(3);
 
     THCTensor_(resize4d)(state, output, sizeD, osizeT, osizeH, osizeW);
 
@@ -50,10 +50,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
     isizeH = input->size(3);
     isizeW = input->size(4);
 
-    istrideD = input->stride[1];
-    istrideT = input->stride[2];
-    istrideH = input->stride[3];
-    istrideW = input->stride[4];
+    istrideD = input->stride(1);
+    istrideT = input->stride(2);
+    istrideH = input->stride(3);
+    istrideW = input->stride(4);
 
     THCTensor_(resize5d)(state, output, sizeB, sizeD, osizeT, osizeH, osizeW);
 

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
@@ -29,10 +29,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size[0];
-    isizeT = input->size[1];
-    isizeH = input->size[2];
-    isizeW = input->size[3];
+    sizeD = input->size(0);
+    isizeT = input->size(1);
+    isizeH = input->size(2);
+    isizeW = input->size(3);
 
     istrideD = input->stride[0];
     istrideT = input->stride[1];
@@ -46,11 +46,11 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   } else {
     input = THCTensor_(newContiguous)(state, input);
 
-    int64_t sizeB = input->size[0];
-    sizeD = input->size[1];
-    isizeT = input->size[2];
-    isizeH = input->size[3];
-    isizeW = input->size[4];
+    int64_t sizeB = input->size(0);
+    sizeD = input->size(1);
+    isizeT = input->size(2);
+    isizeH = input->size(3);
+    isizeW = input->size(4);
 
     istrideD = input->stride[1];
     istrideT = input->stride[2];
@@ -113,23 +113,23 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size[0];
-    isizeT = input->size[1];
-    isizeH = input->size[2];
-    isizeW = input->size[3];
+    sizeD = input->size(0);
+    isizeT = input->size(1);
+    isizeH = input->size(2);
+    isizeW = input->size(3);
 
-    osizeT = gradOutput->size[1];
-    osizeH = gradOutput->size[2];
-    osizeW = gradOutput->size[3];
+    osizeT = gradOutput->size(1);
+    osizeH = gradOutput->size(2);
+    osizeW = gradOutput->size(3);
   } else {
-    sizeD = input->size[1];
-    isizeT = input->size[2];
-    isizeH = input->size[3];
-    isizeW = input->size[4];
+    sizeD = input->size(1);
+    isizeT = input->size(2);
+    isizeH = input->size(3);
+    isizeW = input->size(4);
 
-    osizeT = gradOutput->size[2];
-    osizeH = gradOutput->size[3];
-    osizeW = gradOutput->size[4];
+    osizeT = gradOutput->size(2);
+    osizeH = gradOutput->size(3);
+    osizeW = gradOutput->size(4);
   }
 
   bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0) || (isizeT%osizeT != 0);
@@ -137,7 +137,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   if (input->dim() == 4) {
     totalZ = sizeD * osizeT;
   } else {
-    int sizeB = input->size[0];
+    int sizeB = input->size(0);
     totalZ = sizeB * sizeD * osizeT;
   }
 

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
@@ -34,10 +34,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
     isizeH = input->size(2);
     isizeW = input->size(3);
 
-    istrideD = input->stride[0];
-    istrideT = input->stride[1];
-    istrideH = input->stride[2];
-    istrideW = input->stride[3];
+    istrideD = input->stride(0);
+    istrideT = input->stride(1);
+    istrideH = input->stride(2);
+    istrideW = input->stride(3);
 
     THCTensor_(resize4d)(state, output, sizeD, osizeT, osizeH, osizeW);
     THCIndexTensor_(resize4d)(state, indices, sizeD, osizeT, osizeH, osizeW);
@@ -52,10 +52,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
     isizeH = input->size(3);
     isizeW = input->size(4);
 
-    istrideD = input->stride[1];
-    istrideT = input->stride[2];
-    istrideH = input->stride[3];
-    istrideW = input->stride[4];
+    istrideD = input->stride(1);
+    istrideT = input->stride(2);
+    istrideH = input->stride(3);
+    istrideW = input->stride(4);
 
     THCTensor_(resize5d)(state, output, sizeB, sizeD, osizeT, osizeH, osizeW);
     THCIndexTensor_(resize5d)(state, indices, sizeB, sizeD, osizeT, osizeH, osizeW);

--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -32,11 +32,11 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
 
   if (!input->is_empty() && THCTensor_(nDimension)(state, input) == 4)
   {
-    THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
-               && input->size[dimt] >= kT, 2,
+    THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
+               && input->size(dimt) >= kT, 2,
                "input image (T: %d H: %d W: %d) smaller than "
                "kernel size (kT: %d kH: %d kW: %d)",
-               input->size[dimt], input->size[dimh], input->size[dimw],
+               input->size(dimt), input->size(dimh), input->size(dimw),
                kT, kH, kW);
 
     /* sizes */
@@ -47,11 +47,11 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   }
   else if (!input->is_empty() && THCTensor_(nDimension)(state, input) == 5)
   {
-    THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
-               && input->size[dimt] >= kT, 2,
+    THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
+               && input->size(dimt) >= kT, 2,
                "input image (T: %d H: %d W: %d) smaller than "
                "kernel size (kT: %d kH: %d kW: %d)",
-               input->size[dimt], input->size[dimh], input->size[dimw],
+               input->size(dimt), input->size(dimh), input->size(dimw),
                kT, kH, kW);
 
     /* sizes */

--- a/aten/src/THCUNN/generic/VolumetricConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricConvolution.cu
@@ -47,11 +47,11 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
   if (weight == NULL) {
     weight = gradWeight;
   }
-  int64_t nOutputPlane = weight->size[0];
-  int64_t nInputPlane  = weight->size[1];
-  int64_t kT           = weight->size[2];
-  int64_t kH           = weight->size[3];
-  int64_t kW           = weight->size[4];
+  int64_t nOutputPlane = weight->size(0);
+  int64_t nInputPlane  = weight->size(1);
+  int64_t kT           = weight->size(2);
+  int64_t kH           = weight->size(3);
+  int64_t kW           = weight->size(4);
 
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 4,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
@@ -69,9 +69,9 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
     dimd++;
   }
 
-  int64_t inputWidth   = input->size[dimw];
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputDepth   = input->size[dimd];
+  int64_t inputWidth   = input->size(dimw);
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputDepth   = input->size(dimd);
 
   int64_t exactInputDepth = inputDepth + 2*padT;
   int64_t exactInputHeight = inputHeight + 2*padH;
@@ -97,7 +97,7 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
   }
 
   if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
+    THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
   }
   THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
 
@@ -128,30 +128,30 @@ void THNN_(VolumetricConvolution_updateOutput)(
         bias, dT, dW, dH, padT, padW, padH);
   input = THCTensor_(newContiguous)(state, input);
 
-  int nOutputPlane = (int)weight->size[0];
-  int nInputPlane  = (int)weight->size[1];
-  int kT           = (int)weight->size[2];
-  int kH           = (int)weight->size[3];
-  int kW           = (int)weight->size[4];
+  int nOutputPlane = (int)weight->size(0);
+  int nInputPlane  = (int)weight->size(1);
+  int kT           = (int)weight->size(2);
+  int kH           = (int)weight->size(3);
+  int kW           = (int)weight->size(4);
 
   int batch = 1;
   if (input->dim() == 4)
   {
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1],
-                          input->size[2], input->size[3]);
+    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1),
+                          input->size(2), input->size(3));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
-  int64_t inputDepth   = input->size[4];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
+  int64_t inputDepth   = input->size(4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize5d)(state, output, batchSize, nOutputPlane,
@@ -163,7 +163,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);
@@ -220,9 +220,9 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size[0];
-    int64_t n = columns->size[1];
-    int64_t k = weight->size[1]*weight->size[2]*weight->size[3]*weight->size[4];
+    int64_t m = weight->size(0);
+    int64_t n = columns->size(1);
+    int64_t k = weight->size(1)*weight->size(2)*weight->size(3)*weight->size(4);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -267,11 +267,11 @@ void THNN_(VolumetricConvolution_updateGradInput)(
            int padT, int padW, int padH)
 {
 
-  int64_t nOutputPlane = weight->size[0];
-  int64_t nInputPlane  = weight->size[1];
-  int64_t kT           = weight->size[2];
-  int64_t kH           = weight->size[3];
-  int64_t kW           = weight->size[4];
+  int64_t nOutputPlane = weight->size(0);
+  int64_t nInputPlane  = weight->size(1);
+  int64_t kT           = weight->size(2);
+  int64_t kH           = weight->size(3);
+  int64_t kW           = weight->size(4);
 
   THCTensor *gradColumns = finput;
 
@@ -287,19 +287,19 @@ void THNN_(VolumetricConvolution_updateGradInput)(
     input = THCTensor_(newContiguous)(state, input);
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
-  int64_t inputDepth   = input->size[4];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
+  int64_t inputDepth   = input->size(4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THCTensor_(resize5d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth, inputDepth);
@@ -320,9 +320,9 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size[1]*weight->size[2]*weight->size[3]*weight->size[4];
-    int64_t n = gradColumns->size[1];
-    int64_t k = weight->size[0];
+    int64_t m = weight->size(1)*weight->size(2)*weight->size(3)*weight->size(4);
+    int64_t n = gradColumns->size(1);
+    int64_t k = weight->size(0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -387,11 +387,11 @@ void THNN_(VolumetricConvolution_accGradParameters)(
         state, input, gradOutput, NULL, gradWeight,
         gradBias, dT, dW, dH, padT, padW, padH);
 
-  int nOutputPlane = (int)gradWeight->size[0];
-  int nInputPlane  = (int)gradWeight->size[1];
-  int kT           = (int)gradWeight->size[2];
-  int kH           = (int)gradWeight->size[3];
-  int kW           = (int)gradWeight->size[4];
+  int nOutputPlane = (int)gradWeight->size(0);
+  int nInputPlane  = (int)gradWeight->size(1);
+  int kT           = (int)gradWeight->size(2);
+  int kH           = (int)gradWeight->size(3);
+  int kW           = (int)gradWeight->size(4);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -401,22 +401,22 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   {
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
-  int64_t inputDepth   = input->size[4];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
+  int64_t inputDepth   = input->size(4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);
@@ -447,9 +447,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = gradWeight->size[0];
-    int64_t n = gradWeight->size[1]*gradWeight->size[2]*gradWeight->size[3]*gradWeight->size[4];
-    int64_t k = columns->size[1];
+    int64_t m = gradWeight->size(0);
+    int64_t n = gradWeight->size(1)*gradWeight->size(2)*gradWeight->size(3)*gradWeight->size(4);
+    int64_t k = columns->size(1);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -51,11 +51,11 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
   }
 
   if (gradOutput != NULL) {
-    if (oT != gradOutput->size[dimt] || oW != gradOutput->size[dimw] || oH != gradOutput->size[dimh])
+    if (oT != gradOutput->size(dimt) || oW != gradOutput->size(dimw) || oH != gradOutput->size(dimh))
     {
       THError(
         "Inconsistent gradOutput size. oT= %d, oH= %d, oW= %d, gradOutput: %dx%dx%d",
-        oT, oH, oW, gradOutput->size[dimt], gradOutput->size[dimh], gradOutput->size[dimw]);
+        oT, oH, oW, gradOutput->size(dimt), gradOutput->size(dimh), gradOutput->size(dimw));
     }
 
     THCUNN_check_dim_size(state, gradOutput, input->dim(), dimn, inputSlices);

--- a/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
@@ -28,9 +28,9 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
     }
 
   int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int idepth = input->size[dimd];
-  int iheight = input->size[dimh];
-  int iwidth = input->size[dimw];
+  int idepth = input->size(dimd);
+  int iheight = input->size(dimh);
+  int iwidth = input->size(dimw);
   int odepth = idepth + pfront + pback;
   int oheight = iheight + ptop + pbottom;
   int owidth  = iwidth + pleft + pright;

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -129,7 +129,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
                 "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
   int64_t batch_dim = (ndim == 3) ? 0 : -1;
-  int64_t nInputPlane  = input->size[batch_dim + 1];
+  int64_t nInputPlane  = input->size(batch_dim + 1);
 
   if (nInputPlane % (kW * kH) != 0) {
     THError("Expected size of input's dimension 1 to be divisible by the "
@@ -137,7 +137,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
             "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
   }
 
-  int64_t inputLength  = input->size[batch_dim + 2];
+  int64_t inputLength  = input->size(batch_dim + 2);
   int64_t nBlocksH = 1 + (outputHeight + 2 * padH - dH * (kH - 1) - 1) / sH;
   int64_t nBlocksW = 1 + ( outputWidth + 2 * padW - dW * (kW - 1) - 1) / sW;
 
@@ -174,11 +174,11 @@ void THNN_(Col2Im_updateOutput)(
   if (input->dim() == 2) {
       // Force batch
       batched_input = false;
-      THTensor_(resize3d)(input, 1, input->size[0], input->size[1]);
+      THTensor_(resize3d)(input, 1, input->size(0), input->size(1));
   }
 
-  long batchSize = input->size[0];
-  long nInputPlane = input->size[1];
+  long batchSize = input->size(0);
+  long nInputPlane = input->size(1);
   long nOutputPlane = nInputPlane / (kW * kH);
 
   input = THTensor_(newContiguous)(input);

--- a/aten/src/THNN/generic/FeatureLPPooling.c
+++ b/aten/src/THNN/generic/FeatureLPPooling.c
@@ -24,9 +24,9 @@ static inline size_t flpGetOffset(FeatureLPPoolingSizes* s,
                            FEATURE_LP_SIZE_TYPE opt1,
                            FEATURE_LP_SIZE_TYPE opt2) {
   return s->stride[0] * batch +
-    s->stride[1] * feature +
-    s->stride[2] * opt1 +
-    s->stride[3] * opt2;
+         s->stride[1] * feature +
+         s->stride[2] * opt1 +
+         s->stride[3] * opt2;
 }
 
 static inline size_t flpOutputSize(FEATURE_LP_SIZE_TYPE inputSize,

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -57,7 +57,7 @@ void THNN_(Im2Col_updateOutput)(
   bool batched_input = true;
   if (input->dim() == 3) {
     batched_input = false;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
   }
 
   int64_t batchSize    = THTensor_(size)(input, 0);

--- a/aten/src/THNN/generic/IndexLinear.c
+++ b/aten/src/THNN/generic/IndexLinear.c
@@ -65,7 +65,7 @@ void THNN_(IndexLinear_updateOutput)(
   real* outputData = THTensor_(data)(output);
   real* valuesData = THTensor_(data)(values);
   real* weightData = THTensor_(data)(weight);
-  int64_t weightStride0 = weight->stride[0];
+  int64_t weightStride0 = weight->stride(0);
   real* biasData = THTensor_(data)(bias);
   int64_t* keysData = THLongTensor_data(keys);
 
@@ -258,7 +258,7 @@ void THNN_(IndexLinear_updateParameters)(
   /* Access the storage data/strides */
   real* gradWeightData = THTensor_(data)(gradWeight);
   real* weightData = THTensor_(data)(weight);
-  int64_t weightStride0 = weight->stride[0];
+  int64_t weightStride0 = weight->stride(0);
   real* gradBiasData = THTensor_(data)(gradBias);
   real* biasData = THTensor_(data)(bias);
   int64_t* keysData = THLongTensor_data(runningKeys);
@@ -406,7 +406,7 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
   real* valuesData =THTensor_(data)(values);
   real* weightData = THTensor_(data)(weight);
   real* biasData = THTensor_(data)(bias);
-  int64_t weightStride0 = weight->stride[0];
+  int64_t weightStride0 = weight->stride(0);
   int64_t* keysData = THLongTensor_data(keys);
   int64_t* sizesData = THLongTensor_data(sizes);
 

--- a/aten/src/THNN/generic/LookupTable.c
+++ b/aten/src/THNN/generic/LookupTable.c
@@ -40,7 +40,7 @@ void THNN_(LookupTable_accGradParameters)(
 
   if (scaleGradByFreq)
   {
-    THIntegerTensor_(resize1d)(count, gradWeight->size[0]);
+    THIntegerTensor_(resize1d)(count, gradWeight->size(0));
     count_data = THIntegerTensor_(data)(count);
   }
 

--- a/aten/src/THNN/generic/MultiLabelMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiLabelMarginCriterion.c
@@ -23,16 +23,16 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size[0];
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == dim),
+    dim = input->size(0);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim),
              "inconsistent target size");
   }
   else
   {
-    nframe = input->size[0];
-    dim = input->size[1];
-    AT_CHECK(!target->is_empty() && target->dim() == 2 && (target->size[0] == nframe)
-             && (target->size[1] == dim), "inconsistent target size");
+    nframe = input->size(0);
+    dim = input->size(1);
+    AT_CHECK(!target->is_empty() && target->dim() == 2 && (target->size(0) == nframe)
+             && (target->size(1) == dim), "inconsistent target size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");
@@ -161,20 +161,20 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size[0];
-    AT_CHECK((!target->is_empty() && target->dim() == 1) && (target->size[0] == dim),
+    dim = input->size(0);
+    AT_CHECK((!target->is_empty() && target->dim() == 1) && (target->size(0) == dim),
              "inconsistent target size");
-    AT_CHECK((!isTarget->is_empty() && isTarget->dim() == 1) && (isTarget->size[0] == dim),
+    AT_CHECK((!isTarget->is_empty() && isTarget->dim() == 1) && (isTarget->size(0) == dim),
              "inconsistent isTarget size");
   }
   else
   {
-    nframe = input->size[0];
-    dim = input->size[1];
-    AT_CHECK(!target->is_empty() && (target->dim() == 2) && (target->size[0] == nframe)
-             && (target->size[1] == dim), 3, "inconsistent target size");
-    AT_CHECK(!isTarget->is_empty() && (isTarget->dim() == 2) && (isTarget->size[0] == nframe)
-             && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
+    nframe = input->size(0);
+    dim = input->size(1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
+             && (target->size(1) == dim), 3, "inconsistent target size");
+    AT_CHECK(!isTarget->is_empty() && (isTarget->dim() == 2) && (isTarget->size(0) == nframe)
+             && (isTarget->size(1) == dim), 3, "inconsistent isTarget size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -26,13 +26,13 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size[0];
+    dim = input->size(0);
   }
   else
   {
-    nframe = input->size[0];
-    dim = input->size[1];
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe),
+    nframe = input->size(0);
+    dim = input->size(1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe),
              "inconsistent target size, got: ", target->sizes());
   }
 
@@ -142,13 +142,13 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size[0];
+    dim = input->size(0);
   }
   else
   {
-    nframe = input->size[0];
-    dim = input->size[1];
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size[0] == nframe),
+    nframe = input->size(0);
+    dim = input->size(1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe),
              "inconsistent target size, got: ", target->sizes());
   }
 

--- a/aten/src/THNN/generic/PReLU.c
+++ b/aten/src/THNN/generic/PReLU.c
@@ -26,13 +26,13 @@ void THNN_(PReLU_updateOutput)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(_nDimension)(input);
-    if (input->size[input_ndim > 1] != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
+    if (input->size(input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size[0];
+        bs = input->size(0);
         for (int d = 2; d < input_ndim; d++) {
-            ks *= input->size[d];
+            ks *= input->size(d);
         }
     }
   }
@@ -91,13 +91,13 @@ void THNN_(PReLU_updateGradInput)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(_nDimension)(input);
-    if (input->size[input_ndim > 1] != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
+    if (input->size(input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size[0];
+        bs = input->size(0);
         for (int d = 2; d < input_ndim; d++) {
-            ks *= input->size[d];
+            ks *= input->size(d);
         }
     }
   }
@@ -162,13 +162,13 @@ void THNN_(PReLU_accGradParameters)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(_nDimension)(input);
-    if (input->size[input_ndim > 1] != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size[input_ndim > 1]);
+    if (input->size(input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size[0];
+        bs = input->size(0);
         for (int d = 2; d < input_ndim; d++) {
-          ks *= input->size[d];
+          ks *= input->size(d);
         }
     }
   }

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -11,22 +11,22 @@
 
 static bool THNN_(checkLegacyInput)(THTensor* t)
 {
-  return !t->is_empty() && t->dim() == 3 && t->size[2] == 2;
+  return !t->is_empty() && t->dim() == 3 && t->size(2) == 2;
 }
 
 static bool THNN_(checkInput)(THTensor* t)
 {
-  return!t->is_empty() && t->dim() == 2 && t->size[1] == 3;
+  return!t->is_empty() && t->dim() == 2 && t->size(1) == 3;
 }
 
 static bool THNN_(checkSize2D)(THTensor* t, int64_t size0, int64_t size1)
 {
-  return !t->is_empty() && t->dim() == 2 && t->size[0] == size0 && t->size[1] == size1;
+  return !t->is_empty() && t->dim() == 2 && t->size(0) == size0 && t->size(1) == size1;
 }
 
 static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 {
-  return !t->is_empty() && t->dim() == 1 && t->size[0] == size0;
+  return !t->is_empty() && t->dim() == 1 && t->size(0) == size0;
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {
@@ -324,8 +324,8 @@ void THNN_(SparseLinear_updateParameters)(
 {
   real learningRate = TH_CONVERT_ACCREAL_TO_REAL(learningRate_);
   int64_t i;
-  int64_t outDim = weight->size[0];
-  int64_t inDim = weight->size[1];
+  int64_t outDim = weight->size(0);
+  int64_t inDim = weight->size(1);
 
   THArgCheck(THNN_(checkSize2D)(gradWeight, outDim, inDim), 4,
              "gradWeight size wrong");
@@ -398,8 +398,8 @@ void THNN_(SparseLinear_legacyUpdateParameters)(
 {
   real learningRate = TH_CONVERT_ACCREAL_TO_REAL(learningRate_);
   int64_t h, i;
-  int64_t outDim = weight->size[0];
-  int64_t inDim = weight->size[1];
+  int64_t outDim = weight->size(0);
+  int64_t inDim = weight->size(1);
 
   THArgCheck(THNN_(checkSize2D)(gradWeight, outDim, inDim), 4,
              "gradWeight size wrong");
@@ -471,8 +471,8 @@ void THNN_(SparseLinear_zeroGradParameters)(
 {
   int64_t i, j;
 
-  int64_t outDim = gradWeight->size[0];
-  int64_t inDim = gradWeight->size[1];
+  int64_t outDim = gradWeight->size(0);
+  int64_t inDim = gradWeight->size(1);
 
   THArgCheck(THNN_(checkSize1D)(gradBias, outDim), 3, "gradBias size wrong");
   THArgCheck(THNN_(checkInput)(lastInput), 4,
@@ -517,8 +517,8 @@ void THNN_(SparseLinear_legacyZeroGradParameters)(
 {
   int64_t h, i, j;
 
-  int64_t outDim = gradWeight->size[0];
-  int64_t inDim = gradWeight->size[1];
+  int64_t outDim = gradWeight->size(0);
+  int64_t inDim = gradWeight->size(1);
 
   THArgCheck(THNN_(checkSize1D)(gradBias, outDim), 3, "gradBias size wrong");
   THArgCheck(THNN_(checkLegacyInput)(lastInput), 4,

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -6,8 +6,8 @@
 #include <omp.h>
 #endif
 
-#define ROW_PTR2(t, r) (THTensor_(data)(t) + (r) * (t)->stride[0])
-#define COL_PTR2(t, c) (THTensor_(data)(t) + (c) * (t)->stride[1])
+#define ROW_PTR2(t, r) (THTensor_(data)(t) + (r) * (t)->stride(0))
+#define COL_PTR2(t, c) (THTensor_(data)(t) + (c) * (t)->stride(1))
 
 static bool THNN_(checkLegacyInput)(THTensor* t)
 {
@@ -30,15 +30,15 @@ static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {
-  THStorage_(set)(t->storage, t->storageOffset + x0*t->stride[0], value);
+  THStorage_(set)(t->storage, t->storageOffset + x0*t->stride(0), value);
 }
 static real THNN_(get3d)(const THTensor *t, int64_t x0, int64_t x1, int64_t x2) {
   return THStorage_(get)(t->storage, t->storageOffset +
-                         x0*t->stride[0] + x1*t->stride[1] + x2*t->stride[2]);
+                         x0*t->stride(0) + x1*t->stride(1) + x2*t->stride(2));
 }
 static real THNN_(get2d)(const THTensor *t, int64_t x0, int64_t x1) {
   return THStorage_(get)(t->storage, t->storageOffset +
-                         x0*t->stride[0] + x1*t->stride[1]);
+                         x0*t->stride(0) + x1*t->stride(1));
 }
 
 void THNN_(SparseLinear_updateOutput)(
@@ -92,8 +92,8 @@ void THNN_(SparseLinear_updateOutput)(
       if (offset >= 0 && offset < inDim) {
         THBlas_(axpy)(outDim,
             val,
-            COL_PTR2(weight, offset), weight->stride[0],
-            ROW_PTR2(output, h), output->stride[1]);
+            COL_PTR2(weight, offset), weight->stride(0),
+            ROW_PTR2(output, h), output->stride(1));
       } else {
         THError("index out of bound. updateOutput: %d not between 1 and %d",
             offset + 1, inDim);
@@ -147,8 +147,8 @@ void THNN_(SparseLinear_legacyUpdateOutput)(
       if (offset >= 0 && offset < inDim) {
         THBlas_(axpy)(outDim,
                       val,
-                      COL_PTR2(weight, offset), weight->stride[0],
-                      ROW_PTR2(output, h), output->stride[1]);
+                      COL_PTR2(weight, offset), weight->stride(0),
+                      ROW_PTR2(output, h), output->stride(1));
       } else {
         THError("index out of bound. updateOutput: %d not between 1 and %d",
                 offset + 1, inDim);
@@ -221,8 +221,8 @@ void THNN_(SparseLinear_accGradParameters)(
       if (offset >= 0 && offset < inDim) {
         THBlas_(axpy)(outDim,
             val,
-            ROW_PTR2(gradOutput, h), gradOutput->stride[1],
-            COL_PTR2(gradWeight, offset), gradWeight->stride[0]);
+            ROW_PTR2(gradOutput, h), gradOutput->stride(1),
+            COL_PTR2(gradWeight, offset), gradWeight->stride(0));
       } else {
         THError(
             "index out of bound. accGradParameters: %d not between 1 and %d",
@@ -289,8 +289,8 @@ void THNN_(SparseLinear_legacyAccGradParameters)(
       if (offset >= 0 && offset < inDim) {
         THBlas_(axpy)(outDim,
                       val,
-                      ROW_PTR2(gradOutput, h), gradOutput->stride[1],
-                      COL_PTR2(gradWeight, offset), gradWeight->stride[0]);
+                      ROW_PTR2(gradOutput, h), gradOutput->stride(1),
+                      COL_PTR2(gradWeight, offset), gradWeight->stride(0));
       } else {
         THError(
           "index out of bound. accGradParameters: %d not between 1 and %d",
@@ -380,8 +380,8 @@ void THNN_(SparseLinear_updateParameters)(
     int64_t offset = (int64_t)uniqueOffsets_p[i];
     THBlas_(axpy)(outDim,
                   -learningRate,
-                  COL_PTR2(gradWeight, offset), gradWeight->stride[0],
-                  COL_PTR2(weight, offset), weight->stride[0]);
+                  COL_PTR2(gradWeight, offset), gradWeight->stride(0),
+                  COL_PTR2(weight, offset), weight->stride(0));
   }
 
   THTensor_(free)(uniqueOffsets);
@@ -456,8 +456,8 @@ void THNN_(SparseLinear_legacyUpdateParameters)(
     int64_t offset = (int64_t)uniqueOffsets_p[i];
     THBlas_(axpy)(outDim,
                   -learningRate,
-                  COL_PTR2(gradWeight, offset), gradWeight->stride[0],
-                  COL_PTR2(weight, offset), weight->stride[0]);
+                  COL_PTR2(gradWeight, offset), gradWeight->stride(0),
+                  COL_PTR2(weight, offset), weight->stride(0));
   }
 
   THTensor_(free)(uniqueOffsets);
@@ -492,10 +492,10 @@ void THNN_(SparseLinear_zeroGradParameters)(
     int64_t offset = (int64_t)(THNN_(get2d)(lastInput, i, 1)) - 1;
     if (offset >= 0 && offset < inDim) {
       real* pGradWeight = COL_PTR2(gradWeight, offset);
-      if (gradWeight->stride[0] == 1) {
+      if (gradWeight->stride(0) == 1) {
         THVector_(fill)(pGradWeight, 0, outDim);
       } else {
-        int64_t stride = gradWeight->stride[0];
+        int64_t stride = gradWeight->stride(0);
         for (j = 0; j < outDim; ++j) {
           pGradWeight[j * stride] = 0;
         }
@@ -540,10 +540,10 @@ void THNN_(SparseLinear_legacyZeroGradParameters)(
       int64_t offset = (int64_t)(THNN_(get3d)(lastInput, h, i, 0)) - 1;
       if (offset >= 0 && offset < inDim) {
         real* pGradWeight = COL_PTR2(gradWeight, offset);
-        if (gradWeight->stride[0] == 1) {
+        if (gradWeight->stride(0) == 1) {
           THVector_(fill)(pGradWeight, 0, outDim);
         } else {
-          int64_t stride = gradWeight->stride[0];
+          int64_t stride = gradWeight->stride(0);
           for (j = 0; j < outDim; ++j) {
             pGradWeight[j * stride] = 0;
           }

--- a/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
@@ -92,7 +92,7 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    istrideB = input->stride[0];
+    istrideB = input->stride(0);
     sizeB = input->size(0);
     dimD++;
     dimH++;
@@ -104,9 +104,9 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   isizeH = input->size(dimH);
   isizeW = input->size(dimW);
   /* strides */
-  istrideD = input->stride[dimD];
-  istrideH = input->stride[dimH];
-  istrideW = input->stride[dimW];
+  istrideD = input->stride(dimD);
+  istrideH = input->stride(dimH);
+  istrideW = input->stride(dimW);
 
   /* resize output */
   if (input->dim() == 3)

--- a/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
@@ -93,16 +93,16 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
   if (input->dim() == 4)
   {
     istrideB = input->stride[0];
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimH++;
     dimW++;
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
   /* strides */
   istrideD = input->stride[dimD];
   istrideH = input->stride[dimH];
@@ -218,18 +218,18 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimH++;
     dimW++;
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
-  osizeH = gradOutput->size[dimH];
-  osizeW = gradOutput->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
+  osizeH = gradOutput->size(dimH);
+  osizeW = gradOutput->size(dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -103,15 +103,15 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   if (input->dim() == 4)
   {
     istrideB = input->stride[0];
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimW++;
     dimH++;
   }
 
   /* sizes */
-  sizeD  = input->size[dimH-1];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
+  sizeD  = input->size(dimH-1);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
   /* strides */
   istrideD = input->stride[dimH-1];
   istrideH = input->stride[dimH];
@@ -223,17 +223,17 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimW++;
     dimH++;
   }
 
   /* sizes */
-  sizeD  = input->size[dimH-1];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
-  osizeH = gradOutput->size[dimH];
-  osizeW = gradOutput->size[dimW];
+  sizeD  = input->size(dimH-1);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
+  osizeH = gradOutput->size(dimH);
+  osizeW = gradOutput->size(dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -102,7 +102,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    istrideB = input->stride[0];
+    istrideB = input->stride(0);
     sizeB = input->size(0);
     dimW++;
     dimH++;
@@ -113,9 +113,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   isizeH = input->size(dimH);
   isizeW = input->size(dimW);
   /* strides */
-  istrideD = input->stride[dimH-1];
-  istrideH = input->stride[dimH];
-  istrideW = input->stride[dimW];
+  istrideD = input->stride(dimH-1);
+  istrideH = input->stride(dimH);
+  istrideW = input->stride(dimW);
 
   /* resize output */
   if (input->dim() == 3)

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -31,9 +31,9 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
 	     "padW = %d, padH = %d, kW = %d, kH = %d",
 	     padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size[dimh-1];
-  int64_t inputHeight = input->size[dimh];
-  int64_t inputWidth = input->size[dimw];
+  int64_t nInputPlane = input->size(dimh-1);
+  int64_t inputHeight = input->size(dimh);
+  int64_t inputWidth = input->size(dimw);
   int64_t outputHeight, outputWidth;
   int64_t nOutputPlane = nInputPlane;
 
@@ -103,15 +103,15 @@ void THNN_(SpatialAveragePooling_updateOutput)(
     (input, NULL, kH, kW, dH, dW, padH, padW, ceil_mode);
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimc++;
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
-  nInputPlane = input->size[dimc];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
+  nInputPlane = input->size(dimc);
 
   if(ceil_mode)
   {
@@ -136,7 +136,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
-    THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
+    THTensor_(resize4d)(output, input->size(0), nInputPlane, outputHeight, outputWidth);
 
   input = THTensor_(newContiguous)(input);
   THArgCheck(THTensor_(isContiguous)(output), 3, "output must be contiguous");
@@ -232,16 +232,16 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
 
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimc++;
     ndim = 4;
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
-  nInputPlane = input->size[dimc];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
+  nInputPlane = input->size(dimc);
 
   if(ceil_mode)
   {

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -29,8 +29,8 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
         "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane = weight->size[2] / (kH * kW);
-  int64_t nOutputPlane = weight->size[1];
+  int64_t nInputPlane = weight->size(2) / (kH * kW);
+  int64_t nOutputPlane = weight->size(1);
 
   if (bias != NULL) {
     THNN_CHECK_DIM_SIZE(bias, 3, 0, nOutputPlane);
@@ -53,9 +53,9 @@ static THTensor* THNN_(view_weight_local)(THTensor *_weight)
   AT_CHECK(!weight->is_empty() && (weight->dim() == 3 || weight->dim() == 6),
            "weight tensor should be (non-empty) 3D or 6D - got size: ", weight->sizes());
   if (weight->dim() == 6) {
-    int64_t s1 = weight->size[0] * weight->size[1];
-    int64_t s2 = weight->size[2];
-    int64_t s3 = weight->size[3] * weight->size[4] * weight->size[5];
+    int64_t s1 = weight->size(0) * weight->size(1);
+    int64_t s2 = weight->size(2);
+    int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage3d)(weight->storage,
                        weight->storageOffset,
@@ -140,7 +140,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
     THTensor_(resize3d)(finput, T, kW*kH*nInputPlane, outputHeight*outputWidth);
@@ -243,7 +243,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
 #pragma omp parallel for private(t)
@@ -339,7 +339,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
     for(t = 0; t < T; t++)

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -123,7 +123,7 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
   if (bias) {
     for(i = 0; i < nOutputPlane; i++)
         THVector_(fill)
-	  (THStorage_(data)(output->storage) + output->storageOffset + output->stride[0] * i,
+	  (THStorage_(data)(output->storage) + output->storageOffset + output->stride(0) * i,
 	   THTensor_(get1d)(bias, i), outputHeight*outputWidth);
   } else {
     THTensor_(zero)(output);
@@ -334,7 +334,7 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride(0);
       for(k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
       (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale*sum;

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -16,7 +16,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                     "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -36,8 +36,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
 		"non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
 
   int64_t exactInputHeight = inputHeight + 2 * padH;
   int64_t exactInputWidth = inputWidth + 2 * padW;
@@ -58,7 +58,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[1];
+    int64_t nInputPlane = weight->size(1);
     if (weight->dim() == 2) {
       nInputPlane /= (kH * kW);
     }
@@ -67,10 +67,10 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[0];
+      int64_t nOutputPlane = weight->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
@@ -81,8 +81,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
   weight = THTensor_(newContiguous)(weight);
   if (weight->dim() == 4) {
-    int64_t s1 = weight->size[0];
-    int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
+    int64_t s1 = weight->size(0);
+    int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage2d)(weight->storage, weight->storageOffset,
 					 s1, -1, s2, -1);
@@ -166,10 +166,10 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     dimw++;
   }
 
-  int64_t nInputPlane = input->size[dimf];
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
-  int64_t nOutputPlane = weight->size[0];
+  int64_t nInputPlane = input->size(dimf);
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
+  int64_t nOutputPlane = weight->size(0);
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
 
@@ -186,7 +186,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
     THTensor_(resize3d)(finput, T, kW*kH*nInputPlane, outputHeight*outputWidth);
@@ -229,8 +229,8 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
     (gradOutput->storage, gradOutput->storageOffset,
-     gradOutput->size[0], -1,
-     gradOutput->size[1]*gradOutput->size[2], -1);
+     gradOutput->size(0), -1,
+     gradOutput->size(1)*gradOutput->size(2), -1);
   THTensor_(addmm)(fgradInput, 0, fgradInput, 1, weight, gradOutput2d);
   THTensor_(free)(gradOutput2d);
 
@@ -238,8 +238,8 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
 
   THNN_(unfolded_acc)(fgradInput, gradInput, kW, kH, dW, dH,
 		      padW, padH,
-		      gradInput->size[0], gradInput->size[2], gradInput->size[1],
-		      gradOutput->size[2], gradOutput->size[1]);
+		      gradInput->size(0), gradInput->size(2), gradInput->size(1),
+		      gradOutput->size(2), gradOutput->size(1));
 }
 
 void THNN_(SpatialConvolutionMM_updateGradInput)(
@@ -283,7 +283,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
 #pragma omp parallel for private(t)
@@ -319,8 +319,8 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
     (gradOutput->storage, gradOutput->storageOffset,
-     gradOutput->size[0], -1,
-     gradOutput->size[1]*gradOutput->size[2], -1);
+     gradOutput->size(0), -1,
+     gradOutput->size(1)*gradOutput->size(2), -1);
 
   if (gradWeight) {
     THTensor *tfinput = THTensor_(new)();
@@ -330,12 +330,12 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
   }
 
   if (gradBias) {
-    for(i = 0; i < gradBias->size[0]; i++)
+    for(i = 0; i < gradBias->size(0); i++)
     {
       int64_t k;
       real sum = 0;
       real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
-      for(k = 0; k < gradOutput2d->size[1]; k++)
+      for(k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
       (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale*sum;
     }
@@ -382,7 +382,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
     for(t = 0; t < T; t++)

--- a/aten/src/THNN/generic/SpatialConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMap.c
@@ -9,7 +9,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size[0] == weight->size[0], 4,
+    && connTable != NULL && connTable->size(0) == weight->size(0), 4,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -22,27 +22,27 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimc++;
     dimw++;
     dimh++;
   }
 
-  const int64_t kH       = weight->size[1];
-  const int64_t kW       = weight->size[2];
+  const int64_t kH       = weight->size(1);
+  const int64_t kW       = weight->size(2);
 
-  THArgCheck(input->size[dimc] >= nInputPlane, 2, "invalid number of input planes");
-  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH, 2, "input image smaller than kernel size");
+  THArgCheck(input->size(dimc) >= nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH, 2, "input image smaller than kernel size");
 
-  const int64_t input_w  = input->size[dimw];
-  const int64_t input_h  = input->size[dimh];
+  const int64_t input_w  = input->size(dimw);
+  const int64_t input_h  = input->size(dimh);
   const int64_t output_w = (input_w - kW) / dW + 1;
   const int64_t output_h = (input_h - kH) / dH + 1;
 
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nOutputPlane, output_h, output_w);
   else
-    THTensor_(resize4d)(output, input->size[0], nOutputPlane, output_h, output_w);
+    THTensor_(resize4d)(output, input->size(0), nOutputPlane, output_h, output_w);
 
   /* contiguous */
   input = THTensor_(newContiguous)(input);
@@ -73,7 +73,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
         ptr_output[j] = z;
 
       /* convolve all maps */
-      int nweight = connTable->size[0];
+      int nweight = connTable->size(0);
       for (k = 0; k < nweight; k++)
       {
         /* get offsets for input/output */
@@ -110,7 +110,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size[0] == weight->size[0], 5,
+    && connTable != NULL && connTable->size(0) == weight->size(0), 5,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -120,17 +120,17 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
   int64_t nbatch = 1;
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
-  const int64_t input_h  = input->size[dimh];
-  const int64_t input_w  = input->size[dimw];
-  const int64_t output_h = gradOutput->size[dimh];
-  const int64_t output_w = gradOutput->size[dimw];
-  const int64_t kH       = weight->size[1];
-  const int64_t kW       = weight->size[2];
+  const int64_t input_h  = input->size(dimh);
+  const int64_t input_w  = input->size(dimw);
+  const int64_t output_h = gradOutput->size(dimh);
+  const int64_t output_w = gradOutput->size(dimw);
+  const int64_t kH       = weight->size(1);
+  const int64_t kW       = weight->size(2);
 
   /* contiguous */
   gradInput = THTensor_(newContiguous)(gradInput);
@@ -157,7 +157,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
     {
       int64_t k;
       /* backward all */
-      int nkernel = connTable->size[0];
+      int nkernel = connTable->size(0);
       for (k = 0; k < nkernel; k++)
       {
         int o = (int)connTable_data[k*2+1] - TH_INDEX_BASE;
@@ -197,7 +197,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
     gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
-    && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
+    && connTable != NULL && connTable->size(0) == gradWeight->size(0), 5,
     "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -207,17 +207,17 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   int64_t nbatch = 1;
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
-  const int64_t input_h  = input->size[dimh];
-  const int64_t input_w  = input->size[dimw];
-  const int64_t output_h = gradOutput->size[dimh];
-  const int64_t output_w = gradOutput->size[dimw];
-  const int64_t kH       = gradWeight->size[1];
-  const int64_t kW       = gradWeight->size[2];
+  const int64_t input_h  = input->size(dimh);
+  const int64_t input_w  = input->size(dimw);
+  const int64_t output_h = gradOutput->size(dimh);
+  const int64_t output_w = gradOutput->size(dimw);
+  const int64_t kH       = gradWeight->size(1);
+  const int64_t kW       = gradWeight->size(2);
 
   /* contiguous */
   input = THTensor_(newContiguous)(input);
@@ -248,7 +248,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   }
 
   /* gradients wrt weight */
-  const int nkernel = connTable->size[0];
+  const int nkernel = connTable->size(0);
 #pragma omp parallel for private(k)
   for (k = 0; k < nkernel; k++)
   {

--- a/aten/src/THNN/generic/SpatialDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialDilatedConvolution.c
@@ -20,7 +20,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
                   "non-empty 4D weight tensor (nOutputPlane, nInputPlane, kH, kW) expected, "
                   "but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -40,8 +40,8 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
 		"non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
 
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
@@ -53,16 +53,16 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[1];
+    int64_t nInputPlane = weight->size(1);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[0];
+      int64_t nOutputPlane = weight->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
@@ -89,8 +89,8 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
      dilationH, dilationW, 0);
 
   // Params:
-  int nInputPlane = weight->size[1];
-  int nOutputPlane = weight->size[0];
+  int nInputPlane = weight->size(1);
+  int nOutputPlane = weight->size(0);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -103,15 +103,15 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
   }
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize4d)(output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -124,7 +124,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
   if (!THTensor_(isContiguous)(ones) || ones->dim() != 2 ||
-      ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+      ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -173,7 +173,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nOutputPlane;
-    int64_t n = columns->size[1];
+    int64_t n = columns->size(1);
     int64_t k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -220,8 +220,8 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
      dilationH, dilationW, 0);
 
   // Params
-  int64_t nInputPlane = weight->size[1];
-  int64_t nOutputPlane = weight->size[0];
+  int64_t nInputPlane = weight->size(1);
+  int64_t nOutputPlane = weight->size(0);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -231,18 +231,18 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1],
-			gradOutput->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1),
+			gradOutput->size(2));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize4d)(gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -263,7 +263,7 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nInputPlane*kW*kH;
-    int64_t n = gradColumns->size[1];
+    int64_t n = gradColumns->size(1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -338,20 +338,20 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0],
-			gradOutput->size[1], gradOutput->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0),
+			gradOutput->size(1), gradOutput->size(2));
   }
 
-  int64_t nInputPlane = input->size[1];
-  int64_t nOutputPlane = gradOutput->size[1];
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t nInputPlane = input->size(1);
+  int64_t nOutputPlane = gradOutput->size(1);
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize temporary columns
   THTensor_(resize2d)(columns, nInputPlane*kW*kH, outputHeight*outputWidth);
@@ -383,7 +383,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
       // M,N,K are dims of matrix A and B
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kW*kH;
-      int64_t k = columns->size[1];
+      int64_t k = columns->size(1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(
@@ -405,7 +405,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
 
       // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       // Define a buffer of ones, for bias accumulation
-      if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+      if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
         // Resize plane and fill with ones...
         THTensor_(resize2d)(ones, outputHeight, outputWidth);
         THTensor_(fill)(ones, 1);

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -34,9 +34,9 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
 	     "padW = %d, padH = %d, kW = %d, kH = %d",
 	     padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size[dimh-1];
-  int64_t inputHeight = input->size[dimh];
-  int64_t inputWidth = input->size[dimw];
+  int64_t nInputPlane = input->size(dimh-1);
+  int64_t inputHeight = input->size(dimh);
+  int64_t inputWidth = input->size(dimw);
   int64_t outputHeight, outputWidth;
   int64_t nOutputPlane = nInputPlane;
 
@@ -184,15 +184,15 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nInputPlane = input->size[dimh-1];
-  inputHeight = input->size[dimh];
-  inputWidth = input->size[dimw];
+  nInputPlane = input->size(dimh-1);
+  inputHeight = input->size(dimh);
+  inputWidth = input->size(dimw);
   if (ceil_mode)
   {
     outputHeight = (int64_t)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
@@ -349,17 +349,17 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nInputPlane = input->size[dimh-1];
-  inputHeight = input->size[dimh];
-  inputWidth = input->size[dimw];
-  outputHeight = gradOutput->size[dimh];
-  outputWidth = gradOutput->size[dimw];
+  nInputPlane = input->size(dimh-1);
+  inputHeight = input->size(dimh);
+  inputWidth = input->size(dimw);
+  outputHeight = gradOutput->size(dimh);
+  outputWidth = gradOutput->size(dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialFullConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialFullConvolutionMap.c
@@ -12,20 +12,20 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   // What does this mean?
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size[0] == weight->size[0], 4,
+    && connTable != NULL && connTable->size(0) == weight->size(0), 4,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
-  const int kH = (int)weight->size[1];
-  const int kW = (int)weight->size[2];
+  const int kH = (int)weight->size(1);
+  const int kW = (int)weight->size(2);
 
   THArgCheck(input != NULL && !input->is_empty() && input->dim() == 3, 2, "non-empty 3D tensor expected");
-  THArgCheck(input->size[0] >= nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(input->size(0) >= nInputPlane, 2, "invalid number of input planes");
 
   THTensor_(resize3d)(
     output_, nOutputPlane,
-    (input->size[1] - 1) * dH + kH,
-    (input->size[2] - 1) * dW + kW
+    (input->size(1) - 1) * dH + kH,
+    (input->size(2) - 1) * dW + kW
   );
 
   /* contiguous */
@@ -40,12 +40,12 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   real *connTable_data = THTensor_(data)(connTable);
 
   /* and dims */
-  const int64_t input_h = input->size[1];
-  const int64_t input_w = input->size[2];
-  const int64_t output_h = output->size[1];
-  const int64_t output_w = output->size[2];
-  const int64_t weight_h = weight->size[1];
-  const int64_t weight_w = weight->size[2];
+  const int64_t input_h = input->size(1);
+  const int64_t input_w = input->size(2);
+  const int64_t output_h = output->size(1);
+  const int64_t output_w = output->size(2);
+  const int64_t weight_h = weight->size(1);
+  const int64_t weight_w = weight->size(2);
 
   int64_t p;
 #pragma omp parallel for private(p)
@@ -61,7 +61,7 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
       ptr_output[j] = bias_data[p];
 
     /* convolve all maps */
-    nweight = connTable->size[0];
+    nweight = connTable->size(0);
     for (k = 0; k < nweight; k++)
     {
       /* get offsets for input/output */
@@ -93,7 +93,7 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size[0] == weight->size[0], 5,
+    && connTable != NULL && connTable->size(0) == weight->size(0), 5,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -112,12 +112,12 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   real *connTable_data = THTensor_(data)(connTable);
 
   /* and dims */
-  const int64_t input_h = input->size[1];
-  const int64_t input_w = input->size[2];
-  const int64_t output_h = gradOutput->size[1];
-  const int64_t output_w = gradOutput->size[2];
-  const int64_t kH = weight->size[1];
-  const int64_t kW = weight->size[2];
+  const int64_t input_h = input->size(1);
+  const int64_t input_w = input->size(2);
+  const int64_t output_h = gradOutput->size(1);
+  const int64_t output_w = gradOutput->size(2);
+  const int64_t kH = weight->size(1);
+  const int64_t kW = weight->size(2);
 
   int64_t p;
 #pragma omp parallel for private(p)
@@ -125,7 +125,7 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   {
     int64_t k;
     /* backward all */
-    int nkernel = connTable->size[0];
+    int nkernel = connTable->size(0);
     for (k = 0; k < nkernel; k++)
     {
       int o = (int)connTable_data[k*2+1] - TH_INDEX_BASE;
@@ -164,7 +164,7 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
     gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
-    && connTable != NULL && connTable->size[0] == gradWeight->size[0], 5,
+    && connTable != NULL && connTable->size(0) == gradWeight->size(0), 5,
     "non-empty 3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -179,12 +179,12 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   real *gradBias_data = THTensor_(data)(gradBias);
 
   /* and dims */
-  const int64_t input_h  = input->size[1];
-  const int64_t input_w  = input->size[2];
-  const int64_t output_h = gradOutput->size[1];
-  const int64_t output_w = gradOutput->size[2];
-  const int64_t weight_h = gradWeight->size[1];
-  const int64_t weight_w = gradWeight->size[2];
+  const int64_t input_h  = input->size(1);
+  const int64_t input_w  = input->size(2);
+  const int64_t output_h = gradOutput->size(1);
+  const int64_t output_w = gradOutput->size(2);
+  const int64_t weight_h = gradWeight->size(1);
+  const int64_t weight_w = gradWeight->size(2);
 
   /* gradients wrt bias */
   int64_t k;
@@ -198,7 +198,7 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   }
 
   /* gradients wrt weight */
-  int nkernel = connTable->size[0];
+  int nkernel = connTable->size(0);
 #pragma omp parallel for private(k)
   for (k = 0; k < nkernel; k++)
   {

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                   "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -43,8 +43,8 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
 		"non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
@@ -55,16 +55,16 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[0];
+    int64_t nInputPlane = weight->size(0);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[1];
+      int64_t nOutputPlane = weight->size(1);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
@@ -105,16 +105,16 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
   }
 
-  int64_t inputHeight  = input->size[2];
-  int64_t inputWidth   = input->size[3];
+  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = input->size(3);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize4d)(output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -126,7 +126,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -145,9 +145,9 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size[1] * weight->size[2] * weight->size[3];
-    int64_t n = columns->size[1];
-    int64_t k = weight->size[0];
+    int64_t m = weight->size(1) * weight->size(2) * weight->size(3);
+    int64_t n = columns->size(1);
+    int64_t k = weight->size(0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -233,17 +233,17 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize4d)(gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -275,9 +275,9 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size[0];
-    int64_t n = gradColumns->size[1];
-    int64_t k = weight->size[1] * weight->size[2] * weight->size[3];
+    int64_t m = weight->size(0);
+    int64_t n = gradColumns->size(1);
+    int64_t k = weight->size(1) * weight->size(2) * weight->size(3);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -352,20 +352,20 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
   }
 
-  int64_t inputWidth   = input->size[3];
-  int64_t inputHeight  = input->size[2];
+  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = input->size(2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size[0]*ones->size[1] < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -401,9 +401,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
 
       // M,N,K are dims of matrix A and B
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-      int64_t n = columns->size[0];   // nOutputPlane * kh * kw
-      int64_t m = input_n->size[0];   // nInputPlane
-      int64_t k = columns->size[1];   // inputHeight * inputWidth
+      int64_t n = columns->size(0);   // nOutputPlane * kh * kw
+      int64_t m = input_n->size(0);   // nInputPlane
+      int64_t k = columns->size(1);   // inputHeight * inputWidth
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(
@@ -444,7 +444,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   // Resize
   if (is_batch == 0) {
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
-    THTensor_(resize3d)(input, input->size[1], inputHeight, inputWidth);
+    THTensor_(resize3d)(input, input->size(1), inputHeight, inputWidth);
   }
 
   THTensor_(free)(input);

--- a/aten/src/THNN/generic/SpatialMaxUnpooling.c
+++ b/aten/src/THNN/generic/SpatialMaxUnpooling.c
@@ -67,15 +67,15 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size[dimh-1];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimh-1);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
 
   /* get contiguous input and indices */
   input = THTensor_(newContiguous)(input);
@@ -184,19 +184,19 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size[dimh-1];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimh-1);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
 
-  if(owidth!=gradOutput->size[dimw] || oheight!=gradOutput->size[dimh]){
+  if(owidth!=gradOutput->size(dimw) || oheight!=gradOutput->size(dimh)){
     THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
-	    oheight, owidth, gradOutput->size[dimh], gradOutput->size[dimw]);
+	    oheight, owidth, gradOutput->size(dimh), gradOutput->size(dimw));
   }
 
   /* get raw pointers */

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -72,16 +72,16 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* input sizes */
-  nslices = input->size[dimslices];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
 
   AT_CHECK(pad_l < iwidth && pad_r < iwidth,
            "Argument #4: Padding size should be less than the corresponding input dimension, "
@@ -211,16 +211,16 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -83,15 +83,13 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   iheight = input->size[dimh];
   iwidth = input->size[dimw];
 
-  THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_l < iwidth && pad_r < iwidth,
+           "Argument #4: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_l, ", ", pad_r, ") at dimension ", dimw, " of input ", input->sizes());
 
-  THArgCheck(pad_t < iheight && pad_b < iheight, 6,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_t, pad_b, dimh, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_t < iheight && pad_b < iheight,
+           "Argument #6: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_t, ", ", pad_b, ") at dimension ", dimh, " of input ", input->sizes());
 
   /* output sizes */
   oheight = iheight + pad_t + pad_b;

--- a/aten/src/THNN/generic/SpatialReplicationPadding.c
+++ b/aten/src/THNN/generic/SpatialReplicationPadding.c
@@ -71,16 +71,16 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
@@ -200,16 +200,16 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 

--- a/aten/src/THNN/generic/SpatialSubSampling.c
+++ b/aten/src/THNN/generic/SpatialSubSampling.c
@@ -24,10 +24,10 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
     dimh++;
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
 
-  THArgCheck(input->size[dimh-1] == nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(input->size(dimh-1) == nInputPlane, 2, "invalid number of input planes");
   THArgCheck(inputWidth >= kW && inputHeight >= kH, 2, "input image smaller than kernel size");
 }
 
@@ -63,20 +63,20 @@ void THNN_(SpatialSubSampling_updateOutput)(
   THNN_(SpatialSubSampling_shapeCheck)(input, NULL, weight, kW, kH);
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
-    THTensor_(resize4d)(output, input->size[0], nInputPlane, outputHeight, outputWidth);
+    THTensor_(resize4d)(output, input->size(0), nInputPlane, outputHeight, outputWidth);
 
   input = THTensor_(newContiguous)(input);
   input_data = THTensor_(data)(input);
@@ -152,13 +152,13 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   int64_t k;
 
   if (input->dim() == 4) {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
@@ -239,11 +239,11 @@ void THNN_(SpatialSubSampling_accGradParameters)(
   if (input->dim() == 4) {
     dimw++;
     dimh++;
-    nbatch = input->size[0];
+    nbatch = input->size(0);
   }
 
-  inputWidth = input->size[dimw];
-  inputHeight = input->size[dimh];
+  inputWidth = input->size(dimw);
+  inputHeight = input->size(dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -25,13 +25,13 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck(input->size[dimF] == *inputFrameSize, 2,
+    THArgCheck(input->size(dimF) == *inputFrameSize, 2,
                "invalid input frame size. Got: %d, Expected: %d",
-               input->size[dimF], *inputFrameSize);
+               input->size(dimF), *inputFrameSize);
   }
-  THArgCheck(input->size[dimS] >= kW, 2,
+  THArgCheck(input->size(dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size[dimS], kW);
+             input->size(dimS), kW);
 }
 
 void THNN_(TemporalConvolution_updateOutput)(
@@ -64,7 +64,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   outputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  nInputFrame = input->size[dimS];
+  nInputFrame = input->size(dimS);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (input->dim() == 2)
@@ -89,14 +89,14 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size[1],
-                              nFrame, inputFrameStride*input->size[1],
-                              kW*input->size[1], 1);
+                              input->storageOffset+k*dW*input->size(1),
+                              nFrame, inputFrameStride*input->size(1),
+                              kW*input->size(1), 1);
 
       THTensor_(setStorage2d)(outputWindow, output->storage,
-                              output->storageOffset + k*output->size[1],
-                              nFrame, outputFrameStride*output->size[1],
-                              output->size[1], 1);
+                              output->storageOffset + k*output->size(1),
+                              nFrame, outputFrameStride*output->size(1),
+                              output->size(1), 1);
 
       THTensor *tweight = THTensor_(new)();
       THTensor_(transpose)(tweight, weight, 0, 1);
@@ -108,7 +108,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   {
     THTensor *outputSample = THTensor_(new)();
     THTensor *inputSample = THTensor_(new)();
-    int nBatchFrame = input->size[0];
+    int nBatchFrame = input->size(0);
 
     THTensor_(resize3d)(output,
                         nBatchFrame,
@@ -137,14 +137,14 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size[1],
-                                nFrame, inputFrameStride*inputSample->size[1],
-                                kW*inputSample->size[1], 1);
+                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                nFrame, inputFrameStride*inputSample->size(1),
+                                kW*inputSample->size(1), 1);
 
         THTensor_(setStorage2d)(outputWindow, outputSample->storage,
-                                outputSample->storageOffset + k*outputSample->size[1],
-                                nFrame, outputFrameStride*outputSample->size[1],
-                                outputSample->size[1], 1);
+                                outputSample->storageOffset + k*outputSample->size(1),
+                                nFrame, outputFrameStride*outputSample->size(1),
+                                outputSample->size(1), 1);
 
         THTensor *tweight = THTensor_(new)();
         THTensor_(transpose)(tweight, weight, 0, 1);
@@ -188,8 +188,8 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
   THNN_(TemporalConvolution_shapeCheck)(
         state, input, kW, dW, NULL);
-  nInputFrame = input->size[dimS];
-  nOutputFrame = gradOutput->size[dimS];
+  nInputFrame = input->size(dimS);
+  nOutputFrame = gradOutput->size(dimS);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -211,14 +211,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size[1],
-                              nFrame, outputFrameStride*gradOutput->size[1],
-                              gradOutput->size[1], 1);
+                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              nFrame, outputFrameStride*gradOutput->size(1),
+                              gradOutput->size(1), 1);
 
       THTensor_(setStorage2d)(gradInputWindow, gradInput->storage,
-                              gradInput->storageOffset+k*dW*gradInput->size[1],
-                              nFrame, inputFrameStride*gradInput->size[1],
-                              kW*gradInput->size[1], 1);
+                              gradInput->storageOffset+k*dW*gradInput->size(1),
+                              nFrame, inputFrameStride*gradInput->size(1),
+                              kW*gradInput->size(1), 1);
 
       THTensor_(addmm)(gradInputWindow, 1, gradInputWindow, 1, gradOutputWindow, weight);
     }
@@ -227,7 +227,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   {
     THTensor *gradOutputSample = THTensor_(new)();
     THTensor *gradInputSample = THTensor_(new)();
-    int nBatchFrame = input->size[0];
+    int nBatchFrame = input->size(0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -244,14 +244,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size[1],
-                                nFrame, outputFrameStride*gradOutputSample->size[1],
-                                gradOutputSample->size[1], 1);
+                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                nFrame, outputFrameStride*gradOutputSample->size(1),
+                                gradOutputSample->size(1), 1);
 
         THTensor_(setStorage2d)(gradInputWindow, gradInputSample->storage,
-                                gradInputSample->storageOffset+k*dW*gradInputSample->size[1],
-                                nFrame, inputFrameStride*gradInputSample->size[1],
-                                kW*gradInputSample->size[1], 1);
+                                gradInputSample->storageOffset+k*dW*gradInputSample->size(1),
+                                nFrame, inputFrameStride*gradInputSample->size(1),
+                                kW*gradInputSample->size(1), 1);
 
         THTensor_(addmm)(gradInputWindow, 1, gradInputWindow, 1, gradOutputWindow, weight);
       }
@@ -294,8 +294,8 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   THNN_(TemporalConvolution_shapeCheck)(
         state, input, kW, dW, NULL);
-  nInputFrame = input->size[dimS];
-  nOutputFrame = gradOutput->size[dimS];
+  nInputFrame = input->size(dimS);
+  nOutputFrame = gradOutput->size(dimS);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -320,14 +320,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size[1],
-                              nFrame, inputFrameStride*input->size[1],
-                              kW*input->size[1], 1);
+                              input->storageOffset+k*dW*input->size(1),
+                              nFrame, inputFrameStride*input->size(1),
+                              kW*input->size(1), 1);
 
       THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size[1],
-                              nFrame, outputFrameStride*gradOutput->size[1],
-                              gradOutput->size[1], 1);
+                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              nFrame, outputFrameStride*gradOutput->size(1),
+                              gradOutput->size(1), 1);
 
       THTensor *tgradOutputWindow = THTensor_(new)();
       THTensor_(transpose)(tgradOutputWindow, gradOutputWindow, 0, 1);
@@ -339,7 +339,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   {
     THTensor *gradOutputSample = THTensor_(new)();
     THTensor *inputSample = THTensor_(new)();
-    int nBatchFrame = input->size[0];
+    int nBatchFrame = input->size(0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -363,14 +363,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size[1],
-                                nFrame, inputFrameStride*inputSample->size[1],
-                                kW*inputSample->size[1], 1);
+                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                nFrame, inputFrameStride*inputSample->size(1),
+                                kW*inputSample->size(1), 1);
 
         THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size[1],
-                                nFrame, outputFrameStride*gradOutputSample->size[1],
-                                gradOutputSample->size[1], 1);
+                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                nFrame, outputFrameStride*gradOutputSample->size(1),
+                                gradOutputSample->size(1), 1);
 
         THTensor *tgradOutputWindow = THTensor_(new)();
         THTensor_(transpose)(tgradOutputWindow, gradOutputWindow, 0, 1);

--- a/aten/src/THNN/generic/TemporalMaxPooling.c
+++ b/aten/src/THNN/generic/TemporalMaxPooling.c
@@ -23,8 +23,8 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
     dimF = 2;
   }
 
-  niframe = input->size[dimS];
-  framesize = input->size[dimF];
+  niframe = input->size(dimS);
+  framesize = input->size(dimF);
   noframe = (niframe - kW) / dW + 1;
 
   THArgCheck(kW > 0, 5,
@@ -34,9 +34,9 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                 "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
-  THArgCheck(input->size[dimS] >= kW, 2,
+  THArgCheck(input->size(dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size[dimS], kW);
+             input->size(dimS), kW);
 
   if (gradOutput != NULL) {
     THNN_CHECK_DIM_SIZE(gradOutput, ndims, dimS, noframe);
@@ -78,8 +78,8 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  niframe = input->size[dimS];
-  framesize = input->size[dimF];
+  niframe = input->size(dimS);
+  framesize = input->size(dimF);
   noframe = (niframe - kW) / dW + 1;
 
   /* get contiguous input */
@@ -129,7 +129,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   else
   {
     /* number of batch frames */
-    int64_t nbframe = input->size[0];
+    int64_t nbframe = input->size(0);
     int64_t i;
 
     /* resize output */
@@ -221,9 +221,9 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
     dimF = 2;
   }
   /* sizes */
-  niframe = input->size[dimS];
-  noframe = gradOutput->size[dimS];
-  framesize = gradOutput->size[dimF];
+  niframe = input->size(dimS);
+  noframe = gradOutput->size(dimS);
+  framesize = gradOutput->size(dimF);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -250,7 +250,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   else
   {
     /* number of batch frames */
-    int64_t nbframe = input->size[0];
+    int64_t nbframe = input->size(0);
     int64_t i;
 
     for(i = 0; i < nbframe; i++)

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -64,10 +64,9 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
   nslices = input->size[dimslices];
   iwidth = input->size[dimw];
 
-  THArgCheck(pad_l < iwidth && pad_r < iwidth, 4,
-             "Padding size should be less than the corresponding input dimension, "
-             "but got: padding (%d, %d) at dimension %d of input %s",
-             pad_l, pad_r, dimw, _THSizeDesc(input->size, input->dim()).str);
+  AT_CHECK(pad_l < iwidth && pad_r < iwidth,
+           "Argument #4: Padding size should be less than the corresponding input dimension, "
+           "but got: padding (", pad_l, ", ", pad_r, ") at dimension ", dimw, " of input ", input->sizes());
 
   /* output size */
   owidth  = iwidth + pad_l + pad_r;

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -55,14 +55,14 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimslices++;
   }
 
   /* input size */
-  nslices = input->size[dimslices];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iwidth = input->size(dimw);
 
   AT_CHECK(pad_l < iwidth && pad_r < iwidth,
            "Argument #4: Padding size should be less than the corresponding input dimension, "
@@ -167,14 +167,14 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iwidth = input->size(dimw);
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,

--- a/aten/src/THNN/generic/TemporalReplicationPadding.c
+++ b/aten/src/THNN/generic/TemporalReplicationPadding.c
@@ -53,14 +53,14 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iwidth = input->size(dimw);
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth >= 1 , 2,
@@ -159,14 +159,14 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  iwidth = input->size(dimw);
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -22,7 +22,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
     THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
 
 	if (bias != NULL) {
-		THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+		THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
 	}
 
 	// we're always looking at (possibly batch) x feats x seq
@@ -38,8 +38,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	THNN_ARGCHECK(!input->is_empty() && (ndim == 2 || ndim == 3), 1, input,
 	              "non-empty 2D or 3D (batch mode) input tensor expected, but got :%s");
 
-	int64_t inputFrameSize = weight->size[0];
-	int64_t nInputFrame = input->size[dimS];
+	int64_t inputFrameSize = weight->size(0);
+	int64_t nInputFrame = input->size(dimS);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	if (nOutputFrame < 1) {
@@ -197,8 +197,8 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 	THNN_(TemporalRowConvolution_shapeCheck)(
 		state, input, NULL, weight, bias, kW, dW, padW);
 
-	int64_t inputFrameSize = weight->size[0];
-	int64_t nInputFrame = input->size[ndim - 1];
+	int64_t inputFrameSize = weight->size(0);
+	int64_t nInputFrame = input->size(ndim - 1);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	if (ndim == 2) { /* non-batch mode */
@@ -215,7 +215,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 		        inputFrameSize, nInputFrame, nOutputFrame);
 
 	} else {
-		int64_t T = input->size[0];
+		int64_t T = input->size(0);
 		int64_t t;
 
 		THTensor_(resize4d)(finput, T, inputFrameSize, kW, nOutputFrame);
@@ -311,8 +311,8 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 	THNN_(TemporalRowConvolution_shapeCheck)(state, input, gradOutput, weight,
 	                                         NULL, kW, dW, padW);
 
-	int64_t inputFrameSize = weight->size[0];
-	int64_t nInputFrame = input->size[ndim - 1];
+	int64_t inputFrameSize = weight->size(0);
+	int64_t nInputFrame = input->size(ndim - 1);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	THTensor_(resizeAs)(fgradInput, finput);
@@ -330,7 +330,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 		        kW, dW, padW,
 		        inputFrameSize, nInputFrame, nOutputFrame);
 	} else {
-		int64_t T = input->size[0];
+		int64_t T = input->size(0);
 		int64_t t;
 
 #pragma omp parallel for private(t)
@@ -373,9 +373,9 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 	int64_t i;
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
 		gradOutput->storage, gradOutput->storageOffset,
-		gradOutput->size[0], -1,
+		gradOutput->size(0), -1,
 		1, -1,
-		gradOutput->size[1], -1);
+		gradOutput->size(1), -1);
 
     THTensor *tfinput = THTensor_(new)();
 	THTensor_(transpose)(tfinput, finput, 1, 2);
@@ -386,13 +386,13 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
     THTensor_(free)(tfinput);
 
 	if (gradBias != NULL) {
-		for (i = 0; i < gradBias->size[0]; i++) {
+		for (i = 0; i < gradBias->size(0); i++) {
 			int64_t k;
 			real sum = 0;
 			real *data = THStorage_(data)(gradOutput3d->storage)
 			             + gradOutput3d->storageOffset
 			             + i * gradOutput3d->stride[0];
-			for (k = 0; k < gradOutput3d->size[2]; k++) {
+			for (k = 0; k < gradOutput3d->size(2); k++) {
 				sum += data[k];
 			}
 			(THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i]
@@ -441,7 +441,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
 		THNN_(TemporalRowConvolution_accGradParameters_frame)(
 			gradOutput, gradWeight, gradBias, finput, scale);
 	} else {
-		int64_t T = input->size[0];
+		int64_t T = input->size(0);
 		int64_t t;
 
 		for (t = 0; t < T; t++) {

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -186,7 +186,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 
 	int ndim = input->dim();
 
-	THTensor *tinput;
+	THTensor *tinput = NULL;
 	if (!featFirst) {
 		tinput = THTensor_(newTranspose)(input, ndim - 1, ndim - 2);
 		input = THTensor_(newContiguous)(tinput);

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -162,7 +162,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 		for (i = 0; i < inputFrameSize; i++)
 			THVector_(fill)
 			        (THStorage_(data)(output->storage) + output->storageOffset
-			        + output->stride[0] * i,
+			        + output->stride(0) * i,
 			        THTensor_(get1d)(bias, i), nOutputFrame);
 	}
 
@@ -391,7 +391,7 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 			real sum = 0;
 			real *data = THStorage_(data)(gradOutput3d->storage)
 			             + gradOutput3d->storageOffset
-			             + i * gradOutput3d->stride[0];
+			             + i * gradOutput3d->stride(0);
 			for (k = 0; k < gradOutput3d->size(2); k++) {
 				sum += data[k];
 			}

--- a/aten/src/THNN/generic/TemporalSubSampling.c
+++ b/aten/src/THNN/generic/TemporalSubSampling.c
@@ -19,15 +19,15 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && input->dim() == 2, 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck( input->size[1] == *inputFrameSize, 2,
+    THArgCheck( input->size(1) == *inputFrameSize, 2,
                 "invalid input frame size.  Got: %d, Expected: %d",
-                input->size[1], *inputFrameSize);
+                input->size(1), *inputFrameSize);
   }
-  THArgCheck( input->size[0] >= kW, 2,
+  THArgCheck( input->size(0) >= kW, 2,
               "input sequence smaller than kernel size.  Got %d, Expected: %d",
-              input->size[0], kW);
+              input->size(0), kW);
 
-  nInputFrame = input->size[0];
+  nInputFrame = input->size(0);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (gradOutput != NULL) {
@@ -59,7 +59,7 @@ void THNN_(TemporalSubSampling_updateOutput)(
   outputFrame = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  nInputFrame = input->size[0];
+  nInputFrame = input->size(0);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   THTensor_(resize2d)(output,
@@ -105,7 +105,7 @@ void THNN_(TemporalSubSampling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  for(k = 0; k < gradOutput->size[0]; k++)
+  for(k = 0; k < gradOutput->size(0); k++)
   {
     THTensor_(narrow)(gradInputWindow, gradInput, 0, k*dW, kW);
     THTensor_(select)(gradOutputFrame, gradOutput, 0, k);
@@ -139,7 +139,7 @@ void THNN_(TemporalSubSampling_accGradParameters)(
   inputWindow = THTensor_(new)();
   buffer = THTensor_(new)();
 
-  for(k = 0; k < gradOutput->size[0]; k++)
+  for(k = 0; k < gradOutput->size(0); k++)
   {
     THTensor_(narrow)(inputWindow, input, 0, k*dW, kW);
     THTensor_(select)(gradOutputFrame, gradOutput, 0, k);

--- a/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
@@ -109,7 +109,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    istrideB = input->stride[0];
+    istrideB = input->stride(0);
     sizeB = input->size(0);
     dimD++;
     dimT++;
@@ -123,10 +123,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   isizeH = input->size(dimH);
   isizeW = input->size(dimW);
   /* strides */
-  istrideD = input->stride[dimD];
-  istrideT = input->stride[dimT];
-  istrideH = input->stride[dimH];
-  istrideW = input->stride[dimW];
+  istrideD = input->stride(dimD);
+  istrideT = input->stride(dimT);
+  istrideH = input->stride(dimH);
+  istrideW = input->stride(dimW);
 
   /* resize output */
   if (input->dim() == 4)

--- a/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
@@ -110,7 +110,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   if (input->dim() == 5)
   {
     istrideB = input->stride[0];
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimT++;
     dimH++;
@@ -118,10 +118,10 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeT = input->size[dimT];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeT = input->size(dimT);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
   /* strides */
   istrideD = input->stride[dimD];
   istrideT = input->stride[dimT];
@@ -253,7 +253,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 5) {
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimT++;
     dimH++;
@@ -261,13 +261,13 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeT = input->size[dimT];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
-  osizeT = gradOutput->size[dimT];
-  osizeH = gradOutput->size[dimH];
-  osizeW = gradOutput->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeT = input->size(dimT);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
+  osizeT = gradOutput->size(dimT);
+  osizeH = gradOutput->size(dimH);
+  osizeW = gradOutput->size(dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -121,7 +121,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   if (input->dim() == 5)
   {
     istrideB = input->stride[0];
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimT++;
     dimH++;
@@ -129,10 +129,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeT = input->size[dimT];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeT = input->size(dimT);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
   /* strides */
   istrideD = input->stride[dimD];
   istrideT = input->stride[dimT];
@@ -254,7 +254,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 5) {
-    sizeB = input->size[0];
+    sizeB = input->size(0);
     dimD++;
     dimT++;
     dimH++;
@@ -262,13 +262,13 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  sizeD  = input->size[dimD];
-  isizeT = input->size[dimT];
-  isizeH = input->size[dimH];
-  isizeW = input->size[dimW];
-  osizeT = gradOutput->size[dimT];
-  osizeH = gradOutput->size[dimH];
-  osizeW = gradOutput->size[dimW];
+  sizeD  = input->size(dimD);
+  isizeT = input->size(dimT);
+  isizeH = input->size(dimH);
+  isizeW = input->size(dimW);
+  osizeT = gradOutput->size(dimT);
+  osizeH = gradOutput->size(dimH);
+  osizeW = gradOutput->size(dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -120,7 +120,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    istrideB = input->stride[0];
+    istrideB = input->stride(0);
     sizeB = input->size(0);
     dimD++;
     dimT++;
@@ -134,10 +134,10 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   isizeH = input->size(dimH);
   isizeW = input->size(dimW);
   /* strides */
-  istrideD = input->stride[dimD];
-  istrideT = input->stride[dimT];
-  istrideH = input->stride[dimH];
-  istrideW = input->stride[dimW];
+  istrideD = input->stride(dimD);
+  istrideT = input->stride(dimT);
+  istrideH = input->stride(dimH);
+  istrideW = input->stride(dimW);
 
   /* resize output */
   if (input->dim() == 4)

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -47,11 +47,11 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
                 "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
-             && input->size[dimt] >= kT, 2,
+  THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
+             && input->size(dimt) >= kT, 2,
              "input image (T: %d H: %d W: %d) smaller than "
              "kernel size (kT: %d kH: %d kW: %d)",
-             input->size[dimt], input->size[dimh], input->size[dimw],
+             input->size(dimt), input->size(dimh), input->size(dimw),
              kT, kH, kW);
 
   // The second argument is argNumber... here is the index of padH.
@@ -61,10 +61,10 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
             padT, padW, padH, kT, kW, kH);
 
   /* sizes */
-  nslices = input->size[dimN];
-  itime   = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth  = input->size[dimw];
+  nslices = input->size(dimN);
+  itime   = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth  = input->size(dimw);
 
   if (ceil_mode) {
     otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
@@ -231,10 +231,10 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   }
 
   /* sizes */
-  nslices = input->size[dimN];
-  itime   = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth  = input->size[dimw];
+  nslices = input->size(dimN);
+  itime   = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth  = input->size(dimw);
   if (ceil_mode)
   {
     otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
@@ -283,7 +283,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   else  /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size[0];
+    int64_t nBatch = input->size(0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;
@@ -445,13 +445,13 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   }
 
   /* sizes */
-  nslices = input->size[dimN];
-  itime = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
-  otime = gradOutput->size[dimt];
-  oheight = gradOutput->size[dimh];
-  owidth = gradOutput->size[dimw];
+  nslices = input->size(dimN);
+  itime = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
+  otime = gradOutput->size(dimt);
+  oheight = gradOutput->size(dimh);
+  owidth = gradOutput->size(dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -473,7 +473,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size[0];
+    int64_t nBatch = input->size(0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;

--- a/aten/src/THNN/generic/VolumetricConvolution.c
+++ b/aten/src/THNN/generic/VolumetricConvolution.c
@@ -33,13 +33,13 @@ void THNN_(VolumetricConvolution_updateOutput)(
     dimw++;
   }
 
-  int64_t nOutputPlane = weight->size[0];
-  int64_t kT           = weight->size[2];
-  int64_t kH           = weight->size[3];
-  int64_t kW           = weight->size[4];
-  int64_t inputDepth   = input->size[dimt];
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t nOutputPlane = weight->size(0);
+  int64_t kT           = weight->size(2);
+  int64_t kH           = weight->size(3);
+  int64_t kW           = weight->size(4);
+  int64_t inputDepth   = input->size(dimt);
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
   int64_t outputDepth  = (inputDepth - kT) / dT + 1;
   int64_t outputWidth  = (inputWidth - kW) / dW + 1;
   int64_t outputHeight = (inputHeight - kH) / dH + 1;
@@ -51,7 +51,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
     /* add bias */
     if (bias) {
-      for (i = 0; i < bias->size[0]; i++)
+      for (i = 0; i < bias->size(0); i++)
       {
         THTensor_(select)(outn, output, 0, i);
         THTensor_(fill)(outn, THTensor_(get1d)(bias, i));
@@ -65,7 +65,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = input->size[0];
+    int64_t nBatch = input->size(0);
     THTensor_(resize5d)(output, nBatch, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor *inb = THTensor_(new)();
     THTensor *outb = THTensor_(new)();
@@ -78,7 +78,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
       /* add bias */
       if (bias) {
-        for (i = 0; i < bias->size[0]; i++)
+        for (i = 0; i < bias->size(0); i++)
         {
           THTensor_(select)(outn, outb, 0, i);
           THTensor_(fill)(outn, THTensor_(get1d)(bias, i));
@@ -117,7 +117,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for weight, but got: %s");
 
-  int nOutputPlane = (int)weight->size[0];
+  int nOutputPlane = (int)weight->size(0);
 
   THNN_ARGCHECK(!gradOutput->is_empty() && (gradOutput->dim() == 4 || gradOutput->dim() == 5), 3,
 		gradOutput,
@@ -129,7 +129,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
     dimPlane++;
   }
 
-  THArgCheck(nOutputPlane == gradOutput->size[dimPlane], 1,
+  THArgCheck(nOutputPlane == gradOutput->size(dimPlane), 1,
     "Number of output features is not equal to nOutputPlane"
   );
 
@@ -141,13 +141,13 @@ void THNN_(VolumetricConvolution_updateGradInput)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = gradOutput->size[0];
+    int64_t nBatch = gradOutput->size(0);
     THTensor *ginpb = THTensor_(new)();
     THTensor *goutb = THTensor_(new)();
     int64_t j;
 
     THTensor_(resize5d)(gradInput,
-      input->size[0], input->size[1], input->size[2], input->size[3], input->size[4]
+      input->size(0), input->size(1), input->size(2), input->size(3), input->size(4)
     );
 
     /* loop over batches */
@@ -187,9 +187,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
 		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for gradWeight, but got: %s");
 
-  int nOutputPlane = (int)gradWeight->size[0];
+  int nOutputPlane = (int)gradWeight->size(0);
   if (gradBias) {
-    THArgCheck(!gradBias->is_empty() && gradBias->dim() == 1 && gradBias->size[0] == nOutputPlane, 5,
+    THArgCheck(!gradBias->is_empty() && gradBias->dim() == 1 && gradBias->size(0) == nOutputPlane, 5,
       "gradBias tensor has wrong size"
     );
   }
@@ -203,7 +203,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
     dimPlane++;
   }
 
-  THArgCheck(nOutputPlane == gradOutput->size[dimPlane], 1,
+  THArgCheck(nOutputPlane == gradOutput->size(dimPlane), 1,
     "Number of output features is not equal to nOutputPlane"
   );
 
@@ -226,7 +226,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = gradOutput->size[0];
+    int64_t nBatch = gradOutput->size(0);
     THTensor *inpb = THTensor_(new)();
     THTensor *goutb = THTensor_(new)();
     int64_t j;

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -435,7 +435,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
       for (i = 0; i < nOutputPlane; i++)
       {
         THVector_(fill)(
-          THStorage_(data)(output->storage)+output->storageOffset+output->stride[0]*i,
+          THStorage_(data)(output->storage)+output->storageOffset+output->stride(0)*i,
           THTensor_(get1d)(bias, i),
           outputDepth*outputHeight*outputWidth
         );
@@ -693,7 +693,7 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride(0);
       for (k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
 

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -31,7 +31,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 5), 5, weight,
                     "non-empty 2D or 5D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -62,9 +62,9 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
   int64_t outputHeight;
   int64_t outputWidth;
 
-  inputDepth = input->size[dimt];
-  inputHeight  = input->size[dimh];
-  inputWidth   = input->size[dimw];
+  inputDepth = input->size(dimt);
+  inputHeight  = input->size(dimh);
+  inputWidth   = input->size(dimw);
 
   exactInputDepth = inputDepth + 2*pT;
   exactInputHeight = inputHeight + 2*pH;
@@ -88,7 +88,7 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[1];
+    int64_t nInputPlane = weight->size(1);
     if (weight->dim() == 2) {
       nInputPlane /= (kT * kH * kW);
     }
@@ -97,10 +97,10 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[0];
+      int64_t nOutputPlane = weight->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimt, outputDepth);
@@ -113,8 +113,8 @@ static THTensor* THNN_(newViewWeight)(THTensor *weight)
 {
   weight = THTensor_(newContiguous)(weight);
   if (weight->dim() == 5) {
-    int64_t s1 = weight->size[0];
-    int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
+    int64_t s1 = weight->size(0);
+    int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage2d)(weight->storage, weight->storageOffset,
 					 s1, -1, s2, -1);
@@ -494,11 +494,11 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
     dimw++;
   }
 
-  nInputPlane = input->size[dimf];
-  inputDepth = input->size[dimt];
-  inputHeight  = input->size[dimh];
-  inputWidth   = input->size[dimw];
-  nOutputPlane = weight->size[0];
+  nInputPlane = input->size(dimf);
+  inputDepth = input->size(dimt);
+  inputHeight  = input->size(dimh);
+  inputWidth   = input->size(dimw);
+  nOutputPlane = weight->size(0);
   outputDepth  = (inputDepth + 2*pT - kT) / dT + 1;
   outputHeight = (inputHeight + 2*pH - kH) / dH + 1;
   outputWidth  = (inputWidth + 2*pW - kW) / dW + 1;
@@ -521,7 +521,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
     THTensor_(resize3d)(finput, T, kT*kW*kH*nInputPlane, outputDepth*outputHeight*outputWidth);
@@ -571,8 +571,8 @@ static void THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
     gradOutput->storage, gradOutput->storageOffset,
-    gradOutput->size[0], -1,
-    gradOutput->size[1]*gradOutput->size[2]*gradOutput->size[3], -1
+    gradOutput->size(0), -1,
+    gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );
 
   THTensor_(addmm)(fgradInput, 0, fgradInput, 1, weight, gradOutput2d);
@@ -585,8 +585,8 @@ static void THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
     kT, kW, kH,
     dT, dW, dH,
     pT, pW, pH,
-    gradInput->size[0], gradInput->size[1], gradInput->size[3], gradInput->size[2],
-    gradOutput->size[1], gradOutput->size[3], gradOutput->size[2]
+    gradInput->size(0), gradInput->size(1), gradInput->size(3), gradInput->size(2),
+    gradOutput->size(1), gradOutput->size(3), gradOutput->size(2)
   );
 }
 
@@ -636,7 +636,7 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
   }
   else
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
 #ifdef _OPENMP
@@ -677,8 +677,8 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
     gradOutput->storage, gradOutput->storageOffset,
-    gradOutput->size[0], -1,
-    gradOutput->size[1]*gradOutput->size[2]*gradOutput->size[3], -1
+    gradOutput->size(0), -1,
+    gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );
 
   if (gradWeight){
@@ -689,12 +689,12 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
   }
 
   if (gradBias) {
-    for (i = 0; i < gradBias->size[0]; i++)
+    for (i = 0; i < gradBias->size(0); i++)
     {
       int64_t k;
       real sum = 0;
       real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
-      for (k = 0; k < gradOutput2d->size[1]; k++)
+      for (k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
 
       (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale * sum;
@@ -735,7 +735,7 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
   }
   else  // batch mode
   {
-    int64_t T = input->size[0];
+    int64_t T = input->size(0);
     int64_t t;
 
 #ifdef _OPENMP

--- a/aten/src/THNN/generic/VolumetricDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricDilatedConvolution.c
@@ -24,7 +24,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                   "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -44,9 +44,9 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
-  int64_t inputDepth  = input->size[dimd];
-  int64_t inputHeight  = input->size[dimh];
-  int64_t inputWidth   = input->size[dimw];
+  int64_t inputDepth  = input->size(dimd);
+  int64_t inputHeight  = input->size(dimh);
+  int64_t inputWidth   = input->size(dimw);
   int64_t outputDepth  = (inputDepth  + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int64_t outputWidth  = (inputWidth  + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
@@ -58,16 +58,16 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size[1];
+    int64_t nInputPlane = weight->size(1);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size[0];
+      int64_t nOutputPlane = weight->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size[0];
+      int64_t nOutputPlane = bias->size(0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimd, outputDepth);
@@ -95,8 +95,8 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
         dilationT, dilationH, dilationW, 0);
 
   // Params:
-  int64_t nInputPlane = weight->size[1];
-  int64_t nOutputPlane = weight->size[0];
+  int64_t nInputPlane = weight->size(1);
+  int64_t nOutputPlane = weight->size(0);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -109,18 +109,18 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
+    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
   }
 
-  int64_t inputDepth  = input->size[2];
-  int64_t inputHeight  = input->size[3];
-  int64_t inputWidth   = input->size[4];
+  int64_t inputDepth  = input->size(2);
+  int64_t inputHeight  = input->size(3);
+  int64_t inputWidth   = input->size(4);
   int64_t outputDepth  = (inputDepth  + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int64_t outputWidth  = (inputWidth  + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize5d)(output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -133,7 +133,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
   if (ones->dim() != 3 ||
-      ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+      ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -182,7 +182,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nOutputPlane;
-    int64_t n = columns->size[1];
+    int64_t n = columns->size(1);
     int64_t k = nInputPlane*kT*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -230,8 +230,8 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
         dilationT, dilationH, dilationW, 0);
 
   // Params
-  int64_t nInputPlane = weight->size[1];
-  int64_t nOutputPlane = weight->size[0];
+  int64_t nInputPlane = weight->size(1);
+  int64_t nOutputPlane = weight->size(0);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -242,19 +242,19 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
   }
 
-  int64_t inputDepth  = input->size[2];
-  int64_t inputWidth   = input->size[4];
-  int64_t inputHeight  = input->size[3];
+  int64_t inputDepth  = input->size(2);
+  int64_t inputWidth   = input->size(4);
+  int64_t inputHeight  = input->size(3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Resize output
   THTensor_(resize5d)(gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -275,7 +275,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nInputPlane*kT*kW*kH;
-    int64_t n = gradColumns->size[1];
+    int64_t n = gradColumns->size(1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -352,24 +352,24 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
   }
 
-  int64_t nInputPlane = input->size[1];
-  int64_t nOutputPlane = gradOutput->size[1];
-  int64_t inputDepth  = input->size[2];
-  int64_t inputWidth   = input->size[4];
-  int64_t inputHeight  = input->size[3];
+  int64_t nInputPlane = input->size(1);
+  int64_t nOutputPlane = gradOutput->size(1);
+  int64_t inputDepth  = input->size(2);
+  int64_t inputWidth   = input->size(4);
+  int64_t inputHeight  = input->size(3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size[0];
+  int64_t batchSize = input->size(0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -405,7 +405,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
       // M,N,K are dims of matrix A and B
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kT*kW*kH;
-      int64_t k = columns->size[1];
+      int64_t k = columns->size(1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -51,10 +51,10 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "kT: %d kW: %d, kH: %d, padT: %d, padW: %d, padH: %d",
              kT, kW, kH, pT, pW, pH);
 
-  nslices = input->size[dimN];
-  itime   = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth  = input->size[dimw];
+  nslices = input->size(dimN);
+  itime   = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth  = input->size(dimw);
   if (ceilMode)
   {
     otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
@@ -241,10 +241,10 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
         ceilMode);
 
   /* sizes */
-  nslices = input->size[dimN];
-  itime   = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth  = input->size[dimw];
+  nslices = input->size(dimN);
+  itime   = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth  = input->size(dimw);
   if (ceilMode)
   {
     otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
@@ -298,7 +298,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size[0];
+    int64_t nBatch = input->size(0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;
@@ -444,13 +444,13 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  nslices = input->size[dimN];
-  itime = input->size[dimt];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
-  otime = gradOutput->size[dimt];
-  oheight = gradOutput->size[dimh];
-  owidth = gradOutput->size[dimw];
+  nslices = input->size(dimN);
+  itime = input->size(dimt);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
+  otime = gradOutput->size(dimt);
+  oheight = gradOutput->size(dimh);
+  owidth = gradOutput->size(dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -474,7 +474,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size[0];
+    int64_t nBatch = input->size(0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;

--- a/aten/src/THNN/generic/VolumetricMaxUnpooling.c
+++ b/aten/src/THNN/generic/VolumetricMaxUnpooling.c
@@ -38,14 +38,14 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
     dimh++;
     dimn++;
   }
-  int nslices = input->size[dimn];
+  int nslices = input->size(dimn);
 
   if (gradOutput != NULL) {
-    if (oT != gradOutput->size[dimt] || oW != gradOutput->size[dimw] || oH != gradOutput->size[dimh])
+    if (oT != gradOutput->size(dimt) || oW != gradOutput->size(dimw) || oH != gradOutput->size(dimh))
     {
       THError(
         "Inconsistent gradOutput size. oT= %d, oH= %d, oW= %d, gradOutput: %dx%dx%d",
-        oT, oH, oW, gradOutput->size[dimt], gradOutput->size[dimh], gradOutput->size[dimw]
+        oT, oH, oW, gradOutput->size(dimt), gradOutput->size(dimh), gradOutput->size(dimw)
       );
     }
 
@@ -140,17 +140,17 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimt++;
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size[dimt-1];
-  iT = input->size[dimt];
-  iH = input->size[dimh];
-  iW = input->size[dimw];
+  nslices = input->size(dimt-1);
+  iT = input->size(dimt);
+  iH = input->size(dimh);
+  iW = input->size(dimw);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
@@ -287,17 +287,17 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimt++;
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size[dimt-1];
-  iT = input->size[dimt];
-  iH = input->size[dimh];
-  iW = input->size[dimw];
+  nslices = input->size(dimt-1);
+  iT = input->size(dimt);
+  iH = input->size(dimh);
+  iW = input->size(dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricReplicationPadding.c
+++ b/aten/src/THNN/generic/VolumetricReplicationPadding.c
@@ -33,10 +33,10 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  idepth = input->size[dimd];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  idepth = input->size(dimd);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;
@@ -151,7 +151,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimd++;
@@ -159,10 +159,10 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  idepth = input->size[dimd];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  idepth = input->size(dimd);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;
@@ -295,7 +295,7 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 5)
   {
-    nbatch = input->size[0];
+    nbatch = input->size(0);
     dimw++;
     dimh++;
     dimd++;
@@ -303,10 +303,10 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
   }
 
   /* sizes */
-  nslices = input->size[dimslices];
-  idepth = input->size[dimd];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  nslices = input->size(dimslices);
+  idepth = input->size(dimd);
+  iheight = input->size(dimh);
+  iwidth = input->size(dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -176,6 +176,7 @@ function(aten_compile_options libname)
     -Wextra
     -fexceptions
     -Wno-missing-field-initializers
+    -Wno-strict-overflow
     -Wno-type-limits
     -Wno-unused-parameter
     -Wno-unknown-warning-option

--- a/setup.py
+++ b/setup.py
@@ -644,6 +644,7 @@ else:
         '-std=c++11',
         '-Wall',
         '-Wextra',
+        '-Wno-strict-overflow',
         '-Wno-unused-parameter',
         '-Wno-missing-field-initializers',
         '-Wno-write-strings',

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -238,7 +238,7 @@ set_source_files_properties(
 
 if (MSVC)
 elseif ($ENV{WERROR})
-  target_compile_options(torch PRIVATE -Werror)
+  target_compile_options(torch PRIVATE -Werror -Wno-strict-overflow)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
* THTensor now stores `sizes_` and `strides_` which is a `std::vector<int64_t>`
* Anywhere a "public" API function made use of a int64_t* of sizes, I opted to just finagle it out of the tensor using THTensor_getSizePtr rather than try to rewrite all of these sites to use ArrayRef. They should use ArrayRef eventually, but not yet.
* There are new utility functions for resizing sizes/strides in one go (THTensor_resizeDim), or replacing sizes and strides with completely new values (THTensor_setSizesAndStrides)
* Anywhere you said `t->size[n] = 0`, we now say `THTensor_setSizeAt(t, n, 0)`, ditto for strides
* Anywhere you said `t->size[n]`, we now say `t->size(n)` (coming soon: ditto for strides)

Previous review of just the `std::vector` change in #9518, but I'm planning to merge this all in one go.

Note for @gchanan: review from commit "ci" and after