### PR TITLE
Test case for c10d DDP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -816,11 +816,9 @@ if USE_DISTRIBUTED:
     main_link_args += [THD_LIB]
 
 if USE_C10D:
-    extra_compile_args.append('-DUSE_C10D')
-    if USE_NCCL:
-        extra_compile_args.append('-DUSE_C10D_NCCL')
-    main_sources.append('torch/csrc/distributed/c10d/init.cpp')
-    main_link_args.append(C10D_LIB)
+    extra_compile_args += ['-DUSE_C10D']
+    main_sources += ['torch/csrc/distributed/c10d/init.cpp']
+    main_link_args += [C10D_LIB]
 
 if USE_CUDA:
     nvtoolext_lib_name = None

--- a/setup.py
+++ b/setup.py
@@ -816,9 +816,11 @@ if USE_DISTRIBUTED:
     main_link_args += [THD_LIB]
 
 if USE_C10D:
-    extra_compile_args += ['-DUSE_C10D']
-    main_sources += ['torch/csrc/distributed/c10d/init.cpp']
-    main_link_args += [C10D_LIB]
+    extra_compile_args.append('-DUSE_C10D')
+    if USE_NCCL:
+        extra_compile_args.append('-DUSE_C10D_NCCL')
+    main_sources.append('torch/csrc/distributed/c10d/init.cpp')
+    main_link_args.append(C10D_LIB)
 
 if USE_CUDA:
     nvtoolext_lib_name = None


### PR DESCRIPTION
Before I can rewrite portions of the c10d DDP in C++ I need proper tests in place to make sure I am not breaking anything as I port code. There were no tests for the c10d DDP in place so I wrote some.

I refactored the c10d tests to derive some tests cases from a general `MultiGPUTestCase` and followed lots of patterns from `test_distributed.py` w.r.t. how tests are skipped (such that the main process doesn't initialize CUDA, which I found is a super important detail!!!).

I am largely unfamiliar with this code so feel free to scrutinize. The DDP test code itself is also largely taken from `test_distributed.py` but more inlined which I find easier to read.

Test Plan:
1. Ran gloo backend tests successfully on my devgpu
2. Ran NCCL (and gloo) backend tests on devfair successfully.

@apaszke @pietern @teng-li 