### PR TITLE
Small fixups for enabling zero size dims.

### DIFF
--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -859,6 +859,16 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     THTensor_(free)(cmat);
   }
 
+  // In gemv (x,0).mv(0) does not
+  // handle beta, whereas gemm does for case where (x,0).mm(0,y).
+  if (vec->size(0) == 0 && mat->size(0) != 0) {
+    if (beta == 0) {
+      THTensor_(zero)(r_);
+    } else if (beta != 1) {
+      THTensor_(mul)(r_, r_, beta);
+    }
+  }
+
   #undef LDA_COND
 }
 

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -116,7 +116,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THCTensor_(free)(state, cmat);
   }
 
-  // cublasSgemv, cublasDgemv have a bug where (x,0).mv(0) does not
+  // In cublasSgemv, cublasDgemv (x,0).mv(0) does not
   // handle beta, whereas cublasSgemm, cublasDgemm do for case where (x,0).mm(0,y).
   if (vec->size(0) == 0 && mat->size(0) != 0) {
     if(THCNumerics<real>::eq(beta, ScalarConvert<int, real>::to(0))) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6326,7 +6326,7 @@ class TestTorch(TestCase):
     @skipIfNoZeroSize
     def test_blas_alpha_beta_empty(self):
         devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
-        for device in ['cuda']:
+        for device in devices:
             # ensure beta is respected
             value = 11
             input = torch.full((2,), value, device=device)
@@ -7568,8 +7568,6 @@ class TestTorch(TestCase):
         self.assertEqual(y, x.contiguous().view(2, 1, 4))
         y = x.clone().unsqueeze_(2)
         self.assertEqual(y, x.contiguous().view(2, 4, 1))
-
-        self.assertRaises(RuntimeError, lambda: torch.Tensor().unsqueeze(0))
 
     def test_iter(self):
         x = torch.randn(5, 5)


### PR DESCRIPTION
1) Properly test cpu for alpha/beta addmm cases.
2) Unsqueeze on empty no longer throws an exception.

