### PR TITLE
Make GraphExecutors work on Stacks instead of variable_tensor_lists

### DIFF
--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -17,14 +17,15 @@ namespace torch { namespace jit {
 // since it is used along the hot-path of the JIT to check if the code
 // we have created is valid for the given inputs.
 
-// TensorInfoPOD is only used internally in ArgumentSpec
-// API users should use TensorInfo
-struct TensorInfoPOD {
+// ArgumentInfoPOD is only used internally in ArgumentSpec
+// API users should use ArgumentInfo
+struct ArgumentInfoPOD {
   // total size is 64-bit
-  unsigned type : 8;
+  unsigned kind : 8; // kind of the IValue
+  unsigned type : 8; // scalar type
   unsigned defined : 1;
   unsigned requires_grad : 1;
-  signed device : 22;
+  signed device : 14;
   uint32_t total_dims; // all TensorInfoPODs are in ArgumentSpec's tensor_info() array.
                        // total_dims is the total number of dimensions seen so far
                        // in all previous members of tensor_info(), including this tensor
@@ -33,33 +34,33 @@ struct TensorInfoPOD {
                        // for tensor 0, the offset is always 0
 };
 
-static_assert(sizeof(TensorInfoPOD) == sizeof(int64_t),
-  "TensorInfoPOD must be 64-bit struct for ArgumentSpec encoding to work");
+static_assert(sizeof(ArgumentInfoPOD) == sizeof(int64_t),
+  "ArgumentInfoPOD must be 64-bit struct for ArgumentSpec encoding to work");
 
-struct TensorInfo;
+struct ArgumentInfo;
 
 struct ArgumentSpec {
   ArgumentSpec(bool with_grad, const Stack & inputs)
-  :  hash_code(0), ntensors(0) {
+  :  hash_code(0), ninputs(inputs.size()) {
     int32_t all_dims = 0;
     const int32_t num_inputs = inputs.size();
     for (int32_t i = 0; i < num_inputs; i++) {
       if (!inputs[i].isTensor()) continue;
-      ntensors++;
       auto tensor = inputs[i].toTensor();
       all_dims += tensor.defined() ? tensor.ndimension() : 0;
     }
     // allocate enough room for all TensorPODs and dimensions
-    data.resize(ntensors + all_dims*2);
+    data.resize(ninputs + all_dims*2);
 
     // and reinterpret our data array as these structs
-    TensorInfoPOD * pods = reinterpret_cast<TensorInfoPOD*>(data.data());
+    ArgumentInfoPOD * pods = reinterpret_cast<ArgumentInfoPOD*>(data.data());
     int64_t * next_dim = sizes_strides();
     int32_t total_dims = 0;
     for(int32_t i = 0; i < num_inputs; i++) {
+      auto & pod = pods[i];
+      pod.kind = static_cast<uint32_t>(inputs[i].kind());
       if (!inputs[i].isTensor()) continue;
       const auto & t = inputs[i].toTensor();
-      auto & pod = pods[i];
       pod.defined = t.defined();
       if (pod.defined) {
         pod.type = static_cast<int>(t.type().scalarType());
@@ -78,51 +79,54 @@ struct ArgumentSpec {
     }
     // we precompute the hash_code to minimize the time inside of hash
     // table operations where we may need to hold a compiler cache lock.
-    hash_code = hash_combine(0, ntensors);
+    hash_code = hash_combine(0, ninputs);
     for(auto d : data) {
       hash_code = hash_combine(hash_code, d);
     }
   }
 
-  // equality is fast: check ntensors, and then check the raw array data,
+  // equality is fast: check ninputs, and then check the raw array data,
   // there are no size/stride indirections
   bool operator==(const ArgumentSpec & spec) const {
-    return ntensors == spec.ntensors && data == spec.data;
+    return ninputs == spec.ninputs && data == spec.data;
   }
   bool operator!=(const ArgumentSpec & spec) const {
     return !(*this == spec);
   }
-  friend struct TensorInfo;
-  TensorInfo tensorInfo(size_t i) const;
+  friend struct ArgumentInfo;
+  ArgumentInfo at(size_t i) const;
   size_t size() const {
-    return ntensors;
+    return ninputs;
   }
   size_t hashCode() const {
     return hash_code;
   }
 
 private:
-  ArrayRef<TensorInfoPOD> tensor_info() const {
-    return ArrayRef<TensorInfoPOD>(reinterpret_cast<const TensorInfoPOD*>(data.data()), ntensors);
+  ArrayRef<ArgumentInfoPOD> tensor_info() const {
+    return ArrayRef<ArgumentInfoPOD>(reinterpret_cast<const ArgumentInfoPOD*>(data.data()), ninputs);
   }
-  // the start of the sizes_strides information, which comes after the TensorInfoPOD list.
+  // the start of the sizes_strides information, which comes after the ArgumentInfoPOD list.
   const int64_t* sizes_strides() const {
-    return data.data() + ntensors;
+    return data.data() + ninputs;
   }
   int64_t* sizes_strides() {
-    return data.data() + ntensors;
+    return data.data() + ninputs;
   }
   size_t hash_code; // precomputed on construction
-  int32_t ntensors;
-  // layout is ntensors of TensorPOD (each 64-bit) followed by their size and stride info
+  int32_t ninputs;
+  // layout is ninputs of TensorPOD (each 64-bit) followed by their size and stride info
   // for 3 tensors: [t0POD][t1POD][t2POD][t0 sizes][t0 strides][t1 sizes][t1 strides][t2 sizes][t2 strides]
   std::vector<int64_t> data;
 };
 
-// public view of compressed TensorInfo
-struct TensorInfo {
-  TensorInfo(const ArgumentSpec & spec, const int i)
+// public view of compressed ArgumentInfo
+struct ArgumentInfo {
+  ArgumentInfo(const ArgumentSpec & spec, const int i)
   : spec(spec), i(i) {}
+  IValueKind kind() const {
+    return IValueKind(pod(i).kind);
+  }
   at::ScalarType type() const {
     return at::ScalarType(pod(i).type);
   }
@@ -153,20 +157,20 @@ struct TensorInfo {
   }
 private:
   // offsetinto sizes_strides() array where the sizes start for tensor j
-  // [valid range] valid range is [0, ntensors]
-  // (i.e. you can ask for the offset at ntensors, which would be the offset of the next tensor if it existed)
+  // [valid range] valid range is [0, ninputs]
+  // (i.e. you can ask for the offset at ninputs, which would be the offset of the next tensor if it existed)
   int sizes_strides_offset(int j) const {
     if(j == 0) return 0;
     return 2*pod(j - 1).total_dims;
   }
-  const TensorInfoPOD & pod(int j) const {
+  const ArgumentInfoPOD & pod(int j) const {
     return spec.tensor_info().at(j);
   }
   const ArgumentSpec & spec;
   const int i;
 };
 
-inline std::ostream & operator<<(std::ostream & out, const TensorInfo & info) {
+inline std::ostream & operator<<(std::ostream & out, const ArgumentInfo & info) {
   if(!info.defined()) {
     return out << "<undefined>";
   }
@@ -183,14 +187,14 @@ inline std::ostream& operator<<(std::ostream & out, const ArgumentSpec & spec) {
   for(size_t i = 0; i < spec.size(); ++i) {
     if (i > 0)
       out << ", ";
-    out << spec.tensorInfo(i);
+    out << spec.at(i);
   }
   out << "}";
   return out;
 }
 
-inline TensorInfo ArgumentSpec::tensorInfo(size_t i) const {
-  return TensorInfo(*this, i);
+inline ArgumentInfo ArgumentSpec::at(size_t i) const {
+  return ArgumentInfo(*this, i);
 }
 
 }}

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -83,7 +83,7 @@ struct ExecutionPlanAutogradFunction : public autograd::Function {
     const bool is_tensor = val.isTensor();
     is_var_capture.push_back(is_tensor);
     if (is_tensor) {
-      var_captures.emplace_back(autograd::as_variable_ref(val.toTensor()), false);
+      var_captures.emplace_back(Variable(val.toTensor()), false);
     } else {
       ivalue_captures.push_back(val);
     }
@@ -163,7 +163,7 @@ private:
       grad.df_input_captured_inputs.size() + grad.df_input_captured_outputs.size());
     // hook up the outputs of df to the gradient functions of the inputs that require gradients
     for(auto idx : grad.df_output_vjps) {
-      auto & v = autograd::as_variable_ref(stack[idx].toTensor());
+      auto v = Variable(stack[idx].toTensor());
       grad_fn->add_next_edge(v.gradient_edge());
     }
     captureInputs(*grad_fn, stack);

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -364,7 +364,7 @@ private:
 
   bool argumentSpecRequiresGradient(const ArgumentSpec & spec) {
     for(size_t i = 0; i < spec.size(); ++i) {
-      if(spec.tensorInfo(i).requires_grad())
+      if(spec.at(i).requires_grad())
         return true;
     }
     return false;
@@ -384,7 +384,7 @@ private:
     std::vector<bool> requires_grads;
     requires_grads.reserve(spec.size());
     for(size_t i = 0; i < spec.size(); i++)
-      requires_grads.push_back(spec.tensorInfo(i).requires_grad());
+      requires_grads.push_back(spec.at(i).requires_grad());
 
     Gradient gradient = differentiate(graph_, requires_grads);
     graph_ = gradient.f;
@@ -469,7 +469,7 @@ void specializeToSpec(const std::shared_ptr<Graph>& graph_, const ArgumentSpec& 
   // this must be first because later passes do not know what GradOfs are
   std::vector<bool> defined;
   for(size_t i = 0; i < spec.size(); ++i) {
-    defined.push_back(spec.tensorInfo(i).defined());
+    defined.push_back(spec.at(i).defined());
   }
   specializeUndef(*graph_, defined);
 

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -38,12 +38,12 @@ struct TORCH_API GraphExecutor {
   GraphExecutor(std::shared_ptr<Graph> graph, bool optimize = true);
   // note: if not specified, symbolically_differentiable is computed from the graph.
   GraphExecutor(std::shared_ptr<Graph> graph, bool optimize, bool symbolically_differentiable);
-  variable_tensor_list run(variable_tensor_list && inputs);
+  void run(Stack & inputs);
   explicit operator bool() const {
     return pImpl != nullptr;
   }
   std::shared_ptr<Graph> graph() const;
-  std::shared_ptr<Graph> graphFor(const variable_tensor_list& inputs) const;
+  std::shared_ptr<Graph> graphFor(const Stack& inputs) const;
   GraphExecutorState getDebugState();
 private:
   std::shared_ptr<GraphExecutorImpl> pImpl;

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -617,16 +617,9 @@ struct CodeImpl {
 
     auto executor = std::make_shared<GraphExecutor>(node->g(attr::Subgraph));
     graph_executors.emplace_back(executor.get());
-    auto num_inputs = node->inputs().size();
     return [=](Stack& stack) mutable {
       autograd::profiler::RecordFunction record("GraphExecutor");
-      auto inputs = last(stack, num_inputs);
-      variable_tensor_list tinputs(
-          fmap(inputs, [](const IValue& v) { return v.toTensor(); }));
-      drop(stack, num_inputs);
-      //TODO: has graph executor work from a stack as well
-      variable_tensor_list toutputs = executor->run(variable_tensor_list(std::move(tinputs)));
-      stack.insert(stack.end(), toutputs.begin(), toutputs.end());
+      executor->run(stack);
       return 0;
     };
   }

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -4,6 +4,8 @@
 
 #include <ATen/ATen.h>
 
+#include <type_traits>
+
 namespace torch { namespace jit {
 
 // smart pointer to hold onto at::Retainable objects in a generic way

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -455,7 +455,9 @@ void PropagateShapeOnBlock(Block * block, bool insert_expands) {
 void PropagateInputShapes(Graph & graph, const ArgumentSpec & spec) {
   JIT_ASSERT(graph.inputs().size() == spec.size());
   for(size_t i = 0; i < spec.size(); ++i) {
-    graph.inputs()[i]->setType(spec.tensorInfo(i));
+    auto argspec = spec.at(i);
+    if (argspec.kind() != IValueKind::Tensor) continue;
+    graph.inputs()[i]->setType(argspec);
   }
   PropagateShapeOnBlock(graph.block());
 }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -456,7 +456,7 @@ void PropagateInputShapes(Graph & graph, const ArgumentSpec & spec) {
   JIT_ASSERT(graph.inputs().size() == spec.size());
   for(size_t i = 0; i < spec.size(); ++i) {
     auto argspec = spec.at(i);
-    if (argspec.kind() != IValueKind::Tensor) continue;
+    if (!argspec.isTensor()) continue;
     graph.inputs()[i]->setType(argspec);
   }
   PropagateShapeOnBlock(graph.block());

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -145,7 +145,7 @@ void initPythonIRBindings(PyObject * module_) {
       return ss.str();
     })
     .def("propagate_shapes", [](Graph& g, std::vector<at::Tensor> inputs, bool with_grad) {
-      PropagateInputShapes(g, ArgumentSpec(with_grad, variable_tensor_list(std::move(inputs))));
+      PropagateInputShapes(g, ArgumentSpec(with_grad, fmap<IValue>(inputs)));
     })
     .def("export", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
                       int64_t onnx_opset_version, bool defer_weight_export,

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -371,9 +371,9 @@ static void gatherParametersAndBuffers(std::vector<at::Tensor*> & values, const 
 }
 
 py::object runMethodFromPython(Method& m, py::args args) {
-  auto inputs = createVariableTensorList(args);
-  auto outputs = m.run(std::move(inputs));
-  return unpackVariableTensorList(std::move(outputs));
+  auto stack = createStack(args);
+  m.run(stack);
+  return wrapStack(std::move(stack));
 }
 
 void initJitScriptBindings(PyObject* module) {
@@ -502,7 +502,7 @@ void initJitScriptBindings(PyObject* module) {
       })
       .def("graph_for", [](Module& self, py::args args) {
         if (self.find_method("forward")) {
-          return self.get_method("forward").graph_for(createVariableTensorList(args));
+          return self.get_method("forward").graph_for(createStack(args));
         }
         throw std::runtime_error("Attempted to call graph_for on a Module without a compiled forward()");
       })
@@ -530,7 +530,7 @@ void initJitScriptBindings(PyObject* module) {
     .def("propagate_and_assign_input_and_output_shapes", &Method::propagate_and_assign_input_and_output_shapes)
     .def("params", &Method::params)
     .def("graph_for", [](Method& self, py::args args) {
-      return self.graph_for(createVariableTensorList(args));
+      return self.graph_for(createStack(args));
     })
     .def("set_arg_and_return_types", [](Method &self, TypedDef &typed_def, bool method) {
       std::vector<Argument> arg_type_args, return_type_args;

--- a/torch/csrc/jit/stack.h
+++ b/torch/csrc/jit/stack.h
@@ -27,10 +27,10 @@ static inline IValue & peek(Stack & stack, size_t i, size_t N) {
 }
 // treat the last N elements of the stack as a list, looking up the
 // slice starting at index i and having length len
-static inline at::ArrayRef<IValue> peekSlice(Stack & stack, size_t i, size_t len, size_t N) {
+static inline at::ArrayRef<IValue> peekSlice(const Stack & stack, size_t i, size_t len, size_t N) {
   return at::ArrayRef<IValue>(stack).slice(stack.size() - N + i, len);
 }
-static inline at::ArrayRef<IValue> last(Stack & stack, size_t N) {
+static inline at::ArrayRef<IValue> last(const Stack & stack, size_t N) {
   return peekSlice(stack, 0, N, N);
 }
 static inline void drop(Stack & stack, size_t n) {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -715,7 +715,7 @@ bool isEqual(at::IntList lhs, at::IntList rhs) {
 }
 
 bool isEqual(const ArgumentInfo & ti, const autograd::Variable & v) {
-  REQUIRE(ti.kind() == IValueKind::Tensor);
+  REQUIRE(ti.isTensor());
   if(!ti.defined())
     return ti.defined() == v.defined();
   return

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -714,7 +714,8 @@ bool isEqual(at::IntList lhs, at::IntList rhs) {
   return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
-bool isEqual(const TensorInfo & ti, const autograd::Variable & v) {
+bool isEqual(const ArgumentInfo & ti, const autograd::Variable & v) {
+  REQUIRE(ti.kind() == IValueKind::Tensor);
   if(!ti.defined())
     return ti.defined() == v.defined();
   return
@@ -758,7 +759,7 @@ void argumentSpecTest() {
   REQUIRE(d.hashCode() == a.hashCode());
 
   for(size_t i = 0; i < list.size(); ++i) {
-    REQUIRE(isEqual(a.tensorInfo(i), list[i].toTensor()));
+    REQUIRE(isEqual(a.at(i), list[i].toTensor()));
   }
   ArgumentSpec no_grad(/*with_grad=*/false, list);
   REQUIRE(no_grad != a);

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -45,15 +45,13 @@ PreTraceInfo preRecordTrace(Symbol op,
 
 void postRecordTrace(const PreTraceInfo& info,
                      at::ArrayRef<Variable> outputs) {
-  auto assignOutput = [&info](const Variable & output, Value * value) {
+  for (size_t i = 0; i < outputs.size(); i++) {
+    auto & output = outputs[i];
+    Value * value = info.n->addOutput();
     if (output.defined()) {
       value->inferTypeFrom(output.data());
       setValueTrace(output, value);
     }
-  };
-
-  for (size_t i = 0; i < outputs.size(); i++) {
-    assignOutput(outputs[i], info.n->addOutput());
   }
 }
 


### PR DESCRIPTION
This is blocking the IR operator unification, because I need to be able to pass scalars to backward functions.

@zdevito 