### PR TITLE
Parse and register schema declarations lazily

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -632,7 +632,7 @@ bool Node::matches(const char *signature_literal, at::ArrayRef<Symbol> const_inp
 }
 
 void Node::findSchema() const {
-  schema_ = &getOperatorFor(this).schema;
+  schema_ = &getOperatorFor(this).schema();
 }
 
 PythonOp* defaultAllocPythonOp(Graph*g) {

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -248,8 +248,12 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
 
 using OperatorMap = std::unordered_map<Symbol, std::vector<std::shared_ptr<Operator>>>;
 struct OperatorRegistry  {
-  OperatorMap operators;
+private:
   std::mutex lock;
+  OperatorMap operators;
+  // list of operators whose schema have not yet been parsed, and must
+  // be registered before any call to lookup an opeator
+  std::vector<std::shared_ptr<Operator>> to_register;
   // Those two maps are used to implement lookupByLiteral, which is needed for the n->match(...) calls.
   // Basically, every function schema is assigned a unique string you can use to match it. However,
   // parsing those strings or comparing and hashing them character by character would be very slow, so
@@ -260,18 +264,26 @@ struct OperatorRegistry  {
   // by performing a lookup in the operators_by_sig map.
   std::unordered_map<std::string, std::shared_ptr<Operator>> operators_by_sig;
   std::unordered_map<const char *, std::shared_ptr<Operator>> operators_by_sig_literal;
-  void registerOperator(Operator&& op){
+
+  // XXX - caller must be holding lock
+  void registerPendingOperators() {
+    for(auto op : to_register) {
+      Symbol sym = Symbol::fromQualString(op->schema().name);
+      operators[sym].push_back(op);
+      operators_by_sig[canonicalSchemaString(op->schema())] = op;
+    }
+    to_register.clear();
+  }
+
+public:
+  void registerOperator(Operator&& op) {
     std::lock_guard<std::mutex> guard(lock);
-
-    Symbol sym = Symbol::fromQualString(op.schema.name);
-    auto op_ptr = std::make_shared<Operator>(std::move(op));
-
-    operators[sym].push_back(op_ptr);
-
-    operators_by_sig[canonicalSchemaString(op.schema)] = op_ptr;
+    to_register.push_back(std::make_shared<Operator>(std::move(op)));
   }
 
   const std::shared_ptr<Operator>& lookupByLiteral(const char * name) {
+    std::lock_guard<std::mutex> guard(lock);
+    registerPendingOperators();
     auto it = operators_by_sig_literal.find(name);
     if (it == operators_by_sig_literal.end()) {
       auto op_ptr_it = operators_by_sig.find(name);
@@ -289,8 +301,10 @@ struct OperatorRegistry  {
     return it->second;
   }
 
+
   const std::vector<std::shared_ptr<Operator>>& getOperators(Symbol name) {
     std::lock_guard<std::mutex> guard(lock);
+    registerPendingOperators();
     static std::vector<std::shared_ptr<Operator>> empty;
     auto it = operators.find(name);
     if(it != operators.end())
@@ -342,16 +356,16 @@ bool typeMatches(TypePtr actual, TypePtr formal) {
 }
 
 bool Operator::matches(const Node* node) const {
-  if (node->kind().toQualString() != schema.name) {
+  if (node->kind().toQualString() != schema().name) {
     return false;
   }
   size_t attributes_size = node->numAttributes();
   size_t attributes_seen = 0;
   auto inputs_size = node->inputs().size();
   size_t input_i = 0;
-  for(size_t arg_i = 0; arg_i < schema.arguments.size(); ++arg_i) {
+  for(size_t arg_i = 0; arg_i < schema().arguments.size(); ++arg_i) {
     at::optional<AttributeKind> attribute_kind;
-    const Argument& arg = schema.arguments[arg_i];
+    const Argument& arg = schema().arguments[arg_i];
     if(attributes_size > 0 && (attribute_kind = attributeKindOf(arg.type))) {
       auto name = Symbol::fromQualString("attr::" + arg.name);
       if(!node->hasAttribute(name) || node->kindOf(name) != *attribute_kind) {
@@ -372,11 +386,11 @@ bool Operator::matches(const Node* node) const {
     }
   }
 
-  if(!schema.is_vararg && input_i != inputs_size) {
+  if(!schema().is_vararg && input_i != inputs_size) {
     // std::cout << "not all inputs used\n" << input_i << " " << inputs_size << "\n";
     return false;
   }
-  if(!schema.is_vararg && attributes_seen != attributes_size) {
+  if(!schema().is_vararg && attributes_seen != attributes_size) {
     // std::cout << "not all attributes used\n" << attributes_seen << " " << attributes_size << "\n";
     return false;
   }
@@ -410,7 +424,7 @@ const Operator& getOperatorFor(const Node* node) {
   er << "\ncandidates were:\n";
   const auto& candidates = getAllOperatorsFor(node->kind());
   for(auto & candidate : candidates) {
-    er << "  " << candidate->schema << "\n";
+    er << "  " << candidate->schema() << "\n";
   }
   throw er;
 }
@@ -420,7 +434,7 @@ OperatorSet::OperatorSet(std::initializer_list<const char *> sig_literals) {
   auto & registry = getRegistry();
   for (const char * sig : sig_literals) {
     auto op = registry.lookupByLiteral(sig);
-    ops[Symbol::fromQualString(op->schema.name)].push_back(op);
+    ops[Symbol::fromQualString(op->schema().name)].push_back(op);
   }
 }
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -355,12 +355,15 @@ at::optional<std::vector<int64_t>> getIntListAttribute(at::optional<int32_t> N, 
   auto list = constant_as<Shared<jit::IntList>>(input);
   if(list)
     return std::vector<int64_t>(list.value()->elements());
+
   // broadcast IntList[3] with value 4 -> {4, 4, 4}
   if(!N)
     return at::nullopt;
+
   auto r = constant_as<int64_t>(input);
   if(!r)
     return at::nullopt;
+
   // broadcast to attribute size
   return std::vector<int64_t>(*N, *r);
 }
@@ -487,8 +490,16 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
   at::ArrayRef<NamedValue> attributes) {
 
   auto graph = method.graph();
+<<<<<<< HEAD
   auto matched_inputs = tryMatchSchema(op->schema, loc, *graph, inputs, attributes, failure_messages);
   if(!matched_inputs)
+||||||| merged common ancestors
+  auto flat_inputs = tryMatchSchema(op->schema, loc, *graph, inputs, attributes, failure_messages);
+  if(!flat_inputs)
+=======
+  auto flat_inputs = tryMatchSchema(op->schema(), loc, *graph, inputs, attributes, failure_messages);
+  if(!flat_inputs)
+>>>>>>> Parse and register schema declarations lazily
     return nullptr;
   // we successfully matched this schema, construct the node
 
@@ -507,11 +518,21 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
     for(int64_t i = 0; i < *value; ++i)
       n->addOutput();
   } else {
-    for(auto & ret : op->schema.returns) {
+    for(auto & ret : op->schema().returns) {
       n->addOutput()->setType(ret.type);
     }
   }
 
+<<<<<<< HEAD
+||||||| merged common ancestors
+  if(op->hasAttributedVersion())
+    liftConstantAttributes(op->schema, n);
+
+=======
+  if(op->hasAttributedVersion())
+    liftConstantAttributes(op->schema(), n);
+
+>>>>>>> Parse and register schema declarations lazily
   // assert that we did indeed create an op that has implementation
   // otherwise schema and dispatch are not in sync
   getOperation(n);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -490,16 +490,8 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
   at::ArrayRef<NamedValue> attributes) {
 
   auto graph = method.graph();
-<<<<<<< HEAD
-  auto matched_inputs = tryMatchSchema(op->schema, loc, *graph, inputs, attributes, failure_messages);
+  auto matched_inputs = tryMatchSchema(op->schema(), loc, *graph, inputs, attributes, failure_messages);
   if(!matched_inputs)
-||||||| merged common ancestors
-  auto flat_inputs = tryMatchSchema(op->schema, loc, *graph, inputs, attributes, failure_messages);
-  if(!flat_inputs)
-=======
-  auto flat_inputs = tryMatchSchema(op->schema(), loc, *graph, inputs, attributes, failure_messages);
-  if(!flat_inputs)
->>>>>>> Parse and register schema declarations lazily
     return nullptr;
   // we successfully matched this schema, construct the node
 
@@ -523,16 +515,6 @@ static std::shared_ptr<SugaredValue> tryEmitBuiltin(
     }
   }
 
-<<<<<<< HEAD
-||||||| merged common ancestors
-  if(op->hasAttributedVersion())
-    liftConstantAttributes(op->schema, n);
-
-=======
-  if(op->hasAttributedVersion())
-    liftConstantAttributes(op->schema(), n);
-
->>>>>>> Parse and register schema declarations lazily
   // assert that we did indeed create an op that has implementation
   // otherwise schema and dispatch are not in sync
   getOperation(n);


### PR DESCRIPTION
This should prevent slow startup times, and will not report as many
errors during static initialization time which are hard to debug

@ezyang @apaszke 