### PR TITLE
Correctly share CUDA Parameters.

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -12,6 +12,7 @@ import torch.multiprocessing as mp
 from torch.autograd import Variable
 from torch.nn import Parameter
 from common import TestCase, run_tests, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, TEST_WITH_ASAN
+from multiprocessing.reduction import ForkingPickler
 
 
 TEST_REPEATS = 30
@@ -86,18 +87,28 @@ def cuda_multiply_two(queue, ready, done):
         del cuda_event
 
 
-def autograd_sharing(queue, ready, master_modified):
+def requires_grad_variable_sharing(queue, ready):
+    var = queue.get()
+    ready.set()
+    queue.put(var.requires_grad)
+
+
+def autograd_sharing(queue, ready, master_modified, device, is_parameter):
     var = queue.get()
     ready.set()
     master_modified.wait()
 
-    expected_var = torch.arange(1., 26).view(5, 5)
+    expected_var = torch.arange(1., 26, device=device).view(5, 5)
     expected_var[0, 0] = 1000
     is_ok = var.data.equal(expected_var)
-    var.data[:] = torch.ones(5, 5)
+    var.data[:] = torch.ones(5, 5, device=device)
 
     is_ok &= var.grad is None
-    var._grad = Variable(torch.ones(5, 5), requires_grad=False)
+    if is_parameter:
+        is_ok &= type(var) == Parameter
+    else:
+        is_ok &= type(var) == torch.Tensor
+    var._grad = Variable(torch.ones(5, 5, device=device), requires_grad=False)
 
     queue.put(is_ok)
 
@@ -389,26 +400,28 @@ class TestMultiprocessing(TestCase):
         self._test_empty_tensor_sharing(torch.float32, torch.device('cuda'))
         self._test_empty_tensor_sharing(torch.int64, torch.device('cuda'))
 
-    def _test_autograd_sharing(self, var):
-        ready = mp.Event()
-        master_modified = mp.Event()
-        queue = mp.Queue()
-        p = mp.Process(target=autograd_sharing, args=(queue, ready, master_modified))
+    def _test_autograd_sharing(self, var, ctx=mp, is_parameter=False):
+        device = 'cuda' if var.is_cuda else 'cpu'
+
+        ready = ctx.Event()
+        master_modified = ctx.Event()
+        queue = ctx.Queue()
+        p = ctx.Process(target=autograd_sharing, args=(queue, ready, master_modified, device, is_parameter))
         p.daemon = True
         p.start()
-        var._grad = Variable(torch.zeros(5, 5), requires_grad=False)
+        var._grad = Variable(torch.zeros(5, 5, device=device), requires_grad=False)
         queue.put(var)
 
         ready.wait()
         var.data[0, 0] = 1000
-        var.grad.data[:] = torch.ones(5, 5) * 4
+        var.grad.data[:] = torch.ones(5, 5, device=device) * 4
         master_modified.set()
 
         worker_ok = queue.get()
         self.assertTrue(worker_ok)
 
-        self.assertEqual(var.data, torch.ones(5, 5))
-        self.assertEqual(var.grad.data, torch.ones(5, 5) * 4)
+        self.assertEqual(var.data, torch.ones(5, 5, device=device))
+        self.assertEqual(var.grad.data, torch.ones(5, 5, device=device) * 4)
         p.join(1)
         self.assertFalse(p.is_alive())
 
@@ -418,9 +431,54 @@ class TestMultiprocessing(TestCase):
                            requires_grad=requires_grad)
             self._test_autograd_sharing(var)
 
+    def test_leaf_variable_sharing(self):
+        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        for device in devices:
+            for requires_grad in [True, False]:
+                var = Variable(torch.arange(1., 26, device=device).view(5, 5), requires_grad=requires_grad)
+                self.assertTrue(var.is_leaf)
+                ctx = mp.get_context('spawn') if device == 'cuda' else mp
+                ready = ctx.Event()
+                queue = ctx.Queue()
+                p = ctx.Process(target=requires_grad_variable_sharing, args=(queue, ready))
+                p.daemon = True
+                p.start()
+                queue.put(var)
+                ready.wait()
+                worker_requires_grad = queue.get()
+                self.assertTrue(worker_requires_grad == requires_grad)
+
+    def test_non_leaf_variable_sharing(self):
+        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        for device in devices:
+            var0 = Variable(torch.arange(1., 26, device=device).view(5, 5), requires_grad=True)
+            var = var0 * 2
+            # We can't do the pickling indirectly, e.g., with a queue.put,
+            # because pickling happens in a separate thread, so we can't catch
+            # the exception.
+            with open(os.devnull, "w") as devnull:
+                pickler = ForkingPickler(devnull)
+                self.assertRaisesRegex(RuntimeError, r'requires_grad', lambda: pickler.dump(var))
+
+    @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
+                     don't support multiprocessing with spawn start method")
+    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
+    def test_cuda_variable_sharing(self):
+        for requires_grad in [True, False]:
+            var = Variable(torch.arange(1., 26, device='cuda').view(5, 5),
+                           requires_grad=requires_grad)
+            self._test_autograd_sharing(var, mp.get_context('spawn'))
+
     def test_parameter_sharing(self):
         param = Parameter(torch.arange(1., 26).view(5, 5))
