### PR TITLE
Add torch.compiled_with_cxx11_abi().

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -301,3 +301,7 @@ BLAS and LAPACK Operations
 .. autofunction:: svd
 .. autofunction:: symeig
 .. autofunction:: trtrs
+
+Utilities
+----------------------------------
+.. autofunction:: compiled_with_cxx11_abi

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -294,3 +294,8 @@ _C._init_names(list(torch._storage_classes))
 # attach docstrings to torch and tensor functions
 from . import _torch_docs, _tensor_docs, _storage_docs
 del _torch_docs, _tensor_docs, _storage_docs
+
+
+def compiled_with_cxx11_abi():
+    r"""Returns whether PyTorch was built with _GLIBCXX_USE_CXX11_ABI=1"""
+    return _C._GLIBCXX_USE_CXX11_ABI

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -624,6 +624,13 @@ static PyObject* initModule() {
 
   ASSERT_TRUE(PyModule_AddObject(module, "has_mkl", at::hasMKL() ? Py_True : Py_False) == 0);
 
+#ifdef _GLIBCXX_USE_CXX11_ABI
+  ASSERT_TRUE(PyModule_AddObject(module, "_GLIBCXX_USE_CXX11_ABI",
+        _GLIBCXX_USE_CXX11_ABI ? Py_True : Py_False) == 0);
+#else
+  ASSERT_TRUE(PyModule_AddObject(module, "_GLIBCXX_USE_CXX11_ABI", Py_False) == 0);
+#endif
+
   auto& defaultGenerator = at::globalContext().defaultGenerator(at::kCPU);
   THPDefaultGenerator = (THPGenerator*)THPGenerator_NewWithGenerator(
     defaultGenerator);


### PR DESCRIPTION
It returns whether PyTorch was built with _GLIBCXX_USE_CXX11_ABI=1.

Fixes #8385

Test Plan:

- Checked that when compiled with gcc 4.8.5,
torch.compiled_with_cxx11_abi() returns False.
- Checked that when compiled with gcc 5.4,
torch.compiled_with_cxx11_abi() returns True

cc @soumith 