### PR TITLE
Errors out when Openmpi < 2.x.x with distributed.

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -62,7 +62,7 @@ def init_process_group(backend, init_method='env://', **kwargs):
 
     To enable ``backend == mpi``, PyTorch needs to built from source on a system that
     supports MPI. If you want to use Openmpi with CUDA-aware support, please use Openmpi
-    2.x.x and above.
+    major version 2 and above.
 
     """
     world_size = kwargs.pop('world_size', -1)

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -61,7 +61,8 @@ def init_process_group(backend, init_method='env://', **kwargs):
         group_name (str, optional): Group name. See description of init methods.
 
     To enable ``backend == mpi``, PyTorch needs to built from source on a system that
-    supports MPI.
+    supports MPI. If you want to use Openmpi with CUDA-aware support, please use Openmpi
+    2.x.x and above.
 
     """
     world_size = kwargs.pop('world_size', -1)

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -106,7 +106,7 @@ bool DataChannelMPI::init() {
   if (int(OMPI_MAJOR_VERSION) < 2) {
       throw std::runtime_error("Please use MPI 2.x.x and above for distributed.");
   }
-#endif /* OMPI_RELEASE_VERSION */
+#endif /* OMPI_MAJOR_VERSION */
 
   int provided;
   MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided);

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -104,7 +104,7 @@ bool DataChannelMPI::init() {
   // OMPI_* is specific to Openmpi implementation.
   // Openmpi v1.10 segfaults in MPI_Bcast with CUDA buffer.
   if (int(OMPI_MAJOR_VERSION) < 2) {
-      throw std::runtime_error("Please use MPI 2.x.x and above for distributed.");
+      throw std::runtime_error("Please use Openmpi major version 2 and above for distributed.");
   }
 #endif /* OMPI_MAJOR_VERSION */
 

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -100,6 +100,14 @@ void DataChannelMPI::destroy() {}
 
 
 bool DataChannelMPI::init() {
+#ifdef OMPI_MAJOR_VERSION
+  // OMPI_* is specific to Openmpi implementation.
+  // Openmpi v1.10 segfaults in MPI_Bcast with CUDA buffer.
+  if (int(OMPI_MAJOR_VERSION) < 2) {
+      throw std::runtime_error("Please use MPI 2.x.x and above for distributed.");
+  }
+#endif /* OMPI_RELEASE_VERSION */
+
   int provided;
   MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided);
   if (provided != MPI_THREAD_MULTIPLE) {


### PR DESCRIPTION
This PR fixes #9418 .
Openmpi 1.10 segfaults in MPI_Bcast with CUDA buffer. And it's a retired openmpi version. 
I've tested on 2.1.1 and 3.0.0 and they work well.