### PR TITLE
[jit][script] fix off-by-one bug in open-ended slicing

### DIFF
--- a/aten/src/ATen/core/ArrayRef.h
+++ b/aten/src/ATen/core/ArrayRef.h
@@ -100,10 +100,6 @@ class ArrayRef final {
   /// @}
   /// @name Simple Operations
   /// @{
-  void reset(const std::initializer_list<T>& Vec) {
-    Data = Vec.begin() == Vec.end() ? static_cast<T*>(nullptr) : Vec.begin();
-    Length = Vec.size();
-  }
 
   constexpr iterator begin() const {
     return Data;

--- a/aten/src/ATen/core/ArrayRef.h
+++ b/aten/src/ATen/core/ArrayRef.h
@@ -100,6 +100,10 @@ class ArrayRef final {
   /// @}
   /// @name Simple Operations
   /// @{
+  void reset(const std::initializer_list<T>& Vec) {
+    Data = Vec.begin() == Vec.end() ? static_cast<T*>(nullptr) : Vec.begin();
+    Length = Vec.size();
+  }
 
   constexpr iterator begin() const {
     return Data;

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1948,6 +1948,11 @@ a")
         x = torch.rand(10, dtype=torch.float, requires_grad=True)
         self.checkScript(func, [x], optimize=True)
 
+        def func2(x):
+            return x[5:]
+
+        self.checkScript(func2, [x], optimize=True)
+
     def test_gather(self):
         def func(x):
             return x[0]

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1436,17 +1436,19 @@ private:
     NamedValue step = NamedValue(loc, "step", graph->insertConstant(1, loc));
 
     const auto has_end = slice.end().present();
-    at::ArrayRef<NamedValue> input_args = {tensor, dim, begin};
     if (has_end) {
       // If the user specified an `end` index, pass it down
       NamedValue end =
           NamedValue(loc, "end", emitExpr(Expr(slice.end().get()), identity));
-      input_args.reset({tensor, dim, begin, end});
+      return emitBuiltinCall(
+                 loc, method, "slice", {tensor, dim, begin, end}, {step}, true)
+          ->asValue(loc, method);
+    } else {
+      // Otherwise rely on the schema default argument
+      return emitBuiltinCall(
+                 loc, method, "slice", {tensor, dim, begin}, {step}, true)
+          ->asValue(loc, method);
     }
-
-    // Otherwise rely on the schema default argument
-    return emitBuiltinCall(loc, method, "slice", input_args, {step}, true)
-        ->asValue(loc, method);
   }
 
   // Desugars gather syntactic sugar tensor[idx] -> tensor.select(idx).

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1359,10 +1359,7 @@ private:
         return emitNone(tree->range());
       } break;
       case TK_SLICE: {
-        const auto slice = Slice(tree);
-        return emitSlice(
-            slice.range(),
-            {slice.value(), slice.startOr(0), slice.endOr(-1)});
+        return emitSlice(Slice(tree));
       } break;
       case TK_GATHER: {
         const auto gather = Gather(tree);
@@ -1424,24 +1421,31 @@ private:
 
   // Desugars slice syntactic sugar tensor[begin:end] -> tensor.slice(begin,
   // end).
-  Value* emitSlice(
-      const SourceRange& loc,
-      TreeList&& inputs) {
-    const auto applyInputs =
-        Compound::create(TK_LIST, loc, std::move(inputs));
-    const auto input_values = getNamedValues(applyInputs->trees(),
-                                             /*maybe_unpack*/false,
-                                             identity);
+  Value* emitSlice(const Slice& slice) {
+    const auto& loc = slice.range();
+    TreeList inputs = {slice.value(), slice.startOr(0)};
+    const auto applyInputs = Compound::create(TK_LIST, loc, std::move(inputs));
+    const auto input_values = getNamedValues(
+        applyInputs->trees(),
+        /*maybe_unpack*/ false,
+        identity);
+
     NamedValue tensor = input_values[0];
     NamedValue begin = input_values[1];
-    NamedValue end = input_values[2];
-    NamedValue dim = NamedValue(loc, "dim",
-        graph->insertConstant(0, loc));
-    NamedValue step = NamedValue(loc, "step",
-        graph->insertConstant(1, loc));
+    NamedValue dim = NamedValue(loc, "dim", graph->insertConstant(0, loc));
+    NamedValue step = NamedValue(loc, "step", graph->insertConstant(1, loc));
 
-    return emitBuiltinCall(
-               loc, method, "slice", {tensor, dim, begin, end, step}, {}, true)
+    const auto has_end = slice.end().present();
+    at::ArrayRef<NamedValue> input_args = {tensor, dim, begin};
+    if (has_end) {
+      // If the user specified an `end` index, pass it down
+      NamedValue end =
+          NamedValue(loc, "end", emitExpr(Expr(slice.end().get()), identity));
+      input_args.reset({tensor, dim, begin, end});
+    }
+
+    // Otherwise rely on the schema default argument
+    return emitBuiltinCall(loc, method, "slice", input_args, {step}, true)
         ->asValue(loc, method);
   }
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1435,20 +1435,16 @@ private:
     NamedValue dim = NamedValue(loc, "dim", graph->insertConstant(0, loc));
     NamedValue step = NamedValue(loc, "step", graph->insertConstant(1, loc));
 
+    std::vector<NamedValue> args = {tensor, dim, begin};
     const auto has_end = slice.end().present();
     if (has_end) {
       // If the user specified an `end` index, pass it down
-      NamedValue end =
-          NamedValue(loc, "end", emitExpr(Expr(slice.end().get()), identity));
-      return emitBuiltinCall(
-                 loc, method, "slice", {tensor, dim, begin, end}, {step}, true)
-          ->asValue(loc, method);
-    } else {
-      // Otherwise rely on the schema default argument
-      return emitBuiltinCall(
-                 loc, method, "slice", {tensor, dim, begin}, {step}, true)
-          ->asValue(loc, method);
+      args.emplace_back(loc, "end", emitExpr(Expr(slice.end().get()), identity));
     }
+
+    // Otherwise rely on the schema default argument
+    return emitBuiltinCall(loc, method, "slice", args, {step}, true)
+        ->asValue(loc, method);
   }
 
   // Desugars gather syntactic sugar tensor[idx] -> tensor.select(idx).


### PR DESCRIPTION
Previously, `tensor[i:]` was transformed to `tensor[i:-1]`. This incorrectly leaves off the last element. Noticed this when implementing slicing for list types.