### PR TITLE
Add support for rand_like op in fusion compiler

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -438,6 +438,30 @@ class TestJit(JitTestCase):
         ge = self.checkTrace(f, (x, y))
         self.assertExpectedGraph(ge.graph_for(x, y))
 
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_fusion_rand(self):
+        class M(torch.jit.ScriptModule):
+            __constants__ = ['d']
+
+            def __init__(self):
+                self.d = torch.device('cuda')
+
+            @torch.jit.script_method
+            def create(self, x):
+                return x * x + x + torch.rand_like(x)
+
+        x = torch.zeros([3, 4, 5], dtype=torch.float, device='cuda')
+        y = torch.ones([3, 4, 5], dtype=torch.float, device='cuda')
+        m = M()
+        out1 = m.create(x)
+        out2 = m.create(x)
+        self.assertNotEqual(out1, out2)
+        self.assertTrue(torch.all(out1 >= 0))
+        self.assertTrue(torch.all(out1 < 1))
+        self.assertTrue(torch.all(out2 >= 0))
+        self.assertTrue(torch.all(out2 < 1))
+
     @staticmethod
     def fn_test_comparison_gt_lt(x, y):
         mask = (x > 0).type_as(x)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -452,7 +452,6 @@ class TestJit(JitTestCase):
                 return x * x + x + torch.rand_like(x)
 
         x = torch.zeros([3, 4, 5], dtype=torch.float, device='cuda')
