### PR TITLE
Split the dependence of ONNX from test_operators.py

### DIFF
--- a/test/onnx/expect/TestOperators.test_add_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_broadcast.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_addconstant.expect
+++ b/test/onnx/expect/TestOperators.test_addconstant.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     output: "1"

--- a/test/onnx/expect/TestOperators.test_addmm.expect
+++ b/test/onnx/expect/TestOperators.test_addmm.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_at_op.expect
+++ b/test/onnx/expect/TestOperators.test_at_op.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_basic.expect
+++ b/test/onnx/expect/TestOperators.test_basic.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_batchnorm.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -12,7 +12,7 @@ graph {
     op_type: "BatchNormalization"
     attribute {
       name: "epsilon"
-      f: 9.99999974737875e-06
+      f: 1e-05
       type: FLOAT
     }
     attribute {

--- a/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -22,7 +22,7 @@ graph {
     op_type: "BatchNormalization"
     attribute {
       name: "epsilon"
-      f: 9.99999974737875e-06
+      f: 1e-05
       type: FLOAT
     }
     attribute {

--- a/test/onnx/expect/TestOperators.test_batchnorm_training.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_training.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -16,12 +16,12 @@ graph {
     op_type: "BatchNormalization"
     attribute {
       name: "epsilon"
-      f: 9.99999974737875e-06
+      f: 1e-05
       type: FLOAT
     }
     attribute {
       name: "momentum"
-      f: 0.899999976158142
+      f: 0.9
       type: FLOAT
     }
   }

--- a/test/onnx/expect/TestOperators.test_chunk.expect
+++ b/test/onnx/expect/TestOperators.test_chunk.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -8,7 +8,7 @@ graph {
     op_type: "Clip"
     attribute {
       name: "max"
-      f: 0.100000001490116
+      f: 0.1
       type: FLOAT
     }
   }

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -8,7 +8,7 @@ graph {
     op_type: "Clip"
     attribute {
       name: "min"
-      f: -0.100000001490116
+      f: -0.1
       type: FLOAT
     }
   }

--- a/test/onnx/expect/TestOperators.test_concat2.expect
+++ b/test/onnx/expect/TestOperators.test_concat2.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_conv.expect
+++ b/test/onnx/expect/TestOperators.test_conv.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_convtranspose.expect
+++ b/test/onnx/expect/TestOperators.test_convtranspose.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_elu.expect
+++ b/test/onnx/expect/TestOperators.test_elu.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_equal.expect
+++ b/test/onnx/expect/TestOperators.test_equal.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_exp.expect
+++ b/test/onnx/expect/TestOperators.test_exp.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_ge.expect
+++ b/test/onnx/expect/TestOperators.test_ge.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "1"

--- a/test/onnx/expect/TestOperators.test_gt.expect
+++ b/test/onnx/expect/TestOperators.test_gt.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_hardtanh.expect
+++ b/test/onnx/expect/TestOperators.test_hardtanh.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_le.expect
+++ b/test/onnx/expect/TestOperators.test_le.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "1"

--- a/test/onnx/expect/TestOperators.test_logsoftmax.expect
+++ b/test/onnx/expect/TestOperators.test_logsoftmax.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_lt.expect
+++ b/test/onnx/expect/TestOperators.test_lt.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_max.expect
+++ b/test/onnx/expect/TestOperators.test_max.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_maxpool.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_mean.expect
+++ b/test/onnx/expect/TestOperators.test_mean.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_min.expect
+++ b/test/onnx/expect/TestOperators.test_min.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_mm.expect
+++ b/test/onnx/expect/TestOperators.test_mm.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     output: "2"

--- a/test/onnx/expect/TestOperators.test_norm.expect
+++ b/test/onnx/expect/TestOperators.test_norm.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_params.expect
+++ b/test/onnx/expect/TestOperators.test_params.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_permute2.expect
+++ b/test/onnx/expect/TestOperators.test_permute2.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_pow.expect
+++ b/test/onnx/expect/TestOperators.test_pow.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_prod.expect
+++ b/test/onnx/expect/TestOperators.test_prod.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_mean.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_prod.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_sum.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     output: "1"

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     output: "1"

--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     output: "1"

--- a/test/onnx/expect/TestOperators.test_selu.expect
+++ b/test/onnx/expect/TestOperators.test_selu.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_sqrt.expect
+++ b/test/onnx/expect/TestOperators.test_sqrt.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_sum.expect
+++ b/test/onnx/expect/TestOperators.test_sum.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_symbolic_override.expect
+++ b/test/onnx/expect/TestOperators.test_symbolic_override.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"
@@ -10,7 +10,7 @@ graph {
     op_type: "InstanceNormalization"
     attribute {
       name: "epsilon"
-      f: 9.99999971718069e-10
+      f: 1e-09
       type: FLOAT
     }
   }

--- a/test/onnx/expect/TestOperators.test_symbolic_override_nested.expect
+++ b/test/onnx/expect/TestOperators.test_symbolic_override_nested.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/expect/TestOperators.test_transpose.expect
+++ b/test/onnx/expect/TestOperators.test_transpose.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   name: "torch-jit-export"
   input {

--- a/test/onnx/expect/TestOperators.test_type_as.expect
+++ b/test/onnx/expect/TestOperators.test_type_as.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   name: "torch-jit-export"
   input {

--- a/test/onnx/expect/TestOperators.test_view.expect
+++ b/test/onnx/expect/TestOperators.test_view.expect
@@ -1,6 +1,6 @@
 ir_version: 3
 producer_name: "pytorch"
-producer_version: "0.3"
+producer_version: "0.4"
 graph {
   node {
     input: "0"

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -1,17 +1,10 @@
 from test_pytorch_common import TestCase, run_tests, skipIfNoLapack, flatten
-import test_onnx_common
 
 import torch
 import torch.onnx
 from torch.autograd import Variable, Function
 from torch.nn import Module
 import torch.nn as nn
-
-import onnx
-import onnx.checker
-import onnx.helper
-
-import google.protobuf.text_format
 
 import itertools
 import io
@@ -23,12 +16,25 @@ import os
 import shutil
 import sys
 import common
-from onnx import numpy_helper
-
-_onnx_test = False
 
 
-def export_to_string(model, inputs, *args, **kwargs):
+'''Usage: python test/onnx/test_operators.py [--no-onnx] [--produce-onnx-test-data]
+          --no-onnx: no onnx python dependence
+          --produce-onnx-test-data: generate onnx test data
+'''
+
+_onnx_test = False  # flag to produce onnx test cases.
+_onnx_dep = True  # flag to import onnx package.
+
+
+def export_to_pbtxt(model, inputs, *args, **kwargs):
+    return torch.onnx.export_to_pretty_string(
+        model, inputs, None, verbose=False, google_printer=True,
+        *args, **kwargs)
+
+
+def export_to_pb(model, inputs, *args, **kwargs):
+    kwargs['operator_export_type'] = torch.onnx.OperatorExportTypes.ONNX
     f = io.BytesIO()
     with torch.no_grad():
         torch.onnx.export(model, inputs, f, *args, **kwargs)
@@ -47,54 +53,56 @@ class FuncModule(Module):
 
 class TestOperators(TestCase):
 
-    def assertONNXExpected(self, binary_pb, subname=None):
-        model_def = onnx.ModelProto.FromString(binary_pb)
-        onnx.checker.check_model(model_def)
-        # doc_string contains stack trace in it, strip it
-        onnx.helper.strip_doc_string(model_def)
-        self.assertExpected(google.protobuf.text_format.MessageToString(model_def, float_format='.15g'), subname)
-        return model_def
-
     def assertONNX(self, f, args, params=tuple(), **kwargs):
         if isinstance(f, nn.Module):
             m = f
         else:
             m = FuncModule(f, params)
-        onnx_model_pb = export_to_string(m, args, **kwargs)
-        model_def = self.assertONNXExpected(onnx_model_pb)
-        if _onnx_test:
-            test_function = inspect.stack()[1][0].f_code.co_name
-            test_name = test_function[0:4] + "_operator" + test_function[4:]
-            output_dir = os.path.join(test_onnx_common.pytorch_operator_dir, test_name)
-            # Assume:
-            #     1) the old test should be delete before the test.
-            #     2) only one assertONNX in each test, otherwise will override the data.
-            assert not os.path.exists(output_dir), "{} should not exist!".format(output_dir)
-            os.makedirs(output_dir)
-            with open(os.path.join(output_dir, "model.onnx"), 'wb') as file:
-                file.write(model_def.SerializeToString())
-            data_dir = os.path.join(output_dir, "test_data_set_0")
-            os.makedirs(data_dir)
-            if isinstance(args, Variable):
-                args = (args,)
-            for index, var in enumerate(flatten(args)):
-                tensor = numpy_helper.from_array(var.data.numpy())
-                with open(os.path.join(data_dir, "input_{}.pb".format(index)), 'wb') as file:
-                    file.write(tensor.SerializeToString())
-            outputs = m(*args)
-            if isinstance(outputs, Variable):
-                outputs = (outputs,)
-            for index, var in enumerate(flatten(outputs)):
-                tensor = numpy_helper.from_array(var.data.numpy())
-                with open(os.path.join(data_dir, "output_{}.pb".format(index)), 'wb') as file:
-                    file.write(tensor.SerializeToString())
+        onnx_model_pbtxt = export_to_pbtxt(m, args, **kwargs)
+        subname = kwargs.pop('subname', None)
+        self.assertExpected(onnx_model_pbtxt, subname)
+        if _onnx_dep:
+            onnx_model_pb = export_to_pb(m, args, **kwargs)
+            import onnx
+            import onnx.checker
+            import onnx.numpy_helper
+            import test_onnx_common
+            model_def = onnx.ModelProto.FromString(onnx_model_pb)
+            onnx.checker.check_model(model_def)
+
+            if _onnx_test:
+                test_function = inspect.stack()[1][0].f_code.co_name
+                test_name = test_function[0:4] + "_operator" + test_function[4:]
+                output_dir = os.path.join(test_onnx_common.pytorch_operator_dir, test_name)
+                # Assume:
+                #     1) the old test should be delete before the test.
+                #     2) only one assertONNX in each test, otherwise will override the data.
+                assert not os.path.exists(output_dir), "{} should not exist!".format(output_dir)
+                os.makedirs(output_dir)
+                with open(os.path.join(output_dir, "model.onnx"), 'wb') as file:
+                    file.write(model_def.SerializeToString())
+                data_dir = os.path.join(output_dir, "test_data_set_0")
+                os.makedirs(data_dir)
+                if isinstance(args, Variable):
+                    args = (args,)
+                for index, var in enumerate(flatten(args)):
+                    tensor = onnx.numpy_helper.from_array(var.data.numpy())
+                    with open(os.path.join(data_dir, "input_{}.pb".format(index)), 'wb') as file:
+                        file.write(tensor.SerializeToString())
+                outputs = m(*args)
+                if isinstance(outputs, Variable):
+                    outputs = (outputs,)
+                for index, var in enumerate(flatten(outputs)):
+                    tensor = onnx.numpy_helper.from_array(var.data.numpy())
+                    with open(os.path.join(data_dir, "output_{}.pb".format(index)), 'wb') as file:
+                        file.write(tensor.SerializeToString())
 
     def assertONNXRaises(self, err, f, args, params=tuple(), **kwargs):
         if isinstance(f, nn.Module):
             m = f
         else:
             m = FuncModule(f, params)
-        self.assertExpectedRaises(err, lambda: export_to_string(m, args, **kwargs))
+        self.assertExpectedRaises(err, lambda: export_to_pbtxt(m, args, **kwargs))
 
     def assertONNXRaisesRegex(self, err, reg, f, args, params=tuple(), **kwargs):
         if isinstance(f, nn.Module):
@@ -102,7 +110,7 @@ class TestOperators(TestCase):
         else:
             m = FuncModule(f, params)
         with self.assertRaisesRegex(err, reg):
-            export_to_string(m, args, **kwargs)
+            export_to_pbtxt(m, args, **kwargs)
 
     def test_basic(self):
         x = Variable(torch.Tensor([0.4]), requires_grad=True)
@@ -208,7 +216,7 @@ class TestOperators(TestCase):
         # NB: Don't use expect test here, the type error wobbles depending
         # on Python version
         with self.assertRaisesRegex(TypeError, "occurred when translating MyFun"):
-            export_to_string(FuncModule(MyFun().apply), (x, y))
+            export_to_pbtxt(FuncModule(MyFun().apply), (x, y))
 
     # TODO: Do an nn style test for these
     def test_batchnorm(self):
@@ -454,11 +462,17 @@ class TestOperators(TestCase):
 
 
 if __name__ == '__main__':
-    onnx_test_flag = '--onnx-test'
+    no_onnx_dep_flag = '--no-onnx'
+    _onnx_dep = no_onnx_dep_flag not in common.UNITTEST_ARGS
+    if no_onnx_dep_flag in common.UNITTEST_ARGS:
+        common.UNITTEST_ARGS.remove(no_onnx_dep_flag)
+    onnx_test_flag = '--produce-onnx-test-data'
     _onnx_test = onnx_test_flag in common.UNITTEST_ARGS
     if onnx_test_flag in common.UNITTEST_ARGS:
         common.UNITTEST_ARGS.remove(onnx_test_flag)
     if _onnx_test:
+        _onnx_dep = True
+        import test_onnx_common
         for d in glob.glob(os.path.join(test_onnx_common.pytorch_operator_dir, "test_operator_*")):
             shutil.rmtree(d)
     run_tests()

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -66,7 +66,7 @@ void validateGraph(const std::shared_ptr<Graph>& graph, onnx_torch::OperatorExpo
 
 class EncoderBase {
  public:
-  EncoderBase(onnx_torch::OperatorExportTypes operator_export_type);
+  EncoderBase(onnx_torch::OperatorExportTypes operator_export_type, bool strip_doc);
 
   onnx::ModelProto get_model_proto() {
     return model_proto_;
@@ -97,6 +97,7 @@ class EncoderBase {
   onnx::ModelProto model_proto_;
   size_t num_blocks_;
   onnx_torch::OperatorExportTypes operator_export_type_;
+  bool strip_doc_;
 };
 
 onnx::TensorProto_DataType ATenTypeToOnnxType(at::ScalarType at_type) {
@@ -122,12 +123,13 @@ onnx::TensorProto_DataType ATenTypeToOnnxType(at::ScalarType at_type) {
   }
 }
 
-EncoderBase::EncoderBase(onnx_torch::OperatorExportTypes operator_export_type)
+EncoderBase::EncoderBase(onnx_torch::OperatorExportTypes operator_export_type, bool strip_doc)
     : num_blocks_(0),
-      operator_export_type_(operator_export_type) {
+      operator_export_type_(operator_export_type),
+      strip_doc_(strip_doc) {
   model_proto_.set_producer_name("pytorch");
   model_proto_.set_ir_version(onnx::IR_VERSION);
-  model_proto_.set_producer_version("0.3");
+  model_proto_.set_producer_version("0.4");
 }
 
 void EncoderBase::EncodeValueInfo(
@@ -184,7 +186,7 @@ void EncoderBase::EncodeBlock(
       continue;
     }
     auto p_n = graph_proto->add_node();
-    if (node->getSourceLocation()) {
+    if (node->getSourceLocation() && !strip_doc_) {
       std::stringstream ss;
       node->getSourceLocation()->highlight(ss);
       p_n->set_doc_string(ss.str());
@@ -325,7 +327,8 @@ class GraphEncoder: public EncoderBase {
                int64_t onnx_opset_version,
                onnx_torch::OperatorExportTypes operator_export_type,
                const std::vector<at::Tensor> &initializers,
-               bool defer_weight_export);
+               bool defer_weight_export,
+               bool strip_doc);
 
   RawDataExportMap get_raw_data_export_map() {
     return raw_data_export_map_;
@@ -345,8 +348,9 @@ GraphEncoder::GraphEncoder(
     int64_t onnx_opset_version,
     onnx_torch::OperatorExportTypes operator_export_type,
     const std::vector<at::Tensor> &initializers,
-    bool defer_weight_export)
-    : EncoderBase(operator_export_type),
+    bool defer_weight_export,
+    bool strip_doc)
+    : EncoderBase(operator_export_type, strip_doc),
       defer_weight_export_(defer_weight_export) {
   if (operator_export_type != onnx_torch::OperatorExportTypes::RAW) {
     validateGraph(graph, operator_export_type);
@@ -439,7 +443,7 @@ class ModuleEncoder: public EncoderBase {
 ModuleEncoder::ModuleEncoder(
     const script::Module &module,
     const std::string &filename)
-    : EncoderBase(onnx_torch::OperatorExportTypes::RAW),
+    : EncoderBase(onnx_torch::OperatorExportTypes::RAW, false),
       file_writer_(filename) {
   model_proto_.set_doc_string("THIS PROTO IS NOT STANDARD ONNX");
   EncodeModule(model_proto_.mutable_graph(), module);
@@ -830,9 +834,13 @@ std::string PrettyPrintExportedGraph(
                         const std::vector<at::Tensor> &initializers,
                         int64_t onnx_opset_version,
                         bool defer_weight_export,
-                        ::torch::onnx::OperatorExportTypes operator_export_type) {
+                        ::torch::onnx::OperatorExportTypes operator_export_type,
+                        bool google_printer) {
   auto graph_encoder = GraphEncoder(
-    graph, onnx_opset_version, operator_export_type, initializers, defer_weight_export);
+    graph, onnx_opset_version, operator_export_type, initializers, defer_weight_export, true);
+  if (google_printer) {
+    return graph_encoder.get_model_proto().DebugString();
+  }
   return prettyPrint(graph_encoder.get_model_proto());
 }
 
@@ -848,7 +856,7 @@ std::tuple<std::string, RawDataExportMap> ExportGraph(
                         bool defer_weight_export,
                         ::torch::onnx::OperatorExportTypes operator_export_type) {
   auto graph_encoder = GraphEncoder(
-    graph, onnx_opset_version, operator_export_type, initializers, defer_weight_export);
+    graph, onnx_opset_version, operator_export_type, initializers, defer_weight_export, false);
   return std::make_tuple(graph_encoder.get_model_proto().SerializeAsString(),
                          graph_encoder.get_raw_data_export_map());
 }

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -31,7 +31,8 @@ TORCH_API std::string PrettyPrintExportedGraph(
     int64_t onnx_opset_version,
     bool defer_weight_export,
     ::torch::onnx::OperatorExportTypes operator_export_type
-      = ::torch::onnx::OperatorExportTypes::ONNX);
+      = ::torch::onnx::OperatorExportTypes::ONNX,
+    bool google_printer = false);
 
 TORCH_API void ExportModule(
     const script::Module& module,

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -167,15 +167,19 @@ void initPythonIRBindings(PyObject * module_) {
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
        py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX)
-    .def("prettyPrintExport", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export,
-                      ::torch::onnx::OperatorExportTypes operator_export_type) {
+    .def("prettyPrintExport", [](const std::shared_ptr<Graph> g,
+          const std::vector<at::Tensor>& initializers,
+          int64_t onnx_opset_version, bool defer_weight_export,
+          ::torch::onnx::OperatorExportTypes operator_export_type,
+          bool google_printer) {
       return PrettyPrintExportedGraph(
-        g, initializers, onnx_opset_version, defer_weight_export, operator_export_type);
+        g, initializers, onnx_opset_version, defer_weight_export, operator_export_type,
+        google_printer);
     }, py::arg("initializers"),
        py::arg("onnx_opset_version")=0,
        py::arg("defer_weight_export")=false,
-       py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX)
+       py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX,
+       py::arg("google_printer")=false)
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function
       // that should have different behavior when exporting for JIT interpreter

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -210,7 +210,7 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=False,
                             input_names=None, output_names=None, aten=False, export_raw_ir=False,
                             operator_export_type=None, export_type=ExportTypes.PROTOBUF_FILE,
-                            example_outputs=None, propagate=False):
+                            example_outputs=None, propagate=False, google_printer=False):
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir
@@ -219,19 +219,20 @@ def export_to_pretty_string(model, args, f, export_params=True, verbose=False, t
         operator_export_type = OperatorExportTypes.ONNX
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
-                                    export_type, example_outputs, propagate)
+                                    export_type, example_outputs, propagate, google_printer)
 
 
 def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=False,
                              input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
-                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False):
+                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False,
+                             google_printer=False):
     graph, params, torch_out = _model_to_graph(model, args, f, verbose,
                                                training, input_names,
                                                output_names, operator_export_type,
                                                example_outputs, propagate)
 
     from torch.onnx.symbolic import _onnx_opset_version
-    return graph.prettyPrintExport(params, _onnx_opset_version, False, operator_export_type)
+    return graph.prettyPrintExport(params, _onnx_opset_version, False, operator_export_type, google_printer)
 
 
 # NOTE: the output `torch_out` will contain the output tensors resulting from


### PR DESCRIPTION
Now, run `python test/onnx/test_operators.py --no-onnx`, we won't introduce any onnx python dependence. (No onnx/protobuf python packages needs to be installed)

The major changes:
- output pbtxt from C++ exporter directly, so the floating format may be slightly different. (This should be fine, since it's just to guard ONNX exporting.)
- ONNX python packages are only imported if we run the ONNX related checks. Those checks are disabled when using `--no-onnx` flag.