### PR TITLE
Renumber typeid.h so that the number lines up with ScalarType

### DIFF
--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -10,16 +10,16 @@
 namespace at {
 
 // NB: Order matters for this macro; it is relied upon in
-// _promoteTypesLookup and probably other places.
+// _promoteTypesLookup and the serialization format.
 #define AT_FORALL_SCALAR_TYPES(_) \
-_(uint8_t,Byte,i) \
-_(int8_t,Char,i) \
-_(int16_t,Short,i) \
-_(int,Int,i) \
-_(int64_t,Long,i) \
-_(at::Half,Half,d) \
-_(float,Float,d) \
-_(double,Double,d)
+_(uint8_t,Byte,i)  /* 0 */ \
+_(int8_t,Char,i)   /* 1 */ \
+_(int16_t,Short,i) /* 2 */ \
+_(int,Int,i)       /* 3 */ \
+_(int64_t,Long,i)  /* 4 */ \
+_(at::Half,Half,d) /* 5 */ \
+_(float,Float,d)   /* 6 */ \
+_(double,Double,d) /* 7 */
 
 #define AT_FORALL_SCALAR_TYPES_EXCEPT_HALF(_) \
 _(uint8_t,Byte,i) \
@@ -35,7 +35,7 @@ enum class ScalarType {
   n,
   AT_FORALL_SCALAR_TYPES(DEFINE_ENUM)
 #undef DEFINE_ENUM
-  Undefined,
+  Undefined, // 8
   NumOptions
 };
 

--- a/aten/src/ATen/core/Half-inl.h
+++ b/aten/src/ATen/core/Half-inl.h
@@ -8,6 +8,10 @@
 #include <cuda_fp16.h>
 #endif
 
+#if defined(__HIP_DEVICE_COMPILE__)
+#include <hip/hip_fp16.h>
+#endif
+
 namespace at {
 
 /// Constructors

--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -24,6 +24,10 @@
 #include <cuda_fp16.h>
 #endif
 
+#if defined(__HIP_DEVICE_COMPILE__)
+#include <hip/hip_fp16.h>
+#endif
+
 #ifndef AT_HOSTDEVICE
 #ifdef __CUDACC__
 #define AT_HOSTDEVICE __host__ __device__

--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -10,7 +10,6 @@ at::Backend ATenOp<CPUContext>::backend() const {
 }
 
 OPERATOR_SCHEMA(ATen);
-CAFFE_KNOWN_TYPE(at::Half);
 
 namespace math {
 template <>

--- a/caffe2/core/typeid.h
+++ b/caffe2/core/typeid.h
@@ -14,6 +14,7 @@
 
 #include <exception>
 
+#include "ATen/core/Half.h"
 #include "caffe2/core/common.h"
 #include "caffe2/utils/IdWrapper.h"
 
@@ -39,9 +40,9 @@ public:
   friend std::ostream& ::operator<<(std::ostream& stream, CaffeTypeId typeId);
   friend bool operator<(CaffeTypeId lhs, CaffeTypeId rhs);
 
-  // TODO Can we get rid of uninitialized?
+  // This is 8, because 0 is uint8_t (due to ScalarType BC constraint)
   static constexpr CaffeTypeId uninitialized() {
-    return CaffeTypeId(0);
+    return CaffeTypeId(8);
   }
 
 private:
@@ -439,35 +440,41 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
 
 class Tensor;
 
-// note: first preallocated id is 1, because 0 is used for uninitialized type
-// ids.
+// Note: we have preallocated the numbers 0-8 so they line up exactly
+// with at::ScalarType's numbering.  All other numbers do not matter.
+//
+// Notably, the "uninitialized" type id is 8, not 0, for hysterical raisins.
+
 struct _CaffeHighestPreallocatedTypeId final {};
 
-CAFFE_DECLARE_KNOWN_TYPE(1, Tensor);
-CAFFE_DECLARE_KNOWN_TYPE(2, float);
+CAFFE_DECLARE_KNOWN_TYPE(0, uint8_t);
+CAFFE_DECLARE_KNOWN_TYPE(1, int8_t);
+CAFFE_DECLARE_KNOWN_TYPE(2, int16_t);
 CAFFE_DECLARE_KNOWN_TYPE(3, int);
-CAFFE_DECLARE_KNOWN_TYPE(4, std::string);
-CAFFE_DECLARE_KNOWN_TYPE(5, bool);
-CAFFE_DECLARE_KNOWN_TYPE(6, uint8_t);
-CAFFE_DECLARE_KNOWN_TYPE(7, int8_t);
-CAFFE_DECLARE_KNOWN_TYPE(8, uint16_t);
-CAFFE_DECLARE_KNOWN_TYPE(9, int16_t);
-CAFFE_DECLARE_KNOWN_TYPE(10, int64_t);
-CAFFE_DECLARE_KNOWN_TYPE(11, double);
-CAFFE_DECLARE_KNOWN_TYPE(12, char);
-CAFFE_DECLARE_KNOWN_TYPE(13, std::unique_ptr<std::mutex>);
-CAFFE_DECLARE_KNOWN_TYPE(14, std::unique_ptr<std::atomic<bool>>);
-CAFFE_DECLARE_KNOWN_TYPE(15, std::vector<int32_t>);
-CAFFE_DECLARE_KNOWN_TYPE(16, std::vector<int64_t>);
-CAFFE_DECLARE_KNOWN_TYPE(17, std::vector<unsigned long>);
-CAFFE_DECLARE_KNOWN_TYPE(18, bool*);
-CAFFE_DECLARE_KNOWN_TYPE(19, char*);
-CAFFE_DECLARE_KNOWN_TYPE(20, int*);
+CAFFE_DECLARE_KNOWN_TYPE(4, int64_t);
+CAFFE_DECLARE_KNOWN_TYPE(5, at::Half);
+CAFFE_DECLARE_KNOWN_TYPE(6, float);
+CAFFE_DECLARE_KNOWN_TYPE(7, double);
+// 8 = undefined type id
+
+CAFFE_DECLARE_KNOWN_TYPE(9, Tensor);
+CAFFE_DECLARE_KNOWN_TYPE(10, std::string);
+CAFFE_DECLARE_KNOWN_TYPE(11, bool);
+CAFFE_DECLARE_KNOWN_TYPE(12, uint16_t);
+CAFFE_DECLARE_KNOWN_TYPE(13, char);
+CAFFE_DECLARE_KNOWN_TYPE(14, std::unique_ptr<std::mutex>);
+CAFFE_DECLARE_KNOWN_TYPE(15, std::unique_ptr<std::atomic<bool>>);
+CAFFE_DECLARE_KNOWN_TYPE(16, std::vector<int32_t>);
+CAFFE_DECLARE_KNOWN_TYPE(17, std::vector<int64_t>);
+CAFFE_DECLARE_KNOWN_TYPE(18, std::vector<unsigned long>);
+CAFFE_DECLARE_KNOWN_TYPE(19, bool*);
+CAFFE_DECLARE_KNOWN_TYPE(20, char*);
+CAFFE_DECLARE_KNOWN_TYPE(21, int*);
 
 #ifdef CAFFE2_UNIQUE_LONG_TYPEMETA
-CAFFE_DECLARE_KNOWN_TYPE(21, long);
-CAFFE_DECLARE_KNOWN_TYPE(22, std::vector<long>);
+CAFFE_DECLARE_KNOWN_TYPE(22, long);
+CAFFE_DECLARE_KNOWN_TYPE(23, std::vector<long>);
 #endif // CAFFE2_UNIQUE_LONG_TYPEMETA
 
-CAFFE_DECLARE_KNOWN_TYPE(23, _CaffeHighestPreallocatedTypeId);
+CAFFE_DECLARE_KNOWN_TYPE(24, _CaffeHighestPreallocatedTypeId);
 }


### PR DESCRIPTION
Summary:
We want CaffeTypeId to be interconvertible with at::ScalarType, and
this means we should have the numbers line up exactly.  Fortunately
this is not too hard to do.

Reviewed By: smessmer

Differential Revision: D9123058
