### PR TITLE
inline TypeMeta::Id

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -65,7 +65,7 @@ class OperatorBase : public Observable<OperatorBase> {
 
   // Get the inputs and outputs as specific types.
   template <typename T>
-  inline const T& Input(int idx) {
+  const T& Input(int idx) const {
     DCHECK_LT(idx, inputs_.size());
     try {
       return inputs_.at(idx)->template Get<T>();

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -66,7 +66,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
   static constexpr const int& kOutputChannels = 3;
 
   // We read this much noise per vectorized cycle
-  static constexpr const int& kNeonNoiseReadSize = kOutputChannels * 16;
+  static constexpr const int& kNeonNoiseReadSize = 3 * 16;
 
   USE_OPERATOR_FUNCTIONS(CPUContext);
   PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp(
@@ -213,20 +213,20 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     // Loop unroll factor
     // FIXME: this doesn't actually unroll; clang has per-loop unroll
     // pragmas but GCC does not
-    constexpr int kUnroll = 1;
+    static constexpr const int& kUnroll = 1;
 
     // How much data we load for each inner loop
-    constexpr int kInnerLoadSize = sizeof(uint8x16x4_t);
+    static constexpr const int& kInnerLoadSize = sizeof(uint8x16x4_t);
 
     // What we write out
-    constexpr int kInnerStoreSize = sizeof(float32x4_t);
+    static constexpr const int& kInnerStoreSize = sizeof(float32x4_t);
 
     // We load 16 pixels at a time, with 4 channels each
-    constexpr int kLoadPixels = kInnerLoadSize / kInputChannels;
+    static constexpr const int& kLoadPixels = kInnerLoadSize / kInputChannels;
     static_assert(kLoadPixels == 16, "unexpected");
 
     // How many pixels we load per loop
-    constexpr int kLoadPixelsPerLoop = kLoadPixels * kUnroll;
+    static constexpr const int& kLoadPixelsPerLoop = kLoadPixels * kUnroll;
 
     // We need at least this much noise each loop through
     CAFFE_ENFORCE_GE(noiseCycle, kOutputChannels * kLoadPixelsPerLoop);
@@ -489,14 +489,15 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
     // Vectorized load parameters:
 
     // We load in chunks of this size
-    constexpr int kLoadUnit = sizeof(float32x4_t);
-    constexpr int kLoadFloats = (sizeof(float32x4_t) / sizeof(float));
+    static constexpr const int& kLoadUnit = sizeof(float32x4_t);
+    static constexpr const int& kLoadFloats =
+        (sizeof(float32x4_t) / sizeof(float));
 
     // We store in chunks of this size
-    constexpr int kStoreUni& = sizeof(uint8x8x4_t);
+    static constexpr const int& kStoreUnit = sizeof(uint8x8x4_t);
 
     // The vector portion loads this many f32 pixels at a time (8)
-    constexpr int kLoadPixels = 2 * kLoadFloats;
+    static constexpr const int& kLoadPixels = 2 * kLoadFloats;
 
     float mean[kInputChannels] = {
         meanChannel[0], meanChannel[1], meanChannel[2]};

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -60,13 +60,13 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     : public Operator<CPUContext> {
  public:
   // Expect this many channels as input
-  static constexpr int kInputChannels = 4;
+  static constexpr const int& kInputChannels = 4;
 
   // Expect this many channels as output
-  static constexpr int kOutputChannels = 3;
+  static constexpr const int& kOutputChannels = 3;
 
   // We read this much noise per vectorized cycle
-  static constexpr int kNeonNoiseReadSize = kOutputChannels * 16;
+  static constexpr const int& kNeonNoiseReadSize = kOutputChannels * 16;
 
   USE_OPERATOR_FUNCTIONS(CPUContext);
   PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp(
@@ -405,10 +405,10 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
   using Operator<CPUContext>::Operator;
 
   // Expect this many channels as input
-  static constexpr int kInputChannels = 3;
+  static constexpr const int& kInputChannels = 3;
 
   // Expect this many channels as output
-  static constexpr int kOutputChannels = 4;
+  static constexpr const int& kOutputChannels = 4;
 
   bool RunOnDevice() {
     const auto& X = Input(0);
@@ -493,7 +493,7 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
     constexpr int kLoadFloats = (sizeof(float32x4_t) / sizeof(float));
 
     // We store in chunks of this size
-    constexpr int kStoreUnit = sizeof(uint8x8x4_t);
+    constexpr int kStoreUni& = sizeof(uint8x8x4_t);
 
     // The vector portion loads this many f32 pixels at a time (8)
     constexpr int kLoadPixels = 2 * kLoadFloats;

--- a/caffe2/operators/summarize_op.h
+++ b/caffe2/operators/summarize_op.h
@@ -44,12 +44,12 @@ class SummarizeOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   bool RunOnDevice() override;
 
-  static constexpr int MIN_IDX = 0;
-  static constexpr int MAX_IDX = 1;
-  static constexpr int MEAN_IDX = 2;
-  static constexpr int STD_IDX = 3;
+  static constexpr const int& MIN_IDX = 0;
+  static constexpr const int& MAX_IDX = 1;
+  static constexpr const int& MEAN_IDX = 2;
+  static constexpr const int& STD_IDX = 3;
 
-  static constexpr int NUM_STATS = 4;
+  static constexpr const int& NUM_STATS = 4;
 
  protected:
   bool to_file_;


### PR DESCRIPTION
Summary:
TypeMeta::Id is a hot function, but it's not an inline one due to the implementation.
Make it inline function with some trick can improve the performance.

Differential Revision: D8949612
