### PR TITLE
Fix shared_ptr refcycle in graph executor

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -108,6 +108,8 @@ def get_fn(file_name, script_path):
 
 
 class JitTestCase(TestCase):
+    _do_cuda_memory_leak_check = True
+
     def assertExpectedONNXGraph(self, trace, *args, **kwargs):
         torch.onnx._optimize_trace(trace, operator_export_type=OperatorExportTypes.ONNX)
         self.assertExpectedGraph(trace, *args, **kwargs)

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -80,11 +80,11 @@ struct ExecutionPlanAutogradFunction : public autograd::Function {
     });
   }
 
-  void capture(const IValue & val) {
+  void capture(const IValue & val, bool is_output) {
     const bool is_tensor = val.isTensor();
     is_var_capture.push_back(is_tensor);
     if (is_tensor) {
-      var_captures.emplace_back(Variable(val.toTensor()), false);
+      var_captures.emplace_back(Variable(val.toTensor()), is_output);
     } else {
       ivalue_captures.push_back(val);
     }
@@ -160,12 +160,12 @@ private:
   // Capture (save) inputs that would be required to subsequently run backwards
   void captureInputs(ExecutionPlanAutogradFunction & grad_fn, at::ArrayRef<IValue> inputs) const {
     for (size_t offset : grad.df_input_captured_inputs) {
-      grad_fn.capture(inputs[offset]);
+      grad_fn.capture(inputs[offset], /*is_output*/false);
     }
   }
   void captureOutputs(ExecutionPlanAutogradFunction & grad_fn, at::ArrayRef<IValue> outputs) const {
     for (size_t offset : grad.df_input_captured_outputs) {
-      grad_fn.capture(outputs[offset]);
+      grad_fn.capture(outputs[offset], /*is_output*/true);
     }
   }
 


### PR DESCRIPTION
Fixes #10032

When capturing an output, GraphExecutorAutogradFunction creates
SavedVariable with is_output=False and owns it:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/graph_executor.cpp#L87

Constructing SavedVariable with is_output=False makes it own a copy of
the shared_ptr<GraphExecutorAutogradFunction>, which causes a reference
cycle:
https://github.com/pytorch/pytorch/blob/6456b944fd3dfe1b7db830b27afd44b15ba5a6e9/torch/csrc/autograd/saved_variable.cpp#L27

The solution in this PR is to construct the SavedVariable with
is_output=True if the captured value is an output.

Test Plan

Turn on cuda memory checking for JitTestCase. If the test's name
includes "cuda" or "gpu" in it, the cuda memory checking test happens.

cc @zdevito 