### PR TITLE
Fixes xcode 10 beta 4 compile error

### DIFF
--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
@@ -68,6 +68,14 @@
 - (void*)weights {
   return self.weights_;
 }
+
+- (id)copyWithZone:(NSZone*)zone {
+  ConvDataSource* newDataSource = [[self class] allocWithZone:zone];
+  newDataSource.weights_ = self.weights_;
+  newDataSource.bias_ = self.bias_;
+  newDataSource.desc_ = self.desc_;
+  return newDataSource;
+}
 @end
 
 namespace caffe2 {


### PR DESCRIPTION
Summary: When building iOS apps with a caffe2 dependency, we were seeing the `caffe2/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm:33:17: error: method 'copyWithZone:' in protocol 'NSCopying' not implemented [-Werror,-Wprotocol]`. This fixes it by implementing a shallow copy with that method.

Differential Revision: D8954332
