### PR TITLE
Kill Tensor::shares_data

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -527,11 +527,9 @@ TensorShape GetTensorShapeOfBlob(const Blob* b) {
     tp.set_data_type(TypeMetaToDataType(type_fun(b->GetRaw())));
   }
   if (tensor_info_fun) {
-    bool _shares_data;
     size_t _capacity;
     DeviceOption _device;
-    auto shape =
-        tensor_info_fun(b->GetRaw(), &_shares_data, &_capacity, &_device);
+    auto shape = tensor_info_fun(b->GetRaw(), &_capacity, &_device);
     for (auto d : shape) {
       tp.add_dims(d);
     }
@@ -615,12 +613,10 @@ std::map<string, std::pair<DeviceOption, DeviceOption>> ValidateTensorDevices(
   auto Check = [&](const Blob& blob, std::string blob_name) {
     TensorInfoCall tensor_info_fun = GetTensorInfoFunction(blob.meta().id());
     if (tensor_info_fun) {
-      bool _shares_data;
       size_t _capacity;
       DeviceOption blob_device;
       tensor_info_fun(
           const_cast<Blob&>(blob).GetRaw(),
-          &_shares_data,
           &_capacity,
           &blob_device);
 

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -87,11 +87,9 @@ int GetGPUIDForPointer(const void* ptr);
 
 vector<TIndex> GetTensorInfo(
     const void* c,
-    bool* shares_data,
     size_t* capacity,
     DeviceOption* device) {
   const Tensor* tc = static_cast<const Tensor*>(c);
-  *shares_data = tc->shares_data();
   *capacity = tc->capacity_nbytes();
   tc->ExtractDeviceOption(device);
   return tc->dims();

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -189,7 +189,6 @@ class Tensor {
       dims_.clear();
       size_ = -1;
       data_.reset();
-      shares_data_ = false;
       capacity_ = 0;
       reserved_ = false;
       return;
@@ -415,7 +414,6 @@ class Tensor {
     std::swap(size_, other.size_);
     std::swap(meta_, other.meta_);
     std::swap(data_, other.data_);
-    std::swap(shares_data_, other.shares_data_);
     std::swap(capacity_, other.capacity_);
     std::swap(reserved_, other.reserved_);
     std::swap(device_type_, other.device_type_);
@@ -448,7 +446,6 @@ class Tensor {
     // Finally, do sharing.
     data_ = src.data_;
     capacity_ = src.capacity_;
-    shares_data_ = true;
   }
 
   /**
@@ -494,11 +491,6 @@ class Tensor {
     } else {
       capacity_ = nbytes();
     }
-    shares_data_ = true;
-  }
-
-  bool shares_data() const {
-    return shares_data_;
   }
 
   /**
@@ -747,7 +739,6 @@ class Tensor {
   TIndex size_ = -1;
   TypeMeta meta_;
   std::shared_ptr<void> data_;
-  bool shares_data_ = false;
   size_t capacity_ = 0;
   bool reserved_ = false;
   DeviceType device_type_ = CPU;
@@ -827,6 +818,9 @@ using TensorCPU = Tensor;
 
 constexpr int k_limit_default_ = 1000;
 
+// TODO: the following logic can be merged into regular Tensor class methods
+// after MKLMemory starts to implement Tensor interface
+
 // Type call registry
 typedef TypeMeta (*TypeCall)(const void*);
 TypeCall GetTypeCallFunction(TypeIdentifier id);
@@ -835,7 +829,6 @@ void RegisterTypeCallFunction(TypeIdentifier id, TypeCall c);
 // Shape call registry
 typedef vector<TIndex> (*TensorInfoCall)(
     const void*,
-    bool* shares_data,
     size_t* capacity,
     DeviceOption* device);
 TensorInfoCall GetTensorInfoFunction(TypeIdentifier id);

--- a/caffe2/core/workspace.cc
+++ b/caffe2/core/workspace.cc
@@ -28,14 +28,11 @@ void Workspace::PrintBlobSizes() {
     Blob* b = this->GetBlob(s);
     TensorInfoCall shape_fun = GetTensorInfoFunction(b->meta().id());
     if (shape_fun) {
-      bool shares_data = false;
       size_t capacity;
       DeviceOption _device;
-      auto shape = shape_fun(b->GetRaw(), &shares_data, &capacity, &_device);
-      if (shares_data) {
-        // Blobs sharing data do not actually take any memory
-        capacity = 0;
-      }
+      auto shape = shape_fun(b->GetRaw(), &capacity, &_device);
+      // NB: currently it overcounts capacity of shared storages
+      // TODO: fix it after the storage sharing is merged
       cumtotal += capacity;
       blob_sizes.push_back(make_pair(capacity, s));
     }
@@ -55,11 +52,10 @@ void Workspace::PrintBlobSizes() {
     Blob* b = this->GetBlob(sb.second);
     TensorInfoCall shape_fun = GetTensorInfoFunction(b->meta().id());
     CHECK(shape_fun != nullptr);
-    bool _shares_data = false;
     size_t capacity;
     DeviceOption _device;
 
-    auto shape = shape_fun(b->GetRaw(), &_shares_data, &capacity, &_device);
+    auto shape = shape_fun(b->GetRaw(), &capacity, &_device);
     std::stringstream ss;
     ss << sb.second << ";";
     for (const auto d : shape) {

--- a/caffe2/mkl/utils/mkl_memory.cc
+++ b/caffe2/mkl/utils/mkl_memory.cc
@@ -21,12 +21,9 @@ CAFFE_KNOWN_TYPE(mkl::MKLMemory<double>);
 template <typename T>
 static vector<TIndex> GetMKLTensorInfo(
     const void* c,
-    bool* shares_data,
     size_t* capacity,
     DeviceOption* device) {
   const mkl::MKLMemory<T>* tc = static_cast<const mkl::MKLMemory<T>*>(c);
-  // it's too hard to get sharing info from mkl::MKLMemory
-  *shares_data = false;
   *capacity = tc->size() * sizeof(T);
   device->set_device_type(MKLDNN);
   device->set_cuda_gpu_id(0);


### PR DESCRIPTION
Summary: It's only used in debug printing and is not that reliable anyway. If we want to implement it later - we should do it proper accounting for shared storages.

Differential Revision: D9155685
