### PR TITLE
Create IDEEP fallback operators for ctc decoder ops

### DIFF
--- a/caffe2/ideep/operators/operator_fallback_ideep.cc
+++ b/caffe2/ideep/operators/operator_fallback_ideep.cc
@@ -7,6 +7,8 @@
 #include <caffe2/operators/collect_and_distribute_fpn_rpn_proposals_op.h>
 #include <caffe2/operators/conv_transpose_op.h>
 #include <caffe2/operators/cross_entropy_op.h>
+#include <caffe2/operators/ctc_beam_search_decoder_op.h>
+#include <caffe2/operators/ctc_greedy_decoder_op.h>
 #include <caffe2/operators/dropout_op.h>
 #include <caffe2/operators/elementwise_ops.h>
 #include <caffe2/operators/filler_op.h>
@@ -111,5 +113,13 @@ REGISTER_IDEEP_OPERATOR(
 REGISTER_IDEEP_OPERATOR(
     PRelu,
     IDEEPFallbackOp<PReluOp<float, CPUContext>>);
+
+// ctc decoder operators
+REGISTER_IDEEP_OPERATOR(
+    CTCGreedyDecoder,
+    IDEEPFallbackOp<CTCGreedyDecoderOp<CPUContext>>);
+REGISTER_IDEEP_OPERATOR(
+    CTCBeamSearchDecoder,
+    IDEEPFallbackOp<CTCBeamSearchDecoderOp<CPUContext>>);
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
CTCBeamSearchDecoder and CTCGreedyDecoder do not currently support IDEEP
execution. Add fallback operators to allow IDEEP execution of models that use
these operators.

Differential Revision: D9006234
