### PR TITLE
add .gitattributes for EOL conversion.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat	text eol=crlf


### PR DESCRIPTION
`.bat` file's EOL is LF, so a build is failed on some Windows machines.
To fix this, add `.gitattributes` and set batch file's EOL to CRLF.

Discussion is in #9677.
