### PR TITLE
fix a grammatical error: accelerate compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ If you use NumPy, then you have used Tensors (a.k.a ndarray).
 
 ![Tensor illustration](https://github.com/pytorch/pytorch/blob/master/docs/source/_static/img/tensor_illustration.png)
 
-PyTorch provides Tensors that can live either on the CPU or the GPU, and accelerate
-compute by a huge amount.
+PyTorch provides Tensors that can live either on the CPU or the GPU, and accelerates the
+computation by a huge amount.
 
 We provide a wide variety of tensor routines to accelerate and fit your scientific computation needs
 such as slicing, indexing, math operations, linear algebra, reductions.


### PR DESCRIPTION
"accelerate compute"
a verb shouldn't go with another verb.