### PR TITLE
Add operator<< overloads for TensorOptions

### DIFF
--- a/aten/src/ATen/Layout.h
+++ b/aten/src/ATen/Layout.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ScalarType.h>
+#include <ATen/Error.h>
 
 #include <iostream>
 
@@ -22,5 +23,12 @@ inline Layout layout_from_backend(Backend backend) {
 } // namespace at
 
 inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
-  return stream << ((layout == at::kStrided) ? "Strided" : "Sparse");
+  switch (layout) {
+    case at::kStrided:
+      return stream << "Strided";
+    case at::kSparse:
+      return stream << "Sparse";
+    default:
+      AT_ERROR("Unknown layout");
+  }
 }

--- a/aten/src/ATen/Layout.h
+++ b/aten/src/ATen/Layout.h
@@ -2,6 +2,8 @@
 
 #include <ATen/ScalarType.h>
 
+#include <iostream>
+
 namespace at {
 enum class Layout { Strided, Sparse };
 
@@ -18,3 +20,7 @@ inline Layout layout_from_backend(Backend backend) {
   }
 }
 } // namespace at
+
+inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
+  return stream << ((layout == at::kStrided) ? "Strided" : "Sparse");
+}

--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <stdint.h>
-
 #include "ATen/ArrayRef.h"
 #include "ATen/ATenGeneral.h"
 #include "ATen/Half.h"
+
+#include <cstdint>
+#include <iostream>
 
 namespace at {
 
@@ -168,3 +169,9 @@ typedef ArrayRef<int64_t> IntList;
 typedef ArrayRef<Tensor> TensorList;
 
 } // namespace at
+
+inline std::ostream& operator<<(
+    std::ostream& stream,
+    at::ScalarType scalar_type) {
+  return stream << at::toString(scalar_type);
+}

--- a/aten/src/ATen/TensorOptions.cpp
+++ b/aten/src/ATen/TensorOptions.cpp
@@ -6,6 +6,8 @@
 #include <ATen/ScalarType.h>
 #include <ATen/optional.h>
 
+#include <iostream>
+
 namespace at {
 
 TensorOptions::TensorOptions(bool use_thread_local_default_options) {
@@ -17,3 +19,13 @@ TensorOptions::TensorOptions(bool use_thread_local_default_options) {
   }
 }
 } // namespace at
+
+std::ostream& operator<<(
+    std::ostream& stream,
+    const at::TensorOptions& options) {
+  return stream << "TensorOptions(dtype=" << options.dtype()
+                << ", device=" << options.device()
+                << ", layout=" << options.layout()
+                << ", requires_grad=" << std::boolalpha
+                << options.requires_grad() << ")";
+}

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -9,6 +9,7 @@
 #include <ATen/Type.h>
 
 #include <cstddef>
+#include <iosfwd>
 #include <utility>
 
 namespace at {
@@ -277,3 +278,7 @@ inline Tensor Tensor::to(Device device, bool non_blocking) const {
   return detail::to(*this, options().device(device), non_blocking);
 }
 } // namespace at
+
+std::ostream& operator<<(
+    std::ostream& stream,
+    const at::TensorOptions& options);


### PR DESCRIPTION
Added `operator<<` overloads for `at::TensorOptions` on request of @ebetica 

Example output:

```
TensorOptions(dtype=Double, device=cpu, layout=Strided, requires_grad=false)
```

@ezyang @apaszke