### PR TITLE
Fix ONNX LogSoftmax export.

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -599,6 +599,12 @@ def le(g, input, other):
 
 @parse_args('v', 'i')
 def log_softmax(g, input, dim=None):
+    # PyTorch dim and ONNX axis have different meanings.
+    # See Softmax comment for details.
+    if dim < 0:
+        dim = len(input.type().sizes()) + dim
+    if len(input.type().sizes()) != dim + 1:
+        return _unimplemented("dim", "ONNX and PyTorch use different strategies to split the input.")
     return g.op("LogSoftmax", input, axis_i=dim)
 
 


### PR DESCRIPTION
This fixes an issue with incorrect `axis=-1` in the exported ONNX.