### PR TITLE
[TEST, DO NOT REVIEW] Create Pad Operator (mode=constant) in Caffe2

### DIFF
--- a/caffe2/operators/pad_new_op.cc
+++ b/caffe2/operators/pad_new_op.cc
@@ -1,0 +1,143 @@
+#include "caffe2/operators/pad_new_op.h"
+
+#include <algorithm>
+
+namespace caffe2 {
+
+using std::max;
+using std::min;
+
+template <>
+bool PadOp<float, CPUContext>::RunOnDevice() {
+  auto& X = Input(0);
+  auto* Y = Output(0);
+  const int n_dim = X.ndim();
+  CAFFE_ENFORCE(
+      pads_.size() == 2 * n_dim,
+      "The length of pads must be equal to twice of number of dimensions of X");
+  const vector<TIndex> x_dims = X.dims();
+  vector<TIndex> y_dims(n_dim, 0);
+  for (int i = 0; i < n_dim; ++i) {
+    y_dims[i] = X.dim32(i) + pads_[i] + pads_[n_dim + i];
+  }
+  Y->Resize(y_dims);
+  vector<int> x_size_from(n_dim, 0);
+  vector<int> y_size_from(n_dim, 0);
+  for (int i = 0; i < n_dim; ++i) {
+    x_size_from[i] = X.size_from_dim(i + 1);
+    y_size_from[i] = Y->size_from_dim(i + 1);
+  }
+  vector<int> pos(n_dim, 0);
+  const float* Xdata = X.data<float>();
+  float* Ydata = Y->mutable_data<float>();
+  // The main loop
+  switch (mode_) {
+    case PadMode::CONSTANT:
+      math::Set<float, CPUContext>(Y->size(), value_, Ydata, &context_);
+      for (int i = 0; i < X.size(); i += x_dims[n_dim - 1]) {
+        // convert flat index i of X into multi-dimensions index of X
+        int temp = i;
+        for (int j = 0; j < n_dim; ++j) {
+          pos[j] = temp / x_size_from[j];
+          temp %= x_size_from[j];
+        }
+        // convert multi-dimensions index of X into multi-dimensions index of Y
+        for (int j = 0; j < n_dim; ++j) {
+          pos[j] += pads_[j];
+        }
+        // convert multi-dimensions index of Y into flat index k of Y
+        int k = 0;
+        for (int j = 0; j < n_dim; ++j) {
+          k += y_size_from[j] * pos[j];
+        }
+        // copy over
+        auto p = Xdata + i;
+        std::copy(p, p + x_dims[n_dim - 1], Ydata + k);
+      }
+      break;
+    case PadMode::EDGE:
+      break;
+    case PadMode::REFLECT:
+      break;
+  }
+  return true;
+}
+
+template <>
+bool PadGradientOp<float, CPUContext>::RunOnDevice() {
+  auto& dY = Input(0);
+  auto* dX = Output(0);
+  const int n_dim = dY.ndim();
+  const vector<TIndex> dY_dims = dY.dims();
+  vector<TIndex> dX_dims(n_dim, 0);
+  for (int i = 0; i < n_dim; ++i) {
+    dX_dims[i] = dY.dim32(i) - pads_[i] - pads_[n_dim + i];
+  }
+  dX->Resize(dX_dims);
+  vector<int> dY_size_from(n_dim, 0);
+  vector<int> dX_size_from(n_dim, 0);
+  for (int i = 0; i < n_dim; ++i) {
+    dY_size_from[i] = dY.size_from_dim(i + 1);
+    dX_size_from[i] = dX->size_from_dim(i + 1);
+  }
+  vector<int> pos(n_dim, 0);
+  const float* dYdata = dY.data<float>();
+  float* dXdata = dX->mutable_data<float>();
+  math::Set<float, CPUContext>(dX->size(), 0, dXdata, &context_);
+  switch (mode_) {
+    case PadMode::CONSTANT:
+      for (int i = 0; i < dX->size(); i += dX_dims[n_dim - 1]) {
+        int temp = i;
+        for (int j = 0; j < n_dim; ++j) {
+          pos[j] = temp / dX_size_from[j];
+          temp %= dX_size_from[j];
+        }
+        for (int j = 0; j < n_dim; ++j) {
+          pos[j] += pads_[j];
+        }
+        int k = 0;
+        for (int j = 0; j < n_dim; ++j) {
+          k += dY_size_from[j] * pos[j];
+        }
+        auto p = dYdata + k;
+        std::copy(p, p + dX_dims[n_dim - 1], dXdata + i);
+      }
+      break;
+    case PadMode::REFLECT:
+      break;
+    case PadMode::EDGE:
+      break;
+  }
+  return true;
+}
+
+REGISTER_CPU_OPERATOR(Pad, PadOp<float, CPUContext>);
+REGISTER_CPU_OPERATOR(PadGradient, PadGradientOp<float, CPUContext>);
+
+OPERATOR_SCHEMA(Pad)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .SetDoc(R"DOC(
+Pads a tensor according to the pads you specify.
+  )DOC")
+    .Input(0, "X", "Input Tensor.")
+    .Output(0, "Y", "Tensor after padding.")
+    .Arg("mode", "Three modes: constant(default), reflect, edge.")
+    .Arg(
+        "pads",
+        "Required: list of ints indicating the number of padding elements to add at the beginning and end of each axis.")
+    .Arg("value", "One float, indicates the value to be filled, default is 0.")
+    .InheritOnnxSchema("Pad");
+
+OPERATOR_SCHEMA(PadGradient).NumInputs(1).NumOutputs(1);
+
+class GetPadGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  vector<OperatorDef> GetGradientDefs() override {
+    return SingleGradientDef(
+        "Pad", "", vector<string>{GO(0)}, vector<string>{GI(0)});
+  }
+};
+REGISTER_GRADIENT(Pad, GetPadGradient);
+
+} // namespace caffe2

