### PR TITLE
[jit][script][easy] Change empty list literal compiler error to match actual builtin name

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1380,7 +1380,8 @@ private:
         auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
         if (values.size() == 0) {
           throw ErrorReport(tree) << "Empty list literals not allowed. "
-                                  << "Use _construct_empty_FOO_list() instead";
+                                  << "Use _construct_empty_foo_list() instead. "
+                                  << "`foo` can be `int`, `float` or `tensor`";
         }
         const auto elem_type = values.at(0)->type();
         for (auto v : values) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1380,7 +1380,7 @@ private:
         auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
         if (values.size() == 0) {
           throw ErrorReport(tree) << "Empty list literals not allowed. "
-                                  << "Use _constructEmptyFooList() instead";
+                                  << "Use _construct_empty_FOO_list() instead";
         }
         const auto elem_type = values.at(0)->type();
         for (auto v : values) {


### PR DESCRIPTION
I changed the name of this builtin to match Python's native style, but forgot to change the compiler error to match.