### PR TITLE
Travis CI: Run flake on Python 2.7 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
         python: "2.7"
         install: pip install flake8
         script: flake8
+      - env: LINT_CHECK
+        python: "3.7"
+        dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+        sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+        install: pip install flake8
+        script: flake8
       - env: MYPY_TYPE_CHECK
         python: "3.6"
         install: pip install mypy mypy-extensions


### PR DESCRIPTION
Flake8 will produce different results on Python 2 and 3.  Python 3.7 has __async__ as a reserved word https://github.com/pytorch/pytorch/pull/4999.

