### PR TITLE
nomnigraph - Add way to check if a NodeRef is in a graph

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -335,6 +335,18 @@ inline T* get(N n) {
 }
 
 template <typename T, typename G>
+std::vector<typename G::NodeRef> nodeIterator(G& g) {
+  std::vector<typename G::NodeRef> out;
+  for (auto node : g.getMutableNodes()) {
+    if (!is<T>(node)) {
+      continue;
+    }
+    out.emplace_back(node);
+  }
+  return out;
+}
+
+template <typename T, typename G>
 std::vector<std::pair<T*, typename G::NodeRef>> dataIterator(G& g) {
   std::vector<std::pair<T*, typename G::NodeRef>> out;
   for (auto node : g.getMutableNodes()) {

--- a/caffe2/core/nomnigraph/tests/basic_test.cc
+++ b/caffe2/core/nomnigraph/tests/basic_test.cc
@@ -15,6 +15,8 @@ TEST(Basic, CreateNodeAndEdge) {
   nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
   nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
   g.createEdge(n1, n2);
+  EXPECT_TRUE(g.hasNode(n1));
+  EXPECT_TRUE(g.hasNode(n2));
 }
 
 TEST(Basic, DeleteNode) {
@@ -24,7 +26,9 @@ TEST(Basic, DeleteNode) {
   nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
   nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
   g.createEdge(n1, n2);
+  EXPECT_TRUE(g.hasNode(n1));
   g.deleteNode(n1);
+  EXPECT_FALSE(g.hasNode(n1));
 }
 
 TEST(Basic, DeleteEdge) {
@@ -37,3 +41,43 @@ TEST(Basic, DeleteEdge) {
   g.deleteEdge(e);
 }
 
+TEST(Basic, HasNode) {
+  TestClass t1;
+  TestClass t2;
+  TestClass t3;
+  nom::Graph<TestClass> g;
+  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
+  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
+  nom::Graph<TestClass>::NodeRef n3 = g.createNode(std::move(t3));
+  g.createEdge(n1, n2);
+  g.createEdge(n1, n3);
+  // Current graph: 1 -> 2 -> 3
+  EXPECT_TRUE(g.hasNode(n1));
+  EXPECT_TRUE(g.hasNode(n2));
+  EXPECT_TRUE(g.hasNode(n3));
+  g.swapNodes(n1, n3);
+  // Current graph: 3 -> 2 -> 1
+  EXPECT_TRUE(g.hasNode(n1));
+  EXPECT_TRUE(g.hasNode(n3));
+  g.deleteNode(n1);
+  // Current graph: 3 -> 2
+  EXPECT_FALSE(g.hasNode(n1));
+  TestClass t4;
+  nom::Graph<TestClass>::NodeRef n4 = g.createNode(std::move(t4));
+  EXPECT_TRUE(g.hasNode(n4));
+  g.replaceNode(n2, n4);
+  // Current graph: 3 -> 4  ,   2
+  // replaceNode doesn't delete n2.
+  EXPECT_TRUE(g.hasNode(n2));
+
+  // Create a second graph g2, and import the nodes from g2 to g.
+  TestClass t5;
+  nom::Graph<TestClass> g2;
+  nom::Graph<TestClass>::NodeRef n5 = g2.createNode(std::move(t5));
+  EXPECT_TRUE(g2.hasNode(n5));
+
+  EXPECT_FALSE(g.hasNode(n5));
+  g2.importNode(n5, g);
+  // Current graph (g1): 3 -> 4, 2, 5
+  EXPECT_TRUE(g.hasNode(n5));
+}


### PR DESCRIPTION
Summary:
- Add way to check if a NodeRef is in a graph
- Make a nodeIterator (similar to dataIterator) but only iterate through nodes.

Differential Revision: D8980903
