### PR TITLE
[c10d] Port queue reduction to C++

### DIFF
--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -1,8 +1,13 @@
 #pragma once
 
-#include <nccl.h>
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <THC/THC.h>
+
+#include <nccl.h>
+
+#include <cstddef>
+#include <vector>
 
 namespace torch { namespace cuda { namespace nccl {
 
@@ -42,11 +47,30 @@ using comm_list = std::vector<ncclComm_t>;
 using stream_list = std::vector<THCStream*>;
 
 std::uint64_t version();
+
 bool is_available(at::TensorList tensors);
+
 void broadcast(at::TensorList tensors,
                const stream_list& streams = {},
                const comm_list& user_comms = {});
 
 size_t get_max_count();
 
-}}}
+void reduce(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    int32_t root = 0,
+    int32_t op = ncclSum,
+    at::optional<std::vector<at::cuda::CUDAStream>> streams = at::nullopt,
+    at::optional<std::vector<ncclComm_t>> user_comms = at::nullopt);
+
+void reduce(
+    std::vector<at::Tensor>& inputs,
+    int32_t root = 0,
+    int32_t op = ncclSum,
+    at::optional<std::vector<at::cuda::CUDAStream>> streams = at::nullopt,
+    at::optional<std::vector<ncclComm_t>> user_comms = at::nullopt);
+
+} // namespace nccl
+} // namespace cuda
+} // namespace torch

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -63,9 +63,7 @@ std::vector<at::cuda::CUDAStream> py_object_to_cuda_streams(
     py::handle handle(py_streams);
     thc_streams = THPUtils_PySequence_to_THCStreamList(handle.ptr());
   }
-  return fmap(std::move(thc_streams), [](THCStream* stream) {
-    return at::cuda::CUDAStream(stream, /*retain=*/true);
-  });
+  return fmap<at::cuda::CUDAStream>(thc_streams);
 }
 
 }}}

--- a/torch/csrc/cuda/python_comm.h
+++ b/torch/csrc/cuda/python_comm.h
@@ -1,7 +1,17 @@
 #pragma once
 
+#include <torch/csrc/python_headers.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include <vector>
+
 namespace torch { namespace cuda { namespace python {
 
 void initCommMethods(PyObject *module);
+
+std::vector<at::cuda::CUDAStream> py_object_to_cuda_streams(
+    py::object py_streams);
 
 }}}

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -7,8 +7,10 @@
 #include "torch/csrc/cuda/THCP.h"
 #include "torch/csrc/cuda/nccl.h"
 #include "torch/csrc/Exceptions.h"
+#include "torch/csrc/utils/functional.h"
 
 #include <nccl.h>
+
 #include <sstream>
 #include <unordered_map>
 
@@ -129,29 +131,14 @@ PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
 
   std::vector<at::Tensor> inputs = extract_tensors(_inputs);
   std::vector<at::Tensor> outputs = extract_tensors(_outputs);
-  std::vector<THCStream*> streams = unpack_streams(_streams, inputs.size());
+  auto thc_streams = unpack_streams(_streams, inputs.size());
+  auto streams = fmap(thc_streams, [](THCStream* stream) {
+    return at::cuda::CUDAStream(stream, /*retain=*/true);
+  });
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
-
   with_no_gil([&]{
-    _check_inputs(inputs, outputs, 1, 1);
-    size_t len = inputs.size();
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel();
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    at::DeviceGuard device_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      device_guard.set_index(device);
-      auto stream = (streams[i] == nullptr) ? nullptr : THCStream_stream(streams[i]);
-      CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-           count, data_type, (ncclRedOp_t) op, root, comms[i], stream));
-    }
+    torch::cuda::nccl::reduce(inputs, outputs, root, op, streams, user_comms);
   });
 
   Py_RETURN_NONE;

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -132,9 +132,7 @@ PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
   std::vector<at::Tensor> inputs = extract_tensors(_inputs);
   std::vector<at::Tensor> outputs = extract_tensors(_outputs);
   auto thc_streams = unpack_streams(_streams, inputs.size());
