### PR TITLE
quick patch for PackPadded removal to propagate the correct size.

### DIFF
--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -259,6 +259,20 @@ void pushPackingPastRnn(Block *b) {
     newPackPadded->addInput(next->outputs()[0]);
     newPackPadded->addInput(n->inputs()[1]);
 
+    // See https://github.com/pytorch/pytorch/issues/9043 for a full
+    // description.  Since PackPadded is for now treated in an
+    // unhygenic way, Pytorch ends up propagating an incorrect type.
+    // Until a long-term cleanup comes around, we can fix this by
+    // resetting the size to the correct value.
+    TensorType* oldType = rnn->inputs()[0]->type()->cast<TensorType>();
+    std::vector<int64_t> new_sizes;
+    new_sizes.push_back(oldType->sizes()[0]);
+    new_sizes.push_back(oldType->sizes()[1]);
+    new_sizes.push_back(rnn->i(attr::hidden_size));
+    TensorTypePtr newType = std::make_shared<TensorType>(
+        oldType->scalarType(), oldType->device(), new_sizes);
+    next->outputs()[0]->setType(newType);
+
     it.destroyCurrent();
   }
 }


### PR DESCRIPTION
Summary:

The underlying reason why this is even an issue is that the conversion
into and out of the 'fictional' onnx operators is done in an unhygenic
order. This doesn't address that, but it does fix the one observable
case where this produces an incorrect result, and unblocks some other
work being done.

