### PR TITLE
Move scalar boolean to THTensor, rename scalar in this context to zer…

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2604,7 +2604,7 @@
       throw std::runtime_error("Input must be 1-d or 2-d");
     }
     ${THTensor}_diag(${state,}result_->tensor, self_->tensor, diagonal);
-    result_->maybeScalar(self_->dim() == 0);
+    result_->maybe_zero_dim(self_->dim() == 0);
 ]]
 [[
   name: th_addmm

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -46,6 +46,13 @@ Scalar SparseTensorImpl::localScalar() {
   // a cookie.
   return values_.sum().pImpl->localScalar();
 }
+TensorImpl* SparseTensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
+  AT_CHECK(condition_when_zero_dim == (dim() == 0),
+           "Attempted to maybe_zero_dim on a SparseTensorImpl to ", condition_when_zero_dim,
+           " but the SparseTensor's dim() is ", dim(), " and SparseTensors do not support"
+           " changing dimensionality via maybe_zero_dim");
+  return this;
+}
 void * SparseTensorImpl::unsafeGetTH(bool retain) {
   AT_ERROR("unsafeGetTH not supported for new style TensorImpl");
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -61,6 +61,7 @@ public:
   IntList strides() const override;
   int64_t dim() const override;
   Scalar localScalar() override;
+  TensorImpl* maybe_zero_dim(bool condition_when_scalar) override;
   void * unsafeGetTH(bool retain) override;
   std::unique_ptr<Storage> storage() override;
 

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -61,7 +61,7 @@ public:
   IntList strides() const override;
   int64_t dim() const override;
   Scalar localScalar() override;
-  TensorImpl* maybe_zero_dim(bool condition_when_scalar) override;
+  TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override;
   void * unsafeGetTH(bool retain) override;
   std::unique_ptr<Storage> storage() override;
 

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -65,10 +65,17 @@ void TensorImpl::release_resources() {
 }
 
 int64_t TensorImpl::dim() const {
-  if(is_scalar) {
+  if(THTensor_isZeroDim(tensor)) {
     return 0;
   }
   return tensor->dim();
+}
+
+TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
+  AT_CHECK(tensor, "TensorImpl without THTensor in maybe_zero_dim");
+  bool is_zero_dim = condition_when_zero_dim && tensor->sizes().size() == 1 && tensor->size(0) == 1;
+  THTensor_setIsZeroDim(tensor, is_zero_dim);
+  return this;
 }
 
 void * TensorImpl::unsafeGetTH(bool retain) {

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -19,7 +19,7 @@ struct Tensor;
 namespace at {
 struct AT_API TensorImpl : public Retainable {
   explicit TensorImpl(Type * type, THTensor * tensor)
-  : is_scalar(false), type_(type), tensor(tensor) {}
+  : type_(type), tensor(tensor) {}
 
   virtual ~TensorImpl();
 
@@ -50,18 +50,11 @@ struct AT_API TensorImpl : public Retainable {
   }
 
   // this is called by the generated wrapper code when there are conditions
-  // when this output tensor should be a scalar. e.g. when all inputs
-  // to a function 'add' were scalars, then condition_when_scalar == true.
-  // we also prevent this from getting marked as a scalar if it is not
+  // when this output tensor should be zero dimensional. e.g. when all inputs
+  // to a function 'add' were zero dimensional, then condition_when_zero_dim == true.
+  // we also prevent this from getting marked as a zero dim tensor if it is not
   // the right shape afterall.
-  TensorImpl* maybeScalar(bool condition_when_scalar) {
-    is_scalar = false; //force dim() to tell the truth for TH
-    is_scalar = condition_when_scalar && dim() == 1 && sizes()[0] == 1;
-    return this;
-  }
-  void setScalar(bool s) {
-    is_scalar = s;
-  }
+  virtual TensorImpl* maybe_zero_dim(bool condition_when_zero_dim);
 
   // ~~~~~ Autograd API ~~~~~
   // Some methods below are defined in TensorImpl.cpp because Tensor is an
@@ -90,7 +83,6 @@ struct AT_API TensorImpl : public Retainable {
   virtual void set_data(Tensor new_data);
 
 protected:
-  bool is_scalar;
   Type * type_;
 public:
   THTensor * tensor;

--- a/aten/src/ATen/copy_wrapper.py
+++ b/aten/src/ATen/copy_wrapper.py
@@ -70,7 +70,7 @@ Tensor & ${Type}::s_copy_(Tensor & dst, const Tensor & src, bool non_blocking) c
     default:
       ${function_fallthrough}
   }
-  dst.pImpl->setScalar(src.pImpl->dim() == 0);
+  dst.pImpl->maybe_zero_dim(src.pImpl->dim() == 0);
   return dst;
 }
 """)
@@ -91,7 +91,7 @@ Tensor & ${Type}::_s_copy_from(const Tensor & src, Tensor & dst, bool non_blocki
       AT_ERROR("copy does not support ", toString(), " to ", dst.type().toString(), " copy.");
       break;
   }
-  dst.pImpl->setScalar(src.pImpl->dim() == 0);
+  dst.pImpl->maybe_zero_dim(src.pImpl->dim() == 0);
   return dst; // NB! dst
 }
 """)

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1435,7 +1435,7 @@ def create_derived(backend_type_env, declarations):
                     scalar_check_arg = (scalar_check if not isinstance(scalar_check, dict)
                                         else scalar_check.get(arg['name']))  # type: ignore
                     if scalar_check_arg is not None:
-                        stmt = "{}_->maybeScalar({});".format(arg['name'], scalar_check_arg)
+                        stmt = "{}_->maybe_zero_dim({});".format(arg['name'], scalar_check_arg)
                         if nullable_argument(arg):
                             stmt = "if ({}_) {}".format(arg['name'], stmt)
                         body.append(stmt)
@@ -1459,7 +1459,7 @@ def create_derived(backend_type_env, declarations):
                     option['aten_custom_call']).substitute(env))
 
             if ret['type'] in ALLOC_WRAP.keys():
-                maybe_scalar = "->maybeScalar({})".format(scalar_check) \
+                maybe_scalar = "->maybe_zero_dim({})".format(scalar_check) \
                                if scalar_check is not None \
                                else ""
                 wrapped_tensor = CodeTemplate(ALLOC_WRAP[ret['type']]).substitute(

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       auto aScalar = ones({1}, T);
-      aScalar.get()->maybeScalar(true);
+      aScalar.get()->maybe_zero_dim(true);
       auto b = randn({3, 5}, T);
       REQUIRE((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
     }
@@ -60,7 +60,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       auto aTensorScalar = ones({1}, T);
-      aTensorScalar.get()->maybeScalar(true);
+      aTensorScalar.get()->maybe_zero_dim(true);
       auto b = randn({3, 2, 1}, T);
       auto c = randn({1, 2, 5}, T);
       std::vector<int64_t> expanded_sizes = {3, 2, 5};
@@ -93,7 +93,7 @@ TEST_CASE( "broadcast", "[]" ) {
     SECTION( "with scalar" ) {
       auto a = randn({3, 5}, T);
       auto bScalar = ones({1}, T);
-      bScalar.get()->maybeScalar(true);
+      bScalar.get()->maybe_zero_dim(true);
       REQUIRE((a + bScalar).equal(a + bScalar.expand(a.sizes())));
     }
 
@@ -118,7 +118,7 @@ TEST_CASE( "broadcast", "[]" ) {
     SECTION( "with scalar" ) {
       auto aClone = a.clone();
       auto bScalar = ones({1}, T);
-      bScalar.get()->maybeScalar(true);
+      bScalar.get()->maybe_zero_dim(true);
       REQUIRE(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
     }
 
@@ -142,7 +142,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       Tensor aScalar = ones({1}, T);
-      aScalar.get()->maybeScalar(true);
+      aScalar.get()->maybe_zero_dim(true);
       REQUIRE(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
     }
 

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE( "wrapdim test", "[]" ) {
 
     // can unsqueeze scalar
     auto b = randn(1, T);
-    b.get()->maybeScalar(true);
+    b.get()->maybe_zero_dim(true);
     REQUIRE(b.unsqueeze(0).equal(b.unsqueeze(-1)));
   }
 
@@ -36,7 +36,7 @@ TEST_CASE( "wrapdim test", "[]" ) {
   SECTION( "scalar vs 1-dim, 1-size" ) {
     auto a = randn(1, T);
     REQUIRE(a.prod(0).equal(a.prod(-1)));
-    a.get()->maybeScalar(true);
+    a.get()->maybe_zero_dim(true);
     REQUIRE(a.get()->dim() == 0);
     REQUIRE(a.prod(0).equal(a.prod(-1)));
   }

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -156,7 +156,7 @@ inline bool THTensor_isZeroDim(const THTensor *tensor) {
 }
 
 inline void THTensor_setIsZeroDim(THTensor *tensor, bool is_zero_dim) {
-  tensor->is_zero_dim_ = tensor;
+  tensor->is_zero_dim_ = is_zero_dim;
 }
 
 TH_API void THTensor_free(THTensor *self);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -17,6 +17,7 @@ struct THTensor
       , storage_offset_(0)
       , sizes_{0}
       , strides_{1}
+      , is_zero_dim_(false)
       {}
 
     ~THTensor() {
@@ -34,6 +35,9 @@ struct THTensor
 
     std::vector<int64_t> sizes_;
     std::vector<int64_t> strides_;
+
+    // TODO: get rid of this, use the sizes_/strides_ .size() instead
+    bool is_zero_dim_;
 
     template <typename T>
     inline T * data() const {
@@ -142,6 +146,14 @@ inline THStorage* THTensor_getStoragePtr(const THTensor* tensor) {
 // NB: Steals ownership of storage
 inline void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
   tensor->storage_ = storage;
+}
+
+inline bool THTensor_isZeroDim(const THTensor *tensor) {
+  return tensor->is_zero_dim_;
+}
+
+inline void THTensor_setIsZeroDim(THTensor *tensor, bool is_zero_dim) {
+  tensor->is_zero_dim_ = tensor;
 }
 
 TH_API void THTensor_free(THTensor *self);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -36,7 +36,10 @@ struct THTensor
     std::vector<int64_t> sizes_;
     std::vector<int64_t> strides_;
 
-    // TODO: get rid of this, use the sizes_/strides_ .size() instead
+    // TODO: get rid of this, use the sizes_/strides_ .size() instead.
+    // This requires making sure TH code can handle zero dims (empty sizes, strides).
+    // Short-term plan is to dispatch dim/size/stride through a function that gives these
+    // in a "legacy" format, i.e. 0-dim becomes 1-dim.  Then medium term we remove the legacy calls.
     bool is_zero_dim_;
 
     template <typename T>


### PR DESCRIPTION
…o dim.

Manifest:
1) The scalar boolean is now in THTensor, although it isn't hooked up at the TH level yet.
2) setScalar is gone, everything now goes through the maybeScalar equivalent (which is renamed)
3) all "scalars" in this context now refer to "zero_dim" in order to differentiate this concept from the "Scalar" class.

