### PR TITLE
CAFFE_ENFORCE -> CAFFE_ENFORCE_EQ for error with more information

### DIFF
--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -25,21 +25,23 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const int N = X.dim32(0), C = X.dim32(1);
   CAFFE_ENFORCE_EQ(X.ndim(), filter.ndim());
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE(
-      C == filter.dim32(1) * group_,
+  CAFFE_ENFORCE_EQ(
+      C,
+      filter.dim32(1) * group_,
       "Convolution op: input channels does not match: # of input channels ",
       C,
       " is not equal to kernel channels * group:",
       filter.dim32(1),
       "*",
       group_);
-  CAFFE_ENFORCE(
-      M % group_ == 0,
+  CAFFE_ENFORCE_EQ(
+      M % group_,
+      0,
       "The number of output channels is not divisible by group.");
 
   int kernel_dims_size = 1;
   for (int i = 0; i < kernel_.size(); ++i) {
-    CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
+    CAFFE_ENFORCE_EQ(filter.dim32(i + 2), kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
 
@@ -180,21 +182,22 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
 // The implementations.
 template <typename T, class Context>
 bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
-  const Tensor& X = Input(INPUT);
-  auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
-  const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
-
   CAFFE_ENFORCE_EQ(
       kernel_.size(),
       2,
       "Only 2d convolution is supported for NHWC storage type");
 
-  CAFFE_ENFORCE(X.ndim(), filter.ndim());
+  const Tensor& X = Input(INPUT);
+  auto& filter = Input(FILTER);
+  Tensor* Y = Output(0);
+  CAFFE_ENFORCE_EQ(X.ndim(), 4);
+  const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
+
+  CAFFE_ENFORCE_EQ(X.ndim(), filter.ndim());
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE(filter.dim32(1) == kernel_h());
-  CAFFE_ENFORCE(filter.dim32(2) == kernel_w());
-  CAFFE_ENFORCE(filter.dim32(3) == C);
+  CAFFE_ENFORCE_EQ(filter.dim32(1), kernel_h());
+  CAFFE_ENFORCE_EQ(filter.dim32(2), kernel_w());
+  CAFFE_ENFORCE_EQ(filter.dim32(3), C);
 
   ConvPoolOpBase<Context>::SetOutputSize(X, Y, filter.dim32(0));
   // The dimension of each kernel
@@ -637,11 +640,11 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
 
   const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
   ConvPoolOpBase<Context>::ComputePads({H, W});
-  CAFFE_ENFORCE(4 == filter.ndim());
+  CAFFE_ENFORCE_EQ(filter.ndim(), 4);
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE(filter.dim32(1) == kernel_h());
-  CAFFE_ENFORCE(filter.dim32(2) == kernel_w());
-  CAFFE_ENFORCE(filter.dim32(3) == C);
+  CAFFE_ENFORCE_EQ(filter.dim32(1), kernel_h());
+  CAFFE_ENFORCE_EQ(filter.dim32(2), kernel_w());
+  CAFFE_ENFORCE_EQ(filter.dim32(3), C);
   dfilter->ResizeLike(filter);
 
   // The dimension of each kernel

--- a/caffe2/opt/fusion.cc
+++ b/caffe2/opt/fusion.cc
@@ -56,8 +56,7 @@ bool fuseConvBNHelper(repr::NNModule* nn, caffe2::Workspace* ws) {
 #undef EXPOSE_TENSOR_DATA
 
     // Assume M{CHW,HWC}
-    auto chwDim = filterTensor->dim32(1) * filterTensor->dim32(2) *
-        filterTensor->dim32(3);
+    auto chwDim = filterTensor->size_from_dim(1);
     for (auto c = 0; c < filterTensor->dim32(0); ++c) {
       float coeff =
           scaleData[c] / std::sqrt(varianceData[c] + bn->getEpsilon());

--- a/caffe2/python/transformations_test.py
+++ b/caffe2/python/transformations_test.py
@@ -224,3 +224,60 @@ class TestTransformations(test_util.TestCase):
             rtol=1e-02,
             atol=1e-04
         )
+
+    @given(
+        size=st.integers(7, 10),
+        input_channels=st.integers(1, 10),
+        kt=st.integers(3, 5),
+        kh=st.integers(3, 5),
+        kw=st.integers(3, 5),
+        seed=st.integers(0, 65535),
+        epsilon=st.floats(min_value=1e-5, max_value=1e-2),
+    )
+    def test_transformer_FuseConv3DBN(
+        self, size, input_channels, kt, kh, kw, seed, epsilon
+    ):
+        workspace.ResetWorkspace()
+        net = core.Net("net")
+        c = input_channels
+        t = size
+        h = size
+        w = size
+        net.Conv(
+            ["X", "w", "b"],
+            ["Y"],
+            kernels=[kt, kh, kw],
+        )
+        net.SpatialBN(
+            ["Y", "scale", "bias", "mean", "var"],
+            ["Y2"],
+            is_test=True,
+            epsilon=epsilon,
+        )
+
+        np.random.seed(seed)
+        workspace.FeedBlob("X", np.random.rand(1, c, t, h, w).astype(np.float32))
+        workspace.FeedBlob("w", np.random.rand(c, c, kt, kh, kw).astype(np.float32))
+        workspace.FeedBlob("b", np.random.rand(c).astype(np.float32))
+        workspace.FeedBlob("scale", np.random.rand(c).astype(np.float32))
+        workspace.FeedBlob("bias", np.random.rand(c).astype(np.float32))
+        workspace.FeedBlob("mean", np.random.rand(c).astype(np.float32))
+        # This is necessary because 1/sqrt(var) is used and if var is too small
+        # we get floating point artifacts that cause test failures
+        workspace.FeedBlob("var", np.random.rand(c).astype(np.float32) + 0.5)
+        workspace.RunNetOnce(net)
+        preTransformOutput = workspace.FetchBlob("Y2").flatten()
+        workspace.FeedBlob("Y2", np.zeros((1, 1)))
+        transformer.FuseConvBN(net)
+
+        # Ensure fusion
+        assert len(net.Proto().op) == 1
+        workspace.RunNetOnce(net)
+        postTransformOutput = workspace.FetchBlob("Y2").flatten()
+        # Check that there is no numerical difference
+        assert np.allclose(
+            preTransformOutput,
+            postTransformOutput,
+            rtol=1e-02,
+            atol=1e-04
+        )


### PR DESCRIPTION
Summary: Use CAFFE_ENFORCE_EQ(x, y) instead of CAFFE_ENFORCE(x == y) in conv_op_impl.h for error messages with more information.

Differential Revision: D9177091
