### PR TITLE
[JIT] Change expect, cast on Type to return shared pointers, make isSubtypeOf accept TypePtr

### DIFF
--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -144,7 +144,7 @@ struct TensorInfo {
   operator TypePtr() const {
     if(!defined())
       return DynamicType::get();
-    return std::make_shared<TensorType>(type(), device(), sizes(), strides());
+    return TensorType::create(type(), device(), sizes(), strides());
   }
 private:
   // offsetinto sizes_strides() array where the sizes start for tensor j

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -35,7 +35,7 @@ bool isDifferentiable(Node * n) {
     if (!hasOneValuedInput(n, attr::alpha) || !hasOneValuedInput(n, attr::beta))
       return false;
   }
-  auto isTensor = [](Value* v) { return v->type()->isSubtypeOf(*DynamicType::get()); };
+  auto isTensor = [](Value* v) { return v->type()->isSubtypeOf(DynamicType::get()); };
 
   if(!std::all_of(n->inputs().begin(), n->inputs().end(), isTensor)
     || !std::all_of(n->outputs().begin(), n->outputs().end(), isTensor))

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -38,14 +38,14 @@ RegisterOperators reg({
       prim::Constant,
       [](Node* node) -> Operation {
         TypePtr type = node->output()->type();
-        if(type->isSubtypeOf(*DynamicType::get())) {
+        if(type->isSubtypeOf(DynamicType::get())) {
           auto t = autograd::make_variable(node->t(attr::value));
           return [t](Stack& stack) {
             stack.push_back(t);
             return 0;
           };
         } else if (
-            type->isSubtypeOf(*NumberType::get()) &&
+            type->isSubtypeOf(NumberType::get()) &&
             node->kindOf(attr::value) == AttributeKind::i) {
           auto i = node->i(attr::value);
           return [i](Stack& stack) {
@@ -53,14 +53,14 @@ RegisterOperators reg({
             return 0;
           };
         } else if (
-            type->isSubtypeOf(*NumberType::get()) &&
+            type->isSubtypeOf(NumberType::get()) &&
             node->kindOf(attr::value) == AttributeKind::f) {
           auto f = node->f(attr::value);
           return [f](Stack& stack) {
             push(stack, f);
             return 0;
           };
-        } else if(type->isSubtypeOf(*ListType::ofInts())) {
+        } else if(type->isSubtypeOf(ListType::ofInts())) {
           auto is = node->is(attr::value);
           return [is](Stack& stack) {
             push(stack, is);

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -156,7 +156,7 @@ void addAttribute(onnx::NodeProto * n_p, jit::Node * n, jit::Symbol name, Export
 
 void encodeTypeProtoTensorType(onnx::TypeProtoTensor* tensor_type, Value* n) {
   onnx::TensorShapeProto* shape = tensor_type->mutable_shape();
-  if (TensorType* node_type = n->type()->cast<TensorType>()) {
+  if (TensorTypePtr node_type = n->type()->cast<TensorType>()) {
     const std::vector<std::int64_t>& sizes = node_type->sizes();
     for (std::int64_t s : sizes) {
       shape->add_dim(s);

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -29,7 +29,7 @@ struct TensorDesc {
   : TensorDesc(type, TensorDesc::findContiguous(sizes, strides)) {}
   TensorDesc(const at::Tensor& t)
     : TensorDesc(t.type().scalarType(), t.sizes(), t.strides()) {}
-  TensorDesc(TensorType *type)
+  TensorDesc(TensorTypePtr type)
     : TensorDesc(type->scalarType(), type->sizes(), type->strides()) {}
 
   // number of dimensions after contiguity compression

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -240,7 +240,7 @@ static void checkSameDevice(const Node* node) {
   bool has_device = false;
   int device;
   auto checkValue = [&](const Value* v) {
-    if(TensorType* type = v->type()->cast<TensorType>()) {
+    if(TensorTypePtr type = v->type()->cast<TensorType>()) {
       if(!has_device) {
         has_device = true;
         device = type->device();
@@ -596,7 +596,7 @@ at::optional<IValue> Node::get(Symbol name) const {
         // disambiguate via schema
         at::Tensor ten = t(name);
         const Argument* arg = findArgument(schema(), name).second;
-        if(arg->type->isSubtypeOf(*NumberType::get())) {
+        if(arg->type->isSubtypeOf(NumberType::get())) {
           return IValue(at::Scalar(ten));
         }
         return IValue(ten);

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1001,7 +1001,7 @@ public:
     return n;
   }
   Node* createTupleUnpack(Value * v) {
-    TupleType* tt = v->type()->expect<TupleType>();
+    TupleTypePtr tt = v->type()->expect<TupleType>();
     auto n = create(prim::TupleUnpack, {v}, 0);
     for(auto & element : tt->elements()) {
       n->addOutput()->setType(element);
@@ -1011,7 +1011,7 @@ public:
   Node* createList(const TypePtr& elem_type, at::ArrayRef<Value*> values) {
     auto n = create(prim::ListConstruct, values);
     for(const auto & v : values) {
-      JIT_ASSERT(v->type()->isSubtypeOf(*elem_type));
+      JIT_ASSERT(v->type()->isSubtypeOf(elem_type));
     }
     n->output()->setType(std::make_shared<ListType>(elem_type));
     return n;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -181,7 +181,7 @@ private:
 public:
   Value* setType(const TypePtr type);
   void inferTypeFrom(const at::Tensor& output) {
-    setType(std::make_shared<TensorType>(output));
+    setType(TensorType::create(output));
   }
   const TypePtr & type() const {
     JIT_ASSERT(type_ != nullptr);
@@ -995,7 +995,7 @@ public:
   }
   Node* createTuple(at::ArrayRef<Value*> values) {
     auto types = fmap(values, [](Value* v) { return v->type(); });
-    auto tt = std::make_shared<TupleType>(std::move(types));
+    auto tt = TupleType::create(std::move(types));
     auto n = create(prim::TupleConstruct, values);
     n->output()->setType(tt);
     return n;
@@ -1013,7 +1013,7 @@ public:
     for(const auto & v : values) {
       JIT_ASSERT(v->type()->isSubtypeOf(elem_type));
     }
-    n->output()->setType(std::make_shared<ListType>(elem_type));
+    n->output()->setType(ListType::create(elem_type));
     return n;
   }
   Node* createNumToTensor(Value* value) {

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -65,7 +65,7 @@ struct SchemaParser {
   void parseType(Argument& arg) {
     arg.type = parseBaseType();
     if(L.nextIf('[')) {
-      arg.type = std::make_shared<ListType>(arg.type);
+      arg.type = ListType::create(arg.type);
       if(L.cur().kind == TK_NUMBER) {
         arg.N = std::stoll(L.next().text());
       }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -328,7 +328,7 @@ at::optional<AttributeKind> attributeKindOf(TypePtr type) {
     case TypeKind::FloatType: return AttributeKind::f;
     case TypeKind::NumberType: return AttributeKind::t;
     case TypeKind::ListType:
-      if(type->isSubtypeOf(*ListType::ofInts()))
+      if(type->isSubtypeOf(ListType::ofInts()))
         return AttributeKind::is;
       else
         return at::nullopt;
@@ -338,7 +338,7 @@ at::optional<AttributeKind> attributeKindOf(TypePtr type) {
 }
 
 bool typeMatches(TypePtr actual, TypePtr formal) {
-  return actual->isSubtypeOf(*formal);
+  return actual->isSubtypeOf(formal);
 }
 
 bool Operator::matches(const Node* node) const {

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -13,7 +13,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
       case prim::Constant: {
         // remove primitive constants, replacing with tensor equivalent
         // ONNX does not support non-tensor constants
-        if(it->output()->type()->isSubtypeOf(*NumberType::get())) {
+        if(it->output()->type()->isSubtypeOf(NumberType::get())) {
           auto s = *constant_as<at::Scalar>(it->output());
           WithInsertPoint guard(*it);
           Value* r = insertConstant(*block->owningGraph(), s.toTensor());
@@ -27,7 +27,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
       } break;
       default: {
         for(auto o : it->outputs()) {
-          if (o->type()->isSubtypeOf(*NumberType::get())) {
+          if (o->type()->isSubtypeOf(NumberType::get())) {
             o->setType(TensorType::fromNumberType(o->type()));
           }
         }

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -87,7 +87,7 @@ bool isSimpleMap(Node *node) {
   if (!expected_type) return false;
 //type checking is intentionally dropped from isSimpleMap
 //isFusable is checking input/output types as there are some exceptions from allFloatIO requirement
-  static const auto equal_modulo_strides = [](TensorTypePtr expected, const TypePtr& _actual) {
+  static const auto equal_modulo_strides = [](const TensorTypePtr& expected, const TypePtr& _actual) {
      TensorTypePtr actual = _actual->cast<TensorType>();
      return actual &&
            expected->device() == actual->device() &&

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -83,12 +83,12 @@ bool isSimpleMap(Node *node) {
     return false;
   // Make sure that the node doesn't broadcast.
   JIT_ASSERT(node->inputs().size() > 0);
-  TensorType* expected_type = node->inputs()[0]->type()->cast<TensorType>();
+  TensorTypePtr expected_type = node->inputs()[0]->type()->cast<TensorType>();
   if (!expected_type) return false;
 //type checking is intentionally dropped from isSimpleMap
 //isFusable is checking input/output types as there are some exceptions from allFloatIO requirement
-  static const auto equal_modulo_strides = [](TensorType* expected, const TypePtr& _actual) {
-     TensorType* actual = _actual->cast<TensorType>();
+  static const auto equal_modulo_strides = [](TensorTypePtr expected, const TypePtr& _actual) {
+     TensorTypePtr actual = _actual->cast<TensorType>();
      return actual &&
            expected->device() == actual->device() &&
            expected->sizes() == actual->sizes();
@@ -182,7 +182,7 @@ struct GraphFuser {
   }
 
   bool allOutputsHaveSameSize(Node * node) {
-    TensorType *tt_ptr = nullptr;
+    TensorTypePtr tt_ptr = nullptr;
     for (const auto i : node->inputs()) {
       auto cur_tt_ptr = i->type()->cast<TensorType>();
       if (!cur_tt_ptr) {

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -43,7 +43,7 @@ static void VisitNode(Node* n, Node* insert_point) {
   // flatten the input list  op(a, tup, b) --> op(a, t0, t1, b)
   for(size_t i = 0; i < n->inputs().size();) {
     auto input = n->inputs()[i];
-    if(TupleType* tt = input->type()->cast<TupleType>()) {
+    if(TupleTypePtr tt = input->type()->cast<TupleType>()) {
       JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
       JIT_ASSERTM(input->node()->kind() == prim::TupleConstruct, "tuple use not matched to tuple construct");
       for(size_t j = 0; j < tt->elements().size(); ++j) {
@@ -68,7 +68,7 @@ static void VisitNode(Node* n, Node* insert_point) {
     // and:
     //    tup = (t0, t1)
     // is placed at the current insertion point
-    if(TupleType* tt = output->type()->cast<TupleType>()) {
+    if(TupleTypePtr tt = output->type()->cast<TupleType>()) {
       JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
       for(size_t j = 0; j < tt->elements().size(); j++) {
         n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -271,7 +271,7 @@ void pushPackingPastRnn(Block *b) {
       new_sizes.push_back(oldType->sizes()[0]);
       new_sizes.push_back(oldType->sizes()[1]);
       new_sizes.push_back(rnn->i(attr::hidden_size));
-      TensorTypePtr newType = std::make_shared<TensorType>(
+      TensorTypePtr newType = TensorType::create(
           oldType->scalarType(), oldType->device(), new_sizes);
       next->outputs()[0]->setType(newType);
     }

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -265,7 +265,7 @@ void pushPackingPastRnn(Block *b) {
     // unhygenic way, Pytorch ends up propagating an incorrect type.
     // Until a long-term cleanup comes around, we can fix this by
     // resetting the size to the correct value.
-    TensorType* oldType = rnn->inputs()[0]->type()->cast<TensorType>();
+    TensorTypePtr oldType = rnn->inputs()[0]->type()->cast<TensorType>();
     if (oldType) {
       std::vector<int64_t> new_sizes;
       new_sizes.push_back(oldType->sizes()[0]);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -42,12 +42,12 @@ IValue representativeValue(Value* v) {
   if(auto iv = toIValue(v)) {
     return *iv;
   }
-  if (TensorType* type = type_->cast<TensorType>()) {
+  if (TensorTypePtr type = type_->cast<TensorType>()) {
     auto backend = type->device() == -1 ? at::kCPU : at::kCUDA;
     at::DeviceGuard device_guard(type->device());
     auto& attype = at::getType(backend, type->scalarType());
     return attype.tensor(type->sizes(), type->strides()).zero_();
-  } else if (type_->isSubtypeOf(*FloatType::get())) {
+  } else if (type_->isSubtypeOf(FloatType::get())) {
     return 0.f;
   }
   // we should not get here because isValidArgumentForRunning should have
@@ -63,8 +63,8 @@ void PropagateShapeOnBlock(Block * block, bool insert_expands=true);
 // for each node in the schema with type Tensor, extract the TensorType
 // returns at::nullopt if any Tensor in the schema does not have a known shape
 // ignores non-tensor in the list of inputs
-at::optional<std::vector<TensorType*>> gatherTensorTypes(Node *node) {
-  std::vector<TensorType*> tensor_types;
+at::optional<std::vector<TensorTypePtr>> gatherTensorTypes(Node *node) {
+  std::vector<TensorTypePtr> tensor_types;
 
   auto & schema = node->schema();
   auto & args = schema.arguments;
@@ -75,12 +75,12 @@ at::optional<std::vector<TensorType*>> gatherTensorTypes(Node *node) {
   size_t input_i = 0;
   for (auto& arg : args) {
     size_t consume_n; // how many tensors do we check for in the input list
-    if (arg.type->isSubtypeOf(*ListType::ofTensors())) {
+    if (arg.type->isSubtypeOf(ListType::ofTensors())) {
       // we have a list of tensor, there is only ever one list
       // so we calculte how many elements must be in it by how much bigger
       // or smaller the input list is compared to the arguments in the schema
       consume_n = node->inputs().size() + 1 - args.size();
-    } else if (arg.type->isSubtypeOf(*DynamicType::get())) {
+    } else if (arg.type->isSubtypeOf(DynamicType::get())) {
       // a single Tensor for this argument
       consume_n = 1;
     } else {
@@ -89,7 +89,7 @@ at::optional<std::vector<TensorType*>> gatherTensorTypes(Node *node) {
     }
     for(size_t j = 0; j < consume_n; j++) {
       // bail out if a tensor does not have a size
-      TensorType *type = node->input(input_i++)->type()->cast<TensorType>();
+      TensorTypePtr type = node->input(input_i++)->type()->cast<TensorType>();
       if (!type)
         return at::nullopt;
       tensor_types.push_back(type);
@@ -117,10 +117,10 @@ bool mergeTypes(ArrayRef<Value*> lhs, ArrayRef<Value*> rhs, ArrayRef<Value*> out
 
 void PropagateShapeOnNode(Node * node, bool insert_expands=true);
 
-void broadcastBinary(Node *node, std::vector<TensorType*>& types, size_t idx1, size_t idx2) {
+void broadcastBinary(Node *node, std::vector<TensorTypePtr>& types, size_t idx1, size_t idx2) {
   auto expected_size = at::infer_size(types[idx1]->sizes(), types[idx2]->sizes());
   auto broadcast = [&](size_t input_idx) {
-    TensorType* input_type = types.at(input_idx);
+    TensorTypePtr input_type = types.at(input_idx);
     if (input_type->sizes() == expected_size)
       return;
     auto graph = node->owningGraph();
@@ -178,14 +178,14 @@ bool isValidArgumentForRunning(Value* v) {
   // allow constants
   if(toIValue(v))
     return true;
-  if(TensorType* tt = v->type()->cast<TensorType>()) {
+  if(TensorTypePtr tt = v->type()->cast<TensorType>()) {
     return !at::isIntegralType(tt->scalarType());
   }
-  return v->type()->isSubtypeOf(*FloatType::get());
+  return v->type()->isSubtypeOf(FloatType::get());
 }
 bool isValidReturnForRunning(Value* v) {
-  return v->type()->isSubtypeOf(*DynamicType::get()) ||
-      v->type()->isSubtypeOf(*NumberType::get());
+  return v->type()->isSubtypeOf(DynamicType::get()) ||
+      v->type()->isSubtypeOf(NumberType::get());
 }
 
 bool canPropagateShapeByRunningIt(Node* node) {
@@ -244,7 +244,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     case prim::NumToTensor:
       return; // correct num type is already set
     case prim::Constant: {
-      if(node->output()->type()->isSubtypeOf(*DynamicType::get())) {
+      if(node->output()->type()->isSubtypeOf(DynamicType::get())) {
         node->output()->inferTypeFrom(node->t(attr::value));
       }
       return;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -296,7 +296,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     auto lhs_type = tensor_types.at(0);
     auto rhs_type = tensor_types.at(1);
     SHAPE_ASSERT(lhs_type->sizes().size() == 2 && rhs_type->sizes().size() == 2);
-    node->output()->setType(std::make_shared<TensorType>(
+    node->output()->setType(TensorType::create(
       lhs_type->scalarType(), lhs_type->device(),
       at::IntList{lhs_type->sizes().at(0), rhs_type->sizes().at(1)}));
     return;
@@ -419,7 +419,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     std::vector<int64_t> dim_vec = {(int64_t)tensor_types.at(0)->sizes().size()};
     at::IntList dims(dim_vec);
     node->output()->setType(
-        std::make_shared<TensorType>(at::kLong, -1, dims));
+        TensorType::create(at::kLong, -1, dims));
     return;
   } else if (node->kind() == onnx::Reshape) {
     setUnshapedType(node);

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -451,9 +451,9 @@ void initPythonIRBindings(PyObject * module_) {
     ;
 
   py::class_<DynamicType, Type, std::shared_ptr<DynamicType>>(m, "DynamicType")
-    .def(py::init<>());
+    .def(py::init([](){ return DynamicType::create(); }));
   py::class_<TupleType, Type, std::shared_ptr<TupleType>>(m, "TupleType")
-    .def(py::init<std::vector<TypePtr>>())
+    .def(py::init([](std::vector<TypePtr> a){ return TupleType::create(a); }))
     .def("elements", [](TupleType &self){
       std::vector<TypePtr> types;
       for (auto type : self.elements()) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -202,7 +202,7 @@ RegisterOperators reg({
         prim::ListConstruct,
         [](Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
-          ListType* lt = node->output()->type()->expect<ListType>();
+          ListTypePtr lt = node->output()->type()->expect<ListType>();
           if(IntType::get() == lt->getElementType()) {
             return [=](Stack& stack) {
               auto inputs = peekSlice(stack, 0, num_inputs, num_inputs);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -787,7 +787,7 @@ struct to_ir {
         TypePtr type = DynamicType::get();
         if (typed_def.schema) {
           type = typed_def.schema->returns.at(return_type_idx).type;
-          if (!r->type()->isSubtypeOf(*type)) {
+          if (!r->type()->isSubtypeOf(type)) {
             throw ErrorReport(return_stmt.range()) << "Return value at position "
               << return_type_idx << " was annotated as having type " << type->str()
               << " but is actually of type " << r->type()->str();

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -93,9 +93,9 @@ struct CastValue : public SugaredValue {
         throw ErrorReport(loc) << "expected a single argument for cast";
       auto values = toValues(inputs);
       Value* input = values.at(0);
-      if(!input->type()->isSubtypeOf(*type)) {
+      if(!input->type()->isSubtypeOf(type)) {
         if(*type == *DynamicType::get()) {
-          if(!input->type()->isSubtypeOf(*NumberType::get())) {
+          if(!input->type()->isSubtypeOf(NumberType::get())) {
             throw ErrorReport(loc) << "expected a number";
           }
           input = numToTensor(loc, input);
@@ -244,7 +244,7 @@ struct Environment {
         throw ErrorReport(loc) << "Cannot re-assign '" << name << "' because it has type " << value->kind() <<
 	" and " << name << " is not a first-class value.  Only reassignments to first-class values are allowed";
       }
-      if(!as_simple_value->type()->isSubtypeOf(*unshapedType(simple_parent->type()))) {
+      if(!as_simple_value->type()->isSubtypeOf(unshapedType(simple_parent->type()))) {
         throw ErrorReport(loc) << "variable '" << name << "' previously has type " << simple_parent->type()->str()
         << " but is now being assigned to a value of type " << as_simple_value->type()->str();
       }
@@ -368,7 +368,7 @@ Value* createStack(Graph& g, const SourceRange& loc, at::ArrayRef<Value*> inputs
 }
 
 static bool isTensorSubtype(Value* v) {
-  return v->type()->isSubtypeOf(*DynamicType::get());
+  return v->type()->isSubtypeOf(DynamicType::get());
 }
 
 at::optional<std::vector<int64_t>> getIntListAttribute(at::optional<int32_t> N, Value* input) {
@@ -538,12 +538,12 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       // Allow tuples that only contain integers to turn into lists of integers
       if(*ListType::ofInts() == *arg.type &&
          v.value->type()->kind() == TypeKind::TupleType &&
-         v.value->type()->isSubtypeOf(*ListType::ofInts())) {
+         v.value->type()->isSubtypeOf(ListType::ofInts())) {
         auto unpacked = createTupleUnpack(v.value);
         v.value = graph.insertNode(graph.createList(IntType::get(), unpacked))->output();
       }
 
-      if(!v.value->type()->isSubtypeOf(*arg.type)) {
+      if(!v.value->type()->isSubtypeOf(arg.type)) {
         err() << "expected a value of type " << arg.type->str() << " for argument '" << arg.name << "' but found "
               << v.value->type()->str() << "\n"
               << v.loc;
@@ -551,7 +551,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       }
 
       // we only support tensor lists for builtins, where they must be flattened
-      if(arg.type->isSubtypeOf(*ListType::ofTensors())) {
+      if(arg.type->isSubtypeOf(ListType::ofTensors())) {
         auto outputs = createTupleUnpack(v.value);
         flat_inputs.insert(flat_inputs.end(), outputs.begin(), outputs.end());
       } else {
@@ -663,7 +663,7 @@ static Value* ensureTensor(const SourceRange& range, Value* v) {
 }
 
 static Value* ensureInt(const SourceRange& range, Value* v) {
-  if(!v->type()->isSubtypeOf(*IntType::get())) {
+  if(!v->type()->isSubtypeOf(IntType::get())) {
     throw ErrorReport(range) << "expected a int but found a "
                              << v->type()->str();
   }
@@ -778,7 +778,7 @@ struct to_ir {
       auto range = return_stmt.range();
       size_t return_type_idx = 0;
       for (auto& r : results) {
-        if(r->type()->isSubtypeOf(*NumberType::get())) {
+        if(r->type()->isSubtypeOf(NumberType::get())) {
           graph->registerOutput(numToTensor(range, r));
         } else {
           ensureTensor(range, r);
@@ -914,10 +914,10 @@ private:
 
   Value* emitCond(Expr cond) {
     Value* v = emitExpr(cond, identity);
-    if(v->type()->isSubtypeOf(*DynamicType::get())) {
+    if(v->type()->isSubtypeOf(DynamicType::get())) {
       v = tensorToNum(cond.range(), v, IntType::get());
     }
-    if(!v->type()->isSubtypeOf(*IntType::get())) {
+    if(!v->type()->isSubtypeOf(IntType::get())) {
       throw ErrorReport(cond) << "expected a tensor or integer expression for condition but found " << v->type()->str();
     }
     return v;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -86,7 +86,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
                              << "of arguments: expected " << arguments.size() << ", but got "
                              << inputs.size();
     for (size_t i = 0; i < arguments.size(); ++i) {
-      if (!inputs[i]->type()->isSubtypeOf(*arguments[i]))
+      if (!inputs[i]->type()->isSubtypeOf(arguments[i]))
         throw ErrorReport(loc) << "type mismatch at argument " << i << ": expected "
                                << arguments[i]->str() << ", but got " << inputs[i]->type()->str();
     }
@@ -135,7 +135,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     // equivalent, but the PythonOp impl ends with an optional tuple unpack, so we need
     // to do it.
     for (auto & ret_type_elem : returns) {
-      if (!ret_type_elem->isSubtypeOf(*DynamicType::get())) {
+      if (!ret_type_elem->isSubtypeOf(DynamicType::get())) {
         throw ErrorReport(loc) << "Python functions can currently only return Tensors";
       }
     }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -117,14 +117,14 @@ struct Method {
     for (size_t i=0; i < retval->inputs().size(); ++i) {
       auto scalar_type = inputs[i].type().scalarType();
       auto sizes = inputs[i].sizes();
-      auto type = std::make_shared<torch::jit::TensorType>(scalar_type, -1, sizes);
+      auto type = torch::jit::TensorType::create(scalar_type, -1, sizes);
       retval->inputs()[i]->setType(type);
     }
     JIT_ASSERT(retval->outputs().size() == outputs.size());
     for (size_t i=0; i < retval->outputs().size(); ++i) {
       auto scalar_type = outputs[i].type().scalarType();
       auto sizes = outputs[i].sizes();
-      auto type = std::make_shared<torch::jit::TensorType>(scalar_type, -1, sizes);
+      auto type = torch::jit::TensorType::create(scalar_type, -1, sizes);
       retval->outputs()[i]->setType(type);
     }
     return retval;

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -641,7 +641,7 @@ std::string toString(std::shared_ptr<Graph>& graph) {
 void testDifferentiate(std::ostream & out) {
   auto graph = std::make_shared<Graph>();
   at::ScalarType s = at::ScalarType::Float;
-  auto type = std::shared_ptr<TensorType>(new TensorType(s, -1, {2, 3, 4}, {12, 4, 1}));
+  auto type = TensorType::create(s, -1, {2, 3, 4}, {12, 4, 1});
 
   // Build up a fake graph
   auto a = SymbolicVariable::asNewInput(*graph, type);
@@ -668,7 +668,7 @@ void testDifferentiate(std::ostream & out) {
 void testDifferentiateWithRequiresGrad(std::ostream & out) {
   auto graph = std::make_shared<Graph>();
   at::ScalarType s = at::ScalarType::Float;
-  auto type = std::shared_ptr<TensorType>(new TensorType(s, -1, {2, 3, 4}, {12, 4, 1}));
+  auto type = TensorType::create(s, -1, {2, 3, 4}, {12, 4, 1});
 
   // Build up a fake graph
   auto a = SymbolicVariable::asNewInput(*graph, type);

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -45,29 +45,29 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
 }
 
 TypePtr DynamicType::get() {
-  static auto value = std::make_shared<DynamicType>();
+  static auto value = DynamicType::create();
   return value;
 }
 TypePtr NumberType::get() {
-  static auto value = std::make_shared<NumberType>();
+  static auto value = NumberType::create();
   return value;
 }
 TypePtr IntType::get() {
-  static auto value = std::make_shared<IntType>();
+  static auto value = IntType::create();
   return value;
 }
 TypePtr FloatType::get() {
-  static auto value = std::make_shared<FloatType>();
+  static auto value = FloatType::create();
   return value;
 }
 
 
 TypePtr ListType::ofTensors() {
-  static auto value = std::make_shared<ListType>(DynamicType::get());
+  static auto value = ListType::create(DynamicType::get());
   return value;
 }
 TypePtr ListType::ofInts() {
-  static auto value = std::make_shared<ListType>(IntType::get());
+  static auto value = ListType::create(IntType::get());
   return value;
 }
 


### PR DESCRIPTION
Follow up task of #9584. 

Commit 1:

- change expect/cast to return shared pointers instead of raw pointer
- isSubtypeOf accept TypePtr instead. Use `x->isSubtypeOf(NumberType::get())` rather than `x->isSubtypeOf(*NumberType::get())`

Commit 2: 

- to address enable_shared_from_this pitfalls, we make the constructor private and expose the factory method to make sure user can only create it using our factory method. 
