### PR TITLE
Rename CaffeTypeId to TypeIdentifier

### DIFF
--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -322,7 +322,7 @@ void TensorSerializer::StoreDeviceDetail(
 // The actual serialization registry objects.
 CAFFE_DEFINE_TYPED_REGISTRY(
     BlobSerializerRegistry,
-    CaffeTypeId,
+    TypeIdentifier,
     BlobSerializerBase,
     std::unique_ptr);
 

--- a/caffe2/core/blob_serialization.h
+++ b/caffe2/core/blob_serialization.h
@@ -26,13 +26,13 @@ constexpr auto kChunkIdSeparator = "#%";
 // The Blob serialization registry and serializer creator functions.
 CAFFE_DECLARE_TYPED_REGISTRY(
     BlobSerializerRegistry,
-    CaffeTypeId,
+    TypeIdentifier,
     BlobSerializerBase,
     std::unique_ptr);
 #define REGISTER_BLOB_SERIALIZER(id, ...) \
   CAFFE_REGISTER_TYPED_CLASS(BlobSerializerRegistry, id, __VA_ARGS__)
 // Creates an operator with the given operator definition.
-inline unique_ptr<BlobSerializerBase> CreateSerializer(CaffeTypeId id) {
+inline unique_ptr<BlobSerializerBase> CreateSerializer(TypeIdentifier id) {
   return BlobSerializerRegistry()->Create(id);
 }
 

--- a/caffe2/core/blob_stats.cc
+++ b/caffe2/core/blob_stats.cc
@@ -2,7 +2,7 @@
 
 namespace caffe2 {
 
-const BlobStatGetter* BlobStatRegistry::get(CaffeTypeId id) {
+const BlobStatGetter* BlobStatRegistry::get(TypeIdentifier id) {
   auto it = map_.find(id);
   if (it == map_.end()) {
     return nullptr;
@@ -16,7 +16,7 @@ BlobStatRegistry& BlobStatRegistry::instance() {
 }
 
 void BlobStatRegistry::doRegister(
-    CaffeTypeId id,
+    TypeIdentifier id,
     std::unique_ptr<BlobStatGetter>&& v) {
   // don't use CAFFE_ENFORCE_EQ to avoid static initialization order fiasco.
   if (map_.count(id) > 0) {

--- a/caffe2/core/blob_stats.h
+++ b/caffe2/core/blob_stats.h
@@ -15,8 +15,8 @@ struct BlobStatGetter {
 
 struct BlobStatRegistry {
  private:
-  std::unordered_map<CaffeTypeId, std::unique_ptr<BlobStatGetter>> map_;
-  void doRegister(CaffeTypeId id, std::unique_ptr<BlobStatGetter>&& v);
+  std::unordered_map<TypeIdentifier, std::unique_ptr<BlobStatGetter>> map_;
+  void doRegister(TypeIdentifier id, std::unique_ptr<BlobStatGetter>&& v);
 
  public:
   template <typename T, typename Getter>
@@ -27,7 +27,7 @@ struct BlobStatRegistry {
     }
   };
 
-  const BlobStatGetter* get(CaffeTypeId id);
+  const BlobStatGetter* get(TypeIdentifier id);
   static BlobStatRegistry& instance();
 };
 

--- a/caffe2/core/dispatch/DispatchKey.h
+++ b/caffe2/core/dispatch/DispatchKey.h
@@ -16,8 +16,8 @@ struct TensorParameterDispatchKey final {
   // note: This dispatch key structure is not final yet and will change. Don't rely on it.
   DeviceTypeId deviceTypeId;
   LayoutId layoutId;
-  // TODO Move this CaffeTypeId to c10 namespace
-  caffe2::CaffeTypeId dataType;
+  // TODO Move this TypeIdentifier to c10 namespace
+  caffe2::TypeIdentifier dataType;
 };
 inline constexpr bool operator==(const TensorParameterDispatchKey& lhs, const TensorParameterDispatchKey& rhs) {
   return lhs.deviceTypeId == rhs.deviceTypeId && lhs.layoutId == rhs.layoutId && lhs.dataType == rhs.dataType;
@@ -34,7 +34,7 @@ namespace std {
   struct hash<c10::details::TensorParameterDispatchKey> {
     // TODO constexpr hashing
     size_t operator()(const c10::details::TensorParameterDispatchKey& obj) const {
-      return std::hash<c10::DeviceTypeId>()(obj.deviceTypeId) ^ std::hash<c10::LayoutId>()(obj.layoutId) ^ std::hash<caffe2::CaffeTypeId>()(obj.dataType);
+      return std::hash<c10::DeviceTypeId>()(obj.deviceTypeId) ^ std::hash<c10::LayoutId>()(obj.layoutId) ^ std::hash<caffe2::TypeIdentifier>()(obj.dataType);
     }
   };
 }  // namespace std

--- a/caffe2/core/dispatch/KernelRegistration.h
+++ b/caffe2/core/dispatch/KernelRegistration.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "caffe2/core/common.h"
 #include "caffe2/core/dispatch/OpSchema.h"
 #include "caffe2/core/dispatch/Dispatcher.h"
 #include "caffe2/utils/Optional.h"

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -100,7 +100,7 @@ std::function<bool(int64_t)> getContinuationTest(
 
 // if the blob doesn't exist or is not initiaized, return false
 inline bool getShouldStop(const Blob* b) {
-  if (!b || b->meta().id() == CaffeTypeId::uninitialized()) { // not exist or uninitialized
+  if (!b || b->meta().id() == TypeIdentifier::uninitialized()) { // not exist or uninitialized
     return false;
   }
 

--- a/caffe2/core/registry.h
+++ b/caffe2/core/registry.h
@@ -178,7 +178,7 @@ class Registerer {
       key,                                                                    \
       RegistryName(),                                                         \
       Registerer##RegistryName::DefaultCreator<__VA_ARGS__>,                  \
-      DemangleType<__VA_ARGS__>());                                           \
+      at::demangle_type<__VA_ARGS__>());                                           \
   }
 
 // CAFFE_DECLARE_REGISTRY and CAFFE_DEFINE_REGISTRY are hard-wired to use string

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -68,10 +68,10 @@ TypeMeta GetTensorType(const void* c) {
 }
 
 // TODO(jerryzh): Remove
-static CaffeMap<CaffeTypeId, TypeCall> type_call_registry_{
+static CaffeMap<TypeIdentifier, TypeCall> type_call_registry_{
     {TypeMeta::Id<Tensor>(), GetTensorType}};
 
-TypeCall GetTypeCallFunction(CaffeTypeId id) {
+TypeCall GetTypeCallFunction(TypeIdentifier id) {
   auto f = type_call_registry_.find(id);
   if (f == type_call_registry_.end()) {
     return nullptr;
@@ -79,7 +79,7 @@ TypeCall GetTypeCallFunction(CaffeTypeId id) {
   return f->second;
 }
 
-void RegisterTypeCallFunction(CaffeTypeId id, TypeCall c) {
+void RegisterTypeCallFunction(TypeIdentifier id, TypeCall c) {
   type_call_registry_[id] = c;
 }
 
@@ -98,12 +98,12 @@ vector<TIndex> GetTensorInfo(
 }
 
 // since we only have one tensor, probably need to remove this at some point?
-static CaffeMap<CaffeTypeId, TensorInfoCall> tensor_info_call_registry_{
+static CaffeMap<TypeIdentifier, TensorInfoCall> tensor_info_call_registry_{
     {TypeMeta::Id<Tensor>(), GetTensorInfo}};
 
 // TODO: Remove this code in a separate diff, since we only have one
 // GetTensorInfo function now
-TensorInfoCall GetTensorInfoFunction(CaffeTypeId id) {
+TensorInfoCall GetTensorInfoFunction(TypeIdentifier id) {
   auto f = tensor_info_call_registry_.find(id);
   if (f == tensor_info_call_registry_.end()) {
     return nullptr;
@@ -111,7 +111,7 @@ TensorInfoCall GetTensorInfoFunction(CaffeTypeId id) {
   return f->second;
 }
 
-void RegisterTensorInfoFunction(CaffeTypeId id, TensorInfoCall c) {
+void RegisterTensorInfoFunction(TypeIdentifier id, TensorInfoCall c) {
   tensor_info_call_registry_[id] = c;
 }
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -473,7 +473,7 @@ class Tensor {
       Deleter d = nullptr) {
     meta_ = meta;
     CAFFE_ENFORCE_WITH_CALLER(
-        meta_.id() != CaffeTypeId::uninitialized(),
+        meta_.id() != TypeIdentifier::uninitialized(),
         "To share with a raw external pointer you need to have meta "
         "already set.");
     CAFFE_ENFORCE_WITH_CALLER(
@@ -600,7 +600,7 @@ class Tensor {
    */
   inline void* raw_mutable_data() {
     CAFFE_ENFORCE_WITH_CALLER(
-        meta_.id() != CaffeTypeId::uninitialized(),
+        meta_.id() != TypeIdentifier::uninitialized(),
         "Calling raw_mutable_data() without meta, but the current meta is "
         "of unknown type.");
     return raw_mutable_data(meta_);
@@ -829,8 +829,8 @@ constexpr int k_limit_default_ = 1000;
 
 // Type call registry
 typedef TypeMeta (*TypeCall)(const void*);
-TypeCall GetTypeCallFunction(CaffeTypeId id);
-void RegisterTypeCallFunction(CaffeTypeId id, TypeCall c);
+TypeCall GetTypeCallFunction(TypeIdentifier id);
+void RegisterTypeCallFunction(TypeIdentifier id, TypeCall c);
 
 // Shape call registry
 typedef vector<TIndex> (*TensorInfoCall)(
@@ -838,8 +838,8 @@ typedef vector<TIndex> (*TensorInfoCall)(
     bool* shares_data,
     size_t* capacity,
     DeviceOption* device);
-TensorInfoCall GetTensorInfoFunction(CaffeTypeId id);
-void RegisterTensorInfoFunction(CaffeTypeId id, TensorInfoCall c);
+TensorInfoCall GetTensorInfoFunction(TypeIdentifier id);
+void RegisterTensorInfoFunction(TypeIdentifier id, TensorInfoCall c);
 
 // resize helper function
 void TensorVectorResize(

--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -28,26 +28,9 @@ std::mutex& gTypeRegistrationMutex() {
   return g_type_registration_mutex;
 }
 
-#if defined(_MSC_VER)
-// Windows does not have cxxabi.h, so we will simply return the original.
-string Demangle(const char* name) {
-  return string(name);
-}
-#else
-string Demangle(const char* name) {
-  int status = 0;
-  auto demangled = ::abi::__cxa_demangle(name, nullptr, nullptr, &status);
-  if (demangled) {
-    auto guard = caffe2::MakeGuard([demangled]() { free(demangled); });
-    return string(demangled);
-  }
-  return name;
-}
-#endif
-
 string GetExceptionString(const std::exception& e) {
 #ifdef __GXX_RTTI
-  return Demangle(typeid(e).name()) + ": " + e.what();
+  return at::demangle(typeid(e).name()) + ": " + e.what();
 #else
   return string("Exception (no RTTI available): ") + e.what();
 #endif // __GXX_RTTI

--- a/caffe2/core/typeid.cc
+++ b/caffe2/core/typeid.cc
@@ -13,8 +13,8 @@ using std::string;
 
 namespace caffe2 {
 
-std::unordered_map<CaffeTypeId, string>& gTypeNames() {
-  static std::unordered_map<CaffeTypeId, string> g_type_names;
+std::unordered_map<TypeIdentifier, string>& gTypeNames() {
+  static std::unordered_map<TypeIdentifier, string> g_type_names;
   return g_type_names;
 }
 
@@ -42,14 +42,14 @@ void TypeMeta::_ThrowRuntimeTypeLogicError(const std::string& msg) {
   CAFFE_THROW(msg);
 }
 
-CaffeTypeId CaffeTypeId::createTypeId() {
-  static std::atomic<CaffeTypeId::underlying_type> counter(
+TypeIdentifier TypeIdentifier::createTypeId() {
+  static std::atomic<TypeIdentifier::underlying_type> counter(
       TypeMeta::Id<_CaffeHighestPreallocatedTypeId>().underlyingId());
-  const CaffeTypeId::underlying_type new_value = ++counter;
-  if (new_value == std::numeric_limits<CaffeTypeId::underlying_type>::max()) {
-    throw std::logic_error("Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase CaffeTypeId to use more than 16 bit.");
+  const TypeIdentifier::underlying_type new_value = ++counter;
+  if (new_value == std::numeric_limits<TypeIdentifier::underlying_type>::max()) {
+    throw std::logic_error("Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase TypeIdentifier to use more than 16 bit.");
   }
-  return CaffeTypeId(new_value);
+  return TypeIdentifier(new_value);
 }
 
 CAFFE_DEFINE_KNOWN_TYPE(Tensor);
@@ -86,7 +86,7 @@ namespace {
 // intended to be only instantiated once here.
 struct UninitializedTypeNameRegisterer {
     UninitializedTypeNameRegisterer() {
-      gTypeNames()[CaffeTypeId::uninitialized()] = "nullptr (uninitialized)";
+      gTypeNames()[TypeIdentifier::uninitialized()] = "nullptr (uninitialized)";
     }
 };
 static UninitializedTypeNameRegisterer g_uninitialized_type_name_registerer;

--- a/caffe2/core/typeid_test.cc
+++ b/caffe2/core/typeid_test.cc
@@ -37,7 +37,7 @@ TEST(TypeMetaTest, Names) {
   EXPECT_TRUE(
       string(string_meta.name()) != typeid(string).name());
   EXPECT_TRUE(
-      string(string_meta.name()) == Demangle(typeid(string).name()));
+      string(string_meta.name()) == at::demangle(typeid(string).name()));
 #endif  // __GXX_RTTI
 }
 

--- a/caffe2/core/types.cc
+++ b/caffe2/core/types.cc
@@ -13,7 +13,7 @@ CAFFE_KNOWN_TYPE(caffe2::float16);
 TensorProto::DataType TypeMetaToDataType(const TypeMeta& meta) {
   static_assert(sizeof(int) == 4,
                 "int in this compiler does not equal to 4 bytes.");
-  static std::map<CaffeTypeId, TensorProto::DataType> data_type_map {
+  static std::map<TypeIdentifier, TensorProto::DataType> data_type_map {
     {TypeMeta::Id<float>(), TensorProto_DataType_FLOAT},
     {TypeMeta::Id<int>(), TensorProto_DataType_INT32},
     // BYTE does not have a type meta to proto mapping: we should

--- a/caffe2/operators/quant_decode_op.h
+++ b/caffe2/operators/quant_decode_op.h
@@ -73,7 +73,7 @@ inline void DecodeGeneral(
     Tensor* outDecoded,
     bool resizeOnly) {
   const static std::map<
-      std::pair<CaffeTypeId, CaffeTypeId>,
+      std::pair<TypeIdentifier, TypeIdentifier>,
       std::function<void(
           const Tensor& codebook,
           const Tensor& codes,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -53,7 +53,7 @@ BlobFeederBase::~BlobFeederBase() {}
 
 CAFFE_DEFINE_TYPED_REGISTRY(
     BlobFetcherRegistry,
-    CaffeTypeId,
+    TypeIdentifier,
     BlobFetcherBase,
     std::unique_ptr);
 CAFFE_DEFINE_TYPED_REGISTRY(
@@ -82,7 +82,7 @@ static_assert(
     "We make an assumption that int is always int32 for numpy "
     "type mapping.");
 int CaffeToNumpyType(const TypeMeta& meta) {
-  static std::map<CaffeTypeId, int> numpy_type_map{
+  static std::map<TypeIdentifier, int> numpy_type_map{
       {TypeMeta::Id<bool>(), NPY_BOOL},
       {TypeMeta::Id<double>(), NPY_DOUBLE},
       {TypeMeta::Id<float>(), NPY_FLOAT},

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -62,12 +62,12 @@ class BlobFeederBase {
 
 CAFFE2_EXPORT CAFFE_DECLARE_TYPED_REGISTRY(
     BlobFetcherRegistry,
-    CaffeTypeId,
+    TypeIdentifier,
     BlobFetcherBase,
     std::unique_ptr);
 #define REGISTER_BLOB_FETCHER(id, ...) \
   CAFFE_REGISTER_TYPED_CLASS(BlobFetcherRegistry, id, __VA_ARGS__)
-inline unique_ptr<BlobFetcherBase> CreateFetcher(CaffeTypeId id) {
+inline unique_ptr<BlobFetcherBase> CreateFetcher(TypeIdentifier id) {
   return BlobFetcherRegistry()->Create(id);
 }
 
@@ -168,7 +168,7 @@ class TensorFeeder : public BlobFeederBase {
     const auto npy_type = PyArray_TYPE(array);
     const TypeMeta& meta = NumpyTypeToCaffe(npy_type);
     CAFFE_ENFORCE(
-        meta.id() != CaffeTypeId::uninitialized(),
+        meta.id() != TypeIdentifier::uninitialized(),
         "This numpy data type is not supported: ",
         PyArray_TYPE(array),
         ".");

--- a/caffe2/python/pybind_state_dlpack.cc
+++ b/caffe2/python/pybind_state_dlpack.cc
@@ -15,7 +15,7 @@ const DLDeviceType* CaffeToDLDeviceType(int device_type) {
 }
 
 const DLDataType* CaffeToDLType(const TypeMeta& meta) {
-  static std::map<CaffeTypeId, DLDataType> dl_type_map{
+  static std::map<TypeIdentifier, DLDataType> dl_type_map{
       {TypeMeta::Id<int8_t>(), DLDataType{0, 8, 1}},
       {TypeMeta::Id<int16_t>(), DLDataType{0, 16, 1}},
       {TypeMeta::Id<int32_t>(), DLDataType{0, 32, 1}},

--- a/caffe2/python/pybind_state_dlpack.h
+++ b/caffe2/python/pybind_state_dlpack.h
@@ -39,7 +39,7 @@ class DLPackWrapper {
     if (tensor->size() <= 0) {
       tensor->Resize(0);
     }
-    if (tensor->meta().id() == CaffeTypeId::uninitialized()) {
+    if (tensor->meta().id() == TypeIdentifier::uninitialized()) {
       // treat uninitialized tensor as float tensor
       tensor->template mutable_data<float>();
     }

--- a/caffe2/python/pybind_state_ideep.cc
+++ b/caffe2/python/pybind_state_ideep.cc
@@ -116,7 +116,7 @@ class IDeepFeeder : public BlobFeederBase {
      const auto npy_type = PyArray_TYPE(array);
      const TypeMeta& meta = NumpyTypeToCaffe(npy_type);
      CAFFE_ENFORCE(
-        meta.id() != CaffeTypeId::uninitialized(),
+        meta.id() != TypeIdentifier::uninitialized(),
         "This numpy data type is not supported: ",
         PyArray_TYPE(array),
         ".");


### PR DESCRIPTION
Summary:
We're moving CaffeTypeId to ATen/core, so it will be weird if
it still has Caffe in its name.  TypeIdentifier is easy to grep
for and can be codemodded again later if necessary.

Differential Revision: D9132454
