### PR TITLE
speed up kl div loss

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -59,17 +59,17 @@ Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2, const Ten
   return apply_loss_reduction(output, reduction);
 }
 
-Tensor kl_div_loss(const Tensor& input, const Tensor& target, int64_t reduction) {
+Tensor kl_div(const Tensor& input, const Tensor& target, int64_t reduction) {
   auto zeros = at::zeros_like(target);
   auto output_pos = target * (at::log(target) - input);
   auto output = at::where(target > 0, output_pos, zeros);
   return apply_loss_reduction(output, reduction);
 }
 
-Tensor kl_div_loss_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
+Tensor kl_div_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
   auto grad_input = grad.type().zeros_like(input);
   auto grad_expand = grad.expand_as(input);
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "kl_div_loss_backward", [&]() {
+  AT_DISPATCH_FLOATING_TYPES(input.type(), "kl_div_backward", [&]() {
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
         grad_input,
         target,

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -1,10 +1,21 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
+#include "ATen/Dispatch.h"
+#include "ATen/CPUApplyUtils.h"
 
 #define EPSILON 1e-12
 
 
 namespace at { namespace native {
+
+Tensor apply_loss_reduction(const Tensor& unreduced, int64_t reduction) {
+  if (reduction == Reduction::ElementwiseMean) {
+    return unreduced.sum() / unreduced.numel();
+  } else if (reduction == Reduction::Sum) {
+    return unreduced.sum();
+  }
+  return unreduced;
+}
 
 Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const Tensor& target, double margin, int64_t reduction) {
   auto prod_sum = (input1 * input2).sum(1);
@@ -19,13 +30,7 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
   auto output_pos = at::where(target == 1, pos, zeros);
   auto output_neg = at::where(target == -1, neg, zeros);
   auto output = output_pos + output_neg;
-
-  if (reduction == Reduction::ElementwiseMean) {
-    return output.sum() / target.numel();
-  } else if (reduction == Reduction::Sum) {
-    return output.sum();
-  }
-  return output;
+  return apply_loss_reduction(output, reduction);
 }
 
 Tensor hinge_embedding_loss(const Tensor& self, const Tensor& target, double margin, int64_t reduction) {
@@ -34,13 +39,7 @@ Tensor hinge_embedding_loss(const Tensor& self, const Tensor& target, double mar
   auto output_margin = at::where(target != 1, margin_clamp, zeros);
   auto output_self = at::where(target != -1, self, zeros);
   auto output = output_margin + output_self;
-
-  if (reduction == Reduction::ElementwiseMean) {
-    return output.sum() / self.numel();
-  } else if (reduction == Reduction::Sum) {
-    return output.sum();
-  }
-  return output;
+  return apply_loss_reduction(output, reduction);
 }
 
 Tensor triplet_margin_loss(const Tensor& anchor, const Tensor& positive, const Tensor& negative, double margin,
@@ -52,23 +51,35 @@ Tensor triplet_margin_loss(const Tensor& anchor, const Tensor& positive, const T
     dist_neg = at::min(dist_neg, dist_swap);
   }
   auto output = at::clamp_min(margin + dist_pos - dist_neg, 0);
-
-  if (reduction == Reduction::ElementwiseMean) {
-    return output.sum() / output.numel();
-  } else if (reduction == Reduction::Sum) {
-    return output.sum();
-  }
-  return output;
+  return apply_loss_reduction(output, reduction);
 }
 
 Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2, const Tensor& target, double margin, int64_t reduction) {
   auto output =  (-target * (input1 - input2) + margin).clamp_min_(0);
+  return apply_loss_reduction(output, reduction);
+}
 
-  if (reduction == Reduction::ElementwiseMean) {
-    return output.sum() / output.numel();
-  } else if (reduction == Reduction::Sum) {
-    return output.sum();
-  }
-  return output;
+Tensor kl_div_loss(const Tensor& input, const Tensor& target, int64_t reduction) {
+  auto zeros = at::zeros_like(target);
+  auto output_pos = target * (at::log(target) - input);
+  auto output = at::where(target > 0, output_pos, zeros);
+  return apply_loss_reduction(output, reduction);
+}
+
+Tensor kl_div_loss_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
+  auto grad_input = grad.type().zeros_like(input);
+  auto grad_expand = grad.expand_as(input);
+  AT_DISPATCH_FLOATING_TYPES(input.type(), "kl_div_loss_backward", [&]() {
+    at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+        grad_input,
+        target,
+        grad_expand,
+        [] (scalar_t& grad_input_val, const scalar_t& target_val, const scalar_t& grad_val) {
+          if (target_val > 0) {
+            grad_input_val = -target_val * grad_val;
+          }
+        });
+  });
+  return grad_input;
 }
 }}  // namespace at::native

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -80,6 +80,9 @@ Tensor kl_div_loss_backward_cpu(const Tensor& grad, const Tensor& input, const T
           }
         });
   });
