### PR TITLE
[jit][script] Add support for vararg style functions.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4789,6 +4789,12 @@ def func(t):
         self.assertEqual(r.dtype, torch.float)
         self.assertEqual(torch.zeros([1, 1, 2], dtype=torch.float), r)
 
+    def test_vararg_zeros(self):
+        def foo():
+            return torch.zeros(3, 4, 5, dtype=torch.int)
+
+        self.checkScript(foo, ())
+
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     def test_rand(self):
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2298,7 +2298,7 @@ a")
         x = torch.rand(10, dtype=torch.float, requires_grad=True)
         self.assertEqual(func(x), torch.cat((x, x), dim=0))
 
-        with self.assertRaisesRegex(RuntimeError, "expected at most"):
+        with self.assertRaisesRegex(RuntimeError, "expected a value of type int"):
             @torch.jit.script
             def func(x):
                 return torch.cat((x, x), x, dim=0)
@@ -4606,7 +4606,7 @@ def func(t):
             def f0(a):
                 torch.sum(a, a, a, a)
 
-        with self.assertRaisesRegex(RuntimeError, 'unknown keyword argument'):
+        with self.assertRaisesRegex(RuntimeError, 'argument self not provided'):
             @torch.jit.script
             def f1(a):
                 torch.sum(foo=4)

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -15,7 +15,7 @@ struct Argument {
       TypePtr type = nullptr,
       at::optional<int32_t> N = at::nullopt,
       at::optional<IValue> default_value = at::nullopt,
-      bool kwarg_only = true)
+      bool kwarg_only = false)
       : name(std::move(name)),
         type(type? type : DynamicType::get()),
         N(N),

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -447,9 +447,7 @@ struct GraphFuser {
       // XXX: This hardcodes the "map size" for this FusionGroup.
       // If we want to make the graph fuser more general in the future,
       // we could use aten::broadcast_tensors or add a primitive op that broadcasts.
-      auto * expand = graph->insert(
-          aten::expand,
-          {producer, graph->insertConstant(IValue(map_size)), graph->insertConstant(0)})->node();
+      auto * expand = graph->insert(aten::expand, {producer, map_size})->node();
       {
         std::vector<int64_t> sizes, strides;
         std::tie(sizes, strides) = at::inferExpandGeometry(

--- a/torch/jit/batchop.py
+++ b/torch/jit/batchop.py
@@ -36,7 +36,7 @@ def batch_neg_scalar(data):
 @torch.jit.script
 def batch_add(data1, mask1, dims1, data2, mask2, dims2, alpha_):
     alpha = float(alpha_)
-    data = torch.add(data1, data2, alpha)
+    data = torch.add(data1, data2, alpha=alpha)
     mask = mask1 * mask2
     dims = dims1 or dims2
     return data, mask, dims
@@ -45,14 +45,14 @@ def batch_add(data1, mask1, dims1, data2, mask2, dims2, alpha_):
 @torch.jit.script
 def batch_add_scalar(data, mask, dims, other, alpha_):
     alpha = float(alpha_)
-    data = torch.add(data, other.type_as(data), alpha)
+    data = torch.add(data, other.type_as(data), alpha=alpha)
     return data, mask, dims
 
 
 @torch.jit.script
 def batch_sub(data1, mask1, dims1, data2, mask2, dims2, alpha_):
     alpha = float(alpha_)
-    data = torch.sub(data1, data2, alpha)
+    data = torch.sub(data1, data2, alpha=alpha)
     mask = mask1 * mask2
     dims = dims1 or dims2
     return data, mask, dims


### PR DESCRIPTION
Things like `zeros(1,2,3, dtype=torch.int)` are now supported in the script by altering tryMatchSchema to auto-construct the list `[1,2,3]` when it sees inlined members of the list as the last positional arguments. 

I suggest reading the commits individually, since the first two incrementally change how we do tryMatchSchema to get it ready for adding vararg list conversion, while the third actually does the modification.

closes #10632 
closes #8516