### PR TITLE
[JIT]  Add tracing to custom op and simplify tracer overall 

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -126,15 +126,21 @@ RECORD_FUNCTION = CodeTemplate("""\
 profiler::RecordFunction profiler("${name}");""")
 
 PRE_RECORD_TRACE = CodeTemplate("""\
-jit::tracer::PreTraceInfo trace_info;
+torch::jit::Node* node = nullptr;
 if (jit::tracer::isTracing()) {
-  trace_info = jit::tracer::preRecordTrace(jit::aten::${trace_name}, ${trace_inputs});
+  auto& graph = jit::tracer::getTracingState()->graph;
+  node = graph->create(jit::aten::${trace_name}, /*outputs=*/0);
+  jit::tracer::recordSourceLocation(node);
+  ${add_trace_inputs}
+  graph->appendNode(node);
 }
 """)
 
+ADD_TRACE_INPUT = CodeTemplate("""jit::tracer::addInputs(node, "${input}", ${input});""")
+
 POST_RECORD_TRACE = CodeTemplate("""\
 if (jit::tracer::isTracing()) {
-  jit::tracer::postRecordTrace( trace_info,  ${trace_outputs} );
+  jit::tracer::postRecordTrace(node, ArrayRef<Variable>(${trace_outputs}) );
 }
 """)
 
@@ -372,7 +378,11 @@ def emit_body(declaration):
             return ('', '')
 
         local = {}
-        local['trace_inputs'] = sum([['"{}"'.format(arg['name']), arg['name']] for arg in declaration['arguments']], [])
+
+        add_trace_inputs = []
+        for argument in declaration['arguments']:
+            add_trace_inputs.append(ADD_TRACE_INPUT.substitute(input=argument['name']))
+        local['add_trace_inputs'] = '\n'.join(add_trace_inputs)
 
         # Record inplace operations as out-of-place operations (e.g.,
         # not add_ but add)

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -13,6 +13,7 @@
 #include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/symbolic_variable.h"
+#include "torch/csrc/jit/ir.h"
 
 #include "torch/csrc/utils/variadic.h"
 #include "torch/csrc/autograd/functions/utils.h"

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -558,12 +558,12 @@ static void _assert_not_tracing(const char* name, const variable_list& input_var
   }
 }
 
-static jit::tracer::PreTraceInfo _trace_pre_record(
+static Node* _trace_pre_record(
     PyObject* op_obj,
     PyObject *input_objects,
     const variable_list& input_vars) {
   if (!jit::tracer::isTracing()) {
-    return jit::tracer::PreTraceInfo();
+    return nullptr;
   }
 
   // Save scalar args and the calling convention
@@ -593,7 +593,7 @@ static jit::tracer::PreTraceInfo _trace_pre_record(
 }
 
 static void _trace_post_record(
-    const jit::tracer::PreTraceInfo& trace_info,
+    Node* node,
     PyObject* op_obj,
     const variable_list& input_vars,
     PyObject *output_objects,
@@ -610,15 +610,15 @@ static void _trace_post_record(
     output_vars[i] = var->cdata;
   }
 
-  jit::tracer::postRecordTrace(trace_info, output_vars);
+  jit::tracer::postRecordTrace(node, output_vars);
 
-  trace_info.n->i_(attr::inplace, is_inplace);
+  node->i_(attr::inplace, is_inplace);
 
 }
 
 PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const UnpackedInput& unpacked,
                           PyObject *inputs, THPObjectPtr&& raw_output, bool is_executable,
-                          const jit::tracer::PreTraceInfo& trace_info) {
+                          Node* node) {
   bool unpack_output = ensure_tuple(raw_output);
 
   auto num_outputs = PyTuple_GET_SIZE(raw_output.get());
@@ -639,7 +639,7 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
 
   bool is_inplace = static_cast<bool>(grad_fn->dirty_tensors);
   _wrap_outputs(grad_fn, inputs, raw_output, outputs, is_executable);
-  _trace_post_record(trace_info, op_obj, unpacked.input_vars, outputs, is_inplace);
+  _trace_post_record(node, op_obj, unpacked.input_vars, outputs, is_inplace);
   if (is_executable) {
     _save_variables(grad_fn);
   } else {
@@ -687,7 +687,7 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   }
 
   return process_outputs(nullptr, self, unpacked_input, _inputs, std::move(raw_output),
-                         is_executable, jit::tracer::PreTraceInfo());
+                         is_executable, nullptr);
   END_HANDLE_TH_ERRORS
 }
 
