### PR TITLE
Grid sampler: nearest interpolation & reflection padding

### DIFF
--- a/aten/src/ATen/Device.cpp
+++ b/aten/src/ATen/Device.cpp
@@ -75,8 +75,6 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   }
 }
 
-} // namespace at
-
 std::ostream& operator<<(std::ostream& stream, const at::Device& device) {
   stream << device.type();
   if (device.has_index()) {
@@ -84,3 +82,5 @@ std::ostream& operator<<(std::ostream& stream, const at::Device& device) {
   }
   return stream;
 }
+
+} // namespace at

--- a/aten/src/ATen/Device.h
+++ b/aten/src/ATen/Device.h
@@ -111,9 +111,11 @@ struct Device {
   DeviceType type_;
   int32_t index_ = -1;
 };
-} // namespace at
 
 AT_API std::ostream& operator<<(std::ostream& stream, const at::Device& device);
+
+} // namespace at
+
 
 namespace std {
   template<> struct hash<at::Device>

--- a/aten/src/ATen/Layout.h
+++ b/aten/src/ATen/Layout.h
@@ -20,7 +20,6 @@ inline Layout layout_from_backend(Backend backend) {
       return Layout::Strided;
   }
 }
-} // namespace at
 
 inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
   switch (layout) {
@@ -32,3 +31,5 @@ inline std::ostream& operator<<(std::ostream& stream, at::Layout layout) {
       AT_ERROR("Unknown layout");
   }
 }
+
+} // namespace at

--- a/aten/src/ATen/TensorGeometry.cpp
+++ b/aten/src/ATen/TensorGeometry.cpp
@@ -5,6 +5,9 @@
 namespace at {
 
 bool TensorGeometry::is_contiguous() const {
+  if (numel_ == 0) {
+    return true;
+  }
   int64_t dim = sizes_.size();
   int64_t expected_stride = 1;
   for (int64_t i = dim - 1; i >= 0; i--) {

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -18,12 +18,14 @@ struct AT_API TensorGeometry {
         strides_[i] = expected_stride;
         expected_stride *= sizes_[i];
       }
+      numel_ = expected_stride;
   }
 
   explicit TensorGeometry(const Tensor& t)
     : sizes_(t.sizes().vec())
     , strides_(t.strides().vec())
-    , storage_offset_(t.storage_offset()) {}
+    , storage_offset_(t.storage_offset())
+    , numel_(t.numel()) {}
 
   // true if the tensor is contiguous
   bool is_contiguous() const;
@@ -43,13 +45,7 @@ struct AT_API TensorGeometry {
   }
   IntList strides() const { return IntList{ strides_ }; }
   int64_t storage_offset() const { return storage_offset_; }
-  int64_t numel() const {
-    int64_t r = 1;
-    for (auto s : sizes()) {
-      r *= s;
-    }
-    return r;
-  }
+  int64_t numel() const { return numel_; }
 
   TensorGeometry transpose(int64_t dim0, int64_t dim1) {
     TensorGeometry r = *this; // copy
@@ -63,6 +59,7 @@ struct AT_API TensorGeometry {
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
   int64_t storage_offset_;
+  int64_t numel_;
 };
 
 } // namespace at

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -118,7 +118,7 @@ void checkSameGPU(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
       oss << "Tensor for " << t2 << " is on CPU, ";
     }
     oss << "but expected " << ((!(t1->is_cuda() || t2->is_cuda())) ? "them" : "it")
-	      << " to be on GPU (while checking arguments for " << c << ")";
+        << " to be on GPU (while checking arguments for " << c << ")";
     AT_ERROR(oss.str());
   }
   AT_CHECK(

--- a/aten/src/ATen/core/DeviceType.cpp
+++ b/aten/src/ATen/core/DeviceType.cpp
@@ -34,9 +34,9 @@ std::string DeviceTypeName(at::DeviceType d, bool lower_case) {
   }
 }
 
-} // namespace at
-
 std::ostream& operator<<(std::ostream& stream, at::DeviceType type) {
   stream << at::DeviceTypeName(type, /* lower case */ true);
   return stream;
 }
+
+} // namespace at

--- a/aten/src/ATen/core/DeviceType.h
+++ b/aten/src/ATen/core/DeviceType.h
@@ -27,6 +27,6 @@ AT_CORE_API std::string DeviceTypeName(
     at::DeviceType d,
     bool lower_case = false);
 
-} // namespace at
-
 AT_CORE_API std::ostream& operator<<(std::ostream& stream, at::DeviceType type);
+
+} // namespace at

--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "ATen/ATen.h"
+
 // Contents of this file are copied from THCUNN/common.h for the ease of porting
 // THCUNN functions into ATen.
 
@@ -14,6 +17,7 @@ constexpr int CUDA_NUM_THREADS = 1024;
 // CUDA: number of blocks for threads.
 inline int GET_BLOCKS(const int N)
 {
+  AT_ASSERTM(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
   return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
 }
 

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -1,4 +1,7 @@
 #include "ATen/ATen.h"
+#include "ATen/Layout.h"
+#include "ATen/Device.h"
+#include "ATen/Error.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/detail/CUDAHooksInterface.h"
 #include "ATen/native/GridSampler.h"
@@ -829,8 +832,26 @@ grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
 Tensor grid_sampler(const Tensor& input, const Tensor& grid,
                     int64_t interpolation_mode, int64_t padding_mode) {
   AT_CHECK(
+    input.defined() && grid.defined(),
+    "grid_sampler(): expected input and grid to not be undefined, but input "
+    "is ", input, " and grid is ", grid);
+  auto input_opt = input.options();
+  auto grid_opt = grid.options();
+  AT_CHECK(
+    input_opt.device() == grid_opt.device(),
+    "grid_sampler(): expected input and grid to be on same device, but input "
+    "is on ", input_opt.device(), " and grid is on ", grid_opt.device());
+  AT_CHECK(
+    input_opt.dtype() == grid_opt.dtype(),
+    "grid_sampler(): expected input and grid to have same dtype, but input "
+    "has ", input_opt.dtype(), " and grid has ", grid_opt.dtype());
+  AT_CHECK(
+    input_opt.layout() == kStrided && grid_opt.layout() == kStrided,
+    "grid_sampler(): expected input and grid to have torch.strided layout, but "
+    "input has ", input_opt.layout(), " and grid has ", grid_opt.layout());
+  AT_CHECK(
     (input.dim() == 4 || input.dim() == 5) && input.dim() == grid.dim(),
-    "grid_sampler(): expected 4D or 5D input and grid with same number "
+    "grid_sampler(): expected 4D or 5D input and grid with same number of "
     "dimensions, but got input with sizes ", input.sizes(),
     " and grid with sizes ", grid.sizes());
   AT_CHECK(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -167,40 +167,56 @@ namespace {
             iy = reflect_coordinates(iy, inp_H);
           }
 
-          // get NE, NW, SE, SW pixel values from (x, y)
-          int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-          int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-          int64_t ix_ne = ix_nw + 1;
-          int64_t iy_ne = iy_nw;
-          int64_t ix_sw = ix_nw;
-          int64_t iy_sw = iy_nw + 1;
-          int64_t ix_se = ix_nw + 1;
-          int64_t iy_se = iy_nw + 1;
+          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+            // get NE, NW, SE, SW pixel values from (x, y)
+            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+            int64_t ix_ne = ix_nw + 1;
+            int64_t iy_ne = iy_nw;
+            int64_t ix_sw = ix_nw;
+            int64_t iy_sw = iy_nw + 1;
+            int64_t ix_se = ix_nw + 1;
+            int64_t iy_se = iy_nw + 1;
 
-          // get surfaces to each neighbor:
-          scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-          scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-          scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-          scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+            // get surfaces to each neighbor:
+            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-          // calculate bilinear weighted pixel value and set output pixel
-          scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-          scalar_t *inp_ptr_NC = inp_ptr_N;
-          for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
-            //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
-            // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
-            *out_ptr_NCHW = static_cast<scalar_t>(0);
-            if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-              *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+            // calculate bilinear weighted pixel value and set output pixel
+            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
+              // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
+              *out_ptr_NCHW = static_cast<scalar_t>(0);
+              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+              }
+              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
+              }
+              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
+              }
+              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+              }
             }
-            if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-              *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
-            }
-            if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-              *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
-            }
-            if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-              *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+            int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+            int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+
+            // assign nearest neighor pixel value to output pixel
+            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
+                *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
+              } else {
+                *out_ptr_NCHW = static_cast<scalar_t>(0);
+              }
             }
           }
         }
@@ -273,83 +289,100 @@ namespace {
               iz = reflect_coordinates(iz, inp_D);
             }
 
-            // get corner pixel values from (x, y, z)
-            // for 4d, we used north-east-south-west
-            // for 5d, we add top-bottom
-            int64_t ix_tnw = static_cast<int64_t>(std::floor(ix));
-            int64_t iy_tnw = static_cast<int64_t>(std::floor(iy));
-            int64_t iz_tnw = static_cast<int64_t>(std::floor(iz));
+            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+              // get corner pixel values from (x, y, z)
+              // for 4d, we used north-east-south-west
+              // for 5d, we add top-bottom
+              int64_t ix_tnw = static_cast<int64_t>(std::floor(ix));
+              int64_t iy_tnw = static_cast<int64_t>(std::floor(iy));
+              int64_t iz_tnw = static_cast<int64_t>(std::floor(iz));
 
-            int64_t ix_tne = ix_tnw + 1;
-            int64_t iy_tne = iy_tnw;
-            int64_t iz_tne = iz_tnw;
+              int64_t ix_tne = ix_tnw + 1;
+              int64_t iy_tne = iy_tnw;
+              int64_t iz_tne = iz_tnw;
 
-            int64_t ix_tsw = ix_tnw;
-            int64_t iy_tsw = iy_tnw + 1;
-            int64_t iz_tsw = iz_tnw;
+              int64_t ix_tsw = ix_tnw;
+              int64_t iy_tsw = iy_tnw + 1;
+              int64_t iz_tsw = iz_tnw;
 
-            int64_t ix_tse = ix_tnw + 1;
-            int64_t iy_tse = iy_tnw + 1;
-            int64_t iz_tse = iz_tnw;
+              int64_t ix_tse = ix_tnw + 1;
+              int64_t iy_tse = iy_tnw + 1;
+              int64_t iz_tse = iz_tnw;
 
-            int64_t ix_bnw = ix_tnw;
-            int64_t iy_bnw = iy_tnw;
-            int64_t iz_bnw = iz_tnw + 1;
+              int64_t ix_bnw = ix_tnw;
+              int64_t iy_bnw = iy_tnw;
+              int64_t iz_bnw = iz_tnw + 1;
 
-            int64_t ix_bne = ix_tnw + 1;
-            int64_t iy_bne = iy_tnw;
-            int64_t iz_bne = iz_tnw + 1;
+              int64_t ix_bne = ix_tnw + 1;
+              int64_t iy_bne = iy_tnw;
+              int64_t iz_bne = iz_tnw + 1;
 
-            int64_t ix_bsw = ix_tnw;
-            int64_t iy_bsw = iy_tnw + 1;
-            int64_t iz_bsw = iz_tnw + 1;
+              int64_t ix_bsw = ix_tnw;
+              int64_t iy_bsw = iy_tnw + 1;
+              int64_t iz_bsw = iz_tnw + 1;
 
-            int64_t ix_bse = ix_tnw + 1;
-            int64_t iy_bse = iy_tnw + 1;
-            int64_t iz_bse = iz_tnw + 1;
+              int64_t ix_bse = ix_tnw + 1;
+              int64_t iy_bse = iy_tnw + 1;
+              int64_t iz_bse = iz_tnw + 1;
 
-            // get surfaces to each neighbor:
-            scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
-            scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
-            scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
-            scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
-            scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
-            scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
-            scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
-            scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
+              // get surfaces to each neighbor:
+              scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
+              scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
+              scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
+              scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
+              scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
+              scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
+              scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
+              scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-            // calculate bilinear weighted pixel value and set output pixel
-            scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
-            scalar_t *inp_ptr_NC = inp_ptr_N;
-            for (int c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
-              //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
-              // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
-              // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
-              // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
-              *out_ptr_NCDHW = static_cast<scalar_t>(0);
-              if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
+              // calculate bilinear weighted pixel value and set output pixel
+              scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              for (int c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
+                //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
+                // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
+                // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
+                // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
+                *out_ptr_NCDHW = static_cast<scalar_t>(0);
+                if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
+                }
+                if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
+                }
+                if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
+                }
+                if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
+                }
+                if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
+                }
+                if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
+                }
+                if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
+                }
+                if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
+                }
               }
-              if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
-              }
-              if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
-              }
-              if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
-              }
-              if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
-              }
-              if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
-              }
-              if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
-              }
-              if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
-                *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
+            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+              int64_t iz_nearest = static_cast<int64_t>(std::round(iz));
+
+              // assign nearest neighor pixel value to output pixel
+              scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              for (int c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
+                if (within_bounds_3d(iz_nearest, iy_nearest, ix_nearest, inp_D, inp_H, inp_W)) {
+                  *out_ptr_NCDHW = inp_ptr_NC[iz_nearest * inp_sD + iy_nearest * inp_sH + ix_nearest * inp_sW];
+                } else {
+                  *out_ptr_NCDHW = static_cast<scalar_t>(0);
+                }
               }
             }
           }
@@ -367,6 +400,11 @@ namespace {
                                    GridSamplerPadding padding_mode) {
     auto grad_input = at::zeros_like(input);
     auto grad_grid = at::empty_like(grid);
+    // If interpolation mode is Nearest, then grad_grid is not filled in the
+    // loop below.
+    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+      grad_grid.zero_();
+    }
     int64_t N = input.size(0);
     int64_t C = input.size(1);
     int64_t inp_H = input.size(2);
@@ -430,66 +468,79 @@ namespace {
             giy_mult = static_cast<scalar_t>(1);
           }
 
-          // get NE, NW, SE, SW pixel values from (x, y)
-          int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-          int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-          int64_t ix_ne = ix_nw + 1;
-          int64_t iy_ne = iy_nw;
-          int64_t ix_sw = ix_nw;
-          int64_t iy_sw = iy_nw + 1;
-          int64_t ix_se = ix_nw + 1;
-          int64_t iy_se = iy_nw + 1;
+          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+            // get NE, NW, SE, SW pixel values from (x, y)
+            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+            int64_t ix_ne = ix_nw + 1;
+            int64_t iy_ne = iy_nw;
+            int64_t ix_sw = ix_nw;
+            int64_t iy_sw = iy_nw + 1;
+            int64_t ix_se = ix_nw + 1;
+            int64_t iy_se = iy_nw + 1;
 
-          // get surfaces to each neighbor:
-          scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-          scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-          scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-          scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+            // get surfaces to each neighbor:
+            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-          scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
-          scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-          scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-          scalar_t *inp_ptr_NC = inp_ptr_N;
-          // calculate bilinear weighted pixel value and set output pixel
-          for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
-            scalar_t gOut = *gOut_ptr_NCHW;
+            scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
+            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            // calculate bilinear weighted pixel value and set output pixel
+            for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+              scalar_t gOut = *gOut_ptr_NCHW;
 
-            // calculate and set grad_input
-            safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+              // calculate and set grad_input
+              safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
 
-            // calculate grad_grid
-            if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-              scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
-              gix -= nw_val * (iy_se - iy) * gOut;
-              giy -= nw_val * (ix_se - ix) * gOut;
+              // calculate grad_grid
+              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
+                gix -= nw_val * (iy_se - iy) * gOut;
+                giy -= nw_val * (ix_se - ix) * gOut;
+              }
+              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
+                gix += ne_val * (iy_sw - iy) * gOut;
+                giy -= ne_val * (ix - ix_sw) * gOut;
+              }
+              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
+                gix -= sw_val * (iy - iy_ne) * gOut;
+                giy += sw_val * (ix_ne - ix) * gOut;
+              }
+              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
+                gix += se_val * (iy - iy_nw) * gOut;
+                giy += se_val * (ix - ix_nw) * gOut;
+              }
             }
-            if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-              scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
-              gix += ne_val * (iy_sw - iy) * gOut;
-              giy -= ne_val * (ix - ix_sw) * gOut;
-            }
-            if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-              scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
-              gix -= sw_val * (iy - iy_ne) * gOut;
-              giy += sw_val * (ix_ne - ix) * gOut;
-            }
-            if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-              scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
-              gix += se_val * (iy - iy_nw) * gOut;
-              giy += se_val * (ix - ix_nw) * gOut;
+
+            // un-normalize grad_grid values back to [-1, 1] constraints
+            gix = gix * (inp_W - 1) / 2;
+            giy = giy * (inp_H - 1) / 2;
+
+            // assuming grad_grid is contiguous
+            gGrid_ptr_NHW[0] = gix_mult * gix;
+            gGrid_ptr_NHW[1] = giy_mult * giy;
+          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+            int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+            int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+
+            // assign nearest neighor pixel value to output pixel
+            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+            for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+              // calculate and set grad_input
+              safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW);
             }
           }
