### PR TITLE
Force types on values returned from if blocks to be equivalent

### DIFF
--- a/test/expect/TestScript.test_if_supertype.expect
+++ b/test/expect/TestScript.test_if_supertype.expect
@@ -2,23 +2,12 @@ graph(%y.1 : Float(2, 2)
       %z.2 : Long(2, 4)
       %z.1 : Float(2, 4)) {
   %3 : int = prim::Constant[value=1]()
-  %x.1 : Float(2, 2), %y : Dynamic, %z : Dynamic = prim::If(%3)
+  %x : Float(2, 2), %y : Dynamic, %z : Dynamic = prim::If(%3)
     block0() {
       -> (%y.1, %z.2, %z.1)
     }
     block1() {
       -> (%y.1, %y.1, %z.2)
     }
-  %7 : int = prim::Constant[value=1]()
-  %c : Number = prim::If(%7)
-    block0() {
-      %c.1 : float = prim::Constant[value=1]()
-      -> (%c.1)
-    }
-    block1() {
-      %c.2 : int = prim::Constant[value=1]()
-      -> (%c.2)
-    }
-  %x : Dynamic = aten::clamp(%x.1, %c, %c)
   return (%x, %y, %z);
 }

--- a/test/expect/TestScript.test_if_supertype.expect
+++ b/test/expect/TestScript.test_if_supertype.expect
@@ -1,0 +1,24 @@
+graph(%y.1 : Float(2, 2)
+      %z.2 : Long(2, 4)
+      %z.1 : Float(2, 4)) {
+  %3 : int = prim::Constant[value=1]()
+  %x.1 : Float(2, 2), %y : Dynamic, %z : Dynamic = prim::If(%3)
+    block0() {
+      -> (%y.1, %z.2, %z.1)
+    }
+    block1() {
+      -> (%y.1, %y.1, %z.2)
+    }
+  %7 : int = prim::Constant[value=1]()
+  %c : Number = prim::If(%7)
+    block0() {
+      %c.1 : float = prim::Constant[value=1]()
+      -> (%c.1)
+    }
+    block1() {
+      %c.2 : int = prim::Constant[value=1]()
+      -> (%c.2)
+    }
+  %x : Dynamic = aten::clamp(%x.1, %c, %c)
+  return (%x, %y, %z);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3884,6 +3884,34 @@ def func(t):
                 if True:
                     a = 4
 
+    def test_different_types_from_if_blocks(self):
+        with self.assertRaisesRegex(RuntimeError, "Type mismatch"):
+            @torch.jit.script
+            def diff_tuple_sizes(x):
+                if False:
+                    c0 = ((x, x), (x, x, x))
+                else:
+                    c0 = ((x, x, x), (x, x))
+                return c0
+        with self.assertRaisesRegex(RuntimeError, "Type mismatch: c0 is set to type Tensor "
+                                    "in the true branch and type int in the false branch:"):
+            @torch.jit.script
+            def diff_type(x):
+                if False:
+                    c0 = x
+                else:
+                    c0 = 1
+                return c0
+
+        # testing that different length lists don't throw error
+        @torch.jit.script
+        def foo(x):
+            if True:
+                c = [x, x]
+            else:
+                c = [x, x, x]
+            return torch.cat(c, dim=1)
+
     def test_type_annotations(self):
         def fn(x, y):
             # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor, Tensor]

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -107,10 +107,9 @@ bool mergeTypes(ArrayRef<Value*> lhs, ArrayRef<Value*> rhs, ArrayRef<Value*> out
   bool changed = false;
   for(size_t i = 0; i < lhs.size(); ++i) {
     auto old_output_type = outputs[i]->type();
-    if(*lhs[i]->type() == *rhs[i]->type()) {
-      outputs[i]->setType(lhs[i]->type());
-    } else {
-      outputs[i]->setType(DynamicType::get());
+    auto new_type = unifyTypes(lhs[i]->type(), rhs[i]->type());
+    if (new_type) {
+      outputs[i]->setType(*new_type);
     }
     if(*old_output_type != *outputs[i]->type())
       changed = true;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -108,9 +108,8 @@ bool mergeTypes(ArrayRef<Value*> lhs, ArrayRef<Value*> rhs, ArrayRef<Value*> out
   for(size_t i = 0; i < lhs.size(); ++i) {
     auto old_output_type = outputs[i]->type();
     auto new_type = unifyTypes(lhs[i]->type(), rhs[i]->type());
-    if (new_type) {
-      outputs[i]->setType(*new_type);
-    }
+    JIT_ASSERT(new_type);
+    outputs[i]->setType(*new_type);
     if(*old_output_type != *outputs[i]->type())
       changed = true;
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -908,8 +908,13 @@ private:
     // Register outputs in each block
     for (const auto& x : mutated_variables) {
       auto tv = save_true->getVar(x, stmt.range());
-      true_block->registerOutput(tv);
       auto fv = save_false->getVar(x, stmt.range());
+      if (!tv->type()->isSubtypeOf(unshapedType(fv->type()))) {
+        throw ErrorReport(stmt)
+          << "Type mismatch: " << x << " is set to type " << tv->type()->str() << " in the true branch"
+          << " and type " << fv->type()->str() << " in the false branch";
+      }
+      true_block->registerOutput(tv);
       false_block->registerOutput(fv);
       environment_stack->setVar(stmt.range(), x, n->addOutput()->setType(tv->type()));
     }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -152,9 +152,34 @@ struct Environment {
   Method & method;
   const Resolver& resolver;
   std::vector<std::string> captured_inputs;
+  std::unordered_map<std::string, std::string> error_messages;
   Block* b;
 
   std::shared_ptr<Environment> next;
+
+  // set type error in the lowest environment. if the variable is used after an
+  // error has been set, then it will be thrown.
+  void setVariableTypeError(const std::string& name, const std::string &msg) {
+    auto runner = this;
+    while (runner->next) {
+      runner = runner->next.get();
+    }
+    runner->error_messages[name] = msg;
+  }
+
+  // see if type error has been set for a variable
+  at::optional<std::string> findVariableTypeError(const std::string& name) {
+    auto runner = this;
+    while (runner->next) {
+      runner = runner->next.get();
+    }
+    auto msg = runner->error_messages.find(name);
+    if (msg != runner->error_messages.end()) {
+      return msg->second;
+    } else {
+      return at::nullopt;
+    }
+  }
 
   SugaredValuePtr findInThisFrame(const std::string& name) {
     auto it = value_table.find(name);
@@ -307,6 +332,11 @@ struct Environment {
     }
 
     if (!retval && required) {
+      // check if this value was not emitted in an if statement because of a
+      // type mismatch. if it was, then we print a more informative error msg
+      if (auto msg = findVariableTypeError(ident)) {
+        throw ErrorReport(range) << *msg << "and was used here";
+      }
       throw ErrorReport(range) << "undefined value " << ident;
     }
     return retval;
@@ -472,11 +502,17 @@ at::optional<std::vector<Value*>> tryMatchSchema(
 
       // Allow homogeneous tuples to be casted implicitly to lists of appropriate types
       if (arg.type->kind() == TypeKind::ListType &&
-          value->type()->kind() == TypeKind::TupleType &&
-          value->type()->isSubtypeOf(arg.type)) {
-        auto unpacked = createTupleUnpack(value);
-        auto elem_type = arg.type->expect<ListType>()->getElementType();
-        value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
+          value->type()->kind() == TypeKind::TupleType) {
+          auto list_type = arg.type->cast<ListType>()->getElementType();
+          auto tuple = value->type()->cast<TupleType>();
+          auto castable = std::all_of(tuple->elements().begin(), tuple->elements().end(), [&](const TypePtr& t) {
+            return unifyTypes(list_type, t) != at::nullopt;
+          });
+          if (castable) {
+            auto unpacked = createTupleUnpack(value);
+            auto elem_type = arg.type->expect<ListType>()->getElementType();
+            value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
+          }
       }
 
       if (value->node()->kind() == prim::None){
@@ -910,10 +946,23 @@ private:
       auto tv = save_true->getVar(x, stmt.range());
       auto fv = save_false->getVar(x, stmt.range());
       auto unified = unifyTypes(tv->type(), fv->type());
+
+      // attempt to unify the types. we allow variables to be set to different types
+      // in each branch as long as that variable is not already in scope,
+      // or if that variable does not get used later. here, we save the error
+      // so that the error message will be more informative in the case that is
+      // used later
+
       if (!unified) {
-        throw ErrorReport(stmt)
-          << "Type mismatch: " << x << " is set to type " << tv->type()->str() << " in the true branch"
-          << " and type " << fv->type()->str() << " in the false branch";
+        ErrorReport error(stmt);
+        error << "Type mismatch: " << x << " is set to type " << tv->type()->str() << " in the true branch"
+        << " and type " << fv->type()->str() << " in the false branch";
+        if (save_true->findInParentFrame(x) || save_false->findInParentFrame(x)) {
+          throw error;
+        } else {
+          save_true->setVariableTypeError(x, error.what());
+          continue;
+        }
       }
       true_block->registerOutput(tv);
       false_block->registerOutput(fv);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -909,16 +909,16 @@ private:
     for (const auto& x : mutated_variables) {
       auto tv = save_true->getVar(x, stmt.range());
       auto fv = save_false->getVar(x, stmt.range());
-      if (!tv->type()->isSubtypeOf(unshapedType(fv->type()))) {
+      auto unified = unifyTypes(tv->type(), fv->type());
+      if (!unified) {
         throw ErrorReport(stmt)
           << "Type mismatch: " << x << " is set to type " << tv->type()->str() << " in the true branch"
           << " and type " << fv->type()->str() << " in the false branch";
       }
       true_block->registerOutput(tv);
       false_block->registerOutput(fv);
-      environment_stack->setVar(stmt.range(), x, n->addOutput()->setType(tv->type()));
+      environment_stack->setVar(stmt.range(), x, n->addOutput()->setType(*unified));
     }
-
   }
 
   // *********************** Loop Operators ************************************

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -114,10 +114,10 @@ at::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
     return t1;
   }
 
-  // cases in which two types share a supertype
-  if (t1->isSubtypeOf(NumberType::get()) && t2->isSubtypeOf(NumberType::get())) {
-    return static_cast<TypePtr>(NumberType::get());
-  } else if (t1->isSubtypeOf(DynamicType::get()) && t2->isSubtypeOf(DynamicType::get())) {
+  // NB: we do not return NumberType because there is not currently enough
+  // operator support for it
+
+  if (t1->isSubtypeOf(DynamicType::get()) && t2->isSubtypeOf(DynamicType::get())) {
     return static_cast<TypePtr>(DynamicType::get());;
   }
 

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -267,14 +267,6 @@ struct TORCH_API TupleType : public Type {
     });
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
-    // e.g. (Tensor, Tensor, Tensor) <: List[Tensor]
-    if(auto lt = rhs->cast<ListType>()) {
-      for(auto e : elements()) {
-        if(!e->isSubtypeOf(lt->getElementType()))
-          return false;
-      }
-      return true;
-    }
     // co-variant rules for tuples
     return compare(*rhs, [](const TypePtr a, const TypePtr b) {
       return a->isSubtypeOf(b);
@@ -459,10 +451,12 @@ inline TypePtr TensorType::fromNumberType(TypePtr typ) {
   AT_ERROR("unknown number type", typ->str());
 }
 
-// attempt to find the correct supertype of t1 and t2. If none is found then
+// Attempt to find the correct supertype of t1 and t2. If none is found then
 // nullopt will be returned. If t1 == t2, or t1 is a type refinement of t2,
 // then t2 will be returned (and vice versa).
-// A float and int will return scalar, and two different tensortypes will return dynamic.
+// Two different tensortypes will return dynamic.
+// Currently we chose not to support returning a NumberType for a float & int
+// input because of a lack of operator support for NumberType
 TORCH_API at::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2);
 
 template <typename T>

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -459,6 +459,12 @@ inline TypePtr TensorType::fromNumberType(TypePtr typ) {
   AT_ERROR("unknown number type", typ->str());
 }
 
+// attempt to find the correct supertype of t1 and t2. If none is found then
+// nullopt will be returned. If t1 == t2, or t1 is a type refinement of t2,
+// then t2 will be returned (and vice versa).
+// A float and int will return scalar, and two different tensortypes will return dynamic.
+TORCH_API at::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2);
+
 template <typename T>
 TypePtr getTypePtr() {
 #define TYPE_STR(Type) #Type, " ",


### PR DESCRIPTION
When emitting if Branches, check that the types on each value returned are equivalent. As with reassignment of values, tensors are not forced to be the same shape or subtype.