### PR TITLE
Support production models with predictor benchmark

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -533,10 +533,11 @@ class Operator : public OperatorBase {
     return fillers;
   }
 
-#define DISABLE_INPUT_FILLERS(Context)                                  \
-  std::vector<TensorFiller<Context>> InputFillers(                      \
-      const std::vector<std::vector<TIndex>>& /* unused */) override {  \
-    throw UnsupportedOperatorFeature("Op does not have input fillers"); \
+#define DISABLE_INPUT_FILLERS(Context)                                 \
+  std::vector<TensorFiller<Context>> InputFillers(                     \
+      const std::vector<std::vector<TIndex>>& /* unused */) override { \
+    throw UnsupportedOperatorFeature(                                  \
+        OperatorBase::type() + " does not have input fillers");        \
   }
 
   void SparseLengthsFillerHelper(
@@ -554,7 +555,8 @@ class Operator : public OperatorBase {
       size_t segment_index,
       std::vector<TensorFiller<Context>>* fillers) {
     CAFFE_ENFORCE_EQ(shapes[segment_index].size(), 1);
-    // TODO: what would be a proper #segments
+    // TODO (mnaumov): distribution of value
+    (*fillers)[value_index].Min(0).Max(shapes[value_index].front() * 2);
     (*fillers)[segment_index].SparseSegments(shapes[value_index].front() - 1);
   }
 

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -68,7 +68,21 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     return true;
   }
 
-  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(Context, DATA, INDICES, LENGTHS)
+  std::vector<TensorFiller<Context>> InputFillers(
+      const std::vector<std::vector<TIndex>>& shapes) override {
+    CAFFE_ENFORCE_EQ(shapes.size(), Operator<Context>::Inputs().size());
+    auto fillers = Operator<Context>::InputFillers(shapes);
+    if (with_weights) {
+      // TODO: enable the fillers
+      throw UnsupportedOperatorFeature(
+          OperatorBase::type() + " does not have input fillers");
+    }
+    Operator<Context>::SparseLengthsFillerHelper(
+        shapes, INDICES, LENGTHS, &fillers);
+    Operator<Context>::SparseSegmentsFillerHelper(
+        shapes, DATA, INDICES, &fillers);
+    return fillers;
+  }
 
  private:
   enum {

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -92,7 +92,21 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
     return true;
   }
 
-  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(CPUContext, DATA, INDICES, LENGTHS)
+  std::vector<TensorFiller<CPUContext>> InputFillers(
+      const std::vector<std::vector<TIndex>>& shapes) override {
+    CAFFE_ENFORCE_EQ(shapes.size(), Operator<CPUContext>::Inputs().size());
+    auto fillers = Operator<CPUContext>::InputFillers(shapes);
+    if (USE_WEIGHT) {
+      // TODO: enable the fillers
+      throw UnsupportedOperatorFeature(
+          OperatorBase::type() + " does not have input fillers");
+    }
+    Operator<CPUContext>::SparseLengthsFillerHelper(
+        shapes, INDICES, LENGTHS, &fillers);
+    Operator<CPUContext>::SparseSegmentsFillerHelper(
+        shapes, DATA, INDICES, &fillers);
+    return fillers;
+  }
 
  private:
   enum {

--- a/caffe2/operators/one_hot_ops.cc
+++ b/caffe2/operators/one_hot_ops.cc
@@ -172,6 +172,9 @@ class SegmentOneHotOp : public Operator<CPUContext> {
   SegmentOneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator(operator_def, ws) {}
 
+  // TODO: enable input filler
+  DISABLE_INPUT_FILLERS(CPUContext)
+
   bool RunOnDevice() override {
     auto& lengths = Input(0);
     auto& indices = Input(1);

--- a/caffe2/operators/one_hot_ops.h
+++ b/caffe2/operators/one_hot_ops.h
@@ -13,6 +13,9 @@ class OneHotOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
+  // TODO: enable input filler
+  DISABLE_INPUT_FILLERS(Context)
+
   OneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {}
 
@@ -58,6 +61,8 @@ class BatchOneHotOp final : public Operator<Context> {
   BatchOneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {}
 
+  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(Context, X, VALS, LENS)
+
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(X));
   }
@@ -82,6 +87,9 @@ class BatchBucketOneHotOp final : public Operator<Context> {
       : Operator<Context>(operator_def, ws) {}
 
   bool RunOnDevice() override;
+
+  // TODO: enable input filler
+  DISABLE_INPUT_FILLERS(Context)
 
  protected:
   INPUT_TAGS(X, LENS, BOUNDARIES);

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -212,6 +212,9 @@ class SliceOp : public Operator<Context> {
     return RunOnDeviceImpl(Input(0), Output(0));
   }
 
+  // This cannot be enabled given the output dims depends on the input
+  DISABLE_INPUT_FILLERS(Context)
+
  protected:
   bool RunOnDeviceImpl(const Tensor<Context>& data, Tensor<Context>* output) {
     if (InputSize() > 1) {


### PR DESCRIPTION
Summary:
Support production models with predictor benchmark
Two new flags are added:
`--update_prod`: pull production data (netdef, input types, input dims) from Hive and store locally
`--use_prod`: run benchmark with local production data with the same workload as in production.
By default, 300 models will be loaded.

production vs benchmark
avg net run time:
(collected by prod: https://fburl.com/scuba/6lb91zfx and bench: https://fburl.com/ngjj1dc8)
**prod: `408us` vs bench: `543us`**
(With prod data distribution, this should be even closer)

framework overhead (as of 2018-07-22):
prod:
```
9.111%    BlackBoxPredictor::Run
4.602%    SimpleNet::Run
2.377%    Operator::Run
1.786%    BlackBoxPredictor::AllocateMemory
1.372%    Observable::StartAllObservers
1.358%    Observable::StartObserver
1.206%    Blob::GetMutable
```

bench:
```
8.577%    BlackBoxPredictor::operator()
3.276%    SimpleNet::Run
1.954%    Operator::Run
1.697%    BlackBoxPredictor::AllocateMemory
1.477%    Tensor::ShareData
1.230%    Blob::GetMutable
1.034%    Observable::StartObserver
```

Differential Revision: D8942996
