### PR TITLE
Delete invalid 'template' keyword

### DIFF
--- a/caffe2/experiments/operators/tt_pad_op.h
+++ b/caffe2/experiments/operators/tt_pad_op.h
@@ -52,7 +52,7 @@ class TTPadOp final : public Operator<Context> {
       TIndex padded_dim0 = (X_dim0 / scale_ + 1) * scale_;
       auto dim0_diff = padded_dim0 - X_dim0;
       // set growthPct to the upper bound percentage: (100 * scale_ / X_dim0)
-      X_pad->template Extend(dim0_diff, 100 * scale_ / X_dim0, &context_);
+      X_pad->Extend(dim0_diff, 100 * scale_ / X_dim0, &context_);
 
       auto* X_pad_data = X_pad->template mutable_data<T>();
       TIndex X_size = X_dim0 * X_dim1;


### PR DESCRIPTION
Summary:
With D9024330, `Extend` fundtion is no more a template, which makes
the `template` keyword here invalid. For some reason current version of LLVM
doesn't catch this, but the latest one does.

Differential Revision: D9133462