-
-          // un-normalize grad_grid values back to [-1, 1] constraints
-          gix = gix * (inp_W - 1) / 2;
-          giy = giy * (inp_H - 1) / 2;
-
-          // assuming grad_grid is contiguous
-          gGrid_ptr_NHW[0] = gix_mult * gix;
-          gGrid_ptr_NHW[1] = giy_mult * giy;
         }
       }
     }
@@ -504,6 +555,11 @@ namespace {
                                    GridSamplerPadding padding_mode) {
     auto grad_input = at::zeros_like(input);
     auto grad_grid = at::empty_like(grid);
+    // If interpolation mode is Nearest, then grad_grid is not filled in the
+    // loop below.
+    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+      grad_grid.zero_();
+    }
     int64_t N = input.size(0);
     int64_t C = input.size(1);
     int64_t inp_D = input.size(2);
@@ -580,129 +636,144 @@ namespace {
               giz_mult = static_cast<scalar_t>(1);
             }
 
-            // get corner pixel values from (x, y, z)
-            // for 4d, we used north-east-south-west
-            // for 5d, we add top-bottom
-            int64_t ix_tnw = static_cast<int64_t>(std::floor(ix));
-            int64_t iy_tnw = static_cast<int64_t>(std::floor(iy));
-            int64_t iz_tnw = static_cast<int64_t>(std::floor(iz));
+            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+              // get corner pixel values from (x, y, z)
+              // for 4d, we used north-east-south-west
+              // for 5d, we add top-bottom
+              int64_t ix_tnw = static_cast<int64_t>(std::floor(ix));
+              int64_t iy_tnw = static_cast<int64_t>(std::floor(iy));
+              int64_t iz_tnw = static_cast<int64_t>(std::floor(iz));
 
-            int64_t ix_tne = ix_tnw + 1;
-            int64_t iy_tne = iy_tnw;
-            int64_t iz_tne = iz_tnw;
+              int64_t ix_tne = ix_tnw + 1;
+              int64_t iy_tne = iy_tnw;
+              int64_t iz_tne = iz_tnw;
 
-            int64_t ix_tsw = ix_tnw;
-            int64_t iy_tsw = iy_tnw + 1;
-            int64_t iz_tsw = iz_tnw;
+              int64_t ix_tsw = ix_tnw;
+              int64_t iy_tsw = iy_tnw + 1;
+              int64_t iz_tsw = iz_tnw;
 
-            int64_t ix_tse = ix_tnw + 1;
-            int64_t iy_tse = iy_tnw + 1;
-            int64_t iz_tse = iz_tnw;
+              int64_t ix_tse = ix_tnw + 1;
+              int64_t iy_tse = iy_tnw + 1;
+              int64_t iz_tse = iz_tnw;
 
-            int64_t ix_bnw = ix_tnw;
-            int64_t iy_bnw = iy_tnw;
-            int64_t iz_bnw = iz_tnw + 1;
+              int64_t ix_bnw = ix_tnw;
+              int64_t iy_bnw = iy_tnw;
+              int64_t iz_bnw = iz_tnw + 1;
 
-            int64_t ix_bne = ix_tnw + 1;
-            int64_t iy_bne = iy_tnw;
-            int64_t iz_bne = iz_tnw + 1;
+              int64_t ix_bne = ix_tnw + 1;
+              int64_t iy_bne = iy_tnw;
+              int64_t iz_bne = iz_tnw + 1;
 
-            int64_t ix_bsw = ix_tnw;
-            int64_t iy_bsw = iy_tnw + 1;
-            int64_t iz_bsw = iz_tnw + 1;
+              int64_t ix_bsw = ix_tnw;
+              int64_t iy_bsw = iy_tnw + 1;
+              int64_t iz_bsw = iz_tnw + 1;
 
-            int64_t ix_bse = ix_tnw + 1;
-            int64_t iy_bse = iy_tnw + 1;
-            int64_t iz_bse = iz_tnw + 1;
+              int64_t ix_bse = ix_tnw + 1;
+              int64_t iy_bse = iy_tnw + 1;
+              int64_t iz_bse = iz_tnw + 1;
 
-            // get surfaces to each neighbor:
-            scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
-            scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
-            scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
-            scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
-            scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
-            scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
-            scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
-            scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
+              // get surfaces to each neighbor:
+              scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
+              scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
+              scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
+              scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
+              scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
+              scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
+              scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
+              scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-            scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
-            scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
-            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-            scalar_t *inp_ptr_NC = inp_ptr_N;
-            // calculate bilinear weighted pixel value and set output pixel
-            for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
-              scalar_t gOut = *gOut_ptr_NCDHW;
+              scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
+              scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              // calculate bilinear weighted pixel value and set output pixel
+              for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+                scalar_t gOut = *gOut_ptr_NCDHW;
 
-              // calculate and set grad_input
-              safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
+                // calculate and set grad_input
+                safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
+                safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
 
-              // calculate grad_grid
-              if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
-                scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
-                gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
-                giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
-                giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
+                // calculate grad_grid
+                if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+                  scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
+                  gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
+                  giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
+                  giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
+                }
+                if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+                  scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
+                  gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
+                  giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
+                  giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
+                }
+                if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+                  scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
+                  gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
+                  giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
+                  giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
+                }
+                if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+                  scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
+                  gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
+                  giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
+                  giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
+                }
+                if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+                  scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
+                  gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
+                  giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
+                  giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
+                }
+                if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+                  scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
+                  gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
+                  giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
+                  giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
+                }
+                if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+                  scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
+                  gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
+                  giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
+                  giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
+                }
+                if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+                  scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
+                  gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
+                  giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
+                  giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
+                }
               }
-              if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
-                scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
-                gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
-                giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
-                giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
-              }
-              if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
-                scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
-                gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
-                giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
-                giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
-              }
-              if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
-                scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
-                gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
-                giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
-                giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
-              }
-              if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
-                scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
-                gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
-                giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
-                giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
-              }
-              if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
-                scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
-                gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
-                giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
-                giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
-              }
-              if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
-                scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
-                gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
-                giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
-                giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
-              }
-              if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
-                scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
-                gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
-                giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
-                giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
+
+              // un-normalize grad_grid values back to [-1, 1] constraints
+              gix = gix * (inp_W - 1) / 2;
+              giy = giy * (inp_H - 1) / 2;
+              giz = giz * (inp_D - 1) / 2;
+
+              // assuming grad_grid is contiguous
+              gGrid_ptr_NDHW[0] = gix_mult * gix;
+              gGrid_ptr_NDHW[1] = giy_mult * giy;
+              gGrid_ptr_NDHW[2] = giz_mult * giz;
+            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+              int64_t iz_nearest = static_cast<int64_t>(std::round(iz));
+
+              // assign nearest neighor pixel value to output pixel
+              scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+              for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+                // calculate and set grad_input
+                safe_add_3d(gInp_ptr_NC, iz_nearest, iy_nearest, ix_nearest,
+                            gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW);
               }
             }
-
-            // un-normalize grad_grid values back to [-1, 1] constraints
-            gix = gix * (inp_W - 1) / 2;
-            giy = giy * (inp_H - 1) / 2;
-            giz = giz * (inp_D - 1) / 2;
-
-            // assuming grad_grid is contiguous
-            gGrid_ptr_NDHW[0] = gix_mult * gix;
-            gGrid_ptr_NDHW[1] = giy_mult * giy;
-            gGrid_ptr_NDHW[2] = giz_mult * giz;
           }
         }
       }

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -862,8 +862,15 @@ Tensor grid_sampler(const Tensor& input, const Tensor& grid,
     grid.size(-1) == input.dim() - 2,
     "grid_sampler(): expected grid to have size ", input.dim() - 2, " in last "
     "dimension, but got grid with sizes ", grid.sizes());
