### PR TITLE
Advanced Indexing: Allow skipping wrapping indices if returned from nonzero

### DIFF
--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -142,10 +142,10 @@ static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
   return src.view(sizes);
 }
 
-static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size) {
-  if (index.numel() != 0) {
-    auto max_idx = index.max().toCLong();
-    auto min_idx = index.min().toCLong();
+Tensor _wrap_index_once(const Tensor & self, int64_t dim, int64_t dim_size) {
+  if (self.numel() != 0) {
+    auto max_idx = self.max().toCLong();
+    auto min_idx = self.min().toCLong();
     if (max_idx >= dim_size) {
       AT_ERROR("index ", max_idx, " is out of bounds for dimension ", dim, " with size ", dim_size);
     }
@@ -153,7 +153,7 @@ static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size)
       AT_ERROR("index ", min_idx, " is out of bounds for dimension ", dim, " with size ", dim_size);
     }
   }
-  return index.remainder(dim_size);
+  return self.remainder(dim_size);
 }
 
 static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
@@ -170,7 +170,7 @@ static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
     if (indices[i].defined()) {
       // Cast index to the longType matching src's backend
       // This allows us to support ie indexing a cuda tensor with a cpu tensor
-      Tensor index = (wrapIndexOnce(indices[i], i, src.size(i)) * strides[i]).toType(longType);
+      Tensor index = (indices[i]._wrap_index_once(i, src.size(i)) * strides[i]).toType(longType);
       if (linearIndex.defined()) {
         linearIndex += index;
       } else {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1990,6 +1990,8 @@
 - func: meshgrid(TensorList tensors) -> TensorList
   variants: function
 
+- func: _wrap_index_once(IndexTensor self, int64_t dim, int64_t dim_size) -> Tensor
+
 # This has a method dispatch to work around circular include problems
 - func: _local_scalar(Tensor self) -> Scalar
   variants:

--- a/test/expect/TestScript.test_index_put_trace_with_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_with_view.expect
@@ -7,6 +7,6 @@ graph(%0 : Double(100)
   %6 : int = prim::Constant[value=0]()
   %7 : Long(4) = aten::_cast_Long(%1, %6)
   %8 : Dynamic[] = prim::ListConstruct(%7)
-  %20 : Double(100) = aten::index_put(%0, %8, %5)
-  return (%20);
+  %23 : Double(100) = aten::index_put(%0, %8, %5)
+  return (%23);
 }

--- a/test/expect/TestScript.test_index_put_trace_without_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_without_view.expect
@@ -4,6 +4,6 @@ graph(%0 : Double(100)
   %3 : int = prim::Constant[value=0]()
   %4 : Long(4) = aten::_cast_Long(%1, %3)
   %5 : Dynamic[] = prim::ListConstruct(%4)
-  %17 : Double(100) = aten::index_put(%0, %5, %2)
-  return (%17);
+  %20 : Double(100) = aten::index_put(%0, %5, %2)
+  return (%20);
 }


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/10374, I made the helper function that wrap indices a method of tensor to allow profiling how much overhead this feature adds to advanced indexing. But unfortunately, the indices wrapping is very expensive.

A simple demo is:
```python
import torch
d = torch.device('cuda')

a = torch.rand(1000, 1000, device=d)
i = torch.ones(1000, 1000, dtype=torch.uint8, device=d).triu()

with torch.autograd.profiler.profile(use_cuda=True) as prof:
	a[i]
	
prof.export_chrome_trace('triu')
print(prof)
```

This gives:
```
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                            CPU time        CUDA time            Calls        CPU total       CUDA total
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------
_th_get_device                   5.958us          5.216us                1          5.958us          5.216us
_th_get_device                   2.896us          2.272us                1          2.896us          2.272us
_th_get_device                   3.140us          3.072us                1          3.140us          3.072us
_cast_Byte                      15.384us         15.360us                1         15.384us         15.360us
_th_get_device                   2.801us          2.848us                1          2.801us          2.848us
_th_get_device                   2.805us          2.784us                1          2.805us          2.784us
index                         1832.829us       1862.496us                1       1832.829us       1862.496us
_th_get_device                   2.832us          3.040us                1          2.832us          3.040us
nonzero                        328.179us        605.728us                1        328.179us        605.728us
select                          30.519us          1.024us                1         30.519us          1.024us
select                           5.983us          1.024us                1          5.983us          1.024us
_wrap_index_once               628.163us        442.368us                1        628.163us        442.368us
max                            295.205us         78.048us                1        295.205us         78.048us
_local_scalar                   41.098us         41.088us                1         41.098us         41.088us
_th_get_device                   2.954us          3.072us                1          2.954us          3.072us
_local_scalar_dense             19.456us         19.456us                1         19.456us         19.456us
min                             81.825us         82.240us                1         81.825us         82.240us
_local_scalar                   26.363us         26.240us                1         26.363us         26.240us
_th_get_device                   4.620us          4.864us                1          4.620us          4.864us
_local_scalar_dense             12.135us         12.192us                1         12.135us         12.192us
remainder                      154.303us        195.424us                1        154.303us        195.424us
mul                            234.862us        229.376us                1        234.862us        229.376us
_wrap_index_once               255.512us        277.504us                1        255.512us        277.504us
max                             94.118us         76.192us                1         94.118us         76.192us
_local_scalar                   25.571us         26.016us                1         25.571us         26.016us
_th_get_device                   2.874us          2.432us                1          2.874us          2.432us
_local_scalar_dense             12.734us         12.768us                1         12.734us         12.768us
min                             75.452us         76.576us                1         75.452us         76.576us
_local_scalar                   26.015us         25.952us                1         26.015us         25.952us
_th_get_device                   2.980us          3.008us                1          2.980us          3.008us
_local_scalar_dense             11.987us         12.032us                1         11.987us         12.032us
remainder                       12.788us         55.776us                1         12.788us         55.776us
mul                            151.378us        140.288us                1        151.378us        140.288us
add_                            20.204us         53.248us                1         20.204us         53.248us
view                             9.550us          1.024us                1          9.550us          1.024us
take                            82.686us         80.896us                1         82.686us         80.896us
```
We can see that `_wrap_index_once` is a major cost of computation.

However, wrapping indices is not always necessary. For example, if an index tensor is constructed by `expandByteTensors`, then there is no need to wrap indices because `nonzero` will not return indices out of range.

This PR adds a `bool` to store if wrap index can be skipped. And if yes, then skip this expensive operation. As a result of this change, we get the following profiling:

```
------------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                       CPU time        CUDA time            Calls        CPU total       CUDA total
------------------  ---------------  ---------------  ---------------  ---------------  ---------------
_th_get_device              7.707us          7.328us                1          7.707us          7.328us
_th_get_device              3.011us          2.784us                1          3.011us          2.784us
_th_get_device              3.460us          3.072us                1          3.460us          3.072us
_cast_Byte                 17.001us         17.408us                1         17.001us         17.408us
_th_get_device              4.109us          4.064us                1          4.109us          4.064us
_th_get_device              2.808us          2.752us                1          2.808us          2.752us
index                     975.918us       1005.408us                1        975.918us       1005.408us
_th_get_device              3.208us          3.072us                1          3.208us          3.072us
nonzero                   339.928us        615.424us                1        339.928us        615.424us
select                     30.331us          1.024us                1         30.331us          1.024us
select                      5.766us          1.024us                1          5.766us          1.024us
mul                       257.175us         81.920us                1        257.175us         81.920us
mul                       146.566us        147.456us                1        146.566us        147.456us
add_                       19.227us         53.248us                1         19.227us         53.248us
view                        9.385us          2.048us                1          9.385us          2.048us
take                       86.470us         69.632us                1         86.470us         69.632us
```

We can see that advanced indexing is now much faster.

One more point is, this pull request is based on https://github.com/pytorch/pytorch/pull/10374, so it include changes there. I suggest not reverting these changes. Since wrap indices is expensive, it worth to add a custom cuda kernel to do that job to reduce cost. Adding it to `native_functions.yaml` allows automatic dispatching CPU and GPU. I'm planning this in a future PR to see how much a custom kernel can improve.