### PR TITLE
[JIT] Fix the clamp special case and gradient problem on None, add None to JIT

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -46,11 +46,11 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
 }
 
 Tensor& _clamp__cpu(Tensor& self, Scalar min, Scalar max) {
-  if (!std::isnan(min.toFloat()) && !std::isnan(max.toFloat())) {
+  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
     return _th_clamp_(self, min, max);
-  } else if (std::isnan(min.toFloat())) {
+  } else if (std::isnan(min.toDouble())) {
     return _th_clamp_max_(self, max);
-  } else if (std::isnan(max.toFloat())) {
+  } else if (std::isnan(max.toDouble())) {
     return _th_clamp_min_(self, min);
   } else {
     return self;
@@ -64,12 +64,11 @@ Tensor& _clamp_out_cpu(
     Scalar max) {
   result.resize_(self.sizes());
   result.copy_(self);
-  if (!std::isnan(min.toFloat()) && !std::isnan(max.toFloat())) {
+  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
     _th_clamp_(result, min, max);
-  }
-  else if (std::isnan(min.toFloat())) {
+  } else if (std::isnan(min.toDouble())) {
     _th_clamp_max_(result, max);
-  } else if (std::isnan(max.toFloat())) {
+  } else if (std::isnan(max.toDouble())) {
     _th_clamp_min_(result, min);
   }
   return result;

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -46,7 +46,13 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
 }
 
 Tensor& _clamp__cpu(Tensor& self, Scalar min, Scalar max) {
-  return _th_clamp_(self, min, max);
+  if (std::isnan(min.toFloat())) {
+    return _th_clamp_max_(self, max);
+  } else if (std::isnan(max.toFloat())) {
+    return _th_clamp_min_(self, min);
+  } else {
+    return _th_clamp_(self, min, max);
+  }
 }
 
 Tensor& _clamp_out_cpu(
@@ -56,7 +62,14 @@ Tensor& _clamp_out_cpu(
     Scalar max) {
   result.resize_(self.sizes());
   result.copy_(self);
-  return _th_clamp_(result, min, max);
+  if (std::isnan(min.toFloat())) {
+    _th_clamp_max_(result, max);
+  } else if (std::isnan(max.toFloat())) {
+    _th_clamp_min_(result, min);
+  } else {
+    _th_clamp_(result, min, max);
+  }
+  return result;
 }
 
 Tensor& _clamp_max__cpu(Tensor& self, Scalar max) {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -46,12 +46,14 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
 }
 
 Tensor& _clamp__cpu(Tensor& self, Scalar min, Scalar max) {
-  if (std::isnan(min.toFloat())) {
+  if (!std::isnan(min.toFloat()) && !std::isnan(max.toFloat())) {
+    return _th_clamp_(self, min, max);
+  } else if (std::isnan(min.toFloat())) {
     return _th_clamp_max_(self, max);
   } else if (std::isnan(max.toFloat())) {
     return _th_clamp_min_(self, min);
   } else {
-    return _th_clamp_(self, min, max);
+    return self;
   }
 }
 
@@ -62,12 +64,13 @@ Tensor& _clamp_out_cpu(
     Scalar max) {
   result.resize_(self.sizes());
   result.copy_(self);
-  if (std::isnan(min.toFloat())) {
+  if (!std::isnan(min.toFloat()) && !std::isnan(max.toFloat())) {
+    _th_clamp_(result, min, max);
+  }
+  else if (std::isnan(min.toFloat())) {
     _th_clamp_max_(result, max);
   } else if (std::isnan(max.toFloat())) {
     _th_clamp_min_(result, min);
-  } else {
-    _th_clamp_(result, min, max);
   }
   return result;
 }

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -3,7 +3,13 @@
 namespace at { namespace native {
 
 Tensor& _clamp__cuda(Tensor& self, Scalar min, Scalar max) {
-  return _th_clamp_(self, min, max);
+  if (std::isnan(min.toFloat())) {
+    return _th_clamp_max_(self, max);
+  } else if (std::isnan(max.toFloat())) {
+    return _th_clamp_min_(self, min);
+  } else {
+    return _th_clamp_(self, min, max);
+  }
 }
 
 Tensor& _clamp_out_cuda(
@@ -13,7 +19,14 @@ Tensor& _clamp_out_cuda(
     Scalar max) {
   result.resize_(self.sizes());
   result.copy_(self);
-  return _th_clamp_(result, min, max);
+  if (std::isnan(min.toFloat())) {
+    _th_clamp_max_(result, max);
+  } else if (std::isnan(max.toFloat())) {
+    _th_clamp_min_(result, min);
+  } else {
+    _th_clamp_(result, min, max);
+  }
+  return result;
 }
 
 Tensor& _clamp_max__cuda(Tensor& self, Scalar max) {

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -3,12 +3,14 @@
 namespace at { namespace native {
 
 Tensor& _clamp__cuda(Tensor& self, Scalar min, Scalar max) {
-  if (std::isnan(min.toFloat())) {
+  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
+    return _th_clamp_(self, min, max);
+  } else if (std::isnan(min.toDouble())) {
     return _th_clamp_max_(self, max);
-  } else if (std::isnan(max.toFloat())) {
+  } else if (std::isnan(max.toDouble())) {
     return _th_clamp_min_(self, min);
   } else {
-    return _th_clamp_(self, min, max);
+    return self;
   }
 }
 
@@ -19,12 +21,12 @@ Tensor& _clamp_out_cuda(
     Scalar max) {
   result.resize_(self.sizes());
   result.copy_(self);
-  if (std::isnan(min.toFloat())) {
-    _th_clamp_max_(result, max);
-  } else if (std::isnan(max.toFloat())) {
-    _th_clamp_min_(result, min);
-  } else {
+  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
     _th_clamp_(result, min, max);
+  } else if (std::isnan(min.toDouble())) {
+    _th_clamp_max_(result, max);
+  } else if (std::isnan(max.toDouble())) {
+    _th_clamp_min_(result, min);
   }
   return result;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -266,17 +266,26 @@
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
 
 - func: clamp(Tensor self, Scalar min, Scalar max) -> Tensor
+  python_default_init:
+    min: NAN
+    max: NAN
 
 - func: clamp_(Tensor self, Scalar min, Scalar max) -> Tensor
   dispatch:
     CPU: _clamp__cpu
     CUDA: _clamp__cuda
+  python_default_init:
+    min: NAN
+    max: NAN
 
 - func: clamp_out(Tensor result, Tensor self, Scalar min, Scalar max) -> Tensor
   variants: function
   dispatch:
     CPU: _clamp_out_cpu
     CUDA: _clamp_out_cuda
+  python_default_init:
+    min: NAN
+    max: NAN
 
 - func: clamp_max(Tensor self, Scalar max) -> Tensor
 

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -8,6 +8,10 @@
     (assign
       (list (variable (ident q)))
       (=)
+      (None))
+    (assign
+      (list (variable (ident q)))
+      (=)
       (-
         (+
           (variable (ident x))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1629,6 +1629,7 @@ class TestScript(JitTestCase):
 
     def test_python_frontend(self):
         def fn(x, y, z):
+            q = None
             q = x + y - z.sigmoid()
             print(q)
             w = -z
@@ -1861,6 +1862,23 @@ class TestScript(JitTestCase):
         inputs = self._make_scalar_vars([0], torch.int64)
 
         self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
+
+    def test_script_None(self):
+        @torch.jit.script
+        def func(x):
+            output = None
+            output = x
+            return output
+
+        self.assertEqual(func(torch.rand(1, 2)).shape[1], 2)
+
+    def test_script_clamp_max(self):
+        @torch.jit.script
+        def test_script_clamp_max(x):
+            return torch.clamp(x, min=None, max=0.5)
+
+        input = torch.tensor([[0.3, 0.4], [0.5, 0.51]])
+        self.assertEqual(test_script_clamp_max(input)[1][1], 0.5)
 
     def test_script_bool_constant(self):
         script = '''
@@ -4822,10 +4840,6 @@ EXCLUDE_TRACED = {
 
 # known to be failing in script
 EXCLUDE_SCRIPT = {
-    'test_clamp_max',
-    'test_clamp_max_scalar',
-    'test_clamp_min',
-    'test_clamp_min_scalar',
     # TODO: Fix var/std
     # there are two schemas for var (and std):
     # (1) var(Tensor, int, *, bool, bool, Tensor)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -168,11 +168,10 @@
 - name: ceil(Tensor self)
   self: zeros_like(grad)
 
-# For clamp, clamp_min, and clamp_max, gradient is not defined at the
-# boundaries. But empirically it's helpful to be able to get gradient on min and
-# max, so we return the subgradient 1 for these cases.
+# For clamp, gradient is not defined at the boundaries. But empirically it's helpful 
+# to be able to get gradient on min and max, so we return the subgradient 1 for these cases.
 - name: clamp(Tensor self, Scalar min, Scalar max)
-  self: grad * ((self >= min) * (self <= max)).type_as(grad)
+  self: clamp_backward(grad, self, min, max)
 
 - name: clamp_min(Tensor self, Scalar min)
   self: grad * (self >= min).type_as(grad)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # These functions require manual Python bindings or are not exposed to Python
 SKIP_PYTHON_BINDINGS = [
-    'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
+    'alias', 'contiguous', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_(out|input|weight|bias)', '.*_forward',
     '.*_forward_out', 'sparse_raw_resize_', '_unsafe_view', 'tensor',
     'sparse_coo_tensor', 'th_sparse_coo_tensor', 'native_sparse_coo_tensor',

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -431,6 +431,17 @@ std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<
   return grad_inputs;
 }
 
+Tensor clamp_backward(const Tensor & grad, const Tensor &self, const Scalar & min, const Scalar & max) {
+  // clamp: gradients not defined on min and max, so we return the subgradient 1 for these cases.
+  if (std::isnan(min.toFloat())) {
+    return grad * (self <= max).type_as(grad);
+  } else if (std::isnan(max.toFloat())) {
+    return grad * (self >= min).type_as(grad);
+  } else {
+    return grad * ((self >= min) * (self <= max)).type_as(grad);
+  }
+}
+
 Tensor mm_mat1_backward(const Tensor & grad, const Tensor & mat2, IntList sizes, IntList strides, const Scalar & alpha) {
   // if input was column-major, return grad as column-order for efficiency
   if (strides[0] == 1 && strides[1] == sizes[0]) {

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -191,7 +191,6 @@ static PyObject * THPVariable_as_tensor(PyObject* self, PyObject* args, PyObject
   END_HANDLE_TH_ERRORS
 }
 
-// The Python clamp() syntax has to be mapped to one of three C++ functions
 static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
@@ -201,23 +200,12 @@ static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* 
 
   ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(1) && !r.isNone(2)) {
+  if (!r.isNone(1) || !r.isNone(2)) {
     if (!r.isNone(3)) {
-        return wrap(dispatch_clamp(r.tensor(0), r.scalar(1), r.scalar(2), r.tensor(3)));
+        Tensor result = r.tensor(3);
+        return wrap(at::clamp_out(result, r.tensor(0), r.scalar(1), r.scalar(2)));
     } else {
-        return wrap(dispatch_clamp(r.tensor(0), r.scalar(1), r.scalar(2)));
-    }
-  } else if (!r.isNone(1)) {
-    if (!r.isNone(3)) {
-        return wrap(dispatch_clamp_min(r.tensor(0), r.scalar(1), r.tensor(3)));
-    } else {
-        return wrap(dispatch_clamp_min(r.tensor(0), r.scalar(1)));
-    }
-  } else if (!r.isNone(2)) {
-    if (!r.isNone(3)) {
-        return wrap(dispatch_clamp_max(r.tensor(0), r.scalar(2), r.tensor(3)));
-    } else {
-        return wrap(dispatch_clamp_max(r.tensor(0), r.scalar(2)));
+        return wrap(r.tensor(0).clamp(r.scalar(1), r.scalar(2)));
     }
   } else {
     throw std::runtime_error("At least one of 'min' or 'max' must not be None");

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -191,29 +191,6 @@ static PyObject * THPVariable_as_tensor(PyObject* self, PyObject* args, PyObject
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "clamp(Tensor input, Scalar min=None, Scalar max=None, *, Tensor out=None)",
-  });
-
-  ParsedArgs<4> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(1) || !r.isNone(2)) {
-    if (!r.isNone(3)) {
-        Tensor result = r.tensor(3);
-        return wrap(at::clamp_out(result, r.tensor(0), r.scalar(1), r.scalar(2)));
-    } else {
-        return wrap(r.tensor(0).clamp(r.scalar(1), r.scalar(2)));
-    }
-  } else {
-    throw std::runtime_error("At least one of 'min' or 'max' must not be None");
-  }
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
 static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
 {
   HANDLE_TH_ERRORS
@@ -259,7 +236,6 @@ ${py_methods}
 static PyMethodDef torch_functions[] = {
   {"arange", (PyCFunction)THPVariable_arange, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"as_tensor", (PyCFunction)THPVariable_as_tensor, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
-  {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"dsmm", (PyCFunction)THPVariable_mm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"from_numpy", (PyCFunction)THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
   {"hsmm", (PyCFunction)THPVariable_hspmm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -34,32 +34,6 @@ static void maybe_initialize_cuda(const at::Type &type) {
   }
 }
 
-// manual dispatch code for clamp
-inline Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
-  AutoNoGIL no_gil;
-  return self.clamp(min, max);
-}
-inline Tensor dispatch_clamp_min(const Tensor & self, Scalar min) {
-  AutoNoGIL no_gil;
-  return self.clamp_min(min);
-}
-inline Tensor dispatch_clamp_max(const Tensor & self, Scalar max) {
-  AutoNoGIL no_gil;
-  return self.clamp_max(max);
-}
-inline Tensor & dispatch_clamp(const Tensor & self, Scalar min, Scalar max, Tensor result) {
-  AutoNoGIL no_gil;
-  return at::clamp_out(result, self, min, max);
-}
-inline Tensor & dispatch_clamp_min(const Tensor & self, Scalar min, Tensor result) {
-  AutoNoGIL no_gil;
-  return at::clamp_min_out(result, self, min);
-}
-inline Tensor & dispatch_clamp_max(const Tensor & self, Scalar max, Tensor result) {
-  AutoNoGIL no_gil;
-  return at::clamp_max_out(result, self, max);
-}
-
 ${py_method_dispatch}
 
 }} // namespace torch::autograd

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -55,52 +55,6 @@ static PyObject * THPVariable_apply_(PyObject* self, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
-static Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp(min, max);
-}
-
-static PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "clamp(Scalar min=None, Scalar max=None)",
-  }, /*traceable=*/true);
-  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  ParsedArgs<2> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(0) || !r.isNone(1)) {
-    return THPVariable_Wrap(dispatch_clamp(self_, r.scalar(0), r.scalar(1)));
-  } else {
-    throw std::runtime_error("At least one of 'min' or 'max' must not be None");
-  }
-  END_HANDLE_TH_ERRORS
-}
-
-static Tensor & dispatch_clamp_(Tensor & self, Scalar min, Scalar max) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp_(min, max);
-}
-
-static PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "clamp_(Scalar min=None, Scalar max=None)",
-  }, /*traceable=*/true);
-  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  ParsedArgs<2> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(0) || !r.isNone(1)) {
-    return THPVariable_Wrap(dispatch_clamp_(self_, r.scalar(0), r.scalar(1)));
-  } else {
-    throw std::runtime_error("At least one of 'min' or 'max' must not be None");
-  }
-  END_HANDLE_TH_ERRORS
-}
-
 static PyObject * THPVariable_size(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
@@ -633,8 +587,6 @@ PyMethodDef variable_methods[] = {
   {"apply_", (PyCFunction)THPVariable_apply_, METH_O, NULL},
   {"byte", (PyCFunction)THPVariable_byte, METH_NOARGS, NULL},
   {"char", (PyCFunction)THPVariable_char, METH_NOARGS, NULL},
-  {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS, NULL},
-  {"clamp_", (PyCFunction)THPVariable_clamp_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"contiguous", (PyCFunction)THPVariable_contiguous, METH_NOARGS, NULL},
   {"copy_", (PyCFunction)THPVariable_copy_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"cpu", (PyCFunction)THPVariable_cpu, METH_NOARGS, NULL},

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -60,16 +60,6 @@ static Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
   DeviceGuard device_guard(self);
   return self.clamp(min, max);
 }
-static Tensor dispatch_clamp_min(const Tensor & self, Scalar min) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp_min(min);
-}
-static Tensor dispatch_clamp_max(const Tensor & self, Scalar max) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp_max(max);
-}
 
 static PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kwargs)
 {
@@ -80,12 +70,8 @@ static PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kw
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(0) && !r.isNone(1)) {
+  if (!r.isNone(0) || !r.isNone(1)) {
     return THPVariable_Wrap(dispatch_clamp(self_, r.scalar(0), r.scalar(1)));
-  } else if (!r.isNone(0)) {
-    return THPVariable_Wrap(dispatch_clamp_min(self_, r.scalar(0)));
-  } else if (!r.isNone(1)) {
-    return THPVariable_Wrap(dispatch_clamp_max(self_, r.scalar(1)));
   } else {
     throw std::runtime_error("At least one of 'min' or 'max' must not be None");
   }
@@ -97,16 +83,6 @@ static Tensor & dispatch_clamp_(Tensor & self, Scalar min, Scalar max) {
   DeviceGuard device_guard(self);
   return self.clamp_(min, max);
 }
-static Tensor & dispatch_clamp_min_(Tensor & self, Scalar min) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp_min_(min);
-}
-static Tensor & dispatch_clamp_max_(Tensor & self, Scalar max) {
-  AutoNoGIL no_gil;
-  DeviceGuard device_guard(self);
-  return self.clamp_max_(max);
-}
 
 static PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* kwargs)
 {
@@ -117,12 +93,8 @@ static PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* k
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
-  if (!r.isNone(0) && !r.isNone(1)) {
+  if (!r.isNone(0) || !r.isNone(1)) {
     return THPVariable_Wrap(dispatch_clamp_(self_, r.scalar(0), r.scalar(1)));
-  } else if (!r.isNone(0)) {
-    return THPVariable_Wrap(dispatch_clamp_min_(self_, r.scalar(0)));
-  } else if (!r.isNone(1)) {
-    return THPVariable_Wrap(dispatch_clamp_max_(self_, r.scalar(1)));
   } else {
     throw std::runtime_error("At least one of 'min' or 'max' must not be None");
   }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -19,6 +19,7 @@ _(namespaces, scope) \
 _(namespaces, namespaces) \
 _(prim, Assign) \
 _(prim, Constant) \
+_(prim, None) \
 _(prim, Drop) \
 _(prim, Eval) \
 _(prim, Expand) /* onnx */ \

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -104,6 +104,9 @@ struct SchemaParser {
       case TK_FALSE:
         L.next();
         return false;
+      case TK_NONE:
+        L.next();
+        return at::Scalar(NAN);
       case TK_IDENT: {
         auto tok = L.next();
         auto text = tok.text();
@@ -160,11 +163,9 @@ struct SchemaParser {
   }
 
   IValue parseTensorDefault(const SourceRange& range) {
-    if("None" == L.expect(TK_IDENT).text()) {
-      return at::Tensor();
-    } else {
-      throw ErrorReport(range) << "invalid tensor default value";
-    }
+  at::Tensor parseTensorDefault(const SourceRange& range) {
+    L.expect(TK_NONE);
+    return at::Tensor();
   }
   void parseDefaultValue(Argument& arg) {
     auto range = L.cur().range;

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -106,7 +106,7 @@ struct SchemaParser {
         return false;
       case TK_NONE:
         L.next();
-        return at::Scalar(NAN);
+        return IValue();
       case TK_IDENT: {
         auto tok = L.next();
         auto text = tok.text();
@@ -164,7 +164,7 @@ struct SchemaParser {
 
   IValue parseTensorDefault(const SourceRange& range) {
     L.expect(TK_NONE);
-    return at::Tensor();
+    return IValue();
   }
   void parseDefaultValue(Argument& arg) {
     auto range = L.cur().range;

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -163,7 +163,6 @@ struct SchemaParser {
   }
 
   IValue parseTensorDefault(const SourceRange& range) {
-  at::Tensor parseTensorDefault(const SourceRange& range) {
     L.expect(TK_NONE);
     return at::Tensor();
   }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -91,6 +91,14 @@ RegisterOperators reg({
           };
         }),
     Operator(
+        prim::None,
+        [](Node* node) {
+          return [](Stack& stack) {
+            stack.push_back(IValue());
+            return 0;
+          };
+        }),
+    Operator(
         prim::Print,
         [](Node* node) {
           size_t num_inputs = node->inputs().size();

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1358,6 +1358,9 @@ private:
       case TK_FALSE: {
         return insertConstant(*graph, false, tree->range());
       } break;
+      case TK_NONE: {
+        return emitNone(tree->range());
+      } break;
       case TK_SLICE: {
         const auto slice = Slice(tree);
         return emitSlice(
@@ -1381,6 +1384,13 @@ private:
         throw ErrorReport(tree) << "NYI: " << tree;
         break;
     }
+  }
+
+  Value* emitNone(SourceRange range) {
+    auto& g = *method.graph();
+    return g.insertNode(
+        g.create(prim::None, {}, 1)->setSourceLocation(
+          std::make_shared<SourceRange>(range)))->output();
   }
 
   Value* emitConst(const Const& c) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -476,6 +476,13 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         v.value = graph.insertNode(graph.createList(IntType::get(), unpacked))->output();
       }
 
+      if (v.value->node()->kind() == prim::None){
+        if (arg.type->isSubtypeOf(NumberType::get()))
+          v.value = insertConstant(graph, at::Scalar(NAN), loc);
+        else
+          v.value = graph.insertNode(graph.createUndefined())->output();
+      }
+
       if(!v.value->type()->isSubtypeOf(arg.type)) {
         err() << "expected a value of type " << arg.type->str() << " for argument '" << arg.name << "' but found "
               << v.value->type()->str() << "\n"

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -59,6 +59,7 @@ namespace script {
   _(TK_IF_EXPR, "if", "")                        \
   _(TK_TRUE, "True", "True")                     \
   _(TK_FALSE, "False", "False")                  \
+  _(TK_NONE, "None", "None")                     \
   _(TK_AND, "and", "and")                        \
   _(TK_OR, "or", "or")                           \
   _(TK_NOT, "not", "not")                        \

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -52,7 +52,8 @@ struct Parser {
         prefix = parseConst();
       } break;
       case TK_TRUE:
-      case TK_FALSE: {
+      case TK_FALSE:
+      case TK_NONE: {
         auto k = L.cur().kind;
         auto r = L.cur().range;
         prefix = c(k, r, {});

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -97,6 +97,9 @@ void initTreeViewBindings(PyObject *module) {
   m.def("FalseLiteral", [](const SourceRange& range) {
     return Expr(Compound::create(TK_FALSE, range, {}));
   });
+  m.def("NoneLiteral", [](const SourceRange& range) {
+    return Expr(Compound::create(TK_NONE, range, {}));
+  });
   py::class_<Type, TreeView>(m, "Type");
   py::class_<TensorType, Type>(m, "TensorType")
     .def(py::init(&TensorType::create));

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -247,6 +247,7 @@ struct Expr : public TreeView {
       case TK_CONST:
       case TK_TRUE:
       case TK_FALSE:
+      case TK_NONE:
       case TK_CAST:
       case TK_APPLY:
       case '.':

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -38,6 +38,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   } else if(t.kind() == TypeKind::ListType) {
     auto prim = t.cast<ListType>()->getElementType();
     out << *prim << "[]";
+  } else if(t.kind() == TypeKind::NoneType) {
+    out << "None";
   } else {
     AT_ERROR("unknown type kind");
   }
@@ -60,8 +62,10 @@ TypePtr FloatType::get() {
   static auto value = FloatType::create();
   return value;
 }
-
-
+TypePtr NoneType::get() {
+  static auto value = std::make_shared<NoneType>();
+  return value;
+}
 TypePtr ListType::ofTensors() {
   static auto value = ListType::create(DynamicType::get());
   return value;

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -63,7 +63,7 @@ TypePtr FloatType::get() {
   return value;
 }
 TypePtr NoneType::get() {
-  static auto value = std::make_shared<NoneType>();
+  static auto value = NoneType::create();
   return value;
 }
 TypePtr ListType::ofTensors() {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -20,6 +20,7 @@ _(ListType) \
 _(NumberType) \
 _(FloatType) \
 _(IntType) \
+_(NoneType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -379,6 +380,24 @@ struct TORCH_API IntType : public Type {
 private:
   IntType()
   : Type(TypeKind::IntType) {}
+};
+
+// This node represents a Python int number value
+struct NoneType : public Type {
+  NoneType()
+  : Type(TypeKind::NoneType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string str() const override {
+    return "None";
+  }
+  virtual bool isSubtypeOf(const Type& rhs) const override {
+    return *this == rhs;
+  }
+  static const TypeKind Kind = TypeKind::NoneType;
+  // global singleton
+  static TypePtr get();
 };
 
 

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -382,22 +382,29 @@ private:
   : Type(TypeKind::IntType) {}
 };
 
+struct NoneType;
+using NoneTypePtr = std::shared_ptr<NoneType>;
 // This node represents a Python int number value
 struct NoneType : public Type {
-  NoneType()
-  : Type(TypeKind::NoneType) {}
+  template<typename ... T>
+  static NoneTypePtr create( T&& ... all ) {
+    return NoneTypePtr(new NoneType( std::forward<T>(all)... ));
+  }
   virtual bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
   virtual std::string str() const override {
     return "None";
   }
-  virtual bool isSubtypeOf(const Type& rhs) const override {
-    return *this == rhs;
+  virtual bool isSubtypeOf(const TypePtr rhs) const override {
+    return *this == *rhs;
   }
   static const TypeKind Kind = TypeKind::NoneType;
   // global singleton
   static TypePtr get();
+private:
+  NoneType()
+  : Type(TypeKind::NoneType) {}
 };
 
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -333,16 +333,21 @@ class ExprBuilder(Builder):
             return TrueLiteral(r)
         elif expr.id == "False":
             return FalseLiteral(r)
+        elif expr.id == "None":
+            return NoneLiteral(r)
         return Var(Ident(r, expr.id))
 
     @staticmethod
     def build_NameConstant(ctx, expr):
-        text = "True" if expr.value else "False"
-        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(text))
-        if expr.value:
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(str(expr.value)))
+        if expr.value is True:
             return TrueLiteral(r)
-        else:
+        elif expr.value is False:
             return FalseLiteral(r)
+        elif expr.value is None:
+            return NoneLiteral(r)
+        else:
+            raise ValueError("Name constant value unsupported: " + str(expr.value))
 
     @staticmethod
     def build_BinOp(ctx, expr):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -708,7 +708,14 @@ def pow(g, self, exponent):
 
 @parse_args('v', 'f', 'f')
 def clamp(g, self, min, max):
-    return g.op("Clip", self, min_f=min, max_f=max)
+    # check min/max is NaN or not, and dispatch the call
+    # a != a means a == NaN
+    if min != min:
+        return clamp_max(g, self, max)
+    elif max != max:
+        return clamp_min(g, self, min)
+    else:
+        return g.op("Clip", self, min_f=min, max_f=max)
 
 
 @parse_args('v', 'f')


### PR DESCRIPTION
Supersedes #8925 

This PR fixes #8502, it fixes the gradients problem for clamp when passing None to the function, and add support for the NoneLiteral and NoneType in script to enable clamp tests. Now we could have corner cases like:

```python
@torch.jit.script
def func():
    x = torch.randn(3, 3, requires_grad=True)
    y = torch.clamp(x, None, 0) # max = 0
    y = torch.clamp(x, min=None, max=0)
```

In both JIT and Aten, we use Scalar(NAN) as a sentinel value when passing None type to function clamp, this is the current way we used to support None type in JIT and to solve the gradient problem when user explicitly passing None into clamp. 

In JIT side, we create a tensor(NAN) and undefinedTensor if we encounter None when matching the function schema, and later in the interpreter, it will translate to Scalar(NAN) if needed. 

Ideally we don't need clamp_min and clamp_max in ATenNative/Autograd and could only support clamp after this change, but since bunch of other operators (e.g. Activation.cpp, Loss.cpp) is using clamp_min in several places, we will still have the functions available, but all python invocations will only call clamp instead of clamp_min/max (with calling underlying th_max/th_min in clamp). 

@zdevito @jamesr66a 