--- a/caffe2/operators/pad_new_op.h
+++ b/caffe2/operators/pad_new_op.h
@@ -1,0 +1,70 @@
+#ifndef CAFFE2_OPERATORS_PAD_NEW_OP_H_
+#define CAFFE2_OPERATORS_PAD_NEW_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/pad_op.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <typename T, class Context>
+class PadOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  PadOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        pads_(OperatorBase::GetRepeatedArgument<int>("pads")),
+        mode_(StringToPadMode(
+            OperatorBase::GetSingleArgument<string>("mode", "constant"))),
+        value_(static_cast<T>(
+            OperatorBase::GetSingleArgument<float>("value", 0.0))) {
+    for (int i = 0; i < pads_.size(); i++) {
+      CAFFE_ENFORCE(pads_[i] >= 0, "pads value must be non-negative");
+    }
+  }
+  ~PadOp() {}
+
+  bool RunOnDevice() override;
+
+  static std::vector<TensorShape> PadTensorInference(
+      const OperatorDef& def,
+      const vector<TensorShape>& in);
+
+ private:
+  vector<int> pads_;
+  PadMode mode_;
+  T value_;
+  // Input: X
+  // Output: Y
+};
+
+template <typename T, class Context>
+class PadGradientOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  PadGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        pads_(OperatorBase::GetRepeatedArgument<int>("pads")),
+        mode_(StringToPadMode(
+            OperatorBase::GetSingleArgument<string>("mode", "constant"))) {
+    for (int i = 0; i < pads_.size(); i++) {
+      CAFFE_ENFORCE(pads_[i] >= 0, "pads value must be non-negative");
+    }
+  }
+  ~PadGradientOp() {}
+
+  bool RunOnDevice() override;
+
+ private:
+  vector<int> pads_;
+  PadMode mode_;
+  T value_;
+  // Input: dY
+  // Output: dX
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_PAD_NEW_OP_H_