+  for (int64_t i = 2; i < input.dim(); i++) {
+    AT_CHECK(input.size(i) > 0,
+      "grid_sampler(): expected input to have non-empty spatial dimensions, "
+      "but input has sizes ", input.sizes(), " with dimension ", i, " being "
+      "empty");
+  }
   // cudnn does not support inputs larger than 1024
   if (at::native::cudnn_is_acceptable(input) &&
+      at::native::cudnn_is_acceptable(grid) &&
       static_cast<GridSamplerInterpolation>(interpolation_mode) == GridSamplerInterpolation::Bilinear &&
       static_cast<GridSamplerPadding>(padding_mode) == GridSamplerPadding::Zeros &&
       input.dim() == 4 &&

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -13,8 +13,9 @@ using at::native::detail::GridSamplerInterpolation;
 using at::native::detail::GridSamplerPadding;
 
 namespace {
-  static inline int64_t clip_coordinates(int64_t in, int64_t clip_limit) {
-    return std::min(clip_limit - 1, std::max(in, static_cast<int64_t>(0)));
+  template<typename scalar_t>
+  static inline scalar_t clip_coordinates(scalar_t in, int64_t clip_limit) {
+    return std::min(static_cast<scalar_t>(clip_limit - 1), std::max(in, static_cast<scalar_t>(0)));
   }
 
   static inline bool within_bounds_2d(int64_t h, int64_t w, int64_t H, int64_t W) {
@@ -45,7 +46,7 @@ namespace {
   }
 
   template<typename scalar_t>
-  Tensor grid_sampler2d_cpu_impl(const Tensor& input, const Tensor& grid,
+  Tensor grid_sampler_2d_cpu_impl(const Tensor& input, const Tensor& grid,
                                  GridSamplerInterpolation interpolation_mode,
                                  GridSamplerPadding padding_mode) {
     int64_t N = input.size(0);
@@ -87,6 +88,12 @@ namespace {
           ix = ((ix + 1) / 2) * (inp_W - 1);
           iy = ((iy + 1) / 2) * (inp_H - 1);
 
+          if (padding_mode == GridSamplerPadding::Border) {
+            // clip coordinates to image borders
+            ix = clip_coordinates(ix, inp_W);
+            iy = clip_coordinates(iy, inp_H);
+          }
+
           // get NE, NW, SE, SW pixel values from (x, y)
           int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
           int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
@@ -103,18 +110,6 @@ namespace {
           scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
           scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-          if (padding_mode == GridSamplerPadding::Border) {
-            // clip coordinates to image borders
-            ix_nw = clip_coordinates(ix_nw, inp_W);
-            iy_nw = clip_coordinates(iy_nw, inp_H);
-            ix_ne = clip_coordinates(ix_ne, inp_W);
-            iy_ne = clip_coordinates(iy_ne, inp_H);
-            ix_sw = clip_coordinates(ix_sw, inp_W);
-            iy_sw = clip_coordinates(iy_sw, inp_H);
-            ix_se = clip_coordinates(ix_se, inp_W);
-            iy_se = clip_coordinates(iy_se, inp_H);
-          }
-
           // calculate bilinear weighted pixel value and set output pixel
           scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
           scalar_t *inp_ptr_NC = inp_ptr_N;
@@ -122,16 +117,16 @@ namespace {
             //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
             // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
             *out_ptr_NCHW = static_cast<scalar_t>(0);
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+            if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
               *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+            if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
               *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+            if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
               *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+            if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
               *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
             }
           }
@@ -142,7 +137,7 @@ namespace {
   }
 
   template<typename scalar_t>
-  Tensor grid_sampler3d_cpu_impl(const Tensor& input, const Tensor& grid,
+  Tensor grid_sampler_3d_cpu_impl(const Tensor& input, const Tensor& grid,
                                  GridSamplerInterpolation interpolation_mode,
                                  GridSamplerPadding padding_mode) {
     int64_t N = input.size(0);
@@ -193,6 +188,13 @@ namespace {
             iy = ((iy + 1) / 2) * (inp_H - 1);
             iz = ((iz + 1) / 2) * (inp_D - 1);
 
+            if (padding_mode == GridSamplerPadding::Border) {
+              // clip coordinates to image borders
+              ix = clip_coordinates(ix, inp_W);
+              iy = clip_coordinates(iy, inp_H);
+              iz = clip_coordinates(iz, inp_D);
+            }
+
             // get corner pixel values from (x, y, z)
             // for 4d, we used north-east-south-west
             // for 5d, we add top-bottom
@@ -238,34 +240,6 @@ namespace {
             scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
             scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-            if (padding_mode == GridSamplerPadding::Border) {
-              // clip coordinates to image borders
-              ix_tnw = clip_coordinates(ix_tnw, inp_W);
-              iy_tnw = clip_coordinates(iy_tnw, inp_H);
-              iz_tnw = clip_coordinates(iz_tnw, inp_D);
-              ix_tne = clip_coordinates(ix_tne, inp_W);
-              iy_tne = clip_coordinates(iy_tne, inp_H);
-              iz_tne = clip_coordinates(iz_tne, inp_D);
-              ix_tsw = clip_coordinates(ix_tsw, inp_W);
-              iy_tsw = clip_coordinates(iy_tsw, inp_H);
-              iz_tsw = clip_coordinates(iz_tsw, inp_D);
-              ix_tse = clip_coordinates(ix_tse, inp_W);
-              iy_tse = clip_coordinates(iy_tse, inp_H);
-              iz_tse = clip_coordinates(iz_tse, inp_D);
-              ix_bnw = clip_coordinates(ix_bnw, inp_W);
-              iy_bnw = clip_coordinates(iy_bnw, inp_H);
-              iz_bnw = clip_coordinates(iz_bnw, inp_D);
-              ix_bne = clip_coordinates(ix_bne, inp_W);
-              iy_bne = clip_coordinates(iy_bne, inp_H);
-              iz_bne = clip_coordinates(iz_bne, inp_D);
-              ix_bsw = clip_coordinates(ix_bsw, inp_W);
-              iy_bsw = clip_coordinates(iy_bsw, inp_H);
-              iz_bsw = clip_coordinates(iz_bsw, inp_D);
-              ix_bse = clip_coordinates(ix_bse, inp_W);
-              iy_bse = clip_coordinates(iy_bse, inp_H);
-              iz_bse = clip_coordinates(iz_bse, inp_D);
-            }
-
             // calculate bilinear weighted pixel value and set output pixel
             scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
             scalar_t *inp_ptr_NC = inp_ptr_N;
@@ -275,28 +249,28 @@ namespace {
               // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
               // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
               *out_ptr_NCDHW = static_cast<scalar_t>(0);
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+              if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
                 *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
               }
             }
@@ -309,7 +283,7 @@ namespace {
 
   template<typename scalar_t>
   std::tuple<Tensor, Tensor>
-  grid_sampler2d_backward_cpu_impl(const Tensor& grad_output,
+  grid_sampler_2d_backward_cpu_impl(const Tensor& grad_output,
                                    const Tensor& input, const Tensor& grid,
                                    GridSamplerInterpolation interpolation_mode,
                                    GridSamplerPadding padding_mode) {
@@ -362,6 +336,23 @@ namespace {
           ix = ((ix + 1) / 2) * (inp_W - 1);
           iy = ((iy + 1) / 2) * (inp_H - 1);
 
+          // multipliers for gradients on ix and iy
+          // E.g.,  0 for out-of-bound indices when GridSamplerPadding::Border
+          //       -1 for out-of-bound indices when GridSamplerPadding::Reflection
+          scalar_t gix_mult = static_cast<scalar_t>(1), giy_mult = static_cast<scalar_t>(1);
+
+          if (padding_mode == GridSamplerPadding::Border) {
+            // clip coordinates to image borders
+            if (ix < static_cast<scalar_t>(0) || ix >= static_cast<scalar_t>(inp_W - 1)) {
+              gix_mult = static_cast<scalar_t>(0);
+              ix = clip_coordinates(ix, inp_W);
+            }
+            if (iy < static_cast<scalar_t>(0) || iy >= static_cast<scalar_t>(inp_H - 1)) {
+              giy_mult = static_cast<scalar_t>(0);
+              iy = clip_coordinates(iy, inp_H);
+            }
+          }
+
           // get NE, NW, SE, SW pixel values from (x, y)
           int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
           int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
@@ -378,29 +369,6 @@ namespace {
           scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
           scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-          int64_t ix_nw_cl, iy_nw_cl, ix_ne_cl, iy_ne_cl, ix_sw_cl, iy_sw_cl, ix_se_cl, iy_se_cl;
-
-          if (padding_mode == GridSamplerPadding::Border) {
-            // get clipped NE, NW, SE, SW pixel values from (x, y)
-            ix_nw_cl = clip_coordinates(ix_nw, inp_W);
-            iy_nw_cl = clip_coordinates(iy_nw, inp_H);
-            ix_ne_cl = clip_coordinates(ix_ne, inp_W);
-            iy_ne_cl = clip_coordinates(iy_ne, inp_H);
-            ix_sw_cl = clip_coordinates(ix_sw, inp_W);
-            iy_sw_cl = clip_coordinates(iy_sw, inp_H);
-            ix_se_cl = clip_coordinates(ix_se, inp_W);
-            iy_se_cl = clip_coordinates(iy_se, inp_H);
-          } else {
-            ix_nw_cl = ix_nw;
-            iy_nw_cl = iy_nw;
-            ix_ne_cl = ix_ne;
-            iy_ne_cl = iy_ne;
-            ix_sw_cl = ix_sw;
-            iy_sw_cl = iy_sw;
-            ix_se_cl = ix_se;
-            iy_se_cl = iy_se;
-          }
-
           scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
           scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
           scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
@@ -410,29 +378,29 @@ namespace {
             scalar_t gOut = *gOut_ptr_NCHW;
 
             // calculate and set grad_input
-            safe_add_2d(gInp_ptr_NC, iy_nw_cl, ix_nw_cl, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_ne_cl, ix_ne_cl, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_sw_cl, ix_sw_cl, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-            safe_add_2d(gInp_ptr_NC, iy_se_cl, ix_se_cl, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+            safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+            safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+            safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+            safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
 
             // calculate grad_grid
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_nw_cl, ix_nw_cl, inp_H, inp_W)) {
-              scalar_t nw_val = inp_ptr_NC[iy_nw_cl * inp_sH + ix_nw_cl * inp_sW];
+            if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+              scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
               gix -= nw_val * (iy_se - iy) * gOut;
               giy -= nw_val * (ix_se - ix) * gOut;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_ne_cl, ix_ne_cl, inp_H, inp_W)) {
-              scalar_t ne_val = inp_ptr_NC[iy_ne_cl * inp_sH + ix_ne_cl * inp_sW];
+            if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+              scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
               gix += ne_val * (iy_sw - iy) * gOut;
               giy -= ne_val * (ix - ix_sw) * gOut;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_sw_cl, ix_sw_cl, inp_H, inp_W)) {
-              scalar_t sw_val = inp_ptr_NC[iy_sw_cl * inp_sH + ix_sw_cl * inp_sW];
+            if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+              scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
               gix -= sw_val * (iy - iy_ne) * gOut;
               giy += sw_val * (ix_ne - ix) * gOut;
             }
-            if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_se_cl, ix_se_cl, inp_H, inp_W)) {
-              scalar_t se_val = inp_ptr_NC[iy_se_cl * inp_sH + ix_se_cl * inp_sW];
+            if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+              scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
               gix += se_val * (iy - iy_nw) * gOut;
               giy += se_val * (ix - ix_nw) * gOut;
             }
@@ -443,8 +411,8 @@ namespace {
           giy = giy * (inp_H - 1) / 2;
 
           // assuming grad_grid is contiguous
-          gGrid_ptr_NHW[0] = gix;
-          gGrid_ptr_NHW[1] = giy;
+          gGrid_ptr_NHW[0] = gix_mult * gix;
+          gGrid_ptr_NHW[1] = giy_mult * giy;
         }
       }
     }
@@ -453,7 +421,7 @@ namespace {
 
   template<typename scalar_t>
   std::tuple<Tensor, Tensor>
-  grid_sampler3d_backward_cpu_impl(const Tensor& grad_output,
+  grid_sampler_3d_backward_cpu_impl(const Tensor& grad_output,
                                    const Tensor& input, const Tensor& grid,
                                    GridSamplerInterpolation interpolation_mode,
                                    GridSamplerPadding padding_mode) {
@@ -516,6 +484,29 @@ namespace {
             iy = ((iy + 1) / 2) * (inp_H - 1);
             iz = ((iz + 1) / 2) * (inp_D - 1);
 
+            // multipliers for gradients on ix, iy, and iz
+            // E.g.,  0 for out-of-bound indices when GridSamplerPadding::Border
+            //       -1 for out-of-bound indices when GridSamplerPadding::Reflection
+            scalar_t gix_mult = static_cast<scalar_t>(1),
+                     giy_mult = static_cast<scalar_t>(1),
+                     giz_mult = static_cast<scalar_t>(1);
+
+            if (padding_mode == GridSamplerPadding::Border) {
+              // clip coordinates to image borders
+              if (ix < static_cast<scalar_t>(0) || ix >= static_cast<scalar_t>(inp_W - 1)) {
+                gix_mult = static_cast<scalar_t>(0);
+                ix = clip_coordinates(ix, inp_W);
+              }
+              if (iy < static_cast<scalar_t>(0) || iy >= static_cast<scalar_t>(inp_H - 1)) {
+                giy_mult = static_cast<scalar_t>(0);
+                iy = clip_coordinates(iy, inp_H);
+              }
+              if (iz < static_cast<scalar_t>(0) || iz >= static_cast<scalar_t>(inp_D - 1)) {
+                giz_mult = static_cast<scalar_t>(0);
+                iz = clip_coordinates(iz, inp_D);
+              }
+            }
+
             // get corner pixel values from (x, y, z)
             // for 4d, we used north-east-south-west
             // for 5d, we add top-bottom
@@ -561,64 +552,6 @@ namespace {
             scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
             scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-            int64_t ix_tnw_cl, iy_tnw_cl, iz_tnw_cl, ix_tne_cl, iy_tne_cl, iz_tne_cl;
-            int64_t ix_tsw_cl, iy_tsw_cl, iz_tsw_cl, ix_tse_cl, iy_tse_cl, iz_tse_cl;
-            int64_t ix_bnw_cl, iy_bnw_cl, iz_bnw_cl, ix_bne_cl, iy_bne_cl, iz_bne_cl;
-            int64_t ix_bsw_cl, iy_bsw_cl, iz_bsw_cl, ix_bse_cl, iy_bse_cl, iz_bse_cl;
-
-            if (padding_mode == GridSamplerPadding::Border) {
-              // clip coordinates to image borders
-              ix_tnw_cl = clip_coordinates(ix_tnw, inp_W);
-              iy_tnw_cl = clip_coordinates(iy_tnw, inp_H);
-              iz_tnw_cl = clip_coordinates(iz_tnw, inp_D);
-              ix_tne_cl = clip_coordinates(ix_tne, inp_W);
-              iy_tne_cl = clip_coordinates(iy_tne, inp_H);
-              iz_tne_cl = clip_coordinates(iz_tne, inp_D);
-              ix_tsw_cl = clip_coordinates(ix_tsw, inp_W);
-              iy_tsw_cl = clip_coordinates(iy_tsw, inp_H);
-              iz_tsw_cl = clip_coordinates(iz_tsw, inp_D);
-              ix_tse_cl = clip_coordinates(ix_tse, inp_W);
-              iy_tse_cl = clip_coordinates(iy_tse, inp_H);
-              iz_tse_cl = clip_coordinates(iz_tse, inp_D);
-              ix_bnw_cl = clip_coordinates(ix_bnw, inp_W);
-              iy_bnw_cl = clip_coordinates(iy_bnw, inp_H);
-              iz_bnw_cl = clip_coordinates(iz_bnw, inp_D);
-              ix_bne_cl = clip_coordinates(ix_bne, inp_W);
-              iy_bne_cl = clip_coordinates(iy_bne, inp_H);
-              iz_bne_cl = clip_coordinates(iz_bne, inp_D);
-              ix_bsw_cl = clip_coordinates(ix_bsw, inp_W);
-              iy_bsw_cl = clip_coordinates(iy_bsw, inp_H);
-              iz_bsw_cl = clip_coordinates(iz_bsw, inp_D);
-              ix_bse_cl = clip_coordinates(ix_bse, inp_W);
-              iy_bse_cl = clip_coordinates(iy_bse, inp_H);
-              iz_bse_cl = clip_coordinates(iz_bse, inp_D);
-            } else {
-              ix_tnw_cl = ix_tnw;
-              iy_tnw_cl = iy_tnw;
-              iz_tnw_cl = iz_tnw;
-              ix_tne_cl = ix_tne;
-              iy_tne_cl = iy_tne;
-              iz_tne_cl = iz_tne;
-              ix_tsw_cl = ix_tsw;
-              iy_tsw_cl = iy_tsw;
-              iz_tsw_cl = iz_tsw;
-              ix_tse_cl = ix_tse;
-              iy_tse_cl = iy_tse;
-              iz_tse_cl = iz_tse;
-              ix_bnw_cl = ix_bnw;
-              iy_bnw_cl = iy_bnw;
-              iz_bnw_cl = iz_bnw;
-              ix_bne_cl = ix_bne;
-              iy_bne_cl = iy_bne;
-              iz_bne_cl = iz_bne;
-              ix_bsw_cl = ix_bsw;
-              iy_bsw_cl = iy_bsw;
-              iz_bsw_cl = iz_bsw;
-              ix_bse_cl = ix_bse;
-              iy_bse_cl = iy_bse;
-              iz_bse_cl = iz_bse;
-            }
-
             scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
             scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
             scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
@@ -628,60 +561,60 @@ namespace {
               scalar_t gOut = *gOut_ptr_NCDHW;
 
               // calculate and set grad_input
-              safe_add_3d(gInp_ptr_NC, iz_tnw_cl, iy_tnw_cl, ix_tnw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tne_cl, iy_tne_cl, ix_tne_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tsw_cl, iy_tsw_cl, ix_tsw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_tse_cl, iy_tse_cl, ix_tse_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bnw_cl, iy_bnw_cl, ix_bnw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bne_cl, iy_bne_cl, ix_bne_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bsw_cl, iy_bsw_cl, ix_bsw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
-              safe_add_3d(gInp_ptr_NC, iz_bse_cl, iy_bse_cl, ix_bse_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
+              safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
 
               // calculate grad_grid
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tnw_cl, iy_tnw_cl, ix_tnw_cl, inp_D, inp_H, inp_W)) {
-                scalar_t tnw_val = inp_ptr_NC[iz_tnw_cl * inp_sD + iy_tnw_cl * inp_sH + ix_tnw_cl * inp_sW];
+              if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+                scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
                 gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
                 giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
                 giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tne_cl, iy_tne_cl, ix_tne_cl, inp_D, inp_H, inp_W)) {
-                scalar_t tne_val = inp_ptr_NC[iz_tne_cl * inp_sD + iy_tne_cl * inp_sH + ix_tne_cl * inp_sW];
+              if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+                scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
                 gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
                 giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
                 giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tsw_cl, iy_tsw_cl, ix_tsw_cl, inp_D, inp_H, inp_W)) {
-                scalar_t tsw_val = inp_ptr_NC[iz_tsw_cl * inp_sD + iy_tsw_cl * inp_sH + ix_tsw_cl * inp_sW];
+              if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+                scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
                 gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
                 giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
                 giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tse_cl, iy_tse_cl, ix_tse_cl, inp_D, inp_H, inp_W)) {
-                scalar_t tse_val = inp_ptr_NC[iz_tse_cl * inp_sD + iy_tse_cl * inp_sH + ix_tse_cl * inp_sW];
+              if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+                scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
                 gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
                 giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
                 giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bnw_cl, iy_bnw_cl, ix_bnw_cl, inp_D, inp_H, inp_W)) {
-                scalar_t bnw_val = inp_ptr_NC[iz_bnw_cl * inp_sD + iy_bnw_cl * inp_sH + ix_bnw_cl * inp_sW];
+              if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+                scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
                 gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
                 giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
                 giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bne_cl, iy_bne_cl, ix_bne_cl, inp_D, inp_H, inp_W)) {
-                scalar_t bne_val = inp_ptr_NC[iz_bne_cl * inp_sD + iy_bne_cl * inp_sH + ix_bne_cl * inp_sW];
+              if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+                scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
                 gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
                 giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
                 giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bsw_cl, iy_bsw_cl, ix_bsw_cl, inp_D, inp_H, inp_W)) {
-                scalar_t bsw_val = inp_ptr_NC[iz_bsw_cl * inp_sD + iy_bsw_cl * inp_sH + ix_bsw_cl * inp_sW];
+              if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+                scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
                 gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
                 giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
                 giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
               }
-              if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bse_cl, iy_bse_cl, ix_bse_cl, inp_D, inp_H, inp_W)) {
-                scalar_t bse_val = inp_ptr_NC[iz_bse_cl * inp_sD + iy_bse_cl * inp_sH + ix_bse_cl * inp_sW];
+              if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+                scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
                 gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
                 giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
                 giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
@@ -694,9 +627,9 @@ namespace {
             giz = giz * (inp_D - 1) / 2;
 
             // assuming grad_grid is contiguous
-            gGrid_ptr_NDHW[0] = gix;
-            gGrid_ptr_NDHW[1] = giy;
-            gGrid_ptr_NDHW[2] = giz;
+            gGrid_ptr_NDHW[0] = gix_mult * gix;
+            gGrid_ptr_NDHW[1] = giy_mult * giy;
+            gGrid_ptr_NDHW[2] = giz_mult * giz;
           }
         }
       }
@@ -709,7 +642,7 @@ namespace {
 Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
                            int64_t interpolation_mode, int64_t padding_mode) {
   return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler2d_cpu", [&] {
-    return grid_sampler2d_cpu_impl<scalar_t>(
+    return grid_sampler_2d_cpu_impl<scalar_t>(
       input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
       static_cast<GridSamplerPadding>(padding_mode));
   });
@@ -719,7 +652,7 @@ Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
 Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
                            int64_t interpolation_mode, int64_t padding_mode) {
   return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler3d_cpu", [&] {
-    return grid_sampler3d_cpu_impl<scalar_t>(
+    return grid_sampler_3d_cpu_impl<scalar_t>(
       input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
       static_cast<GridSamplerPadding>(padding_mode));
   });
@@ -730,7 +663,7 @@ std::tuple<Tensor, Tensor>
 grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
                              int64_t interpolation_mode, int64_t padding_mode) {
   return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_2d_backward_cpu", [&] {
-    return grid_sampler2d_backward_cpu_impl<scalar_t>(
+    return grid_sampler_2d_backward_cpu_impl<scalar_t>(
       grad_output, input, grid,
       static_cast<GridSamplerInterpolation>(interpolation_mode),
       static_cast<GridSamplerPadding>(padding_mode));
@@ -742,14 +675,15 @@ std::tuple<Tensor, Tensor>
 grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
                              int64_t interpolation_mode, int64_t padding_mode) {
   return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_3d_backward_cpu", [&] {
-    return grid_sampler3d_backward_cpu_impl<scalar_t>(
+    return grid_sampler_3d_backward_cpu_impl<scalar_t>(
       grad_output, input, grid,
       static_cast<GridSamplerInterpolation>(interpolation_mode),
       static_cast<GridSamplerPadding>(padding_mode));
   });
 }
 
-Tensor grid_sampler(const Tensor& input, const Tensor& grid, int64_t padding_mode) {
+Tensor grid_sampler(const Tensor& input, const Tensor& grid,
+                    int64_t interpolation_mode, int64_t padding_mode) {
   AT_CHECK(
     (input.dim() == 4 || input.dim() == 5) && input.dim() == grid.dim(),
     "grid_sampler(): expected 4D or 5D input and grid with same number "
@@ -765,15 +699,16 @@ Tensor grid_sampler(const Tensor& input, const Tensor& grid, int64_t padding_mod
     "dimension, but got grid with sizes ", grid.sizes());
   // cudnn does not support inputs larger than 1024
   if (at::native::cudnn_is_acceptable(input) &&
+      static_cast<GridSamplerInterpolation>(interpolation_mode) == GridSamplerInterpolation::Bilinear &&
       static_cast<GridSamplerPadding>(padding_mode) == GridSamplerPadding::Zeros &&
       input.dim() == 4 &&
       input.size(1) <= 1024) {
     return cudnn_grid_sampler(input, grid);
   }
   if (input.dim() == 4) {
-    return at::grid_sampler_2d(input, grid, 0, padding_mode);
+    return at::grid_sampler_2d(input, grid, interpolation_mode, padding_mode);
   } else {
-    return at::grid_sampler_3d(input, grid, 0, padding_mode);
+    return at::grid_sampler_3d(input, grid, interpolation_mode, padding_mode);
   }
 }
 

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -29,6 +29,11 @@ bool cudnn_is_acceptable(const Tensor& self) {
   auto st = self.type().scalarType();
   if (!(st == kDouble || st == kFloat || st == kHalf)) return false;
   if (!detail::getCUDAHooks().compiledWithCuDNN()) return false;
+  // cuDNN functions like grid_sampler returns CUDNN_STATUS_BAD_PARAM on empty
+  // tensors. Maybe some cuDNN functions actually support empty tensors, but
+  // native/THNN kernels shouldn't be much slower because the output is also
+  // likely empty.
+  if (self.numel() == 0) return false;
   // NB: In the old Python code, there was also a test to see if the
   // cuDNN library was actually dynamically linked or not.  I'm not
   // sure if we can actually test this.

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -788,17 +788,19 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
   auto H = grid.size(1);
   auto W = grid.size(2);
   auto output = at::empty({N, input.size(1), H, W}, input.options());
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
-    int count = static_cast<int>(N * H * W);
-    grid_sampler_2d_kernel<scalar_t>
-      <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-        count,
-        getTensorInfo<scalar_t, int>(input),
-        getTensorInfo<scalar_t, int>(grid),
-        getTensorInfo<scalar_t, int>(output),
-        static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode));
-  });
+  int count = static_cast<int>(N * H * W);
+  if (count > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
+      grid_sampler_2d_kernel<scalar_t>
+        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          count,
+          getTensorInfo<scalar_t, int>(input),
+          getTensorInfo<scalar_t, int>(grid),
+          getTensorInfo<scalar_t, int>(output),
+          static_cast<GridSamplerInterpolation>(interpolation_mode),
+          static_cast<GridSamplerPadding>(padding_mode));
+    });
+  }
   return output;
 }
 
