### PR TITLE
Fix default argument value for CTCGreedyDecoder op

### DIFF
--- a/caffe2/operators/ctc_greedy_decoder_op.h
+++ b/caffe2/operators/ctc_greedy_decoder_op.h
@@ -12,10 +12,8 @@ class CTCGreedyDecoderOp : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   CTCGreedyDecoderOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {
-    if (OperatorBase::HasArgument("merge_repeated")) {
-      merge_repeated_ =
-          OperatorBase::GetSingleArgument<bool>("merge_repeated", true);
-    }
+    merge_repeated_ =
+        OperatorBase::GetSingleArgument<bool>("merge_repeated", true);
   }
 
   bool RunOnDevice() override;

--- a/caffe2/python/operator_test/ctc_greedy_decoder_op_test.py
+++ b/caffe2/python/operator_test/ctc_greedy_decoder_op_test.py
@@ -83,6 +83,64 @@ class TestCTCGreedyDecoderOp(hu.HypothesisTestCase):
             reference=ref_ctc_decoder_max_time,
         )
 
+    @given(
+        batch=st.sampled_from([2, 4, 128, 256]),
+        max_time=st.sampled_from([2, 10, 30, 50]),
+        num_classes=st.sampled_from([2, 10, 26, 40]),
+        **hu.gcs_cpu_only
+    )
+    def test_ctc_greedy_decoder_no_merge_arg(
+        self, batch, max_time,
+        num_classes, gc, dc
+    ):
+
+        def input_generater():
+            inputs = np.random.rand(max_time, batch, num_classes)\
+                .astype(np.float32)
+            seq_len = np.random.randint(1, max_time + 1, size=batch)\
+                .astype(np.int32)
+            return inputs, seq_len
+
+        def ref_ctc_decoder_no_merge_arg(inputs, seq_len):
+            merge = True
+
+            output_len = np.array([]).astype(np.int32)
+            val = np.array([]).astype(np.int32)
+            for i in range(batch):
+                prev_id = 0
+                t_dec = 0
+                len_i = seq_len[i] if seq_len is not None else max_time
+                for t in range(len_i):
+                    max_id = np.argmax(inputs[t, i, :])
+                    if max_id == 0:
+                        prev_id = max_id
+                        continue
+                    if max_id == prev_id and merge:
+                        prev_id = max_id
+                        continue
+                    t_dec += 1
+                    val = np.append(val, max_id)
+                    prev_id = max_id
+                output_len = np.append(output_len, t_dec)
+
+            return [output_len, val]
+
+        def ref_ctc_decoder_max_time(inputs):
+            return ref_ctc_decoder_no_merge_arg(inputs, None)
+
+        inputs, seq_len = input_generater()
+
+        op = core.CreateOperator('CTCGreedyDecoder',
+            ['INPUTS'],
+            ['OUTPUT_LEN', 'VALUES'])
+
+        self.assertReferenceChecks(
+            device_option=gc,
+            op=op,
+            inputs=[inputs],
+            reference=ref_ctc_decoder_max_time,
+        )
+
 
 if __name__ == "__main__":
     import random


### PR DESCRIPTION
Summary: Currently the ctc_greedy_decoder op initializes the `merge_repeated` argument only if it has been provided by the user. Change to initialize in all cases.

Differential Revision: D8963635
