### PR TITLE
[TENSOR MERGE] Native localScalar

### DIFF
--- a/aten/src/ATen/Scalar.cpp
+++ b/aten/src/ATen/Scalar.cpp
@@ -6,6 +6,7 @@
 
 #include "ATen/Tensor.h"
 #include "ATen/Context.h"
+#include "ATen/TensorMethods.h"
 
 namespace at {
 Tensor Scalar::toTensor() const {

--- a/aten/src/ATen/Scalar.cpp
+++ b/aten/src/ATen/Scalar.cpp
@@ -18,4 +18,12 @@ Tensor Scalar::toTensor() const {
     return CPU(kLong).scalarTensor(*this);
   }
 }
+
+Scalar Scalar::local() const {
+  if (Tag::HAS_t != tag) {
+    return *this;
+  }
+  return Tensor(t)._local_scalar();
+}
+
 }

--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -38,12 +38,7 @@ public:
 #undef DEFINE_IMPLICIT_CTOR
 
   // return a new scalar that is guarenteed to be not backed by a tensor.
-  Scalar local() const {
-    if (Tag::HAS_t != tag) {
-      return *this;
-    }
-    return t.pImpl->localScalar();
-  }
+  Scalar local() const;
 
 #define DEFINE_ACCESSOR(type,name,member) \
   type to##name () const { \

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -41,15 +41,6 @@ IntList SparseTensorImpl::strides() const {
 int64_t SparseTensorImpl::dim() const {
   return sparseDims_ + denseDims_;
 }
-Scalar SparseTensorImpl::localScalar() {
-  int64_t n = numel();
-  AT_CHECK(n == 1, "a Tensor with ", n, " elements cannot be converted to Scalar");
-  if (nnz_ == 0) return Scalar(0);
-  if (coalesced_) return values_.pImpl->localScalar();
-  // You have a non-coalesced scalar sparse tensor?!  Wow!  Have
-  // a cookie.
-  return values_.sum().pImpl->localScalar();
-}
 void * SparseTensorImpl::unsafeGetTH(bool retain) {
   AT_ERROR("unsafeGetTH not supported for new style TensorImpl");
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -61,7 +61,6 @@ public:
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;
-  Scalar localScalar() override;
   void * unsafeGetTH(bool retain) override;
   std::unique_ptr<Storage> storage() override;
 

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -46,6 +46,12 @@ IntList TensorImpl::sizes() const {
   return IntList(THTensor_getSizePtr(tensor), dim());
 }
 
+IntList TensorImpl::strides() const {
+  // NB: dim in tensor is not synchronized with THTensor, so it's
+  // important to apply dim here
+  return IntList(THTensor_getStridePtr(tensor), dim());
+}
+
 void TensorImpl::release_resources() {
   if (tensor) {
       tensor->release();

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -32,11 +32,6 @@ struct AT_API TensorImpl : public Retainable {
   virtual IntList sizes() const;
   virtual IntList strides() const;
   virtual int64_t dim() const;
-  /**
-   * Perform a conversion of this tensor to a scalar, if numel() == 1.
-   * Otherwise, raise an error.
-   */
-  virtual Scalar localScalar() = 0;
   virtual void * unsafeGetTH(bool retain);
   virtual std::unique_ptr<Storage> storage() = 0;
   friend struct Type;

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -30,7 +30,7 @@ struct AT_API TensorImpl : public Retainable {
   }
   virtual const char * toString() const = 0;
   virtual IntList sizes() const;
-  virtual IntList strides() const = 0;
+  virtual IntList strides() const;
   virtual int64_t dim() const;
   /**
    * Perform a conversion of this tensor to a scalar, if numel() == 1.

--- a/aten/src/ATen/UndefinedTensor.cpp
+++ b/aten/src/ATen/UndefinedTensor.cpp
@@ -34,10 +34,6 @@ std::unique_ptr<Storage> UndefinedTensor::storage() {
 IntList UndefinedTensor::strides() const {
   AT_ERROR("strides() called on undefined Tensor");
 }
-Scalar UndefinedTensor::localScalar() {
-  AT_ERROR("localScalar() called on undefined Tensor");
-}
-
 UndefinedTensor UndefinedTensor::_singleton;
 
 }

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -13,7 +13,6 @@ public:
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;
-  Scalar localScalar() override;
   void * unsafeGetTH(bool retain) override;
   std::unique_ptr<Storage> storage() override;
   static const char * typeString();

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -179,6 +179,15 @@ There are a few situations where you might like to use this functionality:
 If you grep for `python_default_init`, you can find examples of this being used;
 in general, most functions will not need to use this.
 
+### `cpu_half`
+
+```
+cpu_half: True
+```
+
+By default, we do not generate dispatch for CPU half, because most kernels will
+not work.  You probably don't actually want to use this.
+
 ## Writing an implementation in C++
 
 Implementations of native functions go in an appropriate C++ file in the

--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -1,0 +1,29 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+
+namespace at {
+namespace native {
+
+Scalar _local_scalar(const Tensor& self) {
+  int64_t numel = self.numel();
+  AT_CHECK(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
+  if (self.is_sparse()) {
+    if (self._nnz() == 0) return Scalar(0);
+    if (self.is_coalesced()) return at::_local_scalar_dense(self._values());
+    return at::_local_scalar_dense(self._values().sum());
+  } else {
+    return _local_scalar_dense(self);
+  }
+}
+
+Scalar _local_scalar_dense_cpu(const Tensor& self) {
+  Scalar r;
+  AT_DISPATCH_ALL_TYPES_AND_HALF(
+      self.type(), "_local_scalar_dense_cpu", [&] {
+        scalar_t value = *self.data<scalar_t>();
+        r = Scalar(value);
+      });
+  return r;
+}
+
+}} // at::native

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -59,7 +59,7 @@ bool is_nonzero(const Tensor& self) {
   if (n > 1) {
     AT_ERROR("bool value of Tensor with more than one value is ambiguous");
   }
-  Scalar localScalar = self.pImpl->localScalar();
+  Scalar localScalar = self._local_scalar();
   if (localScalar.isFloatingPoint()) {
     return localScalar.to<double>() != 0;
   } else if (localScalar.isIntegral()){

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -1,0 +1,23 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+
+#include "ATen/cuda/CUDAContext.h"
+#include "cuda.h"
+
+namespace at {
+namespace native {
+
+Scalar _local_scalar_dense_cuda(const Tensor& self) {
+  Scalar r;
+  AT_DISPATCH_ALL_TYPES_AND_HALF(
+      self.type(), "_local_scalar_dense_cuda", [&] {
+        scalar_t value;
+        cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+        AT_CUDA_CHECK(cudaMemcpyAsync(&value, self.data<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream));
+        AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+        r = Scalar(value);
+      });
+  return r;
+}
+
+}} // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1970,3 +1970,18 @@
 
 - func: meshgrid(TensorList tensors) -> TensorList
   variants: function
+
+# This has a method dispatch to work around circular include problems
+- func: _local_scalar(Tensor self) -> Scalar
+  variants:
+    - function
+    - method
+
+# NB: Does NOT check precondition that numel == 1
+- func: _local_scalar_dense(Tensor self) -> Scalar
+  cpu_half: True
+  dispatch:
+    CPU: _local_scalar_dense_cpu
+    CUDA: _local_scalar_dense_cuda
+  variants:
+    - function

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -129,6 +129,7 @@ def run(paths):
                 output_arguments = [x for x in arguments if x.get('output')]
                 declaration['return'] = return_type if len(output_arguments) == 0 else output_arguments
                 declaration['variants'] = func.get('variants', ['method', 'function'])
+                declaration['cpu_half'] = func.get('cpu_half', False)
                 declaration['deprecated'] = func.get('deprecated', False)
                 declaration['device_guard'] = func.get('device_guard', True)
                 declaration['arguments'] = func.get('arguments', arguments)

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,10 +1,5 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
-Scalar ${Tensor}::localScalar() {
-  int64_t numel = ${THTensor}_nElement(${state,}tensor);
-  AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
-  return Scalar(${to_at_type}(${THStorage}_get(${state,} THTensor_getStoragePtr(tensor), tensor->storage_offset())));
-}
 std::unique_ptr<Storage> ${Tensor}::storage() {
   auto storage = THTensor_getStoragePtr(tensor);
   THStorage_retain(storage);

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,17 +1,12 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
-IntList ${Tensor}::strides() const {
-  // NB: THTensor doesn't agree with Tensor for scalars, so we
-  // have to construct a fresh IntList
-  return IntList(THTensor_getStridePtr(tensor), dim());
-}
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
   AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
   return Scalar(${to_at_type}(${THStorage}_get(${state,} THTensor_getStoragePtr(tensor), tensor->storage_offset())));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {
-  auto storage = ${THTensor}_storage(${state,}tensor);
-  ${THStorage}_retain(${state,}storage);
+  auto storage = THTensor_getStoragePtr(tensor);
+  THStorage_retain(storage);
   return std::unique_ptr<Storage>(new ${Storage}(storage));
 }

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -14,7 +14,6 @@ struct ${Tensor} final : public TensorImpl {
 public:
   ${Tensor}(THTensor * tensor);
   virtual const char * toString() const override;
-  virtual IntList strides() const override;
   virtual Scalar localScalar() override;
   virtual std::unique_ptr<Storage> storage() override;
   static const char * typeString();

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -14,7 +14,6 @@ struct ${Tensor} final : public TensorImpl {
 public:
   ${Tensor}(THTensor * tensor);
   virtual const char * toString() const override;
-  virtual Scalar localScalar() override;
   virtual std::unique_ptr<Storage> storage() override;
   static const char * typeString();
 };

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -54,7 +54,7 @@ AT_FORALL_SCALAR_TYPES(DEFINE_CAST)
 #undef DEFINE_CAST
 
 #define DEFINE_TO_C_TYPE(T,name,_) \
-inline T Tensor::toC##name () const { return pImpl->localScalar().to##name (); }
+inline T Tensor::toC##name () const { return _local_scalar().to##name (); }
 
 AT_FORALL_SCALAR_TYPES(DEFINE_TO_C_TYPE)
 #undef DEFINE_TO_C_TYPE

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -70,10 +70,6 @@ std::unique_ptr<at::Storage> Variable::Impl::storage() {
   return data_.storage();
 }
 
-Scalar Variable::Impl::localScalar() {
-  return data_.pImpl->localScalar();
-}
-
 std::shared_ptr<Function> Variable::Impl::get_grad_accumulator() {
   if (grad_fn_) {
     throw std::logic_error(

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -272,7 +272,6 @@ struct Variable::Impl : public at::TensorImpl {
   at::IntList sizes() const override;
   at::IntList strides() const override;
   int64_t dim() const override;
-  at::Scalar localScalar() override;
   void* unsafeGetTH(bool retain) override;
   std::unique_ptr<at::Storage> storage() override;
   static const char* typeString();

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -351,9 +351,6 @@ public:
   virtual int64_t dim() const override {
     throw std::runtime_error("dim() on ContainerTensor");
   }
-  virtual at::Scalar localScalar() override {
-    throw std::runtime_error("localScalar() on ContainerTensor");
-  }
   virtual void * unsafeGetTH(bool retain) override {
     throw std::runtime_error("unsafeGetTH() on ContainerTensor");
   }


### PR DESCRIPTION
Reimplement localScalar as a native function.

I split it into two parts, _local_scalar and _local_scalar_dense (unchecked)
so I could reuse the sparse logic in both paths.

_local_scalar became a method on Tensor to work around a circular
include problem.

Stacked on #9644
Just https://github.com/pytorch/pytorch/commit/c082a7839942ea0f8826a36ce00c9418419b16da