@@ -811,16 +813,18 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
   auto W = grid.size(3);
   auto output = at::empty({N, input.size(1), D, H, W}, input.options());
   int count = static_cast<int>(N * D * H * W);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
-    grid_sampler_3d_kernel<scalar_t>
-      <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-        count,
-        getTensorInfo<scalar_t, int>(input),
-        getTensorInfo<scalar_t, int>(grid),
-        getTensorInfo<scalar_t, int>(output),
-        static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode));
-  });
+  if (count > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
+      grid_sampler_3d_kernel<scalar_t>
+        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          count,
+          getTensorInfo<scalar_t, int>(input),
+          getTensorInfo<scalar_t, int>(grid),
+          getTensorInfo<scalar_t, int>(output),
+          static_cast<GridSamplerInterpolation>(interpolation_mode),
+          static_cast<GridSamplerPadding>(padding_mode));
+    });
+  }
   return output;
 }
 
@@ -834,18 +838,20 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_input = at::zeros_like(input);
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * H * W);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_backward_cuda", [&] {
-    grid_sampler_2d_backward_kernel<scalar_t>
-      <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-        count,
-        getTensorInfo<scalar_t, int>(grad_output),
-        getTensorInfo<scalar_t, int>(input),
-        getTensorInfo<scalar_t, int>(grid),
-        getTensorInfo<scalar_t, int>(grad_input),
-        getTensorInfo<scalar_t, int>(grad_grid),
-        static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode));
-  });
+  if (count > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_backward_cuda", [&] {
+      grid_sampler_2d_backward_kernel<scalar_t>
+        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          count,
+          getTensorInfo<scalar_t, int>(grad_output),
+          getTensorInfo<scalar_t, int>(input),
+          getTensorInfo<scalar_t, int>(grid),
+          getTensorInfo<scalar_t, int>(grad_input),
+          getTensorInfo<scalar_t, int>(grad_grid),
+          static_cast<GridSamplerInterpolation>(interpolation_mode),
+          static_cast<GridSamplerPadding>(padding_mode));
+    });
+  }
   return std::make_tuple(grad_input, grad_grid);
 }
 
@@ -860,18 +866,20 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_input = at::zeros_like(input);
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * D * H * W);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_3d_backward_cuda", [&] {
-    grid_sampler_3d_backward_kernel<scalar_t>
-      <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-        count,
-        getTensorInfo<scalar_t, int>(grad_output),
-        getTensorInfo<scalar_t, int>(input),
-        getTensorInfo<scalar_t, int>(grid),
-        getTensorInfo<scalar_t, int>(grad_input),
-        getTensorInfo<scalar_t, int>(grad_grid),
-        static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode));
-  });
+  if (count > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_3d_backward_cuda", [&] {
+      grid_sampler_3d_backward_kernel<scalar_t>
+        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          count,
+          getTensorInfo<scalar_t, int>(grad_output),
+          getTensorInfo<scalar_t, int>(input),
+          getTensorInfo<scalar_t, int>(grid),
+          getTensorInfo<scalar_t, int>(grad_input),
+          getTensorInfo<scalar_t, int>(grad_grid),
+          static_cast<GridSamplerInterpolation>(interpolation_mode),
+          static_cast<GridSamplerPadding>(padding_mode));
+    });
+  }
   return std::make_tuple(grad_input, grad_grid);
 }
 

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -125,6 +125,7 @@ namespace {
       TensorInfo<scalar_t, int> input,
       TensorInfo<scalar_t, int> grid,
       TensorInfo<scalar_t, int> output,
+      const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode) {
 
     int C = input.sizes[1];
@@ -172,38 +173,54 @@ namespace {
       ix = static_cast<scalar_t>(ixf);
       iy = static_cast<scalar_t>(iyf);
 
-      // get NE, NW, SE, SW pixel values from (x, y)
-      int ix_nw = static_cast<int>(::floor(ixf));
-      int iy_nw = static_cast<int>(::floor(iyf));
-      int ix_ne = ix_nw + 1;
-      int iy_ne = iy_nw;
-      int ix_sw = ix_nw;
-      int iy_sw = iy_nw + 1;
-      int ix_se = ix_nw + 1;
-      int iy_se = iy_nw + 1;
+      if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+        // get NE, NW, SE, SW pixel values from (x, y)
+        int ix_nw = static_cast<int>(::floor(ixf));
+        int iy_nw = static_cast<int>(::floor(iyf));
+        int ix_ne = ix_nw + 1;
+        int iy_ne = iy_nw;
+        int ix_sw = ix_nw;
+        int iy_sw = iy_nw + 1;
+        int ix_se = ix_nw + 1;
+        int iy_se = iy_nw + 1;
 
-      // get surfaces to each neighbor:
-      scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-      scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-      scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-      scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+        // get surfaces to each neighbor:
+        scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+        scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+        scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+        scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-      // calculate bilinear weighted pixel value and set output pixel
-      auto inp_ptr_NC = input.data + n * inp_sN;
-      auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
-      for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
-        *out_ptr_NCHW = static_cast<scalar_t>(0);
-        if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-          *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+        // calculate bilinear weighted pixel value and set output pixel
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
+        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
+          *out_ptr_NCHW = static_cast<scalar_t>(0);
+          if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+            *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+          }
+          if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+            *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
+          }
+          if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+            *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
+          }
+          if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+            *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+          }
         }
-        if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-          *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
-        }
-        if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-          *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
-        }
-        if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-          *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+      } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+        int ix_nearest = static_cast<int>(::round(ixf));
+        int iy_nearest = static_cast<int>(::round(iyf));
+
+        // assign nearest neighor pixel value to output pixel
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
+        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
+          if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
+            *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
+          } else {
+            *out_ptr_NCHW = static_cast<scalar_t>(0);
+          }
         }
       }
     }
@@ -216,6 +233,7 @@ namespace {
       TensorInfo<scalar_t, int> input,
       TensorInfo<scalar_t, int> grid,
       TensorInfo<scalar_t, int> output,
+      const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode) {
 
     int C = input.sizes[1];
@@ -270,86 +288,103 @@ namespace {
         izf = reflect_coordinates(izf, inp_D);
       }
 
-      ix = static_cast<scalar_t>(ixf);
-      iy = static_cast<scalar_t>(iyf);
-      iz = static_cast<scalar_t>(izf);
+      if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+        ix = static_cast<scalar_t>(ixf);
+        iy = static_cast<scalar_t>(iyf);
+        iz = static_cast<scalar_t>(izf);
 
-      // get corner pixel values from (x, y, z)
-      // for 4d, we used north-east-south-west
-      // for 5d, we add top-bottom
-      int ix_tnw = static_cast<int>(::floor(ix));
-      int iy_tnw = static_cast<int>(::floor(iy));
-      int iz_tnw = static_cast<int>(::floor(iz));
+        // get corner pixel values from (x, y, z)
+        // for 4d, we used north-east-south-west
+        // for 5d, we add top-bottom
+        int ix_tnw = static_cast<int>(::floor(ix));
+        int iy_tnw = static_cast<int>(::floor(iy));
+        int iz_tnw = static_cast<int>(::floor(iz));
 
-      int ix_tne = ix_tnw + 1;
-      int iy_tne = iy_tnw;
-      int iz_tne = iz_tnw;
+        int ix_tne = ix_tnw + 1;
+        int iy_tne = iy_tnw;
+        int iz_tne = iz_tnw;
 
-      int ix_tsw = ix_tnw;
-      int iy_tsw = iy_tnw + 1;
-      int iz_tsw = iz_tnw;
+        int ix_tsw = ix_tnw;
+        int iy_tsw = iy_tnw + 1;
+        int iz_tsw = iz_tnw;
 
-      int ix_tse = ix_tnw + 1;
-      int iy_tse = iy_tnw + 1;
-      int iz_tse = iz_tnw;
+        int ix_tse = ix_tnw + 1;
+        int iy_tse = iy_tnw + 1;
+        int iz_tse = iz_tnw;
 
-      int ix_bnw = ix_tnw;
-      int iy_bnw = iy_tnw;
-      int iz_bnw = iz_tnw + 1;
+        int ix_bnw = ix_tnw;
+        int iy_bnw = iy_tnw;
+        int iz_bnw = iz_tnw + 1;
 
-      int ix_bne = ix_tnw + 1;
-      int iy_bne = iy_tnw;
-      int iz_bne = iz_tnw + 1;
+        int ix_bne = ix_tnw + 1;
+        int iy_bne = iy_tnw;
+        int iz_bne = iz_tnw + 1;
 
-      int ix_bsw = ix_tnw;
-      int iy_bsw = iy_tnw + 1;
-      int iz_bsw = iz_tnw + 1;
+        int ix_bsw = ix_tnw;
+        int iy_bsw = iy_tnw + 1;
+        int iz_bsw = iz_tnw + 1;
 
-      int ix_bse = ix_tnw + 1;
-      int iy_bse = iy_tnw + 1;
-      int iz_bse = iz_tnw + 1;
+        int ix_bse = ix_tnw + 1;
+        int iy_bse = iy_tnw + 1;
+        int iz_bse = iz_tnw + 1;
 
-      // get surfaces to each neighbor:
-      scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
-      scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
-      scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
-      scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
-      scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
-      scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
-      scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
-      scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
+        // get surfaces to each neighbor:
+        scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
+        scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
+        scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
+        scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
+        scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
+        scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
+        scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
+        scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-      auto inp_ptr_NC = input.data + n * inp_sN;
-      auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
-      for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
-        //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
-        // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
-        // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
-        // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
-        *out_ptr_NCDHW = static_cast<scalar_t>(0);
-        if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+          //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
+          // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
+          // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
+          // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
+          *out_ptr_NCDHW = static_cast<scalar_t>(0);
+          if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
+          }
+          if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
+          }
+          if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
+          }
+          if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
+          }
+          if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
+          }
+          if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
+          }
+          if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
+          }
+          if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
+          }
         }
-        if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
-        }
-        if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
-        }
-        if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
-        }
-        if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
-        }
-        if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
-        }
-        if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
-        }
-        if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
-          *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
+      } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+        int ix_nearest = static_cast<int>(::round(ixf));
+        int iy_nearest = static_cast<int>(::round(iyf));
+        int iz_nearest = static_cast<int>(::round(izf));
+
+        // assign nearest neighor pixel value to output pixel
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+          if (within_bounds_3d(iz_nearest, iy_nearest, ix_nearest, inp_D, inp_H, inp_W)) {
+            *out_ptr_NCDHW = inp_ptr_NC[iz_nearest * inp_sD + iy_nearest * inp_sH + ix_nearest * inp_sW];
+          } else {
+            *out_ptr_NCDHW = static_cast<scalar_t>(0);
+          }
         }
       }
     }
@@ -364,6 +399,7 @@ namespace {
       TensorInfo<scalar_t, int> grid,
       TensorInfo<scalar_t, int> grad_input,  // initialized to zeros
       TensorInfo<scalar_t, int> grad_grid,   // initialized to empty
+      const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode) {
 
     int C = input.sizes[1];
@@ -419,72 +455,93 @@ namespace {
         giy_mult = static_cast<scalar_t>(1);
       }
 
-      ix = static_cast<scalar_t>(ixf);
-      iy = static_cast<scalar_t>(iyf);
+      if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+        ix = static_cast<scalar_t>(ixf);
+        iy = static_cast<scalar_t>(iyf);
 
-      // get NE, NW, SE, SW pixel values from (x, y)
-      int ix_nw = static_cast<int>(::floor(ixf));
-      int iy_nw = static_cast<int>(::floor(iyf));
-      int ix_ne = ix_nw + 1;
-      int iy_ne = iy_nw;
-      int ix_sw = ix_nw;
-      int iy_sw = iy_nw + 1;
-      int ix_se = ix_nw + 1;
-      int iy_se = iy_nw + 1;
+        // get NE, NW, SE, SW pixel values from (x, y)
+        int ix_nw = static_cast<int>(::floor(ixf));
+        int iy_nw = static_cast<int>(::floor(iyf));
+        int ix_ne = ix_nw + 1;
+        int iy_ne = iy_nw;
+        int ix_sw = ix_nw;
+        int iy_sw = iy_nw + 1;
+        int ix_se = ix_nw + 1;
+        int iy_se = iy_nw + 1;
 
-      // get surfaces to each neighbor:
-      scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-      scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-      scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-      scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+        // get surfaces to each neighbor:
+        scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+        scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+        scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+        scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-      scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
-      scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-      scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
-      scalar_t *inp_ptr_NC = input.data + n * inp_sN;
-      for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
-        scalar_t gOut = *gOut_ptr_NCHW;
+        scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
+        scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+        scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
+        scalar_t *inp_ptr_NC = input.data + n * inp_sN;
+        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+          scalar_t gOut = *gOut_ptr_NCHW;
 
-        // calculate and set grad_input
-        safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+          // calculate and set grad_input
+          safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+          safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+          safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+          safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
 
-        // calculate grad_grid
-        if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-          scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
-          gix -= nw_val * (iy_se - iy) * gOut;
-          giy -= nw_val * (ix_se - ix) * gOut;
+          // calculate grad_grid
+          if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+            scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
+            gix -= nw_val * (iy_se - iy) * gOut;
+            giy -= nw_val * (ix_se - ix) * gOut;
+          }
+          if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+            scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
+            gix += ne_val * (iy_sw - iy) * gOut;
+            giy -= ne_val * (ix - ix_sw) * gOut;
+          }
+          if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+            scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
+            gix -= sw_val * (iy - iy_ne) * gOut;
+            giy += sw_val * (ix_ne - ix) * gOut;
+          }
+          if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+            scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
+            gix += se_val * (iy - iy_nw) * gOut;
+            giy += se_val * (ix - ix_nw) * gOut;
+          }
         }
-        if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-          scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
-          gix += ne_val * (iy_sw - iy) * gOut;
-          giy -= ne_val * (ix - ix_sw) * gOut;
+
+        // un-normalize grad_grid values back to [-1, 1] constraints
+        gix = gix * (inp_W - 1.f) / 2;
+        giy = giy * (inp_H - 1.f) / 2;
+
+        // assuming grad_grid is contiguous
+        // thus we can
+        //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NHW
+        //   2. directly assign to gGrid_ptr_NHW[0], gGrid_ptr_NHW[1]
+        scalar_t *gGrid_ptr_NHW = grad_grid.data + index * gGrid_sW;
+        gGrid_ptr_NHW[0] = gix_mult * gix;
+        gGrid_ptr_NHW[1] = giy_mult * giy;
+      } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+        int ix_nearest = static_cast<int>(::round(ixf));
+        int iy_nearest = static_cast<int>(::round(iyf));
+
+        // assign nearest neighor pixel value to output pixel
+        scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+        scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
+        for (int c = 0; c < C; ++c, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+          // calculate and set grad_input
+          safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW);
         }
