### PR TITLE
Export uint8 tensors as byte string in mobile_exporter and add GivenTensorStringToUInt8FillOp

### DIFF
--- a/caffe2/operators/given_tensor_string_to_uint8_fill_op.cc
+++ b/caffe2/operators/given_tensor_string_to_uint8_fill_op.cc
@@ -1,0 +1,33 @@
+#include "caffe2/operators/given_tensor_string_to_uint8_fill_op.h"
+
+namespace caffe2 {
+REGISTER_CPU_OPERATOR(
+    GivenTensorStringToUInt8Fill,
+    GivenTensorStringToUInt8FillOp<CPUContext>);
+
+NO_GRADIENT(GivenTensorStringToUInt8Fill);
+
+OPERATOR_SCHEMA(GivenTensorStringToUInt8Fill)
+    .NumInputs(0, 1)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}})
+    .Arg(
+        "values",
+        "The value for the elements of the output tensor.",
+        true /* required */)
+    .Arg(
+        "shape",
+        "The shape of the output tensor."
+        "Cannot set the shape argument and pass in an input at the same time.")
+    .Arg(
+        "extra_shape",
+        "The additional dimensions appended at the end of the shape indicated"
+        "by the input blob."
+        "Cannot set the extra_shape argument when there is no input blob.")
+    .Arg(
+        "input_as_shape",
+        "1D tensor containing the desired output shape. First input must be in CPU context.")
+    .TensorInferenceFunction(
+        FillerTensorInference<TensorProto_DataType_STRING>);
+
+} // namespace caffe2

--- a/caffe2/operators/given_tensor_string_to_uint8_fill_op.cu
+++ b/caffe2/operators/given_tensor_string_to_uint8_fill_op.cu
@@ -1,0 +1,9 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/given_tensor_string_to_uint8_fill_op.h"
+
+namespace caffe2 {
+
+REGISTER_CUDA_OPERATOR(
+    GivenTensorStringToUInt8Fill,
+    GivenTensorStringToUInt8FillOp<CUDAContext>);
+}

--- a/caffe2/operators/given_tensor_string_to_uint8_fill_op.h
+++ b/caffe2/operators/given_tensor_string_to_uint8_fill_op.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/filler_op.h"
+#include "caffe2/utils/cast.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+class GivenTensorStringToUInt8FillOp final : public FillerOp<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  GivenTensorStringToUInt8FillOp(const OperatorDef& operator_def, Workspace* ws)
+      : FillerOp<Context>(operator_def, ws) {
+    const ArgumentHelper helper(operator_def);
+    if (!helper.HasArgument("dtype")) {
+      Extract();
+    } else {
+      auto dtype = cast::GetCastDataType(helper, "dtype");
+      switch (dtype) {
+        case TensorProto_DataType_STRING:
+          Extract();
+          break;
+        case TensorProto_DataType_UNDEFINED:
+          CAFFE_THROW("Cannot have undefined 'dtype' argument");
+        default:
+          CAFFE_THROW("Unexpected 'dtype' argument value: ", dtype);
+      }
+    }
+  }
+
+  bool Fill(Tensor* output) override {
+    DCHECK_EQ(output->size(), values_.size())
+        << "output size: " << output->size()
+        << " given size: " << values_.size();
+    auto* data = output->template mutable_data<uint8_t>();
+    const uint8_t* values_data = values_.template data<uint8_t>();
+    if (output->size()) {
+      context_.template CopySameDevice<uint8_t>(
+          output->size(), values_data, data);
+    }
+    return true;
+  }
+
+ private:
+  void Extract() {
+    auto source_values = OperatorBase::GetRepeatedArgument<string>("values");
+    DCHECK_EQ(source_values.size(), 1)
+        << "expected size: 1 "
+        << " given size: " << source_values.size();
+
+    auto str = source_values[0];
+    values_.Resize(str.size());
+    uint8_t* values_data = values_.template mutable_data<uint8_t>();
+    for (int i = 0; i < str.size(); i++) {
+      values_data[i] = static_cast<uint8_t>(str[i]);
+    }
+  }
+
+  Tensor values_{CPU};
+};
+} // namespace caffe2

--- a/caffe2/python/operator_test/given_tensor_string_to_uint8_fill_op_test.py
+++ b/caffe2/python/operator_test/given_tensor_string_to_uint8_fill_op_test.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import core
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+
+import unittest
+
+
+class TestGivenTensorStringToUInt8FillOps(hu.HypothesisTestCase):
+    @given(X=hu.tensor(min_dim=1, max_dim=4, dtype=np.int32),
+           **hu.gcs)
+    def test_given_tensor_string_to_uint8_fill(self, X, gc, dc):
+        X = X.astype(np.uint8)
+        print('X: ', str(X))
+        op = core.CreateOperator(
+            "GivenTensorStringToUInt8Fill",
+            [], ["Y"],
+            shape=X.shape,
+            dtype=core.DataType.STRING,
+            values=[X.tobytes()],
+        )
+
+        def constant_fill(*args, **kw):
+            return [X]
+
+        self.assertReferenceChecks(gc, op, [], constant_fill)
+        self.assertDeviceChecks(dc, op, [], [0])
+
+    @given(**hu.gcs)
+    def test_empty_given_tensor_string_to_uint8_fill(self, gc, dc):
+        X = np.array([], dtype=np.uint8)
+        print('X: ', str(X))
+        op = core.CreateOperator(
+            "GivenTensorStringToUInt8Fill",
+            [], ["Y"],
+            shape=X.shape,
+            values=[X.tobytes()],
+        )
+
+        def constant_fill(*args, **kw):
+            return [X]
+
+        self.assertReferenceChecks(gc, op, [], constant_fill)
+        self.assertDeviceChecks(dc, op, [], [0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/caffe2/python/predictor/mobile_exporter.py
+++ b/caffe2/python/predictor/mobile_exporter.py
@@ -19,7 +19,7 @@ def add_tensor(net, name, blob):
         np.dtype('float32'): "GivenTensorFill",
         np.dtype('int32'): "GivenTensorIntFill",
         np.dtype('int64'): "GivenTensorInt64Fill",
-        np.dtype('uint8'): "GivenTensorStringFill",
+        np.dtype('uint8'): "GivenTensorStringToUInt8Fill",
         np.dtype('O'): "GivenTensorStringFill"
     }
 
@@ -28,8 +28,8 @@ def add_tensor(net, name, blob):
     # pass array of uint8 as a string to save storage
     # storing uint8_t has a large overhead for now
     if blob.dtype == np.dtype('uint8'):
-        shape = [1]
-        values = [str(blob.data)]
+        shape = blob.shape
+        values = [blob.tobytes()]
     # Only allow string arrays as objects.
     # The only intended use case for this is to store arrays of strings in the
     # model which can be used for post processing results in subsequent ops.


### PR DESCRIPTION
Summary: Because Protobuf encodes uint8_t tensors using a less space efficient varint uin32_t encoding, we are adding a new operator that reads back a byte string into a uint8_t tensor.

Differential Revision: D9004839
