### PR TITLE
Fix grad_fn=<Error> in printing sparse Variable

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -224,8 +224,12 @@ def get_summarized_data(self):
 def _str(self):
     if self.is_sparse:
         size_str = str(tuple(self.shape)).replace(' ', '')
-        return '{} of size {} with indices:\n{}\nand values:\n{}'.format(
-            self.type(), size_str, self._indices(), self._values())
+        suffix = ""
+        if self.grad_fn is not None:
+            suffix += '\nand grad_fn=<{}>'.format(type(self.grad_fn).__name__)
+        with torch.no_grad():
+            return '{} of size {} with indices:\n{}\nand values:\n{}{}'.format(
+                self.type(), size_str, self._indices(), self._values(), suffix)
 
     prefix = 'tensor('
     indent = len(prefix)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -226,7 +226,10 @@ def _str(self):
         size_str = str(tuple(self.shape)).replace(' ', '')
         suffix = ""
         if self.grad_fn is not None:
-            suffix += '\nand grad_fn=<{}>'.format(type(self.grad_fn).__name__)
+            suffix = '\nand grad_fn=<{}>'.format(type(self.grad_fn).__name__)
+        elif self.requires_grad:
+            suffix = '\nand requires_grad=True'
+
         with torch.no_grad():
             return '{} of size {} with indices:\n{}\nand values:\n{}{}'.format(
                 self.type(), size_str, self._indices(), self._values(), suffix)


### PR DESCRIPTION
## Summary
- simple fix for #4204 and #9412, long term fix will probably allow autograd for `_values` in sparse tensor
- current behavior:
```
>>> a = torch.zeros((3, 3), layout=torch.sparse_coo, requires_grad=True)
>>> print(a)
torch.sparse.FloatTensor of size (3,3) with indices:
tensor([], dtype=torch.int64)
and values:
tensor([])
and requires_grad=True

>>> b = a * 2
>>> print(b)
torch.sparse.FloatTensor of size (3,3) with indices:
tensor([], dtype=torch.int64)
and values:
tensor([])
and grad_fn=<MulBackward>
```