### PR TITLE
Schema-based creation of graph nodes

### DIFF
--- a/test/expect/TestScript.test_call_python_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_script_fn.expect
@@ -1,7 +1,7 @@
 graph(%x : Dynamic) {
   %1 : Dynamic = ^python_fn()(%x)
   %2 : int = prim::Constant[value=1]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%1, %2, %4)
-  return (%5);
+  %3 : int = prim::Constant[value=1]()
+  %4 : Dynamic = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 3)) {
   %2 : Double(3, 4) = aten::neg(%0), scope: TracedModule
-  %4 : Double(3, 3) = aten::mm(%2, %1), scope: TracedModule
-  return (%4);
+  %3 : Double(3, 3) = aten::mm(%2, %1), scope: TracedModule
+  return (%3);
 }

--- a/test/expect/TestScript.test_call_python_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_script_fn.expect
@@ -1,7 +1,7 @@
 graph(%x : Dynamic) {
   %1 : Dynamic = ^<python_value>()(%x)
   %2 : int = prim::Constant[value=1]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%1, %2, %4)
-  return (%5);
+  %3 : int = prim::Constant[value=1]()
+  %4 : Dynamic = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
@@ -1,10 +1,10 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 5)
       %2 : Double(5, 7)) {
-  %4 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %6 : Double(3, 7) = aten::mm(%4, %2), scope: TracedModule/PythonModule[mod]
-  %7 : Long() = prim::Constant[value={1}](), scope: TracedModule
-  %8 : int = prim::Constant[value=1](), scope: TracedModule
-  %9 : Double(3, 7) = aten::add(%6, %7, %8), scope: TracedModule
-  return (%9);
+  %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
+  %4 : Double(3, 7) = aten::mm(%3, %2), scope: TracedModule/PythonModule[mod]
+  %5 : Long() = prim::Constant[value={1}](), scope: TracedModule
+  %6 : int = prim::Constant[value=1](), scope: TracedModule
+  %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
+  return (%7);
 }

--- a/test/expect/TestScript.test_call_python_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_tracing_fn.expect
@@ -1,8 +1,8 @@
 graph(%0 : Double(3, 4)) {
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: PythonMod
-  %3 : Double(3, 3) = aten::mm(%0, %1), scope: PythonMod
-  %4 : Long() = prim::Constant[value={1}]()
-  %5 : int = prim::Constant[value=1]()
-  %6 : Double(3, 3) = aten::add(%3, %4, %5)
-  return (%6);
+  %2 : Double(3, 3) = aten::mm(%0, %1), scope: PythonMod
+  %3 : Long() = prim::Constant[value={1}]()
+  %4 : int = prim::Constant[value=1]()
+  %5 : Double(3, 3) = aten::add(%2, %3, %4)
+  return (%5);
 }

--- a/test/expect/TestScript.test_call_script_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_script_fn.expect
@@ -1,7 +1,7 @@
 graph(%x : Dynamic) {
   %1 : Dynamic = aten::neg(%x)
   %2 : int = prim::Constant[value=1]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%1, %2, %4)
-  return (%5);
+  %3 : int = prim::Constant[value=1]()
+  %4 : Dynamic = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 5)) {
-  %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %5 : Double(3, 5) = aten::neg(%3), scope: TracedModule/ScriptModule
-  return (%5);
+  %2 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
+  %3 : Double(3, 5) = aten::neg(%2), scope: TracedModule/ScriptModule
+  return (%3);
 }

