### PR TITLE
Use IntLists rather than THLongStorage for sizes/strides for a number of functions in TH.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -43,23 +43,23 @@
       scalar_check: False
       arguments:
         - THTensor* self
-        - CONSTANT NULL, 0, THLongStorageView({0}, THLongStorageViewKind::SIZE), NULL
+        - CONSTANT NULL, 0, {0}, {}
     - cname: setStorage
       scalar_check: False
       arguments:
         - THTensor* self
         - THStorage* source
         - CONSTANT 0
-        - CONSTANT __storage_size.get()
-        - CONSTANT NULL
+        - CONSTANT {static_cast<int64_t>(source.pImpl()->size())}
+        - CONSTANT {}
     - cname: setStorage
       arguments:
         - THTensor* self
         - THStorage* source
         - long storage_offset
-        - THSize* size
-        - arg: THStride* stride
-          default: NULL
+        - IntListSize size
+        - arg: IntListStride stride
+          default: {}
 ]]
 [[
   name: _fill_
@@ -171,7 +171,7 @@
   return: THTensor*
   arguments:
     - THTensor* self
-    - arg: THSize* size
+    - arg: IntListSize size
       long_args: True
 ]]
 [[
@@ -3410,9 +3410,9 @@
       arguments:
         - THStorage* storage
         - int64_t storageOffset
-        - THSize* size
-        - arg: THStride* stride
-          default: NULL
+        - IntListSize size
+        - arg: IntListStride stride
+          default: {}
 ]]
 
 # In theory, this could be a part of the above declaration. But in

--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ATen/optional.h>
+#include <ATen/ScalarType.h>
+#include <sstream>
+#include <vector>
+
+namespace at {
+
+// Infers the size of a dim with size -1, if it exists. Also checks that new
+// shape is compatible with the number of elements.
+static std::vector<int64_t> infer_size(IntList shape, int64_t numel) {
+  auto res = shape.vec();
+  int64_t newsize = 1;
+  auto infer_dim = at::optional<int64_t>();
+  for (int64_t dim = 0, ndim = shape.size(); dim != ndim; dim++) {
+    if (shape[dim] == -1) {
+      if (infer_dim) {
+        throw std::runtime_error("only one dimension can be inferred");
+      }
+      infer_dim = dim;
+    } else if (shape[dim] >= 0) {
+      newsize *= shape[dim];
+    } else {
+      AT_ERROR("invalid shape dimension ", shape[dim]);
+    }
+  }
+
+  if (numel == newsize || (infer_dim && newsize > 0 && numel % newsize == 0)) {
+    if (infer_dim) {
+      // we have a degree of freedom here to select the dimension size; follow NumPy semantics
+      // and just bail.
+      AT_CHECK(newsize != 0, "cannot reshape tensor of 0 elements into shape ", shape);
+      res[*infer_dim] = numel / newsize;
+    }
+    return res;
+  }
+
+  std::ostringstream ss;
+  ss << "shape '" << shape << "' is invalid for input of size " << numel;
+  throw std::runtime_error(ss.str());
+}
+
+}

