### PR TITLE
[C++ API] Make error message for empty module friendlier

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -350,3 +350,31 @@ TEST_CASE("module/buffers") {
     REQUIRE(buffers.contains("c"));
   }
 }
+
+TEST_CASE("module/default-constructor") {
+  struct AImpl : torch::nn::Module {
+    AImpl() : x_(123) {}
+    AImpl(int x) : x_(x) {}
+    int x_;
+  };
+  TORCH_MODULE(A);
+
+  {
+    A a;
+    REQUIRE(a);
+    REQUIRE(!a.is_empty());
+    REQUIRE(a->x_ == 123);
+  }
+  {
+    A a(5);
+    REQUIRE(a);
+    REQUIRE(!a.is_empty());
+    REQUIRE(a->x_ == 5);
+  }
+  {
+    A a = nullptr;
+    REQUIRE(!a);
+    REQUIRE(a.is_empty());
+    REQUIRE_THROWS_WITH(a->x_, StartsWith("Accessing empty ModuleHolder"));
+  }
+}

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -19,9 +19,8 @@ struct BatchNormOptions {
 
 class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
  public:
-  template <typename... Ts>
-  explicit BatchNormImpl(Ts&&... ts)
-      : BatchNormImpl(BatchNormOptions(std::forward<Ts>(ts)...)) {}
+  explicit BatchNormImpl(int64_t features)
+      : BatchNormImpl(BatchNormOptions(features)) {}
   explicit BatchNormImpl(BatchNormOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -32,9 +32,11 @@ struct ConvOptions {
 template <size_t D, typename Derived>
 class ConvImpl : public torch::nn::Cloneable<Derived> {
  public:
-  template <typename... Ts>
-  explicit ConvImpl(Ts&&... ts)
-      : ConvImpl(ConvOptions<D>(std::forward<Ts>(ts)...)) {}
+  ConvImpl(
+      int64_t input_channels,
+      int64_t output_channels,
+      ExpandingArray<D> kernel_size)
+      : ConvImpl(ConvOptions<D>(input_channels, output_channels, kernel_size)) {}
   explicit ConvImpl(ConvOptions<D> options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -18,9 +18,8 @@ namespace detail {
 template <typename Derived>
 class DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  template <typename... Ts>
-  explicit DropoutImplBase(Ts&&... ts)
-      : DropoutImplBase(DropoutOptions(std::forward<Ts>(ts)...)) {}
+  explicit DropoutImplBase(double rate)
+      : DropoutImplBase(DropoutOptions(rate)) {}
   explicit DropoutImplBase(DropoutOptions options_);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -18,9 +18,8 @@ struct EmbeddingOptions {
 
 class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
  public:
-  template <typename... Ts>
-  explicit EmbeddingImpl(Ts&&... ts)
-      : EmbeddingImpl(EmbeddingOptions(std::forward<Ts>(ts)...)) {}
+  EmbeddingImpl(int64_t count, int64_t dimension)
+      : EmbeddingImpl(EmbeddingOptions(count, dimension)) {}
   explicit EmbeddingImpl(EmbeddingOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -19,9 +19,7 @@ struct LinearOptions {
 
 class LinearImpl : public Cloneable<LinearImpl> {
  public:
-  template <typename... Ts>
-  explicit LinearImpl(Ts&&... ts)
-      : LinearImpl(LinearOptions(std::forward<Ts>(ts)...)) {}
+  LinearImpl(int64_t in, int64_t out) : LinearImpl(LinearOptions(in, out)) {}
   explicit LinearImpl(LinearOptions options);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -121,8 +121,8 @@ struct RNNOptions {
 
 class RNNImpl : public detail::RNNImplBase<RNNImpl> {
  public:
-  template <typename... Ts>
-  explicit RNNImpl(Ts&&... ts) : RNNImpl(RNNOptions(std::forward<Ts>(ts)...)) {}
+  RNNImpl(int64_t input_size, int64_t hidden_size)
+      : RNNImpl(RNNOptions(input_size, hidden_size)) {}
   explicit RNNImpl(RNNOptions options);
 
   RNNOptions options;
@@ -140,9 +140,8 @@ using LSTMOptions = detail::RNNOptionsBase;
 
 class LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
  public:
-  template <typename... Ts>
-  explicit LSTMImpl(Ts&&... ts)
-      : LSTMImpl(LSTMOptions(std::forward<Ts>(ts)...)) {}
+  LSTMImpl(int64_t input_size, int64_t hidden_size)
+      : LSTMImpl(LSTMOptions(input_size, hidden_size)) {}
   explicit LSTMImpl(LSTMOptions options);
 
  private:
@@ -157,8 +156,8 @@ using GRUOptions = detail::RNNOptionsBase;
 
 class GRUImpl : public detail::RNNImplBase<GRUImpl> {
  public:
-  template <typename... Ts>
-  explicit GRUImpl(Ts&&... ts) : GRUImpl(GRUOptions(std::forward<Ts>(ts)...)) {}
+  GRUImpl(int64_t input_size, int64_t hidden_size)
+      : GRUImpl(GRUOptions(input_size, hidden_size)) {}
   explicit GRUImpl(GRUOptions options);
 
  private:

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -42,12 +42,12 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   /// else produces a static error. NOTE: This uses the behavior of template
   /// classes in C++ that constructors (or any methods) are only compiled when
   /// actually used.
-  ModuleHolder()  {
+  ModuleHolder() : impl_(default_construct()) {
     static_assert(
         std::is_default_constructible<Contained>::value,
         "You are trying to default construct a module which has "
         "no default constructor. Use = nullptr to give it the empty state "
-        "(like an empty std::shared_ptr).");
+        "(e.g. `Linear linear = nullptr;` instead of `Linear linear;`).");
   }
 
   /// Constructs the `ModuleHolder` with an empty contained value. Access to
@@ -135,7 +135,7 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   /// } else {
   ///   return nullptr;
   /// }
-  /// In C++11, we use SFINAE instead of `if contexpr`.
+  /// In C++11, we use SFINAE instead of `if constexpr`.
 
   template <
       typename T = Contained,

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -38,10 +38,22 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
  public:
   using ContainedType = Contained;
 
+  /// Default constructs the contained module if if has a default constructor,
+  /// else produces a static error. NOTE: This uses the behavior of template
+  /// classes in C++ that constructors (or any methods) are only compiled when
+  /// actually used.
+  ModuleHolder()  {
+    static_assert(
+        std::is_default_constructible<Contained>::value,
+        "You are trying to default construct a module which has "
+        "no default constructor. Use = nullptr to give it the empty state "
+        "(like an empty std::shared_ptr).");
+  }
+
   /// Constructs the `ModuleHolder` with an empty contained value. Access to
   /// the underlying module is not permitted and will throw an exception, until
   /// a value is assigned.
-  explicit ModuleHolder(std::nullptr_t) : impl_(nullptr) {}
+  /* implicit */ ModuleHolder(std::nullptr_t) : impl_(nullptr) {}
 
   /// Constructs the `ModuleHolder` with a contained module, forwarding all
   /// arguments to its constructor.
@@ -114,6 +126,30 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   /// Returns true if the `ModuleHolder` does not contain a module.
   bool is_empty() const noexcept {
     return impl_ == nullptr;
+  }
+
+ private:
+  /// In C++17, the two methods below could be written as the following:
+  /// if constexpr (std::is_default_constructible_v<Contained>) {
+  ///   return std::make_shared<Contained>();
+  /// } else {
+  ///   return nullptr;
+  /// }
+  /// In C++11, we use SFINAE instead of `if contexpr`.
+
+  template <
+      typename T = Contained,
+      typename = torch::enable_if_t<std::is_default_constructible<T>::value>>
+  std::shared_ptr<Contained> default_construct() {
+    return std::make_shared<Contained>();
+  }
+
+  template <typename T = Contained>
+  torch::disable_if_t<
+      std::is_default_constructible<T>::value,
+      std::shared_ptr<Contained>>
+  default_construct() {
+    return nullptr;
   }
 };
 } // namespace nn


### PR DESCRIPTION
In our pimpl system, default constructing a module holder default constructs the contained module. This means `Linear linear;` is ill-formed, since `Linear` doesn't have a default constructor. Instead we require `Linear linear = nullptr;` to get the empty state of the `Linear`. This PR makes the error message for the ill-formed case nicer.

I had to change the forwarding constructors of most of our modules for this, but that's a minor adjustment.

E.g.

```
Linear linear;

In file included from /home/psag/pytorch/pytorch/torch/csrc/api/include/torch/nn/module.h:5:0,
                 from /home/psag/pytorch/pytorch/test/cpp/api/module.cpp:3:
/home/psag/pytorch/pytorch/torch/csrc/api/include/torch/nn/pimpl.h: In instantiation of ‘torch::nn::ModuleHolder<Contained>::ModuleHolder() [with Contained = torch::nn::LinearImpl]’:
/home/psag/pytorch/pytorch/torch/csrc/api/include/torch/nn/modules/dropout.h:45:1:   required from here
/home/psag/pytorch/pytorch/torch/csrc/api/include/torch/nn/pimpl.h:46:5: error: static assertion failed: You are trying to default construct a module which has no default constructor. Use = nullptr to give it the empty state (like an empt
y std::shared_ptr).
     static_assert(
```

@ebetica @ezyang 