### PR TITLE
Hide all other fields in THTensor

### DIFF
--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -8,7 +8,7 @@ IntList ${Tensor}::strides() const {
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
   AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
-  return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storage_offset())));
+  return Scalar(${to_at_type}(${THStorage}_get(${state,} THTensor_getStoragePtr(tensor), tensor->storage_offset())));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {
   auto storage = ${THTensor}_storage(${state,}tensor);

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -8,7 +8,7 @@ IntList ${Tensor}::strides() const {
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
   AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
-  return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storageOffset)));
+  return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storage_offset())));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {
   auto storage = ${THTensor}_storage(${state,}tensor);

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -22,8 +22,9 @@ ${Tensor}::${Tensor}(Context* context, ${THTensor} * tensor)
 : TensorImpl(&context->getType(Backend::${Backend},ScalarType::${ScalarName})),
   tensor(tensor),
   context(context) {}
+
 ${Tensor}::~${Tensor}() {
-  ${THTensor}_free(${state,} tensor);
+  tensor->release();
 }
 
 const char * ${Tensor}::toString() const {
@@ -46,13 +47,14 @@ const char * ${Tensor}::typeString() {
   return "${Type}";
 }
 void * ${Tensor}::unsafeGetTH(bool retain) {
-  if (retain)
-      ${THTensor}_retain(${state,} tensor);
+  if (retain) {
+    tensor->retain();
+  }
   return tensor;
 }
 
 void ${Tensor}::release_resources() {
-  ${THTensor}_free(${state,} tensor);
+  tensor->release();
   tensor = nullptr;
 }
 

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -24,7 +24,7 @@ ${Tensor}::${Tensor}(Context* context, ${THTensor} * tensor)
   context(context) {}
 
 ${Tensor}::~${Tensor}() {
-  tensor->release();
+  if (tensor) tensor->release();
 }
 
 const char * ${Tensor}::toString() const {

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -40,13 +40,8 @@
 
 void THTensor_free(THTensor *self)
 {
-  if(!self)
-    return;
-
-  if(--self->refcount == 0)
-  {
-    delete self;
-  }
+  if (!self) return;
+  self->release();
 }
 
 // On a high level,

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -6,6 +6,11 @@
 
 #define THTensor_(NAME)   TH_CONCAT_4(TH,Real,Tensor_,NAME)
 
+#ifdef __cplusplus
+struct THTensor;
+THStorage* THTensor_getStoragePtr(const THTensor* tensor);
+#endif
+
 /* basics */
 #include "generic/THTensor.h"
 #include "THGenerateAllTypes.h"

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -12,9 +12,9 @@
 struct THTensor
 {
     THTensor(THStorage* storage)
-      : refcount(1)
-      , storage(storage)
-      , storageOffset(0)
+      : refcount_(1)
+      , storage_(storage)
+      , storage_offset_(0)
       , sizes_{0}
       , strides_{1}
       , dim_(1)
@@ -26,12 +26,12 @@ struct THTensor
       }
     }
 
-    std::atomic<int> refcount;
+    std::atomic<int> refcount_;
 
     // Note: storage->size may be greater than the recorded size
     // of a tensor
-    THStorage *storage;
-    ptrdiff_t storageOffset;
+    THStorage *storage_;
+    ptrdiff_t storage_offset_;
 
     std::vector<int64_t> sizes_;
     std::vector<int64_t> strides_;
@@ -39,12 +39,12 @@ struct THTensor
 
     template <typename T>
     inline T * data() const {
-      return storage->data<T>() + storageOffset;
+      return storage->data<T>() + storage_offset_;
     }
 
     template <typename T>
     inline T * unsafe_data() const {
-      return storage->unsafe_data<T>() + storageOffset;
+      return storage->unsafe_data<T>() + storage_offset_;
     }
 
     // [NOTE: _dim() vs dim()]
@@ -56,6 +56,10 @@ struct THTensor
 
     inline int64_t dim() const {
       return dim_;
+    }
+
+    ptrdiff_t storage_offset() const {
+      return storage_offset_;
     }
 
     // represents that numel() == 0.
@@ -84,6 +88,16 @@ struct THTensor
 
     inline at::IntList strides() {
       return strides_;
+    }
+
+    void retain() {
+      ++refcount_;
+    }
+
+    void release() {
+      if(--refcount_ == 0) {
+        delete this;
+      }
     }
 };
 
@@ -118,6 +132,15 @@ inline void THTensor_setSizeAtDim(THTensor* tensor, int dim, int64_t new_size) {
 
 inline void THTensor_setStrideAtDim(THTensor* tensor, int dim, int64_t new_stride) {
   tensor->strides_[dim] = new_stride;
+}
+
+inline void THTensor_setStorageOffset(THTensor* tensor, ptrdiff_t storage_offset) {
+  tensor->storage_offset_ = storage_offset;
+}
+
+// NB: Non-retaining
+inline THStorage* THTensor_getStoragePtr(THTensor* tensor) {
+  return tensor->storage_;
 }
 
 TH_API void THTensor_free(THTensor *self);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -143,6 +143,11 @@ inline THStorage* THTensor_getStoragePtr(THTensor* tensor) {
   return tensor->storage_;
 }
 
+// NB: Steals ownership of storage
+inline void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
+  tensor->storage_ = storage;
+}
+
 TH_API void THTensor_free(THTensor *self);
 at::optional<std::vector<int64_t>> THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride,
                                                            at::IntList newshape);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -21,8 +21,8 @@ struct THTensor
       {}
 
     ~THTensor() {
-      if (storage) {
-        THStorage_free(storage);
+      if (storage_) {
+        THStorage_free(storage_);
       }
     }
 
@@ -39,12 +39,12 @@ struct THTensor
 
     template <typename T>
     inline T * data() const {
-      return storage->data<T>() + storage_offset_;
+      return storage_->data<T>() + storage_offset_;
     }
 
     template <typename T>
     inline T * unsafe_data() const {
-      return storage->unsafe_data<T>() + storage_offset_;
+      return storage_->unsafe_data<T>() + storage_offset_;
     }
 
     // [NOTE: _dim() vs dim()]
@@ -139,7 +139,7 @@ inline void THTensor_setStorageOffset(THTensor* tensor, ptrdiff_t storage_offset
 }
 
 // NB: Non-retaining
-inline THStorage* THTensor_getStoragePtr(THTensor* tensor) {
+inline THStorage* THTensor_getStoragePtr(const THTensor* tensor) {
   return tensor->storage_;
 }
 

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -43,7 +43,7 @@
     TH_TENSOR_APPLY_hasFinished = 1; \
   else \
   { \
-    TENSOR##_data = TENSOR->storage->data<TYPE>()+TENSOR->storageOffset; \
+    TENSOR##_data = TENSOR->storage->data<TYPE>()+TENSOR->storage_offset(); \
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
     for(TENSOR##_i = TENSOR->_dim()-1; TENSOR##_i >= 0; TENSOR##_i--) { \
@@ -321,7 +321,7 @@
   ptrdiff_t TENSOR##Size = THTensor_(nElement)(TENSOR);                     \
   if(TENSOR##Contg){                                                        \
     ptrdiff_t iter = 0;                                                     \
-    TYPE *rp = TENSOR->storage->data<TYPE>()+TENSOR->storageOffset;         \
+    TYPE *rp = TENSOR->storage->data<TYPE>()+TENSOR->storage_offset();         \
     PRAGMA( omp parallel for if (TENSOR##Size > OMP_THRESHOLD * 10) firstprivate(rp) reduction(OPERATION) ) \
     for (iter = 0; iter < TENSOR##Size; iter++) { \
       TYPE *TENSOR##_data = rp+iter;                    \
@@ -365,8 +365,8 @@
 {                                                                                              \
   /* for advanced searching index*/                                                            \
   if( CONTIG1 && CONTIG2 ){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storageOffset;                        \
-    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storageOffset;                        \
+    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storage_offset();                        \
+    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storage_offset();                        \
     ptrdiff_t iter = 0;                                                                        \
     if(tp != (TYPE2*)rp) {                                                                             \
       PRAGMA(ivdep) \
@@ -444,9 +444,9 @@
 {                                                                             \
   /* for adveanced searching index*/                                                                    \
   if(CONTIG1 && CONTIG2 && CONTIG3){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storageOffset;                                 \
-    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storageOffset;                                 \
-    TYPE3 *srcp = TENSOR3->storage->data<TYPE3>()+TENSOR3->storageOffset;                               \
+    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storage_offset();                                 \
+    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storage_offset();                                 \
+    TYPE3 *srcp = TENSOR3->storage->data<TYPE3>()+TENSOR3->storage_offset();                               \
     ptrdiff_t iter = 0;\
     if(tp != (TYPE2*)rp) {                                                                             \
       PRAGMA(ivdep) \

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -43,7 +43,7 @@
     TH_TENSOR_APPLY_hasFinished = 1; \
   else \
   { \
-    TENSOR##_data = TENSOR->storage->data<TYPE>()+TENSOR->storage_offset(); \
+    TENSOR##_data = THTensor_getStoragePtr(TENSOR)->data<TYPE>()+TENSOR->storage_offset(); \
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
     for(TENSOR##_i = TENSOR->_dim()-1; TENSOR##_i >= 0; TENSOR##_i--) { \
@@ -321,7 +321,7 @@
   ptrdiff_t TENSOR##Size = THTensor_(nElement)(TENSOR);                     \
   if(TENSOR##Contg){                                                        \
     ptrdiff_t iter = 0;                                                     \
-    TYPE *rp = TENSOR->storage->data<TYPE>()+TENSOR->storage_offset();         \
+    TYPE *rp = THTensor_getStoragePtr(TENSOR)->data<TYPE>()+TENSOR->storage_offset();         \
     PRAGMA( omp parallel for if (TENSOR##Size > OMP_THRESHOLD * 10) firstprivate(rp) reduction(OPERATION) ) \
     for (iter = 0; iter < TENSOR##Size; iter++) { \
       TYPE *TENSOR##_data = rp+iter;                    \
@@ -365,8 +365,8 @@
 {                                                                                              \
   /* for advanced searching index*/                                                            \
   if( CONTIG1 && CONTIG2 ){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storage_offset();                        \
-    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storage_offset();                        \
+    TYPE1 *rp = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+TENSOR1->storage_offset();                        \
+    TYPE2 *tp = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+TENSOR2->storage_offset();                        \
     ptrdiff_t iter = 0;                                                                        \
     if(tp != (TYPE2*)rp) {                                                                             \
       PRAGMA(ivdep) \
@@ -444,9 +444,9 @@
 {                                                                             \
   /* for adveanced searching index*/                                                                    \
   if(CONTIG1 && CONTIG2 && CONTIG3){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storage_offset();                                 \
-    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storage_offset();                                 \
-    TYPE3 *srcp = TENSOR3->storage->data<TYPE3>()+TENSOR3->storage_offset();                               \
+    TYPE1 *rp = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+TENSOR1->storage_offset();                                 \
+    TYPE2 *tp = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+TENSOR2->storage_offset();                                 \
+    TYPE3 *srcp = THTensor_getStoragePtr(TENSOR3)->data<TYPE3>()+TENSOR3->storage_offset();                               \
     ptrdiff_t iter = 0;\
     if(tp != (TYPE2*)rp) {                                                                             \
       PRAGMA(ivdep) \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -60,15 +60,15 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storage_offset(); \
+  TENSOR1##_data = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+(TENSOR1)->storage_offset(); \
   TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storage_offset(); \
+  TENSOR2##_data = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+(TENSOR2)->storage_offset(); \
   TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
-  TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storage_offset(); \
+  TENSOR3##_data = THTensor_getStoragePtr(TENSOR3)->data<TYPE3>()+(TENSOR3)->storage_offset(); \
   TENSOR3##_stride = (TENSOR3)->stride(DIMENSION); \
   TENSOR3##_size = TENSOR3->size(DIMENSION); \
 \
@@ -167,11 +167,11 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storage_offset(); \
+  TENSOR1##_data = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+(TENSOR1)->storage_offset(); \
   TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storage_offset(); \
+  TENSOR2##_data = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+(TENSOR2)->storage_offset(); \
   TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
@@ -269,7 +269,7 @@
   if( (DIMENSION < 0) || (DIMENSION >= TENSOR->_dim()) ) \
     THError("invalid dimension"); \
 \
-  TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storage_offset(); \
+  TENSOR##_data = THTensor_getStoragePtr(TENSOR)->data<TYPE>()+(TENSOR)->storage_offset(); \
   TENSOR##_stride = (TENSOR)->stride(DIMENSION); \
   TENSOR##_size = TENSOR->size(DIMENSION); \
   /* Counter stores the indices into the Tensor at any time */ \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -60,15 +60,15 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
+  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storage_offset(); \
   TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
+  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storage_offset(); \
   TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
-  TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storageOffset; \
+  TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storage_offset(); \
   TENSOR3##_stride = (TENSOR3)->stride(DIMENSION); \
   TENSOR3##_size = TENSOR3->size(DIMENSION); \
 \
@@ -167,11 +167,11 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->dim(); TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
+  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storage_offset(); \
   TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
   TENSOR1##_size = TENSOR1->size(DIMENSION); \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
+  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storage_offset(); \
   TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
   TENSOR2##_size = TENSOR2->size(DIMENSION); \
 \
@@ -269,7 +269,7 @@
   if( (DIMENSION < 0) || (DIMENSION >= TENSOR->_dim()) ) \
     THError("invalid dimension"); \
 \
-  TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storageOffset; \
+  TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storage_offset(); \
   TENSOR##_stride = (TENSOR)->stride(DIMENSION); \
   TENSOR##_size = TENSOR->size(DIMENSION); \
   /* Counter stores the indices into the Tensor at any time */ \

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -873,11 +873,4 @@ THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
   return buf;
 }
 
-THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
-  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
-  THDescBuff buf = THLongStorage_sizeDesc(size);
-  THLongStorage_free(size);
-  return buf;
-}
-
 #endif

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -698,7 +698,6 @@ void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t stora
 
     if(storage)
     {
-      THTensor_setStoragePtrSteal();
       THTensor_stealAndSetStoragePtr(self, storage);
       THStorage_(retain)(THTensor_getStoragePtr(self));
     }

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -876,4 +876,11 @@ THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
   return buf;
 }
 
+THDescBuff THTensor_(sizeDesc)(const THTensor *tensor) {
+  THLongStorage *size = THTensor_(newSizeOf)((THTensor*)tensor);
+  THDescBuff buf = THLongStorage_sizeDesc(size);
+  THLongStorage_free(size);
+  return buf;
+}
+
 #endif

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -293,8 +293,8 @@ void THTensor_(set)(THTensor *self, THTensor *src)
 {
   if(self != src)
     THTensor_(setStorageNd)(self,
-                            src->storage,
-                            src->storageOffset,
+                            THTensor_getStoragePtr(src),
+                            src->storage_offset(),
                             src->dim(),
                             THTensor_getSizePtr(src),
                             THTensor_getStridePtr(src));
@@ -382,8 +382,9 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, int64_t fir
 
   THTensor_(set)(self, src);
 
-  if(firstIndex > 0)
-    self->storageOffset += firstIndex*self->stride(dimension);
+  if (firstIndex > 0) {
+    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*self->stride(dimension));
+  }
 
   THTensor_setSizeAtDim(self, dimension, size);
 }
@@ -636,10 +637,10 @@ int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor* src)
 
 int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
 {
-  if (!self->storage)
+  if (!THTensor_getStoragePtr(self))
     return 0;
-  if (self->storage == src->storage &&
-      self->storageOffset == src->storageOffset &&
+  if (THTensor_getStoragePtr(self) == THTensor_getStoragePtr(src) &&
+      self->storage_offset() == src->storage_offset() &&
       self->_dim() == src->_dim())
   {
     int d;
@@ -690,18 +691,19 @@ void THTensor_(freeCopyTo)(THTensor *self, THTensor *dst)
 void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)
 {
   /* storage */
-  if(self->storage != storage)
+  if(THTensor_getStoragePtr(self) != storage)
   {
-    if(self->storage)
-      THStorage_(free)(self->storage);
+    if(THTensor_getStoragePtr(self))
+      THStorage_(free)(THTensor_getStoragePtr(self));
 
     if(storage)
     {
-      self->storage = storage;
-      THStorage_(retain)(self->storage);
+      THTensor_setStoragePtrSteal();
+      THTensor_stealAndSetStoragePtr(self, storage);
+      THStorage_(retain)(THTensor_getStoragePtr(self));
     }
     else
-      self->storage = THStorage_(new)();
+      THTensor_stealAndSetStoragePtr(self, THStorage_(new)());
   }
 
   /* storageOffset */
@@ -776,13 +778,13 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
     totalSize += (self->size(d)-1)*self->stride(d);
   }
 
-  if(totalSize+self->storageOffset > 0)
+  if(totalSize+self->storage_offset() > 0)
   {
-    if(!self->storage) {
-      self->storage = THStorage_(new)();
+    if(!THTensor_getStoragePtr(self)) {
+      THTensor_stealAndSetStoragePtr(self, THStorage_(new)());
     }
-    if(totalSize+self->storageOffset > self->storage->size) {
-      THStorage_(resize)(self->storage, totalSize+self->storageOffset);
+    if(totalSize+self->storage_offset() > THTensor_getStoragePtr(self)->size) {
+      THStorage_(resize)(THTensor_getStoragePtr(self), totalSize+self->storage_offset());
     }
   }
 }
@@ -791,56 +793,56 @@ void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)
 {
   THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0), value);
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0), value);
 }
 
 real THTensor_(get1d)(const THTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->_dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0));
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0));
 }
 
 void THTensor_(set2d)(THTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1), value);
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
 }
 
 real THTensor_(get2d)(const THTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->_dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1));
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
 }
 
 void THTensor_(set3d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
 }
 
 real THTensor_(get3d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->_dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
 }
 
 void THTensor_(set4d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
 }
 
 real THTensor_(get4d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->_dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THStorage_(get)(tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
 }
 
 THDescBuff THTensor_(desc)(const THTensor *tensor) {

--- a/aten/src/TH/generic/THTensorFastGetSet.hpp
+++ b/aten/src/TH/generic/THTensorFastGetSet.hpp
@@ -3,43 +3,43 @@
 #else
 
 static inline real THTensor_(fastGet1d)(THTensor *self, int64_t x0) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)];
+  return (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)];
 }
 
 static inline real THTensor_(fastGet2d)(THTensor *self, int64_t x0, int64_t x1) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)];
+  return (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)];
 }
 
 static inline real THTensor_(fastGet3d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)];
+  return (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)];
 }
 
 static inline real THTensor_(fastGet4d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)];
+  return (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)];
 }
 
 static inline real THTensor_(fastGet5d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, int64_t x4) {
-  return (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)];
+  return (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)];
 }
 
 static inline void THTensor_(fastSet1d)(THTensor *self, int64_t x0, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)] = value;