+  if (reduction == Reduction::ElementwiseMean) {
+    return grad_input / input.numel();
+  }
   return grad_input;
 }
 }}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -1,0 +1,27 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/Dispatch.h"
+#include "ATen/cuda/CUDAApplyUtils.cuh"
+#include <THC/THCNumerics.cuh>
+
+
+namespace at { namespace native {
+
+Tensor kl_div_loss_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
+  auto grad_input = grad.type().zeros_like(input);
+  auto grad_expand = grad.expand_as(input);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_loss_backward", [&]() {
+    at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+        grad_input,
+        target,
+        grad_expand,
+        [] __device__(
+            scalar_t& grad_input_val, const scalar_t& target_val, const scalar_t& grad_val) {
+          if (target_val > 0) {
+            grad_input_val = -target_val * grad_val;
+          }
+        });
+  });
+  return grad_input;
+}
+}}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -9,7 +9,7 @@ namespace {
 using namespace at;
 
 template<typename scalar_t>
-void kl_div_loss_backward_kernel(const Tensor& grad_input, const Tensor& target, const Tensor& grad) {
+void kl_div_backward_kernel(const Tensor& grad_input, const Tensor& target, const Tensor& grad) {
   at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
       grad_input,
       target,
@@ -25,11 +25,11 @@ void kl_div_loss_backward_kernel(const Tensor& grad_input, const Tensor& target,
 
 namespace at { namespace native {
 
-Tensor kl_div_loss_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
+Tensor kl_div_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
   Tensor grad_input = grad.type().zeros_like(input);
   Tensor grad_expand = grad.expand_as(input);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_loss_backward", [&]() {
-    kl_div_loss_backward_kernel<scalar_t>(grad_input, target, grad_expand);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_backward", [&]() {
+    kl_div_backward_kernel<scalar_t>(grad_input, target, grad_expand);
   });
   if (reduction == Reduction::ElementwiseMean) {
     return grad_input / input.numel();

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -2,8 +2,26 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/Dispatch.h"
 #include "ATen/cuda/CUDAApplyUtils.cuh"
-#include <THC/THCNumerics.cuh>
 
+
+namespace {
+
+using namespace at;
+
+template<typename scalar_t>
+void kl_div_loss_backward_kernel(const Tensor& grad_input, const Tensor& target, const Tensor& grad) {
+  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+      grad_input,
+      target,
+      grad,
+      [] __device__(
+          scalar_t& grad_input_val, const scalar_t& target_val, const scalar_t& grad_val) {
+        if (target_val > 0) {
+          grad_input_val = -target_val * grad_val;
+        }
+      });
+}
+} // namespace
 
 namespace at { namespace native {
 
@@ -11,16 +29,7 @@ Tensor kl_div_loss_backward_cuda(const Tensor& grad, const Tensor& input, const 
   Tensor grad_input = grad.type().zeros_like(input);
   Tensor grad_expand = grad.expand_as(input);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_loss_backward", [&]() {
-    at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
-        grad_input,
-        target,
-        grad_expand,
-        [] __device__(
-            scalar_t& grad_input_val, const scalar_t& target_val, const scalar_t& grad_val) {
-          if (target_val > 0) {
-            grad_input_val = -target_val * grad_val;
-          }
-        });
+    kl_div_loss_backward_kernel<scalar_t>(grad_input, target, grad_expand);
   });
   return grad_input;
 }

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -31,6 +31,9 @@ Tensor kl_div_loss_backward_cuda(const Tensor& grad, const Tensor& input, const 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_loss_backward", [&]() {
     kl_div_loss_backward_kernel<scalar_t>(grad_input, target, grad_expand);
   });
+  if (reduction == Reduction::ElementwiseMean) {
+    return grad_input / input.numel();
+  }
   return grad_input;
 }
 }}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -26,7 +26,7 @@ void kl_div_backward_kernel(const Tensor& grad_input, const Tensor& target, cons
 namespace at { namespace native {
 
 Tensor kl_div_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
-  Tensor grad_input = grad.type().zeros_like(input);
+  auto grad_input = at::zeros_like(input);
   Tensor grad_expand = grad.expand_as(input);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_backward", [&]() {
     kl_div_backward_kernel<scalar_t>(grad_input, target, grad_expand);

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -8,8 +8,8 @@
 namespace at { namespace native {
 
 Tensor kl_div_loss_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto grad_input = grad.type().zeros_like(input);
-  auto grad_expand = grad.expand_as(input);
+  Tensor grad_input = grad.type().zeros_like(input);
+  Tensor grad_expand = grad.expand_as(input);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_loss_backward", [&]() {
     at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
         grad_input,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -920,14 +920,14 @@
 - func: is_sparse(Tensor self) -> bool
   device_guard: false
 
-- func: kl_div_loss(Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
+- func: kl_div(Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
   variants: function
 
-- func: kl_div_loss_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
+- func: kl_div_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
   variants: function
   dispatch:
-    CPU: kl_div_loss_backward_cpu
-    CUDA: kl_div_loss_backward_cuda
+    CPU: kl_div_backward_cpu
+    CUDA: kl_div_backward_cuda
 
 - func: kthvalue(Tensor self, int64_t k, int64_t dim=-1, bool keepdim=false) -> (Tensor, Tensor)
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -920,6 +920,15 @@
 - func: is_sparse(Tensor self) -> bool
   device_guard: false
 
+- func: kl_div_loss(Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
+  variants: function
+
+- func: kl_div_loss_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean) -> Tensor
+  variants: function
+  dispatch:
+    CPU: kl_div_loss_backward_cpu
+    CUDA: kl_div_loss_backward_cuda
+
 - func: kthvalue(Tensor self, int64_t k, int64_t dim=-1, bool keepdim=false) -> (Tensor, Tensor)
 
 - func: kthvalue_out(Tensor values, Tensor indices, Tensor self, int64_t k, int64_t dim=-1, bool keepdim=false) -> (Tensor, Tensor)

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -5,11 +5,6 @@
   scalar_check:
     output: reduction != Reduction::None || self_->dim() == 0
 
-- name: kl_div(Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean)
-  cname: DistKLDivCriterion
-  scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
-
 - name: l1_loss(Tensor self, Tensor target, int64_t reduction=Reduction::ElementwiseMean)
   cname: AbsCriterion
   scalar_check:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -783,8 +783,8 @@
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   self: not_implemented("embedding_renorm")
 
-- name: kl_div_loss(Tensor self, Tensor target, int64_t reduction)
-  self: kl_div_loss_backward(grad, self, target, reduction)
+- name: kl_div(Tensor self, Tensor target, int64_t reduction)
+  self: kl_div_backward(grad, self, target, reduction)
   target: kl_div_target_backward(grad, self, target, reduction)
 
 - name: l1_loss_forward(Tensor self, Tensor target, int64_t reduction)
@@ -1028,7 +1028,7 @@
   grad_output: hardtanh_backward(grad, self, min_val, max_val)
   self: zeros_like(grad)
 
-- name: kl_div_loss_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction)
+- name: kl_div_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction)
   grad_output: kl_div_double_backward_grad_output(grad, self, target, reduction)
   self: zeros_like(grad)
   target: zeros_like(grad)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -783,8 +783,8 @@
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   self: not_implemented("embedding_renorm")
 
-- name: kl_div_forward(Tensor self, Tensor target, int64_t reduction)
-  self: kl_div_backward(grad, self, target, reduction)
+- name: kl_div_loss(Tensor self, Tensor target, int64_t reduction)
+  self: kl_div_loss_backward(grad, self, target, reduction)
   target: kl_div_target_backward(grad, self, target, reduction)
 
 - name: l1_loss_forward(Tensor self, Tensor target, int64_t reduction)
@@ -1028,7 +1028,7 @@
   grad_output: hardtanh_backward(grad, self, min_val, max_val)
   self: zeros_like(grad)
 
-- name: kl_div_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction)
+- name: kl_div_loss_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction)
   grad_output: kl_div_double_backward_grad_output(grad, self, target, reduction)
   self: zeros_like(grad)
   target: zeros_like(grad)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -715,7 +715,7 @@ Tensor glu_double_backward_grad_output(const Tensor & grad, const Tensor & input
 }
 
 Tensor kl_div_double_backward_grad_output(const Tensor & grad, const Tensor & input, const Tensor & target, int64_t reduction) {
-  auto result = kl_div_loss_backward(grad, input, target, Reduction::None);
+  auto result = kl_div_backward(grad, input, target, Reduction::None);
   if (reduction == Reduction::ElementwiseMean) {
     return result.mean();
   } else if (reduction == Reduction::Sum) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -715,7 +715,7 @@ Tensor glu_double_backward_grad_output(const Tensor & grad, const Tensor & input
 }
 
 Tensor kl_div_double_backward_grad_output(const Tensor & grad, const Tensor & input, const Tensor & target, int64_t reduction) {
-  auto result = kl_div_backward(grad, input, target, Reduction::None);
+  auto result = kl_div_loss_backward(grad, input, target, Reduction::None);
   if (reduction == Reduction::ElementwiseMean) {
     return result.mean();
   } else if (reduction == Reduction::Sum) {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1576,7 +1576,7 @@ def kl_div(input, target, size_average=None, reduce=None, reduction='elementwise
         reduction = _Reduction.legacy_get_enum(size_average, reduce)
     else:
         reduction = _Reduction.get_enum(reduction)
-    return torch._C._nn.kl_div(input, target, reduction)
+    return torch.kl_div_loss(input, target, reduction)
 
 
 def cross_entropy(input, target, weight=None, size_average=None, ignore_index=-100,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1576,7 +1576,7 @@ def kl_div(input, target, size_average=None, reduce=None, reduction='elementwise
         reduction = _Reduction.legacy_get_enum(size_average, reduce)
     else:
         reduction = _Reduction.get_enum(reduction)
-    return torch.kl_div_loss(input, target, reduction)
+    return torch.kl_div(input, target, reduction)
 
 
 def cross_entropy(input, target, weight=None, size_average=None, ignore_index=-100,


### PR DESCRIPTION
Moved kl div loss to aten.

benchmarks for 5000 iterations on input size (1000,100)

New
```
cuda:
forward [0.9736350309103727, 0.9922929517924786, 0.9694818360731006]
input requires_grad=True:
backward [0.5595634011551738, 0.558339926879853, 0.5546616851352155]
double backward [1.2445648494176567, 1.2245905152522027, 1.2349751549772918]
target requires_grad=True:
backward (new C++) [0.9489959231577814, 0.9553070571273565, 0.9556351029314101]
double backward (new C++) [1.8184774098917842, 1.8164670099504292, 1.845708406995982]

cpu:
forward (new C++) [7.892430987209082, 8.3068826389499, 7.985283812973648]
input requires_grad=True:
backward (new C++) [4.328460982069373, 4.45323242014274, 4.27946363389492]
double backward (new C++) [5.153504415880889, 4.629372010007501, 4.712803596165031]
target requires_grad=True:
backward (new C++) [3.4181493939831853, 3.3771288259886205, 3.7086612950079143]
double backward (new C++) [0.21922698011621833, 0.1858532396145165, 0.19477044604718685]
```

Old
```
cuda:
forward [3.101281268056482, 3.068499860819429, 3.0527669726870954]
input requires_grad=True:
backward [0.5650290949270129, 0.5730433077551425, 0.5588279226794839]
double backward [1.1287697306834161, 1.13834543293342, 1.1298578432761133]
target requires_grad=True:
backward [0.9470391101203859, 0.9560198178514838, 0.9750375030562282]
double backward [1.85760727385059, 1.7989214668050408, 1.788982989732176]

cpu:
forward (new C++) [12.474591840058565, 12.511441555805504, 12.666544185951352]
input requires_grad=True:
backward (new C++) [7.660991386976093, 7.449987292289734, 7.513917901087552]
double backward (new C++) [4.073225498665124, 4.264980792999268, 4.429787891916931]
target requires_grad=True:
backward (new C++) [3.448499082121998, 3.9072313378565013, 3.2433970272541046]
double backward (new C++) [2.126378359273076, 1.9045450473204255, 1.7932004742324352]
```