--- a/aten/src/ATen/THSizeStrideCompat.h
+++ b/aten/src/ATen/THSizeStrideCompat.h
@@ -10,12 +10,13 @@
 
 namespace at {
 
-static inline std::vector<int64_t> get_intlist_size_th(IntList sizes) {
+static inline at::IntList get_intlist_size_th(IntList sizes) {
+  static int64_t one = 1;
   if (sizes.size() == 0) {
     // fake scalar
-    return std::vector<int64_t>({1});
+    return IntList({one});
   } else {
-    return sizes.vec();
+    return sizes;
   }
 }
 

--- a/aten/src/ATen/THSizeStrideCompat.h
+++ b/aten/src/ATen/THSizeStrideCompat.h
@@ -14,7 +14,7 @@ static inline at::IntList get_intlist_size_th(IntList sizes) {
   static int64_t one = 1;
   if (sizes.size() == 0) {
     // fake scalar
-    return IntList({one});
+    return IntList(&one, 1);
   } else {
     return sizes;
   }

--- a/aten/src/ATen/THSizeStrideCompat.h
+++ b/aten/src/ATen/THSizeStrideCompat.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <ATen/ScalarType.h>
+#include <vector>
+
+// NOTE: these functions are for compatibility into TH functions that takes sizes and strides.
+// We should just write the TH functions that don't require this, but that involves two steps:
+// 1) first class scalar support (for sizes)
+// 2) differentiating between nullptr/non-nullptr strides (the former "infers" strides).
+
+namespace at {
+
+static inline std::vector<int64_t> get_intlist_size_th(IntList sizes) {
+  if (sizes.size() == 0) {
+    // fake scalar
+    return std::vector<int64_t>({1});
+  } else {
+    return sizes.vec();
+  }
+}
+
+static inline IntList get_intlist_stride_th(IntList strides) {
+  if (strides.size() == 0) {
+    // differentiating between nullptr/non-nullptr strides (the former "infers" strides)
+    return IntList();
+  } else {
+    return strides;
+  }
+}
+
+}

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -212,6 +212,8 @@ TYPE_FORMAL_GENERIC = {
     'THGenerator*': 'Generator *',
     'THSize*': 'IntList',
     'THStride*': 'IntList',
+    'IntListSize': 'IntList',
+    'IntListStride': 'IntList',
     'accreal': 'Scalar',
     'real': 'Scalar',
     'long': 'int64_t',
@@ -229,6 +231,8 @@ DYNAMIC_TYPE = {
     'THGenerator*': 'Generator*',
     'THSize*': 'IntList',
     'THStride*': 'IntList',
+    'IntListSize': 'IntList',
+    'IntListStride': 'IntList',
     'accreal': 'accreal',
     'real': 'real',
     'long': 'int64_t',
@@ -300,6 +304,8 @@ CHECKED_CAST = {
     'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE);'),
     # This is a cast done via direct-construction
     'THStride*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::STRIDE);'),
+    'IntListSize': CodeTemplate('std::vector<int64_t> ${result_name} = get_intlist_size_th(${arg_name});'),
+    'IntListStride': CodeTemplate('at::IntList ${result_name} = get_intlist_stride_th(${arg_name});'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate(
@@ -309,7 +315,7 @@ CHECKED_CAST = {
     'IntList': CodeTemplate('check_intlist<${size}>(${arg_name}, "${arg_name}", ${arg_pos}${,default_init})')
 }
 
-DIRECT_CONSTRUCTION_CHECKED_CAST = {'THSize*', 'THStride*'}
+DIRECT_CONSTRUCTION_CHECKED_CAST = {'THSize*', 'THStride*', 'IntListSize', 'IntListStride'}
 
 CHECKED_USE = {
     'THTensor*': '{}_->tensor',
@@ -349,8 +355,6 @@ ALLOC_WRAP = {
 # Replacements for constants when calling into TH
 CONSTANT_REPLACEMENTS = [
     ('AS_REAL', '${AS_REAL}'),
-    ('__storage_size.get\\(\\)',
-     'THLongStorageView(static_cast<int64_t>(source.pImpl()->size()), THLongStorageViewKind::LENGTH)'),
     ('__last_dim', 'self.ndimension()-1'),
 ]
 
@@ -1327,7 +1331,7 @@ def create_derived(backend_type_env, declarations):
         output_count = 0
 
         # scalar_check is the heuristic conditions when a result may be a scalar_check
-        # if there is a THSize* argument, then its dimensions are used to determine scalar.
+        # if there is a THSize*/IntListSize argument, then its dimensions are used to determine scalar.
         # otherwise, it is true if all the input tensors are scalars,
         scalar_check_is_from_size = False
         scalar_check_is_from_option = False
@@ -1343,7 +1347,7 @@ def create_derived(backend_type_env, declarations):
         for arg in option['arguments']:
             if is_real_argument_to_wrapper(arg):
                 count += 1
-            if arg['type'] == 'THSize*' and not scalar_check_is_from_option:
+            if (arg['type'] == 'THSize*' or arg['type'] == 'IntListSize') and not scalar_check_is_from_option:
                 scalar_check_is_from_size = True
                 scalar_check = '{}.size() == 0'.format(arg['name'])
             if arg['type'] == 'TensorList':

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -304,7 +304,7 @@ CHECKED_CAST = {
     'THSize*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::SIZE);'),
     # This is a cast done via direct-construction
     'THStride*': CodeTemplate('THLongStorageView ${result_name}(${arg_name}, THLongStorageViewKind::STRIDE);'),
-    'IntListSize': CodeTemplate('std::vector<int64_t> ${result_name} = get_intlist_size_th(${arg_name});'),
+    'IntListSize': CodeTemplate('at::IntList ${result_name} = get_intlist_size_th(${arg_name});'),
     'IntListStride': CodeTemplate('at::IntList ${result_name} = get_intlist_stride_th(${arg_name});'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1,6 +1,7 @@
 #include "ATen/ATen.h"
 #include "ATen/Error.h"
 #include "ATen/ExpandUtils.h"
+#include "ATen/InferSize.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/WrapDimUtils.h"
 #include "ATen/optional.h"
@@ -215,40 +216,6 @@ Tensor repeat(const Tensor& self, IntList repeats) {
   urtensor.copy_(xtensor.expand_as(urtensor));
 
   return result;
-}
-
-// Infers the size of a dim with size -1, if it exists. Also checks that new
-// shape is compatible with the number of elements.
-static std::vector<int64_t> infer_size(IntList shape, int64_t numel) {
-  auto res = shape.vec();
-  int64_t newsize = 1;
-  auto infer_dim = at::optional<int64_t>();
-  for (int64_t dim = 0, ndim = shape.size(); dim != ndim; dim++) {
-    if (shape[dim] == -1) {
-      if (infer_dim) {
-        throw std::runtime_error("only one dimension can be inferred");
-      }
-      infer_dim = dim;
-    } else if (shape[dim] >= 0) {
-      newsize *= shape[dim];
-    } else {
-      AT_ERROR("invalid shape dimension ", shape[dim]);
-    }
-  }
-
-  if (numel == newsize || (infer_dim && newsize > 0 && numel % newsize == 0)) {
-    if (infer_dim) {
-      // we have a degree of freedom here to select the dimension size; follow NumPy semantics
-      // and just bail.
-      AT_CHECK(newsize != 0, "cannot reshape tensor of 0 elements into shape ", shape);
-      res[*infer_dim] = numel / newsize;
-    }
-    return res;
-  }
-
-  std::ostringstream ss;
-  ss << "shape '" << shape << "' is invalid for input of size " << numel;
-  throw std::runtime_error(ss.str());
 }
 
 Tensor reshape(const Tensor& self, IntList proposed_shape) {

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -15,6 +15,7 @@
 #include "ATen/WrapDimUtils.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/THLongStorageView.h"
+#include "ATen/THSizeStrideCompat.h"
 #include "ATen/UndefinedTensor.h"
 #include "ATen/Utils.h"
 #include "ATen/DeviceGuard.h"

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -16,6 +16,7 @@ $storage_tensor_headers
 #include "ATen/WrapDimUtils.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/THLongStorageView.h"
+#include "ATen/THSizeStrideCompat.h"
 #include "ATen/UndefinedTensor.h"
 #include "ATen/Utils.h"
 #include "ATen/DeviceGuard.h"

--- a/aten/src/TH/CMakeLists.txt
+++ b/aten/src/TH/CMakeLists.txt
@@ -122,6 +122,7 @@ INSTALL(FILES
   generic/THStorageCopy.h
   generic/THTensor.cpp
   generic/THTensor.h
+  generic/THTensor.hpp
   generic/THTensorConv.cpp
   generic/THTensorConv.h
   generic/THTensorCopy.cpp

--- a/aten/src/TH/THStorageFunctions.cpp
+++ b/aten/src/TH/THStorageFunctions.cpp
@@ -14,6 +14,15 @@
 #include "generic/THStorageCopy.cpp"
 #include "THGenerateHalfType.h"
 
+THStorage* THStorage_new(at::ScalarType scalar_type) {
+  THStorage* storage = new THStorage(
+      scalar_type,
+      0,
+      getTHDefaultAllocator(),
+      true);
+  return storage;
+}
+
 // Free a non-weak pointer to THStorage
 void THStorage_free(THStorage* storage) {
   if (!storage) {
@@ -42,36 +51,6 @@ THStorage* THStorage_weakLock(THStorage *weak_storage) {
 
 THDescBuff THLongStorage_sizeDesc(const THLongStorage *size) {
   return _THSizeDesc(THLongStorage_data(size), size->size());
-}
-
-THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElement)
-{
-  ptrdiff_t total_size = (size->size() > 0 ? 1 : 0);
-  ptrdiff_t dim_infer = -1;
-  ptrdiff_t i;
-  for (i = 0; i < size->size(); i++) {
-    if (THLongStorage_data(size)[i] == -1) {
-      THArgCheck(dim_infer == -1, 1, "only one dimension can be inferred");
-      dim_infer = i;
-    } else {
-      total_size *= THLongStorage_data(size)[i];
-    }
-  }
-  if (dim_infer != -1) {
-    THDescBuff buf = THLongStorage_sizeDesc(size);
-    THArgCheck(total_size > 0 && nElement % total_size == 0, 2,
-        "size '%s' is invalid for input with %td elements", buf.str, nElement);
-  } else {
-    THDescBuff buf = THLongStorage_sizeDesc(size);
-    THArgCheck(nElement == total_size, 2,
-        "size '%s' is invalid for input with %td elements", buf.str, nElement);
-  }
-  THLongStorage* copy = THLongStorage_newWithSize(size->size());
-  THLongStorage_copy(copy, size);
-  if (dim_infer != -1) {
-    THLongStorage_data(copy)[dim_infer] = nElement / total_size;
-  }
-  return copy;
 }
 
 ptrdiff_t THStorage_size(const THStorage *self)

--- a/aten/src/TH/THStorageFunctions.h
+++ b/aten/src/TH/THStorageFunctions.h
@@ -22,4 +22,3 @@ TH_API void THStorage_free(THStorage *storage);
 TH_API void THStorage_weakFree(THStorage *storage);
 
 TH_API THDescBuff THLongStorage_sizeDesc(const THLongStorage *size);
-TH_API THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElement);

--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -33,6 +33,7 @@
 //    If it is not, you must report that the storage is dead.
 //
 
+TH_CPP_API THStorage* THStorage_new(at::ScalarType scalar_type);
 TH_API ptrdiff_t THStorage_size(const THStorage *self);
 
 TH_API void THStorage_retain(THStorage *storage);

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -14,6 +14,128 @@ void THTensor_free(THTensor *self)
   self->release();
 }
 
+void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_) {
+  if(size_.data() && stride_.data())
+    THArgCheck(size_.size() == stride_.size(), 5, "inconsistent size/stride sizes");
+
+  AT_CHECK(size_.data(), "size must not be null");
+#ifdef DEBUG
+  THAssert(size_.size() <= INT_MAX);
+#endif
+  THTensor_setStorageNd(self,
+                        storage_,
+                        storageOffset_,
+                        size_.size(),
+                        size_.data(),
+                        stride_.data());
+}
+
+void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride)
+{
+  /* storage */
+  if(THTensor_getStoragePtr(self) != storage)
+  {
+    if (!THTensor_getStoragePtr(self)) {
+      THError("Tensor: invalid null storage");
+    }
+    auto scalar_type = THTensor_getStoragePtr(self)->scalar_type();
+    THStorage_free(THTensor_getStoragePtr(self));
+    if(storage)
+    {
+      THTensor_stealAndSetStoragePtr(self, storage);
+      THStorage_retain(THTensor_getStoragePtr(self));
+    }
+    else {
+      THTensor_stealAndSetStoragePtr(self, THStorage_new(scalar_type));
+    }
+  }
+
+  /* storageOffset */
+  if(storageOffset < 0)
+    THError("Tensor: invalid storage offset");
+  THTensor_setStorageOffset(self, storageOffset);
+
+  /* size and stride */
+  THTensor_resizeNd(self, nDimension, size, stride);
+}
+
+void THTensor_resize(THTensor *self, THLongStorage *size, THLongStorage *stride)
+{
+  THArgCheck(size != NULL, 2, "invalid size");
+  if(stride)
+    THArgCheck(stride->size() == size->size(), 3, "invalid stride");
+
+#ifdef DEBUG
+  THAssert(size->size() <= INT_MAX);
+#endif
+  THTensor_resizeNd(self, size->size(), THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
+}
+
+void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
+{
+  int d;
+  ptrdiff_t totalSize;
+  bool hascorrectsize = true;
+
+#ifndef USE_TH_SCALAR
+  AT_CHECK(nDimension > 0, "resizeNd nDimension must be greater than 0");
+#else
+  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
+#endif
+
+  for(d = 0; d < nDimension; d++)
+  {
+    if((self->dim() > d) && (size[d] != self->size(d))) {
+      hascorrectsize = false;
+    }
+
+    // NB: this used to test that stride[d] was >= 0
+    if((self->dim() > d) && stride && (stride[d] != self->stride(d))) {
+      hascorrectsize = false;
+    }
+  }
+
+  if(nDimension != self->dim()) {
+    hascorrectsize = false;
+  }
+
+  if(hascorrectsize) {
+    return;
+  }
+
+  if(nDimension != self->dim())
+  {
+    THTensor_resizeDim(self, nDimension);
+  }
+
+  totalSize = 1;
+  for(d = nDimension-1; d >= 0; d--)
+  {
+    THTensor_setSizeAtDim(self, d, size[d]);
+    if(stride && (stride[d] >= 0) ) {
+      THTensor_setStrideAtDim(self, d, stride[d]);
+    } else {
+      if(d == nDimension-1) {
+        THTensor_setStrideAtDim(self, d, 1);
+      } else {
+        // Keep stride monotonically increasing to match NumPy.
+        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1), 1)*self->stride(d+1));
+      }
+    }
+    totalSize += (self->size(d)-1)*self->stride(d);
+  }
+
+  if(totalSize+self->storage_offset() > 0)
+  {
+    if(!THTensor_getStoragePtr(self)) {
+      THTensor_stealAndSetStoragePtr(self, THStorage_new(self->scalar_type()));
+    }
+    if(totalSize+self->storage_offset() > THTensor_getStoragePtr(self)->size()) {
+      THStorage_resize(THTensor_getStoragePtr(self), totalSize+self->storage_offset());
+    }
+  }
+}
+
 // On a high level,
 // 1. separate oldshape chunks of dimensions, where the dimensions are
 //    ``contiguous'' in each chunk, i.e., oldstride[i] = oldshape[i+1] * oldstride[i+1]

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -211,5 +211,16 @@ inline void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage)
 }
 
 TH_API void THTensor_free(THTensor *self);
+TH_API void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride);
+TH_API void THTensor_resize(THTensor *self, THLongStorage *size, THLongStorage *stride);
+TH_API void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride);
+
+TH_CPP_API void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_);
 TH_CPP_API at::optional<std::vector<int64_t>> THTensor_compute_stride(at::IntList oldshape, at::IntList oldstride,
                                                                       at::IntList newshape);
+
+#include "generic/THTensor.hpp"
+#include "THGenerateAllTypes.h"
+
+#include "generic/THTensor.hpp"
+#include "THGenerateHalfType.h"

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -21,12 +21,7 @@ size_t THStorage_(elementSize)()
 
 THStorage* THStorage_(new)(void)
 {
-  THStorage* storage = new THStorage(
-      at::CTypeToScalarType<th::from_type<real>>::to(),
-      0,
-      getTHDefaultAllocator(),
-      true);
-  return storage;
+  return THStorage_new(at::CTypeToScalarType<th::from_type<real>>::to());
 }
 
 THStorage* THStorage_(newWithSize)(ptrdiff_t size)

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -2,6 +2,7 @@
 #define TH_GENERIC_FILE "generic/THTensor.cpp"
 #else
 
+#include <ATen/InferSize.h>
 #include <new>
 
 /**** access methods ****/
@@ -79,29 +80,11 @@ THTensor *THTensor_(newWithTensor)(THTensor *tensor)
 }
 
 /* Storage init */
-THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset, THLongStorage *size, THLongStorage *stride)
-{
-  if(size && stride) {
-    THArgCheck(size->size() == stride->size(), 4, "inconsistent size");
+THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
+  if (sizes.data() && strides.data()) {
+    AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
-  AT_CHECK(size, "size must not be null");
-
-  THTensor *self = new THTensor(THStorage_(new)());
-#ifdef DEBUG
-  THAssert(size->size() <= INT_MAX);
-#endif
-  THTensor_(setStorageNd)(self,
-                          storage,
-                          storageOffset,
-                          size->size(),
-                          THLongStorage_data(size),
-                          (stride ? THLongStorage_data(stride) : NULL));
-
-  return self;
-}
-
-THTensor *THTensor_(newWithStorageIntLists)(THStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
-  AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
+  AT_CHECK(sizes.data(), "size must not be null");
   THTensor *self = new THTensor(THStorage_(new)());
   THTensor_(setStorageNd)(self, storage, storageOffset, sizes.size(),
                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
@@ -112,14 +95,14 @@ THTensor *THTensor_(newWithStorageIntLists)(THStorage *storage, ptrdiff_t storag
 THTensor *THTensor_(newWithStorage1d)(THStorage *storage, ptrdiff_t storageOffset,
                                int64_t size0, int64_t stride0)
 {
-  return THTensor_(newWithStorageIntLists)(storage, storageOffset, {size0}, {stride0});
+  return THTensor_(newWithStorage)(storage, storageOffset, {size0}, {stride0});
 }
 
 THTensor *THTensor_(newWithStorage2d)(THStorage *storage, ptrdiff_t storageOffset,
                                int64_t size0, int64_t stride0,
                                int64_t size1, int64_t stride1)
 {
-  return THTensor_(newWithStorageIntLists)(storage, storageOffset, {size0, size1}, {stride0, stride1});
+  return THTensor_(newWithStorage)(storage, storageOffset, {size0, size1}, {stride0, stride1});
 }
 
 THTensor *THTensor_(newWithStorage3d)(THStorage *storage, ptrdiff_t storageOffset,
@@ -127,7 +110,7 @@ THTensor *THTensor_(newWithStorage3d)(THStorage *storage, ptrdiff_t storageOffse
                                int64_t size1, int64_t stride1,
                                int64_t size2, int64_t stride2)
 {
-  return THTensor_(newWithStorageIntLists)(storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
+  return THTensor_(newWithStorage)(storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
 }
 
 THTensor *THTensor_(newWithStorage4d)(THStorage *storage, ptrdiff_t storageOffset,
@@ -136,14 +119,16 @@ THTensor *THTensor_(newWithStorage4d)(THStorage *storage, ptrdiff_t storageOffse
                                int64_t size2, int64_t stride2,
                                int64_t size3, int64_t stride3)
 {
-  return THTensor_(newWithStorageIntLists)(storage, storageOffset,
+  return THTensor_(newWithStorage)(storage, storageOffset,
                                           {size0, size1, size2, size3},
                                           {stride0, stride1, stride2, stride3});
 }
 
 THTensor *THTensor_(newWithSize)(THLongStorage *size, THLongStorage *stride)
 {
-  return THTensor_(newWithStorage)(NULL, 0, size, stride);
+  at::IntList size_(size == nullptr ? nullptr : size->data<int64_t>(), size == nullptr ? 0 : size->size());
+  at::IntList stride_(stride == nullptr ? nullptr : stride->data<int64_t>(), stride == nullptr ? 0 : stride->size());
+  return THTensor_(newWithStorage)(NULL, 0, size_, stride_);
 }
 
 THTensor *THTensor_(newWithSizeIntList)(at::IntList sizes) {
@@ -220,37 +205,26 @@ THTensor *THTensor_(newUnfold)(THTensor *tensor, int dimension_, int64_t size_, 
   return self;
 }
 
-THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size)
+THTensor *THTensor_(newView)(THTensor *tensor, at::IntList size)
 {
   ptrdiff_t numel = THTensor_(nElement)(tensor);
   THTensor *self = THTensor_(new)();
-  THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
+  auto inferred_size = at::infer_size(size, numel);
   auto stride = THTensor_compute_stride(tensor->sizes(),
                                         tensor->strides(),
-                                        at::IntList(inferred_size->data<int64_t>(), inferred_size->size()));
+                                        inferred_size);
   THArgCheck(stride.has_value(), 2, "view size is "
     "not compatible with input tensor's size and stride (at least one dimension spans "
     "across two contiguous subspaces). Call .contiguous() before .view().");
   auto stride_value = *stride;
-  THLongStorage *new_stride = THLongStorage_newWithSize(stride_value.size());
-  THLongStorage_rawCopy(new_stride, stride_value.data());
-  THTensor_(setStorage)(self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, new_stride);
-  THLongStorage_free(inferred_size);
-  THLongStorage_free(new_stride);
+  THTensor_setStorage(self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, stride_value);
   return self;
 }
 
 /* Resize */
 void THTensor_(resize)(THTensor *self, THLongStorage *size, THLongStorage *stride)
 {
-  THArgCheck(size != NULL, 2, "invalid size");
-  if(stride)
-    THArgCheck(stride->size() == size->size(), 3, "invalid stride");
-
-#ifdef DEBUG
-  THAssert(size->size() <= INT_MAX);
-#endif
-  THTensor_(resizeNd)(self, size->size(), THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
+  return THTensor_resize(self, size, stride);
 }
 
 void THTensor_(resizeAs)(THTensor *self, THTensor *src)
@@ -300,46 +274,25 @@ void THTensor_(set)(THTensor *self, THTensor *src)
                             THTensor_getStridePtr(src));
 }
 
-void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_)
+void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_)
 {
-  if(size_ && stride_)
-    THArgCheck(size_->size() == stride_->size(), 5, "inconsistent size/stride sizes");
-
-  AT_CHECK(size_, "size must not be null");
-#ifdef DEBUG
-  THAssert(size_ <= INT_MAX);
-#endif
-  THTensor_(setStorageNd)(self,
-                          storage_,
-                          storageOffset_,
-                          size_->size(),
-                          THLongStorage_data(size_),
-                          (stride_ ? THLongStorage_data(stride_) : NULL));
-}
-
-void THTensor_(setStorageIntLists)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
-                                   at::IntList sizes, at::IntList strides)
-{
-  AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
-
-  THTensor_(setStorageNd)(self, storage_, storageOffset_, sizes.size(),
-                          const_cast<int64_t *>(sizes.data()), const_cast<int64_t *>(strides.data()));
+  THTensor_setStorage(self, storage_, storageOffset_, size_, stride_);
 }
 
 void THTensor_(setStorage1d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
                              int64_t size0_, int64_t stride0_)
 {
-  THTensor_(setStorageIntLists)(self, storage_, storageOffset_,
-                                {size0_}, {stride0_});
+  THTensor_(setStorage)(self, storage_, storageOffset_,
+                       {size0_}, {stride0_});
 }
 
 void THTensor_(setStorage2d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
                              int64_t size0_, int64_t stride0_,
                              int64_t size1_, int64_t stride1_)
 {
-  THTensor_(setStorageIntLists)(self, storage_, storageOffset_,
-                                {size0_, size1_},
-                                {stride0_, stride1_});
+  THTensor_(setStorage)(self, storage_, storageOffset_,
+                       {size0_, size1_},
+                       {stride0_, stride1_});
 }
 
 void THTensor_(setStorage3d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
@@ -347,9 +300,9 @@ void THTensor_(setStorage3d)(THTensor *self, THStorage *storage_, ptrdiff_t stor
                              int64_t size1_, int64_t stride1_,
                              int64_t size2_, int64_t stride2_)
 {
-  THTensor_(setStorageIntLists)(self, storage_, storageOffset_,
-                                {size0_, size1_, size2_},
-                                {stride0_, stride1_, stride2_});
+  THTensor_(setStorage)(self, storage_, storageOffset_,
+                        {size0_, size1_, size2_},
+                        {stride0_, stride1_, stride2_});
 }
 
 void THTensor_(setStorage4d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
@@ -362,7 +315,7 @@ void THTensor_(setStorage4d)(THTensor *self, THStorage *storage_, ptrdiff_t stor
   int64_t size[4] = {size0_, size1_, size2_, size3_};
   int64_t stride[4] = {stride0_, stride1_, stride2_, stride3_};
 
-  THTensor_(setStorageIntLists)(self, storage_, storageOffset_, size, stride);
+  THTensor_(setStorage)(self, storage_, storageOffset_, size, stride);
 }
 
 
@@ -664,93 +617,12 @@ void THTensor_(freeCopyTo)(THTensor *self, THTensor *dst)
 
 void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)
 {
-  /* storage */
-  if(THTensor_getStoragePtr(self) != storage)
-  {
-    if(THTensor_getStoragePtr(self))
-      THStorage_(free)(THTensor_getStoragePtr(self));
-
-    if(storage)
-    {
-      THTensor_stealAndSetStoragePtr(self, storage);
-      THStorage_(retain)(THTensor_getStoragePtr(self));
-    }
-    else
-      THTensor_stealAndSetStoragePtr(self, THStorage_(new)());
-  }
-
-  /* storageOffset */
-  if(storageOffset < 0)
-    THError("Tensor: invalid storage offset");
-  THTensor_setStorageOffset(self, storageOffset);
-
-  /* size and stride */
-  THTensor_(resizeNd)(self, nDimension, size, stride);
+  return THTensor_setStorageNd(self, storage, storageOffset, nDimension, size, stride);
 }
 
 void THTensor_(resizeNd)(THTensor *self, int nDimension, int64_t *size, int64_t *stride)
 {
-  int d;
-  ptrdiff_t totalSize;
-  bool hascorrectsize = true;
-
-#ifndef USE_TH_SCALAR
-  AT_CHECK(nDimension > 0, "resizeNd nDimension must be greater than 0");
-#else
-  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
-#endif
-
-  for(d = 0; d < nDimension; d++)
-  {
-    if((self->dim() > d) && (size[d] != self->size(d))) {
-      hascorrectsize = false;
-    }
-
-    // NB: this used to test that stride[d] was >= 0
-    if((self->dim() > d) && stride && (stride[d] != self->stride(d))) {
-      hascorrectsize = false;
-    }
-  }
-
-  if(nDimension != self->dim()) {
-    hascorrectsize = false;
-  }
-
-  if(hascorrectsize) {
-    return;
-  }
-
-  if(nDimension != self->dim())
-  {
-    THTensor_resizeDim(self, nDimension);
-  }
-
-  totalSize = 1;
-  for(d = nDimension-1; d >= 0; d--)
-  {
-    THTensor_setSizeAtDim(self, d, size[d]);
-    if(stride && (stride[d] >= 0) ) {
-      THTensor_setStrideAtDim(self, d, stride[d]);
-    } else {
-      if(d == nDimension-1) {
-        THTensor_setStrideAtDim(self, d, 1);
-      } else {
-        // Keep stride monotonically increasing to match NumPy.
-        THTensor_setStrideAtDim(self, d, std::max<int64_t>(self->size(d+1), 1)*self->stride(d+1));
-      }
-    }
-    totalSize += (self->size(d)-1)*self->stride(d);
-  }
-
-  if(totalSize+self->storage_offset() > 0)
-  {
-    if(!THTensor_getStoragePtr(self)) {
-      THTensor_stealAndSetStoragePtr(self, THStorage_(new)());
-    }
-    if(totalSize+self->storage_offset() > THTensor_getStoragePtr(self)->size()) {
-      THStorage_(resize)(THTensor_getStoragePtr(self), totalSize+self->storage_offset());
-    }
-  }
+  return THTensor_resizeNd(self, nDimension, size, stride);
 }
 
 void THTensor_(set1d)(THTensor *tensor, int64_t x0, real value)

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -37,8 +37,6 @@ TH_API real *THTensor_(data)(const THTensor *self);
 /**** creation methods ****/
 TH_API THTensor *THTensor_(new)(void);
 TH_API THTensor *THTensor_(newWithTensor)(THTensor *tensor);
-/* stride might be NULL */
-TH_API THTensor *THTensor_(newWithStorage)(THStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);
 TH_API THTensor *THTensor_(newWithStorage1d)(THStorage *storage_, ptrdiff_t storageOffset_,
                                 int64_t size0_, int64_t stride0_);
 TH_API THTensor *THTensor_(newWithStorage2d)(THStorage *storage_, ptrdiff_t storageOffset_,
@@ -67,7 +65,6 @@ TH_API THTensor *THTensor_(newSelect)(THTensor *tensor, int dimension_, int64_t 
 TH_API THTensor *THTensor_(newNarrow)(THTensor *tensor, int dimension_, int64_t firstIndex_, int64_t size_);
 TH_API THTensor *THTensor_(newTranspose)(THTensor *tensor, int dimension1_, int dimension2_);
 TH_API THTensor *THTensor_(newUnfold)(THTensor *tensor, int dimension_, int64_t size_, int64_t step_);
-TH_API THTensor *THTensor_(newView)(THTensor *tensor, THLongStorage *size);
 
 // resize* methods simply resize the storage. So they may not retain the current data at current indices.
 // This is especially likely to happen when the tensor is not contiguous. In general, if you still need the
@@ -83,7 +80,6 @@ TH_API void THTensor_(resize5d)(THTensor *tensor, int64_t size0_, int64_t size1_
 // Note: these are legacy resize functions that treat sizes as size->size() == 0 and size->data<int64_t>() as being 0-terminated.
 
 TH_API void THTensor_(set)(THTensor *self, THTensor *src);
-TH_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);
 TH_API void THTensor_(setStorageNd)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, int nDimension, int64_t *size, int64_t *stride);
 TH_API void THTensor_(setStorage1d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
                                     int64_t size0_, int64_t stride0_);

--- a/aten/src/TH/generic/THTensor.hpp
+++ b/aten/src/TH/generic/THTensor.hpp
@@ -1,0 +1,17 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/THTensor.hpp"
+#else
+
+// STOP!!! Thinking of including this header directly?  Please
+// read Note [TH abstraction violation]
+
+// NOTE: functions exist here only to support dispatch via Declarations.cwrap.  You probably don't want to put
+// new functions in here, they should probably be un-genericized.
+
+TH_CPP_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
+                                      at::IntList size_, at::IntList stride_);
+TH_CPP_API THTensor *THTensor_(newView)(THTensor *tensor, at::IntList size);
+/* strides.data() might be NULL */
+TH_CPP_API THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
+                                               at::IntList sizes, at::IntList strides);
+#endif

--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -124,6 +124,7 @@ INSTALL(FILES
           generic/THCTensor.cpp
           generic/THCTensor.cu
           generic/THCTensor.h
+          generic/THCTensor.hpp
           generic/THCStorageCopy.cpp
           generic/THCStorageCopy.cu
           generic/THCStorageCopy.h

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -95,7 +95,7 @@ void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
     THCTensor_resizeNd(state, self, src->dim(), THTensor_getSizePtr(src), NULL);
 }
 
-void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, int64_t *size, int64_t *stride)
+void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
 {
   int d;
   ptrdiff_t totalSize;
@@ -172,7 +172,22 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
                            THTensor_getStridePtr(src));
 }
 
-void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride)
+void THCTensor_setStorage(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_)
+{
+  if(size_.data() && stride_.data())
+    THArgCheck(size_.size() == stride_.size(), 5, "inconsistent size/stride sizes");
+
+  AT_CHECK(size_.data(), "size must not be null");
+  THCTensor_setStorageNd(state,
+                         self,
+                         storage_,
+                         storageOffset_,
+                         size_.size(),
+                         size_.data(),
+                         stride_.data());
+}
+
+void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride)
 {
   /* storage */
   if(THTensor_getStoragePtr(self) != storage)

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -24,11 +24,12 @@ THC_API THLongStorage *THCTensor_newSizeOf(THCState *state, THCTensor *self);
 THC_API THCTensor *THCTensor_new(THCState *state, at::ScalarType scalar_type);
 
 THC_API void THCTensor_resize(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
-THC_API void THCTensor_resizeNd(THCState *state, THCTensor *tensor, int nDimension, int64_t *size, int64_t *stride);
+THC_API void THCTensor_resizeNd(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
 THC_API void THCTensor_resizeAs(THCState *state, THCTensor *tensor, THCTensor *src);
 
 THC_API void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride);
+THC_API void THCTensor_setStorage(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_);
+THC_API void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride);
 
 THC_API void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
 THC_API void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
@@ -53,3 +54,6 @@ THC_API void THCTensor_preserveReduceDimSemantics(THCState *state, THCTensor *te
 /* has more than one index that references the same datapoint, */
 /* true otherwise.                                             */
 THC_API bool THCTensor_maybeOverlappingIndices(THCState* state, const THCTensor* t);
+
+#include "generic/THCTensor.hpp"
+#include "THCGenerateAllTypes.h"

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/THCTensor.cpp"
 #else
 
+#include <ATen/InferSize.h>
+
 /**** access methods ****/
 THCStorage *THCTensor_(storage)(THCState *state, const THCTensor *self)
 {
@@ -86,26 +88,11 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
 }
 
 /* Storage init */
-THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset, THLongStorage *size, THLongStorage *stride)
-{
-  if(size && stride)
-    THArgCheck(size->size() == stride->size(), 4, "inconsistent size");
-
-  AT_CHECK(size, "size must not be null");
-  THCTensor *self = new THCTensor(THCStorage_(new)(state));
-  THCTensor_(setStorageNd)(state,
-                           self,
-                           storage,
-                           storageOffset,
-                           size->size(),
-                           THLongStorage_data(size),
-                           (stride ? THLongStorage_data(stride) : NULL));
-
-  return self;
-}
-
-THCTensor *THCTensor_(newWithStorageIntLists)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
-  AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
+THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
+  if (sizes.data() && strides.data()) {
+    AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
+  }
+  AT_CHECK(sizes.data(), "size must not be null");
   THCTensor *self = new THCTensor(THCStorage_(new)(state));
   THCTensor_(setStorageNd)(state, self, storage, storageOffset, sizes.size(),
                            const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
@@ -116,14 +103,14 @@ THCTensor *THCTensor_(newWithStorageIntLists)(THCState *state, THCStorage *stora
 THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
                                int64_t size0, int64_t stride0)
 {
-  return THCTensor_(newWithStorageIntLists)(state, storage, storageOffset, {size0}, {stride0});
+  return THCTensor_(newWithStorage)(state, storage, storageOffset, {size0}, {stride0});
 }
 
 THCTensor *THCTensor_(newWithStorage2d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
                                int64_t size0, int64_t stride0,
                                int64_t size1, int64_t stride1)
 {
-  return THCTensor_(newWithStorageIntLists)(state, storage, storageOffset, {size0, size1}, {stride0, stride1});
+  return THCTensor_(newWithStorage)(state, storage, storageOffset, {size0, size1}, {stride0, stride1});
 }
 
 THCTensor *THCTensor_(newWithStorage3d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
@@ -131,7 +118,7 @@ THCTensor *THCTensor_(newWithStorage3d)(THCState *state, THCStorage *storage, pt
                                int64_t size1, int64_t stride1,
                                int64_t size2, int64_t stride2)
 {
-  return THCTensor_(newWithStorageIntLists)(state, storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
+  return THCTensor_(newWithStorage)(state, storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
 }
 
 THCTensor *THCTensor_(newWithStorage4d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
@@ -140,14 +127,16 @@ THCTensor *THCTensor_(newWithStorage4d)(THCState *state, THCStorage *storage, pt
                                int64_t size2, int64_t stride2,
                                int64_t size3, int64_t stride3)
 {
-  return THCTensor_(newWithStorageIntLists)(state, storage, storageOffset,
+  return THCTensor_(newWithStorage)(state, storage, storageOffset,
                                             {size0, size1, size2, size3},
                                             {stride0, stride1, stride2, stride3});
 }
 
 THCTensor *THCTensor_(newWithSize)(THCState *state, THLongStorage *size, THLongStorage *stride)
 {
-  return THCTensor_(newWithStorage)(state, NULL, 0, size, stride);
+  at::IntList size_(size == nullptr ? nullptr : size->data<int64_t>(), size == nullptr ? 0 : size->size());
+  at::IntList stride_(stride == nullptr ? nullptr :stride->data<int64_t>(), stride == nullptr ? 0 : stride->size());
+  return THCTensor_(newWithStorage)(state, NULL, 0, size_, stride_);
 }
 
 THCTensor *THCTensor_(newWithSizeIntList)(THCState *state, at::IntList sizes) {
@@ -223,23 +212,19 @@ THCTensor *THCTensor_(newUnfold)(THCState *state, THCTensor *tensor, int dimensi
   return self;
 }
 
-THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage *size)
+THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntList size)
 {
   ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
   THCTensor *self = THCTensor_(new)(state);
-  THLongStorage *inferred_size = THLongStorage_newInferSize(size, numel);
+  auto inferred_size = at::infer_size(size, numel);
   auto stride = THTensor_compute_stride(tensor->sizes(),
                                         tensor->strides(),
-                                        at::IntList(inferred_size->data<int64_t>(), inferred_size->size()));
+                                        inferred_size);
   THArgCheck(stride.has_value(), 2, "view size is "
     "not compatible with input tensor's size and stride (at least one dimension spans "
     "across two contiguous subspaces). Call .contiguous() before .view().");
   auto stride_value = *stride;
-  THLongStorage *new_stride = THLongStorage_newWithSize(stride_value.size());
-  THLongStorage_rawCopy(new_stride, stride_value.data());
-  THCTensor_(setStorage)(state, self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, new_stride);
-  THLongStorage_free(inferred_size);
-  THLongStorage_free(new_stride);
+  THCTensor_setStorage(state, self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, stride_value);
   return self;
 }
 
@@ -250,13 +235,12 @@ THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
   THArgCheck(in_dims >= 2, 1, "Tensor needs to have at least two dimensions");
   THArgCheck(THCTensor_(isContiguous)(state, input), 1,
              "Tensor must be contiguous");
-  THLongStorage *newSize = THLongStorage_newWithSize(in_dims - 1);
-  THLongStorage_data(newSize)[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
+  std::vector<int64_t> new_size(in_dims - 1);
+  new_size[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
   for (int i = 2; i < in_dims; i++) {
-    THLongStorage_data(newSize)[i - 1] = THCTensor_(size)(state, input, i);
+    new_size[i - 1] = THCTensor_(size)(state, input, i);
   }
-  THCTensor *output = THCTensor_(newView)(state, input, newSize);
-  THLongStorage_free(newSize);
+  THCTensor *output = THCTensor_(newView)(state, input, new_size);
   return output;
 }
 
@@ -306,44 +290,24 @@ void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src)
   THCTensor_set(state, self, src);
 }
 
-void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_)
-{
-  if(size_ && stride_)
-    THArgCheck(size_->size() == stride_->size(), 5, "inconsistent size/stride sizes");
-
-  AT_CHECK(size_, "size must not be null");
-  THCTensor_(setStorageNd)(state,
-                           self,
-                           storage_,
-                           storageOffset_,
-                           size_->size(),
-                           THLongStorage_data(size_),
-                           (stride_ ? THLongStorage_data(stride_) : NULL));
-}
-
-void THCTensor_(setStorageIntLists)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
-                                    at::IntList sizes, at::IntList strides)
-{
-  AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
-
-  THCTensor_(setStorageNd)(state, self, storage_, storageOffset_, sizes.size(),
-                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
+void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_) {
+  THCTensor_setStorage(state, self, storage_, storageOffset_, size_, stride_);
 }
 
 void THCTensor_(setStorage1d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
                              int64_t size0_, int64_t stride0_)
 {
-  THCTensor_(setStorageIntLists)(state, self, storage_, storageOffset_,
-                                 {size0_}, {stride0_});
+  THCTensor_(setStorage)(state, self, storage_, storageOffset_,
+                         {size0_}, {stride0_});
 }
 
 void THCTensor_(setStorage2d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
                              int64_t size0_, int64_t stride0_,
                              int64_t size1_, int64_t stride1_)
 {
-  THCTensor_(setStorageIntLists)(state, self, storage_, storageOffset_,
-                                 {size0_, size1_},
-                                 {stride0_, stride1_});
+  THCTensor_(setStorage)(state, self, storage_, storageOffset_,
+                         {size0_, size1_},
+                         {stride0_, stride1_});
 }
 
 void THCTensor_(setStorage3d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
@@ -351,9 +315,9 @@ void THCTensor_(setStorage3d)(THCState *state, THCTensor *self, THCStorage *stor
                              int64_t size1_, int64_t stride1_,
                              int64_t size2_, int64_t stride2_)
 {
-  THCTensor_(setStorageIntLists)(state, self, storage_, storageOffset_,
-                                 {size0_, size1_, size2_},
-                                 {stride0_, stride1_, stride2_});
+  THCTensor_(setStorage)(state, self, storage_, storageOffset_,
+                         {size0_, size1_, size2_},
+                         {stride0_, stride1_, stride2_});
 }
 
 void THCTensor_(setStorage4d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
@@ -366,7 +330,7 @@ void THCTensor_(setStorage4d)(THCState *state, THCTensor *self, THCStorage *stor
   int64_t size[4] = {size0_, size1_, size2_, size3_};
   int64_t stride[4] = {stride0_, stride1_, stride2_, stride3_};
 
-  THCTensor_(setStorageIntLists)(state, self, storage_, storageOffset_, size, stride);
+  THCTensor_(setStorage)(state, self, storage_, storageOffset_, size, stride);
 }
 
 

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -40,8 +40,6 @@ THC_API void THCTensor_(clearFlag)(THCState *state, THCTensor *self, const char 
 /**** creation methods ****/
 THC_API THCTensor *THCTensor_(new)(THCState *state);
 THC_API THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor);
-/* stride might be NULL */
-THC_API THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);
 THC_API THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
                                 int64_t size0_, int64_t stride0_);
 THC_API THCTensor *THCTensor_(newWithStorage2d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
@@ -70,7 +68,6 @@ THC_API THCTensor *THCTensor_(newSelect)(THCState *state, THCTensor *tensor, int
 THC_API THCTensor *THCTensor_(newNarrow)(THCState *state, THCTensor *tensor, int dimension_, int64_t firstIndex_, int64_t size_);
 THC_API THCTensor *THCTensor_(newTranspose)(THCState *state, THCTensor *tensor, int dimension1_, int dimension2_);
 THC_API THCTensor *THCTensor_(newUnfold)(THCState *state, THCTensor *tensor, int dimension_, int64_t size_, int64_t step_);
-THC_API THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage *size);
 THC_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input);
 
 // resize* methods simply resize the storage. So they may not retain the current data at current indices.
@@ -86,7 +83,6 @@ THC_API void THCTensor_(resize4d)(THCState *state, THCTensor *tensor, int64_t si
 THC_API void THCTensor_(resize5d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_, int64_t size4_);
 
 THC_API void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, THLongStorage *size_, THLongStorage *stride_);
 THC_API void THCTensor_(setStorageNd)(THCState *state, THCTensor *self, THCStorage *storage, ptrdiff_t storageOffset, int nDimension, int64_t *size, int64_t *stride);
 THC_API void THCTensor_(setStorage1d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
                                     int64_t size0_, int64_t stride0_);

--- a/aten/src/THC/generic/THCTensor.hpp
+++ b/aten/src/THC/generic/THCTensor.hpp
@@ -1,0 +1,19 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/THCTensor.hpp"
+#else
+
+// STOP!!! Thinking of including this header directly?  Please
+// read Note [TH abstraction violation]
+
+// NOTE: functions exist here only to support dispatch via Declarations.cwrap.  You probably don't want to put
+// new functions in here, they should probably be un-genericized.
+
+THC_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
+                                    at::IntList size_, at::IntList stride_);
+THC_API THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntList size);
+/* strides.data() might be nullptr */
+THC_API THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
+                                              at::IntList sizes, at::IntList strides);
+
+
+#endif

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -375,10 +375,7 @@ THCTensor_(medianall)(THCState *state, THCTensor *self) {
   nelem = THCTensor_(nElement)(state, self);
   k = (nelem-1) >> 1;
 
-  THLongStorage *size = THLongStorage_newWithSize1(nelem);
-  THCTensor *view = THCTensor_(newView)(state, self, size);
-
-  THLongStorage_free(size);
+  THCTensor *view = THCTensor_(newView)(state, self, {nelem});
 
   THCTensor *sorted = THCTensor_(new)(state);
   THCudaLongTensor *indices = THCudaLongTensor_new(state);

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -240,17 +240,10 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   THCDeviceTensor<real, 4> cudaOutput;
   cudaOutput = toDeviceTensor<real, 4>(state, output);
 
-  THLongStorage *indicesSize = THLongStorage_newWithSize(4);
-  int64_t indicesSizeRaw[4] = { batchSize * inputSlices,
-                            outputTime, outputHeight, outputWidth };
-  THLongStorage_rawCopy(indicesSize, indicesSizeRaw);
-
   THCIndexTensor *indices1 = THCIndexTensor_(newWithStorage)(
     state, THCIndexTensor_(storage)(state, indices),
     THCIndexTensor_(storageOffset)(state, indices),
-    indicesSize, NULL);
-
-  THLongStorage_free(indicesSize);
+    { batchSize * inputSlices, outputTime, outputHeight, outputWidth }, {});
 
   THCDeviceTensor<THCIndex_t, 4> cudaIndices =
     toDeviceTensor<THCIndex_t, 4>(state, indices1);
@@ -365,14 +358,10 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   cudaGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
   real* gradInputData = THCTensor_(data)(state, gradInput);
 
-  THLongStorage *indicesSize = THLongStorage_newWithSize(4);
-  int64_t indicesSizeRaw[4] = { batchSize * inputSlices,
-                           outputTime, outputHeight, outputWidth };
-  THLongStorage_rawCopy(indicesSize, indicesSizeRaw);
   THCIndexTensor *indices1 = THCIndexTensor_(newWithStorage)(
     state, THCIndexTensor_(storage)(state, indices),
-    THCIndexTensor_(storageOffset)(state, indices), indicesSize, NULL);
-  THLongStorage_free(indicesSize);
+    THCIndexTensor_(storageOffset)(state, indices),
+    { batchSize * inputSlices, outputTime, outputHeight, outputWidth }, {});
 
   THCDeviceTensor<THCIndex_t, 4> cudaIndices =
     toDeviceTensor<THCIndex_t, 4>(state, indices1);


### PR DESCRIPTION
This changes setStorage (called by set_), newView (view), and newWithStorage (tensor) as per the title.

This also allows us to share size inference code between TH and ATen, so I killed e.g. newInferSize in TH; we just use at::infer_size inside of TH now.
Finally, I reorganized the TH/THC tensor/storage code to more closely match up; e.g. if THC has a non-generic version of a function, TH will as well.

NOTE: I didn't completely kill THSize, THStride yet because I haven't moved all the functions over yet.  This has the unfortunate effect that we now have both IntList and Storage versions of the same concepts, e.g. there are IntListSize and IntListStride in Declarations.cwrap that pull out the LongStorage-ness, but not the 0-dim-to-1-dim or 0-dim-to-null functionality of THLongStorageView.  Both of these limitations will be addressed in further PRs.