+  (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)] = value;
 }
 
 static inline void THTensor_(fastSet2d)(THTensor *self, int64_t x0, int64_t x1, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)] = value;
+  (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)] = value;
 }
 
 static inline void THTensor_(fastSet3d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)] = value;
+  (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)] = value;
 }
 
 static inline void THTensor_(fastSet4d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)] = value;
+  (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)] = value;
 }
 
 static inline void THTensor_(fastSet5d)(THTensor *self, int64_t x0, int64_t x1, int64_t x2, int64_t x3, int64_t x4, real value) {
-  (THStorage_(data)(self->storage)+self->storageOffset)[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)] = value;
+  (THStorage_(data)(THTensor_getStoragePtr(self))+self->storage_offset())[(x0)*self->stride(0)+(x1)*self->stride(1)+(x2)*self->stride(2)+(x3)*self->stride(3)+(x4)*self->stride(4)] = value;
 }
 
 #endif

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -118,7 +118,7 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
       "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
+    b = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(b), b->storage_offset(), b->size(0),
             b->stride(0), 1, 0);
     free_b = 1;
   }
@@ -171,7 +171,7 @@ void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,
       "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
+    b = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(b), b->storage_offset(), b->size(0),
             b->stride(0), 1, 0);
     free_b = 1;
   }