--- a/test/expect/TestScript.test_call_script_fn_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_tracing_fn.expect
@@ -1,7 +1,7 @@
 graph(%0 : Double(3, 4)) {
-  %2 : Double(3, 4) = aten::neg(%0), scope: ScriptModule
-  %3 : Long() = prim::Constant[value={1}]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Double(3, 4) = aten::add(%2, %3, %4)
-  return (%5);
+  %1 : Double(3, 4) = aten::neg(%0), scope: ScriptModule
+  %2 : Long() = prim::Constant[value={1}]()
+  %3 : int = prim::Constant[value=1]()
+  %4 : Double(3, 4) = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
@@ -8,7 +8,7 @@ graph(%x : Dynamic) {
   %7 : Dynamic = aten::zeros(%3, %4, %5, %6)
   %8 : Dynamic = aten::mm(%x, %7)
   %9 : int = prim::Constant[value=1]()
-  %11 : int = prim::Constant[value=1]()
-  %12 : Dynamic = aten::add(%8, %9, %11)
-  return (%12);
+  %10 : int = prim::Constant[value=1]()
+  %11 : Dynamic = aten::add(%8, %9, %10)
+  return (%11);
 }

--- a/test/expect/TestScript.test_call_script_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_tracing_fn.expect
@@ -1,8 +1,8 @@
 graph(%0 : Double(3, 4)) {
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: ScriptMod
-  %4 : Double(3, 3) = aten::mm(%0, %1), scope: ScriptMod
-  %5 : Long() = prim::Constant[value={1}]()
-  %6 : int = prim::Constant[value=1]()
-  %7 : Double(3, 3) = aten::add(%4, %5, %6)
-  return (%7);
+  %2 : Double(3, 3) = aten::mm(%0, %1), scope: ScriptMod
+  %3 : Long() = prim::Constant[value={1}]()
+  %4 : int = prim::Constant[value=1]()
+  %5 : Double(3, 3) = aten::add(%2, %3, %4)
+  return (%5);
 }

--- a/test/expect/TestScript.test_call_script_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_module_from_traced_module.expect
@@ -1,10 +1,10 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 5)
       %2 : Double(5, 7)) {
-  %4 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %7 : Double(3, 7) = aten::mm(%4, %2), scope: TracedModule/ScriptMod[mod]
-  %8 : Long() = prim::Constant[value={1}](), scope: TracedModule
-  %9 : int = prim::Constant[value=1](), scope: TracedModule
-  %10 : Double(3, 7) = aten::add(%7, %8, %9), scope: TracedModule
-  return (%10);
+  %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
+  %4 : Double(3, 7) = aten::mm(%3, %2), scope: TracedModule/ScriptMod[mod]
+  %5 : Long() = prim::Constant[value={1}](), scope: TracedModule
+  %6 : int = prim::Constant[value=1](), scope: TracedModule
+  %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
+  return (%7);
 }

--- a/test/expect/TestScript.test_call_traced_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_script_fn.expect
@@ -1,7 +1,7 @@
 graph(%x : Dynamic) {
   %1 : Double(3, 4) = aten::neg(%x)
   %2 : int = prim::Constant[value=1]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%1, %2, %4)
-  return (%5);
+  %3 : int = prim::Constant[value=1]()
+  %4 : Dynamic = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 5)) {
-  %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %5 : Double(3, 4) = aten::neg(%3), scope: TracedModule/traced_fn
-  return (%5);
+  %2 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
+  %3 : Double(3, 4) = aten::neg(%2), scope: TracedModule/traced_fn
+  return (%3);
 }