-  auto streams = fmap(thc_streams, [](THCStream* stream) {
-    return at::cuda::CUDAStream(stream, /*retain=*/true);
-  });
+  auto streams = fmap<at::cuda::CUDAStream>(thc_streams);
   auto user_comms = unpack_comms(_comms, inputs.size());
 
   with_no_gil([&]{

--- a/torch/csrc/distributed/c10d/ddp.cpp
+++ b/torch/csrc/distributed/c10d/ddp.cpp
@@ -36,8 +36,7 @@ void copyBroadcastTensorsToReplicas(
 void distBroadcastCoalesced(
     ProcessGroup& processGroup,
     std::vector<at::Tensor>& tensors,
-    int64_t bufferSize,
-    ProcessGroup& processGroup) {
+    int64_t bufferSize) {
   auto tensorGroups = torch::utils::take_tensors(tensors, bufferSize);
   // We store single-element vectors in `flatTensors` because
   // `ProcessGroup::broadcast` takes a reference to a vector, which must be

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -1,20 +1,21 @@
 #pragma once
 
+#include <c10d/ProcessGroup.hpp>
+
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/optional.h>
 
 #include <cstddef>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 namespace c10d {
-class ProcessGroup;
-} // namespace c10d
-
-namespace c10d {
 void distBroadcastCoalesced(
+    ProcessGroup& processGroup,
     std::vector<at::Tensor>& tensors,
-    int64_t bufferSize,
-    ProcessGroup& processGroup);
+    int64_t bufferSize);
 
 void syncParams(
     ProcessGroup& processGroup,
@@ -23,4 +24,10 @@ void syncParams(
     const std::vector<int64_t>& devices,
     int64_t broadcastBucketSize,
     bool broadcastBuffers);
+
+std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
+    ProcessGroup& processGroup,
+    std::vector<std::vector<at::Tensor>>& gradsBatch,
+    at::IntList devices,
+    at::optional<std::vector<at::cuda::CUDAStream>> streams = at::nullopt);
 } // namespace c10d

--- a/torch/nn/parallel/distributed_c10d.py
+++ b/torch/nn/parallel/distributed_c10d.py
@@ -251,7 +251,7 @@ class _DistributedDataParallelC10d(Module):
             module.train(mode)
 
     def _dist_broadcast_coalesced(self, tensors, buffer_size):
-        c10d._dist_broadcast_coalesced(tensors, buffer_size, self.process_group)
+        c10d._dist_broadcast_coalesced(self.process_group, tensors, buffer_size)
 
     def _sync_params(self):
         c10d._sync_params(self.process_group,
@@ -319,27 +319,13 @@ class _DistributedDataParallelC10d(Module):
         return distributed_data_parallel_hook
 
     def _queue_reduction(self, bucket_idx):
-        grads_batch = self.buckets[bucket_idx]
-        grads_batch_coalesced = []
-
-        # coalesce the bucket
-        for dev_id, dev_grads_batch in zip(self.device_ids, grads_batch):
-            with torch.cuda.device(dev_id):
-                dev_grads_batch_coalesced = _flatten_dense_tensors(dev_grads_batch)
-                grads_batch_coalesced.append(dev_grads_batch_coalesced)
-
-        # reduce to the first GPU in self.device_ids
-        if len(self.device_ids) > 1:
-            nccl.reduce(grads_batch_coalesced, root=0, streams=self.default_streams)
-
-        # divide by the number of processes here to reduce chances of overflow
-        grads_batch_coalesced[0] /= self.process_group.size()
-
-        # now work on the first gpu
-        reduction_work = self.process_group.allreduce([grads_batch_coalesced[0]],
-                                                      self.allreduce_opts)
-        self.reduction_works[bucket_idx] = reduction_work
-        self.buckets_coalesced[bucket_idx] = grads_batch_coalesced[0]
+        result = c10d._queue_reduction(
+            self.process_group,
+            self.buckets[bucket_idx],
+            self.device_ids,
+            self.default_streams)
+        self.reduction_works[bucket_idx] = result[0]
+        self.buckets_coalesced[bucket_idx] = result[1]
 
     def _sync_reduction_works(self):
         # Now only work on the first GPU of self.device_ids, uncoalesce


### PR DESCRIPTION
This PR moves the `_queue_reduction` code from Python to C++. It is stacked on top of #9729 and #9805.

For this PR I had to do some more work:
1. Move `nccl::reduce` from `python_nccl.cpp` into `nccl.{h,cpp}`
2. Rewrite the `queue_reduction` function.

I also made a helper to convert `py::object` to a vector of `at::cuda::CUDAStream`, because there were now two places where we needed this.

@apaszke @teng-li @pietern 