### PR TITLE
[TENSOR MERGE] Devirtualize TensorImpl::toString

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -28,10 +28,6 @@ SparseTensorImpl::SparseTensorImpl(Type * type)
       AT_ASSERT(type->is_sparse());
     }
 
-const char * SparseTensorImpl::toString() const {
-  // TODO: also give back type information
-  return "SparseTensor";
-}
 IntList SparseTensorImpl::sizes() const {
   return size_;
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -57,7 +57,6 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  const char * toString() const override;
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -46,6 +46,12 @@ IntList TensorImpl::sizes() const {
   return IntList(THTensor_getSizePtr(tensor), dim());
 }
 
+IntList TensorImpl::strides() const {
+  // NB: dim in tensor is not synchronized with THTensor, so it's
+  // important to apply dim here
+  return IntList(THTensor_getStridePtr(tensor), dim());
+}
+
 void TensorImpl::release_resources() {
   if (tensor) {
       tensor->release();

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -18,6 +18,50 @@ Tensor TensorImpl::detach() const {
   AT_ERROR("detach is not implemented for Tensor");
 }
 
+const char* TensorImpl::toString() const {
+  switch (type().backend()) {
+    case Backend::CPU:
+      switch (type().scalarType()) {
+#define DEFINE_CPU_STRING(_,name,_2) \
+        case ScalarType::name: return "CPU" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
+#undef DEFINE_CPU_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::CUDA:
+      switch (type().scalarType()) {
+#define DEFINE_CUDA_STRING(_,name,_2) \
+        case ScalarType::name: return "CUDA" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
+#undef DEFINE_CUDA_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::SparseCPU:
+      switch (type().scalarType()) {
+#define DEFINE_CPU_STRING(_,name,_2) \
+        case ScalarType::name: return "SparseCPU" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
+#undef DEFINE_CPU_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::SparseCUDA:
+      switch (type().scalarType()) {
+#define DEFINE_CUDA_STRING(_,name,_2) \
+        case ScalarType::name: return "SparseCUDA" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
+#undef DEFINE_CUDA_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::Undefined: return "UndefinedTensor";
+    case Backend::NumOptions: AT_ASSERT(false);
+  }
+  AT_ASSERT(false);
+}
+
 void TensorImpl::backward(
     at::optional<Tensor> gradient,
     bool keep_graph,

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -30,7 +30,7 @@ struct AT_API TensorImpl : public Retainable {
   }
   virtual const char * toString() const = 0;
   virtual IntList sizes() const;
-  virtual IntList strides() const = 0;
+  virtual IntList strides() const;
   virtual int64_t dim() const;
   /**
    * Perform a conversion of this tensor to a scalar, if numel() == 1.

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -28,7 +28,7 @@ struct AT_API TensorImpl : public Retainable {
   Type & type() const {
     return *type_;
   }
-  virtual const char * toString() const = 0;
+  const char * toString() const;
   virtual IntList sizes() const;
   virtual IntList strides() const;
   virtual int64_t dim() const;

--- a/aten/src/ATen/UndefinedTensor.cpp
+++ b/aten/src/ATen/UndefinedTensor.cpp
@@ -9,10 +9,6 @@ UndefinedTensor::UndefinedTensor()
 : TensorImpl(&(globalContext().getType(Backend::Undefined,ScalarType::Undefined)), nullptr) {
 }
 
-const char * UndefinedTensor::toString() const {
-  return "UndefinedTensor";
-}
-
 IntList UndefinedTensor::sizes() const {
   AT_ERROR("sizes() called on undefined Tensor");
 }

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -9,7 +9,6 @@ public:
   static inline UndefinedTensor * singleton() {
     return &_singleton;
   }
-  const char * toString() const override;
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,17 +1,12 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
-IntList ${Tensor}::strides() const {
-  // NB: THTensor doesn't agree with Tensor for scalars, so we
-  // have to construct a fresh IntList
-  return IntList(THTensor_getStridePtr(tensor), dim());
-}
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
   AT_CHECK(numel == 1,"a Tensor with ", numel, " elements cannot be converted to Scalar");
   return Scalar(${to_at_type}(${THStorage}_get(${state,} THTensor_getStoragePtr(tensor), tensor->storage_offset())));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {
-  auto storage = ${THTensor}_storage(${state,}tensor);
-  ${THStorage}_retain(${state,}storage);
+  auto storage = THTensor_getStoragePtr(tensor);
+  THStorage_retain(storage);
   return std::unique_ptr<Storage>(new ${Storage}(storage));
 }

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -25,10 +25,6 @@ ${Tensor}::${Tensor}(${THTensor} * tensor)
 : TensorImpl(&globalContext().getType(Backend::${Backend},ScalarType::${ScalarName}), tensor)
 {}
 
-const char * ${Tensor}::toString() const {
-  return "${Tensor}";
-}
-
 const char * ${Tensor}::typeString() {
   return "${Type}";
 }

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -13,7 +13,6 @@ namespace at {
 struct ${Tensor} final : public TensorImpl {
 public:
   ${Tensor}(THTensor * tensor);
-  virtual const char * toString() const override;
   virtual Scalar localScalar() override;
   virtual std::unique_ptr<Storage> storage() override;
   static const char * typeString();

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -14,7 +14,6 @@ struct ${Tensor} final : public TensorImpl {
 public:
   ${Tensor}(THTensor * tensor);
   virtual const char * toString() const override;
-  virtual IntList strides() const override;
   virtual Scalar localScalar() override;
   virtual std::unique_ptr<Storage> storage() override;
   static const char * typeString();

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -40,12 +40,6 @@ Variable::Impl::Impl(at::Tensor data, bool requires_grad, Edge gradient_edge)
 
 Variable::Impl::~Impl() = default;
 
-const char* Variable::Impl::toString() const {
-  // technically this will say Variable[CPUFloatType] rather than
-  // Variable[CPUFloatTensor], but this is better than just Variable
-  return type().toString();
-}
-
 IntList Variable::Impl::sizes() const {
   return data_.sizes();
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -268,7 +268,6 @@ struct Variable::Impl : public at::TensorImpl {
 
   ~Impl() override;
 
-  const char* toString() const override;
   at::IntList sizes() const override;
   at::IntList strides() const override;
   int64_t dim() const override;

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -339,9 +339,6 @@ public:
   : TensorImpl(&(at::globalContext().getType(at::Backend::Undefined,at::ScalarType::Undefined)), nullptr) {}
 
   virtual ~ContainerTensor() {}
-  virtual const char * toString() const override {
-    throw std::runtime_error("toString() on ContainerTensor");
-  }
   virtual at::IntList sizes() const override {
     throw std::runtime_error("sizes() on ContainerTensor");
   }


### PR DESCRIPTION
This can hardly be called an improvement (we now have a giant
switch-of-switches) but it was the simplest way I could think
of devirtualizing this function in the short term.  Probably
need some sort of native function that gives string information
about a tensor.

Stacked on #9652
Diff to review: https://github.com/pytorch/pytorch/pull/9710/files/dce2b78e44078dd83af87b10848fe115b71e266f..HEAD