@@ -221,7 +221,7 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
       "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
+    b = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(b), b->storage_offset(), b->size(0),
             b->stride(0), 1, 0);
     free_b = 1;
   }
@@ -644,7 +644,7 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
       "rows, B has %ld", a->size(0), b->size(0));
 
   if (b->_dim() == 1) {
-    b = THTensor_(newWithStorage2d)(b->storage, b->storageOffset, b->size(0),
+    b = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(b), b->storage_offset(), b->size(0),
             b->stride(0), 1, 0);
     free_b = 1;
   }

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -3674,12 +3674,12 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   // Second path for non-contiguous
   int64_t offset;
   if (dimension == 0 && allContiguous) {
-    real* result_data = THStorage_(data)(result->storage) + result->storageOffset;
+    real* result_data = THStorage_(data)(THTensor_getStoragePtr(result)) + result->storage_offset();
     offset = 0;
     for (int j = 0; j < numInputs; j++) {
       if (!should_skip(inputs[j])) {
         THTensor* input0 = inputs[j];
-        real* input0_data = THStorage_(data)(input0->storage) + input0->storageOffset;
+        real* input0_data = THStorage_(data)(THTensor_getStoragePtr(input0)) + input0->storage_offset();
         int64_t input0_size = THTensor_(nElement)(input0);
         // C standard says you can't pass nullptrs to memcpy, even if the size is 0; ubsan checks this.
         if (input0_size != 0) {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -148,13 +148,13 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
     totalSize += (self->size(d)-1)*self->stride(d);
   }
 
-  if(totalSize+self->storageOffset > 0)
+  if(totalSize+self->storage_offset() > 0)
   {
     if(!self->storage) {
       THError("Tensor: invalid null storage");
     }
-    if(totalSize+self->storageOffset > self->storage->size) {
-      THCStorage_resize(state, self->storage, totalSize+self->storageOffset);
+    if(totalSize+self->storage_offset() > self->storage->size) {
+      THCStorage_resize(state, self->storage, totalSize+self->storage_offset());
     }
   }
 }
@@ -165,7 +165,7 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
     THCTensor_setStorageNd(state,
                            self,
                            src->storage,
-                           src->storageOffset,
+                           src->storage_offset(),
                            src->dim(),
                            THTensor_getSizePtr(src),
                            THTensor_getStridePtr(src));
@@ -192,9 +192,10 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
   }
 
   /* storageOffset */
-  if(storageOffset < 0)
+  if (storageOffset < 0) {
     THError("Tensor: invalid storage offset");
-  self->storageOffset = storageOffset;
+  }
+  THTensor_setStorageOffset(self, storageOffset);
 
   /* size and stride */
   THCTensor_resizeNd(state, self, nDimension, size, stride);

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -153,7 +153,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
     if(!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
-    if(totalSize+self->storage_offset() > self->storage->size) {
+    if(totalSize+self->storage_offset() > THTensor_getStoragePtr(self)->size) {
       THCStorage_resize(state, self->storage, totalSize+self->storage_offset());
     }
   }
@@ -179,7 +179,7 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
     if (!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
-    auto scalar_type = self->storage->scalar_type;
+    auto scalar_type = THTensor_getStoragePtr(self)->scalar_type;
     THStorage_free(THTensor_getStoragePtr(self));
 
     if(storage)

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -150,7 +150,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_
 
   if(totalSize+self->storage_offset() > 0)
   {
-    if(!self->storage) {
+    if(!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
     if(totalSize+self->storage_offset() > self->storage->size) {
@@ -176,16 +176,16 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
   /* storage */
   if(self->storage != storage)
   {
-    if (!self->storage) {
+    if (!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
     auto scalar_type = self->storage->scalar_type;
-    THStorage_free(self->storage);
+    THStorage_free(THTensor_getStoragePtr(self));
 
     if(storage)
     {
       self->storage = storage;
-      THStorage_retain(self->storage);
+      THStorage_retain(THTensor_getStoragePtr(self));
     }
     else
       self->storage = THCStorage_new(state, scalar_type);
@@ -304,8 +304,8 @@ void THCTensor_free(THCState *state, THCTensor *self) {
 }
 
 int THCTensor_getDevice(THCState* state, const THCTensor* tensor) {
-  if (!tensor->storage) return -1;
-  return THCStorage_getDevice(state, tensor->storage);
+  if (!THTensor_getStoragePtr(tensor)) return -1;
+  return THCStorage_getDevice(state, THTensor_getStoragePtr(tensor));
 }
 
 bool THCTensor_allSameDevice(THCState* state, THCTensor ** inputs, int numInputs) {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -294,9 +294,8 @@ ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self) {
 }
 
 void THCTensor_retain(THCState *state, THCTensor *self) {
-  self->refcount++;
+  self->retain();
 }
-
 
 void THCTensor_free(THCState *state, THCTensor *self) {
   THTensor_free(self);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -377,7 +377,7 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
   THCTensor_(set)(state, self, src);
 
   if (firstIndex > 0) {
-    THTensor_setStorageOffset(self, firstIndex*self->stride(dimension));
+    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*self->stride(dimension));
   }
 
   THTensor_setSizeAtDim(self, dimension, size);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -47,8 +47,8 @@ THLongStorage *THCTensor_(newStrideOf)(THCState *state, THCTensor *self)
 
 real *THCTensor_(data)(THCState *state, const THCTensor *self)
 {
-  if(self->storage)
-    return (THCStorage_(data)(state, self->storage)+self->storage_offset());
+  if(THTensor_getStoragePtr(self))
+    return (THCStorage_(data)(state, THTensor_getStoragePtr(self))+self->storage_offset());
   else
     return NULL;
 }

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -10,7 +10,7 @@ THCStorage *THCTensor_(storage)(THCState *state, const THCTensor *self)
 
 ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *self)
 {
-  return self->storageOffset;
+  return self->storage_offset();
 }
 
 int THCTensor_(nDimension)(THCState *state, const THCTensor *self)
@@ -48,7 +48,7 @@ THLongStorage *THCTensor_(newStrideOf)(THCState *state, THCTensor *self)
 real *THCTensor_(data)(THCState *state, const THCTensor *self)
 {
   if(self->storage)
-    return (THCStorage_(data)(state, self->storage)+self->storageOffset);
+    return (THCStorage_(data)(state, self->storage)+self->storage_offset());
   else
     return NULL;
 }
@@ -68,7 +68,7 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
   THCTensor_(setStorageNd)(state,
                            self,
                            tensor->storage,
-                           tensor->storageOffset,
+                           tensor->storage_offset(),
                            tensor->dim(),
                            THTensor_getSizePtr(tensor),
                            THTensor_getStridePtr(tensor));
@@ -227,7 +227,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   auto stride_value = *stride;
   THLongStorage *new_stride = THLongStorage_newWithSize(stride_value.size());
   THLongStorage_rawCopy(new_stride, stride_value.data());
-  THCTensor_(setStorage)(state, self, tensor->storage, tensor->storageOffset, inferred_size, new_stride);
+  THCTensor_(setStorage)(state, self, tensor->storage, tensor->storage_offset(), inferred_size, new_stride);
   THLongStorage_free(inferred_size);
   THLongStorage_free(new_stride);
   return self;
@@ -376,8 +376,9 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
 
   THCTensor_(set)(state, self, src);
 
-  if(firstIndex > 0)
-    self->storageOffset += firstIndex*self->stride(dimension);
+  if (firstIndex > 0) {
+    THTensor_setStorageOffset(self, firstIndex*self->stride(dimension));
+  }
 
   THTensor_setSizeAtDim(self, dimension, size);
 }
@@ -538,7 +539,7 @@ int THCTensor_(isSize)(THCState *state, const THCTensor *self, const THLongStora
 int THCTensor_(isSetTo)(THCState *state, const THCTensor *self, const THCTensor *src)
 {
   if (self->storage == src->storage &&
-      self->storageOffset == src->storageOffset &&
+      self->storage_offset() == src->storage_offset() &&
       self->dim() == src->dim())
   {
     int d;
@@ -604,56 +605,56 @@ void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real valu
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0), value);
+  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0), value);
 }
 
 real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0));
+  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0));
 }
 
 void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1), value);
