### PR TITLE
Add g.insertConstant and clean up dead attributes code

### DIFF
--- a/caffe2/contrib/script/lexer.h
+++ b/caffe2/contrib/script/lexer.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "caffe2/core/common.h"
-#include "torch/csrc/jit/source_range.h"
 
 namespace caffe2 {
 namespace script {

--- a/caffe2/contrib/script/lexer.h
+++ b/caffe2/contrib/script/lexer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "caffe2/core/common.h"
+#include "torch/csrc/jit/source_range.h"
 
 namespace caffe2 {
 namespace script {

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -8,7 +8,7 @@ namespace torch { namespace jit {
 Value* insertConstant(
     Graph& g,
     IValue val,
-    at::optional<script::SourceRange> loc) {
+    at::optional<SourceRange> loc) {
   Node * n = g.create(prim::Constant);
   if(val.isTensor()) {
     at::Tensor ref = std::move(val).toTensor();
@@ -36,7 +36,7 @@ Value* insertConstant(
     throw std::runtime_error("Unsupported value kind: " + val.tagKind());
   }
   if(loc)
-    n->setSourceLocation(std::make_shared<script::SourceRange>(*loc));
+    n->setSourceLocation(std::make_shared<SourceRange>(*loc));
   return g.insertNode(n)->output();
 }
 

--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -1,8 +1,6 @@
 #pragma once
-#include "ATen/ATen.h"
 #include "torch/csrc/jit/ivalue.h"
-#include "torch/csrc/jit/ir.h"
-#include "torch/csrc/jit/script/lexer.h"
+#include "torch/csrc/jit/source_range.h"
 #include "torch/csrc/WindowsTorchApiMacro.h"
 
 // helpers for handling constants in the IR
@@ -10,10 +8,16 @@
 // - implement primitive constant ops.
 namespace torch { namespace jit {
 
+struct Graph;
+struct Value;
+
+// note: prefer g.insertConsant(val, loc) which does exactly the same thing
+// this function is only declared/defined here because its implementation is
+// closely related to the implementation of prim::Constant that is also in constants.cpp
 TORCH_API Value* insertConstant(
     Graph& g,
     IValue val,
-    at::optional<script::SourceRange> loc = at::nullopt);
+    at::optional<SourceRange> loc = at::nullopt);
 
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -94,7 +94,7 @@ void desugarTripCounts(Block * b) {
       {
         WithInsertPoint guard(n);
         // int i = 0
-        Value* initial_trip_count = insertConstant(*g, 0);
+        Value* initial_trip_count = g->insertConstant(0);
         // Set up initial iteration number value for loop-carried dependency
         n->removeInput(0);
         // Input 0 is now initial termination condition, insert this after that.
@@ -112,7 +112,7 @@ void desugarTripCounts(Block * b) {
         // increment the trip count at the end of the body. Then, emit the same
         // conjunctive stopping condition as above.
 
-        Value* const_one = insertConstant(*g, 1);
+        Value* const_one = g->insertConstant(1);
 
         Value* inc_trip_count =
             g->insertNode(g->create(

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -628,7 +628,7 @@ Value* Node::namedInput(Symbol name) const {
   if(hasAttribute(name)) {
     // XXX - const cast because this really should not be modifying graph
     // and once we remove attributes it no longer will
-    Value* v = insertConstant(const_cast<Graph&>(*owningGraph()), get(name).value());
+    Value* v = const_cast<Graph&>(*owningGraph()).insertConstant(get(name).value());
     // XXX - insert point can be anywhere since modifying the graph is unexpected,
     // so this is completely unsafe and needs to be gone as soon as possible.
     return v;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -8,6 +8,8 @@
 #include "torch/csrc/jit/interned_strings.h"
 #include "torch/csrc/jit/resource_guard.h"
 #include "torch/csrc/jit/source_location.h"
+#include "torch/csrc/jit/source_range.h"
+#include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/ivalue.h"
 #include "torch/csrc/jit/type.h"
@@ -1051,6 +1053,12 @@ public:
       }
     }
     return r;
+  }
+
+  Value* insertConstant(
+      IValue val,
+      at::optional<SourceRange> loc = at::nullopt) {
+    return jit::insertConstant(*this, std::move(val), loc);
   }
 
   Node * appendNode(Node * n) {

--- a/torch/csrc/jit/named_value.h
+++ b/torch/csrc/jit/named_value.h
@@ -1,17 +1,17 @@
 #pragma once
 #include "ATen/ATen.h"
 #include "torch/csrc/jit/ir.h"
-#include "torch/csrc/jit/script/tree.h"
+#include "torch/csrc/jit/source_range.h"
 
 namespace torch { namespace jit {
 
 struct NamedValue {
-  NamedValue(const script::SourceRange& loc, const std::string& name, Value* value)
+  NamedValue(const SourceRange& loc, const std::string& name, Value* value)
   : loc(loc), name(name), value(value) {}
-  NamedValue(const script::SourceRange& loc, int i, Value* value)
+  NamedValue(const SourceRange& loc, int i, Value* value)
   : loc(loc), name("argument " + std::to_string(i)), value(value) {}
 
-  script::SourceRange loc;
+  SourceRange loc;
   std::string name;
   Value* value;
 };

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -57,7 +57,7 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-    auto new_output = insertConstant(*graph, outputs[i]);
+    auto new_output = graph->insertConstant(outputs[i]);
     n->outputs()[i]->replaceAllUsesWith(new_output);
     // let dce elimination remove n
   }

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -16,7 +16,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
         if(it->output()->type()->isSubtypeOf(NumberType::get())) {
           auto s = *constant_as<at::Scalar>(it->output());
           WithInsertPoint guard(*it);
-          Value* r = insertConstant(*block->owningGraph(), s.toTensor());
+          Value* r = block->owningGraph()->insertConstant(s.toTensor());
           it->output()->replaceAllUsesWith(r);
         }
       } break;

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -145,7 +145,7 @@ Value* intMath(Symbol sym, Value* a, Value* b) {
       ->setType(IntType::get());
 }
 Value* intMath(Symbol sym, Value* a, int64_t b) {
-  return intMath(sym, a, insertConstant(*a->owningGraph(), b));
+  return intMath(sym, a, a->owningGraph()->insertConstant(b));
 }
 
 // Replaces the builtin loop counter with a "mutable" variable outside of the loop.
@@ -153,7 +153,7 @@ void replaceLoopCounter(Node *loop) {
   Graph *graph = loop->owningGraph();
   Block *body = loop->blocks().at(0);
   WithInsertPoint guard(loop);
-  Value* init_counter = insertConstant(*graph, 0);
+  Value* init_counter = graph->insertConstant(0);
 
   loop->insertInput(2, init_counter);
   loop->insertOutput(0);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -130,8 +130,8 @@ void broadcastBinary(Node *node, std::vector<TensorTypePtr>& types, size_t idx1,
     WithInsertPoint point_guard { node };
     Node *expand = graph->create(aten::expand,
                                  {node->inputs().at(input_idx),
-                                  insertConstant(*graph, expected_size),
-                                  insertConstant(*graph, 0)})
+                                  graph->insertConstant(expected_size),
+                                  graph->insertConstant(0)})
                         ->insertBefore(node);
     PropagateShapeOnNode(expand);
     node->replaceInput(input_idx, expand->output());

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -313,24 +313,24 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   auto& g = *m.graph();
   if (is_constant) {
     if (py::isinstance<py::int_>(obj)) {
-      return toSimple(insertConstant(g, py::cast<int64_t>(obj), loc));
+      return toSimple(g.insertConstant(py::cast<int64_t>(obj), loc));
     } else if (py::isinstance<py::float_>(obj)) {
-      return toSimple(insertConstant(g, py::cast<float>(obj), loc));
+      return toSimple(g.insertConstant(py::cast<float>(obj), loc));
     } else if (py::isinstance<py::bool_>(obj)) {
-      return toSimple(insertConstant(g, py::cast<bool>(obj), loc));
+      return toSimple(g.insertConstant(py::cast<bool>(obj), loc));
     } else if (THPDevice_Check(obj.ptr())) {
       auto device = (THPDevice*)obj.ptr();
       std::vector<int64_t> v = {static_cast<int64_t>(device->device.type()),
                                 device->device.index()};
-      return toSimple(insertConstant(g, std::move(v)));
+      return toSimple(g.insertConstant(std::move(v)));
     } else if (THPLayout_Check(obj.ptr())) {
       auto layout = (THPLayout*)obj.ptr();
       const auto v = static_cast<int64_t>(layout->layout);
-      return toSimple(insertConstant(g, v, loc));
+      return toSimple(g.insertConstant(v, loc));
     } else if (THPDtype_Check(obj.ptr())) {
       auto dtype = (THPDtype*)(obj.ptr());
       const auto v = static_cast<int64_t>(dtype->scalar_type);
-      return toSimple(insertConstant(g, v, loc));
+      return toSimple(g.insertConstant(v, loc));
     } else if (py::isinstance<py::tuple>(obj)) {
      return std::make_shared<ConstantPythonTupleValue>(obj);
     }

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <vector>
 #include "torch/csrc/jit/assertions.h"
-#include "torch/csrc/jit/source_location.h"
+#include "torch/csrc/jit/source_range.h"
 
 
 namespace torch {
@@ -353,80 +353,6 @@ struct SharedParserData {
 };
 
 SharedParserData& sharedParserData();
-
-// a range of a shared string 'file_' with functions to help debug by highlight
-// that
-// range.
-struct SourceRange : public SourceLocation {
-  SourceRange(
-      const std::shared_ptr<std::string>& file_,
-      size_t start_,
-      size_t end_)
-      : file_(file_), start_(start_), end_(end_) {}
-  const std::string text() const {
-    return file().substr(start(), end() - start());
-  }
-  size_t size() const {
-    return end() - start();
-  }
-
-  static const size_t CONTEXT = 10;
-  virtual void highlight(std::ostream& out) const override {
-    const std::string& str = file();
-    size_t begin_line = start(); // beginning of line to highlight
-    size_t end_line = start(); // end of line to highlight
-    while (begin_line > 0 && str[begin_line - 1] != '\n')
-      --begin_line;
-    while (end_line < str.size() && str[end_line] != '\n')
-      ++end_line;
-    JIT_ASSERT(begin_line == 0 || str[begin_line - 1] == '\n');
-    JIT_ASSERT(end_line == str.size() || str[end_line] == '\n');
-
-    size_t begin_highlight = begin_line; // beginning of context, CONTEXT lines before the highlight line
-    for(size_t i = 0; begin_highlight > 0; --begin_highlight) {
-      if(str[begin_highlight - 1] == '\n')
-        ++i;
-      if(i >= CONTEXT)
-        break;
-    }
-    JIT_ASSERT(begin_highlight == 0 || str[begin_highlight - 1] == '\n');
-
-    size_t end_highlight = end_line; // end of context, CONTEXT lines after the highlight line
-    for(size_t i = 0; end_highlight < str.size(); ++end_highlight) {
-      if(str[end_highlight] == '\n')
-        ++i;
-      if(i >= CONTEXT)
-        break;
-    }
-    JIT_ASSERT(end_highlight == str.size() || str[end_highlight] == '\n');
-
-    out << str.substr(begin_highlight, end_line - begin_highlight) << "\n";
-    out << std::string(start() - begin_line, ' ');
-    size_t len = std::min(size(), end_line - start());
-    out << std::string(len, '~')
-        << (len < size() ? "...  <--- HERE" : " <--- HERE");
-    out << str.substr(end_line, end_highlight - end_line);
-    if (str.size() > 0 && str.back() != '\n')
-      out << "\n";
-  }
-  const std::string& file() const {
-    return *file_;
-  }
-  const std::shared_ptr<std::string>& file_ptr() const {
-    return file_;
-  }
-  size_t start() const {
-    return start_;
-  }
-  size_t end() const {
-    return end_;
-  }
-
- private:
-  std::shared_ptr<std::string> file_;
-  size_t start_;
-  size_t end_;
-};
 
 struct Token {
   int kind;

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -7,6 +7,7 @@
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/assertions.h"
 #include "torch/csrc/jit/named_value.h"
+#include "torch/csrc/jit/source_range.h"
 
 #include <torch/csrc/api/include/torch/detail/ordered_dict.h>
 
@@ -34,8 +35,6 @@ namespace torch { namespace jit { namespace script {
 //     ...
 // Note: because Method/Module are exposed to python these
 // classes use python method naming conventions
-
-struct SourceRange;
 
 struct Method {
   Method(std::string name, bool optimize,

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -1,0 +1,83 @@
+#pragma once
+#include "torch/csrc/jit/source_location.h"
+
+
+namespace torch {
+namespace jit {
+
+// a range of a shared string 'file_' with functions to help debug by highlight
+// that
+// range.
+struct SourceRange : public SourceLocation {
+  SourceRange(
+      const std::shared_ptr<std::string>& file_,
+      size_t start_,
+      size_t end_)
+      : file_(file_), start_(start_), end_(end_) {}
+  const std::string text() const {
+    return file().substr(start(), end() - start());
+  }
+  size_t size() const {
+    return end() - start();
+  }
+
+  static const size_t CONTEXT = 10;
+  virtual void highlight(std::ostream& out) const override {
+    const std::string& str = file();
+    size_t begin_line = start(); // beginning of line to highlight
+    size_t end_line = start(); // end of line to highlight
+    while (begin_line > 0 && str[begin_line - 1] != '\n')
+      --begin_line;
+    while (end_line < str.size() && str[end_line] != '\n')
+      ++end_line;
+    JIT_ASSERT(begin_line == 0 || str[begin_line - 1] == '\n');
+    JIT_ASSERT(end_line == str.size() || str[end_line] == '\n');
+
+    size_t begin_highlight = begin_line; // beginning of context, CONTEXT lines before the highlight line
+    for(size_t i = 0; begin_highlight > 0; --begin_highlight) {
+      if(str[begin_highlight - 1] == '\n')
+        ++i;
+      if(i >= CONTEXT)
+        break;
+    }
+    JIT_ASSERT(begin_highlight == 0 || str[begin_highlight - 1] == '\n');
+
+    size_t end_highlight = end_line; // end of context, CONTEXT lines after the highlight line
+    for(size_t i = 0; end_highlight < str.size(); ++end_highlight) {
+      if(str[end_highlight] == '\n')
+        ++i;
+      if(i >= CONTEXT)
+        break;
+    }
+    JIT_ASSERT(end_highlight == str.size() || str[end_highlight] == '\n');
+
+    out << str.substr(begin_highlight, end_line - begin_highlight) << "\n";
+    out << std::string(start() - begin_line, ' ');
+    size_t len = std::min(size(), end_line - start());
+    out << std::string(len, '~')
+        << (len < size() ? "...  <--- HERE" : " <--- HERE");
+    out << str.substr(end_line, end_highlight - end_line);
+    if (str.size() > 0 && str.back() != '\n')
+      out << "\n";
+  }
+  const std::string& file() const {
+    return *file_;
+  }
+  const std::shared_ptr<std::string>& file_ptr() const {
+    return file_;
+  }
+  size_t start() const {
+    return start_;
+  }
+  size_t end() const {
+    return end_;
+  }
+
+ private:
+  std::shared_ptr<std::string> file_;
+  size_t start_;
+  size_t end_;
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -176,7 +176,7 @@ struct SymbolicVariable {
   }
 private:
   Value * insertConstant(IValue value) const {
-    return jit::insertConstant(*v->owningGraph(), value);
+    return v->owningGraph()->insertConstant(value);
   }
   SymbolicVariable typeLike(SymbolicVariable other) {
     if (auto other_type = other.v->type()->cast<TensorType>())

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -21,7 +21,7 @@ namespace detail {
 
 template<typename T>
 void genericAddInput(Node *n, T value) {
-  n->addInput(insertConstant(*n->owningGraph(), value));
+  n->addInput(n->owningGraph()->insertConstant(value));
 }
 
 void badArgType() {
@@ -52,7 +52,7 @@ void addInputs(Node *n, const char * name, at::IntList value) {
   auto& g = getTracingState()->graph;
   for (size_t i = 0; i < info.size(); ++i) {
     if (info[i] != nullptr) continue;
-    info[i] = insertConstant(*g, value[i]);
+    info[i] = g->insertConstant(value[i]);
   }
   for (jit::Value* v : info) {
     if (*v->type() != *jit::IntType::get()) {
@@ -100,7 +100,7 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   auto size_var = autograd::make_variable(at::Scalar(var.size(dim)).toTensor());
   auto* value = getValueTrace(var);
   WithInsertPoint ipoint { graph->block() };
-  auto* node = graph->insertNode(graph->create(aten::size, {value, insertConstant(*graph, dim)}));
+  auto* node = graph->insertNode(graph->create(aten::size, {value, graph->insertConstant(dim)}));
   node->output()->setType(jit::IntType::get());
 
   auto ten =

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -121,7 +121,7 @@ inline Value* getValueTrace(const Variable& var) {
   auto & value_map = getTracingState()->value_map;
   auto it = value_map.find(var);
   if (it == value_map.end()) {
-    Value *constant = insertConstant(*state->graph, var.data());
+    Value *constant = state->graph->insertConstant(var.data());
     constant->inferTypeFrom(var.data());
     it = value_map.emplace_hint(it, var, constant);
   }


### PR DESCRIPTION
* Changes `insertConstant(g, val)` to `g.insertConstant(val)`.
* Moves SourceRange to its own file to enable it.
* Cleans up dead attribute code in schema matching and graph.