### PR TITLE
add BEGIN NOT-CLEAN-FILES marker to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,10 +141,6 @@ docs/source/scripts/activation_images/
 # PyCharm files
 .idea
 
-# Visual Studio Code files
-.vscode
-.vs
-
 # OSX dir files
 .DS_Store
 
@@ -195,3 +191,11 @@ caffe2.egg-info
 
 # Atom/Watchman required file
 .watchmanconfig
+
+# BEGIN NOT-CLEAN-FILES (setup.py handles this marker. Do not change.)
+#
+# Below files are not deleted by "setup.py clean".
+
+# Visual Studio Code files
+.vscode
+.vs

--- a/setup.py
+++ b/setup.py
@@ -601,7 +601,7 @@ class clean(distutils.command.clean.clean):
         import re
         with open('.gitignore', 'r') as f:
             ignores = f.read()
-            pat = re.compile('^#( BEGIN NOT-CLEAN-FILES )*')
+            pat = re.compile(r'^#( BEGIN NOT-CLEAN-FILES )?')
             for wildcard in filter(None, ignores.split('\n')):
                 match = pat.match(wildcard)
                 if match:

--- a/setup.py
+++ b/setup.py
@@ -598,14 +598,23 @@ class clean(distutils.command.clean.clean):
 
     def run(self):
         import glob
+        import re
         with open('.gitignore', 'r') as f:
             ignores = f.read()
-            for wildcard in filter(bool, ignores.split('\n')):
-                for filename in glob.glob(wildcard):
-                    try:
-                        os.remove(filename)
-                    except OSError:
-                        shutil.rmtree(filename, ignore_errors=True)
+            pat = re.compile('^#( BEGIN NOT-CLEAN-FILES )*')
+            for wildcard in filter(None, ignores.split('\n')):
+                match = pat.match(wildcard)
+                if match:
+                    if match.group(1):
+                        # Marker is found and stop reading .gitignore.
+                        break
+                    # Ignore lines which begin with '#'.
+                else:
+                    for filename in glob.glob(wildcard):
+                        try:
+                            os.remove(filename)
+                        except OSError:
+                            shutil.rmtree(filename, ignore_errors=True)
 
         # It's an old-style class in Python 2.7...
         distutils.command.clean.clean.run(self)


### PR DESCRIPTION
Using Visual Studio Code and Visual Studio, these IDEs store configurations to `FOLDER/.vscode` and `FOLDER/.vs`.
But "setup.py clean" deletes these folders because those are described in `.gitignore` file.

To prevent this, add "BEGIN NOT-CLEAN-FILES" marker to `.gitignore` file and "setup.py clean" ignores lines after this marker.

Discussed in #10206