### PR TITLE
Creates ATen CUDAEvent

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -1,5 +1,9 @@
 #include "ATen/cuda/CUDAContext.h"
+#include "ATen/cuda/Exceptions.h"
+#include "ATen/Error.h"
+
 #include "THC/THCGeneral.h"
+
 
 namespace at { namespace cuda { 
 
@@ -14,6 +18,10 @@ int64_t current_device() {
   int cur_device;
   AT_CUDA_CHECK(cudaGetDevice(&cur_device));
   return cur_device;
+}
+
+AT_API void set_device(int64_t device) {
+  AT_CUDA_CHECK(cudaSetDevice((int)device));
 }
 
 cudaDeviceProp* getCurrentDeviceProperties() {

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -20,7 +20,7 @@ int64_t current_device() {
   return cur_device;
 }
 
-AT_API void set_device(int64_t device) {
+void set_device(int64_t device) {
   AT_CUDA_CHECK(cudaSetDevice((int)device));
 }
 

--- a/aten/src/ATen/cuda/CUDAContext.h
+++ b/aten/src/ATen/cuda/CUDAContext.h
@@ -37,6 +37,8 @@ AT_API int64_t getNumGPUs();
 
 AT_API int64_t current_device();
 
+AT_API void set_device(int64_t device);
+
 AT_API cudaDeviceProp* getCurrentDeviceProperties();
 
 AT_API cudaDeviceProp* getDeviceProperties(int64_t device);

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "ATen/cuda/CUDAContext.h"
+#include "ATen/cuda/CUDAStream.h"
+#include "ATen/cuda/Exceptions.h"
+#include "ATen/DeviceGuard.h"
+#include "ATen/Error.h"
+
+#include "cuda_runtime_api.h"
+
+#include <cstdint> 
+
+namespace at { namespace cuda { 
+
+/*
+A CUDAEvent is an RAII for a cudaEvent. It provides easy to use mechanisms
+for recording and blocking streams on its completion.
+
+This class is intended for internal use, and not as a replacement for 
+events in the Python API. 
+
+CUDAEvent is NOT thread safe. 
+*/
+struct CUDAEvent {
+  CUDAEvent() = default;
+
+  // CUDAEvents are not copyable
+  CUDAEvent& operator=(const CUDAEvent&) = delete;
+  CUDAEvent(const CUDAEvent&) = delete;
+
+  // CUDAEvents are movable. 
+  CUDAEvent& operator=(CUDAEvent&& other) { 
+    moveHelper(std::move(other)); 
+    return *this;
+  }
+  CUDAEvent(CUDAEvent&& other) { moveHelper(std::move(other)); }
+
+  void recordOnce(CUDAStream stream) {
+    if (!is_created) {
+      create(stream);
+      AT_CUDA_CHECK(cudaEventRecord(event_, stream));
+    }
+  }
+
+  void record(CUDAStream stream) {
+    if (is_created) {
+      AT_ASSERT(device_ == stream.device());
+    } else {
+      create(stream);
+    }
+
+    AT_CUDA_CHECK(cudaEventRecord(event_, stream));
+  } 
+
+  void block(CUDAStream stream) { 
+    AT_CUDA_CHECK(cudaStreamWaitEvent(stream, event_, 0));
+  }
+
+  int64_t device() { return device_; }
+
+  bool happened() { return (cudaEventQuery(event_) == cudaSuccess); }
+
+  ~CUDAEvent() { 
+    if (is_created) {
+      at::DeviceGuard device_guard{device_};
+      AT_CUDA_CHECK(cudaEventDestroy(event_)); 
+    }
+  }
+  
+private:
+  bool is_created = false;
+  cudaEvent_t event_;
+  int64_t device_ = -1;
+
+  void moveHelper(CUDAEvent&& other) {
+    std::swap(is_created, other.is_created);
+    std::swap(event_, other.event_);
+    std::swap(device_, other.device_);
+  }
+
+  void create(CUDAStream stream) {
+    at::DeviceGuard device_guard{stream.device()};
+    AT_CUDA_CHECK(cudaEventCreateWithFlags(&event_, cudaEventDisableTiming));
+
+    is_created = true;
+    device_ = stream.device();
+  }
+};
+
+} // namespace cuda
+} // namespace at

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -63,7 +63,7 @@ struct CUDAEvent {
   ~CUDAEvent() { 
     if (is_created) {
       at::DeviceGuard device_guard{device_};
-      AT_CUDA_CHECK(cudaEventDestroy(event_)); 
+      cudaEventDestroy(event_); // Unchecked
     }
   }
   


### PR DESCRIPTION
This PR:

- Creates an ATen version of CUDAEvent
- Adds set_device() to ATen's CUDAContext
- Extends ATen's cpp tests to exercise the new CUDAEvent

The design of CUDAEvent is based on the CUDAEvent class first proposed for #8354 (incorporating @apaszke's suggestions), with additional requirements taken from the c10d CUDAEvent (incorporating #9415, for example, @pietern's request). The key differences are:

- Recording and blocking are done with the CUDAEvent itself, and the behavior is validated.
- recordOnce() is added to support scenarios like #8354 requires.
- Creation is deferred until the event is recorded, and the event's device matches the stream's. This eliminates the bookkeeping complexity of pre-declaring events to be suitable to be associated with a 
particular stream later.
- The actual events are created with the cudaEventDisableTiming flag, which improves performance.

This PR does not:

- Replace the c10d CUDAEvent with this CUDAEvent.

A separate PR will have to resolve the c10d vs ATen divergence of CUDAEvent, CUDAStream, and DeviceGuard. 