### PR TITLE
Move halfbits2float and float2halfbits conversions to ATen.

### DIFF
--- a/aten/src/ATen/Half.cpp
+++ b/aten/src/ATen/Half.cpp
@@ -1,9 +1,5 @@
 #include "ATen/Half.h"
 
-#include "ATen/Tensor.h"
-#include "ATen/Context.h"
-
-#include <TH/TH.h>
 #include <iostream>
 
 namespace at {
@@ -12,16 +8,91 @@ static_assert(std::is_standard_layout<Half>::value, "at::Half must be standard l
 
 namespace detail {
 
-float halfbits2float(unsigned short bits) {
-  float value;
-  TH_halfbits2float(&bits, &value);
-  return value;
+// Host functions for converting between FP32 and FP16 formats
+
+float halfbits2float(unsigned short h)
+{
+    unsigned sign = ((h >> 15) & 1);
+    unsigned exponent = ((h >> 10) & 0x1f);
+    unsigned mantissa = ((h & 0x3ff) << 13);
+
+    if (exponent == 0x1f) {  /* NaN or Inf */
+        mantissa = (mantissa ? (sign = 0, 0x7fffff) : 0);
+        exponent = 0xff;
+    } else if (!exponent) {  /* Denorm or Zero */
+        if (mantissa) {
+            unsigned int msb;
+            exponent = 0x71;
+            do {
+                msb = (mantissa & 0x400000);
+                mantissa <<= 1;  /* normalize */
+                --exponent;
+            } while (!msb);
+            mantissa &= 0x7fffff;  /* 1.mantissa is implicit */
+        }
+    } else {
+        exponent += 0x70;
+    }
+
+    unsigned result_bit = (sign << 31) | (exponent << 23) | mantissa;
+
+    // Reinterpret the result bit pattern as a float
+    float result_float;
+    std::memcpy(&result_float, &result_bit, sizeof(result_float));
+    return result_float;
 }
 
-unsigned short float2halfbits(float value) {
-  unsigned short bits;
-  TH_float2halfbits(&value, &bits);
-  return bits;
+unsigned short float2halfbits(float src)
+{
+    // Reinterpret the float as a bit pattern
+    unsigned x;
+    std::memcpy(&x, &src, sizeof(x));
+
+    unsigned u = (x & 0x7fffffff), remainder, shift, lsb, lsb_s1, lsb_m1;
+    unsigned sign, exponent, mantissa;
+
+    // Get rid of +NaN/-NaN case first.
+    if (u > 0x7f800000) {
+      return 0x7fffU;
+    }
+
+    sign = ((x >> 16) & 0x8000);
+
+    // Get rid of +Inf/-Inf, +0/-0.
+    if (u > 0x477fefff) {
+      return sign | 0x7c00U;
+    }
+    if (u < 0x33000001) {
+      return (sign | 0x0000);
+    }
+
+    exponent = ((u >> 23) & 0xff);
+    mantissa = (u & 0x7fffff);
+
+    if (exponent > 0x70) {
+        shift = 13;
+        exponent -= 0x70;
+    } else {
+        shift = 0x7e - exponent;
+        exponent = 0;
+        mantissa |= 0x800000;
+    }
+    lsb = (1 << shift);
+    lsb_s1 = (lsb >> 1);
+    lsb_m1 = (lsb - 1);
+
+    // Round to nearest even.
+    remainder = (mantissa & lsb_m1);
+    mantissa >>= shift;
+    if (remainder > lsb_s1 || (remainder == lsb_s1 && (mantissa & 0x1))) {
+        ++mantissa;
+        if (!(mantissa & 0x3ff)) {
+            ++exponent;
+            mantissa = 0;
+        }
+    }
+
+    return (sign | (exponent << 10) | mantissa);
 }
 
 } // namespace detail

--- a/aten/src/TH/THHalf.cpp
+++ b/aten/src/TH/THHalf.cpp
@@ -1,4 +1,5 @@
 #include "THHalf.h"
+#include <ATen/Half.h>
 
 /* Copyright 1993-2014 NVIDIA Corporation.  All rights reserved. */
 
@@ -16,85 +17,14 @@ TH_API float TH_half2float(THHalf h)
   return f;
 }
 
-// Host functions for converting between FP32 and FP16 formats
 
 void TH_halfbits2float(unsigned short* src, float* res)
 {
-    unsigned h = *src;
-    unsigned sign = ((h >> 15) & 1);
-    unsigned exponent = ((h >> 10) & 0x1f);
-    unsigned mantissa = ((h & 0x3ff) << 13);
-
-    if (exponent == 0x1f) {  /* NaN or Inf */
-        mantissa = (mantissa ? (sign = 0, 0x7fffff) : 0);
-        exponent = 0xff;
-    } else if (!exponent) {  /* Denorm or Zero */
-        if (mantissa) {
-            unsigned int msb;
-            exponent = 0x71;
-            do {
-                msb = (mantissa & 0x400000);
-                mantissa <<= 1;  /* normalize */
-                --exponent;
-            } while (!msb);
-            mantissa &= 0x7fffff;  /* 1.mantissa is implicit */
-        }
-    } else {
-        exponent += 0x70;
-    }
-
-    *(unsigned*)res = ((sign << 31) | (exponent << 23) | mantissa);
+  *res = at::detail::halfbits2float(*src);
 }
+
 
 void TH_float2halfbits(float* src, unsigned short* dest)
 {
-    unsigned x = *(unsigned*)src;
-    unsigned u = (x & 0x7fffffff), remainder, shift, lsb, lsb_s1, lsb_m1;
-    unsigned sign, exponent, mantissa;
-
-    // Get rid of +NaN/-NaN case first.
-    if (u > 0x7f800000) {
-      *dest = 0x7fffU;
-      return ;
-    }
-  
-    sign = ((x >> 16) & 0x8000);
-  
-    // Get rid of +Inf/-Inf, +0/-0.
-    if (u > 0x477fefff) {
-      *dest = sign | 0x7c00U;
-      return; 
-    }
-    if (u < 0x33000001) {
-      *dest = (sign | 0x0000);
-      return;
-    }
-
-    exponent = ((u >> 23) & 0xff);
-    mantissa = (u & 0x7fffff);
-
-    if (exponent > 0x70) {
-        shift = 13;
-        exponent -= 0x70;
-    } else {
-        shift = 0x7e - exponent;
-        exponent = 0;
-        mantissa |= 0x800000;
-    }
-    lsb = (1 << shift);
-    lsb_s1 = (lsb >> 1);
-    lsb_m1 = (lsb - 1);
-  
-    // Round to nearest even.
-    remainder = (mantissa & lsb_m1);
-    mantissa >>= shift;
-    if (remainder > lsb_s1 || (remainder == lsb_s1 && (mantissa & 0x1))) {
-        ++mantissa;
-        if (!(mantissa & 0x3ff)) {
-            ++exponent;
-            mantissa = 0;
-        }
-    }  
-
-    *dest = (sign | (exponent << 10) | mantissa);  
+  *dest = at::detail::float2halfbits(*src);
 }


### PR DESCRIPTION
This will be needed soon because I want to move Half.h into
ATen/core, and then I cannot have a TH dependency.

I also took the liberty of making the code more strict-aliasing
safe (this is not actually useful, since we will never built Torch
with strict aliasing) by replacing pointer casts between
float and unsigned with a memcpy instead.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

