### PR TITLE
Add LARC implementation to Caffe2

### DIFF
--- a/caffe2/python/operator_test/larc_test.py
+++ b/caffe2/python/operator_test/larc_test.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import core
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+
+
+class TestLarc(hu.HypothesisTestCase):
+
+    @given(offset=st.floats(min_value=0, max_value=100),
+    trust=st.floats(min_value=1e-3, max_value=1.0),
+    lr_min=st.floats(min_value=1e-8, max_value=1e-6),
+    **hu.gcs)
+    def test_larc(self, offset, trust, lr_min, dc, gc):
+        X = np.random.rand(6, 7, 8, 9).astype(np.float32)
+        dX = np.random.rand(6, 7, 8, 9).astype(np.float32)
+        wd = np.array([1e-4]).astype(np.float32)
+        lr_max = np.random.rand(1).astype(np.float32)
+        def ref_larc(X, dX, wd, lr_max):
+            rescale_factor = trust / (np.linalg.norm(dX) / np.linalg.norm(X) + wd + offset)
+            rescale_factor = np.minimum(rescale_factor, lr_max)
+            rescale_factor = np.maximum(rescale_factor, lr_min)
+            return [rescale_factor]
+
+        op = core.CreateOperator(
+            "Larc",
+            ["X", "dX", "wd", "lr_max"],
+            ["rescale_factor"],
+            offset=offset,
+            trust=trust,
+            lr_min=lr_min,
+        )
+
+        self.assertReferenceChecks(
+            device_option=gc,
+            op=op,
+            inputs=[X, dX, wd, lr_max],
+            reference=ref_larc
+        )

--- a/caffe2/sgd/larc_op.cc
+++ b/caffe2/sgd/larc_op.cc
@@ -1,0 +1,64 @@
+#include "caffe2/sgd/larc_op.h"
+#include <math.h>
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <>
+void LarcOp<float, CPUContext>::Compute(
+    TIndex N,
+    const float* X_data,
+    const float* dX_data,
+    const float* wd,
+    const float* lr_max,
+    float offset,
+    float trust,
+    float lr_min,
+    float* lr_rescaled) {
+  float val = 1.0;
+  float X_norm =
+      sqrtf((ConstEigenVectorMap<float>(X_data, N).array()).square().sum());
+  if (X_norm > 0) {
+    float dX_norm =
+        sqrtf((ConstEigenVectorMap<float>(dX_data, N).array()).square().sum());
+    val = trust / (dX_norm / X_norm + (*wd) + offset);
+  }
+  val = fmin(val, *lr_max);
+  val = fmax(val, lr_min);
+  *lr_rescaled = val;
+}
+
+REGISTER_CPU_OPERATOR(Larc, LarcOp<float, CPUContext>);
+
+OPERATOR_SCHEMA(Larc)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .SetDoc(R"DOC(
+Implement Layer-wise Adaptive Rate Scaling Control (LARC). Before adding weight
+decay, given a parameter tensor X and its gradient dX, the local learning rate
+for X will be
+
+local_lr = trust * norm(X) / ( norm(dX) + wd * norm(X) + offset * norm(X) )
+
+      = trust / ( norm(dX) / norm(X) + wd + offset ),
+
+where offset is a preset hyper-parameter to avoid numerical issue and trust
+indicates how much we trust the layer to change its parameters during one update.
+In this implementation, we uses l2 norm and the computed local learning rate is
+clipped based on the upper bound lr_max and the lower bound lr_min:
+
+local_lr = min(local_lr, lr_max) and local_lr = max(local_lr, lr_min)
+
+)DOC")
+    .Input(0, "X", "Parameter tensor")
+    .Input(1, "dX", "Gradient tensor")
+    .Input(2, "wd", "Weight decay")
+    .Input(3, "lr_max)", "Upper bound of learning rate")
+    .Output(0, "lr_rescaled", "Rescaled local learning rate")
+    .Arg("offset", "rescaling offset parameter")
+    .Arg("trust", "trust of the layer to change its weights")
+    .Arg("lr_min", "minimum learning rate for clipping");
+
+SHOULD_NOT_DO_GRADIENT(Larc);
+} // namespace caffe2

--- a/caffe2/sgd/larc_op.h
+++ b/caffe2/sgd/larc_op.h
@@ -1,0 +1,67 @@
+#ifndef CAFFE2_OPERATORS_LARC_OP_H_
+#define CAFFE2_OPERATORS_LARC_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+template <typename T, class Context>
+class LarcOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  LarcOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        offset_(OperatorBase::GetSingleArgument<float>("offset", 0.5)),
+        trust_(OperatorBase::GetSingleArgument<float>("trust", 0.001)),
+        lr_min_(OperatorBase::GetSingleArgument<float>("lr_min", 0.02)) {}
+
+  bool RunOnDevice() override {
+    auto& X = Input(0);
+    auto& dX = Input(1);
+    CAFFE_ENFORCE(
+        dX.size() == X.size(), "Gradient size doesn't match parameter size.");
+    CAFFE_ENFORCE_GE(offset_, 0);
+    CAFFE_ENFORCE_GE(trust_, 0);
+    CAFFE_ENFORCE_GE(lr_min_, 0);
+
+    auto& wd = Input(2);
+    auto& lr_max = Input(3);
+    auto* lr_rescaled = Output(0);
+    lr_rescaled->Resize(vector<TIndex>{1});
+
+    Compute(
+        dX.size(),
+        X.template data<T>(),
+        dX.template data<T>(),
+        wd.template data<T>(),
+        lr_max.template data<T>(),
+        offset_,
+        trust_,
+        lr_min_,
+        lr_rescaled->template mutable_data<T>());
+
+    return true;
+  }
+
+ private:
+  void Compute(
+      TIndex N,
+      const T* X_data,
+      const T* dX_data,
+      const T* wd,
+      const T* lr_max,
+      T offset,
+      T trust,
+      T lr_min,
+      T* lr_rescaled);
+
+  T offset_;
+  T trust_;
+  T lr_min_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_LARC_OP_H_

--- a/caffe2/sgd/larc_op_gpu.cu
+++ b/caffe2/sgd/larc_op_gpu.cu
@@ -1,0 +1,7 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/operator_fallback_gpu.h"
+#include "caffe2/sgd/larc_op.h"
+
+namespace caffe2 {
+REGISTER_CUDA_OPERATOR(Larc, GPUFallbackOp<LarcOp<float, CPUContext>>);
+}


### PR DESCRIPTION
Summary: This diff added layer-wise adapted learning rate control (LARC) to Caffe2. LARC optimization enables us to train larger batch size within the same number of epochs without significant loss in accuracy.

Differential Revision: D8959161
