### PR TITLE
[JIT] Simplified Operator

### DIFF
--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -54,7 +54,7 @@ at::Device as_device(const std::vector<int64_t>& elements) {
 }
 
 RegisterOperators reg({
-${constructors}
+  ${constructors}
 });
 
 } // anon namespace

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -102,6 +102,7 @@ add_custom_command(
   "${TOOLS_PATH}/autograd/gen_autograd.py"
   "${TOOLS_PATH}/autograd/gen_autograd_functions.py"
   "${TOOLS_PATH}/autograd/gen_variable_type.py"
+  "${TOOLS_PATH}/jit/gen_jit_dispatch.py"
   "${TOOLS_PATH}/jit/templates/register_aten_ops.cpp"
   "${TOOLS_PATH}/jit/templates/aten_interned_strings.h"
   WORKING_DIRECTORY "${TORCH_SRC_DIR}/..")

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -2,11 +2,21 @@
 // once C10 exists this can be removed, or stubbed out, but we need
 // it now to implement correct semantic checking for script
 #pragma once
-#include "ATen/ATen.h"
+
 #include "torch/csrc/jit/assertions.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/stack.h"
+
+#include "ATen/ATen.h"
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace torch { namespace jit {
 
@@ -15,42 +25,39 @@ FunctionSchema parseSchema(const std::string& schema);
 using OperationCreator = std::function<Operation(Node*)>;
 
 struct TORCH_API Operator {
-  Operator(FunctionSchema schema, OperationCreator op, OperationCreator op_const_attributes = nullptr)
-    : schema_(std::make_shared<FunctionSchema>(std::move(schema)))
-    , op(std::move(op))
-    , op_const_attributes(std::move(op_const_attributes)) {}
+  Operator(FunctionSchema schema, OperationCreator op_creator)
+      : schema_(std::make_shared<FunctionSchema>(std::move(schema))),
+        op_creator_(std::move(op_creator)) {}
 
-  Operator(const std::string& schema, OperationCreator op, OperationCreator op_const_attributes = nullptr)
-    : schema_string_(schema)
-    , op(std::move(op))
-    , op_const_attributes(std::move(op_const_attributes)) {}
+  Operator(const std::string& schema, OperationCreator op_creator)
+      : schema_string_(schema), op_creator_(std::move(op_creator)) {}
 
-  // Helper constructor to regsiter `op` to run
+  // Helper constructor to register `op` to run
   // run for _every_ IR Node where n.kind() == name, regardless of arguments.
-  // This is accomplished by marking the schema varargs and having no required arguments.
-  // This is used for things like prim::While or prim::If that can take a number
-  // of different valid input types and lengths.
-  Operator(Symbol name, OperationCreator op)
-  : Operator(FunctionSchema(name, {}, {}, true), op, op) {}
+  // This is accomplished by marking the schema varargs and having no required
+  // arguments. This is used for things like prim::While or prim::If that can
+  // take a number of different valid input types and lengths.
+  Operator(Symbol name, OperationCreator op_creator)
+      : Operator(FunctionSchema(name, {}, {}, true), std::move(op_creator)) {}
 
+  Operator(FunctionSchema schema, Operation op)
+      : schema_(std::make_shared<FunctionSchema>(std::move(schema))),
+        op_(std::make_shared<Operation>(std::move(op))) {}
+
+  Operator(const std::string& schema, Operation op)
+      : schema_string_(schema),
+        op_(std::make_shared<Operation>(std::move(op))) {}
 
   bool matches(const Node* node) const;
-  // Operators have different versions depending on if some inputs are encoded
-  // as attributes or inputs. This function returns the right Operation function,
-  // given a node encoded for one variant.
-  // Behavior is undefined if matches(n) == false
-  // TODO (apaszke) : remove
-  Operation selectVariant(Node* n) const {
-    if(n->hasAttributes()) {
-      JIT_ASSERT(op_const_attributes != nullptr);
-      return op_const_attributes(n);
-    } else {
-      return op(n);
+
+  Operation getOperation(Node* node = nullptr) const {
+    if (op_) {
+      return *op_;
     }
+    AT_ASSERT(node != nullptr);
+    return op_creator_(node);
   }
-  bool hasAttributedVersion() const {
-    return op_const_attributes != nullptr;
-  }
+
   const FunctionSchema & schema() const {
     // we lazily parse schema initialized from strings so that
     // we do less work during static operator registration
@@ -65,8 +72,11 @@ private:
   // cannot use at::optional because windows has issues that require an assignment operator to be generated
   // cannot use std::unique_ptr because initializer lists of Operators end up copying the Operator
   mutable std::shared_ptr<FunctionSchema> schema_;
-  OperationCreator op;
-  OperationCreator op_const_attributes;
+
+  // Essentially a variant<Operation, OperationCreator>.
+  // NB: std::function has a default state (where it == nullptr).
+  std::shared_ptr<Operation> op_;
+  OperationCreator op_creator_;
 };
 
 const std::vector<std::shared_ptr<Operator>>& getAllOperatorsFor(Symbol name);
@@ -76,7 +86,7 @@ const Operator& getOperatorFor(const Node* node);
 inline Operation getOperation(Node* node) {
   // note: getOperatorFor ensures that getOperatorFor(node).matches(node) == true
   // so the call to selectVariant is always valid.
-  return getOperatorFor(node).selectVariant(node);
+  return getOperatorFor(node).getOperation(node);
 }
 
 void registerOperator(Operator&& op);


### PR DESCRIPTION
@zdevito explained that the attributed versions of `Operator`s are no longer necessary. This PR does two things:

1. Removes all code associated with attributed operators,
2. Adds a second kind of state to `Operator` where it is constructed with an `Operation` directly instead of an `OperationCreator`. This will be useful to test custom operators which don't require a node (you can just retrieve it directly).

Now rebased on top of https://github.com/pytorch/pytorch/pull/9801

@zdevito