### PR TITLE
nomnigraph - new utility for graph transformation

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
@@ -1,0 +1,174 @@
+#ifndef NOM_TRANFORMATIONS_SUBGRAPH_MATCHER_H
+#define NOM_TRANFORMATIONS_SUBGRAPH_MATCHER_H
+
+namespace nom {
+
+namespace matcher {
+
+/*
+ * Subtree matching criteria consists of
+ * - Node matching criteria for the subtree's root.
+ * - Children subtree matching criteria
+ * - A count, which means we may want more than one of this subtree. The count
+ * can be unlimited. The count is only used when we match children of a
+ * subtree root, not matching the subtree itself.
+ */
+template <typename NodeMatchCriteria>
+class SubtreeMatchCriteria {
+ public:
+  static const int kStarCount = -1;
+  SubtreeMatchCriteria(
+      const NodeMatchCriteria& root,
+      const std::vector<SubtreeMatchCriteria>& children,
+      int count)
+      : root_(root), children_(children), count_(count){};
+
+ private:
+  NodeMatchCriteria root_;
+  std::vector<SubtreeMatchCriteria> children_;
+  int count_;
+
+  template <typename, typename, typename>
+  friend class SubgraphMatcher;
+};
+
+/*
+ * Utilities for subgraph matching.
+ */
+template <
+    typename GraphType,
+    typename NodeMatchCriteria,
+    typename NodeMatcherClass>
+struct SubgraphMatcher {
+  static bool isNodeMatch(
+      typename GraphType::NodeRef node,
+      const NodeMatchCriteria& criteria) {
+    return NodeMatcherClass::isMatch(node, criteria);
+  }
+
+  // Check if there can be a sub-tree that matches the given criteria that
+  // is rooted at the given rootNode.
+  // The flag invertGraphTraversal specify if we should follow out edges or
+  // in edges. The default is true which is useful for a functional
+  // intepretation of a dataflow graph.
+  static bool isSubtreeMatch(
+      typename GraphType::NodeRef root,
+      const SubtreeMatchCriteria<NodeMatchCriteria>& criteria,
+      bool invertGraphTraversal = true) {
+    if (!isNodeMatch(root, criteria.root_)) {
+      return false;
+    }
+    auto& edges =
+        invertGraphTraversal ? root->getInEdges() : root->getOutEdges();
+
+    int numEdges = edges.size();
+    int numChildrenCriteria = criteria.children_.size();
+
+    // The current algorithm implies that the ordering of the children is
+    // important. The children nodes will be matched with the children subtree
+    // criteria in the given order.
+
+    int currentEdgeIdx = 0;
+    for (int criteriaIdx = 0; criteriaIdx < numChildrenCriteria;
+         criteriaIdx++) {
+      auto childrenCriteria = criteria.children_[criteriaIdx];
+
+      int expectedCount = childrenCriteria.count_;
+      bool isStarCount =
+          expectedCount == SubtreeMatchCriteria<NodeMatchCriteria>::kStarCount;
+
+      int countMatch = 0;
+
+      // Continue to match subsequent edges with the current children criteria.
+      // Note that if the child criteria is a * pattern, this greedy algorithm
+      // will attempt to find the longest possible sequence that matches the
+      // children criteria.
+      for (; currentEdgeIdx < numEdges &&
+           (isStarCount || countMatch < expectedCount);
+           currentEdgeIdx++) {
+        auto edge = edges[currentEdgeIdx];
+        auto nextNode = invertGraphTraversal ? edge->tail() : edge->head();
+
+        if (!isSubtreeMatch(nextNode, childrenCriteria, invertGraphTraversal)) {
+          if (!isStarCount) {
+            // If the current criteria isn't a * pattern, this indicates a
+            // failure.
+            return false;
+          } else {
+            // Otherwise, we should move on to the next children criteria.
+            break;
+          }
+        }
+
+        countMatch++;
+      }
+
+      if (countMatch < expectedCount) {
+        // Fails because there are not enough matches as specified by the
+        // criteria.
+        return false;
+      }
+    }
+
+    if (currentEdgeIdx < numEdges) {
+      // Fails because there are unmatched edges.
+      return false;
+    }
+    return true;
+  }
+
+  // Utility to transform a graph by looking for subtrees that match
+  // a given pattern and then allow callers to mutate the graph based on
+  // subtrees that are found.
+  // The current implementation doesn't handle any graph transformation
+  // itself. Callers should be responsible for all intended mutation, including
+  // deleting nodes in the subtrees found by this algorithm.
+  // Note: if the replaceFunction lambda returns false, the entire procedure
+  // is aborted. This maybe useful in certain cases when we want to terminate
+  // the subtree search early.
+  // invertGraphTraversal flag: see documentation in isSubtreeMatch
+  static void replaceSubtree(
+      GraphType& graph,
+      const SubtreeMatchCriteria<NodeMatchCriteria>& criteria,
+      const std::function<
+          bool(GraphType& g, typename GraphType::NodeRef subtreeRoot)>&
+          replaceFunction,
+      bool invertGraphTraversal = true) {
+    for (auto nodeRef : graph.getMutableNodes()) {
+      // Make sure the node is still in the graph.
+      if (!graph.hasNode(nodeRef)) {
+        continue;
+      }
+      if (isSubtreeMatch(nodeRef, criteria, invertGraphTraversal)) {
+        if (!replaceFunction(graph, nodeRef)) {
+          // If replaceFunction returns false, it means that we should abort
+          // the entire procedure.
+          break;
+        }
+      }
+    }
+  }
+};
+
+// Convenient methods to create subtree matching criteria.
+template <typename NodeMatchCriteria>
+SubtreeMatchCriteria<NodeMatchCriteria> tree(
+    const NodeMatchCriteria& root,
+    const std::vector<SubtreeMatchCriteria<NodeMatchCriteria>>& children = {},
+    int count = 1) {
+  return SubtreeMatchCriteria<NodeMatchCriteria>(root, children, count);
+}
+
+template <typename NodeMatchCriteria>
+SubtreeMatchCriteria<NodeMatchCriteria> treeStar(
+    const NodeMatchCriteria& root,
+    const std::vector<SubtreeMatchCriteria<NodeMatchCriteria>>& children = {}) {
+  return tree(
+      root, children, SubtreeMatchCriteria<NodeMatchCriteria>::kStarCount);
+}
+
+} // namespace matcher
+
+} // namespace nom
+
+#endif // NOM_TRANFORMATIONS_SUBGRAPH_MATCHER_H

