### PR TITLE
fix argmax/min perf gap with numpy

### DIFF
--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -296,7 +296,7 @@ bool THC_reduceAll(THCState* state,
 
     /*
     Only instantiates the all 1D special case and the fallback all nD case for
-    large (64-bit indexed) tensors to reduce compilation time. 
+    large (64-bit indexed) tensors to reduce compilation time.
     */
     if (inInfo.dims == 1) {
       HANDLE_IN_CASE(uint64_t, 1);

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -17,7 +17,7 @@
 #endif
 
 /*
-Reductions that (only) operate on accumulate types. 
+Reductions that (only) operate on accumulate types.
 */
 
 template <typename T>
@@ -108,9 +108,9 @@ inline __device__ T THCMax(const T a, const T b) {
 }
 
 template<typename T, typename AccT>
-__global__ void THCTensor_kernel_renorm(T *data, 
-                                        const AccT value, 
-                                        const ptrdiff_t size, 
+__global__ void THCTensor_kernel_renorm(T *data,
+                                        const AccT value,
+                                        const ptrdiff_t size,
                                         const AccT maxnorm) {
   __shared__ AccT buffer[32];
   int64_t tx = threadIdx.x;
@@ -141,7 +141,7 @@ __global__ void THCTensor_kernel_renorm(T *data,
     // get norm of axis
     for (ptrdiff_t i = tx; i < size; i += step) {
       const AccT val = scalar_cast<AccT>(row[i]);
-      buffer[tx] = THCNumerics<AccT>::add( 
+      buffer[tx] = THCNumerics<AccT>::add(
         buffer[tx],
         THCNumerics<AccT>::pow(THCNumerics<AccT>::abs(val), value)
       );
@@ -178,7 +178,7 @@ struct TensorNonZeroOp {
   __host__ __device__ T operator()(const T lhs) const {
     const T zero = scalar_cast<T>(0);
     if (THCNumerics<T>::eq(lhs, zero)) return zero;
-      
+
     return scalar_cast<T>(1);
   }
 };
@@ -209,7 +209,7 @@ struct ThrustTensorDistOp {
     const AccT x = scalar_cast<AccT>(_x);
     const AccT y = scalar_cast<AccT>(_y);
     return THCNumerics<AccT>::pow(
-      THCNumerics<AccT>::abs(THCNumerics<AccT>::sub(x, y)), 
+      THCNumerics<AccT>::abs(THCNumerics<AccT>::sub(x, y)),
       exponent);
   }
 
@@ -221,8 +221,8 @@ struct ThrustTensorDistOp {
 // Given the sum of values and the sum of squares, compute the variance or standard deviation.
 template<typename T, bool flag, bool apply_sqrt>
 __forceinline__ __device__ T THCTensor_computeVar(
-  T sum, 
-  T sum2, 
+  T sum,
+  T sum2,
   const unsigned row_size) {
 
   T rs2 = scalar_cast<T>(row_size);
@@ -246,7 +246,7 @@ __forceinline__ __device__ T THCTensor_computeVar(
 
   if (apply_sqrt)
     return THCNumerics<T>::sqrt(sum2);
-  
+
   return sum2;
 }
 
@@ -396,10 +396,10 @@ __global__ void THCTensor_kernel_varInnermostDim(T *tgt, T *src_, unsigned num_r
      * true sum.
      */
     for (unsigned lane_mask = 8; lane_mask > 0; lane_mask >>= 1) {
-      local_sum = THCNumerics<AccT>::add(local_sum, 
+      local_sum = THCNumerics<AccT>::add(local_sum,
           WARP_SHFL_XOR((row < num_rows) ? local_sum : acc_zero, lane_mask, 16));
     }
-    AccT true_mean = THCNumerics<AccT>::div(local_sum, 
+    AccT true_mean = THCNumerics<AccT>::div(local_sum,
       scalar_cast<AccT>(row_size));
 
     /*
@@ -422,7 +422,7 @@ __global__ void THCTensor_kernel_varInnermostDim(T *tgt, T *src_, unsigned num_r
      * the total sum, which is equal to the M2 for the entire input row.
      */
     for (unsigned s = 8; s >= 1; s >>= 1) {
-      adjusted_M2 = THCNumerics<AccT>::add(adjusted_M2, 
+      adjusted_M2 = THCNumerics<AccT>::add(adjusted_M2,
           WARP_SHFL_DOWN((row < num_rows) ? adjusted_M2 : acc_zero, s, 16));
     }
 
@@ -543,6 +543,8 @@ THC_transformReduceOuterDimIndex(THCState *state,
 
 /* Reduce the innermost dimension of a tensor (on thrust::pair functors which are (value, index))
  *
+ * This kernel should be called with BlockDim=(512, 1, 1)
+ *
  * For an n-d tensor (n <= 4) where the reduction is along the innermost dimension:
  *
  * - block.x is the innermost dimension, i.e. dimension 0;
@@ -560,8 +562,8 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
                                        unsigned row_size,
                                        thrust::pair<K, Index> init,
                                        BinaryFunction binary_op) {
-  __shared__ K sbuf[32][16 + 1]; // avoid bank conflict
-  __shared__ Index ibuf[32][16 + 1]; // avoid bank conflict
+  __shared__ K sbuf[512 + 1]; // avoid bank conflict
+  __shared__ Index ibuf[512 + 1]; // avoid bank conflict
 
   for (unsigned block_row = blockIdx.x * blockDim.y;
        block_row < num_rows;
@@ -576,15 +578,15 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
       }
     }
 
-    sbuf[threadIdx.y][threadIdx.x] = acc.first;
-    ibuf[threadIdx.y][threadIdx.x] = acc.second;
+    sbuf[threadIdx.x] = acc.first;
+    ibuf[threadIdx.x] = acc.second;
 
     __syncthreads();
 
     // Reduce intermediate values to single value.
-    K* sline = &sbuf[threadIdx.y][0];
-    Index* iline = &ibuf[threadIdx.y][0];
-    for (unsigned s = 8; s > 0; s >>= 1) {
+    K* sline = &sbuf[0];
+    Index* iline = &ibuf[0];
+    for (unsigned s = 256; s > 0; s >>= 1) {
       if (row < num_rows && threadIdx.x < s) {
         thrust::pair<K, Index> arg1 =
           thrust::make_pair<K, Index>(sline[threadIdx.x], iline[threadIdx.x]);
@@ -625,7 +627,7 @@ THC_transformReduceInnermostDimIndex(THCState *state,
   }
   unsigned row_size = THCTensor_size(state, src, ndim - 1);
 
-  dim3 threads(16, 32);
+  dim3 threads(512);
   dim3 grid(min(1024, THCCeilDiv(num_rows, threads.y)));
 
   kernelTransformReduceInnermostDimIndex

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -257,7 +257,7 @@ THCTensor_(normall)(THCState *state, THCTensor *self, real _value)
                         ReduceAdd<accreal>{},
                         scalar_cast<accreal>(0),
                         &result, 0);
-    result = THCNumerics<accreal>::pow(result, 
+    result = THCNumerics<accreal>::pow(result,
                                        THCNumerics<accreal>::cinv(value));
   }
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -296,8 +296,9 @@ def argmin(input, dim=None, keepdim=False):
     if dim is None:
         # Instead of squeeze to 1 dimension, do it multiple passes for better perf.
         t, pos = torch.min(input, dim=0)
-        index = _reduceDim(t, pos, torch.min)
-        shape = input.shape
-        return _translate_idx(shape, index)
+        idx = _reduceDim(t, pos, torch.min)
+        tensor_dim = input.shape
+        idx_tensor = torch.tensor(_translate_idx(tensor_dim, idx), device=input.device)
+        return idx_tensor
 
     return torch._argmin(input, dim, keepdim)


### PR DESCRIPTION
This PR fix #8817 (also master track of 0.4.1 #9280) the perf gap from GPU argmax/argmin with numpy argmax/argmin.


I will explain using argmax, where argmin is almost the same. There were two issues:
1. The way kernel was designed was not friendly to tensors with very long rows. The old logic was designed to use a kernel with `BlockDim(16,32,1)`, all 16 threads in the same column of block handles the reduction over one row. Given an edge case of `[1, 1440000]`, we actually only have 16 thread doing the reduction over 1440000 elements which is slow. We used `BlockDim.y=32` to coordinate handling different rows, which is actually not necessary. A better logic is to have `BlockDim(512,1,1)`, let 512 threads working on a single row. And let `GridDim(min(1024, num_rows))` to handle reduction for different rows.
2. When dim=None(argmax over the  whole tensor), we squeeze the tensor to a 1-d tensor first and then reduce over dim=0. This actually always put us in an edge case that our old kernel fails to handle efficiently. To fix, it actually makes sense to do it multiple passes over each dimension, and then translates the index back. 



This PR implements the logic above and here's a brief perf comparison.

Comparison for kernel: `argmax(dim=1)` of shape 

|  | [1, 1440000]  | [14400, 14400]|
|---|---|---|
|old kernel [16,32]:|37.5|4.49|
|new kernel [512, 1]:|1.96| 3.58|
|numpy:	|2.25|446|
|cpu:|2.01|448|

Comparing for multiple pass: `argmax()` of shape 

| |[14400, 14400] | [1, 1440000]|
|---|---|---|
|gpu with multi pass:|  3.59|	2.35|
|gpu without multi pass:|  175 | 1.97|
|numpy:| 458  |2.17|
|cpu with multi pass:	|  733 | 22|
|cpu without multi pass: |  411| 1.98|

We can see that with a regular large tensor shape, multiple pass could help a lot in GPU perf.
But doing so is not good from cpu side. On the other side, even without this multiple pass, our GPU perf with new kernel is still better than CPU and numpy. So I'm not sure if we would like to aggressively optimize for this. Attaching some perf numbers for our reference.  IIRC we do this multiple pass logic in kernels of torch.max() so that we could keep CPU separate. We could also do that if it's preferred.

cc: @soumith  @SsnL 



