### PR TITLE
Fix dimension check in 1D instance norm, allowing 2D tensors alongside 3D.

### DIFF
--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -109,8 +109,8 @@ class InstanceNorm1d(_InstanceNorm):
     """
 
     def _check_input_dim(self, input):
-        if input.dim() != 3:
-            raise ValueError('expected 3D input (got {}D input)'
+        if input.dim() != 2 and input.dim() != 3:
+            raise ValueError('expected 2D or 3D input (got {}D input)'
                              .format(input.dim()))
 
 


### PR DESCRIPTION
Fixes #9776.