### PR TITLE
[JIT] Unified type annotation parsing for script frontends

### DIFF
--- a/test/expect/TestScript.test_annot_ast_mypy_fn.expect
+++ b/test/expect/TestScript.test_annot_ast_mypy_fn.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_ast_mypy_method.expect
+++ b/test/expect/TestScript.test_annot_ast_mypy_method.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_ast_py3_fn.expect
+++ b/test/expect/TestScript.test_annot_ast_py3_fn.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_ast_py3_method.expect
+++ b/test/expect/TestScript.test_annot_ast_py3_method.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_string_mypy_fn.expect
+++ b/test/expect/TestScript.test_annot_string_mypy_fn.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_string_mypy_method.expect
+++ b/test/expect/TestScript.test_annot_string_mypy_method.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_string_py3_fn.expect
+++ b/test/expect/TestScript.test_annot_string_py3_fn.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annot_string_py3_method.expect
+++ b/test/expect/TestScript.test_annot_string_py3_method.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_annotated_script_fn.expect
+++ b/test/expect/TestScript.test_annotated_script_fn.expect
@@ -1,1 +1,1 @@
-forward(Tensor x, (Tensor, Tensor, Tensor) y, (Tensor, (Tensor, Tensor)) z) -> Tensor
+foo(Tensor x, (Tensor, Tensor, Tensor) y, (Tensor, (Tensor, Tensor)) z) -> Tensor

