### PR TITLE
use Ubuntu PPA to get Git 2.9 in Dockerfile

### DIFF
--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN add-apt-repository ppa:git-core/ppa && apt-get update \
+     && apt-get install -y --no-install-recommends \
          build-essential \
          cmake \
          git \

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common
+
 RUN add-apt-repository ppa:git-core/ppa && apt-get update \
      && apt-get install -y --no-install-recommends \
          build-essential \


### PR DESCRIPTION
Should fix #3542. My use case is trying to get PyTorch to build with Google Cloud Build using an equivalent of `docker build https://github.com/pytorch/pytorch.git#master:docker/pytorch` (which also runs into this problem locally).