### PR TITLE
Simplify order switch operators

### DIFF
--- a/caffe2/operators/order_switch_ops.cc
+++ b/caffe2/operators/order_switch_ops.cc
@@ -9,16 +9,12 @@ bool NHWC2NCHWOp<float, CPUContext>::RunOnDevice() {
   CAFFE_ENFORCE(X.ndim() == 4);
   const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
   Y->Resize(N, C, H, W);
-  const float* Xdata = X.data<float>();
-  float* Ydata = Y->mutable_data<float>();
-  for (int n = 0; n < N; ++n) {
-    for (int h = 0; h < H; ++h) {
-      for (int w = 0; w < W; ++w) {
-        for (int c = 0; c < C; ++c) {
-          Ydata[((n * C + c) * H + h) * W + w] = *(Xdata++);
-        }
-      }
-    }
+  if (X.size() > 0) {
+    const float* Xdata = X.data<float>();
+    float* Ydata = Y->template mutable_data<float>();
+    std::array<int, 4> dims = {N, H, W, C};
+    std::array<int, 4> axes = {0, 3, 1, 2};
+    math::Transpose(4, dims.data(), axes.data(), Xdata, Ydata, &context_);
   }
   return true;
 }
@@ -30,20 +26,15 @@ bool NCHW2NHWCOp<float, CPUContext>::RunOnDevice() {
   CAFFE_ENFORCE(X.ndim() == 4);
   const int N = X.dim32(0), C = X.dim32(1), H = X.dim32(2), W = X.dim32(3);
   Y->Resize(N, H, W, C);
-  const float* Xdata = X.data<float>();
-  float* Ydata = Y->mutable_data<float>();
-  for (int n = 0; n < N; ++n) {
-    for (int c = 0; c < C; ++c) {
-      for (int h = 0; h < H; ++h) {
-        for (int w = 0; w < W; ++w) {
-          Ydata[((n * H + h) * W + w) * C + c] = *(Xdata++);
-        }
-      }
-    }
+  if (X.size() > 0) {
+    const float* Xdata = X.data<float>();
+    float* Ydata = Y->template mutable_data<float>();
+    std::array<int, 4> dims = {N, C, H, W};
+    std::array<int, 4> axes = {0, 2, 3, 1};
+    math::Transpose(4, dims.data(), axes.data(), Xdata, Ydata, &context_);
   }
   return true;
 }
-
 
 REGISTER_CPU_OPERATOR(NHWC2NCHW, NHWC2NCHWOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(NCHW2NHWC, NCHW2NHWCOp<float, CPUContext>);
@@ -100,4 +91,4 @@ class GetNCHW2NHWCGradient : public GradientMakerBase {
   }
 };
 REGISTER_GRADIENT(NCHW2NHWC, GetNCHW2NHWCGradient);
-}  // namespace caffe2
+} // namespace caffe2

--- a/caffe2/python/operator_test/order_switch_test.py
+++ b/caffe2/python/operator_test/order_switch_test.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import caffe2.python.hypothesis_test_util as hu
+from caffe2.python import core
+from hypothesis import given
+import hypothesis.strategies as st
+
+
+class OrderSwitchOpsTest(hu.HypothesisTestCase):
+    @given(
+        n=st.integers(1, 5),
+        c=st.integers(1, 5),
+        h=st.integers(1, 5),
+        w=st.integers(1, 5),
+        **hu.gcs)
+    def test_nchw2nhwc(self, n, c, h, w, gc, dc):
+        X = np.random.randn(n, c, h, w).astype(np.float32)
+
+        op = core.CreateOperator("NCHW2NHWC", ["X"], ["Y"],
+                                 device_option=gc)
+
+        def nchw2nhwc_ref(X):
+            X_reshaped = X.transpose((0, 2, 3, 1))
+            return (X_reshaped,)
+
+        self.assertReferenceChecks(gc, op, [X], nchw2nhwc_ref)
+        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+    @given(
+        n=st.integers(1, 5),
+        c=st.integers(1, 5),
+        h=st.integers(1, 5),
+        w=st.integers(1, 5),
+        **hu.gcs)
+    def test_nhwc2nchw(self, n, c, h, w, gc, dc):
+        X = np.random.randn(n, h, w, c).astype(np.float32)
+
+        op = core.CreateOperator("NHWC2NCHW", ["X"], ["Y"],
+                                 device_option=gc)
+
+        def nhwc2nchw_ref(X):
+            X_reshaped = X.transpose((0, 3, 1, 2))
+            return (X_reshaped,)
+
+        self.assertReferenceChecks(gc, op, [X], nhwc2nchw_ref)
+        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertDeviceChecks(dc, op, [X], [0])


### PR DESCRIPTION
Summary:
Reattempt of D8909766 with early return when the input tensor is empty because it was clashing in Android.
Mostly to simplify code. Should also improve performance but order switch ops don't take much time anyway.

Differential Revision: D9041659
