### PR TITLE
fix list returned from loop/if in shape prop

### DIFF
--- a/test/expect/TestJit.test_shape_analysis_list_loops.expect
+++ b/test/expect/TestJit.test_shape_analysis_list_loops.expect
@@ -12,12 +12,12 @@ graph(%x : Double(2, 4, 5)) {
   %5 : int = prim::Constant[value=2147483647]()
   %6 : int = prim::Constant[value=0]()
   %y : Dynamic[] = prim::Loop(%5, %6, %y.3)
-    block0(%7 : int, %10 : Dynamic[]) {
+    block0(%8 : int, %9 : Dynamic[]) {
       %y.4 : Dynamic[] = prim::ListConstruct(%x, %x, %x)
       %11 : int = prim::Constant[value=0]()
       -> (%11, %y.4)
     }
-  %13 : int = prim::Constant[value=1]()
-  %14 : Dynamic = aten::cat(%y, %13)
-  return (%14);
+  %12 : int = prim::Constant[value=1]()
+  %13 : Dynamic = aten::cat(%y, %12)
+  return (%13);
 }

--- a/test/expect/TestScript.test_list_literal.expect
+++ b/test/expect/TestScript.test_list_literal.expect
@@ -1,0 +1,23 @@
+graph(%x : Double(2, 4, 5)) {
+  %y.1 : Dynamic[] = prim::ListConstruct(%x)
+  %2 : int = prim::Constant[value=1]()
+  %y.3 : Dynamic[] = prim::If(%2)
+    block0() {
+      %y.2 : Dynamic[] = prim::ListConstruct(%x, %x)
+      -> (%y.2)
+    }
+    block1() {
+      -> (%y.1)
+    }
+  %5 : int = prim::Constant[value=2147483647]()
+  %6 : int = prim::Constant[value=0]()
+  %y : Dynamic[] = prim::Loop(%5, %6, %y.3)
+    block0(%7 : int, %10 : Dynamic[]) {
+      %y.4 : Dynamic[] = prim::ListConstruct(%x, %x, %x)
+      %11 : int = prim::Constant[value=0]()
+      -> (%11, %y.4)
+    }
+  %13 : int = prim::Constant[value=1]()
+  %14 : Dynamic = aten::cat(%y, %13)
+  return (%14);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -666,6 +666,20 @@ class TestJit(JitTestCase):
         torch._C._jit_pass_shape_analysis(graph, (x, y), False)
         self.assertExpectedGraph(graph)
 
+    def test_shape_analysis_list_loops(self):
+        def list_control(x):
+            y = [x]
+            if True:
+                y = [x, x]
+            while False:
+                y = [x, x, x]
+            return torch.cat(y, dim=1)
+
+        x = torch.zeros(2, 4, 5)
+        graph = torch.jit.script(list_control).graph
+        torch._C._jit_pass_shape_analysis(graph, (x,), False)
+        self.assertExpectedGraph(graph)
+
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA_MULTI_GPU, "needs non-zero device")
     def test_fuse_last_device(self):
@@ -2104,19 +2118,6 @@ a")
                 x = [2, 3]
             return
         self.checkScript(reassign, (), optimize=True)
-
-        def shape_analysis(x):
-            y = [x]
-            if True:
-                y = [x, x]
-            while False:
-                y = [x, x, x]
-            return torch.cat(y, dim=1)
-
-        x = torch.zeros(2, 4, 5)
-        graph = torch.jit.script(shape_analysis).graph
-        torch._C._jit_pass_shape_analysis(graph, (x,), False)
-        self.assertExpected(str(graph))
 
         def reassign_arity_change():
             x = [1]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2105,6 +2105,19 @@ a")
             return
         self.checkScript(reassign, (), optimize=True)
 
+        def shape_analysis(x):
+            y = [x]
+            if True:
+                y = [x, x]
+            while False:
+                y = [x, x, x]
+            return torch.cat(y, dim=1)
+
+        x = torch.zeros(2, 4, 5)
+        graph = torch.jit.script(shape_analysis).graph
+        torch._C._jit_pass_shape_analysis(graph, (x,), False)
+        self.assertExpected(str(graph))
+
         def reassign_arity_change():
             x = [1]
             if True:

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -265,10 +265,9 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
   }
   if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*with_const=*/attr::dim)) {
     auto list_node = node->namedInput(attr::tensors)->node();
-    if (list_node->kind() == prim::Loop || list_node->kind() == prim::If) {
-      goto cat_fail;;
+    if (list_node->kind() != prim::ListConstruct) {
+      goto cat_fail;
     }
-    JIT_ASSERT(list_node->kind() == prim::ListConstruct);
     auto tensors = list_node->inputs();
     if (tensors.size() > 0) {
       auto input_types = fmap(tensors, [](Value *v) { return v->type()->cast<TensorType>(); });

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -265,6 +265,9 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
   }
   if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*with_const=*/attr::dim)) {
     auto list_node = node->namedInput(attr::tensors)->node();
+    if (list_node->kind() == prim::Loop || list_node->kind() == prim::If) {
+      goto cat_fail;;
+    }
     JIT_ASSERT(list_node->kind() == prim::ListConstruct);
     auto tensors = list_node->inputs();
     if (tensors.size() > 0) {


### PR DESCRIPTION
Previously an error was thrown in shape propagation if a list was returned from an If or Loop node and used in aten::cat. 

This prevents the error but does not correctly propagate the shape. Support for shape prop on lists returned from control could be added in a future diff. 