### PR TITLE
add a rebuild_libtorch command for speedier iteration.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,13 @@ working on:
 - Working on the Python bindings?  Run `python setup.py develop` to rebuild
   (NB: no `build` here!)
 
-- Working on `torch/csrc` or `aten`?  Run `python setup.py build_caffe2` to
+- Working on `torch/csrc` or `aten`?  Run `python setup.py rebuild_libtorch` to
   rebuild and avoid having to rebuild other dependent libraries we
-  depend on.  The other valid targets are listed in `dep_libs` in `setup.py`
-  (prepend `build_` to get a target).
+  depend on.
+
+- Working on one of the other dependent libraries? The other valid
+  targets are listed in `dep_libs` in `setup.py`. prepend `build_` to
+  get a target, and run as e.g. `python setup.py build_gloo`.
 
 - Working on a test binary?  Run `(cd build && ninja bin/test_binary_name)` to
   rebuild only that test binary (without rerunning cmake).  (Replace `ninja` with

--- a/setup.py
+++ b/setup.py
@@ -599,6 +599,13 @@ class install(setuptools.command.install.install):
         setuptools.command.install.install.run(self)
 
 
+class rebuild_libtorch(distutils.command.build.build):
+    def run(self):
+        if subprocess.call(['ninja', 'install'], cwd='build') != 0:
+            print("Failed to run `ninja install` for the `rebuild_libtorch` command")
+            sys.exit(1)
+
+
 class clean(distutils.command.clean.clean):
 
     def run(self):
@@ -1023,6 +1030,7 @@ cmdclass = {
     'build_ext': build_ext,
     'build_deps': build_deps,
     'build_module': build_module,
+    'rebuild_libtorch': rebuild_libtorch,
     'develop': develop,
     'install': install,
     'clean': clean,


### PR DESCRIPTION
It just calls into `ninja install`. For iterative work on
libtorch.so/_C.so,
`python setup.py rebuild_libtorch develop` should provide quick iteration

