### PR TITLE
Avoid std::thread ctor "cannot resolve" error

### DIFF
--- a/aten/src/ATen/test/tbb_init_test.cpp
+++ b/aten/src/ATen/test/tbb_init_test.cpp
@@ -4,14 +4,13 @@
 #include "test_seed.h"
 #include <thread>
 
-using namespace at;
 
 // This checks whether threads can see the global
 // numbers of threads set and also whether the scheduler
 // will throw an exception when multiple threads call
 // their first parallel construct.
 void test(int given_num_threads) {
-  auto t = ones({1000 * 1000}, CPU(kFloat));
+  auto t = at::ones({1000 * 1000}, at::CPU(at::kFloat));
   if (given_num_threads >= 0) {
     ASSERT(at::get_num_threads() == given_num_threads);
   } else {


### PR DESCRIPTION
If an `at::test` function is added, gcc can't figure out the `std::thread(test, -1)` resolution. 

It is not a problem for current code. I bumped into this when playing with native functions. But I think it is good to just prevent it from happening in future by removing `using namespace at;`, especially considering that it is a simple change.