### PR TITLE
Add intrinsic support for external_input/output to nomnigraph

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -242,6 +242,8 @@ using NNCFGraph = nom::repr::ControlFlowGraph<NNGraph>;
 struct NNModule {
   NNGraph dataFlow;
   NNCFGraph controlFlow;
+  std::unordered_set<NNGraph::NodeRef> inputs;
+  std::unordered_set<NNGraph::NodeRef> outputs;
   NNModule(const NNModule&) = delete;
   NNModule(NNModule&&) = default;
   NNModule() {}

--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -241,8 +241,9 @@ std::unique_ptr<repr::NeuralNetOperator> convertToNeuralNetOperator(
 /// \param net The caffe2 protobuf NetDef
 /// \param blobMap [optional][output] A pointer to a blobMap to be populated with all the output blobs of the NetDef by name->NodeRef
 repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::string, repr::NNGraph::NodeRef>* blobMapOut) {
-  repr::NNGraph dfg;
-  repr::NNCFGraph cfg;
+  repr::NNModule module;
+  repr::NNGraph& dfg = module.dataFlow;
+  repr::NNCFGraph& cfg = module.controlFlow;
   /// \brief We keep track of the producer of the blob.
   /// Because Caffe2 Nets are really just ordered operations
   /// we can just keep track of the most recent producer of
@@ -250,6 +251,11 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
   /// come by. If a new operator produces the blob we simply
   /// replace it in this map.
   std::unordered_map<std::string, repr::NNGraph::NodeRef> blobMap;
+
+  std::unordered_set<std::string> externalInputNames;
+  for (const auto& inputName : net.external_input()) {
+    externalInputNames.insert(inputName);
+  }
 
   /// \brief For the construction of the control flow graph we keep track
   /// of a current basic block, which we split up as we come accross control
@@ -267,6 +273,10 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
         auto tensor = util::make_unique<repr::Tensor>(input);
         blobMap[input] =
             dfg.createNode(unique_dyn_cast<repr::NeuralNetData>(tensor));
+        if (externalInputNames.count(input)) {
+          module.inputs.insert(blobMap[input]);
+          externalInputNames.erase(input);
+        }
       }
 
       auto tensorNode = blobMap[input];
@@ -287,9 +297,17 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
     currentBasicBlock->pushInstructionNode(opNode);
   }
 
-  repr::NNModule module;
-  module.dataFlow = std::move(dfg);
-  module.controlFlow = std::move(cfg);
+  CAFFE_ENFORCE(
+      externalInputNames.size() == 0,
+      "Attempting to convert an ill-formed network: \
+      external_input contains unused blobs");
+
+  for (const auto& outputName : net.external_output()) {
+    CAFFE_ENFORCE(
+        blobMap.count(outputName), "NetDef has ill-formed external_output");
+    module.outputs.insert(blobMap[outputName]);
+  }
+
   if (blobMapOut) {
     *blobMapOut = blobMap;
   }
@@ -327,6 +345,34 @@ caffe2::OperatorDef convertToOperatorDef(
 caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m) {
   auto predictNet = caffe2::NetDef();
   return convertToCaffe2Proto(m, predictNet);
+}
+
+std::vector<std::string> mergeExternalTensors(
+    const std::unordered_set<repr::NNGraph::NodeRef>& currExternal,
+    const std::vector<std::string>& oldExternal) {
+  std::vector<std::string> out;
+
+  // Maximally preserve the order of external inputs and outputs.
+  std::unordered_set<std::string> newExternal;
+  for (const auto& tensorNode : currExternal) {
+    CAFFE_ENFORCE(
+        repr::nn::is<repr::NeuralNetData>(tensorNode),
+        "A non-tensor node was added to external inputs/outputs of the NNModule");
+    auto name = repr::nn::get<repr::NeuralNetData>(tensorNode)->getName();
+    newExternal.insert(name);
+  }
+
+  for (const auto& tensorName : oldExternal) {
+    if (newExternal.count(tensorName)) {
+      out.emplace_back(tensorName);
+      newExternal.erase(tensorName);
+    }
+  }
+  for (const auto& tensorName : newExternal) {
+    out.emplace_back(tensorName);
+  }
+
+  return out;
 }
 
 caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m, const caffe2::NetDef& oldNet) {
@@ -387,6 +433,31 @@ caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m, const caffe2::NetDef& old
       // Save the operator to the net.
       *predictNet.add_op() = op;
     }
+  }
+
+  // Maximally preserve the order of external inputs and outputs.
+  std::vector<std::string> oldExternalInputs;
+  std::vector<std::string> oldExternalOutputs;
+
+  for (const auto& inputName : predictNet.external_input()) {
+    oldExternalInputs.emplace_back(inputName);
+  }
+  for (const auto& outputName : predictNet.external_output()) {
+    oldExternalOutputs.emplace_back(outputName);
+  }
+
+  auto newExternalInputs = mergeExternalTensors(m.inputs, oldExternalInputs);
+  auto newExternalOutputs = mergeExternalTensors(m.outputs, oldExternalOutputs);
+
+  predictNet.clear_external_input();
+  predictNet.clear_external_output();
+
+  for (const auto& inputName : newExternalInputs) {
+    predictNet.add_external_input(inputName);
+  }
+
+  for (const auto& outputName : newExternalOutputs) {
+    predictNet.add_external_output(outputName);
   }
 
   return predictNet;

--- a/caffe2/opt/converter_nomigraph_test.cc
+++ b/caffe2/opt/converter_nomigraph_test.cc
@@ -48,3 +48,53 @@ TEST(Converter, UnknownType) {
   auto new_netdef = caffe2::convertToCaffe2Proto(nn);
 }
 
+caffe2::NetDef fakeNet() {
+  caffe2::NetDef net;
+
+  {
+    caffe2::OperatorDef* def = net.add_op();
+    def->set_type("Fake");
+    def->add_input("X");
+    def->add_output("Y");
+  }
+  {
+    caffe2::OperatorDef* def = net.add_op();
+    def->set_type("Fake");
+    def->add_input("Y");
+    def->add_output("Z");
+  }
+  {
+    caffe2::OperatorDef* def = net.add_op();
+    def->set_type("Fake");
+    def->add_input("Z");
+    def->add_input("X");
+    def->add_output("W");
+  }
+  net.add_external_input("X");
+  net.add_external_output("Y");
+  net.add_external_output("W");
+
+  return net;
+}
+
+TEST(Converter, ExternalInputs) {
+  auto net = fakeNet();
+
+  auto nn = caffe2::convertToNNModule(net);
+  auto new_netdef = caffe2::convertToCaffe2Proto(nn);
+  EXPECT_EQ(new_netdef.external_input().size(), net.external_input().size());
+  for (auto i = 0; i < net.external_input().size(); ++i) {
+    EXPECT_EQ(new_netdef.external_input(i), net.external_input(i));
+  }
+}
+
+TEST(Converter, ExternalOutputs) {
+  auto net = fakeNet();
+
+  auto nn = caffe2::convertToNNModule(net);
+  auto new_netdef = caffe2::convertToCaffe2Proto(nn);
+  EXPECT_EQ(new_netdef.external_output().size(), net.external_output().size());
+  for (auto i = 0; i < net.external_output().size(); ++i) {
+    EXPECT_EQ(new_netdef.external_output(i), net.external_output(i));
+  }
+}


### PR DESCRIPTION
Summary: nomnigraph has until this point tried to ignore external input and output, as they aren't very well defined (does order matter?).  but for DCE and some of Keren's work they are becoming necessary.  I went ahead and added this to the core nomnigraph converter

Differential Revision: D9105487
