### PR TITLE
Initial documentation for building libtorch

### DIFF
--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -1,0 +1,19 @@
+libtorch (C++-only)
+===================
+
+The core of pytorch can be built and used without Python. A
+CMake-based build system compiles the C++ source code into a shared
+object, libtorch.so.
+
+Building libtorch
+-----------------
+
+There is a script which wraps the CMake build. Invoke it with
+
+::
+   cd pytorch
+   BUILD_TORCH=ON ONNX_NAMESPACE=onnx_torch bash tools/build_pytorch_libs.sh --use-nnpack caffe2
+   ls torch/lib/tmp_install # output is produced here
+   ls torch/lib/tmp_install/lib/libtorch.so # of particular interest
+
+Future work will simplify this further.


### PR DESCRIPTION
It's not a particularly pretty process right now, but it may as well
be documented.  I'm not aware of an ideal location for this, so I'm
just dropping it in the docs/ folder for now as recommended by
@soumith

