### PR TITLE
Enable 0-dim tensors in TH.

### DIFF
--- a/aten/src/ATen/THSizeStrideCompat.h
+++ b/aten/src/ATen/THSizeStrideCompat.h
@@ -4,21 +4,10 @@
 #include <vector>
 
 // NOTE: these functions are for compatibility into TH functions that takes sizes and strides.
-// We should just write the TH functions that don't require this, but that involves two steps:
-// 1) first class scalar support (for sizes)
-// 2) differentiating between nullptr/non-nullptr strides (the former "infers" strides).
+// We should just write the TH functions that don't require this, but that involves:
+// differentiating between nullptr/non-nullptr strides (the former "infers" strides).
 
 namespace at {
-
-static inline at::IntList get_intlist_size_th(IntList sizes) {
-  static int64_t one = 1;
-  if (sizes.size() == 0) {
-    // fake scalar
-    return IntList(&one, 1);
-  } else {
-    return sizes;
-  }
-}
 
 static inline IntList get_intlist_stride_th(IntList strides) {
   if (strides.size() == 0) {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -297,7 +297,6 @@ CHECKED_CAST = {
         CodeTemplate(
             'check_generator<${Backend}Generator>(${arg_name}, &globalContext().defaultGenerator(backend()))'),
     # This is a cast done via direct-construction
-    'IntListSize': CodeTemplate('at::IntList ${result_name} = get_intlist_size_th(${arg_name});'),
     'IntListStride': CodeTemplate('at::IntList ${result_name} = get_intlist_stride_th(${arg_name});'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
@@ -308,7 +307,7 @@ CHECKED_CAST = {
     'IntList': CodeTemplate('check_intlist<${size}>(${arg_name}, "${arg_name}", ${arg_pos}${,default_init})')
 }
 
-DIRECT_CONSTRUCTION_CHECKED_CAST = {'IntListSize', 'IntListStride'}
+DIRECT_CONSTRUCTION_CHECKED_CAST = {'IntListStride'}
 
 CHECKED_USE = {
     'THTensor*': '{}_->tensor',

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -110,7 +110,9 @@ void TensorIterator::compute_common_type() {
 
 DimVector TensorIterator::compatible_stride(int element_size) const {
   auto stride = DimVector();
-  stride.push_back(element_size);
+  if (ndim() > 0) {
+    stride.push_back(element_size);
+  }
   for (int i = 0; i < ndim() - 1; i++) {
     stride.push_back(shape_[i] * stride[i]);
   }

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -15,10 +15,10 @@ void THTensor_free(THTensor *self)
 }
 
 void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_) {
-  if(size_.data() && stride_.data())
+  if (stride_.data()) {
     THArgCheck(size_.size() == stride_.size(), 5, "inconsistent size/stride sizes");
+  }
 
-  AT_CHECK(size_.data(), "size must not be null");
 #ifdef DEBUG
   THAssert(size_.size() <= INT_MAX);
 #endif
@@ -61,9 +61,9 @@ void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storage
 
 void THTensor_resize(THTensor *self, at::IntList size, at::IntList stride)
 {
-  THArgCheck(size.data() != NULL, 2, "invalid size");
-  if(stride.data())
+  if (stride.data()) {
     THArgCheck(stride.size() == size.size(), 3, "invalid stride");
+  }
 
 #ifdef DEBUG
   THAssert(size.size() <= INT_MAX);
@@ -73,15 +73,10 @@ void THTensor_resize(THTensor *self, at::IntList size, at::IntList stride)
 
 void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
 {
+  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
   int d;
   ptrdiff_t totalSize;
   bool hascorrectsize = true;
-
-#ifndef USE_TH_SCALAR
-  AT_CHECK(nDimension > 0, "resizeNd nDimension must be greater than 0");
-#else
-  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
-#endif
 
   for(d = 0; d < nDimension; d++)
   {

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -53,7 +53,7 @@ struct THTensor
     }
 
     inline int64_t dim() const {
-      return sizes_.size();
+      return is_zero_dim_ ? 0 : sizes_.size();
     }
 
     at::ScalarType scalar_type() const {
@@ -85,11 +85,11 @@ struct THTensor
     }
 
     inline at::IntList sizes() const {
-      return sizes_;
+      return at::IntList(sizes_.data(), dim());
     }
 
     inline at::IntList strides() const {
-      return strides_;
+      return at::IntList(strides_.data(), dim());
     }
 
     void retain() {
@@ -205,13 +205,26 @@ inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
   // NB: This is *truly* a resize; calling code (e.g., squeeze)
   // assumes that old values are preserved
   tensor->is_zero_dim_ = bool(ndim == 0);
-  tensor->sizes_.resize(ndim);
-  tensor->strides_.resize(ndim);
+  if (!tensor->is_zero_dim_) {
+    tensor->sizes_.resize(ndim);
+    tensor->strides_.resize(ndim);
+  } else {
+    tensor->sizes_.assign({1});
+    tensor->strides_.assign({1});
+  }
 }
 
 inline void THTensor_setSizesAndStrides(THTensor* tensor, std::vector<int64_t>&& new_size, std::vector<int64_t>&& new_stride) {
-  tensor->sizes_ = std::move(new_size);
-  tensor->strides_ = std::move(new_stride);
+  AT_CHECK(new_size.size() == new_stride.size(), "dimensionality of sizes (",
+           new_size.size(), ") must match dimensionality of strides (", new_stride.size(), ")");
+  tensor->is_zero_dim_ = bool(new_size.size() == 0);
+  if (!tensor->is_zero_dim_) {
+    tensor->sizes_ = std::move(new_size);
+    tensor->strides_ = std::move(new_stride);
+  } else {
+    tensor->sizes_.assign({1});
+    tensor->strides_.assign({1});
+  }
 }
 
 inline void THTensor_setSizeAtDim(THTensor* tensor, int dim, int64_t new_size) {

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -72,10 +72,9 @@ THTensor *THTensor_(newWithTensor)(THTensor *tensor)
 
 /* Storage init */
 THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
-  if (sizes.data() && strides.data()) {
+  if (strides.data()) {
     AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
-  AT_CHECK(sizes.data(), "size must not be null");
   THTensor *self = new THTensor(THStorage_(new)());
   THTensor_(setStorageNd)(self, storage, storageOffset, sizes.size(),
                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
@@ -327,9 +326,7 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, int64_t sli
   if(!src)
     src = self;
 
-#ifndef USE_TH_SCALAR
-  THArgCheck(src->dim() > 1, 1, "cannot select on a vector");
-#endif
+  THArgCheck(src->dim() > 0, 1, "cannot select on a 0-dim tensor");
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 2, "out of range");
   THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size(dimension)), 3, "out of range");
 
@@ -426,15 +423,6 @@ void THTensor_(squeeze)(THTensor *self, THTensor *src)
     }
   }
 
-#ifndef USE_TH_SCALAR
-  /* right now, we do not handle 0-dimension tensors */
-  if(ndim == 0 && src->dim() > 0)
-  {
-    THTensor_setSizeAtDim(self, 0, 1);
-    THTensor_setStrideAtDim(self, 0, 1);
-    ndim = 1;
-  }
-#endif
   THTensor_resizeDim(self, ndim);
 }
 
@@ -449,11 +437,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
 
   THTensor_(set)(self, src);
 
-#ifdef USE_TH_SCALAR
   if(src->size(dimension) == 1)
-#else
-  if(src->size(dimension) == 1 && src->dim() > 1)
-#endif
   {
     for(d = dimension; d < self->dim()-1; d++)
     {

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -890,11 +890,7 @@ void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimensio
 
   THTensor_(resizeAs)(rt_, t);
   THTensor_(copy)(rt_, t);
-
-  {
-    std::vector<int64_t> size = THTensor_sizesLegacyNoScalars(t);
-    THLongTensor_resize(ri_, size, {});
-  }
+  THLongTensor_resize(ri_, t->sizes(), {});
 
   if(descendingOrder)
   {
@@ -1180,8 +1176,10 @@ void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, i
   THLongTensor_resize1d(tmpIndices, sliceSize);
   int64_t *tmpi__data = THLongTensor_data(tmpIndices);
 
-  std::vector<int64_t> topKSize = THTensor_sizesLegacyNoScalars(t);
-  topKSize[dim] = k;
+  std::vector<int64_t> topKSize = t->sizes().vec();
+  if (topKSize.size() > 0) { // handle 0-dim vs 1-dim differences.
+    topKSize[dim] = k;
+  }
   THTensor_(resize)(rt_, topKSize, {});
   THLongTensor_resize(ri_, topKSize, {});
 

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -67,8 +67,9 @@ THCTensor *THCTensor_new(THCState *state, at::ScalarType scalar_type) {
 
 void THCTensor_resize(THCState *state, THCTensor *self, at::IntList size, at::IntList stride) {
   THArgCheck(size.data() != NULL, 2, "invalid size");
-  if(stride.data())
+  if(stride.data()) {
     THArgCheck(stride.size() == size.size(), 3, "invalid stride");
+  }
 
 #ifdef DEBUG
   THAssert(size.size() <= INT_MAX);
@@ -98,15 +99,10 @@ void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
 
 void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
 {
+  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
   int d;
   ptrdiff_t totalSize;
   bool hascorrectsize = true;
-
-#ifndef USE_TH_SCALAR
-  AT_CHECK(nDimension > 0, "resizeNd nDimension must be greater than 0");
-#else
-  AT_CHECK(nDimension >= 0, "resizeNd nDimension must be non-negative");
-#endif
 
   for(d = 0; d < nDimension; d++)
   {
@@ -175,10 +171,10 @@ void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)
 
 void THCTensor_setStorage(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_)
 {
-  if(size_.data() && stride_.data())
+  if (stride_.data()) {
     THArgCheck(size_.size() == stride_.size(), 5, "inconsistent size/stride sizes");
+  }
 
-  AT_CHECK(size_.data(), "size must not be null");
   THCTensor_setStorageNd(state,
                          self,
                          storage_,
@@ -228,11 +224,7 @@ void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int d
 
   THCTensor_set(state, self, src);
 
-#ifdef TH_SCALAR
   if(src->size(dimension) == 1)
-#else
-  if(src->size(dimension) == 1 && src->dim() > 1)
-#endif
   {
     for(d = dimension; d < self->dim()-1; d++)
     {

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -66,7 +66,6 @@ THCTensor *THCTensor_new(THCState *state, at::ScalarType scalar_type) {
 }
 
 void THCTensor_resize(THCState *state, THCTensor *self, at::IntList size, at::IntList stride) {
-  THArgCheck(size.data() != NULL, 2, "invalid size");
   if(stride.data()) {
     THArgCheck(stride.size() == size.size(), 3, "invalid stride");
   }

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -82,10 +82,9 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
 
 /* Storage init */
 THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset, at::IntList sizes, at::IntList strides) {
-  if (sizes.data() && strides.data()) {
+  if (strides.data()) {
     AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
-  AT_CHECK(sizes.data(), "size must not be null");
   THCTensor *self = new THCTensor(THCStorage_(new)(state));
   THCTensor_(setStorageNd)(state, self, storage, storageOffset, sizes.size(),
                            const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
@@ -344,9 +343,7 @@ void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int di
   if(!src)
     src = self;
 
-#ifndef USE_TH_SCALAR
-  THArgCheck(src->dim() > 1, 1, "cannot select on a vector");
-#endif
+  THArgCheck(src->dim() > 0, 1, "cannot select on a 0-dim tensor");
   THArgCheck((dimension >= 0) && (dimension < src->dim()), 3, "out of range");
   THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size(dimension)), 4, "out of range");
 
@@ -444,15 +441,6 @@ void THCTensor_(squeeze)(THCState *state, THCTensor *self, THCTensor *src)
     }
   }
 
-#ifndef USE_TH_SCALAR
-  /* right now, we do not handle 0-dimension tensors */
-  if(ndim == 0 && src->dim() > 0)
-  {
-    THTensor_setSizeAtDim(self, 0, 1);
-    THTensor_setStrideAtDim(self, 0, 1);
-    ndim = 1;
-  }
-#endif
   THTensor_resizeDim(self, ndim);
 }
 


### PR DESCRIPTION
This does the following:
1) Delete USE_TH_SCALAR ifdefs, since this is now enabled.
2) sizes_, strides_ in THTensor are always at least size 1 (and may have is_zero_dim_ set).
A future PR will remove is_zero_dim_, so sizes_ and strides_ will just be size 0.
3) Allow IntList sizes with nullptr; this wasn't allowed previously because sizes were always at least size 1 in TH.
4) Get rid of get_intlist_size_th compatibility call in ATen; we now just use the IntList size directly.
We still use the stride compatibility call; a future PR will remove this.
5) Fix a case in TensorIterator where a tensor was resized with shape length 0 and stride length 1.

