### PR TITLE
Correctly set CAFFE2_DISABLE_NUMA when USE_NUMA=OFF in cmake

### DIFF
--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -83,22 +83,26 @@ endif()
 cmake_pop_check_state()
 
 # ---[ Check for NUMA support
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
-CHECK_CXX_SOURCE_COMPILES(
+if (USE_NUMA)
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+  CHECK_CXX_SOURCE_COMPILES(
     "#include <numa.h>
     #include <numaif.h>
 
     int main(int argc, char** argv) {
     }" CAFFE2_IS_NUMA_AVAILABLE)
-
-if (CAFFE2_IS_NUMA_AVAILABLE)
-  message(STATUS "NUMA is available")
+  if (CAFFE2_IS_NUMA_AVAILABLE)
+    message(STATUS "NUMA is available")
+  else()
+    message(STATUS "NUMA is not available")
+    set(CAFFE2_DISABLE_NUMA 1)
+  endif()
+  cmake_pop_check_state()
 else()
-  message(STATUS "NUMA is not available")
+  message(STATUS "NUMA is disabled")
   set(CAFFE2_DISABLE_NUMA 1)
 endif()
-cmake_pop_check_state()
 
 # ---[ Check if we want to turn off deprecated warning due to glog.
 # Note(jiayq): on ubuntu 14.04, the default glog install uses ext/hash_set that


### PR DESCRIPTION
previously https://github.com/pytorch/pytorch/blob/master/caffe2/core/numa.cc still gets compiled even when USE_NUMA=OFF