### PR TITLE
Cleaner semantics for Reserve

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -232,6 +232,17 @@ class Tensor {
   virtual ~Tensor() noexcept {}
 
   /**
+   * @brief Extend the outer-most dimension of this tensor
+   *        to dimension of `num`.
+   */
+  void ExtendTo(TIndex num, float growthPct, BaseContext* context) {
+    CAFFE_ENFORCE_GE_WITH_CALLER(dims_.size(), 1);
+    CAFFE_ENFORCE_GE_WITH_CALLER(growthPct, 0);
+    CAFFE_ENFORCE(context != nullptr, "Context must be provided.");
+    Extend(num - dims_[0], growthPct, context);
+  }
+
+  /**
    * @brief Extends the outer-most dimension of this tensor by num elements,
    * preserving the existing data.
    *
@@ -242,6 +253,8 @@ class Tensor {
    */
   void Extend(TIndex num, float growthPct, BaseContext* context) {
     CAFFE_ENFORCE_GE_WITH_CALLER(dims_.size(), 1);
+    CAFFE_ENFORCE_GE_WITH_CALLER(
+        num, 0, "`num` must be non-negative for Extend");
     auto newDims = dims_;
     newDims[0] += num;
     if (!data_) {
@@ -261,30 +274,17 @@ class Tensor {
     auto newCapacity = dims_;
     newCapacity[0] = std::max<size_t>(
         newDims[0], std::ceil(dims_[0] * (growthPct + 100) / 100));
-    Reserve(newCapacity, context);
-    dims_ = newDims;
-    size_ = newSize;
-  }
-
-  template <class T>
-  void Reserve(const std::vector<T>& newCapacity, BaseContext* context) {
-    auto newSize = std::accumulate(
-        newCapacity.begin(),
-        newCapacity.end(),
-        static_cast<TIndex>(1),
-        std::multiplies<TIndex>());
-    if (newSize * meta_.itemsize() <= capacity_) {
-      return;
-    }
     auto oldData = std::move(data_);
     auto oldSize = size_;
     auto oldDims = dims_;
     Resize(newCapacity);
     auto* newData = raw_mutable_data(meta_);
+    CAFFE_ENFORCE(
+        context != nullptr, "Context must be provided to Extend the tensor");
     context->CopyItemsSameDevice(meta_, oldSize, oldData.get(), newData);
-    dims_ = oldDims;
-    size_ = oldSize;
     reserved_ = true;
+    dims_ = newDims;
+    size_ = newSize;
   }
 
   /**
@@ -293,7 +293,7 @@ class Tensor {
    * This method guarantees that no re-allocations are carried out, which means
    * that the extra capacity after the end of the shurnk tensor is maintained.
    */
-  void Shrink(TIndex outer_dim) {
+  void ShrinkTo(TIndex outer_dim) {
     CAFFE_ENFORCE_WITH_CALLER(dims_.size() >= 1, "Tensor must be at least 1D");
     CAFFE_ENFORCE_WITH_CALLER(
         outer_dim <= dims_[0],
@@ -304,6 +304,38 @@ class Tensor {
         dims_.end(),
         static_cast<TIndex>(1),
         std::multiplies<TIndex>());
+  }
+
+  /**
+   * @brief Reserve space for the underlying tensor.
+   *
+   * This must be called after Resize(), since we only specify the first
+   * dimension This does not copy over the old data to the newly allocated space
+   */
+  template <class T>
+  void ReserveSpace(const T& outer_dim) {
+    CAFFE_ENFORCE(
+        size_ != -1, "size should be initialized before calling ReserveSpace");
+    auto newCapacity = dims_;
+    newCapacity[0] = outer_dim;
+    auto newSize = std::accumulate(
+        newCapacity.begin(),
+        newCapacity.end(),
+        static_cast<TIndex>(1),
+        std::multiplies<TIndex>());
+    if (newSize * meta_.itemsize() <= capacity_) {
+      return;
+    }
+    // Old data is discarded
+    data_.reset();
+    auto oldSize = size_;
+    auto oldDims = dims_;
+    Resize(newCapacity);
+    // Allocate new memory and don't copy over the data
+    raw_mutable_data(meta_);
+    dims_ = oldDims;
+    size_ = oldSize;
+    reserved_ = true;
   }
 
   /**
@@ -389,7 +421,7 @@ class Tensor {
     capacity_ = 0;
     // If reserved is true and we changed tensor memory then it is fine
     // to switch it to false, if Resize is called from Reserve and it triggers
-    // FreeMemory() then reserved_ will be set to true at end of Reserve()
+    // FreeMemory() then reserved_ will be set to true at end of ReserveSpace()
     reserved_ = false;
   }
 
@@ -740,6 +772,10 @@ class Tensor {
   TypeMeta meta_;
   std::shared_ptr<void> data_;
   size_t capacity_ = 0;
+  // we decide to keep reserved and it will
+  // live in Tensor after the split
+  // The logic is that if Extend() or ReserveSpace() were ever called,
+  // then subsequent Resize()s will not free up Storage.
   bool reserved_ = false;
   DeviceType device_type_ = CPU;
   // In case of chunk load we store how much data was already loaded

--- a/caffe2/experiments/operators/tt_pad_op.h
+++ b/caffe2/experiments/operators/tt_pad_op.h
@@ -83,7 +83,7 @@ class TTPadGradientOp final : public Operator<Context> {
     auto dim1 = G.dim(1);
 
     if (old_dim0 < new_dim0) {
-      output->Shrink(old_dim0);
+      output->ShrinkTo(old_dim0);
     }
 
     return true;

--- a/caffe2/mobile/contrib/ulp2/ulp_neon.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_neon.cc
@@ -537,7 +537,7 @@ void run2b1bConvIm2ColGEMM(QConvState* state,
   } else {
     CAFFE_ENFORCE_EQ(Y->dim32(0), divRoundUp(X.dim32(0) * OH * OW, kGEMMTileSize) * kGEMMTileSize);
     CAFFE_ENFORCE_EQ(Y->dim32(1), OC);
-    Y->Shrink(X.dim32(0) * OH * OW);
+    Y->ShrinkTo(X.dim32(0) * OH * OW);
     Y->Reshape(std::vector<TIndex>{{TIndex(X.dim(0)), TIndex(OH), TIndex(OW), TIndex(OC)}});
   }
 }

--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -1004,7 +1004,7 @@ class TrimDatasetOp : public Operator<CPUContext> {
     // trim each column to the offset
     for (int col = 0; col < walker.fields().size(); ++col) {
       auto newOuterSize = walker.fields().at(col).offset();
-      Output(col)->Shrink(newOuterSize);
+      Output(col)->ShrinkTo(newOuterSize);
     }
     return true;
   }

--- a/caffe2/operators/last_n_window_collector.cc
+++ b/caffe2/operators/last_n_window_collector.cc
@@ -46,8 +46,7 @@ class LastNWindowCollectorOp : public Operator<Context> {
       }
     }
 
-    auto dims = input.dims();
-    auto num_entries = dims[0];
+    auto num_entries = input.dims()[0];
 
     if (OutputSize() > NUM_VISITED) {
       auto* num_visited_tensor = Output(NUM_VISITED);
@@ -60,8 +59,14 @@ class LastNWindowCollectorOp : public Operator<Context> {
       *num_visited += num_entries;
     }
 
-    dims[0] = numToCollect_;
-    output->Reserve(dims, &context_);
+    if (!output_initialized) {
+      auto dims = input.dims();
+      dims[0] = 0;
+      output->Resize(dims);
+      // pass meta to output
+      output->raw_mutable_data(input.meta());
+      output->ReserveSpace(numToCollect_);
+    }
 
     if (num_entries == 0) {
       if (!output_initialized) {
@@ -73,10 +78,14 @@ class LastNWindowCollectorOp : public Operator<Context> {
 
     auto num_to_copy = std::min<int32_t>(num_entries, numToCollect_);
     auto output_batch_size = output_initialized ? output->dim(0) : 0;
-    dims[0] = std::min<size_t>(numToCollect_, output_batch_size + num_to_copy);
-    if (output_batch_size < numToCollect_) {
-      output->Resize(dims);
+    auto output_num =
+        std::min<size_t>(numToCollect_, output_batch_size + num_to_copy);
+
+    // output_num is >= output_batch_size
+    if (output_num > output_batch_size) {
+      output->ExtendTo(output_num, 50, &context_);
     }
+
     auto* output_data =
         static_cast<char*>(output->raw_mutable_data(input.meta()));
 

--- a/caffe2/operators/text_file_reader.cc
+++ b/caffe2/operators/text_file_reader.cc
@@ -150,7 +150,7 @@ class TextFileReaderReadOp : public Operator<CPUContext> {
     }
 
     for (int i = 0; i < numFields; ++i) {
-      Output(i)->Shrink(rowsRead);
+      Output(i)->ShrinkTo(rowsRead);
     }
     return true;
   }


### PR DESCRIPTION
Summary:
1. Reserve
Currently, Reserve will allocate new memory and old data in the tensor is also preserved,
and Resize is relying on this behavior in some call-site, e.g. https://github.com/pytorch/pytorch/blob/master/caffe2/operators/reservoir_sampling.cc#L103, where we should be using Extend.
We want to bring semantics of Reserve to be more aligned with std::vector, i.e. we want it to be
an optimization about memory allocation and remove the semantics about preserving the data. We'll remove the guarantee that data will be preserved after Reserve, and Extend will be the only API that preserves old data when we do in-place extension of memory. This also helps with the later refactoring on split Storage from Tensor.
Also, we'll only pass in the outer dimension to Reserve which means the later dimensions should be set before we call Reserve.
2. Extend/Shrink
Previously, Extend actually means ExtendBy and Shrink means ShrinkTo, I would like to add a ExtendTo for convenience, and change Shrink to ShrinkTo.
Old functions calling Extend is still there, although it actually means Extend by, but I think it still makes sense to have it.
3. Usage Patterns

The expected usage patterns right now is:
```
t->Resize({0, 32, 32, 32});
t->template mutable_data<T>(); // set meta_
t->Reserve(100);
auto* t_data = t->template mutable_data<T>();
// feed data to tensor using t_data
for (int i = 0; i < 100; ++i) {
  t->Extend(1, 50, &context_);
  // you can continue to use t_data if you have reserved enough space
  // otherwise, you should call t->template mutable_data<T> again to
  // get the new data pointer since Extend will allocate new memory even
  // though the original data is preserved.
}
```

Reviewed By: ezyang

Differential Revision: D9128147
