### PR TITLE
Add html-stable target to docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,6 +23,13 @@ docset: html
 	cp $(SPHINXPROJ).docset/icon.png $(SPHINXPROJ).docset/icon@2x.png
 	convert $(SPHINXPROJ).docset/icon@2x.png -resize 16x16 $(SPHINXPROJ).docset/icon.png
 
+html-stable:
+	# stable differs from `make html` in two ways:
+	# 1) The stable logo is used instead of the unstable logo
+	# 2) There will not be a link to the stable docs.
+	# See conf.py for more details.
+	RELEASE=1 make html
+
 .PHONY: help Makefile docset
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import torch
@@ -27,6 +27,8 @@ except ImportError:
     import warnings
     warnings.warn('unable to load "torchvision" package')
 import sphinx_rtd_theme
+
+RELEASE = os.environ.get('RELEASE', False)
 
 
 # -- General configuration ------------------------------------------------
@@ -54,6 +56,8 @@ napoleon_use_ivar = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+if RELEASE:
+    templates_path = ['_templates-stable']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -122,6 +126,9 @@ html_theme_options = {
 }
 
 html_logo = '_static/img/pytorch-logo-dark-unstable.png'
+if RELEASE:
+    html_logo = '_static/img/pytorch-logo-dark.svg'
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This lets one build docs for the release easier. All of the unstable
warnings are removed in `make html-stable`.

cc @soumith @SsnL 

Sample build:
![image](https://user-images.githubusercontent.com/5652049/43277115-05e2f720-90d5-11e8-9977-b0b4a6ee4b8e.png)

