### PR TITLE
use logsigmoid at multilabel_soft_margin_loss, and change output from shape=(N, C)to (N,)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6205,7 +6205,7 @@ new_criterion_tests = [
         input_fn=lambda: torch.randn(5, 10),
         target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
         reference_fn=lambda i, t, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * get_weight(m)).sum() /
-            (i.numel() if get_reduction(m) == 'elementwise_mean' else 1),
+            (i.numel() if get_reduction(m) == 'elementwise_mean' else i.size(1) if get_reduction(m) == 'sum' else 1),
         desc='weights',
         check_sum_reduction=True,
         check_gradgrad=False,
@@ -6698,7 +6698,7 @@ def multilabelsoftmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()),
+        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum(dim=1),
         check_gradgrad=False,
         pickle=False)
 
@@ -6712,7 +6712,7 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
                                                     weight=weights.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights),
+        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights).sum(dim=1),
         check_sum_reduction=True,
         check_gradgrad=False,
         pickle=False)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6698,7 +6698,8 @@ def multilabelsoftmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum(dim=1).div(i.size(1)),
+        reference_fn=lambda i, m:
+            (-(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log())).sum(dim=1) / i.size(1),
         check_gradgrad=False,
         pickle=False)
 
@@ -6712,7 +6713,8 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
                                                     weight=weights.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights).sum(dim=1).div(i.size(1)),
+        reference_fn=lambda i, m:
+            (-(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights).sum(dim=1) / i.size(1),
         check_sum_reduction=True,
         check_gradgrad=False,
         pickle=False)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6698,7 +6698,7 @@ def multilabelsoftmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum(dim=1),
+        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum(dim=1).div(i.size(1)),
         check_gradgrad=False,
         pickle=False)
 
@@ -6712,7 +6712,7 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
                                                     weight=weights.type_as(i), reduction='none')),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights).sum(dim=1),
+        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights).sum(dim=1).div(i.size(1)),
         check_sum_reduction=True,
         check_gradgrad=False,
         pickle=False)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1829,17 +1829,18 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
     loss = -(target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
-    loss = loss.sum(dim=1)  # only return N loss values
 
     if weight is not None:
         loss = loss * weight
 
+    loss = loss.sum(dim=1)  # only return N loss values
+
     if reduction == 'none':
         return loss
     elif reduction == 'elementwise_mean':
-        return loss.mean()
+        return loss.sum() / input.numel()
     elif reduction == 'sum':
-        return loss.sum()
+        return loss.sum() / input.size(1)
     else:
         raise ValueError(reduction + " is not valid")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1833,14 +1833,14 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
     if weight is not None:
         loss = loss * weight
 
-    loss = loss.sum(dim=1)  # only return N loss values
+    loss = loss.sum(dim=1) / input.size(1)  # only return N loss values
 
     if reduction == 'none':
         return loss
     elif reduction == 'elementwise_mean':
-        return loss.sum() / input.numel()
+        return loss.mean()
     elif reduction == 'sum':
-        return loss.sum() / input.size(1)
+        return loss.sum()
     else:
         raise ValueError(reduction + " is not valid")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1827,8 +1827,24 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
     """
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
-    input = torch.sigmoid(input)
-    return binary_cross_entropy(input, target, weight, None, None, reduction)
+
+    loss = - (target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
+
+    if weight is not None:
+        loss = loss * weight
+
+    if reduction != 'none':
+        if reduction == 'sum':
+            return loss.sum()
+        else:  # elementwise_mean
+            return loss.mean()
+    else:
+        if size_average and reduce:
+            return loss.mean()
+        elif reduce:
+            return loss.sum()
+        else:
+            return loss
 
 
 def cosine_embedding_loss(input1, input2, target, margin=0, size_average=None,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1828,23 +1828,20 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
-    loss = - (target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
+    loss = -(target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
+    loss.sum(dim=0)  # only return N loss values
 
     if weight is not None:
         loss = loss * weight
 
-    if reduction != 'none':
-        if reduction == 'sum':
-            return loss.sum()
-        else:  # global mean
-            return loss.mean()
+    if reduction == 'none':
+        return loss
+    elif reduction == 'elementwise_mean':
+        return loss.mean()
+    elif reduction == 'sum':
+        return loss.sum()
     else:
-        if size_average and reduce:
-            return loss.mean()
-        elif reduce:
-            return loss.sum()
-        else:
-            return loss
+        raise ValueError(reduction + " is not valid")
 
 
 def cosine_embedding_loss(input1, input2, target, margin=0, size_average=None,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1829,7 +1829,7 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
     loss = -(target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
-    loss.sum(dim=0)  # only return N loss values
+    loss = loss.sum(dim=0)  # only return N loss values
 
     if weight is not None:
         loss = loss * weight

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1829,7 +1829,7 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
     loss = -(target * logsigmoid(input) + (1 - target) * logsigmoid(-input))
-    loss = loss.sum(dim=0)  # only return N loss values
+    loss = loss.sum(dim=1)  # only return N loss values
 
     if weight is not None:
         loss = loss * weight

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1836,7 +1836,7 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=None,
     if reduction != 'none':
         if reduction == 'sum':
             return loss.sum()
-        else:  # elementwise_mean
+        else:  # global mean
             return loss.mean()
     else:
         if size_average and reduce:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -868,7 +868,7 @@ class MultiLabelSoftMarginLoss(_WeightedLoss):
     For each sample in the minibatch:
 
     .. math::
-        loss(x, y) = - \sum_i y[i] * \log((1 + \exp(-x[i]))^{-1})
+        loss(x, y) = - \frac{1}{C} * \sum_i y[i] * \log((1 + \exp(-x[i]))^{-1})
                          + (1-y[i]) * \log\left(\frac{\exp(-x[i])}{(1 + \exp(-x[i]))}\right)
 
     where `i == 0` to `x.nElement()-1`, `y[i]  in {0,1}`.


### PR DESCRIPTION
- fixes #9141, #9301
- use logsigmoid at multilabel_soft_margin_loss to make it more stable (NOT fixing legacy MultiLabelSoftMarginCriterion)
- return (N) instead of (N, C) to match the same behavior as MultiMarginLoss
- Note that with this PR, the following behavior is expected:
```
loss = F.multilabel_soft_margin_loss(outputs, labels, reduction='none')
loss_mean = F.multilabel_soft_margin_loss(outputs, labels, reduction='elementwise_mean')
loss_sum = F.multilabel_soft_margin_loss(outputs, labels, reduction='sum')

loss.sum() == loss_sum  # True
loss.mean() == loss_mean  # True
```