### PR TITLE
Rename kernel function in cross_entropy_op.cu and Register bilinear upsample operator on GPU.

### DIFF
--- a/caffe2/operators/cross_entropy_op.cu
+++ b/caffe2/operators/cross_entropy_op.cu
@@ -213,7 +213,7 @@ __global__ void SigmoidCrossEntropyWithLogitsKernel(
   }
 }
 
-__global__ void SigmoidCrossEntropyGradientWithLogitsKernel(
+__global__ void SigmoidCrossEntropyWithLogitsGradientKernel(
     const int outer_size,
     const int inner_size,
     const bool log_D_trick,
@@ -299,7 +299,7 @@ bool SigmoidCrossEntropyWithLogitsGradientOp<float, CUDAContext>::
   auto* targets_ptr = targets.data<float>();
   auto* g_ptr = g.data<float>();
 
-  SigmoidCrossEntropyGradientWithLogitsKernel<<<
+  SigmoidCrossEntropyWithLogitsGradientKernel<<<
       CAFFE_GET_BLOCKS(outer_size * inner_size),
       CAFFE_CUDA_NUM_THREADS,
       0,
@@ -341,7 +341,7 @@ __global__ void WeightedSigmoidCrossEntropyWithLogitsKernel(
   }
 }
 
-__global__ void WeightedSigmoidCrossEntropyGradientWithLogitsKernel(
+__global__ void WeightedSigmoidCrossEntropyWithLogitsGradientKernel(
     const int outer_size,
     const int inner_size,
     const float* g_ptr,
@@ -414,7 +414,7 @@ bool WeightedSigmoidCrossEntropyWithLogitsGradientOp<float, CUDAContext>::
   auto* weights_ptr = weights.data<float>();
   auto* g_ptr = g.data<float>();
 
-  WeightedSigmoidCrossEntropyGradientWithLogitsKernel<<<
+  WeightedSigmoidCrossEntropyWithLogitsGradientKernel<<<
       CAFFE_GET_BLOCKS(outer_size * inner_size),
       CAFFE_CUDA_NUM_THREADS,
       0,

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -1,0 +1,14 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/upsample_op.h"
+#include "caffe2/operators/operator_fallback_gpu.h"
+
+namespace caffe2 {
+
+namespace {}  // namespace
+
+REGISTER_CUDA_OPERATOR(UpsampleBilinear,
+		GPUFallbackOp<UpsampleBilinearOp<float, CPUContext>>);
+REGISTER_CUDA_OPERATOR(UpsampleBilinearGradient,
+		GPUFallbackOp<UpsampleBilinearGradientOp<float, CPUContext>>);
+
+}  // namespace caffe2


### PR DESCRIPTION
1. Rename kernel function in cross_entropy_op.cu.
2. Register bilinear upsample operator on GPU to prevent the following error:
`
RuntimeError: [enforce fail at operator.cc:187] op. Cannot create operator of type 'UpsampleBilinear' on the device 'CUDA'. Verify that implementation for the corresponding device exist. It might also happen if the binary is not linked with the operator implementation code. If Python frontend is used it might happen if dyndep.InitOpsLibrary call is missing.
`