### PR TITLE
[jit][script] Distinguish TupleLiteral from ListLiteral

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1368,6 +1368,11 @@ private:
         auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
         return graph->insertNode(graph->createTuple(values))->output();
       } break;
+      case TK_TUPLE_LITERAL: {
+        auto ll = TupleLiteral(tree);
+        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
+        return graph->insertNode(graph->createTuple(values))->output();
+      } break;
       default:
         throw ErrorReport(tree) << "NYI: " << tree;
         break;

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -75,6 +75,7 @@ namespace script {
   _(TK_GATHER, "gather", "")                     \
   _(TK_NOTHING, "nothing", "")                   \
   _(TK_LIST_LITERAL, "list-literal", "")         \
+  _(TK_TUPLE_LITERAL, "tuple-literal", "")       \
   _(TK_FOR, "for", "for")                        \
   _(TK_IN, "in", "in")                           \
   _(TK_STARRED, "starred", "")                   \

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -30,7 +30,7 @@ struct Parser {
         List<Attribute>(makeList(range, std::move(attributes))));
   }
   // exp | expr, | expr, expr, ...
-  TreeRef parseExpOrExpList(int end) {
+  TreeRef parseExpOrExpTuple(int end) {
     auto prefix = parseExp();
     if(L.cur().kind == ',') {
       std::vector<Expr> exprs = { prefix };
@@ -39,7 +39,7 @@ struct Parser {
         exprs.push_back(parseExp());
       }
       auto list = List<Expr>::create(prefix.range(), exprs);
-      prefix = ListLiteral::create(list.range(), list);
+      prefix = TupleLiteral::create(list.range(), list);
     }
     return prefix;
   }
@@ -60,15 +60,15 @@ struct Parser {
         L.next();
       } break;
       case '(': {
-	L.next();
-	if (L.nextIf(')')) {
-	  ///here we have the empty tuple case
-	  std::vector<Expr> vecExpr;
-	  List<Expr> listExpr = List<Expr>::create(L.cur().range, vecExpr);
-	  prefix = ListLiteral::create(L.cur().range, listExpr);
-	  break;
-	}
-        prefix = parseExpOrExpList(')');
+        L.next();
+        if (L.nextIf(')')) {
+          /// here we have the empty tuple case
+          std::vector<Expr> vecExpr;
+          List<Expr> listExpr = List<Expr>::create(L.cur().range, vecExpr);
+          prefix = TupleLiteral::create(L.cur().range, listExpr);
+          break;
+        }
+        prefix = parseExpOrExpTuple(')');
         L.expect(')');
       } break;
       case '[': {
@@ -249,7 +249,7 @@ struct Parser {
   // first[,other,lhs] = rhs
   Assign parseAssign(List<Expr> list) {
     auto red = parseOptionalReduction();
-    auto rhs = parseExpOrExpList(TK_NEWLINE);
+    auto rhs = parseExpOrExpTuple(TK_NEWLINE);
     L.expect(TK_NEWLINE);
     return Assign::create(list.range(), list, AssignKind(red), Expr(rhs));
   }

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -193,6 +193,10 @@ void initTreeViewBindings(PyObject *module) {
     .def(py::init([](const SourceRange& range, std::vector<Expr> args) {
       return ListLiteral::create(range, wrap_list(range, std::move(args)));
     }));
+  py::class_<TupleLiteral, Expr>(m, "TupleLiteral")
+    .def(py::init([](const SourceRange& range, std::vector<Expr> args) {
+      return TupleLiteral::create(range, wrap_list(range, std::move(args)));
+    }));
   py::class_<Gather, Expr>(m, "Gather")
     .def(py::init([](const Expr& base, const Expr& index) {
       return Gather::create(base.range(), base, index);

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -58,6 +58,7 @@ namespace script {
 //       | Gather(Expr value, Expr indices)                             TK_GATHER
 //       | Var(Ident name)                                              TK_VAR
 //       | ListLiteral(List<Expr> inputs)                               TK_LIST_LITERAL
+//       | TupleLiteral(List<Expr> inputs)                              TK_TUPLE_LITERAL
 //       | Starred(Expr expr)                                           TK_STARRED
 //
 // -- NB: only allowed expressions are Const or List(Const)
@@ -255,6 +256,7 @@ struct Expr : public TreeView {
       case TK_GATHER:
       case TK_VAR:
       case TK_LIST_LITERAL:
+      case TK_TUPLE_LITERAL:
       case '@':
       case TK_POW:
         return;
@@ -694,6 +696,17 @@ struct ListLiteral : public Expr {
   }
 };
 
+struct TupleLiteral : public Expr {
+  explicit TupleLiteral(const TreeRef& tree) : Expr(tree) {
+    tree_->match(TK_TUPLE_LITERAL);
+  }
+  List<Expr> inputs() const {
+    return subtree(0);
+  }
+  static TupleLiteral create(const SourceRange& range, const List<Expr>& inputs) {
+    return TupleLiteral(Compound::create(TK_TUPLE_LITERAL, range, {inputs}));
+  }
+};
 
 struct Starred : public Expr {
   explicit Starred(const TreeRef& tree) : Expr(tree) {

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -435,8 +435,8 @@ class ExprBuilder(Builder):
 
     @staticmethod
     def build_Tuple(ctx, expr):
-        return ListLiteral(ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1),
-                           [build_expr(ctx, e) for e in expr.elts])
+        return TupleLiteral(ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1),
+                            [build_expr(ctx, e) for e in expr.elts])
 
     @staticmethod
     def build_Num(ctx, expr):


### PR DESCRIPTION
Previously, the parser was emitting list literals for tuples, but the IR was representing list literals internally with TupleTypes.

For implementing most list operations, I think it will be helpful distinguish between lists (dynamic size, homogeneous types) and tuples (fixed arity, heterogeneous types)

This diff modifies the parser logic to emit tuple literals. This frees us to represent lists as ListType in the IR, while still properly mapping tuple literals to TupleTypes.

A following diff will actually switch over list literals to emit ListTypes.