@@ -708,7 +708,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   InputFlags& input_info = info_pair.second;
 
   // Record input nodes if tracing
-  auto trace_info = _trace_pre_record(cls, inputs, unpacked_input.input_vars);
+  auto* node = _trace_pre_record(cls, inputs, unpacked_input.input_vars);
 
   // Initialize backward function (and ctx)
   bool is_executable = input_info.is_executable;
@@ -737,7 +737,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   }
 
   return process_outputs(cls, ctx, unpacked_input, inputs, std::move(tensor_outputs),
-                         is_executable, trace_info);
+                         is_executable, node);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1131,7 +1131,7 @@ public:
     return oss.str();
   }
 
-  friend std::ostream& operator<<(std::ostream & out, const Graph & g);
+  friend TORCH_API std::ostream& operator<<(std::ostream & out, const Graph & g);
   TORCH_API std::shared_ptr<Graph> copy();
 
 private:

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
   }
 }
 
-PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
+Node* preRecordPythonTrace(THPObjectPtr pyobj,
                                   std::string arg_types,
                                   at::ArrayRef<Variable> inputs,
                                   pyobj_list scalar_args) {
@@ -78,14 +78,10 @@ PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
     throw python_error();
   }
 
-  PreTraceInfo info;
-  auto & state = getTracingState();
-  auto & graph = state->graph;
+  auto & graph = getTracingState()->graph;
 