+  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
 }
 
 real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1));
+  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
 }
 
 void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
+  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
 }
 
 real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
+  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
 }
 
 void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
+  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
 }
 
 real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
+  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
 }
 
 int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...)

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -5,7 +5,7 @@
 /**** access methods ****/
 THCStorage *THCTensor_(storage)(THCState *state, const THCTensor *self)
 {
-  return self->storage;
+  return THTensor_getStoragePtr(self);
 }
 
 ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *self)
@@ -67,7 +67,7 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
   THCTensor *self = new THCTensor(THCStorage_(new)(state));
   THCTensor_(setStorageNd)(state,
                            self,
-                           tensor->storage,
+                           THTensor_getStoragePtr(tensor),
                            tensor->storage_offset(),
                            tensor->dim(),
                            THTensor_getSizePtr(tensor),
@@ -227,7 +227,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   auto stride_value = *stride;
   THLongStorage *new_stride = THLongStorage_newWithSize(stride_value.size());
   THLongStorage_rawCopy(new_stride, stride_value.data());
-  THCTensor_(setStorage)(state, self, tensor->storage, tensor->storage_offset(), inferred_size, new_stride);
+  THCTensor_(setStorage)(state, self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, new_stride);
   THLongStorage_free(inferred_size);
   THLongStorage_free(new_stride);
   return self;
@@ -538,7 +538,7 @@ int THCTensor_(isSize)(THCState *state, const THCTensor *self, const THLongStora
 
 int THCTensor_(isSetTo)(THCState *state, const THCTensor *self, const THCTensor *src)
 {
-  if (self->storage == src->storage &&
+  if (THTensor_getStoragePtr(self) == THTensor_getStoragePtr(src) &&
       self->storage_offset() == src->storage_offset() &&
       self->dim() == src->dim())
   {
@@ -605,56 +605,56 @@ void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real valu
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0), value);
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0), value);
 }
 
 real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0));
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0));
 }
 
 void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
 }
 
 real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
 }
 
 void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
 }
 
 real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
 }
 
 void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THCStorage_(set)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
 }
 
 real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THCStorage_(get)(state, tensor->storage, tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
 }
 
 int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...)

--- a/aten/src/THC/generic/THCTensorCopy.cpp
+++ b/aten/src/THC/generic/THCTensorCopy.cpp
@@ -131,7 +131,7 @@ void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, struct THTensor 
                               cudaMemcpyHostToDevice,
                               THCStream_stream(stream)));
 
-  THCudaCheck(THCCachingHostAllocator_recordEvent(THStorage_(data)(src->storage), stream));
+  THCudaCheck(THCCachingHostAllocator_recordEvent(THStorage_(data)(THTensor_getStoragePtr(src)), stream));
 
   if (currentDevice != tensorDevice) {
     THCudaCheck(cudaSetDevice(currentDevice));
@@ -162,7 +162,7 @@ void THTensor_(copyAsyncCuda)(THCState *state, THTensor *self, struct THCTensor 
                               cudaMemcpyDeviceToHost,
                               THCStream_stream(stream)));
 
-  THCudaCheck(THCCachingHostAllocator_recordEvent(THCStorage_(data)(state, src->storage), stream));
+  THCudaCheck(THCCachingHostAllocator_recordEvent(THCStorage_(data)(state, THTensor_getStoragePtr(src)), stream));
 
   if (currentDevice != tensorDevice) {
     THCudaCheck(cudaSetDevice(currentDevice));

--- a/aten/src/THC/generic/THCTensorCopy.cu
+++ b/aten/src/THC/generic/THCTensorCopy.cu
@@ -10,7 +10,7 @@ THCTensor_(copy)(THCState* state, THCTensor* dst, THCTensor* src) {
 
 template <>
 THCTensor *THCTensor_newClone<real>(THCState *state, THCTensor *self) {
-  THCTensor *tensor = THCTensor_new(state, self->storage->scalar_type);
+  THCTensor *tensor = THCTensor_new(state, THTensor_getStoragePtr(self)->scalar_type);
   THCTensor_resizeAs(state, tensor, self);
   THC_copyTensor<real, real>(state, tensor, self);
   return tensor;

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -383,7 +383,7 @@ void THCTensor_(eye)(THCState *state, THCTensor *self_, int64_t n, int64_t m)
   int64_t stride = THCTensor_(stride)(state, self_, 0) +
                    THCTensor_(stride)(state, self_, 1);
 
-  THCTensor *diag = THCTensor_(newWithStorage1d)(state, self_->storage,
+  THCTensor *diag = THCTensor_(newWithStorage1d)(state, THTensor_getStoragePtr(self_),
       self_->storage_offset(),  sz, stride);
 
   THCTensor_(fill)(state, diag, ScalarConvert<int, real>::to(1));

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -384,7 +384,7 @@ void THCTensor_(eye)(THCState *state, THCTensor *self_, int64_t n, int64_t m)
                    THCTensor_(stride)(state, self_, 1);
 
   THCTensor *diag = THCTensor_(newWithStorage1d)(state, self_->storage,
-      self_->storageOffset,  sz, stride);
+      self_->storage_offset(),  sz, stride);
 
   THCTensor_(fill)(state, diag, ScalarConvert<int, real>::to(1));
   THCTensor_(free)(state, diag);

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -12,7 +12,7 @@ static void THCTensor_(copyArray1d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[1] = { 1 };
   THCTensor_(resizeNd)(state, self, 1, size, stride);
   size_t len = k * sizeof(real);
-  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src, int m, int n)
@@ -21,7 +21,7 @@ static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[2] = { 1, m };
   THCTensor_(resizeNd)(state, self, 2, size, stride);
   size_t len = m * n * sizeof(real);
-  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self)
@@ -30,7 +30,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
   size_t len = THCTensor_(nElement)(state, self)*sizeof(real);
   THCTensor *temp = THCTensor_(newTranspose)(state, self, 0, 1);
   THCTensor *selfc = THCTensor_(newContiguous)(state, temp);
-  THCudaCheck(cudaMemcpy(dst, THCStorage_(data)(state, selfc->storage) + selfc->storageOffset, len, cudaMemcpyDeviceToHost));
+  THCudaCheck(cudaMemcpy(dst, THCStorage_(data)(state, selfc->storage) + selfc->storage_offset(), len, cudaMemcpyDeviceToHost));
   THCTensor_(free)(state, temp);
   THCTensor_(free)(state, selfc);
 }
@@ -289,8 +289,8 @@ THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
   {
     THCTensor_(resize2d)(state, re_, 2, n);
     THCTensor *re = THCTensor_(newContiguous)(state, re_);
-    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storageOffset, wr, n*sizeof(real), cudaMemcpyHostToDevice));
-    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storageOffset + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storage_offset(), wr, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storage_offset() + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
     THCTensor_(freeCopyTo)(state, re, re_);
     THCTensor_(transpose)(state, re_, NULL, 0, 1);
   }

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -12,7 +12,7 @@ static void THCTensor_(copyArray1d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[1] = { 1 };
   THCTensor_(resizeNd)(state, self, 1, size, stride);
   size_t len = k * sizeof(real);
-  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, THTensor_getStoragePtr(self)) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src, int m, int n)
@@ -21,7 +21,7 @@ static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[2] = { 1, m };
   THCTensor_(resizeNd)(state, self, 2, size, stride);
   size_t len = m * n * sizeof(real);
-  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, THTensor_getStoragePtr(self)) + self->storage_offset(), src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self)
@@ -30,7 +30,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
   size_t len = THCTensor_(nElement)(state, self)*sizeof(real);
   THCTensor *temp = THCTensor_(newTranspose)(state, self, 0, 1);
   THCTensor *selfc = THCTensor_(newContiguous)(state, temp);
-  THCudaCheck(cudaMemcpy(dst, THCStorage_(data)(state, selfc->storage) + selfc->storage_offset(), len, cudaMemcpyDeviceToHost));
+  THCudaCheck(cudaMemcpy(dst, THCStorage_(data)(state, THTensor_getStoragePtr(selfc)) + selfc->storage_offset(), len, cudaMemcpyDeviceToHost));
   THCTensor_(free)(state, temp);
   THCTensor_(free)(state, selfc);
 }
