### PR TITLE
avoid printing c++ source code to a file at cmake time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
   endif()
   if ((APPLE AND (NOT ("${CLANG_VERSION_STRING}" VERSION_LESS "9.0")))
-    OR (CMAKE_COMPILER_IS_GNUCXX 
+    OR (CMAKE_COMPILER_IS_GNUCXX
     AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 AND NOT APPLE)))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
   endif()
@@ -379,6 +379,7 @@ if (BUILD_SHARED_LIBS)
       COMPONENT dev)
   install(FILES
       ${PROJECT_SOURCE_DIR}/cmake/public/cuda.cmake
+      ${PROJECT_SOURCE_DIR}/cmake/public/detect_cuda_version.cc
       ${PROJECT_SOURCE_DIR}/cmake/public/glog.cmake
       ${PROJECT_SOURCE_DIR}/cmake/public/gflags.cmake
       ${PROJECT_SOURCE_DIR}/cmake/public/protobuf.cmake

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/detect_cuda_compute_capabilities.cpp
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/detect_cuda_compute_capabilities.cpp
@@ -1,0 +1,15 @@
+#include <cuda_runtime.h>
+#include <cstdio>
+int main()
+{
+  int count = 0;
+  if (cudaSuccess != cudaGetDeviceCount(&count)) return -1;
+  if (count == 0) return -1;
+  for (int device = 0; device < count; ++device)
+  {
+    cudaDeviceProp prop;
+    if (cudaSuccess == cudaGetDeviceProperties(&prop, device))
+      std::printf("%d.%d ", prop.major, prop.minor);
+  }
+  return 0;
+}

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/detect_cuda_compute_capabilities.cu
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/detect_cuda_compute_capabilities.cu
@@ -1,0 +1,15 @@
+#include <cuda_runtime.h>
+#include <cstdio>
+int main()
+{
+  int count = 0;
+  if (cudaSuccess != cudaGetDeviceCount(&count)) return -1;
+  if (count == 0) return -1;
+  for (int device = 0; device < count; ++device)
+  {
+    cudaDeviceProp prop;
+    if (cudaSuccess == cudaGetDeviceProperties(&prop, device))
+      std::printf("%d.%d ", prop.major, prop.minor);
+  }
+  return 0;
+}

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -48,6 +48,8 @@ else()
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "6.1+PTX")
 endif()
 
+set(SELECT_COMPUTE_ARCH_CMAKE_FILE ${CMAKE_CURRENT_LIST_DIR})
+
 ################################################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is enabled)
 # Usage:
@@ -56,27 +58,10 @@ endif()
 function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
   if(NOT CUDA_GPU_DETECT_OUTPUT)
     if(CMAKE_CUDA_COMPILER_LOADED) # CUDA as a language
-      set(file "${PROJECT_BINARY_DIR}/detect_cuda_compute_capabilities.cu")
+      set(file "${SELECT_COMPUTE_ARCH_CMAKE_FILE}/detect_cuda_compute_capabilities.cu")
     else()
-      set(file "${PROJECT_BINARY_DIR}/detect_cuda_compute_capabilities.cpp")
+      set(file "${SELECT_COMPUTE_ARCH_CMAKE_FILE}/detect_cuda_compute_capabilities.cpp")
     endif()
-
-    file(WRITE ${file} ""
-      "#include <cuda_runtime.h>\n"
-      "#include <cstdio>\n"
-      "int main()\n"
-      "{\n"
-      "  int count = 0;\n"
-      "  if (cudaSuccess != cudaGetDeviceCount(&count)) return -1;\n"
-      "  if (count == 0) return -1;\n"
-      "  for (int device = 0; device < count; ++device)\n"
-      "  {\n"
-      "    cudaDeviceProp prop;\n"
-      "    if (cudaSuccess == cudaGetDeviceProperties(&prop, device))\n"
-      "      std::printf(\"%d.%d \", prop.major, prop.minor);\n"
-      "  }\n"
-      "  return 0;\n"
-      "}\n")
 
     if(CMAKE_CUDA_COMPILER_LOADED) # CUDA as a language
       try_run(run_result compile_result ${PROJECT_BINARY_DIR} ${file}

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -18,20 +18,14 @@ message(STATUS "Caffe2: CUDA detected: " ${CUDA_VERSION})
 message(STATUS "Caffe2: CUDA nvcc is: " ${CUDA_NVCC_EXECUTABLE})
 message(STATUS "Caffe2: CUDA toolkit directory: " ${CUDA_TOOLKIT_ROOT_DIR})
 
+set(CUDA_CMAKE_FILE ${CMAKE_CURRENT_LIST_DIR})
+
 if(CUDA_FOUND)
   # Sometimes, we may mismatch nvcc with the CUDA headers we are
   # compiling with, e.g., if a ccache nvcc is fed to us by CUDA_NVCC_EXECUTABLE
   # but the PATH is not consistent with CUDA_HOME.  It's better safe
   # than sorry: make sure everything is consistent.
-  set(file "${PROJECT_BINARY_DIR}/detect_cuda_version.cc")
-  file(WRITE ${file} ""
-    "#include <cuda.h>\n"
-    "#include <cstdio>\n"
-    "int main() {\n"
-    "  printf(\"%d.%d\", CUDA_VERSION / 1000, (CUDA_VERSION / 10) % 100);\n"
-    "  return 0;\n"
-    "}\n"
-    )
+  set(file "${CUDA_CMAKE_FILE}/detect_cuda_version.cc")
   try_run(run_result compile_result ${PROJECT_BINARY_DIR} ${file}
     CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CUDA_INCLUDE_DIRS}"
     LINK_LIBRARIES ${CUDA_LIBRARIES}

--- a/cmake/public/detect_cuda_version.cc
+++ b/cmake/public/detect_cuda_version.cc
@@ -1,0 +1,6 @@
+#include <cuda.h>
+#include <cstdio>
+int main() {
+  printf("%d.%d", CUDA_VERSION / 1000, (CUDA_VERSION / 10) % 100);
+  return 0;
+}


### PR DESCRIPTION
this was (1) needlessly complex, and (2) causing spurious
rebuilds. The first time running ninja after running cmake,
build.ninja was detected as having an updated dependency on the
generated cpp file, causing a re-cmake. Since setup.py always runs
`cmake; ninja`, this was causing cmake to be invoked twice on every
build.

Manually tested with `ninja -d explain` that this no longer occurs

