### PR TITLE
Fix bug that always uses the same blob when repeating poolings

### DIFF
--- a/caffe2/python/layers/sparse_lookup.py
+++ b/caffe2/python/layers/sparse_lookup.py
@@ -257,7 +257,7 @@ class SparseLookup(ModelLayer):
 
             segment_ids = net.LengthsToSegmentIds(
                 self.input_record.lengths(),
-                self.input_record.lengths() + '_sid')
+                net.NextScopedBlob(self.input_record.lengths() + '_sid'))
             net.__getattr__('SortedSegmentRange' + self.reducer)(
                 [table_rows, segment_ids],
                 self.output_schema.field_blobs(),


### PR DESCRIPTION
Summary:
When repeating pooling multiple times, i.e., num_repeat > 1, the output blob of SortedSegmentRangeXX is always the same no matter using different NameScopre. It leads the error in f63836286.

BTW, the latest codebase has some issues when running buck test. Thus, I used the old version and will rebase to the lastest one once the issues are resolved.

Differential Revision: D9027902
