### PR TITLE
[c10d] Send, Recv, RecvAnysource, Barrier Op for MPI PG and Python Bindings

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -237,7 +237,7 @@ PyObject* c10d_init(PyObject* _unused) {
               py::call_guard<py::gil_scoped_release>())
 
           .def(
-              "recvAnysource",
+              "recv_anysource",
               &::c10d::ProcessGroup::recvAnysource,
               py::call_guard<py::gil_scoped_release>())
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -224,6 +224,26 @@ PyObject* c10d_init(PyObject* _unused) {
               py::arg("output_tensor"),
               py::arg("tensors"),
               py::arg("root"),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "send",
+              &::c10d::ProcessGroup::send,
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "recv",
+              &::c10d::ProcessGroup::recv,
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "recvAnysource",
+              &::c10d::ProcessGroup::recvAnysource,
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "barrier",
+              &::c10d::ProcessGroup::barrier,
               py::call_guard<py::gil_scoped_release>());
 
   auto processGroupGloo = shared_ptr_class_<::c10d::ProcessGroupGloo>(

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -113,13 +113,16 @@ class ProcessGroup {
       const ScatterOptions& opts = ScatterOptions()) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors, int dstRank) = 0;
+      std::vector<at::Tensor>& tensors,
+      int dstRank) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors, int srcRank) = 0;
+      std::vector<at::Tensor>& tensors,
+      int srcRank) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors, int* srcRank) = 0;
+      std::vector<at::Tensor>& tensors,
+      int* srcRank) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> barrier() = 0;
 

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -112,6 +112,17 @@ class ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) = 0;
 
