### PR TITLE
[c10d] Added Reduce,AllGather,Gather,Scatter Ops for NCCL and MPI process groups

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -138,7 +138,7 @@ target_include_directories(c10d PRIVATE ${CMAKE_BINARY_DIR}/include)
 
 install(TARGETS c10d ARCHIVE DESTINATION lib)
 
-option(BUILD_EXAMPLES "Build examples" OFF)
+option(BUILD_EXAMPLES "Build examples" ON)
 if(BUILD_EXAMPLES)
   add_subdirectory(example)
 endif()

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -105,12 +105,12 @@ class ProcessGroup {
   virtual std::shared_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const GatherOptions& ops = GatherOptions()) = 0;
+      const GatherOptions& opts = GatherOptions()) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ScatterOptions& ops = ScatterOptions()) = 0;
+      const ScatterOptions& opts = ScatterOptions()) = 0;
 
  protected:
   const int rank_;

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -94,6 +94,24 @@ class ProcessGroup {
       std::vector<at::Tensor>& data,
       const AllreduceOptions& opts = AllreduceOptions()) = 0;
 
+  virtual std::shared_ptr<ProcessGroup::Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& ops = GatherOptions()) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& ops = ScatterOptions()) = 0;
+
  protected:
   const int rank_;
   const int size_;

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -570,28 +570,28 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::reduce(
-    std::vector<at::Tensor>& tensors,
-    const ReduceOptions& opts) {
+    std::vector<at::Tensor>& /* unused */,
+    const ReduceOptions& /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support reduce");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors) {
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    std::vector<at::Tensor>& /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support allgather");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
-    const GatherOptions& opts) {
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    std::vector<at::Tensor>& /* unused */,
+    const GatherOptions& /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support gather");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
-    const ScatterOptions& opts) {
+    std::vector<at::Tensor>& /* unused */,
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    const ScatterOptions& /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support scatter");
 }
 

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -584,14 +584,14 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
-    const GatherOptions& ops) {
+    const GatherOptions& opts) {
   throw std::runtime_error("ProcessGroupGloo does not support gather");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
-    const ScatterOptions& ops) {
+    const ScatterOptions& opts) {
   throw std::runtime_error("ProcessGroupGloo does not support scatter");
 }
 

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -569,4 +569,30 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
   return enqueue(entry);
 }
 
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts) {
+  throw std::runtime_error("ProcessGroupGloo does not support reduce");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors) {
+  throw std::runtime_error("ProcessGroupGloo does not support allgather");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const GatherOptions& ops) {
+  throw std::runtime_error("ProcessGroupGloo does not support gather");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ScatterOptions& ops) {
+  throw std::runtime_error("ProcessGroupGloo does not support scatter");
+}
+
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -255,12 +255,12 @@ class ProcessGroupGloo : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const GatherOptions& ops = GatherOptions()) override;
+      const GatherOptions& opts = GatherOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ScatterOptions& ops = ScatterOptions()) override;
+      const ScatterOptions& opts = ScatterOptions()) override;
 
  protected:
   using KeyType = AlgorithmKey;

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -243,6 +243,25 @@ class ProcessGroupGloo : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
+  // Unsupported Ops
+  std::shared_ptr<ProcessGroup::Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors) override;
+
+  std::shared_ptr<ProcessGroup::Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& ops = GatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& ops = ScatterOptions()) override;
+
  protected:
   using KeyType = AlgorithmKey;
   using EntryType = std::unique_ptr<AlgorithmEntry>;

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -61,10 +61,26 @@ void checkSingleTensor(const std::vector<at::Tensor>& tensors) {
   if (!tensors[0].is_contiguous()) {
     throw std::runtime_error("input tensor has to be contiguous");
   }
+  if (tensors[0].is_sparse()) {
+    throw std::runtime_error("input tensor has to be dense");
+  }
   if (tensors[0].is_cuda() && !cudaAwareMpiCheck()) {
     throw std::runtime_error(
         "CUDA tensor detected and the MPI used doesn't "
         "have CUDA-aware MPI support");
+  }
+}
+
+void checkSameSizeAndType(
+    const at::Tensor& tensor,
+    const std::vector<at::Tensor>& tensors) {
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    if ((tensors[i].numel() != tensor.numel()) ||
+        (tensors[i].type() != tensor.type())) {
+      throw std::runtime_error("Tensors are not equal in size or data type");
+    }
+    std::vector<at::Tensor> temp{tensors[i]};
+    checkSingleTensor(temp);
   }
 }
 
