### PR TITLE
Add fallback to TensorCPU if there are unsupported types for IDEEP Tensor

### DIFF
--- a/caffe2/ideep/operators/utility_ops.cc
+++ b/caffe2/ideep/operators/utility_ops.cc
@@ -30,10 +30,22 @@ class CopyIDEEPToCPUOp final : public IDEEPOperator {
   USE_SIMPLE_IDEEP_CTOR_DTOR(CopyIDEEPToCPUOp);
   USE_IDEEP_DEF_ALIASES();
   bool RunOnDevice() override {
-    const auto& X = OperatorBase::Input<itensor>(0);
-    auto* Y = OperatorBase::Output<TensorCPU>(0);
-    Y->Resize(X.get_dims());
-    X.reorder_to(Y->template mutable_data<float>());
+    const auto& input_blob = OperatorBase::InputBlob(0);
+    if (input_blob.template IsType<TensorCPU>()) {
+      VLOG(2) << "Directing sharing of TensorCPU";
+      const auto& X = OperatorBase::Input<TensorCPU>(0);
+      auto* Y = OperatorBase::Output<TensorCPU>(0);
+      Y->CopyFrom(X);
+    } else {
+      const auto& X = OperatorBase::Input<itensor>(0);
+      auto* Y = OperatorBase::Output<TensorCPU>(0);
+      Y->Resize(X.get_dims());
+      if (X.get_data_type() == itensor::data_type::f32) {
+        X.reorder_to(Y->template mutable_data<float>());
+      } else {
+        CAFFE_THROW("Unsupported ideep type: ", X.get_data_type());
+      }
+    }
     return true;
   }
 };

--- a/caffe2/python/ideep/copy_op_test.py
+++ b/caffe2/python/ideep/copy_op_test.py
@@ -16,9 +16,9 @@ class CopyTest(unittest.TestCase):
 
     def test_copy_to_ideep(self):
         op = core.CreateOperator(
-                "CopyCPUToIDEEP",
-                ["X"],
-                ["X_ideep"],
+            "CopyCPUToIDEEP",
+            ["X"],
+            ["X_ideep"],
             )
         op.device_option.CopyFrom(self._get_deep_device())
         n = randint(1, 128)
@@ -33,9 +33,9 @@ class CopyTest(unittest.TestCase):
 
     def test_copy_from_ideep(self):
         op = core.CreateOperator(
-                "CopyIDEEPToCPU",
-                ["X_ideep"],
-                ["X"],
+            "CopyIDEEPToCPU",
+            ["X_ideep"],
+            ["X"],
             )
         op.device_option.CopyFrom(self._get_deep_device())
         n = randint(1, 128)
@@ -48,3 +48,18 @@ class CopyTest(unittest.TestCase):
         X_ideep = workspace.FetchBlob("X")
         np.testing.assert_allclose(X, X_ideep)
 
+    def test_copy_from_ideep_fallthrough(self):
+        op = core.CreateOperator(
+            "CopyIDEEPToCPU",
+            ["X_ideep"],
+            ["X"],)
+        op.device_option.CopyFrom(self._get_deep_device())
+        n = randint(1, 128)
+        c = randint(1, 64)
+        h = randint(1, 128)
+        w = randint(1, 128)
+        X = np.random.rand(n, c, h, w).astype(np.float32)
+        workspace.FeedBlob("X_ideep", X)
+        workspace.RunOperatorOnce(op)
+        X_ideep = workspace.FetchBlob("X")
+        np.testing.assert_allclose(X, X_ideep)


### PR DESCRIPTION
Summary: MKL-DNN doesn't support 64-bit integger (https://github.com/intel/mkl-dnn/blob/cfee61bf81322b1ca315d5ed6cb9a9419618426b/include/mkldnn_types.h#L62-L75). So force converting from `TensorCPU<long>` to `s32` Ideep tensor will cause memory issue. This diff gives an alternative solution, where we just fall through to TensorCPU. The reasoning is that since MKL-DNN doesn't support 64 bit integer tensor, downstream ops have to be in CPUConext. So there is no reason force converting to ideep tensor and back.

Differential Revision: D8943544