-        if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-          scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
-          gix -= sw_val * (iy - iy_ne) * gOut;
-          giy += sw_val * (ix_ne - ix) * gOut;
-        }
-        if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-          scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
-          gix += se_val * (iy - iy_nw) * gOut;
-          giy += se_val * (ix - ix_nw) * gOut;
-        }
+
+        // assuming grad_grid is contiguous
+        // thus we can
+        //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NHW
+        //   2. directly assign to gGrid_ptr_NHW[0], gGrid_ptr_NHW[1]
+        scalar_t *gGrid_ptr_NHW = grad_grid.data + index * gGrid_sW;
+        gGrid_ptr_NHW[0] = static_cast<scalar_t>(0);
+        gGrid_ptr_NHW[1] = static_cast<scalar_t>(0);
       }
-
-      // un-normalize grad_grid values back to [-1, 1] constraints
-      gix = gix * (inp_W - 1.f) / 2;
-      giy = giy * (inp_H - 1.f) / 2;
-
-      // assuming grad_grid is contiguous
-      // thus we can
-      //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NHW
-      //   2. directly assign to gGrid_ptr_NHW[0], gGrid_ptr_NHW[1]
-      scalar_t *gGrid_ptr_NHW = grad_grid.data + index * gGrid_sW;
-      gGrid_ptr_NHW[0] = gix_mult * gix;
-      gGrid_ptr_NHW[1] = giy_mult * giy;
     }
   }
 
@@ -497,6 +554,7 @@ namespace {
       TensorInfo<scalar_t, int> grid,
       TensorInfo<scalar_t, int> grad_input,  // initialized to zeros
       TensorInfo<scalar_t, int> grad_grid,   // initialized to empty
+      const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode) {
 
     int C = input.sizes[1];
@@ -564,137 +622,161 @@ namespace {
         giz_mult = static_cast<scalar_t>(1);
       }
 
-      ix = static_cast<scalar_t>(ixf);
-      iy = static_cast<scalar_t>(iyf);
-      iz = static_cast<scalar_t>(izf);
+      if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+        ix = static_cast<scalar_t>(ixf);
+        iy = static_cast<scalar_t>(iyf);
+        iz = static_cast<scalar_t>(izf);
 
-      // get corner pixel values from (x, y, z)
-      // for 4d, we used north-east-south-west
-      // for 5d, we add top-bottom
-      int ix_tnw = static_cast<int>(::floor(ix));
-      int iy_tnw = static_cast<int>(::floor(iy));
-      int iz_tnw = static_cast<int>(::floor(iz));
+        // get corner pixel values from (x, y, z)
+        // for 4d, we used north-east-south-west
+        // for 5d, we add top-bottom
+        int ix_tnw = static_cast<int>(::floor(ix));
+        int iy_tnw = static_cast<int>(::floor(iy));
+        int iz_tnw = static_cast<int>(::floor(iz));
 
-      int ix_tne = ix_tnw + 1;
-      int iy_tne = iy_tnw;
-      int iz_tne = iz_tnw;
+        int ix_tne = ix_tnw + 1;
+        int iy_tne = iy_tnw;
+        int iz_tne = iz_tnw;
 
-      int ix_tsw = ix_tnw;
-      int iy_tsw = iy_tnw + 1;
-      int iz_tsw = iz_tnw;
+        int ix_tsw = ix_tnw;
+        int iy_tsw = iy_tnw + 1;
+        int iz_tsw = iz_tnw;
 
-      int ix_tse = ix_tnw + 1;
-      int iy_tse = iy_tnw + 1;
-      int iz_tse = iz_tnw;
+        int ix_tse = ix_tnw + 1;
+        int iy_tse = iy_tnw + 1;
+        int iz_tse = iz_tnw;
 
-      int ix_bnw = ix_tnw;
-      int iy_bnw = iy_tnw;
-      int iz_bnw = iz_tnw + 1;
+        int ix_bnw = ix_tnw;
+        int iy_bnw = iy_tnw;
+        int iz_bnw = iz_tnw + 1;
 
-      int ix_bne = ix_tnw + 1;
-      int iy_bne = iy_tnw;
-      int iz_bne = iz_tnw + 1;
+        int ix_bne = ix_tnw + 1;
+        int iy_bne = iy_tnw;
+        int iz_bne = iz_tnw + 1;
 
-      int ix_bsw = ix_tnw;
-      int iy_bsw = iy_tnw + 1;
-      int iz_bsw = iz_tnw + 1;
+        int ix_bsw = ix_tnw;
+        int iy_bsw = iy_tnw + 1;
+        int iz_bsw = iz_tnw + 1;
 
-      int ix_bse = ix_tnw + 1;
-      int iy_bse = iy_tnw + 1;
-      int iz_bse = iz_tnw + 1;
+        int ix_bse = ix_tnw + 1;
+        int iy_bse = iy_tnw + 1;
+        int iz_bse = iz_tnw + 1;
 
-      // get surfaces to each neighbor:
-      scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
-      scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
-      scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
-      scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
-      scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
-      scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
-      scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
-      scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
+        // get surfaces to each neighbor:
+        scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
+        scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
+        scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
+        scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
+        scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
+        scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
+        scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
+        scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-      scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
-      scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
-      scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
-      scalar_t *inp_ptr_NC = input.data + n * inp_sN;
-      // calculate bilinear weighted pixel value and set output pixel
-      for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
-        scalar_t gOut = *gOut_ptr_NCDHW;
+        scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
+        scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+        scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
+        scalar_t *inp_ptr_NC = input.data + n * inp_sN;
+        // calculate bilinear weighted pixel value and set output pixel
+        for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+          scalar_t gOut = *gOut_ptr_NCDHW;
 
-        // calculate and set grad_input
-        safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
+          // calculate and set grad_input
+          safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
+          safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
 
-        // calculate grad_grid
-        if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
-          scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
-          gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
-          giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
-          giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
+          // calculate grad_grid
+          if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+            scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
+            gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
+            giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
+            giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
+          }
+          if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+            scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
+            gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
+            giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
+            giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
+          }
+          if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+            scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
+            gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
+            giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
+            giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
+          }
+          if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+            scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
+            gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
+            giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
+            giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
+          }
+          if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+            scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
+            gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
+            giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
+            giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
+          }
+          if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+            scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
+            gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
+            giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
+            giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
+          }
+          if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+            scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
+            gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
+            giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
+            giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
+          }
+          if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+            scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
+            gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
+            giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
+            giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
+          }
         }
-        if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
-          scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
-          gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
-          giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
-          giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
+
+        // un-normalize grad_grid values back to [-1, 1] constraints
+        gix = gix * (inp_W - 1) / 2;
+        giy = giy * (inp_H - 1) / 2;
+        giz = giz * (inp_D - 1) / 2;
+
+        // assuming grad_grid is contiguous
+        // thus we can
+        //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NDHW
+        //   2. directly assign to gGrid_ptr_NDHW[0], gGrid_ptr_NDHW[1], gGrid_ptr_NDHW[2]
+        scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
+        gGrid_ptr_NDHW[0] = gix_mult * gix;
+        gGrid_ptr_NDHW[1] = giy_mult * giy;
+        gGrid_ptr_NDHW[2] = giz_mult * giz;
+      } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+        int ix_nearest = static_cast<int>(::round(ixf));
+        int iy_nearest = static_cast<int>(::round(iyf));
+        int iz_nearest = static_cast<int>(::round(izf));
+
+        // assign nearest neighor pixel value to output pixel
+        scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+        scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
+        for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+          // calculate and set grad_input
+          safe_add_3d(gInp_ptr_NC, iz_nearest, iy_nearest, ix_nearest,
+                      gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW);
         }
-        if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
-          scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
-          gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
-          giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
-          giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
-        }
-        if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
-          scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
-          gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
-          giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
-          giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
-        }
-        if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
-          scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
-          gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
-          giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
-          giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
-        }
-        if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
-          scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
-          gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
-          giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
-          giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
-        }
-        if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
-          scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
-          gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
-          giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
-          giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
-        }
-        if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
-          scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
-          gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
-          giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
-          giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
-        }
+
+        // assuming grad_grid is contiguous
+        // thus we can
+        //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NDHW
+        //   2. directly assign to gGrid_ptr_NDHW[0], gGrid_ptr_NDHW[1], gGrid_ptr_NDHW[2]
+        scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
+        gGrid_ptr_NDHW[0] = static_cast<scalar_t>(0);
+        gGrid_ptr_NDHW[1] = static_cast<scalar_t>(0);
+        gGrid_ptr_NDHW[2] = static_cast<scalar_t>(0);
       }
-
-      // un-normalize grad_grid values back to [-1, 1] constraints
-      gix = gix * (inp_W - 1) / 2;
-      giy = giy * (inp_H - 1) / 2;
-      giz = giz * (inp_D - 1) / 2;
-
-      // assuming grad_grid is contiguous
-      // thus we can
-      //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NDHW
-      //   2. directly assign to gGrid_ptr_NDHW[0], gGrid_ptr_NDHW[1], gGrid_ptr_NDHW[2]
-      scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
-      gGrid_ptr_NDHW[0] = gix_mult * gix;
-      gGrid_ptr_NDHW[1] = giy_mult * giy;
-      gGrid_ptr_NDHW[2] = giz_mult * giz;
     }
   }
 }  // namespace
@@ -714,6 +796,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
         getTensorInfo<scalar_t, int>(input),
         getTensorInfo<scalar_t, int>(grid),
         getTensorInfo<scalar_t, int>(output),
+        static_cast<GridSamplerInterpolation>(interpolation_mode),
         static_cast<GridSamplerPadding>(padding_mode));
   });
   return output;
@@ -735,6 +818,7 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
         getTensorInfo<scalar_t, int>(input),
         getTensorInfo<scalar_t, int>(grid),
         getTensorInfo<scalar_t, int>(output),
+        static_cast<GridSamplerInterpolation>(interpolation_mode),
         static_cast<GridSamplerPadding>(padding_mode));
   });
   return output;
@@ -749,8 +833,8 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto W = grid.size(2);
   auto grad_input = at::zeros_like(input);
   auto grad_grid = at::empty_like(grid);
+  int count = static_cast<int>(N * H * W);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_backward_cuda", [&] {
-    int count = static_cast<int>(N * H * W);
     grid_sampler_2d_backward_kernel<scalar_t>
       <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
         count,
@@ -759,6 +843,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
         getTensorInfo<scalar_t, int>(grid),
         getTensorInfo<scalar_t, int>(grad_input),
         getTensorInfo<scalar_t, int>(grad_grid),
+        static_cast<GridSamplerInterpolation>(interpolation_mode),
         static_cast<GridSamplerPadding>(padding_mode));
   });
   return std::make_tuple(grad_input, grad_grid);
@@ -774,8 +859,8 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto W = grid.size(3);
   auto grad_input = at::zeros_like(input);
   auto grad_grid = at::empty_like(grid);
+  int count = static_cast<int>(N * D * H * W);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_3d_backward_cuda", [&] {
-    int count = static_cast<int>(N * D * H * W);
     grid_sampler_3d_backward_kernel<scalar_t>
       <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
         count,
@@ -784,6 +869,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
         getTensorInfo<scalar_t, int>(grid),
         getTensorInfo<scalar_t, int>(grad_input),
         getTensorInfo<scalar_t, int>(grad_grid),
+        static_cast<GridSamplerInterpolation>(interpolation_mode),
         static_cast<GridSamplerPadding>(padding_mode));
   });
   return std::make_tuple(grad_input, grad_grid);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -810,8 +810,8 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
   auto H = grid.size(2);
   auto W = grid.size(3);
   auto output = at::empty({N, input.size(1), D, H, W}, input.options());
+  int count = static_cast<int>(N * D * H * W);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
-    int count = static_cast<int>(N * D * H * W);
     grid_sampler_3d_kernel<scalar_t>
       <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
         count,

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -15,8 +15,8 @@ using at::native::detail::GridSamplerPadding;
 
 namespace {
   static __forceinline__ __device__
-  int clip_coordinates(int in, int clip_limit) {
-    return ::min(clip_limit - 1, ::max(in, static_cast<int>(0)));
+  float clip_coordinates(float in, int clip_limit) {
+    return ::min(static_cast<float>(clip_limit - 1), ::max(in, 0.f));
   }
 
   static __forceinline__ __device__
@@ -90,6 +90,12 @@ namespace {
       float ixf = ((ix + 1.f) / 2) * (inp_W - 1);
       float iyf = ((iy + 1.f) / 2) * (inp_H - 1);
 
+      if (padding_mode == GridSamplerPadding::Border) {
+        // clip coordinates to image borders
+        ixf = clip_coordinates(ixf, inp_W);
+        iyf = clip_coordinates(iyf, inp_H);
+      }
+
       ix = static_cast<scalar_t>(ixf);
       iy = static_cast<scalar_t>(iyf);
 
@@ -110,32 +116,20 @@ namespace {
       scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
       // calculate bilinear weighted pixel value and set output pixel
-      if (padding_mode == GridSamplerPadding::Border) {
-        // clip coordinates to image borders
-        ix_nw = clip_coordinates(ix_nw, inp_W);
-        iy_nw = clip_coordinates(iy_nw, inp_H);
-        ix_ne = clip_coordinates(ix_ne, inp_W);
-        iy_ne = clip_coordinates(iy_ne, inp_H);
-        ix_sw = clip_coordinates(ix_sw, inp_W);
-        iy_sw = clip_coordinates(iy_sw, inp_H);
-        ix_se = clip_coordinates(ix_se, inp_W);
-        iy_se = clip_coordinates(iy_se, inp_H);
-      }
-
       auto inp_ptr_NC = input.data + n * inp_sN;
       auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
       for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
         *out_ptr_NCHW = static_cast<scalar_t>(0);
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+        if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
           *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+        if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
           *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+        if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
           *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+        if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
           *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
         }
       }
@@ -191,6 +185,13 @@ namespace {
       float iyf = ((iy + 1.f) / 2) * (inp_H - 1);
       float izf = ((iz + 1.f) / 2) * (inp_D - 1);
 
+      if (padding_mode == GridSamplerPadding::Border) {
+        // clip coordinates to image borders
+        ixf = clip_coordinates(ixf, inp_W);
+        iyf = clip_coordinates(iyf, inp_H);
+        izf = clip_coordinates(izf, inp_D);
+      }
+
       ix = static_cast<scalar_t>(ixf);
       iy = static_cast<scalar_t>(iyf);
       iz = static_cast<scalar_t>(izf);
@@ -240,34 +241,6 @@ namespace {
       scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
       scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-      if (padding_mode == GridSamplerPadding::Border) {
-        // clip coordinates to image borders
-        ix_tnw = clip_coordinates(ix_tnw, inp_W);
-        iy_tnw = clip_coordinates(iy_tnw, inp_H);
-        iz_tnw = clip_coordinates(iz_tnw, inp_D);
-        ix_tne = clip_coordinates(ix_tne, inp_W);
-        iy_tne = clip_coordinates(iy_tne, inp_H);
-        iz_tne = clip_coordinates(iz_tne, inp_D);
-        ix_tsw = clip_coordinates(ix_tsw, inp_W);
-        iy_tsw = clip_coordinates(iy_tsw, inp_H);
-        iz_tsw = clip_coordinates(iz_tsw, inp_D);
-        ix_tse = clip_coordinates(ix_tse, inp_W);
-        iy_tse = clip_coordinates(iy_tse, inp_H);
-        iz_tse = clip_coordinates(iz_tse, inp_D);
-        ix_bnw = clip_coordinates(ix_bnw, inp_W);
-        iy_bnw = clip_coordinates(iy_bnw, inp_H);
-        iz_bnw = clip_coordinates(iz_bnw, inp_D);
-        ix_bne = clip_coordinates(ix_bne, inp_W);
-        iy_bne = clip_coordinates(iy_bne, inp_H);
-        iz_bne = clip_coordinates(iz_bne, inp_D);
-        ix_bsw = clip_coordinates(ix_bsw, inp_W);
-        iy_bsw = clip_coordinates(iy_bsw, inp_H);
-        iz_bsw = clip_coordinates(iz_bsw, inp_D);
-        ix_bse = clip_coordinates(ix_bse, inp_W);
-        iy_bse = clip_coordinates(iy_bse, inp_H);
-        iz_bse = clip_coordinates(iz_bse, inp_D);
-      }
-
       auto inp_ptr_NC = input.data + n * inp_sN;
       auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
       for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
@@ -276,28 +249,28 @@ namespace {
         // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
         // + (c, iz_bsw, iy_bsw, ix_bsw) * bsw + (c, iz_bse, iy_bse, ix_bse) * bse
         *out_ptr_NCDHW = static_cast<scalar_t>(0);
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW] * tnw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW] * tne;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW] * tsw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW] * tse;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW] * bnw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW] * bne;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW] * bsw;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+        if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
           *out_ptr_NCDHW += inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW] * bse;
         }
       }
