### PR TITLE
Fix the error in UnpackSegmentsOp when calculating the gradient with "max_length" argument

### DIFF
--- a/caffe2/operators/pack_segments.cc
+++ b/caffe2/operators/pack_segments.cc
@@ -119,7 +119,12 @@ bool UnpackSegmentsOp<CPUContext>::DoRunWithType2() {
 
   CAFFE_ENFORCE_GE(data.ndim(), 2, "DATA should be at least 2-D");
   CAFFE_ENFORCE_EQ(lengths.ndim(), 1, "LENGTH should be 1-D");
-
+  if (max_length_ != -1) {
+    CAFFE_ENFORCE_EQ(
+        max_length_,
+        data.dim(1),
+        "max_length should be equal to the second dimension of the packed segments");
+  }
   const T* l = lengths.template data<T>();
 
   TIndex total_l = std::accumulate(l, l + lengths.dim(0), (TIndex)0);
@@ -175,6 +180,7 @@ OPERATOR_SCHEMA(PackSegments)
         "presence_mask",
         "2 dim boolean tensor"
         ", false where packed_tensor is padded, true otherwise.")
+    .Arg("max_length", "The pre-defined max_length for the packed segments")
     .Arg(
         "pad_minf",
         "Padding number in the packed segments. Use true to pad \
@@ -191,7 +197,8 @@ OPERATOR_SCHEMA(UnpackSegments)
         "lengths",
         "1-d int/long tensor contains the length in each of the input.")
     .Input(1, "tensor", "N+1 dim Tensor.")
-    .Output(0, "packed_tensor", "N dim Tensor");
+    .Output(0, "packed_tensor", "N dim Tensor")
+    .Arg("max_length", "The pre-defined max_length for the packed segments");
 
 class GetPackSegmentsGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/pack_segments.cu
+++ b/caffe2/operators/pack_segments.cu
@@ -256,7 +256,12 @@ bool UnpackSegmentsOp<CUDAContext>::DoRunWithType2() {
 
   CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
   CAFFE_ENFORCE_EQ(lengths.ndim(), 1, "LENGTH should be 1-D");
-
+  if (max_length_ != -1) {
+    CAFFE_ENFORCE_EQ(
+        max_length_,
+        data.dim(1),
+        "max_length should be equal to the packed segments");
+  }
   // Compute prefix sum over the lengths
   array_prefix_sum_exclusive<T>(
       lengths_ptr, num_seq, dev_buffer_, dev_lengths_prefix_sum_, context_);

--- a/caffe2/operators/pack_segments.h
+++ b/caffe2/operators/pack_segments.h
@@ -16,7 +16,6 @@ template <class Context>
 class PackSegmentsOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
-  // USE_SIMPLE_CTOR_DTOR(PackSegmentsOp)
   USE_DISPATCH_HELPER;
 
   PackSegmentsOp(const OperatorDef& operator_def, Workspace* ws)
@@ -62,8 +61,11 @@ template <class Context>
 class UnpackSegmentsOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
-  USE_SIMPLE_CTOR_DTOR(UnpackSegmentsOp)
   USE_DISPATCH_HELPER;
+
+  UnpackSegmentsOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        max_length_(OperatorBase::GetSingleArgument<int>("max_length", -1)) {}
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int, long>>::call(this, Input(LENGTHS));
@@ -78,6 +80,7 @@ class UnpackSegmentsOp final : public Operator<Context> {
   INPUT_TAGS(LENGTHS, DATA);
 
  private:
+  TIndex max_length_;
   Tensor<Context> dev_buffer_;
   Tensor<Context> dev_lengths_prefix_sum_;
   Tensor<Context> dev_max_length_;

--- a/caffe2/python/operator_test/pack_ops_test.py
+++ b/caffe2/python/operator_test/pack_ops_test.py
@@ -101,6 +101,7 @@ class TestTensorPackOps(hu.HypothesisTestCase):
             'UnpackSegments',
             ['l', 't'],
             ['newd'],
+            max_length=max_length,
             device_option=gc))
         assert(workspace.FetchBlob('t').shape[1] == max_length)
         assert((workspace.FetchBlob('newd') == workspace.FetchBlob('d')).all())


### PR DESCRIPTION
Summary: The "max_length" should be passed to UnPackSegmentsOp if "max_length" is given when calling PackSegmentsOp.

Differential Revision: D8919799
