### PR TITLE
Adds the default value for the amsgrad arg to the Adam docstring

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -19,6 +19,7 @@ class Adam(Optimizer):
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
         amsgrad (boolean, optional): whether to use the AMSGrad variant of this
             algorithm from the paper `On the Convergence of Adam and Beyond`_
+            (default: False)
 
     .. _Adam\: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980


### PR DESCRIPTION
Minor addition to the docstring of `torch.nn.optim.Adam`, adding the default argument description for the `amsgrad` argument to the docstring for concistency.