### PR TITLE
Fix some backwards definitions wrt keepdim.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2962,6 +2962,7 @@ method_tests = [
     ('zero_', (S, S, S), NO_ARGS),
     ('zero_', (), NO_ARGS, 'scalar'),
     ('logsumexp', (S, S), (1,)),
+    ('logsumexp', (), (0,), 'scalar'),
     ('norm', (S, S), (2,)),
     ('norm', (S, S), (0,), '0'),
     ('norm', (S, S), (0.5,), '0_5'),

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -152,8 +152,8 @@ Tensor sum_backward(const Tensor & grad, IntList sizes, IntList dims, bool keepd
       auto dims_to_unsqueeze = dim_list_to_bitset(dims, sizes.size());
       Tensor res = grad;
       for (size_t i = 0; i < sizes.size(); i++){
-	if (dims_to_unsqueeze[i])
-	  res = res.unsqueeze(i);
+        if (dims_to_unsqueeze[i])
+        res = res.unsqueeze(i);
       }
       return res.expand(sizes);
     }
@@ -381,7 +381,7 @@ Tensor cumsum_backward(const Tensor & x, int64_t dim) {
 }
 
 Tensor logsumexp_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim, bool keepdim) {
-  if (! keepdim) {
+  if (!keepdim && self.dim() != 0) {
     grad = grad.unsqueeze(dim);
     result = result.unsqueeze(dim);
   }
@@ -531,7 +531,7 @@ Tensor select_equals_backward(Tensor grad, const Tensor & input, const Tensor & 
 }
 
 Tensor index_select_backward(Tensor grad, int64_t dim, Tensor indices, IntList sizes, bool keepdim) {
-  if (!keepdim) {
+  if (!keepdim && sizes.size() > 0) {
     grad = grad.unsqueeze(dim);
     indices = indices.unsqueeze(dim);
   }

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -152,8 +152,9 @@ Tensor sum_backward(const Tensor & grad, IntList sizes, IntList dims, bool keepd
       auto dims_to_unsqueeze = dim_list_to_bitset(dims, sizes.size());
       Tensor res = grad;
       for (size_t i = 0; i < sizes.size(); i++){
-        if (dims_to_unsqueeze[i])
-        res = res.unsqueeze(i);
+        if (dims_to_unsqueeze[i]) {
+          res = res.unsqueeze(i);
+        }
       }
       return res.expand(sizes);
     }


### PR DESCRIPTION
Before we had 0-dim tensors in TH, we were flexible in what we accepted wrt to the difference between size [] and size [1] tensors in backwards functions because they were identical in TH.  So, we had backwards definitions that were technically incorrect, but happened to work.  This often masks shape issues, adds greatly to code complexity  and thus IMO isn't worth keeping.

