### PR TITLE
[JIT] Add the first torch nn script module (activation)

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3649,6 +3649,13 @@ def func(t):
         with self.assertRaisesRegex(RuntimeError, "cannot be used as a tuple"):
             M()
 
+    def test_script_nn_module(self):
+        from torch.nn.script import Threshold, RReLU
+
+        # self.checkTrace(nnscript.Tanh(), (torch.rand(3, 4),))
+        self.checkTrace(RReLU(lower=0.1, upper=0.3), (torch.rand(3, 4),))
+        self.checkTrace(Threshold(threshold=0.5, value=0.1), (torch.rand(3, 4),))
+
     def test_script_sequential_for(self):
         class Sub(torch.jit.ScriptModule):
             def __init__(self):
@@ -6393,7 +6400,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                     outputs = torch.cat((outputs, output), 1)
                 return outputs
 
-        self.checkTrace(Sequence(), (torch.rand(3, 4),))
+        self.checkTrace(Sequence(), (torch.rand(3, 4),), verbose=True)
 
     def test_vae(self):
         class VAE(nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -23,8 +23,7 @@ import shutil
 import warnings
 from test_autograd import method_tests, create_input, unpack_variables, \
     exclude_tensor_method, non_differentiable, EXCLUDE_GRADCHECK, EXCLUDE_FUNCTIONAL
-from test_nn import NewModuleTest
-from common_nn import module_tests, TestBase
+from common_nn import TestBase
 from copy import deepcopy
 import random
 
@@ -3651,13 +3650,6 @@ def func(t):
         with self.assertRaisesRegex(RuntimeError, "cannot be used as a tuple"):
             M()
 
-    def test_script_nn_module(self):
-        from torch.nn.script import Threshold, RReLU
-
-        # self.checkTrace(nnscript.Tanh(), (torch.rand(3, 4),))
-        self.checkTrace(RReLU(lower=0.1, upper=0.3), (torch.rand(3, 4),))
-        self.checkTrace(Threshold(threshold=0.5, value=0.1), (torch.rand(3, 4),))
-
     def test_script_sequential_for(self):
         class Sub(torch.jit.ScriptModule):
             def __init__(self):
@@ -6402,7 +6394,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                     outputs = torch.cat((outputs, output), 1)
                 return outputs
 
-        self.checkTrace(Sequence(), (torch.rand(3, 4),), verbose=True)
+        self.checkTrace(Sequence(), (torch.rand(3, 4),))
 
     def test_vae(self):
         class VAE(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8530,7 +8530,7 @@ new_module_tests = [
 for test_params in module_tests + new_module_tests:
     # TODO: CUDA is not implemented yet
     if 'constructor' not in test_params:
-        name = test_params.pop('module_name')
+        name = test_params.get('module_name')
         test_params['constructor'] = getattr(nn, name)
     decorator = test_params.pop('decorator', None)
     test = NewModuleTest(**test_params)
@@ -8553,7 +8553,7 @@ for test_params in module_tests + new_module_tests:
         add_test(test, decorator)
 
 for test_params in criterion_tests + new_criterion_tests:
-    name = test_params.pop('module_name')
+    name = test_params.get('module_name')
     test_params['constructor'] = getattr(nn, name)
     test = NewCriterionTest(**test_params)
     decorator = test_params.pop('decorator', None)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -642,6 +642,7 @@ def threshold(input, threshold, value, inplace=False):
 
     See :class:`~torch.nn.Threshold` for more details.
     """
+
     if inplace:
         return torch._C._nn.threshold_(input, threshold, value)
     return torch._C._nn.threshold(input, threshold, value)
@@ -794,7 +795,6 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
     if inplace:
         return torch._C._nn.leaky_relu_(input, negative_slope)
     return torch._C._nn.leaky_relu(input, negative_slope)
-
 
 leaky_relu_ = _add_docstr(torch._C._nn.leaky_relu_, r"""
 leaky_relu_(input, negative_slope=0.01) -> Tensor

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -642,7 +642,6 @@ def threshold(input, threshold, value, inplace=False):
 
     See :class:`~torch.nn.Threshold` for more details.
     """
-
     if inplace:
         return torch._C._nn.threshold_(input, threshold, value)
     return torch._C._nn.threshold(input, threshold, value)
@@ -795,6 +794,7 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
     if inplace:
         return torch._C._nn.leaky_relu_(input, negative_slope)
     return torch._C._nn.leaky_relu(input, negative_slope)
+
 
 leaky_relu_ = _add_docstr(torch._C._nn.leaky_relu_, r"""
 leaky_relu_(input, negative_slope=0.01) -> Tensor

--- a/torch/nn/script/__init__.py
+++ b/torch/nn/script/__init__.py
@@ -1,0 +1,25 @@
+from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
+    Softmax, Softmax2d, LogSoftmax, ELU, SELU, Hardshrink, LeakyReLU, LogSigmoid, \
+    Softplus, Softshrink, PReLU, Softsign, Softmin, Tanhshrink, RReLU, GLU
+
+__all__ = [
+    'Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
+    'ConvTranspose2d', 'ConvTranspose3d', 'Threshold', 'ReLU', 'Hardtanh', 'ReLU6',
+    'Sigmoid', 'Tanh', 'Softmax', 'Softmax2d', 'LogSoftmax', 'ELU', 'SELU', 'GLU', 'Hardshrink',
+    'LeakyReLU', 'LogSigmoid', 'Softplus', 'Softshrink', 'PReLU', 'Softsign', 'Softmin',
+    'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss',
+    'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',
+    'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss',
+    'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList', 'ModuleDict',
+    'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
+    'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
+    'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
+    'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout',
+    'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d',
+    'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
+    'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
+    'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
+    'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
+    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
+    'AdaptiveLogSoftmaxWithLoss',
+]

--- a/torch/nn/script/__init__.py
+++ b/torch/nn/script/__init__.py
@@ -1,25 +1,3 @@
 from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
     Softmax, Softmax2d, LogSoftmax, ELU, SELU, Hardshrink, LeakyReLU, LogSigmoid, \
     Softplus, Softshrink, PReLU, Softsign, Softmin, Tanhshrink, RReLU, GLU
-
-__all__ = [
-    'Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
-    'ConvTranspose2d', 'ConvTranspose3d', 'Threshold', 'ReLU', 'Hardtanh', 'ReLU6',
-    'Sigmoid', 'Tanh', 'Softmax', 'Softmax2d', 'LogSoftmax', 'ELU', 'SELU', 'GLU', 'Hardshrink',
-    'LeakyReLU', 'LogSigmoid', 'Softplus', 'Softshrink', 'PReLU', 'Softsign', 'Softmin',
-    'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss',
-    'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',
-    'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss',
-    'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList', 'ModuleDict',
-    'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
-    'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
-    'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
-    'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout',
-    'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d',
-    'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
-    'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
-    'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
-    'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
-    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
-    'AdaptiveLogSoftmaxWithLoss',
-]

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -1,5 +1,6 @@
 import warnings
 import torch
+import torch.nn as nn
 from torch.nn.parameter import Parameter
 
 from ..modules.module import Module
@@ -23,6 +24,8 @@ class Threshold(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, input):
+        aa = torch.zeros([3, 6, 4]).fill_(0)
+        # aa.fill_(0)
         return F.threshold(input, self.threshold, self.value)
 
     def extra_repr(self):

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -1,4 +1,3 @@
-import warnings
 import torch
 import torch.nn as nn
 from torch.nn.parameter import Parameter
@@ -11,48 +10,22 @@ from torch.jit import ScriptModule
 # NB: We don't support inplace operation since script don't support it.
 
 
-class Threshold(ScriptModule):
+class Threshold(nn.Threshold, ScriptModule):
     __doc__ = nn.Threshold.__doc__
     __constants__ = ['threshold', 'value', 'inplace']
-
-    def __init__(self, threshold, value, inplace=False):
-        super(Threshold, self).__init__()
-        self.threshold = threshold
-        self.value = value
-        self.inplace = inplace
-        # TODO: check in THNN (if inplace == True, then assert value <= threshold)
 
     @torch.jit.script_method
     def forward(self, input):
         return F.threshold(input, self.threshold, self.value)
 
-    def extra_repr(self):
-        inplace_str = ', inplace' if self.inplace else ''
-        return 'threshold={}, value={}{}'.format(
-            self.threshold, self.value, inplace_str
-        )
 
-
-class ReLU(Threshold):
+class ReLU(nn.ReLU, Threshold):
     __doc__ = nn.ReLU.__doc__
 
-    def __init__(self, inplace=False):
-        super(ReLU, self).__init__(0, 0, inplace)
 
-    def extra_repr(self):
-        inplace_str = 'inplace' if self.inplace else ''
-        return inplace_str
-
-
-class RReLU(ScriptModule):
+class RReLU(nn.RReLU, ScriptModule):
     __doc__ = nn.RReLU.__doc__
     __constants__ = ['lower', 'upper', 'inplace', 'training']
-
-    def __init__(self, lower=1. / 8, upper=1. / 3, inplace=False):
-        super(RReLU, self).__init__()
-        self.lower = lower
-        self.upper = upper
-        self.inplace = inplace
 
     @torch.jit.script_method
     def forward(self, input):
@@ -61,52 +34,21 @@ class RReLU(ScriptModule):
 
         return F.rrelu(input, self.lower, self.upper, self.training, None)
 
-    def extra_repr(self):
-        inplace_str = ', inplace' if self.inplace else ''
-        return 'lower={}, upper={}{}'.format(self.lower, self.upper, inplace_str)
 
-
-class Hardtanh(ScriptModule):
+class Hardtanh(nn.Hardtanh, ScriptModule):
     __doc__ = nn.Hardtanh.__doc__
     __constants__ = ['min_val', 'max_val']
-
-    def __init__(self, min_val=-1, max_val=1, inplace=False, min_value=None, max_value=None):
-        super(Hardtanh, self).__init__()
-        if min_value is not None:
-            warnings.warn("keyword argument min_value is deprecated and renamed to min_val")
-            min_val = min_value
-        if max_value is not None:
-            warnings.warn("keyword argument max_value is deprecated and renamed to max_val")
-            max_val = max_value
-
-        self.min_val = min_val
-        self.max_val = max_val
-        self.inplace = inplace
-        assert self.max_val > self.min_val
 
     @torch.jit.script_method
     def forward(self, input):
         return F.hardtanh(input, self.min_val, self.max_val)
 
-    def extra_repr(self):
-        inplace_str = ', inplace' if self.inplace else ''
-        return 'min_val={}, max_val={}{}'.format(
-            self.min_val, self.max_val, inplace_str
-        )
 
-
-class ReLU6(Hardtanh):
+class ReLU6(nn.ReLU6, Hardtanh):
     __doc__ = nn.ReLU6.__doc__
 
-    def __init__(self, inplace=False):
-        super(ReLU6, self).__init__(0, 6, inplace)
 
-    def extra_repr(self):
-        inplace_str = 'inplace' if self.inplace else ''
-        return inplace_str
-
-
-class Sigmoid(ScriptModule):
+class Sigmoid(nn.Sigmoid, ScriptModule):
     __doc__ = nn.Sigmoid.__doc__
 
     @torch.jit.script_method
@@ -114,7 +56,7 @@ class Sigmoid(ScriptModule):
         return torch.sigmoid(input)
 
 
-class Tanh(ScriptModule):
+class Tanh(nn.Tanh, ScriptModule):
     __doc__ = nn.Tanh.__doc__
 
     @torch.jit.script_method
@@ -122,92 +64,52 @@ class Tanh(ScriptModule):
         return torch.tanh(input)
 
 
-class ELU(ScriptModule):
+class ELU(nn.ELU, ScriptModule):
     __doc__ = nn.ELU.__doc__
     __constants__ = ['alpha', 'inplace']
-
-    def __init__(self, alpha=1., inplace=False):
-        super(ELU, self).__init__()
-        self.alpha = alpha
-        self.inplace = inplace
 
     @torch.jit.script_method
     def forward(self, input):
         return F.elu(input, self.alpha)
 
-    def extra_repr(self):
-        inplace_str = ', inplace' if self.inplace else ''
-        return 'alpha={}{}'.format(self.alpha, inplace_str)
 
-
-class SELU(ScriptModule):
+class SELU(nn.SELU, ScriptModule):
     __doc__ = nn.SELU.__doc__
     __constants__ = ['inplace']
-
-    def __init__(self, inplace=False):
-        super(SELU, self).__init__()
-        self.inplace = inplace
 
     @torch.jit.script_method
     def forward(self, input):
         return F.selu(input)
 
-    def extra_repr(self):
-        inplace_str = 'inplace' if self.inplace else ''
-        return inplace_str
 
-
-class GLU(ScriptModule):
+class GLU(nn.GLU, ScriptModule):
     __doc__ = nn.GLU.__doc__
     __constants__ = ['dim']
-
-    def __init__(self, dim=-1):
-        super(GLU, self).__init__()
-        self.dim = dim
 
     @torch.jit.script_method
     def forward(self, input):
         return F.glu(input, self.dim)
 
-    def extra_repr(self):
-        return 'dim={}'.format(self.dim)
 
-
-class Hardshrink(ScriptModule):
+class Hardshrink(nn.Hardshrink, ScriptModule):
     __doc__ = nn.Hardshrink.__doc__
     __constants__ = ['lambd']
-
-    def __init__(self, lambd=0.5):
-        super(Hardshrink, self).__init__()
-        self.lambd = lambd
 
     @torch.jit.script_method
     def forward(self, input):
         return F.hardshrink(input, self.lambd)
 
-    def extra_repr(self):
-        return '{}'.format(self.lambd)
 
-
-class LeakyReLU(ScriptModule):
+class LeakyReLU(nn.LeakyReLU, ScriptModule):
     __doc__ = nn.LeakyReLU.__doc__
     __constants__ = ['negative_slope', 'inplace']
-
-    def __init__(self, negative_slope=1e-2, inplace=False):
-        super(LeakyReLU, self).__init__()
-        self.negative_slope = negative_slope
-        self.inplace = inplace
 
     @torch.jit.script_method
     def forward(self, input):
         return F.leaky_relu(input, self.negative_slope)
 
-    def extra_repr(self):
-        inplace_str = ', inplace' if self.inplace else ''
-        return 'negative_slope={}{}'.format(self.negative_slope, inplace_str)
 
-
-class LogSigmoid(ScriptModule):
+class LogSigmoid(nn.LogSigmoid, ScriptModule):
     __doc__ = nn.LogSigmoid.__doc__
 
     @torch.jit.script_method
@@ -215,57 +117,33 @@ class LogSigmoid(ScriptModule):
         return F.logsigmoid(input)
 
 
-class Softplus(ScriptModule):
+class Softplus(nn.Softplus, ScriptModule):
     __doc__ = nn.Softplus.__doc__
     __constants__ = ['beta', 'threshold']
-
-    def __init__(self, beta=1, threshold=20):
-        super(Softplus, self).__init__()
-        self.beta = beta
-        self.threshold = threshold
 
     @torch.jit.script_method
     def forward(self, input):
         return F.softplus(input, self.beta, self.threshold)
 
-    def extra_repr(self):
-        return 'beta={}, threshold={}'.format(self.beta, self.threshold)
 
-
-class Softshrink(ScriptModule):
+class Softshrink(nn.Softshrink, ScriptModule):
     __doc__ = nn.Softshrink.__doc__
     __constants__ = ['lambd']
-
-    def __init__(self, lambd=0.5):
-        super(Softshrink, self).__init__()
-        self.lambd = lambd
 
     @torch.jit.script_method
     def forward(self, input):
         return F.softshrink(input, self.lambd)
 
-    def extra_repr(self):
-        return str(self.lambd)
 
-
-class PReLU(ScriptModule):
+class PReLU(nn.PReLU, ScriptModule):
     __doc__ = nn.PReLU.__doc__
-    # __constants__ = ['weight']
-
-    def __init__(self, num_parameters=1, init=0.25):
-        self.num_parameters = num_parameters
-        super(PReLU, self).__init__()
-        self.weight = Parameter(torch.Tensor(num_parameters).fill_(init))
 
     @torch.jit.script_method
     def forward(self, input):
         return F.prelu(input, self.weight)
 
-    def extra_repr(self):
-        return 'num_parameters={}'.format(self.num_parameters)
 
-
-class Softsign(ScriptModule):
+class Softsign(nn.Softsign, ScriptModule):
     __doc__ = nn.Softsign.__doc__
 
     @torch.jit.script_method
@@ -273,7 +151,7 @@ class Softsign(ScriptModule):
         return F.softsign(input)
 
 
-class Tanhshrink(ScriptModule):
+class Tanhshrink(nn.Tanhshrink, ScriptModule):
     __doc__ = nn.Tanhshrink.__doc__
 
     @torch.jit.script_method
@@ -281,31 +159,18 @@ class Tanhshrink(ScriptModule):
         return F.tanhshrink(input)
 
 
-class Softmin(ScriptModule):
+class Softmin(nn.Softmin, ScriptModule):
     __doc__ = nn.Softmin.__doc__
     __constants__ = ['dim']
-
-    def __init__(self, dim=None):
-        super(Softmin, self).__init__()
-        self.dim = dim
 
     @torch.jit.script_method
     def forward(self, input):
         return F.softmin(input, self.dim, _stacklevel=5)
 
 
-class Softmax(ScriptModule):
+class Softmax(nn.Softmax, ScriptModule):
     __doc__ = nn.Softmax.__doc__
     __constants__ = ['dim']
-
-    def __init__(self, dim=None):
-        super(Softmax, self).__init__()
-        self.dim = dim
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        if not hasattr(self, 'dim'):
-            self.dim = None
 
     @torch.jit.script_method
     def forward(self, input):
@@ -313,7 +178,7 @@ class Softmax(ScriptModule):
         return F.softmax(input, self.dim)
 
 
-class Softmax2d(ScriptModule):
+class Softmax2d(nn.Softmax2d, ScriptModule):
     __doc__ = nn.Softmax2d.__doc__
 
     @torch.jit.script_method
@@ -325,18 +190,9 @@ class Softmax2d(ScriptModule):
         return F.softmax(input, 1)
 
 
-class LogSoftmax(ScriptModule):
+class LogSoftmax(nn.LogSoftmax, ScriptModule):
     __doc__ = nn.LogSoftmax.__doc__
     __constants__ = ['dim']
-
-    def __init__(self, dim=None):
-        super(LogSoftmax, self).__init__()
-        self.dim = dim
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        if not hasattr(self, 'dim'):
-            self.dim = None
 
     @torch.jit.script_method
     def forward(self, input):

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -1,0 +1,840 @@
+import warnings
+import torch
+from torch.nn.parameter import Parameter
+
+from ..modules.module import Module
+from .. import functional as F
+from torch.jit import ScriptModule
+
+
+# NB: We don't support inplace operation since script don't support it.
+
+
+class Threshold(ScriptModule):
+    r"""Thresholds each element of the input Tensor
+
+    Threshold is defined as:
+
+    .. math::
+        y =
+        \begin{cases}
+        x, &\text{ if } x > \text{threshold} \\
+        \text{value}, &\text{ otherwise }
+        \end{cases}
+
+    Args:
+        threshold: The value to threshold at
+        value: The value to replace with
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.Threshold(0.1, 20)
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+    __constants__ = ['threshold', 'value', 'inplace']
+
+    def __init__(self, threshold, value, inplace=False):
+        super(Threshold, self).__init__()
+        self.threshold = threshold
+        self.value = value
+        self.inplace = inplace
+        # TODO: check in THNN (if inplace == True, then assert value <= threshold)
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.threshold(input, self.threshold, self.value)
+
+    def extra_repr(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return 'threshold={}, value={}{}'.format(
+            self.threshold, self.value, inplace_str
+        )
+
+
+class ReLU(Threshold):
+    r"""Applies the rectified linear unit function element-wise
+    :math:`\text{ReLU}(x)= \max(0, x)`
+
+    .. image:: scripts/activation_images/ReLU.png
+
+    Args:
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.ReLU()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, inplace=False):
+        super(ReLU, self).__init__(0, 0, inplace)
+
+    def extra_repr(self):
+        inplace_str = 'inplace' if self.inplace else ''
+        return inplace_str
+
+
+class RReLU(ScriptModule):
+    r"""Applies the randomized leaky rectified liner unit function element-wise
+    described in the paper
+    `Empirical Evaluation of Rectified Activations in Convolutional Network`_.
+
+    The function is defined as:
+
+    .. math::
+        \text{RReLU}(x) = \begin{cases}
+            x & \text{if } x \geq 0 \\
+            ax & \text{ otherwise }
+        \end{cases},
+
+    where :math:`a` is randomly sampled from uniform distribution
+    :math:`\mathcal{U}(\text{lower}, \text{upper})`.
+
+     See: https://arxiv.org/pdf/1505.00853.pdf
+
+    Args:
+        lower: lower bound of the uniform distribution. Default: :math:`\frac{1}{8}`
+        upper: upper bound of the uniform distribution. Default: :math:`\frac{1}{3}`
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.RReLU(0.1, 0.3)
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+
+    .. _`Empirical Evaluation of Rectified Activations in Convolutional Network`:
+        https://arxiv.org/abs/1505.00853
+    """
+    def __init__(self, lower=1. / 8, upper=1. / 3, inplace=False):
+        super(RReLU, self).__init__()
+        self.lower = lower
+        self.upper = upper
+        self.inplace = inplace
+
+    __constants__ = ['lower', 'upper', 'inplace', 'training']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        # NB: aten::rrelu(Tensor self, Scalar lower=<default>, Scalar upper=<default>, int training=<default>
+        # , Tensor generator=<default>) function signature has additional argument `generator`
+
+        return F.rrelu(input, self.lower, self.upper, self.training, None)
+
+    def extra_repr(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return 'lower={}, upper={}{}'.format(self.lower, self.upper, inplace_str)
+
+
+class Hardtanh(ScriptModule):
+    r"""Applies the HardTanh function element-wise
+
+    HardTanh is defined as:
+
+    .. math::
+        \text{HardTanh}(x) = \begin{cases}
+            1 & \text{ if } x > 1 \\
+            -1 & \text{ if } x < -1 \\
+            x & \text{ otherwise } \\
+        \end{cases}
+
+    The range of the linear region :math:`[-1, 1]` can be adjusted using
+    :attr:`min_val` and :attr:`max_val`.
+
+    .. image:: scripts/activation_images/Hardtanh.png
+
+    Args:
+        min_val: minimum value of the linear region range. Default: -1
+        max_val: maximum value of the linear region range. Default: 1
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Keyword arguments :attr:`min_value` and :attr:`max_value`
+    have been deprecated in favor of :attr:`min_val` and :attr:`max_val`.
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.Hardtanh(-2, 2)
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, min_val=-1, max_val=1, inplace=False, min_value=None, max_value=None):
+        super(Hardtanh, self).__init__()
+        if min_value is not None:
+            warnings.warn("keyword argument min_value is deprecated and renamed to min_val")
+            min_val = min_value
+        if max_value is not None:
+            warnings.warn("keyword argument max_value is deprecated and renamed to max_val")
+            max_val = max_value
+
+        self.min_val = min_val
+        self.max_val = max_val
+        self.inplace = inplace
+        assert self.max_val > self.min_val
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.hardtanh(input, self.min_val, self.max_val)
+
+    def extra_repr(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return 'min_val={}, max_val={}{}'.format(
+            self.min_val, self.max_val, inplace_str
+        )
+
+
+class ReLU6(Hardtanh):
+    r"""Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`
+
+    Args:
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/ReLU6.png
+
+    Examples::
+
+        >>> m = nn.ReLU6()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, inplace=False):
+        super(ReLU6, self).__init__(0, 6, inplace)
+
+    def extra_repr(self):
+        inplace_str = 'inplace' if self.inplace else ''
+        return inplace_str
+
+
+class Sigmoid(ScriptModule):
+    r"""Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Sigmoid.png
+
+    Examples::
+
+        >>> m = nn.Sigmoid()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return torch.sigmoid(input)
+
+
+class Tanh(ScriptModule):
+    r"""Applies element-wise,
+    :math:`\text{Tanh}(x) = \tanh(x) = \frac{e^x - e^{-x}} {e^x + e^{-x}}`
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Tanh.png
+
+    Examples::
+
+        >>> m = nn.Tanh()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return torch.tanh(input)
+
+
+class ELU(ScriptModule):
+    r"""Applies element-wise,
+    :math:`\text{ELU}(x) = \max(0,x) + \min(0, \alpha * (\exp(x) - 1))`
+
+    Args:
+        alpha: the :math:`\alpha` value for the ELU formulation. Default: 1.0
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/ELU.png
+
+    Examples::
+
+        >>> m = nn.ELU()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, alpha=1., inplace=False):
+        super(ELU, self).__init__()
+        self.alpha = alpha
+        self.inplace = inplace
+
+    __constants__ = ['alpha', 'inplace']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.elu(input, self.alpha)
+
+    def extra_repr(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return 'alpha={}{}'.format(self.alpha, inplace_str)
+
+
+class SELU(ScriptModule):
+    r"""Applies element-wise,
+    :math:`\text{SELU}(x) = \text{scale} * (\max(0,x) + \min(0, \alpha * (\exp(x) - 1)))`,
+    with :math:`\alpha = 1.6732632423543772848170429916717` and
+    :math:`\text{scale} = 1.0507009873554804934193349852946`.
+
+    .. image:: scripts/activation_images/SELU.png
+
+    More details can be found in the paper `Self-Normalizing Neural Networks`_ .
+
+    Args:
+        inplace (bool, optional): can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.SELU()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+
+    .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515
+    """
+
+    def __init__(self, inplace=False):
+        super(SELU, self).__init__()
+        self.inplace = inplace
+
+    __constants__ = ['inplace']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.selu(input)
+
+    def extra_repr(self):
+        inplace_str = 'inplace' if self.inplace else ''
+        return inplace_str
+
+
+class GLU(ScriptModule):
+    r"""Applies the gated linear unit function
+    :math:`{GLU}(a, b)= a \otimes \sigma(b)` where `a` is the first half of
+    the input vector and `b` is the second half.
+
+    Args:
+        dim (int): the dimension on which to split the input. Default: -1
+
+    Shape:
+        - Input: :math:`(*, N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(*, N / 2, *)`
+
+    Examples::
+
+        >>> m = nn.GLU()
+        >>> input = torch.randn(4, 2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, dim=-1):
+        super(GLU, self).__init__()
+        self.dim = dim
+
+    __constants__ = ['dim']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.glu(input, self.dim)
+
+    def extra_repr(self):
+        return 'dim={}'.format(self.dim)
+
+
+class Hardshrink(ScriptModule):
+    r"""Applies the hard shrinkage function element-wise
+    Hardshrink is defined as:
+
+    .. math::
+        \text{HardShrink}(x) =
+        \begin{cases}
+        x, & \text{ if } x > \lambda \\
+        x, & \text{ if } x < -\lambda \\
+        0, & \text{ otherwise }
+        \end{cases}
+
+    Args:
+        lambd: the :math:`\lambda` value for the Hardshrink formulation. Default: 0.5
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Hardshrink.png
+
+    Examples::
+
+        >>> m = nn.Hardshrink()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, lambd=0.5):
+        super(Hardshrink, self).__init__()
+        self.lambd = lambd
+
+    __constants__ = ['lambd']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.hardshrink(input, self.lambd)
+
+    def extra_repr(self):
+        return '{}'.format(self.lambd)
+
+
+class LeakyReLU(ScriptModule):
+    r"""Applies element-wise,
+    :math:`\text{LeakyReLU}(x) = \max(0, x) + \text{negative_slope} * \min(0, x)` or
+
+    .. math::
+        \text{LeakyRELU}(x) =
+        \begin{cases}
+        x, & \text{ if } x \geq 0 \\
+        \text{negative_slope} \times x, & \text{ otherwise }
+        \end{cases}
+
+    Args:
+        negative_slope: Controls the angle of the negative slope. Default: 1e-2
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/LeakyReLU.png
+
+    Examples::
+
+        >>> m = nn.LeakyReLU(0.1)
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, negative_slope=1e-2, inplace=False):
+        super(LeakyReLU, self).__init__()
+        self.negative_slope = negative_slope
+        self.inplace = inplace
+
+    __constants__ = ['negative_slope', 'inplace']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.leaky_relu(input, self.negative_slope, self.inplace)
+
+    def extra_repr(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return 'negative_slope={}{}'.format(self.negative_slope, inplace_str)
+
+
+class LogSigmoid(ScriptModule):
+    r"""Applies element-wise :math:`\text{LogSigmoid}(x) = \log\left(\frac{ 1 }{ 1 + \exp(-x)}\right)`
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/LogSigmoid.png
+
+    Examples::
+
+        >>> m = nn.LogSigmoid()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.logsigmoid(input)
+
+
+class Softplus(ScriptModule):
+    r"""Applies element-wise :math:`\text{Softplus}(x) = \frac{1}{\beta} * \log(1 + \exp(\beta * x))`
+
+    SoftPlus is a smooth approximation to the ReLU function and can be used
+    to constrain the output of a machine to always be positive.
+
+    For numerical stability the implementation reverts to the linear function
+    for inputs above a certain value.
+
+    Args:
+        beta: the :math:`\beta` value for the Softplus formulation. Default: 1
+        threshold: values above this revert to a linear function. Default: 20
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Softplus.png
+
+    Examples::
+
+        >>> m = nn.Softplus()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, beta=1, threshold=20):
+        super(Softplus, self).__init__()
+        self.beta = beta
+        self.threshold = threshold
+
+    __constants__ = ['beta', 'threshold']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.softplus(input, self.beta, self.threshold)
+
+    def extra_repr(self):
+        return 'beta={}, threshold={}'.format(self.beta, self.threshold)
+
+
+class Softshrink(ScriptModule):
+    r"""Applies the soft shrinkage function elementwise
+
+    SoftShrinkage function is defined as:
+
+    .. math::
+        \text{SoftShrinkage}(x) =
+        \begin{cases}
+        x - \lambda, & \text{ if } x > \lambda \\
+        x + \lambda, & \text{ if } x < -\lambda \\
+        0, & \text{ otherwise }
+        \end{cases}
+
+    Args:
+        lambd: the :math:`\lambda` value for the Softshrink formulation. Default: 0.5
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Softshrink.png
+
+    Examples::
+
+        >>> m = nn.Softshrink()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, lambd=0.5):
+        super(Softshrink, self).__init__()
+        self.lambd = lambd
+
+    __constants__ = ['lambd']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.softshrink(input, self.lambd)
+
+    def extra_repr(self):
+        return str(self.lambd)
+
+
+class PReLU(ScriptModule):
+    r"""Applies element-wise the function
+    :math:`\text{PReLU}(x) = \max(0,x) + a * \min(0,x)` or
+
+    .. math::
+        \text{PReLU}(x) =
+        \begin{cases}
+        x, & \text{ if } x \geq 0 \\
+        ax, & \text{ otherwise }
+        \end{cases}
+
+    Here :math:`a` is a learnable parameter. When called without arguments, `nn.PReLU()` uses a single
+    parameter :math:`a` across all input channels. If called with `nn.PReLU(nChannels)`,
+    a separate :math:`a` is used for each input channel.
+
+
+    .. note::
+        weight decay should not be used when learning :math:`a` for good performance.
+
+    Args:
+        num_parameters: number of :math:`a` to learn. Default: 1
+        init: the initial value of :math:`a`. Default: 0.25
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/PReLU.png
+
+    Examples::
+
+        >>> m = nn.PReLU()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    def __init__(self, num_parameters=1, init=0.25):
+        self.num_parameters = num_parameters
+        super(PReLU, self).__init__()
+        self.weight = Parameter(torch.Tensor(num_parameters).fill_(init))
+
+    # __constants__ = ['weight']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.prelu(input, self.weight)
+
+    def extra_repr(self):
+        return 'num_parameters={}'.format(self.num_parameters)
+
+
+class Softsign(ScriptModule):
+    r"""Applies element-wise, the function :math:`\text{SoftSign}(x) = \frac{x}{ 1 + |x|}`
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Softsign.png
+
+    Examples::
+
+        >>> m = nn.Softsign()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.softsign(input)
+
+
+class Tanhshrink(ScriptModule):
+    r"""Applies element-wise, :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/Tanhshrink.png
+
+    Examples::
+
+        >>> m = nn.Tanhshrink()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.tanhshrink(input)
+
+
+class Softmin(ScriptModule):
+    r"""Applies the Softmin function to an n-dimensional input Tensor
+    rescaling them so that the elements of the n-dimensional output Tensor
+    lie in the range `(0, 1)` and sum to 1
+
+    :math:`\text{Softmin}(x_{i}) = \frac{\exp(-x_i)}{\sum_j \exp(-x_j)}`
+
+    Shape:
+        - Input: any shape
+        - Output: same as input
+
+    Arguments:
+        dim (int): A dimension along which Softmin will be computed (so every slice
+            along dim will sum to 1).
+
+    Returns:
+        a Tensor of the same dimension and shape as the input, with
+        values in the range [0, 1]
+
+    Examples::
+
+        >>> m = nn.Softmin()
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
+    """
+    def __init__(self, dim=None):
+        super(Softmin, self).__init__()
+        self.dim = dim
+
+    __constants__ = ['dim']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.softmin(input, self.dim, _stacklevel=5)
+
+
+class Softmax(ScriptModule):
+    r"""Applies the Softmax function to an n-dimensional input Tensor
+    rescaling them so that the elements of the n-dimensional output Tensor
+    lie in the range (0,1) and sum to 1
+
+    Softmax is defined as
+    :math:`\text{Softmax}(x_{i}) = \frac{\exp(x_i)}{\sum_j \exp(x_j)}`
+
+    Shape:
+        - Input: any shape
+        - Output: same as input
+
+    Returns:
+        a Tensor of the same dimension and shape as the input with
+        values in the range [0, 1]
+
+    Arguments:
+        dim (int): A dimension along which Softmax will be computed (so every slice
+            along dim will sum to 1).
+
+    .. note::
+        This module doesn't work directly with NLLLoss,
+        which expects the Log to be computed between the Softmax and itself.
+        Use `LogSoftmax` instead (it's faster and has better numerical properties).
+
+    Examples::
+
+        >>> m = nn.Softmax()
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
+    """
+
+    def __init__(self, dim=None):
+        super(Softmax, self).__init__()
+        self.dim = dim
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if not hasattr(self, 'dim'):
+            self.dim = None
+
+    __constants__ = ['dim']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.softmax(input, self.dim, _stacklevel=5)
+
+
+class Softmax2d(ScriptModule):
+    r"""Applies SoftMax over features to each spatial location.
+
+    When given an image of ``Channels x Height x Width``, it will
+    apply `Softmax` to each location :math:`(Channels, h_i, w_j)`
+
+    Shape:
+        - Input: :math:`(N, C, H, W)`
+        - Output: :math:`(N, C, H, W)` (same shape as input)
+
+    Returns:
+        a Tensor of the same dimension and shape as the input with
+        values in the range [0, 1]
+
+    Examples::
+
+        >>> m = nn.Softmax2d()
+        >>> # you softmax over the 2nd dimension
+        >>> input = torch.randn(2, 3, 12, 13)
+        >>> output = m(input)
+    """
+
+    @torch.jit.script_method
+    def forward(self, input):
+        # assert input.dim() == 4, 'Softmax2d requires a 4D tensor as input'
+        if (input.dim() != 4):
+            print("Error: Softmax2d requires a 4D tensor as input")
+        return F.softmax(input, 1, _stacklevel=5)
+
+
+class LogSoftmax(ScriptModule):
+    r"""Applies the `Log(Softmax(x))` function to an n-dimensional input Tensor.
+    The LogSoftmax formulation can be simplified as
+
+    :math:`\text{LogSoftmax}(x_{i}) = \log\left(\frac{\exp(x_i) }{ \sum_j \exp(x_j)} \right)`
+
+    Shape:
+        - Input: any shape
+        - Output: same as input
+
+    Arguments:
+        dim (int): A dimension along which Softmax will be computed (so every slice
+            along dim will sum to 1).
+
+    Returns:
+        a Tensor of the same dimension and shape as the input with
+        values in the range [-inf, 0)
+
+    Examples::
+
+        >>> m = nn.LogSoftmax()
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
+    """
+
+    def __init__(self, dim=None):
+        super(LogSoftmax, self).__init__()
+        self.dim = dim
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if not hasattr(self, 'dim'):
+            self.dim = None
+
+    __constants__ = ['dim']
+
+    @torch.jit.script_method
+    def forward(self, input):
+        return F.log_softmax(input, self.dim, _stacklevel=5)

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -11,33 +11,7 @@ from torch.jit import ScriptModule
 
 
 class Threshold(ScriptModule):
-    r"""Thresholds each element of the input Tensor
-
-    Threshold is defined as:
-
-    .. math::
-        y =
-        \begin{cases}
-        x, &\text{ if } x > \text{threshold} \\
-        \text{value}, &\text{ otherwise }
-        \end{cases}
-
-    Args:
-        threshold: The value to threshold at
-        value: The value to replace with
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    Examples::
-
-        >>> m = nn.Threshold(0.1, 20)
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Threshold.__doc__
     __constants__ = ['threshold', 'value', 'inplace']
 
     def __init__(self, threshold, value, inplace=False):
@@ -59,25 +33,7 @@ class Threshold(ScriptModule):
 
 
 class ReLU(Threshold):
-    r"""Applies the rectified linear unit function element-wise
-    :math:`\text{ReLU}(x)= \max(0, x)`
-
-    .. image:: scripts/activation_images/ReLU.png
-
-    Args:
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    Examples::
-
-        >>> m = nn.ReLU()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.ReLU.__doc__
 
     def __init__(self, inplace=False):
         super(ReLU, self).__init__(0, 0, inplace)
@@ -88,49 +44,14 @@ class ReLU(Threshold):
 
 
 class RReLU(ScriptModule):
-    r"""Applies the randomized leaky rectified liner unit function element-wise
-    described in the paper
-    `Empirical Evaluation of Rectified Activations in Convolutional Network`_.
+    __doc__ = nn.RReLU.__doc__
+    __constants__ = ['lower', 'upper', 'inplace', 'training']
 
-    The function is defined as:
-
-    .. math::
-        \text{RReLU}(x) = \begin{cases}
-            x & \text{if } x \geq 0 \\
-            ax & \text{ otherwise }
-        \end{cases},
-
-    where :math:`a` is randomly sampled from uniform distribution
-    :math:`\mathcal{U}(\text{lower}, \text{upper})`.
-
-     See: https://arxiv.org/pdf/1505.00853.pdf
-
-    Args:
-        lower: lower bound of the uniform distribution. Default: :math:`\frac{1}{8}`
-        upper: upper bound of the uniform distribution. Default: :math:`\frac{1}{3}`
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    Examples::
-
-        >>> m = nn.RReLU(0.1, 0.3)
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-
-    .. _`Empirical Evaluation of Rectified Activations in Convolutional Network`:
-        https://arxiv.org/abs/1505.00853
-    """
     def __init__(self, lower=1. / 8, upper=1. / 3, inplace=False):
         super(RReLU, self).__init__()
         self.lower = lower
         self.upper = upper
         self.inplace = inplace
-
-    __constants__ = ['lower', 'upper', 'inplace', 'training']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -145,41 +66,7 @@ class RReLU(ScriptModule):
 
 
 class Hardtanh(ScriptModule):
-    r"""Applies the HardTanh function element-wise
-
-    HardTanh is defined as:
-
-    .. math::
-        \text{HardTanh}(x) = \begin{cases}
-            1 & \text{ if } x > 1 \\
-            -1 & \text{ if } x < -1 \\
-            x & \text{ otherwise } \\
-        \end{cases}
-
-    The range of the linear region :math:`[-1, 1]` can be adjusted using
-    :attr:`min_val` and :attr:`max_val`.
-
-    .. image:: scripts/activation_images/Hardtanh.png
-
-    Args:
-        min_val: minimum value of the linear region range. Default: -1
-        max_val: maximum value of the linear region range. Default: 1
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Keyword arguments :attr:`min_value` and :attr:`max_value`
-    have been deprecated in favor of :attr:`min_val` and :attr:`max_val`.
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    Examples::
-
-        >>> m = nn.Hardtanh(-2, 2)
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Hardtanh.__doc__
 
     def __init__(self, min_val=-1, max_val=1, inplace=False, min_value=None, max_value=None):
         super(Hardtanh, self).__init__()
@@ -207,24 +94,7 @@ class Hardtanh(ScriptModule):
 
 
 class ReLU6(Hardtanh):
-    r"""Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`
-
-    Args:
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/ReLU6.png
-
-    Examples::
-
-        >>> m = nn.ReLU6()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.ReLU6.__doc__
 
     def __init__(self, inplace=False):
         super(ReLU6, self).__init__(0, 6, inplace)
@@ -235,21 +105,7 @@ class ReLU6(Hardtanh):
 
 
 class Sigmoid(ScriptModule):
-    r"""Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Sigmoid.png
-
-    Examples::
-
-        >>> m = nn.Sigmoid()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Sigmoid.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -257,22 +113,7 @@ class Sigmoid(ScriptModule):
 
 
 class Tanh(ScriptModule):
-    r"""Applies element-wise,
-    :math:`\text{Tanh}(x) = \tanh(x) = \frac{e^x - e^{-x}} {e^x + e^{-x}}`
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Tanh.png
-
-    Examples::
-
-        >>> m = nn.Tanh()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Tanh.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -280,33 +121,13 @@ class Tanh(ScriptModule):
 
 
 class ELU(ScriptModule):
-    r"""Applies element-wise,
-    :math:`\text{ELU}(x) = \max(0,x) + \min(0, \alpha * (\exp(x) - 1))`
-
-    Args:
-        alpha: the :math:`\alpha` value for the ELU formulation. Default: 1.0
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/ELU.png
-
-    Examples::
-
-        >>> m = nn.ELU()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.ELU.__doc__
+    __constants__ = ['alpha', 'inplace']
 
     def __init__(self, alpha=1., inplace=False):
         super(ELU, self).__init__()
         self.alpha = alpha
         self.inplace = inplace
-
-    __constants__ = ['alpha', 'inplace']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -318,37 +139,12 @@ class ELU(ScriptModule):
 
 
 class SELU(ScriptModule):
-    r"""Applies element-wise,
-    :math:`\text{SELU}(x) = \text{scale} * (\max(0,x) + \min(0, \alpha * (\exp(x) - 1)))`,
-    with :math:`\alpha = 1.6732632423543772848170429916717` and
-    :math:`\text{scale} = 1.0507009873554804934193349852946`.
-
-    .. image:: scripts/activation_images/SELU.png
-
-    More details can be found in the paper `Self-Normalizing Neural Networks`_ .
-
-    Args:
-        inplace (bool, optional): can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    Examples::
-
-        >>> m = nn.SELU()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-
-    .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515
-    """
+    __doc__ = nn.SELU.__doc__
+    __constants__ = ['inplace']
 
     def __init__(self, inplace=False):
         super(SELU, self).__init__()
         self.inplace = inplace
-
-    __constants__ = ['inplace']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -360,30 +156,12 @@ class SELU(ScriptModule):
 
 
 class GLU(ScriptModule):
-    r"""Applies the gated linear unit function
-    :math:`{GLU}(a, b)= a \otimes \sigma(b)` where `a` is the first half of
-    the input vector and `b` is the second half.
-
-    Args:
-        dim (int): the dimension on which to split the input. Default: -1
-
-    Shape:
-        - Input: :math:`(*, N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(*, N / 2, *)`
-
-    Examples::
-
-        >>> m = nn.GLU()
-        >>> input = torch.randn(4, 2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.GLU.__doc__
+    __constants__ = ['dim']
 
     def __init__(self, dim=-1):
         super(GLU, self).__init__()
         self.dim = dim
-
-    __constants__ = ['dim']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -394,39 +172,12 @@ class GLU(ScriptModule):
 
 
 class Hardshrink(ScriptModule):
-    r"""Applies the hard shrinkage function element-wise
-    Hardshrink is defined as:
-
-    .. math::
-        \text{HardShrink}(x) =
-        \begin{cases}
-        x, & \text{ if } x > \lambda \\
-        x, & \text{ if } x < -\lambda \\
-        0, & \text{ otherwise }
-        \end{cases}
-
-    Args:
-        lambd: the :math:`\lambda` value for the Hardshrink formulation. Default: 0.5
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Hardshrink.png
-
-    Examples::
-
-        >>> m = nn.Hardshrink()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Hardshrink.__doc__
+    __constants__ = ['lambd']
 
     def __init__(self, lambd=0.5):
         super(Hardshrink, self).__init__()
         self.lambd = lambd
-
-    __constants__ = ['lambd']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -437,40 +188,13 @@ class Hardshrink(ScriptModule):
 
 
 class LeakyReLU(ScriptModule):
-    r"""Applies element-wise,
-    :math:`\text{LeakyReLU}(x) = \max(0, x) + \text{negative_slope} * \min(0, x)` or
-
-    .. math::
-        \text{LeakyRELU}(x) =
-        \begin{cases}
-        x, & \text{ if } x \geq 0 \\
-        \text{negative_slope} \times x, & \text{ otherwise }
-        \end{cases}
-
-    Args:
-        negative_slope: Controls the angle of the negative slope. Default: 1e-2
-        inplace: can optionally do the operation in-place. Default: ``False``
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/LeakyReLU.png
-
-    Examples::
-
-        >>> m = nn.LeakyReLU(0.1)
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.LeakyReLU.__doc__
+    __constants__ = ['negative_slope', 'inplace']
 
     def __init__(self, negative_slope=1e-2, inplace=False):
         super(LeakyReLU, self).__init__()
         self.negative_slope = negative_slope
         self.inplace = inplace
-
-    __constants__ = ['negative_slope', 'inplace']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -482,21 +206,7 @@ class LeakyReLU(ScriptModule):
 
 
 class LogSigmoid(ScriptModule):
-    r"""Applies element-wise :math:`\text{LogSigmoid}(x) = \log\left(\frac{ 1 }{ 1 + \exp(-x)}\right)`
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/LogSigmoid.png
-
-    Examples::
-
-        >>> m = nn.LogSigmoid()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.LogSigmoid.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -504,38 +214,13 @@ class LogSigmoid(ScriptModule):
 
 
 class Softplus(ScriptModule):
-    r"""Applies element-wise :math:`\text{Softplus}(x) = \frac{1}{\beta} * \log(1 + \exp(\beta * x))`
-
-    SoftPlus is a smooth approximation to the ReLU function and can be used
-    to constrain the output of a machine to always be positive.
-
-    For numerical stability the implementation reverts to the linear function
-    for inputs above a certain value.
-
-    Args:
-        beta: the :math:`\beta` value for the Softplus formulation. Default: 1
-        threshold: values above this revert to a linear function. Default: 20
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Softplus.png
-
-    Examples::
-
-        >>> m = nn.Softplus()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Softplus.__doc__
+    __constants__ = ['beta', 'threshold']
 
     def __init__(self, beta=1, threshold=20):
         super(Softplus, self).__init__()
         self.beta = beta
         self.threshold = threshold
-
-    __constants__ = ['beta', 'threshold']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -546,40 +231,12 @@ class Softplus(ScriptModule):
 
 
 class Softshrink(ScriptModule):
-    r"""Applies the soft shrinkage function elementwise
-
-    SoftShrinkage function is defined as:
-
-    .. math::
-        \text{SoftShrinkage}(x) =
-        \begin{cases}
-        x - \lambda, & \text{ if } x > \lambda \\
-        x + \lambda, & \text{ if } x < -\lambda \\
-        0, & \text{ otherwise }
-        \end{cases}
-
-    Args:
-        lambd: the :math:`\lambda` value for the Softshrink formulation. Default: 0.5
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Softshrink.png
-
-    Examples::
-
-        >>> m = nn.Softshrink()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Softshrink.__doc__
+    __constants__ = ['lambd']
 
     def __init__(self, lambd=0.5):
         super(Softshrink, self).__init__()
         self.lambd = lambd
-
-    __constants__ = ['lambd']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -590,48 +247,13 @@ class Softshrink(ScriptModule):
 
 
 class PReLU(ScriptModule):
-    r"""Applies element-wise the function
-    :math:`\text{PReLU}(x) = \max(0,x) + a * \min(0,x)` or
-
-    .. math::
-        \text{PReLU}(x) =
-        \begin{cases}
-        x, & \text{ if } x \geq 0 \\
-        ax, & \text{ otherwise }
-        \end{cases}
-
-    Here :math:`a` is a learnable parameter. When called without arguments, `nn.PReLU()` uses a single
-    parameter :math:`a` across all input channels. If called with `nn.PReLU(nChannels)`,
-    a separate :math:`a` is used for each input channel.
-
-
-    .. note::
-        weight decay should not be used when learning :math:`a` for good performance.
-
-    Args:
-        num_parameters: number of :math:`a` to learn. Default: 1
-        init: the initial value of :math:`a`. Default: 0.25
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/PReLU.png
-
-    Examples::
-
-        >>> m = nn.PReLU()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.PReLU.__doc__
+    # __constants__ = ['weight']
 
     def __init__(self, num_parameters=1, init=0.25):
         self.num_parameters = num_parameters
         super(PReLU, self).__init__()
         self.weight = Parameter(torch.Tensor(num_parameters).fill_(init))
-
-    # __constants__ = ['weight']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -642,21 +264,7 @@ class PReLU(ScriptModule):
 
 
 class Softsign(ScriptModule):
-    r"""Applies element-wise, the function :math:`\text{SoftSign}(x) = \frac{x}{ 1 + |x|}`
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Softsign.png
-
-    Examples::
-
-        >>> m = nn.Softsign()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Softsign.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -664,21 +272,7 @@ class Softsign(ScriptModule):
 
 
 class Tanhshrink(ScriptModule):
-    r"""Applies element-wise, :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
-
-    Shape:
-        - Input: :math:`(N, *)` where `*` means, any number of additional
-          dimensions
-        - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: scripts/activation_images/Tanhshrink.png
-
-    Examples::
-
-        >>> m = nn.Tanhshrink()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Tanhshrink.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -686,35 +280,12 @@ class Tanhshrink(ScriptModule):
 
 
 class Softmin(ScriptModule):
-    r"""Applies the Softmin function to an n-dimensional input Tensor
-    rescaling them so that the elements of the n-dimensional output Tensor
-    lie in the range `(0, 1)` and sum to 1
+    __doc__ = nn.Softmin.__doc__
+    __constants__ = ['dim']
 
-    :math:`\text{Softmin}(x_{i}) = \frac{\exp(-x_i)}{\sum_j \exp(-x_j)}`
-
-    Shape:
-        - Input: any shape
-        - Output: same as input
-
-    Arguments:
-        dim (int): A dimension along which Softmin will be computed (so every slice
-            along dim will sum to 1).
-
-    Returns:
-        a Tensor of the same dimension and shape as the input, with
-        values in the range [0, 1]
-
-    Examples::
-
-        >>> m = nn.Softmin()
-        >>> input = torch.randn(2, 3)
-        >>> output = m(input)
-    """
     def __init__(self, dim=None):
         super(Softmin, self).__init__()
         self.dim = dim
-
-    __constants__ = ['dim']
 
     @torch.jit.script_method
     def forward(self, input):
@@ -722,36 +293,8 @@ class Softmin(ScriptModule):
 
 
 class Softmax(ScriptModule):
-    r"""Applies the Softmax function to an n-dimensional input Tensor
-    rescaling them so that the elements of the n-dimensional output Tensor
-    lie in the range (0,1) and sum to 1
-
-    Softmax is defined as
-    :math:`\text{Softmax}(x_{i}) = \frac{\exp(x_i)}{\sum_j \exp(x_j)}`
-
-    Shape:
-        - Input: any shape
-        - Output: same as input
-
-    Returns:
-        a Tensor of the same dimension and shape as the input with
-        values in the range [0, 1]
-
-    Arguments:
-        dim (int): A dimension along which Softmax will be computed (so every slice
-            along dim will sum to 1).
-
-    .. note::
-        This module doesn't work directly with NLLLoss,
-        which expects the Log to be computed between the Softmax and itself.
-        Use `LogSoftmax` instead (it's faster and has better numerical properties).
-
-    Examples::
-
-        >>> m = nn.Softmax()
-        >>> input = torch.randn(2, 3)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Softmax.__doc__
+    __constants__ = ['dim']
 
     def __init__(self, dim=None):
         super(Softmax, self).__init__()
@@ -762,34 +305,13 @@ class Softmax(ScriptModule):
         if not hasattr(self, 'dim'):
             self.dim = None
 
-    __constants__ = ['dim']
-
     @torch.jit.script_method
     def forward(self, input):
         return F.softmax(input, self.dim, _stacklevel=5)
 
 
 class Softmax2d(ScriptModule):
-    r"""Applies SoftMax over features to each spatial location.
-
-    When given an image of ``Channels x Height x Width``, it will
-    apply `Softmax` to each location :math:`(Channels, h_i, w_j)`
-
-    Shape:
-        - Input: :math:`(N, C, H, W)`
-        - Output: :math:`(N, C, H, W)` (same shape as input)
-
-    Returns:
-        a Tensor of the same dimension and shape as the input with
-        values in the range [0, 1]
-
-    Examples::
-
-        >>> m = nn.Softmax2d()
-        >>> # you softmax over the 2nd dimension
-        >>> input = torch.randn(2, 3, 12, 13)
-        >>> output = m(input)
-    """
+    __doc__ = nn.Softmax2d.__doc__
 
     @torch.jit.script_method
     def forward(self, input):
@@ -800,29 +322,8 @@ class Softmax2d(ScriptModule):
 
 
 class LogSoftmax(ScriptModule):
-    r"""Applies the `Log(Softmax(x))` function to an n-dimensional input Tensor.
-    The LogSoftmax formulation can be simplified as
-
-    :math:`\text{LogSoftmax}(x_{i}) = \log\left(\frac{\exp(x_i) }{ \sum_j \exp(x_j)} \right)`
-
-    Shape:
-        - Input: any shape
-        - Output: same as input
-
-    Arguments:
-        dim (int): A dimension along which Softmax will be computed (so every slice
-            along dim will sum to 1).
-
-    Returns:
-        a Tensor of the same dimension and shape as the input with
-        values in the range [-inf, 0)
-
-    Examples::
-
-        >>> m = nn.LogSoftmax()
-        >>> input = torch.randn(2, 3)
-        >>> output = m(input)
-    """
+    __doc__ = nn.LogSoftmax.__doc__
+    __constants__ = ['dim']
 
     def __init__(self, dim=None):
         super(LogSoftmax, self).__init__()
@@ -832,8 +333,6 @@ class LogSoftmax(ScriptModule):
         self.__dict__.update(state)
         if not hasattr(self, 'dim'):
             self.dim = None
-
-    __constants__ = ['dim']
 
     @torch.jit.script_method
     def forward(self, input):

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -68,6 +68,7 @@ class RReLU(ScriptModule):
 
 class Hardtanh(ScriptModule):
     __doc__ = nn.Hardtanh.__doc__
+    __constants__ = ['min_val', 'max_val']
 
     def __init__(self, min_val=-1, max_val=1, inplace=False, min_value=None, max_value=None):
         super(Hardtanh, self).__init__()
@@ -199,7 +200,7 @@ class LeakyReLU(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, input):
-        return F.leaky_relu(input, self.negative_slope, self.inplace)
+        return F.leaky_relu(input, self.negative_slope)
 
     def extra_repr(self):
         inplace_str = ', inplace' if self.inplace else ''
@@ -308,7 +309,8 @@ class Softmax(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, input):
-        return F.softmax(input, self.dim, _stacklevel=5)
+        # return F.softmax(input, self.dim, _stacklevel=5)
+        return F.softmax(input, self.dim)
 
 
 class Softmax2d(ScriptModule):
@@ -319,7 +321,8 @@ class Softmax2d(ScriptModule):
         # assert input.dim() == 4, 'Softmax2d requires a 4D tensor as input'
         if (input.dim() != 4):
             print("Error: Softmax2d requires a 4D tensor as input")
-        return F.softmax(input, 1, _stacklevel=5)
+        # return F.softmax(input, 1, _stacklevel=5)
+        return F.softmax(input, 1)
 
 
 class LogSoftmax(ScriptModule):
@@ -337,4 +340,5 @@ class LogSoftmax(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, input):
-        return F.log_softmax(input, self.dim, _stacklevel=5)
+        # return F.log_softmax(input, self.dim, _stacklevel=5)
+        return F.log_softmax(input, self.dim)

--- a/torch/nn/script/activation.py
+++ b/torch/nn/script/activation.py
@@ -24,8 +24,6 @@ class Threshold(ScriptModule):
 
     @torch.jit.script_method
     def forward(self, input):
-        aa = torch.zeros([3, 6, 4]).fill_(0)
-        # aa.fill_(0)
         return F.threshold(input, self.threshold, self.value)
 
     def extra_repr(self):


### PR DESCRIPTION
This is the first torch nn module in JIT script, it provides a scripted version of torch.nn.activation and add proper nn modules tests in test_jit.py. 

Next steps:
* add scripted version of nn.functional to JIT
* add other scripted version of nn.modules and proper tests to JIT
* registration of scripted nn.functional/modules

For more details, here is the master task #10750 for supporting torch.nn in JIT.  

A design doc can be find in [quip](https://fb.quip.com/gmOdACxKGfu8) or in [gist](https://gist.github.com/wanchaol/1beeb077526ef72512f6f6a9bfae7477)

CCing @zdevito @apaszke @jamesr66a 