### PR TITLE
Make lengths_host_.CopyFrom synced in LengthsCosineCoherenceOp and LengthsTileOp

### DIFF
--- a/caffe2/operators/lengths_tile_op.h
+++ b/caffe2/operators/lengths_tile_op.h
@@ -24,7 +24,8 @@ class LengthsTileOp : public Operator<Context> {
     // Context::CopyFrom and math::Sum need the same context to avoid race
     // conditions
     // why? CPUContext is not used in Sum
-    lengths_host_.CopyFrom(lengths);
+    lengths_host_.CopyFrom(lengths, &context_);
+    context_.FinishDeviceComputation();
     auto lengths_size = lengths_host_.size();
     auto* lengths_data = lengths_host_.data<int32_t>();
 


### PR DESCRIPTION
Summary:
It seems `lengths_host_.CopyFrom(lengthsInput, &context_);` is asynchronous w.r.t. the host while `lengths_host_.CopyFrom(lengthsInput);` is synchronous.

However, according to jerryzh168,  `lengths_host_.CopyFrom(lengths, &context_); context_.FinishDeviceComputation();` is the safest way to guarantee synchronization.

Differential Revision: D9197923