+  virtual std::shared_ptr<ProcessGroup::Work> send(
+      std::vector<at::Tensor>& tensors, int dstRank) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> recv(
+      std::vector<at::Tensor>& tensors, int srcRank) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> recvAnysource(
+      std::vector<at::Tensor>& tensors, int* srcRank) = 0;
+
+  virtual std::shared_ptr<ProcessGroup::Work> barrier() = 0;
+
  protected:
   const int rank_;
   const int size_;

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -596,17 +596,20 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::send(
-    std::vector<at::Tensor>& tensors, int dstRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support send");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::recv(
-    std::vector<at::Tensor>& tensors, int srcRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support recv");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::recvAnysource(
-    std::vector<at::Tensor>& tensors, int* srcRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int* /* unused */) {
   throw std::runtime_error("ProcessGroupGloo does not support recv");
 }
 

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -595,4 +595,23 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
   throw std::runtime_error("ProcessGroupGloo does not support scatter");
 }
 
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::send(
+    std::vector<at::Tensor>& tensors, int dstRank) {
+  throw std::runtime_error("ProcessGroupGloo does not support send");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::recv(
+    std::vector<at::Tensor>& tensors, int srcRank) {
+  throw std::runtime_error("ProcessGroupGloo does not support recv");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::recvAnysource(
+    std::vector<at::Tensor>& tensors, int* srcRank) {
+  throw std::runtime_error("ProcessGroupGloo does not support recv");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::barrier() {
+  throw std::runtime_error("ProcessGroupGloo does not support barrier");
+}
+
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -263,13 +263,16 @@ class ProcessGroupGloo : public ProcessGroup {
       const ScatterOptions& opts = ScatterOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors, int dstRank) override;
+      std::vector<at::Tensor>& tensors,
+      int dstRank) override;
 
   std::shared_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors, int srcRank) override;
+      std::vector<at::Tensor>& tensors,
+      int srcRank) override;
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors, int* srcRank) override;
+      std::vector<at::Tensor>& tensors,
+      int* srcRank) override;
 
   std::shared_ptr<ProcessGroup::Work> barrier() override;
 

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -262,6 +262,17 @@ class ProcessGroupGloo : public ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> send(
+      std::vector<at::Tensor>& tensors, int dstRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> recv(
+      std::vector<at::Tensor>& tensors, int srcRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> recvAnysource(
+      std::vector<at::Tensor>& tensors, int* srcRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> barrier() override;
+
  protected:
   using KeyType = AlgorithmKey;
   using EntryType = std::unique_ptr<AlgorithmEntry>;

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -2,8 +2,8 @@
 
 #include <map>
 
-#include <mpi-ext.h> // Needed for CUDA-aware check
 #include <mpi.h>
+#include <mpi-ext.h> // Needed for CUDA-aware check
 
 namespace c10d {
 

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -408,7 +408,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
         auto data = (*entry->src)[0];
         void* recvbuf = nullptr;
         at::Tensor flatOutputTensor;
-        std::vector<at::Tensor>* outputDataVec;
+        std::vector<at::Tensor>* outputDataVec = nullptr;
 
         if (rank_ == opts.rootRank) {
           outputDataVec = entry->dst;
@@ -506,6 +506,78 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
         new WorkEntry(nullptr, &outputTensors, std::move(runFunc)));
     return enqueue(std::move(entry));
   }
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
+    std::vector<at::Tensor>& tensors, int dstRank) {
+  checkSingleTensor(tensors);
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [dstRank](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        MPI_CHECK(MPI_Send(
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            dstRank,
+            0,
+            MPI_COMM_WORLD));
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
+  return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
+    std::vector<at::Tensor>& tensors, int srcRank) {
+  checkSingleTensor(tensors);
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [srcRank](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        MPI_CHECK(MPI_Recv(
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            srcRank,
+            0,
+            MPI_COMM_WORLD,
+            MPI_STATUS_IGNORE));
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
+  return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
+    std::vector<at::Tensor>& tensors, int* srcRank) {
+  checkSingleTensor(tensors);
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [srcRank](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (*entry->src)[0];
+        MPI_Status status;
+        MPI_CHECK(MPI_Recv(
+            data.data_ptr(),
+            data.numel(),
+            mpiDatatype.at(data.type().scalarType()),
+            MPI_ANY_SOURCE,
+            0,
+            MPI_COMM_WORLD,
+            &status));
+        *(entry->srcRank) = status.MPI_SOURCE;
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
+  entry->srcRank = srcRank;
+  return enqueue(std::move(entry));
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::barrier() {
+   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [](std::unique_ptr<WorkEntry>& entry) {
+        MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(nullptr, nullptr, std::move(runFunc)));
+  return enqueue(std::move(entry));
 }
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -509,7 +509,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
-    std::vector<at::Tensor>& tensors, int dstRank) {
+    std::vector<at::Tensor>& tensors,
+    int dstRank) {
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [dstRank](std::unique_ptr<WorkEntry>& entry) {
@@ -528,7 +529,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
-    std::vector<at::Tensor>& tensors, int srcRank) {
+    std::vector<at::Tensor>& tensors,
+    int srcRank) {
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [srcRank](std::unique_ptr<WorkEntry>& entry) {
@@ -548,7 +550,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
-    std::vector<at::Tensor>& tensors, int* srcRank) {
+    std::vector<at::Tensor>& tensors,
+    int* srcRank) {
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [srcRank](std::unique_ptr<WorkEntry>& entry) {
@@ -571,7 +574,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::barrier() {
-   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [](std::unique_ptr<WorkEntry>& entry) {
         MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
       };

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -32,6 +32,8 @@ struct WorkEntry {
   // For input and output tensors (in-place), we will always use src
   std::vector<at::Tensor>* src;
   std::vector<at::Tensor>* dst;
+  // src rank returned, for recv only
+  int* srcRank;
   std::function<void(std::unique_ptr<WorkEntry>&)> run;
 };
 
@@ -129,6 +131,17 @@ class ProcessGroupMPI : public ProcessGroup {
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> send(
+      std::vector<at::Tensor>& tensors, int dstRank);
+
+  std::shared_ptr<ProcessGroup::Work> recv(
+      std::vector<at::Tensor>& tensors, int srcRank);
+
+  std::shared_ptr<ProcessGroup::Work> recvAnysource(
+      std::vector<at::Tensor>& tensor, int* srcRank);
+
+  std::shared_ptr<ProcessGroup::Work> barrier();
 
   // Creating a new ProcessGroupMPI, will initiialize MPI if not initialized
   static std::shared_ptr<ProcessGroupMPI> createProcessGroupMPI();

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -133,13 +133,16 @@ class ProcessGroupMPI : public ProcessGroup {
       const ScatterOptions& opts = ScatterOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors, int dstRank);
+      std::vector<at::Tensor>& tensors,
+      int dstRank);
 
   std::shared_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors, int srcRank);
+      std::vector<at::Tensor>& tensors,
+      int srcRank);
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensor, int* srcRank);
+      std::vector<at::Tensor>& tensor,
+      int* srcRank);
 
   std::shared_ptr<ProcessGroup::Work> barrier();
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -595,17 +595,20 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::scatter(
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::send(
-    std::vector<at::Tensor>& tensors, int dstRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support send");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recv(
-    std::vector<at::Tensor>& tensors, int srcRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support recv");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recvAnysource(
-    std::vector<at::Tensor>& tensors, int* srcRank) {
+    std::vector<at::Tensor>& /* unused */,
+    int* /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support recv");
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -594,4 +594,23 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::scatter(
   throw std::runtime_error("ProcessGroupNCCL does not support scatter");
 }
 
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::send(
+    std::vector<at::Tensor>& tensors, int dstRank) {
+  throw std::runtime_error("ProcessGroupNCCL does not support send");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recv(
+    std::vector<at::Tensor>& tensors, int srcRank) {
+  throw std::runtime_error("ProcessGroupNCCL does not support recv");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recvAnysource(
+    std::vector<at::Tensor>& tensors, int* srcRank) {
+  throw std::runtime_error("ProcessGroupNCCL does not support recv");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier() {
+  throw std::runtime_error("ProcessGroupNCCL does not support barrier");
+}
+
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -128,6 +128,17 @@ class ProcessGroupNCCL : public ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> send(
+      std::vector<at::Tensor>& tensors, int dstRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> recv(
+      std::vector<at::Tensor>& tensors, int srcRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> recvAnysource(
+      std::vector<at::Tensor>& tensors, int* srcRank) override;
+
+  std::shared_ptr<ProcessGroup::Work> barrier() override;
+
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store
   void broadcastUniqueNCCLID(ncclUniqueId* ncclID);

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -129,13 +129,16 @@ class ProcessGroupNCCL : public ProcessGroup {
       const ScatterOptions& opts = ScatterOptions()) override;
 
   std::shared_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors, int dstRank) override;
+      std::vector<at::Tensor>& tensors,
+      int dstRank) override;
 
   std::shared_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors, int srcRank) override;
+      std::vector<at::Tensor>& tensors,
+      int srcRank) override;
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors, int* srcRank) override;
+      std::vector<at::Tensor>& tensors,
+      int* srcRank) override;
 
   std::shared_ptr<ProcessGroup::Work> barrier() override;
 

--- a/torch/lib/c10d/test/ProcessGroupMPITest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupMPITest.cpp
@@ -16,7 +16,7 @@ void testAllreduce(int iter = 1000) {
   // Generate inputs
   std::vector<std::vector<at::Tensor>> allTensors(iter);
   for (auto i = 0; i < iter; ++i) {
-    auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i;
+    auto tensor = at::ones({16, 16}) * i;
     allTensors[i] = std::vector<at::Tensor>({tensor});
   }
 
@@ -58,10 +58,10 @@ void testBroadcast(int iter = 10000) {
 
   for (auto i = 0; i < iter; ++i) {
     if (pg->getRank() == 0) {
-      auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i;
+      auto tensor = at::ones({16, 16}) * i;
       allTensors[i] = std::vector<at::Tensor>({tensor});
     } else {
-      auto tensor = at::zeros(at::CPU(at::kFloat), {16, 16});
+      auto tensor = at::zeros({16, 16});
       allTensors[i] = std::vector<at::Tensor>({tensor});
     }
   }
@@ -100,7 +100,7 @@ void testReduce(int iter = 10000) {
   std::vector<std::vector<at::Tensor>> allTensors(iter);
 
   for (auto i = 0; i < iter; ++i) {
-    auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i;
+    auto tensor = at::ones({16, 16}) * i;
     allTensors[i] = std::vector<at::Tensor>({tensor});
   }
 
@@ -148,12 +148,12 @@ void testAllgather(int iter = 10000) {
 
   // Generate inputs
   for (auto i = 0; i < iter; ++i) {
-    auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i * rank;
+    auto tensor = at::ones({16, 16}) * i * rank;
     allTensors[i] = std::vector<at::Tensor>({tensor});
     allOutputTensors[i] = std::vector<std::vector<at::Tensor>>(1);
     allOutputTensors[i][0].resize(worldSize);
     for (auto j = 0; j < worldSize; ++j) {
-      allOutputTensors[i][0][j] = at::zeros(at::CPU(at::kFloat), {16, 16});
+      allOutputTensors[i][0][j] = at::zeros({16, 16});
     }
   }
 
@@ -199,13 +199,13 @@ void testGather(int iter = 10000) {
 
   // Generate inputs
   for (auto i = 0; i < iter; ++i) {
-    auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i * rank;
+    auto tensor = at::ones({16, 16}) * i * rank;
     allTensors[i] = std::vector<at::Tensor>({tensor});
     if (rank == 0) {
       allOutputTensors[i] = std::vector<std::vector<at::Tensor>>(1);
       allOutputTensors[i][0].resize(worldSize);
       for (auto j = 0; j < worldSize; ++j) {
-        allOutputTensors[i][0][j] = at::zeros(at::CPU(at::kFloat), {16, 16});
+        allOutputTensors[i][0][j] = at::zeros({16, 16});
       }
     } else {
       allOutputTensors[i] = std::vector<std::vector<at::Tensor>>();
@@ -256,14 +256,14 @@ void testScatter(int iter = 1) {
 
   // Generate inputs
   for (auto i = 0; i < iter; ++i) {
-    auto tensor = at::zeros(at::CPU(at::kFloat), {16, 16});
+    auto tensor = at::zeros({16, 16});
     allTensors[i] = std::vector<at::Tensor>({tensor});
     if (rank == 0) {
       allInputTensors[i] = std::vector<std::vector<at::Tensor>>(1);
       allInputTensors[i][0].resize(worldSize);
       for (auto j = 0; j < worldSize; ++j) {
         allInputTensors[i][0][j] =
-            at::ones(at::CPU(at::kFloat), {16, 16}) * rank * i;
+            at::ones({16, 16}) * rank * i;
       }
     } else {
       allInputTensors[i] = std::vector<std::vector<at::Tensor>>();
@@ -300,6 +300,76 @@ void testScatter(int iter = 1) {
   }
 }
 
+void testSendRecv(bool recvAnysource, int iter = 10000) {
+  auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
+  // Generate inputs
+  std::vector<std::vector<at::Tensor>> allTensors(iter);
+  auto rank = pg->getRank();
+  for (auto i = 0; i < iter; ++i) {
+    if (rank == 0) {
+      auto tensor = at::ones({16, 16}) * i;
+      allTensors[i] = std::vector<at::Tensor>({tensor});
+    } else {
+      auto tensor = at::zeros({16, 16});
+      allTensors[i] = std::vector<at::Tensor>({tensor});
+    }
+  }
+
+  if (rank == 0) {
+    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    for (auto& tensors : allTensors) {
+      // Kick off work
+      std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->send(tensors, 1);
+      works.push_back(std::move(work));
+    }
+    for (auto& work : works) {
+      // Wait for work to complete
+      if (!work->wait()) {
+        std::cerr << "Exception received: " << work->exception().what()
+          << std::endl;
+        pg->abort();
+      }
+    }
+  }
+  if (rank == 1) {
+    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<int> srcRanks(allTensors.size(), -1);
+    size_t i = 0;
+    for (auto& tensors : allTensors) {
+      // Kick off work
+      if (!recvAnysource) {
+        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->recv(tensors, 0);
+        works.push_back(std::move(work));
+      } else {
+        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+          pg->recvAnysource(tensors, &srcRanks[i]);
+      }
+      ++i;
+    }
+    for (auto& work : works) {
+      // Wait for work to complete
+      if (!work->wait()) {
+        std::cerr << "Exception received: " << work->exception().what()
+          << std::endl;
+        pg->abort();
+      }
+    }
+    // Verify outputs
+    for (int i = 0; i < iter; ++i) {
+      if (recvAnysource && srcRanks[i] != 0) {
+        throw std::runtime_error("src rank is wrong for recvAnysource");
+      }
+      const auto expected = i;
+      auto data = allTensors[i][0].data<float>();
+      for (auto j = 0; j < allTensors[i][0].numel(); ++j) {
+        if (data[j] != expected) {
+          throw std::runtime_error("BOOM!");
+        }
+      }
+    }
+  }
+}
+
 int main(int argc, char** argv) {
 #ifdef MPIEXEC
   // If we are within an openmpi mpirun, then skip the exec
@@ -314,6 +384,8 @@ int main(int argc, char** argv) {
   testAllgather();
   testGather();
   testScatter();
+  testSendRecv(false);
+  testSendRecv(true);
 
   std::cout << "Test successful" << std::endl;
 #else

--- a/torch/lib/c10d/test/ProcessGroupMPITest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupMPITest.cpp
@@ -262,8 +262,7 @@ void testScatter(int iter = 1) {
       allInputTensors[i] = std::vector<std::vector<at::Tensor>>(1);
       allInputTensors[i][0].resize(worldSize);
       for (auto j = 0; j < worldSize; ++j) {
-        allInputTensors[i][0][j] =
-            at::ones({16, 16}) * rank * i;
+        allInputTensors[i][0][j] = at::ones({16, 16}) * rank * i;
       }
     } else {
       allInputTensors[i] = std::vector<std::vector<at::Tensor>>();
@@ -326,7 +325,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
       // Wait for work to complete
       if (!work->wait()) {
         std::cerr << "Exception received: " << work->exception().what()
-          << std::endl;
+                  << std::endl;
         pg->abort();
       }
     }
@@ -342,7 +341,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
         works.push_back(std::move(work));
       } else {
         std::shared_ptr<::c10d::ProcessGroup::Work> work =
-          pg->recvAnysource(tensors, &srcRanks[i]);
+            pg->recvAnysource(tensors, &srcRanks[i]);
       }
       ++i;
     }
@@ -350,7 +349,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
       // Wait for work to complete
       if (!work->wait()) {
         std::cerr << "Exception received: " << work->exception().what()
-          << std::endl;
+                  << std::endl;
         pg->abort();
       }
     }


### PR DESCRIPTION
Based on: https://github.com/pytorch/pytorch/pull/10199
Added:
(1) send, recv, recvanysource, and barrier for MPI process group.
(2) python binding
(3) testing

Please review: https://github.com/pytorch/pytorch/commit/2e64f5d675bbbefda9d5ce6319be47c9b520562b