@@ -352,6 +325,23 @@ namespace {
       float ixf = ((ix + 1.f) / 2) * (inp_W - 1);
       float iyf = ((iy + 1.f) / 2) * (inp_H - 1);
 
+      // multipliers for gradients on ix and iy
+      // E.g.,  0 for out-of-bound indices when GridSamplerPadding::Border
+      //       -1 for out-of-bound indices when GridSamplerPadding::Reflection
+      scalar_t gix_mult = static_cast<scalar_t>(1), giy_mult = static_cast<scalar_t>(1);
+
+      if (padding_mode == GridSamplerPadding::Border) {
+        // clip coordinates to image borders
+        if (ixf < 0.f || ixf >= static_cast<float>(inp_W - 1)) {
+          gix_mult = static_cast<scalar_t>(0);
+          ixf = clip_coordinates(ixf, inp_W);
+        }
+        if (iyf < 0.f || iyf >= static_cast<float>(inp_H - 1)) {
+          giy_mult = static_cast<scalar_t>(0);
+          iyf = clip_coordinates(iyf, inp_H);
+        }
+      }
+
       ix = static_cast<scalar_t>(ixf);
       iy = static_cast<scalar_t>(iyf);
 
@@ -371,30 +361,6 @@ namespace {
       scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
       scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
 
-      int ix_nw_cl, iy_nw_cl, ix_ne_cl, iy_ne_cl, ix_sw_cl, iy_sw_cl, ix_se_cl, iy_se_cl;
-
-      // calculate bilinear weighted pixel value and set output pixel
-      if (padding_mode == GridSamplerPadding::Border) {
-        // clip coordinates to image borders
-        ix_nw_cl = clip_coordinates(ix_nw, inp_W);
-        iy_nw_cl = clip_coordinates(iy_nw, inp_H);
-        ix_ne_cl = clip_coordinates(ix_ne, inp_W);
-        iy_ne_cl = clip_coordinates(iy_ne, inp_H);
-        ix_sw_cl = clip_coordinates(ix_sw, inp_W);
-        iy_sw_cl = clip_coordinates(iy_sw, inp_H);
-        ix_se_cl = clip_coordinates(ix_se, inp_W);
-        iy_se_cl = clip_coordinates(iy_se, inp_H);
-      } else {
-        ix_nw_cl = ix_nw;
-        iy_nw_cl = iy_nw;
-        ix_ne_cl = ix_ne;
-        iy_ne_cl = iy_ne;
-        ix_sw_cl = ix_sw;
-        iy_sw_cl = iy_sw;
-        ix_se_cl = ix_se;
-        iy_se_cl = iy_se;
-      }
-
       scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
       scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
       scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
@@ -403,29 +369,29 @@ namespace {
         scalar_t gOut = *gOut_ptr_NCHW;
 
         // calculate and set grad_input
-        safe_add_2d(gInp_ptr_NC, iy_nw_cl, ix_nw_cl, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_ne_cl, ix_ne_cl, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_sw_cl, ix_sw_cl, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-        safe_add_2d(gInp_ptr_NC, iy_se_cl, ix_se_cl, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+        safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+        safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+        safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+        safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
 
         // calculate grad_grid
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_nw_cl, ix_nw_cl, inp_H, inp_W)) {
-          scalar_t nw_val = inp_ptr_NC[iy_nw_cl * inp_sH + ix_nw_cl * inp_sW];
+        if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+          scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
           gix -= nw_val * (iy_se - iy) * gOut;
           giy -= nw_val * (ix_se - ix) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_ne_cl, ix_ne_cl, inp_H, inp_W)) {
-          scalar_t ne_val = inp_ptr_NC[iy_ne_cl * inp_sH + ix_ne_cl * inp_sW];
+        if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+          scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
           gix += ne_val * (iy_sw - iy) * gOut;
           giy -= ne_val * (ix - ix_sw) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_sw_cl, ix_sw_cl, inp_H, inp_W)) {
-          scalar_t sw_val = inp_ptr_NC[iy_sw_cl * inp_sH + ix_sw_cl * inp_sW];
+        if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+          scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
           gix -= sw_val * (iy - iy_ne) * gOut;
           giy += sw_val * (ix_ne - ix) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_2d(iy_se_cl, ix_se_cl, inp_H, inp_W)) {
-          scalar_t se_val = inp_ptr_NC[iy_se_cl * inp_sH + ix_se_cl * inp_sW];
+        if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+          scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
           gix += se_val * (iy - iy_nw) * gOut;
           giy += se_val * (ix - ix_nw) * gOut;
         }
@@ -440,8 +406,8 @@ namespace {
       //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NHW
       //   2. directly assign to gGrid_ptr_NHW[0], gGrid_ptr_NHW[1]
       scalar_t *gGrid_ptr_NHW = grad_grid.data + index * gGrid_sW;
-      gGrid_ptr_NHW[0] = gix;
-      gGrid_ptr_NHW[1] = giy;
+      gGrid_ptr_NHW[0] = gix_mult * gix;
+      gGrid_ptr_NHW[1] = giy_mult * giy;
     }
   }
 
@@ -502,6 +468,29 @@ namespace {
       float iyf = ((iy + 1.f) / 2) * (inp_H - 1);
       float izf = ((iz + 1.f) / 2) * (inp_D - 1);
 
+      // multipliers for gradients on ix, iy, and iz
+      // E.g.,  0 for out-of-bound indices when GridSamplerPadding::Border
+      //       -1 for out-of-bound indices when GridSamplerPadding::Reflection
+      scalar_t gix_mult = static_cast<scalar_t>(1),
+               giy_mult = static_cast<scalar_t>(1),
+               giz_mult = static_cast<scalar_t>(1);
+
+      if (padding_mode == GridSamplerPadding::Border) {
+        // clip coordinates to image borders
+        if (ixf < 0.f || ixf >= static_cast<float>(inp_W - 1)) {
+          gix_mult = static_cast<scalar_t>(0);
+          ixf = clip_coordinates(ixf, inp_W);
+        }
+        if (iyf < 0.f || iyf >= static_cast<float>(inp_H - 1)) {
+          giy_mult = static_cast<scalar_t>(0);
+          iyf = clip_coordinates(iyf, inp_H);
+        }
+        if (izf < 0.f || izf >= static_cast<float>(inp_D - 1)) {
+          giz_mult = static_cast<scalar_t>(0);
+          izf = clip_coordinates(izf, inp_D);
+        }
+      }
+
       ix = static_cast<scalar_t>(ixf);
       iy = static_cast<scalar_t>(iyf);
       iz = static_cast<scalar_t>(izf);
@@ -551,64 +540,6 @@ namespace {
       scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
       scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
 
-      int ix_tnw_cl, iy_tnw_cl, iz_tnw_cl, ix_tne_cl, iy_tne_cl, iz_tne_cl;
-      int ix_tsw_cl, iy_tsw_cl, iz_tsw_cl, ix_tse_cl, iy_tse_cl, iz_tse_cl;
-      int ix_bnw_cl, iy_bnw_cl, iz_bnw_cl, ix_bne_cl, iy_bne_cl, iz_bne_cl;
-      int ix_bsw_cl, iy_bsw_cl, iz_bsw_cl, ix_bse_cl, iy_bse_cl, iz_bse_cl;
-
-      if (padding_mode == GridSamplerPadding::Border) {
-        // clip coordinates to image borders
-        ix_tnw_cl = clip_coordinates(ix_tnw, inp_W);
-        iy_tnw_cl = clip_coordinates(iy_tnw, inp_H);
-        iz_tnw_cl = clip_coordinates(iz_tnw, inp_D);
-        ix_tne_cl = clip_coordinates(ix_tne, inp_W);
-        iy_tne_cl = clip_coordinates(iy_tne, inp_H);
-        iz_tne_cl = clip_coordinates(iz_tne, inp_D);
-        ix_tsw_cl = clip_coordinates(ix_tsw, inp_W);
-        iy_tsw_cl = clip_coordinates(iy_tsw, inp_H);
-        iz_tsw_cl = clip_coordinates(iz_tsw, inp_D);
-        ix_tse_cl = clip_coordinates(ix_tse, inp_W);
-        iy_tse_cl = clip_coordinates(iy_tse, inp_H);
-        iz_tse_cl = clip_coordinates(iz_tse, inp_D);
-        ix_bnw_cl = clip_coordinates(ix_bnw, inp_W);
-        iy_bnw_cl = clip_coordinates(iy_bnw, inp_H);
-        iz_bnw_cl = clip_coordinates(iz_bnw, inp_D);
-        ix_bne_cl = clip_coordinates(ix_bne, inp_W);
-        iy_bne_cl = clip_coordinates(iy_bne, inp_H);
-        iz_bne_cl = clip_coordinates(iz_bne, inp_D);
-        ix_bsw_cl = clip_coordinates(ix_bsw, inp_W);
-        iy_bsw_cl = clip_coordinates(iy_bsw, inp_H);
-        iz_bsw_cl = clip_coordinates(iz_bsw, inp_D);
-        ix_bse_cl = clip_coordinates(ix_bse, inp_W);
-        iy_bse_cl = clip_coordinates(iy_bse, inp_H);
-        iz_bse_cl = clip_coordinates(iz_bse, inp_D);
-      } else {
-        ix_tnw_cl = ix_tnw;
-        iy_tnw_cl = iy_tnw;
-        iz_tnw_cl = iz_tnw;
-        ix_tne_cl = ix_tne;
-        iy_tne_cl = iy_tne;
-        iz_tne_cl = iz_tne;
-        ix_tsw_cl = ix_tsw;
-        iy_tsw_cl = iy_tsw;
-        iz_tsw_cl = iz_tsw;
-        ix_tse_cl = ix_tse;
-        iy_tse_cl = iy_tse;
-        iz_tse_cl = iz_tse;
-        ix_bnw_cl = ix_bnw;
-        iy_bnw_cl = iy_bnw;
-        iz_bnw_cl = iz_bnw;
-        ix_bne_cl = ix_bne;
-        iy_bne_cl = iy_bne;
-        iz_bne_cl = iz_bne;
-        ix_bsw_cl = ix_bsw;
-        iy_bsw_cl = iy_bsw;
-        iz_bsw_cl = iz_bsw;
-        ix_bse_cl = ix_bse;
-        iy_bse_cl = iy_bse;
-        iz_bse_cl = iz_bse;
-      }
-
       scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
       scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
       scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
@@ -618,60 +549,60 @@ namespace {
         scalar_t gOut = *gOut_ptr_NCDHW;
 
         // calculate and set grad_input
-        safe_add_3d(gInp_ptr_NC, iz_tnw_cl, iy_tnw_cl, ix_tnw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tne_cl, iy_tne_cl, ix_tne_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tsw_cl, iy_tsw_cl, ix_tsw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_tse_cl, iy_tse_cl, ix_tse_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bnw_cl, iy_bnw_cl, ix_bnw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bne_cl, iy_bne_cl, ix_bne_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bsw_cl, iy_bsw_cl, ix_bsw_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
-        safe_add_3d(gInp_ptr_NC, iz_bse_cl, iy_bse_cl, ix_bse_cl, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut);
+        safe_add_3d(gInp_ptr_NC, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut);
 
         // calculate grad_grid
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tnw_cl, iy_tnw_cl, ix_tnw_cl, inp_D, inp_H, inp_W)) {
-          scalar_t tnw_val = inp_ptr_NC[iz_tnw_cl * inp_sD + iy_tnw_cl * inp_sH + ix_tnw_cl * inp_sW];
+        if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
+          scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
           gix -= tnw_val * (iy_bse - iy)    * (iz_bse - iz)    * gOut;
           giy -= tnw_val * (ix_bse - ix)    * (iz_bse - iz)    * gOut;
           giz -= tnw_val * (ix_bse - ix)    * (iy_bse - iy)    * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tne_cl, iy_tne_cl, ix_tne_cl, inp_D, inp_H, inp_W)) {
-          scalar_t tne_val = inp_ptr_NC[iz_tne_cl * inp_sD + iy_tne_cl * inp_sH + ix_tne_cl * inp_sW];
+        if (within_bounds_3d(iz_tne, iy_tne, ix_tne, inp_D, inp_H, inp_W)) {
+          scalar_t tne_val = inp_ptr_NC[iz_tne * inp_sD + iy_tne * inp_sH + ix_tne * inp_sW];
           gix += tne_val * (iy_bsw - iy)    * (iz_bsw - iz)    * gOut;
           giy -= tne_val * (ix    - ix_bsw) * (iz_bsw - iz)    * gOut;
           giz -= tne_val * (ix    - ix_bsw) * (iy_bsw - iy)    * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tsw_cl, iy_tsw_cl, ix_tsw_cl, inp_D, inp_H, inp_W)) {
-          scalar_t tsw_val = inp_ptr_NC[iz_tsw_cl * inp_sD + iy_tsw_cl * inp_sH + ix_tsw_cl * inp_sW];
+        if (within_bounds_3d(iz_tsw, iy_tsw, ix_tsw, inp_D, inp_H, inp_W)) {
+          scalar_t tsw_val = inp_ptr_NC[iz_tsw * inp_sD + iy_tsw * inp_sH + ix_tsw * inp_sW];
           gix -= tsw_val * (iy - iy_bne)    * (iz_bne - iz)    * gOut;
           giy += tsw_val * (ix_bne - ix)    * (iz_bne - iz)    * gOut;
           giz -= tsw_val * (ix_bne - ix)    * (iy    - iy_bne) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_tse_cl, iy_tse_cl, ix_tse_cl, inp_D, inp_H, inp_W)) {
-          scalar_t tse_val = inp_ptr_NC[iz_tse_cl * inp_sD + iy_tse_cl * inp_sH + ix_tse_cl * inp_sW];
+        if (within_bounds_3d(iz_tse, iy_tse, ix_tse, inp_D, inp_H, inp_W)) {
+          scalar_t tse_val = inp_ptr_NC[iz_tse * inp_sD + iy_tse * inp_sH + ix_tse * inp_sW];
           gix += tse_val * (iy - iy_bnw)    * (iz_bnw - iz)    * gOut;
           giy += tse_val * (ix    - ix_bnw) * (iz_bnw - iz)    * gOut;
           giz -= tse_val * (ix    - ix_bnw) * (iy    - iy_bnw) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bnw_cl, iy_bnw_cl, ix_bnw_cl, inp_D, inp_H, inp_W)) {
-          scalar_t bnw_val = inp_ptr_NC[iz_bnw_cl * inp_sD + iy_bnw_cl * inp_sH + ix_bnw_cl * inp_sW];
+        if (within_bounds_3d(iz_bnw, iy_bnw, ix_bnw, inp_D, inp_H, inp_W)) {
+          scalar_t bnw_val = inp_ptr_NC[iz_bnw * inp_sD + iy_bnw * inp_sH + ix_bnw * inp_sW];
           gix -= bnw_val * (iy_tse - iy)    * (iz - iz_tse)    * gOut;
           giy -= bnw_val * (ix_tse - ix)    * (iz - iz_tse)    * gOut;
           giz += bnw_val * (ix_tse - ix)    * (iy_tse - iy)    * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bne_cl, iy_bne_cl, ix_bne_cl, inp_D, inp_H, inp_W)) {
-          scalar_t bne_val = inp_ptr_NC[iz_bne_cl * inp_sD + iy_bne_cl * inp_sH + ix_bne_cl * inp_sW];
+        if (within_bounds_3d(iz_bne, iy_bne, ix_bne, inp_D, inp_H, inp_W)) {
+          scalar_t bne_val = inp_ptr_NC[iz_bne * inp_sD + iy_bne * inp_sH + ix_bne * inp_sW];
           gix += bne_val * (iy_tsw - iy)    * (iz - iz_tsw)    * gOut;
           giy -= bne_val * (ix    - ix_tsw) * (iz - iz_tsw)    * gOut;
           giz += bne_val * (ix    - ix_tsw) * (iy_tsw - iy)    * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bsw_cl, iy_bsw_cl, ix_bsw_cl, inp_D, inp_H, inp_W)) {
-          scalar_t bsw_val = inp_ptr_NC[iz_bsw_cl * inp_sD + iy_bsw_cl * inp_sH + ix_bsw_cl * inp_sW];
+        if (within_bounds_3d(iz_bsw, iy_bsw, ix_bsw, inp_D, inp_H, inp_W)) {
+          scalar_t bsw_val = inp_ptr_NC[iz_bsw * inp_sD + iy_bsw * inp_sH + ix_bsw * inp_sW];
           gix -= bsw_val * (iy - iy_tne)    * (iz - iz_tne)    * gOut;
           giy += bsw_val * (ix_tne - ix)    * (iz - iz_tne)    * gOut;
           giz += bsw_val * (ix_tne - ix)    * (iy    - iy_tne) * gOut;
         }
-        if (padding_mode != GridSamplerPadding::Zeros || within_bounds_3d(iz_bse_cl, iy_bse_cl, ix_bse_cl, inp_D, inp_H, inp_W)) {
-          scalar_t bse_val = inp_ptr_NC[iz_bse_cl * inp_sD + iy_bse_cl * inp_sH + ix_bse_cl * inp_sW];
+        if (within_bounds_3d(iz_bse, iy_bse, ix_bse, inp_D, inp_H, inp_W)) {
+          scalar_t bse_val = inp_ptr_NC[iz_bse * inp_sD + iy_bse * inp_sH + ix_bse * inp_sW];
           gix += bse_val * (iy - iy_tnw)    * (iz - iz_tnw)    * gOut;
           giy += bse_val * (ix    - ix_tnw) * (iz - iz_tnw)    * gOut;
           giz += bse_val * (ix    - ix_tnw) * (iy    - iy_tnw) * gOut;
@@ -688,9 +619,9 @@ namespace {
       //   1. use index with gGrid_sW to diectly compute gGrid_ptr_NDHW
       //   2. directly assign to gGrid_ptr_NDHW[0], gGrid_ptr_NDHW[1], gGrid_ptr_NDHW[2]
       scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
-      gGrid_ptr_NDHW[0] = gix;
-      gGrid_ptr_NDHW[1] = giy;
-      gGrid_ptr_NDHW[2] = giz;
+      gGrid_ptr_NDHW[0] = gix_mult * gix;
+      gGrid_ptr_NDHW[1] = giy_mult * giy;
+      gGrid_ptr_NDHW[2] = giz_mult * giz;
     }
   }
 }  // namespace

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -759,9 +759,6 @@
 # Additionally, arguments `padding_mode` and `interpolation_mode` are cast to
 # enums defined in `native/GridSampler.h`. `cudnn_grid_sampler` doesn't take in
 # `interpolation_mode` because it only supports Bilinear interpolation mode.
-#
-# ssnl: Currently `interpolation_mode` is just a placeholder. It is not really
-#       used. Everywhere Bilinear is assumed. I will add Nearest soon.
 - func: grid_sampler(Tensor input, Tensor grid, int64_t interpolation_mode, int64_t padding_mode) -> Tensor
   variants: function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -762,7 +762,7 @@
 #
 # ssnl: Currently `interpolation_mode` is just a placeholder. It is not really
 #       used. Everywhere Bilinear is assumed. I will add Nearest soon.
-- func: grid_sampler(Tensor input, Tensor grid, int64_t padding_mode) -> Tensor
+- func: grid_sampler(Tensor input, Tensor grid, int64_t interpolation_mode, int64_t padding_mode) -> Tensor
   variants: function
 
 - func: grid_sampler_2d(Tensor input, Tensor grid, int64_t interpolation_mode, int64_t padding_mode) -> Tensor

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4889,40 +4889,72 @@ class TestNN(NNTestCase):
         input2 = torch.randn(input_size, requires_grad=True)
         self.assertEqual(F.cosine_similarity(input1, input2, dim=1).size(), expected_size)
 
-    def test_grid_sample_unsupported_mode(self):
-        with self.assertRaisesRegex(NotImplementedError, "nn.functional.grid_sample got unsupported mode: 'garbage'"):
-            F.grid_sample(torch.tensor([]), torch.tensor([]), mode='garbage')
+    def test_grid_sample_error_checking(self):
+        input = torch.empty(1, 1, 2, 2)
+        grid = torch.empty(1, 1, 1, 2)
+
+        # assert no error
+        F.grid_sample(input, grid)
+
+        with self.assertRaisesRegex(ValueError, "but got: 'garbage'"):
+            F.grid_sample(input, grid, mode='garbage')
+
+        with self.assertRaisesRegex(ValueError, "but got: 'garbage'"):
+            F.grid_sample(input, grid, padding_mode='garbage')
+
+        with self.assertRaisesRegex(RuntimeError, "expected input and grid to have same dtype"):
+            F.grid_sample(input.float(), grid.double())
+
+        with self.assertRaisesRegex(RuntimeError, "expected 4D or 5D input"):
+            F.grid_sample(input[0], grid)
+
+        with self.assertRaisesRegex(RuntimeError, "grid with same number of dimensions"):
+            F.grid_sample(input, torch.empty(1, 1, 1, 1, 3))
+
+        with self.assertRaisesRegex(RuntimeError, "expected grid and input to have same batch size"):
+            F.grid_sample(input, torch.empty(2, 1, 1, 2))
+
+        with self.assertRaisesRegex(RuntimeError, "expected grid to have size 2 in last dimension"):
+            F.grid_sample(input, torch.empty(1, 1, 1, 3))
+
+        with self.assertRaisesRegex(RuntimeError, "expected input to have non-empty spatial dimensions"):
+            F.grid_sample(torch.empty(1, 1, 0, 2), grid)
+
+        if TEST_CUDA:
+            with self.assertRaisesRegex(RuntimeError, "expected input and grid to be on same device"):
+                F.grid_sample(input.cuda(), grid)
 
     def test_grid_sample(self):
-        def test_cpu_against_cuda(N, C, H, W, mode, padding_mode):
+        def test(N, C, H, W, mode, padding_mode):
             def test_shape(N, C, IH, IW, H, W, mode, padding_mode):
-
                 input_cpu = torch.randn(C, N, IH, IW).transpose(0, 1).requires_grad_()
                 grid_cpu = torch.randn(H, N, W, 2).transpose(0, 1).requires_grad_()
                 out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
                 self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
 
-                input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                grid_cuda = grid_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                self.assertEqual(out_cpu, out_cuda)
-
                 gradients = torch.randn_like(out_cpu)
                 out_cpu.backward(gradients)
-                out_cuda.backward(gradients.cuda())
-                self.assertEqual(input_cpu.grad, input_cuda.grad)
-                self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
 
-                # check that zero-dimensional input strides don't error out
-                base_input = torch.randn(N, C, 1, IW)
-                input_cpu = base_input.expand_as(input_cuda).requires_grad_()
-                grid_cpu = torch.randn(N, H, W, 2, requires_grad=True)
-                out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+                if TEST_CUDA:
+                    input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                    grid_cuda = grid_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                    self.assertEqual(out_cpu, out_cuda)
 
-                input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
-                grid_cuda = grid_cpu.detach().cuda().requires_grad_()
-                out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                self.assertEqual(out_cpu, out_cuda)
+                    out_cuda.backward(gradients.cuda())
+                    self.assertEqual(input_cpu.grad, input_cuda.grad)
+                    self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
+
+                    # check that zero-dimensional input strides don't error out
+                    base_input = torch.randn(N, C, 1, IW)
+                    input_cpu = base_input.expand_as(input_cuda).requires_grad_()
+                    grid_cpu = torch.randn(N, H, W, 2, requires_grad=True)
+                    out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+
+                    input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
+                    grid_cuda = grid_cpu.detach().cuda().requires_grad_()
+                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                    self.assertEqual(out_cpu, out_cuda)
 
             # test same size output
             test_shape(N, C, H, W, H, W, mode, padding_mode)
@@ -4945,8 +4977,38 @@ class TestNN(NNTestCase):
             W = random.randint(2, IW)
             test_shape(N, C, IH, IW, H, W, mode, padding_mode)
 
+            # test 1x1 inpput
+            N = random.randint(2, 8)
+            C = random.randint(2, 8)
+            IH = 1
+            IW = 1
+            H = random.randint(2, 5)
+            W = random.randint(2, 5)
+            test_shape(N, C, IH, IW, H, W, mode, padding_mode)
+
             # testing empty grid
+            N = random.randint(2, 8)
+            C = random.randint(2, 8)
+            IH = random.randint(2, 8)
+            IW = random.randint(2, 8)
+            W = random.randint(3, IW + 2)
             test_shape(N, C, IH, IW, 0, W, mode, padding_mode)
+
+            # testing empty channel
+            N = random.randint(2, 8)
+            IH = random.randint(2, 8)
+            IW = random.randint(2, 8)
+            H = random.randint(3, IH + 2)
+            W = random.randint(3, IW + 2)
+            test_shape(N, 0, IH, IW, H, W, mode, padding_mode)
+
+            # testing empty batch
+            C = random.randint(2, 8)
+            IH = random.randint(2, 8)
+            IW = random.randint(2, 8)
+            H = random.randint(3, IH + 2)
+            W = random.randint(3, IW + 2)
+            test_shape(0, C, IH, IW, H, W, mode, padding_mode)
 
         for mode in ('bilinear', 'nearest'):
             for padding_mode in ('zeros', 'border', 'reflection'):
@@ -4959,7 +5021,6 @@ class TestNN(NNTestCase):
                      [-1, -0.5, 0, 0.3333, 1],
                      [-1, -0.2, 0, 1.5, 0.5]]).view(1, 2, 5, 2)
                 output = F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode)