@@ -289,8 +289,8 @@ THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
   {
     THCTensor_(resize2d)(state, re_, 2, n);
     THCTensor *re = THCTensor_(newContiguous)(state, re_);
-    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storage_offset(), wr, n*sizeof(real), cudaMemcpyHostToDevice));
-    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storage_offset() + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, THTensor_getStoragePtr(re)) + re->storage_offset(), wr, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, THTensor_getStoragePtr(re)) + re->storage_offset() + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
     THCTensor_(freeCopyTo)(state, re, re_);
     THCTensor_(transpose)(state, re_, NULL, 0, 1);
   }

--- a/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -61,7 +61,7 @@ static THCTensor* THNN_(view_weight_local)(
     int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
     THCTensor *old_weight = weight;
     weight = THCTensor_(newWithStorage3d)(state,
-                          weight->storage,
+                          THTensor_getStoragePtr(weight),
                           weight->storage_offset(),
                           s1, -1, s2, -1, s3, -1);
     THCTensor_(free)(state, old_weight);
@@ -140,12 +140,12 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
       1, 1, THCTensor_(data)(state, finput_n)
     );
 
-    output3d = THCTensor_(newWithStorage3d)(state, output_n->storage, output_n->storage_offset(),
+    output3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(output_n), output_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
 
-    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storage_offset(),
+    finput3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(finput_n), finput_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              kW*kH*nInputPlane, outputHeight*outputWidth,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -247,11 +247,11 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
     THCTensor_(select)(state, fgradInput_n, fgradInput, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storage_offset(),
+    gradOutput3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(gradOutput_n), gradOutput_n->storage_offset(),
                                                outputHeight*outputWidth, 1,
                                                nOutputPlane, outputHeight*outputWidth,
                                                1, nOutputPlane*outputHeight*outputWidth);
-    fgradInput3d = THCTensor_(newWithStorage3d)(state, fgradInput_n->storage, fgradInput_n->storage_offset(),
+    fgradInput3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(fgradInput_n), fgradInput_n->storage_offset(),
                                                outputHeight*outputWidth, 1,
                                                kW*kH*nInputPlane, outputHeight*outputWidth,
                                                1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -358,11 +358,11 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
     THCTensor_(select)(state, finput_n, finput, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storage_offset(),
+    gradOutput3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(gradOutput_n), gradOutput_n->storage_offset(),
                                                  outputHeight*outputWidth, 1,
                                                  nOutputPlane, outputHeight*outputWidth,
                                                  1, nOutputPlane*outputHeight*outputWidth);
-    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storage_offset(),
+    finput3d = THCTensor_(newWithStorage3d)(state, THTensor_getStoragePtr(finput_n), finput_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth,
                                              kW*kH*nInputPlane, outputHeight*outputWidth);

--- a/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -62,7 +62,7 @@ static THCTensor* THNN_(view_weight_local)(
     THCTensor *old_weight = weight;
     weight = THCTensor_(newWithStorage3d)(state,
                           weight->storage,
-                          weight->storageOffset,
+                          weight->storage_offset(),
                           s1, -1, s2, -1, s3, -1);
     THCTensor_(free)(state, old_weight);
   }
@@ -140,12 +140,12 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
       1, 1, THCTensor_(data)(state, finput_n)
     );
 
-    output3d = THCTensor_(newWithStorage3d)(state, output_n->storage, output_n->storageOffset,
+    output3d = THCTensor_(newWithStorage3d)(state, output_n->storage, output_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
 
-    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storageOffset,
+    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              kW*kH*nInputPlane, outputHeight*outputWidth,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -247,11 +247,11 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
     THCTensor_(select)(state, fgradInput_n, fgradInput, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storageOffset,
+    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storage_offset(),
                                                outputHeight*outputWidth, 1,
                                                nOutputPlane, outputHeight*outputWidth,
                                                1, nOutputPlane*outputHeight*outputWidth);
-    fgradInput3d = THCTensor_(newWithStorage3d)(state, fgradInput_n->storage, fgradInput_n->storageOffset,
+    fgradInput3d = THCTensor_(newWithStorage3d)(state, fgradInput_n->storage, fgradInput_n->storage_offset(),
                                                outputHeight*outputWidth, 1,
                                                kW*kH*nInputPlane, outputHeight*outputWidth,
                                                1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -358,11 +358,11 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
     THCTensor_(select)(state, finput_n, finput, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storageOffset,
+    gradOutput3d = THCTensor_(newWithStorage3d)(state, gradOutput_n->storage, gradOutput_n->storage_offset(),
                                                  outputHeight*outputWidth, 1,
                                                  nOutputPlane, outputHeight*outputWidth,
                                                  1, nOutputPlane*outputHeight*outputWidth);
-    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storageOffset,
+    finput3d = THCTensor_(newWithStorage3d)(state, finput_n->storage, finput_n->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth,
                                              kW*kH*nInputPlane, outputHeight*outputWidth);

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -109,7 +109,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   if (weight->dim() == 4) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
-    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storage_offset(), s1, -1, s2, -1);
+    weight = THCTensor_(newWithStorage2d)(state, THTensor_getStoragePtr(weight), weight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 
@@ -264,7 +264,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   if (weight->dim() == 4) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
-    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storage_offset(), s1, -1, s2, -1);
+    weight = THCTensor_(newWithStorage2d)(state, THTensor_getStoragePtr(weight), weight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 
@@ -398,7 +398,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   if (gradWeight && gradWeight->dim() == 4) {
     int64_t s1 = gradWeight->size(0);
     int64_t s2 = gradWeight->size(1) * gradWeight->size(2) * gradWeight->size(3);
-    gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storage_offset(), s1, -1, s2, -1);
+    gradWeight = THCTensor_(newWithStorage2d)(state, THTensor_getStoragePtr(gradWeight), gradWeight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -109,7 +109,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   if (weight->dim() == 4) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
-    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
+    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 
@@ -264,7 +264,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   if (weight->dim() == 4) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
-    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
+    weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 
@@ -398,7 +398,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   if (gradWeight && gradWeight->dim() == 4) {
     int64_t s1 = gradWeight->size(0);
     int64_t s2 = gradWeight->size(1) * gradWeight->size(2) * gradWeight->size(3);
-    gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storageOffset, s1, -1, s2, -1);
+    gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storage_offset(), s1, -1, s2, -1);
     freeWeight = 1;
   }
 

--- a/aten/src/THCUNN/generic/TemporalConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalConvolution.cu
@@ -91,12 +91,12 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size(1),
+                              input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
       THCTensor_(setStorage2d)(state, outputWindow, output->storage,
-                              output->storageOffset + k*output->size(1),
+                              output->storage_offset() + k*output->size(1),
                               nFrame, outputFrameStride*output->size(1),
                               output->size(1), 1);
 
@@ -139,12 +139,12 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, outputWindow, outputSample->storage,
-                                outputSample->storageOffset + k*outputSample->size(1),
+                                outputSample->storage_offset() + k*outputSample->size(1),
                                 nFrame, outputFrameStride*outputSample->size(1),
                                 outputSample->size(1), 1);
 
@@ -216,12 +216,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
       THCTensor_(setStorage2d)(state, gradInputWindow, gradInput->storage,
-                              gradInput->storageOffset+k*dW*gradInput->size(1),
+                              gradInput->storage_offset()+k*dW*gradInput->size(1),
                               nFrame, inputFrameStride*gradInput->size(1),
                               kW*gradInput->size(1), 1);
 
@@ -248,12 +248,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, gradInputWindow, gradInputSample->storage,
-                                gradInputSample->storageOffset+k*dW*gradInputSample->size(1),
+                                gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
                                 nFrame, inputFrameStride*gradInputSample->size(1),
                                 kW*gradInputSample->size(1), 1);
 
@@ -325,12 +325,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size(1),
+                              input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
@@ -368,12 +368,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 

--- a/aten/src/THCUNN/generic/TemporalConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalConvolution.cu
@@ -90,12 +90,12 @@ void THNN_(TemporalConvolution_updateOutput)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THCTensor_(setStorage2d)(state, inputWindow, input->storage,
+      THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(input),
                               input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
-      THCTensor_(setStorage2d)(state, outputWindow, output->storage,
+      THCTensor_(setStorage2d)(state, outputWindow, THTensor_getStoragePtr(output),
                               output->storage_offset() + k*output->size(1),
                               nFrame, outputFrameStride*output->size(1),
                               output->size(1), 1);
@@ -138,12 +138,12 @@ void THNN_(TemporalConvolution_updateOutput)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
+        THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(inputSample),
                                 inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
-        THCTensor_(setStorage2d)(state, outputWindow, outputSample->storage,
+        THCTensor_(setStorage2d)(state, outputWindow, THTensor_getStoragePtr(outputSample),
                                 outputSample->storage_offset() + k*outputSample->size(1),
                                 nFrame, outputFrameStride*outputSample->size(1),
                                 outputSample->size(1), 1);
@@ -215,12 +215,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
+      THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutput),
                               gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
-      THCTensor_(setStorage2d)(state, gradInputWindow, gradInput->storage,
+      THCTensor_(setStorage2d)(state, gradInputWindow, THTensor_getStoragePtr(gradInput),
                               gradInput->storage_offset()+k*dW*gradInput->size(1),
                               nFrame, inputFrameStride*gradInput->size(1),
                               kW*gradInput->size(1), 1);
@@ -247,12 +247,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
+        THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
                                 gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 
-        THCTensor_(setStorage2d)(state, gradInputWindow, gradInputSample->storage,
+        THCTensor_(setStorage2d)(state, gradInputWindow, THTensor_getStoragePtr(gradInputSample),
                                 gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
                                 nFrame, inputFrameStride*gradInputSample->size(1),
                                 kW*gradInputSample->size(1), 1);
@@ -324,12 +324,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THCTensor_(setStorage2d)(state, inputWindow, input->storage,
+      THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(input),
                               input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
-      THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutput->storage,
+      THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutput),
                               gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
@@ -367,12 +367,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THCTensor_(setStorage2d)(state, inputWindow, inputSample->storage,
+        THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(inputSample),
                                 inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
-        THCTensor_(setStorage2d)(state, gradOutputWindow, gradOutputSample->storage,
+        THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
                                 gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);

--- a/aten/src/THCUNN/generic/TemporalRowConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalRowConvolution.cu
@@ -151,7 +151,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
             THCTensor_(data)(state, columns));
 
     THCTensor *output3d = THCTensor_(newWithStorage3d)(
-        state, output_n->storage, output_n->storage_offset(), inputFrameSize, -1,
+        state, THTensor_getStoragePtr(output_n), output_n->storage_offset(), inputFrameSize, -1,
         1, -1, nOutputFrame, -1);
 
     // weight:    inputFrameSize x 1 x kW
@@ -251,7 +251,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
     THCTensor *gradOutput3d = THCTensor_(newWithStorage3d)(
-        state, gradOutput_n->storage, gradOutput_n->storage_offset(),
+        state, THTensor_getStoragePtr(gradOutput_n), gradOutput_n->storage_offset(),
         inputFrameSize, -1, 1, -1, nOutputFrame, -1);
 
     // weight:          inputFrameSize x kW x 1
@@ -365,7 +365,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
     THCTensor *gradOutput3d = THCTensor_(newWithStorage3d)(
-        state, gradOutput_n->storage, gradOutput_n->storage_offset(),
+        state, THTensor_getStoragePtr(gradOutput_n), gradOutput_n->storage_offset(),
         inputFrameSize, -1, 1, -1, nOutputFrame, -1);
 
     // Extract columns

--- a/aten/src/THCUNN/generic/TemporalRowConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalRowConvolution.cu
@@ -151,7 +151,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
             THCTensor_(data)(state, columns));
 
     THCTensor *output3d = THCTensor_(newWithStorage3d)(
-        state, output_n->storage, output_n->storageOffset, inputFrameSize, -1,
+        state, output_n->storage, output_n->storage_offset(), inputFrameSize, -1,
         1, -1, nOutputFrame, -1);
 
     // weight:    inputFrameSize x 1 x kW
@@ -251,7 +251,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
     THCTensor *gradOutput3d = THCTensor_(newWithStorage3d)(
-        state, gradOutput_n->storage, gradOutput_n->storageOffset,
+        state, gradOutput_n->storage, gradOutput_n->storage_offset(),
         inputFrameSize, -1, 1, -1, nOutputFrame, -1);
 
     // weight:          inputFrameSize x kW x 1
@@ -365,7 +365,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
     THCTensor *gradOutput3d = THCTensor_(newWithStorage3d)(
-        state, gradOutput_n->storage, gradOutput_n->storageOffset,
+        state, gradOutput_n->storage, gradOutput_n->storage_offset(),
         inputFrameSize, -1, 1, -1, nOutputFrame, -1);
 
     // Extract columns

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -30,14 +30,14 @@ static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {
-  THStorage_(set)(t->storage, t->storage_offset() + x0*t->stride(0), value);
+  THStorage_(set)(THTensor_getStoragePtr(t), t->storage_offset() + x0*t->stride(0), value);
 }
 static real THNN_(get3d)(const THTensor *t, int64_t x0, int64_t x1, int64_t x2) {
-  return THStorage_(get)(t->storage, t->storage_offset() +
+  return THStorage_(get)(THTensor_getStoragePtr(t), t->storage_offset() +
                          x0*t->stride(0) + x1*t->stride(1) + x2*t->stride(2));
 }
 static real THNN_(get2d)(const THTensor *t, int64_t x0, int64_t x1) {
-  return THStorage_(get)(t->storage, t->storage_offset() +
+  return THStorage_(get)(THTensor_getStoragePtr(t), t->storage_offset() +
                          x0*t->stride(0) + x1*t->stride(1));
 }
 

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -30,14 +30,14 @@ static bool THNN_(checkSize1D)(THTensor* t, int64_t size0)
 }
 
 static void THNN_(set1d)(THTensor *t, int64_t x0, real value) {
-  THStorage_(set)(t->storage, t->storageOffset + x0*t->stride(0), value);
+  THStorage_(set)(t->storage, t->storage_offset() + x0*t->stride(0), value);
 }
 static real THNN_(get3d)(const THTensor *t, int64_t x0, int64_t x1, int64_t x2) {
-  return THStorage_(get)(t->storage, t->storageOffset +
+  return THStorage_(get)(t->storage, t->storage_offset() +
                          x0*t->stride(0) + x1*t->stride(1) + x2*t->stride(2));
 }
 static real THNN_(get2d)(const THTensor *t, int64_t x0, int64_t x1) {
-  return THStorage_(get)(t->storage, t->storageOffset +
+  return THStorage_(get)(t->storage, t->storage_offset() +
                          x0*t->stride(0) + x1*t->stride(1));
 }
 

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -58,7 +58,7 @@ static THTensor* THNN_(view_weight_local)(THTensor *_weight)
     int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage3d)(weight->storage,
-                       weight->storageOffset,
+                       weight->storage_offset(),
                        s1, -1, s2, -1, s3, -1);
     THTensor_(free)(old_weight);
   }
@@ -82,13 +82,13 @@ static void THNN_(SpatialConvolutionLocal_updateOutput_frame)
   THTensor_(copy)(output, bias);
 
   output3d = THTensor_(newWithStorage3d)
-    (output->storage, output->storageOffset,
+    (output->storage, output->storage_offset(),
      outputHeight * outputWidth, 1,
      nOutputPlane, outputHeight * outputWidth,
      1, nOutputPlane * outputHeight * outputWidth);
 
   finput3d = THTensor_(newWithStorage3d)
-    (finput->storage, finput->storageOffset,
+    (finput->storage, finput->storage_offset(),
      outputHeight * outputWidth, 1,
      kW * kH * nInputPlane, outputHeight * outputWidth,
      1, kW * kH * nInputPlane * outputHeight * outputWidth);
@@ -178,11 +178,11 @@ static void THNN_(SpatialConvolutionLocal_updateGradInput_frame)
       int64_t nOutputPlane, int64_t outputWidth, int64_t outputHeight)
 {
   THTensor *gradOutput3d, *fgradInput3d;
-  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storageOffset,
+  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
-  fgradInput3d = THTensor_(newWithStorage3d)(fgradInput->storage, fgradInput->storageOffset,
+  fgradInput3d = THTensor_(newWithStorage3d)(fgradInput->storage, fgradInput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              kW*kH*nInputPlane, outputHeight*outputWidth,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -280,11 +280,11 @@ static void THNN_(SpatialConvolutionLocal_accGradParameters_frame)
 {
 
   THTensor *gradOutput3d, *finput3d;
-  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storageOffset,
+  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
-  finput3d = THTensor_(newWithStorage3d)(finput->storage, finput->storageOffset,
+  finput3d = THTensor_(newWithStorage3d)(finput->storage, finput->storage_offset(),
                                          outputHeight*outputWidth, 1,
                                          1, kW*kH*nInputPlane*outputHeight*outputWidth,
                                          kW*kH*nInputPlane, outputHeight*outputWidth);

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -57,7 +57,7 @@ static THTensor* THNN_(view_weight_local)(THTensor *_weight)
     int64_t s2 = weight->size(2);
     int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
     THTensor *old_weight = weight;
-    weight = THTensor_(newWithStorage3d)(weight->storage,
+    weight = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(weight),
                        weight->storage_offset(),
                        s1, -1, s2, -1, s3, -1);
     THTensor_(free)(old_weight);
@@ -82,13 +82,13 @@ static void THNN_(SpatialConvolutionLocal_updateOutput_frame)
   THTensor_(copy)(output, bias);
 
   output3d = THTensor_(newWithStorage3d)
-    (output->storage, output->storage_offset(),
+    (THTensor_getStoragePtr(output), output->storage_offset(),
      outputHeight * outputWidth, 1,
      nOutputPlane, outputHeight * outputWidth,
      1, nOutputPlane * outputHeight * outputWidth);
 
   finput3d = THTensor_(newWithStorage3d)
-    (finput->storage, finput->storage_offset(),
+    (THTensor_getStoragePtr(finput), finput->storage_offset(),
      outputHeight * outputWidth, 1,
      kW * kH * nInputPlane, outputHeight * outputWidth,
      1, kW * kH * nInputPlane * outputHeight * outputWidth);
@@ -178,11 +178,11 @@ static void THNN_(SpatialConvolutionLocal_updateGradInput_frame)
       int64_t nOutputPlane, int64_t outputWidth, int64_t outputHeight)
 {
   THTensor *gradOutput3d, *fgradInput3d;
-  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storage_offset(),
+  gradOutput3d = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
-  fgradInput3d = THTensor_(newWithStorage3d)(fgradInput->storage, fgradInput->storage_offset(),
+  fgradInput3d = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(fgradInput), fgradInput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              kW*kH*nInputPlane, outputHeight*outputWidth,
                                              1, kW*kH*nInputPlane*outputHeight*outputWidth);
@@ -280,11 +280,11 @@ static void THNN_(SpatialConvolutionLocal_accGradParameters_frame)
 {
 
   THTensor *gradOutput3d, *finput3d;
-  gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storage_offset(),
+  gradOutput3d = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
                                              outputHeight*outputWidth, 1,
                                              nOutputPlane, outputHeight*outputWidth,
                                              1, nOutputPlane*outputHeight*outputWidth);
-  finput3d = THTensor_(newWithStorage3d)(finput->storage, finput->storage_offset(),
+  finput3d = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(finput), finput->storage_offset(),
                                          outputHeight*outputWidth, 1,
                                          1, kW*kH*nInputPlane*outputHeight*outputWidth,
                                          kW*kH*nInputPlane, outputHeight*outputWidth);

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -84,7 +84,7 @@ static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
     THTensor *old_weight = weight;
-    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storage_offset(),
+    weight = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(weight), weight->storage_offset(),
 					 s1, -1, s2, -1);
 	THTensor_(free)(old_weight);
   }
@@ -117,7 +117,7 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
 		       nInputPlane, inputWidth, inputHeight,
 		       outputWidth, outputHeight);
 
-  output2d = THTensor_(newWithStorage2d)(output->storage, output->storage_offset(),
+  output2d = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(output), output->storage_offset(),
                                          nOutputPlane, -1,
                                          outputHeight*outputWidth, -1);
   if (bias) {
@@ -228,7 +228,7 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
           int padH)
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
-    (gradOutput->storage, gradOutput->storage_offset(),
+    (THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
      gradOutput->size(0), -1,
      gradOutput->size(1)*gradOutput->size(2), -1);
   THTensor_(addmm)(fgradInput, 0, fgradInput, 1, weight, gradOutput2d);
@@ -318,7 +318,7 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
 {
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
-    (gradOutput->storage, gradOutput->storage_offset(),
+    (THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
      gradOutput->size(0), -1,
      gradOutput->size(1)*gradOutput->size(2), -1);
 

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -84,7 +84,7 @@ static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
     THTensor *old_weight = weight;
-    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storageOffset,
+    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storage_offset(),
 					 s1, -1, s2, -1);
 	THTensor_(free)(old_weight);
   }
@@ -117,13 +117,13 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
 		       nInputPlane, inputWidth, inputHeight,
 		       outputWidth, outputHeight);
 
-  output2d = THTensor_(newWithStorage2d)(output->storage, output->storageOffset,
+  output2d = THTensor_(newWithStorage2d)(output->storage, output->storage_offset(),
                                          nOutputPlane, -1,
                                          outputHeight*outputWidth, -1);
   if (bias) {
     for(i = 0; i < nOutputPlane; i++)
         THVector_(fill)
-	  (THStorage_(data)(output->storage) + output->storageOffset + output->stride(0) * i,
+	  (THStorage_(data)(output->storage) + output->storage_offset() + output->stride(0) * i,
 	   THTensor_(get1d)(bias, i), outputHeight*outputWidth);
   } else {
     THTensor_(zero)(output);
@@ -228,7 +228,7 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
           int padH)
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
-    (gradOutput->storage, gradOutput->storageOffset,
+    (gradOutput->storage, gradOutput->storage_offset(),
      gradOutput->size(0), -1,
      gradOutput->size(1)*gradOutput->size(2), -1);
   THTensor_(addmm)(fgradInput, 0, fgradInput, 1, weight, gradOutput2d);
@@ -318,7 +318,7 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
 {
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
-    (gradOutput->storage, gradOutput->storageOffset,
+    (gradOutput->storage, gradOutput->storage_offset(),
      gradOutput->size(0), -1,
      gradOutput->size(1)*gradOutput->size(2), -1);
 
@@ -334,10 +334,10 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride(0);
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
       for(k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
-      (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale*sum;
+      (THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i] += scale*sum;
     }
   }
 

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -123,7 +123,7 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
   if (bias) {
     for(i = 0; i < nOutputPlane; i++)
         THVector_(fill)
-	  (THStorage_(data)(output->storage) + output->storage_offset() + output->stride(0) * i,
+	  (THStorage_(data)(THTensor_getStoragePtr(output)) + output->storage_offset() + output->stride(0) * i,
 	   THTensor_(get1d)(bias, i), outputHeight*outputWidth);
   } else {
     THTensor_(zero)(output);
@@ -334,10 +334,10 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
+      real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput2d)) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
       for(k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
-      (THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i] += scale*sum;
+      (THStorage_(data)(THTensor_getStoragePtr(gradBias)) + gradBias->storage_offset())[i] += scale*sum;
     }
   }
 

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -88,12 +88,12 @@ void THNN_(TemporalConvolution_updateOutput)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THTensor_(setStorage2d)(inputWindow, input->storage,
+      THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(input),
                               input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
-      THTensor_(setStorage2d)(outputWindow, output->storage,
+      THTensor_(setStorage2d)(outputWindow, THTensor_getStoragePtr(output),
                               output->storage_offset() + k*output->size(1),
                               nFrame, outputFrameStride*output->size(1),
                               output->size(1), 1);
@@ -136,12 +136,12 @@ void THNN_(TemporalConvolution_updateOutput)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THTensor_(setStorage2d)(inputWindow, inputSample->storage,
+        THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(inputSample),
                                 inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
-        THTensor_(setStorage2d)(outputWindow, outputSample->storage,
+        THTensor_(setStorage2d)(outputWindow, THTensor_getStoragePtr(outputSample),
                                 outputSample->storage_offset() + k*outputSample->size(1),
                                 nFrame, outputFrameStride*outputSample->size(1),
                                 outputSample->size(1), 1);
@@ -210,12 +210,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
+      THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutput),
                               gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
-      THTensor_(setStorage2d)(gradInputWindow, gradInput->storage,
+      THTensor_(setStorage2d)(gradInputWindow, THTensor_getStoragePtr(gradInput),
                               gradInput->storage_offset()+k*dW*gradInput->size(1),
                               nFrame, inputFrameStride*gradInput->size(1),
                               kW*gradInput->size(1), 1);
@@ -243,12 +243,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
+        THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
                                 gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 
-        THTensor_(setStorage2d)(gradInputWindow, gradInputSample->storage,
+        THTensor_(setStorage2d)(gradInputWindow, THTensor_getStoragePtr(gradInputSample),
                                 gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
                                 nFrame, inputFrameStride*gradInputSample->size(1),
                                 kW*gradInputSample->size(1), 1);
@@ -319,12 +319,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
       int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
       nOutputFrame -= nFrame;
 
-      THTensor_(setStorage2d)(inputWindow, input->storage,
+      THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(input),
                               input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
-      THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
+      THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutput),
                               gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
@@ -362,12 +362,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
         int64_t nFrame = (nInputFrame-k*dW-kW)/inputFrameStride + 1;
         nOutputSampleFrame -= nFrame;
 
-        THTensor_(setStorage2d)(inputWindow, inputSample->storage,
+        THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(inputSample),
                                 inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
-        THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
+        THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
                                 gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -89,12 +89,12 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size(1),
+                              input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
       THTensor_(setStorage2d)(outputWindow, output->storage,
-                              output->storageOffset + k*output->size(1),
+                              output->storage_offset() + k*output->size(1),
                               nFrame, outputFrameStride*output->size(1),
                               output->size(1), 1);
 
@@ -137,12 +137,12 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
         THTensor_(setStorage2d)(outputWindow, outputSample->storage,
-                                outputSample->storageOffset + k*outputSample->size(1),
+                                outputSample->storage_offset() + k*outputSample->size(1),
                                 nFrame, outputFrameStride*outputSample->size(1),
                                 outputSample->size(1), 1);
 
@@ -211,12 +211,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
       THTensor_(setStorage2d)(gradInputWindow, gradInput->storage,
-                              gradInput->storageOffset+k*dW*gradInput->size(1),
+                              gradInput->storage_offset()+k*dW*gradInput->size(1),
                               nFrame, inputFrameStride*gradInput->size(1),
                               kW*gradInput->size(1), 1);
 
@@ -244,12 +244,12 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 
         THTensor_(setStorage2d)(gradInputWindow, gradInputSample->storage,
-                                gradInputSample->storageOffset+k*dW*gradInputSample->size(1),
+                                gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
                                 nFrame, inputFrameStride*gradInputSample->size(1),
                                 kW*gradInputSample->size(1), 1);
 
@@ -320,12 +320,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, input->storage,
-                              input->storageOffset+k*dW*input->size(1),
+                              input->storage_offset()+k*dW*input->size(1),
                               nFrame, inputFrameStride*input->size(1),
                               kW*input->size(1), 1);
 
       THTensor_(setStorage2d)(gradOutputWindow, gradOutput->storage,
-                              gradOutput->storageOffset + k*gradOutput->size(1),
+                              gradOutput->storage_offset() + k*gradOutput->size(1),
                               nFrame, outputFrameStride*gradOutput->size(1),
                               gradOutput->size(1), 1);
 
@@ -363,12 +363,12 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, inputSample->storage,
-                                inputSample->storageOffset+k*dW*inputSample->size(1),
+                                inputSample->storage_offset()+k*dW*inputSample->size(1),
                                 nFrame, inputFrameStride*inputSample->size(1),
                                 kW*inputSample->size(1), 1);
 
         THTensor_(setStorage2d)(gradOutputWindow, gradOutputSample->storage,
-                                gradOutputSample->storageOffset + k*gradOutputSample->size(1),
+                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
                                 nFrame, outputFrameStride*gradOutputSample->size(1),
                                 gradOutputSample->size(1), 1);
 

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -161,7 +161,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 	if (bias != NULL) {
 		for (i = 0; i < inputFrameSize; i++)
 			THVector_(fill)
-			        (THStorage_(data)(output->storage) + output->storage_offset()
+			        (THStorage_(data)(THTensor_getStoragePtr(output)) + output->storage_offset()
 			        + output->stride(0) * i,
 			        THTensor_(get1d)(bias, i), nOutputFrame);
 	}
@@ -389,13 +389,13 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 		for (i = 0; i < gradBias->size(0); i++) {
 			int64_t k;
 			real sum = 0;
-			real *data = THStorage_(data)(gradOutput3d->storage)
+			real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput3d))
 			             + gradOutput3d->storage_offset()
 			             + i * gradOutput3d->stride(0);
 			for (k = 0; k < gradOutput3d->size(2); k++) {
 				sum += data[k];
 			}
-			(THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i]
+			(THStorage_(data)(THTensor_getStoragePtr(gradBias)) + gradBias->storage_offset())[i]
 			        += scale * sum;
 		}
 	}

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -148,7 +148,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 	int64_t i;
 
 	THTensor *output3d = THTensor_(newWithStorage3d)(
-		output->storage, output->storageOffset,
+		output->storage, output->storage_offset(),
 		inputFrameSize, -1,
 		1, -1,
 		nOutputFrame, -1);
@@ -161,7 +161,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 	if (bias != NULL) {
 		for (i = 0; i < inputFrameSize; i++)
 			THVector_(fill)
-			        (THStorage_(data)(output->storage) + output->storageOffset
+			        (THStorage_(data)(output->storage) + output->storage_offset()
 			        + output->stride(0) * i,
 			        THTensor_(get1d)(bias, i), nOutputFrame);
 	}
@@ -261,7 +261,7 @@ static void THNN_(TemporalRowConvolution_updateGradInput_frame)(
 	int64_t nOutputFrame) {
 
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
-		gradOutput->storage, gradOutput->storageOffset,
+		gradOutput->storage, gradOutput->storage_offset(),
 		inputFrameSize, -1,
 		1, -1,
 		nOutputFrame, -1);
@@ -372,7 +372,7 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 
 	int64_t i;
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
-		gradOutput->storage, gradOutput->storageOffset,
+		gradOutput->storage, gradOutput->storage_offset(),
 		gradOutput->size(0), -1,
 		1, -1,
 		gradOutput->size(1), -1);
@@ -390,12 +390,12 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 			int64_t k;
 			real sum = 0;
 			real *data = THStorage_(data)(gradOutput3d->storage)
-			             + gradOutput3d->storageOffset
+			             + gradOutput3d->storage_offset()
 			             + i * gradOutput3d->stride(0);
 			for (k = 0; k < gradOutput3d->size(2); k++) {
 				sum += data[k];
 			}
-			(THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i]
+			(THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i]
 			        += scale * sum;
 		}
 	}

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -148,7 +148,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 	int64_t i;
 
 	THTensor *output3d = THTensor_(newWithStorage3d)(
-		output->storage, output->storage_offset(),
+		THTensor_getStoragePtr(output), output->storage_offset(),
 		inputFrameSize, -1,
 		1, -1,
 		nOutputFrame, -1);
@@ -261,7 +261,7 @@ static void THNN_(TemporalRowConvolution_updateGradInput_frame)(
 	int64_t nOutputFrame) {
 
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
-		gradOutput->storage, gradOutput->storage_offset(),
+		THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
 		inputFrameSize, -1,
 		1, -1,
 		nOutputFrame, -1);
@@ -372,7 +372,7 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 
 	int64_t i;
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
-		gradOutput->storage, gradOutput->storage_offset(),
+		THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
 		gradOutput->size(0), -1,
 		1, -1,
 		gradOutput->size(1), -1);

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -116,7 +116,7 @@ static THTensor* THNN_(newViewWeight)(THTensor *weight)
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
     THTensor *old_weight = weight;
-    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storage_offset(),
+    weight = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(weight), weight->storage_offset(),
 					 s1, -1, s2, -1);
     THTensor_(free)(old_weight);
   }
@@ -427,7 +427,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
   );
 
   output2d = THTensor_(newWithStorage2d)(
-    output->storage, output->storage_offset(), nOutputPlane, -1,
+    THTensor_getStoragePtr(output), output->storage_offset(), nOutputPlane, -1,
     outputDepth*outputHeight*outputWidth, -1
   );
 
@@ -570,7 +570,7 @@ static void THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
           int pH)
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
-    gradOutput->storage, gradOutput->storage_offset(),
+    THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
     gradOutput->size(0), -1,
     gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );
@@ -676,7 +676,7 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
 {
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
-    gradOutput->storage, gradOutput->storage_offset(),
+    THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
     gradOutput->size(0), -1,
     gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -116,7 +116,7 @@ static THTensor* THNN_(newViewWeight)(THTensor *weight)
     int64_t s1 = weight->size(0);
     int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
     THTensor *old_weight = weight;
-    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storageOffset,
+    weight = THTensor_(newWithStorage2d)(weight->storage, weight->storage_offset(),
 					 s1, -1, s2, -1);
     THTensor_(free)(old_weight);
   }
@@ -427,7 +427,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
   );
 
   output2d = THTensor_(newWithStorage2d)(
-    output->storage, output->storageOffset, nOutputPlane, -1,
+    output->storage, output->storage_offset(), nOutputPlane, -1,
     outputDepth*outputHeight*outputWidth, -1
   );
 
@@ -435,7 +435,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
       for (i = 0; i < nOutputPlane; i++)
       {
         THVector_(fill)(
-          THStorage_(data)(output->storage)+output->storageOffset+output->stride(0)*i,
+          THStorage_(data)(output->storage)+output->storage_offset()+output->stride(0)*i,
           THTensor_(get1d)(bias, i),
           outputDepth*outputHeight*outputWidth
         );
@@ -570,7 +570,7 @@ static void THNN_(VolumetricConvolutionMM_updateGradInput_frame)(
           int pH)
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
-    gradOutput->storage, gradOutput->storageOffset,
+    gradOutput->storage, gradOutput->storage_offset(),
     gradOutput->size(0), -1,
     gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );
@@ -676,7 +676,7 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
 {
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)(
-    gradOutput->storage, gradOutput->storageOffset,
+    gradOutput->storage, gradOutput->storage_offset(),
     gradOutput->size(0), -1,
     gradOutput->size(1)*gradOutput->size(2)*gradOutput->size(3), -1
   );
@@ -693,11 +693,11 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride(0);
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
       for (k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
 
-      (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale * sum;
+      (THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i] += scale * sum;
     }
   }
 

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -435,7 +435,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
       for (i = 0; i < nOutputPlane; i++)
       {
         THVector_(fill)(
-          THStorage_(data)(output->storage)+output->storage_offset()+output->stride(0)*i,
+          THStorage_(data)(THTensor_getStoragePtr(output))+output->storage_offset()+output->stride(0)*i,
           THTensor_(get1d)(bias, i),
           outputDepth*outputHeight*outputWidth
         );
@@ -693,11 +693,11 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
+      real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput2d)) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
       for (k = 0; k < gradOutput2d->size(1); k++)
         sum += data[k];
 
-      (THStorage_(data)(gradBias->storage) + gradBias->storage_offset())[i] += scale * sum;
+      (THStorage_(data)(THTensor_getStoragePtr(gradBias)) + gradBias->storage_offset())[i] += scale * sum;
     }
   }
 


### PR DESCRIPTION
This pops off `refcount_`, `storage_`, `storage_offset_`; there are now no more direct accesses to these fields and we can make them private (with appropriate friending).

Stacked on #9561