@@ -291,6 +307,202 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
   auto entry = std::unique_ptr<WorkEntry>(
       new WorkEntry(&tensors, nullptr, std::move(runFunc)));
   return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts) {
+  checkSingleTensor(tensors);
+
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [opts, this](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        auto dataPtr = (*entry->src)[0].data_ptr();
+        void* sendbuf = (rank_ == opts.rootRank) ? MPI_IN_PLACE : dataPtr;
+        void* recvbuf = (rank_ == opts.rootRank) ? dataPtr : nullptr;
+
+        MPI_CHECK(MPI_Reduce(
+            sendbuf,
+            recvbuf,
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            mpiOp.at(opts.reduceOp),
+            opts.rootRank,
+            MPI_COMM_WORLD));
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
+  return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors) {
+  checkSingleTensor(inputTensors);
+  if (outputTensors.size() != 1) {
+    throw std::runtime_error(
+        "MPI process group only supports a single "
+        "tensor op");
+  }
+  if (static_cast<size_t>(size_) != outputTensors[0].size()) {
+    throw std::runtime_error(
+        "All gather: number of output tensors should equal "
+        "to the world size");
+  }
+
+  checkSameSizeAndType(inputTensors[0], outputTensors[0]);
+
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        std::vector<at::Tensor>& outputDataVec = *(entry->dst);
+        auto flatOutputTensor = newLikeFlat(outputDataVec);
+
+        MPI_CHECK(MPI_Allgather(
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            flatOutputTensor.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            MPI_COMM_WORLD));
+
+        for (size_t i = 0; i < outputDataVec.size(); ++i) {
+          outputDataVec[i].copy_(flatOutputTensor[i]);
+        }
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&inputTensors, &outputTensors[0], std::move(runFunc)));
+  return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const GatherOptions& opts) {
+  checkSingleTensor(inputTensors);
+
+  if (rank_ != opts.rootRank) {
+    if (outputTensors.size() > 0) {
+      throw std::runtime_error(
+          "Gather: number of output tensors should be 0 "
+          "for non-root");
+    }
+  } else {
+    if (outputTensors.size() != 1) {
+      throw std::runtime_error("Gather: only single tensor op supported");
+    }
+    if (static_cast<size_t>(size_) != outputTensors[0].size()) {
+      throw std::runtime_error(
+          "Gather: number of output tensors should equal "
+          "to the world size");
+    }
+    checkSameSizeAndType(inputTensors[0], outputTensors[0]);
+  }
+
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [opts, this](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        void* recvbuf = nullptr;
+        at::Tensor flatOutputTensor;
+        std::vector<at::Tensor>* outputDataVec;
+
+        if (rank_ == opts.rootRank) {
+          outputDataVec = entry->dst;
+          flatOutputTensor = newLikeFlat(*outputDataVec);
+          recvbuf = flatOutputTensor.data_ptr();
+        }
+        MPI_CHECK(MPI_Gather(
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            recvbuf,
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            opts.rootRank,
+            MPI_COMM_WORLD));
+
+        if (rank_ == opts.rootRank) {
+          // copy the flattened output tensors to the outputs
+          for (size_t i = 0; i < outputDataVec->size(); ++i) {
+            outputDataVec->at(i).copy_(flatOutputTensor[i]);
+          }
+        }
+      };
+
+  if (rank_ == opts.rootRank) {
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(&inputTensors, &outputTensors[0], std::move(runFunc)));
+    return enqueue(std::move(entry));
+  } else {
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(&inputTensors, nullptr, std::move(runFunc)));
+    return enqueue(std::move(entry));
+  }
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ScatterOptions& opts) {
+  checkSingleTensor(outputTensors);
+
+  if (rank_ != opts.rootRank) {
+    if (inputTensors.size() > 0) {
+      throw std::runtime_error(
+          "Scatter: number of input tensors should be 0 "
+          "for non-root");
+    }
+  } else {
+    if (inputTensors.size() != 1) {
+      throw std::runtime_error("Gather: only single tensor op supported");
+    }
+    if (static_cast<size_t>(size_) != inputTensors[0].size()) {
+      throw std::runtime_error(
+          "Scatter: number of input tensors should equal "
+          "to the world size");
+    }
+    checkSameSizeAndType(outputTensors[0], inputTensors[0]);
+  }
+
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [opts, this](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->dst)[0];
+        void* sendbuf = nullptr;
+        at::Tensor flatInputTensor;
+        std::vector<at::Tensor>* inputDataVec;
+
+        if (rank_ == opts.rootRank) {
+          inputDataVec = entry->src;
+          flatInputTensor = newLikeFlat(*inputDataVec);
+          sendbuf = flatInputTensor.data_ptr();
+
+          // copy the input tensors to the flatten large send buffer
+          for (size_t i = 0; i < inputDataVec->size(); ++i) {
+            flatInputTensor[i].copy_(inputDataVec->at(i));
+          }
+        }
+
+        MPI_CHECK(MPI_Scatter(
+            sendbuf,
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            opts.rootRank,
+            MPI_COMM_WORLD));
+      };
+
+  if (rank_ == opts.rootRank) {
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(&inputTensors[0], &outputTensors, std::move(runFunc)));
+    return enqueue(std::move(entry));
+  } else {
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(nullptr, &outputTensors, std::move(runFunc)));
+    return enqueue(std::move(entry));
+  }
 }
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -125,12 +125,12 @@ class ProcessGroupMPI : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const GatherOptions& ops = GatherOptions()) override;
+      const GatherOptions& opts = GatherOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ScatterOptions& ops = ScatterOptions()) override;
+      const ScatterOptions& opts = ScatterOptions()) override;
 
   // Creating a new ProcessGroupMPI, will initiialize MPI if not initialized
   static std::shared_ptr<ProcessGroupMPI> createProcessGroupMPI();

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -114,6 +114,24 @@ class ProcessGroupMPI : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors) override;
+
+  std::shared_ptr<ProcessGroup::Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& ops = GatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& ops = ScatterOptions()) override;
+
   // Creating a new ProcessGroupMPI, will initiialize MPI if not initialized
   static std::shared_ptr<ProcessGroupMPI> createProcessGroupMPI();
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -583,14 +583,14 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
-    const GatherOptions& ops) {
+    const GatherOptions& opts) {
   throw std::runtime_error("ProcessGroupNCCL does not support gather");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
-    const ScatterOptions& ops) {
+    const ScatterOptions& opts) {
   throw std::runtime_error("ProcessGroupNCCL does not support scatter");
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -581,16 +581,16 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
-    const GatherOptions& opts) {
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    std::vector<at::Tensor>& /* unused */,
+    const GatherOptions& /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support gather");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
-    const ScatterOptions& opts) {
+    std::vector<at::Tensor>& /* unused */,
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    const ScatterOptions& /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support scatter");
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -6,6 +6,7 @@
 #include <THC.h>
 #include <THC/THCGeneral.hpp>
 
+#include <c10d/Utils.hpp>
 #include <c10d/private/CUDAUtils.hpp>
 
 namespace c10d {
@@ -54,7 +55,7 @@ std::string getKeyFromDevices(const std::vector<at::Device>& devices) {
 }
 
 // Get the list of devices from list of tensors
-std::vector<at::Device> getDevices(const std::vector<at::Tensor>& tensors) {
+std::vector<at::Device> getDeviceList(const std::vector<at::Tensor>& tensors) {
   std::vector<at::Device> res;
   res.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -280,7 +281,7 @@ void ProcessGroupNCCL::tensorCheckHelper(
     const std::vector<at::Tensor>& input,
     const std::vector<at::Tensor>& output,
     int outputOverInput) {
-  if (input.size() != output.size()) {
+  if (input.size() * outputOverInput != output.size()) {
     throw std::runtime_error(
         "Input tensor sequence should have the same "
         "number of tensors as the output tensor sequence");
@@ -325,7 +326,7 @@ void ProcessGroupNCCL::tensorCheckHelper(
           "number of elements");
     }
     // Check the output tensor size equals to input tensor size
-    if (output[i].numel() != inputNumElement * outputOverInput) {
+    if (output[i].numel() != inputNumElement) {
       throw std::runtime_error(
           "The number of elements of output tensor does "
           "not match the number of elements of the input "
@@ -357,7 +358,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
     const AllreduceOptions& opts) {
   tensorCheckHelper(tensors, tensors);
 
-  auto devices = getDevices(tensors);
+  auto devices = getDeviceList(tensors);
   auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices);
 
@@ -407,7 +408,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
     const BroadcastOptions& opts) {
   tensorCheckHelper(tensors, tensors);
 
-  auto devices = getDevices(tensors);
+  auto devices = getDeviceList(tensors);
   auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices);
 
@@ -451,6 +452,146 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
   }
 
   return work;
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts) {
+  tensorCheckHelper(tensors, tensors);
+
+  auto devices = getDeviceList(tensors);
+  auto key = getKeyFromDevices(devices);
+  auto& ncclComms = getNCCLComm(key, devices);
+
+  // First let NCCL streams wait for THC stream
+  syncStreams(thcState_, devices, ncclEvents_[key], ncclStreams_[key]);
+
+  // Work itself will create the CUDA events on all GPUs of tensors
+  auto work = std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices);
+
+  at::DeviceGuard gpuGuard;
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  C10D_NCCL_CHECK(ncclGroupStart());
+
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    gpuGuard.set_index(devices[i].index());
+    CUDAStream& ncclStream = ncclStreams_[key][i];
+    // root rank of the the GPU
+    int root = opts.rootRank * tensors.size() + opts.rootTensor;
+
+    C10D_NCCL_CHECK(ncclReduce(
+        tensors[i].data_ptr(),
+        tensors[i].data_ptr(),
+        tensors[i].numel(),
+        getNcclDataType(tensors[i].type().scalarType()),
+        ncclOp[opts.reduceOp],
+        root,
+        ncclComms[i]->getNcclComm(),
+        ncclStream.getStream()));
+  }
+
+  C10D_NCCL_CHECK(ncclGroupEnd());
+
+  // Event should only be recorded after the ncclGroupEnd()
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    CUDAStream& ncclStream = ncclStreams_[key][i];
+    CUDAEvent& cudaEvent = work->cudaEvents_[i];
+
+    C10D_CUDA_CHECK(
+        cudaEventRecord(cudaEvent.getEvent(), ncclStream.getStream()));
+  }
+
+  return work;
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors) {
+  if (outputTensors.size() != inputTensors.size()) {
+    throw std::runtime_error("allgather: input and output size mismatch");
+  }
+  std::vector<at::Tensor> flattenOutputTensors;
+  flattenOutputTensors.resize(outputTensors.size());
+
+  for (size_t i = 0; i < outputTensors.size(); ++i) {
+    tensorCheckHelper(
+        std::vector<at::Tensor>{inputTensors[i]}, outputTensors[i], size_);
+    // Flatten the output tensors (from all ranks) to a single big tensor
+    flattenOutputTensors[i] = newLikeFlat(outputTensors);
+  }
+
+  auto devices = getDeviceList(inputTensors);
+  auto key = getKeyFromDevices(devices);
+  auto& ncclComms = getNCCLComm(key, devices);
+
+  // First let NCCL streams wait for THC stream
+  syncStreams(thcState_, devices, ncclEvents_[key], ncclStreams_[key]);
+
+  // Work itself will create the CUDA events on all GPUs of tensors
+  auto work = std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices);
+
+  at::DeviceGuard gpuGuard;
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  C10D_NCCL_CHECK(ncclGroupStart());
+
+  for (size_t i = 0; i < inputTensors.size(); ++i) {
+    gpuGuard.set_index(devices[i].index());
+
+    /**
+     * TODO: use the NCCL stream, currently, there are issues using NCCL stream
+     * for both NCCL and the copy. That's why we are using default stream for
+     * allGather temporarily. work->wait() is currently a no-op
+     */
+    auto currentThcStream =
+        THCState_getCurrentStreamOnDevice(thcState_, devices[i].index());
+
+    C10D_NCCL_CHECK(ncclAllGather(
+        inputTensors[i].data_ptr(),
+        flattenOutputTensors[i].data_ptr(),
+        inputTensors[i].numel(),
+        getNcclDataType(inputTensors[i].type().scalarType()),
+        ncclComms[i]->getNcclComm(),
+        currentThcStream));
+  }
+
+  C10D_NCCL_CHECK(ncclGroupEnd());
+
+  // Copy the flattened output tensors to the outputs
+  for (size_t i = 0; i < outputTensors.size(); ++i) {
+    for (size_t j = 0; j < outputTensors[0].size(); ++j) {
+      outputTensors[i][j].copy_(flattenOutputTensors[i][j][i], true);
+    }
+  }
+
+  // Event should only be recorded after the ncclGroupEnd()
+  for (size_t i = 0; i < inputTensors.size(); ++i) {
+    CUDAStream& ncclStream = ncclStreams_[key][i];
+    CUDAEvent& cudaEvent = work->cudaEvents_[i];
+
+    C10D_CUDA_CHECK(
+        cudaEventRecord(cudaEvent.getEvent(), ncclStream.getStream()));
+  }
+  return work;
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const GatherOptions& ops) {
+  throw std::runtime_error("ProcessGroupNCCL does not support gather");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ScatterOptions& ops) {
+  throw std::runtime_error("ProcessGroupNCCL does not support scatter");
 }
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -121,12 +121,12 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const GatherOptions& ops = GatherOptions()) override;
+      const GatherOptions& opts = GatherOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ScatterOptions& ops = ScatterOptions()) override;
+      const ScatterOptions& opts = ScatterOptions()) override;
 
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -109,6 +109,25 @@ class ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors) override;
+
+  // Unsupported Ops
+  std::shared_ptr<ProcessGroup::Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& ops = GatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& ops = ScatterOptions()) override;
+
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store
   void broadcastUniqueNCCLID(ncclUniqueId* ncclID);

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -27,4 +27,18 @@ struct AllreduceOptions {
   ReduceOp reduceOp = ReduceOp::SUM;
 };
 
