### PR TITLE
Create torch::from_blob for variables

### DIFF
--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -35,7 +35,7 @@ inline Tensor from_blob(
     void* data,
     IntList sizes,
     const TensorOptions& options = {}) {
-  return native::from_blob(data, sizes, [](void*) {}, options);
+  return native::from_blob(data, sizes, /*deleter=*/[](void*) {}, options);
 }
 
 // These functions are defined in native/TensorFactories.cpp.

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -5,6 +5,8 @@
 #include <ATen/ATen.h>
 
 #include <cmath>
+#include <cstddef>
+#include <vector>
 
 template <typename T>
 bool exactly_equal(at::Tensor left, T right) {
@@ -178,4 +180,15 @@ TEST_CASE("Tensor/UsesOptionsThatAreSupplied") {
   REQUIRE(exactly_equal(tensor[0], 1));
   REQUIRE(exactly_equal(tensor[1], 2));
   REQUIRE(exactly_equal(tensor[2], 3));
+}
+
+TEST_CASE("FromBlob") {
+  std::vector<int32_t> v = {1, 2, 3};
+  auto tensor = torch::from_blob(
+      reinterpret_cast<void*>(v.data()), v.size(), torch::kInt32);
+  REQUIRE(tensor.is_variable());
+  REQUIRE(tensor.numel() == 3);
+  REQUIRE(tensor[0].toCInt() == 1);
+  REQUIRE(tensor[1].toCInt() == 2);
+  REQUIRE(tensor[2].toCInt() == 3);
 }

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -7,6 +7,7 @@
 #include <ATen/ATen.h>
 #include <ATen/ArrayRef.h>
 
+#include <functional>
 #include <initializer_list>
 #include <utility>
 
@@ -38,5 +39,24 @@ namespace torch {
 AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(TENSOR)
 #undef TENSOR
 
+inline autograd::Variable from_blob(
+    void* data,
+    at::IntList sizes,
+    const std::function<void(void*)>& deleter,
+    const at::TensorOptions& options = {}) {
+  at::Tensor tensor =
+      at::from_blob(data, sizes, deleter, options.discard_runtime_type());
+  return autograd::make_variable(
+      tensor, /*requires_grad=*/options.requires_grad());
+}
+
+inline autograd::Variable from_blob(
+    void* data,
+    at::IntList sizes,
+    const at::TensorOptions& options = {}) {
+  return torch::from_blob(data, sizes, /*deleter=*/[](void*) {}, options);
+}
+
 ${function_definitions}
+
 } // namespace torch


### PR DESCRIPTION
Need an overload of `at::from_blob` for Variables.

@ezyang @colesbury @ebetica 