### PR TITLE
Redirect size/strides calls in TH to a "safe" version that returns an…

### DIFF
--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -177,6 +177,19 @@ inline int THTensor_nDimensionLegacyAll(const THTensor* tensor) {
   }
 }
 
+inline int64_t THTensor_strideLegacyNoScalars(const THTensor *self, int dim) {
+  THArgCheck((dim >= 0) && (dim < THTensor_nDimensionLegacyNoScalars(self)), 2, "dimension %d out of range of %dD tensor",
+      dim+TH_INDEX_BASE, THTensor_nDimensionLegacyNoScalars(self));
+  return self->stride(dim);
+}
+
+inline int64_t THTensor_sizeLegacyNoScalars(const THTensor *self, int dim)
+{
+  THArgCheck((dim >= 0) && (dim < self->dim()), 2, "dimension %d out of range of %dD tensor",
+      dim+TH_INDEX_BASE, THTensor_nDimensionLegacyNoScalars(self));
+  return self->size(dim);
+}
+
 TH_API void THTensor_free(THTensor *self);
 TH_CPP_API at::optional<std::vector<int64_t>> THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride,
                                                                       at::IntList newshape);

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -37,7 +37,7 @@
   int TENSOR##_contiguous = ALLOW_CONTIGUOUS && DIM < 0; \
   TENSOR##_n = 1; \
   for(TENSOR##_i = 0; TENSOR##_i < TENSOR->dim(); TENSOR##_i++) \
-    TENSOR##_n *= TENSOR->size(TENSOR##_i); \
+    TENSOR##_n *= THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i); \
 \
   if(TENSOR->is_empty()) \
     TH_TENSOR_APPLY_hasFinished = 1; \
@@ -47,9 +47,9 @@
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
     for(TENSOR##_i = THTensor_nDimensionLegacyAll(TENSOR)-1; TENSOR##_i >= 0; TENSOR##_i--) { \
-      if(TENSOR->size(TENSOR##_i) != 1) { \
-        if(TENSOR->stride(TENSOR##_i) == TENSOR##_size && TENSOR##_i != DIM) \
-          TENSOR##_size *= TENSOR->size(TENSOR##_i); \
+      if(THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i) != 1) { \
+        if(THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i) == TENSOR##_size && TENSOR##_i != DIM) \
+          TENSOR##_size *= THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i); \
         else{ \
           TENSOR##_contiguous = 0; \
           break; \
@@ -61,7 +61,7 @@
       TENSOR##_dim = 1; \
       for(TENSOR##_i = THTensor_nDimensionLegacyAll(TENSOR)-2; TENSOR##_i >= 0; TENSOR##_i--) \
       { \
-        if(TENSOR->stride(TENSOR##_i) != TENSOR->stride(TENSOR##_i+1) * TENSOR->size(TENSOR##_i+1) || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
+        if(THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i) != THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i+1) * THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i+1) || TENSOR##_i == DIM || TENSOR##_i+1 == DIM) \
           TENSOR##_dim++; \
       } \
       /* Allocate an array of 3*dim elements, where dim is the number of contiguous sections */ \
@@ -70,8 +70,8 @@
       TENSOR##_strides = TENSOR##_counter + 2*TENSOR##_dim; \
       TH_TENSOR_dim_index = TENSOR##_dim-1; \
       TENSOR##_dimOffset = (DIM == THTensor_nDimensionLegacyAll(TENSOR)-1) ? &TENSOR##_i : &TENSOR##_counter[DIM]; \
-      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(THTensor_nDimensionLegacyAll(TENSOR)-1); \
-      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride(THTensor_nDimensionLegacyAll(TENSOR)-1); \
+      TENSOR##_sizes[TH_TENSOR_dim_index] = THTensor_sizeLegacyNoScalars(TENSOR, THTensor_nDimensionLegacyAll(TENSOR)-1); \
+      TENSOR##_strides[TH_TENSOR_dim_index] = THTensor_strideLegacyNoScalars(TENSOR, THTensor_nDimensionLegacyAll(TENSOR)-1); \
       /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
       /* storage is given by storage_offset + (i * j), where i is the stride */ \
       /* vector and j is tensor_counter vector. This sets the starting position for the loop. */ \
@@ -79,14 +79,14 @@
         TENSOR##_counter[TENSOR##_i] = 0; \
       } \
       for(TENSOR##_i = THTensor_nDimensionLegacyAll(TENSOR)-2; TENSOR##_i >= 0; --TENSOR##_i) { \
-        if (TENSOR->stride(TENSOR##_i) == TENSOR->stride(TENSOR##_i+1) * TENSOR->size(TENSOR##_i+1) && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
-          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i) * TENSOR##_sizes[TH_TENSOR_dim_index]; \
+        if (THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i) == THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i+1) * THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i+1) && TENSOR##_i != DIM && TENSOR##_i+1 != DIM) { \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i) * TENSOR##_sizes[TH_TENSOR_dim_index]; \
           if (DIM != THTensor_nDimensionLegacyAll(TENSOR)-1 && TENSOR##_i < DIM) \
             TENSOR##_dimOffset--; \
         } else { \
           --TH_TENSOR_dim_index; \
-          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size(TENSOR##_i); \
-          TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride(TENSOR##_i); \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = THTensor_sizeLegacyNoScalars(TENSOR, TENSOR##_i); \
+          TENSOR##_strides[TH_TENSOR_dim_index] = THTensor_strideLegacyNoScalars(TENSOR, TENSOR##_i); \
         } \
       } \
       /* Size of the inner most section */ \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -13,11 +13,11 @@
   { \
     if (TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
-    if (TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
+    if (THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i) != THTensor_sizeLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \
-    if(TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR3->size(TH_TENSOR_DIM_APPLY_i)) { \
+    if(THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i) != THTensor_sizeLegacyNoScalars(TENSOR3, TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \
@@ -61,16 +61,16 @@
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+(TENSOR1)->storage_offset(); \
-  TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
-  TENSOR1##_size = TENSOR1->size(DIMENSION); \
+  TENSOR1##_stride = THTensor_strideLegacyNoScalars(TENSOR1, DIMENSION); \
+  TENSOR1##_size = THTensor_sizeLegacyNoScalars(TENSOR1, DIMENSION); \
 \
   TENSOR2##_data = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+(TENSOR2)->storage_offset(); \
-  TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
-  TENSOR2##_size = TENSOR2->size(DIMENSION); \
+  TENSOR2##_stride = THTensor_strideLegacyNoScalars(TENSOR2, DIMENSION); \
+  TENSOR2##_size = THTensor_sizeLegacyNoScalars(TENSOR2, DIMENSION); \
 \
   TENSOR3##_data = THTensor_getStoragePtr(TENSOR3)->data<TYPE3>()+(TENSOR3)->storage_offset(); \
-  TENSOR3##_stride = (TENSOR3)->stride(DIMENSION); \
-  TENSOR3##_size = TENSOR3->size(DIMENSION); \
+  TENSOR3##_stride = THTensor_strideLegacyNoScalars(TENSOR3, DIMENSION); \
+  TENSOR3##_size = THTensor_sizeLegacyNoScalars(TENSOR3, DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
   { \
@@ -92,11 +92,11 @@
       } \
 \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR1##_data += TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
-      TENSOR2##_data += TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
-      TENSOR3##_data += TENSOR3->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR1##_data += THTensor_strideLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i); \
+      TENSOR2##_data += THTensor_strideLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i); \
+      TENSOR3##_data += THTensor_strideLegacyNoScalars(TENSOR3, TH_TENSOR_DIM_APPLY_i); \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i)) \
       { \
         if(TH_TENSOR_DIM_APPLY_i == TENSOR1->dim()-1) \
         { \
@@ -105,9 +105,9 @@
         } \
         else \
         { \
-          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
-          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
-          TENSOR3##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR3->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i); \
+          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i); \
+          TENSOR3##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR3, TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \
@@ -155,7 +155,7 @@
   { \
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \
       continue; \
-    if(TENSOR1->size(TH_TENSOR_DIM_APPLY_i) != TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
+    if(THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i) != THTensor_sizeLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i)) { \
       AT_ERROR("Expected ", #TENSOR1, " ", TENSOR1->sizes(), " and ", #TENSOR2, " ", TENSOR2->sizes(), " to have the same size in dimension ", DIMENSION); \
     }                                                                   \
   } \
@@ -168,12 +168,12 @@
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
   TENSOR1##_data = THTensor_getStoragePtr(TENSOR1)->data<TYPE1>()+(TENSOR1)->storage_offset(); \
-  TENSOR1##_stride = (TENSOR1)->stride(DIMENSION); \
-  TENSOR1##_size = TENSOR1->size(DIMENSION); \
+  TENSOR1##_stride = THTensor_strideLegacyNoScalars(TENSOR1, DIMENSION); \
+  TENSOR1##_size = THTensor_sizeLegacyNoScalars(TENSOR1, DIMENSION); \
 \
   TENSOR2##_data = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+(TENSOR2)->storage_offset(); \
-  TENSOR2##_stride = (TENSOR2)->stride(DIMENSION); \
-  TENSOR2##_size = TENSOR2->size(DIMENSION); \
+  TENSOR2##_stride = THTensor_strideLegacyNoScalars(TENSOR2, DIMENSION); \
+  TENSOR2##_size = THTensor_sizeLegacyNoScalars(TENSOR2, DIMENSION); \
 \
   while(!TH_TENSOR_DIM_APPLY_hasFinished) \
   { \
@@ -195,10 +195,10 @@
       } \
 \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR1##_data += TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
-      TENSOR2##_data += TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR1##_data += THTensor_strideLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i); \
+      TENSOR2##_data += THTensor_strideLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i); \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i)) \
       { \
         if(TH_TENSOR_DIM_APPLY_i == TENSOR1->dim()-1) \
         { \
@@ -207,8 +207,8 @@
         } \
         else \
         { \
-          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR1->stride(TH_TENSOR_DIM_APPLY_i); \
-          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR2->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR1##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i); \
+          TENSOR2##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \
@@ -270,8 +270,8 @@
     THError("invalid dimension"); \
 \
   TENSOR##_data = THTensor_getStoragePtr(TENSOR)->data<TYPE>()+(TENSOR)->storage_offset(); \
-  TENSOR##_stride = (TENSOR)->stride(DIMENSION); \
-  TENSOR##_size = TENSOR->size(DIMENSION); \
+  TENSOR##_stride = THTensor_strideLegacyNoScalars(TENSOR, DIMENSION); \
+  TENSOR##_size = THTensor_sizeLegacyNoScalars(TENSOR, DIMENSION); \
   /* Counter stores the indices into the Tensor at any time */ \
   TH_TENSOR_DIM_APPLY_counter = (int64_t*)THAlloc(sizeof(int64_t)*(THTensor_nDimensionLegacyAll(TENSOR))); \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < THTensor_nDimensionLegacyAll(TENSOR); TH_TENSOR_DIM_APPLY_i++) \
@@ -302,11 +302,11 @@
 \
       /* Bump the counter at this index, update the pointer */ \
       TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]++; \
-      TENSOR##_data += TENSOR->stride(TH_TENSOR_DIM_APPLY_i); \
+      TENSOR##_data += THTensor_strideLegacyNoScalars(TENSOR, TH_TENSOR_DIM_APPLY_i); \
 \
-      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == TENSOR->size(TH_TENSOR_DIM_APPLY_i)) \
+      if(TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] == THTensor_sizeLegacyNoScalars(TENSOR, TH_TENSOR_DIM_APPLY_i)) \
       { \
-        /* Handled TENSOR_size(dim) iterations for DIM_APPLY_i. If this is the last dimension, exit */ \
+        /* Handled THTensor_sizeLegacyNoScalars(dim) iterations for DIM_APPLY_i. If this is the last dimension, exit */ \
         if(TH_TENSOR_DIM_APPLY_i == THTensor_nDimensionLegacyAll(TENSOR)-1) \
         { \
           TH_TENSOR_DIM_APPLY_hasFinished = 1; \
@@ -315,7 +315,7 @@
         else \
         { \
           /* Reset the counter, and the pointer to the beginning of the storage for this combination of indices */ \
-          TENSOR##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*TENSOR->stride(TH_TENSOR_DIM_APPLY_i); \
+          TENSOR##_data -= TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i]*THTensor_strideLegacyNoScalars(TENSOR, TH_TENSOR_DIM_APPLY_i); \
           TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
         } \
       } \

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -25,18 +25,14 @@ int THTensor_(nDimensionLegacyAll)(const THTensor *self)
   return THTensor_nDimensionLegacyAll(self);
 }
 
-int64_t THTensor_(size)(const THTensor *self, int dim)
+int64_t THTensor_(sizeLegacyNoScalars)(const THTensor *self, int dim)
 {
-  THArgCheck((dim >= 0) && (dim < self->dim()), 2, "dimension %d out of range of %dD tensor",
-      dim+TH_INDEX_BASE, THTensor_(nDimensionLegacyNoScalars)(self));
-  return self->size(dim);
+  return THTensor_sizeLegacyNoScalars(self, dim);
 }
 
-int64_t THTensor_(stride)(const THTensor *self, int dim)
+int64_t THTensor_(strideLegacyNoScalars)(const THTensor *self, int dim)
 {
-  THArgCheck((dim >= 0) && (dim < self->dim()), 2, "dimension %d out of range of %dD tensor",
-      dim+TH_INDEX_BASE, THTensor_(nDimensionLegacyNoScalars)(self));
-  return self->stride(dim);
+  return THTensor_strideLegacyNoScalars(self, dim);
 }
 
 THLongStorage *THTensor_(newSizeOf)(THTensor *self)
@@ -378,12 +374,12 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, int64_t fir
 #else
   THArgCheck( size > 0, 4, "out of range");
 #endif
-  THArgCheck(firstIndex <= src->size(dimension) - size, 4, "out of range");
+  THArgCheck(firstIndex <= THTensor_sizeLegacyNoScalars(src, dimension) - size, 4, "out of range");
 
   THTensor_(set)(self, src);
 
   if (firstIndex > 0) {
-    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*self->stride(dimension));
+    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*THTensor_strideLegacyNoScalars(self, dimension));
   }
 
   THTensor_setSizeAtDim(self, dimension, size);
@@ -404,14 +400,14 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
 #endif
 #endif
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
-  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size(dimension)), 3, "out of range");
+  THArgCheck((sliceIndex >= 0) && (sliceIndex < THTensor_sizeLegacyNoScalars(src, dimension)), 3, "out of range");
 
   THTensor_(set)(self, src);
   THTensor_(narrow)(self, NULL, dimension, sliceIndex, 1);
   for(d = dimension; d < self->dim()-1; d++)
   {
-    THTensor_setSizeAtDim(self, d, self->size(d+1));
-    THTensor_setStrideAtDim(self, d, self->stride(d+1));
+    THTensor_setSizeAtDim(self, d, THTensor_sizeLegacyNoScalars(self, d+1));
+    THTensor_setStrideAtDim(self, d, THTensor_strideLegacyNoScalars(self, d+1));
   }
   THTensor_resizeDim(self, self->dim() - 1);
 }
@@ -431,11 +427,11 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
   if(dimension1 == dimension2)
     return;
 
-  z = self->stride(dimension1);
-  THTensor_setStrideAtDim(self, dimension1, self->stride(dimension2));
+  z = THTensor_strideLegacyNoScalars(self, dimension1);
+  THTensor_setStrideAtDim(self, dimension1, THTensor_strideLegacyNoScalars(self, dimension2));
   THTensor_setStrideAtDim(self, dimension2, z);
-  z = self->size(dimension1);
-  THTensor_setSizeAtDim(self, dimension1, self->size(dimension2));
+  z = THTensor_sizeLegacyNoScalars(self, dimension1);
+  THTensor_setSizeAtDim(self, dimension1, THTensor_sizeLegacyNoScalars(self, dimension2));
   THTensor_setSizeAtDim(self, dimension2, z);
 }
 
@@ -450,7 +446,7 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
 #endif
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
-  THArgCheck(size <= src->size(dimension), 3, "out of range");
+  THArgCheck(size <= THTensor_sizeLegacyNoScalars(src, dimension), 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THTensor_(set)(self, src);
@@ -459,18 +455,18 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, int64_t siz
   std::vector<int64_t> newStride(/* size */ self->dim()+1);
 
   newSize[self->dim()] = size;
-  newStride[self->dim()] = self->stride(dimension);
+  newStride[self->dim()] = THTensor_strideLegacyNoScalars(self, dimension);
   for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {
-      newSize[d] = (self->size(d) - size) / step + 1;
-      newStride[d] = step*self->stride(d);
+      newSize[d] = (THTensor_sizeLegacyNoScalars(self, d) - size) / step + 1;
+      newStride[d] = step*THTensor_strideLegacyNoScalars(self, d);
     }
     else
     {
-      newSize[d] = self->size(d);
-      newStride[d] = self->stride(d);
+      newSize[d] = THTensor_sizeLegacyNoScalars(self, d);
+      newStride[d] = THTensor_strideLegacyNoScalars(self, d);
     }
   }
 
@@ -490,12 +486,12 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
 
   for(d = 0; d < src->dim(); d++)
   {
-    if(src->size(d) != 1)
+    if(THTensor_sizeLegacyNoScalars(src, d) != 1)
     {
       if(d != ndim)
       {
-        THTensor_setSizeAtDim(self, ndim, src->size(d));
-        THTensor_setStrideAtDim(self, ndim, src->stride(d));
+        THTensor_setSizeAtDim(self, ndim, THTensor_sizeLegacyNoScalars(src, d));
+        THTensor_setStrideAtDim(self, ndim, THTensor_strideLegacyNoScalars(src, d));
       }
       ndim++;
     }
@@ -525,15 +521,15 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
   THTensor_(set)(self, src);
 
 #ifdef USE_TH_SCALAR
-  if(src->size(dimension) == 1)
+  if(THTensor_sizeLegacyNoScalars(src, dimension) == 1)
 #else
-  if(src->size(dimension) == 1 && src->dim() > 1)
+  if(THTensor_sizeLegacyNoScalars(src, dimension) == 1 && src->dim() > 1)
 #endif
   {
     for(d = dimension; d < self->dim()-1; d++)
     {
-      THTensor_setSizeAtDim(self, d, self->size(d+1));
-      THTensor_setStrideAtDim(self, d, self->stride(d+1));
+      THTensor_setSizeAtDim(self, d, THTensor_sizeLegacyNoScalars(self, d+1));
+      THTensor_setStrideAtDim(self, d, THTensor_strideLegacyNoScalars(self, d+1));
     }
     THTensor_resizeDim(self, self->dim() - 1);
   }
@@ -555,11 +551,11 @@ void THTensor_(unsqueeze1d)(THTensor *self, THTensor *src, int dimension)
 
   THTensor_resizeDim(self, self->dim() + 1);
   for (d = self->dim()-1; d > dimension; d--) {
-    THTensor_setSizeAtDim(self, d, self->size(d-1));
-    THTensor_setStrideAtDim(self, d, self->stride(d-1));
+    THTensor_setSizeAtDim(self, d, THTensor_sizeLegacyNoScalars(self, d-1));
+    THTensor_setStrideAtDim(self, d, THTensor_strideLegacyNoScalars(self, d-1));
   }
   if (dimension+1 < self->dim()) {
-    THTensor_setStrideAtDim(self, dimension, self->size(dimension+1) * self->stride(dimension+1));
+    THTensor_setStrideAtDim(self, dimension, THTensor_sizeLegacyNoScalars(self, dimension+1) * THTensor_strideLegacyNoScalars(self, dimension+1));
   } else {
     THTensor_setStrideAtDim(self, dimension, 1);
   }
@@ -576,13 +572,13 @@ int THTensor_(isTransposed)(const THTensor *self)
   int64_t z = 1;
   int d;
   for (d = 0; d < THTensor_nDimensionLegacyAll(self); ++d) {
-    if (self->stride(d) == 0 && self->size(d) != 1)
+    if (THTensor_strideLegacyNoScalars(self, d) == 0 && THTensor_sizeLegacyNoScalars(self, d) != 1)
       return 0;
-    if (self->stride(d) > max_stride) {
-      max_stride = self->stride(d);
-      size_max_stride = self->size(d);
+    if (THTensor_strideLegacyNoScalars(self, d) > max_stride) {
+      max_stride = THTensor_strideLegacyNoScalars(self, d);
+      size_max_stride = THTensor_sizeLegacyNoScalars(self, d);
     }
-    z *= self->size(d);
+    z *= THTensor_sizeLegacyNoScalars(self, d);
   }
   if (z == max_stride * size_max_stride) {
     return 1;
@@ -597,10 +593,10 @@ int THTensor_(isContiguous)(const THTensor *self)
   int d;
   for(d = self->dim()-1; d >= 0; d--)
   {
-    if(self->size(d) != 1)
+    if(THTensor_sizeLegacyNoScalars(self, d) != 1)
     {
-      if(self->stride(d) == z)
-        z *= self->size(d);
+      if(THTensor_strideLegacyNoScalars(self, d) == z)
+        z *= THTensor_sizeLegacyNoScalars(self, d);
       else
         return 0;
     }
@@ -616,7 +612,7 @@ int THTensor_(isSize)(const THTensor *self, const THLongStorage *dims)
 
   for(d = 0; d < THTensor_nDimensionLegacyAll(self); ++d)
   {
-    if(self->size(d) != THLongStorage_data(dims)[d])
+    if(THTensor_sizeLegacyNoScalars(self, d) != THLongStorage_data(dims)[d])
       return 0;
   }
   return 1;
@@ -629,7 +625,7 @@ int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor* src)
     return 0;
   for(d = 0; d < self->dim(); ++d)
   {
-    if(self->size(d) != src->size(d))
+    if(THTensor_sizeLegacyNoScalars(self, d) != THTensor_sizeLegacyNoScalars(src, d))
       return 0;
   }
   return 1;
@@ -646,7 +642,7 @@ int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
     int d;
     for (d = 0; d < THTensor_nDimensionLegacyAll(self); ++d)
     {
-      if (self->size(d) != src->size(d) || self->stride(d) != src->stride(d))
+      if (THTensor_sizeLegacyNoScalars(self, d) != THTensor_sizeLegacyNoScalars(src, d) || THTensor_strideLegacyNoScalars(self, d) != THTensor_strideLegacyNoScalars(src, d))
         return 0;
     }
     return 1;
@@ -663,7 +659,7 @@ ptrdiff_t THTensor_(nElement)(const THTensor *self)
     ptrdiff_t nElement = 1;
     int d;
     for(d = 0; d < THTensor_nDimensionLegacyAll(self); d++)
-      nElement *= self->size(d);
+      nElement *= THTensor_sizeLegacyNoScalars(self, d);
     return nElement;
   }
 }
@@ -737,12 +733,12 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
       AT_CHECK(size[d] > 0, "sizes must be non-negative");
     }
 #endif
-    if((self->dim() > d) && (size[d] != self->size(d))) {
+    if((self->dim() > d) && (size[d] != THTensor_sizeLegacyNoScalars(self, d))) {
       hascorrectsize = false;
     }
 
     // NB: this used to test that stride[d] was >= 0
-    if((self->dim() > d) && stride && (stride[d] != self->stride(d))) {
+    if((self->dim() > d) && stride && (stride[d] != THTensor_strideLegacyNoScalars(self, d))) {
       hascorrectsize = false;
     }
   }
@@ -771,10 +767,10 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
         THTensor_setStrideAtDim(self, d, 1);
       } else {
         // Keep stride monotonically increasing to match NumPy.
-        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1), 1)*self->stride(d+1));
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(THTensor_sizeLegacyNoScalars(self, d+1), 1)*THTensor_strideLegacyNoScalars(self, d+1));
       }
     }
-    totalSize += (self->size(d)-1)*self->stride(d);
+    totalSize += (THTensor_sizeLegacyNoScalars(self, d)-1)*THTensor_strideLegacyNoScalars(self, d);
   }
 
   if(totalSize+self->storage_offset() > 0)
@@ -791,57 +787,57 @@ void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t 
 void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0), value);
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)), 2, "out of range");
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0), value);
 }
 
 real THTensor_(get1d)(const THTensor *tensor, int64_t x0)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0));
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)), 2, "out of range");
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0));
 }
 
 void THTensor_(set2d)(THTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)), 2, "out of range");
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1), value);
 }
 
 real THTensor_(get2d)(const THTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)), 2, "out of range");
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1));
 }
 
 void THTensor_(set3d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)), 2, "out of range");
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2), value);
 }
 
 real THTensor_(get3d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)), 2, "out of range");
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2));
 }
 
 void THTensor_(set4d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)) && (x3 >= 0) && (x3 < THTensor_sizeLegacyNoScalars(tensor, 3)), 2, "out of range");
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2)+x3*THTensor_strideLegacyNoScalars(tensor, 3), value);
 }
 
 real THTensor_(get4d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(THTensor_nDimensionLegacyAll(tensor) == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)) && (x3 >= 0) && (x3 < THTensor_sizeLegacyNoScalars(tensor, 3)), 2, "out of range");
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2)+x3*THTensor_strideLegacyNoScalars(tensor, 3));
 }
 
 THDescBuff THTensor_(desc)(const THTensor *tensor) {
@@ -855,7 +851,7 @@ THDescBuff THTensor_(desc)(const THTensor *tensor) {
   int i;
   for(i = 0; i < THTensor_nDimensionLegacyAll(tensor); i++) {
     if(n >= L) break;
-    n += snprintf(str+n, L-n, "%" PRId64, tensor->size(i));
+    n += snprintf(str+n, L-n, "%" PRId64, THTensor_sizeLegacyNoScalars(tensor, i));
     if(i < THTensor_nDimensionLegacyAll(tensor)-1) {
       n += snprintf(str+n, L-n, "x");
     }

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -27,8 +27,8 @@ TH_API ptrdiff_t THTensor_(storageOffset)(const THTensor *self);
 // See [NOTE: nDimension vs nDimensionLegacyNoScalars vs nDimensionLegacyAll]
 TH_API int THTensor_(nDimensionLegacyNoScalars)(const THTensor *self);
 TH_API int THTensor_(nDimensionLegacyAll)(const THTensor *self);
-TH_API int64_t THTensor_(size)(const THTensor *self, int dim);
-TH_API int64_t THTensor_(stride)(const THTensor *self, int dim);
+TH_API int64_t THTensor_(sizeLegacyNoScalars)(const THTensor *self, int dim);
+TH_API int64_t THTensor_(strideLegacyNoScalars)(const THTensor *self, int dim);
 TH_API THLongStorage *THTensor_(newSizeOf)(THTensor *self);
 TH_API THLongStorage *THTensor_(newStrideOf)(THTensor *self);
 TH_API real *THTensor_(data)(const THTensor *self);

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -114,21 +114,21 @@
 //         TENSOR2 is src
 //         TENSOR3 is index
 // Tests:
-//   1. index->size(d) <= src->size(d) for all d
-//   2. index->size(d) <= real->size(d) for all d != dim
+//   1. THTensor_sizeLegacyNoScalars(index, d) <= THTensor_sizeLegacyNoScalars(src, d) for all d
+//   2. THTensor_sizeLegacyNoScalars(index, d) <= THTensor_sizeLegacyNoScalars(real, d) for all d != dim
 #define TH_TENSOR_DIM_APPLY3_SIZE_SCATTER(TENSOR1, TENSOR2, TENSOR3, DIMENSION) \
 { \
   int shape_check_flag = 0; \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < THTensor_nDimensionLegacyAll(TENSOR1); TH_TENSOR_DIM_APPLY_i++) \
   { \
-    int64_t TENSOR3##_dim_size = TENSOR3->size(TH_TENSOR_DIM_APPLY_i); \
+    int64_t TENSOR3##_dim_size = THTensor_sizeLegacyNoScalars(TENSOR3, TH_TENSOR_DIM_APPLY_i); \
     if (TH_TENSOR_DIM_APPLY_i != DIMENSION) { \
-      if (TENSOR3##_dim_size > TENSOR1->size(TH_TENSOR_DIM_APPLY_i)) { \
+      if (TENSOR3##_dim_size > THTensor_sizeLegacyNoScalars(TENSOR1, TH_TENSOR_DIM_APPLY_i)) { \
         shape_check_flag = 1; \
         break; \
       } \
     } \
-    if (TENSOR3##_dim_size > TENSOR2->size(TH_TENSOR_DIM_APPLY_i)) { \
+    if (TENSOR3##_dim_size > THTensor_sizeLegacyNoScalars(TENSOR2, TH_TENSOR_DIM_APPLY_i)) { \
       shape_check_flag = 1; \
       break; \
     } \

--- a/aten/src/TH/generic/THTensorConv.cpp
+++ b/aten/src/TH/generic/THTensorConv.cpp
@@ -600,15 +600,15 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
 
-  kstride0 = kernel->stride(0);
-  nKernelPlane = kernel->size(0);
-  nKernelRows = kernel->size(1);
-  nKernelCols = kernel->size(2);
+  kstride0 = THTensor_strideLegacyNoScalars(kernel, 0);
+  nKernelPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 2);
 
   THArgCheck(nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "covn2DRevger : Input image is smaller than kernel");
 
@@ -627,7 +627,7 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
     /*THTensor_(zero)(r_);*/
 
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -639,7 +639,7 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -706,21 +706,21 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride(0);
-  istride1    = input->stride(1);
-  nbatch      = input->size(0);
-  nInputPlane = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  istride1    = THTensor_strideLegacyNoScalars(input, 1);
+  nbatch      = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0 = kernel->stride(0);
-  kstride1 = kernel->stride(1);
-  nKernelPlane = kernel->size(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
+  kstride0 = THTensor_strideLegacyNoScalars(kernel, 0);
+  kstride1 = THTensor_strideLegacyNoScalars(kernel, 1);
+  nKernelPlane = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
 
   THArgCheck(nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "conv2DRevger : Input image is smaller than kernel");
-  THArgCheck(kernel->size(0) == input->size(0) , 2, "conv2DRevger : Input batch and kernel batch is not same size");
+  THArgCheck(THTensor_sizeLegacyNoScalars(kernel, 0) == THTensor_sizeLegacyNoScalars(input, 0) , 2, "conv2DRevger : Input batch and kernel batch is not same size");
 
   nOutputRows = nInputRows - (nKernelRows - 1) * srow;
   nOutputCols = nInputCols - (nKernelCols - 1) * scol;
@@ -737,7 +737,7 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
     /*THTensor_(zero)(r_);*/
 
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -749,7 +749,7 @@ void THTensor_(conv2DRevgerm)(THTensor *r_, real beta, real alpha, THTensor *t_,
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -820,15 +820,15 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
 
-  kstride0 = kernel->stride(0);
-  nKernelPlane = kernel->size(0);
-  nKernelRows = kernel->size(1);
-  nKernelCols = kernel->size(2);
+  kstride0 = THTensor_strideLegacyNoScalars(kernel, 0);
+  nKernelPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 2);
 
   THArgCheck((nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dger : Input image is smaller than kernel");
 
@@ -851,7 +851,7 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -863,7 +863,7 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0)*r_->size(1); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0)*THTensor_sizeLegacyNoScalars(r_, 1); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -949,24 +949,24 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride(3) == 1) || !(k_->stride(2) == k_->size(3))) {
+  if (!(THTensor_strideLegacyNoScalars(k_, 3) == 1) || !(THTensor_strideLegacyNoScalars(k_, 2) == THTensor_sizeLegacyNoScalars(k_, 3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
 
-  kstride0    = kernel->stride(0);
-  kstride1    = kernel->stride(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
-  nOutputPlane = kernel->size(0);
-  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  kstride1    = THTensor_strideLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  THArgCheck(THTensor_sizeLegacyNoScalars(kernel, 1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmv : Input image is smaller than kernel");
 
@@ -989,7 +989,7 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -1001,7 +1001,7 @@ void THTensor_(conv2Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(k)
-    for (k = 0; k < r_->size(0); k++)
+    for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 0); k++)
     {
       real* ptr_output = output_data + k*nOutputCols*nOutputRows;
       int64_t l;
@@ -1087,24 +1087,24 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 7, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride(3) == 1) || !(k_->stride(2) == k_->size(3))) {
+  if (!(THTensor_strideLegacyNoScalars(k_, 3) == 1) || !(THTensor_strideLegacyNoScalars(k_, 2) == THTensor_sizeLegacyNoScalars(k_, 3))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nbatch = input->size(0);
-  nInputPlane = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  nbatch = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0    = kernel->stride(0);
-  kstride1    = kernel->stride(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
-  nOutputPlane = kernel->size(0);
-  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  kstride1    = THTensor_strideLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  THArgCheck(THTensor_sizeLegacyNoScalars(kernel, 1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmv : Input image is smaller than kernel");
 
@@ -1127,10 +1127,10 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(zero)(r_);*/
 #pragma omp parallel for private(p)
-    for (p=0; p < r_->size(0); p++)
+    for (p=0; p < THTensor_sizeLegacyNoScalars(r_, 0); p++)
     {
       int64_t k;
-      for (k = 0; k < r_->size(1); k++)
+      for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 1); k++)
       {
         real* ptr_output = output_data + p*nOutputPlane*nOutputRows*nOutputCols + k*nOutputCols*nOutputRows;
         int64_t l;
@@ -1143,10 +1143,10 @@ void THTensor_(conv2Dmm)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   {
     /*THTensor_(mul)(r_, beta);*/
 #pragma omp parallel for private(p)
-    for(p=0; p < r_->size(0); p++)
+    for(p=0; p < THTensor_sizeLegacyNoScalars(r_, 0); p++)
     {
       int64_t k;
-      for (k = 0; k < r_->size(1); k++)
+      for (k = 0; k < THTensor_sizeLegacyNoScalars(r_, 1); k++)
       {
         real* ptr_output = output_data + p*nOutputPlane*nOutputRows*nOutputCols + k*nOutputCols*nOutputRows;
         int64_t l;
@@ -1236,10 +1236,10 @@ void THTensor_(conv2Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputRows  = input->size(0);
-  nInputCols  = input->size(1);
-  nKernelRows = kernel->size(0);
-  nKernelCols = kernel->size(1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 1);
 
   THArgCheck((nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dmul : Input image is smaller than kernel");
 
@@ -1295,15 +1295,15 @@ void THTensor_(conv2Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride(0);
-  nInputPlane = input->size(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
 
-  kstride0    = kernel->stride(0);
-  nOutputPlane = kernel->size(0);
-  nKernelRows = kernel->size(1);
-  nKernelCols = kernel->size(2);
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 2);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dcmul : Input image is smaller than kernel");
@@ -1374,15 +1374,15 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride(0);
-  nInputPlane = input->size(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
 
-  kstride0    = kernel->stride(0);
-  nOutputPlane = kernel->size(0);
-  nKernelRows = kernel->size(1);
-  nKernelCols = kernel->size(2);
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 2);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputRows >= nKernelRows && nInputCols >= nKernelCols)
@@ -1405,7 +1405,7 @@ void THTensor_(conv2Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   weight_data = THTensor_(data)(kernel);
   output_data = THTensor_(data)(r_);
 
-  nmaps = map->size(0);
+  nmaps = THTensor_sizeLegacyNoScalars(map, 0);
 
   for(k = 0; k < nmaps; k++)
   {
@@ -1462,17 +1462,17 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputDepth = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0 = kernel->stride(0);
-  nKernelPlane = kernel->size(0);
-  nKernelDepth= kernel->size(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
+  kstride0 = THTensor_strideLegacyNoScalars(kernel, 0);
+  nKernelPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelDepth= THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
 
   THArgCheck(nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "conv3DRevger : Input image is smaller than kernel");
 
@@ -1550,17 +1550,17 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputDepth = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0     = kernel->stride(0);
-  nKernelPlane = kernel->size(0);
-  nKernelDepth = kernel->size(1);
-  nKernelRows  = kernel->size(2);
-  nKernelCols  = kernel->size(3);
+  kstride0     = THTensor_strideLegacyNoScalars(kernel, 0);
+  nKernelPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelDepth = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelRows  = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols  = THTensor_sizeLegacyNoScalars(kernel, 3);
 
   THArgCheck((nInputDepth >= nKernelDepth
               && nInputRows >= nKernelRows
@@ -1639,26 +1639,26 @@ void THTensor_(conv3Dmv)(THTensor *r_, real beta, real alpha, THTensor *t_, THTe
   THArgCheck(*xc == 'C' || *xc == 'X', 8, "type of convolution can 'X' or 'C'");
 
   input = THTensor_(newContiguous)(t_);
-  if (!(k_->stride(4) == 1) || !(k_->stride(3) == k_->size(4))) {
+  if (!(THTensor_strideLegacyNoScalars(k_, 4) == 1) || !(THTensor_strideLegacyNoScalars(k_, 3) == THTensor_sizeLegacyNoScalars(k_, 4))) {
     kernel = THTensor_(newContiguous)(k_);
   } else {
     THTensor_(retain)(k_);
     kernel = k_;
   }
 
-  nInputPlane = input->size(0);
-  istride0    = input->stride(0);
-  nInputDepth = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0    = kernel->stride(0);
-  kstride1    = kernel->stride(1);
-  nKernelDepth = kernel->size(2);
-  nKernelRows = kernel->size(3);
-  nKernelCols = kernel->size(4);
-  nOutputPlane = kernel->size(0);
-  THArgCheck(kernel->size(1) == nInputPlane, 2, "invalid number of input planes");
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  kstride1    = THTensor_strideLegacyNoScalars(kernel, 1);
+  nKernelDepth = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 3);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 4);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  THArgCheck(THTensor_sizeLegacyNoScalars(kernel, 1) == nInputPlane, 2, "invalid number of input planes");
 
   THArgCheck( (nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dmv : Input image is smaller than kernel");
 
@@ -1736,12 +1736,12 @@ void THTensor_(conv3Dmul)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  nInputDepth = input->size(0);
-  nInputRows  = input->size(1);
-  nInputCols  = input->size(2);
-  nKernelDepth = kernel->size(0);
-  nKernelRows = kernel->size(1);
-  nKernelCols = kernel->size(2);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 2);
+  nKernelDepth = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 2);
 
   THArgCheck((nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dmul : Input image is smaller than kernel");
 
@@ -1802,17 +1802,17 @@ void THTensor_(conv3Dcmul)(THTensor *r_, real beta, real alpha, THTensor *t_, TH
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride(0);
-  nInputPlane = input->size(0);
-  nInputDepth = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0    = kernel->stride(0);
-  nOutputPlane = kernel->size(0);
-  nKernelDepth = kernel->size(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelDepth = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck( (nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv3Dcmul : Input image is smaller than kernel");
@@ -1889,17 +1889,17 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   input = THTensor_(newContiguous)(t_);
   kernel = THTensor_(newContiguous)(k_);
 
-  istride0    = input->stride(0);
-  nInputPlane = input->size(0);
-  nInputDepth = input->size(1);
-  nInputRows  = input->size(2);
-  nInputCols  = input->size(3);
+  istride0    = THTensor_strideLegacyNoScalars(input, 0);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+  nInputDepth = THTensor_sizeLegacyNoScalars(input, 1);
+  nInputRows  = THTensor_sizeLegacyNoScalars(input, 2);
+  nInputCols  = THTensor_sizeLegacyNoScalars(input, 3);
 
-  kstride0    = kernel->stride(0);
-  nOutputPlane = kernel->size(0);
-  nKernelDepth = kernel->size(1);
-  nKernelRows = kernel->size(2);
-  nKernelCols = kernel->size(3);
+  kstride0    = THTensor_strideLegacyNoScalars(kernel, 0);
+  nOutputPlane = THTensor_sizeLegacyNoScalars(kernel, 0);
+  nKernelDepth = THTensor_sizeLegacyNoScalars(kernel, 1);
+  nKernelRows = THTensor_sizeLegacyNoScalars(kernel, 2);
+  nKernelCols = THTensor_sizeLegacyNoScalars(kernel, 3);
 
   THArgCheck(nOutputPlane == nInputPlane, 2, "invalid number of input/kernel planes");
   THArgCheck((nInputDepth >= nKernelDepth
@@ -1925,7 +1925,7 @@ void THTensor_(conv3Dmap)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   weight_data = THTensor_(data)(kernel);
   output_data = THTensor_(data)(r_);
 
-  nmaps = map->size(0);
+  nmaps = THTensor_sizeLegacyNoScalars(map, 0);
 
   for(k = 0; k < nmaps; k++)
   {

--- a/aten/src/TH/generic/THTensorCopy.cpp
+++ b/aten/src/TH/generic/THTensorCopy.cpp
@@ -18,8 +18,8 @@ int THTensor_(copyTransposeValid)(THTensor *tensor, THTensor *src) {
   return THTensor_(isContiguous)(tensor) &&
          !src->is_empty() &&
          THTensor_(nDimensionLegacyNoScalars)(src) == 2 &&
-         THTensor_(stride)(src, 0) == 1 &&
-         THTensor_(stride)(src, 1) == THTensor_(size)(src, 0) &&
+         THTensor_(strideLegacyNoScalars)(src, 0) == 1 &&
+         THTensor_(strideLegacyNoScalars)(src, 1) == THTensor_(sizeLegacyNoScalars)(src, 0) &&
          THTensor_(nElement)(tensor) >= MIN_SZ;
 }
 
@@ -41,8 +41,8 @@ void THTensor_(copyTranspose)(THTensor *tensor, THTensor *src) {
   real *bp = THTensor_(data)(buf);
 
 
-  int64_t NR = THTensor_(size)(src, 0);
-  int64_t NC = THTensor_(size)(src, 1);
+  int64_t NR = THTensor_(sizeLegacyNoScalars)(src, 0);
+  int64_t NC = THTensor_(sizeLegacyNoScalars)(src, 1);
   for (int64_t R = 0; R < NR; R += BLOCK_SZ) {
     for (int64_t C = 0; C < NC; C += BLOCK_SZ) {
       real *spo = sp + R + C * NR;

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -132,8 +132,8 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
                     div = 1;
 
                     for (dim = tensor->dim() - 1; dim >= 0; dim--) {
-                      *(subscript_data + dim) = (i/div) % tensor->size(dim);
-                      div *= tensor->size(dim);
+                      *(subscript_data + dim) = (i/div) % THTensor_sizeLegacyNoScalars(tensor, dim);
+                      div *= THTensor_sizeLegacyNoScalars(tensor, dim);
                     }
 
                     subscript_data += tensor->dim();
@@ -177,10 +177,10 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   {
     tensor_data = THTensor_(data)(tensor);
     src_data = THTensor_(data)(src);
-    ptrdiff_t rowsize = src->size(0) == 0 ? 1: THTensor_(nElement)(src) / src->size(0);
+    ptrdiff_t rowsize = THTensor_sizeLegacyNoScalars(src, 0) == 0 ? 1: THTensor_(nElement)(src) / THTensor_sizeLegacyNoScalars(src, 0);
 
     // check that the indices are within range
-    int64_t max = src->size(0) - 1 + TH_INDEX_BASE;
+    int64_t max = THTensor_sizeLegacyNoScalars(src, 0) - 1 + TH_INDEX_BASE;
     for (i=0; i<numel; i++) {
       if (index_data[i] < TH_INDEX_BASE || index_data[i] > max) {
         THLongTensor_free(index);
@@ -361,7 +361,7 @@ void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTenso
   THArgCheck(index->dim() == 1, 3, "Index is supposed to be a vector");
   THArgCheck(dim < src->dim(), 4,"Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
 #endif
-  THArgCheck(numel == src->size(dim),4,"Number of indices should be equal to source:size(dim)");
+  THArgCheck(numel == THTensor_sizeLegacyNoScalars(src, dim),4,"Number of indices should be equal to source:size(dim)");
 
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
@@ -439,7 +439,7 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(src) == THTensor_(nDimensionLegacyNoScalars)(tensor), 2,
              "Input tensor must have same dimensions as output tensor");
 
-  elems_per_row = THLongTensor_size(index, dim);
+  elems_per_row = THLongTensor_sizeLegacyNoScalars(index, dim);
 
   TH_TENSOR_DIM_APPLY3(real, tensor, real, src, int64_t, index, dim,
                        TH_TENSOR_DIM_APPLY3_SIZE_EQ_EXCEPT_DIM,
@@ -473,7 +473,7 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
              "Input tensor must have same dimensions as output tensor");
 #endif
 
-  elems_per_row = THLongTensor_size(index, dim);
+  elems_per_row = THLongTensor_sizeLegacyNoScalars(index, dim);
 
   TH_TENSOR_DIM_APPLY3(real, tensor, real, src, int64_t, index, dim,
                        TH_TENSOR_DIM_APPLY3_SIZE_SCATTER,
@@ -499,7 +499,7 @@ void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTen
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(src) == THTensor_(nDimensionLegacyNoScalars)(tensor), 4,
              "Input tensor must have same dimensions as output tensor");
 
-  elems_per_row = THLongTensor_size(index, dim);
+  elems_per_row = THLongTensor_sizeLegacyNoScalars(index, dim);
 
   TH_TENSOR_DIM_APPLY3(real, tensor, real, src, int64_t, index, dim,
                        TH_TENSOR_DIM_APPLY3_SIZE_SCATTER,
@@ -523,7 +523,7 @@ void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, real
   THArgCheck(THLongTensor_nDimensionLegacyAll(index) == THTensor_(nDimensionLegacyAll)(tensor), 3,
              "Index tensor must have same dimensions as output tensor");
 
-  elems_per_row = THLongTensor_size(index, dim);
+  elems_per_row = THLongTensor_sizeLegacyNoScalars(index, dim);
 
   TH_TENSOR_DIM_APPLY2(real, tensor, int64_t, index, dim,
                        for (i = 0; i < elems_per_row; ++i)

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -809,7 +809,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     THError("matrix and vector expected, got %dD, %dD",
       mat->dim(), vec->dim());
 
-  if( mat->size(1) != vec->size(0) ) {
+  if( THTensor_sizeLegacyNoScalars(mat, 1) != THTensor_sizeLegacyNoScalars(vec, 0) ) {
     THDescBuff bm = THTensor_(sizeDesc)(mat);
     THDescBuff bv = THTensor_(sizeDesc)(vec);
     THError("size mismatch, %s, %s", bm.str, bv.str);
@@ -818,7 +818,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if(t->dim() != 1)
     THError("vector expected, got t: %dD", t->dim());
 
-  if(t->size(0) != mat->size(0)) {
+  if(THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(mat, 0)) {
     THDescBuff bt = THTensor_(sizeDesc)(t);
     THDescBuff bm = THTensor_(sizeDesc)(mat);
     THError("size mismatch, t: %s, mat: %s", bt.str, bm.str);
@@ -833,35 +833,35 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(mat->stride(0) == 1 && LDA_COND(mat->size(0), mat->size(1), mat->stride(1)))
+  if(THTensor_strideLegacyNoScalars(mat, 0) == 1 && LDA_COND(THTensor_sizeLegacyNoScalars(mat, 0), THTensor_sizeLegacyNoScalars(mat, 1), THTensor_strideLegacyNoScalars(mat, 1)))
   {
-    THBlas_(gemv)('n', mat->size(0), mat->size(1),
-                  alpha, THTensor_(data)(mat), mat->stride(1),
-                  THTensor_(data)(vec), vec->stride(0),
-                  beta, THTensor_(data)(r_), r_->stride(0));
+    THBlas_(gemv)('n', THTensor_sizeLegacyNoScalars(mat, 0), THTensor_sizeLegacyNoScalars(mat, 1),
+                  alpha, THTensor_(data)(mat), THTensor_strideLegacyNoScalars(mat, 1),
+                  THTensor_(data)(vec), THTensor_strideLegacyNoScalars(vec, 0),
+                  beta, THTensor_(data)(r_), THTensor_strideLegacyNoScalars(r_, 0));
   }
-  else if(mat->stride(1) == 1 && LDA_COND(mat->size(1), mat->size(0), mat->stride(0)))
+  else if(THTensor_strideLegacyNoScalars(mat, 1) == 1 && LDA_COND(THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0), THTensor_strideLegacyNoScalars(mat, 0)))
   {
-    THBlas_(gemv)('t',  mat->size(1), mat->size(0),
-                  alpha, THTensor_(data)(mat), mat->stride(0),
-                  THTensor_(data)(vec), vec->stride(0),
-                  beta, THTensor_(data)(r_), r_->stride(0));
+    THBlas_(gemv)('t',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                  alpha, THTensor_(data)(mat), THTensor_strideLegacyNoScalars(mat, 0),
+                  THTensor_(data)(vec), THTensor_strideLegacyNoScalars(vec, 0),
+                  beta, THTensor_(data)(r_), THTensor_strideLegacyNoScalars(r_, 0));
   }
   else
   {
     THTensor *cmat = THTensor_(newContiguous)(mat);
 
-    THBlas_(gemv)('t',  mat->size(1), mat->size(0),
-                  alpha, THTensor_(data)(cmat), cmat->stride(0),
-                  THTensor_(data)(vec), vec->stride(0),
-                  beta, THTensor_(data)(r_), r_->stride(0));
+    THBlas_(gemv)('t',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                  alpha, THTensor_(data)(cmat), THTensor_strideLegacyNoScalars(cmat, 0),
+                  THTensor_(data)(vec), THTensor_strideLegacyNoScalars(vec, 0),
+                  beta, THTensor_(data)(r_), THTensor_strideLegacyNoScalars(r_, 0));
 
     THTensor_(free)(cmat);
   }
 
   // In gemv (x,0).mv(0) does not
   // handle beta, whereas gemm does for case where (x,0).mm(0,y).
-  if (vec->size(0) == 0 && mat->size(0) != 0) {
+  if (THTensor_sizeLegacyNoScalars(vec, 0) == 0 && THTensor_sizeLegacyNoScalars(mat, 0) != 0) {
     if (beta == 0) {
       THTensor_(zero)(r_);
     } else if (beta != 1) {
@@ -874,8 +874,8 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
 void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
 {
-  int64_t N1 = m1->size(0);
-  int64_t N2 = m2->size(0);
+  int64_t N1 = THTensor_sizeLegacyNoScalars(m1, 0);
+  int64_t N2 = THTensor_sizeLegacyNoScalars(m2, 0);
   int64_t dim;
   real *m1_p;
   real *m2_p;
@@ -890,8 +890,8 @@ void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
   THTensor_(resize2d)(m1, N1, THTensor_(nElement)(m1) / N1);
   THTensor_(resize2d)(m2, N2, THTensor_(nElement)(m2) / N2);
 
-  dim = m1->size(1);
-  THArgCheck(m1->size(1) == m2->size(1), 3, "m1 and m2 must have the same inner vector dim");
+  dim = THTensor_sizeLegacyNoScalars(m1, 1);
+  THArgCheck(THTensor_sizeLegacyNoScalars(m1, 1) == THTensor_sizeLegacyNoScalars(m2, 1), 3, "m1 and m2 must have the same inner vector dim");
 
   m1_p = THTensor_(data)(m1);
   m2_p = THTensor_(data)(m2);
@@ -924,7 +924,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if( (m1->dim() != 2) || (m2->dim() != 2))
     THError("matrices expected, got %dD, %dD tensors", m1->dim(), m2->dim());
 
-  if(m1->size(1) != m2->size(0)) {
+  if(THTensor_sizeLegacyNoScalars(m1, 1) != THTensor_sizeLegacyNoScalars(m2, 0)) {
     THDescBuff bm1 = THTensor_(sizeDesc)(m1);
     THDescBuff bm2 = THTensor_(sizeDesc)(m2);
     THError("size mismatch, m1: %s, m2: %s", bm1.str, bm2.str);
@@ -933,7 +933,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if( t->dim() != 2 )
     THError("matrix expected, got %dD tensor for t", t->dim());
 
-  if( (t->size(0) != m1->size(0)) || (t->size(1) != m2->size(1)) ) {
+  if( (THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(m1, 0)) || (THTensor_sizeLegacyNoScalars(t, 1) != THTensor_sizeLegacyNoScalars(m2, 1)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
     THDescBuff bm1 = THTensor_(sizeDesc)(m1);
     THDescBuff bm2 = THTensor_(sizeDesc)(m2);
@@ -952,14 +952,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   #define LDC_COND(M, N, LDC) ((N) == 1 || (LDC) >= THMax(1, M))
 
   /* r_ */
-  if(r_->stride(0) == 1 &&
-     LDC_COND(r_->size(0), r_->size(1), r_->stride(1)))
+  if(THTensor_strideLegacyNoScalars(r_, 0) == 1 &&
+     LDC_COND(THTensor_sizeLegacyNoScalars(r_, 0), THTensor_sizeLegacyNoScalars(r_, 1), THTensor_strideLegacyNoScalars(r_, 1)))
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride(1) == 1 &&
-          LDC_COND(r_->size(1), r_->size(0), r_->stride(0)))
+  else if(THTensor_strideLegacyNoScalars(r_, 1) == 1 &&
+          LDC_COND(THTensor_sizeLegacyNoScalars(r_, 1), THTensor_sizeLegacyNoScalars(r_, 0), THTensor_strideLegacyNoScalars(r_, 0)))
   {
     THTensor *swap = m2;
     m2 = m1;
@@ -979,21 +979,21 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   #undef LDC_COND
 
-  int64_t m = r__->size((transpose_r == 'n' ? 0 : 1));
-  int64_t n = r__->size((transpose_r == 'n' ? 1 : 0));
-  int64_t k = m1->size((transpose_r == 'n' ? 1 : 0));
-  int64_t ldr__ = r__->stride((transpose_r == 'n' ? 1 : 0));
+  int64_t m = THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 0 : 1));
+  int64_t n = THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0));
+  int64_t k = THTensor_sizeLegacyNoScalars(m1, (transpose_r == 'n' ? 1 : 0));
+  int64_t ldr__ = THTensor_strideLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0));
 
   /* m1 */
   /* Need ldm1_ >= max(1, (transpose_m1 == 'n' ? m : k)) */
-  if(m1->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
-     m1->stride((transpose_r == 'n' ? 1 : 0)) >= THMax(1, m))
+  if(THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 0 : 1)) == 1 &&
+     THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 1 : 0)) >= THMax(1, m))
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
-          m1->stride((transpose_r == 'n' ? 0 : 1)) >= THMax(1, k))
+  else if(THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 1 : 0)) == 1 &&
+          THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 0 : 1)) >= THMax(1, k))
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -1007,14 +1007,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   /* m2 */
   /* Need ldm2_ >= max(1, (transpose_m2 == 'n' ? k : n)) */
-  if(m2->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
-     m2->stride((transpose_r == 'n' ? 1 : 0)) >= THMax(1, k))
+  if(THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 0 : 1)) == 1 &&
+     THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 1 : 0)) >= THMax(1, k))
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
-          m2->stride((transpose_r == 'n' ? 0 : 1)) >= THMax(1, n))
+  else if(THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 1 : 0)) == 1 &&
+          THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 0 : 1)) >= THMax(1, n))
   {
     transpose_m2 = 't';
     m2_ = m2;
@@ -1026,8 +1026,8 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     free_m2 = 1;
   }
 
-  int64_t ldm1_ = (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1)));
-  int64_t ldm2_ = (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1)));
+  int64_t ldm1_ = (transpose_m1 == 'n' ? THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 0 : 1)));
+  int64_t ldm2_ = (transpose_m2 == 'n' ? THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 0 : 1)));
 
 #pragma omp critical(blasgemm)
   /* do the operation */
@@ -1065,7 +1065,7 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   if(t->dim() != 2)
     THError("expected matrix, got %dD tensor for t", t->dim());
 
-  if( (t->size(0) != vec1->size(0)) || (t->size(1) != vec2->size(0)) ) {
+  if( (THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(vec1, 0)) || (THTensor_sizeLegacyNoScalars(t, 1) != THTensor_sizeLegacyNoScalars(vec2, 0)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
     THDescBuff bv1 = THTensor_(sizeDesc)(vec1);
     THDescBuff bv2 = THTensor_(sizeDesc)(vec2);
@@ -1087,28 +1087,28 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   // n == 1 || lda >= max(1, m)
   #define LDA_COND(M, N, LDA) ((N) == 1 || (LDA) >= THMax(1, (M)))
 
-  if(r_->stride(0) == 1 && LDA_COND(vec1->size(0), vec2->size(0), r_->stride(1)))
+  if(THTensor_strideLegacyNoScalars(r_, 0) == 1 && LDA_COND(THTensor_sizeLegacyNoScalars(vec1, 0), THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_strideLegacyNoScalars(r_, 1)))
   {
-    THBlas_(ger)(vec1->size(0), vec2->size(0),
-                 alpha, THTensor_(data)(vec1), vec1->stride(0),
-                 THTensor_(data)(vec2), vec2->stride(0),
-                 THTensor_(data)(r_), r_->stride(1));
+    THBlas_(ger)(THTensor_sizeLegacyNoScalars(vec1, 0), THTensor_sizeLegacyNoScalars(vec2, 0),
+                 alpha, THTensor_(data)(vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                 THTensor_(data)(vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                 THTensor_(data)(r_), THTensor_strideLegacyNoScalars(r_, 1));
   }
-  else if(r_->stride(1) == 1 && LDA_COND(vec2->size(0), vec1->size(0), r_->stride(0)))
+  else if(THTensor_strideLegacyNoScalars(r_, 1) == 1 && LDA_COND(THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0), THTensor_strideLegacyNoScalars(r_, 0)))
   {
-    THBlas_(ger)(vec2->size(0), vec1->size(0),
-                 alpha, THTensor_(data)(vec2), vec2->stride(0),
-                 THTensor_(data)(vec1), vec1->stride(0),
-                 THTensor_(data)(r_), r_->stride(0));
+    THBlas_(ger)(THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                 alpha, THTensor_(data)(vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                 THTensor_(data)(vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                 THTensor_(data)(r_), THTensor_strideLegacyNoScalars(r_, 0));
   }
   else
   {
     THTensor *cr = THTensor_(newClone)(r_);
 
-    THBlas_(ger)(vec2->size(0), vec1->size(0),
-                 alpha, THTensor_(data)(vec2), vec2->stride(0),
-                 THTensor_(data)(vec1), vec1->stride(0),
-                 THTensor_(data)(cr), cr->stride(0));
+    THBlas_(ger)(THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                 alpha, THTensor_(data)(vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                 THTensor_(data)(vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                 THTensor_(data)(cr), THTensor_strideLegacyNoScalars(cr, 0));
 
     THTensor_(freeCopyTo)(cr, r_);
   }
@@ -1122,18 +1122,18 @@ void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THT
 
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(batch1) == 3, 1, "expected 3D tensor");
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(batch2) == 3, 2, "expected 3D tensor");
-  THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(batch1, 0) == THTensor_(sizeLegacyNoScalars)(batch2, 0), 2,
              "equal number of batches expected, got %d, %d",
-             THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
-  THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
+             THTensor_(sizeLegacyNoScalars)(batch1, 0), THTensor_(sizeLegacyNoScalars)(batch2, 0));
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(batch1, 2) == THTensor_(sizeLegacyNoScalars)(batch2, 1), 2,
              "wrong matrix size, batch1: %dx%d, batch2: %dx%d",
-             THTensor_(size)(batch1, 1), THTensor_(size)(batch1,2),
-             THTensor_(size)(batch2, 1), THTensor_(size)(batch2,2));
+             THTensor_(sizeLegacyNoScalars)(batch1, 1), THTensor_(sizeLegacyNoScalars)(batch1,2),
+             THTensor_(sizeLegacyNoScalars)(batch2, 1), THTensor_(sizeLegacyNoScalars)(batch2,2));
 
-  int64_t dim1 = THTensor_(size)(batch1, 1);
-  int64_t dim2 = THTensor_(size)(batch2, 2);
-  THArgCheck(THTensor_(size)(t, 0) == dim1, 1, "output tensor of incorrect size");
-  THArgCheck(THTensor_(size)(t, 1) == dim2, 1, "output tensor of incorrect size");
+  int64_t dim1 = THTensor_(sizeLegacyNoScalars)(batch1, 1);
+  int64_t dim2 = THTensor_(sizeLegacyNoScalars)(batch2, 2);
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(t, 0) == dim1, 1, "output tensor of incorrect size");
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(t, 1) == dim2, 1, "output tensor of incorrect size");
 
   if (t != result) {
     THTensor_(resizeAs)(result, t);
@@ -1145,7 +1145,7 @@ void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THT
   THTensor *matrix1 = THTensor_(new)();
   THTensor *matrix2 = THTensor_(new)();
 
-  for (batch = 0; batch < THTensor_(size)(batch1, 0); ++batch) {
+  for (batch = 0; batch < THTensor_(sizeLegacyNoScalars)(batch1, 0); ++batch) {
     THTensor_(select)(matrix1, batch1, 0, batch);
     THTensor_(select)(matrix2, batch2, 0, batch);
 

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -10,20 +10,20 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
 
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(batch1) == 3, 1, "expected 3D tensor, got %dD", THTensor_(nDimensionLegacyNoScalars)(batch1));
   THArgCheck(THTensor_(nDimensionLegacyNoScalars)(batch2) == 3, 2, "expected 3D tensor, got %dD", THTensor_(nDimensionLegacyNoScalars)(batch2));
-  THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(batch1, 0) == THTensor_(sizeLegacyNoScalars)(batch2, 0), 2,
              "equal number of batches expected, got %d, %d",
-             THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
-  THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
+             THTensor_(sizeLegacyNoScalars)(batch1, 0), THTensor_(sizeLegacyNoScalars)(batch2, 0));
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(batch1, 2) == THTensor_(sizeLegacyNoScalars)(batch2, 1), 2,
              "wrong matrix size, batch1: %dx%d, batch2: %dx%d",
-             THTensor_(size)(batch1, 1), THTensor_(size)(batch1, 2),
-             THTensor_(size)(batch2, 1), THTensor_(size)(batch2, 2));
+             THTensor_(sizeLegacyNoScalars)(batch1, 1), THTensor_(sizeLegacyNoScalars)(batch1, 2),
+             THTensor_(sizeLegacyNoScalars)(batch2, 1), THTensor_(sizeLegacyNoScalars)(batch2, 2));
 
-  int64_t bs = THTensor_(size)(batch1, 0);
-  int64_t dim1 = THTensor_(size)(batch1, 1);
-  int64_t dim2 = THTensor_(size)(batch2, 2);
-  THArgCheck(THTensor_(size)(t, 0) == bs, 1,   "output tensor of incorrect size");
-  THArgCheck(THTensor_(size)(t, 1) == dim1, 1, "output tensor of incorrect size");
-  THArgCheck(THTensor_(size)(t, 2) == dim2, 1, "output tensor of incorrect size");
+  int64_t bs = THTensor_(sizeLegacyNoScalars)(batch1, 0);
+  int64_t dim1 = THTensor_(sizeLegacyNoScalars)(batch1, 1);
+  int64_t dim2 = THTensor_(sizeLegacyNoScalars)(batch2, 2);
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(t, 0) == bs, 1,   "output tensor of incorrect size");
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(t, 1) == dim1, 1, "output tensor of incorrect size");
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(t, 2) == dim2, 1, "output tensor of incorrect size");
 
   if (t != result) {
     THTensor_(resizeAs)(result, t);
@@ -36,7 +36,7 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
   THTensor *matrix2 = THTensor_(new)();
   THTensor *result_matrix = THTensor_(new)();
 
-  for (batch = 0; batch < THTensor_(size)(batch1, 0); ++batch) {
+  for (batch = 0; batch < THTensor_(sizeLegacyNoScalars)(batch1, 0); ++batch) {
     THTensor_(select)(matrix1, batch1, 0, batch);
     THTensor_(select)(matrix2, batch2, 0, batch);
     THTensor_(select)(result_matrix, result, 0, batch);
@@ -88,7 +88,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
-  if (t->stride(dimension) == 1) {
+  if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
     real theMax;
     real value;
     int64_t theIndex;
@@ -121,7 +121,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     }
     THLongTensor_zero(indices_);
 
-    if(t->size(dimension) == 1) {
+    if(THTensor_sizeLegacyNoScalars(t, dimension) == 1) {
       if (!keepdim) {
         THTensor_(squeeze1d)(values_, values_, dimension);
         THLongTensor_squeeze1d(indices_, indices_, dimension);
@@ -131,12 +131,12 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    THTensor_setSizeAtDim(tempValues_, dimension, t->size(dimension));
+    THTensor_setSizeAtDim(tempValues_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
     THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    THTensor_setSizeAtDim(tempIndices_, dimension, t->size(dimension));
+    THTensor_setSizeAtDim(tempIndices_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
     THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -172,7 +172,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   // two implementations optimized for data locality
-  if (t->stride(dimension) == 1) {
+  if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
     real theMax;
     real value;
     int64_t theIndex;
@@ -205,7 +205,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     }
     THLongTensor_zero(indices_);
 
-    if(t->size(dimension) == 1) {
+    if(THTensor_sizeLegacyNoScalars(t, dimension) == 1) {
       if (!keepdim) {
         THTensor_(squeeze1d)(values_, values_, dimension);
         THLongTensor_squeeze1d(indices_, indices_, dimension);
@@ -215,12 +215,12 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
 
     THTensor *tempValues_ = THTensor_(newWithTensor)(values_);
     // tempValues_.expand_as(t)
-    THTensor_setSizeAtDim(tempValues_, dimension, t->size(dimension));
+    THTensor_setSizeAtDim(tempValues_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
     THTensor_setStrideAtDim(tempValues_, dimension, 0);
 
     THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
-    THTensor_setSizeAtDim(tempIndices_, dimension, t->size(dimension));
+    THTensor_setSizeAtDim(tempIndices_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
     THTensor_setStrideAtDim(tempIndices_, dimension, 0);
 
     TH_TENSOR_APPLY3_D(real, t, real, tempValues_, int64_t, tempIndices_, dimension,
@@ -274,16 +274,16 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride(j);
-            rem = rem%r_->stride(j);
-            tBasicIndex += quot*t->stride(j);
+            quot = rem/THTensor_strideLegacyNoScalars(r_, j);
+            rem = rem%THTensor_strideLegacyNoScalars(r_, j);
+            tBasicIndex += quot*THTensor_strideLegacyNoScalars(t, j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
-        for(j=0; j < t->size(dimension); ++j) {
-          *r__data += *(t_data + j*t->stride(dimension));
+        for(j=0; j < THTensor_sizeLegacyNoScalars(t, dimension); ++j) {
+          *r__data += *(t_data + j*THTensor_strideLegacyNoScalars(t, dimension));
         }
       }
     } else {
@@ -295,7 +295,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 #endif
   if (serial_path) {
     // two implementations optimized for data locality
-    if (t->stride(dimension) == 1) {
+    if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal sum = 0;
                            int64_t i;
@@ -306,7 +306,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
+      THTensor_setSizeAtDim(temp_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
@@ -354,16 +354,16 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride(j);
-            rem = rem%r_->stride(j);
-            tBasicIndex += quot*t->stride(j);
+            quot = rem/THTensor_strideLegacyNoScalars(r_, j);
+            rem = rem%THTensor_strideLegacyNoScalars(r_, j);
+            tBasicIndex += quot*THTensor_strideLegacyNoScalars(t, j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
-        for(j=0; j < t->size(dimension); ++j) {
-          *r__data *= *(t_data + j*t->stride(dimension));
+        for(j=0; j < THTensor_sizeLegacyNoScalars(t, dimension); ++j) {
+          *r__data *= *(t_data + j*THTensor_strideLegacyNoScalars(t, dimension));
         }
       }
     } else {
@@ -376,7 +376,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 
   if(serial_path) {
     // two implementations optimized for data locality
-    if (t->stride(dimension) == 1) {
+    if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal prod = 1;
                            int64_t i;
@@ -387,7 +387,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
+      THTensor_setSizeAtDim(temp_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
@@ -460,9 +460,9 @@ accreal THTensor_(trace)(THTensor *t)
 
   THArgCheck(THTensor_(nDimensionLegacyAll)(t) == 2, 1, "expected a matrix");
 
-  t_stride_0 = THTensor_(stride)(t, 0);
-  t_stride_1 = THTensor_(stride)(t, 1);
-  t_diag_size = THMin(THTensor_(size)(t, 0), THTensor_(size)(t, 1));
+  t_stride_0 = THTensor_(strideLegacyNoScalars)(t, 0);
+  t_stride_1 = THTensor_(strideLegacyNoScalars)(t, 1);
+  t_diag_size = THMin(THTensor_(sizeLegacyNoScalars)(t, 0), THTensor_(sizeLegacyNoScalars)(t, 1));
   while(i < t_diag_size)
   {
     sum += t_data[i*(t_stride_0+t_stride_1)];
@@ -482,7 +482,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
 
   for(i = 0; i < THTensor_(nDimensionLegacyNoScalars)(a); i++)
   {
-    if(THTensor_(size)(a, i) != THTensor_(size)(b, i)) {
+    if(THTensor_(sizeLegacyNoScalars)(a, i) != THTensor_(sizeLegacyNoScalars)(b, i)) {
         THDescBuff ba = THTensor_(sizeDesc)(a);
         THDescBuff bb = THTensor_(sizeDesc)(b);
         THError("inconsistent tensor sizes %s, %s", ba.str, bb.str);
@@ -493,7 +493,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
   {
     for(i = 0; i < THTensor_(nDimensionLegacyNoScalars)(a); i++)
     {
-      if(THTensor_(size)(a, i) == 3)
+      if(THTensor_(sizeLegacyNoScalars)(a, i) == 3)
       {
         dimension = i;
         break;
@@ -507,7 +507,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyNoScalars)(a), 3, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
-  THArgCheck(THTensor_(size)(a, dimension) == 3, 3, "dimension %d does not have size 3",
+  THArgCheck(THTensor_(sizeLegacyNoScalars)(a, dimension) == 3, 3, "dimension %d does not have size 3",
       dimension + TH_INDEX_BASE);
 
   THTensor_(resizeAs)(r_, a);
@@ -565,8 +565,8 @@ void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
   if(THTensor_(nDimensionLegacyNoScalars)(t) == 1)
   {
     real *t_data = THTensor_(data)(t);
-    int64_t t_stride_0 = THTensor_(stride)(t, 0);
-    int64_t t_size = THTensor_(size)(t, 0);
+    int64_t t_stride_0 = THTensor_(strideLegacyNoScalars)(t, 0);
+    int64_t t_size = THTensor_(sizeLegacyNoScalars)(t, 0);
     int64_t sz = t_size + (k >= 0 ? k : -k);
     real *r__data;
     int64_t r__stride_0;
@@ -576,8 +576,8 @@ void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
     THTensor_(resize2d)(r_, sz, sz);
     THTensor_(zero)(r_);
     r__data = THTensor_(data)(r_);
-    r__stride_0 = THTensor_(stride)(r_, 0);
-    r__stride_1 = THTensor_(stride)(r_, 1);
+    r__stride_0 = THTensor_(strideLegacyNoScalars)(r_, 0);
+    r__stride_1 = THTensor_(strideLegacyNoScalars)(r_, 1);
     r__data += (k >= 0 ? k*r__stride_1 : -k*r__stride_0);
 
     for(i = 0; i < t_size; i++)
@@ -586,20 +586,20 @@ void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
   else
   {
     real *t_data = THTensor_(data)(t);
-    int64_t t_stride_0 = THTensor_(stride)(t, 0);
-    int64_t t_stride_1 = THTensor_(stride)(t, 1);
+    int64_t t_stride_0 = THTensor_(strideLegacyNoScalars)(t, 0);
+    int64_t t_stride_1 = THTensor_(strideLegacyNoScalars)(t, 1);
     int64_t sz;
     real *r__data;
     int64_t r__stride_0;
     int64_t i;
 
     if(k >= 0)
-      sz = THMin(THTensor_(size)(t, 0), THTensor_(size)(t, 1)-k);
+      sz = THMin(THTensor_(sizeLegacyNoScalars)(t, 0), THTensor_(sizeLegacyNoScalars)(t, 1)-k);
     else
-      sz = THMin(THTensor_(size)(t, 0)+k, THTensor_(size)(t, 1));
+      sz = THMin(THTensor_(sizeLegacyNoScalars)(t, 0)+k, THTensor_(sizeLegacyNoScalars)(t, 1));
     THTensor_(resize1d)(r_, sz);
     r__data = THTensor_(data)(r_);
-    r__stride_0 = THTensor_(stride)(r_, 0);
+    r__stride_0 = THTensor_(strideLegacyNoScalars)(r_, 0);
 
     t_data += (k >= 0 ? k*t_stride_1 : -k*t_stride_0);
     for(i = 0; i < sz; i++)
@@ -622,9 +622,9 @@ void THTensor_(eye)(THTensor *r_, int64_t n, int64_t m)
 
   i = 0;
   r__data = THTensor_(data)(r_);
-  sz = THMin(THTensor_(size)(r_, 0), THTensor_(size)(r_, 1));
+  sz = THMin(THTensor_(sizeLegacyNoScalars)(r_, 0), THTensor_(sizeLegacyNoScalars)(r_, 1));
   for(i = 0; i < sz; i++)
-    r__data[i*(r_->stride(0)+r_->stride(1))] = 1;
+    r__data[i*(THTensor_strideLegacyNoScalars(r_, 0)+THTensor_strideLegacyNoScalars(r_, 1))] = 1;
 }
 
 
@@ -673,7 +673,7 @@ void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n)
 
   THTensor_(resize1d)(r_, n);
   r__data = THTensor_(data)(r_);
-  r__stride_0 = THTensor_(stride)(r_,0);
+  r__stride_0 = THTensor_(strideLegacyNoScalars)(r_,0);
 
   for(i = 0; i < n; i++)
     r__data[i*r__stride_0] = (real)(i);
@@ -1074,7 +1074,7 @@ void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int
   THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
-  t_size_dim = THTensor_(size)(t, dimension);
+  t_size_dim = THTensor_(sizeLegacyNoScalars)(t, dimension);
 
   temp_ = THTensor_(new)();
   THTensor_(resize1d)(temp_, t_size_dim);
@@ -1132,7 +1132,7 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   int64_t t_size_dim;
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyAll)(t), 3, "dimension out of range");
-  THArgCheck(k > 0 && k <= t->size(dimension), 2, "selected index out of range");
+  THArgCheck(k > 0 && k <= THTensor_sizeLegacyNoScalars(t, dimension), 2, "selected index out of range");
 
   int in_dims = THTensor_(nDimensionLegacyAll)(t);
   THTensor_(preserveReduceDimSemantics)(values_, in_dims, dimension, keepdim);
@@ -1143,7 +1143,7 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   THLongTensor_resize(indices_, dim, NULL);
   THLongStorage_free(dim);
 
-  t_size_dim = THTensor_(size)(t, dimension);
+  t_size_dim = THTensor_(sizeLegacyNoScalars)(t, dimension);
 
   temp_ = THTensor_(new)();
   THTensor_(resize1d)(temp_, t_size_dim);
@@ -1178,7 +1178,7 @@ void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, i
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyAll)(t), 3, "dimension out of range");
 
-  t_size_dim = THTensor_(size)(t, dimension);
+  t_size_dim = THTensor_(sizeLegacyNoScalars)(t, dimension);
   k = (t_size_dim-1) >> 1; /* take middle or one-before-middle element */
 
   THTensor_(kthvalue)(values_, indices_, t, k+1, dimension, keepdim);
@@ -1193,7 +1193,7 @@ void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, i
 #endif
   THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
 
-  int64_t sliceSize = THTensor_(size)(t, dim);
+  int64_t sliceSize = THTensor_(sizeLegacyNoScalars)(t, dim);
 #ifndef USE_TH_SIZE_ZERO_DIM
   THArgCheck(k > 0 && k <= sliceSize, 2, "k not in range for dimension");
 #else
@@ -1271,12 +1271,12 @@ void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k)
 
   THTensor_(resizeAs)(r_, t);
 
-  t_size_0 = THTensor_(size)(t, 0);
-  t_size_1 = THTensor_(size)(t, 1);
-  t_stride_0 = THTensor_(stride)(t, 0);
-  t_stride_1 = THTensor_(stride)(t, 1);
-  r__stride_0 = THTensor_(stride)(r_, 0);
-  r__stride_1 = THTensor_(stride)(r_, 1);
+  t_size_0 = THTensor_(sizeLegacyNoScalars)(t, 0);
+  t_size_1 = THTensor_(sizeLegacyNoScalars)(t, 1);
+  t_stride_0 = THTensor_(strideLegacyNoScalars)(t, 0);
+  t_stride_1 = THTensor_(strideLegacyNoScalars)(t, 1);
+  r__stride_0 = THTensor_(strideLegacyNoScalars)(r_, 0);
+  r__stride_1 = THTensor_(strideLegacyNoScalars)(r_, 1);
   r__data = THTensor_(data)(r_);
   t_data = THTensor_(data)(t);
 
@@ -1302,12 +1302,12 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
 
   THTensor_(resizeAs)(r_, t);
 
-  t_size_0 = THTensor_(size)(t, 0);
-  t_size_1 = THTensor_(size)(t, 1);
-  t_stride_0 = THTensor_(stride)(t, 0);
-  t_stride_1 = THTensor_(stride)(t, 1);
-  r__stride_0 = THTensor_(stride)(r_, 0);
-  r__stride_1 = THTensor_(stride)(r_, 1);
+  t_size_0 = THTensor_(sizeLegacyNoScalars)(t, 0);
+  t_size_1 = THTensor_(sizeLegacyNoScalars)(t, 1);
+  t_stride_0 = THTensor_(strideLegacyNoScalars)(t, 0);
+  t_stride_1 = THTensor_(strideLegacyNoScalars)(t, 1);
+  r__stride_0 = THTensor_(strideLegacyNoScalars)(r_, 0);
+  r__stride_1 = THTensor_(strideLegacyNoScalars)(r_, 1);
   r__data = THTensor_(data)(r_);
   t_data = THTensor_(data)(t);
 
@@ -1341,8 +1341,8 @@ inline void THTensor_(check_shape_except_dim)(THTensor *first, THTensor *second,
     if (dim == dimension) {
       continue;
     }
-    int64_t first_dim_size = first->size(dim);
-    int64_t second_dim_size = second->size(dim);
+    int64_t first_dim_size = THTensor_sizeLegacyNoScalars(first, dim);
+    int64_t second_dim_size = THTensor_sizeLegacyNoScalars(second, dim);
     THArgCheck(first_dim_size == second_dim_size, 0,
         "Sizes of tensors must match except in dimension %d. Got %lld and %lld in dimension %d",
         dimension, (long long)first_dim_size, (long long)second_dim_size, dim);
@@ -1386,13 +1386,13 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
       continue;
     }
     THTensor_(check_shape_except_dim)(notSkippedTensor, tensor, dimension);
-    cat_dim_size += tensor->size(dimension);
+    cat_dim_size += THTensor_sizeLegacyNoScalars(tensor, dimension);
   }
 
   // Compute the size of the result
   THLongStorage *size = THLongStorage_newWithSize(nDims);
   for (int dim = 0; dim < nDims; dim++) {
-    int64_t result_dim_size = notSkippedTensor->size(dim);
+    int64_t result_dim_size = THTensor_sizeLegacyNoScalars(notSkippedTensor, dim);
     if (dim == dimension) {
       result_dim_size = cat_dim_size;
     }
@@ -1431,7 +1431,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
     offset = 0;
     for (int j = 0; j < numInputs; j++) {
       if (!should_skip(inputs[j])) {
-        int64_t dimSize = inputs[j]->size(dimension);
+        int64_t dimSize = THTensor_sizeLegacyNoScalars(inputs[j], dimension);
         THTensor *nt = THTensor_(newWithTensor)(result);
         THTensor_(narrow)(nt, NULL, dimension, offset, dimSize);
         THTensor_(copy)(nt, inputs[j]);
@@ -1690,16 +1690,16 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride(j);
-            rem = rem%r_->stride(j);
-            tBasicIndex += quot*t->stride(j);
+            quot = rem/THTensor_strideLegacyNoScalars(r_, j);
+            rem = rem%THTensor_strideLegacyNoScalars(r_, j);
+            tBasicIndex += quot*THTensor_strideLegacyNoScalars(t, j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 1;
-        for(j=0; j < t->size(dimension); ++j) {
-          *r__data = *r__data && *(t_data + j*t->stride(dimension));
+        for(j=0; j < THTensor_sizeLegacyNoScalars(t, dimension); ++j) {
+          *r__data = *r__data && *(t_data + j*THTensor_strideLegacyNoScalars(t, dimension));
         }
       }
     } else {
@@ -1712,7 +1712,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
   if(serial_path) {
     // two implementations optimized for data locality
-    if (t->stride(dimension) == 1) {
+    if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal prod = 1;
                            int64_t i;
@@ -1723,7 +1723,7 @@ void THTensor_(logicalAnd)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(fill)(r_, 1);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
+      THTensor_setSizeAtDim(temp_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data && *t_data;);
@@ -1770,16 +1770,16 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
 
         for(j = 0; j < r_Dim; ++j) {
           if(j != dimension){
-            quot = rem/r_->stride(j);
-            rem = rem%r_->stride(j);
-            tBasicIndex += quot*t->stride(j);
+            quot = rem/THTensor_strideLegacyNoScalars(r_, j);
+            rem = rem%THTensor_strideLegacyNoScalars(r_, j);
+            tBasicIndex += quot*THTensor_strideLegacyNoScalars(t, j);
           }
         }
         real *t_data = tp+tBasicIndex;
         real *r__data = rp+iter;
         *r__data = 0;
-        for(j=0; j < t->size(dimension); ++j) {
-          *r__data = *r__data || *(t_data + j*t->stride(dimension));
+        for(j=0; j < THTensor_sizeLegacyNoScalars(t, dimension); ++j) {
+          *r__data = *r__data || *(t_data + j*THTensor_strideLegacyNoScalars(t, dimension));
         }
       }
     } else {
@@ -1791,7 +1791,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
 #endif
   if (serial_path) {
     // two implementations optimized for data locality
-    if (t->stride(dimension) == 1) {
+    if (THTensor_strideLegacyNoScalars(t, dimension) == 1) {
       TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                            accreal sum = 0;
                            int64_t i;
@@ -1802,7 +1802,7 @@ void THTensor_(logicalAny)(THTensor *r_, THTensor *t, int dimension, int keepdim
       THTensor_(zero)(r_);
       THTensor *temp_ = THTensor_(newWithTensor)(r_);
       // r_.expand_as(t)
-      THTensor_setSizeAtDim(temp_, dimension, t->size(dimension));
+      THTensor_setSizeAtDim(temp_, dimension, THTensor_sizeLegacyNoScalars(t, dimension));
       THTensor_setStrideAtDim(temp_, dimension, 0);
 
       TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data || *t_data;);
@@ -1887,7 +1887,7 @@ void THTensor_(mean)(THTensor *r_, THTensor *t, int dimension, int keepdim)
       dimension + TH_INDEX_BASE);
 
   THTensor_(sum)(r_, t, dimension, keepdim);
-  THTensor_(div)(r_, r_, t->size(dimension));
+  THTensor_(div)(r_, r_, THTensor_sizeLegacyNoScalars(t, dimension));
 }
 
 void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim)
@@ -2065,7 +2065,7 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
 
   THTensor_(resizeAs)(res, src);
 
-  for (int64_t i = 0; i < src->size(dimension); i++)
+  for (int64_t i = 0; i < THTensor_sizeLegacyNoScalars(src, dimension); i++)
   {
     real norm = 0;
     real new_norm;
@@ -2217,7 +2217,7 @@ void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, real min
   real minval;
   real maxval;
 
-  THTensor_(resize2d)(hist, tensor->size(0), nbins);
+  THTensor_(resize2d)(hist, THTensor_sizeLegacyNoScalars(tensor, 0), nbins);
   THTensor_(zero)(hist);
 
   minval = minvalue;

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -284,9 +284,9 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
       small = THLongTensor_fastGet1d(smaller, small_c-1);
 
       THLongTensor_fastSet1d(J, small, large);
-      q_data[large * q->stride(0)] -= 1.0 - THTensor_(fastGet1d)(q, small);
+      q_data[large * THTensor_strideLegacyNoScalars(q, 0)] -= 1.0 - THTensor_(fastGet1d)(q, small);
 
-      if(q_data[large * q->stride(0)] < 1.0)
+      if(q_data[large * THTensor_strideLegacyNoScalars(q, 0)] < 1.0)
         {
           THLongTensor_fastSet1d(smaller, small_c-1, large);
           large_c -= 1;
@@ -317,7 +317,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     {
       for (i=0; i < inputsize; i++)
         {
-          q_data[i*q->stride(0)] /= q_max;
+          q_data[i*THTensor_strideLegacyNoScalars(q, 0)] /= q_max;
         }
     }
   for (i=0; i < inputsize; i++)
@@ -368,8 +368,8 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
     THTensor_(unsqueeze1d)(prob_dist, prob_dist, 0);
   }
 
-  n_dist = THTensor_(size)(prob_dist, 0);
-  n_categories = THTensor_(size)(prob_dist, 1);
+  n_dist = THTensor_(sizeLegacyNoScalars)(prob_dist, 0);
+  n_categories = THTensor_(sizeLegacyNoScalars)(prob_dist, 1);
 
   THArgCheckWithCleanup(n_sample > 0,
     THCleanup(if (start_dim == 1) THTensor_(squeeze1d)(prob_dist, prob_dist, 0);),
@@ -399,7 +399,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
     {
       val = THStorage_(get)( \
         THTensor_getStoragePtr(prob_dist), \
-        prob_dist->storage_offset()+i*prob_dist->stride(0)+j*prob_dist->stride(1) \
+        prob_dist->storage_offset()+i*THTensor_strideLegacyNoScalars(prob_dist, 0)+j*THTensor_strideLegacyNoScalars(prob_dist, 1) \
       );
       THArgCheckWithCleanup((val >= 0),
                             THCleanup(THDoubleTensor_free(cum_dist); if (start_dim == 1) THTensor_(squeeze1d)(prob_dist, prob_dist, 0);),
@@ -412,7 +412,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
       sum += val;
       THDoubleStorage_set(
         THTensor_getStoragePtr(cum_dist), \
-        cum_dist->storage_offset()+j*cum_dist->stride(0), \
+        cum_dist->storage_offset()+j*THTensor_strideLegacyNoScalars(cum_dist, 0), \
         sum \
       );
     }
@@ -426,7 +426,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
     {
       for (j=0; j<n_categories; j++)
       {
-        THDoubleTensor_data(cum_dist)[j*cum_dist->stride(0)] /= sum;
+        THDoubleTensor_data(cum_dist)[j*THTensor_strideLegacyNoScalars(cum_dist, 0)] /= sum;
       }
     }
 
@@ -442,14 +442,14 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
       double cum_prob;
       int sample_idx;
       /* Make sure the last cumulative distribution bucket sums to 1 */
-      THDoubleTensor_data(cum_dist)[(n_categories-1)*cum_dist->stride(0)] = 1;
+      THDoubleTensor_data(cum_dist)[(n_categories-1)*THTensor_strideLegacyNoScalars(cum_dist, 0)] = 1;
 
       while(right_pointer - left_pointer > 0)
       {
           mid_pointer = left_pointer + (right_pointer - left_pointer) / 2;
           cum_prob = THDoubleStorage_get( \
             THTensor_getStoragePtr(cum_dist), \
-            cum_dist->storage_offset()+mid_pointer*cum_dist->stride(0) \
+            cum_dist->storage_offset()+mid_pointer*THTensor_strideLegacyNoScalars(cum_dist, 0) \
           );
           if (cum_prob < uniform_sample)
           {
@@ -465,7 +465,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
        /* store in result tensor (will be incremented for lua compat by wrapper) */
       THLongStorage_set( \
         THTensor_getStoragePtr(self), \
-        self->storage_offset()+i*self->stride(0)+j*self->stride(1), \
+        self->storage_offset()+i*THTensor_strideLegacyNoScalars(self, 0)+j*THTensor_strideLegacyNoScalars(self, 1), \
         sample_idx \
       );
 
@@ -481,13 +481,13 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
         {
           new_val = THDoubleStorage_get( \
             THTensor_getStoragePtr(cum_dist), \
-            cum_dist->storage_offset()+(sample_idx-1)*cum_dist->stride(0) \
+            cum_dist->storage_offset()+(sample_idx-1)*THTensor_strideLegacyNoScalars(cum_dist, 0) \
           );
         }
         /* marginal cumulative mass (i.e. original probability) of sample */
         diff = THDoubleStorage_get( \
           THTensor_getStoragePtr(cum_dist), \
-          cum_dist->storage_offset()+sample_idx*cum_dist->stride(0) \
+          cum_dist->storage_offset()+sample_idx*THTensor_strideLegacyNoScalars(cum_dist, 0) \
         ) - new_val;
         /* new sum of marginals is not one anymore... */
         sum = 1.0 - diff;
@@ -495,7 +495,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
         {
           new_val = THDoubleStorage_get( \
             THTensor_getStoragePtr(cum_dist), \
-            cum_dist->storage_offset()+k*cum_dist->stride(0) \
+            cum_dist->storage_offset()+k*THTensor_strideLegacyNoScalars(cum_dist, 0) \
           );
           if (k >= sample_idx)
           {
@@ -506,7 +506,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
           new_val /= sum;
           THDoubleStorage_set( \
             THTensor_getStoragePtr(cum_dist), \
-            cum_dist->storage_offset()+k*cum_dist->stride(0), \
+            cum_dist->storage_offset()+k*THTensor_strideLegacyNoScalars(cum_dist, 0), \
             new_val \
           );
         }

--- a/aten/src/THC/THCDeviceTensorUtils.cuh
+++ b/aten/src/THC/THCDeviceTensorUtils.cuh
@@ -58,8 +58,8 @@ toDeviceTensor(THCState* state, THCTensor* t) {
   IndexT strides[Dim];
 
   for (int i = 0; i < Dim; ++i) {
-    int64_t size = THCTensor_size(state, t, i);
-    int64_t stride = THCTensor_stride(state, t, i);
+    int64_t size = THCTensor_sizeLegacyNoScalars(state, t, i);
+    int64_t stride = THCTensor_strideLegacyNoScalars(state, t, i);
 
     maxOffset += (size - 1) * stride;
 

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -410,8 +410,8 @@ bool THC_reduceDim(THCState* state,
                    int keepdim) {
   ptrdiff_t inElements = THCTensor_nElement(state, in);
 
-  int64_t reductionSize = THCTensor_size(state, in, dim);
-  int64_t reductionStride = THCTensor_stride(state, in, dim);
+  int64_t reductionSize = THCTensor_sizeLegacyNoScalars(state, in, dim);
+  int64_t reductionStride = THCTensor_strideLegacyNoScalars(state, in, dim);
   ptrdiff_t outElements = inElements / reductionSize;
 
   if (THCTensor_nDimensionLegacyAll(state, out) > MAX_CUTORCH_DIMS ||

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -15,8 +15,8 @@
 THC_API int THCTensor_nDimensionLegacyNoScalars(THCState *state, const THCTensor *self);
 THC_API int THCTensor_nDimensionLegacyAll(THCState *state, const THCTensor *self);
 
-THC_API int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim);
+THC_API int64_t THCTensor_sizeLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
+THC_API int64_t THCTensor_strideLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
 THC_API THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self);
 
 THC_API THCTensor *THCTensor_new(THCState *state, at::ScalarType scalar_type);

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -300,13 +300,13 @@ __host__ void THCTensor_varOuterDim(THCState *state, TensorTypeK *tgt, TensorTyp
   // Treat all outer dimensions (i.e. dim < dimension) as one.
   unsigned num_orows = 1;
   for (int64_t dim = 0; dim < dimension; dim++) {
-    num_orows *= THCTensor_size(state, src, dim);
+    num_orows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
-  unsigned row_size = THCTensor_size(state, src, dimension);
+  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, dimension);
   // Treat all inner dimensions (i.e. dim > dimension) as one.
   unsigned num_irows = 1;
   for (unsigned dim = dimension + 1; dim < ndim; dim++) {
-    num_irows *= THCTensor_size(state, src, dim);
+    num_irows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
 
   dim3 threads(min(512, num_irows));
@@ -446,9 +446,9 @@ __host__ void THCTensor_varInnermostDim(THCState *state, TensorTypeK *tgt, Tenso
   // Treat all outer dimensions as a single dimension.
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
-    num_rows *= THCTensor_size(state, src, dim);
+    num_rows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
-  unsigned row_size = THCTensor_size(state, src, ndim - 1);
+  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, ndim - 1);
 
   // From limited testing, 16x32 seemed a good compromise for handling both long and short dimensions.
   dim3 threads(16, 32);
@@ -518,12 +518,12 @@ THC_transformReduceOuterDimIndex(THCState *state,
   unsigned ndim = THCTensor_nDimensionLegacyAll(state, src);
   unsigned num_orows = 1;
   for (int64_t dim = 0; dim < rdim; dim++) {
-    num_orows *= THCTensor_size(state, src, dim);
+    num_orows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
-  unsigned row_size = THCTensor_size(state, src, rdim);
+  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, rdim);
   unsigned num_irows = 1;
   for (unsigned dim = rdim + 1; dim < ndim; dim++) {
-    num_irows *= THCTensor_size(state, src, dim);
+    num_irows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
 
   dim3 threads(min(512, num_irows));
@@ -621,9 +621,9 @@ THC_transformReduceInnermostDimIndex(THCState *state,
   unsigned ndim = THCTensor_nDimensionLegacyAll(state, src);
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
-    num_rows *= THCTensor_size(state, src, dim);
+    num_rows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
   }
-  unsigned row_size = THCTensor_size(state, src, ndim - 1);
+  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, ndim - 1);
 
   dim3 threads(16, 32);
   dim3 grid(min(1024, THCCeilDiv(num_rows, threads.y)));

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -160,8 +160,8 @@ sampleMultinomialOnce(int64_t* dest,
                       int categories,
                       T* sampled,
                       T* dist,
-                      int stride_dist,        // dist->stride(0)
-                      int stride_categories   // dist->stride(1)
+                      int stride_dist,        // THTensor_strideLegacyNoScalars(dist, 0)
+                      int stride_categories   // THTensor_strideLegacyNoScalars(dist, 1)
                       ) {
   extern __shared__  unsigned char my_smem[];
   __shared__ bool found;

--- a/aten/src/THC/THCTensorSort.cu
+++ b/aten/src/THC/THCTensorSort.cu
@@ -8,7 +8,7 @@ void THCudaLongTensor_fillSliceWithIndex(THCState* state,
 
   ptrdiff_t inElements = THCudaLongTensor_nElement(state, t);
   if (inElements > 0) {
-    int64_t sliceSize = THCudaLongTensor_size(state, t, dim);
+    int64_t sliceSize = THCudaLongTensor_sizeLegacyNoScalars(state, t, dim);
     ptrdiff_t numSlices = inElements / sliceSize;
 
     dim3 grid;

--- a/aten/src/THC/THCTensorTypeUtils.cuh
+++ b/aten/src/THC/THCTensorTypeUtils.cuh
@@ -62,8 +62,8 @@ getTensorInfo(THCState* state, TensorType* t) {
 
   int dims = THCTensor_nDimensionLegacyNoScalars(state, t);
   for (int i = 0; i < dims; ++i) {
-    sz[i] = THCTensor_size(state, t, i);
-    st[i] = THCTensor_stride(state, t, i);
+    sz[i] = THCTensor_sizeLegacyNoScalars(state, t, i);
+    st[i] = THCTensor_strideLegacyNoScalars(state, t, i);
   }
 
   return TensorInfo<ScalarType, IndexType>(

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -23,14 +23,14 @@ int THCTensor_(nDimensionLegacyAll)(THCState *state, const THCTensor *self)
   return THCTensor_nDimensionLegacyAll(state, self);
 }
 
-int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim)
+int64_t THCTensor_(sizeLegacyNoScalars)(THCState *state, const THCTensor *self, int dim)
 {
-  return THCTensor_size(state, self, dim);
+  return THCTensor_sizeLegacyNoScalars(state, self, dim);
 }
 
-int64_t THCTensor_(stride)(THCState *state, const THCTensor *self, int dim)
+int64_t THCTensor_(strideLegacyNoScalars)(THCState *state, const THCTensor *self, int dim)
 {
-  return THCTensor_stride(state, self, dim);
+  return THTensor_strideLegacyNoScalars(self, dim);
 }
 
 THLongStorage *THCTensor_(newSizeOf)(THCState *state, THCTensor *self)
@@ -241,9 +241,9 @@ THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
   THArgCheck(THCTensor_(isContiguous)(state, input), 1,
              "Tensor must be contiguous");
   THLongStorage *newSize = THLongStorage_newWithSize(in_dims - 1);
-  THLongStorage_data(newSize)[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
+  THLongStorage_data(newSize)[0] = THCTensor_(sizeLegacyNoScalars)(state, input, 0) * THCTensor_(sizeLegacyNoScalars)(state, input, 1);
   for (int i = 2; i < in_dims; i++) {
-    THLongStorage_data(newSize)[i - 1] = THCTensor_(size)(state, input, i);
+    THLongStorage_data(newSize)[i - 1] = THCTensor_(sizeLegacyNoScalars)(state, input, i);
   }
   THCTensor *output = THCTensor_(newView)(state, input, newSize);
   THLongStorage_free(newSize);
@@ -372,12 +372,12 @@ void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int di
 #else
   THArgCheck( size > 0, 5, "out of range");
 #endif
-  THArgCheck(firstIndex+size <= src->size(dimension), 5, "out of range");
+  THArgCheck(firstIndex+size <= THTensor_sizeLegacyNoScalars(src, dimension), 5, "out of range");
 
   THCTensor_(set)(state, self, src);
 
   if (firstIndex > 0) {
-    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*self->stride(dimension));
+    THTensor_setStorageOffset(self, self->storage_offset() + firstIndex*THTensor_strideLegacyNoScalars(self, dimension));
   }
 
   THTensor_setSizeAtDim(self, dimension, size);
@@ -398,14 +398,14 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
 #endif
 #endif
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 3, "out of range");
-  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size(dimension)), 4, "out of range");
+  THArgCheck((sliceIndex >= 0) && (sliceIndex < THTensor_sizeLegacyNoScalars(src, dimension)), 4, "out of range");
 
   THCTensor_(set)(state, self, src);
   THCTensor_(narrow)(state, self, NULL, dimension, sliceIndex, 1);
   for(d = dimension; d < self->dim()-1; d++)
   {
-    THTensor_setSizeAtDim(self, d, self->size(d+1));
-    THTensor_setStrideAtDim(self, d, self->stride(d+1));
+    THTensor_setSizeAtDim(self, d, THTensor_sizeLegacyNoScalars(self, d+1));
+    THTensor_setStrideAtDim(self, d, THTensor_strideLegacyNoScalars(self, d+1));
   }
   THTensor_resizeDim(self, self->dim() - 1);
 }
@@ -425,11 +425,11 @@ void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int
   if(dimension1 == dimension2)
     return;
 
-  z = self->stride(dimension1);
-  THTensor_setStrideAtDim(self, dimension1, self->stride(dimension2));
+  z = THTensor_strideLegacyNoScalars(self, dimension1);
+  THTensor_setStrideAtDim(self, dimension1, THTensor_strideLegacyNoScalars(self, dimension2));
   THTensor_setStrideAtDim(self, dimension2, z);
-  z = self->size(dimension1);
-  THTensor_setSizeAtDim(self, dimension1, self->size(dimension2));
+  z = THTensor_sizeLegacyNoScalars(self, dimension1);
+  THTensor_setSizeAtDim(self, dimension1, THTensor_sizeLegacyNoScalars(self, dimension2));
   THTensor_setSizeAtDim(self, dimension2, z);
 }
 
@@ -444,7 +444,7 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   THArgCheck(!src->is_empty(), 1, "cannot unfold an empty tensor");
 #endif
   THArgCheck(dimension < src->dim(), 2, "out of range");
-  THArgCheck(size <= src->size(dimension), 3, "out of range");
+  THArgCheck(size <= THTensor_sizeLegacyNoScalars(src, dimension), 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
   THCTensor_(set)(state, self, src);
@@ -453,18 +453,18 @@ void THCTensor_(unfold)(THCState *state, THCTensor *self, THCTensor *src, int di
   std::vector<int64_t> newStride(self->dim() + 1);
 
   newSize[self->dim()] = size;
-  newStride[self->dim()] = self->stride(dimension);
+  newStride[self->dim()] = THTensor_strideLegacyNoScalars(self, dimension);
   for(d = 0; d < self->dim(); d++)
   {
     if(d == dimension)
     {
-      newSize[d] = (self->size(d) - size) / step + 1;
-      newStride[d] = step*self->stride(d);
+      newSize[d] = (THTensor_sizeLegacyNoScalars(self, d) - size) / step + 1;
+      newStride[d] = step*THTensor_strideLegacyNoScalars(self, d);
     }
     else
     {
-      newSize[d] = self->size(d);
-      newStride[d] = self->stride(d);
+      newSize[d] = THTensor_sizeLegacyNoScalars(self, d);
+      newStride[d] = THTensor_strideLegacyNoScalars(self, d);
     }
   }
 
@@ -484,12 +484,12 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
 
   for(d = 0; d < src->dim(); d++)
   {
-    if(src->size(d) != 1)
+    if(THTensor_sizeLegacyNoScalars(src, d) != 1)
     {
       if(d != ndim)
       {
-        THTensor_setSizeAtDim(self, ndim, src->size(d));
-        THTensor_setStrideAtDim(self, ndim, src->stride(d));
+        THTensor_setSizeAtDim(self, ndim, THTensor_sizeLegacyNoScalars(src, d));
+        THTensor_setStrideAtDim(self, ndim, THTensor_strideLegacyNoScalars(src, d));
       }
       ndim++;
     }
@@ -530,7 +530,7 @@ int THCTensor_(isSize)(THCState *state, const THCTensor *self, const THLongStora
 
   for (d = 0; d < self->dim(); ++d)
   {
-    if (self->size(d) != THLongStorage_data(dims)[d])
+    if (THTensor_sizeLegacyNoScalars(self, d) != THLongStorage_data(dims)[d])
       return 0;
   }
   return 1;
@@ -545,7 +545,7 @@ int THCTensor_(isSetTo)(THCState *state, const THCTensor *self, const THCTensor 
     int d;
     for (d = 0; d < self->dim(); ++d)
     {
-      if (self->size(d) != src->size(d) || self->stride(d) != src->stride(d))
+      if (THTensor_sizeLegacyNoScalars(self, d) != THTensor_sizeLegacyNoScalars(src, d) || THTensor_strideLegacyNoScalars(self, d) != THTensor_strideLegacyNoScalars(src, d))
         return 0;
     }
     return 1;
@@ -560,7 +560,7 @@ int THCTensor_(isSameSizeAs)(THCState *state, const THCTensor *self, const THCTe
     return 0;
   for(d = 0; d < self->dim(); ++d)
   {
-    if(self->size(d) != src->size(d))
+    if(THTensor_sizeLegacyNoScalars(self, d) != THTensor_sizeLegacyNoScalars(src, d))
       return 0;
   }
   return 1;
@@ -604,57 +604,57 @@ void THCTensor_(resizeNd)(THCState *state, THCTensor *self, int nDimension, int6
 void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, real value)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0), value);
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)), 2, "out of range");
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0), value);
 }
 
 real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0)
 {
   THArgCheck(tensor->dim() == 1, 1, "tensor must have one dimension");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)), 2, "out of range");
-  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0));
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)), 2, "out of range");
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0));
 }
 
 void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, real value)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1), value);
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)), 2, "out of range");
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1), value);
 }
 
 real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1)
 {
   THArgCheck(tensor->dim() == 2, 1, "tensor must have two dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)), 2, "out of range");
-  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1));
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)), 2, "out of range");
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1));
 }
 
 void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, real value)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2), value);
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)), 2, "out of range");
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2), value);
 }
 
 real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2)
 {
   THArgCheck(tensor->dim() == 3, 1, "tensor must have three dimensions");
-  THArgCheck( (x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)), 2, "out of range");
-  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2));
+  THArgCheck( (x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)), 2, "out of range");
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2));
 }
 
 void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, real value)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3), value);
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)) && (x3 >= 0) && (x3 < THTensor_sizeLegacyNoScalars(tensor, 3)), 2, "out of range");
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2)+x3*THTensor_strideLegacyNoScalars(tensor, 3), value);
 }
 
 real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3)
 {
   THArgCheck(tensor->dim() == 4, 1, "tensor must have four dimensions");
-  THArgCheck((x0 >= 0) && (x0 < tensor->size(0)) && (x1 >= 0) && (x1 < tensor->size(1)) && (x2 >= 0) && (x2 < tensor->size(2)) && (x3 >= 0) && (x3 < tensor->size(3)), 2, "out of range");
-  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*tensor->stride(0)+x1*tensor->stride(1)+x2*tensor->stride(2)+x3*tensor->stride(3));
+  THArgCheck((x0 >= 0) && (x0 < THTensor_sizeLegacyNoScalars(tensor, 0)) && (x1 >= 0) && (x1 < THTensor_sizeLegacyNoScalars(tensor, 1)) && (x2 >= 0) && (x2 < THTensor_sizeLegacyNoScalars(tensor, 2)) && (x3 >= 0) && (x3 < THTensor_sizeLegacyNoScalars(tensor, 3)), 2, "out of range");
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset()+x0*THTensor_strideLegacyNoScalars(tensor, 0)+x1*THTensor_strideLegacyNoScalars(tensor, 1)+x2*THTensor_strideLegacyNoScalars(tensor, 2)+x3*THTensor_strideLegacyNoScalars(tensor, 3));
 }
 
 int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...)
@@ -713,7 +713,7 @@ THCDescBuff THCTensor_(sizeDesc)(THCState *state, const THCTensor *tensor) {
   int i;
   for(i = 0; i < tensor->dim(); i++) {
     if(n >= L) break;
-    n += snprintf(str+n, L-n, "%" PRId64, tensor->size(i));
+    n += snprintf(str+n, L-n, "%" PRId64, THTensor_sizeLegacyNoScalars(tensor, i));
     if(i < tensor->dim()-1) {
       n += snprintf(str+n, L-n, " x ");
     }

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -25,8 +25,8 @@ THC_API ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *se
 THC_API int THCTensor_(nDimensionLegacyNoScalars)(THCState *state, const THCTensor *self);
 THC_API int THCTensor_(nDimensionLegacyAll)(THCState *state, const THCTensor *self);
 
-THC_API int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_(stride)(THCState *state, const THCTensor *self, int dim);
+THC_API int64_t THCTensor_(sizeLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
+THC_API int64_t THCTensor_(strideLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
 THC_API THLongStorage *THCTensor_(newSizeOf)(THCState *state, THCTensor *self);
 THC_API THLongStorage *THCTensor_(newStrideOf)(THCState *state, THCTensor *self);
 THC_API real *THCTensor_(data)(THCState *state, const THCTensor *self);

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -19,14 +19,14 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
   ptrdiff_t dstSliceSize = 1;
   for (int d = 0; d < dstDims; d++) {
     if (d != dim) {
-      dstSliceSize *= dst->size(d);
+      dstSliceSize *= THTensor_sizeLegacyNoScalars(dst, d);
     }
   }
 
   if (src == nullptr) return dstSliceSize;
 
   THArgCheck(dim < srcDims, 3, "Indexing dim is out of bounds");
-  THArgCheck(THCudaLongTensor_nElement(state, index) == src->size(dim), 4,
+  THArgCheck(THCudaLongTensor_nElement(state, index) == THTensor_sizeLegacyNoScalars(src, dim), 4,
              "length of src.size[dim] is not equal to length of indices");
 
   ptrdiff_t srcSliceSize = 1;
@@ -36,8 +36,8 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
 
   for (int d = 0; d < srcDims; d++) {
     if (d != dim) {
-      srcSliceSize *= src->size(d);
-      if (!mismatch && dst->size(d) != src->size(d)) mismatch = true;
+      srcSliceSize *= THTensor_sizeLegacyNoScalars(src, d);
+      if (!mismatch && THTensor_sizeLegacyNoScalars(dst, d) != THTensor_sizeLegacyNoScalars(src, d)) mismatch = true;
     }
   }
 
@@ -111,7 +111,7 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   // of the tensor `indices`.
   ptrdiff_t sliceSize = THCTensor_(getSliceSize)(state, dst, dim, indices, src);
   ptrdiff_t srcTotalSize = THCTensor_(nElement)(state, src);
-  int64_t dstCopyDimSize = THCTensor_(size)(state, dst, dim);
+  int64_t dstCopyDimSize = THCTensor_(sizeLegacyNoScalars)(state, dst, dim);
   ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
 
   if (sliceSize == 0) {
@@ -300,7 +300,7 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
   // of the tensor `indices`.
   ptrdiff_t sliceSize = THCTensor_(getSliceSize)(state, dst, dim, indices, src);
   ptrdiff_t srcTotalSize = THCTensor_(nElement)(state, src);
-  int64_t dstAddDimSize = THCTensor_(size)(state, dst, dim);
+  int64_t dstAddDimSize = THCTensor_(sizeLegacyNoScalars)(state, dst, dim);
   ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
 
   if (sliceSize == 0) {
@@ -422,7 +422,7 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   ptrdiff_t sliceSize =
     THCTensor_(getSliceSize)(state, dst, dim, indices, nullptr);
   ptrdiff_t dstTotalSize = THCTensor_(nElement)(state, dst);
-  int64_t dstFillDimSize = THCTensor_(size)(state, dst, dim);
+  int64_t dstFillDimSize = THCTensor_(sizeLegacyNoScalars)(state, dst, dim);
   ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
 
   if (sliceSize == 0) {
@@ -564,7 +564,7 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
   // total size of the tensor ignoring dimension `dim`;
   // -the number of indices we are choosing, which is the total size
   // of the tensor `indices`.
-  int64_t srcSelectDimSize = THCTensor_(size)(state, src, dim);
+  int64_t srcSelectDimSize = THCTensor_(sizeLegacyNoScalars)(state, src, dim);
   ptrdiff_t sliceSize = dstTotalSize / numIndices;
 
   int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -53,13 +53,13 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THError("2D tensor and 1D tensor expected, got %dD, %dD tensors",
        mat->dim(), vec->dim());
 
-  if( mat->size(1) != vec->size(0) )
+  if( THTensor_sizeLegacyNoScalars(mat, 1) != THTensor_sizeLegacyNoScalars(vec, 0) )
     THError("size mismatch");
 
   if(t->dim() != 1)
     THError("size mismatch");
 
-  if(t->size(0) != mat->size(0))
+  if(THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(mat, 0))
     THError("size mismatch");
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
@@ -69,32 +69,32 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THCTensor_(copy)(state, r_, t);
   }
 
-  if(mat->stride(0) == 1)
+  if(THTensor_strideLegacyNoScalars(mat, 0) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 'n', mat->size(0), mat->size(1),
-                    alpha, THCTensor_(data)(state, mat), mat->stride(1),
-                    THCTensor_(data)(state, vec), vec->stride(0),
-                    beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Sgemv(state, 'n', THTensor_sizeLegacyNoScalars(mat, 0), THTensor_sizeLegacyNoScalars(mat, 1),
+                    alpha, THCTensor_(data)(state, mat), THTensor_strideLegacyNoScalars(mat, 1),
+                    THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                    beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 'n', mat->size(0), mat->size(1),
-                    alpha, THCTensor_(data)(state, mat), mat->stride(1),
-                    THCTensor_(data)(state, vec), vec->stride(0),
-                    beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Dgemv(state, 'n', THTensor_sizeLegacyNoScalars(mat, 0), THTensor_sizeLegacyNoScalars(mat, 1),
+                    alpha, THCTensor_(data)(state, mat), THTensor_strideLegacyNoScalars(mat, 1),
+                    THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                    beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #endif
   }
-  else if(mat->stride(1) == 1)
+  else if(THTensor_strideLegacyNoScalars(mat, 1) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, mat), mat->stride(0),
-                    THCTensor_(data)(state, vec), vec->stride(0),
-                    beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Sgemv(state, 't',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                    alpha, THCTensor_(data)(state, mat), THTensor_strideLegacyNoScalars(mat, 0),
+                    THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                    beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
-                     alpha, THCTensor_(data)(state, mat), mat->stride(0),
-                     THCTensor_(data)(state, vec), vec->stride(0),
-                     beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Dgemv(state, 't',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                     alpha, THCTensor_(data)(state, mat), THTensor_strideLegacyNoScalars(mat, 0),
+                     THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                     beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #endif
   }
   else
@@ -102,15 +102,15 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
     THCTensor *cmat = THCTensor_(newContiguous)(state, mat);
 
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, cmat), cmat->stride(0),
-                    THCTensor_(data)(state, vec), vec->stride(0),
-                    beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Sgemv(state, 't',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                    alpha, THCTensor_(data)(state, cmat), THTensor_strideLegacyNoScalars(cmat, 0),
+                    THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                    beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemv(state, 't',  mat->size(1), mat->size(0),
-                    alpha, THCTensor_(data)(state, cmat), cmat->stride(0),
-                    THCTensor_(data)(state, vec), vec->stride(0),
-                    beta, THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Dgemv(state, 't',  THTensor_sizeLegacyNoScalars(mat, 1), THTensor_sizeLegacyNoScalars(mat, 0),
+                    alpha, THCTensor_(data)(state, cmat), THTensor_strideLegacyNoScalars(cmat, 0),
+                    THCTensor_(data)(state, vec), THTensor_strideLegacyNoScalars(vec, 0),
+                    beta, THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #endif
 
     THCTensor_(free)(state, cmat);
@@ -118,7 +118,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 
   // In cublasSgemv, cublasDgemv (x,0).mv(0) does not
   // handle beta, whereas cublasSgemm, cublasDgemm do for case where (x,0).mm(0,y).
-  if (vec->size(0) == 0 && mat->size(0) != 0) {
+  if (THTensor_sizeLegacyNoScalars(vec, 0) == 0 && THTensor_sizeLegacyNoScalars(mat, 0) != 0) {
     if(THCNumerics<real>::eq(beta, ScalarConvert<int, real>::to(0))) {
       THCTensor_(zero)(state, r_);
     } else if(THCNumerics<real>::ne(beta, ScalarConvert<int, real>::to(1))) {
@@ -129,15 +129,15 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 #elif defined(THC_REAL_IS_HALF)
     // Currently no Hgemv/SgemvEx in Cublas
     THCTensor *vecAsMatrix = THCTensor_(newWithTensor)(state, vec);
-    THCTensor_(resize2d)(state, vecAsMatrix, vecAsMatrix->size(0), 1);
+    THCTensor_(resize2d)(state, vecAsMatrix, THTensor_sizeLegacyNoScalars(vecAsMatrix, 0), 1);
 
     THCTensor *tAsMatrix = THCTensor_(newWithTensor)(state, t);
-    THCTensor_(resize2d)(state, tAsMatrix, tAsMatrix->size(0), 1);
+    THCTensor_(resize2d)(state, tAsMatrix, THTensor_sizeLegacyNoScalars(tAsMatrix, 0), 1);
 
     THCTensor_(addmm)(state, r_, beta, tAsMatrix, alpha, mat, vecAsMatrix);
 
     // r_ will have answer as matrix, need to return a vector
-    THCTensor_(resize1d)(state, r_, r_->size(0));
+    THCTensor_(resize1d)(state, r_, THTensor_sizeLegacyNoScalars(r_, 0));
     THCTensor_(free)(state, vecAsMatrix);
     THCTensor_(free)(state, tAsMatrix);
 #endif
@@ -160,7 +160,7 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THError("size mismatch");
   }
 
-  if ( (t->size(0) != vec1->size(0)) || (t->size(1) != vec2->size(0)) ) {
+  if ( (THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(vec1, 0)) || (THTensor_sizeLegacyNoScalars(t, 1) != THTensor_sizeLegacyNoScalars(vec2, 0)) ) {
     THError("size mismatch");
   }
 
@@ -176,32 +176,32 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THCTensor_(mul)(state, r_, r_, beta);
   }
 
-  if(r_->stride(0) == 1)
+  if(THTensor_strideLegacyNoScalars(r_, 0) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec1->size(0), vec2->size(0),
-                   alpha, THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, r_), r_->stride(1));
+    THCudaBlas_Sger(state, THTensor_sizeLegacyNoScalars(vec1, 0), THTensor_sizeLegacyNoScalars(vec2, 0),
+                   alpha, THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 1));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec1->size(0), vec2->size(0),
-                   alpha, THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, r_), r_->stride(1));
+    THCudaBlas_Dger(state, THTensor_sizeLegacyNoScalars(vec1, 0), THTensor_sizeLegacyNoScalars(vec2, 0),
+                   alpha, THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 1));
 #endif
   }
-  else if(r_->stride(1) == 1)
+  else if(THTensor_strideLegacyNoScalars(r_, 1) == 1)
   {
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Sger(state, THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                   alpha, THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, r_), r_->stride(0));
+    THCudaBlas_Dger(state, THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                   alpha, THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, r_), THTensor_strideLegacyNoScalars(r_, 0));
 #endif
   }
   else
@@ -209,15 +209,15 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
     THCTensor *cr = THCTensor_(newClone)(state, r_);
 
 #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, cr), cr->stride(0));
+    THCudaBlas_Sger(state, THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                   alpha, THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, cr), THTensor_strideLegacyNoScalars(cr, 0));
 #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dger(state, vec2->size(0), vec1->size(0),
-                   alpha, THCTensor_(data)(state, vec2), vec2->stride(0),
-                   THCTensor_(data)(state, vec1), vec1->stride(0),
-                   THCTensor_(data)(state, cr), cr->stride(0));
+    THCudaBlas_Dger(state, THTensor_sizeLegacyNoScalars(vec2, 0), THTensor_sizeLegacyNoScalars(vec1, 0),
+                   alpha, THCTensor_(data)(state, vec2), THTensor_strideLegacyNoScalars(vec2, 0),
+                   THCTensor_(data)(state, vec1), THTensor_strideLegacyNoScalars(vec1, 0),
+                   THCTensor_(data)(state, cr), THTensor_strideLegacyNoScalars(cr, 0));
 #endif
 
     THCTensor_(freeCopyTo)(state, cr, r_);
@@ -225,11 +225,11 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
 #elif defined(THC_REAL_IS_HALF)
   // currently no Hger/SgerEx in Cublas.
   THCTensor *vec2T = THCTensor_(newWithTensor)(state, vec2);
-  THCTensor_(resize2d)(state, vec2T, vec2T->size(0), 1);
+  THCTensor_(resize2d)(state, vec2T, THTensor_sizeLegacyNoScalars(vec2T, 0), 1);
   THCTensor_(transpose)(state, vec2T, NULL, 0, 1);
 
   THCTensor *vec1M = THCTensor_(newWithTensor)(state, vec1);
-  THCTensor_(resize2d)(state, vec1M, vec1M->size(0), 1);
+  THCTensor_(resize2d)(state, vec1M, THTensor_sizeLegacyNoScalars(vec1M, 0), 1);
 
   THCTensor_(addmm)(state, r_, beta, t, alpha, vec1M, vec2T);
   THCTensor_(free)(state, vec2T);
@@ -255,13 +255,13 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   if(t->dim() != 2)
     THError("2D tensor expected, got %dD tensor for t", t->dim());
 
-  if(m1->size(1) != m2->size(0)) {
+  if(THTensor_sizeLegacyNoScalars(m1, 1) != THTensor_sizeLegacyNoScalars(m2, 0)) {
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
     THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
     THError("size mismatch, m1: %s, m2: %s", bm1.str, bm2.str);
   }
 
-  if( (t->size(0) != m1->size(0)) || (t->size(1) != m2->size(1)) ) {
+  if( (THTensor_sizeLegacyNoScalars(t, 0) != THTensor_sizeLegacyNoScalars(m1, 0)) || (THTensor_sizeLegacyNoScalars(t, 1) != THTensor_sizeLegacyNoScalars(m2, 1)) ) {
     THCDescBuff bt  = THCTensor_(sizeDesc)(state, t);
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
     THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
@@ -277,14 +277,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* r_ */
-  if(r_->stride(0) == 1 &&
-     r_->stride(1) != 0)
+  if(THTensor_strideLegacyNoScalars(r_, 0) == 1 &&
+     THTensor_strideLegacyNoScalars(r_, 1) != 0)
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride(1) == 1 &&
-          r_->stride(0) != 0)
+  else if(THTensor_strideLegacyNoScalars(r_, 1) == 1 &&
+          THTensor_strideLegacyNoScalars(r_, 0) != 0)
   {
     THCTensor *swap = m2;
     m2 = m1;
@@ -303,14 +303,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* m1 */
-  if(m1->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
-     m1->stride((transpose_r == 'n' ? 1 : 0)) != 0)
+  if(THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 0 : 1)) == 1 &&
+     THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 1 : 0)) != 0)
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
-          m1->stride((transpose_r == 'n' ? 0 : 1)) != 0)
+  else if(THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 1 : 0)) == 1 &&
+          THTensor_strideLegacyNoScalars(m1, (transpose_r == 'n' ? 0 : 1)) != 0)
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -322,14 +322,14 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   }
 
   /* m2 */
-  if(m2->stride((transpose_r == 'n' ? 0 : 1)) == 1 &&
-     m2->stride((transpose_r == 'n' ? 1 : 0)) != 0)
+  if(THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 0 : 1)) == 1 &&
+     THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 1 : 0)) != 0)
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride((transpose_r == 'n' ? 1 : 0)) == 1 &&
-          m2->stride((transpose_r == 'n' ? 0 : 1)) != 0)
+  else if(THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 1 : 0)) == 1 &&
+          THTensor_strideLegacyNoScalars(m2, (transpose_r == 'n' ? 0 : 1)) != 0)
   {
     transpose_m2 = 't';
     m2_ = m2;
@@ -344,47 +344,47 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCudaBlas_Hgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size((transpose_r == 'n' ? 0 : 1)),
-                   r__->size((transpose_r == 'n' ? 1 : 0)),
-                   m1_->size((transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 0 : 1)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m1 == 'n' ? THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m2 == 'n' ? THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride((transpose_r == 'n' ? 1 : 0)));
+                   THTensor_strideLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)));
 #elif defined(THC_REAL_IS_FLOAT)
   THCudaBlas_Sgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size((transpose_r == 'n' ? 0 : 1)),
-                   r__->size((transpose_r == 'n' ? 1 : 0)),
-                   m1_->size((transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 0 : 1)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m1 == 'n' ? THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m2 == 'n' ? THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride((transpose_r == 'n' ? 1 : 0)));
+                   THTensor_strideLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)));
 #elif defined(THC_REAL_IS_DOUBLE)
   THCudaBlas_Dgemm(state,
                    transpose_m1,
                    transpose_m2,
-                   r__->size((transpose_r == 'n' ? 0 : 1)),
-                   r__->size((transpose_r == 'n' ? 1 : 0)),
-                   m1_->size((transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 0 : 1)),
+                   THTensor_sizeLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)),
+                   THTensor_sizeLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)),
                    alpha,
                    THCTensor_(data)(state, m1_),
-                   (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m1 == 'n' ? THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m1_, (transpose_r == 'n' ? 0 : 1))),
                    THCTensor_(data)(state, m2_),
-                   (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1))),
+                   (transpose_m2 == 'n' ? THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 1 : 0)) : THTensor_strideLegacyNoScalars(m2_, (transpose_r == 'n' ? 0 : 1))),
                    beta,
                    THCTensor_(data)(state, r__),
-                   r__->stride((transpose_r == 'n' ? 1 : 0)));
+                   THTensor_strideLegacyNoScalars(r__, (transpose_r == 'n' ? 1 : 0)));
 #endif
 
   /* free intermediate variables */
@@ -413,19 +413,19 @@ THCTensor_(addbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, batch1) == 3, 6, "expected 3D tensor");
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, batch2) == 3, 7, "expected 3D tensor");
 
-  int64_t batchnum = THCTensor_(size)(state, batch1, 0);
-  int64_t m1d1 = THCTensor_(size)(state, batch1, 1);
-  int64_t innerdim = THCTensor_(size)(state, batch1, 2);
-  int64_t m2d2 = THCTensor_(size)(state, batch2, 2);
+  int64_t batchnum = THCTensor_(sizeLegacyNoScalars)(state, batch1, 0);
+  int64_t m1d1 = THCTensor_(sizeLegacyNoScalars)(state, batch1, 1);
+  int64_t innerdim = THCTensor_(sizeLegacyNoScalars)(state, batch1, 2);
+  int64_t m2d2 = THCTensor_(sizeLegacyNoScalars)(state, batch2, 2);
 
-  THArgCheck(batchnum == THCTensor_(size)(state, batch2, 0), 7,
+  THArgCheck(batchnum == THCTensor_(sizeLegacyNoScalars)(state, batch2, 0), 7,
       "equal number of batches expected");
   // M is t, as listed in the docs under addbmm
-  THArgCheck(m1d1 == THCTensor_(size)(state, t, 0), 6,
+  THArgCheck(m1d1 == THCTensor_(sizeLegacyNoScalars)(state, t, 0), 6,
       "first dimension must match first dimension of M");
-  THArgCheck(m2d2 == THCTensor_(size)(state, t, 1), 7,
+  THArgCheck(m2d2 == THCTensor_(sizeLegacyNoScalars)(state, t, 1), 7,
       "second dimension must match second dimension of M");
-  THArgCheck(innerdim == THCTensor_(size)(state, batch2, 1), 6,
+  THArgCheck(innerdim == THCTensor_(sizeLegacyNoScalars)(state, batch2, 1), 6,
       "second dimension must match first dimension of batch2");
 
   if (t != result) {
@@ -477,15 +477,15 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, t) == 3, 4, "expected 3D tensor");
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, batch1) == 3, 6, "expected 3D tensor");
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, batch2) == 3, 7, "expected 3D tensor");
-  THArgCheck(THCTensor_(size)(state, t, 0) == THCTensor_(size)(state, batch1, 0), 6,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, t, 0) == THCTensor_(sizeLegacyNoScalars)(state, batch1, 0), 6,
              "equal number of batches expected");
-  THArgCheck(THCTensor_(size)(state, t, 0) == THCTensor_(size)(state, batch2, 0), 7,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, t, 0) == THCTensor_(sizeLegacyNoScalars)(state, batch2, 0), 7,
              "equal number of batches expected");
-  THArgCheck(THCTensor_(size)(state, t, 1) == THCTensor_(size)(state, batch1, 1), 6,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, t, 1) == THCTensor_(sizeLegacyNoScalars)(state, batch1, 1), 6,
              "wrong matrix size");
-  THArgCheck(THCTensor_(size)(state, t, 2) == THCTensor_(size)(state, batch2, 2), 7,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, t, 2) == THCTensor_(sizeLegacyNoScalars)(state, batch2, 2), 7,
              "wrong matrix size");
-  THArgCheck(THCTensor_(size)(state, batch1, 2) == THCTensor_(size)(state, batch2, 1), 6,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, batch1, 2) == THCTensor_(sizeLegacyNoScalars)(state, batch2, 1), 6,
              "wrong matrix size");
 
   if (t != result) {
@@ -499,13 +499,13 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   char transpose_batch1, transpose_batch2;
   int64_t lda, ldb, ldc;
   THCTensor *result_, *batch1_, *batch2_;
-  if (result->stride(1) == 1)
+  if (THTensor_strideLegacyNoScalars(result, 1) == 1)
   {
     transpose_result = false;
     result_ = result;
-    ldc = result_->stride(2);
+    ldc = THTensor_strideLegacyNoScalars(result_, 2);
   }
-  else if (result->stride(2) == 1)
+  else if (THTensor_strideLegacyNoScalars(result, 2) == 1)
   {
     transpose_result = true;
 
@@ -514,7 +514,7 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     batch1 = swap;
 
     result_ = result;
-    ldc = result_->stride(1);
+    ldc = THTensor_strideLegacyNoScalars(result_, 1);
   }
   else
   {
@@ -525,22 +525,22 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, result_, NULL, 1, 2);
 
-    ldc = result_->stride(2);
+    ldc = THTensor_strideLegacyNoScalars(result_, 2);
   }
 
-  if (batch1->stride(transpose_result ? 2 : 1) == 1 &&
-   batch1->stride(transpose_result ? 1 : 2) != 0)
+  if (THTensor_strideLegacyNoScalars(batch1, transpose_result ? 2 : 1) == 1 &&
+   THTensor_strideLegacyNoScalars(batch1, transpose_result ? 1 : 2) != 0)
   {
     transpose_batch1 = 'n';
     batch1_ = batch1;
-    lda = batch1_->stride(transpose_result ? 1 : 2);
+    lda = THTensor_strideLegacyNoScalars(batch1_, transpose_result ? 1 : 2);
   }
-  else if (batch1->stride(transpose_result ? 1 : 2) == 1 &&
-   batch1->stride(transpose_result ? 2 : 1) != 0)
+  else if (THTensor_strideLegacyNoScalars(batch1, transpose_result ? 1 : 2) == 1 &&
+   THTensor_strideLegacyNoScalars(batch1, transpose_result ? 2 : 1) != 0)
   {
     transpose_batch1 = 't';
     batch1_ = batch1;
-    lda = batch1_->stride(transpose_result ? 2 : 1);
+    lda = THTensor_strideLegacyNoScalars(batch1_, transpose_result ? 2 : 1);
   }
   else
   {
@@ -551,22 +551,22 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     } else {
       batch1_ = THCTensor_(newContiguous)(state, batch1);
     }
-    lda = batch1_->stride(1);
+    lda = THTensor_strideLegacyNoScalars(batch1_, 1);
   }
 
-  if (batch2->stride(transpose_result ? 2 : 1) == 1 &&
-   batch2->stride(transpose_result ? 1 : 2) != 0)
+  if (THTensor_strideLegacyNoScalars(batch2, transpose_result ? 2 : 1) == 1 &&
+   THTensor_strideLegacyNoScalars(batch2, transpose_result ? 1 : 2) != 0)
   {
     transpose_batch2 = 'n';
     batch2_ = batch2;
-    ldb = batch2_->stride(transpose_result ? 1 : 2);
+    ldb = THTensor_strideLegacyNoScalars(batch2_, transpose_result ? 1 : 2);
   }
-  else if (batch2->stride(transpose_result ? 1 : 2) == 1 &&
-   batch2->stride(transpose_result ? 2 : 1) != 0)
+  else if (THTensor_strideLegacyNoScalars(batch2, transpose_result ? 1 : 2) == 1 &&
+   THTensor_strideLegacyNoScalars(batch2, transpose_result ? 2 : 1) != 0)
   {
     transpose_batch2 = 't';
     batch2_ = batch2;
-    ldb = batch2_->stride(transpose_result ? 2 : 1);
+    ldb = THTensor_strideLegacyNoScalars(batch2_, transpose_result ? 2 : 1);
   }
   else
   {
@@ -577,9 +577,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
     } else {
       batch2_ = THCTensor_(newContiguous)(state, batch2);
     }
-    ldb = batch2_->stride(1);
+    ldb = THTensor_strideLegacyNoScalars(batch2_, 1);
   }
-  int64_t num_batches = result_->size(0);
+  int64_t num_batches = THTensor_sizeLegacyNoScalars(result_, 0);
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   // Compute pointers to matrices in each batch.
@@ -597,16 +597,16 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
   createBatchGemmBuffer3<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     d_matrices1, d_matrices2, (const real**)d_result_matrices, THCTensor_(data)(state, batch1_),
     THCTensor_(data)(state, batch2_), THCTensor_(data)(state, result_),
-    batch1_->stride(0), batch2_->stride(0), result_->stride(0), num_batches);
+    THTensor_strideLegacyNoScalars(batch1_, 0), THTensor_strideLegacyNoScalars(batch2_, 0), THTensor_strideLegacyNoScalars(result_, 0), num_batches);
 
 #ifdef THC_REAL_IS_FLOAT
   THCudaBlas_SgemmBatched(
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size(transpose_result ? 2 : 1),
-      result_->size(transpose_result ? 1 : 2),
-      batch1_->size(transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
       alpha,
       d_matrices1, lda,
       d_matrices2, ldb,
@@ -618,9 +618,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size(transpose_result ? 2 : 1),
-      result_->size(transpose_result ? 1 : 2),
-      batch1_->size(transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
       alpha,
       d_matrices1, lda,
       d_matrices2, ldb,
@@ -639,28 +639,28 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size(transpose_result ? 2 : 1),
-      result_->size(transpose_result ? 1 : 2),
-      batch1_->size(transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
+      THCTensor_(data)(state, batch1_), lda, THTensor_strideLegacyNoScalars(batch1_, 0),
+      THCTensor_(data)(state, batch2_), ldb, THTensor_strideLegacyNoScalars(batch2_, 0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride(0),
+      THCTensor_(data)(state, result_), ldc, THTensor_strideLegacyNoScalars(result_, 0),
       num_batches);
 #elif defined(THC_REAL_IS_DOUBLE)
   THCudaBlas_DgemmStridedBatched(
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size(transpose_result ? 2 : 1),
-      result_->size(transpose_result ? 1 : 2),
-      batch1_->size(transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
+      THCTensor_(data)(state, batch1_), lda, THTensor_strideLegacyNoScalars(batch1_, 0),
+      THCTensor_(data)(state, batch2_), ldb, THTensor_strideLegacyNoScalars(batch2_, 0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride(0),
+      THCTensor_(data)(state, result_), ldc, THTensor_strideLegacyNoScalars(result_, 0),
       num_batches);
 #endif //THC_REAL
 #endif //CUDA_VERSION
@@ -674,14 +674,14 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         state,
         transpose_batch1,
         transpose_batch2,
-        result_->size(transpose_result ? 2 : 1),
-        result_->size(transpose_result ? 1 : 2),
-        batch1_->size(transpose_result ? 1 : 2),
+        THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+        THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+        THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
         alpha,
-        THCTensor_(data)(state, batch1_) + i * batch1_->stride(0), lda,
-        THCTensor_(data)(state, batch2_) + i * batch2_->stride(0), ldb,
+        THCTensor_(data)(state, batch1_) + i * THTensor_strideLegacyNoScalars(batch1_, 0), lda,
+        THCTensor_(data)(state, batch2_) + i * THTensor_strideLegacyNoScalars(batch2_, 0), ldb,
         beta,
-        THCTensor_(data)(state, result_) + i * result_->stride(0), ldc);
+        THCTensor_(data)(state, result_) + i * THTensor_strideLegacyNoScalars(result_, 0), ldc);
   }
 #else
   cudaDeviceProp* prop = THCState_getCurrentDeviceProperties(state);
@@ -691,14 +691,14 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
       state,
       transpose_batch1,
       transpose_batch2,
-      result_->size(transpose_result ? 2 : 1),
-      result_->size(transpose_result ? 1 : 2),
-      batch1_->size(transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+      THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+      THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
       alpha,
-      THCTensor_(data)(state, batch1_), lda, batch1_->stride(0),
-      THCTensor_(data)(state, batch2_), ldb, batch2_->stride(0),
+      THCTensor_(data)(state, batch1_), lda, THTensor_strideLegacyNoScalars(batch1_, 0),
+      THCTensor_(data)(state, batch2_), ldb, THTensor_strideLegacyNoScalars(batch2_, 0),
       beta,
-      THCTensor_(data)(state, result_), ldc, result_->stride(0),
+      THCTensor_(data)(state, result_), ldc, THTensor_strideLegacyNoScalars(result_, 0),
       num_batches);
    } else {
       for (int64_t i = 0; i < num_batches; ++i) {
@@ -706,14 +706,14 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
         state,
         transpose_batch1,
         transpose_batch2,
-        result_->size(transpose_result ? 2 : 1),
-        result_->size(transpose_result ? 1 : 2),
-        batch1_->size(transpose_result ? 1 : 2),
+        THTensor_sizeLegacyNoScalars(result_, transpose_result ? 2 : 1),
+        THTensor_sizeLegacyNoScalars(result_, transpose_result ? 1 : 2),
+        THTensor_sizeLegacyNoScalars(batch1_, transpose_result ? 1 : 2),
         alpha,
-        THCTensor_(data)(state, batch1_) + i * batch1_->stride(0), lda,
-        THCTensor_(data)(state, batch2_) + i * batch2_->stride(0), ldb,
+        THCTensor_(data)(state, batch1_) + i * THTensor_strideLegacyNoScalars(batch1_, 0), lda,
+        THCTensor_(data)(state, batch2_) + i * THTensor_strideLegacyNoScalars(batch2_, 0), ldb,
         beta,
-        THCTensor_(data)(state, result_) + i * result_->stride(0), ldc);
+        THCTensor_(data)(state, result_) + i * THTensor_strideLegacyNoScalars(result_, 0), ldc);
       }
    }
 
@@ -741,25 +741,25 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
   THAssert(THCTensor_(checkGPU)(state, 2, ra_, a));
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, a) == 3, 3, "expected 3D tensor");
-  THArgCheck(THCTensor_(size)(state, a, 1) ==
-             THCTensor_(size)(state, a, 2), 3, "matrices must be square");
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, a, 1) ==
+             THCTensor_(sizeLegacyNoScalars)(state, a, 2), 3, "matrices must be square");
 
   if (ra_ != a) {
     THCTensor_(resizeAs)(state, ra_, a);
-    if (ra_->stride(2) == 1) {
+    if (THTensor_strideLegacyNoScalars(ra_, 2) == 1) {
       THCTensor_(transpose)(state, ra_, NULL, 1, 2);
     }
     THCTensor_(copy)(state, ra_, a);
   }
 
 
-  int n = a->size(1);
+  int n = THTensor_sizeLegacyNoScalars(a, 1);
   int lda;
   THCTensor *ra__;
 
-  if (ra_->stride(1) == 1) {
+  if (THTensor_strideLegacyNoScalars(ra_, 1) == 1) {
     // column ordered, what BLAS wants
-    lda = ra_->stride(2);
+    lda = THTensor_strideLegacyNoScalars(ra_, 2);
     ra__ = ra_;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -767,10 +767,10 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
     ra__ = THCTensor_(newClone)(state, transp_r_);
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, ra__, NULL, 1, 2);
-    lda = ra__->stride(2);
+    lda = THTensor_strideLegacyNoScalars(ra__, 2);
   }
 
-  int64_t num_batches = ra__->size(0);
+  int64_t num_batches = THTensor_sizeLegacyNoScalars(ra__, 0);
 
   if (!pivot) {
     THCudaIntTensor *t = THCudaIntTensor_new(state);
@@ -804,7 +804,7 @@ THC_API void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTens
     const int64_t grid = (num_batches + block - 1) / block;
     createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
       (const real**)d_result, THCTensor_(data)(state, ra__),
-      ra__->stride(0), num_batches);
+      THTensor_strideLegacyNoScalars(ra__, 0), num_batches);
   }
 
   int *pivots_gpu = NULL;
@@ -851,12 +851,12 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   THArgCheck(THCTensor_(nDimensionLegacyAll)(state, atf) == 3, 3, "expected 3D tensor");
   THArgCheck(THCTensor_(nDimensionLegacyAll)(state, b) == 3 ||
              THCTensor_(nDimensionLegacyAll)(state, b) == 2, 4, "expected 2D or 3D tensor");
-  THArgCheck(THCTensor_(size)(state, atf, 0) ==
-             THCTensor_(size)(state, b, 0), 3, "number of batches must be equal");
-  THArgCheck(THCTensor_(size)(state, atf, 1) ==
-             THCTensor_(size)(state, atf, 2), 3, "A matrices must be square");
-  THArgCheck(THCTensor_(size)(state, atf, 1) ==
-             THCTensor_(size)(state, b, 1), 3, "dimensions of A and b must be equal");
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, atf, 0) ==
+             THCTensor_(sizeLegacyNoScalars)(state, b, 0), 3, "number of batches must be equal");
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, atf, 1) ==
+             THCTensor_(sizeLegacyNoScalars)(state, atf, 2), 3, "A matrices must be square");
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, atf, 1) ==
+             THCTensor_(sizeLegacyNoScalars)(state, b, 1), 3, "dimensions of A and b must be equal");
 
   if (rb_ != b) {
     THCTensor_(resizeAs)(state, rb_, b);
@@ -864,16 +864,16 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   }
 
 
-  int n = atf->size(1);
-  int nrhs = THTensor_nDimensionLegacyAll(rb_) > 2 ? rb_->size(2) : 1;
+  int n = THTensor_sizeLegacyNoScalars(atf, 1);
+  int nrhs = THTensor_nDimensionLegacyAll(rb_) > 2 ? THTensor_sizeLegacyNoScalars(rb_, 2) : 1;
   THCTensor *atf_;
   THCTensor *rb__;
   int lda, ldb;
 
   // correct ordering of A_tf
-  if (atf->stride(1) == 1) {
+  if (THTensor_strideLegacyNoScalars(atf, 1) == 1) {
     // column ordered, what BLAS wants
-    lda = atf->stride(2);
+    lda = THTensor_strideLegacyNoScalars(atf, 2);
     atf_ = atf;
   } else {
     // not column ordered, need to make it such (requires copy)
@@ -884,16 +884,16 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
     atf_ = THCTensor_(newClone)(state, transp_r_);
     THCTensor_(free)(state, transp_r_);
     THCTensor_(transpose)(state, atf_, NULL, 1, 2);
-    lda = atf_->stride(2);
+    lda = THTensor_strideLegacyNoScalars(atf_, 2);
   }
 
   // correct ordering of B
-  if (rb_->stride(1) == 1) {
+  if (THTensor_strideLegacyNoScalars(rb_, 1) == 1) {
     // column ordered
-    if (THTensor_nDimensionLegacyAll(rb_) == 2 || rb_->size(2) == 1) {
+    if (THTensor_nDimensionLegacyAll(rb_) == 2 || THTensor_sizeLegacyNoScalars(rb_, 2) == 1) {
       ldb = n;
     } else {
-      ldb = rb_->stride(2);
+      ldb = THTensor_strideLegacyNoScalars(rb_, 2);
     }
     rb__ = rb_;
   } else {
@@ -903,14 +903,14 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
       rb__ = THCTensor_(newClone)(state, transp_r_);
       THCTensor_(free)(state, transp_r_);
       THCTensor_(transpose)(state, rb__, NULL, 1, 2);
-      ldb = rb__->stride(2);
+      ldb = THTensor_strideLegacyNoScalars(rb__, 2);
     } else {
       rb__ = THCTensor_(newClone)(state, rb_);
       ldb = n;
     }
   }
 
-  int64_t num_batches = rb_->size(0);
+  int64_t num_batches = THTensor_sizeLegacyNoScalars(rb_, 0);
   size_t matrices_size = num_batches * sizeof(real*);
 
   // Copy pointers to device.
@@ -921,10 +921,10 @@ THC_API void THCTensor_(btrisolve)(THCState *state, THCTensor *rb_, THCTensor *b
   const int64_t grid = (num_batches + block - 1) / block;
   createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     (const real**)d_result, THCTensor_(data)(state, rb__),
-    rb__->stride(0), num_batches);
+    THTensor_strideLegacyNoScalars(rb__, 0), num_batches);
   createBatchGemmBuffer<<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     d_atf, THCTensor_(data)(state, atf_),
-    atf_->stride(0), num_batches);
+    THTensor_strideLegacyNoScalars(atf_, 0), num_batches);
 
   if (!THCudaIntTensor_isContiguous(state, pivots)) {
       THError("Error: pivots is not contiguous.");

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -40,7 +40,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
 static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, THCTensor *src)
 {
   THAssert(src->dim() == 2);
-  if (self == src && self->stride(0) == 1 && self->stride(1) == self->size(0))
+  if (self == src && THTensor_strideLegacyNoScalars(self, 0) == 1 && THTensor_strideLegacyNoScalars(self, 1) == THTensor_sizeLegacyNoScalars(self, 0))
   {
     THCTensor_(retain)(state, self);
     return self;
@@ -51,8 +51,8 @@ static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, T
   else
     THCTensor_(retain)(state, self);
 
-  int64_t size[2] = { src->size(0), src->size(1) };
-  int64_t stride[2] = { 1, src->size(0) };
+  int64_t size[2] = { THTensor_sizeLegacyNoScalars(src, 0), THTensor_sizeLegacyNoScalars(src, 1) };
+  int64_t stride[2] = { 1, THTensor_sizeLegacyNoScalars(src, 0) };
 
   THCTensor_(resizeNd)(state, self, 2, size, stride);
   THCTensor_(copy)(state, self, src);
@@ -65,11 +65,11 @@ THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 2, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size(0) == a_->size(1), 1, "A should be square");
-  THArgCheck(b_->size(0) == a_->size(0), 2, "A,b size incompatible");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a_, 0) == THTensor_sizeLegacyNoScalars(a_, 1), 1, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(b_, 0) == THTensor_sizeLegacyNoScalars(a_, 0), 2, "A,b size incompatible");
 
-  int64_t n = a_->size(0);
-  int64_t nrhs = b_->size(1);
+  int64_t n = THTensor_sizeLegacyNoScalars(a_, 0);
+  int64_t nrhs = THTensor_sizeLegacyNoScalars(b_, 1);
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
   THCTensor *b = THCTensor_(newColumnMajor)(state, rb_, b_);
@@ -104,8 +104,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 2, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size(0) == a_->size(1), 1, "A should be square");
-  THArgCheck(b_->size(0) == a_->size(0), 2, "A,b size incompatible");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a_, 0) == THTensor_sizeLegacyNoScalars(a_, 1), 1, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(b_, 0) == THTensor_sizeLegacyNoScalars(a_, 0), 2, "A,b size incompatible");
 
   magma_side_t sz = MagmaLeft;
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
@@ -114,8 +114,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
 
   real alpha = 1;
 
-  int64_t n = a_->size(0);
-  int64_t nrhs = b_->size(1);
+  int64_t n = THTensor_sizeLegacyNoScalars(a_, 0);
+  int64_t nrhs = THTensor_sizeLegacyNoScalars(b_, 1);
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
   THCTensor *b = THCTensor_(newColumnMajor)(state, rb_, b_);
@@ -140,9 +140,9 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 #ifdef USE_MAGMA
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 1, "A should be (non-empty) 2 dimensional");
   THArgCheck(!b_->is_empty() && b_->dim() == 2, 1, "b should be (non-empty) 2 dimensional");
-  THArgCheck(a_->size(0) == b_->size(0), 2, "Expected A and b to have same size "
+  THArgCheck(THTensor_sizeLegacyNoScalars(a_, 0) == THTensor_sizeLegacyNoScalars(b_, 0), 2, "Expected A and b to have same size "
       "at dim 0, but they have incompatible sizes");
-  THArgCheck(a_->size(0) >= a_->size(1), 2, "Expected A with shape (m x n) to have "
+  THArgCheck(THTensor_sizeLegacyNoScalars(a_, 0) >= THTensor_sizeLegacyNoScalars(a_, 1), 2, "Expected A with shape (m x n) to have "
       "m >= n. The case for m < n is not implemented yet.");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
@@ -150,9 +150,9 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
   real *a_data = THCTensor_(data)(state, a);
   real *b_data = THCTensor_(data)(state, b);
 
-  int64_t m = a->size(0);
-  int64_t n = a->size(1);
-  int64_t nrhs = b->size(1);
+  int64_t m = THTensor_sizeLegacyNoScalars(a, 0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 1);
+  int64_t nrhs = THTensor_sizeLegacyNoScalars(b, 1);
   real wkopt;
 
   int info;
@@ -185,7 +185,7 @@ THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a, const char *jobzs, const char *uplos)
 {
 #ifdef USE_MAGMA
-  int64_t n = a->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
   int64_t lda = n;
 
   magma_uplo_t uplo = uplos[0] == 'U' ?  MagmaUpper : MagmaLower;
@@ -245,10 +245,10 @@ THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
 {
 #ifdef USE_MAGMA
   THArgCheck(a_->dim() == 2, 3, "A should be 2 dimensional");
-  THArgCheck(a_->size(0) == a_->size(1), 3, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a_, 0) == THTensor_sizeLegacyNoScalars(a_, 1), 3, "A should be square");
 
   magma_vec_t jobvr = jobvrs[0] == 'N' ? MagmaNoVec : MagmaVec;
-  int64_t n = a_->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a_, 0);
 
   real *a_data = th_magma_malloc_pinned<real>(n * n);
   THCTensor_(copyTensor2d)(state, a_data, a_);
@@ -334,8 +334,8 @@ THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_,
   magma_vec_t jobz = jobus[0] == 'A' ? MagmaAllVec : jobus[0] == 'S' ? MagmaSomeVec : jobus[0] == 'O' ? MagmaOverwriteVec : MagmaNoVec;
 
   int iunused[1];
-  int64_t m = a->size(0);
-  int64_t n = a->size(1);
+  int64_t m = THTensor_sizeLegacyNoScalars(a, 0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 1);
   int64_t k = m < n ? m : n;
   int64_t j = (jobz == MagmaAllVec) ? m : k;
   int64_t jv = (jobz == MagmaAllVec) ? n : k;
@@ -393,11 +393,11 @@ THC_API void THCTensor_(gesvd2)(THCState *state, THCTensor *ru_, THCTensor *rs_,
 THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
 {
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be non-empty 2 dimensional");
-  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a, 0) == THTensor_sizeLegacyNoScalars(a, 1), 2, "A should be square");
 
 #ifdef USE_MAGMA
   int info;
-  int64_t n = a->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
   int lwork = n * magma_get_sgetri_nb(n);
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -436,7 +436,7 @@ THC_API void THCTensor_(getri)(THCState *state, THCTensor *ra_, THCTensor *a)
   magma_free_pinned(ipiv);
   THCTensor_(freeCopyTo)(state, input, ra_);
 #else
-  int64_t n = a->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
 
   // input
   THCTensor *input = THCTensor_(newColumnMajor)(state, a, a);
@@ -522,9 +522,9 @@ THC_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, co
 {
 #ifdef USE_MAGMA
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be non-empty 2 dimensional");
-  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a, 0) == THTensor_sizeLegacyNoScalars(a, 1), 2, "A should be square");
 
-  int64_t n = a->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -562,9 +562,9 @@ THC_API void THCTensor_(potrf)(THCState *state, THCTensor *ra_, THCTensor *a, co
 {
 #ifdef USE_MAGMA
   THArgCheck(!a->is_empty() && a->dim() == 2, 2, "A should be (non-empty) 2 dimensional");
-  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a, 0) == THTensor_sizeLegacyNoScalars(a, 1), 2, "A should be square");
 
-  int64_t n = a->size(0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *input = THCTensor_(newColumnMajor)(state, ra_, a);
@@ -597,10 +597,10 @@ THC_API void THCTensor_(potrf)(THCState *state, THCTensor *ra_, THCTensor *a, co
 THC_API void THCTensor_(potrs)(THCState *state, THCTensor *rb_, THCTensor *b, THCTensor *a, const char *uplo)
 {
 #ifdef USE_MAGMA
-  THArgCheck(a->size(0) == a->size(1), 2, "A should be square");
+  THArgCheck(THTensor_sizeLegacyNoScalars(a, 0) == THTensor_sizeLegacyNoScalars(a, 1), 2, "A should be square");
 
-  int64_t n = a->size(0);
-  int64_t nrhs = b->size(1);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 0);
+  int64_t nrhs = THTensor_sizeLegacyNoScalars(b, 1);
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
 
   THCTensor *b_ = THCTensor_(newColumnMajor)(state, rb_, b);
@@ -632,8 +632,8 @@ THC_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 2, "A should be non-empty 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
-  int64_t m = a->size(0);
-  int64_t n = a->size(1);
+  int64_t m = THTensor_sizeLegacyNoScalars(a, 0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 1);
   int64_t k = (m < n ? m : n);
 
 #if defined(THC_REAL_IS_FLOAT)
@@ -669,8 +669,8 @@ THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THC
   THArgCheck(!a_->is_empty() && a_->dim() == 2, 2, "A should be non-empty 2 dimensional");
 
   THCTensor *a = THCTensor_(newColumnMajor)(state, rr_, a_);
-  int64_t m = a->size(0);
-  int64_t n = a->size(1);
+  int64_t m = THTensor_sizeLegacyNoScalars(a, 0);
+  int64_t n = THTensor_sizeLegacyNoScalars(a, 1);
   int64_t k = (m < n ? m : n);
 
 #if defined(THC_REAL_IS_FLOAT)

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -196,8 +196,8 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = self_->stride(0);
-  int64_t stride1 = self_->stride(1);
+  int64_t stride0 = THTensor_strideLegacyNoScalars(self_, 0);
+  int64_t stride1 = THTensor_strideLegacyNoScalars(self_, 1);
   real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 0> op(start, stride0, stride1, k);
@@ -225,8 +225,8 @@ void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   if (self_ != src_)
     THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = self_->stride(0);
-  int64_t stride1 = self_->stride(1);
+  int64_t stride0 = THTensor_strideLegacyNoScalars(self_, 0);
+  int64_t stride1 = THTensor_strideLegacyNoScalars(self_, 1);
   real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 1> op(start, stride0, stride1, k);

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -118,20 +118,20 @@ THCTensor_(cross)(THCState *state, THCTensor *self, THCTensor *x, THCTensor *y, 
   ptrdiff_t nelem = THCTensor_(nElement)(state, x);
   THArgCheck(nd == THCTensor_(nDimensionLegacyNoScalars)(state, y), 1, "tensors must have same number of dimensions");
   for (i = 0; i < nd; i++) {
-    THArgCheck(THCTensor_(size)(state, x, i) == THCTensor_(size)(state, y, i), 1, "dimension %i of x and y does not match", i);
-    if (dimension < 0 && THCTensor_(size)(state, x, i) == 3) {
+    THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, x, i) == THCTensor_(sizeLegacyNoScalars)(state, y, i), 1, "dimension %i of x and y does not match", i);
+    if (dimension < 0 && THCTensor_(sizeLegacyNoScalars)(state, x, i) == 3) {
       dimension = i;
     }
   }
 
   THArgCheck(dimension >= 0 && dimension < nd, 3, "dimension %d out of range", dimension+1);
-  THArgCheck(THCTensor_(size)(state, x, dimension) == 3, 3,
+  THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, x, dimension) == 3, 3,
       "dimension %d does not have size 3", dimension+1);
   THCTensor_(resizeAs)(state, self, x);
 
-  int64_t sx = THCTensor_(stride)(state, x, dimension);
-  int64_t sy = THCTensor_(stride)(state, y, dimension);
-  int64_t so = THCTensor_(stride)(state, self, dimension);
+  int64_t sx = THCTensor_(strideLegacyNoScalars)(state, x, dimension);
+  int64_t sy = THCTensor_(strideLegacyNoScalars)(state, y, dimension);
+  int64_t so = THCTensor_(strideLegacyNoScalars)(state, self, dimension);
   THCTensor *nx = THCTensor_(newNarrow)(state, x, dimension, 0, 1);
   THCTensor *ny = THCTensor_(newNarrow)(state, y, dimension, 0, 1);
   THCTensor *nself = THCTensor_(newNarrow)(state, self, dimension, 0, 1);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -38,7 +38,7 @@ THC_API void
 THCTensor_(mean)(THCState *state, THCTensor *self, THCTensor *src, int dim, int keepdim)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
-  const accreal size = scalar_cast<accreal>(THCTensor_(size)(state, src, dim));
+  const accreal size = scalar_cast<accreal>(THCTensor_(sizeLegacyNoScalars)(state, src, dim));
   if (!THC_reduceDim<real>(state, self, src,
                            thrust::identity<accreal>{},
                            ReduceAdd<accreal>{},
@@ -68,8 +68,8 @@ THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, real value,
   THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, src) > 1, 1, "need at least 2 dimensions");
 
   if (numel > 0) {
-    ptrdiff_t size = numel / data->size(0);
-    dim3 grid(data->size(0));
+    ptrdiff_t size = numel / THTensor_sizeLegacyNoScalars(data, 0);
+    dim3 grid(THTensor_sizeLegacyNoScalars(data, 0));
     dim3 threads(32);
 
     THCTensor_kernel_renorm<real, accreal>
@@ -407,7 +407,7 @@ THCTensor_(median)(THCState *state,
 
   int64_t t_size_dim, k;
 
-  t_size_dim = THCTensor_(size)(state, self, dimension);
+  t_size_dim = THCTensor_(sizeLegacyNoScalars)(state, self, dimension);
 
   k = (t_size_dim-1) >> 1;
 

--- a/aten/src/THC/generic/THCTensorMathScan.cu
+++ b/aten/src/THC/generic/THCTensorMathScan.cu
@@ -32,13 +32,13 @@ __host__ void THCTensor_(scanOuterDim)(THCState *state, THCTensor *tgt,
   // Treat all outer dimensions (i.e. dim < dimension) as one.
   unsigned num_orows = 1;
   for (int dim = 0; dim < dimension; dim++) {
-    num_orows *= THCTensor_(size)(state, src, dim);
+    num_orows *= THCTensor_(sizeLegacyNoScalars)(state, src, dim);
   }
-  unsigned row_size = THCTensor_(size)(state, src, dimension);
+  unsigned row_size = THCTensor_(sizeLegacyNoScalars)(state, src, dimension);
   // Treat all inner dimensions (i.e. dim > dimension) as one.
   unsigned num_irows = 1;
   for (unsigned dim = dimension + 1; dim < ndim; dim++) {
-    num_irows *= THCTensor_(size)(state, src, dim);
+    num_irows *= THCTensor_(sizeLegacyNoScalars)(state, src, dim);
   }
 
   dim3 threads(min(512, num_irows));
@@ -61,9 +61,9 @@ __host__ void THCTensor_(scanInnermostDim)(THCState *state, THCTensor *tgt,
   // Treat all outer dimensions as a single dimension.
   unsigned num_rows = 1;
   for (unsigned dim = 0; dim < ndim - 1; dim++) {
-    num_rows *= THCTensor_(size)(state, src, dim);
+    num_rows *= THCTensor_(sizeLegacyNoScalars)(state, src, dim);
   }
-  unsigned row_size = THCTensor_(size)(state, src, ndim - 1);
+  unsigned row_size = THCTensor_(sizeLegacyNoScalars)(state, src, ndim - 1);
 
   dim3 threads(16, 32);
   dim3 grid(min(1024, THCCeilDiv(num_rows, threads.y)));

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -17,10 +17,10 @@ THC_API void THCTensor_(calculateMode)(THCState *state,
   // calculations to get an offset
   real *data = THCTensor_(data)(state, input);
   for (int i = 0; i < THLongStorage_size(position); ++i) {
-    data += THLongStorage_data(position)[i] * THCTensor_(stride)(state, input, i);
+    data += THLongStorage_data(position)[i] * THCTensor_(strideLegacyNoScalars)(state, input, i);
   }
 
-  int64_t nElement = THCTensor_(size)(state, input, THCTensor_(nDimensionLegacyAll)(state, input) - 1);
+  int64_t nElement = THCTensor_(sizeLegacyNoScalars)(state, input, THCTensor_(nDimensionLegacyAll)(state, input) - 1);
   THCThrustAllocator thrustAlloc(state);
 
   // Wrap input data, sortBuffer, in Thrust device vectors
@@ -121,8 +121,8 @@ THC_API void THCTensor_(calculateMode)(THCState *state,
 
   for (int i = 0; i < THLongStorage_size(position); ++i) {
     int64_t pos = THLongStorage_data(position)[i];
-    valuesOffset += THCTensor_(stride)(state, values, i) * pos;
-    indicesOffset += THCudaLongTensor_stride(state, indices, i) * pos;
+    valuesOffset += THCTensor_(strideLegacyNoScalars)(state, values, i) * pos;
+    indicesOffset += THCudaLongTensor_strideLegacyNoScalars(state, indices, i) * pos;
   }
   THCStorage_(set)(state, THCTensor_(storage)(state, values), valuesOffset, mode);
   THCudaLongStorage_set(state, THCudaLongTensor_storage(state, indices), indicesOffset, index);
@@ -145,7 +145,7 @@ THC_API void THCTensor_(dimApplyMode)(THCState *state,
     THCTensor_(calculateMode)(state, values, indices, input, sortBuffer, dimension, position);
   } else {
     // Loop through the values and recurse
-    for (int i = 0; i < THCTensor_(size)(state, input, curDim); ++i) {
+    for (int i = 0; i < THCTensor_(sizeLegacyNoScalars)(state, input, curDim); ++i) {
       THLongStorage_data(position)[curDim] = i;
       THCTensor_(dimApplyMode)(state, values, indices, input, sortBuffer, dimension, position, curDim + 1);
     }
@@ -175,7 +175,7 @@ THC_API void THCTensor_(mode)(THCState *state,
   ndim = THCTensor_(nDimensionLegacyAll)(state, input);
   THArgCheck(dimension >= 0 && dimension < ndim, 4, "Dimension of out bounds");
 
-  sliceSize = THCTensor_(size)(state, input, dimension);
+  sliceSize = THCTensor_(sizeLegacyNoScalars)(state, input, dimension);
   slices = THCTensor_(nElement)(state, input) / sliceSize;
 
   // Resize output value, index Tensors to appropriate sizes (i.e. the same as

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -110,8 +110,8 @@ THC_API void THCTensor_(cauchy)(THCState* state, THCTensor *self_, double median
 void THCTensor_(renormRows)(struct THCState* state,
                              THCTensor* t) {
   THAssert(THCTensor_(nDimensionLegacyAll)(state, t) == 2);
-  int64_t rows = THCTensor_(size)(state, t, 0);
-  int64_t cols = THCTensor_(size)(state, t, 1);
+  int64_t rows = THCTensor_(sizeLegacyNoScalars)(state, t, 0);
+  int64_t cols = THCTensor_(sizeLegacyNoScalars)(state, t, 1);
 
   cudaDeviceProp* props = THCState_getCurrentDeviceProperties(state);
   THAssert(props != NULL);
@@ -143,10 +143,10 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
 
   // Categories are in the innermost dimension
   int64_t numDist =
-    inputSize == 1 ? 1 : THCTensor_(size)(state, prob_dist, 0);
+    inputSize == 1 ? 1 : THCTensor_(sizeLegacyNoScalars)(state, prob_dist, 0);
   int64_t numCategoriesLong =
-    inputSize == 1 ? THCTensor_(size)(state, prob_dist, 0) :
-    THCTensor_(size)(state, prob_dist, 1);
+    inputSize == 1 ? THCTensor_(sizeLegacyNoScalars)(state, prob_dist, 0) :
+    THCTensor_(sizeLegacyNoScalars)(state, prob_dist, 1);
 
   // Since the index tensor is float, numCategories cannot exceed max
   // float integer precision
@@ -203,8 +203,8 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
       numCategories,
       THCTensor_(data)(state, sampled),
       THCTensor_(data)(state, prob_dist),
-      THCTensor_(stride)(state, prob_dist, 0),
-      THCTensor_(stride)(state, prob_dist, 1)
+      THCTensor_(strideLegacyNoScalars)(state, prob_dist, 0),
+      THCTensor_(strideLegacyNoScalars)(state, prob_dist, 1)
       );
     THCTensor_(free)(state, sampled);
   } else {

--- a/aten/src/THC/generic/THCTensorScatterGather.cu
+++ b/aten/src/THC/generic/THCTensorScatterGather.cu
@@ -25,7 +25,7 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
 
   for (int d = 0; d < THCTensor_(nDimensionLegacyNoScalars)(state, tensor); d++) {
     if (d != dim) {
-      THArgCheck(THCTensor_(size)(state, tensor, d) == THCTensor_(size)(state, src, d), 2,
+      THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, tensor, d) == THCTensor_(sizeLegacyNoScalars)(state, src, d), 2,
                  "Input tensor must have same size as output tensor apart from the specified dimension");
     }
   }
@@ -117,13 +117,13 @@ void THCTensor_(scatter)(THCState* state, THCTensor *tensor, int dim, THCudaLong
              "Input tensor must have same dimensions as output tensor");
 
   for (int d = 0; d < THCTensor_(nDimensionLegacyNoScalars)(state, tensor); d++) {
-    int64_t indexSizeD = THCudaLongTensor_size(state, index, d);
+    int64_t indexSizeD = THCudaLongTensor_sizeLegacyNoScalars(state, index, d);
     if (d != dim) {
-      THArgCheck(indexSizeD <= THCTensor_(size)(state, tensor, d), 3,
+      THArgCheck(indexSizeD <= THCTensor_(sizeLegacyNoScalars)(state, tensor, d), 3,
                  "Index tensor must not have larger size than output tensor apart from the specified dimension %d, but got index %s output %s",
                  dim, THCudaLongTensor_sizeDesc(state, index).str, THCTensor_(sizeDesc)(state, tensor).str);
     }
-    THArgCheck(indexSizeD <= THCTensor_(size)(state, src, d), 3,
+    THArgCheck(indexSizeD <= THCTensor_(sizeLegacyNoScalars)(state, src, d), 3,
                "Index tensor must not have larger size than input tensor, but got index %s input %s",
                THCudaLongTensor_sizeDesc(state, index).str, THCTensor_(sizeDesc)(state, src).str);
   }
@@ -209,13 +209,13 @@ void THCTensor_(scatterAdd)(THCState* state, THCTensor *tensor, int dim, THCudaL
              "Input tensor must have same dimensions as output tensor");
 
   for (int d = 0; d < THCTensor_(nDimensionLegacyNoScalars)(state, tensor); d++) {
-    int64_t indexSizeD = THCudaLongTensor_size(state, index, d);
+    int64_t indexSizeD = THCudaLongTensor_sizeLegacyNoScalars(state, index, d);
     if (d != dim) {
-      THArgCheck(indexSizeD <= THCTensor_(size)(state, tensor, d), 3,
+      THArgCheck(indexSizeD <= THCTensor_(sizeLegacyNoScalars)(state, tensor, d), 3,
                  "Index tensor must not have larger size than output tensor apart from the specified dimension %d, but got index %s output %s",
                  dim, THCudaLongTensor_sizeDesc(state, index).str, THCTensor_(sizeDesc)(state, tensor).str);
     }
-    THArgCheck(indexSizeD <= THCTensor_(size)(state, src, d), 3,
+    THArgCheck(indexSizeD <= THCTensor_(sizeLegacyNoScalars)(state, src, d), 3,
                "Index tensor must not have larger size than input tensor, but got index %s input %s",
                THCudaLongTensor_sizeDesc(state, index).str, THCTensor_(sizeDesc)(state, src).str);
   }
@@ -303,8 +303,8 @@ THCTensor_(scatterFill)(THCState* state, THCTensor *tensor,
 
   for (int d = 0; d < THCTensor_(nDimensionLegacyNoScalars)(state, tensor); d++) {
     if (d != dim) {
-      THArgCheck(THCTensor_(size)(state, tensor, d) ==
-                 THCudaLongTensor_size(state, index, d), 4,
+      THArgCheck(THCTensor_(sizeLegacyNoScalars)(state, tensor, d) ==
+                 THCudaLongTensor_sizeLegacyNoScalars(state, index, d), 4,
                  "Index tensor must have same size as output tensor apart from the specified dimension");
     }
   }

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -24,7 +24,7 @@ THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
     return;
   }
 
-  int64_t keySliceSize = THCTensor_(size)(state, key, dim);
+  int64_t keySliceSize = THCTensor_(sizeLegacyNoScalars)(state, key, dim);
   ptrdiff_t keySlices = inElements / keySliceSize;
 
   // The amount of shared memory and block size is based on
@@ -161,8 +161,8 @@ void THCTensor_(sortViaThrust)(THCState* state,
   int nDims = THCTensor_(nDimensionLegacyAll)(state, input);
 
   ptrdiff_t totalElements = THCTensor_(nElement)(state, input);
-  int64_t sliceSize = THCTensor_(size)(state, input, dim);
-  int64_t sliceStride = THCTensor_(stride)(state, input, dim);
+  int64_t sliceSize = THCTensor_(sizeLegacyNoScalars)(state, input, dim);
+  int64_t sliceStride = THCTensor_(strideLegacyNoScalars)(state, input, dim);
 
   // We perform a vectorized segmented sort in Thrust.
   // Say we are sorting a (2, 3) tensor. We have in flattened form:
@@ -297,7 +297,7 @@ THC_API void THCTensor_(sort)(THCState* state,
   THLongStorage_free(inputSize);
 
   // How large are the slices that we are sorting?
-  int64_t sliceSize = THCTensor_(size)(state, input, dim);
+  int64_t sliceSize = THCTensor_(sizeLegacyNoScalars)(state, input, dim);
 
   // Workaround:
   // CUDA 8 uses more shared memory than 7.5 for bitonicSortKVInPlace,

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -17,7 +17,7 @@ THC_API void THCTensor_(topk)(THCState* state,
 
   THArgCheck(dim >= 0 && dim < numDims, 6, "dim not in range");
 
-  int64_t sliceSize = THCTensor_(size)(state, input_, dim);
+  int64_t sliceSize = THCTensor_(sizeLegacyNoScalars)(state, input_, dim);
   THArgCheck(k >= 0 && k <= sliceSize, 5, "k not in range for dimension");
 
   THCTensor *input = THCTensor_(newContiguous)(state, input_);

--- a/aten/src/THCUNN/common.h
+++ b/aten/src/THCUNN/common.h
@@ -62,7 +62,7 @@ inline int GET_BLOCKS(const int N)
 
 #define THCUNN_check_dim_size(STATE, T, DIM, DIM_SIZE, SIZE) \
   if (THCTensor_(nDimensionLegacyNoScalars)(STATE, T) != DIM ||             \
-      THCTensor_(size)(STATE, T, DIM_SIZE) != SIZE) {        \
+      THCTensor_(sizeLegacyNoScalars)(STATE, T, DIM_SIZE) != SIZE) {        \
       THCDescBuff s1 = THCTensor_(sizeDesc)(state, T);       \
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
               " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \
@@ -70,7 +70,7 @@ inline int GET_BLOCKS(const int N)
 
 #define THCUNN_check_dim_size_indices(STATE, T, DIM, DIM_SIZE, SIZE)  \
   if (THCIndexTensor_(nDimensionLegacyNoScalars)(STATE, T) != DIM ||                 \
-      THCIndexTensor_(size)(STATE, T, DIM_SIZE) != SIZE) {            \
+      THCIndexTensor_(sizeLegacyNoScalars)(STATE, T, DIM_SIZE) != SIZE) {            \
       THCDescBuff s1 = THCIndexTensor_(sizeDesc)(state, T);           \
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d" \
               " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \

--- a/aten/src/THCUNN/generic/BatchNormalization.cu
+++ b/aten/src/THCUNN/generic/BatchNormalization.cu
@@ -21,11 +21,11 @@ static THCDeviceTensor<real, Dim> THNN_(devicetensor)(THCState *state, THCTensor
   int size[Dim];
   for (int i = 0; i < Dim || i < inDim; ++i) {
     if (i < Dim && i < inDim) {
-      size[i] = t->size(i);
+      size[i] = THTensor_sizeLegacyNoScalars(t, i);
     } else if (i < Dim) {
       size[i] = 1;
     } else {
-      size[Dim - 1] *= t->size(i);
+      size[Dim - 1] *= THTensor_sizeLegacyNoScalars(t, i);
     }
   }
   return THCDeviceTensor<real, Dim>(t->data<real>(), size);
@@ -39,7 +39,7 @@ void THNN_(BatchNormalization_updateOutput)(
 
   THCTensor_(resizeAs)(state, output_, input_);
   if (train) {
-    int64_t nInput = THCTensor_(size)(state, input_, 1);
+    int64_t nInput = THCTensor_(sizeLegacyNoScalars)(state, input_, 1);
     THCTensor_(resize1d)(state, saveMean_, nInput);
     THCTensor_(resize1d)(state, saveStd_, nInput);
   }

--- a/aten/src/THCUNN/generic/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/ClassNLLCriterion.cu
@@ -16,7 +16,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
   }
 
   int n_dims = THCTensor_(nDimensionLegacyNoScalars)(state, input);
-  int n_classes = THCTensor_(size)(state, input, n_dims - 1);
+  int n_classes = THCTensor_(sizeLegacyNoScalars)(state, input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
   if (weights) {
@@ -31,8 +31,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
 
   THArgCheck(!input->is_empty() && (n_dims <= 2 && n_dims > 0), 2, "non-empty vector or matrix expected");
 
-  int64_t batch_size = n_dims == 1 ? 1 : THCTensor_(size)(state, input, 0);
-  int64_t num_targets = THCudaLongTensor_size(state, target, 0);
+  int64_t batch_size = n_dims == 1 ? 1 : THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t num_targets = THCudaLongTensor_sizeLegacyNoScalars(state, target, 0);
   THArgCheck(batch_size == num_targets,
       2, "mismatch between the batch size of input (%ld) and that of target (%ld)",
       batch_size, num_targets);
@@ -102,8 +102,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         target_data,
         weights_data,
         reduction == Reduction::ElementwiseMean,
-        THCTensor_(size)(state, input, 0),
-        THCTensor_(size)(state, input, 1),
+        THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+        THCTensor_(sizeLegacyNoScalars)(state, input, 1),
         n_classes,
         ignore_index
     );
@@ -132,7 +132,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   }
 
   int n_dims = THCTensor_(nDimensionLegacyNoScalars)(state, input);
-  int n_classes = THCTensor_(size)(state, input, n_dims - 1);
+  int n_classes = THCTensor_(sizeLegacyNoScalars)(state, input, n_dims - 1);
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);
@@ -151,8 +151,8 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
 
   THArgCheck(!input->is_empty() && (n_dims <= 2 && n_dims > 0), 2, "non-empty vector or matrix expected");
 
-  int64_t batch_size = n_dims == 1 ? 1 : THCTensor_(size)(state, input, 0);
-  int64_t num_targets = THCudaLongTensor_size(state, target, 0);
+  int64_t batch_size = n_dims == 1 ? 1 : THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t num_targets = THCudaLongTensor_sizeLegacyNoScalars(state, target, 0);
   THArgCheck(batch_size == num_targets,
       2, "mismatch between the batch size of input (%ld) and that of target (%ld)",
       batch_size, num_targets);
@@ -218,8 +218,8 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         weights_data,
         total_weight_data,
         reduction == Reduction::ElementwiseMean,
-        THCTensor_(size)(state, input, 0),
-        THCTensor_(size)(state, input, 1),
+        THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+        THCTensor_(sizeLegacyNoScalars)(state, input, 1),
         n_classes,
         ignore_index
     );

--- a/aten/src/THCUNN/generic/Col2Im.cu
+++ b/aten/src/THCUNN/generic/Col2Im.cu
@@ -24,7 +24,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
                   "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
   int batch_dim = (ndim == 3) ? 0 : -1;
-  int64_t nInputPlane  = input->size(batch_dim + 1);
+  int64_t nInputPlane  = THTensor_sizeLegacyNoScalars(input, batch_dim + 1);
 
   if (nInputPlane % (kW * kH) != 0) {
     THError("Expected size of input's dimension 1 to be divisible by the "
@@ -32,7 +32,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
             "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
   }
 
-  int64_t inputLength  = input->size(batch_dim + 2);
+  int64_t inputLength  = THTensor_sizeLegacyNoScalars(input, batch_dim + 2);
   int64_t nBlocksH = div_rtn<int64_t>(outputHeight + 2 * padH - dH * (kH - 1) - 1, sH) + 1;
   int64_t nBlocksW = div_rtn<int64_t>(outputWidth + 2 * padW - dW * (kW - 1) - 1, sW) + 1;
 
@@ -71,11 +71,11 @@ void THNN_(Col2Im_updateOutput)(
   if (input->dim() == 2) {
       // Force batch
       batched_input = false;
-      THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
+      THCTensor_(resize3d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1));
   }
 
-  int64_t batchSize = input->size(0);
-  int64_t nInputPlane = input->size(1);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
   int64_t nOutputPlane = nInputPlane / (kW * kH);
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/FeatureLPPooling.cu
+++ b/aten/src/THCUNN/generic/FeatureLPPooling.cu
@@ -62,11 +62,11 @@ THNN_(FeatureLPPooling_resizeForOutput)(THCState* state,
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   int64_t outSize =
-    lpPoolingOutputSize(THCTensor_(size)(state, input, 0), width, stride);
+    lpPoolingOutputSize(THCTensor_(sizeLegacyNoScalars)(state, input, 0), width, stride);
   if (batchMode) {
     THAssert(inputDim > 1);
     outSize =
-      lpPoolingOutputSize(THCTensor_(size)(state, input, 1), width, stride);
+      lpPoolingOutputSize(THCTensor_(sizeLegacyNoScalars)(state, input, 1), width, stride);
   } else {
     THAssert(inputDim < 4);
   }
@@ -76,31 +76,31 @@ THNN_(FeatureLPPooling_resizeForOutput)(THCState* state,
   } else if (inputDim == 2) {
     if (batchMode) {
       THCTensor_(resize2d)(
-        state, toResize, THCTensor_(size)(state, input, 0), outSize);
+        state, toResize, THCTensor_(sizeLegacyNoScalars)(state, input, 0), outSize);
     } else {
       THCTensor_(resize2d)(
-        state, toResize, outSize, THCTensor_(size)(state, input, 1));
+        state, toResize, outSize, THCTensor_(sizeLegacyNoScalars)(state, input, 1));
     }
   } else if (inputDim == 3) {
     if (batchMode) {
       THCTensor_(resize3d)(
         state,
         toResize,
-        THCTensor_(size)(state, input, 0), outSize,
-        THCTensor_(size)(state, input, 2));
+        THCTensor_(sizeLegacyNoScalars)(state, input, 0), outSize,
+        THCTensor_(sizeLegacyNoScalars)(state, input, 2));
     } else {
       THCTensor_(resize3d)(
         state,
         toResize,
-        outSize, THCTensor_(size)(state, input, 1),
-        THCTensor_(size)(state, input, 2));
+        outSize, THCTensor_(sizeLegacyNoScalars)(state, input, 1),
+        THCTensor_(sizeLegacyNoScalars)(state, input, 2));
     }
   } else if (inputDim == 4) {
     THCTensor_(resize4d)(
       state,
       toResize,
-      THCTensor_(size)(state, input, 0), outSize,
-      THCTensor_(size)(state, input, 2), THCTensor_(size)(state, input, 3));
+      THCTensor_(sizeLegacyNoScalars)(state, input, 0), outSize,
+      THCTensor_(sizeLegacyNoScalars)(state, input, 2), THCTensor_(sizeLegacyNoScalars)(state, input, 3));
   }
 }
 
@@ -115,28 +115,28 @@ THNN_(FeatureLPPooling_resize)(THCState* state,
   if (inputDim == 1) {
     THCTensor_(resize1d)(state,
                          toResize,
-                         THCTensor_(size)(state, src, 0));
+                         THCTensor_(sizeLegacyNoScalars)(state, src, 0));
   } else if (inputDim == 2) {
     THCTensor_(resize2d)(
       state,
       toResize,
-      THCTensor_(size)(state, src, 0),
-      THCTensor_(size)(state, src, 1));
+      THCTensor_(sizeLegacyNoScalars)(state, src, 0),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 1));
   } else if (inputDim == 3) {
     THCTensor_(resize3d)(
       state,
       toResize,
-      THCTensor_(size)(state, src, 0),
-      THCTensor_(size)(state, src, 1),
-      THCTensor_(size)(state, src, 2));
+      THCTensor_(sizeLegacyNoScalars)(state, src, 0),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 1),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 2));
   } else if (inputDim == 4) {
     THCTensor_(resize4d)(
       state,
       toResize,
-      THCTensor_(size)(state, src, 0),
-      THCTensor_(size)(state, src, 1),
-      THCTensor_(size)(state, src, 2),
-      THCTensor_(size)(state, src, 3));
+      THCTensor_(sizeLegacyNoScalars)(state, src, 0),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 1),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 2),
+      THCTensor_(sizeLegacyNoScalars)(state, src, 3));
   }
 }
 

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -12,10 +12,10 @@ void THNN_(GatedLinear_updateOutput)(
 
   // size output to half of input
   dim = dim - TH_INDEX_BASE;
-  const int64_t nIn = THCTensor_(size)(state, input, dim);
+  const int64_t nIn = THCTensor_(sizeLegacyNoScalars)(state, input, dim);
   THArgCheck(nIn % 2 == 0, 2, "Halving dimension must be even. Dim %d is size %ld",
       dim + TH_INDEX_BASE, nIn);
-  const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
+  const int64_t inputSize = THCTensor_(sizeLegacyNoScalars)(state, input, dim) / 2;
   THLongStorage *newSizes = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(newSizes, dim, inputSize);
   THCTensor_(resize)(state, output, newSizes, NULL);
@@ -41,16 +41,16 @@ void THNN_(GatedLinear_updateGradInput)(
 {
   THCUNN_assertSameGPU(state, 2, gradOutput, gradInput);
   dim = dim - TH_INDEX_BASE;
-  const int64_t nIn = THCTensor_(size)(state, input, dim);
+  const int64_t nIn = THCTensor_(sizeLegacyNoScalars)(state, input, dim);
   THArgCheck(nIn % 2 == 0, 2, "Halving dimension must be even. Dim %d is size %ld",
       dim + TH_INDEX_BASE, nIn);
 
   THCTensor_(resizeAs)(state, gradInput, input);
-  const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
+  const int64_t inputSize = THCTensor_(sizeLegacyNoScalars)(state, input, dim) / 2;
   THCTensor *firstHalf = THCTensor_(newNarrow)(state, input, dim, 0, inputSize);
   THCTensor *gradInputfirstHalf = THCTensor_(newNarrow)(state, gradInput, dim, 0, inputSize);
-  const int64_t stride_i = THCTensor_(stride)(state, input, dim) * inputSize;
-  const int64_t stride_gI = THCTensor_(stride)(state, gradInput, dim) * inputSize;
+  const int64_t stride_i = THCTensor_(strideLegacyNoScalars)(state, input, dim) * inputSize;
+  const int64_t stride_gI = THCTensor_(strideLegacyNoScalars)(state, gradInput, dim) * inputSize;
   THC_pointwiseApply3<real, real, real>(state, gradInputfirstHalf, gradOutput, firstHalf, gatedLinearDerivative<real,accreal>(stride_i, stride_gI)); 
   THCTensor_(free)(state, firstHalf);
   THCTensor_(free)(state, gradInputfirstHalf);

--- a/aten/src/THCUNN/generic/Im2Col.cu
+++ b/aten/src/THCUNN/generic/Im2Col.cu
@@ -28,9 +28,9 @@ static inline void THNN_(Im2Col_shapeCheck)(
   if (ndim == 3) {
     dim_batch = -1;
   }
-  int64_t nInputPlane  = THCTensor_(size)(state, input, dim_batch + 1);
-  int64_t inputHeight  = THCTensor_(size)(state, input, dim_batch + 2);
-  int64_t inputWidth   = THCTensor_(size)(state, input, dim_batch + 3);
+  int64_t nInputPlane  = THCTensor_(sizeLegacyNoScalars)(state, input, dim_batch + 1);
+  int64_t inputHeight  = THCTensor_(sizeLegacyNoScalars)(state, input, dim_batch + 2);
+  int64_t inputWidth   = THCTensor_(sizeLegacyNoScalars)(state, input, dim_batch + 3);
   int64_t outputHeight = div_rtn<int64_t>(inputHeight + 2 * padH - (dH * (kH - 1) + 1),  sH) + 1;
   int64_t outputWidth  = div_rtn<int64_t>(inputWidth + 2 * padW - (dW * (kW - 1) + 1), sW) + 1;
 
@@ -61,13 +61,13 @@ void THNN_(Im2Col_updateOutput)(
   bool batched_input = true;
   if (input->dim() == 3) {
     batched_input = false;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
   }
 
-  int64_t batchSize    = THCTensor_(size)(state, input, 0);
-  int64_t nInputPlane  = THCTensor_(size)(state, input, 1);
-  int64_t inputHeight  = THCTensor_(size)(state, input, 2);
-  int64_t inputWidth   = THCTensor_(size)(state, input, 3);
+  int64_t batchSize    = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t nInputPlane  = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t inputHeight  = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t inputWidth   = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
 
   int64_t outputHeight = (inputHeight + 2 * padH - (dH * (kH - 1) + 1)) / sH + 1;
   int64_t outputWidth  = (inputWidth + 2 * padW - (dW * (kW - 1) + 1)) / sW + 1;

--- a/aten/src/THCUNN/generic/IndexLinear.cu
+++ b/aten/src/THCUNN/generic/IndexLinear.cu
@@ -5,7 +5,7 @@
 static bool THNN_(checkKeysValues)(THCState *state, THCudaLongTensor* keys,
                                    THCTensor* values)
 {
-    return THCudaLongTensor_size(state, keys, 0) == THCTensor_(nElement)(state, values)
+    return THCudaLongTensor_sizeLegacyNoScalars(state, keys, 0) == THCTensor_(nElement)(state, values)
         && THCTensor_(nDimensionLegacyAll)(state, values) == 1
         && THCudaLongTensor_nDimensionLegacyAll(state, keys) == 1;
 }
@@ -41,12 +41,12 @@ void THNN_(IndexLinear_updateOutput)(
     THArgCheck(THNN_(checkKeysValues)(state, keys, values), 1,
                "Keys and values should have the same number of elements");
 
-    int64_t batchSize = sizes->size(0);
-    int64_t outDim = bias->size(0);
-    int64_t wDim = weight->size(1);
-    int64_t weightStride = weight->stride(0);
+    int64_t batchSize = THTensor_sizeLegacyNoScalars(sizes, 0);
+    int64_t outDim = THTensor_sizeLegacyNoScalars(bias, 0);
+    int64_t wDim = THTensor_sizeLegacyNoScalars(weight, 1);
+    int64_t weightStride = THTensor_strideLegacyNoScalars(weight, 0);
     int maxNormalize = wDim - outDim;
-    int64_t keysSize = keys->size(0);
+    int64_t keysSize = THTensor_sizeLegacyNoScalars(keys, 0);
     int64_t nnzPerRow = divup(keysSize, batchSize);
 
     THCTensor_(resize2d)(state, output, batchSize, outDim);
@@ -100,10 +100,10 @@ void THNN_(IndexLinear_accGradParameters)(
     accreal weightDecay,
     accreal scale)
 {
-    int64_t keysSize = keys->size(0);
-    int64_t batchSize = sizes->size(0);
-    int64_t outDim = bias->size(0);
-    int64_t wDim = weight->size(1);
+    int64_t keysSize = THTensor_sizeLegacyNoScalars(keys, 0);
+    int64_t batchSize = THTensor_sizeLegacyNoScalars(sizes, 0);
+    int64_t outDim = THTensor_sizeLegacyNoScalars(bias, 0);
+    int64_t wDim = THTensor_sizeLegacyNoScalars(weight, 1);
     int maxNormalize = wDim - outDim;
 
     // Make sure these inputs are contiguous to accelerate computations
@@ -137,7 +137,7 @@ void THNN_(IndexLinear_accGradParameters)(
     real *gradOutputData  = THCTensor_(data)      (state, gradOutput);
     real *gradBiasData    = THCTensor_(data)      (state, gradBias);
     real *gradWeightData  = THCTensor_(data)      (state, gradWeight);
-    int64_t gradWeightStride = gradWeight->stride(0);
+    int64_t gradWeightStride = THTensor_strideLegacyNoScalars(gradWeight, 0);
 
     cudaStream_t stream = THCState_getCurrentStream(state);
     dim3 threads(THREADS_X, THREADS_Y);
@@ -182,10 +182,10 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
     THArgCheck(THNN_(checkKeysValues)(state, keys, values), 1,
                "Keys and values should have the same number of elements");
 
-    int64_t batchSize = sizes->size(0);
-    int64_t outDim = bias->size(0);
-    int64_t keysSize = keys->size(0);
-    int64_t wDim = weight->size(1);
+    int64_t batchSize = THTensor_sizeLegacyNoScalars(sizes, 0);
+    int64_t outDim = THTensor_sizeLegacyNoScalars(bias, 0);
+    int64_t keysSize = THTensor_sizeLegacyNoScalars(keys, 0);
+    int64_t wDim = THTensor_sizeLegacyNoScalars(weight, 1);
     int maxNormalize = wDim - outDim;
 
     real *biasData         = THCTensor_(data)      (state, bias);
@@ -194,7 +194,7 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
     real *valuesData       = THCTensor_(data)      (state, values);
     int64_t *keysData         = THCudaLongTensor_data (state, keys);
     int64_t *cumSumSizesData  = THCudaLongTensor_data (state, cumSumSizes);
-    int64_t weightStride = weight->stride(0);
+    int64_t weightStride = THTensor_strideLegacyNoScalars(weight, 0);
 
     cudaStream_t stream = THCState_getCurrentStream(state);
     dim3 threads(THREADS_X, THREADS_Y);
@@ -241,15 +241,15 @@ void THNN_(IndexLinear_updateParameters)(
     THArgCheck(THCudaLongTensor_isContiguous(state, cumSumSizes), 6,
                "cumSumSizes vector must be contiguous");
 
-    int64_t outDim = bias->size(0);
-    int64_t wDim = weight->size(1);
+    int64_t outDim = THTensor_sizeLegacyNoScalars(bias, 0);
+    int64_t wDim = THTensor_sizeLegacyNoScalars(weight, 1);
     int maxNormalize = wDim - outDim;
-    int64_t keysSize = runningKeys->size(0);
-    int64_t batchSize = cumSumSizes->size(0);
+    int64_t keysSize = THTensor_sizeLegacyNoScalars(runningKeys, 0);
+    int64_t batchSize = THTensor_sizeLegacyNoScalars(cumSumSizes, 0);
 
     THCTensor_(cadd)(state, bias, bias, -learningRate, gradBias);
-    int64_t gradWeightStride = gradWeight->stride(0);
-    int64_t weightStride = weight->stride(0);
+    int64_t gradWeightStride = THTensor_strideLegacyNoScalars(gradWeight, 0);
+    int64_t weightStride = THTensor_strideLegacyNoScalars(weight, 0);
 
     int64_t *keysData        = THCudaLongTensor_data (state, runningKeys);
     int64_t *cumSumSizesData = THCudaLongTensor_data (state, cumSumSizes);

--- a/aten/src/THCUNN/generic/LookupTable.cu
+++ b/aten/src/THCUNN/generic/LookupTable.cu
@@ -29,7 +29,7 @@ void THNN_(LookupTable_accGradParameters)(
   }
 
   ptrdiff_t numel = THCIndexTensor_(nElement)(state, input);
-  int64_t stride = THCTensor_(stride)(state, gradWeight, 0);
+  int64_t stride = THCTensor_(strideLegacyNoScalars)(state, gradWeight, 0);
 
   cudaStream_t stream = THCState_getCurrentStream(state);
 
@@ -155,7 +155,7 @@ void THNN_(LookupTable_accGradParameters)(
 #define RUN(NORM, IDXTYPE) \
   calculate_norms_and_renorm<real, accreal, IDXTYPE, NORM> \
     <<<numel, THREADS/2, THREADS * sizeof(accreal), THCState_getCurrentStream(state)>>> \
-    (weightsRaw, idxRaw, normType, maxNorm, THCTensor_(stride)(state, weight, 0))
+    (weightsRaw, idxRaw, normType, maxNorm, THCTensor_(strideLegacyNoScalars)(state, weight, 0))
 
 void THNN_(LookupTable_renorm)(
            THCState *state,

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -21,9 +21,9 @@ void THNN_(LookupTableBag_updateOutput)(
     THError("Tensors must be contiguous");
   }
 
-  ptrdiff_t numIndices = THCIndexTensor_(size)(state, input, 0);
-  ptrdiff_t numBags = THCIndexTensor_(size)(state, offsets, 0);
-  ptrdiff_t stride = THCTensor_(size)(state, weight, 1);
+  ptrdiff_t numIndices = THCIndexTensor_(sizeLegacyNoScalars)(state, input, 0);
+  ptrdiff_t numBags = THCIndexTensor_(sizeLegacyNoScalars)(state, offsets, 0);
+  ptrdiff_t stride = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
   int64_t *bag_size_data = NULL;
   if (bag_size != NULL) {
     bag_size_data = THCIndexTensor_(data)(state, bag_size);
@@ -95,7 +95,7 @@ void THNN_(LookupTableBag_accGradParameters)(
   }
 
   ptrdiff_t numel = THCIndexTensor_(nElement)(state, input);
-  int64_t stride = THCTensor_(stride)(state, gradWeight, 0);
+  int64_t stride = THCTensor_(strideLegacyNoScalars)(state, gradWeight, 0);
 
   cudaStream_t stream = THCState_getCurrentStream(state);
 

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -18,8 +18,8 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
 
   if(input->dim() == 1)
   {
-    int dim = input->size(0);
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim), 3,
+    int dim = THTensor_sizeLegacyNoScalars(input, 0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == dim), 3,
         "inconsistent target size");
     THCTensor_(resize1d)(state, output, 1);
 
@@ -39,17 +39,17 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   }
   else if(input->dim() == 2)
   {
-    int nframe = input->size(0);
-    int dim = input->size(1);
-    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
-               && (target->size(1) == dim), 3, "inconsistent target size");
+    int nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    int dim = THTensor_sizeLegacyNoScalars(input, 1);
+    THArgCheck(!target->is_empty() && (target->dim() == 2) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe)
+               && (THTensor_sizeLegacyNoScalars(target, 1) == dim), 3, "inconsistent target size");
 
-    dim3 blocks(input->size(0));
+    dim3 blocks(THTensor_sizeLegacyNoScalars(input, 0));
     dim3 threads(MULTILABELMARGIN_THREADS);
 
     if (reduction != Reduction::None)
     {
-      THCTensor *output_tmp = THCTensor_(newWithSize1d)(state, input->size(0));
+      THCTensor *output_tmp = THCTensor_(newWithSize1d)(state, THTensor_sizeLegacyNoScalars(input, 0));
       THCTensor_(resize1d)(state, output, 1);
 
       cunn_MultiLabelMarginCriterion_updateOutput_kernel<real, accreal>
@@ -67,7 +67,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
     }
     else
     {
-    THCTensor_(resize1d)(state, output, input->size(0));
+    THCTensor_(resize1d)(state, output, THTensor_sizeLegacyNoScalars(input, 0));
 
     cunn_MultiLabelMarginCriterion_updateOutput_kernel<real, accreal>
       <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
@@ -106,10 +106,10 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
 
   if(gradInput->dim() == 1)
   {
-    int dim = gradInput->size(0);
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim), 3,
+    int dim = THTensor_sizeLegacyNoScalars(gradInput, 0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == dim), 3,
                "inconsistent target size");
-    THArgCheck(!istarget->is_empty() && (istarget->dim() == 1) && (istarget->size(0) == dim), 3,
+    THArgCheck(!istarget->is_empty() && (istarget->dim() == 1) && (THTensor_sizeLegacyNoScalars(istarget, 0) == dim), 3,
                "inconsistent isTarget size");
     dim3 blocks(1);
     dim3 threads(MULTILABELMARGIN_THREADS);
@@ -121,20 +121,20 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         THCTensor_(data)(state, istarget),
-        1, gradInput->size(0),
+        1, THTensor_sizeLegacyNoScalars(gradInput, 0),
         reduction == Reduction::ElementwiseMean,
         reduction != Reduction::None);
 
   }
   else if(gradInput->dim() == 2)
   {
-    int nframe = gradInput->size(0);
-    int dim = gradInput->size(1);
-    THArgCheck(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
-               && (target->size(1) == dim), 3, "inconsistent target size");
-    THArgCheck(!istarget->is_empty() && (istarget->dim() == 2) && (istarget->size(0) == nframe)
-               && (istarget->size(1) == dim), 3, "inconsistent isTarget size");
-    dim3 blocks(gradInput->size(0));
+    int nframe = THTensor_sizeLegacyNoScalars(gradInput, 0);
+    int dim = THTensor_sizeLegacyNoScalars(gradInput, 1);
+    THArgCheck(!target->is_empty() && (target->dim() == 2) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe)
+               && (THTensor_sizeLegacyNoScalars(target, 1) == dim), 3, "inconsistent target size");
+    THArgCheck(!istarget->is_empty() && (istarget->dim() == 2) && (THTensor_sizeLegacyNoScalars(istarget, 0) == nframe)
+               && (THTensor_sizeLegacyNoScalars(istarget, 1) == dim), 3, "inconsistent isTarget size");
+    dim3 blocks(THTensor_sizeLegacyNoScalars(gradInput, 0));
     dim3 threads(MULTILABELMARGIN_THREADS);
 
     cunn_MultiLabelMarginCriterion_updateGradInput_kernel<real, accreal>
@@ -144,7 +144,7 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         THCTensor_(data)(state, istarget),
-        gradInput->size(0), gradInput->size(1),
+        THTensor_sizeLegacyNoScalars(gradInput, 0), THTensor_sizeLegacyNoScalars(gradInput, 1),
         reduction == Reduction::ElementwiseMean,
         reduction != Reduction::None);
   }

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -30,7 +30,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, input->size(0),
+        1, THTensor_sizeLegacyNoScalars(input, 0),
         reduction == Reduction::ElementwiseMean,
         margin
       );
@@ -42,7 +42,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, input->size(0),
+        1, THTensor_sizeLegacyNoScalars(input, 0),
         reduction == Reduction::ElementwiseMean,
         margin
       );
@@ -51,15 +51,15 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   }
   else if (input->dim() == 2)
   {
-    int nframe = input->size(0);
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe), 3,
+    int nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe), 3,
                "inconsistent target size");
-    dim3 blocks(input->size(0));
+    dim3 blocks(THTensor_sizeLegacyNoScalars(input, 0));
     dim3 threads(MULTIMARGIN_THREADS);
 
     if (reduction == Reduction::None)
     {
-      THCTensor_(resize1d)(state, output, input->size(0));
+      THCTensor_(resize1d)(state, output, THTensor_sizeLegacyNoScalars(input, 0));
       if (p == 1)
       {
         cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
@@ -67,7 +67,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size(1),
+          nframe, THTensor_sizeLegacyNoScalars(input, 1),
           false,
           margin
         );
@@ -79,7 +79,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size(1),
+          nframe, THTensor_sizeLegacyNoScalars(input, 1),
           false,
           margin
         );
@@ -89,7 +89,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
     else
     {
       THCTensor_(resize1d)(state, output, 1);
-      THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size(0));  // tmp output buffer
+      THCTensor *output_ = THCTensor_(newWithSize1d)(state, THTensor_sizeLegacyNoScalars(input, 0));  // tmp output buffer
       if (p == 1)
       {
         cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
@@ -97,7 +97,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          nframe, input->size(1),
+          nframe, THTensor_sizeLegacyNoScalars(input, 1),
           reduction == Reduction::ElementwiseMean,
           margin
         );
@@ -109,7 +109,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          input->size(0), input->size(1),
+          THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1),
           reduction == Reduction::ElementwiseMean,
           margin
         );
@@ -162,7 +162,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, gradInput->size(0),
+        1, THTensor_sizeLegacyNoScalars(gradInput, 0),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -176,7 +176,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        1, gradInput->size(0),
+        1, THTensor_sizeLegacyNoScalars(gradInput, 0),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -186,10 +186,10 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   }
   else if (input->dim() == 2)
   {
-    int nframe = gradInput->size(0);
-    THArgCheck(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe), 3,
+    int nframe = THTensor_sizeLegacyNoScalars(gradInput, 0);
+    THArgCheck(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe), 3,
                "inconsistent target size");
-    dim3 blocks(gradInput->size(0));
+    dim3 blocks(THTensor_sizeLegacyNoScalars(gradInput, 0));
     dim3 threads(MULTIMARGIN_THREADS);
 
     if (p == 1)
@@ -200,7 +200,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        nframe, gradInput->size(1),
+        nframe, THTensor_sizeLegacyNoScalars(gradInput, 1),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None
@@ -214,7 +214,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        nframe, gradInput->size(1),
+        nframe, THTensor_sizeLegacyNoScalars(gradInput, 1),
         reduction == Reduction::ElementwiseMean,
         margin,
         reduction != Reduction::None

--- a/aten/src/THCUNN/generic/PReLU.cu
+++ b/aten/src/THCUNN/generic/PReLU.cu
@@ -24,12 +24,12 @@ void THNN_(PReLU_updateOutput)(
     input = THCTensor_(newContiguous)(state, input);
 
     int n = THCTensor_(nElement)(state, input);
-    if (input->size(ndim > 1) != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(ndim > 1));
+    if (THTensor_sizeLegacyNoScalars(input, ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, THTensor_sizeLegacyNoScalars(input, ndim > 1));
 
     int mapSize = 1;
     for (int d = 2; d < ndim; d++) {
-      mapSize *= input->size(d);
+      mapSize *= THTensor_sizeLegacyNoScalars(input, d);
     }
     int nElemsPerSample = nOutputPlane * mapSize;
     preluForward<<<GET_BLOCKS(n), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
@@ -69,12 +69,12 @@ void THNN_(PReLU_updateGradInput)(
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
     int n = THCTensor_(nElement)(state, input);
-    if (input->size(ndim > 1) != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(ndim > 1));
+    if (THTensor_sizeLegacyNoScalars(input, ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, THTensor_sizeLegacyNoScalars(input, ndim > 1));
 
     int mapSize = 1;
     for (int d = 2; d < ndim; d++) {
-      mapSize *= input->size(d);
+      mapSize *= THTensor_sizeLegacyNoScalars(input, d);
     }
     int nElemsPerSample = nOutputPlane * mapSize;
     preluBackward<<<GET_BLOCKS(n), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
@@ -142,10 +142,10 @@ void THNN_(PReLU_accGradParameters)(
         THCTensor *buffer = THCTensor_(newContiguous)(state, gradInput);
         int64_t size3 = 1;
         for (int d = 2; d < ndim; d++) {
-          size3 *= input->size(d);
+          size3 *= THTensor_sizeLegacyNoScalars(input, d);
         }
-        THCTensor_(resize3d)(state, buffer, input->size(0), nOutputPlane, size3);
-        THCTensor_(resize2d)(state, sumbuf, input->size(0), nOutputPlane);
+        THCTensor_(resize3d)(state, buffer, THTensor_sizeLegacyNoScalars(input, 0), nOutputPlane, size3);
+        THCTensor_(resize2d)(state, sumbuf, THTensor_sizeLegacyNoScalars(input, 0), nOutputPlane);
         THCTensor_(sum)(state, sumbuf, buffer, 2, 1);
         THCTensor_(sum)(state, gradWeightBuf, sumbuf, 0, 1);
         THCTensor_(cadd)(state, gradWeight, gradWeight, scale, gradWeightBuf);

--- a/aten/src/THCUNN/generic/SparseLinear.cu
+++ b/aten/src/THCUNN/generic/SparseLinear.cu
@@ -4,17 +4,17 @@
 
 static bool THNN_(checkInput)(THCTensor* t)
 {
-  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 2 && t->size(1) == 3;
+  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 2 && THTensor_sizeLegacyNoScalars(t, 1) == 3;
 }
 
 static bool THNN_(checkSize2D)(THCTensor* t, int64_t size0, int64_t size1)
 {
-  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 2 && t->size(0) == size0 && t->size(1) == size1;
+  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 2 && THTensor_sizeLegacyNoScalars(t, 0) == size0 && THTensor_sizeLegacyNoScalars(t, 1) == size1;
 }
 
 static bool THNN_(checkSize1D)(THCTensor* t, int64_t size0)
 {
-  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 1 && t->size(0) == size0;
+  return !t->is_empty() && THTensor_nDimensionLegacyAll(t) == 1 && THTensor_sizeLegacyNoScalars(t, 0) == size0;
 }
 
 static inline void THNN_(copyCudaFloatingType)(THCState *state, THCudaIntTensor *buf, THCTensor *t) {
@@ -37,8 +37,8 @@ void THNN_(SparseLinear_updateOutput)(
   THAssert(THCTensor_(checkGPU)(state, 4, input, output, weight, bias));
 
   int64_t h;
-  int64_t outDim = THCTensor_(size)(state, weight, 0);
-  int64_t inDim = THCTensor_(size)(state, weight, 1);
+  int64_t outDim = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int64_t inDim = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THArgCheck(THNN_(checkInput)(input), 2, "input size must be nnz x 3");
   AT_CHECK(!output->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, output) == 2,
@@ -47,8 +47,8 @@ void THNN_(SparseLinear_updateOutput)(
 
   weight = THCTensor_(newContiguous)(state, weight);
   
-  int64_t batchnum = THCTensor_(size)(state, output, 0);
-  int64_t nnz = THCTensor_(size)(state, input, 0);
+  int64_t batchnum = THCTensor_(sizeLegacyNoScalars)(state, output, 0);
+  int64_t nnz = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
 
   THCTensor *buffer = THCTensor_(new)(state);
   THCTensor *sel = THCTensor_(new)(state);
@@ -134,16 +134,16 @@ void THNN_(SparseLinear_accGradParameters)(
            accreal weightDecay,
            accreal scale)
 {
-  int64_t outDim = THCTensor_(size)(state, weight, 0);
-  int64_t inDim = THCTensor_(size)(state, weight, 1);
+  int64_t outDim = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int64_t inDim = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THArgCheck(THNN_(checkInput)(input), 2, "input size must be batchsize x nnz x 2");
   THArgCheck(THNN_(checkSize2D)(gradWeight, outDim, inDim), 4, "gradWeight size wrong");
   THArgCheck(THNN_(checkSize1D)(gradBias, outDim), 5, "gradBias size wrong");
 
   weight = THCTensor_(newContiguous)(state, weight);
-  int64_t nnz = THCTensor_(size)(state, input, 0);
-  int64_t batchnum = THCTensor_(size)(state, gradOutput, 0);
+  int64_t nnz = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t batchnum = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 0);
 
   THCTensor *buf = THCTensor_(new)(state);
   THCTensor *cols = THCTensor_(new)(state);

--- a/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveAveragePooling.cu
@@ -22,13 +22,13 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size(0);
-    int64_t isizeH = input->size(1);
-    int64_t isizeW = input->size(2);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 2);
 
-    int64_t istrideD = input->stride(0);
-    int64_t istrideH = input->stride(1);
-    int64_t istrideW = input->stride(2);
+    int64_t istrideD = THTensor_strideLegacyNoScalars(input, 0);
+    int64_t istrideH = THTensor_strideLegacyNoScalars(input, 1);
+    int64_t istrideW = THTensor_strideLegacyNoScalars(input, 2);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -49,14 +49,14 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
 
   } else {
     input = THCTensor_(newContiguous)(state, input);
-    int64_t sizeB  = input->size(0);
-    int64_t sizeD  = input->size(1);
-    int64_t isizeH = input->size(2);
-    int64_t isizeW = input->size(3);
+    int64_t sizeB  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    int64_t istrideD = input->stride(1);
-    int64_t istrideH = input->stride(2);
-    int64_t istrideW = input->stride(3);
+    int64_t istrideD = THTensor_strideLegacyNoScalars(input, 1);
+    int64_t istrideH = THTensor_strideLegacyNoScalars(input, 2);
+    int64_t istrideW = THTensor_strideLegacyNoScalars(input, 3);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -95,12 +95,12 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size(0);
-    int64_t isizeH = input->size(1);
-    int64_t isizeW = input->size(2);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 2);
 
-    int64_t osizeH = gradOutput->size(1);
-    int64_t osizeW = gradOutput->size(2);
+    int64_t osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+    int64_t osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 2);
 
     //bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 
@@ -129,13 +129,13 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t sizeB  = input->size(0);
-    int64_t sizeD  = input->size(1);
-    int64_t isizeH = input->size(2);
-    int64_t isizeW = input->size(3);
+    int64_t sizeB  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    int64_t osizeH = gradOutput->size(2);
-    int64_t osizeW = gradOutput->size(3);
+    int64_t osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    int64_t osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 3);
 
     //bool atomic = //(isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 

--- a/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -24,13 +24,13 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size(0);
-    int64_t isizeH = input->size(1);
-    int64_t isizeW = input->size(2);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 2);
 
-    int64_t istrideD = input->stride(0);
-    int64_t istrideH = input->stride(1);
-    int64_t istrideW = input->stride(2);
+    int64_t istrideD = THTensor_strideLegacyNoScalars(input, 0);
+    int64_t istrideH = THTensor_strideLegacyNoScalars(input, 1);
+    int64_t istrideW = THTensor_strideLegacyNoScalars(input, 2);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -55,14 +55,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
   } else {
     input = THCTensor_(newContiguous)(state, input);
-    int64_t sizeB  = input->size(0);
-    int64_t sizeD  = input->size(1);
-    int64_t isizeH = input->size(2);
-    int64_t isizeW = input->size(3);
+    int64_t sizeB  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    int64_t istrideD = input->stride(1);
-    int64_t istrideH = input->stride(2);
-    int64_t istrideW = input->stride(3);
+    int64_t istrideD = THTensor_strideLegacyNoScalars(input, 1);
+    int64_t istrideH = THTensor_strideLegacyNoScalars(input, 2);
+    int64_t istrideW = THTensor_strideLegacyNoScalars(input, 3);
 
     input_data = THCTensor_(data)(state, input);
 
@@ -107,12 +107,12 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   if (input->dim() == 3) {
-    int64_t sizeD  = input->size(0);
-    int64_t isizeH = input->size(1);
-    int64_t isizeW = input->size(2);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 2);
 
-    int64_t osizeH = gradOutput->size(1);
-    int64_t osizeW = gradOutput->size(2);
+    int64_t osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+    int64_t osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 2);
 
     //bool atomic = (isizeH%osizeH != 0) || (isizeW%osizeW != 0);
 
@@ -145,13 +145,13 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t sizeB  = input->size(0);
-    int64_t sizeD  = input->size(1);
-    int64_t isizeH = input->size(2);
-    int64_t isizeW = input->size(3);
+    int64_t sizeB  = THTensor_sizeLegacyNoScalars(input, 0);
+    int64_t sizeD  = THTensor_sizeLegacyNoScalars(input, 1);
+    int64_t isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    int64_t osizeH = gradOutput->size(2);
-    int64_t osizeW = gradOutput->size(3);
+    int64_t osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    int64_t osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 3);
 
     //bool atomic = (isizeH%osizeH != 0) || (isizeW%osizeW != 0);
 

--- a/aten/src/THCUNN/generic/SpatialAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAveragePooling.cu
@@ -32,9 +32,9 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
              "padW = %d, padH = %d, kW = %d, kH = %d",
              padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size(dimh-1);
-  int64_t nInputRows = input->size(dimh);
-  int64_t nInputCols = input->size(dimw);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
@@ -88,17 +88,17 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   int64_t nOutputCols, nOutputRows;
 
   if (input->dim() == 3) {
-    nInputCols = input->size(2);
-    nInputRows = input->size(1);
-    nInputPlane = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size(3);
-    nInputRows = input->size(2);
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
 
   if(ceil_mode) {
@@ -174,18 +174,18 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
   int dimRow = 1;
 
   if (input->dim() == 3) {
-    nInputPlane = input->size(0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
     dimCol = 3;
     dimRow = 2;
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
-  nInputCols = input->size(dimCol);
-  nInputRows = input->size(dimRow);
+  nInputCols = THTensor_sizeLegacyNoScalars(input, dimCol);
+  nInputRows = THTensor_sizeLegacyNoScalars(input, dimRow);
 
   if(ceil_mode) {
     nOutputCols = ceil(float(nInputCols - kW + 2*padW) / float(dW)) + 1;

--- a/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -14,16 +14,16 @@ void THNN_(SpatialClassNLLCriterion_shapeCheck)(
   AT_CHECK(!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4, 2,
            "only batches of spatial inputs supported (non-empty 4D tensors), "      \
            "but got input of size: ", input->sizes());
-  if (THCTensor_(size)(state, input, 0) != THCIndexTensor_(size)(state, target, 0) ||
-      THCTensor_(size)(state, input, 2) != THCIndexTensor_(size)(state, target, 1) ||
-      THCTensor_(size)(state, input, 3) != THCIndexTensor_(size)(state, target, 2)) {
+  if (THCTensor_(sizeLegacyNoScalars)(state, input, 0) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 0) ||
+      THCTensor_(sizeLegacyNoScalars)(state, input, 2) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 1) ||
+      THCTensor_(sizeLegacyNoScalars)(state, input, 3) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 2)) {
     THCDescBuff input_size = THCTensor_(sizeDesc)(state, input);
     THCDescBuff target_size = THCIndexTensor_(sizeDesc)(state, target);
     THError("input and target batch or spatial sizes don't match: target %s, input %s",
             target_size.str, input_size.str);
   }
 
-  if (weights && THCTensor_(nElement)(state, weights) != THCTensor_(size)(state, input, 1)) {
+  if (weights && THCTensor_(nElement)(state, weights) != THCTensor_(sizeLegacyNoScalars)(state, input, 1)) {
     THError("weight tensor should be defined either for all or no classes");
   }
 }
@@ -35,9 +35,9 @@ static void THNN_(SpatialClassNLLCriterion_gradOutput_no_reduce_shapeCheck)(
 {
   AT_CHECK(!gradOutput->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, gradOutput) == 3, 2,
            "Expected non-empty dimension 3 but got gradOutput of size: ", gradOutput->sizes());
-  if (THCTensor_(size)(state, gradOutput, 0) != THCIndexTensor_(size)(state, target, 0) ||
-      THCTensor_(size)(state, gradOutput, 1) != THCIndexTensor_(size)(state, target, 1) ||
-      THCTensor_(size)(state, gradOutput, 2) != THCIndexTensor_(size)(state, target, 2)) {
+  if (THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 0) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 0) ||
+      THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 1) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 1) ||
+      THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 2) != THCIndexTensor_(sizeLegacyNoScalars)(state, target, 2)) {
     THCDescBuff gradOutput_size = THCTensor_(sizeDesc)(state, gradOutput);
     THCDescBuff target_size = THCIndexTensor_(sizeDesc)(state, target);
     THError("gradOutput sizes don't match target sizes: target %s, gradOutput %s",
@@ -66,9 +66,9 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
     THCUNN_assertSameGPU(state, 4, input, target, output, total_weight);
 
   if (reduction == Reduction::None) {
-    int64_t batch_size = THCTensor_(size)(state, input, 0);
-    int64_t H = THCTensor_(size)(state, input, 2);
-    int64_t W = THCTensor_(size)(state, input, 3);
+    int64_t batch_size = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    int64_t H = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    int64_t W = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
 
     THCTensor_(resize3d)(state, output, batch_size, H, W);
 
@@ -102,7 +102,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   real *output_data = THCTensor_(data)(state, output);
   real *total_weight_data = THCTensor_(data)(state, total_weight);
 
-  THCIndex_t batch_size = THCIndexTensor_(size)(state, target, 0);
+  THCIndex_t batch_size = THCIndexTensor_(sizeLegacyNoScalars)(state, target, 0);
   THCIndex_t map_nelem = THCIndexTensor_(nElement)(state, target) / batch_size;
   int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
   blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
@@ -119,9 +119,9 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
       target_data,
       weights_data,
       reduction == Reduction::ElementwiseMean,
-      THCTensor_(size)(state, input, 0),
-      THCTensor_(size)(state, input, 1),
-      THCTensor_(size)(state, input, 2) * THCTensor_(size)(state, input, 3),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 1),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 2) * THCTensor_(sizeLegacyNoScalars)(state, input, 3),
       blocks_per_sample,
       ignore_index
   );
@@ -168,9 +168,9 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
         gradOutput,
         target);
 
-    int64_t batch_size = THCTensor_(size)(state, input, 0);
-    int64_t H = THCTensor_(size)(state, input, 2);
-    int64_t W = THCTensor_(size)(state, input, 3);
+    int64_t batch_size = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    int64_t H = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    int64_t W = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
 
     if (weights) {
       weights = THCTensor_(newContiguous)(state, weights);
@@ -202,7 +202,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   THCIndex_t *target_data = THCIndexTensor_(data)(state, target);
   real *total_weight_data = THCTensor_(data)(state, total_weight);
 
-  THCIndex_t batch_size = THCIndexTensor_(size)(state, target, 0);
+  THCIndex_t batch_size = THCIndexTensor_(sizeLegacyNoScalars)(state, target, 0);
   THCIndex_t map_nelem = THCIndexTensor_(nElement)(state, target) / batch_size;
   int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
   blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
@@ -216,9 +216,9 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
       weights_data,
       total_weight_data,
       reduction == Reduction::ElementwiseMean,
-      THCTensor_(size)(state, input, 0),
-      THCTensor_(size)(state, input, 1),
-      THCTensor_(size)(state, input, 2) *THCTensor_(size)(state, input, 3),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 1),
+      THCTensor_(sizeLegacyNoScalars)(state, input, 2) *THCTensor_(sizeLegacyNoScalars)(state, input, 3),
       blocks_per_sample,
       ignore_index
   );

--- a/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -30,8 +30,8 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
                   "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane = weight->size(2) / (kH * kW);
-  int64_t nOutputPlane = weight->size(1);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 2) / (kH * kW);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
 
   if (bias != NULL) {
    THCUNN_check_dim_size(state, bias, 3, 0, nOutputPlane);
@@ -56,9 +56,9 @@ static THCTensor* THNN_(view_weight_local)(
   AT_CHECK(!weight->is_empty() && (weight->dim() == 3 || weight->dim() == 6), 4,
            "weight tensor should be (non-empty) 3D or 6D - got size: ", weight->sizes());
   if (weight->dim() == 6) {
-    int64_t s1 = weight->size(0) * weight->size(1);
-    int64_t s2 = weight->size(2);
-    int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
+    int64_t s1 = THTensor_sizeLegacyNoScalars(weight, 0) * THTensor_sizeLegacyNoScalars(weight, 1);
+    int64_t s2 = THTensor_sizeLegacyNoScalars(weight, 2);
+    int64_t s3 = THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4) * THTensor_sizeLegacyNoScalars(weight, 5);
     THCTensor *old_weight = weight;
     weight = THCTensor_(newWithStorage3d)(state,
                           THTensor_getStoragePtr(weight),
@@ -94,8 +94,8 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
 
   input = THCTensor_(newContiguous)(state, input);
 
-  int64_t nInputPlane = THCTensor_(size)(state,weight,2)/(kW*kH);
-  int64_t nOutputPlane = THCTensor_(size)(state,weight,1);
+  int64_t nInputPlane = THCTensor_(sizeLegacyNoScalars)(state,weight,2)/(kW*kH);
+  int64_t nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state,weight,1);
 
   int batch = 1;
   if (input->dim() == 3) {
@@ -105,7 +105,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -207,8 +207,8 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  int64_t nInputPlane = THCTensor_(size)(state,weight,2)/(kW*kH);
-  int64_t nOutputPlane = THCTensor_(size)(state,weight,1);
+  int64_t nInputPlane = THCTensor_(sizeLegacyNoScalars)(state,weight,2)/(kW*kH);
+  int64_t nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state,weight,1);
 
   int batch = 1;
   if (input->dim() == 3) {
@@ -219,7 +219,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -327,8 +327,8 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  int64_t nInputPlane = THCTensor_(size)(state,gradWeight,2)/(kW*kH);
-  int64_t nOutputPlane = THCTensor_(size)(state,gradWeight,1);
+  int64_t nInputPlane = THCTensor_(sizeLegacyNoScalars)(state,gradWeight,2)/(kW*kH);
+  int64_t nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state,gradWeight,1);
 
   int batch = 1;
   if (input->dim() == 3) {
@@ -339,7 +339,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   }
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Helpers
   THCTensor *input_n = THCTensor_(new)(state);

--- a/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
+++ b/aten/src/THCUNN/generic/SpatialCrossMapLRN.cu
@@ -19,16 +19,16 @@ void THNN_(LRNforward)(THCState* state, THCTensor* input, THCTensor* output,
 
   if (input->dim() == 3) {
     batchSize = 1;
-    nInputPlane = input->size(0);
-    imsize_h = input->size(1);
-    imsize_w = input->size(2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+    imsize_h = THTensor_sizeLegacyNoScalars(input, 1);
+    imsize_w = THTensor_sizeLegacyNoScalars(input, 2);
   }
   else
   {
-    batchSize = input->size(0);
-    nInputPlane = input->size(1);
-    imsize_h = input->size(2);
-    imsize_w = input->size(3);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    imsize_h = THTensor_sizeLegacyNoScalars(input, 2);
+    imsize_w = THTensor_sizeLegacyNoScalars(input, 3);
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -64,16 +64,16 @@ void THNN_(LRNbackward)(THCState* state, THCTensor* input, THCTensor* output,
 
   if (input->dim() == 3) {
     batchSize = 1;
-    nInputPlane = input->size(0);
-    imsize_h = input->size(1);
-    imsize_w = input->size(2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
+    imsize_h = THTensor_sizeLegacyNoScalars(input, 1);
+    imsize_w = THTensor_sizeLegacyNoScalars(input, 2);
   }
   else
   {
-    batchSize = input->size(0);
-    nInputPlane = input->size(1);
-    imsize_h = input->size(2);
-    imsize_w = input->size(3);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    imsize_h = THTensor_sizeLegacyNoScalars(input, 2);
+    imsize_w = THTensor_sizeLegacyNoScalars(input, 3);
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -23,15 +23,15 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   // the caller, so we verify that here to some extent
 
   // Weight Tensor is shape (output_channels, 1, kH, kW)
-  THAssert(weight->size(1) == 1);
+  THAssert(THTensor_sizeLegacyNoScalars(weight, 1) == 1);
 
   // Input Tensor is shape (N, input_channels, H, W)
   // We verify that the # of output_channels is a multiple of input_channels
-  THAssert(weight->size(0) % input->size(1) == 0);
+  THAssert(THTensor_sizeLegacyNoScalars(weight, 0) % THTensor_sizeLegacyNoScalars(input, 1) == 0);
 
   // Bias has same # of channels as output
   if (bias) {
-    THAssert(bias->size(0) == weight->size(0));
+    THAssert(THTensor_sizeLegacyNoScalars(bias, 0) == THTensor_sizeLegacyNoScalars(weight, 0));
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -41,12 +41,12 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   // Following the behvaior of other THCUNN functions, we shape the output
   // Tensor ourselves
 
-  int batchSize = input->size(0);
-  int height = input->size(2);
-  int width = input->size(3);
+  int batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+  int height = THTensor_sizeLegacyNoScalars(input, 2);
+  int width = THTensor_sizeLegacyNoScalars(input, 3);
   int outputHeight = (height + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int outputWidth = (width + 2 * padW - (dilationW * (kW - 1) + 1)) / dW + 1;
-  int outputChannels = weight->size(0);
+  int outputChannels = THTensor_sizeLegacyNoScalars(weight, 0);
 
   THCTensor_(resize4d)(state, output, batchSize, outputChannels, outputHeight, outputWidth);
 
@@ -61,7 +61,7 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
     dBias = toDeviceTensor<real, 1>(state, bias);
   }
 
-  int inputChannels = input->size(1);
+  int inputChannels = THTensor_sizeLegacyNoScalars(input, 1);
   int depthwiseMultiplier = outputChannels / inputChannels;
 
   // One thread per output value
@@ -113,20 +113,20 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
 
   // Minimal shape checking, as above
   // Same # of elements in batch
-  THAssert(input->size(0) == gradOutput->size(0));
+  THAssert(THTensor_sizeLegacyNoScalars(input, 0) == THTensor_sizeLegacyNoScalars(gradOutput, 0));
   // Same # of filters as outputChannels
-  THAssert(weight->size(0) == gradOutput->size(1));
+  THAssert(THTensor_sizeLegacyNoScalars(weight, 0) == THTensor_sizeLegacyNoScalars(gradOutput, 1));
 
   // Resize GradInput
   THCTensor_(resizeAs)(state, gradInput, input);
 
-  int inputChannels = input->size(1);
-  int height = input->size(2);
-  int width = input->size(3);
+  int inputChannels = THTensor_sizeLegacyNoScalars(input, 1);
+  int height = THTensor_sizeLegacyNoScalars(input, 2);
+  int width = THTensor_sizeLegacyNoScalars(input, 3);
 
-  int outputChannels = gradOutput->size(1);
-  int outputHeight = gradOutput->size(2);
-  int outputWidth = gradOutput->size(3);
+  int outputChannels = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  int outputHeight = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+  int outputWidth = THTensor_sizeLegacyNoScalars(gradOutput, 3);
 
   int depthwiseMultiplier = outputChannels / inputChannels;
 
@@ -210,18 +210,18 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
 
   // Minimal shape checking as above
   // Same # of elements in batch
-  THAssert(input->size(0) == gradOutput->size(0));
+  THAssert(THTensor_sizeLegacyNoScalars(input, 0) == THTensor_sizeLegacyNoScalars(gradOutput, 0));
   // Same # of filters as outputChannels
-  THAssert(gradWeight->size(0) == gradOutput->size(1));
+  THAssert(THTensor_sizeLegacyNoScalars(gradWeight, 0) == THTensor_sizeLegacyNoScalars(gradOutput, 1));
 
-  int batchSize = input->size(0);
-  int inputChannels = input->size(1);
-  int height = input->size(2);
-  int width = input->size(3);
+  int batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+  int inputChannels = THTensor_sizeLegacyNoScalars(input, 1);
+  int height = THTensor_sizeLegacyNoScalars(input, 2);
+  int width = THTensor_sizeLegacyNoScalars(input, 3);
 
-  int outputChannels = gradOutput->size(1);
-  int outputHeight = gradOutput->size(2);
-  int outputWidth = gradOutput->size(3);
+  int outputChannels = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  int outputHeight = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+  int outputWidth = THTensor_sizeLegacyNoScalars(gradOutput, 3);
 
   int depthwiseMultiplier = outputChannels / inputChannels;
 

--- a/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
                     "non-empty 4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
                   "but got: %s");
     if (bias != NULL) {
-      THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
+      THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -43,8 +43,8 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
    THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
                    "non-empty 3D or 4D input tensor expected but got: %s");
 
-   int64_t inputHeight  = input->size(dimh);
-   int64_t inputWidth   = input->size(dimw);
+   int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+   int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
 
    int64_t outputHeight = div_rtn<int64_t>(inputHeight + 2*padH - (dilationH * (kH - 1) + 1), dH) + 1;
    int64_t outputWidth  = div_rtn<int64_t>(inputWidth + 2*padW - (dilationW * (kW - 1) + 1), dW) + 1;
@@ -56,16 +56,16 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(1);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
      THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
   }
 
    if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
      THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
@@ -96,8 +96,8 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
         dilationH, dilationW, 0);
 
   // Params:
-  int nInputPlane = weight->size(1);
-  int nOutputPlane = weight->size(0);
+  int nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   weight = THCTensor_(newContiguous)(state, weight);
@@ -107,16 +107,16 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -127,7 +127,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -186,7 +186,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nOutputPlane;
-    int64_t n = columns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
     int64_t k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -242,8 +242,8 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
         dilationH, dilationW, 0);
 
   // Params
-  int nInputPlane = weight->size(1);
-  int nOutputPlane = weight->size(0);
+  int nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -253,17 +253,17 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THCTensor_(resize4d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -284,7 +284,7 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nInputPlane*kW*kH;
-    int64_t n = gradColumns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -369,22 +369,22 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THCTensor_(resize4d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t nInputPlane = input->size(1);
-  int64_t nOutputPlane = gradOutput->size(1);
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -422,7 +422,7 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kW*kH;
-      int64_t k = columns->size(1);
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       #ifdef THC_REAL_IS_FLOAT

--- a/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -25,7 +25,7 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
   int batchSize = 1;
 
   if (ndim == 4) {
-    batchSize = input->size(0);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
     dimf++;
     dimh++;
     dimw++;
@@ -38,9 +38,9 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
              "padW = %d, padH = %d, kW = %d, kH = %d",
              padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size(dimh-1);
-  int64_t nInputRows = input->size(dimh);
-  int64_t nInputCols = input->size(dimw);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
@@ -102,17 +102,17 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   int64_t nOutputCols, nOutputRows;
 
   if (input->dim() == 3) {
-    nInputCols = input->size(2);
-    nInputRows = input->size(1);
-    nInputPlane = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size(3);
-    nInputRows = input->size(2);
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
 
   if(ceil_mode) {
@@ -181,17 +181,17 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   int64_t nOutputCols, nOutputRows;
 
   if (THTensor_nDimensionLegacyAll(input) == 3) {
-    nInputCols = input->size(2);
-    nInputRows = input->size(1);
-    nInputPlane = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size(3);
-    nInputRows = input->size(2);
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
 
   if(ceil_mode) {

--- a/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
@@ -21,16 +21,16 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 4) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimh++;
     dimw++;
   }
 
   /* sizes */
-  int64_t numPlanes = THCTensor_(size)(state, input, planeDim);
-  int64_t inputH = THCTensor_(size)(state, input, dimh);
-  int64_t inputW = THCTensor_(size)(state, input, dimw);
+  int64_t numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int64_t inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int64_t inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
 
   THArgCheck(outputH + poolSizeH - 1 <= inputH, 6,
              "poolSizeH (%d) too large relative to input height (%d)",
@@ -113,12 +113,12 @@ void THNN_(SpatialFractionalMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  int64_t inputH = THCTensor_(size)(state, input, dimh);
-  int64_t inputW = THCTensor_(size)(state, input, dimw);
+  int64_t inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int64_t inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
 
-  THArgCheck(outputH == THCTensor_(size)(state, gradOutput, dimh), 3,
+  THArgCheck(outputH == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh), 3,
                 "gradOutput height unexpected");
-  THArgCheck(outputW == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(outputW == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
                 "gradOutput width unexpected");
 
   /* resize */

--- a/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
@@ -24,7 +24,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THCUNN_argCheck(state, !weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                     "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THCUNN_check_dim_size(state, bias, 1, 0, weight->size(1));
+      THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -44,8 +44,8 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
                   "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
@@ -56,16 +56,16 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(0);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
     THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(1);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
@@ -88,8 +88,8 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
            int adjW, int adjH)
 {
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
-  int nOutputPlane = THCTensor_(size)(state, weight, 1);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THCUNN_assertSameGPU(state, 6, input, output, weight,
                        bias, columns, ones);
@@ -105,16 +105,16 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -125,7 +125,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -143,9 +143,9 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(1) * weight->size(2) * weight->size(3);
-    int64_t n = columns->size(1);
-    int64_t k = weight->size(0);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -228,8 +228,8 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
            int dilationW, int dilationH,
            int adjW, int adjH)
 {
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
-  int nOutputPlane = THCTensor_(size)(state, weight, 1);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                        gradColumns, gradInput);
@@ -244,17 +244,17 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THCTensor_(resize4d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize4d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -285,9 +285,9 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(0);
-    int64_t n = gradColumns->size(1);
-    int64_t k = weight->size(1) * weight->size(2) * weight->size(3);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 0);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -349,9 +349,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
 
   int nOutputPlane;
   if (gradWeight != NULL) {
-    nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
+    nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, gradWeight, 1);
   } else if (gradBias != NULL) {
-    nOutputPlane = THCTensor_(size)(state, gradBias, 0);
+    nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, gradBias, 0);
   } else {
     return;
   }
@@ -371,20 +371,20 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size(0), input->size(1), input->size(2));
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THCTensor_(resize4d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THCTensor_(resize4d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -419,9 +419,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
 
       // M,N,K are dims of matrix A and B
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-      int64_t n = columns->size(0);   // nOutputPlane * kh * kw
-      int64_t m = input_n->size(0);   // nInputPlane
-      int64_t k = columns->size(1);   // inputHeight * inputWidth
+      int64_t n = THTensor_sizeLegacyNoScalars(columns, 0);   // nOutputPlane * kh * kw
+      int64_t m = THTensor_sizeLegacyNoScalars(input_n, 0);   // nInputPlane
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);   // inputHeight * inputWidth
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       #ifdef THC_REAL_IS_FLOAT
@@ -488,7 +488,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   // Resize
   if (is_batch == 0) {
     THCTensor_(resize3d)(state, gradOutput, nOutputPlane, outputHeight, outputWidth);
-    THCTensor_(resize3d)(state, input, input->size(1), inputHeight, inputWidth);
+    THCTensor_(resize3d)(state, input, THTensor_sizeLegacyNoScalars(input, 1), inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);

--- a/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -12,12 +12,12 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)(
   THCUNN_argCheck(state, !grid->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, grid) == 4, 2, grid,
       "4D grid tensor expected but got: %s");
 
-  int64_t nbatch   = THCTensor_(size)(state, input, 0);
-  int64_t channels = THCTensor_(size)(state, input, 1);
-  int64_t iheight   = THCTensor_(size)(state, input, 2);
-  int64_t iwidth    = THCTensor_(size)(state, input, 3);
-  int64_t oheight   = THCTensor_(size)(state, grid, 1);
-  int64_t owidth    = THCTensor_(size)(state, grid, 2);
+  int64_t nbatch   = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t iheight   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t iwidth    = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t oheight   = THCTensor_(sizeLegacyNoScalars)(state, grid, 1);
+  int64_t owidth    = THCTensor_(sizeLegacyNoScalars)(state, grid, 2);
 
   THCUNN_check_dim_size(state, grid, 4, 0, nbatch);
   THCUNN_check_dim_size(state, grid, 4, 3, 2);
@@ -39,12 +39,12 @@ THC_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 3, input, grid, output);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, NULL);
-  int64_t N = THCTensor_(size)(state, input, 0);
-  int64_t C = THCTensor_(size)(state, input, 1);
-  int64_t IH = THCTensor_(size)(state, input, 2);
-  int64_t IW = THCTensor_(size)(state, input, 3);
-  int64_t H = THCTensor_(size)(state,grid, 1);
-  int64_t W = THCTensor_(size)(state, grid, 2);
+  int64_t N = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t C = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t IH = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t IW = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t H = THCTensor_(sizeLegacyNoScalars)(state,grid, 1);
+  int64_t W = THCTensor_(sizeLegacyNoScalars)(state, grid, 2);
 
   // resize output to the same shape as input
   THCTensor_(resize4d)(state, output, N, C, H, W);
@@ -69,12 +69,12 @@ THC_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
 
   THCUNN_assertSameGPU(state, 5, input, gradInput, grid, gradGrid, gradOutput);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, gradOutput);
-  int64_t N = THCTensor_(size)(state, input, 0);
-  int64_t C = THCTensor_(size)(state, input, 1);
-  int64_t IH = THCTensor_(size)(state, input, 2);
-  int64_t IW = THCTensor_(size)(state, input, 3);
-  int64_t H = THCTensor_(size)(state, grid, 1);
-  int64_t W = THCTensor_(size)(state, grid, 2);
+  int64_t N = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t C = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t IH = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t IW = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t H = THCTensor_(sizeLegacyNoScalars)(state, grid, 1);
+  int64_t W = THCTensor_(sizeLegacyNoScalars)(state, grid, 2);
 
   THCTensor_(resize4d)(state, gradInput, N, C, IH, IW);
   THCTensor_(resize4d)(state, gradGrid, N, H, W, 2);

--- a/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/SpatialMaxUnpooling.cu
@@ -17,17 +17,17 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   int64_t nInputCols, nInputRows, nInputPlane, batchSize;
 
   if (input->dim() == 3) {
-    nInputCols = input->size(2);
-    nInputRows = input->size(1);
-    nInputPlane = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size(3);
-    nInputRows = input->size(2);
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
 
   input = THCTensor_(newContiguous)(state, input);
@@ -65,22 +65,22 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   int dimh = 1;
 
   if (input->dim() == 3) {
-    nInputPlane = input->size(0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 0);
     batchSize = 1;
   }
   else
   {
     ++dimw;
     ++dimh;
-    nInputPlane = input->size(1);
-    batchSize = input->size(0);
+    nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+    batchSize = THTensor_sizeLegacyNoScalars(input, 0);
   }
-  nInputCols = input->size(dimw);
-  nInputRows = input->size(dimh);
+  nInputCols = THTensor_sizeLegacyNoScalars(input, dimw);
+  nInputRows = THTensor_sizeLegacyNoScalars(input, dimh);
 
-  if(owidth!=gradOutput->size(dimw) || oheight!=gradOutput->size(dimh)){
+  if(owidth!=THTensor_sizeLegacyNoScalars(gradOutput, dimw) || oheight!=THTensor_sizeLegacyNoScalars(gradOutput, dimh)){
      THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
-             oheight, owidth,gradOutput->size(dimh),gradOutput->size(dimw));
+             oheight, owidth,THTensor_sizeLegacyNoScalars(gradOutput, dimh),THTensor_sizeLegacyNoScalars(gradOutput, dimw));
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReflectionPadding.cu
@@ -20,15 +20,15 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THCState *state,
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   if (numInputDims == 4) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimh++;
     dimw++;
   }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int inputH = THCTensor_(size)(state, input, dimh);
-  int inputW = THCTensor_(size)(state, input, dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
 
   THArgCheck(padL < inputW && padR < inputW, 4,
              "Padding size should be less than the corresponding input dimension, "
@@ -97,17 +97,17 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(
     dimh++;
     dimw++;
   }
-  int iheight = input->size(dimh);
-  int iwidth = input->size(dimw);
+  int iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  int iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int oheight = iheight + padT + padB;
   int owidth  = iwidth + padL + padR;
 
-  THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(owidth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
              "gradOutput width unexpected. Expected: %d, Got: %d",
-             owidth, THCTensor_(size)(state, gradOutput, dimw));
-  THArgCheck(oheight == THCTensor_(size)(state, gradOutput, dimh), 3,
+             owidth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw));
+  THArgCheck(oheight == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh), 3,
              "gradOutput height unexpected. Expected: %d, Got: %d",
-             oheight, THCTensor_(size)(state, gradOutput, dimh));
+             oheight, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh));
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);

--- a/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/SpatialReplicationPadding.cu
@@ -21,15 +21,15 @@ void THNN_(SpatialReplicationPadding_updateOutput)(
                   "non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   if (numInputDims == 4) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimh++;
     dimw++;
   }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int inputH = THCTensor_(size)(state, input, dimh);
-  int inputW = THCTensor_(size)(state, input, dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
   int outputH = inputH + padT + padB;
   int outputW  = inputW + padL + padR;
 
@@ -87,17 +87,17 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(
     dimh++;
     dimw++;
   }
-  int iheight = input->size(dimh);
-  int iwidth = input->size(dimw);
+  int iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  int iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int oheight = iheight + padT + padB;
   int owidth  = iwidth + padL + padR;
 
-  THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(owidth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
              "gradOutput width unexpected. Expected: %d, Got: %d",
-             owidth, THCTensor_(size)(state, gradOutput, dimw));
-  THArgCheck(oheight == THCTensor_(size)(state, gradOutput, dimh), 3,
+             owidth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw));
+  THArgCheck(oheight == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh), 3,
              "gradOutput height unexpected. Expected: %d, Got: %d",
-             oheight, THCTensor_(size)(state, gradOutput, dimh));
+             oheight, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh));
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);

--- a/aten/src/THCUNN/generic/SpatialSubSampling.cu
+++ b/aten/src/THCUNN/generic/SpatialSubSampling.cu
@@ -13,7 +13,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (input->dim() == 3 || input->dim() == 4), 2, input,
                   "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
 
   int dimc = 2;
   int dimr = 1;
@@ -25,9 +25,9 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
     dimp++;
   }
 
-  int64_t nInputCols = input->size(dimc);
-  int64_t nInputRows = input->size(dimr);
-  THArgCheck(input->size(dimp) == nInputPlane, 2, "invalid number of input planes");
+  int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, dimc);
+  int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, dimr);
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimp) == nInputPlane, 2, "invalid number of input planes");
   THArgCheck(nInputCols >= kW && nInputRows >= kH, 2, "input image smaller than kernel size");
 }
 
@@ -45,14 +45,14 @@ void THNN_(SpatialSubSampling_updateOutput)(
   real *output_data;
   real *input_data;
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
 
   THCUNN_assertSameGPU(state, 4, input, output, weight, bias);
   THNN_(SpatialSubSampling_shapeCheck)(state, input, NULL, weight, kW, kH);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size(2);
-    int64_t nInputRows = input->size(1);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
     int64_t nOutputCols = (nInputCols - kW) / dW + 1;
     int64_t nOutputRows = (nInputRows - kH) / dH + 1;
 
@@ -74,9 +74,9 @@ void THNN_(SpatialSubSampling_updateOutput)(
       nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW);
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size(3);
-    int64_t nInputRows = input->size(2);
-    int64_t nbatch = input->size(0);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t nOutputCols = (nInputCols - kW) / dW + 1;
     int64_t nOutputRows = (nInputRows - kH) / dH + 1;
 
@@ -116,11 +116,11 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   THCUNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
   THNN_(SpatialSubSampling_shapeCheck)(state, input, gradOutput, weight, kW, kH);
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size(2);
-    int64_t nInputRows = input->size(1);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
 
     real *weight_data = THCTensor_(data)(state, weight);
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -149,9 +149,9 @@ void THNN_(SpatialSubSampling_updateGradInput)(
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size(3);
-    int64_t nInputRows = input->size(2);
-    int64_t nbatch = input->size(0);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nbatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     real *weight_data = THCTensor_(data)(state, weight);
     gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -196,11 +196,11 @@ void THNN_(SpatialSubSampling_accGradParameters)(
   THCUNN_assertSameGPU(state, 4, input, gradOutput, gradWeight, gradBias);
   THNN_(SpatialSubSampling_shapeCheck)(state, input, gradOutput, gradWeight, kW, kH);
 
-  int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, gradWeight, 0);
 
   if (input->dim() == 3) {
-    int64_t nInputCols = input->size(2);
-    int64_t nInputRows = input->size(1);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 1);
 
     real *gradWeight_data = THCTensor_(data)(state, gradWeight);
     real *gradBias_data = THCTensor_(data)(state, gradBias);
@@ -221,9 +221,9 @@ void THNN_(SpatialSubSampling_accGradParameters)(
       nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW, scale);
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size(3);
-    int64_t nInputRows = input->size(2);
-    int64_t nbatch = input->size(0);
+    int64_t nInputCols = THTensor_sizeLegacyNoScalars(input, 3);
+    int64_t nInputRows = THTensor_sizeLegacyNoScalars(input, 2);
+    int64_t nbatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     real *gradWeight_data = THCTensor_(data)(state, gradWeight);
     real *gradBias_data = THCTensor_(data)(state, gradBias);
@@ -242,8 +242,8 @@ void THNN_(SpatialSubSampling_accGradParameters)(
     int64_t sl;
     for (sl=0; sl<nbatch; sl++) {
       subgradweight<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
-        input_data + sl*input->stride(0),
-        gradOutput_data + sl*gradOutput->stride(0),
+        input_data + sl*THTensor_strideLegacyNoScalars(input, 0),
+        gradOutput_data + sl*THTensor_strideLegacyNoScalars(gradOutput, 0),
         gradWeight_data, gradBias_data,
         nInputPlane, nInputRows, nInputCols, kH, kW, dH, dW, scale);
     }

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -36,10 +36,10 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
            int outputWidth,
            bool align_corners)
 {
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputHeight = THCTensor_(size)(state, input, 2);
-  int inputWidth = THCTensor_(size)(state, input, 3);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int inputWidth = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   THNN_(SpatialUpSamplingBilinear_shapeCheck)
        (state, input, NULL,
         nbatch, channels,
@@ -48,8 +48,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resize4d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
                        outputHeight, outputWidth);
   THCTensor_(zero)(state, output);
   THCDeviceTensor<real, 4> idata = toDeviceTensor<real, 4>(state, input);

--- a/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
@@ -37,10 +37,10 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
            int outputWidth)
 {
   THCUNN_assertSameGPU(state, 2, input, output);
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputHeight = THCTensor_(size)(state, input, 2);
-  int inputWidth  = THCTensor_(size)(state, input, 3);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
 
   THNN_(SpatialUpSamplingNearest_shapeCheck)(state, input, NULL, nbatch, channels,
 		  inputHeight, inputWidth,
@@ -48,8 +48,8 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
 
   THCTensor_(resize4d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
 		       outputHeight,
                        outputWidth);
   THCTensor_(zero)(state, output);

--- a/aten/src/THCUNN/generic/TemporalConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalConvolution.cu
@@ -25,13 +25,13 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck(input->size(dimF) == *inputFrameSize, 2,
+    THArgCheck(THTensor_sizeLegacyNoScalars(input, dimF) == *inputFrameSize, 2,
                "invalid input frame size. Got: %d, Expected: %d",
-               input->size(dimF), *inputFrameSize);
+               THTensor_sizeLegacyNoScalars(input, dimF), *inputFrameSize);
   }
-  THArgCheck(input->size(dimS) >= kW, 2,
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size(dimS), kW);
+             THTensor_sizeLegacyNoScalars(input, dimS), kW);
 }
 
 void THNN_(TemporalConvolution_updateOutput)(
@@ -65,7 +65,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   outputWindow = THCTensor_(new)(state);
   inputWindow = THCTensor_(new)(state);
 
-  nInputFrame = input->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (input->dim() == 2)
@@ -91,14 +91,14 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(input),
-                              input->storage_offset()+k*dW*input->size(1),
-                              nFrame, inputFrameStride*input->size(1),
-                              kW*input->size(1), 1);
+                              input->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(input, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(input, 1),
+                              kW*THTensor_sizeLegacyNoScalars(input, 1), 1);
 
       THCTensor_(setStorage2d)(state, outputWindow, THTensor_getStoragePtr(output),
-                              output->storage_offset() + k*output->size(1),
-                              nFrame, outputFrameStride*output->size(1),
-                              output->size(1), 1);
+                              output->storage_offset() + k*THTensor_sizeLegacyNoScalars(output, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(output, 1),
+                              THTensor_sizeLegacyNoScalars(output, 1), 1);
 
       THCTensor *tweight = THCTensor_(new)(state);
       THCTensor_(transpose)(state, tweight, weight, 0, 1);
@@ -110,7 +110,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   {
     THCTensor *outputSample = THCTensor_(new)(state);
     THCTensor *inputSample = THCTensor_(new)(state);
-    int nBatchFrame = input->size(0);
+    int nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
 
     THCTensor_(resize3d)(state, output,
                           nBatchFrame,
@@ -139,14 +139,14 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(inputSample),
-                                inputSample->storage_offset()+k*dW*inputSample->size(1),
-                                nFrame, inputFrameStride*inputSample->size(1),
-                                kW*inputSample->size(1), 1);
+                                inputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(inputSample, 1), 1);
 
         THCTensor_(setStorage2d)(state, outputWindow, THTensor_getStoragePtr(outputSample),
-                                outputSample->storage_offset() + k*outputSample->size(1),
-                                nFrame, outputFrameStride*outputSample->size(1),
-                                outputSample->size(1), 1);
+                                outputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(outputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(outputSample, 1),
+                                THTensor_sizeLegacyNoScalars(outputSample, 1), 1);
 
         THCTensor *tweight = THCTensor_(new)(state);
         THCTensor_(transpose)(state, tweight, weight, 0, 1);
@@ -194,8 +194,8 @@ void THNN_(TemporalConvolution_updateGradInput)(
     dimS = 1;
   }
 
-  nInputFrame = input->size(dimS);
-  nOutputFrame = gradOutput->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
+  nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, dimS);
 
 
   /* Not necessary with partial backprop: */
@@ -216,14 +216,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutput),
-                              gradOutput->storage_offset() + k*gradOutput->size(1),
-                              nFrame, outputFrameStride*gradOutput->size(1),
-                              gradOutput->size(1), 1);
+                              gradOutput->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              THTensor_sizeLegacyNoScalars(gradOutput, 1), 1);
 
       THCTensor_(setStorage2d)(state, gradInputWindow, THTensor_getStoragePtr(gradInput),
-                              gradInput->storage_offset()+k*dW*gradInput->size(1),
-                              nFrame, inputFrameStride*gradInput->size(1),
-                              kW*gradInput->size(1), 1);
+                              gradInput->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(gradInput, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(gradInput, 1),
+                              kW*THTensor_sizeLegacyNoScalars(gradInput, 1), 1);
 
       THCTensor_(addmm)(state, gradInputWindow, ScalarConvert<int, real>::to(1), gradInputWindow, ScalarConvert<int, real>::to(1), gradOutputWindow, weight);
     }
@@ -232,7 +232,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   {
     THCTensor *gradOutputSample = THCTensor_(new)(state);
     THCTensor *gradInputSample = THCTensor_(new)(state);
-    int64_t nBatchFrame = input->size(0);
+    int64_t nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
     for(i = 0; i < nBatchFrame; i++)
     {
       THCTensor_(select)(state, gradOutputSample, gradOutput, 0, i);
@@ -248,14 +248,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
-                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
-                                nFrame, outputFrameStride*gradOutputSample->size(1),
-                                gradOutputSample->size(1), 1);
+                                gradOutputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                THTensor_sizeLegacyNoScalars(gradOutputSample, 1), 1);
 
         THCTensor_(setStorage2d)(state, gradInputWindow, THTensor_getStoragePtr(gradInputSample),
-                                gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
-                                nFrame, inputFrameStride*gradInputSample->size(1),
-                                kW*gradInputSample->size(1), 1);
+                                gradInputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(gradInputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(gradInputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(gradInputSample, 1), 1);
 
         THCTensor_(addmm)(state, gradInputWindow, ScalarConvert<int, real>::to(1), gradInputWindow, ScalarConvert<int, real>::to(1), gradOutputWindow, weight);
       }
@@ -298,8 +298,8 @@ void THNN_(TemporalConvolution_accGradParameters)(
     dimS = 1;
   }
 
-  nInputFrame = input->size(dimS);
-  nOutputFrame = gradOutput->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
+  nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, dimS);
 
   /* Not necessary with partial backprop: */
   input = THCTensor_(newContiguous)(state, input);
@@ -325,14 +325,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(input),
-                              input->storage_offset()+k*dW*input->size(1),
-                              nFrame, inputFrameStride*input->size(1),
-                              kW*input->size(1), 1);
+                              input->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(input, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(input, 1),
+                              kW*THTensor_sizeLegacyNoScalars(input, 1), 1);
 
       THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutput),
-                              gradOutput->storage_offset() + k*gradOutput->size(1),
-                              nFrame, outputFrameStride*gradOutput->size(1),
-                              gradOutput->size(1), 1);
+                              gradOutput->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              THTensor_sizeLegacyNoScalars(gradOutput, 1), 1);
 
       THCTensor *tgradOutputWindow = THCTensor_(new)(state);
       THCTensor_(transpose)(state, tgradOutputWindow, gradOutputWindow, 0, 1);
@@ -344,7 +344,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   {
     THCTensor *gradOutputSample = THCTensor_(new)(state);
     THCTensor *inputSample = THCTensor_(new)(state);
-    int64_t nBatchFrame = input->size(0);
+    int64_t nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -368,14 +368,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THCTensor_(setStorage2d)(state, inputWindow, THTensor_getStoragePtr(inputSample),
-                                inputSample->storage_offset()+k*dW*inputSample->size(1),
-                                nFrame, inputFrameStride*inputSample->size(1),
-                                kW*inputSample->size(1), 1);
+                                inputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(inputSample, 1), 1);
 
         THCTensor_(setStorage2d)(state, gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
-                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
-                                nFrame, outputFrameStride*gradOutputSample->size(1),
-                                gradOutputSample->size(1), 1);
+                                gradOutputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                THTensor_sizeLegacyNoScalars(gradOutputSample, 1), 1);
 
         THCTensor *tgradOutputWindow = THCTensor_(new)(state);
         THCTensor_(transpose)(state, tgradOutputWindow, gradOutputWindow, 0, 1);

--- a/aten/src/THCUNN/generic/TemporalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/TemporalMaxPooling.cu
@@ -27,12 +27,12 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   THCUNN_argCheck(state, !input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
-  THArgCheck(input->size(dimT) >= kW, 2,
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimT) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size(dimT), kW);
+             THTensor_sizeLegacyNoScalars(input, dimT), kW);
 
-  input_w = input->size(dimT);
-  input_n = input->size(dimF);
+  input_w = THTensor_sizeLegacyNoScalars(input, dimT);
+  input_n = THTensor_sizeLegacyNoScalars(input, dimF);
   output_w = (input_w - kW) / dW + 1;
 
   if (gradOutput != NULL) {
@@ -71,23 +71,23 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   {
     dimT = 1;
     dimF = 2;
-    batch = input->size(0);
+    batch = THTensor_sizeLegacyNoScalars(input, 0);
   }
   input = THCTensor_(newContiguous)(state, input);
 
-  input_w = input->size(dimT);
-  input_n = input->size(dimF);
+  input_w = THTensor_sizeLegacyNoScalars(input, dimT);
+  input_n = THTensor_sizeLegacyNoScalars(input, dimF);
   output_w = (input_w - kW) / dW + 1;
 
   if (input->dim() == 2)
   {
-    THCTensor_(resize2d)(state, output, output_w, input->size(dimF));
-    THCIndexTensor_(resize2d)(state, indices, output_w, input->size(dimF));
+    THCTensor_(resize2d)(state, output, output_w, THTensor_sizeLegacyNoScalars(input, dimF));
+    THCIndexTensor_(resize2d)(state, indices, output_w, THTensor_sizeLegacyNoScalars(input, dimF));
   }
   else
   {
-    THCTensor_(resize3d)(state, output, batch, output_w, input->size(dimF));
-    THCIndexTensor_(resize3d)(state, indices, batch, output_w, input->size(dimF));
+    THCTensor_(resize3d)(state, output, batch, output_w, THTensor_sizeLegacyNoScalars(input, dimF));
+    THCIndexTensor_(resize3d)(state, indices, batch, output_w, THTensor_sizeLegacyNoScalars(input, dimF));
   }
 
   input_data = THCTensor_(data)(state, input);
@@ -146,12 +146,12 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   {
     dimT = 1;
     dimF = 2;
-    batch = input->size(0);
+    batch = THTensor_sizeLegacyNoScalars(input, 0);
   }
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  input_w = input->size(dimT);
-  input_n = input->size(dimF);
+  input_w = THTensor_sizeLegacyNoScalars(input, dimT);
+  input_n = THTensor_sizeLegacyNoScalars(input, dimF);
   output_w = (input_w - kW) / dW + 1;
 
   gradInput_data = THCTensor_(data)(state, gradInput);

--- a/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReflectionPadding.cu
@@ -18,13 +18,13 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THCState *state,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s")
 
   if (numInputDims == 3) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimw++;
   }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int inputW = THCTensor_(size)(state, input, dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
 
   THArgCheck(padL < inputW && padR < inputW, 4,
              "Padding size should be less than the corresponding input dimension, "
@@ -84,12 +84,12 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(
     planeDim++;
     dimw++;
   }
-  int iwidth = input->size(dimw);
+  int iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int owidth  = iwidth + padL + padR;
 
-  THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(owidth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
              "gradOutput width unexpected. Expected: %d, Got: %d",
-             owidth, THCTensor_(size)(state, gradOutput, dimw));
+             owidth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw));
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);

--- a/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/TemporalReplicationPadding.cu
@@ -19,13 +19,13 @@ void THNN_(TemporalReplicationPadding_updateOutput)(
                   "2D or 3D (batch mode) tensor expected for input, but got: %s")
 
   if (numInputDims == 3) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimw++;
   }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int inputW = THCTensor_(size)(state, input, dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
   int outputW  = inputW + padL + padR;
 
   THArgCheck(outputW >= 1, 2,
@@ -79,12 +79,12 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(
     planeDim++;
     dimw++;
   }
-  int iwidth = input->size(dimw);
+  int iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int owidth  = iwidth + padL + padR;
 
-  THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(owidth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
              "gradOutput width unexpected. Expected: %d, Got: %d",
-             owidth, THCTensor_(size)(state, gradOutput, dimw));
+             owidth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw));
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);

--- a/aten/src/THCUNN/generic/TemporalRowConvolution.cu
+++ b/aten/src/THCUNN/generic/TemporalRowConvolution.cu
@@ -14,7 +14,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
                   weight, "non-empty 2D or 3D weight tensor expected, but got: %s");
 
   if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
+    THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
   }
 
   int ndim = input->dim();
@@ -29,8 +29,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
   THCUNN_argCheck(state, !input->is_empty() && (ndim == 2 || ndim == 3), 1, input,
                   "non-empty 2D or 3D (batch mode) input tensor expected, but got :%s");
 
-  int64_t inputFrameSize = weight->size(0);
-  int64_t nInputFrame = input->size(dimS);
+  int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
   int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
   if (nOutputFrame < 1) {
@@ -84,16 +84,16 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
+    THCTensor_(resize3d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1));
   }
 
   // Params:
-  int64_t inputFrameSize = weight->size(0);
-  int64_t nInputFrame = input->size(2);
+  int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
   // Batch size
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize3d)(state, output, batchSize, inputFrameSize, nOutputFrame);
@@ -104,7 +104,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever
   // gets increased and always contains ones.
-  if (ones->dim() != 2 || ones->size(0) * ones->size(1) < nOutputFrame) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0) * THTensor_sizeLegacyNoScalars(ones, 1) < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -218,18 +218,18 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
-    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size(0),
-                         gradOutput->size(1));
+    THCTensor_(resize3d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1));
+    THCTensor_(resize3d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0),
+                         THTensor_sizeLegacyNoScalars(gradOutput, 1));
   }
 
   // Params:
-  int64_t inputFrameSize = weight->size(0);
-  int64_t nInputFrame = input->size(2);
-  int64_t nOutputFrame = gradOutput->size(2);
+  int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, 2);
 
   // Batch size
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize3d)(state, gradInput, batchSize, inputFrameSize,
@@ -331,21 +331,21 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
   if (ndim == 2) {
     // Force batch
     batch = 0;
-    THCTensor_(resize3d)(state, input, 1, input->size(0), input->size(1));
-    THCTensor_(resize3d)(state, gradOutput, 1, gradOutput->size(0),
-                         gradOutput->size(1));
+    THCTensor_(resize3d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1));
+    THCTensor_(resize3d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0),
+                         THTensor_sizeLegacyNoScalars(gradOutput, 1));
   }
 
   // Params:
-  int64_t inputFrameSize = gradWeight->size(0);
-  int64_t nInputFrame = input->size(2);
-  int64_t nOutputFrame = gradOutput->size(2);
+  int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(gradWeight, 0);
+  int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, 2);
 
   // Batch size
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size(0) * ones->size(1) < nOutputFrame) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0) * THTensor_sizeLegacyNoScalars(ones, 1) < nOutputFrame) {
     // Resize plane and fill with ones...
     THCTensor_(resize2d)(state, ones, 1, nOutputFrame);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -33,9 +33,9 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
            int outputWidth,
            bool align_corners)
 {
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputWidth = THCTensor_(size)(state, input, 2);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputWidth = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
   THNN_(TemporalUpSamplingLinear_shapeCheck)
        (state, input, NULL,
         nbatch, channels,
@@ -43,8 +43,8 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resize3d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
                        outputWidth);
   THCTensor_(zero)(state, output);
   THCDeviceTensor<real, 3> idata = toDeviceTensor<real, 3>(state, input);

--- a/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
@@ -33,16 +33,16 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
            int outputWidth)
 {
   THCUNN_assertSameGPU(state, 2, input, output);
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputWidth  = THCTensor_(size)(state, input, 2);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
 
   THNN_(TemporalUpSamplingNearest_shapeCheck)(state, input, NULL, nbatch, channels, inputWidth, outputWidth);
   THAssert(inputWidth > 0 && outputWidth > 0);
 
   THCTensor_(resize3d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
                        outputWidth);
   THCTensor_(zero)(state, output);
 

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveAveragePooling.cu
@@ -28,15 +28,15 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size(0);
-    isizeT = input->size(1);
-    isizeH = input->size(2);
-    isizeW = input->size(3);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 0);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    istrideD = input->stride(0);
-    istrideT = input->stride(1);
-    istrideH = input->stride(2);
-    istrideW = input->stride(3);
+    istrideD = THTensor_strideLegacyNoScalars(input, 0);
+    istrideT = THTensor_strideLegacyNoScalars(input, 1);
+    istrideH = THTensor_strideLegacyNoScalars(input, 2);
+    istrideW = THTensor_strideLegacyNoScalars(input, 3);
 
     THCTensor_(resize4d)(state, output, sizeD, osizeT, osizeH, osizeW);
 
@@ -44,16 +44,16 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   } else {
     input = THCTensor_(newContiguous)(state, input);
 
-    int64_t sizeB = input->size(0);
-    sizeD = input->size(1);
-    isizeT = input->size(2);
-    isizeH = input->size(3);
-    isizeW = input->size(4);
+    int64_t sizeB = THTensor_sizeLegacyNoScalars(input, 0);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 3);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 4);
 
-    istrideD = input->stride(1);
-    istrideT = input->stride(2);
-    istrideH = input->stride(3);
-    istrideW = input->stride(4);
+    istrideD = THTensor_strideLegacyNoScalars(input, 1);
+    istrideT = THTensor_strideLegacyNoScalars(input, 2);
+    istrideH = THTensor_strideLegacyNoScalars(input, 3);
+    istrideW = THTensor_strideLegacyNoScalars(input, 4);
 
     THCTensor_(resize5d)(state, output, sizeB, sizeD, osizeT, osizeH, osizeW);
 
@@ -107,23 +107,23 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size(0);
-    isizeT = input->size(1);
-    isizeH = input->size(2);
-    isizeW = input->size(3);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 0);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    osizeT = gradOutput->size(1);
-    osizeH = gradOutput->size(2);
-    osizeW = gradOutput->size(3);
+    osizeT = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+    osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 3);
   } else {
-    sizeD = input->size(1);
-    isizeT = input->size(2);
-    isizeH = input->size(3);
-    isizeW = input->size(4);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 3);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 4);
 
-    osizeT = gradOutput->size(2);
-    osizeH = gradOutput->size(3);
-    osizeW = gradOutput->size(4);
+    osizeT = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 3);
+    osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 4);
   }
 
   // somehow nonatomic is passing all test for volumetric case.
@@ -132,7 +132,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   if (input->dim() == 4) {
     totalZ = atomic ? sizeD * osizeT : sizeD * isizeT;
   } else {
-    int sizeB = input->size(0);
+    int sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     totalZ = atomic ? sizeB * sizeD * osizeT : sizeB * sizeD * isizeT;
   }
 

--- a/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
@@ -29,15 +29,15 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size(0);
-    isizeT = input->size(1);
-    isizeH = input->size(2);
-    isizeW = input->size(3);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 0);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    istrideD = input->stride(0);
-    istrideT = input->stride(1);
-    istrideH = input->stride(2);
-    istrideW = input->stride(3);
+    istrideD = THTensor_strideLegacyNoScalars(input, 0);
+    istrideT = THTensor_strideLegacyNoScalars(input, 1);
+    istrideH = THTensor_strideLegacyNoScalars(input, 2);
+    istrideW = THTensor_strideLegacyNoScalars(input, 3);
 
     THCTensor_(resize4d)(state, output, sizeD, osizeT, osizeH, osizeW);
     THCIndexTensor_(resize4d)(state, indices, sizeD, osizeT, osizeH, osizeW);
@@ -46,16 +46,16 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   } else {
     input = THCTensor_(newContiguous)(state, input);
 
-    int64_t sizeB = input->size(0);
-    sizeD = input->size(1);
-    isizeT = input->size(2);
-    isizeH = input->size(3);
-    isizeW = input->size(4);
+    int64_t sizeB = THTensor_sizeLegacyNoScalars(input, 0);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 3);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 4);
 
-    istrideD = input->stride(1);
-    istrideT = input->stride(2);
-    istrideH = input->stride(3);
-    istrideW = input->stride(4);
+    istrideD = THTensor_strideLegacyNoScalars(input, 1);
+    istrideT = THTensor_strideLegacyNoScalars(input, 2);
+    istrideH = THTensor_strideLegacyNoScalars(input, 3);
+    istrideW = THTensor_strideLegacyNoScalars(input, 4);
 
     THCTensor_(resize5d)(state, output, sizeB, sizeD, osizeT, osizeH, osizeW);
     THCIndexTensor_(resize5d)(state, indices, sizeB, sizeD, osizeT, osizeH, osizeW);
@@ -113,23 +113,23 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   int64_t totalZ;
 
   if (input->dim() == 4) {
-    sizeD = input->size(0);
-    isizeT = input->size(1);
-    isizeH = input->size(2);
-    isizeW = input->size(3);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 0);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 3);
 
-    osizeT = gradOutput->size(1);
-    osizeH = gradOutput->size(2);
-    osizeW = gradOutput->size(3);
+    osizeT = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+    osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 3);
   } else {
-    sizeD = input->size(1);
-    isizeT = input->size(2);
-    isizeH = input->size(3);
-    isizeW = input->size(4);
+    sizeD = THTensor_sizeLegacyNoScalars(input, 1);
+    isizeT = THTensor_sizeLegacyNoScalars(input, 2);
+    isizeH = THTensor_sizeLegacyNoScalars(input, 3);
+    isizeW = THTensor_sizeLegacyNoScalars(input, 4);
 
-    osizeT = gradOutput->size(2);
-    osizeH = gradOutput->size(3);
-    osizeW = gradOutput->size(4);
+    osizeT = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+    osizeH = THTensor_sizeLegacyNoScalars(gradOutput, 3);
+    osizeW = THTensor_sizeLegacyNoScalars(gradOutput, 4);
   }
 
   bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0) || (isizeT%osizeT != 0);
@@ -137,7 +137,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   if (input->dim() == 4) {
     totalZ = sizeD * osizeT;
   } else {
-    int sizeB = input->size(0);
+    int sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     totalZ = sizeB * sizeD * osizeT;
   }
 

--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -32,33 +32,33 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
 
   if (!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4)
   {
-    THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
-               && input->size(dimt) >= kT, 2,
+    THArgCheck(THTensor_sizeLegacyNoScalars(input, dimw) >= kW && THTensor_sizeLegacyNoScalars(input, dimh) >= kH
+               && THTensor_sizeLegacyNoScalars(input, dimt) >= kT, 2,
                "input image (T: %d H: %d W: %d) smaller than "
                "kernel size (kT: %d kH: %d kW: %d)",
-               input->size(dimt), input->size(dimh), input->size(dimw),
+               THTensor_sizeLegacyNoScalars(input, dimt), THTensor_sizeLegacyNoScalars(input, dimh), THTensor_sizeLegacyNoScalars(input, dimw),
                kT, kH, kW);
 
     /* sizes */
-    inputSlices = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else if (!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 5)
   {
-    THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
-               && input->size(dimt) >= kT, 2,
+    THArgCheck(THTensor_sizeLegacyNoScalars(input, dimw) >= kW && THTensor_sizeLegacyNoScalars(input, dimh) >= kH
+               && THTensor_sizeLegacyNoScalars(input, dimt) >= kT, 2,
                "input image (T: %d H: %d W: %d) smaller than "
                "kernel size (kT: %d kH: %d kW: %d)",
-               input->size(dimt), input->size(dimh), input->size(dimw),
+               THTensor_sizeLegacyNoScalars(input, dimt), THTensor_sizeLegacyNoScalars(input, dimh), THTensor_sizeLegacyNoScalars(input, dimw),
                kT, kH, kW);
 
     /* sizes */
-    inputSlices = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
   else
   {
@@ -144,19 +144,19 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   {
     /* sizes */
     batchSize   = 1;
-    inputSlices = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else /* 5D */
   {
     /* sizes */
-    batchSize   = THCTensor_(size)(state, input, 0);
-    inputSlices = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    batchSize   = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
 
   int outputTime;
@@ -288,26 +288,26 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;
-    inputSlices  = THCTensor_(size)(state, input, 0);
-    inputTime    = THCTensor_(size)(state, input, 1);
-    inputHeight  = THCTensor_(size)(state, input, 2);
-    inputWidth   = THCTensor_(size)(state, input, 3);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime    = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight  = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth   = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
 
-    outputTime   = THCTensor_(size)(state, gradOutput, 1);
-    outputHeight = THCTensor_(size)(state, gradOutput, 2);
-    outputWidth  = THCTensor_(size)(state, gradOutput, 3);
+    outputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 1);
+    outputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 2);
+    outputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 3);
   }
   else
   {
-    batchSize    = THCTensor_(size)(state, input, 0);
-    inputSlices  = THCTensor_(size)(state, input, 1);
-    inputTime    = THCTensor_(size)(state, input, 2);
-    inputHeight  = THCTensor_(size)(state, input, 3);
-    inputWidth   = THCTensor_(size)(state, input, 4);
+    batchSize    = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime    = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth   = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
 
-    outputTime   = THCTensor_(size)(state, gradOutput, 2);
-    outputHeight = THCTensor_(size)(state, gradOutput, 3);
-    outputWidth  = THCTensor_(size)(state, gradOutput, 4);
+    outputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 2);
+    outputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 3);
+    outputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 4);
   }
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);

--- a/aten/src/THCUNN/generic/VolumetricConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricConvolution.cu
@@ -49,11 +49,11 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
   if (weight == NULL) {
     weight = gradWeight;
   }
-  int64_t nOutputPlane = weight->size(0);
-  int64_t nInputPlane  = weight->size(1);
-  int64_t kT           = weight->size(2);
-  int64_t kH           = weight->size(3);
-  int64_t kW           = weight->size(4);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t nInputPlane  = THTensor_sizeLegacyNoScalars(weight, 1);
+  int64_t kT           = THTensor_sizeLegacyNoScalars(weight, 2);
+  int64_t kH           = THTensor_sizeLegacyNoScalars(weight, 3);
+  int64_t kW           = THTensor_sizeLegacyNoScalars(weight, 4);
 
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 4,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
@@ -71,9 +71,9 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
     dimd++;
   }
 
-  int64_t inputWidth   = input->size(dimw);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputDepth   = input->size(dimd);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, dimd);
 
   int64_t exactInputDepth = inputDepth + 2*padT;
   int64_t exactInputHeight = inputHeight + 2*padH;
@@ -99,7 +99,7 @@ static inline void THNN_(VolumetricConvolution_shapeCheck)
   }
 
   if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
+    THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
   }
   THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
 
@@ -130,30 +130,30 @@ void THNN_(VolumetricConvolution_updateOutput)(
         bias, dT, dW, dH, padT, padW, padH);
   input = THCTensor_(newContiguous)(state, input);
 
-  int nOutputPlane = (int)weight->size(0);
-  int nInputPlane  = (int)weight->size(1);
-  int kT           = (int)weight->size(2);
-  int kH           = (int)weight->size(3);
-  int kW           = (int)weight->size(4);
+  int nOutputPlane = (int)THTensor_sizeLegacyNoScalars(weight, 0);
+  int nInputPlane  = (int)THTensor_sizeLegacyNoScalars(weight, 1);
+  int kT           = (int)THTensor_sizeLegacyNoScalars(weight, 2);
+  int kH           = (int)THTensor_sizeLegacyNoScalars(weight, 3);
+  int kW           = (int)THTensor_sizeLegacyNoScalars(weight, 4);
 
   int batch = 1;
   if (input->dim() == 4)
   {
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1),
-                          input->size(2), input->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1),
+                          THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
-  int64_t inputDepth   = input->size(4);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, output, batchSize, nOutputPlane,
@@ -165,7 +165,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);
@@ -222,9 +222,9 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(0);
-    int64_t n = columns->size(1);
-    int64_t k = weight->size(1)*weight->size(2)*weight->size(3)*weight->size(4);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 0);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 1)*THTensor_sizeLegacyNoScalars(weight, 2)*THTensor_sizeLegacyNoScalars(weight, 3)*THTensor_sizeLegacyNoScalars(weight, 4);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -269,11 +269,11 @@ void THNN_(VolumetricConvolution_updateGradInput)(
            int padT, int padW, int padH)
 {
 
-  int64_t nOutputPlane = weight->size(0);
-  int64_t nInputPlane  = weight->size(1);
-  int64_t kT           = weight->size(2);
-  int64_t kH           = weight->size(3);
-  int64_t kW           = weight->size(4);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t nInputPlane  = THTensor_sizeLegacyNoScalars(weight, 1);
+  int64_t kT           = THTensor_sizeLegacyNoScalars(weight, 2);
+  int64_t kH           = THTensor_sizeLegacyNoScalars(weight, 3);
+  int64_t kW           = THTensor_sizeLegacyNoScalars(weight, 4);
 
   THCTensor *gradColumns = finput;
 
@@ -289,19 +289,19 @@ void THNN_(VolumetricConvolution_updateGradInput)(
     input = THCTensor_(newContiguous)(state, input);
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
-  int64_t inputDepth   = input->size(4);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, gradInput, batchSize, nInputPlane, inputHeight, inputWidth, inputDepth);
@@ -322,9 +322,9 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(1)*weight->size(2)*weight->size(3)*weight->size(4);
-    int64_t n = gradColumns->size(1);
-    int64_t k = weight->size(0);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 1)*THTensor_sizeLegacyNoScalars(weight, 2)*THTensor_sizeLegacyNoScalars(weight, 3)*THTensor_sizeLegacyNoScalars(weight, 4);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -389,11 +389,11 @@ void THNN_(VolumetricConvolution_accGradParameters)(
         state, input, gradOutput, NULL, gradWeight,
         gradBias, dT, dW, dH, padT, padW, padH);
 
-  int nOutputPlane = (int)gradWeight->size(0);
-  int nInputPlane  = (int)gradWeight->size(1);
-  int kT           = (int)gradWeight->size(2);
-  int kH           = (int)gradWeight->size(3);
-  int kW           = (int)gradWeight->size(4);
+  int nOutputPlane = (int)THTensor_sizeLegacyNoScalars(gradWeight, 0);
+  int nInputPlane  = (int)THTensor_sizeLegacyNoScalars(gradWeight, 1);
+  int kT           = (int)THTensor_sizeLegacyNoScalars(gradWeight, 2);
+  int kH           = (int)THTensor_sizeLegacyNoScalars(gradWeight, 3);
+  int kW           = (int)THTensor_sizeLegacyNoScalars(gradWeight, 4);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -403,22 +403,22 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   {
     // Force batch
     batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
-  int64_t inputDepth   = input->size(4);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 4);
   int64_t outputWidth  = (inputWidth  + 2*padH - kH) / dH + 1;
   int64_t outputHeight = (inputHeight + 2*padT - kT) / dT + 1;
   int64_t outputDepth  = (inputDepth  + 2*padW - kW) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputHeight, outputWidth, outputDepth);
@@ -449,9 +449,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = gradWeight->size(0);
-    int64_t n = gradWeight->size(1)*gradWeight->size(2)*gradWeight->size(3)*gradWeight->size(4);
-    int64_t k = columns->size(1);
+    int64_t m = THTensor_sizeLegacyNoScalars(gradWeight, 0);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradWeight, 1)*THTensor_sizeLegacyNoScalars(gradWeight, 2)*THTensor_sizeLegacyNoScalars(gradWeight, 3)*THTensor_sizeLegacyNoScalars(gradWeight, 4);
+    int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT

--- a/aten/src/THCUNN/generic/VolumetricDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedConvolution.cu
@@ -33,7 +33,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                   "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
-      THCUNN_check_dim_size(state, bias, 1, 0, weight->size(0));
+      THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -52,9 +52,9 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
-  int64_t inputDepth  = input->size(dimd);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, dimd);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputDepth  = div_rtn<int64_t>(inputDepth  + 2*padT - (dilationT * (kT - 1) + 1), dT) + 1;
   int64_t outputHeight = div_rtn<int64_t>(inputHeight + 2*padH - (dilationH * (kH - 1) + 1), dH) + 1;
   int64_t outputWidth  = div_rtn<int64_t>(inputWidth  + 2*padW - (dilationW * (kW - 1) + 1), dW) + 1;
@@ -66,16 +66,16 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(1);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
     THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimd, outputDepth);
@@ -107,8 +107,8 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
         dilationT, dilationH, dilationW, 0);
 
   // Params:
-  int nInputPlane = weight->size(1);
-  int nOutputPlane = weight->size(0);
+  int nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   weight = THCTensor_(newContiguous)(state, weight);
@@ -118,18 +118,18 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
   }
 
-  int64_t inputDepth  = input->size(2);
-  int64_t inputHeight  = input->size(3);
-  int64_t inputWidth   = input->size(4);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
   int64_t outputDepth  = (inputDepth  + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int64_t outputWidth  = (inputWidth  + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -140,7 +140,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -199,7 +199,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nOutputPlane;
-    int64_t n = columns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
     int64_t k = nInputPlane*kT*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -258,8 +258,8 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   weight = THCTensor_(newContiguous)(state, weight);
 
   // Params
-  int nInputPlane = weight->size(1);
-  int nOutputPlane = weight->size(0);
+  int nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
@@ -267,19 +267,19 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputDepth  = input->size(2);
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -300,7 +300,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = nInputPlane*kT*kW*kH;
-    int64_t n = gradColumns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -377,24 +377,24 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t nInputPlane = input->size(1);
-  int64_t nOutputPlane = gradOutput->size(1);
-  int64_t inputDepth  = input->size(2);
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -431,7 +431,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kT*kW*kH;
-      int64_t k = columns->size(1);
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       #ifdef THC_REAL_IS_FLOAT

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -54,18 +54,18 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
   if (THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4)
   {
     /* sizes */
-    inputSlices = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else if (THCTensor_(nDimensionLegacyNoScalars)(state, input) == 5)
   {
     /* sizes */
-    inputSlices = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
   else
   {
@@ -161,19 +161,19 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   {
     /* sizes */
     batchSize   = 1;
-    inputSlices = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else if (fiveDimensionalInput)
   {
     /* sizes */
-    batchSize   = THCTensor_(size)(state, input, 0);
-    inputSlices = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    batchSize   = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
   else
   {
@@ -327,26 +327,26 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;
-    inputSlices  = THCTensor_(size)(state, input, 0);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
 
-    outputTime   = THCTensor_(size)(state, gradOutput, 1);
-    outputHeight = THCTensor_(size)(state, gradOutput, 2);
-    outputWidth  = THCTensor_(size)(state, gradOutput, 3);
-    inputTime   = THCTensor_(size)(state, gradInput, 1);
-    inputHeight = THCTensor_(size)(state, gradInput, 2);
-    inputWidth  = THCTensor_(size)(state, gradInput, 3);
+    outputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 1);
+    outputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 2);
+    outputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 3);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 3);
   }
   else
   {
-    batchSize    = THCTensor_(size)(state, input, 0);
-    inputSlices  = THCTensor_(size)(state, input, 1);
+    batchSize    = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
 
-    outputTime   = THCTensor_(size)(state, gradOutput, 2);
-    outputHeight = THCTensor_(size)(state, gradOutput, 3);
-    outputWidth  = THCTensor_(size)(state, gradOutput, 4);
-    inputTime   = THCTensor_(size)(state, gradInput, 2);
-    inputHeight = THCTensor_(size)(state, gradInput, 3);
-    inputWidth  = THCTensor_(size)(state, gradInput, 4);
+    outputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 2);
+    outputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 3);
+    outputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradOutput, 4);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, gradInput, 4);
   }
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);

--- a/aten/src/THCUNN/generic/VolumetricFractionalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricFractionalMaxPooling.cu
@@ -22,7 +22,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
                   "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 5) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimh++;
     dimw++;
@@ -30,10 +30,10 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  int64_t numPlanes = THCTensor_(size)(state, input, planeDim);
-  int64_t inputH = THCTensor_(size)(state, input, dimh);
-  int64_t inputW = THCTensor_(size)(state, input, dimw);
-  int64_t inputT = THCTensor_(size)(state, input, dimt);
+  int64_t numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int64_t inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int64_t inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
+  int64_t inputT = THCTensor_(sizeLegacyNoScalars)(state, input, dimt);
 
   THArgCheck(outputH + poolSizeH - 1 < inputH, 7,
              "poolSizeH (%d) too large relative to input height (%d)",
@@ -121,15 +121,15 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  int64_t inputH = THCTensor_(size)(state, input, dimh);
-  int64_t inputW = THCTensor_(size)(state, input, dimw);
-  int64_t inputT = THCTensor_(size)(state, input, dimt);
+  int64_t inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int64_t inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
+  int64_t inputT = THCTensor_(sizeLegacyNoScalars)(state, input, dimt);
 
-  THArgCheck(outputH == THCTensor_(size)(state, gradOutput, dimh), 3,
+  THArgCheck(outputH == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh), 3,
                 "gradOutput height unexpected");
-  THArgCheck(outputW == THCTensor_(size)(state, gradOutput, dimw), 3,
+  THArgCheck(outputW == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
                 "gradOutput width unexpected");
-  THArgCheck(outputT == THCTensor_(size)(state, gradOutput, dimt), 3,
+  THArgCheck(outputT == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimt), 3,
                 "gradOutput time unexpected");
 
   /* resize */

--- a/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
@@ -34,7 +34,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                   "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
-      THCUNN_check_dim_size(state, bias, 1, 0, weight->size(1));
+      THCUNN_check_dim_size(state, bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -54,13 +54,13 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    const int64_t nInputPlane = THCTensor_(size)(state, weight, 0);
+    const int64_t nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
     THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
   }
 
-  int64_t inputWidth   = input->size(dimw);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputDepth  = input->size(dimd);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, dimd);
   int64_t outputDepth  = (inputDepth - 1) * dT - 2*padT + (dilationT * (kT - 1) + 1) + adjT;
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
@@ -73,10 +73,10 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      const int64_t nOutputPlane = THCTensor_(size)(state, weight, 1);
+      const int64_t nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      const int64_t nOutputPlane = THCTensor_(size)(state, bias, 0);
+      const int64_t nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, bias, 0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimd, outputDepth);
@@ -103,8 +103,8 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   THCTensor  *columns = finput;
   THCTensor  *ones    = fgradInput;
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
-  int nOutputPlane = THCTensor_(size)(state, weight, 1);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THCUNN_assertSameGPU(state, 6, input, output, weight,
                bias, columns, ones);
@@ -122,18 +122,18 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
   }
 
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
-  int64_t inputDepth  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputDepth  = (inputDepth - 1) * dT - 2*padT + (dilationT * (kT - 1) + 1) + adjT;
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -144,7 +144,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -162,9 +162,9 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
-    int64_t n = columns->size(1);
-    int64_t k = weight->size(0);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -254,8 +254,8 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
 {
   THCTensor  *gradColumns = finput;
 
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
-  int nOutputPlane = THCTensor_(size)(state, weight, 1);
+  int nInputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 0);
+  int nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, weight, 1);
 
   THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                gradColumns, gradInput);
@@ -272,19 +272,19 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
-  int64_t inputDepth   = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputDepth  = (inputDepth - 1) * dT - 2*padT + (dilationT * (kT - 1) + 1) + adjT;
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THCTensor_(resize5d)(state, gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -316,9 +316,9 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(0);
-    int64_t n = gradColumns->size(1);
-    int64_t k = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 0);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     #ifdef THC_REAL_IS_FLOAT
@@ -385,9 +385,9 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
 
   int nOutputPlane;
   if (gradWeight) {
-    nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
+    nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, gradWeight, 1);
   } else if (gradBias) {
-    nOutputPlane = THCTensor_(size)(state, gradBias, 0);
+    nOutputPlane = THCTensor_(sizeLegacyNoScalars)(state, gradBias, 0);
   } else {
     return;
   }
@@ -407,22 +407,22 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THCTensor_(resize5d)(state, input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THCTensor_(resize5d)(state, input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THCTensor_(resize5d)(state, gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
-  int64_t inputDepth   = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputDepth  = (inputDepth - 1) * dT - 2*padT + (dilationT * (kT - 1) + 1) + adjT;
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCTensor_(resize3d)(state, ones, outputDepth, outputHeight, outputWidth);
     THCTensor_(fill)(state, ones, ScalarConvert<int, real>::to(1));
@@ -458,9 +458,9 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
 
       // M,N,K are dims of matrix A and B
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-      int64_t n = columns->size(0);   // nOutputPlane * kt * kh * kw
-      int64_t m = input_n->size(0);   // nInputPlane
-      int64_t k = columns->size(1);   // inputHeight * inputWidth
+      int64_t n = THTensor_sizeLegacyNoScalars(columns, 0);   // nOutputPlane * kt * kh * kw
+      int64_t m = THTensor_sizeLegacyNoScalars(input_n, 0);   // nInputPlane
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);   // inputHeight * inputWidth
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       #ifdef THC_REAL_IS_FLOAT
@@ -527,7 +527,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   // Resize
   if (is_batch == 0) {
     THCTensor_(resize4d)(state, gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
-    THCTensor_(resize4d)(state, input, input->size(1), inputDepth, inputHeight, inputWidth);
+    THCTensor_(resize4d)(state, input, THTensor_sizeLegacyNoScalars(input, 1), inputDepth, inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);

--- a/aten/src/THCUNN/generic/VolumetricGridSamplerBilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricGridSamplerBilinear.cu
@@ -12,14 +12,14 @@ static inline void THNN_(VolumetricGridSamplerBilinear_shapeCheck)(
   THCUNN_argCheck(state, !grid->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, grid) == 5, 2, grid,
       "non-empty 5D grid tensor expected but got: %s");
 
-  int64_t nbatch   = THCTensor_(size)(state, input, 0);
-  int64_t channels = THCTensor_(size)(state, input, 1);
-  int64_t idepth   = THCTensor_(size)(state, input, 2);
-  int64_t iheight   = THCTensor_(size)(state, input, 3);
-  int64_t iwidth    = THCTensor_(size)(state, input, 4);
-  int64_t odepth   = THCTensor_(size)(state, grid, 1);
-  int64_t oheight   = THCTensor_(size)(state, grid, 2);
-  int64_t owidth    = THCTensor_(size)(state, grid, 3);
+  int64_t nbatch   = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t idepth   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t iheight   = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t iwidth    = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
+  int64_t odepth   = THCTensor_(sizeLegacyNoScalars)(state, grid, 1);
+  int64_t oheight   = THCTensor_(sizeLegacyNoScalars)(state, grid, 2);
+  int64_t owidth    = THCTensor_(sizeLegacyNoScalars)(state, grid, 3);
 
   THCUNN_check_dim_size(state, grid, 5, 0, nbatch);
   THCUNN_check_dim_size(state, grid, 5, 4, 3);
@@ -42,14 +42,14 @@ THC_API void THNN_(VolumetricGridSamplerBilinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 3, input, grid, output);
   THNN_(VolumetricGridSamplerBilinear_shapeCheck)(state, input, grid, NULL);
-  int64_t N = THCTensor_(size)(state, input, 0);
-  int64_t C = THCTensor_(size)(state, input, 1);
-  int64_t ID = THCTensor_(size)(state, input, 2);
-  int64_t IH = THCTensor_(size)(state, input, 3);
-  int64_t IW = THCTensor_(size)(state, input, 4);
-  int64_t D = THCTensor_(size)(state,grid, 1);
-  int64_t H = THCTensor_(size)(state,grid, 2);
-  int64_t W = THCTensor_(size)(state, grid, 3);
+  int64_t N = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t C = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t ID = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t IH = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t IW = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
+  int64_t D = THCTensor_(sizeLegacyNoScalars)(state,grid, 1);
+  int64_t H = THCTensor_(sizeLegacyNoScalars)(state,grid, 2);
+  int64_t W = THCTensor_(sizeLegacyNoScalars)(state, grid, 3);
 
   // resize output to the same shape as input
   THCTensor_(resize5d)(state, output, N, C, D, H, W);
@@ -74,14 +74,14 @@ THC_API void THNN_(VolumetricGridSamplerBilinear_updateGradInput)(
 
   THCUNN_assertSameGPU(state, 5, input, gradInput, grid, gradGrid, gradOutput);
   THNN_(VolumetricGridSamplerBilinear_shapeCheck)(state, input, grid, gradOutput);
-  int64_t N = THCTensor_(size)(state, input, 0);
-  int64_t C = THCTensor_(size)(state, input, 1);
-  int64_t ID = THCTensor_(size)(state, input, 2);
-  int64_t IH = THCTensor_(size)(state, input, 3);
-  int64_t IW = THCTensor_(size)(state, input, 4);
-  int64_t D = THCTensor_(size)(state,grid, 1);
-  int64_t H = THCTensor_(size)(state,grid, 2);
-  int64_t W = THCTensor_(size)(state, grid, 3);
+  int64_t N = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int64_t C = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int64_t ID = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int64_t IH = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int64_t IW = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
+  int64_t D = THCTensor_(sizeLegacyNoScalars)(state,grid, 1);
+  int64_t H = THCTensor_(sizeLegacyNoScalars)(state,grid, 2);
+  int64_t W = THCTensor_(sizeLegacyNoScalars)(state, grid, 3);
 
   THCTensor_(resize5d)(state, gradInput, N, C, ID, IH, IW);
   THCTensor_(resize5d)(state, gradGrid, N, D, H, W, 3);

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -26,11 +26,11 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
 
   if (THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4)
   {
-    inputSlices = THCTensor_(size)(state, input, 0);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
   }
   else if (THCTensor_(nDimensionLegacyNoScalars)(state, input) == 5)
   {
-    inputSlices = THCTensor_(size)(state, input, 1);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
   }
   else
   {
@@ -51,11 +51,11 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
   }
 
   if (gradOutput != NULL) {
-    if (oT != gradOutput->size(dimt) || oW != gradOutput->size(dimw) || oH != gradOutput->size(dimh))
+    if (oT != THTensor_sizeLegacyNoScalars(gradOutput, dimt) || oW != THTensor_sizeLegacyNoScalars(gradOutput, dimw) || oH != THTensor_sizeLegacyNoScalars(gradOutput, dimh))
     {
       THError(
         "Inconsistent gradOutput size. oT= %d, oH= %d, oW= %d, gradOutput: %dx%dx%d",
-        oT, oH, oW, gradOutput->size(dimt), gradOutput->size(dimh), gradOutput->size(dimw));
+        oT, oH, oW, THTensor_sizeLegacyNoScalars(gradOutput, dimt), THTensor_sizeLegacyNoScalars(gradOutput, dimh), THTensor_sizeLegacyNoScalars(gradOutput, dimw));
     }
 
     THCUNN_check_dim_size(state, gradOutput, input->dim(), dimn, inputSlices);
@@ -88,19 +88,19 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   {
     /* sizes */
     batchSize   = 1;
-    inputSlices = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else if (fiveDimensionalInput)
   {
     /* sizes */
-    batchSize   = THCTensor_(size)(state, input, 0);
-    inputSlices = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    batchSize   = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
 
   if (!fiveDimensionalInput) /* 4D */
@@ -196,18 +196,18 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;
-    inputSlices  = THCTensor_(size)(state, input, 0);
-    inputTime   = THCTensor_(size)(state, input, 1);
-    inputHeight = THCTensor_(size)(state, input, 2);
-    inputWidth  = THCTensor_(size)(state, input, 3);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
   }
   else
   {
-    batchSize    = THCTensor_(size)(state, input, 0);
-    inputSlices  = THCTensor_(size)(state, input, 1);
-    inputTime   = THCTensor_(size)(state, input, 2);
-    inputHeight = THCTensor_(size)(state, input, 3);
-    inputWidth  = THCTensor_(size)(state, input, 4);
+    batchSize    = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+    inputSlices  = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+    inputTime   = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+    inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+    inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
+++ b/aten/src/THCUNN/generic/VolumetricReplicationPadding.cu
@@ -27,10 +27,10 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
     dimw++;
     }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int idepth = input->size(dimd);
-  int iheight = input->size(dimh);
-  int iwidth = input->size(dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int idepth = THTensor_sizeLegacyNoScalars(input, dimd);
+  int iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  int iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int odepth = idepth + pfront + pback;
   int oheight = iheight + ptop + pbottom;
   int owidth  = iwidth + pleft + pright;
@@ -43,18 +43,18 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
     THArgCheck(THCTensor_canUse32BitIndexMath(state, gradOutput),
                3, "output gradient tensor must fit into 32-bit index math");
 
-    THArgCheck(numPlanes == THCTensor_(size)(state, gradOutput, planeDim), 3,
+    THArgCheck(numPlanes == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, planeDim), 3,
                "gradOutput width unexpected. Expected: %d, Got: %d",
-               numPlanes, THCTensor_(size)(state, gradOutput, planeDim));
-    THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+               numPlanes, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, planeDim));
+    THArgCheck(owidth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw), 3,
                "gradOutput width unexpected. Expected: %d, Got: %d",
-               owidth, THCTensor_(size)(state, gradOutput, dimw));
-    THArgCheck(oheight == THCTensor_(size)(state, gradOutput, dimh), 3,
+               owidth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimw));
+    THArgCheck(oheight == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh), 3,
                "gradOutput height unexpected. Expected: %d, Got: %d",
-               oheight, THCTensor_(size)(state, gradOutput, dimh));
-    THArgCheck(odepth == THCTensor_(size)(state, gradOutput, dimd), 3,
+               oheight, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimh));
+    THArgCheck(odepth == THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimd), 3,
                "gradOutput depth unexpected. Expected: %d, Got: %d",
-               odepth, THCTensor_(size)(state, gradOutput, dimd));
+               odepth, THCTensor_(sizeLegacyNoScalars)(state, gradOutput, dimd));
   }
 }
 
@@ -78,17 +78,17 @@ void THNN_(VolumetricReplicationPadding_updateOutput)(
   int numInputDims = THCTensor_(nDimensionLegacyNoScalars)(state, input);
 
   if (numInputDims == 5) {
-    numBatch = THCTensor_(size)(state, input, 0);
+    numBatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
     planeDim++;
     dimd++;
     dimh++;
     dimw++;
   }
 
-  int numPlanes = THCTensor_(size)(state, input, planeDim);
-  int inputD = THCTensor_(size)(state, input, dimd);
-  int inputH = THCTensor_(size)(state, input, dimh);
-  int inputW = THCTensor_(size)(state, input, dimw);
+  int numPlanes = THCTensor_(sizeLegacyNoScalars)(state, input, planeDim);
+  int inputD = THCTensor_(sizeLegacyNoScalars)(state, input, dimd);
+  int inputH = THCTensor_(sizeLegacyNoScalars)(state, input, dimh);
+  int inputW = THCTensor_(sizeLegacyNoScalars)(state, input, dimw);
   int outputD = inputD + pfront + pback;
   int outputH = inputH + ptop + pbottom;
   int outputW  = inputW + pleft + pright;

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
@@ -39,11 +39,11 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
            int outputWidth)
 {
   THCUNN_assertSameGPU(state, 2, input, output);
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputDepth = THCTensor_(size)(state, input, 2);
-  int inputHeight = THCTensor_(size)(state, input, 3);
-  int inputWidth  = THCTensor_(size)(state, input, 4);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputDepth = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int inputWidth  = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
 
   THNN_(VolumetricUpSamplingNearest_shapeCheck)(state, input, NULL, nbatch, channels,
 		  inputDepth, inputHeight, inputWidth,
@@ -52,8 +52,8 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
 		  outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
 
   THCTensor_(resize5d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
                        outputDepth,
                        outputHeight,
                        outputWidth);

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -38,11 +38,11 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
            int outputWidth,
            bool align_corners)
 {
-  int nbatch = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int inputDepth = THCTensor_(size)(state, input, 2);
-  int inputHeight = THCTensor_(size)(state, input, 3);
-  int inputWidth = THCTensor_(size)(state, input, 4);
+  int nbatch = THCTensor_(sizeLegacyNoScalars)(state, input, 0);
+  int channels = THCTensor_(sizeLegacyNoScalars)(state, input, 1);
+  int inputDepth = THCTensor_(sizeLegacyNoScalars)(state, input, 2);
+  int inputHeight = THCTensor_(sizeLegacyNoScalars)(state, input, 3);
+  int inputWidth = THCTensor_(sizeLegacyNoScalars)(state, input, 4);
   THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
        (state, input, NULL,
         nbatch, channels,
@@ -51,8 +51,8 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resize5d)(state, output,
-                       THCTensor_(size)(state, input, 0),
-                       THCTensor_(size)(state, input, 1),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 0),
+                       THCTensor_(sizeLegacyNoScalars)(state, input, 1),
                        outputDepth, outputHeight, outputWidth);
   THCTensor_(zero)(state, output);
   THCDeviceTensor<real, 5> idata = toDeviceTensor<real, 5>(state, input);

--- a/aten/src/THNN/generic/BatchNormalization.c
+++ b/aten/src/THNN/generic/BatchNormalization.c
@@ -10,7 +10,7 @@ void THNN_(BatchNormalization_updateOutput)(
   bool train, double momentum, double eps)
 {
   THTensor_(resizeAs)(output, input);
-  int64_t nInput = THTensor_(size)(input, 1);
+  int64_t nInput = THTensor_(sizeLegacyNoScalars)(input, 1);
   int64_t f;
   ptrdiff_t n = THTensor_(nElement)(input) / nInput;
 
@@ -81,7 +81,7 @@ void THNN_(BatchNormalization_backward)(
   bool train, double scale, double eps)
 {
   THNN_CHECK_SHAPE(input, gradOutput);
-  int64_t nInput = THTensor_(size)(input, 1);
+  int64_t nInput = THTensor_(sizeLegacyNoScalars)(input, 1);
   int64_t f;
   ptrdiff_t n = THTensor_(nElement)(input) / nInput;
 

--- a/aten/src/THNN/generic/ClassNLLCriterion.c
+++ b/aten/src/THNN/generic/ClassNLLCriterion.c
@@ -14,7 +14,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
 {
   THTensor_(resize1d)(total_weight, 1);
   int n_dims = THTensor_(nDimensionLegacyAll)(input);
-  int n_classes = THTensor_(size)(input, n_dims - 1);
+  int n_classes = THTensor_(sizeLegacyNoScalars)(input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
   if (THIndexTensor_(nDimensionLegacyAll)(target) > 1) {
@@ -30,7 +30,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
   }
 
   if (reduction == Reduction::None && n_dims == 2) {
-    int batch_size = THTensor_(size)(input, 0);
+    int batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
     THTensor_(resize1d)(output, batch_size);
 
     std::atomic<int> invalid_target(-1);  // We cannot throw an exception inside omp parallel
@@ -81,10 +81,10 @@ void THNN_(ClassNLLCriterion_updateOutput)(
       output_data[0] = -input_data[cur_target] * total_weight_data[0];
     }
   } else if (THTensor_(nDimensionLegacyAll)(input) == 2) {
-    int batch_size = THTensor_(size)(input, 0);
-    THAssert(THIndexTensor_(size)(target, 0) == batch_size);
+    int batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+    THAssert(THIndexTensor_(sizeLegacyNoScalars)(target, 0) == batch_size);
 
-    int n_target = THTensor_(size)(input, 1);
+    int n_target = THTensor_(sizeLegacyNoScalars)(input, 1);
 
     int i;
     for (i = 0; i < batch_size; i++) {
@@ -125,7 +125,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   int n_dims = THTensor_(nDimensionLegacyAll)(input);
-  int n_classes = THTensor_(size)(input, n_dims - 1);
+  int n_classes = THTensor_(sizeLegacyNoScalars)(input, n_dims - 1);
   ignore_index -= TH_INDEX_BASE;
 
   if (!THTensor_(isContiguous)(gradInput)) {
@@ -145,7 +145,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   }
 
   if (reduction == Reduction::None && n_dims == 2) {
-    int batch_size = THTensor_(size)(input, 0);
+    int batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
     THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, batch_size);
 
     int i;
@@ -188,10 +188,10 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
     }
 
   } else if (THTensor_(nDimensionLegacyAll)(input) == 2) {
-    int batch_size = THTensor_(size)(input, 0);
-    THAssert(THIndexTensor_(size)(target, 0) == batch_size);
+    int batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+    THAssert(THIndexTensor_(sizeLegacyNoScalars)(target, 0) == batch_size);
 
-    int n_target = THTensor_(size)(input, 1);
+    int n_target = THTensor_(sizeLegacyNoScalars)(input, 1);
 
     int i;
     for (i = 0; i < batch_size; i++){

--- a/aten/src/THNN/generic/Col2Im.c
+++ b/aten/src/THNN/generic/Col2Im.c
@@ -131,7 +131,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
                 "Expected non-empty 2D or 3D input tensor, but got input of shape %s");
 
   int64_t batch_dim = (ndim == 3) ? 0 : -1;
-  int64_t nInputPlane  = input->size(batch_dim + 1);
+  int64_t nInputPlane  = THTensor_sizeLegacyNoScalars(input, batch_dim + 1);
 
   if (nInputPlane % (kW * kH) != 0) {
     THError("Expected size of input's dimension 1 to be divisible by the "
@@ -139,7 +139,7 @@ static inline void THNN_(Col2Im_shapeCheck)(
             "kernel_size=(%d, %d).", (long long) nInputPlane, kH, kW);
   }
 
-  int64_t inputLength  = input->size(batch_dim + 2);
+  int64_t inputLength  = THTensor_sizeLegacyNoScalars(input, batch_dim + 2);
   int64_t nBlocksH = div_rtn<int64_t>(outputHeight + 2 * padH - dH * (kH - 1) - 1, sH) + 1;
   int64_t nBlocksW = div_rtn<int64_t>(outputWidth + 2 * padW - dW * (kW - 1) - 1, sW) + 1;
 
@@ -176,11 +176,11 @@ void THNN_(Col2Im_updateOutput)(
   if (input->dim() == 2) {
       // Force batch
       batched_input = false;
-      THTensor_(resize3d)(input, 1, input->size(0), input->size(1));
+      THTensor_(resize3d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1));
   }
 
-  long batchSize = input->size(0);
-  long nInputPlane = input->size(1);
+  long batchSize = THTensor_sizeLegacyNoScalars(input, 0);
+  long nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
   long nOutputPlane = nInputPlane / (kW * kH);
 
   input = THTensor_(newContiguous)(input);

--- a/aten/src/THNN/generic/FeatureLPPooling.c
+++ b/aten/src/THNN/generic/FeatureLPPooling.c
@@ -51,42 +51,42 @@ THNN_(FeatureLPPooling_upcastCPU)(THTensor* t, bool batchMode) {
   if (dim == 1) {
     THAssert(!batchMode);
     // [feature dim]
-    s.size[1] = THTensor_(size)(t, 0);
-    s.stride[1] = THTensor_(stride)(t, 0);
+    s.size[1] = THTensor_(sizeLegacyNoScalars)(t, 0);
+    s.stride[1] = THTensor_(strideLegacyNoScalars)(t, 0);
   } else if (dim == 2) {
     if (batchMode) {
       // [batch dim][feature dim]
       for (int i = 0; i < 2; ++i) {
-        s.size[i] = THTensor_(size)(t, i);
-        s.stride[i] = THTensor_(stride)(t, i);
+        s.size[i] = THTensor_(sizeLegacyNoScalars)(t, i);
+        s.stride[i] = THTensor_(strideLegacyNoScalars)(t, i);
       }
     } else {
       // [feature dim][opt dim 1]
-      s.size[1] = THTensor_(size)(t, 0);
-      s.stride[1] = THTensor_(stride)(t, 0);
-      s.size[2] = THTensor_(size)(t, 1);
-      s.stride[2] = THTensor_(stride)(t, 1);
+      s.size[1] = THTensor_(sizeLegacyNoScalars)(t, 0);
+      s.stride[1] = THTensor_(strideLegacyNoScalars)(t, 0);
+      s.size[2] = THTensor_(sizeLegacyNoScalars)(t, 1);
+      s.stride[2] = THTensor_(strideLegacyNoScalars)(t, 1);
     }
   } else if (dim == 3) {
     if (batchMode) {
       // [batch dim][feature dim][opt dim 1]
       for (int i = 0; i < 3; ++i) {
-        s.size[i] = THTensor_(size)(t, i);
-        s.stride[i] = THTensor_(stride)(t, i);
+        s.size[i] = THTensor_(sizeLegacyNoScalars)(t, i);
+        s.stride[i] = THTensor_(strideLegacyNoScalars)(t, i);
       }
     } else {
       // [feature dim][opt dim 1][opt dim 2]
       for (int i = 1; i < 4; ++i) {
-        s.size[i] = THTensor_(size)(t, i - 1);
-        s.stride[i] = THTensor_(stride)(t, i - 1);
+        s.size[i] = THTensor_(sizeLegacyNoScalars)(t, i - 1);
+        s.stride[i] = THTensor_(strideLegacyNoScalars)(t, i - 1);
       }
     }
   } else if (dim == 4) {
     // [batch dim][feature dim][opt dim 1][opt dim 2]
     THAssert(batchMode);
     for (int i = 0; i < 4; ++i) {
-      s.size[i] = THTensor_(size)(t, i);
-      s.stride[i] = THTensor_(stride)(t, i);
+      s.size[i] = THTensor_(sizeLegacyNoScalars)(t, i);
+      s.stride[i] = THTensor_(strideLegacyNoScalars)(t, i);
     }
   }
 
@@ -103,11 +103,11 @@ THNN_(FeatureLPPooling_resizeForOutputCPU)(THTensor* toResize,
   THAssert(inputDim >= 1 && inputDim <= 4);
 
   int64_t outSize =
-    flpOutputSize(THTensor_(size)(input, 0), width, stride);
+    flpOutputSize(THTensor_(sizeLegacyNoScalars)(input, 0), width, stride);
   if (batchMode) {
     THAssert(inputDim > 1);
     outSize =
-      flpOutputSize(THTensor_(size)(input, 1), width, stride);
+      flpOutputSize(THTensor_(sizeLegacyNoScalars)(input, 1), width, stride);
   } else {
     THAssert(inputDim < 4);
   }
@@ -117,29 +117,29 @@ THNN_(FeatureLPPooling_resizeForOutputCPU)(THTensor* toResize,
   } else if (inputDim == 2) {
     if (batchMode) {
       THTensor_(resize2d)(toResize,
-                          THTensor_(size)(input, 0),
+                          THTensor_(sizeLegacyNoScalars)(input, 0),
                           outSize);
     } else {
       THTensor_(resize2d)(toResize,
                           outSize,
-                          THTensor_(size)(input, 1));
+                          THTensor_(sizeLegacyNoScalars)(input, 1));
     }
   } else if (inputDim == 3) {
     if (batchMode) {
       THTensor_(resize3d)(toResize,
-                          THTensor_(size)(input, 0), outSize,
-                          THTensor_(size)(input, 2));
+                          THTensor_(sizeLegacyNoScalars)(input, 0), outSize,
+                          THTensor_(sizeLegacyNoScalars)(input, 2));
     } else {
       THTensor_(resize3d)(toResize,
-                          outSize, THTensor_(size)(input, 1),
-                          THTensor_(size)(input, 2));
+                          outSize, THTensor_(sizeLegacyNoScalars)(input, 1),
+                          THTensor_(sizeLegacyNoScalars)(input, 2));
     }
   } else if (inputDim == 4) {
     THTensor_(resize4d)(toResize,
-                        THTensor_(size)(input, 0),
+                        THTensor_(sizeLegacyNoScalars)(input, 0),
                         outSize,
-                        THTensor_(size)(input, 2),
-                        THTensor_(size)(input, 3));
+                        THTensor_(sizeLegacyNoScalars)(input, 2),
+                        THTensor_(sizeLegacyNoScalars)(input, 3));
   }
 }
 
@@ -152,25 +152,25 @@ THNN_(FeatureLPPooling_resizeCPU)(THTensor* toResize,
 
   if (inputDim == 1) {
     THTensor_(resize1d)(toResize,
-                        THTensor_(size)(src, 0));
+                        THTensor_(sizeLegacyNoScalars)(src, 0));
   } else if (inputDim == 2) {
     THTensor_(resize2d)(
       toResize,
-      THTensor_(size)(src, 0),
-      THTensor_(size)(src, 1));
+      THTensor_(sizeLegacyNoScalars)(src, 0),
+      THTensor_(sizeLegacyNoScalars)(src, 1));
   } else if (inputDim == 3) {
     THTensor_(resize3d)(
       toResize,
-      THTensor_(size)(src, 0),
-      THTensor_(size)(src, 1),
-      THTensor_(size)(src, 2));
+      THTensor_(sizeLegacyNoScalars)(src, 0),
+      THTensor_(sizeLegacyNoScalars)(src, 1),
+      THTensor_(sizeLegacyNoScalars)(src, 2));
   } else if (inputDim == 4) {
     THTensor_(resize4d)(
       toResize,
-      THTensor_(size)(src, 0),
-      THTensor_(size)(src, 1),
-      THTensor_(size)(src, 2),
-      THTensor_(size)(src, 3));
+      THTensor_(sizeLegacyNoScalars)(src, 0),
+      THTensor_(sizeLegacyNoScalars)(src, 1),
+      THTensor_(sizeLegacyNoScalars)(src, 2),
+      THTensor_(sizeLegacyNoScalars)(src, 3));
   }
 }
 

--- a/aten/src/THNN/generic/GatedLinearUnit.c
+++ b/aten/src/THNN/generic/GatedLinearUnit.c
@@ -10,11 +10,11 @@ void THNN_(GatedLinear_updateOutput)(
 {
   // size output to half of input
   dim = dim - TH_INDEX_BASE;
-  const int64_t nIn = THTensor_(size)(input, dim);
+  const int64_t nIn = THTensor_(sizeLegacyNoScalars)(input, dim);
   THArgCheck(nIn % 2 == 0, 2, "Halving dimension must be even. Dim %d is size %ld",
       dim + TH_INDEX_BASE, nIn);
 
-  const int64_t inputSize = THTensor_(size)(input, dim) / 2;
+  const int64_t inputSize = THTensor_(sizeLegacyNoScalars)(input, dim) / 2;
   THLongStorage *newSizes = THTensor_(newSizeOf)(input);
   THLongStorage_set(newSizes, dim, inputSize);
   THTensor_(resize)(output, newSizes, NULL);
@@ -41,12 +41,12 @@ void THNN_(GatedLinear_updateGradInput)(
 {
   // set up tensors
   dim = dim - TH_INDEX_BASE;
-  const int64_t nIn = THTensor_(size)(input, dim);
+  const int64_t nIn = THTensor_(sizeLegacyNoScalars)(input, dim);
   THArgCheck(nIn % 2 == 0, 2, "Halving dimension must be even. Dim %d is size %ld",
       dim + TH_INDEX_BASE, nIn);
 
   THTensor_(resizeAs)(gradInput, input);
-  const int64_t inputSize = THTensor_(size)(input, dim) / 2;
+  const int64_t inputSize = THTensor_(sizeLegacyNoScalars)(input, dim) / 2;
   THTensor *firstHalf = THTensor_(newNarrow)(input, dim, 0, inputSize);
   THTensor *secondHalf = THTensor_(newNarrow)(input, dim, inputSize, inputSize);
   THTensor *gradInputfirstHalf = THTensor_(newNarrow)(gradInput, dim, 0, inputSize);

--- a/aten/src/THNN/generic/Im2Col.c
+++ b/aten/src/THNN/generic/Im2Col.c
@@ -26,9 +26,9 @@ static inline void THNN_(Im2Col_shapeCheck)(
   if (ndim == 3) {
     dim_batch = -1;
   }
-  int64_t nInputPlane  = THTensor_(size)(input, dim_batch + 1);
-  int64_t inputHeight  = THTensor_(size)(input, dim_batch + 2);
-  int64_t inputWidth   = THTensor_(size)(input, dim_batch + 3);
+  int64_t nInputPlane  = THTensor_(sizeLegacyNoScalars)(input, dim_batch + 1);
+  int64_t inputHeight  = THTensor_(sizeLegacyNoScalars)(input, dim_batch + 2);
+  int64_t inputWidth   = THTensor_(sizeLegacyNoScalars)(input, dim_batch + 3);
   int64_t outputHeight = div_rtn<int64_t>(inputHeight + 2 * padH - (dH * (kH - 1) + 1), sH) + 1;
   int64_t outputWidth  = div_rtn<int64_t>(inputWidth + 2 * padW - (dW * (kW - 1) + 1), sW) + 1;
   int64_t nOutputPlane = nInputPlane * kW * kH;
@@ -59,13 +59,13 @@ void THNN_(Im2Col_updateOutput)(
   bool batched_input = true;
   if (input->dim() == 3) {
     batched_input = false;
-    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
   }
 
-  int64_t batchSize    = THTensor_(size)(input, 0);
-  int64_t nInputPlane  = THTensor_(size)(input, 1);
-  int64_t inputHeight  = THTensor_(size)(input, 2);
-  int64_t inputWidth   = THTensor_(size)(input, 3);
+  int64_t batchSize    = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int64_t nInputPlane  = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int64_t inputHeight  = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int64_t inputWidth   = THTensor_(sizeLegacyNoScalars)(input, 3);
 
   int64_t outputHeight = (inputHeight + 2 * padH - (dH * (kH - 1) + 1)) / sH + 1;
   int64_t outputWidth  = (inputWidth + 2 * padW - (dW * (kW - 1) + 1)) / sW + 1;

--- a/aten/src/THNN/generic/IndexLinear.c
+++ b/aten/src/THNN/generic/IndexLinear.c
@@ -23,7 +23,7 @@
 
 static bool THNN_(checkKeysValues)(THLongTensor* keys, THTensor* values)
 {
-  return THLongTensor_size(keys, 0) == THTensor_(nElement)(values)
+  return THLongTensor_sizeLegacyNoScalars(keys, 0) == THTensor_(nElement)(values)
                 && THTensor_(nDimensionLegacyAll)(values) == 1
                 && THLongTensor_nDimensionLegacyAll(keys) == 1;
 }
@@ -42,10 +42,10 @@ void THNN_(IndexLinear_updateOutput)(
           int  train)
 {
   /* Retrieve all the dimensions of the problem */
-  int64_t batchSize = THLongTensor_size(sizes, 0);
-  int64_t keysSize = THLongTensor_size(keys, 0);
-  int64_t outDim = THTensor_(size)(bias, 0);
-  int64_t woutDim = THTensor_(size)(weight, 1);
+  int64_t batchSize = THLongTensor_sizeLegacyNoScalars(sizes, 0);
+  int64_t keysSize = THLongTensor_sizeLegacyNoScalars(keys, 0);
+  int64_t outDim = THTensor_(sizeLegacyNoScalars)(bias, 0);
+  int64_t woutDim = THTensor_(sizeLegacyNoScalars)(weight, 1);
   int maxNormalize = woutDim - outDim;
   int64_t* sizesData = THLongTensor_data(sizes);
   int64_t* cumSumSizesData = THLongTensor_data(cumSumSizes);
@@ -65,7 +65,7 @@ void THNN_(IndexLinear_updateOutput)(
   real* outputData = THTensor_(data)(output);
   real* valuesData = THTensor_(data)(values);
   real* weightData = THTensor_(data)(weight);
-  int64_t weightStride0 = weight->stride(0);
+  int64_t weightStride0 = THTensor_strideLegacyNoScalars(weight, 0);
   real* biasData = THTensor_(data)(bias);
   int64_t* keysData = THLongTensor_data(keys);
 
@@ -250,15 +250,15 @@ void THNN_(IndexLinear_updateParameters)(
   real weightDecay = TH_CONVERT_ACCREAL_TO_REAL(weightDecay_);
   real learningRate = TH_CONVERT_ACCREAL_TO_REAL(learningRate_);
   /* Retrieve all the dimensions of the problem */
-  int64_t outDim = THTensor_(size)(bias, 0);
-  int64_t woutDim = THTensor_(size)(weight, 1);
+  int64_t outDim = THTensor_(sizeLegacyNoScalars)(bias, 0);
+  int64_t woutDim = THTensor_(sizeLegacyNoScalars)(weight, 1);
   int maxNormalize = woutDim - outDim;
-  int64_t keysSize = THLongTensor_size(runningKeys, 0);
+  int64_t keysSize = THLongTensor_sizeLegacyNoScalars(runningKeys, 0);
 
   /* Access the storage data/strides */
   real* gradWeightData = THTensor_(data)(gradWeight);
   real* weightData = THTensor_(data)(weight);
-  int64_t weightStride0 = weight->stride(0);
+  int64_t weightStride0 = THTensor_strideLegacyNoScalars(weight, 0);
   real* gradBiasData = THTensor_(data)(gradBias);
   real* biasData = THTensor_(data)(bias);
   int64_t* keysData = THLongTensor_data(runningKeys);
@@ -395,9 +395,9 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
   real weightDecay = TH_CONVERT_ACCREAL_TO_REAL(weightDecay_);
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   /* Retrieve all the dimensions of the problem */
-  int64_t batchSize = THLongTensor_size(sizes, 0);
-  int64_t outDim = THTensor_(size)(bias, 0);
-  int64_t woutDim = THTensor_(size)(weight, 1);
+  int64_t batchSize = THLongTensor_sizeLegacyNoScalars(sizes, 0);
+  int64_t outDim = THTensor_(sizeLegacyNoScalars)(bias, 0);
+  int64_t woutDim = THTensor_(sizeLegacyNoScalars)(weight, 1);
   int maxNormalize = woutDim - outDim;
   THArgCheck(THNN_(checkKeysValues)(keys, values), 1, "Keys and values should have the same number of elements");
 
@@ -406,7 +406,7 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
   real* valuesData =THTensor_(data)(values);
   real* weightData = THTensor_(data)(weight);
   real* biasData = THTensor_(data)(bias);
-  int64_t weightStride0 = weight->stride(0);
+  int64_t weightStride0 = THTensor_strideLegacyNoScalars(weight, 0);
   int64_t* keysData = THLongTensor_data(keys);
   int64_t* sizesData = THLongTensor_data(sizes);
 
@@ -596,10 +596,10 @@ void THNN_(IndexLinear_accGradParameters)(
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   /* Retrieve all the dimensions of the problem */
-  int64_t batchSize = THLongTensor_size(sizes, 0);
-  int64_t keysSize = THLongTensor_size(keys, 0);
-  int64_t outDim = THTensor_(size)(bias, 0);
-  int64_t woutDim = THTensor_(size)(weight, 1);
+  int64_t batchSize = THLongTensor_sizeLegacyNoScalars(sizes, 0);
+  int64_t keysSize = THLongTensor_sizeLegacyNoScalars(keys, 0);
+  int64_t outDim = THTensor_(sizeLegacyNoScalars)(bias, 0);
+  int64_t woutDim = THTensor_(sizeLegacyNoScalars)(weight, 1);
   int64_t maxNormalize = (woutDim - outDim) > 0 ?1:0;
   THArgCheck(THNN_(checkKeysValues)(keys, values), 1, "Keys and values should have the same number of elements");
   int64_t* sizesData = THLongTensor_data(sizes);

--- a/aten/src/THNN/generic/Linear.c
+++ b/aten/src/THNN/generic/Linear.c
@@ -7,7 +7,7 @@ void THNN_(Linear_updateAddBuffer)(
           THTensor *input,
           THTensor *addBuffer)
 {
-  int64_t nframe = THTensor_(size)(input,0);
+  int64_t nframe = THTensor_(sizeLegacyNoScalars)(input,0);
   int64_t nElement = THTensor_(nElement)(addBuffer);
   if (nElement != nframe) {
     THTensor_(resize1d)(addBuffer,nframe);
@@ -25,7 +25,7 @@ void THNN_(Linear_updateOutput)(
 {
   int64_t dim = THTensor_(nDimensionLegacyAll)(input);
   if (dim == 1) {
-    THTensor_(resize1d)(output,THTensor_(size)(weight,0));
+    THTensor_(resize1d)(output,THTensor_(sizeLegacyNoScalars)(weight,0));
     if (bias) {
       THTensor_(copy)(output,bias);
     }
@@ -35,9 +35,9 @@ void THNN_(Linear_updateOutput)(
     THTensor_(addmv)(output,1,output,1,weight,input);
   }
   else if (dim == 2) {
-    int64_t nframe = THTensor_(size)(input,0);
+    int64_t nframe = THTensor_(sizeLegacyNoScalars)(input,0);
     int64_t nElement = THTensor_(nElement)(output);
-    THTensor_(resize2d)(output,nframe,THTensor_(size)(weight,0));
+    THTensor_(resize2d)(output,nframe,THTensor_(sizeLegacyNoScalars)(weight,0));
     if (THTensor_(nElement)(output) != nElement) {
       THTensor_(zero)(output);
     }

--- a/aten/src/THNN/generic/LookupTable.c
+++ b/aten/src/THNN/generic/LookupTable.c
@@ -40,7 +40,7 @@ void THNN_(LookupTable_accGradParameters)(
 
   if (scaleGradByFreq)
   {
-    THIntegerTensor_(resize1d)(count, gradWeight->size(0));
+    THIntegerTensor_(resize1d)(count, THTensor_sizeLegacyNoScalars(gradWeight, 0));
     count_data = THIntegerTensor_(data)(count);
   }
 
@@ -55,7 +55,7 @@ void THNN_(LookupTable_accGradParameters)(
 
   THIndex_t *input_data = THIndexTensor_(data)(input);
   ptrdiff_t numel = THIndexTensor_(nElement)(input);
-  int64_t numw = THTensor_(size)(gradWeight, 0);
+  int64_t numw = THTensor_(sizeLegacyNoScalars)(gradWeight, 0);
 
   // check that inputs are all within range
   for (i=0; i<numel; i++)
@@ -69,7 +69,7 @@ void THNN_(LookupTable_accGradParameters)(
 
   real *gw = THTensor_(data)(gradWeight);
   real *go = THTensor_(data)(gradOutput);
-  int64_t stride = THTensor_(stride)(gradWeight, 0);
+  int64_t stride = THTensor_(strideLegacyNoScalars)(gradWeight, 0);
 
   if (count_data)
     THNN_(LookupTable_resetCount)(count_data, input);
@@ -182,8 +182,8 @@ void THNN_(LookupTable_renorm)(
   THIndex_t *row_idx = THIndexTensor_(data)(idx);
   ptrdiff_t numel = THIndexTensor_(nElement)(idx);
 
-  int64_t numw = THTensor_(size)(weight, 0);
-  int64_t stride = THTensor_(stride)(weight, 0);
+  int64_t numw = THTensor_(sizeLegacyNoScalars)(weight, 0);
+  int64_t stride = THTensor_(strideLegacyNoScalars)(weight, 0);
   real *gw = THTensor_(data)(weight);
   for (i=0; i<numel; i++) {
     if (row_idx[i] < TH_INDEX_BASE || row_idx[i] >= numw + TH_INDEX_BASE) {

--- a/aten/src/THNN/generic/MultiLabelMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiLabelMarginCriterion.c
@@ -23,16 +23,16 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size(0);
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == dim),
+    dim = THTensor_sizeLegacyNoScalars(input, 0);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == dim),
              "inconsistent target size");
   }
   else
   {
-    nframe = input->size(0);
-    dim = input->size(1);
-    AT_CHECK(!target->is_empty() && target->dim() == 2 && (target->size(0) == nframe)
-             && (target->size(1) == dim), "inconsistent target size");
+    nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    dim = THTensor_sizeLegacyNoScalars(input, 1);
+    AT_CHECK(!target->is_empty() && target->dim() == 2 && (THTensor_sizeLegacyNoScalars(target, 0) == nframe)
+             && (THTensor_sizeLegacyNoScalars(target, 1) == dim), "inconsistent target size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");
@@ -161,20 +161,20 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size(0);
-    AT_CHECK((!target->is_empty() && target->dim() == 1) && (target->size(0) == dim),
+    dim = THTensor_sizeLegacyNoScalars(input, 0);
+    AT_CHECK((!target->is_empty() && target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == dim),
              "inconsistent target size");
-    AT_CHECK((!isTarget->is_empty() && isTarget->dim() == 1) && (isTarget->size(0) == dim),
+    AT_CHECK((!isTarget->is_empty() && isTarget->dim() == 1) && (THTensor_sizeLegacyNoScalars(isTarget, 0) == dim),
              "inconsistent isTarget size");
   }
   else
   {
-    nframe = input->size(0);
-    dim = input->size(1);
-    AT_CHECK(!target->is_empty() && (target->dim() == 2) && (target->size(0) == nframe)
-             && (target->size(1) == dim), 3, "inconsistent target size");
-    AT_CHECK(!isTarget->is_empty() && (isTarget->dim() == 2) && (isTarget->size(0) == nframe)
-             && (isTarget->size(1) == dim), 3, "inconsistent isTarget size");
+    nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    dim = THTensor_sizeLegacyNoScalars(input, 1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 2) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe)
+             && (THTensor_sizeLegacyNoScalars(target, 1) == dim), 3, "inconsistent target size");
+    AT_CHECK(!isTarget->is_empty() && (isTarget->dim() == 2) && (THTensor_sizeLegacyNoScalars(isTarget, 0) == nframe)
+             && (THTensor_sizeLegacyNoScalars(isTarget, 1) == dim), 3, "inconsistent isTarget size");
   }
 
   THArgCheck(THIndexTensor_(minall)(target) >= -1+TH_INDEX_BASE, 3, "target out of range");

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -26,13 +26,13 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size(0);
+    dim = THTensor_sizeLegacyNoScalars(input, 0);
   }
   else
   {
-    nframe = input->size(0);
-    dim = input->size(1);
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe),
+    nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    dim = THTensor_sizeLegacyNoScalars(input, 1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe),
              "inconsistent target size, got: ", target->sizes());
   }
 
@@ -142,13 +142,13 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   if (input->dim() == 1)
   {
     nframe = 1;
-    dim = input->size(0);
+    dim = THTensor_sizeLegacyNoScalars(input, 0);
   }
   else
   {
-    nframe = input->size(0);
-    dim = input->size(1);
-    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (target->size(0) == nframe),
+    nframe = THTensor_sizeLegacyNoScalars(input, 0);
+    dim = THTensor_sizeLegacyNoScalars(input, 1);
+    AT_CHECK(!target->is_empty() && (target->dim() == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe),
              "inconsistent target size, got: ", target->sizes());
   }
 

--- a/aten/src/THNN/generic/PReLU.c
+++ b/aten/src/THNN/generic/PReLU.c
@@ -26,13 +26,13 @@ void THNN_(PReLU_updateOutput)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(nDimensionLegacyAll)(input);
-    if (input->size(input_ndim > 1) != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
+    if (THTensor_sizeLegacyNoScalars(input, input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, THTensor_sizeLegacyNoScalars(input, input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size(0);
+        bs = THTensor_sizeLegacyNoScalars(input, 0);
         for (int d = 2; d < input_ndim; d++) {
-            ks *= input->size(d);
+            ks *= THTensor_sizeLegacyNoScalars(input, d);
         }
     }
   }
@@ -91,13 +91,13 @@ void THNN_(PReLU_updateGradInput)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(nDimensionLegacyAll)(input);
-    if (input->size(input_ndim > 1) != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
+    if (THTensor_sizeLegacyNoScalars(input, input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, THTensor_sizeLegacyNoScalars(input, input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size(0);
+        bs = THTensor_sizeLegacyNoScalars(input, 0);
         for (int d = 2; d < input_ndim; d++) {
-            ks *= input->size(d);
+            ks *= THTensor_sizeLegacyNoScalars(input, d);
         }
     }
   }
@@ -162,13 +162,13 @@ void THNN_(PReLU_accGradParameters)(
   int64_t bs = 1, ks = 1;
   {
     int64_t input_ndim = THTensor_(nDimensionLegacyAll)(input);
-    if (input->size(input_ndim > 1) != nOutputPlane)
-      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, input->size(input_ndim > 1));
+    if (THTensor_sizeLegacyNoScalars(input, input_ndim > 1) != nOutputPlane)
+      THError("Wrong number of input planes. Expected %d but got %d.", nOutputPlane, THTensor_sizeLegacyNoScalars(input, input_ndim > 1));
 
     if (input_ndim > 1) {
-        bs = input->size(0);
+        bs = THTensor_sizeLegacyNoScalars(input, 0);
         for (int d = 2; d < input_ndim; d++) {
-          ks *= input->size(d);
+          ks *= THTensor_sizeLegacyNoScalars(input, d);
         }
     }
   }

--- a/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveAveragePooling.c
@@ -92,21 +92,21 @@ void THNN_(SpatialAdaptiveAveragePooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    istrideB = input->stride(0);
-    sizeB = input->size(0);
+    istrideB = THTensor_strideLegacyNoScalars(input, 0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimH++;
     dimW++;
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
   /* strides */
-  istrideD = input->stride(dimD);
-  istrideH = input->stride(dimH);
-  istrideW = input->stride(dimW);
+  istrideD = THTensor_strideLegacyNoScalars(input, dimD);
+  istrideH = THTensor_strideLegacyNoScalars(input, dimH);
+  istrideW = THTensor_strideLegacyNoScalars(input, dimW);
 
   /* resize output */
   if (input->dim() == 3)
@@ -218,18 +218,18 @@ void THNN_(SpatialAdaptiveAveragePooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    sizeB = input->size(0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimH++;
     dimW++;
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
-  osizeH = gradOutput->size(dimH);
-  osizeW = gradOutput->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
+  osizeH = THTensor_sizeLegacyNoScalars(gradOutput, dimH);
+  osizeW = THTensor_sizeLegacyNoScalars(gradOutput, dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -102,20 +102,20 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    istrideB = input->stride(0);
-    sizeB = input->size(0);
+    istrideB = THTensor_strideLegacyNoScalars(input, 0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimW++;
     dimH++;
   }
 
   /* sizes */
-  sizeD  = input->size(dimH-1);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimH-1);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
   /* strides */
-  istrideD = input->stride(dimH-1);
-  istrideH = input->stride(dimH);
-  istrideW = input->stride(dimW);
+  istrideD = THTensor_strideLegacyNoScalars(input, dimH-1);
+  istrideH = THTensor_strideLegacyNoScalars(input, dimH);
+  istrideW = THTensor_strideLegacyNoScalars(input, dimW);
 
   /* resize output */
   if (input->dim() == 3)
@@ -223,17 +223,17 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    sizeB = input->size(0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimW++;
     dimH++;
   }
 
   /* sizes */
-  sizeD  = input->size(dimH-1);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
-  osizeH = gradOutput->size(dimH);
-  osizeW = gradOutput->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimH-1);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
+  osizeH = THTensor_sizeLegacyNoScalars(gradOutput, dimH);
+  osizeW = THTensor_sizeLegacyNoScalars(gradOutput, dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -31,9 +31,9 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
 	     "padW = %d, padH = %d, kW = %d, kH = %d",
 	     padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size(dimh-1);
-  int64_t inputHeight = input->size(dimh);
-  int64_t inputWidth = input->size(dimw);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  int64_t inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputHeight, outputWidth;
   int64_t nOutputPlane = nInputPlane;
 
@@ -103,15 +103,15 @@ void THNN_(SpatialAveragePooling_updateOutput)(
     (input, NULL, kH, kW, dH, dW, padH, padW, ceil_mode);
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimc++;
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
-  nInputPlane = input->size(dimc);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, dimc);
 
   if(ceil_mode)
   {
@@ -136,7 +136,7 @@ void THNN_(SpatialAveragePooling_updateOutput)(
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
-    THTensor_(resize4d)(output, input->size(0), nInputPlane, outputHeight, outputWidth);
+    THTensor_(resize4d)(output, THTensor_sizeLegacyNoScalars(input, 0), nInputPlane, outputHeight, outputWidth);
 
   input = THTensor_(newContiguous)(input);
   THArgCheck(THTensor_(isContiguous)(output), 3, "output must be contiguous");
@@ -232,16 +232,16 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
 
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimc++;
     ndim = 4;
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
-  nInputPlane = input->size(dimc);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, dimc);
 
   if(ceil_mode)
   {

--- a/aten/src/THNN/generic/SpatialClassNLLCriterion.c
+++ b/aten/src/THNN/generic/SpatialClassNLLCriterion.c
@@ -10,18 +10,18 @@
   THArgCheck(THTensor_(nDimensionLegacyAll)(input) == 4, 2,			         \
 	     "only batches of spatial inputs supported (4D tensors), "	         \
 	     "but got input of dimension: %d", THTensor_(nDimensionLegacyAll)(input));    \
-  if (weights && THTensor_(nElement)(weights) != THTensor_(size)(input, 1)) {    \
+  if (weights && THTensor_(nElement)(weights) != THTensor_(sizeLegacyNoScalars)(input, 1)) {    \
     THError("weight tensor should be defined either for all or no classes");     \
   }                                                                              \
                                                                                  \
   {                                                                              \
-    int64_t input0 = THTensor_(size)(input, 0);                                     \
-    int64_t input1 = THTensor_(size)(input, 1);                                     \
-    int64_t input2 = THTensor_(size)(input, 2);                                     \
-    int64_t input3 = THTensor_(size)(input, 3);                                     \
-    int64_t target0 = THIndexTensor_(size)(target, 0);                              \
-    int64_t target1 = THIndexTensor_(size)(target, 1);                              \
-    int64_t target2 = THIndexTensor_(size)(target, 2);                              \
+    int64_t input0 = THTensor_(sizeLegacyNoScalars)(input, 0);                                     \
+    int64_t input1 = THTensor_(sizeLegacyNoScalars)(input, 1);                                     \
+    int64_t input2 = THTensor_(sizeLegacyNoScalars)(input, 2);                                     \
+    int64_t input3 = THTensor_(sizeLegacyNoScalars)(input, 3);                                     \
+    int64_t target0 = THIndexTensor_(sizeLegacyNoScalars)(target, 0);                              \
+    int64_t target1 = THIndexTensor_(sizeLegacyNoScalars)(target, 1);                              \
+    int64_t target2 = THIndexTensor_(sizeLegacyNoScalars)(target, 2);                              \
     THAssertMsg(input0 == target0 && input2 == target1 && input3 == target2,     \
               "size mismatch (got input: %ldx%ldx%ldx%ld, target: %ldx%ldx%ld)", \
               input0, input1, input2, input3, target0, target1, target2);        \
@@ -33,12 +33,12 @@
 	     " but got dimension: %d",			                                        \
 	     THTensor_(nDimensionLegacyAll)(gradOutput));			                              \
   {                                                                           \
-    int64_t gradOutput0 = THTensor_(size)(gradOutput, 0);                     \
-    int64_t gradOutput1 = THTensor_(size)(gradOutput, 1);                     \
-    int64_t gradOutput2 = THTensor_(size)(gradOutput, 2);                     \
-    int64_t target0 = THIndexTensor_(size)(target, 0);                        \
-    int64_t target1 = THIndexTensor_(size)(target, 1);                        \
-    int64_t target2 = THIndexTensor_(size)(target, 2);                        \
+    int64_t gradOutput0 = THTensor_(sizeLegacyNoScalars)(gradOutput, 0);                     \
+    int64_t gradOutput1 = THTensor_(sizeLegacyNoScalars)(gradOutput, 1);                     \
+    int64_t gradOutput2 = THTensor_(sizeLegacyNoScalars)(gradOutput, 2);                     \
+    int64_t target0 = THIndexTensor_(sizeLegacyNoScalars)(target, 0);                        \
+    int64_t target1 = THIndexTensor_(sizeLegacyNoScalars)(target, 1);                        \
+    int64_t target2 = THIndexTensor_(sizeLegacyNoScalars)(target, 2);                        \
     THAssertMsg(                                                              \
         gradOutput0 == target0 && gradOutput1 == target1 && gradOutput2 == target2, \
         "size mismatch (got gradOutput: %ldx%ldx%ld, target: %ldx%ldx%ld)",   \
@@ -62,9 +62,9 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   ignore_index -= TH_INDEX_BASE;
 
   if (reduction == Reduction::None) {
-    int64_t batch_size = THTensor_(size)(input, 0);
-    int64_t H = THTensor_(size)(input, 2);
-    int64_t W = THTensor_(size)(input, 3);
+    int64_t batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+    int64_t H = THTensor_(sizeLegacyNoScalars)(input, 2);
+    int64_t W = THTensor_(sizeLegacyNoScalars)(input, 3);
     THTensor_(resize3d)(output, batch_size, H, W);
 
     int64_t b, h, w;
@@ -96,9 +96,9 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   real *output_data = THTensor_(data)(output);
   real *total_weight_data = THTensor_(data)(total_weight);
 
-  int64_t batch_size = THTensor_(size)(input, 0);
-  int64_t n_classes = THTensor_(size)(input, 1);
-  int64_t map_size = THTensor_(size)(input, 2) * THTensor_(size)(input, 3);
+  int64_t batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int64_t n_classes = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int64_t map_size = THTensor_(sizeLegacyNoScalars)(input, 2) * THTensor_(sizeLegacyNoScalars)(input, 3);
   int64_t sample_size = map_size * n_classes;
 
   real total_weight_acc = 0;
@@ -148,9 +148,9 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   if (reduction == Reduction::None) {
     GRADOUTPUT_SHAPE_CHECK;
 
-    int64_t batch_size = THTensor_(size)(input, 0);
-    int64_t H = THTensor_(size)(input, 2);
-    int64_t W = THTensor_(size)(input, 3);
+    int64_t batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+    int64_t H = THTensor_(sizeLegacyNoScalars)(input, 2);
+    int64_t W = THTensor_(sizeLegacyNoScalars)(input, 3);
 
     int64_t b, h, w;
     #pragma omp parallel for private(b, h, w)
@@ -183,9 +183,9 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   real *weights_data = weights ? THTensor_(data)(weights) : NULL;
   real *gradInput_data = THTensor_(data)(gradInput);
 
-  int64_t batch_size = THTensor_(size)(input, 0);
-  int64_t n_classes = THTensor_(size)(input, 1);
-  int64_t map_size = THTensor_(size)(input, 2) * THTensor_(size)(input, 3);
+  int64_t batch_size = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int64_t n_classes = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int64_t map_size = THTensor_(sizeLegacyNoScalars)(input, 2) * THTensor_(sizeLegacyNoScalars)(input, 3);
   int64_t sample_size = map_size * n_classes;
 
   real normalize = (reduction == Reduction::ElementwiseMean) ? *total_weight_data : 1.0f;

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -29,8 +29,8 @@ static inline void THNN_(SpatialConvolutionLocal_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
         "non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane = weight->size(2) / (kH * kW);
-  int64_t nOutputPlane = weight->size(1);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 2) / (kH * kW);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
 
   if (bias != NULL) {
     THNN_CHECK_DIM_SIZE(bias, 3, 0, nOutputPlane);
@@ -53,9 +53,9 @@ static THTensor* THNN_(view_weight_local)(THTensor *_weight)
   AT_CHECK(!weight->is_empty() && (weight->dim() == 3 || weight->dim() == 6),
            "weight tensor should be (non-empty) 3D or 6D - got size: ", weight->sizes());
   if (weight->dim() == 6) {
-    int64_t s1 = weight->size(0) * weight->size(1);
-    int64_t s2 = weight->size(2);
-    int64_t s3 = weight->size(3) * weight->size(4) * weight->size(5);
+    int64_t s1 = THTensor_sizeLegacyNoScalars(weight, 0) * THTensor_sizeLegacyNoScalars(weight, 1);
+    int64_t s2 = THTensor_sizeLegacyNoScalars(weight, 2);
+    int64_t s3 = THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4) * THTensor_sizeLegacyNoScalars(weight, 5);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage3d)(THTensor_getStoragePtr(weight),
                        weight->storage_offset(),
@@ -124,8 +124,8 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
 
-  int64_t nInputPlane = THTensor_(size)(weight, 2)/ (kW * kH);
-  int64_t nOutputPlane = THTensor_(size)(weight, 1);
+  int64_t nInputPlane = THTensor_(sizeLegacyNoScalars)(weight, 2)/ (kW * kH);
+  int64_t nOutputPlane = THTensor_(sizeLegacyNoScalars)(weight, 1);
 
   if(input->dim() == 3)
   {
@@ -140,7 +140,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
     THTensor_(resize3d)(finput, T, kW*kH*nInputPlane, outputHeight*outputWidth);
@@ -224,8 +224,8 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
-  int64_t nInputPlane = THTensor_(size)(weight,2)/(kW*kH);
-  int64_t nOutputPlane = THTensor_(size)(weight,1);
+  int64_t nInputPlane = THTensor_(sizeLegacyNoScalars)(weight,2)/(kW*kH);
+  int64_t nOutputPlane = THTensor_(sizeLegacyNoScalars)(weight,1);
 
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(resizeAs)(fgradInput, finput);
@@ -243,7 +243,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
 #pragma omp parallel for private(t)
@@ -326,8 +326,8 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
-  int64_t nInputPlane = THTensor_(size)(gradWeight,2)/(kW*kH);
-  int64_t nOutputPlane = THTensor_(size)(gradWeight,1);
+  int64_t nInputPlane = THTensor_(sizeLegacyNoScalars)(gradWeight,2)/(kW*kH);
+  int64_t nOutputPlane = THTensor_(sizeLegacyNoScalars)(gradWeight,1);
 
   if(input->dim() == 3)
   {
@@ -339,7 +339,7 @@ void THNN_(SpatialConvolutionLocal_accGradParameters)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
     for(t = 0; t < T; t++)

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -18,7 +18,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                     "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -38,8 +38,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
 		"non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
 
   int64_t exactInputHeight = inputHeight + 2 * padH;
   int64_t exactInputWidth = inputWidth + 2 * padW;
@@ -60,7 +60,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(1);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
     if (weight->dim() == 2) {
       nInputPlane /= (kH * kW);
     }
@@ -69,10 +69,10 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
@@ -83,8 +83,8 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
 static THTensor* THNN_(newViewWeightMM2d)(THTensor *weight) {
   weight = THTensor_(newContiguous)(weight);
   if (weight->dim() == 4) {
-    int64_t s1 = weight->size(0);
-    int64_t s2 = weight->size(1) * weight->size(2) * weight->size(3);
+    int64_t s1 = THTensor_sizeLegacyNoScalars(weight, 0);
+    int64_t s2 = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3);
     THTensor *old_weight = weight;
     weight = THTensor_(newWithStorage2d)(THTensor_getStoragePtr(weight), weight->storage_offset(),
 					 s1, -1, s2, -1);
@@ -125,7 +125,7 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
   if (bias) {
     for(i = 0; i < nOutputPlane; i++)
         THVector_(fill)
-	  (THStorage_(data)(THTensor_getStoragePtr(output)) + output->storage_offset() + output->stride(0) * i,
+	  (THStorage_(data)(THTensor_getStoragePtr(output)) + output->storage_offset() + THTensor_strideLegacyNoScalars(output, 0) * i,
 	   THTensor_(get1d)(bias, i), outputHeight*outputWidth);
   } else {
     THTensor_(zero)(output);
@@ -168,10 +168,10 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     dimw++;
   }
 
-  int64_t nInputPlane = input->size(dimf);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
-  int64_t nOutputPlane = weight->size(0);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, dimf);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
   int64_t outputHeight = (inputHeight + 2*padH - kH) / dH + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - kW) / dW + 1;
 
@@ -188,7 +188,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
     THTensor_(resize3d)(finput, T, kW*kH*nInputPlane, outputHeight*outputWidth);
@@ -231,8 +231,8 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
 {
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
     (THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
-     gradOutput->size(0), -1,
-     gradOutput->size(1)*gradOutput->size(2), -1);
+     THTensor_sizeLegacyNoScalars(gradOutput, 0), -1,
+     THTensor_sizeLegacyNoScalars(gradOutput, 1)*THTensor_sizeLegacyNoScalars(gradOutput, 2), -1);
   THTensor_(addmm)(fgradInput, 0, fgradInput, 1, weight, gradOutput2d);
   THTensor_(free)(gradOutput2d);
 
@@ -240,8 +240,8 @@ static void THNN_(SpatialConvolutionMM_updateGradInput_frame)(
 
   THNN_(unfolded_acc)(fgradInput, gradInput, kW, kH, dW, dH,
 		      padW, padH,
-		      gradInput->size(0), gradInput->size(2), gradInput->size(1),
-		      gradOutput->size(2), gradOutput->size(1));
+		      THTensor_sizeLegacyNoScalars(gradInput, 0), THTensor_sizeLegacyNoScalars(gradInput, 2), THTensor_sizeLegacyNoScalars(gradInput, 1),
+		      THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 1));
 }
 
 void THNN_(SpatialConvolutionMM_updateGradInput)(
@@ -285,7 +285,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
 #pragma omp parallel for private(t)
@@ -321,8 +321,8 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
   int64_t i;
   THTensor *gradOutput2d = THTensor_(newWithStorage2d)
     (THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
-     gradOutput->size(0), -1,
-     gradOutput->size(1)*gradOutput->size(2), -1);
+     THTensor_sizeLegacyNoScalars(gradOutput, 0), -1,
+     THTensor_sizeLegacyNoScalars(gradOutput, 1)*THTensor_sizeLegacyNoScalars(gradOutput, 2), -1);
 
   if (gradWeight) {
     THTensor *tfinput = THTensor_(new)();
@@ -332,12 +332,12 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
   }
 
   if (gradBias) {
-    for(i = 0; i < gradBias->size(0); i++)
+    for(i = 0; i < THTensor_sizeLegacyNoScalars(gradBias, 0); i++)
     {
       int64_t k;
       real sum = 0;
-      real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput2d)) + gradOutput2d->storage_offset() + i*gradOutput2d->stride(0);
-      for(k = 0; k < gradOutput2d->size(1); k++)
+      real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput2d)) + gradOutput2d->storage_offset() + i*THTensor_strideLegacyNoScalars(gradOutput2d, 0);
+      for(k = 0; k < THTensor_sizeLegacyNoScalars(gradOutput2d, 1); k++)
         sum += data[k];
       (THStorage_(data)(THTensor_getStoragePtr(gradBias)) + gradBias->storage_offset())[i] += scale*sum;
     }
@@ -384,7 +384,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   }
   else
   {
-    int64_t T = input->size(0);
+    int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t t;
 
     for(t = 0; t < T; t++)

--- a/aten/src/THNN/generic/SpatialConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMap.c
@@ -9,7 +9,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size(0) == weight->size(0), 4,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(weight, 0), 4,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -22,27 +22,27 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimc++;
     dimw++;
     dimh++;
   }
 
-  const int64_t kH       = weight->size(1);
-  const int64_t kW       = weight->size(2);
+  const int64_t kH       = THTensor_sizeLegacyNoScalars(weight, 1);
+  const int64_t kW       = THTensor_sizeLegacyNoScalars(weight, 2);
 
-  THArgCheck(input->size(dimc) >= nInputPlane, 2, "invalid number of input planes");
-  THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH, 2, "input image smaller than kernel size");
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimc) >= nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimw) >= kW && THTensor_sizeLegacyNoScalars(input, dimh) >= kH, 2, "input image smaller than kernel size");
 
-  const int64_t input_w  = input->size(dimw);
-  const int64_t input_h  = input->size(dimh);
+  const int64_t input_w  = THTensor_sizeLegacyNoScalars(input, dimw);
+  const int64_t input_h  = THTensor_sizeLegacyNoScalars(input, dimh);
   const int64_t output_w = (input_w - kW) / dW + 1;
   const int64_t output_h = (input_h - kH) / dH + 1;
 
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nOutputPlane, output_h, output_w);
   else
-    THTensor_(resize4d)(output, input->size(0), nOutputPlane, output_h, output_w);
+    THTensor_(resize4d)(output, THTensor_sizeLegacyNoScalars(input, 0), nOutputPlane, output_h, output_w);
 
   /* contiguous */
   input = THTensor_(newContiguous)(input);
@@ -73,7 +73,7 @@ void THNN_(SpatialConvolutionMap_updateOutput)(
         ptr_output[j] = z;
 
       /* convolve all maps */
-      int nweight = connTable->size(0);
+      int nweight = THTensor_sizeLegacyNoScalars(connTable, 0);
       for (k = 0; k < nweight; k++)
       {
         /* get offsets for input/output */
@@ -110,7 +110,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size(0) == weight->size(0), 5,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(weight, 0), 5,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -120,17 +120,17 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
   int64_t nbatch = 1;
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
-  const int64_t input_h  = input->size(dimh);
-  const int64_t input_w  = input->size(dimw);
-  const int64_t output_h = gradOutput->size(dimh);
-  const int64_t output_w = gradOutput->size(dimw);
-  const int64_t kH       = weight->size(1);
-  const int64_t kW       = weight->size(2);
+  const int64_t input_h  = THTensor_sizeLegacyNoScalars(input, dimh);
+  const int64_t input_w  = THTensor_sizeLegacyNoScalars(input, dimw);
+  const int64_t output_h = THTensor_sizeLegacyNoScalars(gradOutput, dimh);
+  const int64_t output_w = THTensor_sizeLegacyNoScalars(gradOutput, dimw);
+  const int64_t kH       = THTensor_sizeLegacyNoScalars(weight, 1);
+  const int64_t kW       = THTensor_sizeLegacyNoScalars(weight, 2);
 
   /* contiguous */
   gradInput = THTensor_(newContiguous)(gradInput);
@@ -157,7 +157,7 @@ void THNN_(SpatialConvolutionMap_updateGradInput)(
     {
       int64_t k;
       /* backward all */
-      int nkernel = connTable->size(0);
+      int nkernel = THTensor_sizeLegacyNoScalars(connTable, 0);
       for (k = 0; k < nkernel; k++)
       {
         int o = (int)connTable_data[k*2+1] - TH_INDEX_BASE;
@@ -197,7 +197,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
     gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
-    && connTable != NULL && connTable->size(0) == gradWeight->size(0), 5,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(gradWeight, 0), 5,
     "3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -207,17 +207,17 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   int64_t nbatch = 1;
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
-  const int64_t input_h  = input->size(dimh);
-  const int64_t input_w  = input->size(dimw);
-  const int64_t output_h = gradOutput->size(dimh);
-  const int64_t output_w = gradOutput->size(dimw);
-  const int64_t kH       = gradWeight->size(1);
-  const int64_t kW       = gradWeight->size(2);
+  const int64_t input_h  = THTensor_sizeLegacyNoScalars(input, dimh);
+  const int64_t input_w  = THTensor_sizeLegacyNoScalars(input, dimw);
+  const int64_t output_h = THTensor_sizeLegacyNoScalars(gradOutput, dimh);
+  const int64_t output_w = THTensor_sizeLegacyNoScalars(gradOutput, dimw);
+  const int64_t kH       = THTensor_sizeLegacyNoScalars(gradWeight, 1);
+  const int64_t kW       = THTensor_sizeLegacyNoScalars(gradWeight, 2);
 
   /* contiguous */
   input = THTensor_(newContiguous)(input);
@@ -248,7 +248,7 @@ void THNN_(SpatialConvolutionMap_accGradParameters)(
   }
 
   /* gradients wrt weight */
-  const int nkernel = connTable->size(0);
+  const int nkernel = THTensor_sizeLegacyNoScalars(connTable, 0);
 #pragma omp parallel for private(k)
   for (k = 0; k < nkernel; k++)
   {

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -34,9 +34,9 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
 	     "padW = %d, padH = %d, kW = %d, kH = %d",
 	     padW, padH, kW, kH);
 
-  int64_t nInputPlane = input->size(dimh-1);
-  int64_t inputHeight = input->size(dimh);
-  int64_t inputWidth = input->size(dimw);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  int64_t inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputHeight, outputWidth;
   int64_t nOutputPlane = nInputPlane;
 
@@ -184,15 +184,15 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nInputPlane = input->size(dimh-1);
-  inputHeight = input->size(dimh);
-  inputWidth = input->size(dimw);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
   if (ceil_mode)
   {
     outputHeight = (int64_t)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
@@ -349,17 +349,17 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nInputPlane = input->size(dimh-1);
-  inputHeight = input->size(dimh);
-  inputWidth = input->size(dimw);
-  outputHeight = gradOutput->size(dimh);
-  outputWidth = gradOutput->size(dimw);
+  nInputPlane = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  outputHeight = THTensor_sizeLegacyNoScalars(gradOutput, dimh);
+  outputWidth = THTensor_sizeLegacyNoScalars(gradOutput, dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
@@ -107,16 +107,16 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
 		"non-empty 3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 4) {
-    numBatch = THTensor_(size)(input, 0);
+    numBatch = THTensor_(sizeLegacyNoScalars)(input, 0);
     planeDim++;
     heightDim++;
     widthDim++;
   }
 
   /* sizes */
-  int64_t numPlanes = THTensor_(size)(input, planeDim);
-  int64_t inputH = THTensor_(size)(input, heightDim);
-  int64_t inputW = THTensor_(size)(input, widthDim);
+  int64_t numPlanes = THTensor_(sizeLegacyNoScalars)(input, planeDim);
+  int64_t inputH = THTensor_(sizeLegacyNoScalars)(input, heightDim);
+  int64_t inputW = THTensor_(sizeLegacyNoScalars)(input, widthDim);
 
   THArgCheck(outputH + poolSizeH - 1 <= inputH, 7,
              "poolSizeH (%d) too large relative to input height (%d)",
@@ -204,20 +204,20 @@ void THNN_(SpatialFractionalMaxPooling_updateGradInput)(
 
   int64_t numInputDims = THTensor_(nDimensionLegacyNoScalars)(input);
   if (numInputDims == 4) {
-    numBatch = THTensor_(size)(input, 0);
+    numBatch = THTensor_(sizeLegacyNoScalars)(input, 0);
     planeDim = 1;
     heightDim++;
     widthDim++;
   }
 
   /* sizes */
-  int64_t numPlanes = THTensor_(size)(input, planeDim);
-  int64_t inputH = THTensor_(size)(input, heightDim);
-  int64_t inputW = THTensor_(size)(input, widthDim);
+  int64_t numPlanes = THTensor_(sizeLegacyNoScalars)(input, planeDim);
+  int64_t inputH = THTensor_(sizeLegacyNoScalars)(input, heightDim);
+  int64_t inputW = THTensor_(sizeLegacyNoScalars)(input, widthDim);
 
-  THArgCheck(outputW == THTensor_(size)(gradOutput, widthDim), 3,
+  THArgCheck(outputW == THTensor_(sizeLegacyNoScalars)(gradOutput, widthDim), 3,
              "gradOutput width unexpected");
-  THArgCheck(outputH == THTensor_(size)(gradOutput, heightDim), 3,
+  THArgCheck(outputH == THTensor_(sizeLegacyNoScalars)(gradOutput, heightDim), 3,
              "gradOutput height unexpected");
 
   /* get contiguous gradOutput */

--- a/aten/src/THNN/generic/SpatialFullConvolutionMap.c
+++ b/aten/src/THNN/generic/SpatialFullConvolutionMap.c
@@ -12,20 +12,20 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   // What does this mean?
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size(0) == weight->size(0), 4,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(weight, 0), 4,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
-  const int kH = (int)weight->size(1);
-  const int kW = (int)weight->size(2);
+  const int kH = (int)THTensor_sizeLegacyNoScalars(weight, 1);
+  const int kW = (int)THTensor_sizeLegacyNoScalars(weight, 2);
 
   THArgCheck(input != NULL && !input->is_empty() && input->dim() == 3, 2, "non-empty 3D tensor expected");
-  THArgCheck(input->size(0) >= nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, 0) >= nInputPlane, 2, "invalid number of input planes");
 
   THTensor_(resize3d)(
     output_, nOutputPlane,
-    (input->size(1) - 1) * dH + kH,
-    (input->size(2) - 1) * dW + kW
+    (THTensor_sizeLegacyNoScalars(input, 1) - 1) * dH + kH,
+    (THTensor_sizeLegacyNoScalars(input, 2) - 1) * dW + kW
   );
 
   /* contiguous */
@@ -40,12 +40,12 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
   real *connTable_data = THTensor_(data)(connTable);
 
   /* and dims */
-  const int64_t input_h = input->size(1);
-  const int64_t input_w = input->size(2);
-  const int64_t output_h = output->size(1);
-  const int64_t output_w = output->size(2);
-  const int64_t weight_h = weight->size(1);
-  const int64_t weight_w = weight->size(2);
+  const int64_t input_h = THTensor_sizeLegacyNoScalars(input, 1);
+  const int64_t input_w = THTensor_sizeLegacyNoScalars(input, 2);
+  const int64_t output_h = THTensor_sizeLegacyNoScalars(output, 1);
+  const int64_t output_w = THTensor_sizeLegacyNoScalars(output, 2);
+  const int64_t weight_h = THTensor_sizeLegacyNoScalars(weight, 1);
+  const int64_t weight_w = THTensor_sizeLegacyNoScalars(weight, 2);
 
   int64_t p;
 #pragma omp parallel for private(p)
@@ -61,7 +61,7 @@ void THNN_(SpatialFullConvolutionMap_updateOutput)(
       ptr_output[j] = bias_data[p];
 
     /* convolve all maps */
-    nweight = connTable->size(0);
+    nweight = THTensor_sizeLegacyNoScalars(connTable, 0);
     for (k = 0; k < nweight; k++)
     {
       /* get offsets for input/output */
@@ -93,7 +93,7 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
 {
   THArgCheck(
     weight != NULL && !weight->is_empty() && weight->dim() == 3
-    && connTable != NULL && connTable->size(0) == weight->size(0), 5,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(weight, 0), 5,
     "non-empty 3D weight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -112,12 +112,12 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   real *connTable_data = THTensor_(data)(connTable);
 
   /* and dims */
-  const int64_t input_h = input->size(1);
-  const int64_t input_w = input->size(2);
-  const int64_t output_h = gradOutput->size(1);
-  const int64_t output_w = gradOutput->size(2);
-  const int64_t kH = weight->size(1);
-  const int64_t kW = weight->size(2);
+  const int64_t input_h = THTensor_sizeLegacyNoScalars(input, 1);
+  const int64_t input_w = THTensor_sizeLegacyNoScalars(input, 2);
+  const int64_t output_h = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  const int64_t output_w = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+  const int64_t kH = THTensor_sizeLegacyNoScalars(weight, 1);
+  const int64_t kW = THTensor_sizeLegacyNoScalars(weight, 2);
 
   int64_t p;
 #pragma omp parallel for private(p)
@@ -125,7 +125,7 @@ void THNN_(SpatialFullConvolutionMap_updateGradInput)(
   {
     int64_t k;
     /* backward all */
-    int nkernel = connTable->size(0);
+    int nkernel = THTensor_sizeLegacyNoScalars(connTable, 0);
     for (k = 0; k < nkernel; k++)
     {
       int o = (int)connTable_data[k*2+1] - TH_INDEX_BASE;
@@ -164,7 +164,7 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THArgCheck(
     gradWeight != NULL && !gradWeight->is_empty() && gradWeight->dim() == 3
-    && connTable != NULL && connTable->size(0) == gradWeight->size(0), 5,
+    && connTable != NULL && THTensor_sizeLegacyNoScalars(connTable, 0) == THTensor_sizeLegacyNoScalars(gradWeight, 0), 5,
     "non-empty 3D gradWeight tensor expected (connTable:size(%d) x kH x kW)", TH_INDEX_BASE
   );
 
@@ -179,12 +179,12 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   real *gradBias_data = THTensor_(data)(gradBias);
 
   /* and dims */
-  const int64_t input_h  = input->size(1);
-  const int64_t input_w  = input->size(2);
-  const int64_t output_h = gradOutput->size(1);
-  const int64_t output_w = gradOutput->size(2);
-  const int64_t weight_h = gradWeight->size(1);
-  const int64_t weight_w = gradWeight->size(2);
+  const int64_t input_h  = THTensor_sizeLegacyNoScalars(input, 1);
+  const int64_t input_w  = THTensor_sizeLegacyNoScalars(input, 2);
+  const int64_t output_h = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  const int64_t output_w = THTensor_sizeLegacyNoScalars(gradOutput, 2);
+  const int64_t weight_h = THTensor_sizeLegacyNoScalars(gradWeight, 1);
+  const int64_t weight_w = THTensor_sizeLegacyNoScalars(gradWeight, 2);
 
   /* gradients wrt bias */
   int64_t k;
@@ -198,7 +198,7 @@ void THNN_(SpatialFullConvolutionMap_accGradParameters)(
   }
 
   /* gradients wrt weight */
-  int nkernel = connTable->size(0);
+  int nkernel = THTensor_sizeLegacyNoScalars(connTable, 0);
 #pragma omp parallel for private(k)
   for (k = 0; k < nkernel; k++)
   {

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                   "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(1));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -43,8 +43,8 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (ndim == 3 || ndim == 4), 2, input,
 		"non-empty 3D or 4D input tensor expected but got: %s");
 
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
@@ -55,16 +55,16 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(0);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(1);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
@@ -90,8 +90,8 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
     (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW,
      dilationH, dilationW, adjH, adjW, 0);
 
-  int nInputPlane = THTensor_(size)(weight,0);
-  int nOutputPlane = THTensor_(size)(weight,1);
+  int nInputPlane = THTensor_(sizeLegacyNoScalars)(weight,0);
+  int nOutputPlane = THTensor_(sizeLegacyNoScalars)(weight,1);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -105,16 +105,16 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
+    THTensor_(resize4d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
   }
 
-  int64_t inputHeight  = input->size(2);
-  int64_t inputWidth   = input->size(3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize4d)(output, batchSize, nOutputPlane, outputHeight, outputWidth);
@@ -126,7 +126,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -145,9 +145,9 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(1) * weight->size(2) * weight->size(3);
-    int64_t n = columns->size(1);
-    int64_t k = weight->size(0);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -221,8 +221,8 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
     (input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW,
      dilationH, dilationW, adjH, adjW, 0);
 
-  int64_t nInputPlane = THTensor_(size)(weight,0);
-  int64_t nOutputPlane = THTensor_(size)(weight,1);
+  int64_t nInputPlane = THTensor_(sizeLegacyNoScalars)(weight,0);
+  int64_t nOutputPlane = THTensor_(sizeLegacyNoScalars)(weight,1);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -233,17 +233,17 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THTensor_(resize4d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THTensor_(resize4d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize4d)(gradInput, batchSize, nInputPlane, inputHeight, inputWidth);
@@ -275,9 +275,9 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = weight->size(0);
-    int64_t n = gradColumns->size(1);
-    int64_t k = weight->size(1) * weight->size(2) * weight->size(3);
+    int64_t m = THTensor_sizeLegacyNoScalars(weight, 0);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
+    int64_t k = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -330,9 +330,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
 
   int64_t nOutputPlane;
   if (gradWeight) {
-    nOutputPlane = THTensor_(size)(gradWeight, 1);
+    nOutputPlane = THTensor_(sizeLegacyNoScalars)(gradWeight, 1);
   } else if (gradBias) {
-    nOutputPlane = THTensor_(size)(gradBias, 0);
+    nOutputPlane = THTensor_(sizeLegacyNoScalars)(gradBias, 0);
   } else {
     return;
   }
@@ -352,20 +352,20 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   if (input->dim() == 3) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize4d)(input, 1, input->size(0), input->size(1), input->size(2));
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2));
+    THTensor_(resize4d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2));
+    THTensor_(resize4d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2));
   }
 
-  int64_t inputWidth   = input->size(3);
-  int64_t inputHeight  = input->size(2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 2);
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 2 || ones->size(0)*ones->size(1) < outputHeight*outputWidth) {
+  if (ones->dim() != 2 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1) < outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize2d)(ones, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -401,9 +401,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
 
       // M,N,K are dims of matrix A and B
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-      int64_t n = columns->size(0);   // nOutputPlane * kh * kw
-      int64_t m = input_n->size(0);   // nInputPlane
-      int64_t k = columns->size(1);   // inputHeight * inputWidth
+      int64_t n = THTensor_sizeLegacyNoScalars(columns, 0);   // nOutputPlane * kh * kw
+      int64_t m = THTensor_sizeLegacyNoScalars(input_n, 0);   // nInputPlane
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);   // inputHeight * inputWidth
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(
@@ -444,7 +444,7 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   // Resize
   if (is_batch == 0) {
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
-    THTensor_(resize3d)(input, input->size(1), inputHeight, inputWidth);
+    THTensor_(resize3d)(input, THTensor_sizeLegacyNoScalars(input, 1), inputHeight, inputWidth);
   }
 
   THTensor_(free)(input);

--- a/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
@@ -17,10 +17,10 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
   THNN_ARGCHECK(!grid->is_empty() && grid->dim() == 4, 2, grid,
     "non-empty 4D grid tensor expected but got: %s");
 
-  int nbatch   = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int oheight   = THTensor_(size)(grid, 1);
-  int owidth    = THTensor_(size)(grid, 2);
+  int nbatch   = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int oheight   = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int owidth    = THTensor_(sizeLegacyNoScalars)(grid, 2);
 
   THNN_CHECK_DIM_SIZE(grid, 4, 0, nbatch);
   THNN_CHECK_DIM_SIZE(grid, 4, 3, 2);
@@ -46,12 +46,12 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
     int padding_mode) {
 
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(input, grid, NULL);
-  int N = THTensor_(size)(input, 0);
-  int C = THTensor_(size)(input, 1);
-  int IH = THTensor_(size)(input, 2);
-  int IW = THTensor_(size)(input, 3);
-  int H = THTensor_(size)(grid, 1);
-  int W = THTensor_(size)(grid, 2);
+  int N = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int C = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int IH = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int IW = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int H = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int W = THTensor_(sizeLegacyNoScalars)(grid, 2);
 
   // resize output to the same shape as input
   THTensor_(resize4d)(output, N, C, H, W);
@@ -130,12 +130,12 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
     int padding_mode) {
 
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(input, grid, gradOutput);
-  int N = THTensor_(size)(input, 0);
-  int C = THTensor_(size)(input, 1);
-  int IH = THTensor_(size)(input, 2);
-  int IW = THTensor_(size)(input, 3);
-  int H = THTensor_(size)(grid, 1);
-  int W = THTensor_(size)(grid, 2);
+  int N = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int C = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int IH = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int IW = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int H = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int W = THTensor_(sizeLegacyNoScalars)(grid, 2);
 
   THTensor_(resize4d)(gradInput, N, C, IH, IW);
   THTensor_(resize4d)(gradGrid, N, H, W, 2);

--- a/aten/src/THNN/generic/SpatialMaxUnpooling.c
+++ b/aten/src/THNN/generic/SpatialMaxUnpooling.c
@@ -67,15 +67,15 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size(dimh-1);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
 
   /* get contiguous input and indices */
   input = THTensor_(newContiguous)(input);
@@ -184,19 +184,19 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size(dimh-1);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimh-1);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
 
-  if(owidth!=gradOutput->size(dimw) || oheight!=gradOutput->size(dimh)){
+  if(owidth!=THTensor_sizeLegacyNoScalars(gradOutput, dimw) || oheight!=THTensor_sizeLegacyNoScalars(gradOutput, dimh)){
     THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
-	    oheight, owidth, gradOutput->size(dimh), gradOutput->size(dimw));
+	    oheight, owidth, THTensor_sizeLegacyNoScalars(gradOutput, dimh), THTensor_sizeLegacyNoScalars(gradOutput, dimw));
   }
 
   /* get raw pointers */

--- a/aten/src/THNN/generic/SpatialReflectionPadding.c
+++ b/aten/src/THNN/generic/SpatialReflectionPadding.c
@@ -72,16 +72,16 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* input sizes */
-  nslices = input->size(dimslices);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
 
   AT_CHECK(pad_l < iwidth && pad_r < iwidth,
            "Argument #4: Padding size should be less than the corresponding input dimension, "
@@ -211,25 +211,25 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
+  THArgCheck(owidth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimw), 3,
 	     "gradOutput width unexpected. Expected: %d, Got: %d",
-	     owidth, THTensor_(size)(gradOutput, dimw));
-  THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
+	     owidth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimw));
+  THArgCheck(oheight == THTensor_(sizeLegacyNoScalars)(gradOutput, dimh), 3,
                 "gradOutput height unexpected. Expected: %d, Got: %d",
-	     oheight, THTensor_(size)(gradOutput, dimh));
+	     oheight, THTensor_(sizeLegacyNoScalars)(gradOutput, dimh));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/SpatialReplicationPadding.c
+++ b/aten/src/THNN/generic/SpatialReplicationPadding.c
@@ -71,16 +71,16 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
@@ -200,25 +200,25 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 4)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
+  THArgCheck(owidth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimw), 3,
 	     "gradOutput width unexpected. Expected: %d, Got: %d",
-	     owidth, THTensor_(size)(gradOutput, dimw));
-  THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
+	     owidth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimw));
+  THArgCheck(oheight == THTensor_(sizeLegacyNoScalars)(gradOutput, dimh), 3,
                 "gradOutput height unexpected. Expected: %d, Got: %d",
-	     oheight, THTensor_(size)(gradOutput, dimh));
+	     oheight, THTensor_(sizeLegacyNoScalars)(gradOutput, dimh));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/SpatialSubSampling.c
+++ b/aten/src/THNN/generic/SpatialSubSampling.c
@@ -11,7 +11,7 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
                   "3D or 4D input tensor expected but got: %s");
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
 
-  int nInputPlane = THTensor_(size)(weight, 0);
+  int nInputPlane = THTensor_(sizeLegacyNoScalars)(weight, 0);
 
   int dimw = 2;
   int dimh = 1;
@@ -24,10 +24,10 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
     dimh++;
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
 
-  THArgCheck(input->size(dimh-1) == nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimh-1) == nInputPlane, 2, "invalid number of input planes");
   THArgCheck(inputWidth >= kW && inputHeight >= kH, 2, "input image smaller than kernel size");
 }
 
@@ -56,27 +56,27 @@ void THNN_(SpatialSubSampling_updateOutput)(
   int64_t outputWidth;
   int64_t outputHeight;
 
-  int nInputPlane = THTensor_(size)(weight,0);
+  int nInputPlane = THTensor_(sizeLegacyNoScalars)(weight,0);
 
   int64_t k;
 
   THNN_(SpatialSubSampling_shapeCheck)(input, NULL, weight, kW, kH);
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
   if (input->dim() == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
   else
-    THTensor_(resize4d)(output, input->size(0), nInputPlane, outputHeight, outputWidth);
+    THTensor_(resize4d)(output, THTensor_sizeLegacyNoScalars(input, 0), nInputPlane, outputHeight, outputWidth);
 
   input = THTensor_(newContiguous)(input);
   input_data = THTensor_(data)(input);
@@ -143,7 +143,7 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   int64_t outputWidth;
   int64_t outputHeight;
 
-  int nInputPlane = THTensor_(size)(weight,0);
+  int nInputPlane = THTensor_(sizeLegacyNoScalars)(weight,0);
 
   real *weight_data;
   real *gradOutput_data;
@@ -152,13 +152,13 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   int64_t k;
 
   if (input->dim() == 4) {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 
@@ -227,7 +227,7 @@ void THNN_(SpatialSubSampling_accGradParameters)(
   int64_t outputWidth;
   int64_t outputHeight;
 
-  int nInputPlane = THTensor_(size)(gradWeight,0);
+  int nInputPlane = THTensor_(sizeLegacyNoScalars)(gradWeight,0);
 
   real *gradWeight_data;
   real *gradBias_data;
@@ -239,11 +239,11 @@ void THNN_(SpatialSubSampling_accGradParameters)(
   if (input->dim() == 4) {
     dimw++;
     dimh++;
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
   }
 
-  inputWidth = input->size(dimw);
-  inputHeight = input->size(dimh);
+  inputWidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  inputHeight = THTensor_sizeLegacyNoScalars(input, dimh);
   outputWidth = (inputWidth - kW) / dW + 1;
   outputHeight = (inputHeight - kH) / dH + 1;
 

--- a/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
@@ -38,10 +38,10 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
     int outputWidth,
     bool align_corners){
 
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputHeight = THTensor_(size)(input, 2);
-  int inputWidth = THTensor_(size)(input, 3);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputHeight = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 3);
 
   THNN_(SpatialUpSamplingBilinear_shapeCheck)
     (input, NULL,
@@ -51,8 +51,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   THTensor_(resize4d)(output,
-		      THTensor_(size)(input, 0),
-		      THTensor_(size)(input, 1),
+		      THTensor_(sizeLegacyNoScalars)(input, 0),
+		      THTensor_(sizeLegacyNoScalars)(input, 1),
 		      outputHeight, outputWidth);
   THTensor_(zero)(output);
   real *idata = THTensor_(data)(input);

--- a/aten/src/THNN/generic/SpatialUpSamplingNearest.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingNearest.c
@@ -35,10 +35,10 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
     int outputHeight,
     int outputWidth)
 {
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputHeight = THTensor_(size)(input, 2);
-  int inputWidth = THTensor_(size)(input, 3);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputHeight = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 3);
   const float height_scale = (float) inputHeight / (float) outputHeight;
   const float width_scale = (float) inputWidth / (float) outputWidth;
 
@@ -46,8 +46,8 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
 		  inputHeight, inputWidth, outputHeight, outputWidth);
 
   THTensor_(resize4d)(output,
-                      THTensor_(size)(input, 0),
-                      THTensor_(size)(input, 1),
+                      THTensor_(sizeLegacyNoScalars)(input, 0),
+                      THTensor_(sizeLegacyNoScalars)(input, 1),
                       outputHeight,
                       outputWidth);
   channels = channels * nbatch;

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -25,13 +25,13 @@ static inline void THNN_(TemporalConvolution_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck(input->size(dimF) == *inputFrameSize, 2,
+    THArgCheck(THTensor_sizeLegacyNoScalars(input, dimF) == *inputFrameSize, 2,
                "invalid input frame size. Got: %d, Expected: %d",
-               input->size(dimF), *inputFrameSize);
+               THTensor_sizeLegacyNoScalars(input, dimF), *inputFrameSize);
   }
-  THArgCheck(input->size(dimS) >= kW, 2,
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size(dimS), kW);
+             THTensor_sizeLegacyNoScalars(input, dimS), kW);
 }
 
 void THNN_(TemporalConvolution_updateOutput)(
@@ -64,7 +64,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   outputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  nInputFrame = input->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (input->dim() == 2)
@@ -89,14 +89,14 @@ void THNN_(TemporalConvolution_updateOutput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(input),
-                              input->storage_offset()+k*dW*input->size(1),
-                              nFrame, inputFrameStride*input->size(1),
-                              kW*input->size(1), 1);
+                              input->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(input, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(input, 1),
+                              kW*THTensor_sizeLegacyNoScalars(input, 1), 1);
 
       THTensor_(setStorage2d)(outputWindow, THTensor_getStoragePtr(output),
-                              output->storage_offset() + k*output->size(1),
-                              nFrame, outputFrameStride*output->size(1),
-                              output->size(1), 1);
+                              output->storage_offset() + k*THTensor_sizeLegacyNoScalars(output, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(output, 1),
+                              THTensor_sizeLegacyNoScalars(output, 1), 1);
 
       THTensor *tweight = THTensor_(new)();
       THTensor_(transpose)(tweight, weight, 0, 1);
@@ -108,7 +108,7 @@ void THNN_(TemporalConvolution_updateOutput)(
   {
     THTensor *outputSample = THTensor_(new)();
     THTensor *inputSample = THTensor_(new)();
-    int nBatchFrame = input->size(0);
+    int nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
 
     THTensor_(resize3d)(output,
                         nBatchFrame,
@@ -137,14 +137,14 @@ void THNN_(TemporalConvolution_updateOutput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(inputSample),
-                                inputSample->storage_offset()+k*dW*inputSample->size(1),
-                                nFrame, inputFrameStride*inputSample->size(1),
-                                kW*inputSample->size(1), 1);
+                                inputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(inputSample, 1), 1);
 
         THTensor_(setStorage2d)(outputWindow, THTensor_getStoragePtr(outputSample),
-                                outputSample->storage_offset() + k*outputSample->size(1),
-                                nFrame, outputFrameStride*outputSample->size(1),
-                                outputSample->size(1), 1);
+                                outputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(outputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(outputSample, 1),
+                                THTensor_sizeLegacyNoScalars(outputSample, 1), 1);
 
         THTensor *tweight = THTensor_(new)();
         THTensor_(transpose)(tweight, weight, 0, 1);
@@ -188,8 +188,8 @@ void THNN_(TemporalConvolution_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
   THNN_(TemporalConvolution_shapeCheck)(
         state, input, kW, dW, NULL);
-  nInputFrame = input->size(dimS);
-  nOutputFrame = gradOutput->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
+  nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, dimS);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -211,14 +211,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutput),
-                              gradOutput->storage_offset() + k*gradOutput->size(1),
-                              nFrame, outputFrameStride*gradOutput->size(1),
-                              gradOutput->size(1), 1);
+                              gradOutput->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              THTensor_sizeLegacyNoScalars(gradOutput, 1), 1);
 
       THTensor_(setStorage2d)(gradInputWindow, THTensor_getStoragePtr(gradInput),
-                              gradInput->storage_offset()+k*dW*gradInput->size(1),
-                              nFrame, inputFrameStride*gradInput->size(1),
-                              kW*gradInput->size(1), 1);
+                              gradInput->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(gradInput, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(gradInput, 1),
+                              kW*THTensor_sizeLegacyNoScalars(gradInput, 1), 1);
 
       THTensor_(addmm)(gradInputWindow, 1, gradInputWindow, 1, gradOutputWindow, weight);
     }
@@ -227,7 +227,7 @@ void THNN_(TemporalConvolution_updateGradInput)(
   {
     THTensor *gradOutputSample = THTensor_(new)();
     THTensor *gradInputSample = THTensor_(new)();
-    int nBatchFrame = input->size(0);
+    int nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -244,14 +244,14 @@ void THNN_(TemporalConvolution_updateGradInput)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
-                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
-                                nFrame, outputFrameStride*gradOutputSample->size(1),
-                                gradOutputSample->size(1), 1);
+                                gradOutputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                THTensor_sizeLegacyNoScalars(gradOutputSample, 1), 1);
 
         THTensor_(setStorage2d)(gradInputWindow, THTensor_getStoragePtr(gradInputSample),
-                                gradInputSample->storage_offset()+k*dW*gradInputSample->size(1),
-                                nFrame, inputFrameStride*gradInputSample->size(1),
-                                kW*gradInputSample->size(1), 1);
+                                gradInputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(gradInputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(gradInputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(gradInputSample, 1), 1);
 
         THTensor_(addmm)(gradInputWindow, 1, gradInputWindow, 1, gradOutputWindow, weight);
       }
@@ -294,8 +294,8 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   THNN_(TemporalConvolution_shapeCheck)(
         state, input, kW, dW, NULL);
-  nInputFrame = input->size(dimS);
-  nOutputFrame = gradOutput->size(dimS);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
+  nOutputFrame = THTensor_sizeLegacyNoScalars(gradOutput, dimS);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -320,14 +320,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
       nOutputFrame -= nFrame;
 
       THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(input),
-                              input->storage_offset()+k*dW*input->size(1),
-                              nFrame, inputFrameStride*input->size(1),
-                              kW*input->size(1), 1);
+                              input->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(input, 1),
+                              nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(input, 1),
+                              kW*THTensor_sizeLegacyNoScalars(input, 1), 1);
 
       THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutput),
-                              gradOutput->storage_offset() + k*gradOutput->size(1),
-                              nFrame, outputFrameStride*gradOutput->size(1),
-                              gradOutput->size(1), 1);
+                              gradOutput->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutput, 1),
+                              THTensor_sizeLegacyNoScalars(gradOutput, 1), 1);
 
       THTensor *tgradOutputWindow = THTensor_(new)();
       THTensor_(transpose)(tgradOutputWindow, gradOutputWindow, 0, 1);
@@ -339,7 +339,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   {
     THTensor *gradOutputSample = THTensor_(new)();
     THTensor *inputSample = THTensor_(new)();
-    int nBatchFrame = input->size(0);
+    int nBatchFrame = THTensor_sizeLegacyNoScalars(input, 0);
 
     for(i = 0; i < nBatchFrame; i++)
     {
@@ -363,14 +363,14 @@ void THNN_(TemporalConvolution_accGradParameters)(
         nOutputSampleFrame -= nFrame;
 
         THTensor_(setStorage2d)(inputWindow, THTensor_getStoragePtr(inputSample),
-                                inputSample->storage_offset()+k*dW*inputSample->size(1),
-                                nFrame, inputFrameStride*inputSample->size(1),
-                                kW*inputSample->size(1), 1);
+                                inputSample->storage_offset()+k*dW*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                nFrame, inputFrameStride*THTensor_sizeLegacyNoScalars(inputSample, 1),
+                                kW*THTensor_sizeLegacyNoScalars(inputSample, 1), 1);
 
         THTensor_(setStorage2d)(gradOutputWindow, THTensor_getStoragePtr(gradOutputSample),
-                                gradOutputSample->storage_offset() + k*gradOutputSample->size(1),
-                                nFrame, outputFrameStride*gradOutputSample->size(1),
-                                gradOutputSample->size(1), 1);
+                                gradOutputSample->storage_offset() + k*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                nFrame, outputFrameStride*THTensor_sizeLegacyNoScalars(gradOutputSample, 1),
+                                THTensor_sizeLegacyNoScalars(gradOutputSample, 1), 1);
 
         THTensor *tgradOutputWindow = THTensor_(new)();
         THTensor_(transpose)(tgradOutputWindow, gradOutputWindow, 0, 1);

--- a/aten/src/THNN/generic/TemporalMaxPooling.c
+++ b/aten/src/THNN/generic/TemporalMaxPooling.c
@@ -23,8 +23,8 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
     dimF = 2;
   }
 
-  niframe = input->size(dimS);
-  framesize = input->size(dimF);
+  niframe = THTensor_sizeLegacyNoScalars(input, dimS);
+  framesize = THTensor_sizeLegacyNoScalars(input, dimF);
   noframe = (niframe - kW) / dW + 1;
 
   THArgCheck(kW > 0, 5,
@@ -34,9 +34,9 @@ static inline void THNN_(TemporalMaxPooling_shapeCheck)(
 
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 2 || input->dim() == 3), 2, input,
                 "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
-  THArgCheck(input->size(dimS) >= kW, 2,
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimS) >= kW, 2,
              "input sequence smaller than kernel size. Got: %d, Expected: %d",
-             input->size(dimS), kW);
+             THTensor_sizeLegacyNoScalars(input, dimS), kW);
 
   if (gradOutput != NULL) {
     THNN_CHECK_DIM_SIZE(gradOutput, ndims, dimS, noframe);
@@ -78,8 +78,8 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  niframe = input->size(dimS);
-  framesize = input->size(dimF);
+  niframe = THTensor_sizeLegacyNoScalars(input, dimS);
+  framesize = THTensor_sizeLegacyNoScalars(input, dimF);
   noframe = (niframe - kW) / dW + 1;
 
   /* get contiguous input */
@@ -129,7 +129,7 @@ void THNN_(TemporalMaxPooling_updateOutput)(
   else
   {
     /* number of batch frames */
-    int64_t nbframe = input->size(0);
+    int64_t nbframe = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t i;
 
     /* resize output */
@@ -221,9 +221,9 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
     dimF = 2;
   }
   /* sizes */
-  niframe = input->size(dimS);
-  noframe = gradOutput->size(dimS);
-  framesize = gradOutput->size(dimF);
+  niframe = THTensor_sizeLegacyNoScalars(input, dimS);
+  noframe = THTensor_sizeLegacyNoScalars(gradOutput, dimS);
+  framesize = THTensor_sizeLegacyNoScalars(gradOutput, dimF);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -250,7 +250,7 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
   else
   {
     /* number of batch frames */
-    int64_t nbframe = input->size(0);
+    int64_t nbframe = THTensor_sizeLegacyNoScalars(input, 0);
     int64_t i;
 
     for(i = 0; i < nbframe; i++)

--- a/aten/src/THNN/generic/TemporalReflectionPadding.c
+++ b/aten/src/THNN/generic/TemporalReflectionPadding.c
@@ -55,14 +55,14 @@ void THNN_(TemporalReflectionPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimslices++;
   }
 
   /* input size */
-  nslices = input->size(dimslices);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
 
   AT_CHECK(pad_l < iwidth && pad_r < iwidth,
            "Argument #4: Padding size should be less than the corresponding input dimension, "
@@ -167,19 +167,19 @@ void THNN_(TemporalReflectionPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
+  THArgCheck(owidth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimw), 3,
 	     "gradOutput width unexpected. Expected: %d, Got: %d",
-	     owidth, THTensor_(size)(gradOutput, dimw));
+	     owidth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimw));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/TemporalReplicationPadding.c
+++ b/aten/src/THNN/generic/TemporalReplicationPadding.c
@@ -53,14 +53,14 @@ void THNN_(TemporalReplicationPadding_updateOutput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth >= 1 , 2,
@@ -159,19 +159,19 @@ void THNN_(TemporalReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 3)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimslices++;
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
+  THArgCheck(owidth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimw), 3,
 	     "gradOutput width unexpected. Expected: %d, Got: %d",
-	     owidth, THTensor_(size)(gradOutput, dimw));
+	     owidth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimw));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -22,7 +22,7 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
     THArgCheck(!bias || THTensor_(isContiguous)(bias), 5, "bias must be contiguous");
 
 	if (bias != NULL) {
-		THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
+		THNN_CHECK_DIM_SIZE(bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
 	}
 
 	// we're always looking at (possibly batch) x feats x seq
@@ -38,8 +38,8 @@ static inline void THNN_(TemporalRowConvolution_shapeCheck)(
 	THNN_ARGCHECK(!input->is_empty() && (ndim == 2 || ndim == 3), 1, input,
 	              "non-empty 2D or 3D (batch mode) input tensor expected, but got :%s");
 
-	int64_t inputFrameSize = weight->size(0);
-	int64_t nInputFrame = input->size(dimS);
+	int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+	int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, dimS);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	if (nOutputFrame < 1) {
@@ -162,7 +162,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 		for (i = 0; i < inputFrameSize; i++)
 			THVector_(fill)
 			        (THStorage_(data)(THTensor_getStoragePtr(output)) + output->storage_offset()
-			        + output->stride(0) * i,
+			        + THTensor_strideLegacyNoScalars(output, 0) * i,
 			        THTensor_(get1d)(bias, i), nOutputFrame);
 	}
 
@@ -197,8 +197,8 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 	THNN_(TemporalRowConvolution_shapeCheck)(
 		state, input, NULL, weight, bias, kW, dW, padW);
 
-	int64_t inputFrameSize = weight->size(0);
-	int64_t nInputFrame = input->size(ndim - 1);
+	int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+	int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, ndim - 1);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	if (ndim == 2) { /* non-batch mode */
@@ -215,7 +215,7 @@ void THNN_(TemporalRowConvolution_updateOutput)(
 		        inputFrameSize, nInputFrame, nOutputFrame);
 
 	} else {
-		int64_t T = input->size(0);
+		int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
 		int64_t t;
 
 		THTensor_(resize4d)(finput, T, inputFrameSize, kW, nOutputFrame);
@@ -311,8 +311,8 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 	THNN_(TemporalRowConvolution_shapeCheck)(state, input, gradOutput, weight,
 	                                         NULL, kW, dW, padW);
 
-	int64_t inputFrameSize = weight->size(0);
-	int64_t nInputFrame = input->size(ndim - 1);
+	int64_t inputFrameSize = THTensor_sizeLegacyNoScalars(weight, 0);
+	int64_t nInputFrame = THTensor_sizeLegacyNoScalars(input, ndim - 1);
 	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	THTensor_(resizeAs)(fgradInput, finput);
@@ -330,7 +330,7 @@ void THNN_(TemporalRowConvolution_updateGradInput)(
 		        kW, dW, padW,
 		        inputFrameSize, nInputFrame, nOutputFrame);
 	} else {
-		int64_t T = input->size(0);
+		int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
 		int64_t t;
 
 #pragma omp parallel for private(t)
@@ -373,9 +373,9 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 	int64_t i;
 	THTensor *gradOutput3d = THTensor_(newWithStorage3d)(
 		THTensor_getStoragePtr(gradOutput), gradOutput->storage_offset(),
-		gradOutput->size(0), -1,
+		THTensor_sizeLegacyNoScalars(gradOutput, 0), -1,
 		1, -1,
-		gradOutput->size(1), -1);
+		THTensor_sizeLegacyNoScalars(gradOutput, 1), -1);
 
     THTensor *tfinput = THTensor_(new)();
 	THTensor_(transpose)(tfinput, finput, 1, 2);
@@ -386,13 +386,13 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
     THTensor_(free)(tfinput);
 
 	if (gradBias != NULL) {
-		for (i = 0; i < gradBias->size(0); i++) {
+		for (i = 0; i < THTensor_sizeLegacyNoScalars(gradBias, 0); i++) {
 			int64_t k;
 			real sum = 0;
 			real *data = THStorage_(data)(THTensor_getStoragePtr(gradOutput3d))
 			             + gradOutput3d->storage_offset()
-			             + i * gradOutput3d->stride(0);
-			for (k = 0; k < gradOutput3d->size(2); k++) {
+			             + i * THTensor_strideLegacyNoScalars(gradOutput3d, 0);
+			for (k = 0; k < THTensor_sizeLegacyNoScalars(gradOutput3d, 2); k++) {
 				sum += data[k];
 			}
 			(THStorage_(data)(THTensor_getStoragePtr(gradBias)) + gradBias->storage_offset())[i]
@@ -441,7 +441,7 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
 		THNN_(TemporalRowConvolution_accGradParameters_frame)(
 			gradOutput, gradWeight, gradBias, finput, scale);
 	} else {
-		int64_t T = input->size(0);
+		int64_t T = THTensor_sizeLegacyNoScalars(input, 0);
 		int64_t t;
 
 		for (t = 0; t < T; t++) {

--- a/aten/src/THNN/generic/TemporalSubSampling.c
+++ b/aten/src/THNN/generic/TemporalSubSampling.c
@@ -19,15 +19,15 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && input->dim() == 2, 2, input,
                   "non-empty 2D or 3D (batch mode) tensor expected for input, but got: %s");
   if (inputFrameSize != NULL) {
-    THArgCheck( input->size(1) == *inputFrameSize, 2,
+    THArgCheck( THTensor_sizeLegacyNoScalars(input, 1) == *inputFrameSize, 2,
                 "invalid input frame size.  Got: %d, Expected: %d",
-                input->size(1), *inputFrameSize);
+                THTensor_sizeLegacyNoScalars(input, 1), *inputFrameSize);
   }
-  THArgCheck( input->size(0) >= kW, 2,
+  THArgCheck( THTensor_sizeLegacyNoScalars(input, 0) >= kW, 2,
               "input sequence smaller than kernel size.  Got %d, Expected: %d",
-              input->size(0), kW);
+              THTensor_sizeLegacyNoScalars(input, 0), kW);
 
-  nInputFrame = input->size(0);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, 0);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   if (gradOutput != NULL) {
@@ -59,7 +59,7 @@ void THNN_(TemporalSubSampling_updateOutput)(
   outputFrame = THTensor_(new)();
   inputWindow = THTensor_(new)();
 
-  nInputFrame = input->size(0);
+  nInputFrame = THTensor_sizeLegacyNoScalars(input, 0);
   nOutputFrame = (nInputFrame - kW) / dW + 1;
 
   THTensor_(resize2d)(output,
@@ -105,7 +105,7 @@ void THNN_(TemporalSubSampling_updateGradInput)(
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);
 
-  for(k = 0; k < gradOutput->size(0); k++)
+  for(k = 0; k < THTensor_sizeLegacyNoScalars(gradOutput, 0); k++)
   {
     THTensor_(narrow)(gradInputWindow, gradInput, 0, k*dW, kW);
     THTensor_(select)(gradOutputFrame, gradOutput, 0, k);
@@ -139,7 +139,7 @@ void THNN_(TemporalSubSampling_accGradParameters)(
   inputWindow = THTensor_(new)();
   buffer = THTensor_(new)();
 
-  for(k = 0; k < gradOutput->size(0); k++)
+  for(k = 0; k < THTensor_sizeLegacyNoScalars(gradOutput, 0); k++)
   {
     THTensor_(narrow)(inputWindow, input, 0, k*dW, kW);
     THTensor_(select)(gradOutputFrame, gradOutput, 0, k);

--- a/aten/src/THNN/generic/TemporalUpSamplingLinear.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingLinear.c
@@ -34,9 +34,9 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
     int outputWidth,
     bool align_corners){
 
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputWidth = THTensor_(size)(input, 2);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 2);
 
   THNN_(TemporalUpSamplingLinear_shapeCheck)
     (input, NULL,
@@ -45,8 +45,8 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   THTensor_(resize3d)(output,
-		      THTensor_(size)(input, 0),
-		      THTensor_(size)(input, 1),
+		      THTensor_(sizeLegacyNoScalars)(input, 0),
+		      THTensor_(sizeLegacyNoScalars)(input, 1),
 		      outputWidth);
   THTensor_(zero)(output);
   real *idata = THTensor_(data)(input);

--- a/aten/src/THNN/generic/TemporalUpSamplingNearest.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingNearest.c
@@ -30,16 +30,16 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
     THTensor *output,
     int outputWidth)
 {
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputWidth = THTensor_(size)(input, 2);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 2);
   const float scale = (float) inputWidth / (float)outputWidth;
 
   THNN_(TemporalUpSamplingNearest_shapeCheck)(input, NULL, nbatch, channels, inputWidth, outputWidth);
 
     THTensor_(resize3d)(output,
-			THTensor_(size)(input, 0),
-      THTensor_(size)(input, 1),
+			THTensor_(sizeLegacyNoScalars)(input, 0),
+      THTensor_(sizeLegacyNoScalars)(input, 1),
       outputWidth);
     channels = channels * nbatch;
 

--- a/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveAveragePooling.c
@@ -109,8 +109,8 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    istrideB = input->stride(0);
-    sizeB = input->size(0);
+    istrideB = THTensor_strideLegacyNoScalars(input, 0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimT++;
     dimH++;
@@ -118,15 +118,15 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeT = input->size(dimT);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeT = THTensor_sizeLegacyNoScalars(input, dimT);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
   /* strides */
-  istrideD = input->stride(dimD);
-  istrideT = input->stride(dimT);
-  istrideH = input->stride(dimH);
-  istrideW = input->stride(dimW);
+  istrideD = THTensor_strideLegacyNoScalars(input, dimD);
+  istrideT = THTensor_strideLegacyNoScalars(input, dimT);
+  istrideH = THTensor_strideLegacyNoScalars(input, dimH);
+  istrideW = THTensor_strideLegacyNoScalars(input, dimW);
 
   /* resize output */
   if (input->dim() == 4)
@@ -253,7 +253,7 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 5) {
-    sizeB = input->size(0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimT++;
     dimH++;
@@ -261,13 +261,13 @@ void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeT = input->size(dimT);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
-  osizeT = gradOutput->size(dimT);
-  osizeH = gradOutput->size(dimH);
-  osizeW = gradOutput->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeT = THTensor_sizeLegacyNoScalars(input, dimT);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
+  osizeT = THTensor_sizeLegacyNoScalars(gradOutput, dimT);
+  osizeH = THTensor_sizeLegacyNoScalars(gradOutput, dimH);
+  osizeW = THTensor_sizeLegacyNoScalars(gradOutput, dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -120,8 +120,8 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    istrideB = input->stride(0);
-    sizeB = input->size(0);
+    istrideB = THTensor_strideLegacyNoScalars(input, 0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimT++;
     dimH++;
@@ -129,15 +129,15 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeT = input->size(dimT);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeT = THTensor_sizeLegacyNoScalars(input, dimT);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
   /* strides */
-  istrideD = input->stride(dimD);
-  istrideT = input->stride(dimT);
-  istrideH = input->stride(dimH);
-  istrideW = input->stride(dimW);
+  istrideD = THTensor_strideLegacyNoScalars(input, dimD);
+  istrideT = THTensor_strideLegacyNoScalars(input, dimT);
+  istrideH = THTensor_strideLegacyNoScalars(input, dimH);
+  istrideW = THTensor_strideLegacyNoScalars(input, dimW);
 
   /* resize output */
   if (input->dim() == 4)
@@ -254,7 +254,7 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->dim() == 5) {
-    sizeB = input->size(0);
+    sizeB = THTensor_sizeLegacyNoScalars(input, 0);
     dimD++;
     dimT++;
     dimH++;
@@ -262,13 +262,13 @@ void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  sizeD  = input->size(dimD);
-  isizeT = input->size(dimT);
-  isizeH = input->size(dimH);
-  isizeW = input->size(dimW);
-  osizeT = gradOutput->size(dimT);
-  osizeH = gradOutput->size(dimH);
-  osizeW = gradOutput->size(dimW);
+  sizeD  = THTensor_sizeLegacyNoScalars(input, dimD);
+  isizeT = THTensor_sizeLegacyNoScalars(input, dimT);
+  isizeH = THTensor_sizeLegacyNoScalars(input, dimH);
+  isizeW = THTensor_sizeLegacyNoScalars(input, dimW);
+  osizeT = THTensor_sizeLegacyNoScalars(gradOutput, dimT);
+  osizeH = THTensor_sizeLegacyNoScalars(gradOutput, dimH);
+  osizeW = THTensor_sizeLegacyNoScalars(gradOutput, dimW);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -47,11 +47,11 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   THNN_ARGCHECK(!input->is_empty() && (input->dim() == 4 || input->dim() == 5), 2, input,
                 "non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  THArgCheck(input->size(dimw) >= kW && input->size(dimh) >= kH
-             && input->size(dimt) >= kT, 2,
+  THArgCheck(THTensor_sizeLegacyNoScalars(input, dimw) >= kW && THTensor_sizeLegacyNoScalars(input, dimh) >= kH
+             && THTensor_sizeLegacyNoScalars(input, dimt) >= kT, 2,
              "input image (T: %d H: %d W: %d) smaller than "
              "kernel size (kT: %d kH: %d kW: %d)",
-             input->size(dimt), input->size(dimh), input->size(dimw),
+             THTensor_sizeLegacyNoScalars(input, dimt), THTensor_sizeLegacyNoScalars(input, dimh), THTensor_sizeLegacyNoScalars(input, dimw),
              kT, kH, kW);
 
   // The second argument is argNumber... here is the index of padH.
@@ -61,10 +61,10 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
             padT, padW, padH, kT, kW, kH);
 
   /* sizes */
-  nslices = input->size(dimN);
-  itime   = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth  = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime   = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth  = THTensor_sizeLegacyNoScalars(input, dimw);
 
   if (ceil_mode) {
     otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
@@ -231,10 +231,10 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   }
 
   /* sizes */
-  nslices = input->size(dimN);
-  itime   = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth  = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime   = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth  = THTensor_sizeLegacyNoScalars(input, dimw);
   if (ceil_mode)
   {
     otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
@@ -283,7 +283,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   else  /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;
@@ -445,13 +445,13 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   }
 
   /* sizes */
-  nslices = input->size(dimN);
-  itime = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
-  otime = gradOutput->size(dimt);
-  oheight = gradOutput->size(dimh);
-  owidth = gradOutput->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  otime = THTensor_sizeLegacyNoScalars(gradOutput, dimt);
+  oheight = THTensor_sizeLegacyNoScalars(gradOutput, dimh);
+  owidth = THTensor_sizeLegacyNoScalars(gradOutput, dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -473,7 +473,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;

--- a/aten/src/THNN/generic/VolumetricConvolution.c
+++ b/aten/src/THNN/generic/VolumetricConvolution.c
@@ -33,13 +33,13 @@ void THNN_(VolumetricConvolution_updateOutput)(
     dimw++;
   }
 
-  int64_t nOutputPlane = weight->size(0);
-  int64_t kT           = weight->size(2);
-  int64_t kH           = weight->size(3);
-  int64_t kW           = weight->size(4);
-  int64_t inputDepth   = input->size(dimt);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
+  int64_t kT           = THTensor_sizeLegacyNoScalars(weight, 2);
+  int64_t kH           = THTensor_sizeLegacyNoScalars(weight, 3);
+  int64_t kW           = THTensor_sizeLegacyNoScalars(weight, 4);
+  int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, dimt);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputDepth  = (inputDepth - kT) / dT + 1;
   int64_t outputWidth  = (inputWidth - kW) / dW + 1;
   int64_t outputHeight = (inputHeight - kH) / dH + 1;
@@ -51,7 +51,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
     /* add bias */
     if (bias) {
-      for (i = 0; i < bias->size(0); i++)
+      for (i = 0; i < THTensor_sizeLegacyNoScalars(bias, 0); i++)
       {
         THTensor_(select)(outn, output, 0, i);
         THTensor_(fill)(outn, THTensor_(get1d)(bias, i));
@@ -65,7 +65,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = input->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(input, 0);
     THTensor_(resize5d)(output, nBatch, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor *inb = THTensor_(new)();
     THTensor *outb = THTensor_(new)();
@@ -78,7 +78,7 @@ void THNN_(VolumetricConvolution_updateOutput)(
 
       /* add bias */
       if (bias) {
-        for (i = 0; i < bias->size(0); i++)
+        for (i = 0; i < THTensor_sizeLegacyNoScalars(bias, 0); i++)
         {
           THTensor_(select)(outn, outb, 0, i);
           THTensor_(fill)(outn, THTensor_(get1d)(bias, i));
@@ -117,7 +117,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for weight, but got: %s");
 
-  int nOutputPlane = (int)weight->size(0);
+  int nOutputPlane = (int)THTensor_sizeLegacyNoScalars(weight, 0);
 
   THNN_ARGCHECK(!gradOutput->is_empty() && (gradOutput->dim() == 4 || gradOutput->dim() == 5), 3,
 		gradOutput,
@@ -129,7 +129,7 @@ void THNN_(VolumetricConvolution_updateGradInput)(
     dimPlane++;
   }
 
-  THArgCheck(nOutputPlane == gradOutput->size(dimPlane), 1,
+  THArgCheck(nOutputPlane == THTensor_sizeLegacyNoScalars(gradOutput, dimPlane), 1,
     "Number of output features is not equal to nOutputPlane"
   );
 
@@ -141,13 +141,13 @@ void THNN_(VolumetricConvolution_updateGradInput)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = gradOutput->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(gradOutput, 0);
     THTensor *ginpb = THTensor_(new)();
     THTensor *goutb = THTensor_(new)();
     int64_t j;
 
     THTensor_(resize5d)(gradInput,
-      input->size(0), input->size(1), input->size(2), input->size(3), input->size(4)
+      THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3), THTensor_sizeLegacyNoScalars(input, 4)
     );
 
     /* loop over batches */
@@ -187,9 +187,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
 		"non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
 		"expected for gradWeight, but got: %s");
 
-  int nOutputPlane = (int)gradWeight->size(0);
+  int nOutputPlane = (int)THTensor_sizeLegacyNoScalars(gradWeight, 0);
   if (gradBias) {
-    THArgCheck(!gradBias->is_empty() && gradBias->dim() == 1 && gradBias->size(0) == nOutputPlane, 5,
+    THArgCheck(!gradBias->is_empty() && gradBias->dim() == 1 && THTensor_sizeLegacyNoScalars(gradBias, 0) == nOutputPlane, 5,
       "gradBias tensor has wrong size"
     );
   }
@@ -203,7 +203,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
     dimPlane++;
   }
 
-  THArgCheck(nOutputPlane == gradOutput->size(dimPlane), 1,
+  THArgCheck(nOutputPlane == THTensor_sizeLegacyNoScalars(gradOutput, dimPlane), 1,
     "Number of output features is not equal to nOutputPlane"
   );
 
@@ -226,7 +226,7 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   }
   else /* batch mode */
   {
-    int64_t nBatch = gradOutput->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(gradOutput, 0);
     THTensor *inpb = THTensor_(new)();
     THTensor *goutb = THTensor_(new)();
     int64_t j;

--- a/aten/src/THNN/generic/VolumetricDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricDilatedConvolution.c
@@ -26,7 +26,7 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
                   "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -46,9 +46,9 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
-  int64_t inputDepth  = input->size(dimd);
-  int64_t inputHeight  = input->size(dimh);
-  int64_t inputWidth   = input->size(dimw);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, dimd);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
   int64_t outputDepth  = div_rtn<int64_t>(inputDepth  + 2*padT - (dilationT * (kT - 1) + 1), dT) + 1;
   int64_t outputHeight = div_rtn<int64_t>(inputHeight + 2*padH - (dilationH * (kH - 1) + 1), dH) + 1;
   int64_t outputWidth  = div_rtn<int64_t>(inputWidth  + 2*padW - (dilationW * (kW - 1) + 1), dW) + 1;
@@ -60,16 +60,16 @@ static inline void THNN_(VolumetricDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    int64_t nInputPlane = weight->size(1);
+    int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      int64_t nOutputPlane = weight->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = bias->size(0);
+      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimd, outputDepth);
@@ -97,8 +97,8 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
         dilationT, dilationH, dilationW, 0);
 
   // Params:
-  int64_t nInputPlane = weight->size(1);
-  int64_t nOutputPlane = weight->size(0);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -111,18 +111,18 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
   }
 
-  int64_t inputDepth  = input->size(2);
-  int64_t inputHeight  = input->size(3);
-  int64_t inputWidth   = input->size(4);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
   int64_t outputDepth  = (inputDepth  + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
   int64_t outputWidth  = (inputWidth  + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize5d)(output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -135,7 +135,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
   if (ones->dim() != 3 ||
-      ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+      THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -184,7 +184,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nOutputPlane;
-    int64_t n = columns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
     int64_t k = nInputPlane*kT*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -232,8 +232,8 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
         dilationT, dilationH, dilationW, 0);
 
   // Params
-  int64_t nInputPlane = weight->size(1);
-  int64_t nOutputPlane = weight->size(0);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -244,19 +244,19 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THTensor_(resize5d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t inputDepth  = input->size(2);
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize5d)(gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -277,7 +277,7 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     int64_t m = nInputPlane*kT*kW*kH;
-    int64_t n = gradColumns->size(1);
+    int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
     int64_t k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
@@ -354,24 +354,24 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   if (input->dim() == 4) {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THTensor_(resize5d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  int64_t nInputPlane = input->size(1);
-  int64_t nOutputPlane = gradOutput->size(1);
-  int64_t inputDepth  = input->size(2);
-  int64_t inputWidth   = input->size(4);
-  int64_t inputHeight  = input->size(3);
+  int64_t nInputPlane = THTensor_sizeLegacyNoScalars(input, 1);
+  int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(gradOutput, 1);
+  int64_t inputDepth  = THTensor_sizeLegacyNoScalars(input, 2);
+  int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
   int64_t outputDepth  = (inputDepth + 2*padT - (dilationT * (kT - 1) + 1)) / dT + 1;
   int64_t outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   int64_t outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   // Batch size + input planes
-  int64_t batchSize = input->size(0);
+  int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth) {
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
     THTensor_(fill)(ones, 1);
@@ -407,7 +407,7 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
       // M,N,K are dims of matrix A and B
       int64_t m = nOutputPlane;
       int64_t n = nInputPlane*kT*kW*kH;
-      int64_t k = columns->size(1);
+      int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -51,10 +51,10 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "kT: %d kW: %d, kH: %d, padT: %d, padW: %d, padH: %d",
              kT, kW, kH, pT, pW, pH);
 
-  nslices = input->size(dimN);
-  itime   = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth  = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime   = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth  = THTensor_sizeLegacyNoScalars(input, dimw);
   if (ceilMode)
   {
     otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
@@ -241,10 +241,10 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
         ceilMode);
 
   /* sizes */
-  nslices = input->size(dimN);
-  itime   = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth  = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime   = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth  = THTensor_sizeLegacyNoScalars(input, dimw);
   if (ceilMode)
   {
     otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
@@ -298,7 +298,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;
@@ -444,13 +444,13 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  nslices = input->size(dimN);
-  itime = input->size(dimt);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
-  otime = gradOutput->size(dimt);
-  oheight = gradOutput->size(dimh);
-  owidth = gradOutput->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimN);
+  itime = THTensor_sizeLegacyNoScalars(input, dimt);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
+  otime = THTensor_sizeLegacyNoScalars(gradOutput, dimt);
+  oheight = THTensor_sizeLegacyNoScalars(gradOutput, dimh);
+  owidth = THTensor_sizeLegacyNoScalars(gradOutput, dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -474,7 +474,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   else /* batch mode */
   {
     int64_t p;
-    int64_t nBatch = input->size(0);
+    int64_t nBatch = THTensor_sizeLegacyNoScalars(input, 0);
 
     int64_t istride = nslices * itime * iwidth * iheight;
     int64_t ostride = nslices * otime * owidth * oheight;

--- a/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricFractionalMaxPooling.c
@@ -119,7 +119,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
 		"non-empty 4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 5) {
-    numBatch = THTensor_(size)(input, 0);
+    numBatch = THTensor_(sizeLegacyNoScalars)(input, 0);
     planeDim++;
     heightDim++;
     widthDim++;
@@ -127,10 +127,10 @@ void THNN_(VolumetricFractionalMaxPooling_updateOutput)(
   }
 
   /* sizes */
-  int64_t numPlanes = THTensor_(size)(input, planeDim);
-  int64_t inputH = THTensor_(size)(input, heightDim);
-  int64_t inputW = THTensor_(size)(input, widthDim);
-  int64_t inputT = THTensor_(size)(input, timeDim);
+  int64_t numPlanes = THTensor_(sizeLegacyNoScalars)(input, planeDim);
+  int64_t inputH = THTensor_(sizeLegacyNoScalars)(input, heightDim);
+  int64_t inputW = THTensor_(sizeLegacyNoScalars)(input, widthDim);
+  int64_t inputT = THTensor_(sizeLegacyNoScalars)(input, timeDim);
 
   THArgCheck(outputH + poolSizeH - 1 < inputH, 9,
              "poolSizeH (%d) too large relative to input height (%d)",
@@ -226,7 +226,7 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
 
   int64_t numInputDims = THTensor_(nDimensionLegacyNoScalars)(input);
   if (numInputDims == 5) {
-    numBatch = THTensor_(size)(input, 0);
+    numBatch = THTensor_(sizeLegacyNoScalars)(input, 0);
     planeDim = 1;
     heightDim++;
     widthDim++;
@@ -234,16 +234,16 @@ void THNN_(VolumetricFractionalMaxPooling_updateGradInput)(
   }
 
   /* sizes */
-  int64_t numPlanes = THTensor_(size)(input, planeDim);
-  int64_t inputH = THTensor_(size)(input, heightDim);
-  int64_t inputW = THTensor_(size)(input, widthDim);
-  int64_t inputT = THTensor_(size)(input, timeDim);
+  int64_t numPlanes = THTensor_(sizeLegacyNoScalars)(input, planeDim);
+  int64_t inputH = THTensor_(sizeLegacyNoScalars)(input, heightDim);
+  int64_t inputW = THTensor_(sizeLegacyNoScalars)(input, widthDim);
+  int64_t inputT = THTensor_(sizeLegacyNoScalars)(input, timeDim);
 
-  THArgCheck(outputT == THTensor_(size)(gradOutput, timeDim), 3,
+  THArgCheck(outputT == THTensor_(sizeLegacyNoScalars)(gradOutput, timeDim), 3,
              "gradOutput time unexpected");
-  THArgCheck(outputW == THTensor_(size)(gradOutput, widthDim), 3,
+  THArgCheck(outputW == THTensor_(sizeLegacyNoScalars)(gradOutput, widthDim), 3,
              "gradOutput width unexpected");
-  THArgCheck(outputH == THTensor_(size)(gradOutput, heightDim), 3,
+  THArgCheck(outputH == THTensor_(sizeLegacyNoScalars)(gradOutput, heightDim), 3,
              "gradOutput height unexpected");
 
   /* get contiguous gradOutput */

--- a/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricFullDilatedConvolution.c
@@ -112,7 +112,7 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                   "non-empty 5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
                   "expected for weight, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(1));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, THTensor_sizeLegacyNoScalars(weight, 1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");
@@ -132,13 +132,13 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
   }
 
   if (weight != NULL) {
-    const int64_t nInputPlane = weight->size(0);
+    const int64_t nInputPlane = THTensor_sizeLegacyNoScalars(weight, 0);
     THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
 
-  const int64_t inputWidth   = input->size(dimw);
-  const int64_t inputHeight  = input->size(dimh);
-  const int64_t inputDepth   = input->size(dimd);
+  const int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, dimw);
+  const int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, dimh);
+  const int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, dimd);
   const int64_t outputDepth  = (inputDepth - 1) * dT - 2*pT + (dilationT * (kT - 1) + 1) + aT;
   const int64_t outputHeight = (inputHeight - 1) * dH - 2*pH + (dilationH * (kH - 1) + 1) + aH;
   const int64_t outputWidth  = (inputWidth - 1) * dW - 2*pW + (dilationW * (kW - 1) + 1) + aW;
@@ -151,10 +151,10 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
 
   if (gradOutput != NULL) {
     if (weight != NULL) {
-      const int64_t nOutputPlane = weight->size(1);
+      const int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      const int64_t nOutputPlane = bias->size(0);
+      const int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
       THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
     }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimd, outputDepth);
@@ -184,8 +184,8 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
         input, NULL, weight, bias, kT, kW, kH,
         dT, dW, dH, pT, pW, pH, dilationT, dilationW, dilationH, aT, aW, aH, 0);
 
-  const int nInputPlane  = (int)weight->size(0);
-  const int nOutputPlane = (int)weight->size(1);
+  const int nInputPlane  = (int)THTensor_sizeLegacyNoScalars(weight, 0);
+  const int nOutputPlane = (int)THTensor_sizeLegacyNoScalars(weight, 1);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -195,18 +195,18 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
   }
 
-  const int64_t inputWidth   = input->size(4);
-  const int64_t inputHeight  = input->size(3);
-  const int64_t inputDepth   = input->size(2);
+  const int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  const int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  const int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 2);
   const int64_t outputDepth  = (inputDepth - 1) * dT - 2*pT + (dilationT * (kT - 1) + 1) + aT;
   const int64_t outputHeight = (inputHeight - 1) * dH - 2*pH + (dilationH * (kH - 1) + 1) + aH;
   const int64_t outputWidth  = (inputWidth - 1) * dW - 2*pW + (dilationW * (kW - 1) + 1) + aW;
 
   // Batch size + input planes
-  const int64_t batchSize = input->size(0);
+  const int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize5d)(output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
@@ -218,7 +218,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -239,9 +239,9 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    const int64_t m = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
-    const int64_t n = columns->size(1);
-    const int64_t k = weight->size(0);
+    const int64_t m = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4);
+    const int64_t n = THTensor_sizeLegacyNoScalars(columns, 1);
+    const int64_t k = THTensor_sizeLegacyNoScalars(weight, 0);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -324,8 +324,8 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
         input, gradOutput, weight, NULL, kT, kW, kH,
         dT, dW, dH, pT, pW, pH, dilationT, dilationW, dilationH, aT, aW, aH, 0);
 
-  const int64_t nInputPlane  = weight->size(0);
-  const int64_t nOutputPlane = weight->size(1);
+  const int64_t nInputPlane  = THTensor_sizeLegacyNoScalars(weight, 0);
+  const int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(weight, 1);
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
@@ -336,19 +336,19 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THTensor_(resize5d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  const int64_t inputWidth   = input->size(4);
-  const int64_t inputHeight  = input->size(3);
-  const int64_t inputDepth   = input->size(2);
+  const int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  const int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  const int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 2);
   const int64_t outputDepth  = (inputDepth - 1) * dT - 2*pT + (dilationT * (kT - 1) + 1) + aT;
   const int64_t outputHeight = (inputHeight - 1) * dH - 2*pH + (dilationH * (kH - 1) + 1) + aH;
   const int64_t outputWidth  = (inputWidth - 1) * dW - 2*pW + (dilationW * (kW - 1) + 1) + aW;
 
   // Batch size + input planes
-  const int64_t batchSize = input->size(0);
+  const int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Resize output
   THTensor_(resize5d)(gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -383,9 +383,9 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
 
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    const int64_t m = weight->size(0);
-    const int64_t n = gradColumns->size(1);
-    const int64_t k = weight->size(1) * weight->size(2) * weight->size(3) * weight->size(4);
+    const int64_t m = THTensor_sizeLegacyNoScalars(weight, 0);
+    const int64_t n = THTensor_sizeLegacyNoScalars(gradColumns, 1);
+    const int64_t k = THTensor_sizeLegacyNoScalars(weight, 1) * THTensor_sizeLegacyNoScalars(weight, 2) * THTensor_sizeLegacyNoScalars(weight, 3) * THTensor_sizeLegacyNoScalars(weight, 4);
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THBlas_(gemm)(
@@ -439,9 +439,9 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
 
   int64_t nOutputPlane;
   if (gradWeight) {
-    nOutputPlane = THTensor_(size)(gradWeight, 1);
+    nOutputPlane = THTensor_(sizeLegacyNoScalars)(gradWeight, 1);
   } else if (gradBias) {
-    nOutputPlane = THTensor_(size)(gradBias, 0);
+    nOutputPlane = THTensor_(sizeLegacyNoScalars)(gradBias, 0);
   } else {
     return;
   }
@@ -464,22 +464,22 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   {
     // Force batch
     is_batch = 0;
-    THTensor_(resize5d)(input, 1, input->size(0), input->size(1), input->size(2), input->size(3));
-    THTensor_(resize5d)(gradOutput, 1, gradOutput->size(0), gradOutput->size(1), gradOutput->size(2), gradOutput->size(3));
+    THTensor_(resize5d)(input, 1, THTensor_sizeLegacyNoScalars(input, 0), THTensor_sizeLegacyNoScalars(input, 1), THTensor_sizeLegacyNoScalars(input, 2), THTensor_sizeLegacyNoScalars(input, 3));
+    THTensor_(resize5d)(gradOutput, 1, THTensor_sizeLegacyNoScalars(gradOutput, 0), THTensor_sizeLegacyNoScalars(gradOutput, 1), THTensor_sizeLegacyNoScalars(gradOutput, 2), THTensor_sizeLegacyNoScalars(gradOutput, 3));
   }
 
-  const int64_t inputWidth   = input->size(4);
-  const int64_t inputHeight  = input->size(3);
-  const int64_t inputDepth   = input->size(2);
+  const int64_t inputWidth   = THTensor_sizeLegacyNoScalars(input, 4);
+  const int64_t inputHeight  = THTensor_sizeLegacyNoScalars(input, 3);
+  const int64_t inputDepth   = THTensor_sizeLegacyNoScalars(input, 2);
   const int64_t outputDepth  = (inputDepth - 1) * dT - 2*pT + (dilationT * (kT - 1) + 1) + aT;
   const int64_t outputHeight = (inputHeight - 1) * dH - 2*pH + (dilationH * (kH - 1) + 1) + aH;
   const int64_t outputWidth  = (inputWidth - 1) * dW - 2*pW + (dilationW * (kW - 1) + 1) + aW;
 
   // Batch size + input planes
-  const int64_t batchSize = input->size(0);
+  const int64_t batchSize = THTensor_sizeLegacyNoScalars(input, 0);
 
   // Define a buffer of ones, for bias accumulation
-  if (ones->dim() != 3 || ones->size(0)*ones->size(1)*ones->size(2) < outputDepth*outputHeight*outputWidth)
+  if (ones->dim() != 3 || THTensor_sizeLegacyNoScalars(ones, 0)*THTensor_sizeLegacyNoScalars(ones, 1)*THTensor_sizeLegacyNoScalars(ones, 2) < outputDepth*outputHeight*outputWidth)
   {
     // Resize plane and fill with ones...
     THTensor_(resize3d)(ones, outputDepth, outputHeight, outputWidth);
@@ -519,9 +519,9 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
 
       // M,N,K are dims of matrix A and B
       // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-      const int64_t n = columns->size(0);   // nOutputPlane * kt * kh * kw
-      const int64_t m = input_n->size(0);   // nInputPlane
-      const int64_t k = columns->size(1);   // inputHeight * inputWidth
+      const int64_t n = THTensor_sizeLegacyNoScalars(columns, 0);   // nOutputPlane * kt * kh * kw
+      const int64_t m = THTensor_sizeLegacyNoScalars(input_n, 0);   // nInputPlane
+      const int64_t k = THTensor_sizeLegacyNoScalars(columns, 1);   // inputHeight * inputWidth
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
       THBlas_(gemm)(
@@ -563,7 +563,7 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   if (is_batch == 0)
   {
     THTensor_(resize4d)(gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
-    THTensor_(resize4d)(input, input->size(1), inputDepth, inputHeight, inputWidth);
+    THTensor_(resize4d)(input, THTensor_sizeLegacyNoScalars(input, 1), inputDepth, inputHeight, inputWidth);
   }
 
   THTensor_(free)(input);

--- a/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/VolumetricGridSamplerBilinear.c
@@ -17,11 +17,11 @@ static inline void THNN_(VolumetricGridSamplerBilinear_shapeCheck)
   THNN_ARGCHECK(!grid->is_empty() && grid->dim() == 5, 2, grid,
     "non-empty 5D grid tensor expected but got: %s");
 
-  int nbatch   = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int odepth    = THTensor_(size)(grid, 1);
-  int oheight   = THTensor_(size)(grid, 2);
-  int owidth    = THTensor_(size)(grid, 3);
+  int nbatch   = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int odepth    = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int oheight   = THTensor_(sizeLegacyNoScalars)(grid, 2);
+  int owidth    = THTensor_(sizeLegacyNoScalars)(grid, 3);
 
   THNN_CHECK_DIM_SIZE(grid, 5, 0, nbatch);
   THNN_CHECK_DIM_SIZE(grid, 5, 4, 3);
@@ -49,14 +49,14 @@ TH_API void THNN_(VolumetricGridSamplerBilinear_updateOutput)(
     int padding_mode) {
 
   THNN_(VolumetricGridSamplerBilinear_shapeCheck)(input, grid, NULL);
-  int N = THTensor_(size)(input, 0);
-  int C = THTensor_(size)(input, 1);
-  int ID = THTensor_(size)(input, 2);
-  int IH = THTensor_(size)(input, 3);
-  int IW = THTensor_(size)(input, 4);
-  int D = THTensor_(size)(grid, 1);
-  int H = THTensor_(size)(grid, 2);
-  int W = THTensor_(size)(grid, 3);
+  int N = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int C = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int ID = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int IH = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int IW = THTensor_(sizeLegacyNoScalars)(input, 4);
+  int D = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int H = THTensor_(sizeLegacyNoScalars)(grid, 2);
+  int W = THTensor_(sizeLegacyNoScalars)(grid, 3);
 
   // resize output to the same shape as input
   THTensor_(resize5d)(output, N, C, D, H, W);
@@ -189,14 +189,14 @@ TH_API void THNN_(VolumetricGridSamplerBilinear_updateGradInput)(
     int padding_mode) {
 
   THNN_(VolumetricGridSamplerBilinear_shapeCheck)(input, grid, gradOutput);
-  int N = THTensor_(size)(input, 0);
-  int C = THTensor_(size)(input, 1);
-  int ID = THTensor_(size)(input, 2);
-  int IH = THTensor_(size)(input, 3);
-  int IW = THTensor_(size)(input, 4);
-  int D = THTensor_(size)(grid, 1);
-  int H = THTensor_(size)(grid, 2);
-  int W = THTensor_(size)(grid, 3);
+  int N = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int C = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int ID = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int IH = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int IW = THTensor_(sizeLegacyNoScalars)(input, 4);
+  int D = THTensor_(sizeLegacyNoScalars)(grid, 1);
+  int H = THTensor_(sizeLegacyNoScalars)(grid, 2);
+  int W = THTensor_(sizeLegacyNoScalars)(grid, 3);
 
   THTensor_(resize5d)(gradInput, N, C, ID, IH, IW);
   THTensor_(resize5d)(gradGrid, N, D, H, W, 3);

--- a/aten/src/THNN/generic/VolumetricMaxUnpooling.c
+++ b/aten/src/THNN/generic/VolumetricMaxUnpooling.c
@@ -38,14 +38,14 @@ static inline void THNN_(VolumetricMaxUnpooling_shapeCheck)(
     dimh++;
     dimn++;
   }
-  int nslices = input->size(dimn);
+  int nslices = THTensor_sizeLegacyNoScalars(input, dimn);
 
   if (gradOutput != NULL) {
-    if (oT != gradOutput->size(dimt) || oW != gradOutput->size(dimw) || oH != gradOutput->size(dimh))
+    if (oT != THTensor_sizeLegacyNoScalars(gradOutput, dimt) || oW != THTensor_sizeLegacyNoScalars(gradOutput, dimw) || oH != THTensor_sizeLegacyNoScalars(gradOutput, dimh))
     {
       THError(
         "Inconsistent gradOutput size. oT= %d, oH= %d, oW= %d, gradOutput: %dx%dx%d",
-        oT, oH, oW, gradOutput->size(dimt), gradOutput->size(dimh), gradOutput->size(dimw)
+        oT, oH, oW, THTensor_sizeLegacyNoScalars(gradOutput, dimt), THTensor_sizeLegacyNoScalars(gradOutput, dimh), THTensor_sizeLegacyNoScalars(gradOutput, dimw)
       );
     }
 
@@ -140,17 +140,17 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimt++;
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size(dimt-1);
-  iT = input->size(dimt);
-  iH = input->size(dimh);
-  iW = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimt-1);
+  iT = THTensor_sizeLegacyNoScalars(input, dimt);
+  iH = THTensor_sizeLegacyNoScalars(input, dimh);
+  iW = THTensor_sizeLegacyNoScalars(input, dimw);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
@@ -287,17 +287,17 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimt++;
     dimw++;
     dimh++;
   }
 
   /* sizes */
-  nslices = input->size(dimt-1);
-  iT = input->size(dimt);
-  iH = input->size(dimh);
-  iW = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimt-1);
+  iT = THTensor_sizeLegacyNoScalars(input, dimt);
+  iH = THTensor_sizeLegacyNoScalars(input, dimh);
+  iW = THTensor_sizeLegacyNoScalars(input, dimw);
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/VolumetricReplicationPadding.c
+++ b/aten/src/THNN/generic/VolumetricReplicationPadding.c
@@ -33,10 +33,10 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  idepth = input->size(dimd);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  idepth = THTensor_sizeLegacyNoScalars(input, dimd);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;
@@ -47,18 +47,18 @@ static inline void THNN_(VolumetricReplicationPadding_shapeCheck)(
              idepth, iheight, iwidth, odepth, oheight, owidth);
 
   if (gradOutput != NULL) {
-    THArgCheck(nslices == THTensor_(size)(gradOutput, dimslices), 3,
+    THArgCheck(nslices == THTensor_(sizeLegacyNoScalars)(gradOutput, dimslices), 3,
                "gradOutput width unexpected. Expected: %d, Got: %d",
-               nslices, THTensor_(size)(gradOutput, dimslices));
-    THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
+               nslices, THTensor_(sizeLegacyNoScalars)(gradOutput, dimslices));
+    THArgCheck(owidth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimw), 3,
                "gradOutput width unexpected. Expected: %d, Got: %d",
-               owidth, THTensor_(size)(gradOutput, dimw));
-    THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
+               owidth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimw));
+    THArgCheck(oheight == THTensor_(sizeLegacyNoScalars)(gradOutput, dimh), 3,
                "gradOutput height unexpected. Expected: %d, Got: %d",
-               oheight, THTensor_(size)(gradOutput, dimh));
-    THArgCheck(odepth == THTensor_(size)(gradOutput, dimd), 3,
+               oheight, THTensor_(sizeLegacyNoScalars)(gradOutput, dimh));
+    THArgCheck(odepth == THTensor_(sizeLegacyNoScalars)(gradOutput, dimd), 3,
                "gradOutput depth unexpected. Expected: %d, Got: %d",
-               odepth, THTensor_(size)(gradOutput, dimd));
+               odepth, THTensor_(sizeLegacyNoScalars)(gradOutput, dimd));
   }
 }
 
@@ -151,7 +151,7 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
 
   if (input->dim() == 5)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimd++;
@@ -159,10 +159,10 @@ THNN_(VolumetricReplicationPadding_shapeCheck)(
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  idepth = input->size(dimd);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  idepth = THTensor_sizeLegacyNoScalars(input, dimd);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;
@@ -295,7 +295,7 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
 
   if (input->dim() == 5)
   {
-    nbatch = input->size(0);
+    nbatch = THTensor_sizeLegacyNoScalars(input, 0);
     dimw++;
     dimh++;
     dimd++;
@@ -303,10 +303,10 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
   }
 
   /* sizes */
-  nslices = input->size(dimslices);
-  idepth = input->size(dimd);
-  iheight = input->size(dimh);
-  iwidth = input->size(dimw);
+  nslices = THTensor_sizeLegacyNoScalars(input, dimslices);
+  idepth = THTensor_sizeLegacyNoScalars(input, dimd);
+  iheight = THTensor_sizeLegacyNoScalars(input, dimh);
+  iwidth = THTensor_sizeLegacyNoScalars(input, dimw);
   odepth = idepth + pfront + pback;
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;

--- a/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingNearest.c
@@ -37,11 +37,11 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
     int outputHeight,
     int outputWidth)
 {
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputDepth = THTensor_(size)(input, 2);
-  int inputHeight = THTensor_(size)(input, 3);
-  int inputWidth = THTensor_(size)(input, 4);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputDepth = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int inputHeight = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 4);
   const float depth_scale = (float) inputDepth / (float) outputDepth;
   const float height_scale = (float) inputHeight / (float)outputHeight;
   const float width_scale = (float) inputWidth / (float)outputWidth;
@@ -49,8 +49,8 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   THNN_(VolumetricUpSamplingNearest_shapeCheck)(input, NULL, nbatch, channels, inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
 
   THTensor_(resize5d)(output,
-                      THTensor_(size)(input, 0),
-                      THTensor_(size)(input, 1),
+                      THTensor_(sizeLegacyNoScalars)(input, 0),
+                      THTensor_(sizeLegacyNoScalars)(input, 1),
                       outputDepth,
                       outputHeight,
                       outputWidth);

--- a/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
+++ b/aten/src/THNN/generic/VolumetricUpSamplingTrilinear.c
@@ -40,11 +40,11 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
     int outputWidth,
     bool align_corners){
 
-  int nbatch = THTensor_(size)(input, 0);
-  int channels = THTensor_(size)(input, 1);
-  int inputDepth = THTensor_(size)(input, 2);
-  int inputHeight = THTensor_(size)(input, 3);
-  int inputWidth = THTensor_(size)(input, 4);
+  int nbatch = THTensor_(sizeLegacyNoScalars)(input, 0);
+  int channels = THTensor_(sizeLegacyNoScalars)(input, 1);
+  int inputDepth = THTensor_(sizeLegacyNoScalars)(input, 2);
+  int inputHeight = THTensor_(sizeLegacyNoScalars)(input, 3);
+  int inputWidth = THTensor_(sizeLegacyNoScalars)(input, 4);
 
   THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
     (input, NULL,
@@ -54,8 +54,8 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   THTensor_(resize5d)(output,
-		      THTensor_(size)(input, 0),
-		      THTensor_(size)(input, 1),
+		      THTensor_(sizeLegacyNoScalars)(input, 0),
+		      THTensor_(sizeLegacyNoScalars)(input, 1),
 		      outputDepth, outputHeight, outputWidth);
   THTensor_(zero)(output);
   real *idata = THTensor_(data)(input);

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -45,7 +45,7 @@
 
 #define THNN_CHECK_DIM_SIZE(T, DIM, DIM_SIZE, SIZE)			\
   if (THTensor_(nDimensionLegacyNoScalars)(T) != DIM ||				\
-      THTensor_(size)(T, DIM_SIZE) != SIZE) {				\
+      THTensor_(sizeLegacyNoScalars)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
 	      " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \
@@ -53,7 +53,7 @@
 
 #define THNN_CHECK_DIM_SIZE_INDICES(T, DIM, DIM_SIZE, SIZE)			\
   if (THIndexTensor_(nDimensionLegacyNoScalars)(T) != DIM ||				\
-      THIndexTensor_(size)(T, DIM_SIZE) != SIZE) {				\
+      THIndexTensor_(sizeLegacyNoScalars)(T, DIM_SIZE) != SIZE) {				\
       THDescBuff s1 = THIndexTensor_(sizeDesc)(T);				\
       THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
         " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -41,13 +41,13 @@ int THDTensor_(nDimensionLegacyNoScalars)(const THDTensor *self) {
   return self->nDimension;
 }
 
-int64_t THDTensor_(size)(const THDTensor *self, int dim) {
+int64_t THDTensor_(sizeLegacyNoScalars)(const THDTensor *self, int dim) {
   THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "dimension %d out of range of %dD tensor",
       dim+1, THDTensor_(nDimensionLegacyNoScalars)(self));
   return self->size[dim];
 }
 
-int64_t THDTensor_(stride)(const THDTensor *self, int dim) {
+int64_t THDTensor_(strideLegacyNoScalars)(const THDTensor *self, int dim) {
   THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "dimension %d out of range of %dD tensor", dim+1,
       THDTensor_(nDimensionLegacyNoScalars)(self));
   return self->stride[dim];

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.h
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.h
@@ -24,8 +24,8 @@ THD_API THDDescBuff THDTensor_(sizeDesc)(const THDTensor *tensor);
 THD_API THDStorage* THDTensor_(storage)(const THDTensor *self);
 THD_API ptrdiff_t THDTensor_(storageOffset)(const THDTensor *self);
 THD_API int THDTensor_(nDimensionLegacyNoScalars)(const THDTensor *self);
-THD_API int64_t THDTensor_(size)(const THDTensor *self, int dim);
-THD_API int64_t THDTensor_(stride)(const THDTensor *self, int dim);
+THD_API int64_t THDTensor_(sizeLegacyNoScalars)(const THDTensor *self, int dim);
+THD_API int64_t THDTensor_(strideLegacyNoScalars)(const THDTensor *self, int dim);
 THD_API THLongStorage *THDTensor_(newSizeOf)(THDTensor *self);
 THD_API THLongStorage *THDTensor_(newStrideOf)(THDTensor *self);
 

--- a/torch/lib/THD/master_worker/master/generic/THDTensorMath.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensorMath.cpp
@@ -319,7 +319,7 @@ void THDTensor_(diag)(THDTensor *r_, THDTensor *t, int k) {
       1, "matrix or a vector expected");
 
   if (THDTensor_(nDimensionLegacyNoScalars)(t) == 1) {
-    int64_t t_size = THDTensor_(size)(t, 0);
+    int64_t t_size = THDTensor_(sizeLegacyNoScalars)(t, 0);
     int64_t sz = t_size + (k >= 0 ? k : -k);
 
     THDTensor_(resize2d)(r_, sz, sz);
@@ -327,9 +327,9 @@ void THDTensor_(diag)(THDTensor *r_, THDTensor *t, int k) {
   } else {
     int64_t sz;
     if (k >= 0)
-      sz = std::min(THDTensor_(size)(t, 0), THDTensor_(size)(t, 1)-k);
+      sz = std::min(THDTensor_(sizeLegacyNoScalars)(t, 0), THDTensor_(sizeLegacyNoScalars)(t, 1)-k);
     else
-      sz = std::min(THDTensor_(size)(t, 0)+k, THDTensor_(size)(t, 1));
+      sz = std::min(THDTensor_(sizeLegacyNoScalars)(t, 0)+k, THDTensor_(sizeLegacyNoScalars)(t, 1));
     THDTensor_(resize1d)(r_, sz);
   }
   masterCommandChannel->sendMessage(
@@ -412,7 +412,7 @@ void THDTensor_(topk)(THDTensor *rt_, THDLongTensor *ri_,
   int numDims = THDTensor_(nDimensionLegacyNoScalars)(t);
   THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
 
-  int64_t sliceSize = THDTensor_(size)(t, dim);
+  int64_t sliceSize = THDTensor_(sizeLegacyNoScalars)(t, dim);
   THArgCheck(k > 0 && k <= sliceSize, 2, "k not in range for dimension");
 
   THLongStorage *topKSize = THDTensor_(newSizeOf)(t);

--- a/torch/lib/THD/master_worker/master/generic/THDTensorRandom.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensorRandom.cpp
@@ -90,11 +90,11 @@ void THDTensor_(multinomial)(THDLongTensor *self, THDGenerator *_generator,
                              int with_replacement) {
   int start_dim = THDTensor_(nDimensionLegacyNoScalars)(prob_dist);
   if (start_dim == 1) {
-    THDTensor_(resize2d)(prob_dist, 1, THDTensor_(size)(prob_dist, 0));
+    THDTensor_(resize2d)(prob_dist, 1, THDTensor_(sizeLegacyNoScalars)(prob_dist, 0));
   }
 
-  long n_dist = THDTensor_(size)(prob_dist, 0);
-  long n_categories = THDTensor_(size)(prob_dist, 1);
+  long n_dist = THDTensor_(sizeLegacyNoScalars)(prob_dist, 0);
+  long n_categories = THDTensor_(sizeLegacyNoScalars)(prob_dist, 1);
 
   THArgCheck(n_sample > 0, 2, "cannot sample n_sample < 0 samples");
 


### PR DESCRIPTION
… unscalared view.

NOTE: the "un-scalared" version is not implemented yet, because we haven't hooked up is_zero_dim_ to sizes/strides in TH.

This is functionality the equivalent change as the nDimension / nDimensionLegacyAll / nDimensionLegacyNoScalars change.

One difference is that sizes/strides don't have a LegacyAll version (because LegacyAll collapses empty to 0-dim, which won't have a size/stride).

