### PR TITLE
nomnigraph - Enhancements to subgraph matching APIs

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -181,6 +181,24 @@ void coalesceInsertedDataDependencies(repr::NNModule* m) {
   }
 }
 
+bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
+  auto nodeOutputs = nn::getOutputs(nodeRef);
+  NOM_REQUIRE_OR_RET_FALSE(nodeOutputs.size() == 1);
+  auto nodeConsumers = nn::getConsumers(nodeOutputs.front());
+  return nodeConsumers.size() == 1;
+}
+
+NNNodeMatchCriteria matchAnyNode() {
+  return [](NNGraph::NodeRef /* unused */) { return true; };
+}
+
+NNSubtree operatorTree(
+    const NNNodeMatchCriteria& root,
+    const std::vector<NNSubtree>& childrenCriteria,
+    int count) {
+  return NNSubtree(matchAnyNode(), {NNSubtree(root, childrenCriteria)}, count);
+}
+
 } // namespace nn
 
 } // namespace repr

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -399,6 +399,10 @@ class Graph {
     return result;
   }
 
+  const size_t getNodesCount() const {
+    return (size_t)nodes_.size();
+  }
+
   const std::vector<EdgeRef> getMutableEdges() {
     std::vector<EdgeRef> result;
     for (auto& e : edges_) {

--- a/caffe2/core/nomnigraph/include/nomnigraph/Support/Common.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Support/Common.h
@@ -31,6 +31,7 @@
 #define NOM_REQUIRE_OR_BREAK(_cond) NOM_REQUIRE_OR_(_cond, break)
 #define NOM_REQUIRE_OR_RET_NULL(_cond) NOM_REQUIRE_OR_(_cond, return nullptr)
 #define NOM_REQUIRE_OR_RET_FALSE(_cond) NOM_REQUIRE_OR_(_cond, return false)
+#define NOM_REQUIRE_OR_RET_TRUE(_cond) NOM_REQUIRE_OR_(_cond, return true)
 #define NOM_REQUIRE_OR_RET(_cond) NOM_REQUIRE_OR_(_cond, return )
 
 // Implements accessors for a generic type T. If the type is not

--- a/caffe2/core/nomnigraph/tests/neural_net_test.cc
+++ b/caffe2/core/nomnigraph/tests/neural_net_test.cc
@@ -1,0 +1,92 @@
+#include <algorithm>
+
+#include "test_util.h"
+
+#include "nomnigraph/Representations/NeuralNet.h"
+#include "nomnigraph/Support/Pointer.h"
+#include "nomnigraph/Transformations/SubgraphMatcher.h"
+
+#include <gtest/gtest.h>
+
+using namespace nom;
+using namespace nom::repr;
+using namespace nom::repr::nn;
+
+// Test for the NNGraph subgraph matching APIs.
+TEST(NeuralNetGraph, ReplaceGraph) {
+  NNGraph graph;
+
+  auto input1 = graph.createNode(util::make_unique<Tensor>("input1"));
+  auto input2 = graph.createNode(util::make_unique<Tensor>("input2"));
+  auto sum = graph.createNode(util::make_unique<Sum>());
+  auto sumOutput = graph.createNode(util::make_unique<Tensor>("sumOutput"));
+  auto relu = graph.createNode(util::make_unique<Relu>());
+  auto reluOutput = graph.createNode(util::make_unique<Tensor>("reluOutput"));
+
+  graph.createEdge(input1, sum);
+  graph.createEdge(input2, sum);
+  graph.createEdge(sum, sumOutput);
+  graph.createEdge(sumOutput, relu);
+  graph.createEdge(relu, reluOutput);
+
+  /* input1       input2
+         \        /
+          \      /
+            sum
+             |
+             |
+        sumOutput
+             |
+           relu
+             |
+        reluOutput
+  */
+
+  // clang-format off
+  auto pattern = NNSubtree(
+      matchNodeType<Relu>(), {
+          operatorTree(
+              matchNodeType<Sum>(), {
+                NNSubtree::nonTerminal(matchNodeType<Tensor>(), 2)
+              }),
+      });
+  // clang-format on
+
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern));
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern));
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern));
+
+  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern));
+
+  NNSubgraphMatcher::replaceSubtree(
+      graph, pattern, [](NNGraph& g, NNGraph::NodeRef relu) {
+        auto sumOutput = getInputs(relu)[0];
+        auto sum = getProducer(sumOutput);
+
+        auto fusedNode = g.createNode(util::make_unique<SumRelu>());
+        g.deleteNode(sumOutput);
+        g.replaceNode(relu, fusedNode);
+        g.replaceNode(sum, fusedNode);
+
+        g.deleteNode(sum);
+        g.deleteNode(relu);
+
+        return true;
+      });
+
+  /*
+      Fused graph:
+
+      input1       input2
+         \        /
+          \      /
+          sumRelu
+             |
+             |
+           output
+  */
+  EXPECT_EQ(graph.getNodesCount(), 4);
+  auto fusedNode = getProducer(reluOutput);
+  EXPECT_TRUE(is<SumRelu>(fusedNode));
+  EXPECT_EQ(getInputs(fusedNode).size(), 2);
+}


### PR DESCRIPTION
Summary:
SubtreeMatchCriteria now supports these additional requirements:
- nonTerminal flag : if this is set, it means we only match the root of the subtree and do not care about the children. Example use case: to match an "input" node but does not care how the input is produced.
- multiEdges flag : this goes together with "count" parameter and only applies when matching children nodes . If this is set, it means that the parent is expected to have multiple edges to the same subtree, rather than multiple subtrees matching the same criteria.
Additional tests for these new logic are added to subgraph_matcher_test.cc.

Subgraph matching APIs for NNGraph is also added.

(Further enhancement to make the SubgraphMatching API constructs a Subgraph object/more diagnostic information will go later).

Differential Revision: D9156092
