### PR TITLE
fix list returned from loop/if in shape prop

### DIFF
--- a/test/expect/TestScript.test_list_literal.expect
+++ b/test/expect/TestScript.test_list_literal.expect
@@ -1,0 +1,23 @@
+graph(%x : Double(2, 4, 5)) {
+  %y.1 : Dynamic[] = prim::ListConstruct(%x)
+  %2 : int = prim::Constant[value=1]()
+  %y.3 : Dynamic[] = prim::If(%2)
+    block0() {
+      %y.2 : Dynamic[] = prim::ListConstruct(%x, %x)
+      -> (%y.2)
+    }
+    block1() {
+      -> (%y.1)
+    }
+  %5 : int = prim::Constant[value=2147483647]()
+  %6 : int = prim::Constant[value=0]()
+  %y : Dynamic[] = prim::Loop(%5, %6, %y.3)
+    block0(%7 : int, %10 : Dynamic[]) {
+      %y.4 : Dynamic[] = prim::ListConstruct(%x, %x, %x)
+      %11 : int = prim::Constant[value=0]()
+      -> (%11, %y.4)
+    }
+  %13 : int = prim::Constant[value=1]()
+  %14 : Dynamic = aten::cat(%y, %13)
+  return (%14);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2105,6 +2105,19 @@ a")
             return
         self.checkScript(reassign, (), optimize=True)
 
+        def shape_analysis(x):
+            y = [x]
+            if True:
+                y = [x, x]
+            while False:
+                y = [x, x, x]
+            return torch.cat(y, dim=1)
+
+        x = torch.zeros(2, 4, 5)
+        graph = torch.jit.script(shape_analysis).graph
+        torch._C._jit_pass_shape_analysis(graph, (x,), False)
+        self.assertExpected(str(graph))
+
         def reassign_arity_change():
             x = [1]
             if True:

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -265,7 +265,8 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
   }
   if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*with_const=*/attr::dim)) {
     auto list_node = node->namedInput(attr::tensors)->node();
-    JIT_ASSERT(list_node->kind() == prim::ListConstruct);
+    JIT_ASSERT(list_node->kind() == prim::ListConstruct || list_node->kind() == prim::If ||
+      list_node->kind() == prim::Loop);
     auto tensors = list_node->inputs();
     if (tensors.size() > 0) {
       auto input_types = fmap(tensors, [](Value *v) { return v->type()->cast<TensorType>(); });


### PR DESCRIPTION
Previously shape_analysis asserted that lists were outputs of list construct. Lists can also be outputs of loops or if nodes. 