-        self._test_autograd_sharing(param)
+        self._test_autograd_sharing(param, is_parameter=True)
+
+    @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
+                     don't support multiprocessing with spawn start method")
+    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
+    def test_cuda_parameter_sharing(self):
+        param = Parameter(torch.arange(1., 26, device='cuda').view(5, 5))
+        self._test_autograd_sharing(param, mp.get_context('spawn'), is_parameter=True)
 
     def test_empty_shared(self):
         t = torch.Tensor()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -434,7 +434,9 @@ class TestMultiprocessing(TestCase):
             self._test_autograd_sharing(var)
 
     def test_leaf_variable_sharing(self):
-        devices = ['cpu'] if not torch.cuda.is_available() or NO_MULTIPROCESSING_SPAWN else ['cpu', 'cuda']
+        devices = ['cpu']
+        if torch.cuda.is_available() and not NO_MULTIPROCESSING_SPAWN and TEST_CUDA_IPC:
+            devices.append('cuda')
         for device in devices:
             for requires_grad in [True, False]:
                 var = Variable(torch.arange(1., 26, device=device).view(5, 5), requires_grad=requires_grad)

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -360,6 +360,8 @@ class TestMultiprocessing(TestCase):
         p.join()
         self.assertIsInstance(outq.get(), RuntimeError)
 
+    @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
+                     don't support multiprocessing with spawn start method")
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     def test_event(self):
         ctx = mp.get_context('spawn')
@@ -432,7 +434,7 @@ class TestMultiprocessing(TestCase):
             self._test_autograd_sharing(var)
 
     def test_leaf_variable_sharing(self):
-        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        devices = ['cpu'] if not torch.cuda.is_available() or NO_MULTIPROCESSING_SPAWN else ['cpu', 'cuda']
         for device in devices:
             for requires_grad in [True, False]:
                 var = Variable(torch.arange(1., 26, device=device).view(5, 5), requires_grad=requires_grad)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -9,6 +9,9 @@ from torch._six import imap
 from torch._C import _add_docstr
 
 
+# NB: If you subclass Tensor, and want to share the subclassed class
+# across processes, you must also update torch/multiprocessing/reductions.py
+# to define a ForkingPickler serialization mode for the class.
 class Tensor(torch._C._TensorBase):
     def __deepcopy__(self, memo):
         if not self.is_leaf:


### PR DESCRIPTION
```
    Correctly share CUDA Parameters, requires_grad and hooks.
    
    Previously, the following was true:
    
    - If you put a Parameter for a CUDA tensor
      in multiprocessing queue (or otherwise tried to transfer it),
      this failed, saying that we cannot pickle CUDA storage.
      This is issue #9996.
    
    - If you put a leaf Tensor that requires_grad=True through the
      multiprocessing queue, it would come out the other end as
      requires_grad=False (It should have come out the other end
      as requires_grad=True).  Similarly, backwards hooks were
      lost.
    
    - If you put a non-leaf Tensor that requires_grad=True through
      the multiprocessing queue, it would come out the other end
      as requires_grad=False.
    
    The root cause for the first issue was that implementation of
    reductions for Parameter used the superclass implementation
    (tensor) in __reduce_ex__, but this always picks up the
    non-ForkingPickler reduction, which doesn't work with CUDA tensors.
    So, we registered a new ForkingPickler specifically for Parameter,
    and adjusted the code to correctly rewrap a Tensor in a Parameter
    if it was originally a parameter.
        
    While working on this, we realized that requires_grad and backwards
    hooks would not be preserved in the ForkingPickler reduction
    implementation.  We fixed the reducer to save these parameters.
    However, Adam Paszke pointed out that we shouldn't allow sending
    requires_grad=True, non-leaf Tensors over a multiprocessing
    queue, since we don't actually support autograd over process
    boundar.  We now throw an error in this case; this may cause
    previously working code to fail, but this is easy enough to fix;
    just detach() the tensor before sending it.  The error message says
    so.
    
    Fixes #9996.
```