-                print(mode, padding_mode, output)
                 if mode == 'bilinear':
                     if padding_mode == 'zeros':
                         groundtruth = torch.tensor(
@@ -4996,7 +5057,7 @@ class TestNN(NNTestCase):
 
                 # do gradcheck
                 N = random.randint(2, 8)
-                C = random.randint(2, 8)
+                C = random.randint(2, 6)
                 H = random.randint(2, 8)
                 W = random.randint(2, 8)
                 input = torch.randn(N, C, H, W, requires_grad=True)
@@ -5005,77 +5066,113 @@ class TestNN(NNTestCase):
                     lambda inp, grid: F.grid_sample(inp, grid, mode=mode, padding_mode=padding_mode),
                     (input, grid)))
 
-                # test CUDA against CPU
-                if TEST_CUDA:
-                    test_cpu_against_cuda(N, C, H, W, mode, padding_mode)
-                    if TEST_CUDNN:
-                        with cudnn.flags(enabled=False):
-                            test_cpu_against_cuda(N, C, H, W, mode, padding_mode)
+                test(N, C, H, W, mode, padding_mode)
+                if TEST_CUDNN:
+                    with cudnn.flags(enabled=False):
+                        test(N, C, H, W, mode, padding_mode)
 
     def test_grid_sample_3d(self):
-        def test_cpu_against_cuda(N, C, D, H, W, mode, padding_mode):
+        def test(N, C, D, H, W, mode, padding_mode):
             def test_shape(N, C, ID, IH, IW, D, H, W, mode, padding_mode):
-
                 input_cpu = torch.randn(C, N, ID, IH, IW).transpose(0, 1).requires_grad_()
                 grid_cpu = torch.randn(D, N, H, W, 3).transpose(0, 1).requires_grad_()
                 out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
                 self.assertTrue(out_cpu.size() == torch.Size([N, C, D, H, W]))
 
-                input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                grid_cuda = grid_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                self.assertEqual(out_cpu, out_cuda)
-
                 gradients = torch.randn_like(out_cpu)
                 out_cpu.backward(gradients)
-                out_cuda.backward(gradients.cuda())
-                self.assertEqual(input_cpu.grad, input_cuda.grad)
-                self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
 
-                # check that zero-dimensional input strides don't error out
-                base_input = torch.randn(N, C, 1, IH, IW)
-                input_cpu = base_input.expand_as(input_cuda).requires_grad_()
-                grid_cpu = torch.randn(N, D, H, W, 3, requires_grad=True)
-                out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+                if TEST_CUDA:
+                    input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                    grid_cuda = grid_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                    self.assertEqual(out_cpu, out_cuda)
 
-                input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
-                grid_cuda = grid_cpu.detach().cuda().requires_grad_()
-                out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                self.assertEqual(out_cpu, out_cuda)
+                    out_cuda.backward(gradients.cuda())
+                    self.assertEqual(input_cpu.grad, input_cuda.grad)
+                    self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
+
+                    # check that zero-dimensional input strides don't error out
+                    base_input = torch.randn(N, C, 1, IH, IW)
+                    input_cpu = base_input.expand_as(input_cuda).requires_grad_()
+                    grid_cpu = torch.randn(N, D, H, W, 3, requires_grad=True)
+                    out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+
+                    input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
+                    grid_cuda = grid_cpu.detach().cuda().requires_grad_()
+                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                    self.assertEqual(out_cpu, out_cuda)
 
             # test same size output
             test_shape(N, C, D, H, W, D, H, W, mode, padding_mode)
 
             # test larger output
-            N = random.randint(2, 8)
-            C = random.randint(2, 8)
-            ID = random.randint(2, 8)
-            IH = random.randint(2, 8)
-            IW = random.randint(2, 8)
-            D = random.randint(ID + 1, 12)
-            H = random.randint(IH + 1, 12)
-            W = random.randint(IW + 1, 12)
+            N = random.randint(2, 7)
+            C = random.randint(2, 5)
+            ID = random.randint(2, 7)
+            IH = random.randint(2, 7)
+            IW = random.randint(2, 7)
+            D = random.randint(ID + 1, 10)
+            H = random.randint(IH + 1, 10)
+            W = random.randint(IW + 1, 10)
             test_shape(N, C, ID, IH, IW, D, H, W, mode, padding_mode)
 
             # test smaller output
-            N = random.randint(2, 8)
-            C = random.randint(2, 8)
-            ID = random.randint(2, 8)
-            IH = random.randint(2, 8)
-            IW = random.randint(2, 8)
+            N = random.randint(2, 7)
+            C = random.randint(2, 5)
+            ID = random.randint(2, 7)
+            IH = random.randint(2, 7)
+            IW = random.randint(2, 7)
             D = random.randint(2, ID)
             H = random.randint(2, IH)
             W = random.randint(2, IW)
             test_shape(N, C, ID, IH, IW, D, H, W, mode, padding_mode)
 
+            # test 1x1 inpput
+            N = random.randint(2, 7)
+            C = random.randint(2, 7)
+            ID = 1
+            IH = 1
+            IW = 1
+            H = random.randint(2, 5)
+            W = random.randint(2, 5)
+            test_shape(N, C, ID, IH, IW, D, H, W, mode, padding_mode)
+
             # testing empty grid
+            N = random.randint(2, 7)
+            C = random.randint(2, 5)
+            ID = random.randint(2, 7)
+            IH = random.randint(2, 7)
+            IW = random.randint(2, 7)
+            D = random.randint(3, ID + 2)
+            W = random.randint(3, IW + 2)
             test_shape(N, C, ID, IH, IW, D, 0, W, mode, padding_mode)
+
+            # testing empty channel
+            N = random.randint(2, 7)
+            ID = random.randint(2, 5)
+            IH = random.randint(2, 7)
+            IW = random.randint(2, 7)
+            D = random.randint(3, ID + 2)
+            H = random.randint(3, IH + 2)
+            W = random.randint(3, IW + 2)
+            test_shape(N, 0, ID, IH, IW, D, H, W, mode, padding_mode)
+
+            # testing empty batch
+            C = random.randint(2, 5)
+            ID = random.randint(2, 7)
+            IH = random.randint(2, 7)
+            IW = random.randint(2, 7)
+            D = random.randint(3, ID + 2)
+            H = random.randint(3, IH + 2)
+            W = random.randint(3, IW + 2)
+            test_shape(0, C, ID, IH, IW, D, H, W, mode, padding_mode)
 
         for mode in ('bilinear', 'nearest'):
             for padding_mode in ('zeros', 'border', 'reflection'):
                 # do gradcheck
                 N = random.randint(2, 5)
-                C = random.randint(2, 5)
+                C = random.randint(2, 4)
                 D = random.randint(2, 5)
                 H = random.randint(2, 5)
                 W = random.randint(2, 5)
@@ -5085,9 +5182,7 @@ class TestNN(NNTestCase):
                     lambda inp, grid: F.grid_sample(inp, grid, mode=mode, padding_mode=padding_mode),
                     (input, grid)))
 
-                # test CUDA against CPU
-                if TEST_CUDA:
-                    test_cpu_against_cuda(N, C, D, H, W, mode, padding_mode)
+                test(N, C, D, H, W, mode, padding_mode)
 
     def test_affine_grid(self):
         # test known input on CPU

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4945,6 +4945,9 @@ class TestNN(NNTestCase):
             W = random.randint(2, IW)
             test_shape(N, C, IH, IW, H, W, mode, padding_mode)
 
