### PR TITLE
Nomnigraph - add diagnostic ability for Subgraph matching API

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -181,6 +181,12 @@ void coalesceInsertedDataDependencies(repr::NNModule* m) {
   }
 }
 
+std::ostream& operator<<(
+    std::ostream& oss,
+    const NNNodeMatchCriteria& criteria) {
+  return oss << criteria.debugString;
+}
+
 bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
   auto nodeOutputs = nn::getOutputs(nodeRef);
   NOM_REQUIRE_OR_RET_FALSE(nodeOutputs.size() == 1);
@@ -189,7 +195,8 @@ bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
 }
 
 NNNodeMatchCriteria matchAnyNode() {
-  return [](NNGraph::NodeRef /* unused */) { return true; };
+  return NNNodeMatchCriteria(
+      [](NNGraph::NodeRef /* unused */) { return true; }, "matchAnyNode");
 }
 
 NNSubtree operatorTree(

--- a/caffe2/core/nomnigraph/tests/neural_net_test.cc
+++ b/caffe2/core/nomnigraph/tests/neural_net_test.cc
@@ -52,11 +52,12 @@ TEST(NeuralNetGraph, ReplaceGraph) {
       });
   // clang-format on
 
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern));
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern));
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern));
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern).isMatch());
+  EXPECT_FALSE(
+      NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern).isMatch());
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern).isMatch());
 
-  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern));
+  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern).isMatch());
 
   NNSubgraphMatcher::replaceSubtree(
       graph, pattern, [](NNGraph& g, NNGraph::NodeRef relu) {


### PR DESCRIPTION
Summary: isSubtreeMatch now returns a SubtreeMatchResult which contains a match flag and a debugMessage string that contains the reason why a subtree is not matched (if requested).

Differential Revision: D9182429
