### PR TITLE
[RFC] mutable list support

### DIFF
--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -3,7 +3,17 @@
 #include <ATen/ATen.h>
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
+  _(MutableIntList) \
+  _(World)
 
 namespace torch { namespace jit {
 std::ostream& operator<<(std::ostream & out, const IValue & v) {

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -54,6 +54,7 @@ struct SchemaParser {
       {"float", FloatType::get() },
       {"int", IntType::get() },
       {"bool", IntType::get() }, // TODO: add separate bool type
+      {"World", WorldType::get() },
     };
     auto tok = L.expect(TK_IDENT);
     auto text = tok.text();
@@ -64,10 +65,14 @@ struct SchemaParser {
   }
   void parseType(Argument& arg) {
     arg.type = parseBaseType();
-    if(L.nextIf('[')) {
-      arg.type = ListType::create(arg.type);
-      if(L.cur().kind == TK_NUMBER) {
-        arg.N = std::stoll(L.next().text());
+    if (L.nextIf('[')) {
+      if (L.nextIf(TK_IDENT)) { // TODO fixup
+        arg.type = MutableListType::create(arg.type);
+      } else {
+        arg.type = ListType::create(arg.type);
+        if (L.cur().kind == TK_NUMBER) {
+          arg.N = std::stoll(L.next().text());
+        }
       }
       L.expect(']');
     }

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -60,6 +60,7 @@ inline IValue toIValue(py::object&& obj, const TypePtr& type) {
         return {};
       case TypeKind::StringType:
       case TypeKind::ListType:
+      case TypeKind::MutableListType:
       case TypeKind::TupleType:
         AT_ERROR("Lists and tuples are not supported yet");
       case TypeKind::NumberType:

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -38,10 +38,15 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   } else if(t.kind() == TypeKind::ListType) {
     auto prim = t.cast<ListType>()->getElementType();
     out << *prim << "[]";
+  } else if(t.kind() == TypeKind::MutableListType) {
+    auto prim = t.cast<MutableListType>()->getElementType();
+    out << *prim << "[&]";
   } else if(t.kind() == TypeKind::NoneType) {
     out << "None";
   } else if(t.kind() == TypeKind::StringType) {
     out << "string";
+  } else if(t.kind() == TypeKind::WorldType) {
+    out << "World";
   } else {
     AT_ERROR("unknown type kind");
   }
@@ -66,6 +71,10 @@ FloatTypePtr FloatType::get() {
 }
 NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
+  return value;
+}
+WorldTypePtr WorldType::get() {
+  static auto value = WorldType::create();
   return value;
 }
 StringTypePtr StringType::get() {


### PR DESCRIPTION
Very rough draft of mutable list support. Lots of TODOs and messy stuff, but I wanted to get early feedback on the approach.

Per @ezyang's [design](https://fb.quip.com/epjvAHP9EJcH), I added a `World` token that tracks memory mutations and a mutable list type. Operations that produce and operate on mutable lists take a `World` and return a new one. The compiler checks that each `World` token is used no more than once (should this be exactly once?)

Right now, this is implemented through builtins so the user has to pass around `World` tokens themselves. After the implementation settles I'll add some sugar so that "regular" Python expressions work.

I wanted to get feedback on the following items:
- What to name the `World` token?
- Better way to check the graph for multiple uses of a given `World` value? I'm concerned that searching every node could be expensive, but we need to wait until after `LowerTuples()` to make sure assignments and argument unpacking don't generate spurious uses of a given `World`.
- Is a distinct mutable list type necessary? Mutations are explicitly tracked using World so it seems redundant.