-        y = torch.ones([3, 4, 5], dtype=torch.float, device='cuda')
         m = M()
         out1 = m.create(x)
         out2 = m.create(x)

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -100,289 +100,103 @@ struct TensorInfo {
 // The TF's version is standalone and thus we don't need to worry too much
 // about including in stuff that we don't need.
 constexpr auto rand_support_literal = R"(
-  /* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  ==============================================================================*/
-
-  // Implement the Philox algorithm to generate random numbers in parallel.
-  // Salmon et al. SC 2011. Parallel random numbers: as easy as 1, 2, 3.
-  //   http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
-
-  #ifndef TENSORFLOW_LIB_RANDOM_PHILOX_RANDOM_H_
-  #define TENSORFLOW_LIB_RANDOM_PHILOX_RANDOM_H_
-
-  // #include <stdlib.h>
-
-  // #include "tensorflow/core/platform/types.h"
-  typedef unsigned long uint32;
-  typedef unsigned long long uint64;
-
-  // Function qualifiers that need to work on both CPU and GPU.
-  #if defined(__CUDACC__)
-  // For nvcc.
-  #define PHILOX_DEVICE_FUNC __host__ __device__
-  #define PHILOX_INLINE __inline__
-  #else
-  // For non-nvcc.
-  #define PHILOX_DEVICE_FUNC
-  #define PHILOX_INLINE inline
-  #endif
-  #define PHILOX_DEVICE_INLINE PHILOX_DEVICE_FUNC PHILOX_INLINE
-
-  // #include <math.h>
-
-  // namespace tensorflow {
-  // namespace random {
-
-  // A class that represents an inline array. It can be used on both CPU and GPU,
-  // and also trivially copyable between CPU and GPU.
-  // Arguments:
-  //   T: the array element type;
-  //   ElementCount: the fixed size of the array;
-  template <typename T, int ElementCount>
-  class Array {
-   public:
-    PHILOX_DEVICE_INLINE Array() {
-      for (int i = 0; i < ElementCount; ++i) {
-        data_[i] = T(0);
-      }
-    }
-
-    PHILOX_DEVICE_INLINE const T& operator[](int index) const {
-      return data_[index];
-    }
-
-    PHILOX_DEVICE_INLINE T& operator[](int index) { return data_[index]; }
-
-    size_t size() const { return ElementCount; }
-
-   private:
-    T data_[ElementCount];
-  };
-
-  // A class that encapsulates all the states for a random number generator using
-  // the philox_4x32_10 algorithm. Each invocation returns a 128-bit random bits
-  // in the form of four uint32.
-  // There are multiple variants of this algorithm, we picked the 4x32_10 version
-  // that is most suited for our applications.
-  // Since this class is meant to be copied between CPU to GPU, it maintains a
-  // value semantics.
-  //
-  // For example: To use this class and populate an array of 1024 randoms on CPU
-  // with two threads,
-  //
-  //  void Fill(PhiloxRandom rnd, uint32* output, int start, int limit) {
-  //    assert(start % 4 == 0);
-  //    assert(limit % 4 == 0);
-  //    rnd.Skip(start / 4);
-  //    for (int i = start; i < limit; i += 4) {
-  //      auto sample = rnd();
-  //      ... copy sample[0..3] to output[i..i+3]
-  //    }
-  //  }
-  //
-  //  PhiloxRandom rng(seed);
-  //  PhiloxRandom rng_copy = rng;
-  //  rng.Skip(1000/4);
-  //
-  //  ... schedule Fill(rng_copy, output, 0, 512) in thread 1;
-  //  ... schedule Fill(rng_copy, output, 512, 1024) in thread 2;
-  //  ... wait for thread 1 & 2 to finish executing Fill().
-  //
-  // NOTE:
-  // 1. PhiloxRandom is trivially copyable.
-  // 2. PhiloxRandom is compilable by gcc and nvcc.
-  class PhiloxRandom {
-   public:
-    using ResultType = Array<uint32, 4>;
-    using ResultElementType = uint32;
-    // The number of elements that will be returned.
-    static const int kResultElementCount = 4;
-    // Cost of generation of a single element (in cycles).
-    static const int kElementCost = 10;
-    // The type for the 64-bit key stored in the form of two 32-bit uint
-    // that are used in the diffusion process.
-    using Key = Array<uint32, 2>;
-
-    PHILOX_DEVICE_INLINE
-    PhiloxRandom() {}
-
-    PHILOX_DEVICE_INLINE
-    explicit PhiloxRandom(uint64 seed) {
-      key_[0] = static_cast<uint32>(seed);
-      key_[1] = static_cast<uint32>(seed >> 32);
-    }
-
-    PHILOX_DEVICE_INLINE
-    explicit PhiloxRandom(uint64 seed_lo, uint64 seed_hi) {
-      key_[0] = static_cast<uint32>(seed_lo);
-      key_[1] = static_cast<uint32>(seed_lo >> 32);
-      counter_[2] = static_cast<uint32>(seed_hi);
-      counter_[3] = static_cast<uint32>(seed_hi >> 32);
-    }
-
-    PHILOX_DEVICE_INLINE
-    PhiloxRandom(ResultType counter, Key key) : counter_(counter), key_(key) {}
-
-    // Skip the specified number of samples of 128-bits in the current stream.
-    PHILOX_DEVICE_INLINE
-    void Skip(uint64 count) {
-      const uint32 count_lo = static_cast<uint32>(count);
-      uint32 count_hi = static_cast<uint32>(count >> 32);
-
-      counter_[0] += count_lo;
-      if (counter_[0] < count_lo) {
-        ++count_hi;
-      }
-
-      counter_[1] += count_hi;
-      if (counter_[1] < count_hi) {
-        if (++counter_[2] == 0) {
-          ++counter_[3];
-        }
-      }
-    }
-
-    // Returns a group of four random numbers using the underlying Philox
-    // algorithm.
-    PHILOX_DEVICE_INLINE ResultType operator()() {
-      ResultType counter = counter_;
-      Key key = key_;
-
-      // Run the single rounds for ten times. Manually unrolling the loop
-      // for better performance.
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-      RaiseKey(&key);
-      counter = ComputeSingleRound(counter, key);
-
-      SkipOne();
-
-      return counter;
-    }
-
-   private:
-    // We use the same constants as recommended by the original paper.
-    static const uint32 kPhiloxW32A = 0x9E3779B9;
-    static const uint32 kPhiloxW32B = 0xBB67AE85;
-    static const uint32 kPhiloxM4x32A = 0xD2511F53;
-    static const uint32 kPhiloxM4x32B = 0xCD9E8D57;
-
-    // Helper function to skip the next sample of 128-bits in the current stream.
-    PHILOX_DEVICE_INLINE void SkipOne() {
-      if (++counter_[0] == 0) {
-        if (++counter_[1] == 0) {
-          if (++counter_[2] == 0) {
-            ++counter_[3];
-          }
-        }
-      }
-    }
-
-    // Helper function to return the lower and higher 32-bits from two 32-bit
-    // integer multiplications.
-    PHILOX_DEVICE_INLINE
-    static void MultiplyHighLow(uint32 a, uint32 b, uint32* result_low,
-                                uint32* result_high) {
-  #ifndef __CUDA_ARCH__
-      const uint64 product = static_cast<uint64>(a) * b;
-      *result_low = static_cast<uint32>(product);
-      *result_high = static_cast<uint32>(product >> 32);
-  #else
-      *result_low = a * b;
-      *result_high = __umulhi(a, b);
-  #endif
-    }
-
-    // Helper function for a single round of the underlying Philox algorithm.
-    PHILOX_DEVICE_INLINE static ResultType ComputeSingleRound(
-        const ResultType& counter, const Key& key) {
-      uint32 lo0;
-      uint32 hi0;
-      MultiplyHighLow(kPhiloxM4x32A, counter[0], &lo0, &hi0);
-
-      uint32 lo1;
-      uint32 hi1;
-      MultiplyHighLow(kPhiloxM4x32B, counter[2], &lo1, &hi1);
-
-      ResultType result;
-      result[0] = hi1 ^ counter[1] ^ key[0];
-      result[1] = lo1;
-      result[2] = hi0 ^ counter[3] ^ key[1];
-      result[3] = lo0;
-      return result;
-    }
-
-    PHILOX_DEVICE_INLINE void RaiseKey(Key* key) {
-      (*key)[0] += kPhiloxW32A;
-      (*key)[1] += kPhiloxW32B;
-    }
-
-   private:
-    ResultType counter_;
-    Key key_;
-  };
-
-  // A Wrapper for Philox to get one random number at a time
-  class PhiloxWrapper {
+  class Philox {
   public:
-    PHILOX_DEVICE_INLINE
-    explicit PhiloxWrapper(uint64 seed_lo, uint64 seed_hi, uint64 offset) {
-      philox = PhiloxRandom(seed_lo, seed_hi);
-      philox.Skip(offset / 4);
-      i = 0;
+    __device__ inline Philox(unsigned long long seed,
+                             unsigned long long subsequence,
+                             unsigned long long offset) {
+      key.x = (unsigned int)seed;
+      key.y = (unsigned int)(seed >> 32);
+      counter = make_uint4(0, 0, 0, 0);
+      counter.z = (unsigned int)(subsequence);
+      counter.w = (unsigned int)(subsequence >> 32);
+      STATE = 0;
+      incr_n(offset / 4);
     }
-    PHILOX_DEVICE_INLINE float operator()() {
-      if(i == 0) buf = philox();
-      uint32 ret = buf[i];
-      i = (i + 1) % 4;
-      const uint32 FLOAT_MASK = (1 << 24) - 1;
-      const float FLOAT_DIVISOR = 1.0f / (1 << 24);
-      return (ret & FLOAT_MASK) * FLOAT_DIVISOR;
+
+    __device__ inline unsigned long operator()() {
+      if(STATE == 0) {
+        uint4 counter_ = counter;
+        uint2 key_ = key;
+        for(int i = 0; i < 9; i++) {
+          counter_ = single_round(counter_, key_);
+          key_.x += (kPhilox10A); key_.y += (kPhilox10B);
+        }
+        output = single_round(counter_, key_);
+        incr();
+      }
+      unsigned long ret;
+      switch(STATE) {
+        case 0: ret = output.x; break;
+        case 1: ret = output.y; break;
+        case 2: ret = output.z; break;
+        case 3: ret = output.w; break;
+      }
+      STATE = (STATE + 1) % 4;
+      return ret;
     }
+
   private:
-    PhiloxRandom philox;
-    using ResultType = Array<uint32, 4>;
-    ResultType buf;
-    int i;
+    uint4 counter;
+    uint4 output;
+    uint2 key;
+    unsigned int STATE;
+    __device__ inline void incr_n(unsigned long long n) {
+      unsigned int nlo = (unsigned int)(n);
+      unsigned int nhi = (unsigned int)(n >> 32);
+      counter.x += nlo;
+      if (counter.x < nlo)
+        nhi++;
+      counter.y += nhi;
+      if (nhi <= counter.y)
+        return;
+      if (++counter.z)
+        return;
+      ++counter.w;
+    }
+    __device__ inline void incr() {
+      if (++counter.x)
+        return;
+      if (++counter.y)
+        return;
+      if (++counter.z)
+        return;
+      ++counter.w;
+    }
+    __device__ unsigned int mulhilo32(unsigned int a, unsigned int b,
+                                      unsigned int *result_high) {
+      *result_high = __umulhi(a, b);
+      return a*b;
+    }
+
+    __device__ inline uint4 single_round(uint4 ctr, uint2 key) {
+      unsigned int hi0;
+      unsigned int hi1;
+      unsigned int lo0 = mulhilo32(kPhiloxSA, ctr.x, &hi0);
+      unsigned int lo1 = mulhilo32(kPhiloxSB, ctr.z, &hi1);
+
+      uint4 ret = {hi1 ^ ctr.y ^ key.x, lo1, hi0 ^ ctr.w ^ key.y, lo0};
+      return ret;
+    }
+
+    static const unsigned long kPhilox10A = 0x9E3779B9;
+    static const unsigned long kPhilox10B = 0xBB67AE85;
+    static const unsigned long kPhiloxSA = 0xD2511F53;
+    static const unsigned long kPhiloxSB = 0xCD9E8D57;
   };
 
-  // }  // namespace random
-  // }  // namespace tensorflow
-
-  #endif  // TENSORFLOW_LIB_RANDOM_PHILOX_RANDOM_H_
+  // Constants are picked from https://www.doornik.com/research/randomdouble.pdf
+  #define M_RAN_INVM32 2.32830643653869628906e-010
+  __device__  __inline__ float uniform(unsigned int x) {
+    return x * M_RAN_INVM32;
+  }
 )";
 
-constexpr auto rand_param = ",uint64 seed, uint64 offset";
+constexpr auto rand_param = ",unsigned long long seed, unsigned long long offset";
 constexpr auto rand_init = R"(
   int idx = blockIdx.x*blockDim.x + threadIdx.x;
-  PhiloxWrapper rnd(seed, idx, offset);
+  Philox rnd(seed, idx, offset);
 )";
 auto cuda_compilation_unit_template = CodeTemplate(R"(
 ${type_declarations}
@@ -580,7 +394,7 @@ std::string encodeRHS(Node * n) {
     //alpha
     {aten::add, "${0} + ${alpha}*${1}"},
     {aten::sub, "(${0} - ${alpha}*${1})"},
-    {aten::rand_like, "rnd()"},
+    {aten::rand_like, "uniform(rnd())"},
 
     // simple derivatives
     {aten::_sigmoid_backward, "${0} * ${1} * (1.f - ${1})"},
@@ -871,15 +685,16 @@ void CompiledFusionFunction::launch_with_tensors(at::ArrayRef<at::Tensor> inputs
     }
   }
 
+  // If the kernel call contains a random op, we need to pass in random seeds as
+  // well.
   #ifdef USE_CUDA
-    // If the kernel call contains a random op, we need to pass in random seeds as
-    // well.
-    if(has_random && this->backend() == at::kCUDA) {
-      auto gen_ = THCRandom_getGenerator(at::globalContext().getTHCState());
-      uint64_t offset = gen_->state.philox_seed_offset.fetch_add(20);
-      arguments.push_back(&gen_->state.initial_seed);
-      arguments.push_back(&offset);
-    }
+  if(has_random && this->backend() == at::kCUDA) {
+    auto gen_ = THCRandom_getGenerator(at::globalContext().getTHCState());
+    uint64_t offset =
+        gen_->state.philox_seed_offset.fetch_add(this->get_rand_offset(numel));
+    arguments.push_back(&gen_->state.initial_seed);
+    arguments.push_back(&offset);
+  }
   #endif
 
   launch_raw(numel, arguments.data());
@@ -959,8 +774,13 @@ protected:
   virtual at::Backend backend() const override {
     return at::kCUDA;
   }
+  virtual uint64_t get_rand_offset(uint32_t numel) override {
+     int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
+     return 4 * (ceil(numel/(4 * blockSize * numBlocks)) + 1);
+  }
   virtual void launch_raw(uint32_t numel, void ** arguments) override {
      int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
+
      //std::cout << "maxBlocks = " << maxBlocks << " needed blocks: " << ceilDiv(numel,blockSize)
      //          << " numblocks =  " << numBlocks;
 
@@ -1134,6 +954,9 @@ struct CPUFusionFunction : public CompiledFusionFunction {
 protected:
   virtual at::Backend backend() const override {
     return at::kCPU;
+  }
+  virtual uint64_t get_rand_offset(uint32_t numel) override {
+     return numel;
   }
   virtual void launch_raw(uint32_t numel, void ** arguments) override {
     kernel(numel, arguments);

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -5,7 +5,6 @@
 #include <torch/csrc/jit/assertions.h>
 
 #include "ATen/ATen.h"
-
 #include <string>
 #include <algorithm>
 #include <unordered_map>
@@ -119,6 +118,7 @@ protected:
   // an output is actually a concatenation of
   // many subtensors that the fusion group produces
   std::vector<ConcatDesc> concat_desc;
+
 };
 
 struct FusionCompilerConfig {

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -108,6 +108,8 @@ protected:
   // launch_with_tensors handles packing at::Tensors into this arguments array.
   // CPU code uses the same convension so that launch_with_tensors can be shared.
   virtual void launch_raw(uint32_t numel, void ** arguments) = 0;
+
+  virtual uint64_t get_rand_offset(uint32_t numel) = 0;
   bool has_random;
   std::string name;
   // We keep these around for debugging

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -108,6 +108,7 @@ protected:
   // launch_with_tensors handles packing at::Tensors into this arguments array.
   // CPU code uses the same convension so that launch_with_tensors can be shared.
   virtual void launch_raw(uint32_t numel, void ** arguments) = 0;
+  bool has_random;
   std::string name;
   // We keep these around for debugging
   std::string compilation_unit;
@@ -118,7 +119,6 @@ protected:
   // an output is actually a concatenation of
   // many subtensors that the fusion group produces
   std::vector<ConcatDesc> concat_desc;
-
 };
 
 struct FusionCompilerConfig {

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -75,6 +75,7 @@ std::unordered_set<NodeKind> simple_mappable = {
   // TODO support those
   //aten::clamp,
   //aten::lerp,
+  aten::rand_like,
 };
 
 bool isSimpleMap(Node *node) {


### PR DESCRIPTION
Enabled support for generating random numbers in fusion compiler. Currently a philox RNG implemented by Tensorflow is used, as the NVRTC couldn't resolve the curand.h header correctly. The two implementation should have exact same behavior according to our tests.