### PR TITLE
Move C++17.h to ATen/core

### DIFF
--- a/aten/src/ATen/core/C++17.cpp
+++ b/aten/src/ATen/core/C++17.cpp
@@ -1,0 +1,1 @@
+#include <ATen/core/C++17.h>

--- a/aten/src/ATen/core/C++17.h
+++ b/aten/src/ATen/core/C++17.h
@@ -95,10 +95,14 @@ template<class T> using decay_t = typename std::decay<T>::type;
 
 #ifdef __cpp_lib_logical_traits
 
-using conjunction = std::conjunction;
-using disjunction = std::disjunction;
-using bool_constant = std::bool_constant;
-using negation = std::negation;
+template <class... B>
+using conjunction = std::conjunction<B...>;
+template <class... B>
+using disjunction = std::disjunction<B...>;
+template <bool B>
+using bool_constant = std::bool_constant<B>;
+template <class B>
+using negation = std::negation<B>;
 
 #else
 
@@ -145,7 +149,10 @@ template<typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 #ifdef __cpp_lib_apply
 
-using apply = std::apply;
+template <class F, class Tuple>
+inline constexpr decltype(auto) apply(F&& f, Tuple&& t) {
+  return std::apply(std::forward<F>(f), std::forward<Tuple>(t));
+}
 
 #else
 

--- a/caffe2/core/dispatch/DeviceId.h
+++ b/caffe2/core/dispatch/DeviceId.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <ATen/core/C++17.h>
 #include <functional>
 #include <iostream>
-#include "caffe2/utils/C++17.h"
 
 namespace c10 {
 

--- a/caffe2/core/dispatch/TensorTypeIdRegistration.cpp
+++ b/caffe2/core/dispatch/TensorTypeIdRegistration.cpp
@@ -1,5 +1,5 @@
 #include "caffe2/core/dispatch/TensorTypeIdRegistration.h"
-#include "caffe2/utils/C++17.h"
+#include <ATen/core/C++17.h>
 
 namespace c10 {
 

--- a/caffe2/utils/Array.h
+++ b/caffe2/utils/Array.h
@@ -38,10 +38,10 @@
 
 #pragma once
 
-#include <utility>
+#include <ATen/core/C++17.h>
 #include <stdexcept>
 #include <string>
-#include "caffe2/utils/C++17.h"
+#include <utility>
 
 namespace c10 { namespace guts {
 

--- a/caffe2/utils/C++17.cpp
+++ b/caffe2/utils/C++17.cpp
@@ -1,1 +1,0 @@
-#include "caffe2/utils/C++17.h"

--- a/caffe2/utils/CMakeLists.txt
+++ b/caffe2/utils/CMakeLists.txt
@@ -63,7 +63,6 @@ set(Caffe2_HIP_TEST_SRCS ${Caffe2_HIP_TEST_SRCS}
 
 set(LIB_SOURCES_CPU
         Array.cpp
-        C++17.cpp
         IdWrapper.cpp
         Optional.cpp
         Metaprogramming.cpp

--- a/caffe2/utils/TypeList.h
+++ b/caffe2/utils/TypeList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "caffe2/utils/C++17.h"
+#include <ATen/core/C++17.h>
 #include "caffe2/utils/TypeTraits.h"
 
 namespace c10 { namespace guts { namespace typelist {

--- a/caffe2/utils/TypeTraits.h
+++ b/caffe2/utils/TypeTraits.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "caffe2/utils/C++17.h"
+#include <ATen/core/C++17.h>
 #include <functional>
 
 namespace c10 {


### PR DESCRIPTION
Summary:
This header is needed for ATen/core stuff

This diff also fixes an issue in C++17.h when run in C++17 enabled compilers.

Reviewed By: ezyang

Differential Revision: D9095209
