### PR TITLE
Deal with undefined tensors in unbind backward

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1302,6 +1302,15 @@ class TestAutograd(TestCase):
         grad = torch.randn(3, 10, 10)
         torch.autograd.backward([x, y, z], grad.unbind())
         self.assertEqual(stacked.grad.data, grad)
+        # check that it works with only one gradient provided (#9977)
+        for i in range(3):
+            stacked = torch.randn(3, 10, 10, requires_grad=True)
+            outs = stacked.unbind()
+            gi = grad.unbind()[i]
+            g, = torch.autograd.grad(outs[i], stacked, gi)
+            g_expected = torch.stack([gi if j == i else torch.zeros_like(gi)
+                                      for j in range(3)], dim=0)
+            self.assertEqual(g, g_expected)
 
     def test_put(self):
         root = torch.randn(4, 5, requires_grad=True)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1223,7 +1223,7 @@
   self: fft_backward(self, grad, signal_ndim, complex_input, complex_output, inverse, checked_signal_sizes, normalized, onesided, output_sizes)
 
 - name: unbind(Tensor self, int64_t dim)
-  self: stack(to_tensor_list(grads), dim)
+  self: unbind_backward(grads, dim)
 
 - name: stack(TensorList tensors, int64_t dim)
   tensors: unbind(grad, dim)


### PR DESCRIPTION
When only part of the outputs of unbind are used in a backward,
the gradients for the others are undefined. This sets those
to zero in to_tensor_list.

Fixes: #9977