+struct ReduceOptions {
+  ReduceOp reduceOp = ReduceOp::SUM;
+  int rootRank = 0;
+  int rootTensor = 0;
+};
+
+struct ScatterOptions {
+  int rootRank = 0;
+};
+
+struct GatherOptions {
+  int rootRank = 0;
+};
+
 } // namespace c10d

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -7,10 +7,6 @@ namespace c10d {
 enum class CollectiveType : std::uint8_t {
   BROADCAST,
   ALLREDUCE,
-  REDUCE,
-  ALLGATHER,
-  GATHER,
-  SCATTER,
   UNUSED,
 };
 

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -7,6 +7,10 @@ namespace c10d {
 enum class CollectiveType : std::uint8_t {
   BROADCAST,
   ALLREDUCE,
+  REDUCE,
+  ALLGATHER,
+  GATHER,
+  SCATTER,
   UNUSED,
 };
 

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -60,6 +60,29 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   }
 }
 
+inline at::Tensor newLikeFlat(std::vector<std::vector<at::Tensor>>& tensors) {
+  if (tensors.size() == 0 || tensors[0].size() == 0) {
+    throw std::runtime_error("Received an empty list");
+  }
+  auto& t = tensors[0][0];
+  at::DeviceGuard gpuGuard(t.is_cuda() ? t.get_device() : -1);
+  std::vector<int64_t> sizes{static_cast<int64_t>(tensors[0].size()),
+                             static_cast<int64_t>(tensors.size())};
+  sizes.insert(sizes.end(), t.sizes().begin(), t.sizes().end());
+  return t.type().tensor(sizes);
+}
+
+inline at::Tensor newLikeFlat(std::vector<at::Tensor>& tensors) {
+  if (tensors.size() == 0) {
+    throw std::runtime_error("Received an empty list");
+  }
+  auto& t = tensors[0];
+  at::DeviceGuard gpuGuard(t.is_cuda() ? t.get_device() : -1);
+  std::vector<int64_t> sizes{static_cast<int64_t>(tensors.size())};
+  sizes.insert(sizes.end(), t.sizes().begin(), t.sizes().end());
+  return t.type().tensor(sizes);
+}
+
 inline std::vector<std::vector<int64_t>> getSizes(
     const std::vector<at::Tensor>& tensors) {
   std::vector<std::vector<int64_t>> sizes(tensors.size());

--- a/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
@@ -40,18 +40,24 @@ class NCCLTestBase {
 
 class NCCLTest : public NCCLTestBase {
  public:
-  NCCLTest(const std::string& path)
+  NCCLTest(const std::string& path, int worldSize)
       : NCCLTestBase(path),
         numDevices_(cudaNumDevices()),
-        state_(::at::globalContext().lazyInitCUDA()) {
+        state_(::at::globalContext().lazyInitCUDA()),
+        worldSize_(worldSize) {
     const auto& type = at::getType(at::kCUDA, at::kFloat);
 
     // Each device has a single tensor to perf the NCCL op
     inputs_.resize(numDevices_);
+    outputs_.resize(numDevices_);
     at::DeviceGuard deviceGuard;
-    for (auto i = 0; i < numDevices_; i++) {
+    for (auto i = 0; i < numDevices_; ++i) {
       deviceGuard.set_index(i);
       inputs_[i] = type.tensor({3, 3});
+      outputs_[i].resize(worldSize_);
+      for (auto j = 0; j < worldSize_; ++j) {
+        outputs_[i][j] = type.tensor({3, 3});
+      }
     }
 
     // Allocate a stream per device.
@@ -96,6 +102,25 @@ class NCCLTest : public NCCLTestBase {
     return outputs;
   }
 
+  std::vector<std::vector<at::Tensor>> getOutputTensors() {
+    std::vector<std::vector<at::Tensor>> outputs(numDevices_);
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      outputs[i] = std::vector<at::Tensor>(worldSize_);
+    }
+
+    // For the duration of this function, make THC use our streams
+    auto guards = createStreamGuard();
+
+    // Copy inputs to outputs
+    for (auto i = 0; i < numDevices_; ++i) {
+      cudaStreamSynchronize(streams_[i].getStream());
+      for (auto j = 0; j < worldSize_; ++j) {
+        outputs[i][j] = outputs_[i][j].toBackend(at::kCPU);
+      }
+    }
+    return outputs;
+  }
+
   int numDevices() const {
     return numDevices_;
   }
@@ -103,13 +128,16 @@ class NCCLTest : public NCCLTestBase {
  protected:
   const int numDevices_;
   THCState* state_;
+  int worldSize_;
   std::vector<at::Tensor> inputs_;
+  std::vector<std::vector<at::Tensor>> outputs_;
   std::vector<CUDAStream> streams_;
 };
 
 class AllreduceNCCLTest : public NCCLTest {
  public:
-  AllreduceNCCLTest(const std::string& path) : NCCLTest(path) {}
+  AllreduceNCCLTest(const std::string& path, int worldSize)
+      : NCCLTest(path, worldSize) {}
 
   std::shared_ptr<c10d::ProcessGroup::Work> run() {
     // For the duration of this function, make THC use our streams
@@ -134,7 +162,8 @@ class AllreduceNCCLTest : public NCCLTest {
 
 class BroadcastNCCLTest : public NCCLTest {
  public:
-  BroadcastNCCLTest(const std::string& path) : NCCLTest(path) {}
+  BroadcastNCCLTest(const std::string& path, int worldSize)
+      : NCCLTest(path, worldSize) {}
 
   std::shared_ptr<c10d::ProcessGroup::Work> run(int rootRank, int rootTensor) {
     // For the duration of this function, make THC use our streams
@@ -160,8 +189,63 @@ class BroadcastNCCLTest : public NCCLTest {
   }
 };
 
+class ReduceNCCLTest : public NCCLTest {
+ public:
+  ReduceNCCLTest(const std::string& path, int worldSize)
+      : NCCLTest(path, worldSize) {}
+
+  std::shared_ptr<c10d::ProcessGroup::Work> run(int rootRank, int rootTensor) {
+    // For the duration of this function, make THC use our streams
+    auto guards = createStreamGuard();
+
+    // Launch sleep on every device
+    at::DeviceGuard deviceGuard;
+    for (auto i = 0; i < numDevices_; i++) {
+      deviceGuard.set_index(i);
+      cudaSleep(streams_[i], 2000 * 1000 * 1000);
+    }
+
+    // Launch value initialization for every tensor
+    for (auto i = 0; i < numDevices_; i++) {
+      deviceGuard.set_index(i);
+      inputs_[i].fill_(pg_->getRank() * numDevices_ + i);
+    }
+
+    ::c10d::ReduceOptions options;
+    options.rootRank = rootRank;
+    options.rootTensor = rootTensor;
+    return pg_->reduce(inputs_, options);
+  }
+};
+
+class AllgatherNCCLTest : public NCCLTest {
+ public:
+  AllgatherNCCLTest(const std::string& path, int worldSize)
+      : NCCLTest(path, worldSize) {}
+
+  std::shared_ptr<c10d::ProcessGroup::Work> run() {
+    // For the duration of this function, make THC use our streams
+    auto guards = createStreamGuard();
+
+    // Launch sleep on every device
+    at::DeviceGuard deviceGuard;
+    for (auto i = 0; i < numDevices_; i++) {
+      deviceGuard.set_index(i);
+      cudaSleep(streams_[i], 2000 * 1000 * 1000);
+    }
+
+    // Launch value initialization for every tensor
+    for (auto i = 0; i < numDevices_; i++) {
+      deviceGuard.set_index(i);
+      inputs_[i].fill_(pg_->getRank() * numDevices_ + i);
+    }
+
+    return pg_->allgather(outputs_, inputs_);
+  }
+};
+
 void testAllreduce(const std::string& path, int rank, int size) {
-  auto test = AllreduceNCCLTest(path);
+  auto test = AllreduceNCCLTest(path, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -184,16 +268,16 @@ void testAllreduce(const std::string& path, int rank, int size) {
 }
 
 void testBroadcast(const std::string& path, int rank, int size) {
-  auto test = BroadcastNCCLTest(path);
+  auto test = BroadcastNCCLTest(path, size);
   test.initialize(rank, size);
 
   const int numDevices = test.numDevices();
-  // Try every permutation of root rank and root tensor
+  // try every permutation of root rank and root tensor
   for (auto rootRank = 0; rootRank < size; rootRank++) {
     for (auto rootTensor = 0; rootTensor < numDevices; rootTensor++) {
       auto work = test.run(rootRank, rootTensor);
 
-      // Wait for work to complete
+      // wait for work to complete
       test.wait(work);
 
       // Check results
@@ -213,6 +297,63 @@ void testBroadcast(const std::string& path, int rank, int size) {
   std::cout << "Broadcast test successful" << std::endl;
 }
 
+void testReduce(const std::string& path, int rank, int size) {
+  auto test = ReduceNCCLTest(path, size);
+  test.initialize(rank, size);
+
+  const int numDevices = test.numDevices();
+  // try every permutation of root rank and root tensor
+  for (auto rootRank = 0; rootRank < size; rootRank++) {
+    for (auto rootTensor = 0; rootTensor < numDevices; rootTensor++) {
+      auto work = test.run(rootRank, rootTensor);
+
+      // wait for work to complete
+      test.wait(work);
+
+      // Validation
+      const int totalNumGPUs = numDevices * size;
+      const auto expected = (totalNumGPUs * (totalNumGPUs - 1)) / 2;
+      auto tensors = test.getTensors();
+      if (rank == rootRank) {
+        auto& tensor = tensors[rootTensor];
+        auto data = tensor.data<float>();
+        for (auto k = 0; k < tensor.numel(); k++) {
+          if (data[k] != expected) {
+            throw std::runtime_error("BOOM!");
+          }
+        }
+      }
+    }
+  }
+  std::cout << "Reduce test successful" << std::endl;
+}
+
+void testAllgather(const std::string& path, int rank, int size) {
+  auto test = AllgatherNCCLTest(path, size);
+  test.initialize(rank, size);
+  auto work = test.run();
+  // Wait for work to finish
+  test.wait(work);
+
+  // Validation
+  auto tensors = test.getOutputTensors();
+  // device index
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    // rank index
+    for (size_t j = 0; j < tensors[i].size(); ++j) {
+      const auto expected = j * size + i;
+      auto& tensor = tensors[i][j];
+      auto data = tensor.data<float>();
+      for (auto k = 0; k < tensor.numel(); k++) {
+        if (data[k] != expected) {
+          throw std::runtime_error("BOOM!");
+        }
+      }
+    }
+  }
+  std::cout << "Allgather test successful" << std::endl;
+}
+
 int main(int argc, char** argv) {
   // Use WORLD_SIZE and RANK environmental variables to do multi-node
   // distributed testing
@@ -228,13 +369,13 @@ int main(int argc, char** argv) {
     std::cout << "Multi-node world size: " << size << " rank: " << rank
               << std::endl;
   }
-  {
-    TemporaryFile file;
-    testAllreduce(file.path, rank, size);
-  }
-  {
-    TemporaryFile file;
-    testBroadcast(file.path, rank, size);
-  }
+  // TemporaryFile file;
+  TemporaryFile file;
+
+  testAllreduce(file.path, rank, size);
+  testBroadcast(file.path, rank, size);
+  testReduce(file.path, rank, size);
+  testAllgather(file.path, rank, size);
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Added 
- Reduce (both NCCL and MPI)
- AllGather (both NCCL and MPI)
- Gather (MPI)
- Scatter (MPI)

for c10d process groups. This basically finalizes all supported ops for C10d to match THD.

All ops are tested as well.

```
mpirun -np 8 ./ProcessGroupMPITest
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
```

```
./ProcessGroupNCCLTest
Allreduce test successful
Broadcast test successful
Reduce test successful
Allgather test successful
```