### PR TITLE
[c10d] Move DDP broadcast coalesced to C++

### DIFF
--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -24,13 +24,19 @@ inline void distBroadcastCoalesced(
   flatTensors.reserve(tensorGroups.size());
   work.reserve(tensorGroups.size());
   for (const auto& group : tensorGroups) {
+    // Flatten each group of tensors (whose size equals `bufferSize`) into a
+    // single tensor.
     flatTensors.push_back({torch::utils::flatten_dense_tensors(group.tensors)});
     BroadcastOptions broadcastOptions;
     broadcastOptions.rootRank = 0;
     broadcastOptions.rootTensor = 0;
+    // Enqueue a work item and collect the `Work` (essntially a "future") so we
+    // can `wait()` for its completion after we have collected all `Work` items.
     work.push_back(
         processGroup.broadcast(flatTensors.back(), broadcastOptions));
   }
+  // Now loop through each group, wait for the broadcast to complete, and
+  // un-flatten the broadcast tensor back into device-local individual tensors.
   for (size_t group = 0; group < tensorGroups.size(); ++group) {
     auto& tensors = tensorGroups[group].tensors;
     work[group]->wait();
@@ -38,6 +44,7 @@ inline void distBroadcastCoalesced(
         torch::utils::unflatten_dense_tensors(flatTensors[group][0], tensors);
     AT_ASSERT(synced.size() == tensors.size());
     for (size_t i = 0; i < synced.size(); ++i) {
+      // Copy into the per-process tensors.
       tensors[i].copy_(synced[i]);
     }
   }

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <torch/csrc/utils/tensor_flatten.h>
+
+#include <c10d/ProcessGroup.hpp>
+
+#include <ATen/ATen.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace c10d {
+inline void dist_broadcast_coalesced(
+    std::vector<at::Tensor>& tensors,
+    int64_t buffer_size,
+    ProcessGroup& process_group) {
+  for (auto& group : torch::utils::take_tensors(tensors, buffer_size)) {
+    std::vector<at::Tensor> flat_tensor = {
+        torch::utils::flatten_dense_tensors(group.tensors)};
+    BroadcastOptions broadcast_options;
+    broadcast_options.rootRank = 0;
+    broadcast_options.rootTensor = 0;
+    process_group.broadcast(flat_tensor, broadcast_options)->wait();
+    auto synced =
+        torch::utils::unflatten_dense_tensors(flat_tensor[0], group.tensors);
+    AT_ASSERT(synced.size() == group.tensors.size());
+    for (size_t i = 0; i < synced.size(); ++i) {
+      group.tensors[i].copy_(synced[i]);
+    }
+  }
+}
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -7,6 +7,7 @@
 #include <ATen/ATen.h>
 
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 namespace c10d {
@@ -14,18 +15,30 @@ inline void distBroadcastCoalesced(
     std::vector<at::Tensor>& tensors,
     int64_t bufferSize,
     ProcessGroup& processGroup) {
-  for (auto& group : torch::utils::take_tensors(tensors, bufferSize)) {
-    std::vector<at::Tensor> flatTensor = {
-        torch::utils::flatten_dense_tensors(group.tensors)};
+  auto tensorGroups = torch::utils::take_tensors(tensors, bufferSize);
+  // We store single-element vectors in `flatTensors` because
+  // `ProcessGroup::broadcast` takes a reference to a vector, which must be
+  // alive until the `wait()` call on the returned `Work` completes.
+  std::vector<std::vector<at::Tensor>> flatTensors;
+  std::vector<std::shared_ptr<ProcessGroup::Work>> work;
+  flatTensors.reserve(tensorGroups.size());
+  work.reserve(tensorGroups.size());
+  for (const auto& group : tensorGroups) {
+    flatTensors.push_back({torch::utils::flatten_dense_tensors(group.tensors)});
     BroadcastOptions broadcastOptions;
     broadcastOptions.rootRank = 0;
     broadcastOptions.rootTensor = 0;
-    processGroup.broadcast(flatTensor, broadcastOptions)->wait();
-    auto synced =
-        torch::utils::unflatten_dense_tensors(flatTensor[0], group.tensors);
-    AT_ASSERT(synced.size() == group.tensors.size());
+    work.push_back(
+        processGroup.broadcast(flatTensors.back(), broadcastOptions));
+  }
+  for (size_t group = 0; group < tensorGroups.size(); ++group) {
+    auto& tensors = tensorGroups[group].tensors;
+    work[group]->wait();
+    const auto synced =
+        torch::utils::unflatten_dense_tensors(flatTensors[group][0], tensors);
+    AT_ASSERT(synced.size() == tensors.size());
     for (size_t i = 0; i < synced.size(); ++i) {
-      group.tensors[i].copy_(synced[i]);
+      tensors[i].copy_(synced[i]);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -45,7 +45,7 @@ inline void distBroadcastCoalesced(
     AT_ASSERT(synced.size() == tensors.size());
     for (size_t i = 0; i < synced.size(); ++i) {
       // Copy into the per-process tensors.
-      tensors[i].copy_(synced[i]);
+      tensors[i].copy_(synced[i], /*non_blocking=*/true);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -10,19 +10,19 @@
 #include <vector>
 
 namespace c10d {
-inline void dist_broadcast_coalesced(
+inline void distBroadcastCoalesced(
     std::vector<at::Tensor>& tensors,
-    int64_t buffer_size,
-    ProcessGroup& process_group) {
-  for (auto& group : torch::utils::take_tensors(tensors, buffer_size)) {
-    std::vector<at::Tensor> flat_tensor = {
+    int64_t bufferSize,
+    ProcessGroup& processGroup) {
+  for (auto& group : torch::utils::take_tensors(tensors, bufferSize)) {
+    std::vector<at::Tensor> flatTensor = {
         torch::utils::flatten_dense_tensors(group.tensors)};
-    BroadcastOptions broadcast_options;
-    broadcast_options.rootRank = 0;
-    broadcast_options.rootTensor = 0;
-    process_group.broadcast(flat_tensor, broadcast_options)->wait();
+    BroadcastOptions broadcastOptions;
+    broadcastOptions.rootRank = 0;
+    broadcastOptions.rootTensor = 0;
+    processGroup.broadcast(flatTensor, broadcastOptions)->wait();
     auto synced =
-        torch::utils::unflatten_dense_tensors(flat_tensor[0], group.tensors);
+        torch::utils::unflatten_dense_tensors(flatTensor[0], group.tensors);
     AT_ASSERT(synced.size() == group.tensors.size());
     for (size_t i = 0; i < synced.size(); ++i) {
       group.tensors[i].copy_(synced[i]);

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -13,9 +13,10 @@
 #include <gloo/transport/tcp/device.h>
 #include <pybind11/chrono.h>
 
-#include "torch/csrc/Exceptions.h"
-#include "torch/csrc/utils/object_ptr.h"
-#include "torch/csrc/utils/pybind.h"
+#include <torch/csrc/Exceptions.h>
+#include <torch/csrc/distributed/c10d/ddp.h>
+#include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/pybind.h>
 
 namespace torch {
 namespace distributed {
@@ -198,6 +199,8 @@ PyObject* c10d_init(PyObject* _unused) {
           "wait",
           &::c10d::ProcessGroup::Work::wait,
           py::call_guard<py::gil_scoped_release>());
+
+  module.def("_dist_broadcast_coalesced", &::c10d::dist_broadcast_coalesced);
 
   Py_RETURN_TRUE;
 }

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -200,7 +200,7 @@ PyObject* c10d_init(PyObject* _unused) {
           &::c10d::ProcessGroup::Work::wait,
           py::call_guard<py::gil_scoped_release>());
 
-  module.def("_dist_broadcast_coalesced", &::c10d::dist_broadcast_coalesced);
+  module.def("_dist_broadcast_coalesced", &::c10d::distBroadcastCoalesced);
 
   Py_RETURN_TRUE;
 }

--- a/torch/nn/parallel/distributed_c10d.py
+++ b/torch/nn/parallel/distributed_c10d.py
@@ -242,11 +242,7 @@ class _DistributedDataParallelC10d(Module):
             module.train(mode)
 
     def _dist_broadcast_coalesced(self, tensors, buffer_size):
-        for tensors in _take_tensors(tensors, buffer_size):
-            flat_tensors = _flatten_dense_tensors(tensors)
-            c10d.broadcast(flat_tensors, 0, self.process_group).wait()
-            for tensor, synced in zip(tensors, _unflatten_dense_tensors(flat_tensors, tensors)):
-                tensor.copy_(synced)
+        c10d._dist_broadcast_coalesced(tensors, buffer_size, self.process_group)
 
     def _sync_params(self):
         if len(self.device_ids) > 1:


### PR DESCRIPTION
This PR depends on the tests added in #9670. It moves the first, tiny function from the c10d DDP to C++: `dist_broadcast_coalesced`. Let me know if ` torch/csrc/distributed/c10d/ddp.h` will be a good place to put these rewritten functions.

@pietern @teng-li @apaszke 