### PR TITLE
Modify barrier net to allow better control over its initialization and execution in DPM/EDPM

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -723,8 +723,14 @@ def _AddBarrierToModelNets(model, barrier_net_timeout_sec):
         # (_DEFAULT_TIMEOUT_SEC).
         # We pass in model.param_init_net so that the barrier net can be run as
         # part of the param_init_net.
-        model._barrier_net = _CreateBarrierNet(model, model.param_init_net,
-                "pre_training", barrier_net_timeout_sec)
+
+        model._barrier_init_net = core.Net("barrier_init_net")
+
+        model._barrier_net = _CreateBarrierNet(model, model._barrier_init_net,
+        "pre_training", barrier_net_timeout_sec)
+
+        model._data_parallel_model_init_nets.insert(0, model._barrier_init_net)
+
         model._data_parallel_model_nets.insert(0, model._barrier_net)
 
 

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -687,15 +687,18 @@ def Parallelize_BMUF(
     ]
     _AddBarrierToModelNets(model_helper_obj, barrier_net_timeout_sec)
 
+def CreateNet(model, overwrite=False):
+    for net_iters in model._data_parallel_model_nets:
+        if isinstance(net_iters, tuple):
+            workspace.CreateNet(net_iters[0], overwrite=overwrite)
+        else:
+            workspace.CreateNet(net_iters, overwrite=overwrite)
+
 
 def RunInitNet(model):
     for init_net in model._data_parallel_model_init_nets:
         workspace.RunNetOnce(init_net)
-    for net_iters in model._data_parallel_model_nets:
-        if isinstance(net_iters, tuple):
-            workspace.CreateNet(net_iters[0])
-        else:
-            workspace.CreateNet(net_iters)
+    CreateNet(model)
 
 
 def RunWarmup(model):


### PR DESCRIPTION
Summary: In data_parallel_model, we isolate synchronizing barrier init net into its own from the param_init_net, so that we could have finer granularity of control over the barrier net.

Differential Revision: D8765059