--- a/test/expect/TestScript.test_call_traced_fn_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_tracing_fn.expect
@@ -1,7 +1,7 @@
 graph(%0 : Double(3, 4)) {
-  %2 : Double(3, 4) = aten::neg(%0), scope: traced_fn1
-  %3 : Long() = prim::Constant[value={1}]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Double(3, 4) = aten::add(%2, %3, %4)
-  return (%5);
+  %1 : Double(3, 4) = aten::neg(%0), scope: traced_fn1
+  %2 : Long() = prim::Constant[value={1}]()
+  %3 : int = prim::Constant[value=1]()
+  %4 : Double(3, 4) = aten::add(%1, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -2,7 +2,7 @@ graph(%x : Dynamic) {
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>]()
   %2 : Double(3, 3) = aten::mm(%x, %1)
   %3 : int = prim::Constant[value=1]()
-  %5 : int = prim::Constant[value=1]()
-  %6 : Dynamic = aten::add(%2, %3, %5)
-  return (%6);
+  %4 : int = prim::Constant[value=1]()
+  %5 : Dynamic = aten::add(%2, %3, %4)
+  return (%5);
 }

--- a/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
@@ -1,8 +1,8 @@
 graph(%0 : Double(3, 4)) {
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: TracedModule[TracedModule]
-  %4 : Double(3, 3) = aten::mm(%0, %1), scope: TracedModule[TracedModule]
-  %5 : Long() = prim::Constant[value={1}]()
-  %6 : int = prim::Constant[value=1]()
-  %7 : Double(3, 3) = aten::add(%4, %5, %6)
-  return (%7);
+  %2 : Double(3, 3) = aten::mm(%0, %1), scope: TracedModule[TracedModule]
+  %3 : Long() = prim::Constant[value={1}]()
+  %4 : int = prim::Constant[value=1]()
+  %5 : Double(3, 3) = aten::add(%2, %3, %4)
+  return (%5);
 }

--- a/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
@@ -1,10 +1,10 @@
 graph(%0 : Double(3, 4)
       %1 : Double(4, 5)
       %2 : Double(5, 7)) {
-  %4 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %7 : Double(3, 7) = aten::mm(%4, %2), scope: TracedModule/TracedModule[TracedModule1][mod]
-  %8 : Long() = prim::Constant[value={1}](), scope: TracedModule
-  %9 : int = prim::Constant[value=1](), scope: TracedModule
-  %10 : Double(3, 7) = aten::add(%7, %8, %9), scope: TracedModule
-  return (%10);
+  %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
+  %4 : Double(3, 7) = aten::mm(%3, %2), scope: TracedModule/TracedModule[TracedModule1][mod]
+  %5 : Long() = prim::Constant[value={1}](), scope: TracedModule
+  %6 : int = prim::Constant[value=1](), scope: TracedModule
+  %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
+  return (%7);
 }

--- a/test/expect/TestScript.test_loop_unrolling.expect
+++ b/test/expect/TestScript.test_loop_unrolling.expect
@@ -9,7 +9,7 @@ graph(%x : Dynamic) {
   %8 : int = aten::mul(%6, %7)
   %9 : int = aten::sub(%2, %8)
   %10 : Dynamic, %y.3 : Dynamic = prim::Loop(%6, %3, %4, %y.1)
-    block0(%i.1 : int, %13 : Dynamic, %14 : Dynamic) {
+    block0(%i.1 : int, %13 : int, %14 : Dynamic) {
       %15 : int = prim::Constant[value=1]()
       %y.12 : Dynamic = aten::add(%14, %13, %15)
       %17 : int = prim::Constant[value=1]()
@@ -46,7 +46,7 @@ graph(%x : Dynamic) {
       -> (%45, %47, %y.11)
     }
   %48 : Dynamic, %y : Dynamic = prim::Loop(%9, %3, %10, %y.3)
-    block0(%i : int, %51 : Dynamic, %52 : Dynamic) {
+    block0(%i : int, %51 : int, %52 : Dynamic) {
       %53 : int = prim::Constant[value=1]()
       %y.4 : Dynamic = aten::add(%52, %51, %53)
       %55 : int = prim::Constant[value=1]()

--- a/test/expect/TestScript.test_loop_unrolling_nested.expect
+++ b/test/expect/TestScript.test_loop_unrolling_nested.expect
@@ -13,7 +13,7 @@ graph(%x : Dynamic) {
       %13 : int = aten::mul(%11, %12)
       %14 : int = aten::sub(%7, %13)
       %15 : Dynamic, %y.4 : Dynamic = prim::Loop(%11, %8, %9, %6)
-        block0(%j.1 : int, %18 : Dynamic, %19 : Dynamic) {
+        block0(%j.1 : int, %18 : int, %19 : Dynamic) {
           %20 : int = prim::Constant[value=1]()
           %y.13 : Dynamic = aten::add(%19, %18, %20)
           %22 : int = prim::Constant[value=1]()
@@ -50,7 +50,7 @@ graph(%x : Dynamic) {
           -> (%50, %52, %y.12)
         }
       %53 : Dynamic, %y.3 : Dynamic = prim::Loop(%14, %8, %15, %y.4)
-        block0(%j : int, %56 : Dynamic, %57 : Dynamic) {
+        block0(%j : int, %56 : int, %57 : Dynamic) {
           %58 : int = prim::Constant[value=1]()
           %y.5 : Dynamic = aten::add(%57, %56, %58)
           %60 : int = prim::Constant[value=1]()

--- a/test/expect/TestScript.test_sum-2.expect
+++ b/test/expect/TestScript.test_sum-2.expect
@@ -1,7 +1,7 @@
 graph(%x : Double(1, 1, 1, 1, 4)) {
   %1 : int = prim::Constant[value=4]()
-  %2 : int = prim::Constant[value=0]()
-  %3 : int[] = prim::ListConstruct(%1)
-  %4 : Dynamic = aten::sum(%x, %3, %2)
+  %2 : int[] = prim::ListConstruct(%1)
+  %3 : int = prim::Constant[value=0]()
+  %4 : Dynamic = aten::sum(%x, %2, %3)
   return (%4);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4746,7 +4746,7 @@ def func(t):
 
         # The neg op in the python function should be properly inlined to the
         # graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_python_mod_from_tracing_fn(self):
         class PythonMod(torch.nn.Module):
@@ -4765,7 +4765,7 @@ def func(t):
 
         # Note: the parameter self.param from the Python module is inlined
         # into the graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_traced_fn_from_tracing_fn(self):
         @torch.jit.trace(torch.rand(3, 4))
@@ -4776,7 +4776,7 @@ def func(t):
         def traced_fn(x):
             return traced_fn1(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_traced_mod_from_tracing_fn(self):
         class TracedModule(torch.nn.Module):
@@ -4795,7 +4795,7 @@ def func(t):
 
         # Note: the parameter self.param from the Python module is inlined
         # into the graph
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_script_fn_from_tracing_fn(self):
         @torch.jit.script
@@ -4806,7 +4806,7 @@ def func(t):
         def traced_fn(x):
             return script_fn(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_script_mod_from_tracing_fn(self):
         class ScriptMod(torch.jit.ScriptModule):
@@ -4824,7 +4824,7 @@ def func(t):
         def traced_fn(x):
             return sm(x) + 1
 
-        self.assertExpected(str(traced_fn.graph))
+        self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_python_fn_from_traced_module(self):
         def python_fn(x):
@@ -4843,7 +4843,7 @@ def func(t):
         # Note: parameter self.param from the traced module should appear as
         # an input to the graph and the neg op from the Python function should
         # be properly inlined
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_python_mod_from_traced_module(self):
         class PythonModule(torch.nn.Module):
@@ -4867,7 +4867,7 @@ def func(t):
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_traced_fn_from_traced_module(self):
         @torch.jit.trace(torch.rand(3, 4))
@@ -4884,7 +4884,7 @@ def func(t):
 
         tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
         # Note: neg op from the traced function should be properly inlined
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):
@@ -4908,7 +4908,7 @@ def func(t):
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_script_fn_from_traced_module(self):
         @torch.jit.script
@@ -4925,7 +4925,7 @@ def func(t):
 
         tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
         # Note: neg op from the script function should be properly inlined
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_script_module_from_traced_module(self):
         class ScriptMod(torch.jit.ScriptModule):
@@ -4950,7 +4950,7 @@ def func(t):
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
-        self.assertExpected(str(tm.graph))
+        self.assertExpected(canonical(tm.graph))
 
     def test_call_python_fn_from_script_fn(self):
         def python_fn(x):
@@ -4962,7 +4962,7 @@ def func(t):
 
         # Note: the call to python_fn appears as `^python_fn()` and is called
         # as a PythonOp in the interpreter
-        self.assertExpected(str(script_fn.graph))
+        self.assertExpected(canonical(script_fn.graph))
 
     def test_call_python_mod_from_script_fn(self):
         class PythonModule(torch.nn.Module):

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -5,6 +5,7 @@
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/script/compiler.h"
 
 #include <iostream>
 #include <unordered_map>
@@ -617,6 +618,15 @@ void Node::dump() const {
 
 void Node::findSchema() const {
   schema_ = &getOperatorFor(this).schema();
+}
+
+inline const SourceRange& fakeRange() {
+  static SourceRange range(std::make_shared<std::string>("<internally-created-node>"), 0, 1);
+  return range;
+}
+
+Value* Graph::insert(Symbol opname, at::ArrayRef<NamedValue> args, at::ArrayRef<NamedValue> kwargs) {
+  return script::emitBuiltinCall(fakeRange(), *this, opname, args, kwargs, /*required=*/true);
 }
 
 PythonOp* defaultAllocPythonOp(Graph*g) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -13,6 +13,7 @@
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/ivalue.h"
 #include "torch/csrc/jit/type.h"
+#include "torch/csrc/jit/named_value.h"
 
 #include "torch/csrc/utils/disallow_copy.h"
 #include "torch/csrc/utils/functional.h"
@@ -1072,6 +1073,13 @@ public:
       at::optional<SourceRange> loc = at::nullopt) {
     return jit::insertConstant(*this, std::move(val), loc);
   }
+
+  // schema-driven insert
+  // this inserts a node into the graph with inputs determined from args and kwargs using Python
+  // argument matching rules, and checks that the op matches a known schema
+  // if this node successfully completes, it guarentees the node is a correctly-formed invocation
+  // of opname
+  Value* insert(Symbol opname, at::ArrayRef<NamedValue> args, at::ArrayRef<NamedValue> kwargs = {});
 
   Node * appendNode(Node * n) {
     return block_->appendNode(n);

--- a/torch/csrc/jit/named_value.h
+++ b/torch/csrc/jit/named_value.h
@@ -2,31 +2,59 @@
 #include "ATen/ATen.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/source_range.h"
+#include "torch/csrc/utils/variadic.h"
 
 namespace torch { namespace jit {
 
 struct NamedValue {
   NamedValue(const SourceRange& loc, const std::string& name, Value* value)
   : loc_(loc), name_(name), value_(value) {}
-  NamedValue(const SourceRange& loc, int i, Value* value)
-  : loc_(loc), name_("argument " + std::to_string(i)), value_(value) {}
+  NamedValue(const SourceRange& loc, Value* value)
+  : loc_(loc), value_(value) {}
 
-  const SourceRange& loc() const {
-    return loc_;
+  /* implicit */ NamedValue(Value* value)
+  : value_(value) {}
+
+  /* implicit */ NamedValue(IValue value)
+  : value_(nullptr), ivalue_(std::move(value)) {}
+
+  template <
+      typename T,
+      typename = enable_if_t<
+          (!std::is_same<decay_t<T>, NamedValue>::value &&
+           !std::is_same<decay_t<T>, Value*>::value && !std::is_same<decay_t<T>, IValue>::value)>>
+  NamedValue(T&& t) : NamedValue(IValue(std::forward<T>(t))) {}
+
+  SourceRange locOr(const SourceRange& backup_location) const {
+    if(!loc_)
+      return backup_location;
+    return loc();
   }
 
-  Value* value() const {
+  // note: this will insert a constant node into the graph at the current
+  // insert point if this NamedValue is actually a constant
+  Value* value(Graph& g) const {
+    if(!value_)
+      return g.insertConstant(ivalue_);
     return value_;
   }
 
   const std::string& name() const {
-    return name_;
+    JIT_ASSERT(name_);
+    return *name_;
+  }
+
+  const SourceRange& loc() const {
+    AT_ASSERT(loc_);
+    return *loc_;
   }
 
 private:
-  SourceRange loc_;
-  std::string name_;
+  at::optional<SourceRange> loc_;
+  at::optional<std::string> name_;
   Value* value_;
+  // only valid if value_ == nullptr;
+  IValue ivalue_;
 };
 
 }}

--- a/torch/csrc/jit/named_value.h
+++ b/torch/csrc/jit/named_value.h
@@ -7,13 +7,26 @@ namespace torch { namespace jit {
 
 struct NamedValue {
   NamedValue(const SourceRange& loc, const std::string& name, Value* value)
-  : loc(loc), name(name), value(value) {}
+  : loc_(loc), name_(name), value_(value) {}
   NamedValue(const SourceRange& loc, int i, Value* value)
-  : loc(loc), name("argument " + std::to_string(i)), value(value) {}
+  : loc_(loc), name_("argument " + std::to_string(i)), value_(value) {}
 
-  SourceRange loc;
-  std::string name;
-  Value* value;
+  const SourceRange& loc() const {
+    return loc_;
+  }
+
+  Value* value() const {
+    return value_;
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+private:
+  SourceRange loc_;
+  std::string name_;
+  Value* value_;
 };
 
 }}

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -134,20 +134,6 @@ void repeatBody(Block *body, int64_t times) {
   EliminateDeadCode(body, false);
 }
 
-//TODO(zach): we need to replace these with a generic facility for resolving overloads
-// currently we cant us SymbolicVariable because it assumes we are computing on tensors
-// once we have something like emitBuiltinCall usable outside of the compiler,
-// we can replace these with symbolic variable
-Value* intMath(Symbol sym, Value* a, Value* b) {
-  auto& g = *a->owningGraph();
-  return g.insertNode(g.create(sym, {a, b}))
-      ->output()
-      ->setType(IntType::get());
-}
-Value* intMath(Symbol sym, Value* a, int64_t b) {
-  return intMath(sym, a, a->owningGraph()->insertConstant(b));
-}
-
 // Replaces the builtin loop counter with a "mutable" variable outside of the loop.
 void replaceLoopCounter(Node *loop) {
   Graph *graph = loop->owningGraph();
@@ -158,11 +144,13 @@ void replaceLoopCounter(Node *loop) {
   loop->insertInput(2, init_counter);
   loop->insertOutput(0);
 
-  Value * internal_counter = body->insertInput(1);
+  Value * internal_counter = body->insertInput(1)->setType(init_counter->type());
   body->inputs()[0]->replaceAllUsesWith(internal_counter);
 
   WithInsertPoint insertPointGuard{ body->return_node() };
-  body->insertOutput(1, intMath(aten::add, internal_counter, 1) );
+  Value* result = graph->insert(aten::add, {internal_counter, 1});
+  std::cout << *result->node() << "\n";
+  body->insertOutput(1, result);
 }
 
 void unroll(Node *loop) {
@@ -201,9 +189,9 @@ void unroll(Node *loop) {
 
   // Change the iteration counts of both loops
   Value* iter_count = loop->inputs().at(0);
-  Value* unrolled_iter_count = intMath(aten::div, iter_count, kUnrollFactor);
+  Value* unrolled_iter_count = graph->insert(aten::div, {iter_count, kUnrollFactor});
   loop->replaceInput(0, unrolled_iter_count);
-  loop_epilogue->replaceInput(0, intMath(aten::sub, iter_count, intMath(aten::mul, unrolled_iter_count , kUnrollFactor)));
+  loop_epilogue->replaceInput(0, graph->insert(aten::sub, {iter_count, graph->insert(aten::mul,{unrolled_iter_count , kUnrollFactor})}));
 }
 
 void UnrollLoops(Block *block) {

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -149,7 +149,6 @@ void replaceLoopCounter(Node *loop) {
 
   WithInsertPoint insertPointGuard{ body->return_node() };
   Value* result = graph->insert(aten::add, {internal_counter, 1});
-  std::cout << *result->node() << "\n";
   body->insertOutput(1, result);
 }
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -420,13 +420,13 @@ at::optional<std::vector<Value*>> tryMatchSchema(
     }
     // fill in named arguments
     for(const NamedValue& nv : attributes) {
-      auto idx = schema.argumentIndexWithName(nv.name);
+      auto idx = schema.argumentIndexWithName(nv.name());
       if(!idx) {
-        err() << "unknown keyword argument '" << nv.name << "'\n" << nv.loc;
+        err() << "unknown keyword argument '" << nv.name() << "'\n" << nv.loc();
         return at::nullopt;
       }
       if(positional_inputs[*idx]) {
-        err() << "argument " <<  nv.name << " specified twice \n" << nv.loc;
+        err() << "argument " <<  nv.name() << " specified twice \n" << nv.loc();
         return at::nullopt;
       }
       positional_inputs[*idx] = nv;
@@ -448,7 +448,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
     // check input types
     std::vector<Value*> matched_inputs;
     for(size_t i = 0; i < schema.arguments.size(); ++i) {
-      Value* value = positional_inputs[i]->value;
+      Value* value = positional_inputs[i]->value();
       const auto& arg = schema.arguments[i];
 
       // some functions that take lists of integers for fixed size arrays
@@ -478,7 +478,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       if(!value->type()->isSubtypeOf(arg.type)) {
         err() << "expected a value of type " << arg.type->str() << " for argument '" << arg.name << "' but found "
               << value->type()->str() << "\n"
-              << positional_inputs[i]->loc;
+              << positional_inputs[i]->loc();
         return at::nullopt;
       }
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -30,7 +30,7 @@ struct TypedDef {
 
 static inline std::vector<Value*> toValues(at::ArrayRef<NamedValue> nvs) {
   return fmap(nvs, [](const NamedValue& v) {
-    return v.value;
+    return v.value();
   });
 }
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -28,9 +28,9 @@ struct TypedDef {
   at::optional<FunctionSchema> schema;
 };
 
-static inline std::vector<Value*> toValues(at::ArrayRef<NamedValue> nvs) {
-  return fmap(nvs, [](const NamedValue& v) {
-    return v.value();
+static inline std::vector<Value*> toValues(Graph& g, at::ArrayRef<NamedValue> nvs) {
+  return fmap(nvs, [&](const NamedValue& v) {
+    return v.value(g);
   });
 }
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -146,7 +146,7 @@ TORCH_API std::shared_ptr<Graph> compileFunction(TypedDef def, const Resolver& r
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.
-TORCH_API std::shared_ptr<SugaredValue> packOutputs(Graph& g, at::ArrayRef<Value*> values);
+TORCH_API Value* packOutputs(Graph& g, at::ArrayRef<Value*> values);
 TORCH_API std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
 TORCH_API void ensureSizeMatches(SourceRange loc, size_t expected, size_t actual, const std::string& what);
 TORCH_API void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values);
@@ -162,6 +162,16 @@ TORCH_API at::optional<std::vector<Value*>> tryMatchSchema(
   at::ArrayRef<NamedValue> attributes,
   std::ostream& failure_messages);
 
+
+TORCH_API Value* emitBuiltinCall(
+  const SourceRange& loc,
+  Graph& graph,
+  Symbol name,
+  at::ArrayRef<NamedValue> inputs,
+  at::ArrayRef<NamedValue> attributes,
+  // if true, emitBuiltinCall will throw an exception if this builtin does not exist,
+  // otherwise it will return nullptr if the builtin is not found.
+  bool required);
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -140,7 +140,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     std::vector<Value*> outputs;
     for(size_t i = 0; i < schema.returns.size(); ++i)
       outputs.push_back(new_node->addOutput());
-    return packOutputs(*m.graph(), outputs);
+    return std::make_shared<SimpleValue>(packOutputs(*m.graph(), outputs));
   }
 
   virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override;
@@ -233,7 +233,7 @@ struct MethodValue : public SugaredValue {
     return "method";
   }
   virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<NamedValue> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
-    return packOutputs(*caller.graph(), caller.emit_call_to(loc, method, inputs, attributes));
+    return std::make_shared<SimpleValue>(packOutputs(*caller.graph(), caller.emit_call_to(loc, method, inputs, attributes)));
   }
 private:
   std::shared_ptr<Module> module;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -108,7 +108,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
 
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<NamedValue> inputs_, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
-    auto inputs = toValues(inputs_);
+    auto inputs = toValues(*m.graph(), inputs_);
     auto schema = getSchema(inputs.size(), n_binders);
 
     std::stringstream failure_messages;


### PR DESCRIPTION
This commit adds the ability to insert a node with inputs, using the schema to check the inputs are valid types, fill in any default values, and perform standard implicit conversions. Since it is schema based, it will discover and use the right overload. 
Constructors to `NamedValue` enable it to be constructed using `IValue` constants so it is possible to use constant values in the input list as well:

```
g.insert(aten::add, {v, 3});
```
 
Keyword arguments are also supported:

```
g.insert(aten::add, {v}, {{"other", t}, {"scalar", 1}});
```
