### PR TITLE
[EASY] Delete dead IsVariable enum.

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -15,12 +15,6 @@
 
 namespace at {
 
-enum class IsVariable {
-  NotVariable,
-  Variable,
-  NumOptions
-};
-
 class AT_API Context {
 public:
   Context();


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@fb.com>

