### PR TITLE
Remove some unnecessary includes.

### DIFF
--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -10,7 +10,6 @@
 #include "ATen/Half.h"
 #include "ATen/ScalarType.h"
 #include "ATen/TensorBase.h"
-#include "ATen/Utils.h"
 
 
 namespace at {

--- a/aten/src/ATen/Storage.cpp
+++ b/aten/src/ATen/Storage.cpp
@@ -1,5 +1,4 @@
 #include <ATen/Storage.h>
-#include <ATen/Context.h>
 #include <iostream>
 
 namespace at {

--- a/aten/src/ATen/StorageImpl.h
+++ b/aten/src/ATen/StorageImpl.h
@@ -40,7 +40,7 @@ namespace at {
 
 struct Type;
 
-struct TH_CPP_API StorageImpl : public Retainable {
+struct AT_API StorageImpl : public Retainable {
 
   StorageImpl() = delete;
   virtual ~StorageImpl() {};
@@ -57,6 +57,8 @@ struct TH_CPP_API StorageImpl : public Retainable {
   StorageImpl(StorageImpl&&) = delete;
   StorageImpl(const StorageImpl&&) = delete;
 
+  // TODO: Rename this into th_data, and move it out of the class;
+  // the real data shouldn't call th::from_type
   template <typename T>
   inline T* data() const {
     auto scalar_type_T = at::CTypeToScalarType<th::from_type<T>>::to();

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -2,7 +2,6 @@
 
 // ${generated_comment}
 
-#include "ATen/Generator.h"
 #include "ATen/Scalar.h"
 #include "ATen/ScalarType.h"
 #include "ATen/SparseTensorRef.h"
@@ -10,12 +9,12 @@
 #include "ATen/TensorAccessor.h"
 #include "ATen/TensorBase.h"
 #include "ATen/TensorImpl.h"
-#include "ATen/Utils.h"
 #include "ATen/Device.h"
 #include "ATen/Layout.h"
 #include "ATen/optional.h"
 
 namespace at {
+struct Generator;
 struct Type;
 struct Tensor;
 struct TensorOptions;

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -5,7 +5,6 @@
 
 // ${generated_comment}
 
-#include "ATen/Config.h"
 #include "ATen/${Tensor}.h"
 #include "ATen/Storage.h"
 #include "ATen/Scalar.h"


### PR DESCRIPTION
The affected files are all files that are planned to be moved
to ATen/core; the includes are for headers which are NOT slated
for movement.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

