### PR TITLE
Remove deprecated masked_copy

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -224,6 +224,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: expand_as
    .. automethod:: exponential_
    .. automethod:: fill_
+   .. automethod:: flatten
    .. automethod:: flip
    .. automethod:: float
    .. automethod:: floor

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -258,6 +258,7 @@ Other Operations
 .. autofunction:: diagflat
 .. autofunction:: diagonal
 .. autofunction:: einsum
+.. autofunction:: flatten
 .. autofunction:: flip
 .. autofunction:: histc
 .. autofunction:: meshgrid

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -292,14 +292,6 @@ class Tensor(torch._C._TensorBase):
     def scatter_add(self, dim, index, source):
         return self.clone().scatter_add_(dim, index, source)
 
-    def masked_copy(self, mask, tensor):
-        warnings.warn("masked_copy is deprecated and renamed to masked_scatter, and will be removed in v0.3")
-        return self.masked_scatter(mask, tensor)
-
-    def masked_copy_(self, mask, tensor):
-        warnings.warn("masked_copy_ is deprecated and renamed to masked_scatter_, and will be removed in v0.3")
-        return self.masked_scatter_(mask, tensor)
-
     def masked_scatter(self, mask, tensor):
         return self.clone().masked_scatter_(mask, tensor)
 


### PR DESCRIPTION
No tests are affected by this removal.

Closes https://github.com/pytorch/pytorch/issues/1885 and closes #9817 

While I was at it, I also fixed #9876 .

