### PR TITLE
Add --allow-change-held-packages to make nccl2 install in docker work

### DIFF
--- a/docker/caffe2/jenkins/common/install_nccl.sh
+++ b/docker/caffe2/jenkins/common/install_nccl.sh
@@ -34,5 +34,5 @@ if [ -n "$NCCL_UBUNTU_VER" ]; then
   NCCL_LIB_VERSION="2.1.15-1+cuda${CUDA_VERSION:0:3}"
 
   apt update
-  apt install -y --allow-downgrades libnccl2=$NCCL_LIB_VERSION libnccl-dev=$NCCL_LIB_VERSION
+  apt install -y --allow-downgrades --allow-change-held-packages libnccl2=$NCCL_LIB_VERSION libnccl-dev=$NCCL_LIB_VERSION
 fi


### PR DESCRIPTION
This was used to build Caffe2 Docker version 170.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

