### PR TITLE
Add new ways of matching nodes with schemas in the JIT

### DIFF
--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -29,11 +29,13 @@ std::vector<int64_t> infer_size(IntList a, IntList b) {
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t>> inferExpandGeometry(
-    const Tensor& tensor,
+    IntList tensor_sizes,
+    IntList tensor_strides,
     IntList sizes) {
   int64_t ndim = sizes.size();
+  int64_t tensor_dim = tensor_sizes.size();
 
-  if (tensor.dim() == 0) {
+  if (tensor_dim == 0) {
     std::vector<int64_t> expandedStrides(ndim, 0);
     return std::tuple<std::vector<int64_t>, std::vector<int64_t>>(
         sizes.vec(), expandedStrides);
@@ -44,9 +46,9 @@ std::tuple<std::vector<int64_t>, std::vector<int64_t>> inferExpandGeometry(
   // create a new geometry for the tensors
   for (int64_t i = ndim - 1; i >= 0; --i) {
     int64_t offset = ndim - 1 - i;
-    int64_t dim = tensor.dim() - 1 - offset;
-    int64_t size = (dim >= 0) ? tensor.sizes()[dim] : 1;
-    int64_t stride = (dim >= 0) ? tensor.strides()[dim]
+    int64_t dim = tensor_dim - 1 - offset;
+    int64_t size = (dim >= 0) ? tensor_sizes[dim] : 1;
+    int64_t stride = (dim >= 0) ? tensor_strides[dim]
                                 : expandedSizes[i + 1] * expandedStrides[i + 1];
     int64_t targetSize = sizes[i];
     if (targetSize == -1) {

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -10,7 +10,8 @@
 namespace at {
 
 AT_API std::vector<int64_t> infer_size(IntList a, IntList b);
-std::tuple<std::vector<int64_t>, std::vector<int64_t> > inferExpandGeometry(const Tensor &tensor, IntList sizes);
+std::tuple<std::vector<int64_t>, std::vector<int64_t> > inferExpandGeometry(
+    IntList tensor_sizes, IntList tensor_strides, IntList sizes);
 
 // avoid copy-construction of Tensor by using a reference_wrapper.
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -126,7 +126,7 @@ Tensor expand(const Tensor& self, IntList size, bool implicit) {
 
   std::vector<int64_t> expandedSizes;
   std::vector<int64_t> expandedStrides;
-  std::tie(expandedSizes, expandedStrides) = inferExpandGeometry(self, size);
+  std::tie(expandedSizes, expandedStrides) = inferExpandGeometry(self.sizes(), self.strides(), size);
 
   return self.as_strided(expandedSizes, expandedStrides);
 }

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -90,7 +90,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         } else if (node->hasAttribute(attr::alpha)) {
           return {grads.at(0), grads.at(0) * at::Scalar(node->t(attr::alpha))};
         } else {
-          return {grads.at(0), nullptr, grads.at(0) * node->getValue(attr::alpha)};
+          return {grads.at(0), nullptr, grads.at(0) * node->input(attr::alpha)};
         }
       case aten::sub:
         // o = self - alpha*other
@@ -99,7 +99,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         } else if (node->hasAttribute(attr::alpha)) {
           return {grads.at(0), -grads.at(0) * at::Scalar(node->t(attr::alpha))};
         } else {
-          return {grads.at(0), nullptr, grads.at(0) * node->getValue(attr::alpha)};
+          return {grads.at(0), nullptr, grads.at(0) * node->input(attr::alpha)};
         }
       case aten::mul:
         // o = self * other
@@ -119,7 +119,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         return {grads.at(0) * (outputs.at(0))};
       case aten::chunk:
       case aten::split:
-        return {SymbolicVariable::cat(grads, node->getValue(attr::dim))};
+        return {SymbolicVariable::cat(grads, node->input(attr::dim))};
       case aten::t:
         return {grads.at(0).t()};
       case aten::neg:
@@ -130,7 +130,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       case aten::type_as:
         return {grads.at(0).type_as(inputs.at(0))};
       case aten::unsqueeze:
-        return {grads.at(0).squeeze(node->getValue(attr::dim))};
+        return {grads.at(0).squeeze(node->input(attr::dim))};
       case aten::mm: {
         SymbolicVariable dmat1, dmat2;
         if (auto type = inputs.at(0).value()->type()->cast<TensorType>()) {

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -79,7 +79,7 @@ struct FunctionSchema {
 
 // for debugging, make sure we can describe the call site
 inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
-  return out << arg.type->str() << " " << arg.name;
+  return out << arg.type->str() << " " << arg.name << (arg.default_value ? "=<default>" : "");
 }
 
 inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema) {

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -79,27 +79,36 @@ struct FunctionSchema {
 
 // for debugging, make sure we can describe the call site
 inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
-  return out << arg.type->str() << " " << arg.name << (arg.default_value ? "=<default>" : "");
+  return out << arg.type->str() << " " << arg.name;
 }
 
 inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema) {
   // eventually this should look almost identical to python arg parser, but
   // it is simpler for now to work directly on this schema
-  auto emitList = [&](const std::vector<Argument>& args) {
-    out << "(";
-    for(size_t i = 0; i < args.size(); ++i) {
-      if(i > 0)
-        out << ", ";
-      out << args[i];
-    }
-    out << ")";
-  };
 
   out << schema.name;
-  emitList(schema.arguments);
-  if(schema.returns.size() > 1) {
-    out << " -> ";
-    emitList(schema.returns);
+  out << "(";
+
+  bool seen_kwarg_only = false;
+  for(size_t i = 0; i < schema.arguments.size(); ++i) {
+    if (i > 0) out << ", ";
+    if (schema.arguments[i].kwarg_only && !seen_kwarg_only) {
+      out << "*, ";
+      seen_kwarg_only = true;
+    }
+    out << schema.arguments[i];
+  }
+
+  out << ") -> ";
+  if (schema.returns.size() == 1) {
+    out << schema.returns.at(0).type->str();
+  } else if (schema.returns.size() > 1) {
+    out << "(";
+    for (size_t i = 0; i < schema.returns.size(); ++i) {
+      if (i > 0) out << ", ";
+      out << schema.returns[i].type->str();
+    }
+    out << ")";
   }
   return out;
 }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -682,7 +682,7 @@ at::optional<IValue> Node::get(Symbol name) {
   return IValue{std::move(value)};
 }
 
-Value* Node::getValue(Symbol name) {
+Value* Node::input(Symbol name) {
   // TODO (apaszke): remove once tracer and compiler stop emitting attributes
   if (hasAttribute(name)) {
     switch (kindOf(name)) {
@@ -725,8 +725,12 @@ std::pair<Value*, const Argument&> Node::findInput(Symbol name) {
   throw std::runtime_error(std::string("Couldn't find an argument called ") + name.toQualString());
 }
 
-bool Node::matches(const char *signature_literal) {
-  return sig(signature_literal).matches(this);
+bool Node::matches(const char *signature_literal, at::ArrayRef<Symbol> const_inputs) {
+  if (!sig(signature_literal).matches(this)) return false;
+  for (Symbol s : const_inputs) {
+    if (!is_constant(s)) return false;
+  }
+  return true;
 }
 
 void Node::findSchema() {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -642,6 +642,10 @@ at::optional<T> Node::get(Symbol name) {
     return getattr<T>()(this, name);
   }
   auto inp = findInput(name);
+  const Argument & arg = inp.second;
+  if (!inp.first) {
+    return tensor_as<T>(arg.default_value.value());
+  }
   Node *producer = inp.first->node();
   if (producer->kind() != prim::Constant) return at::nullopt;
   auto value = producer->t(attr::value);
@@ -655,22 +659,27 @@ template at::optional<std::vector<int64_t>> Node::get(Symbol name);
 
 at::optional<IValue> Node::get(Symbol name) {
   // TODO (apaszke): remove once tracer and compiler stop emitting attributes
-  if (hasAttributes()) {
-    throw std::runtime_error("IValue Node::get() not implemented for the attribute case");
+  if (hasAttribute(name)) {
+    switch (kindOf(name)) {
+      case AttributeKind::i:
+        return IValue{as_tensor(i(name))};
+      case AttributeKind::t:
+        return IValue{as_tensor(t(name))};
+      case AttributeKind::is:
+        return IValue{as_tensor(is(name))};
+      default:
+        throw std::runtime_error("get() NYI");
+    }
   }
   auto inp = findInput(name);
+  const Argument & arg = inp.second;
+  if (!inp.first) {
+    return IValue{arg.default_value.value()};
+  }
   Node * producer = inp.first->node();
   if (producer->kind() != prim::Constant) return at::nullopt;
   auto value = producer->t(attr::value);
-  const Argument & arg = inp.second;
-  if (arg.type->isSubtypeOf(*DynamicType::get())) {
-    return IValue{std::move(value)};
-  } else if (arg.type->isSubtypeOf(*IntType::get())) {
-    return IValue{tensor_as<int64_t>(std::move(value))};
-  } else if (arg.type->isSubtypeOf(*FloatType::get())) {
-    return IValue{tensor_as<double>(std::move(value))};
-  }
-  throw std::runtime_error("Unsupported case in Node::get! File a bug report.");
+  return IValue{std::move(value)};
 }
 
 Value* Node::getValue(Symbol name) {
@@ -687,9 +696,13 @@ Value* Node::getValue(Symbol name) {
         throw std::runtime_error("getValue() NYI");
     }
   }
-  return findInput(name).first;
+  auto inp = findInput(name);
+  if (inp.first) return inp.first;
+  return owningGraph()->insertConstant(inp.second.default_value.value());
 }
 
+// XXX: the first coordinate can be a nullptr, which means that you should use
+// the default value for this arg, because it's optional and missing
 std::pair<Value*, const Argument&> Node::findInput(Symbol name) {
   if (!schema_) {
     findSchema();
@@ -700,11 +713,20 @@ std::pair<Value*, const Argument&> Node::findInput(Symbol name) {
     const auto & arg = schema_->arguments[i];
     if (hasAttributeS(arg.name)) continue;
     if (arg.name == name_str) {
-      return std::pair<Value*, const Argument&>(input(input_i), arg);
+      if (input_i < inputs().size()) {
+        return std::pair<Value*, const Argument&>(input(input_i), arg);
+      } else {
+        JIT_ASSERT(arg.default_value);
+        return std::pair<Value*, const Argument&>(nullptr, arg);
+      }
     }
     input_i++;
   }
   throw std::runtime_error(std::string("Couldn't find an argument called ") + name.toQualString());
+}
+
+bool Node::matches(const char *signature_literal) {
+  return sig(signature_literal).matches(this);
 }
 
 void Node::findSchema() {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -400,6 +400,11 @@ public:
   at::optional<IValue> get(Symbol name);
   Value* getValue(Symbol name);
 
+  // Returns true if the value of input name is statically known
+  bool knows(Symbol name) {
+    return static_cast<bool>(get(name));
+  }
+
   // Graphs
 
   // Note [Topological invariant]
@@ -655,6 +660,14 @@ public:
   T* expect() {
     JIT_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", T::Kind.toDisplayString(), kind().toDisplayString());
     return static_cast<T*>(this);
+  }
+
+  // XXX: this function is meant to be used with string literals only!
+  bool matches(const char *signature_literal);
+
+  const FunctionSchema& schema() {
+    if (!schema_) findSchema();
+    return *schema_;
   }
 
   virtual ~Node() {}

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -398,10 +398,10 @@ public:
   template<typename T>
   at::optional<T> get(Symbol name);
   at::optional<IValue> get(Symbol name);
-  Value* getValue(Symbol name);
+  Value* input(Symbol name);
 
   // Returns true if the value of input name is statically known
-  bool knows(Symbol name) {
+  bool is_constant(Symbol name) {
     return static_cast<bool>(get(name));
   }
 
@@ -663,7 +663,7 @@ public:
   }
 
   // XXX: this function is meant to be used with string literals only!
-  bool matches(const char *signature_literal);
+  bool matches(const char *signature_literal, at::ArrayRef<Symbol> const_inputs={});
 
   const FunctionSchema& schema() {
     if (!schema_) findSchema();

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -32,11 +32,11 @@ struct Operator {
 
   FunctionSchema schema;
 
-  bool matchesNode(Node* n) const;
+  bool matches(Node* n) const;
   // Operators have different versions depending on if some inputs are encoded
   // as attributes or inputs. This function returns the right Operation function,
   // given a node encoded for one variant.
-  // Behavior is undefined if matchesNode(n) == false
+  // Behavior is undefined if matches(n) == false
   Operation selectVariant(Node* n) const {
     if(n->hasAttributes()) {
       JIT_ASSERT(op_const_attributes != nullptr);
@@ -55,12 +55,15 @@ std::shared_ptr<Operator> findOperatorFor(Node* node);
 const Operator& getOperatorFor(Node* node);
 
 inline Operation getOperation(Node* node) {
-  // note: getOperatorFor ensures that getOperatorFor(node).matchesNode(node) == true
+  // note: getOperatorFor ensures that getOperatorFor(node).matches(node) == true
   // so the call to selectVariant is always valid.
   return getOperatorFor(node).selectVariant(node);
 }
 
 void registerOperator(Operator&& op);
+
+// XXX: this function is meant to be used with string literals only!
+Operator& sig(const char *signature_literal);
 
 struct RegisterOperators {
   RegisterOperators(std::vector<Operator> operators) {

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -16,67 +16,59 @@ namespace torch { namespace jit {
 // TODO: Decide what kind of fixed point strategy we will have
 void PeepholeOptimize(Block * block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end(); ++it) {
-    auto* n = *it;
+    auto* node = *it;
 
-    for (Block * sub_block : n->blocks()) {
+    for (Block * sub_block : node->blocks()) {
         PeepholeOptimize(sub_block);
     }
 
     // XXX: remember that if you want to simplify an expression by combining multiple nodes
     // into a different one, then you need to check that they all belong to the given block
-    switch (n->kind()) {
-      case aten::expand: {
-        // Eliminate redundant expand
-        if (!n->input()->isTensor()) break;
-        // the sizes are dynamic
-        if(n->inputs().size() != 1) break;
-        if (n->get<std::vector<int64_t>>(attr::size) == n->input()->type()->expect<TensorType>()->sizes()) {
-          n->output()->replaceAllUsesWith(n->input());
-          // Let DCE clean up any unused nodes at this point
+    if (node->matches("aten::expand(Tensor self, int[] size, *, int implicit) -> Tensor") &&
+        node->knows(attr::size)) {
+      // x.expand(x.size()) == x
+      if (auto input_type = node->getValue(attr::self)->type()->cast<TensorType>()) {
+        auto expanded_sizes = node->get<std::vector<int64_t>>(attr::size);
+        if (expanded_sizes == input_type->sizes()) {
+          node->output()->replaceAllUsesWith(node->input());
         }
-      } break;
-      case aten::t: {
-        // x.t().t() == x
-        auto input_node = n->input()->node();
-        if (input_node->kind() == aten::t)  {
-          n->output()->replaceAllUsesWith(input_node->input());
-          // Let DCE clean up any unused nodes at this point
-        }
-      } break;
-      case aten::type_as: {
-        JIT_ASSERT(n->inputs().size() == 2);
-        Value *lhs = n->input(0);
-        Value *rhs = n->input(1);
-        // If LHS and RHS have the same static type, remove the type_as operator.
-        if (lhs->type()->kind() == TypeKind::TensorType &&
-            rhs->type()->kind() == TypeKind::TensorType) {
-           auto ltype = (*lhs->type()).cast<TensorType>();
-           auto rtype = (*rhs->type()).cast<TensorType>();
-           if(ltype->device() == rtype->device() &&
-              ltype->scalarType() == rtype->scalarType()) {
-              n->output()->replaceAllUsesWith(lhs);
-           }
-        }
-      } break;
-      case aten::add: {
-        // mm + add == addmm
-        if (n->inputs().size() == 2 &&
-            n->get<at::Tensor>(attr::alpha) &&
-            tensor_as<double>(*n->get<at::Tensor>(attr::alpha)) == 1. &&
-            n->input(1)->node()->kind() == aten::mm) {
-          WithInsertPoint guard(n);
+      }
+    } else if (node->matches("aten::t(Tensor self) -> Tensor")) {
+      // x.t().t() == x
+      Node *input_node = node->input()->node();
+      if (input_node->matches("aten::t(Tensor self) -> Tensor")) {
+        node->output()->replaceAllUsesWith(input_node->input());
+      }
+    } else if (node->matches("aten::type_as(Tensor self, Tensor other) -> Tensor")) {
+      // x.type_as(y) == x iff x.type() == y.type()
+      auto self_type = node->input(0)->type()->cast<TensorType>();
+      auto other_type = node->input(1)->type()->cast<TensorType>();
+      if (self_type && other_type &&
+          self_type->scalarType() == other_type->scalarType() &&
+          self_type->device() == other_type->device()) {
+        node->output()->replaceAllUsesWith(node->input(0));
+      }
+    } else if (node->matches("aten::add(Tensor self, Tensor other, *, Scalar alpha) -> Tensor") &&
+               node->knows(attr::alpha)) {
+      // z + x.mm(y) == z.addmm(x, y) == x.mm(y) + z
+      if (tensor_as<double>(node->get<at::Tensor>(attr::alpha).value()) == 1.) {
+        // Look for mm from both sides of the add
+        for (size_t mm_side = 0; mm_side < 2; mm_side++) {
+          if (node->input(mm_side)->node()->matches("aten::mm(Tensor self, Tensor mat2) -> Tensor")) {
+            WithInsertPoint guard(node);
 
-          auto input_node = n->input(1)->node();
-          SymbolicVariable mat(n->input(0));
-          SymbolicVariable mat1(input_node->input(0));
-          SymbolicVariable mat2(input_node->input(1));
-          SymbolicVariable addmm_value = mat.addmm(mat1, mat2);
+            auto mm_node = node->input(mm_side)->node();
+            SymbolicVariable add_mat(node->input(1 - mm_side));
+            SymbolicVariable mat1(mm_node->input(0));
+            SymbolicVariable mat2(mm_node->input(1));
+            SymbolicVariable addmm_value = add_mat.addmm(mat1, mat2);
 
-          // Copy shape information from output node
-          ((Value*)addmm_value)->copyMetadata(n->output());
-          n->output()->replaceAllUsesWith(addmm_value);
+            // Copy shape information from output node
+            ((Value*)addmm_value)->copyMetadata(node->output());
+            node->output()->replaceAllUsesWith(addmm_value);
+          }
         }
-      } break;
+      }
     }
   }
 }


### PR DESCRIPTION
**REVIEW LAST COMMIT ONLY**

As discussed in our yesterday's meeting. Nodes can be now matched to particular overloads using the `matches(...)` function:
```cpp
n->matches("aten::type_as(Tensor self, Tensor other) -> Tensor")
```

This also changes the shape prop and peephole passes to use those functions for matching. This fixes a few bugs, makes them much more robust, and prepares us for removal of attributes.

@zdevito 