### PR TITLE
Constexpr Type Ids -> 6.5% caffe2 perf improvement

### DIFF
--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -59,7 +59,6 @@ CAFFE2_DEFINE_int(
 
 namespace caffe2 {
 
-CAFFE_KNOWN_TYPE(Tensor<CUDAContext>);
 
 thread_local ThreadLocalCUDAObjects CUDAContext::cuda_objects_;
 

--- a/caffe2/core/dispatch/KernelRegistration.h
+++ b/caffe2/core/dispatch/KernelRegistration.h
@@ -133,8 +133,6 @@ public:
 } // namespace c10
 
 // TODO Can the builder logic be moved to compile time?
-#define CONCAT_IMPL( x, y ) x##y
-#define MACRO_CONCAT( x, y ) CONCAT_IMPL( x, y )
 // NB: Semicolon after applying this macro is MANDATORY
 #define C10_REGISTER_KERNEL(OpSchemaDef)                                                           \
   static KernelRegistrar<OpSchemaDef> MACRO_CONCAT(__kernelRegistrationBuilder_, __COUNTER__) = KernelRegistrationBuilder<OpSchemaDef, 0>()

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -15,8 +15,6 @@ CAFFE2_DEFINE_int64(
     "tensor sizes is bigger than this then tensor will be reset.");
 
 namespace caffe2 {
-// declaring it here instead of context.cc because tensor.h includes context.h
-CAFFE_KNOWN_TYPE(Tensor<CPUContext>);
 
 TensorPrinter::TensorPrinter(
     const std::string& tensor_name,

--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -1,6 +1,7 @@
 #include "caffe2/core/typeid.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/scope_guard.h"
+#include "caffe2/core/tensor.h"
 
 #include <atomic>
 
@@ -59,13 +60,43 @@ void TypeMeta::_ThrowRuntimeTypeLogicError(const std::string& msg) {
 }
 
 CaffeTypeId CaffeTypeId::createTypeId() {
-  static std::atomic<CaffeTypeId::underlying_type> counter(0);
-  const CaffeTypeId::underlying_type new_value = ++counter; // note: first type id is 1 because 0 means uninitialized
+  static std::atomic<CaffeTypeId::underlying_type> counter(
+      TypeMeta::Id<_CaffeHighestPreallocatedTypeId>().underlyingId());
+  const CaffeTypeId::underlying_type new_value = ++counter;
   if (new_value == std::numeric_limits<CaffeTypeId::underlying_type>::max()) {
     throw std::logic_error("Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase CaffeTypeId to use more than 16 bit.");
   }
   return CaffeTypeId(new_value);
 }
+
+CAFFE_DEFINE_KNOWN_TYPE(Tensor<CPUContext>);
+CAFFE_DEFINE_KNOWN_TYPE(Tensor<CUDAContext>);
+CAFFE_DEFINE_KNOWN_TYPE(float);
+CAFFE_DEFINE_KNOWN_TYPE(int);
+CAFFE_DEFINE_KNOWN_TYPE(std::string);
+CAFFE_DEFINE_KNOWN_TYPE(bool);
+CAFFE_DEFINE_KNOWN_TYPE(uint8_t);
+CAFFE_DEFINE_KNOWN_TYPE(int8_t);
+CAFFE_DEFINE_KNOWN_TYPE(uint16_t);
+CAFFE_DEFINE_KNOWN_TYPE(int16_t);
+CAFFE_DEFINE_KNOWN_TYPE(int64_t);
+CAFFE_DEFINE_KNOWN_TYPE(double);
+CAFFE_DEFINE_KNOWN_TYPE(char);
+CAFFE_DEFINE_KNOWN_TYPE(std::unique_ptr<std::mutex>);
+CAFFE_DEFINE_KNOWN_TYPE(std::unique_ptr<std::atomic<bool>>);
+CAFFE_DEFINE_KNOWN_TYPE(std::vector<int32_t>);
+CAFFE_DEFINE_KNOWN_TYPE(std::vector<int64_t>);
+CAFFE_DEFINE_KNOWN_TYPE(std::vector<unsigned long>);
+CAFFE_DEFINE_KNOWN_TYPE(bool*);
+CAFFE_DEFINE_KNOWN_TYPE(char*);
+CAFFE_DEFINE_KNOWN_TYPE(int*);
+
+#ifdef CAFFE2_UNIQUE_LONG_TYPEMETA
+CAFFE_DEFINE_KNOWN_TYPE(long);
+CAFFE_DEFINE_KNOWN_TYPE(std::vector<long>);
+#endif // CAFFE2_UNIQUE_LONG_TYPEMETA
+
+CAFFE_DEFINE_KNOWN_TYPE(_CaffeHighestPreallocatedTypeId);
 
 namespace {
 // This single registerer exists solely for us to be able to name a TypeMeta

--- a/caffe2/core/types.cc
+++ b/caffe2/core/types.cc
@@ -8,32 +8,7 @@
 
 namespace caffe2 {
 
-CAFFE_KNOWN_TYPE(float);
-CAFFE_KNOWN_TYPE(int);
-CAFFE_KNOWN_TYPE(std::string);
-CAFFE_KNOWN_TYPE(bool);
-CAFFE_KNOWN_TYPE(uint8_t);
-CAFFE_KNOWN_TYPE(int8_t);
-CAFFE_KNOWN_TYPE(uint16_t);
-CAFFE_KNOWN_TYPE(int16_t);
-CAFFE_KNOWN_TYPE(int64_t);
 CAFFE_KNOWN_TYPE(caffe2::float16);
-CAFFE_KNOWN_TYPE(double);
-CAFFE_KNOWN_TYPE(char);
-CAFFE_KNOWN_TYPE(std::unique_ptr<std::mutex>);
-CAFFE_KNOWN_TYPE(std::unique_ptr<std::atomic<bool>>);
-CAFFE_KNOWN_TYPE(std::vector<int32_t>);
-CAFFE_KNOWN_TYPE(std::vector<int64_t>);
-CAFFE_KNOWN_TYPE(std::vector<unsigned long>);
-CAFFE_KNOWN_TYPE(bool*);
-CAFFE_KNOWN_TYPE(char*);
-CAFFE_KNOWN_TYPE(int*);
-
-#ifdef CAFFE2_UNIQUE_LONG_TYPEMETA
-CAFFE_KNOWN_TYPE(long);
-CAFFE_KNOWN_TYPE(std::vector<long>);
-#endif // CAFFE2_UNIQUE_LONG_TYPEMETA
-
 
 TensorProto::DataType TypeMetaToDataType(const TypeMeta& meta) {
   static_assert(sizeof(int) == 4,

--- a/caffe2/opt/backend_cutting.cc
+++ b/caffe2/opt/backend_cutting.cc
@@ -269,7 +269,8 @@ void ReplaceSubgraph(
     auto op_node = g->createNode();
     for (const auto& input : op.input()) {
       if (!tensor_map.count(input)) {
-        tensor_map[input] = g->createNode(caffe2::make_unique<Tensor>(input));
+        tensor_map[input] =
+            g->createNode(caffe2::make_unique<nom::repr::Tensor>(input));
       }
 
       auto tensor_node = tensor_map[input];
@@ -278,7 +279,8 @@ void ReplaceSubgraph(
 
     for (const auto& output : op.output()) {
       if (!tensor_map.count(output)) {
-        tensor_map[output] = g->createNode(caffe2::make_unique<Tensor>(output));
+        tensor_map[output] =
+            g->createNode(caffe2::make_unique<nom::repr::Tensor>(output));
       }
       auto tensor_node = tensor_map[output];
       g->createEdge(op_node, tensor_node);


### PR DESCRIPTION
Summary:
Using constexpr for some heavily queried type ids gives us a 6.5% perf improvement for caffe2.

Benchmark results: P59829647

Differential Revision: D8841577