--- a/caffe2/core/nomnigraph/tests/subgraph_matcher_test.cc
+++ b/caffe2/core/nomnigraph/tests/subgraph_matcher_test.cc
@@ -1,0 +1,404 @@
+#include <algorithm>
+
+#include "test_util.h"
+
+#include "nomnigraph/Transformations/SubgraphMatcher.h"
+
+#include <gtest/gtest.h>
+
+namespace nom {
+
+namespace matcher {
+
+using NodeType = std::string;
+using Criteria = std::string;
+
+// Node matches a criteria (string) if the data string is the same as the
+// criteria. Special case: "*" will match any thing.
+struct TestNodeMatch {
+  static bool isMatch(
+      const nom::Graph<NodeType>::NodeRef& node,
+      const Criteria& criteria) {
+    return criteria == "*" || criteria == node->data();
+  }
+};
+
+using TestGraph = Graph<NodeType>;
+using TestMatcher = SubgraphMatcher<TestGraph, Criteria, TestNodeMatch>;
+
+Criteria any() {
+  return Criteria("*");
+}
+
+// Make it more concise to create matching criteria in dataflow graph.
+// For example, operatorTree("opA", ...) will refer to a tree like this:
+// ... -> opA -> opA_Output
+SubtreeMatchCriteria<Criteria> operatorTree(
+    const Criteria& root,
+    const std::vector<SubtreeMatchCriteria<Criteria>>& childrenCriteria = {},
+    int count = 1) {
+  return tree(any(), {tree(root, childrenCriteria)}, count);
+}
+
+std::map<std::string, std::string> TestGraphNodePrinter(
+    TestGraph::NodeRef node) {
+  std::map<std::string, std::string> labelMap;
+  labelMap["label"] = node->data();
+  return labelMap;
+};
+
+// Attempts to create a realistic dataflow graph that shows a fuse procedure.
+struct DataFlowTestGraph {
+  const int numInputs = 4;
+
+  TestGraph graph;
+
+  TestGraph::NodeRef opB;
+  TestGraph::NodeRef opF;
+  TestGraph::NodeRef opC;
+  TestGraph::NodeRef opG;
+  TestGraph::NodeRef dataOut;
+
+  // Realistic data flow test graph.
+  /*
+
+
+                          +---------------+
+                          |               |
+                          |  +---------+  |  +---------+
+    +---------------------+  | input_A |  |  | input_B |
+    |                        +---------+  |  +---------+
+    |                          |          |    |
+    |                          |          |    |
+    |                          v          v    v
+  +---------++---------+     +-------------------------+     +--------+
+  | input_C || input_D | --> |           opC           | --> | dataC2 |
+  +---------++---------+     +-------------------------+     +--------+
+                               |
+                               |
+                               v
+                             +---------+
+                             |  dataC  | -+
+                             +---------+  |
+                               |          |
+                               |          |
+                               v          |
+                             +---------+  |
+                             |   opB   | <+
+                             +---------+
+                               |
+                               |
+                               v
+                             +---------+
+                             |  dataB  |
+                             +---------+
+                               |
+                               |
+                               v
+                             +---------+
+                             |   opF   |
+                             +---------+
+                               |
+                               |
+                               v
+                             +---------+
+                             |  dataF  |
+                             +---------+
+                               |
+                               |
+                               v
+             +---------+     +---------+
+             |  dataI  | --> |   opG   |
+             +---------+     +---------+
+                               |
+                               |
+                               v
+                             +---------+
+                             | dataOut |
+                             +---------+
+  */
+  DataFlowTestGraph() {
+    opC = graph.createNode("opC");
+
+    for (int i = 0; i < numInputs; i++) {
+      auto dataInput = graph.createNode("input");
+      graph.createEdge(dataInput, opC);
+    }
+
+    auto dataC = graph.createNode("dataC");
+    auto dataC2 = graph.createNode("dataC2");
+    graph.createEdge(opC, dataC);
+    graph.createEdge(opC, dataC2);
+
+    opB = graph.createNode("opB");
+    // There are 2 edges
+    graph.createEdge(dataC, opB);
+    graph.createEdge(dataC, opB);
+
+    auto dataB = graph.createNode("dataB");
+    graph.createEdge(opB, dataB);
+
+    opF = graph.createNode("opF");
+    graph.createEdge(dataB, opF);
+
+    auto dataF = graph.createNode("dataF");
+    graph.createEdge(opF, dataF);
+
+    auto dataI = graph.createNode("dataI");
+
+    opG = graph.createNode("opG");
+    graph.createEdge(dataF, opG);
+    graph.createEdge(dataI, opG);
+
+    dataOut = graph.createNode("dataOut");
+    graph.createEdge(opG, dataOut);
+
+    // Use nom::converters::convertToDotString(&graph, TestGraphNodePrinter)
+    // to visualize the graph.
+  }
+};
+
+SubtreeMatchCriteria<Criteria> DataFlowTestGraphCriteria() {
+  // clang-format off
+  return tree(
+      Criteria("opG"),{
+        operatorTree("opF", {
+            // Note: we currently don't enforce that these 2 opC nodes
+            // have to be the same.
+            operatorTree("opB", {
+              operatorTree("opC", {
+                treeStar(Criteria("input"))
+              }, 2),
+            })
+        }),
+        tree(any()) // matches dataI
+      });
+  // clang-format on
+}
+
+TestGraph::NodeRef getInNode(TestGraph::NodeRef node, int index) {
+  return node->getInEdges()[index]->tail();
+}
+
+} // namespace matcher
+
+} // namespace nom
+
+using namespace nom::matcher;
+
+// Simple test cases for node matching criteria.
+TEST(SubgraphMatcher, IsNodeMatch) {
+  TestGraph graph;
+  auto n1 = graph.createNode("Hello");
+  auto n2 = graph.createNode("Le");
+  graph.createEdge(n1, n2);
+
+  EXPECT_TRUE(TestMatcher::isNodeMatch(n1, "Hello"));
+  EXPECT_FALSE(TestMatcher::isNodeMatch(n1, "G"));
+  EXPECT_TRUE(TestMatcher::isNodeMatch(n2, "Le"));
+  EXPECT_FALSE(TestMatcher::isNodeMatch(n2, "le"));
+}
+
+// Test subtree matching with a simple tree graph.
+TEST(SubgraphMatcher, IsSubtreeMatch) {
+  TestGraph graph;
+  auto n1 = graph.createNode("1");
+  auto n2 = graph.createNode("2");
+  auto n3 = graph.createNode("3");
+  auto n4 = graph.createNode("4");
+  auto n5 = graph.createNode("5");
+  auto n6 = graph.createNode("6");
+  auto n7 = graph.createNode("7");
+
+  graph.createEdge(n1, n2);
+  graph.createEdge(n2, n3);
+  graph.createEdge(n2, n4);
+  graph.createEdge(n1, n5);
+  graph.createEdge(n5, n6);
+  graph.createEdge(n5, n7);
+  /*       N1
+         /     \
+      N2         N5
+    /    \     /    \
+  N3     N4   N6   N7
+  */
+
+  auto subtree = tree(any(), {tree(any()), tree(any())});
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n4, subtree, false));
+
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n2, subtree, false));
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n5, subtree, false));
+
+  subtree = tree(Criteria("5"), {tree(any()), tree(any())});
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n2, subtree, false));
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n5, subtree, false));
+
+  subtree = tree(any(), {tree(any()), tree(Criteria("4"))});
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n2, subtree, false));
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n5, subtree, false));
+}
+
+// Test subtree matching in which * (repeated) matching of children is allowed.
+TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
+  TestGraph graph;
+  auto n1 = graph.createNode("1");
+  auto n2 = graph.createNode("2");
+  auto n3A = graph.createNode("3");
+  auto n3B = graph.createNode("3");
+  auto n4 = graph.createNode("4");
+  auto n5A = graph.createNode("5");
+  auto n5B = graph.createNode("5");
+  auto n5C = graph.createNode("5");
+  graph.createEdge(n1, n2);
+  graph.createEdge(n1, n3A);
+  graph.createEdge(n1, n3B);
+  graph.createEdge(n1, n4);
+  graph.createEdge(n1, n4);
+  graph.createEdge(n1, n5A);
+  graph.createEdge(n1, n5B);
+  graph.createEdge(n1, n5C);
+
+  auto subtree = tree(any(), {tree(Criteria("2"))});
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  subtree = tree(any(), {treeStar(Criteria("2"))});
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  // clang-format off
+  subtree = tree(any(), {
+    tree(Criteria("2")),
+    tree(Criteria("3"), {}, 2),
+    tree(Criteria("4"), {}, 2),
+    tree(Criteria("5"), {}, 3)
+  });
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  subtree = tree(any(), {
+    tree(Criteria("2")),
+    tree(Criteria("3"), {}, 2),
+    tree(Criteria("4"), {}, 2),
+    treeStar(Criteria("5"))
+  });
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  subtree = tree(any(), {
+    tree(Criteria("2")),
+    treeStar(Criteria("3")),
+    tree(Criteria("4"), {}, 2),
+    treeStar(Criteria("5"))
+  });
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  subtree = tree(any(), {
+    tree(Criteria("2")),
+    treeStar(Criteria("3")),
+  });
+  // Fails because there are unmatched edges.
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+
+  subtree = tree(any(), {
+    tree(Criteria("2")),
+    tree(Criteria("3"), {}, 2),
+    tree(Criteria("4")),
+    tree(Criteria("5"), {}, 3)
+  });
+  // Fails because the count is wrong; we have 2 edges to node N4 while
+  // the pattern expects only 1.
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(n1, subtree, false));
+  // clang-format on
+}
+
+TEST(SubgraphMatcher, IsSubtreeMatchRealistic) {
+  auto graph = DataFlowTestGraph();
+  auto subtree = DataFlowTestGraphCriteria();
+
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(graph.opF, subtree));
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(graph.opC, subtree));
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(graph.opB, subtree));
+  EXPECT_FALSE(TestMatcher::isSubtreeMatch(graph.dataOut, subtree));
+
+  EXPECT_TRUE(TestMatcher::isSubtreeMatch(graph.opG, subtree));
+}
+
+TEST(SubgraphMatcher, ReplaceSubtreeRealistic) {
+  auto graph = DataFlowTestGraph();
+  auto subtree = DataFlowTestGraphCriteria();
+
+  TestMatcher::replaceSubtree(
+      graph.graph, subtree, [](TestGraph& g, TestGraph::NodeRef opG) {
+        auto opFused = g.createNode("opFused");
+
+        auto dataF = getInNode(opG, 0);
+        auto opF = getInNode(dataF, 0);
+        auto dataB = getInNode(opF, 0);
+        auto opB = getInNode(dataB, 0);
+        auto dataC = getInNode(opB, 0);
+        auto opC = getInNode(dataC, 0);
+
+        g.deleteNode(dataF);
+        g.replaceNode(opG, opFused);
+
+        auto outEdgesC = opC->getOutEdges();
+        g.deleteNode(outEdgesC[0]->head());
+        g.deleteNode(outEdgesC[1]->head());
+        g.replaceNode(opC, opFused);
+
+        g.deleteNode(opC);
+        g.deleteNode(opB);
+        g.deleteNode(dataB);
+        g.deleteNode(opF);
+        g.deleteNode(opG);
+
+        return true;
+      });
+
+  // Now the nodes are:
+  // - NumInputs input nodes
+  // - dataI node
+  // - fused node
+  // - output node
+  auto nodes = graph.graph.getMutableNodes();
+
+  // Test that the graph is transformed as expected.
+  EXPECT_EQ(nodes.size(), graph.numInputs + 3);
+  TestGraph::NodeRef opFused;
+  TestGraph::NodeRef dataI;
+  TestGraph::NodeRef dataOut;
+  for (auto node : nodes) {
+    if (node->data() == "opFused") {
+      opFused = node;
+    } else if (node->data() == "dataOut") {
+      dataOut = node;
+    } else if (node->data() == "dataI") {
+      dataI = node;
+    }
+  }
+
+  EXPECT_EQ(getInNode(dataOut, 0), opFused);
+  EXPECT_EQ(getInNode(opFused, 0), dataI);
+  for (int i = 1; i <= graph.numInputs; i++) {
+    EXPECT_EQ(getInNode(opFused, i)->data(), "input");
+  }
+
+  // Use nom::converters::convertToDotString(&graph.graph, TestGraphNodePrinter)
+  // to visualize. The transformed graph looks like This
+  /*
+
+                +---------++---------+
+                | input_A || input_D |
+                +---------++---------+
+                  |          |
+                  |          |
+                  v          v
++---------+     +--------------------+     +---------+
+| input_B | --> |      opFused       | <-- | input_C |
++---------+     +--------------------+     +---------+
+                  |          ^
+                  |          |
+                  v          |
+                +---------++---------+
+                | dataOut ||  dataI  |
+                +---------++---------+
+   */
+}


### PR DESCRIPTION
Summary:
Add new utility that make it easier to write graph transformation. Callers now only need to take care of the actual transformation logic. The subgraph matching is simplified because callers only need to specify a simple construct for subtree matching criteria.

The utlity is SubgraphMatcher::replaceSubtree

Some notes:
- replaceSubtree takes a subtree matching criteria, and a lambda that takes a subtree root. It does't not handle any transformations itself. Callers should be responsible for the transformation part, including deleting all nodes in the matched subtree(s). We could enhance this to also handle the deletion part if it turns out to be useful.
- Only sub tree matching is supported for now but we can add general DAG sub-graph support later if needed.

Differential Revision: D9073297
