### PR TITLE
Adding support for inlining if branches

### DIFF
--- a/test/expect/TestJit.test_constant_prop_if_constant.expect
+++ b/test/expect/TestJit.test_constant_prop_if_constant.expect
@@ -1,0 +1,33 @@
+graph(%a : Dynamic
+      %b : Dynamic) {
+  %c0.1 : int = prim::Constant[value=1]()
+  %c1.1 : int = prim::Constant[value=1]()
+  %4 : int = prim::TensorToNum(%a)
+  %c0.5 : int, %c1 : int = prim::If(%4)
+    block0() {
+      %7 : int = prim::TensorToNum(%b)
+      %c0.4 : int = prim::If(%7)
+        block0() {
+          %9 : int = prim::Constant[value=2]()
+          -> (%9)
+        }
+        block1() {
+          -> (%c0.1)
+        }
+      -> (%c0.4, %c1.1)
+    }
+    block1() {
+      %10 : int = prim::Constant[value=2]()
+      -> (%c0.1, %10)
+    }
+  %11 : int = prim::Constant[value=1]()
+  %c0.6 : int = aten::add(%c0.5, %11)
+  %13 : int = prim::Constant[value=5]()
+  %14 : int = prim::Constant[value=1]()
+  %15 : Dynamic = aten::add(%a, %c0.6, %14)
+  %16 : int = prim::Constant[value=1]()
+  %17 : Dynamic = aten::add(%15, %c1, %16)
+  %18 : int = prim::Constant[value=1]()
+  %19 : Dynamic = aten::add(%17, %13, %18)
+  return (%19);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2082,14 +2082,14 @@ a")
             if True:
                 x = [2, 3]
             return
-        self.checkScript(reassign, (), optimize=True)
+        self.checkScript(reassign, (), optimize=False)
 
         def reassign_arity_change():
             x = [1]
             if True:
                 x = [1, 2, 3]
             return
-        self.checkScript(reassign_arity_change, (), optimize=True)
+        self.checkScript(reassign_arity_change, (), optimize=False)
 
         def reassign_from_empty_literal():
             x = []
@@ -2097,7 +2097,7 @@ a")
                 x = [1, 2, 3]
             return
         with self.assertRaisesRegex(RuntimeError, "Empty list literals not allowed"):
-            self.checkScript(reassign_from_empty_literal, (), optimize=True)
+            self.checkScript(reassign_from_empty_literal, (), optimize=False)
 
         def reassign_from_empty_builtin():
             x = _construct_empty_int_list()
@@ -2110,7 +2110,7 @@ a")
             if True:
                 z = [torch.randn([1])]
             return
-        self.checkScript(reassign_from_empty_builtin, (), optimize=True)
+        self.checkScript(reassign_from_empty_builtin, (), optimize=False)
 
         def reassign_bad_type():
             x = [1]
@@ -2118,7 +2118,7 @@ a")
                 x = [1.0]
             return
         with self.assertRaisesRegex(RuntimeError, "previously has type"):
-            self.checkScript(reassign_bad_type, (), optimize=True)
+            self.checkScript(reassign_bad_type, (), optimize=False)
 
         def reassign_nested():
             x = _construct_empty_int_list()
@@ -2128,7 +2128,7 @@ a")
                     x = [1.0]
             return
         with self.assertRaisesRegex(RuntimeError, "previously has type"):
-            self.checkScript(reassign_nested, (), optimize=True)
+            self.checkScript(reassign_nested, (), optimize=False)
 
     def test_func_call(self):
         script = '''

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1212,7 +1212,7 @@ class TestJit(JitTestCase):
             else:  # -> c0, c1
                 c1 = c1 + 1
 
-            if True:  # removed
+            if True:  # inlined
                 c0 = c0 + 1  # dynamic
                 c2 = c2 + 4  # set to 5
             return a + c0 + c1 + c2

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -13,10 +13,8 @@ namespace torch { namespace jit {
 namespace {
 
 std::unordered_set<Symbol> skip_list = {
-  //FIXME If & Loop require special casing because they cannot be run as a
-  //single node.
   prim::If,
-  prim::Loop,
+  prim::Loop, //TODO: handle Loop
   //FIXME Same problem as in DCE - cpp & python PythonOp and CppOp should be
   //FIXME treated as having side effects but ONNX depends on them being removed
   prim::Print,
@@ -63,28 +61,124 @@ void propagateNode(Node* n) {
   }
 }
 
+void lowerIf(Block *body, Node * n) {
+  auto graph = n->owningGraph();
+  WithInsertPoint insert_point_guard { n };
+
+  std::unordered_map<Value*, Value*> value_map;
+  auto get_value = [&](Value *v) {
+    auto it = value_map.find(v);
+    if (it != value_map.end())
+      return it->second;
+    return v;
+  };
+
+  for (Node *orig : body->nodes()) {
+    Node *clone = graph->insertNode(graph->createClone(orig, get_value));
+    for (size_t i = 0; i < orig->outputs().size(); ++i) {
+      value_map[orig->outputs()[i]] = clone->outputs()[i];
+    }
+  }
+  for (size_t i = 0; i < n->outputs().size(); ++i) {
+    n->outputs().at(i)->replaceAllUsesWith(get_value(body->outputs().at(i)));
+  }
+  // NB: destroy the node here, because it might contain side effects, like print
+  n->destroy();
+}
+
+bool isTrueConstant(Value *val) {
+  at::optional<bool> maybe_value = constant_as<bool>(val);
+  return maybe_value && *maybe_value;
+}
+
+void lowerIf(Node *n) {
+  if (isTrueConstant(n->input())) {
+    lowerIf(n->blocks()[0], n);
+  } else {
+    lowerIf(n->blocks()[1], n);
+  }
+}
+
+//returns true if the mutated variables are changed
+bool recomputeMutatedVariables(Node *n) {
+  JIT_ASSERTM(n->kind() == prim::If, "Only supported for If nodes");
+  std::unordered_set<Value*> mutated_variables;
+  for (Block * block : n->blocks()) {
+    for (Node *n : block->nodes()) {
+      for (size_t i = 0; i < n->outputs().size(); ++i) {
+        mutated_variables.insert(n->outputs()[i]);
+      }
+    }
+  }
+  auto true_block = n->blocks()[0];
+  auto false_block = n->blocks()[1];
+  auto initial_outputs = true_block->outputs().size();
+  for (size_t i = 0; i < true_block->outputs().size();) {
+    //neither block mutates output i
+    if (!mutated_variables.count(true_block->outputs()[i]) &&
+      !mutated_variables.count(false_block->outputs()[i])) {
+      n->outputs().at(i)->replaceAllUsesWith(true_block->outputs()[i]);
+      n->eraseOutput(i);
+      true_block->eraseOutput(i);
+      false_block->eraseOutput(i);
+    } else {
+      i++; //increment bc we didn't remove current index
+    }
+  }
+  //an output was removed
+  return initial_outputs != true_block->outputs().size();
+}
+
 } // anonymous namespace
 
-void ConstantPropagation(Node* n, bool recurse) {
+//returns whether the node's set of mutated variables changed
+bool ConstantPropagation(Node* n, bool recurse) {
   bool constant_inputs = (n->inputs().size() > 0) &&
     std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
       return v->node()->kind() == prim::Constant;
     });
   bool supported_node = skip_list.count(n->kind()) == 0;
-  if (constant_inputs && supported_node) {
+  auto run_blocks = [&]() {
+    bool any_child = false;
+    if (recurse) {
+      for (Block * block : n->blocks()) {
+        auto child = ConstantPropagation(block, recurse);
+        any_child = any_child || child;
+      }
+    }
+    return any_child;
+  };
+  if (n->kind() == prim::If) {
+    //did a child node change
+    bool changed = run_blocks();
+    //inline node if we can, otherwise if a child node changed recompute
+    //mutated variables and see if this node changed
+    if (constant_inputs) {
+      lowerIf(n);
+    } else if (changed) {
+      changed = recomputeMutatedVariables(n);
+    }
+    return constant_inputs || changed;
+  } else if (constant_inputs && supported_node) {
     propagateNode(n);
   }
-  if (recurse) {
-    for (Block * block : n->blocks())
-      ConstantPropagation(block, recurse);
-  }
+  //TODO handle loop nodes. Even if a loop node contains an if that is
+  //inlined its mutated variables currently don't get updated
+  run_blocks();
+  return false;
 }
 
-void ConstantPropagation(Block* block, bool recurse) {
+//returns true if the mutated variables in this block's node have changed
+bool ConstantPropagation(Block* block, bool recurse) {
   ConstantPropagation(block->param_node(), recurse);
-  for (auto n: block->nodes()) {
-    ConstantPropagation(n, recurse);
+  bool any_child = false;
+  for(auto it = block->nodes().begin(); it != block->nodes().end();) {
+    Node *n = *it;
+    it++; //advance iterator bc the current node may be destroyed
+    auto child = ConstantPropagation(n, recurse);
+    any_child = any_child || child;
   }
+  return any_child;
 }
 
 void ConstantPropagation(std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -55,7 +55,7 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-    auto new_output = insertConstant(*graph, outputs[i]);
+    auto new_output = graph->insertConstant(outputs[i]);
     n->outputs()[i]->replaceAllUsesWith(new_output);
     // let dce elimination remove n
   }
@@ -78,7 +78,8 @@ void inlineIf(Block *body, Node * n) {
 
 bool isTrueConstant(Value *val) {
   at::optional<bool> maybe_value = constant_as<bool>(val);
-  return maybe_value && *maybe_value;
+  JIT_ASSERT(maybe_value);
+  return *maybe_value;
 }
 
 void inlineIf(Node *n) {

--- a/torch/csrc/jit/passes/constant_propagation.h
+++ b/torch/csrc/jit/passes/constant_propagation.h
@@ -5,7 +5,7 @@
 namespace torch { namespace jit {
 
 TORCH_API void ConstantPropagation(std::shared_ptr<Graph>& graph);
-TORCH_API void ConstantPropagation(Block* block, bool recurse);
-TORCH_API void ConstantPropagation(Node* n, bool recurse);
+TORCH_API bool ConstantPropagation(Block* block, bool recurse);
+TORCH_API bool ConstantPropagation(Node* n, bool recurse);
 
 }}

--- a/torch/csrc/jit/passes/constant_propagation.h
+++ b/torch/csrc/jit/passes/constant_propagation.h
@@ -5,7 +5,7 @@
 namespace torch { namespace jit {
 
 TORCH_API void ConstantPropagation(std::shared_ptr<Graph>& graph);
-TORCH_API bool ConstantPropagation(Block* block, bool recurse);
-TORCH_API bool ConstantPropagation(Node* n, bool recurse);
+TORCH_API void ConstantPropagation(Block* block, bool recurse);
+TORCH_API void ConstantPropagation(Node* n, bool recurse);
 
 }}


### PR DESCRIPTION
Inlining if branches which have constant inputs.  If an if node gets inlined, the set of mutated variables returned by its ancestors may have changed. In the following example the block should
return a mutated set of (a) and not (a, b). 

```
if cond:
  if True:
	 a = a - 1
    else:
	b = b - 1
```
To calculate this we recursively update mutate variables in if branches from the leaf nodes up. 