--- a/caffe2/operators/pad_new_op_gpu.cu
+++ b/caffe2/operators/pad_new_op_gpu.cu
@@ -1,0 +1,218 @@
+#include <algorithm>
+
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/pad_new_op.h"
+
+namespace caffe2 {
+
+namespace {
+template <typename T>
+__global__ void PadConst(
+    const int nthreads,
+    const T* const Xdata,
+    const int* x_dims,
+    const int* x_size_from,
+    const int* y_size_from,
+    const int n_dim,
+    const int* pads_,
+    T* const Ydata) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    int* pos = new int[n_dim];
+    int temp = index;
+    for (int j = 0; j < n_dim; ++j) {
+      pos[j] = temp / y_size_from[j];
+      temp %= y_size_from[j];
+    }
+    int break_flag = false;
+    for (int j = 0; j < n_dim; ++j) {
+      pos[j] -= pads_[j];
+      if (pos[j] < 0 || pos[j] >= x_dims[j]) {
+        break_flag = true;
+        break;
+      }
+    }
+    if (break_flag == true) {
+      continue;
+    }
+    int k = 0;
+    for (int j = 0; j < n_dim; ++j) {
+      k += x_size_from[j] * pos[j];
+    }
+    Ydata[index] = Xdata[k];
+  }
+}
+
+template <typename T>
+__global__ void PadGradientConst(
+    const int nthreads,
+    const T* const dYdata,
+    const int* dY_size_from,
+    const int* dX_size_from,
+    const int n_dim,
+    const int* pads_,
+    T* const dXdata) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    int* pos = new int[n_dim];
+    int temp = index;
+    for (int j = 0; j < n_dim; ++j) {
+      pos[j] = temp / dX_size_from[j];
+      temp %= dX_size_from[j];
+    }
+    for (int j = 0; j < n_dim; ++j) {
+      pos[j] += pads_[j];
+    }
+    int k = 0;
+    for (int j = 0; j < n_dim; ++j) {
+      k += dY_size_from[j] * pos[j];
+    }
+    dXdata[index] = dYdata[k];
+  }
+}
+
+} // namespace
+
+template <>
+bool PadOp<float, CUDAContext>::RunOnDevice() {
+  auto& X = Input(0);
+  auto* Y = Output(0);
+  const int n_dim = X.ndim();
+  const vector<TIndex> x_dims = X.dims();
+  std::vector<int> x_dims_int(x_dims.begin(), x_dims.end());
+  vector<TIndex> y_dims(n_dim, 0);
+  for (int i = 0; i < n_dim; ++i) {
+    y_dims[i] = X.dim32(i) + pads_[i] + pads_[n_dim + i];
+  }
+  Y->Resize(y_dims);
+  const int output_size = Y->size();
+  int* x_size_from = new int[n_dim];
+  int* y_size_from = new int[n_dim];
+  for (int i = 0; i < n_dim; i++) {
+    x_size_from[i] = X.size_from_dim(i + 1);
+    y_size_from[i] = Y->size_from_dim(i + 1);
+  }
+  const float* Xdata = X.data<float>();
+  float* Ydata = Y->mutable_data<float>();
+
+  auto pads_tmp = CUDAContext::New(2 * n_dim * sizeof(int));
+  auto pads_device_ = (int*)pads_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      sizeof(int) * 2 * n_dim,
+      static_cast<void*>(pads_.data()),
+      static_cast<void*>(pads_device_));
+
+  auto x_dims_tmp = CUDAContext::New(n_dim * sizeof(int));
+  auto x_dims_device_ = (int*)x_dims_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      sizeof(int) * n_dim,
+      static_cast<void*>(x_dims_int.data()),
+      static_cast<void*>(x_dims_device_));
+
+  auto x_size_from_tmp = CUDAContext::New(n_dim * sizeof(int));
+  auto x_size_from_device_ = (int*)x_size_from_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      n_dim * sizeof(int),
+      static_cast<void*>(x_size_from),
+      static_cast<void*>(x_size_from_device_));
+
+  auto y_size_from_tmp = CUDAContext::New(n_dim * sizeof(int));
+  auto y_size_from_device_ = (int*)y_size_from_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      n_dim * sizeof(int),
+      static_cast<void*>(y_size_from),
+      static_cast<void*>(y_size_from_device_));
+
+  switch (mode_) {
+    case PadMode::CONSTANT:
+      math::Set<float, CUDAContext>(output_size, value_, Ydata, &context_);
+      PadConst<float>
+          <<<CAFFE_GET_BLOCKS(output_size),
+             CAFFE_CUDA_NUM_THREADS,
+             0,
+             context_.cuda_stream()>>>(
+              output_size,
+              Xdata,
+              x_dims_device_,
+              x_size_from_device_,
+              y_size_from_device_,
+              n_dim,
+              pads_device_,
+              Ydata);
+      break;
+    case PadMode::REFLECT:
+      break;
+    case PadMode::EDGE:
+      break;
+  }
+  return true;
+}
+
+template <>
+bool PadGradientOp<float, CUDAContext>::RunOnDevice() {
+  auto& dY = Input(0);
+  auto* dX = Output(0);
+  const int n_dim = dY.ndim();
+  const vector<TIndex> dY_dims = dY.dims();
+  vector<TIndex> dX_dims(n_dim, 0);
+  for (int i = 0; i < n_dim; i++) {
+    dX_dims[i] = dY.dim32(i) - pads_[i] - pads_[n_dim + i];
+  }
+  dX->Resize(dX_dims);
+  const int output_size = dX->size();
+  int* dY_size_from = new int[n_dim];
+  int* dX_size_from = new int[n_dim];
+  for (int i = 0; i < n_dim; ++i) {
+    dY_size_from[i] = dY.size_from_dim(i + 1);
+    dX_size_from[i] = dX->size_from_dim(i + 1);
+  }
+  const float* dYdata = dY.data<float>();
+  float* dXdata = dX->mutable_data<float>();
+
+  auto pads_tmp = CUDAContext::New(2 * n_dim * sizeof(int));
+  auto pads_device_ = (int*)pads_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      sizeof(int) * 2 * n_dim,
+      static_cast<void*>(pads_.data()),
+      static_cast<void*>(pads_device_));
+
+  auto dY_size_from_tmp = CUDAContext::New(n_dim * sizeof(int));
+  auto dY_size_from_device_ = (int*)dY_size_from_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      n_dim * sizeof(int),
+      static_cast<void*>(dY_size_from),
+      static_cast<void*>(dY_size_from_device_));
+
+  auto dX_size_from_tmp = CUDAContext::New(n_dim * sizeof(int));
+  auto dX_size_from_device_ = (int*)dX_size_from_tmp.first;
+  context_.CopyBytes<CPUContext, CUDAContext>(
+      n_dim * sizeof(int),
+      static_cast<void*>(dX_size_from),
+      static_cast<void*>(dX_size_from_device_));
+
+  math::Set<float, CUDAContext>(output_size, 0, dXdata, &context_);
+
+  switch (mode_) {
+    case PadMode::CONSTANT:
+      PadGradientConst<float>
+          <<<CAFFE_GET_BLOCKS(output_size),
+             CAFFE_CUDA_NUM_THREADS,
+             0,
+             context_.cuda_stream()>>>(
+              output_size,
+              dYdata,
+              dY_size_from_device_,
+              dX_size_from_device_,
+              n_dim,
+              pads_device_,
+              dXdata);
+      break;
+    case PadMode::REFLECT:
+      break;
+    case PadMode::EDGE:
+      break;
+  }
+  return true;
+}
+
+REGISTER_CUDA_OPERATOR(Pad, PadOp<float, CUDAContext>);
+REGISTER_CUDA_OPERATOR(PadGradient, PadGradientOp<float, CUDAContext>);
+} // namespace caffe2

