### PR TITLE
[JIT] Allow type cast between int and float in Script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -774,7 +774,6 @@ main_sources = [
     "torch/csrc/jit/script/init.cpp",
     "torch/csrc/jit/script/lexer.cpp",
     "torch/csrc/jit/script/module.cpp",
-    "torch/csrc/jit/script/compiler.cpp",
     "torch/csrc/jit/script/python_tree_views.cpp",
     "torch/csrc/nn/THNN.cpp",
     "torch/csrc/onnx/init.cpp",

--- a/setup.py
+++ b/setup.py
@@ -774,6 +774,7 @@ main_sources = [
     "torch/csrc/jit/script/init.cpp",
     "torch/csrc/jit/script/lexer.cpp",
     "torch/csrc/jit/script/module.cpp",
+    "torch/csrc/jit/script/compiler.cpp",
     "torch/csrc/jit/script/python_tree_views.cpp",
     "torch/csrc/nn/THNN.cpp",
     "torch/csrc/onnx/init.cpp",

--- a/test/expect/TestScript.test_type_cast-float_to_int.expect
+++ b/test/expect/TestScript.test_type_cast-float_to_int.expect
@@ -1,0 +1,7 @@
+graph() {
+  %0 : float = prim::Constant[value=2]()
+  %b : int = prim::FloatToInt(%0)
+  %2 : int = prim::Constant[value=1]()
+  %3 : int = aten::add(%b, %2)
+  return (%3);
+}

--- a/test/expect/TestScript.test_type_cast-int_to_float.expect
+++ b/test/expect/TestScript.test_type_cast-int_to_float.expect
@@ -1,0 +1,7 @@
+graph() {
+  %0 : int = prim::Constant[value=2]()
+  %b : float = prim::IntToFloat(%0)
+  %2 : float = prim::Constant[value=1]()
+  %3 : float = aten::add(%b, %2)
+  return (%3);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2441,6 +2441,20 @@ a")
         y = torch.arange(0., 8, 2, requires_grad=True)
         self.checkScript(func, [x, y], optimize=True, capture_output=True)
 
+    def test_type_cast(self):
+        def test_int_to_float():
+            b = float(2)
+            return b + 1.0
+
+        def test_float_to_int():
+            b = int(2.0)
+            return b + 1
+
+        graph1 = torch.jit.script(test_int_to_float).graph
+        self.assertExpectedGraph(graph1, subname="int_to_float")
+        graph2 = torch.jit.script(test_float_to_int).graph
+        self.assertExpectedGraph(graph2, subname="float_to_int")
+
     def test_multiple_assignment(self):
         def outer_func(x):
             return x * 2, x + 2

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -47,6 +47,8 @@ _(prim, TupleUnpack) \
 _(prim, ListConstruct) \
 _(prim, NumToTensor) \
 _(prim, TensorToNum) \
+_(prim, IntToFloat) \
+_(prim, FloatToInt) \
 _(prim, AutogradAdd) \
 _(prim, GradOf) \
 _(prim, AnyDefined) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1027,14 +1027,16 @@ public:
     result->output()->setType(type);
     return result;
   }
-  Node* createIntToFloat(const TypePtr& type, Value* value) {
+  Node* createIntToFloat(Value* value) {
+    JIT_ASSERT(*value->type() == *IntType::get());
     auto* result = create(prim::IntToFloat, {value});
-    result->output()->setType(type);
+    result->output()->setType(FloatType::get());
     return result;
   }
-  Node* createFloatToInt(const TypePtr& type, Value* value) {
+  Node* createFloatToInt(Value* value) {
+    JIT_ASSERT(*value->type() == *FloatType::get());
     auto* result = create(prim::FloatToInt, {value});
-    result->output()->setType(type);
+    result->output()->setType(IntType::get());
     return result;
   }
   Node* createPythonOp(

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1027,6 +1027,16 @@ public:
     result->output()->setType(type);
     return result;
   }
+  Node* createIntToFloat(const TypePtr& type, Value* value) {
+    auto* result = create(prim::IntToFloat, {value});
+    result->output()->setType(type);
+    return result;
+  }
+  Node* createFloatToInt(const TypePtr& type, Value* value) {
+    auto* result = create(prim::FloatToInt, {value});
+    result->output()->setType(type);
+    return result;
+  }
   Node* createPythonOp(
       THPObjectPtr&& pyobj,
       const std::string& cconv,

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -86,9 +86,9 @@ RegisterOperators reg({
         prim::IntToFloat,
         [](Node* node) -> Operation {
           return [](Stack& stack) {
-            at::Scalar s;
-            pop(stack, s);
-            push(stack, s.toFloat());
+            int64_t i;
+            pop(stack, i);
+            push(stack, (float)i);
             return 0;
           };
         }),
@@ -96,9 +96,9 @@ RegisterOperators reg({
         prim::FloatToInt,
         [](Node* node) -> Operation {
           return [](Stack& stack) {
-            at::Scalar s;
-            pop(stack, s);
-            push(stack, s.toInt());
+            double d;
+            pop(stack, d);
+            push(stack, (int64_t)d);
             return 0;
           };
         }),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -83,6 +83,26 @@ RegisterOperators reg({
           };
         }),
     Operator(
+        prim::IntToFloat,
+        [](Node* node) -> Operation {
+          return [](Stack& stack) {
+            at::Scalar s;
+            pop(stack, s);
+            push(stack, s.toFloat());
+            return 0;
+          };
+        }),
+    Operator(
+        prim::FloatToInt,
+        [](Node* node) -> Operation {
+          return [](Stack& stack) {
+            at::Scalar s;
+            pop(stack, s);
+            push(stack, s.toInt());
+            return 0;
+          };
+        }),
+    Operator(
         prim::Undefined,
         [](Node* node) {
           return [](Stack& stack) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -74,12 +74,12 @@ static Value* typeCast(const SourceRange& loc, Value* value, TypePtr dst) {
   } else if (dst->isSubtypeOf(NumberType::get()) && orig->isSubtypeOf(DynamicType::get())) {
     n = graph.createTensorToNum(dst, value);
   } else if(dst->isSubtypeOf(IntType::get()) && orig->isSubtypeOf(FloatType::get())) {
-    n = graph.createFloatToInt(dst, value);
+    n = graph.createFloatToInt(value);
   } else if(dst->isSubtypeOf(FloatType::get()) && orig->isSubtypeOf(IntType::get())) {
-    n = graph.createIntToFloat(dst, value);
+    n = graph.createIntToFloat(value);
   } else {
     throw ErrorReport(loc) << "Cannot cast type '" << orig->str() << "' to type '"
-      << dst->str() << "', no available type casting.";
+      << dst->str() << "'.";
   }
 
   auto* result = graph.insertNode(n)

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -422,9 +422,6 @@ struct NoneType : public Type {
   virtual std::string str() const override {
     return "None";
   }
-  virtual bool isSubtypeOf(const TypePtr rhs) const override {
-    return *this == *rhs;
-  }
   static const TypeKind Kind = TypeKind::NoneType;
   // global singleton
   static NoneTypePtr get();


### PR DESCRIPTION
The PR allows int→float and float→int casts. Current we only allow `tensor→int` and `tensor→float` casts.