### PR TITLE
Increase BC for PackedSequence ctor

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -31,9 +31,10 @@ class PackedSequence(PackedSequence_):
 
     """
     def __new__(cls, data, batch_sizes=None):
-        # Using an `*args` and an if statement on `len(args)` breaks BC of the
-        # calling pattern `PackedSequence(data=..., batch_sizes=...)`, so we
-        # have to provide two arguments with names `data` and `batch_sizes`.
+        # PackedSequence used to only have __init__(self, data, batch_sizes)
+        # without a __new__ like this. So to preserve BC for calling in keyword
+        # arg style (e.g., `PackedSequence(data=..., batch_sizes=...)`), we have
+        # to provide two arguments with exact names `data` and `batch_sizes`.
         #
         # support being called as `PackedSequence(data, batch_sizes)`
         if batch_sizes is not None:

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -30,14 +30,18 @@ class PackedSequence(PackedSequence_):
             information about the batch size at each sequence step
 
     """
-    def __new__(cls, *args):
+    def __new__(cls, data, batch_sizes=None):
+        # Using an `*args` and an if statement on `len(args)` breaks BC of the
+        # calling pattern `PackedSequence(data=..., batch_sizes=...)`, so we
+        # have to provide two arguments with names `data` and `batch_sizes`.
+        #
         # support being called as `PackedSequence(data, batch_sizes)`
-        if len(args) == 2:
-            return super(PackedSequence, cls).__new__(cls, *args)
+        if batch_sizes is not None:
+            return super(PackedSequence, cls).__new__(cls, data, batch_sizes)
         # support being called as `PackedSequence((data, batch_sizes))`
         else:
-            assert len(args) == 1
-            return super(PackedSequence, cls).__new__(cls, *args[0])
+            assert isinstance(data, (list, tuple)) and len(data) == 2
+            return super(PackedSequence, cls).__new__(cls, *data)
 
     def cuda(self, *args, **kwargs):
         """Returns a GPU copy if `self.data` not already on the GPU"""


### PR DESCRIPTION
PackedSequence is never supposed to be created by user, but unfortunately some community repo is already doing this (e.g., [here](https://github.com/huggingface/torchMoji/blob/7c191048ce906fc0404fe156827d97cb990ebecb/torchmoji/model_def.py#L218-L229)). Some change we made break the calling pattern `PackedSequence(data=x, batch_sizes=y)`. This patch adds back support for that.