### PR TITLE
convert lambd directly to scalar_t at hardshrink

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -36,13 +36,14 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {
+    auto lambd_val = lambd.to<scalar_t>();
     at::CPU_tensor_apply2<scalar_t, scalar_t>(
       self,
       out_tensor,
       [&](
         scalar_t& self_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -lambd.to<scalar_t>() && self_val <= lambd.to<scalar_t>()) ? convert<scalar_t, int>(0) : self_val;
+          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? convert<scalar_t, int>(0) : self_val;
     });
   });
   return out_tensor;
@@ -51,6 +52,7 @@ Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
 Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_backward_cpu", [&] {
+    auto lambd_val = lambd.to<scalar_t>();
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
       self,
       grad,
@@ -59,7 +61,7 @@ Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar 
         scalar_t& self_val,
         scalar_t& grad_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -lambd.to<scalar_t>() && self_val <= lambd.to<scalar_t>()) ? convert<scalar_t, int>(0) : grad_val;
+          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? convert<scalar_t, int>(0) : grad_val;
     });
   });
   return out_tensor;

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -43,7 +43,7 @@ Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
       [&](
         scalar_t& self_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? convert<scalar_t, int>(0) : self_val;
+          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0) : self_val;
     });
   });
   return out_tensor;
@@ -61,7 +61,7 @@ Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar 
         scalar_t& self_val,
         scalar_t& grad_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? convert<scalar_t, int>(0) : grad_val;
+          out_tensor_val = (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0) : grad_val;
     });
   });
   return out_tensor;

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -34,36 +34,32 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
 }
 
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {
-    scalar_t* lambd_tensor_d = lambd_tensor.data<scalar_t>();
     at::CPU_tensor_apply2<scalar_t, scalar_t>(
       self,
       out_tensor,
-      [lambd_tensor_d](
+      [&](
         scalar_t& self_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, int>(0) : self_val;
+          out_tensor_val = (self_val >= -lambd.to<scalar_t>() && self_val <= lambd.to<scalar_t>()) ? convert<scalar_t, int>(0) : self_val;
     });
   });
   return out_tensor;
 }
 
 Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_backward_cpu", [&] {
-    scalar_t* lambd_tensor_d = lambd_tensor.data<scalar_t>();
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
       self,
       grad,
       out_tensor,
-      [lambd_tensor_d](
+      [&](
         scalar_t& self_val,
         scalar_t& grad_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, int>(0) : grad_val;
+          out_tensor_val = (self_val >= -lambd.to<scalar_t>() && self_val <= lambd.to<scalar_t>()) ? convert<scalar_t, int>(0) : grad_val;
     });
   });
   return out_tensor;

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -6,45 +6,43 @@
 namespace at { namespace native {
 
 template <typename scalar_t>
-void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, scalar_t* lambd) {
+void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, scalar_t lambd) {
   at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t>(
     self,
     out_tensor,
-    [lambd] __device__ (
+    [=] __device__ (
       scalar_t& self_val,
       scalar_t& out_tensor_val) {
-        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? scalar_t(0) : self_val;
+        out_tensor_val = (self_val >= -lambd && self_val <= lambd) ? scalar_t(0) : self_val;
   });
 }
 
 template <typename scalar_t>
-void hardshrink_backward_cuda_kernel(Tensor& out_tensor, scalar_t* lambd, const Tensor& self, const Tensor& grad) {
+void hardshrink_backward_cuda_kernel(const Tensor& self, Tensor& out_tensor, scalar_t lambd, const Tensor& grad) {
   at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
     self,
     grad,
     out_tensor,
-    [lambd] __device__ (
+    [=] __device__ (
       scalar_t& self_val,
       scalar_t& grad_val,
       scalar_t& out_tensor_val) {
-        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? scalar_t(0) : grad_val;
+        out_tensor_val = (self_val >= -lambd && self_val <= lambd) ? scalar_t(0) : grad_val;
   });
 }
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
-    hardshrink_cuda_kernel<scalar_t>(self, out_tensor, lambd_tensor.data<scalar_t>());
+    hardshrink_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>());
   });
   return out_tensor;
 }
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(grad);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
-    hardshrink_backward_cuda_kernel<scalar_t>(out_tensor, lambd_tensor.data<scalar_t>(), self, grad);
+    hardshrink_backward_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>(), grad);
   });
   return out_tensor;
 }


### PR DESCRIPTION
- convert lambd directly to scalar_t instead of creating a tensor