### PR TITLE
[TENSOR MERGE] Devirtualize TensorImpl::toString

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -28,10 +28,6 @@ SparseTensorImpl::SparseTensorImpl(Type * type)
       AT_ASSERT(type->is_sparse());
     }
 
-const char * SparseTensorImpl::toString() const {
-  // TODO: also give back type information
-  return "SparseTensor";
-}
 IntList SparseTensorImpl::sizes() const {
   return size_;
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -57,7 +57,6 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  const char * toString() const override;
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -18,6 +18,50 @@ Tensor TensorImpl::detach() const {
   AT_ERROR("detach is not implemented for Tensor");
 }
 
+const char* TensorImpl::toString() const {
+  switch (type().backend()) {
+    case Backend::CPU:
+      switch (type().scalarType()) {
+#define DEFINE_CPU_STRING(_,name,_2) \
+        case ScalarType::name: return "CPU" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
+#undef DEFINE_CPU_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::CUDA:
+      switch (type().scalarType()) {
+#define DEFINE_CUDA_STRING(_,name,_2) \
+        case ScalarType::name: return "CUDA" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
+#undef DEFINE_CUDA_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::SparseCPU:
+      switch (type().scalarType()) {
+#define DEFINE_CPU_STRING(_,name,_2) \
+        case ScalarType::name: return "SparseCPU" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
+#undef DEFINE_CPU_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::SparseCUDA:
+      switch (type().scalarType()) {
+#define DEFINE_CUDA_STRING(_,name,_2) \
+        case ScalarType::name: return "SparseCUDA" #name "Tensor";
+        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
+#undef DEFINE_CUDA_STRING
+        case ScalarType::Undefined: AT_ASSERT(false);
+        case ScalarType::NumOptions: AT_ASSERT(false);
+      }
+    case Backend::Undefined: return "UndefinedTensor";
+    case Backend::NumOptions: AT_ASSERT(false);
+  }
+  AT_ASSERT(false);
+}
+
 void TensorImpl::backward(
     at::optional<Tensor> gradient,
     bool keep_graph,

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -19,47 +19,8 @@ Tensor TensorImpl::detach() const {
 }
 
 const char* TensorImpl::toString() const {
-  switch (type().backend()) {
-    case Backend::CPU:
-      switch (type().scalarType()) {
-#define DEFINE_CPU_STRING(_,name,_2) \
-        case ScalarType::name: return "CPU" #name "Tensor";
-        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
-#undef DEFINE_CPU_STRING
-        case ScalarType::Undefined: AT_ASSERT(false);
-        case ScalarType::NumOptions: AT_ASSERT(false);
-      }
-    case Backend::CUDA:
-      switch (type().scalarType()) {
-#define DEFINE_CUDA_STRING(_,name,_2) \
-        case ScalarType::name: return "CUDA" #name "Tensor";
-        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
-#undef DEFINE_CUDA_STRING
-        case ScalarType::Undefined: AT_ASSERT(false);
-        case ScalarType::NumOptions: AT_ASSERT(false);
-      }
-    case Backend::SparseCPU:
-      switch (type().scalarType()) {
-#define DEFINE_CPU_STRING(_,name,_2) \
-        case ScalarType::name: return "SparseCPU" #name "Tensor";
-        AT_FORALL_SCALAR_TYPES(DEFINE_CPU_STRING)
-#undef DEFINE_CPU_STRING
-        case ScalarType::Undefined: AT_ASSERT(false);
-        case ScalarType::NumOptions: AT_ASSERT(false);
-      }
-    case Backend::SparseCUDA:
-      switch (type().scalarType()) {
-#define DEFINE_CUDA_STRING(_,name,_2) \
-        case ScalarType::name: return "SparseCUDA" #name "Tensor";
-        AT_FORALL_SCALAR_TYPES(DEFINE_CUDA_STRING)
-#undef DEFINE_CUDA_STRING
-        case ScalarType::Undefined: AT_ASSERT(false);
-        case ScalarType::NumOptions: AT_ASSERT(false);
-      }
-    case Backend::Undefined: return "UndefinedTensor";
-    case Backend::NumOptions: AT_ASSERT(false);
-  }
-  AT_ASSERT(false);
+  // This matches behavior with VariableImpl
+  return type().toString();
 }
 
 void TensorImpl::backward(

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -28,7 +28,7 @@ struct AT_API TensorImpl : public Retainable {
   Type & type() const {
     return *type_;
   }
-  virtual const char * toString() const = 0;
+  const char * toString() const;
   virtual IntList sizes() const;
   virtual IntList strides() const;
   virtual int64_t dim() const;

--- a/aten/src/ATen/UndefinedTensor.cpp
+++ b/aten/src/ATen/UndefinedTensor.cpp
@@ -9,10 +9,6 @@ UndefinedTensor::UndefinedTensor()
 : TensorImpl(&(globalContext().getType(Backend::Undefined,ScalarType::Undefined)), nullptr) {
 }
 
-const char * UndefinedTensor::toString() const {
-  return "UndefinedTensor";
-}
-
 IntList UndefinedTensor::sizes() const {
   AT_ERROR("sizes() called on undefined Tensor");
 }

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -9,7 +9,6 @@ public:
   static inline UndefinedTensor * singleton() {
     return &_singleton;
   }
-  const char * toString() const override;
   IntList sizes() const override;
   IntList strides() const override;
   int64_t dim() const override;

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -25,10 +25,6 @@ ${Tensor}::${Tensor}(${THTensor} * tensor)
 : TensorImpl(&globalContext().getType(Backend::${Backend},ScalarType::${ScalarName}), tensor)
 {}
 
-const char * ${Tensor}::toString() const {
-  return "${Tensor}";
-}
-
 const char * ${Tensor}::typeString() {
   return "${Type}";
 }

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -13,7 +13,6 @@ namespace at {
 struct ${Tensor} final : public TensorImpl {
 public:
   ${Tensor}(THTensor * tensor);
-  virtual const char * toString() const override;
   virtual Scalar localScalar() override;
   virtual std::unique_ptr<Storage> storage() override;
   static const char * typeString();

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE( "undefined tensor test", "[]" ) {
   std::stringstream ss;
   ss << und << std::endl;
   REQUIRE(!und.defined());
-  REQUIRE(std::string("UndefinedTensor") == und.toString());
+  REQUIRE(std::string("UndefinedType") == und.toString());
 
   REQUIRE_THROWS_WITH(und.strides(), Catch::Contains("strides"));
   REQUIRE_THROWS_WITH(und.dim(), Catch::Contains("dim"));

--- a/test/expect/TestJit.test_python_ir.expect
+++ b/test/expect/TestJit.test_python_ir.expect
@@ -4,6 +4,6 @@ graph(%0 : Dynamic
   %3 : Double(1) = aten::mul(%0, %2)
   %4 : Double(1) = aten::tanh(%3)
   %5 : Double(1) = aten::sigmoid(%4)
-  %6 : Dynamic = prim::TensorTest[a= 1  1  1  1 [ CPUDoubleTensor{2,2} ]]()
+  %6 : Dynamic = prim::TensorTest[a= 1  1  1  1 [ CPUDoubleType{2,2} ]]()
   return (%5);
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -40,12 +40,6 @@ Variable::Impl::Impl(at::Tensor data, bool requires_grad, Edge gradient_edge)
 
 Variable::Impl::~Impl() = default;
 
-const char* Variable::Impl::toString() const {
-  // technically this will say Variable[CPUFloatType] rather than
-  // Variable[CPUFloatTensor], but this is better than just Variable
-  return type().toString();
-}
-
 IntList Variable::Impl::sizes() const {
   return data_.sizes();
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -268,7 +268,6 @@ struct Variable::Impl : public at::TensorImpl {
 
   ~Impl() override;
 
-  const char* toString() const override;
   at::IntList sizes() const override;
   at::IntList strides() const override;
   int64_t dim() const override;

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -339,9 +339,6 @@ public:
   : TensorImpl(&(at::globalContext().getType(at::Backend::Undefined,at::ScalarType::Undefined)), nullptr) {}
 
   virtual ~ContainerTensor() {}
-  virtual const char * toString() const override {
-    throw std::runtime_error("toString() on ContainerTensor");
-  }
   virtual at::IntList sizes() const override {
     throw std::runtime_error("sizes() on ContainerTensor");
   }


### PR DESCRIPTION
This can hardly be called an improvement (we now print
CPUFloatType instead of CPUFloatTensor) but it was the
simplest way I could think of devirtualizing this function in
the short term.  Probably need some sort of native function
that gives string information about a tensor.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Approved in #9710