+            # testing empty grid
+            test_shape(N, C, IH, IW, 0, W, mode, padding_mode)
+
         for mode in ('bilinear', 'nearest'):
             for padding_mode in ('zeros', 'border', 'reflection'):
 
@@ -5064,6 +5067,9 @@ class TestNN(NNTestCase):
             H = random.randint(2, IH)
             W = random.randint(2, IW)
             test_shape(N, C, ID, IH, IW, D, H, W, mode, padding_mode)
+
+            # testing empty grid
+            test_shape(N, C, ID, IH, IW, D, 0, W, mode, padding_mode)
 
         for mode in ('bilinear', 'nearest'):
             for padding_mode in ('zeros', 'border', 'reflection'):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4946,32 +4946,37 @@ class TestNN(NNTestCase):
             test_shape(N, C, IH, IW, H, W, padding_mode)
 
         # test known input on CPU
-        for padding_mode in ['zeros', 'border']:
+        for padding_mode in ['zeros', 'border', 'reflection']:
 
-            input = Variable(torch.arange(1., 11).view(1, 1, 2, 5))
-            grid = Variable(torch.Tensor(
+            input = torch.arange(1., 11).view(1, 1, 2, 5)
+            grid = torch.tensor(
                 [[-0.9, -1.4, 0, 0.2, 1],
                  [-1, -0.333, 0, 0.5, 1],
                  [-1, -0.5, 0, 0.3333, 1],
-                 [-1, -0.2, 0, 1.1, 0.5]]).view(1, 2, 5, 2))
+                 [-1, -0.2, 0, 1.1, 0.5]]).view(1, 2, 5, 2)
             output = F.grid_sample(input, grid, padding_mode=padding_mode)
-
             if padding_mode == 'zeros':
-                groundtruth = torch.Tensor(
+                groundtruth = torch.tensor(
                     [[0.9600, 6.0000000000, 5.0000, 4.8340, 9.0000],
-                     [2.2500, 6.333250045, 5.0000, 5.1000, 7.0000]]).view(1, 1, 2, 5)
-            else:
-                groundtruth = torch.Tensor(
+                     [2.2500, 6.3332500450, 5.0000, 5.1000, 7.0000]]).view(1, 1, 2, 5)
+            elif padding_mode == 'border':
+                groundtruth = torch.tensor(
                     [[1.2000, 6.0000000000, 5.0000, 4.8340, 9.0000],
-                     [2.2500, 6.333250045, 5.0000, 5.1000, 8.7500]]).view(1, 1, 2, 5)
-
-            self.assertEqual(output.data, groundtruth)
+                     [2.2500, 6.3332500450, 5.0000, 5.1000, 8.7500]]).view(1, 1, 2, 5)
+            elif padding_mode == 'reflection':
+                print(output)
+                groundtruth = torch.tensor(
+                    [[2.2000, 6.0000000000, 5.0000, 4.8340, 9.0000],
+                     [2.2500, 6.3332500450, 5.0000, 5.1000, 8.5500]]).view(1, 1, 2, 5)
+            else:
+                assert False, "missing groundtruth test for padding mode '{}'".format(padding_mode)
+            self.assertEqual(output, groundtruth)
 
             # do gradcheck
-            N = random.randint(1, 8)
-            C = random.randint(1, 8)
-            H = random.randint(1, 8)
-            W = random.randint(1, 8)
+            N = random.randint(2, 8)
+            C = random.randint(2, 8)
+            H = random.randint(2, 8)
+            W = random.randint(2, 8)
             input = torch.randn(N, C, H, W, requires_grad=True)
             grid = torch.randn(N, H, W, 2, requires_grad=True)
             self.assertTrue(gradcheck(
@@ -5042,13 +5047,13 @@ class TestNN(NNTestCase):
             test_shape(N, C, ID, IH, IW, D, H, W, padding_mode)
 
         # test known input on CPU
-        for padding_mode in ['zeros', 'border']:
+        for padding_mode in ['zeros', 'border', 'reflection']:
             # do gradcheck
-            N = random.randint(2, 8)
-            C = random.randint(2, 8)
-            D = random.randint(2, 8)
-            H = random.randint(2, 8)
-            W = random.randint(2, 8)
+            N = random.randint(2, 5)
+            C = random.randint(2, 5)
+            D = random.randint(2, 5)
+            H = random.randint(2, 5)
+            W = random.randint(2, 5)
             input = torch.randn(N, C, D, H, W, requires_grad=True)
             grid = torch.randn(N, D, H, W, 3, requires_grad=True)
             self.assertTrue(gradcheck(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2117,38 +2117,53 @@ GRID_SAMPLE_PADDING_MODES = {
 
 def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
-    `output` using input pixel locations from the grid.
+    ``output`` using :attr:`input` values and pixel locations from :attr:`grid`.
 
-    Uses bilinear interpolation to sample the input pixels.
-    Currently, only spatial (4 dimensional) and volumetric (5 dimensional)
-    inputs are supported.
+    Currently, only spatial (4-D) and volumetric (5-D) :attr:`input` are
+    supported.
 
-    For each output location, :attr:`grid` has `x`, `y`
-    input pixel locations which are used to compute output.
-    In the case of 5D inputs, :attr:`grid` has `x`, `y`, `z` pixel locations.
+    In the spatial (4-D) case, for :attr:`input` with shape
+    :math:`(N, C, H_\text{in}, W_\text{in})` and :attr:`grid` with shape
+    :math:`(N, H_\text{out}, W_\text{out}, 2)`, the output will have shape
+    :math:`(N, C, H_\text{out}, W_\text{out})`.
 
-    .. Note::
-        To avoid confusion in notation, let's note that `x` corresponds to the `width` dimension `IW`,
-        `y` corresponds to the height dimension `IH` and `z` corresponds to the `depth` dimension `ID`.
+    For each output location ``output[n, :, h, w]``, the size-2 vector
+    ``grid[n, h, w]`` specifies :attr:`input` pixel locations ``x`` and ``y``,
+    which are used to interpolate the output value ``output[n, :, h, w]``.
+    In the case of 5D inputs, ``grid[n, d, h, w]`` specifies the
+    ``x``, ``y``, ``z`` pixel locations for interpolating
+    ``output[n, :, d, h, w]``. :attr:`mode` argument specifies ``nearest`` or
+    ``bilinear`` interpolation method to sample the input pixels.
 
-    :attr:`grid` has values in the range of `[-1, 1]`. This is because the
-    pixel locations are normalized by the input height and width.
+    :attr:`grid` should have most values in the range of ``[-1, 1]``. This is
+    because the pixel locations are normalized by the :attr:`input` spatial
+    dimensions. For example, values ``x = -1, y = -1`` is the left-top pixel of
+    :attr:`input`, and values  ``x = 1, y = 1`` is the right-bottom pixel of
+    :attr:`input`.
 
-    For example, values: x: -1, y: -1 is the left-top pixel of the input, and
-    values: x: 1, y: 1 is the right-bottom pixel of the input.
+    If :attr:`grid` has values outside the range of ``[-1, 1]``, those locations
+    are handled as defined by :attr:`padding_mode`. Options are
 
-    If :attr:`grid` has values outside the range of `[-1, 1]`, those locations
-    are handled as defined by `padding_mode`. Options are `zeros` or `border`,
-    defining those locations to use 0 or image border values as contribution
-    to the bilinear interpolation.
+        * ``padding_mode="zeros"``: use ``0`` for out-of-bound values,
+        * ``padding_mode="border"``: use border values for out-of-bound values,
+        * ``padding_mode="reflection"``: use values at locations reflected by
+          the border for out-of-bound values. For location far away from the
+          border, it will keep being reflected until becoming in bound, e.g.,
+          (normalized) pixel location ``x = -3.5`` reflects by ``-1`` and
+          becomes ``x' = 2.5``, then reflects by border ``1`` and becomes
+          ``x'' = -0.5``.
 
-    .. Note:: This function is used in building Spatial Transformer Networks
+    .. Note:: This function is often used in building Spatial Transformer Networks.
 
     Args:
-        input (Tensor): input batch (N x C x IH x IW) or (N x C x ID x IH x IW)
-        grid (Tensor): flow-field of size (N x OH x OW x 2) or (N x OD x OH x OW x 3)
+        input (Tensor): input of shape :math:`(N, C, H_\text{in}, W_\text{in})` (4-D case)
+                        or :math:`(N, C, D_\text{in}, H_\text{in}, W_\text{in})` (5-D case)
+        grid (Tensor): flow-field of shape :math:`(N, H_\text{out}, W_\text{out}, 2)` (4-D case)
+                       or :math:`(N, D_\text{out}, H_\text{out}, W_\text{out}, 3)` (5-D case)
+        mode (str): interpolation mode to calculate output values
+            'bilinear' | 'nearest'. Default: 'bilinear'
         padding_mode (str): padding mode for outside grid values
-            'zeros' | 'border'. Default: 'zeros'
+            'zeros' | 'border' | 'reflection'. Default: 'zeros'
 
     Returns:
         output (Tensor): output Tensor

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2156,11 +2156,11 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     """
     if mode not in GRID_SAMPLE_INTERPOLATION_MODES:
         raise ValueError("nn.functional.grid_sample(): expected mode to be "
-                         "'bilinear' or 'nearest', but got : '{}'".format(mode))
+                         "'bilinear' or 'nearest', but got: '{}'".format(mode))
     if padding_mode not in GRID_SAMPLE_PADDING_MODES:
         raise ValueError("nn.functional.grid_sample(): expected padding_mode "
                          "to be 'zeros', 'border', or 'reflection', "
-                         "but got '{}'".format(padding_mode))
+                         "but got: '{}'".format(padding_mode))
     return torch.grid_sampler(input, grid, GRID_SAMPLE_INTERPOLATION_MODES[mode],
                               GRID_SAMPLE_PADDING_MODES[padding_mode])
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,4 +1,4 @@
-"""Functional interface"""
+r"""Functional interface"""
 
 import warnings
 import math
@@ -2103,9 +2103,16 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return interpolate(input, size, scale_factor, mode='bilinear', align_corners=True)
 
 
-GRID_SAMPLE_MODE_ZEROS = 0
-GRID_SAMPLE_MODE_BORDER = 1
+GRID_SAMPLE_INTERPOLATION_MODES = {
+  'bilinear': 0,
+  # 'nearest': 1,
+}
 
+GRID_SAMPLE_PADDING_MODES = {
+  'zeros': 0,
+  'border': 1,
+  'reflection': 2,
+}
 
 def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
@@ -2146,15 +2153,11 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
         output (Tensor): output Tensor
 
     """
-    if mode != 'bilinear':
-        raise NotImplementedError("nn.functional.grid_sample got unsupported mode: '{}'".format(mode))
-    if padding_mode == 'zeros':
-        padding_mode = GRID_SAMPLE_MODE_ZEROS
-    elif padding_mode == 'border':
-        padding_mode = GRID_SAMPLE_MODE_BORDER
-    else:
-        raise ValueError("padding_mode needs to be 'zeros' or 'border', but got {}".format(padding_mode))
-    return torch.grid_sampler(input, grid, padding_mode)
+    if mode not in GRID_SAMPLE_INTERPOLATION_MODES:
+        raise ValueError("nn.functional.grid_sample got unsupported interpolation mode: '{}'".format(mode))
+    if padding_mode not in GRID_SAMPLE_PADDING_MODES:
+        raise ValueError("padding_mode needs to be 'zeros', 'border', or 'reflection', but got '{}'".format(padding_mode))
+    return torch.grid_sampler(input, grid, GRID_SAMPLE_INTERPOLATION_MODES[mode], GRID_SAMPLE_PADDING_MODES[padding_mode])
 
 
 def affine_grid(theta, size):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2104,15 +2104,16 @@ def upsample_bilinear(input, size=None, scale_factor=None):
 
 
 GRID_SAMPLE_INTERPOLATION_MODES = {
-  'bilinear': 0,
-  # 'nearest': 1,
+    'bilinear': 0,
+    'nearest': 1,
 }
 
 GRID_SAMPLE_PADDING_MODES = {
-  'zeros': 0,
-  'border': 1,
-  'reflection': 2,
+    'zeros': 0,
+    'border': 1,
+    'reflection': 2,
 }
+
 
 def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
@@ -2154,10 +2155,14 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
 
     """
     if mode not in GRID_SAMPLE_INTERPOLATION_MODES:
-        raise ValueError("nn.functional.grid_sample got unsupported interpolation mode: '{}'".format(mode))
+        raise ValueError("nn.functional.grid_sample(): expected mode to be "
+                         "'bilinear' or 'nearest', but got : '{}'".format(mode))
     if padding_mode not in GRID_SAMPLE_PADDING_MODES:
-        raise ValueError("padding_mode needs to be 'zeros', 'border', or 'reflection', but got '{}'".format(padding_mode))
-    return torch.grid_sampler(input, grid, GRID_SAMPLE_INTERPOLATION_MODES[mode], GRID_SAMPLE_PADDING_MODES[padding_mode])
+        raise ValueError("nn.functional.grid_sample(): expected padding_mode "
+                         "to be 'zeros', 'border', or 'reflection', "
+                         "but got '{}'".format(padding_mode))
+    return torch.grid_sampler(input, grid, GRID_SAMPLE_INTERPOLATION_MODES[mode],
+                              GRID_SAMPLE_PADDING_MODES[padding_mode])
 
 
 def affine_grid(theta, size):


### PR DESCRIPTION
closes #9702 .

cc @jph00 

Commit structure:

1. Change the index calculation logic. I will explain using 1-D for simplicity.

	Previously we have (in pseudo code):

	```
	// 1. get the float locations from grid
	scalar_t x = from_grid()

	// 2. find the integral surrounding indices
	int x_left = floor(x)
	int x_right = x_left + 1

	// 3. calculate the linear interpolate weights
	scalar_t w_left = x_right - x
	scalar_t w_right = x - x_left

	// 4. manipulate the integral surrounding indices if needed
	// (e.g., clip for border padding_mode)
	x_left = manipulate(x_left, padding_mode)
	x_right = manipulate(x_right, padding_mode)

	// 5. interpolate
	output_val = interpolate(w_left, w_right, x_left, x_right)
	```

	This is actually incorrect (and also unintuitive) because it calculates the 
	weights before manipulate out-of-boundary indices. Fortunately, this 
	isn't manifested in both of the current supported modes, `'zeros'` and 
	`'border'` padding:

	+ `'zeros'`: doesn't clip
	+ `'border'`: clips, but for out-of-bound `x` both `x_left` and `x_right` are 
	  clipped to the same value, so weights don't matter

	But this is a problem with reflection padding, since after each time we reflect,
	the values of `w_left` and `w_right` should be swapped.

	So in this commit I change the algorithm to (numbers corresponding to the 
        ordering in the above pseudo-code)

	```
	1. get float location
	4. clip the float location 
	2. find the integral surrounding indices
	3. calculate the linear interpolate weights
	```

	In the backward, because of this change, I need to add new variables to track
	`d manipulate_output / d manipulate_input`, which is basically a multiplier
	on the gradient calculated for `grid`. From benchmarking this addition doesn't
	cause obvious slow downs.

2. Implement reflection padding. The indices will keep being reflected until 
	they become within boundary.

	Added variant of `clip_coordinates` and `reflect_coordinates` to be used in 
	backward. E.g.,
	```cpp
	// clip_coordinates_set_grad works similarly to clip_coordinates except that
	// it also returns the `d output / d input` via pointer argument `grad_in`.
	// This is useful in the backward pass of grid_sampler.
	scalar_t clip_coordinates_set_grad(scalar_t in, int64_t clip_limit, scalar_t *grad_in)
	```
	For example, if `in` is clipped in `'border'` mode, `grad_in` is set to `0`.
	If `in` is reflected **odd** times in `'reflection'` mode, `grad_in` 
	is set to `-1`.

3. Implement nearest interpolation.

4. Add test cases

5. Add better input checking
  Discussed with @goldsborough for moving `operator<<` of `at::Device`, 
  `at::DeviceType` and `at::Layout` into `at` namespace. (Otherwise 
  `AT_CHECK` can't find them.)

6. Support empty tensors. cc @gchanan

    + Make empty tensors not acceptable by cudnn. 
    + Add `AT_ASSERT(kernel block size  > 0)` if using `GET_BLOCKS`
   + Cache `numel` in `TensorGeometry`
      I was going to use `numel` to test if cudnn descriptor should accept a
      tensor, but it isn't used eventually. I can revert this if needed.

7. Add more test cases, including on input checking and empty tensors

8. Remove an obsolete comment

9. Update docs. Manually tested by generating docs.

