### PR TITLE
LocalHostScheduler __exit__ terminates subprocesses rather than waiting for them on exception

### DIFF
--- a/caffe2/python/session.py
+++ b/caffe2/python/session.py
@@ -168,7 +168,7 @@ class Session(object):
         assert self._open, 'Session already closed.'
         return self
 
-    def __exit__(self, ex_type, value, traceback):
+    def __exit__(self, ex_type, ex_value, traceback):
         if ex_type is None:
             self.close()
 


### PR DESCRIPTION
Summary:
For now, you can't assert in a LocalHostScheduler context. In case the assertion fails (an exception is raised), the LocalHostScheduler get stuck and prints nothing.

For example, the following code will get stuck, and the assertion error is not printed in stdout.

from caffe2.python import task, test_util
from caffe2.python.fb.distribute import runner

class TestLocalHostScheduler(test_util.TestCase):
    def test_handle_exception_from_within_context(self):
        task.Node()
        with runner.LocalHostScheduler():
            self.assertEqual(0, 1)

Code pointer to where I hit this problem: https://fburl.com/l5n8nnm7
I changed to 100 to another number, then the test gets stuck.

This stuck problem only occurs when `ex_value` is not None.

`self.session.__exit__(ex_type, ex_value, traceback)` sends `Worker.CLOSE_CMD`, if `ex_value` is None.

But notice `self.session.__exit__(ex_type, ex_value, traceback)` does nothing, if `ex_value` is not None.

However, it is always followed by
```
for p in self._procs:
  p.join()
```

In the case of being stuck, sub-processes will keep looping in `task_loop()`, because they never received the `Worker.CLOSE_CMD`.

- Only wait (`.join`) if the `Worker.CLOSE_CMD` is actually sent out.
- Even if wait, set a timeout.
- Always terminate the sub-processes at the end as gate keeper (finally).

Differential Revision: D9256501
