### PR TITLE
Fix corner case with torch.multinomial

### DIFF
--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -173,6 +173,7 @@ sampleMultinomialOnce(int64_t* dest,
 
   AccT accZero = ScalarConvert<int, AccT>::to(0);
   T zero = ScalarConvert<int, T>::to(0);
+  T one = ScalarConvert<int, T>::to(1);
 
   for (int64_t curDist = blockIdx.x;
        curDist < distributions; curDist += gridDim.x) {
@@ -203,7 +204,7 @@ sampleMultinomialOnce(int64_t* dest,
     __syncthreads();
 
     sum = asmem[0];
-    T sample = smem[0];
+    T sample = THCNumerics<T>::sub(one, smem[0]);
     __syncthreads();
 
     if (THCNumerics<AccT>::eq(sum,  accZero) || THCNumerics<T>::eq(sample, zero)) {

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -181,7 +181,7 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
   int maxThreads = props->maxThreadsPerBlock;
   int maxShared = props->sharedMemPerBlock;
   int requiredShared = (numCategories < maxThreads ? numCategories : maxThreads)
-                                * (sizeof(real) * sizeof(accreal));
+                                * (sizeof(real) + sizeof(accreal));
 
   if (n_sample == 1 && maxShared >= requiredShared) {
     // Optimized allocation-free implementation

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1462,7 +1462,7 @@ class TestCuda(TestCase):
     def test_multinomial(self):
         TestTorch._test_multinomial(self, torch.cuda.FloatTensor)
 
-        # Test a corner case from older PyTorch (Issue #4858)
+        # Test two corner cases from older PyTorch (Issue #4858)
         freqs = torch.cuda.FloatTensor([
             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             0.03178183361887932, 0.027680952101945877, 0.033176131546497345,
@@ -1482,6 +1482,12 @@ class TestCuda(TestCase):
         torch.cuda.manual_seed(11042)
         sample = torch.multinomial(freqs, 1000, True)
         self.assertNotEqual(freqs[sample].min(), 0)
+
+        p = torch.zeros(3421, 2, device="cuda", dtype=torch.float)
+        p[:, 1] = 1
+        torch.cuda.manual_seed(5214)
+        r = torch.multinomial(p, 1)
+        self.assertNotEqual(r.min().item(), 0)
 
     @staticmethod
     def mute():


### PR DESCRIPTION
In the shortcut for n_sample=1, when category 0 has 0 weight,
we should not map the (uniform) sample 0 to category 0.
The conversion uniform->multinomial was apparently written to work on
a (0,1] range (like curand uses), but PyTorch uses a [0,1) range.

Fixes: #4858. Thank you, Roy Fejgin for reporting.

