### PR TITLE
Lossen enforce for predictor

### DIFF
--- a/caffe2/core/logging.h
+++ b/caffe2/core/logging.h
@@ -129,6 +129,10 @@ class EnforceNotMet : public std::exception {
   const void* caller_;
 };
 
+#ifdef CAFFE_PREDICTOR_MODE
+#define CAFFE_ENFORCE(condition, ...) (condition)
+#define CAFFE_ENFORCE_WITH_CALLER(condition, ...) (condition)
+#else // CAFFE_PREDICTOR_MODE
 #define CAFFE_ENFORCE(condition, ...)                                         \
   do {                                                                        \
     if (!(condition)) {                                                       \
@@ -144,6 +148,7 @@ class EnforceNotMet : public std::exception {
           __FILE__, __LINE__, #condition, ::caffe2::MakeString(__VA_ARGS__), this); \
     }                                                                         \
   } while (false)
+#endif // CAFFE_PREDICTOR_MODE
 
 #define CAFFE_THROW(...)         \
   throw ::caffe2::EnforceNotMet( \
@@ -272,9 +277,24 @@ BINARY_COMP_HELPER(LessEquals, <=)
   } while (false)
 }
 
+#ifdef CAFFE_PREDICTOR_MODE
+#define CAFFE_ENFORCE_THAT(condition, ...) (condition)
+#define CAFFE_ENFORCE_EQ(x, y, ...) ((x) == (y))
+#define CAFFE_ENFORCE_NE(x, y, ...) ((x) != (y))
+#define CAFFE_ENFORCE_LE(x, y, ...) ((x) <= (y))
+#define CAFFE_ENFORCE_LT(x, y, ...) ((x) < (y))
+#define CAFFE_ENFORCE_GE(x, y, ...) ((x) >= (y))
+#define CAFFE_ENFORCE_GT(x, y, ...) ((x) > (y))
+
+#define CAFFE_ENFORCE_EQ_WITH_CALLER(x, y, ...) ((x) == (y))
+#define CAFFE_ENFORCE_NE_WITH_CALLER(x, y, ...) ((x) != (y))
+#define CAFFE_ENFORCE_LE_WITH_CALLER(x, y, ...) ((x) <= (y))
+#define CAFFE_ENFORCE_LT_WITH_CALLER(x, y, ...) ((x) < (y))
+#define CAFFE_ENFORCE_GE_WITH_CALLER(x, y, ...) ((x) >= (y))
+#define CAFFE_ENFORCE_GT_WITH_CALLER(x, y, ...) ((x) > (y))
+#else
 #define CAFFE_ENFORCE_THAT(condition, ...) \
   CAFFE_ENFORCE_THAT_IMPL((condition), #condition, __VA_ARGS__)
-
 #define CAFFE_ENFORCE_EQ(x, y, ...) \
   CAFFE_ENFORCE_THAT_IMPL(Equals((x), (y)), #x " == " #y, __VA_ARGS__)
 #define CAFFE_ENFORCE_NE(x, y, ...) \
@@ -299,6 +319,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
   CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER(GreaterEquals((x), (y)), #x " >= " #y, __VA_ARGS__)
 #define CAFFE_ENFORCE_GT_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER(Greater((x), (y)), #x " > " #y, __VA_ARGS__)
+#endif
 } // namespace caffe2
 
 #endif // CAFFE2_CORE_LOGGING_H_

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -67,6 +67,9 @@ class OperatorBase : public Observable<OperatorBase> {
   template <typename T>
   const T& Input(int idx) const {
     DCHECK_LT(idx, inputs_.size());
+#ifdef CAFFE_PREDICTOR_MODE
+    return inputs_.at(idx)->template Get<T>();
+#else
     try {
       return inputs_.at(idx)->template Get<T>();
     } catch (::caffe2::EnforceNotMet& enf) {
@@ -77,6 +80,7 @@ class OperatorBase : public Observable<OperatorBase> {
       }
       throw enf;
     }
+#endif
   }
 
   template <typename T>

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -65,7 +65,7 @@ class OperatorBase : public Observable<OperatorBase> {
 
   // Get the inputs and outputs as specific types.
   template <typename T>
-  inline const T& Input(int idx) {
+  const T& Input(int idx) const {
     DCHECK_LT(idx, inputs_.size());
     try {
       return inputs_.at(idx)->template Get<T>();

--- a/caffe2/core/operator_gradient.h
+++ b/caffe2/core/operator_gradient.h
@@ -274,6 +274,7 @@ struct ThrowInTheTowelIfGradientIsCalled : public GradientMakerBase {
   GradientOpsMeta Get() override {
     CAFFE_ENFORCE(
         false, "One should not call gradient for operator ", def_.type(), ".");
+    return GradientOpsMeta();
   }
 };
 
@@ -292,6 +293,7 @@ struct GradientNotImplementedYet : public GradientMakerBase {
         "Operator ",
         def_.type(),
         " should have a gradient but is not implemented yet.");
+    return GradientOpsMeta();
   }
 };
 

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -66,7 +66,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
   static constexpr const int& kOutputChannels = 3;
 
   // We read this much noise per vectorized cycle
-  static constexpr const int& kNeonNoiseReadSize = kOutputChannels * 16;
+  static constexpr const int& kNeonNoiseReadSize = 3 * 16;
 
   USE_OPERATOR_FUNCTIONS(CPUContext);
   PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp(
@@ -213,20 +213,20 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     // Loop unroll factor
     // FIXME: this doesn't actually unroll; clang has per-loop unroll
     // pragmas but GCC does not
-    constexpr int kUnroll = 1;
+    static constexpr const int& kUnroll = 1;
 
     // How much data we load for each inner loop
-    constexpr int kInnerLoadSize = sizeof(uint8x16x4_t);
+    static constexpr const int& kInnerLoadSize = sizeof(uint8x16x4_t);
 
     // What we write out
-    constexpr int kInnerStoreSize = sizeof(float32x4_t);
+    static constexpr const int& kInnerStoreSize = sizeof(float32x4_t);
 
     // We load 16 pixels at a time, with 4 channels each
-    constexpr int kLoadPixels = kInnerLoadSize / kInputChannels;
+    static constexpr const int& kLoadPixels = kInnerLoadSize / kInputChannels;
     static_assert(kLoadPixels == 16, "unexpected");
 
     // How many pixels we load per loop
-    constexpr int kLoadPixelsPerLoop = kLoadPixels * kUnroll;
+    static constexpr const int& kLoadPixelsPerLoop = kLoadPixels * kUnroll;
 
     // We need at least this much noise each loop through
     CAFFE_ENFORCE_GE(noiseCycle, kOutputChannels * kLoadPixelsPerLoop);
@@ -489,14 +489,15 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
     // Vectorized load parameters:
 
     // We load in chunks of this size
-    constexpr int kLoadUnit = sizeof(float32x4_t);
-    constexpr int kLoadFloats = (sizeof(float32x4_t) / sizeof(float));
+    static constexpr const int& kLoadUnit = sizeof(float32x4_t);
+    static constexpr const int& kLoadFloats =
+        (sizeof(float32x4_t) / sizeof(float));
 
     // We store in chunks of this size
-    constexpr int kStoreUni& = sizeof(uint8x8x4_t);
+    static constexpr const int& kStoreUnit = sizeof(uint8x8x4_t);
 
     // The vector portion loads this many f32 pixels at a time (8)
-    constexpr int kLoadPixels = 2 * kLoadFloats;
+    static constexpr const int& kLoadPixels = 2 * kLoadFloats;
 
     float mean[kInputChannels] = {
         meanChannel[0], meanChannel[1], meanChannel[2]};

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -60,13 +60,13 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     : public Operator<CPUContext> {
  public:
   // Expect this many channels as input
-  static constexpr int kInputChannels = 4;
+  static constexpr const int& kInputChannels = 4;
 
   // Expect this many channels as output
-  static constexpr int kOutputChannels = 3;
+  static constexpr const int& kOutputChannels = 3;
 
   // We read this much noise per vectorized cycle
-  static constexpr int kNeonNoiseReadSize = kOutputChannels * 16;
+  static constexpr const int& kNeonNoiseReadSize = kOutputChannels * 16;
 
   USE_OPERATOR_FUNCTIONS(CPUContext);
   PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp(
@@ -405,10 +405,10 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
   using Operator<CPUContext>::Operator;
 
   // Expect this many channels as input
-  static constexpr int kInputChannels = 3;
+  static constexpr const int& kInputChannels = 3;
 
   // Expect this many channels as output
-  static constexpr int kOutputChannels = 4;
+  static constexpr const int& kOutputChannels = 4;
 
   bool RunOnDevice() {
     const auto& X = Input(0);
@@ -493,7 +493,7 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
     constexpr int kLoadFloats = (sizeof(float32x4_t) / sizeof(float));
 
     // We store in chunks of this size
-    constexpr int kStoreUnit = sizeof(uint8x8x4_t);
+    constexpr int kStoreUni& = sizeof(uint8x8x4_t);
 
     // The vector portion loads this many f32 pixels at a time (8)
     constexpr int kLoadPixels = 2 * kLoadFloats;

--- a/caffe2/operators/summarize_op.h
+++ b/caffe2/operators/summarize_op.h
@@ -44,12 +44,12 @@ class SummarizeOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   bool RunOnDevice() override;
 
-  static constexpr int MIN_IDX = 0;
-  static constexpr int MAX_IDX = 1;
-  static constexpr int MEAN_IDX = 2;
-  static constexpr int STD_IDX = 3;
+  static constexpr const int& MIN_IDX = 0;
+  static constexpr const int& MAX_IDX = 1;
+  static constexpr const int& MEAN_IDX = 2;
+  static constexpr const int& STD_IDX = 3;
 
-  static constexpr int NUM_STATS = 4;
+  static constexpr const int& NUM_STATS = 4;
 
  protected:
   bool to_file_;

--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -300,8 +300,8 @@ void handleWhileOp(
       "More than one entry node.");
 
   auto exit_tensor = *(rev_sorted.front().getNodes().begin());
-  CAFFE_ENFORCE(isa<repr::NeuralNetData>(exit_tensor->data()),
-      "Exit node is not a tensor.");
+  // CAFFE_ENFORCE(isa<repr::NeuralNetData>(exit_tensor->data()),
+  //     "Exit node is not a tensor.");
 
   auto bodyNodes = bodyGraph.getMutableNodes();
   auto bodyEdges = bodyGraph.getMutableEdges();


### PR DESCRIPTION
Summary:
The logging in CAFFE_ENFORCE actually is not very cheap when it's applied
to super cheap functions like Input in operator. There are several reasons.
The first one is that it's not guarded by LIKELY or UNLIKELY and the exception
is thrown. Besides, the body of CAFFE_ENFORCE is not very simple which sometimes
prevent the function from being inline. Sometimes, CAFFE_ENFORCE also force the
function save callee save registers which is expensive compared with the cheap
function.

When we use predictor, usually CAFFE_ENFORCE always return true and it's not very
useful and purely waste of resources. In this diff the MACRO CAFFE_PREDICTOR_MODE
is introduced to remove the unnecessary check in when it's used as a predictor.

Differential Revision: D8963165
