### PR TITLE
Fix BlobStatRegistry HIP BlobStatGetter registration issue

### DIFF
--- a/caffe2/core/hip/context_hip.cc
+++ b/caffe2/core/hip/context_hip.cc
@@ -239,20 +239,6 @@ struct Caffe2HipInitializerHelper
     }
 };
 
-struct TensorHIPStatGetter : BlobStatGetter {
-  size_t sizeBytes(const Blob& blob) const override {
-    const auto& tensor = blob.Get<TensorHIP>();
-    auto nbytes = tensor.nbytes();
-    if (nbytes > 0 && tensor.IsType<std::string>()) {
-      const auto* data = tensor.data<std::string>();
-      for (int i = 0; i < tensor.size(); ++i) {
-        nbytes += data[i].size();
-      }
-    }
-    return nbytes;
-  }
-};
-REGISTER_BLOB_STAT_GETTER(TensorHIP, TensorHIPStatGetter);
 } // namespace
 
 /**


### PR DESCRIPTION
This was introduced in #9826 following the corresponding cuda file context_gpu.cu file, tests have passed in the PR, at that point master was 94439d7df. However during the long landing process, a new master commit aebf3b4 has come in that removed the `CAFFE_KNOWN_TYPE(Tensor<HIPContext>)` in context_hip.cc file, which then broke the HIP BlobStatGetter, and we did NOT run tests again during merge and so when #9826 later landed to master the rocm tests start breaking.