### PR TITLE
Add documentation for margin arg in Caffe2 MarginRankingCriterionOp

### DIFF
--- a/caffe2/operators/margin_ranking_criterion_op.cc
+++ b/caffe2/operators/margin_ranking_criterion_op.cc
@@ -82,6 +82,7 @@ If y == 1 then it assumed the first input should be ranked higher
 (have a larger value) than the second input, and vice-versa for
 y == -1.
 )DOC")
+    .Arg("margin", "The margin value as a float. Default is 1.0.")
     .Input(0, "X1", "The left input vector as a 1-dim TensorCPU.")
     .Input(1, "X2", "The right input vector as a 1-dim TensorCPU.")
     .Input(2, "Y", "The label as a 1-dim TensorCPU with int value of 1 or -1.")


### PR DESCRIPTION
Summary: The MarginRankingCriterionOp margin argument was undocumented.

Differential Revision: D9141228
