### PR TITLE
Remove implicit ArrayRef -> vector conversion

### DIFF
--- a/aten/src/ATen/ArrayRef.cpp
+++ b/aten/src/ATen/ArrayRef.cpp
@@ -1,0 +1,1 @@
+#include <ATen/ArrayRef.h>

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -109,8 +109,8 @@ struct strided_tensor_iter {
       : data_(tensor.data<T>()),
         dim_(tensor.ndimension()),
         counter_(dim_, 0),
-        sizes_(tensor.sizes()),
-        strides_(tensor.strides()) {
+        sizes_(tensor.sizes().vec()),
+        strides_(tensor.strides().vec()) {
     _setup_arrays(tensor, this);
   }
 };

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -111,7 +111,7 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
     if (!to_expand[i].defined()) {
       continue;
     } else if (first) {
-      sizes = to_expand[i].sizes();
+      sizes = to_expand[i].sizes().vec();
       first = false;
     } else {
       sizes = infer_size(sizes, to_expand[i].sizes());

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -75,7 +75,7 @@ public:
     if (size.size() == 0) {
       size_ = {0};
     } else {
-      size_ = size;
+      size_ = size.vec();
     }
     sparseDims_ = sparseDims;
     denseDims_ = denseDims;

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -9,7 +9,7 @@ struct AT_API TensorGeometry {
   TensorGeometry() : storage_offset_(0) {}
 
   explicit TensorGeometry(IntList sizes)
-    : sizes_(sizes)
+    : sizes_(sizes.vec())
     , strides_(sizes.size())
     , storage_offset_(0) {
       int64_t dim = sizes.size();
@@ -21,8 +21,8 @@ struct AT_API TensorGeometry {
   }
 
   explicit TensorGeometry(const Tensor& t)
-    : sizes_(t.sizes())
-    , strides_(t.strides())
+    : sizes_(t.sizes().vec())
+    , strides_(t.strides().vec())
     , storage_offset_(t.storage_offset()) {}
 
   // true if the tensor is contiguous

--- a/aten/src/ATen/core/ArrayRef.h
+++ b/aten/src/ATen/core/ArrayRef.h
@@ -16,180 +16,192 @@
 #pragma once
 
 #include <ATen/core/Error.h>
-
-// TODO: Consider inverting this dependency, so that SmallVector defines
-// an implicit conversion to ArrayRef, rather than the other way around
 #include <ATen/core/SmallVector.h>
+#include <ATen/core/C++17.h>
 
 #include <array>
 #include <iterator>
 #include <vector>
 
 namespace at {
-  /// ArrayRef - Represent a constant reference to an array (0 or more elements
-  /// consecutively in memory), i.e. a start pointer and a length.  It allows
-  /// various APIs to take consecutive elements easily and conveniently.
-  ///
-  /// This class does not own the underlying data, it is expected to be used in
-  /// situations where the data resides in some other buffer, whose lifetime
-  /// extends past that of the ArrayRef. For this reason, it is not in general
-  /// safe to store an ArrayRef.
-  ///
-  /// This is intended to be trivially copyable, so it should be passed by
-  /// value.
-  template<typename T>
-  class ArrayRef {
-  public:
-    typedef const T *iterator;
-    typedef const T *const_iterator;
-    typedef size_t size_type;
 
-    typedef std::reverse_iterator<iterator> reverse_iterator;
+/// ArrayRef - Represent a constant reference to an array (0 or more elements
+/// consecutively in memory), i.e. a start pointer and a length.  It allows
+/// various APIs to take consecutive elements easily and conveniently.
+///
+/// This class does not own the underlying data, it is expected to be used in
+/// situations where the data resides in some other buffer, whose lifetime
+/// extends past that of the ArrayRef. For this reason, it is not in general
+/// safe to store an ArrayRef.
+///
+/// This is intended to be trivially copyable, so it should be passed by
+/// value.
+template <typename T>
+class ArrayRef final {
+ public:
+  using iterator = const T*;
+  using const_iterator = const T*;
+  using size_type = size_t;
 
-  private:
-    /// The start of the array, in an external buffer.
-    const T *Data;
+  using reverse_iterator = std::reverse_iterator<iterator>;
 
-    /// The number of elements.
-    size_type Length;
+ private:
+  /// The start of the array, in an external buffer.
+  const T* Data;
 
-  public:
-    /// @name Constructors
-    /// @{
+  /// The number of elements.
+  size_type Length;
 
-    /// Construct an empty ArrayRef.
-    /*implicit*/ ArrayRef() : Data(nullptr), Length(0) {}
+ public:
+  /// @name Constructors
+  /// @{
 
-    /// Construct an ArrayRef from a single element.
-    /*implicit*/ ArrayRef(const T &OneElt)
-      : Data(&OneElt), Length(1) {}
+  /// Construct an empty ArrayRef.
+  /* implicit */ constexpr ArrayRef() : Data(nullptr), Length(0) {}
 
-    /// Construct an ArrayRef from a pointer and length.
-    /*implicit*/ ArrayRef(const T *data, size_t length)
+  /// Construct an ArrayRef from a single element.
+  // TODO Make this explicit
+  constexpr ArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
+
+  /// Construct an ArrayRef from a pointer and length.
+  constexpr ArrayRef(const T* data, size_t length)
       : Data(data), Length(length) {}
 
-    /// Construct an ArrayRef from a range.
-    ArrayRef(const T *begin, const T *end)
+  /// Construct an ArrayRef from a range.
+  constexpr ArrayRef(const T* begin, const T* end)
       : Data(begin), Length(end - begin) {}
 
-    /// Construct an ArrayRef from a SmallVector. This is templated in order to
-    /// avoid instantiating SmallVectorTemplateCommon<T> whenever we
-    /// copy-construct an ArrayRef.
-    template<typename U>
-    /*implicit*/ ArrayRef(const SmallVectorTemplateCommon<T, U> &Vec)
-      : Data(Vec.data()), Length(Vec.size()) {
-    }
-
-    /// Construct an ArrayRef from a std::vector.
-    template<typename A>
-    /*implicit*/ ArrayRef(const std::vector<T, A> &Vec)
+  /// Construct an ArrayRef from a SmallVector. This is templated in order to
+  /// avoid instantiating SmallVectorTemplateCommon<T> whenever we
+  /// copy-construct an ArrayRef.
+  template <typename U>
+  /* implicit */ ArrayRef(const SmallVectorTemplateCommon<T, U>& Vec)
       : Data(Vec.data()), Length(Vec.size()) {}
 
-    /// Construct an ArrayRef from a std::array
-    template <size_t N>
-    /*implicit*/ constexpr ArrayRef(const std::array<T, N> &Arr)
-        : Data(Arr.data()), Length(N) {}
+  /// Construct an ArrayRef from a std::vector.
+  template <typename A>
+  /* implicit */ ArrayRef(const std::vector<T, A>& Vec)
+      : Data(Vec.data()), Length(Vec.size()) {}
 
-    /// Construct an ArrayRef from a C array.
-    template <size_t N>
-    /*implicit*/ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
+  /// Construct an ArrayRef from a std::array
+  template <size_t N>
+  /* implicit */ constexpr ArrayRef(const std::array<T, N>& Arr)
+      : Data(Arr.data()), Length(N) {}
 
-    /// Construct an ArrayRef from a std::initializer_list.
-    /*implicit*/ ArrayRef(const std::initializer_list<T> &Vec)
-    : Data(Vec.begin() == Vec.end() ? (T*)nullptr : Vec.begin()),
-      Length(Vec.size()) {}
+  /// Construct an ArrayRef from a C array.
+  template <size_t N>
+  /* implicit */ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
 
-    /// @}
-    /// @name Simple Operations
-    /// @{
+  /// Construct an ArrayRef from a std::initializer_list.
+  /* implicit */ constexpr ArrayRef(const std::initializer_list<T>& Vec)
+      : Data(Vec.begin() == Vec.end() ? static_cast<T*>(nullptr) : Vec.begin()),
+        Length(Vec.size()) {}
 
-    const_iterator begin() const { return Data; }
-    const_iterator end() const { return Data + Length; }
+  /// @}
+  /// @name Simple Operations
+  /// @{
 
-    reverse_iterator rbegin() const { return reverse_iterator(end()); }
-    reverse_iterator rend() const { return reverse_iterator(begin()); }
+  constexpr iterator begin() const {
+    return Data;
+  }
+  constexpr iterator end() const {
+    return Data + Length;
+  }
 
-    /// empty - Check if the array is empty.
-    bool empty() const { return Length == 0; }
+  constexpr reverse_iterator rbegin() const {
+    return reverse_iterator(end());
+  }
+  constexpr reverse_iterator rend() const {
+    return reverse_iterator(begin());
+  }
 
-    const T *data() const { return Data; }
+  /// empty - Check if the array is empty.
+  constexpr bool empty() const {
+    return Length == 0;
+  }
 
-    /// size - Get the array size.
-    size_t size() const { return Length; }
+  constexpr const T* data() const {
+    return Data;
+  }
 
-    /// front - Get the first element.
-    const T &front() const {
-      AT_CHECK(!empty(), "ArrayRef: attempted to access front() of empty list");
-      return Data[0];
-    }
+  /// size - Get the array size.
+  constexpr size_t size() const {
+    return Length;
+  }
 
-    /// back - Get the last element.
-    const T &back() const {
-      AT_CHECK(!empty(), "ArrayRef: attempted to access back() of empty list");
-      return Data[Length-1];
-    }
+  /// front - Get the first element.
+  AT_CPP14_CONSTEXPR const T& front() const {
+    AT_CHECK(!empty(), "ArrayRef: attempted to access front() of empty list");
+    return Data[0];
+  }
 
-    /// equals - Check for element-wise equality.
-    bool equals(ArrayRef RHS) const {
-      if (Length != RHS.Length)
-        return false;
-      return std::equal(begin(), end(), RHS.begin());
-    }
+  /// back - Get the last element.
+  AT_CPP14_CONSTEXPR const T& back() const {
+    AT_CHECK(!empty(), "ArrayRef: attempted to access back() of empty list");
+    return Data[Length - 1];
+  }
 
-    /// slice(n, m) - Chop off the first N elements of the array, and keep M
-    /// elements in the array.
-    ArrayRef<T> slice(size_t N, size_t M) const {
-      AT_CHECK(N+M <= size(), "ArrayRef: invalid slice, ", N, " + ", M, " is not <= ", size());
-      return ArrayRef<T>(data()+N, M);
-    }
+  /// equals - Check for element-wise equality.
+  constexpr bool equals(ArrayRef RHS) const {
+    return Length == RHS.Length && std::equal(begin(), end(), RHS.begin());
+  }
 
-    /// slice(n) - Chop off the first N elements of the array.
-    ArrayRef<T> slice(size_t N) const { return slice(N, size() - N); }
+  /// slice(n, m) - Chop off the first N elements of the array, and keep M
+  /// elements in the array.
+  AT_CPP14_CONSTEXPR ArrayRef<T> slice(size_t N, size_t M) const {
+    AT_CHECK(N + M <= size(), "ArrayRef: invalid slice, N = ", N, "; M = ", M, "; size = ", size());
+    return ArrayRef<T>(data() + N, M);
+  }
 
-    /// @}
-    /// @name Operator Overloads
-    /// @{
-    const T &operator[](size_t Index) const {
-      return Data[Index];
-    }
+  /// slice(n) - Chop off the first N elements of the array.
+  constexpr ArrayRef<T> slice(size_t N) const {
+    return slice(N, size() - N);
+  }
 
-    /// Vector compatibility
-    const T &at(size_t Index) const {
-      AT_CHECK(Index < Length, "ArrayRef: invalid index ", Index, " for length ", Length);
-      return Data[Index];
-    }
+  /// @}
+  /// @name Operator Overloads
+  /// @{
+  constexpr const T& operator[](size_t Index) const {
+    return Data[Index];
+  }
 
-    /// Disallow accidental assignment from a temporary.
-    ///
-    /// The declaration here is extra complicated so that "arrayRef = {}"
-    /// continues to select the move assignment operator.
-    template <typename U>
-    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
-    operator=(U &&Temporary) = delete;
+  /// Vector compatibility
+  AT_CPP14_CONSTEXPR const T& at(size_t Index) const {
+    AT_CHECK(Index < Length, "ArrayRef: invalid index Index = ", Index, "; Length = ", Length);
+    return Data[Index];
+  }
 
-    /// Disallow accidental assignment from a temporary.
-    ///
-    /// The declaration here is extra complicated so that "arrayRef = {}"
-    /// continues to select the move assignment operator.
-    template <typename U>
-    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
-    operator=(std::initializer_list<U>) = delete;
+  /// Disallow accidental assignment from a temporary.
+  ///
+  /// The declaration here is extra complicated so that "arrayRef = {}"
+  /// continues to select the move assignment operator.
+  template <typename U>
+  typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type&
+  operator=(U&& Temporary) = delete;
 
-    /// @}
-    /// @name Expensive Operations
-    /// @{
-    std::vector<T> vec() const {
-      return std::vector<T>(Data, Data+Length);
-    }
+  /// Disallow accidental assignment from a temporary.
+  ///
+  /// The declaration here is extra complicated so that "arrayRef = {}"
+  /// continues to select the move assignment operator.
+  template <typename U>
+  typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type&
+  operator=(std::initializer_list<U>) = delete;
 
-    /// @}
-    /// @name Conversion operators
-    /// @{
-    operator std::vector<T>() const {
-      return std::vector<T>(Data, Data+Length);
-    }
+  /// @}
+  /// @name Expensive Operations
+  /// @{
+  std::vector<T> vec() const {
+    return std::vector<T>(Data, Data + Length);
+  }
 
-    /// @}
-  };
+  /// @}
+  /// @name Conversion operators
+  /// @{
+  operator std::vector<T>() const {
+    return std::vector<T>(Data, Data + Length);
+  }
 
-} // end namespace at
+  /// @}
+};
+
+} // namespace at

--- a/aten/src/ATen/core/ArrayRef.h
+++ b/aten/src/ATen/core/ArrayRef.h
@@ -195,13 +195,6 @@ class ArrayRef final {
   }
 
   /// @}
-  /// @name Conversion operators
-  /// @{
-  operator std::vector<T>() const {
-    return std::vector<T>(Data, Data + Length);
-  }
-
-  /// @}
 };
 
 } // namespace at

--- a/aten/src/ATen/core/C++17.h
+++ b/aten/src/ATen/core/C++17.h
@@ -182,9 +182,9 @@ constexpr auto apply(F&& f, Tuple&& t) -> decltype(detail::apply_impl(
 
 
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
-#  define C10_CPP14_CONSTEXPR constexpr
+#  define AT_CPP14_CONSTEXPR constexpr
 #else
-#  define C10_CPP14_CONSTEXPR
+#  define AT_CPP14_CONSTEXPR
 #endif
 
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -402,11 +402,11 @@ at::Tensor _convolution_nogroup(
     bool transposed, IntList output_padding) {
 
   ConvParams params;
-  params.stride = stride;
-  params.padding = padding;
-  params.dilation = dilation;
+  params.stride = stride.vec();
+  params.padding = padding.vec();
+  params.dilation = dilation.vec();
   params.transposed = transposed;
-  params.output_padding = output_padding;
+  params.output_padding = output_padding.vec();
   params.groups = 1;
   params.benchmark = false;
   params.deterministic = false;
@@ -474,11 +474,11 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward(
   auto weight = weight_r;
 
   ConvParams params;
-  params.stride = stride_;
-  params.padding = padding_;
-  params.dilation = dilation_;
+  params.stride = stride_.vec();
+  params.padding = padding_.vec();
+  params.dilation = dilation_.vec();
   params.transposed = transposed_;
-  params.output_padding = output_padding_;
+  params.output_padding = output_padding_.vec();
   params.groups = groups_;
   params.benchmark = benchmark;
   params.deterministic = deterministic;

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -24,7 +24,7 @@ Tensor embedding(const Tensor & weight, const Tensor & indices,
     return weight.index_select(0, indices);
   }
 
-  auto size = std::vector<int64_t>(indices.sizes());
+  auto size = indices.sizes().vec();
   for (auto d : weight.sizes().slice(1)) {
     size.push_back(d);
   }

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -279,11 +279,11 @@ Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Ten
   }
 
   // Check that source and destination slices have the same size
-  auto selfSlicedSizes = std::vector<int64_t>(self.sizes());
+  auto selfSlicedSizes = self.sizes().vec();
   if (selfSlicedSizes.size() > 0) {
     selfSlicedSizes.erase(selfSlicedSizes.begin() + dim);
   }
-  auto sourceSlicedSizes = std::vector<int64_t>(source.sizes());
+  auto sourceSlicedSizes = source.sizes().vec();
   if (sourceSlicedSizes.size() > 0) {
     sourceSlicedSizes.erase(sourceSlicedSizes.begin() + dim);
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -92,8 +92,8 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
 
   // construct new size and stride: we drop dim1 and dim2 (maximum first for not changing the index of the minumum)
   // the new ("joint") dimension is appended to the end of the shape / stride to match numpy semantics
-  auto sizes = std::vector<int64_t>(self.sizes());
-  auto strides = std::vector<int64_t>(self.strides());
+  auto sizes = self.sizes().vec();
+  auto strides = self.strides().vec();
   sizes.erase(sizes.begin() + std::max(dim1, dim2));
   strides.erase(strides.begin() + std::max(dim1, dim2));
   sizes.erase(sizes.begin() + std::min(dim1, dim2));
@@ -276,8 +276,8 @@ Tensor select(const Tensor& self, int64_t dim, int64_t index) {
   if (index < 0) {
     index += size;
   }
-  auto sizes = std::vector<int64_t>(self.sizes());
-  auto strides = std::vector<int64_t>(self.strides());
+  auto sizes = self.sizes().vec();
+  auto strides = self.strides().vec();
   auto storage_offset = self.storage_offset() + index * strides[dim];
   sizes.erase(sizes.begin() + dim);
   strides.erase(strides.begin() + dim);
@@ -288,8 +288,8 @@ Tensor slice(const Tensor& self, int64_t dim, int64_t start, int64_t end, int64_
   int64_t ndim = self.dim();
   AT_CHECK(ndim > 0, "slice() cannot be applied to a 0-dim tensor.");
   dim = maybe_wrap_dim(dim, ndim);
-  auto sizes = std::vector<int64_t>(self.sizes());
-  auto strides = std::vector<int64_t>(self.strides());
+  auto sizes = self.sizes().vec();
+  auto strides = self.strides().vec();
   if (step <= 0) {
     // TODO: support negative strides
     throw std::runtime_error("slice step must be positive");
@@ -403,7 +403,7 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
   }
 
   if (self._indices().numel() == 0 && self._values().numel() == 0) {
-    std::vector<int64_t> sizes(self.sizes());
+    auto sizes = self.sizes().vec();
     std::swap(sizes[dim0], sizes[dim1]);
 
     return self.sparse_raw_resize_(sizes, self._sparseDims(), self._denseDims());
@@ -418,7 +418,7 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
     row0.copy_(row1);
     row1.copy_(tmp);
 
-    std::vector<int64_t> sizes(self.sizes());
+    auto sizes = self.sizes().vec();
     std::swap(sizes[dim0], sizes[dim1]);
 
     return self.sparse_raw_resize_(sizes, -1, -1);
@@ -437,8 +437,8 @@ Tensor & transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
     return sparse_transpose_(self, dim0, dim1);
   }
 
-  std::vector<int64_t> strides(self.strides());
-  std::vector<int64_t> sizes(self.sizes());
+  auto strides = self.strides().vec();
+  auto sizes = self.sizes().vec();
   std::swap(strides[dim0], strides[dim1]);
   std::swap(sizes[dim0], sizes[dim1]);
   return self.as_strided_(sizes, strides);
@@ -457,8 +457,8 @@ Tensor transpose(const Tensor & self, int64_t dim0, int64_t dim1) {
     return sparse_transpose_(self_clone, dim0, dim1);
   }
 
-  std::vector<int64_t> strides(self.strides());
-  std::vector<int64_t> sizes(self.sizes());
+  auto strides = self.strides().vec();
+  auto sizes = self.sizes().vec();
   std::swap(strides[dim0], strides[dim1]);
   std::swap(sizes[dim0], sizes[dim1]);
   return self.as_strided(sizes, strides);
@@ -518,8 +518,8 @@ inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >
 inferUnsqueezeGeometry(const Tensor& tensor, int64_t dim) {
-  std::vector<int64_t> sizes(tensor.sizes());
-  std::vector<int64_t> strides(tensor.strides());
+  auto sizes = tensor.sizes().vec();
+  auto strides = tensor.strides().vec();
   int64_t new_stride = dim >= tensor.dim() ? 1 : sizes[dim] * strides[dim];
   sizes.insert(sizes.begin() + dim, 1);
   strides.insert(strides.begin() + dim, new_stride);
@@ -537,7 +537,7 @@ Tensor squeeze(const Tensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, dims);
 
   if (dims == 0 || self.sizes()[dim] != 1) {
-    return self.as_strided(self.sizes().vec(), self.strides().vec());
+    return self.as_strided(self.sizes(), self.strides());
   }
   auto g = inferSqueezeGeometry(self, dim);
   return self.as_strided(std::get<0>(g), std::get<1>(g));
@@ -553,7 +553,7 @@ Tensor & squeeze_(Tensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim());
 
   if (dims == 0 || self.sizes()[dim] != 1) {
-    return self.as_strided_(self.sizes().vec(), self.strides().vec());
+    return self.as_strided_(self.sizes(), self.strides());
   }
   auto g = inferSqueezeGeometry(self, dim);
   return self.as_strided_(std::get<0>(g), std::get<1>(g));

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -13,7 +13,7 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
   const int64_t total_dims = self.dim(), flip_dims_size = dims.size();
   flip_check_errors(total_dims, flip_dims_size, dims);
 
-  auto flip_dims_v = std::vector<int64_t>(dims);
+  auto flip_dims_v = dims.vec();
   wrap_all_dims(flip_dims_v, total_dims);
   std::sort(flip_dims_v.begin(), flip_dims_v.end());
   auto final_indices = std::vector<at::Tensor>(total_dims);

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -14,7 +14,7 @@ static inline void flip_check_errors(int64_t total_dims, int64_t flip_dims_size,
   AT_CHECK(flip_dims_size > 0 && flip_dims_size <= total_dims,
     "flip dims size out of range, got flip dims size=", flip_dims_size);
 
-  auto flip_dims_v = std::vector<int64_t>(dims);
+  auto flip_dims_v = dims.vec();
 
   // check if dims axis within range
   auto min_max_d = std::minmax_element(flip_dims_v.begin(), flip_dims_v.end());

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -80,7 +80,7 @@ Tensor flip_cuda(const Tensor& self, IntList dims) {
     return out_tensor;
   }
 
-  auto flip_dims = std::vector<int64_t>(dims);
+  auto flip_dims = dims.vec();
   wrap_all_dims(flip_dims, total_dims);
 
   // use kernel_pointwise_flip_apply2 only when to-flip dim is the 1st or last dim, where collapseDims can reduce the amount of work
@@ -99,10 +99,10 @@ Tensor flip_cuda(const Tensor& self, IntList dims) {
 
   auto flip_dims_t = at::CPU(kLong).tensorFromBlob(flip_dims.data(), {static_cast<int64_t>(flip_dims.size())});
 
-  auto shape = std::vector<int64_t>(in_tensor.sizes());
+  auto shape = in_tensor.sizes().vec();
   auto shape_t = at::CPU(kLong).tensorFromBlob(shape.data(), {static_cast<int64_t>(shape.size())});
 
-  auto strides = std::vector<int64_t>(in_tensor.strides());
+  auto strides = in_tensor.strides().vec();
   auto strides_t = at::CPU(kLong).tensorFromBlob(strides.data(), {static_cast<int64_t>(strides.size())});
 
   // stride_contiguous is the stride of non-contiguous tensor after calling contiguous(),

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -166,7 +166,7 @@ namespace {
     std::vector<TensorDescriptor> descriptors(batch_sizes.size());
     size_t i = 0;
     // To be mutated in the loop
-    std::vector<int64_t> batch_tensor_size(tensor.sizes());
+    auto batch_tensor_size = tensor.sizes().vec();
     for (auto batch_size : batch_sizes) {
       batch_tensor_size[0] = batch_size;
       // NB: cuDNN RNN API does not support 2d descriptors, so we
@@ -994,7 +994,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
   if (output_mask[3]) {
     dw = at::native::_cudnn_rnn_backward_weight(input, weight, weight_stride0, weight_buf, hx, cx, output, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve);
   }
-  return std::tuple<Tensor, Tensor, Tensor, TensorList>{dx, dhx, dcx, dw};
+  return std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>>{dx, dhx, dcx, dw};
 }
 
 // TODO: I am not sure if we actually need the 'dropout' and 'train' parameters

--- a/aten/src/ATen/native/sparse/SparseUtils.h
+++ b/aten/src/ATen/native/sparse/SparseUtils.h
@@ -118,7 +118,7 @@ inline Tensor _new_values_with_size_of(const Tensor& values, int64_t nnz) {
     // That's the assumption this code makes.
     return values.type().tensor({nnz});
   } else {
-    std::vector<int64_t> size = values.sizes();
+    std::vector<int64_t> size = values.sizes().vec();
     size[0] = nnz;
     return values.type().tensor(size);
   }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -81,7 +81,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
   int64_t newNnz = newEnd.first - indicesIter;
 
   indices1D.resize_({1, newNnz});
-  std::vector<int64_t> newValues_size(values.sizes());
+  auto newValues_size = values.sizes().vec();
   newValues_size[0] = newNnz;
   Tensor newValues = at::empty(newValues_size, values.options());
 

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -32,7 +32,7 @@ THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride, at::IntList
   // This could perhaps be combined with the below code, but the complexity didn't seem worth it.
   int64_t numel = std::accumulate(oldshape.begin(), oldshape.end(), 1, std::multiplies<int64_t>());
   if (numel == 0 && oldshape.equals(newshape)) {
-    return std::vector<int64_t>(oldstride);
+    return oldstride.vec();
   }
 
   std::vector<int64_t> newstride(newshape.size());

--- a/caffe2/utils/Array.h
+++ b/caffe2/utils/Array.h
@@ -101,32 +101,32 @@ public:
   // No explicit construct/copy/destroy for aggregate type.
 
   // DR 776.
-  C10_CPP14_CONSTEXPR void fill(const value_type& __u)
+  AT_CPP14_CONSTEXPR void fill(const value_type& __u)
   { std::fill_n(begin(), size(), __u); }
 
-  C10_CPP14_CONSTEXPR void swap(array& __other)
+  AT_CPP14_CONSTEXPR void swap(array& __other)
   { std::swap_ranges(begin(), end(), __other.begin()); }
 
   // Iterators.
-  C10_CPP14_CONSTEXPR iterator begin() noexcept
+  AT_CPP14_CONSTEXPR iterator begin() noexcept
   { return iterator(data()); }
 
   constexpr const_iterator begin() const noexcept
   { return const_iterator(data()); }
 
-  C10_CPP14_CONSTEXPR iterator end() noexcept
+  AT_CPP14_CONSTEXPR iterator end() noexcept
   { return iterator(data() + _Nm); }
 
   constexpr const_iterator end() const noexcept
   { return const_iterator(data() + _Nm); }
 
-  C10_CPP14_CONSTEXPR reverse_iterator rbegin() noexcept
+  AT_CPP14_CONSTEXPR reverse_iterator rbegin() noexcept
   { return reverse_iterator(end()); }
 
   constexpr const_reverse_iterator rbegin() const noexcept
   { return const_reverse_iterator(end()); }
 
-  C10_CPP14_CONSTEXPR reverse_iterator rend() noexcept
+  AT_CPP14_CONSTEXPR reverse_iterator rend() noexcept
   { return reverse_iterator(begin()); }
 
   constexpr const_reverse_iterator rend() const noexcept
@@ -152,13 +152,13 @@ public:
   constexpr bool empty() const noexcept { return size() == 0; }
 
   // Element access.
-  C10_CPP14_CONSTEXPR reference operator[](size_type __n) noexcept
+  AT_CPP14_CONSTEXPR reference operator[](size_type __n) noexcept
   { return _AT_Type::_S_ref(_M_elems, __n); }
 
   constexpr const_reference operator[](size_type __n) const noexcept
   { return _AT_Type::_S_ref(_M_elems, __n); }
 
-  C10_CPP14_CONSTEXPR reference at(size_type __n) {
+  AT_CPP14_CONSTEXPR reference at(size_type __n) {
     if (__n >= _Nm) {
       detail::__throw_out_of_range(std::string() +
           "array::at: __n (which is " + to_string(__n) + ") " +
@@ -177,13 +177,13 @@ public:
          _AT_Type::_S_ref(_M_elems, 0));
      }
 
-  C10_CPP14_CONSTEXPR reference front() noexcept
+  AT_CPP14_CONSTEXPR reference front() noexcept
   { return *begin(); }
 
   constexpr const_reference front() const noexcept
   { return _AT_Type::_S_ref(_M_elems, 0); }
 
-  C10_CPP14_CONSTEXPR reference back() noexcept
+  AT_CPP14_CONSTEXPR reference back() noexcept
   { return _Nm ? *(end() - 1) : *end(); }
 
   constexpr const_reference back() const noexcept
@@ -192,7 +192,7 @@ public:
             : _AT_Type::_S_ref(_M_elems, 0);
   }
 
-  C10_CPP14_CONSTEXPR pointer data() noexcept
+  AT_CPP14_CONSTEXPR pointer data() noexcept
   { return _AT_Type::_S_ptr(_M_elems); }
 
   constexpr const_pointer data() const noexcept

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -340,6 +340,8 @@ def emit_body(declaration):
             elif arg['type'] == 'TensorList':
                 name += '_'
                 expr = 'make_saved_variable_list({})'.format(arg['name'])
+            elif arg['type'] == 'IntList':
+                expr = expr + ".vec()"
             stmts.append('grad_fn->{} = {};'.format(name, expr))
         return stmts
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -175,7 +175,7 @@ Tensor prod_safe_zeros_backward(const Tensor &grad, const Tensor& inp, int64_t d
     return grad;
   }
 
-  std::vector<int64_t> ones_size(inp.sizes());
+  auto ones_size = inp.sizes().vec();
   ones_size[dim] = 1;
   Tensor ones = at::ones(ones_size, grad.type());
   Tensor exclusive_normal_nocp = at::cat({ones, inp.narrow(dim, 0, inp.size(dim) - 1)}, dim);
@@ -328,7 +328,7 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
     return sum_scan_exclusive(result * grad, dim) / input;
   }
 
-  std::vector<int64_t> ones_size(input.sizes());
+  auto ones_size = input.sizes().vec();
   ones_size[dim] = 1;
   Tensor ones = at::ones({1}, grad.type()).expand(ones_size);
   Tensor grad_input = at::zeros(input.sizes(), grad.type());
@@ -461,7 +461,7 @@ Tensor mm_mat2_backward(const Tensor & grad, const Tensor & mat1, IntList sizes,
 }
 
 Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64_t dim, Scalar maxnorm) {
-  auto transposed_sizes = std::vector<int64_t>(self.transpose(dim, 0).sizes());
+  auto transposed_sizes = self.transpose(dim, 0).sizes().vec();
   auto flatten = [&](const Tensor & t) {
     return t.transpose(dim, 0).contiguous().view({t.size(dim), -1});
   };
@@ -637,7 +637,7 @@ Tensor split_with_sizes_backward(const std::vector<torch::autograd::Variable> &g
       grads_all_defined[j] = grads[j];
     } else {
       auto length = split_sizes[j];
-      std::vector<int64_t> grad_size(sizes);
+      auto grad_size = sizes.vec();
       grad_size[dim] = length;
       grads_all_defined[j] = at::zeros(grad_size, type);
     }
@@ -659,7 +659,7 @@ Tensor split_backward(const std::vector<torch::autograd::Variable> &grads,
 
 Tensor max_pool_double_backward(const Tensor & grad, const Tensor & indices, int dim) {
   AT_ASSERT(indices.dim() >= dim);
-  auto size = std::vector<int64_t>(indices.sizes().slice(0, indices.dim() - dim));
+  auto size = indices.sizes().slice(0, indices.dim() - dim).vec();
   size.push_back(-1);
   auto indices_view = indices.view(size);
   return grad.contiguous().view(size).gather(-1, indices_view).view(indices.sizes());
@@ -686,7 +686,7 @@ Tensor glu_double_backward(const Tensor & grad, const Tensor & grad_output, cons
 
 Tensor glu_double_backward_grad_output(const Tensor & grad, const Tensor & input, int64_t dim) {
   if (dim < 0) dim += input.dim();
-  std::vector<int64_t> sizes = input.sizes();
+  auto sizes = input.sizes().vec();
   sizes[dim] /= 2;
   auto tmp = grad * glu_backward(at::ones(sizes, input.type()), input, dim);
   return tmp.narrow(dim, 0, sizes[dim]) + tmp.narrow(dim, sizes[dim], sizes[dim]);
@@ -1545,27 +1545,27 @@ Tensor symeig_backward(const std::vector<torch::autograd::Variable> &grads, cons
                     bool eigenvectors, bool upper, const Tensor& lambda, const Tensor& v) {
     auto glambda = grads[0];
     auto gv = grads[1];
-    
+
     auto vt = v.t();
-    
+
     if (!eigenvectors) {
         throw std::runtime_error(std::string("cannot compute backward without "
                                              "computing eigenvectors in forward pass"));
     }
-    
+
     Tensor result;
     if (gv.defined()) {
         Tensor F = lambda.unsqueeze(0).expand_as(self).clone();
         F.sub_(at::unsqueeze(lambda, 1));
         F.diagonal().fill_(INFINITY);
         F.pow_(-1);
-        
+
         F.mul_(vt.mm(gv));
         result = v.mm(F.mm(vt));
     } else {
         result = at::zeros_like(self);
     }
-    
+
     if (glambda.defined()) {
         result.add_((v * glambda).mm(vt));
     }

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -29,7 +29,7 @@ struct TypeAndSize {
   TypeAndSize() : type(nullptr) {}
   /* implicit */
   TypeAndSize(const Tensor & t)
-    : sizes(t.sizes())
+    : sizes(t.sizes().vec())
     , type(&t.type()) {}
 
   Tensor zeros() { return at::zeros(sizes, *type); }

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -398,7 +398,7 @@ Tensor VariableType::contiguous(const Tensor & self) const {
 static std::vector<std::vector<int64_t>> to_args_sizes(TensorList tensors) {
   std::vector<std::vector<int64_t>> args_sizes(tensors.size());
   for (size_t i = 0; i < tensors.size(); ++i) {
-    args_sizes[i] = tensors[i].sizes();
+    args_sizes[i] = tensors[i].sizes().vec();
   }
   return args_sizes;
 }

--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -42,14 +42,14 @@ int deviceForInputs(Stack & stack, size_t N) {
 }
 
 template<size_t N>
-std::array<bool, N> as_bool_array(const std::vector<int64_t>& vec) {
+std::array<bool, N> as_bool_array(at::ArrayRef<int64_t> vec) {
   std::array<bool, N> res;
   JIT_ASSERT(vec.size() == N);
   std::copy(vec.begin(), vec.end(), res.begin());
   return res;
 }
 
-at::Device as_device(const std::vector<int64_t>& elements) {
+at::Device as_device(ArrayRef<int64_t> elements) {
   return at::Device(static_cast<at::Device::Type>(elements[0]), elements[1]);
 }
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -45,7 +45,7 @@ namespace torch { namespace autograd {
 
 VariableInfo::VariableInfo(const Variable& var)
   : type(&var.type())
-  , size(var.sizes())
+  , size(var.sizes().vec())
   , requires_grad(var.requires_grad()) {
   if (var.type().is_cuda()) {
     device = var.get_device();

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -154,8 +154,8 @@ std::shared_ptr<Function>& Variable::ViewImpl::get_grad_fn() {
     AT_ASSERT(output_nr_ == 0);
     auto fn = std::make_shared<generated::AsStridedBackward>();
     fn->self_geometry = at::TensorGeometry(base_);
-    fn->size = sizes();
-    fn->stride = strides();
+    fn->size = sizes().vec();
+    fn->stride = strides().vec();
     fn->storage_offset = data_.storage_offset();
     fn->set_next_edges(collect_next_edges(base_));
     fn->add_input_metadata(base_.type(), sizes());

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -74,7 +74,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
   }
 
   tensor_list2d outputs(devices.size());
-  outputs[0] = tensors;
+  outputs[0] = tensors.vec();
   for (auto & o : outputs)
     o.reserve(tensors.size());
 

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -22,7 +22,7 @@ Value* insertConstant(
     n->f_(attr::value, val.toDouble());
     n->output()->setType(FloatType::get());
   } else if(val.isIntList()) {
-    n->is_(attr::value, val.toIntList()->elements());
+    n->is_(attr::value, val.toIntList()->elements().vec());
     n->output()->setType(ListType::ofInts());
   } else if(val.isTensorList()) {
     n->ts_(attr::value, fmap(val.toTensorList()->elements(), [](const at::Tensor & t) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -44,9 +44,9 @@ std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
 }
 
 struct const_value_list_with_types {
-  const std::vector<const Value*>& values;
+  const ArrayRef<const Value*> values;
   bool use_newlines;
-  const_value_list_with_types(const std::vector<const Value*>& values, bool use_newlines = false)
+  const_value_list_with_types(ArrayRef<const Value*> values, bool use_newlines = false)
     : values(values), use_newlines(use_newlines) {}
 };
 std::ostream& operator<<(std::ostream & out, const_value_list_with_types l) {

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -392,7 +392,7 @@ inline IValue::IValue(std::vector<at::Tensor> v)
 : IValue(TensorList::create(std::move(v))) {}
 
 inline std::vector<int64_t> IValue::copyToIntList() const {
-  return std::vector<int64_t>(toIntList()->elements());
+  return toIntList()->elements().vec();
 }
 
 }}

--- a/torch/csrc/jit/passes/to_batch.cpp
+++ b/torch/csrc/jit/passes/to_batch.cpp
@@ -14,7 +14,7 @@ void ToBatch::toBatch(Block* block, Block* res_block) {
     res_block->addInput(name + "_data");
     res_block->addInput(name + "_mask");
     res_block->addInput(name + "_dims");
-    batch_map[input] = std::vector<Value*>(res_block->inputs().slice(i * 3, 3));
+    batch_map[input] = res_block->inputs().slice(i * 3, 3).vec();
   }
 
   for (auto it = block->nodes().begin(); it != block->nodes().end(); it++) {

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -14,7 +14,7 @@ namespace torch { namespace jit { namespace python {
 struct IODescriptor {
   struct VariableMetadata {
     VariableMetadata(const autograd::Variable& var)
-      : sizes(var.sizes())
+      : sizes(var.sizes().vec())
       , type(var.type().scalarType())
       , device(var.type().is_cuda() ? var.get_device() : -1)
       , requires_grad(var.requires_grad()) {}

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -354,7 +354,7 @@ Value* createNumber(Graph& g, const SourceRange& loc, const at::Tensor& val) {
 at::optional<std::vector<int64_t>> getIntListAttribute(at::optional<int32_t> N, Value* input) {
   auto list = constant_as<Shared<jit::IntList>>(input);
   if(list)
-    return std::vector<int64_t>(list.value()->elements());
+    return list.value()->elements().vec();
 
   // broadcast IntList[3] with value 4 -> {4, 4, 4}
   if(!N)
@@ -677,7 +677,7 @@ struct to_ir {
       if (return_stmt.values().size() == 1 && results.size() == 1) {
         auto result = results.at(0);
         if(result->type()->cast<TupleType>()) {
-          results = createTupleUnpack(result);
+          results = createTupleUnpack(result).vec();
         }
       }
       if (typed_def.schema && typed_def.schema->returns.size() != results.size()) {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -186,16 +186,16 @@ private:
     : Type(TypeKind::TensorType)
     , scalar_type_(tensor.type().scalarType())
     , device_(tensor.type().is_cuda() ? tensor.get_device() : -1)
-    , sizes_(tensor.sizes())
-    , strides_(tensor.strides()) {}
+    , sizes_(tensor.sizes().vec())
+    , strides_(tensor.strides().vec()) {}
   TensorType(at::ScalarType scalar_type, int device, at::IntList sizes)
     : TensorType(scalar_type, device, sizes, TensorType::contiguousStridesOf(sizes)) {}
   TensorType(at::ScalarType scalar_type, int device, at::IntList sizes, at::IntList strides)
     : Type(TypeKind::TensorType)
     , scalar_type_(scalar_type)
     , device_(device)
-    , sizes_(sizes)
-    , strides_(strides)
+    , sizes_(sizes.vec())
+    , strides_(strides.vec())
     {}
   static std::vector<int64_t> contiguousStridesOf(at::IntList sizes) {
     std::vector<int64_t> strides(sizes.size());

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -64,7 +64,7 @@ inline std::vector<std::vector<int64_t>> getSizes(
     const std::vector<at::Tensor>& tensors) {
   std::vector<std::vector<int64_t>> sizes(tensors.size());
   for (size_t i = 0; i < tensors.size(); i++) {
-    sizes[i] = tensors[i].sizes();
+    sizes[i] = tensors[i].sizes().vec();
   }
   return sizes;
 }


### PR DESCRIPTION
note: First commit of this stack is reviewed in https://github.com/pytorch/pytorch/pull/9610 , only the second commit is important. Review this on Phabricator to only see the changes of this diff without the previous stack.

Summary:
- Remove implicit ArrayRef -> vector conversion
- Fix 4 call sites that accidentally did an implicit expensive vector conversion but wouldn't have needed to
- Remove explicit vector conversion from 4 call sites that also didn't need to do that

Differential Revision: D8961693
