### PR TITLE
Better macro name hygiene prefixing.

### DIFF
--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -23,8 +23,6 @@
 
 // Disable the copy and assignment operator for a class. Note that this will
 // disable the usage of the class in std containers.
-#ifndef DISABLE_COPY_AND_ASSIGN
-#define DISABLE_COPY_AND_ASSIGN(classname)                                     \
-  classname(const classname&) = delete;                                        \
+#define AT_DISABLE_COPY_AND_ASSIGN(classname) \
+  classname(const classname&) = delete;       \
   classname& operator=(const classname&) = delete
-#endif

--- a/aten/src/ATen/core/TensorTypeIdRegistration.h
+++ b/aten/src/ATen/core/TensorTypeIdRegistration.h
@@ -32,7 +32,7 @@ class TensorTypeIdCreator final {
   static constexpr at::TensorTypeId max_id_ = TensorTypeId(
       std::numeric_limits<details::_tensorTypeId_underlyingType>::max());
 
-  DISABLE_COPY_AND_ASSIGN(TensorTypeIdCreator);
+  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdCreator);
 };
 
 class TensorTypeIdRegistry final {
@@ -46,7 +46,7 @@ class TensorTypeIdRegistry final {
   std::unordered_set<at::TensorTypeId> registeredTypeIds_;
   std::mutex mutex_;
 
-  DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistry);
+  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistry);
 };
 
 class TensorTypeIds final {
@@ -64,7 +64,7 @@ class TensorTypeIds final {
   TensorTypeIdCreator creator_;
   TensorTypeIdRegistry registry_;
 
-  DISABLE_COPY_AND_ASSIGN(TensorTypeIds);
+  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIds);
 };
 
 inline constexpr at::TensorTypeId TensorTypeIds::undefined() noexcept {
@@ -81,7 +81,7 @@ class TensorTypeIdRegistrar final {
  private:
   at::TensorTypeId id_;
 
-  DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistrar);
+  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistrar);
 };
 
 inline at::TensorTypeId TensorTypeIdRegistrar::id() const noexcept {

--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -64,6 +64,10 @@ using std::vector;
 #define CAFFE2_USED __attribute__((__used__))
 #endif //_MSC_VER
 
+#ifndef DISABLE_COPY_AND_ASSIGN
+#define DISABLE_COPY_AND_ASSIGN(classname) AT_DISABLE_COPY_AND_ASSIGN(classname)
+#endif
+
 // Define enabled when building for iOS or Android devices
 #if !defined(CAFFE2_MOBILE)
 #if defined(__ANDROID__)


### PR DESCRIPTION
Summary:
Good C++ libraries don't take up un-namespaced identifiers
like DISABLE_COPY_AND_ASSIGN.  Re-prefix this.

Follow up fix: codemod Caffe2 to use the new macro, delete
the forwarding definition

Differential Revision: D9181939
