### PR TITLE
[C++ API] Change behavior of clone to clone to a device

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -295,11 +295,25 @@ TEST_CASE("sequential") {
     REQUIRE(params1.size() == params2.size());
     for (auto& param : params1) {
       REQUIRE(!pointer_equal(param.value, params2[param.key]));
+      REQUIRE(param->device() == params2[param.key].device());
       REQUIRE(param->allclose(params2[param.key]));
       param->data().add_(2);
     }
     for (auto& param : params1) {
       REQUIRE(!param->allclose(params2[param.key]));
     }
+  }
+}
+
+TEST_CASE("sequential/clone-to-device", "[cuda]") {
+  Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
+  torch::Device device(torch::kCUDA, 0);
+  Sequential clone =
+      std::static_pointer_cast<SequentialImpl>(sequential->clone(device));
+  for (const auto& p : clone->parameters()) {
+    REQUIRE(p->device() == device);
+  }
+  for (const auto& b : clone->buffers()) {
+    REQUIRE(b->device() == device);
   }
 }

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -4,6 +4,9 @@
 #include <torch/tensor.h>
 
 #include <ATen/Error.h>
+#include <ATen/OptionsGuard.h>
+#include <ATen/TensorOptions.h>
+#include <ATen/optional.h>
 
 #include <memory>
 #include <utility>
@@ -29,7 +32,12 @@ class Cloneable : public Module {
   /// Performs a recursive "deep copy" of the `Module`, such that all parameters
   /// and submodules in the cloned module are different from those in the
   /// original module.
-  std::shared_ptr<Module> clone() const override {
+  std::shared_ptr<Module> clone(
+      at::optional<Device> device = at::nullopt) const override {
+    auto options = DefaultTensorOptions::get();
+    OptionsGuard options_guard(
+        options.device(device.value_or(options.device())));
+
     const auto& self = static_cast<const Derived&>(*this);
     auto copy = std::make_shared<Derived>(self);
     copy->parameters_.clear();
@@ -43,8 +51,13 @@ class Cloneable : public Module {
         "Are you sure you called register_parameter() inside reset() "
         "and not the constructor?");
     for (const auto& parameter : parameters_) {
-      copy->parameters_[parameter.key].data().copy_(
-          parameter->data(), /*non_blocking=*/true);
+      if (device) {
+        copy->parameters_[parameter.key].data().copy_(
+            parameter->data(), /*non_blocking=*/true);
+      } else {
+        at::detail::set_data(
+            copy->parameters_[parameter.key], parameter->data().clone());
+      }
     }
     AT_CHECK(
         copy->buffers_.size() == buffers_.size(),
@@ -53,8 +66,13 @@ class Cloneable : public Module {
         "Are you sure you called register_buffer() inside reset() "
         "and not the constructor?");
     for (const auto& buffer : buffers_) {
-      copy->buffers_[buffer.key].data().copy_(
-          buffer->data(), /*non_blocking=*/true);
+      if (device) {
+        copy->buffers_[buffer.key].data().copy_(
+            buffer->data(), /*non_blocking=*/true);
+      } else {
+        at::detail::set_data(
+            copy->buffers_[buffer.key], buffer->data().clone());
+      }
     }
     AT_CHECK(
         copy->children_.size() == children_.size(),
@@ -63,17 +81,17 @@ class Cloneable : public Module {
         "Are you sure you called register_module() inside reset() "
         "and not the constructor?");
     for (const auto& child : children_) {
-      copy->children_[child.key]->clone_(*child.value);
+      copy->children_[child.key]->clone_(*child.value, device);
     }
     return copy;
   }
 
  private:
-  void clone_(Module& other) final override {
+  void clone_(Module& other, at::optional<Device> device) final override {
     // Here we are *pretty* certain that `other's` type is `Derived` (because it
     // was registered under the same name as `this`), but you never know what
     // crazy things `reset()` does, so `dynamic_cast` just to be safe.
-    auto clone = std::dynamic_pointer_cast<Derived>(other.clone());
+    auto clone = std::dynamic_pointer_cast<Derived>(other.clone(device));
     AT_CHECK(
         clone != nullptr,
         "Attempted to clone submodule, but it is of a "

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -40,8 +40,11 @@ class Module {
   const std::string& name() const noexcept;
 
   /// Performs a recursive deep copy of the module and all its registered
-  /// parameters, buffers and submodules.
-  virtual std::shared_ptr<Module> clone() const;
+  /// parameters, buffers and submodules, optionally setting the current device
+  /// to the one supplied before cloning. If no device is given, each
+  /// parameter and buffer will be moved to the device of its source.
+  virtual std::shared_ptr<Module> clone(
+      at::optional<Device> device = at::nullopt) const;
 
   /// Provides a means to traverse the `Module` tree.
   ModuleCursor modules();
@@ -144,7 +147,7 @@ class Module {
   template <typename T>
   friend class detail::CursorBase;
 
-  virtual void clone_(Module& other);
+  virtual void clone_(Module& other, at::optional<Device> device);
 
   /// The implementation of the various `to()` methods.
   template <typename... Ts>

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -37,10 +37,11 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
 
   /// Special cloning function for `Sequential` because it does not use
   /// `reset()`.
-  std::shared_ptr<Module> clone() const override {
+  std::shared_ptr<Module> clone(
+      at::optional<Device> device = at::nullopt) const override {
     auto clone = std::make_shared<SequentialImpl>();
     for (const auto& module : modules_) {
-      clone->push_back(module.clone());
+      clone->push_back(module.clone(device));
     }
     return clone;
   }

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -36,14 +36,8 @@ std::vector<std::shared_ptr<ModuleType>> replicate(
   std::vector<std::shared_ptr<ModuleType>> replicas;
   replicas.reserve(devices.size());
   for (const auto& device : devices) {
-    // Here we rely on the property tensors are never (or should never be)
-    // allocated on any particular device, but always the default device, e.g.
-    // in `torch::ones({3, 4})`, the device is unspecified and pulled from the
-    // current thread local default options. As such, we can here modify these
-    // thread local default options and thereby cause all tensors in the cloned
-    // module to be constructed directly on the device we want.
-    OptionsGuard guard(device);
-    replicas.push_back(std::static_pointer_cast<ModuleType>(module->clone()));
+    replicas.push_back(
+        std::static_pointer_cast<ModuleType>(module->clone(device)));
   }
   return replicas;
 }

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/autograd/generated/VariableType.h>
 
 #include <ATen/Error.h>
+#include <ATen/optional.h>
 
 #include <algorithm>
 #include <map>
@@ -34,7 +35,7 @@ const std::string& Module::name() const noexcept {
   return *name_;
 }
 
-std::shared_ptr<Module> Module::clone() const {
+std::shared_ptr<Module> Module::clone(at::optional<Device> device) const {
   AT_ERROR(
       "clone() has not been implemented for ",
       name(),
@@ -130,6 +131,6 @@ Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 
-void Module::clone_(Module& other) {}
+void Module::clone_(Module& other, at::optional<Device> device) {}
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
@ebetica made me aware that `nn::Module::clone()` always clones to the current device (usually CPU) instead of preserving the device of each parameter. This PR changes the signature of `clone` from

`shared_ptr<Module> clone()`

to

`shared_ptr<Module> clone(optional<Device> device = nullopt)`

with semantics of:

1. If a `device` is given, all parameters/buffers are moved to that device,
2. If no `device` is supplied (default), parameters/buffers retain their device.

@ezyang @apaszke @ebetica 