### PR TITLE
Tiny wrapper around build_pytorch_libs.sh

### DIFF
--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -1,0 +1,20 @@
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+
+# Placeholder for future interface. For now just gives a nice -h.
+parser = argparse.ArgumentParser(description='Build libtorch')
+parser.parse_args()
+
+os.environ['BUILD_TORCH'] = 'ON'
+os.environ['ONNX_NAMESPACE'] = 'onnx_torch'
+
+tools_path = os.path.dirname(os.path.abspath(__file__))
+build_pytorch_libs = os.path.join(tools_path, 'build_pytorch_libs.sh')
+command = '{} --use-nnpack caffe2'.format(build_pytorch_libs)
+
+sys.stdout.flush()
+sys.stderr.flush()
+subprocess.call(shlex.split(command), universal_newlines=True)

--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -4,6 +4,8 @@ import shlex
 import subprocess
 import sys
 
+from setup_helpers.cuda import USE_CUDA
+
 # Placeholder for future interface. For now just gives a nice -h.
 parser = argparse.ArgumentParser(description='Build libtorch')
 parser.parse_args()
@@ -13,7 +15,10 @@ os.environ['ONNX_NAMESPACE'] = 'onnx_torch'
 
 tools_path = os.path.dirname(os.path.abspath(__file__))
 build_pytorch_libs = os.path.join(tools_path, 'build_pytorch_libs.sh')
-command = '{} --use-nnpack caffe2'.format(build_pytorch_libs)
+command = '{} --use-nnpack '.format(build_pytorch_libs)
+if USE_CUDA:
+    command += '--use-cuda '
+command += 'caffe2'
 
 sys.stdout.flush()
 sys.stderr.flush()


### PR DESCRIPTION
Let's make this the new interface for `build_pytorch_libs.sh`, under the hood of which we can change whatever we want, with the invariant that `python tools/build_libtorch.py` will always work. I am worried that the build command for libtorch will change too often while we are revamping our build, and don't want to impact our current libtorch users.

@anderspapitto @ezyang 