### PR TITLE
Sleep before run

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -236,7 +236,7 @@ void runNetwork(
     caffe2::wipe_cache();
   }
   if (sleep_before_run > 0) {
-    time.sleep(sleep_before_run);
+    sleep(sleep_before_run);
   }
   LOG(INFO) << "Main runs.";
   CAFFE_ENFORCE(

--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -215,7 +215,8 @@ void runNetwork(
     const bool wipe_cache,
     const bool run_individual,
     const int warmup,
-    const int iter) {
+    const int iter,
+    const int sleep_before_run) {
   if (!net_def.has_name()) {
     net_def.set_name("benchmark");
   }
@@ -233,6 +234,9 @@ void runNetwork(
 
   if (wipe_cache) {
     caffe2::wipe_cache();
+  }
+  if (sleep_before_run > 0) {
+    time.sleep(sleep_before_run);
   }
   LOG(INFO) << "Main runs.";
   CAFFE_ENFORCE(

--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -96,4 +96,5 @@ void runNetwork(
     const bool,
     const bool,
     const int,
+    const int,
     const int);

--- a/binaries/caffe2_benchmark.cc
+++ b/binaries/caffe2_benchmark.cc
@@ -65,7 +65,7 @@ CAFFE2_DEFINE_bool(
 CAFFE2_DEFINE_int(
     sleep_before_run,
     0,
-    "The seconds to sleep before starting the benchmarking.")
+    "The seconds to sleep before starting the benchmarking.");
 CAFFE2_DEFINE_bool(
     text_output,
     false,

--- a/binaries/caffe2_benchmark.cc
+++ b/binaries/caffe2_benchmark.cc
@@ -62,6 +62,10 @@ CAFFE2_DEFINE_bool(
     run_individual,
     false,
     "Whether to benchmark individual operators.");
+CAFFE2_DEFINE_int(
+    sleep_before_run,
+    0,
+    "The seconds to sleep before starting the benchmarking.")
 CAFFE2_DEFINE_bool(
     text_output,
     false,
@@ -115,7 +119,8 @@ int main(int argc, char** argv) {
       caffe2::FLAGS_wipe_cache,
       caffe2::FLAGS_run_individual,
       caffe2::FLAGS_warmup,
-      caffe2::FLAGS_iter);
+      caffe2::FLAGS_iter,
+      caffe2::FLAGS_sleep_before_run);
 
   writeOutput(
       workspace,


### PR DESCRIPTION
Add an argument to benchmark binary to specify the seconds to sleep before the run and after the warmup.