### PR TITLE
Fix tensor check logic in logging

### DIFF
--- a/caffe2/core/operator_gpu.cc
+++ b/caffe2/core/operator_gpu.cc
@@ -11,7 +11,7 @@ void Operator<CUDAContext>::SyncDevice() {
 
   cudaEvent_t ev;
   cudaSetDevice(context->cuda_gpu_id());
-  cudaEventCreate(&ev);
+  cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
   cudaEventRecord(ev, context->cuda_stream());
   cudaEventSynchronize(ev);
   cudaEventDestroy(ev);


### PR DESCRIPTION
Summary:
Note that `TensorCPU` and `TensorGPU` are all refined to be `Tensor` now. Basically they are the same thing. So check like `blob.IsType<TensorCPU>()` is no longer safe as `TensorGPU` can pass the check too.

We need to systematically weed out the such usage in our codebase... 
Differential Revision: D9115273