--- a/test/expect/TestScript.test_parser_type_annotations.expect
+++ b/test/expect/TestScript.test_parser_type_annotations.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, ((Tensor, Tensor), Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_parser_type_annotations_comment.expect
+++ b/test/expect/TestScript.test_parser_type_annotations_comment.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, ((Tensor, Tensor), Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -11,7 +11,7 @@
       (param
         (ident z)
         (variable (ident Tensor))))
-    (tensor_type))
+    (variable (ident Tensor)))
   (list
     (assign
       (list (variable (ident q)))

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -2,9 +2,15 @@
   (ident fn)
   (decl
     (list
-      (param (ident x) (tensor_type))
-      (param (ident y) (tensor_type))
-      (param (ident z) (tensor_type)))
+      (param
+        (ident x)
+        (variable (ident Tensor)))
+      (param
+        (ident y)
+        (variable (ident Tensor)))
+      (param
+        (ident z)
+        (variable (ident Tensor))))
     (tensor_type))
   (list
     (assign

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -1,9 +1,11 @@
 (def
   (ident fn)
-  (list
-    (param (ident x) (tensor_type))
-    (param (ident y) (tensor_type))
-    (param (ident z) (tensor_type)))
+  (decl
+    (list
+      (param (ident x) (tensor_type))
+      (param (ident y) (tensor_type))
+      (param (ident z) (tensor_type)))
+    (tensor_type))
   (list
     (assign
       (list (variable (ident q)))

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -11,7 +11,7 @@
       (param
         (ident z)
         (variable (ident Tensor))))
-    (variable (ident Tensor)))
+    (option))
   (list
     (assign
       (list (variable (ident q)))

--- a/test/expect/TestScript.test_torch_dot_tensor_annotation.expect
+++ b/test/expect/TestScript.test_torch_dot_tensor_annotation.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_torch_dot_tensor_annotation_mypy_string.expect
+++ b/test/expect/TestScript.test_torch_dot_tensor_annotation_mypy_string.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_torch_dot_tensor_annotation_py3_ast.expect
+++ b/test/expect/TestScript.test_torch_dot_tensor_annotation_py3_ast.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/expect/TestScript.test_torch_dot_tensor_annotation_py3_string.expect
+++ b/test/expect/TestScript.test_torch_dot_tensor_annotation_py3_string.expect
@@ -1,0 +1,1 @@
+foo(Tensor x, (Tensor, Tensor) y) -> (Tensor, Tensor)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4331,6 +4331,12 @@ def func(t):
 
         self.checkScript(t2, (torch.zeros(1, 1, 2),))
 
+    def test_parser_type_annotations(self):
+        cu = torch.jit.CompilationUnit('''
+            def foo(x : Tensor, y : Tuple[Tuple[Tensor, Tensor], Tensor]):
+                return x
+        ''')
+
     def test_gather_dynamic_index(self):
         def t(x):
             gather1 = x[0]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4337,6 +4337,13 @@ def func(t):
                 return x
         ''')
 
+    def test_parser_type_annotations_comment(self):
+        cu = torch.jit.CompilationUnit('''
+            def foo(x, y):
+                # type: (Tensor, Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensors]
+                return x
+        ''')
+
     def test_gather_dynamic_index(self):
         def t(x):
             gather1 = x[0]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2399,7 +2399,7 @@ a")
                 q = x
             return x
 
-        ast = torch.jit.frontend.get_jit_ast(fn)
+        ast = torch.jit.frontend.get_jit_ast(fn, is_method=False)
         self.assertExpected(str(ast))
 
     def _make_scalar_vars(self, arr, dtype):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5431,7 +5431,6 @@ def func(t):
     #  Python AST Frontend , Python 3-style type annotations , Script method
     @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_annot_ast_py3_method(self):
-        # TODO: implementation
         code = dedent('''
             from typing import Tuple
             from torch import Tensor

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4333,7 +4333,7 @@ def func(t):
 
     def test_parser_type_annotations(self):
         cu = torch.jit.CompilationUnit('''
-            def foo(x : Tensor, y : Tuple[Tuple[Tensor, Tensor], Tensor]):
+            def foo(x : Tensor, y : Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensors]:
                 return x
         ''')
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4333,15 +4333,15 @@ def func(t):
 
     def test_parser_type_annotations(self):
         cu = torch.jit.CompilationUnit('''
-            def foo(x : Tensor, y : Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensors]:
-                return x
+            def foo(x : Tensor, y : Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensor]:
+                return x, x
         ''')
 
     def test_parser_type_annotations_comment(self):
         cu = torch.jit.CompilationUnit('''
             def foo(x, y):
-                # type: (Tensor, Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensors]
-                return x
+                # type: (Tensor, Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensor]
+                return x, x
         ''')
 
     def test_gather_dynamic_index(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4337,12 +4337,17 @@ def func(t):
                 return x, x
         ''')
 
+        self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
+
     def test_parser_type_annotations_comment(self):
         cu = torch.jit.CompilationUnit('''
             def foo(x, y):
                 # type: (Tensor, Tuple[Tuple[Tensor, Tensor], Tensor]) -> Tuple[Tensor, Tensor]
                 return x, x
         ''')
+
+        self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
+
 
     def test_gather_dynamic_index(self):
         def t(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5363,13 +5363,18 @@ def func(t):
         self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
 
     #  String frontend , Python 3-style type annotations , Script method
-    # def test_annot_string_py3_method(self):
-    #     # TODO: self should not get type Tensor
-    #     cu = torch.jit.CompilationUnit('''
-    #         def foo(self, x : Tensor, y : Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]:
-    #             return x, x
-    #     ''')
-    #     self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
+    def test_annot_string_py3_method(self):
+        class TestModule(torch.jit.ScriptModule):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+                self.define('''
+            def foo(self, x : Tensor, y : Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]:
+                return x, x
+                ''')
+
+        tm = TestModule()
+        self.assertExpected(tm.__getattr__('foo').pretty_print_schema())
 
     #  String frontend , MyPy-style type comments , Script function
     def test_annot_string_mypy_fn(self):
@@ -5381,14 +5386,19 @@ def func(t):
         self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
 
     #  String frontend , MyPy-style type comments , Script method
-    # def test_annot_string_mypy_method(self):
-    #     # TODO: self should not get type Tensor
-    #     cu = torch.jit.CompilationUnit('''
-    #         def foo(self, x, y):
-    #             # type: (Tensor, Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]
-    #             return x, x
-    #     ''')
-    #     self.assertExpected(cu.__getattr__('foo').pretty_print_schema())
+    def test_annot_string_mypy_method(self):
+        class TestModule(torch.jit.ScriptModule):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+                self.define('''
+            def foo(self, x, y):
+                # type: (Tensor, Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]
+                return x, x
+                ''')
+
+        tm = TestModule()
+        self.assertExpected(tm.__getattr__('foo').pretty_print_schema())
 
     # Helper function to eval Python3 code without causing a syntax error for
     # this file under py2

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -160,10 +160,12 @@ FunctionSchema inferAndCheckSchema(const std::string& schemaOrName) {
       providedSchema.arguments,
       inferredSchema,
       providedSchema);
+      AT_CHECK(inferredSchema.returns);
+      AT_CHECK(providedSchema.returns);
   checkArgumentVector(
       "return value",
-      inferredSchema.returns,
-      providedSchema.returns,
+      *inferredSchema.returns,
+      *providedSchema.returns,
       inferredSchema,
       providedSchema);
   return providedSchema;

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -160,12 +160,10 @@ FunctionSchema inferAndCheckSchema(const std::string& schemaOrName) {
       providedSchema.arguments,
       inferredSchema,
       providedSchema);
-      AT_CHECK(inferredSchema.returns);
-      AT_CHECK(providedSchema.returns);
   checkArgumentVector(
       "return value",
-      *inferredSchema.returns,
-      *providedSchema.returns,
+      inferredSchema.returns,
+      providedSchema.returns,
       inferredSchema,
       providedSchema);
   return providedSchema;

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -39,7 +39,7 @@ struct FunctionSchema {
   FunctionSchema(
       std::string name,
       std::vector<Argument> arguments,
-      at::optional<std::vector<Argument>> returns,
+      std::vector<Argument> returns,
       bool is_vararg = false,
       bool is_varret = false)
       : name(std::move(name)),
@@ -55,14 +55,14 @@ struct FunctionSchema {
       bool is_varret = false)
       : FunctionSchema(
             name.toQualString(),
-            std::move(arguments),
-            std::move(returns),
+            std::move(std::move(arguments)),
+            std::move(std::move(returns)),
             is_vararg,
             is_varret) {}
 
   const std::string name;
   const std::vector<Argument> arguments;
-  const at::optional<std::vector<Argument>> returns;
+  const std::vector<Argument> returns;
   // if true then this schema takes an arbitrary number of additional arguments
   // after the argument specified in arguments
   // currently this is used primarily to represent 'primtive' operators whose
@@ -100,19 +100,15 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
     out << schema.arguments[i];
   }
 
-  if (schema.returns) {
-    out << ") -> ";
-    if (schema.returns->size() == 1) {
-      out << schema.returns->at(0).type->str();
-    } else if (schema.returns->size() > 1) {
-      out << "(";
-      for (size_t i = 0; i < schema.returns->size(); ++i) {
-        if (i > 0) out << ", ";
-        out << (*schema.returns)[i].type->str();
-      }
-      out << ")";
+  out << ") -> ";
+  if (schema.returns.size() == 1) {
+    out << schema.returns.at(0).type->str();
+  } else if (schema.returns.size() > 1) {
+    out << "(";
+    for (size_t i = 0; i < schema.returns.size(); ++i) {
+      if (i > 0) out << ", ";
+      out << schema.returns[i].type->str();
     }
-  } else {
     out << ")";
   }
   return out;

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -39,7 +39,7 @@ struct FunctionSchema {
   FunctionSchema(
       std::string name,
       std::vector<Argument> arguments,
-      std::vector<Argument> returns,
+      at::optional<std::vector<Argument>> returns,
       bool is_vararg = false,
       bool is_varret = false)
       : name(std::move(name)),
@@ -62,7 +62,7 @@ struct FunctionSchema {
 
   const std::string name;
   const std::vector<Argument> arguments;
-  const std::vector<Argument> returns;
+  const at::optional<std::vector<Argument>> returns;
   // if true then this schema takes an arbitrary number of additional arguments
   // after the argument specified in arguments
   // currently this is used primarily to represent 'primtive' operators whose
@@ -100,15 +100,19 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
     out << schema.arguments[i];
   }
 
-  out << ") -> ";
-  if (schema.returns.size() == 1) {
-    out << schema.returns.at(0).type->str();
-  } else if (schema.returns.size() > 1) {
-    out << "(";
-    for (size_t i = 0; i < schema.returns.size(); ++i) {
-      if (i > 0) out << ", ";
-      out << schema.returns[i].type->str();
+  if (schema.returns) {
+    out << ") -> ";
+    if (schema.returns->size() == 1) {
+      out << schema.returns->at(0).type->str();
+    } else if (schema.returns->size() > 1) {
+      out << "(";
+      for (size_t i = 0; i < schema.returns->size(); ++i) {
+        if (i > 0) out << ", ";
+        out << (*schema.returns)[i].type->str();
+      }
+      out << ")";
     }
+  } else {
     out << ")";
   }
   return out;

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -232,15 +232,19 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
     out << arg.type->str() << " " << arg.name;
   }
 
-  out << ") -> ";
-  if (schema.returns.size() == 1) {
-    out << schema.returns.at(0).type->str();
-  } else if (schema.returns.size() > 1) {
-    out << "(";
-    for (size_t i = 0; i < schema.returns.size(); ++i) {
-      if (i > 0) out << ", ";
-      out << schema.returns[i].type->str();
+  if (schema.returns) {
+    out << ") -> ";
+    if (schema.returns->size() == 1) {
+      out << schema.returns->at(0).type->str();
+    } else if (schema.returns->size() > 1) {
+      out << "(";
+      for (size_t i = 0; i < schema.returns->size(); ++i) {
+        if (i > 0) out << ", ";
+        out << (*schema.returns)[i].type->str();
+      }
+      out << ")";
     }
+  } else {
     out << ")";
   }
   return out.str();

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -232,19 +232,15 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
     out << arg.type->str() << " " << arg.name;
   }
 
-  if (schema.returns) {
-    out << ") -> ";
-    if (schema.returns->size() == 1) {
-      out << schema.returns->at(0).type->str();
-    } else if (schema.returns->size() > 1) {
-      out << "(";
-      for (size_t i = 0; i < schema.returns->size(); ++i) {
-        if (i > 0) out << ", ";
-        out << (*schema.returns)[i].type->str();
-      }
-      out << ")";
+  out << ") -> ";
+  if (schema.returns.size() == 1) {
+    out << schema.returns.at(0).type->str();
+  } else if (schema.returns.size() > 1) {
+    out << "(";
+    for (size_t i = 0; i < schema.returns.size(); ++i) {
+      if (i > 0) out << ", ";
+      out << schema.returns[i].type->str();
     }
-  } else {
     out << ")";
   }
   return out.str();

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -633,6 +633,9 @@ struct to_ir {
     // Type annotations exclude explicitly typing the "self" parameter, so in the
     // case that this is a method with self we expect one fewer parameter annotation
     // than the number of parameters this Def takes.
+    if (self && def.decl().params().size() == 0) {
+      throw ErrorReport(def.decl().params().range()) << "methods must have a self argument";
+    }
     auto expected_annotation_size = self ? def.decl().params().size() - 1 : def.decl().params().size();
     if (typed_def.schema && typed_def.schema->arguments.size() != expected_annotation_size) {
       throw ErrorReport(def.decl().params().range()) << "Number of type annotations for"

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1598,7 +1598,8 @@ std::vector<Argument> parseArgsFromDecl(Decl decl, bool is_method) {
   for (; i < decl.params().size(); ++i) {
     auto decl_arg = decl.params()[i];
     auto arg = Argument(decl_arg.ident().name(), parseTypeFromExpr(decl_arg.type()),
-                        /*N =*/{}, /*default_value =*/{}, /*kwarg_only =*/false);
+                        /*N =*/at::nullopt, /*default_value =*/at::nullopt,
+                        /*kwarg_only =*/false);
     retval.push_back(arg);
   }
   return retval;
@@ -1616,8 +1617,8 @@ std::vector<Argument> parseReturnsFromDecl(Decl decl) {
     }
     return retval;
   } else {
-    return {Argument("", parsed_type, /*N =*/{}, /*default_value =*/{},
-                     /*kwarg_only =*/false)};
+    return {Argument("", parsed_type, /*N =*/at::nullopt,
+                     /*default_value =*/at::nullopt, /*kwarg_only =*/false)};
   }
 }
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1584,11 +1584,11 @@ TypePtr parseTypeFromExpr(Expr expr) {
                                   << " cannot be used in a type expression";
 }
 
-std::vector<Argument> parseArgsFromDef(Def &def, bool is_method=false) {
+std::vector<Argument> parseArgsFromDecl(Decl decl, bool is_method=false) {
   std::vector<Argument> retval;
   size_t i = is_method ? 1 : 0;
-  for (; i < def.decl().params().size(); ++i) {
-    auto decl_arg = def.decl().params()[i];
+  for (; i < decl.params().size(); ++i) {
+    auto decl_arg = decl.params()[i];
     auto arg = Argument(decl_arg.ident().name(), parseTypeFromExpr(decl_arg.type()),
                         /*N =*/{}, /*default_value =*/{}, /*kwarg_only =*/false);
     retval.push_back(arg);
@@ -1596,9 +1596,9 @@ std::vector<Argument> parseArgsFromDef(Def &def, bool is_method=false) {
   return retval;
 }
 
-std::vector<Argument> parseReturnsFromDef(Def &def) {
-  JIT_ASSERT(def.decl().return_type().present());
-  auto parsed_type = parseTypeFromExpr(def.decl().return_type().get());
+std::vector<Argument> parseReturnsFromDecl(Decl decl) {
+  JIT_ASSERT(decl.return_type().present());
+  auto parsed_type = parseTypeFromExpr(decl.return_type().get());
   if (auto tuple_type = parsed_type->cast<TupleType>()) {
     // Flatten a single return type of type Tuple into its constituent types
     std::vector<Argument> retval;
@@ -1615,10 +1615,10 @@ std::vector<Argument> parseReturnsFromDef(Def &def) {
 
 FunctionSchema extractSchemaFromDef(Def &def, bool is_method=false) {
     auto name = def.name().name();
-    std::vector<Argument> args = parseArgsFromDef(def, is_method);
+    std::vector<Argument> args = parseArgsFromDecl(def.decl(), is_method);
     at::optional<std::vector<Argument>> returns = at::nullopt;
     if (def.decl().return_type().present()) {
-      returns = parseReturnsFromDef(def);
+      returns = parseReturnsFromDecl(def.decl());
     }
     return FunctionSchema(name, args, returns);
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -627,21 +627,21 @@ struct to_ir {
 
     std::vector<Argument> arguments, returns; // for schema
     // inputs
-    auto it = def.params().begin();
-    auto end = def.params().end();
+    auto it = def.decl().params().begin();
+    auto end = def.decl().params().end();
     // Type annotations exclude explicitly typing the "self" parameter, so in the
     // case that this is a method with self we expect one fewer parameter annotation
     // than the number of parameters this Def takes.
-    auto expected_annotation_size = self ? def.params().size() - 1 : def.params().size();
+    auto expected_annotation_size = self ? def.decl().params().size() - 1 : def.decl().params().size();
     if (typed_def.schema && typed_def.schema->arguments.size() != expected_annotation_size) {
-      throw ErrorReport(def.params().range()) << "Number of type annotations for"
+      throw ErrorReport(def.decl().params().range()) << "Number of type annotations for"
         << " function parameters (" << typed_def.schema->arguments.size() << ")"
         << " does not match the number of parameters on the function ("
         << expected_annotation_size << ")!";
     }
     if(self) {
       if(it == end)
-        throw ErrorReport(def.params().range()) << "methods must have a self argument";
+        throw ErrorReport(def.decl().params().range()) << "methods must have a self argument";
       environment_stack->setSugaredVar(def.range(), (*it).ident().name(), self);
       ++it;
     }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1568,7 +1568,7 @@ TypePtr parseTypeFromExpr(Expr expr) {
     }
     auto value_name = Var(subscript.value()).name().name();
     if (!subscriptable_types().count(value_name)) {
-      throw ErrorReport(subscript.value().range()) << "Type cannot be subscripted.";
+      throw ErrorReport(subscript.range()) << "Type " << value_name << " cannot be subscripted";
     }
     if (value_name == "Tuple") {
       std::vector<TypePtr> subscript_expr_types;
@@ -1578,7 +1578,8 @@ TypePtr parseTypeFromExpr(Expr expr) {
       return TupleType::create(subscript_expr_types);
     }
   }
-  throw ErrorReport(expr.range()) << "Incompatible type expression type: " << kindToString(expr.kind());
+  throw ErrorReport(expr.range()) << "Expression of type " << kindToString(expr.kind())
+                                  << " cannot be used in a type expression";
 }
 
 std::vector<Argument> parseArgsFromDef(Def &def) {
@@ -1622,7 +1623,6 @@ void defineMethodsInModule(Module & m, const std::string& source, const Resolver
   std::vector<TypedDef> definitions;
   std::vector<Resolver> resolvers;
   while (p.lexer().cur().kind != TK_EOF) {
-    // TODO: Function schema
     auto def = Def(p.parseFunction());
     auto schema = type_annotations::extractSchemaFromDef(def);
     definitions.emplace_back(def, schema);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1584,7 +1584,7 @@ TypePtr parseTypeFromExpr(Expr expr) {
                                   << " cannot be used in a type expression";
 }
 
-std::vector<Argument> parseArgsFromDecl(Decl decl, bool is_method=false) {
+std::vector<Argument> parseArgsFromDecl(Decl decl, bool is_method) {
   std::vector<Argument> retval;
   size_t i = is_method ? 1 : 0;
   for (; i < decl.params().size(); ++i) {
@@ -1613,7 +1613,7 @@ std::vector<Argument> parseReturnsFromDecl(Decl decl) {
   }
 }
 
-FunctionSchema extractSchemaFromDef(Def &def, bool is_method=false) {
+FunctionSchema extractSchemaFromDef(Def &def, bool is_method) {
     auto name = def.name().name();
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), is_method);
     at::optional<std::vector<Argument>> returns = at::nullopt;
@@ -1636,10 +1636,11 @@ void defineMethodsInModule(Module & m, const std::string& source, const Resolver
   defineMethodsInModule(m, definitions, resolvers, self);
 }
 
-std::shared_ptr<Graph> compileFunction(TypedDef typed_def, const Resolver& resolver) {
+std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver) {
   Module m;
-  defineMethodsInModule(m, {typed_def}, {resolver}, nullptr);
-  return m.get_method(typed_def.def.name().name()).graph();
+  auto schema = extractSchemaFromDef(def);
+  defineMethodsInModule(m, {TypedDef(def, schema)}, {resolver}, nullptr);
+  return m.get_method(def.name().name()).graph();
 }
 
 std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(SourceRange loc, Method& m) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1581,6 +1581,13 @@ TypePtr parseTypeFromExpr(Expr expr) {
       throw ErrorReport(subscript.range()) << "Type " << value_name << " cannot be subscripted";
     }
     return subscript_to_type_fns().at(value_name)(subscript);
+  } else if (expr.kind() == '.') {
+    auto select = Select(expr);
+    if (select.value().kind() == TK_VAR && Var(select.value()).name().name() == "torch"
+        && select.selector().name() == "Tensor") {
+      return ident_to_type_lut().at("Tensor");
+    }
+    std::cout << select << std::endl;
   }
   throw ErrorReport(expr.range()) << "Expression of type " << kindToString(expr.kind())
                                   << " cannot be used in a type expression";

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1638,7 +1638,7 @@ void defineMethodsInModule(Module & m, const std::string& source, const Resolver
   std::vector<Def> definitions;
   std::vector<Resolver> resolvers;
   while (p.lexer().cur().kind != TK_EOF) {
-    auto def = Def(p.parseFunction());
+    auto def = Def(p.parseFunction(/*is_method=*/bool(self)));
     definitions.push_back(def);
     resolvers.push_back(resolver);
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1613,7 +1613,7 @@ std::vector<Argument> parseReturnsFromDecl(Decl decl) {
   }
 }
 
-FunctionSchema extractSchemaFromDef(Def &def, bool is_method) {
+FunctionSchema extractSchemaFromDef(const Def &def, bool is_method) {
     auto name = def.name().name();
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), is_method);
     at::optional<std::vector<Argument>> returns = at::nullopt;

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -17,9 +17,9 @@ struct CallsiteDescriptor {
   bool allow_varargs;
 };
 
-static inline std::vector<Value*> toValues(at::ArrayRef<NamedValue> nvs) {
-  return fmap(nvs, [](const NamedValue& v) {
-    return v.value;
+static inline std::vector<Value*> toValues(Graph& g, at::ArrayRef<NamedValue> nvs) {
+  return fmap(nvs, [&](const NamedValue& v) {
+    return v.value(g);
   });
 }
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -162,7 +162,7 @@ TORCH_API at::optional<std::vector<Value*>> tryMatchSchema(
   at::ArrayRef<NamedValue> attributes,
   std::ostream& failure_messages);
 
-TORCH_API FunctionSchema extractSchemaFromDef(Def &def, bool is_method=false);
+TORCH_API FunctionSchema extractSchemaFromDef(const Def &def, bool is_method=false);
 
 TORCH_API Value* emitBuiltinCall(
   const SourceRange& loc,

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -17,20 +17,9 @@ struct CallsiteDescriptor {
   bool allow_varargs;
 };
 
-struct TypedDef {
-  TypedDef(Def def, at::optional<FunctionSchema> schema)
-    : def(std::move(def)), schema(std::move(schema)) {}
-
-  TypedDef(Def def)
-    : def(std::move(def)), schema(at::nullopt) {}
-
-  Def def;
-  at::optional<FunctionSchema> schema;
-};
-
-static inline std::vector<Value*> toValues(Graph& g, at::ArrayRef<NamedValue> nvs) {
-  return fmap(nvs, [&](const NamedValue& v) {
-    return v.value(g);
+static inline std::vector<Value*> toValues(at::ArrayRef<NamedValue> nvs) {
+  return fmap(nvs, [](const NamedValue& v) {
+    return v.value;
   });
 }
 
@@ -135,7 +124,7 @@ using Resolver = std::function<std::shared_ptr<
     SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
 TORCH_API void defineMethodsInModule(
   Module & m,
-  const std::vector<TypedDef>& definitions,
+  const std::vector<Def>& definitions,
   const std::vector<Resolver>& resolvers, /* determines how we handle free variables in each definition*/
   std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
 );

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -142,7 +142,7 @@ TORCH_API void defineMethodsInModule(
 
 // same as above but parse the definitions from source
 TORCH_API void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
-TORCH_API std::shared_ptr<Graph> compileFunction(TypedDef def, const Resolver& resolver);
+TORCH_API std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.
@@ -162,6 +162,7 @@ TORCH_API at::optional<std::vector<Value*>> tryMatchSchema(
   at::ArrayRef<NamedValue> attributes,
   std::ostream& failure_messages);
 
+TORCH_API FunctionSchema extractSchemaFromDef(Def &def, bool is_method=false);
 
 TORCH_API Value* emitBuiltinCall(
   const SourceRange& loc,

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -553,11 +553,12 @@ void initJitScriptBindings(PyObject* module) {
     return compileFunction(def, pythonResolver(rcb));
   });
 
-  m.def("merge_decl_types_from_comment", [](Decl decl, const std::string& line) {
-    Parser p(line);
-    auto type_comment_decl = Decl(p.parseTypeComment(true));
-    return p.mergeTypesFromTypeComment(decl, type_comment_decl);
+  m.def("parse_type_comment", [](const std::string& comment) {
+    Parser p(comment);
+    return Decl(p.parseTypeComment(true));
   });
+
+  m.def("merge_type_from_type_comment", &mergeTypesFromTypeComment);
 
 }
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -565,8 +565,10 @@ void initJitScriptBindings(PyObject* module) {
         for (const auto &arg_type : typed_def.schema->arguments) {
           arg_type_args.push_back(Argument(typed_def.def.decl().params()[i++].ident().name(), arg_type.type, {}, {}, false));
         }
-        for (const auto &return_type : typed_def.schema->returns) {
-          return_type_args.push_back(Argument("", return_type.type, {}, {}, false));
+        if (typed_def.schema->returns) {
+          for (const auto &return_type : *typed_def.schema->returns) {
+            return_type_args.push_back(Argument("", return_type.type, {}, {}, false));
+          }
         }
         self.setSchema(FunctionSchema(self.name(), arg_type_args, return_type_args));
       }

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -132,14 +132,14 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     // Note that this effectively makes the return type of Tuple[Tensor] and Tensor
     // equivalent, but the PythonOp impl ends with an optional tuple unpack, so we need
     // to do it.
-    for (auto & ret_arg : schema.returns) {
+    for (auto & ret_arg : *schema.returns) {
       if (!ret_arg.type->isSubtypeOf(DynamicType::get())) {
         throw ErrorReport(loc) << "Python functions can currently only return Tensors";
       }
     }
 
     std::vector<Value*> outputs;
-    for(size_t i = 0; i < schema.returns.size(); ++i)
+    for(size_t i = 0; i < schema.returns->size(); ++i)
       outputs.push_back(new_node->addOutput());
     return std::make_shared<SimpleValue>(packOutputs(*m.graph(), outputs));
   }

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -407,7 +407,7 @@ void initJitScriptBindings(PyObject* module) {
     std::vector<Argument> arguments, returns;
     size_t i = method ? 1 : 0;
     for (auto arg_type : arg_types) {
-      arguments.push_back(Argument(def.params()[i++].ident().name(), arg_type, {}, {}, false));
+      arguments.push_back(Argument(def.decl().params()[i++].ident().name(), arg_type, {}, {}, false));
     }
     for (auto ret_type : return_types) {
       returns.push_back(Argument("", ret_type, {}, {}, false));
@@ -563,7 +563,7 @@ void initJitScriptBindings(PyObject* module) {
       size_t i = 0;
       if (typed_def.schema) {
         for (const auto &arg_type : typed_def.schema->arguments) {
-          arg_type_args.push_back(Argument(typed_def.def.params()[i++].ident().name(), arg_type.type, {}, {}, false));
+          arg_type_args.push_back(Argument(typed_def.def.decl().params()[i++].ident().name(), arg_type.type, {}, {}, false));
         }
         for (const auto &return_type : typed_def.schema->returns) {
           return_type_args.push_back(Argument("", return_type.type, {}, {}, false));

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -132,14 +132,14 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     // Note that this effectively makes the return type of Tuple[Tensor] and Tensor
     // equivalent, but the PythonOp impl ends with an optional tuple unpack, so we need
     // to do it.
-    for (auto & ret_arg : *schema.returns) {
+    for (auto & ret_arg : schema.returns) {
       if (!ret_arg.type->isSubtypeOf(DynamicType::get())) {
         throw ErrorReport(loc) << "Python functions can currently only return Tensors";
       }
     }
 
     std::vector<Value*> outputs;
-    for(size_t i = 0; i < schema.returns->size(); ++i)
+    for(size_t i = 0; i < schema.returns.size(); ++i)
       outputs.push_back(new_node->addOutput());
     return std::make_shared<SimpleValue>(packOutputs(*m.graph(), outputs));
   }

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -436,14 +436,19 @@ void initJitScriptBindings(PyObject* module) {
             auto self = has_self ? std::make_shared<ModuleValue>(m) : nullptr;
             return defineMethodsInModule(*m, script, pythonResolver(rcb), self);
           })
-      .def("_create_methods", [](std::shared_ptr<Module> m, const std::vector<TypedDef>& defs, const std::vector<ResolutionCallback>& rcbs) {
+      .def("_create_methods", [](std::shared_ptr<Module> m, const std::vector<Def>& defs, const std::vector<ResolutionCallback>& rcbs) {
         std::vector<Resolver> resolvers;
         for(auto & callback : rcbs) {
           resolvers.push_back(pythonResolver(callback));
         }
+        std::vector<TypedDef> typed_defs;
+        for (auto & def : defs) {
+          auto schema = extractSchemaFromDef(def, true);
+          typed_defs.emplace_back(def, schema);
+        }
         defineMethodsInModule(
           *m,
-          defs,
+          typed_defs,
           resolvers,
           std::make_shared<ModuleValue>(m));
       })

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -40,7 +40,6 @@ namespace script {
   _(TK_OPTION, "option", "")                     \
   _(TK_APPLY, "apply", "")                       \
   _(TK_COMPREHENSION, "comprehension", "")       \
-  _(TK_TENSOR_TYPE, "tensor_type", "")           \
   _(TK_RANGE_CONSTRAINT, "range_constraint", "") \
   _(TK_PARAM, "param", "")                       \
   _(TK_INFERRED, "inferred", "")                 \

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -71,9 +71,8 @@ namespace script {
   _(TK_DIV_EQ, "/=", "/=")                       \
   _(TK_GLOBAL, "global", "global")               \
   _(TK_BUILT_IN, "built-in", "")                 \
-  _(TK_SLICE, "slice", "")                       \
+  _(TK_SUBSCRIPT, "subscript", "")               \
   _(TK_VAR, "variable", "")                      \
-  _(TK_GATHER, "gather", "")                     \
   _(TK_NOTHING, "nothing", "")                   \
   _(TK_LIST_LITERAL, "list-literal", "")         \
   _(TK_TUPLE_LITERAL, "tuple-literal", "")       \
@@ -83,7 +82,8 @@ namespace script {
   _(TK_UNARY_MINUS, "unary minus", "")           \
   _(TK_POW, "pow operator", "**")                \
   _(TK_ARROW, "arrow", "->")                     \
-  _(TK_DECL, "decl", "")
+  _(TK_DECL, "decl", "")                         \
+  _(TK_SLICE_EXPR, "slice expr", "")
 
 static const char* valid_single_char_tokens = "+-*/@()[]:,={}><.?";
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -83,6 +83,7 @@ namespace script {
   _(TK_UNARY_MINUS, "unary minus", "")           \
   _(TK_POW, "pow operator", "**")                \
   _(TK_ARROW, "arrow", "->")                     \
+  _(TK_DECL, "decl", "")
 
 static const char* valid_single_char_tokens = "+-*/@()[]:,={}><.?";
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -82,7 +82,8 @@ namespace script {
   _(TK_POW, "pow operator", "**")                \
   _(TK_ARROW, "arrow", "->")                     \
   _(TK_DECL, "decl", "")                         \
-  _(TK_SLICE_EXPR, "slice expr", "")
+  _(TK_SLICE_EXPR, "slice expr", "")             \
+  _(TK_TYPE_COMMENT, "type comment", "# type:")
 
 static const char* valid_single_char_tokens = "+-*/@()[]:,={}><.?";
 
@@ -227,6 +228,15 @@ struct SharedParserData {
   bool isblank(int n) {
     return isspace(n) && n != '\n';
   }
+  // Make an exception ignoring comments for type annotation comments
+  bool isTypeComment(const std::string& str, size_t pos) {
+    const std::string type_string = "# type:";
+    if (str.size() < pos + type_string.length()) {
+      return false;
+    }
+    auto match_string = str.substr(pos, type_string.size());
+    return match_string == type_string;
+  }
   // find the longest match of str.substring(pos) against a token, return true
   // if successful
   // filling in kind, start,and len
@@ -246,7 +256,7 @@ struct SharedParserData {
 
     // special handling
     if (pos < str.size()) {
-      if (str[pos] == '#') {
+      if (str[pos] == '#' && !isTypeComment(str, pos)) {
         // skip comments
         while (pos < str.size() && str[pos] != '\n')
           pos++;

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -309,12 +309,12 @@ struct Parser {
     auto param_types = parseList('(', ',', ')', &Parser::parseBareTypeAnnotation);
     TreeRef return_type;
     if (L.nextIf(TK_ARROW)) {
-      return_type = parseExp();
+      return_type = Maybe<Expr>::create(L.cur().range, parseExp());
     } else {
-      return_type = Var::create(L.cur().range, Ident::create(L.cur().range, "Tensor"));
+      return_type = Maybe<Expr>::create(L.cur().range);
     }
     L.expect(TK_NEWLINE);
-    return Decl::create(range, param_types, Expr(return_type));
+    return Decl::create(range, param_types, Maybe<Expr>(return_type));
   }
 
   // 'first' has already been parsed since expressions can exist
@@ -431,13 +431,13 @@ struct Parser {
     TreeRef return_type;
     if (L.nextIf(TK_ARROW)) {
       // Exactly one expression for return type annotation
-      return_type = parseExp();
+      return_type = Maybe<Expr>::create(L.cur().range, parseExp());
     } else {
       // Default to returning single tensor. TODO: better sentinel value?
-      return_type = Var::create(L.cur().range, Ident::create(L.cur().range, "Tensor"));
+      return_type = Maybe<Expr>::create(L.cur().range);
     }
     L.expect(':');
-    return Decl::create(paramlist.range(), List<Param>(paramlist), Expr(return_type));
+    return Decl::create(paramlist.range(), List<Param>(paramlist), Maybe<Expr>(return_type));
   }
 
   TreeRef parseFunction() {

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -397,9 +397,6 @@ struct Parser {
     return For::create(r, targets, itrs, body);
   }
 
-  // First return value is the TreeRef to the list of statements we've parsed.
-  // The second one is an optional Decl for if we find type annotations in a
-  // comments
   TreeRef parseStatements(bool expect_indent=true) {
     auto r = L.cur().range;
     if (expect_indent)

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -391,13 +391,17 @@ struct Parser {
     }
     return c(TK_LIST, r, std::move(stmts));
   }
+  TreeRef parseDecl() {
+    auto paramlist = parseList('(', ',', ')', &Parser::parseParam);
+    L.expect(':');
+    return Decl::create(paramlist.range(), List<Param>(paramlist), TensorType::create(L.cur().range));
+  }
   TreeRef parseFunction() {
     L.expect(TK_DEF);
     auto name = parseIdent();
-    auto paramlist = parseList('(', ',', ')', &Parser::parseParam);
-    L.expect(':');
+    auto decl = parseDecl();
     auto stmts_list = parseStatements();
-    return Def::create(name.range(), Ident(name), List<Param>(paramlist),
+    return Def::create(name.range(), Ident(name), Decl(decl),
                        List<Stmt>(stmts_list));
   }
   Lexer& lexer() {

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -391,8 +391,17 @@ struct Parser {
   }
   TreeRef parseDecl() {
     auto paramlist = parseList('(', ',', ')', &Parser::parseParam);
+    // Parse return type annotation
+    TreeRef return_type;
+    if (L.nextIf(TK_ARROW)) {
+      // Exactly one expression for return type annotation
+      return_type = parseExp();
+    } else {
+      // Default to returning single tensor. TODO: better sentinel value?
+      return_type = Var::create(L.cur().range, Ident::create(L.cur().range, "Tensor"));
+    }
     L.expect(':');
-    return Decl::create(paramlist.range(), List<Param>(paramlist), TensorType::create(L.cur().range));
+    return Decl::create(paramlist.range(), List<Param>(paramlist), Expr(return_type));
   }
   TreeRef parseFunction() {
     L.expect(TK_DEF);

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -295,9 +295,14 @@ struct Parser {
   }
 
   TreeRef parseParam() {
-    auto typ = TensorType::create(L.cur().range);
     auto ident = parseIdent();
-    return Param::create(typ.range(), Ident(ident), Type(typ));
+    TreeRef type;
+    if (L.nextIf(':')) {
+      type = parseExp();
+    } else {
+      type = Var::create(L.cur().range, Ident::create(L.cur().range, "Tensor"));
+    }
+    return Param::create(type->range(), Ident(ident), Expr(type));
   }
 
   // 'first' has already been parsed since expressions can exist

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -303,10 +303,9 @@ struct Parser {
     return Param::create(type.range(), Ident::create(type.range(), ""), type);
   }
 
-  TreeRef parseTypeComment(bool expect_type_token=false) {
-    // HACK. Refactor this to not have this boolean flag.
+  TreeRef parseTypeComment(bool parse_full_line=false) {
     auto range = L.cur().range;
-    if (expect_type_token) {
+    if (parse_full_line) {
       L.expect(TK_TYPE_COMMENT);
     }
     auto param_types = parseList('(', ',', ')', &Parser::parseBareTypeAnnotation);
@@ -316,7 +315,7 @@ struct Parser {
     } else {
       return_type = Maybe<Expr>::create(L.cur().range);
     }
-    if (!expect_type_token)
+    if (!parse_full_line)
       L.expect(TK_NEWLINE);
     return Decl::create(range, param_types, Maybe<Expr>(return_type));
   }

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -114,10 +114,10 @@ void initTreeViewBindings(PyObject *module) {
                          wrap_list(r, std::move(body)));
     }));
   py::class_<Decl, TreeView>(m, "Decl")
-    .def(py::init([](std::vector<Param> params,
-                     Expr return_type) {
-      auto r = return_type.range();
-      return Decl::create(r, wrap_list(r, std::move(params)), std::move(return_type));
+    .def(py::init([](const SourceRange& r,
+                     std::vector<Param> params,
+                     Expr *return_type) {
+      return Decl::create(r, wrap_list(r, std::move(params)), wrap_maybe(r, return_type));
     }));
 
 

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -84,7 +84,7 @@ void initTreeViewBindings(PyObject *module) {
           "name", [](const Ident& self) { return self.name(); });
 
   py::class_<Param, TreeView>(m, "Param")
-    .def(py::init([](const Type& type, const Ident& name) {
+    .def(py::init([](const Expr& type, const Ident& name) {
       return Param::create(name.range(), name, type);
     }));
   py::class_<Attribute, TreeView>(m, "Attribute")

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -108,13 +108,19 @@ void initTreeViewBindings(PyObject *module) {
   py::class_<Expr, TreeView>(m, "Expr");
   py::class_<Def, TreeView>(m, "Def")
     .def(py::init([](const Ident& name,
-                     std::vector<Param> params,
+                     Decl decl,
                      std::vector<Stmt> body) {
       auto r = name.range();
       return Def::create(r,
                          name,
-                         wrap_list(r, std::move(params)),
+                         std::move(decl),
                          wrap_list(r, std::move(body)));
+    }));
+  py::class_<Decl, TreeView>(m, "Decl")
+    .def(py::init([](std::vector<Param> params,
+                     Type return_type) {
+      auto r = return_type.range();
+      return Decl::create(r, wrap_list(r, std::move(params)), std::move(return_type));
     }));
 
 

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -207,16 +207,13 @@ void initTreeViewBindings(PyObject *module) {
     .def(py::init([](const SourceRange& range, std::vector<Expr> args) {
       return TupleLiteral::create(range, wrap_list(range, std::move(args)));
     }));
-  py::class_<Gather, Expr>(m, "Gather")
-    .def(py::init([](const Expr& base, const Expr& index) {
-      return Gather::create(base.range(), base, index);
+  py::class_<Subscript, Expr>(m, "Subscript")
+    .def(py::init([](const Expr& base, std::vector<Expr> subscript_exprs) {
+      return Subscript::create(base.range(), base, wrap_list(base.range(), std::move(subscript_exprs)));
     }));
-  py::class_<Slice, Expr>(m, "Slice")
-    .def(py::init([](const Expr& base, Expr* lower, Expr* upper) {
-      return Slice::create(base.range(),
-                           base,
-                           wrap_maybe(base.range(), lower),
-                           wrap_maybe(base.range(), upper));
+  py::class_<SliceExpr, Expr>(m, "SliceExpr")
+    .def(py::init([](const SourceRange& range, Expr *lower, Expr *upper) {
+      return SliceExpr::create(range, wrap_maybe(range, lower), wrap_maybe(range, upper));
     }));
   py::class_<Starred, Expr>(m, "Starred")
     .def(py::init([](const SourceRange& range, Expr expr){

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -100,9 +100,6 @@ void initTreeViewBindings(PyObject *module) {
   m.def("NoneLiteral", [](const SourceRange& range) {
     return Expr(Compound::create(TK_NONE, range, {}));
   });
-  py::class_<Type, TreeView>(m, "Type");
-  py::class_<TensorType, Type>(m, "TensorType")
-    .def(py::init(&TensorType::create));
 
   py::class_<Stmt, TreeView>(m, "Stmt");
   py::class_<Expr, TreeView>(m, "Expr");
@@ -118,7 +115,7 @@ void initTreeViewBindings(PyObject *module) {
     }));
   py::class_<Decl, TreeView>(m, "Decl")
     .def(py::init([](std::vector<Param> params,
-                     Type return_type) {
+                     Expr return_type) {
       auto r = return_type.range();
       return Decl::create(r, wrap_list(r, std::move(params)), std::move(return_type));
     }));

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -18,7 +18,7 @@ namespace script {
 // - Builtin types are: Ident (TK_IDENT), String (TK_STRING)
 //
 // Type  = TensorType()                                                 TK_TENSOR_TYPE
-// Param = Param(Type type, Ident name)                                 TK_PARAM
+// Param = Param(Expr type, Ident name)                                 TK_PARAM
 //
 // Decl  = Decl(List<Param> params, Type return_type)                   TK_DECL
 // Def   = Def(Ident name, Decl decl, List<Stmt> body)                  TK_DEF
@@ -292,14 +292,14 @@ struct Param : public TreeView {
   explicit Param(const TreeRef& tree) : TreeView(tree) {
     tree_->match(TK_PARAM);
   }
-  static Param create(const SourceRange& range, const Ident& ident, const Type& type) {
+  static Param create(const SourceRange& range, const Ident& ident, const Expr& type) {
     return Param(Compound::create(TK_PARAM, range, {ident, type}));
   }
   Ident ident() const {
     return Ident(subtree(0));
   }
-  Type type() const {
-    return Type(subtree(1));
+  Expr type() const {
+    return Expr(subtree(1));
   }
   template<typename T>
   T typeExpect() const {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -53,7 +53,7 @@ namespace script {
 //       | Const(String value)                                          TK_CONST
 //       -- NB: x.name(y) is desugared into name(x, y)
 //       | Apply(Ident name, List<Expr> args, List<Attribute> kwargs)   TK_APPLY
-//       | Select(Expr base, Ident attr_name)                           '.'
+//       | Select(Expr value, Ident selector)                           '.'
 //       | Subscript(Expr value, List<Expr> subscript_exprs)            TK_SUBSCRIPT
 //       | SliceExpr(Maybe<Expr> start, Maybe<Expr> end)                TK_SLICE_EXPR
 //       | Var(Ident name)                                              TK_VAR

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -19,7 +19,7 @@ namespace script {
 //
 // Param = Param(Expr type, Ident name)                                 TK_PARAM
 //
-// Decl  = Decl(List<Param> params, Type return_type)                   TK_DECL
+// Decl  = Decl(List<Param> params, Expr return_type)                   TK_DECL
 // Def   = Def(Ident name, Decl decl, List<Stmt> body)                  TK_DEF
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -17,7 +17,6 @@ namespace script {
 // - Maybe<T> is really a Tree with kind TK_OPTION that has 0 or 1 subtree of type T
 // - Builtin types are: Ident (TK_IDENT), String (TK_STRING)
 //
-// Type  = TensorType()                                                 TK_TENSOR_TYPE
 // Param = Param(Expr type, Ident name)                                 TK_PARAM
 //
 // Decl  = Decl(List<Param> params, Type return_type)                   TK_DECL
@@ -199,17 +198,6 @@ struct Ident : public TreeView {
 // Base types (production LHS)
 ////////////////////////////////////////////////////////////////////////////////
 
-struct Type : public TreeView {
-  explicit Type(const TreeRef& tree) : TreeView(tree) {
-    switch (tree->kind()) {
-      case TK_TENSOR_TYPE:
-        return;
-      default:
-        throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Type";
-    }
-  }
-};
-
 struct Stmt : public TreeView {
   explicit Stmt(const TreeRef& tree) : TreeView(tree) {
     switch (tree->kind()) {
@@ -307,20 +295,6 @@ struct Param : public TreeView {
   }
 };
 
-
-////////////////////////////////////////////////////////////////////////////////
-// Type
-////////////////////////////////////////////////////////////////////////////////
-
-struct TensorType : public Type {
-  explicit TensorType(const TreeRef& tree) : Type(tree) {
-    tree_->match(TK_TENSOR_TYPE);
-  }
-  static TensorType create(const SourceRange& range) {
-    return TensorType(Compound::create(TK_TENSOR_TYPE, range, {}));
-  }
-};
-
 ////////////////////////////////////////////////////////////////////////////////
 // Top level definitions
 ////////////////////////////////////////////////////////////////////////////////
@@ -332,10 +306,10 @@ struct Decl : public TreeView {
   List<Param> params() const {
     return List<Param>(subtree(0));
   }
-  Type return_type() const {
-    return Type(subtree(1));
+  Expr return_type() const {
+    return Expr(subtree(1));
   }
-  static Decl create(const SourceRange& range, const List<Param>& params, Type return_type) {
+  static Decl create(const SourceRange& range, const List<Param>& params, Expr return_type) {
     return Decl(Compound::create(TK_DECL, range, {params, return_type}));
   }
 };

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -19,7 +19,7 @@ namespace script {
 //
 // Param = Param(Expr type, Ident name)                                 TK_PARAM
 //
-// Decl  = Decl(List<Param> params, Expr return_type)                   TK_DECL
+// Decl  = Decl(List<Param> params, Maybe<Expr> return_type)            TK_DECL
 // Def   = Def(Ident name, Decl decl, List<Stmt> body)                  TK_DEF
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF
@@ -306,10 +306,10 @@ struct Decl : public TreeView {
   List<Param> params() const {
     return List<Param>(subtree(0));
   }
-  Expr return_type() const {
-    return Expr(subtree(1));
+  Maybe<Expr> return_type() const {
+    return Maybe<Expr>(subtree(1));
   }
-  static Decl create(const SourceRange& range, const List<Param>& params, Expr return_type) {
+  static Decl create(const SourceRange& range, const List<Param>& params, Maybe<Expr> return_type) {
     return Decl(Compound::create(TK_DECL, range, {params, return_type}));
   }
 };

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -981,8 +981,7 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[1].name == "_1");
     REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
 
-    REQUIRE(op->schema().returns->size() == 1);
-    REQUIRE((*op->schema().returns)[0].type->kind() == TypeKind::DynamicType);
+    REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1010,8 +1009,8 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[1].name == "b");
     REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
 
-    REQUIRE(op->schema().returns->size() == 1);
-    REQUIRE((*op->schema().returns)[0].type->kind() == TypeKind::DynamicType);
+    REQUIRE(op->schema().returns.size() == 1);
+    REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1044,8 +1043,8 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[2].name == "tensors");
     REQUIRE(op->schema().arguments[2].type->isSubtypeOf(ListType::ofTensors()));
 
-    REQUIRE(op->schema().returns->size() == 1);
-    REQUIRE((*op->schema().returns)[0].type->isSubtypeOf(ListType::ofFloats()));
+    REQUIRE(op->schema().returns.size() == 1);
+    REQUIRE(op->schema().returns[0].type->isSubtypeOf(ListType::ofFloats()));
 
     Stack stack;
     push(stack, std::vector<int64_t>{1, 2});

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -981,8 +981,8 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[1].name == "_1");
     REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
 
-    REQUIRE(op->schema().returns.size() == 1);
-    REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
+    REQUIRE(op->schema().returns->size() == 1);
+    REQUIRE((*op->schema().returns)[0].type->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1010,8 +1010,8 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[1].name == "b");
     REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
 
-    REQUIRE(op->schema().returns.size() == 1);
-    REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
+    REQUIRE(op->schema().returns->size() == 1);
+    REQUIRE((*op->schema().returns)[0].type->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1044,8 +1044,8 @@ void testCustomOperators() {
     REQUIRE(op->schema().arguments[2].name == "tensors");
     REQUIRE(op->schema().arguments[2].type->isSubtypeOf(ListType::ofTensors()));
 
-    REQUIRE(op->schema().returns.size() == 1);
-    REQUIRE(op->schema().returns[0].type->isSubtypeOf(ListType::ofFloats()));
+    REQUIRE(op->schema().returns->size() == 1);
+    REQUIRE((*op->schema().returns)[0].type->isSubtypeOf(ListType::ofFloats()));
 
     Stack stack;
     push(stack, std::vector<int64_t>{1, 2});

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -347,7 +347,7 @@ class CompilationUnit(object):
 
 def script(fn, optimize=True, _frames_up=0):
     rcb = createResolutionCallback(_frames_up + 1)
-    ast = get_jit_ast(fn)
+    ast = get_jit_ast(fn, is_method=False)
     graph = _jit_script_compile(ast, rcb)
     mod = ScriptModule()
     mod._create_method_from_graph('forward', graph)
@@ -378,7 +378,7 @@ def script_method(fn):
     # createResolutionCallback internally adds 1 to get us to the scope of this
     # function (the calling function). Adding 2 gets us to the proper surrounding scope.
     rcb = createResolutionCallback(frames_up=2)
-    ast = get_jit_ast(fn)
+    ast = get_jit_ast(fn, is_method=True)
     return ScriptMethodStub(rcb, ast, fn)
 
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -345,16 +345,6 @@ class CompilationUnit(object):
         return self.module._get_method(attr)
 
 
-def _fn_to_typed_def(fn, method=False):
-    schema = annotations.get_signature(fn)
-    ast = get_jit_ast(fn)
-    if schema:
-        typed_def = torch._C._pack_typed_def(ast, schema[0], schema[1], method)
-    else:
-        typed_def = torch._C.TypedDef(ast)
-    return typed_def
-
-
 def script(fn, optimize=True, _frames_up=0):
     rcb = createResolutionCallback(_frames_up + 1)
     ast = get_jit_ast(fn)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -357,15 +357,15 @@ def _fn_to_typed_def(fn, method=False):
 
 def script(fn, optimize=True, _frames_up=0):
     rcb = createResolutionCallback(_frames_up + 1)
-    typed_def = _fn_to_typed_def(fn)
-    graph = _jit_script_compile(typed_def, rcb)
+    ast = get_jit_ast(fn)
+    graph = _jit_script_compile(ast, rcb)
     mod = ScriptModule()
     mod._create_method_from_graph('forward', graph)
     # TODO: refactor everything so we're not 1) creating a ScriptModule
     # 2) Throwing everything away except for the graph 3) Creating a new
     # ScriptModule and dumping that graph in 4) Re-populating the schema
     # because it was lost doing the previous
-    mod.__getattr__('forward').set_arg_and_return_types(typed_def, False)
+    mod.__getattr__('forward').forward_schema(ast, False)
     # Forward docstrings
     mod.__doc__ = fn.__doc__
     return mod

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -142,6 +142,7 @@ def parse_type_line(type_line):
 
     return arg_types, ret_types
 
+
 def get_type_line(source):
     """Tries to find the line containing a comment with the type annotation."""
     lines = source.split('\n')

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -142,25 +142,16 @@ def parse_type_line(type_line):
 
     return arg_types, ret_types
 
-_def_end_regex = re.compile(r'.*\)\s*:.*')
-_def_end_regex_py3 = re.compile(r'.*\)\s*->\s*.*:.*')
-
-
 def get_type_line(source):
     """Tries to find the line containing a comment with the type annotation."""
     lines = source.split('\n')
 
-    def strip_comment(line):
-        return line[:line.index('#') if '#' in line else None]
+    type_line = None
+    for line in lines:
+        if '# type:' in line:
+            type_line = line.strip()
+            break
 
-    i = 0
-    while not _def_end_regex.match(strip_comment(lines[i])) and not _def_end_regex_py3.match(strip_comment(lines[i])):
-        i += 1
-    i += 1
-
-    type_line = lines[i].strip()
-    if not type_line.startswith('# type:'):
-        return None
     return type_line
 
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -143,6 +143,7 @@ def parse_type_line(type_line):
     return arg_types, ret_types
 
 _def_end_regex = re.compile(r'.*\)\s*:.*')
+_def_end_regex_py3 = re.compile(r'.*\)\s*->\s*.*:.*')
 
 
 def get_type_line(source):
@@ -153,7 +154,7 @@ def get_type_line(source):
         return line[:line.index('#') if '#' in line else None]
 
     i = 0
-    while not _def_end_regex.match(strip_comment(lines[i])):
+    while not _def_end_regex.match(strip_comment(lines[i])) and not _def_end_regex_py3.match(strip_comment(lines[i])):
         i += 1
     i += 1
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -424,8 +424,13 @@ class ExprBuilder(Builder):
         base = build_expr(ctx, expr.value)
         sub_type = type(expr.slice)
         if sub_type is ast.Index:
-            index = build_expr(ctx, expr.slice.value)
-            return Subscript(base, [index])
+            if isinstance(expr.slice.value, ast.Tuple) or isinstance(expr.slice.value, ast.List):
+                indices = []
+                for index_expr in expr.slice.value.elts:
+                    indices.append(build_expr(ctx, index_expr))
+                return Subscript(base, indices)
+            else:
+                return Subscript(base, [build_expr(ctx, expr.slice.value)])
         elif sub_type is ast.Slice:
             lower = build_expr(ctx, expr.slice.lower) if expr.slice.lower is not None else None
             upper = build_expr(ctx, expr.slice.upper) if expr.slice.upper is not None else None

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -146,8 +146,10 @@ def build_def(ctx, py_def):
     body = py_def.body
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("def"))
+    # TODO: return type
+    decl = Decl(build_param_list(ctx, py_def.args), TensorType(r))
     return Def(Ident(r, py_def.name),
-               build_param_list(ctx, py_def.args),
+               decl,
                build_stmts(ctx, body))
 
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -146,7 +146,6 @@ def build_def(ctx, py_def):
     body = py_def.body
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("def"))
-    # TODO: return type
     decl = Decl(build_param_list(ctx, py_def.args), Var(Ident(r, 'Tensor')))
     return Def(Ident(r, py_def.name),
                decl,

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -172,7 +172,7 @@ def build_param(ctx, py_arg):
         raise ValueError("Compiled functions don't support annotations")
     name = py_arg.id if PY2 else py_arg.arg
     r = ctx.make_range(py_arg.lineno, py_arg.col_offset, py_arg.col_offset + len(name))
-    return Param(TensorType(r), Ident(r, name))
+    return Param(Var(Ident(r, 'Tensor')), Ident(r, name))
 
 
 class StmtBuilder(Builder):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -153,7 +153,7 @@ def build_def(ctx, py_def, type_line=None):
         return_type = build_expr(ctx, py_def.returns)
     decl = Decl(r, param_list, return_type)
     if type_line is not None:
-        decl = torch._C.merge_decl_types_from_comment(decl, type_line)
+        decl = torch._C.merge_decl_types_from_comment(decl, stripped)
     return Def(Ident(r, py_def.name),
                decl,
                build_stmts(ctx, body))

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -146,7 +146,7 @@ def build_def(ctx, py_def):
     body = py_def.body
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("def"))
-    decl = Decl(build_param_list(ctx, py_def.args), Var(Ident(r, 'Tensor')))
+    decl = Decl(r, build_param_list(ctx, py_def.args), None)
     return Def(Ident(r, py_def.name),
                decl,
                build_stmts(ctx, body))

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -417,14 +417,14 @@ class ExprBuilder(Builder):
         sub_type = type(expr.slice)
         if sub_type is ast.Index:
             index = build_expr(ctx, expr.slice.value)
-            return Gather(base, index)
+            return Subscript(base, [index])
         elif sub_type is ast.Slice:
             lower = build_expr(ctx, expr.slice.lower) if expr.slice.lower is not None else None
             upper = build_expr(ctx, expr.slice.upper) if expr.slice.upper is not None else None
             if expr.slice.step is not None:
                 step = build_expr(ctx, expr.slice.step)
                 raise NotSupportedError(step.range(), "slices with ranges are not supported yet")
-            return Slice(base, lower, upper)
+            return Subscript(base, [SliceExpr(base.range(), lower, upper)])
         elif sub_type is ast.ExtSlice:
             raise NotSupportedError(base.range(), "slicing multiple dimensions at the same time isn't supported yet")
         else:  # Ellipsis (can only happen in Python 2)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -153,7 +153,7 @@ def build_def(ctx, py_def, type_line=None):
         return_type = build_expr(ctx, py_def.returns)
     decl = Decl(r, param_list, return_type)
     if type_line is not None:
-        decl = torch._C.merge_decl_types_from_comment(decl, stripped)
+        decl = torch._C.merge_decl_types_from_comment(decl, type_line)
     return Def(Ident(r, py_def.name),
                decl,
                build_stmts(ctx, body))

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -149,7 +149,7 @@ def build_def(ctx, py_def, type_line=None):
                        py_def.col_offset + len("def"))
     param_list = build_param_list(ctx, py_def.args)
     return_type = None
-    if getattr(py_def, 'returns') is not None:
+    if getattr(py_def, 'returns', None) is not None:
         return_type = build_expr(ctx, py_def.returns)
     decl = Decl(r, param_list, return_type)
     if type_line is not None:

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -141,7 +141,7 @@ class Builder(object):
         return method(ctx, node)
 
 
-def build_def(ctx, py_def, type_line=None):
+def build_def(ctx, py_def, type_line):
     returns = []
     ret_body = []
     body = py_def.body
@@ -153,7 +153,8 @@ def build_def(ctx, py_def, type_line=None):
         return_type = build_expr(ctx, py_def.returns)
     decl = Decl(r, param_list, return_type)
     if type_line is not None:
-        decl = torch._C.merge_decl_types_from_comment(decl, type_line)
+        type_comment_decl = torch._C.parse_type_comment(type_line)
+        decl = torch._C.merge_type_from_type_comment(decl, type_comment_decl)
     return Def(Ident(r, py_def.name),
                decl,
                build_stmts(ctx, body))

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -147,7 +147,7 @@ def build_def(ctx, py_def):
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("def"))
     # TODO: return type
-    decl = Decl(build_param_list(ctx, py_def.args), TensorType(r))
+    decl = Decl(build_param_list(ctx, py_def.args), Var(Ident(r, 'Tensor')))
     return Def(Ident(r, py_def.name),
                decl,
                build_stmts(ctx, body))


### PR DESCRIPTION
After this, all combinations of {String frontend, Python AST Frontend}{Python 3-style type annotations, MyPy-style type comments}{Script method, Script function} should properly accept type annotations.

Possible TODOs:
- Clean up the functions marked HACK
- Clean up the Subscript tree-view to better match the Python AST versions
- Can we use this for Python functions? That's the only place annotations.get_signature() is still needed