### PR TITLE
[C++ API] Rename embedding variable to weight

### DIFF
--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -142,8 +142,13 @@ TEST_CASE("modules") {
 
   SECTION("embedding") {
     SECTION("basic") {
-      int dict_size = 10;
+      const int64_t dict_size = 10;
       Embedding model(dict_size, 2);
+      REQUIRE(model->parameters().contains("weight"));
+      REQUIRE(model->weight.ndimension() == 2);
+      REQUIRE(model->weight.size(0) == dict_size);
+      REQUIRE(model->weight.size(1) == 2);
+
       // Cannot get gradients to change indices (input) - only for embedding
       // params
       auto x = torch::full({10}, dict_size - 1, torch::kInt64);
@@ -156,7 +161,7 @@ TEST_CASE("modules") {
       REQUIRE(y.size(0) == 10);
       REQUIRE(y.size(1) == 2);
 
-      REQUIRE(model->parameters()["table"].grad().numel() == 2 * dict_size);
+      REQUIRE(model->parameters()["weight"].grad().numel() == 2 * dict_size);
     }
 
     SECTION("list") {

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -26,7 +26,7 @@ class EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
   Tensor forward(Tensor);
 
   EmbeddingOptions options;
-  Tensor table;
+  Tensor weight;
 };
 
 TORCH_MODULE(Embedding);

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -18,13 +18,13 @@ EmbeddingImpl::EmbeddingImpl(EmbeddingOptions options)
 }
 
 void EmbeddingImpl::reset() {
-  table = register_parameter(
-      "table", torch::empty({options.count_, options.dimension_}));
-  table.data().normal_(0, 1);
+  weight = register_parameter(
+      "weight", torch::empty({options.count_, options.dimension_}));
+  weight.data().normal_(0, 1);
 }
 
 Tensor EmbeddingImpl::forward(Tensor input) {
-  return torch::embedding(table, /*indices=*/input);
+  return torch::embedding(weight, /*indices=*/input);
 }
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
I renamed the variable in the `Embedding` module from `weight` to `table` a few months ago, because it seemed like a more meaningful name. Turns out it's not such a good idea because it deviates from PyTorch, which unnecessarily breaks C++->Python translated code.

@ebetica @ezyang @apaszke