-  Node *n = info.n = graph->createPythonOp(
-                        std::move(apply),
-                        arg_types,
-                        std::move(scalar_args));
+  Node* n = graph->createPythonOp(
+      std::move(apply), arg_types, std::move(scalar_args));
   recordSourceLocation(n);
 
   for (const Variable & input : inputs) {
@@ -95,7 +91,7 @@ PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
   // NB: Order matters. This must append after inputs but before outputs.
   graph->appendNode(n);
 
-  return info;
+  return n;
 }
 
 void pythonRecordSourceLocation(Node* n) {

--- a/torch/csrc/jit/python_tracer.h
+++ b/torch/csrc/jit/python_tracer.h
@@ -10,7 +10,7 @@ void initPythonTracerBindings(PyObject *module);
 
 
 std::string getPythonInterpreterStackTrace();
-tracer::PreTraceInfo preRecordPythonTrace(
+Node* preRecordPythonTrace(
     THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<autograd::Variable> inputs,
     pyobj_list scalar_args);
 

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -215,20 +215,8 @@ void addInputs(Node *n, const char * name, std::array<bool, N> value) {
 
 TORCH_API void postRecordTrace(Node* node, at::ArrayRef<Variable> outputs);
 
-// All these overloads are to handle (1) single `at::Tensor` (2)
-// `vector<at::Tensor>` because of implicit conversion trouble with `Variable`,
-// as well as any other types, for which we throw an exception.
-
-inline void postRecordTrace(
-    Node* node,
-    at::ArrayRef<at::Tensor> tensors) {
-  postRecordTrace(node, fmap(tensors, [](const at::Tensor& tensor) {
-                    return Variable(tensor);
-                  }));
-}
-
-inline void postRecordTrace(Node* node, at::Tensor tensor) {
-  postRecordTrace(node, at::ArrayRef<Variable>{Variable(tensor)});
+inline void postRecordTrace(Node* node, at::ArrayRef<at::Tensor> tensors) {
+  postRecordTrace(node, fmap<Variable>(tensors));
 }
 
 template <
@@ -240,7 +228,7 @@ template <
 void postRecordTrace(Node* node, T&&) {
   AT_ERROR(
       "Found an unsupported argument type ", at::demangle_type<T>(),
-      " in the JIT tracer. " "File a bug report.");
+      " in the JIT tracer. File a bug report.");
 }
 
 TORCH_API autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -1,13 +1,17 @@
 #pragma once
 
-#include "torch/csrc/jit/assertions.h"
-#include "torch/csrc/jit/ir.h"
-#include "torch/csrc/jit/constants.h"
-#include "torch/csrc/WindowsTorchApiMacro.h"
-#include "torch/csrc/utils/functional.h"
-#include "torch/csrc/utils/variadic.h"
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/constants.h"
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/utils/variadic.h"
+#include "torch/csrc/utils/variadic.h"
+#include "torch/csrc/WindowsTorchApiMacro.h"
+
+#include <ATen/Backtrace.h>
 
 #include <memory>
 #include <mutex>
@@ -187,17 +191,9 @@ inline void abandon() {
   setTracingState(nullptr);
 }
 
-// Pre-recorded information about the trace before we actually carry
-// out the trace
-struct PreTraceInfo {
-  Node *n;
-};
-
 
 TORCH_API void recordSourceLocation(Node* n);
 TORCH_API void setRecordSourceLocation(void (*v)(Node*));
-
-namespace detail {
 
 // NB: those serve both as an intermediate steps in addInputs below,
 // as well as the overloads that terminate template recursion
@@ -208,6 +204,7 @@ void addInputs(Node *n, const char * name, const at::Scalar& value);
 void addInputs(Node *n, const char * name, const at::Tensor& value);
 void addInputs(Node *n, const char * name, at::IntList value);
 void addInputs(Node *n, const char * name, at::TensorList value);
+void addInputs(Node *n, const char * name, const ArrayRef<double>& value);
 void addInputs(Node *n, const char * name, const std::string& value);
 void addInputs(Node *n, const char * name, const at::SparseTensorRef& value);
 
@@ -216,34 +213,31 @@ void addInputs(Node *n, const char * name, std::array<bool, N> value) {
   throw std::runtime_error("Found an unsupported argument type in the JIT tracer. File a bug report.");
 }
 
-template<typename T, typename... Args>
-void addInputs(Node *n, const char * arg_name, T arg, const char * next_arg_name, Args... args) {
-  addInputs(n, arg_name, arg);
-  addInputs(n, next_arg_name, args...);
+TORCH_API void postRecordTrace(Node* node, at::ArrayRef<Variable> outputs);
+
+TORCH_API inline void postRecordTrace(
+    Node* node,
+    at::ArrayRef<at::Tensor> tensors) {
+  postRecordTrace(node, fmap(tensors, [](const at::Tensor& tensor) {
+                    return Variable(tensor);
+                  }));
 }
 
-} // namespace detail
-
-// NB: if you change this function, you might want to take a look at
-// preRecordPythonTrace from python_tracer.cpp
-template<typename... Args>
-PreTraceInfo preRecordTrace(Symbol op, Args... inputs) {
-  PreTraceInfo info;
-  auto & state = getTracingState();
-  auto & graph = state->graph;
-
-  Node * n = info.n = graph->create(op, /*outputs=*/0);
-  recordSourceLocation(n);
-
-  detail::addInputs(n, inputs...);
-
-  // NB: Order matters. This must append after inputs but before outputs.
-  graph->appendNode(n);
-
-  return info;
+TORCH_API inline void postRecordTrace(Node* node, at::Tensor tensor) {
+  postRecordTrace(node, at::ArrayRef<Variable>{Variable(tensor)});
 }
 
-TORCH_API void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
+template <
+    typename T,
+    typename = torch::enable_if_t<
+        (!std::is_convertible<torch::decay_t<T>, ArrayRef<Variable>>::value &&
+         !std::is_convertible<torch::decay_t<T>, ArrayRef<at::Tensor>>::value &&
+         !std::is_convertible<torch::decay_t<T>, Variable>::value)>>
+TORCH_API void postRecordTrace(Node* node, T&&) {
+  AT_ERROR(
+      "Found an unsupported argument type ", at::demangle_type<T>(),
+      " in the JIT tracer. " "File a bug report.");
+}
 
 TORCH_API autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim);
 


### PR DESCRIPTION
This PR adds tracing infrastructure for custom operators. It also simplifies the tracer overall, and changes the codegen to do more metaprogramming there instead of via C++ (which was necessary for the custom op tracing).

To give an example of the tracer/metaprogramming change, what used to look like this in `VariableType.cpp`:

```
jit::tracer::PreTraceInfo trace_info;
  if (jit::tracer::isTracing()) {
    trace_info = jit::tracer::preRecordTrace(jit::aten::index_select, "self", self, "dim", dim, "index", index);
  }
```

is now simply the inlined version of `preRecordTrace`, minus C++ metaprogramming:

```
torch::jit::Node* node = nullptr;
  if (jit::tracer::isTracing()) {
    auto& graph = jit::tracer::getTracingState()->graph;
    node = graph->create(jit::aten::index_select_out, /*outputs=*/0);
    jit::tracer::recordSourceLocation(node);
    jit::tracer::addInputs(node, "result", result);
    jit::tracer::addInputs(node, "self", self);
    jit::tracer::addInputs(node, "dim", dim);
    jit::tracer::addInputs(node, "index", index);
    graph->appendNode(node);
  }
```

@zdevito @apaszke 