### PR TITLE
Fixed a missing '=' in LPPoolNd repr function

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -691,7 +691,7 @@ class _LPPoolNd(Module):
         self.ceil_mode = ceil_mode
 
     def extra_repr(self):
-        return 'norm_type={norm_type}, kernel_size{kernel_size}, stride={stride}, ' \
+        return 'norm_type={norm_type}, kernel_size={kernel_size}, stride={stride}, ' \
             'ceil_mode={ceil_mode}'.format(**self.__dict__)
 
 


### PR DESCRIPTION
In the repr funciton of LPPoolNd(..) class, there was a missing '='. (`kernel_size{kernel_size}`)

Link to line in the code: https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/pooling.py#L694

Original:

       return 'norm_type={norm_type}, kernel_size{kernel_size}, stride={stride}, ' \
              'ceil_mode={ceil_mode}'.format(**self.__dict__)

Fixed:

       return 'norm_type={norm_type}, kernel_size={kernel_size}, stride={stride}, ' \
              'ceil_mode={ceil_mode}'.format(**self.__dict__)