--- a/caffe2/python/operator_test/pad_new_test.py
+++ b/caffe2/python/operator_test/pad_new_test.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import hypothesis.strategies as st
+import unittest
+import caffe2.python.hypothesis_test_util as hu
+from caffe2.python import core
+from hypothesis import given
+
+
+class TestPad(hu.HypothesisTestCase):
+    @given(pads_1_begin=st.integers(0, 1),
+           pads_1_end=st.integers(0, 1),
+           pads_2_begin=st.integers(0, 2),
+           pads_2_end=st.integers(0, 2),
+           pads_3_begin=st.integers(0, 2),
+           pads_3_end=st.integers(0, 2),
+           mode=st.sampled_from(["constant"]),
+           value=st.floats(0.0, 0.0),
+           size_n1=st.integers(4, 4),
+           size_n2=st.integers(5, 5),
+           size_n3=st.integers(6, 6),
+           **hu.gcs)
+    def test_crop(self,
+                  pads_1_begin, pads_2_begin, pads_3_begin,
+                  pads_1_end, pads_2_end, pads_3_end,
+                  mode, value,
+                  size_n1, size_n2, size_n3,
+                  gc, dc):
+        pads = [pads_1_begin, pads_2_begin, pads_3_begin,
+                pads_1_end, pads_2_end, pads_3_end]
+
+        op = core.CreateOperator(
+            "Pad",
+            ["X"],
+            ["Y"],
+            value=value,
+            mode=mode,
+            pads=pads,
+        )
+        X = np.random.rand(
+            size_n1, size_n2, size_n3).astype(np.float32)
+
+        def ref(X):
+            return (np.pad(X, ((pads_1_begin, pads_1_end),
+                               (pads_2_begin, pads_2_end),
+                               (pads_3_begin, pads_3_end)), mode),)
+
+
+        self.assertReferenceChecks(gc, op, [X], ref)
+        self.assertDeviceChecks(dc, op, [X], [0])
+        # self.assertGradientChecks(gc, op, [X], 0, [0])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff implements Pad operator (mode=constant) in Caffe2 for both CPU and GPU.
For the other two modes (reflect and edge) will be submitted in different diffs.

Differential Revision: D8947493
