### PR TITLE
Adds `dim` argument to `torch.unique`

### DIFF
--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -22,7 +22,7 @@ std::tuple<Tensor, Tensor> _unique_cpu_template(
   const scalar_t* input_data = input.data<scalar_t>();
   std::unordered_set<scalar_t> set(input_data, input_data + input.numel());
   Tensor output = at::empty({static_cast<int64_t>(set.size())}, input.type());
-  scalar_t* output_data = output.data<scalar_t>();
+  scalar_t* output_data = output.data<scalar_t>();  
 
   if (sorted) {
     std::vector<scalar_t> vec(set.begin(), set.end());
@@ -47,12 +47,74 @@ std::tuple<Tensor, Tensor> _unique_cpu_template(
   }
   return std::make_tuple(output, inverse_indices);
 }
+
+template <typename scalar_t>
+std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
+    const Tensor& self,
+    const int64_t dim,
+    const bool return_inverse) {
+  // reshape tensor as [dim, -1]
+  Tensor input_flat = self.transpose(dim, 0);
+  std::vector<int64_t> orig_sizes(input_flat.sizes());
+
+  input_flat = input_flat.contiguous().view({input_flat.size(0), -1});
+
+  // unbind to use in std::sort and sort
+  std::vector<Tensor> input_unbind = at::unbind(input_flat, 0);
+  std::sort(input_unbind.begin(), input_unbind.end(),
+    [](const Tensor& lhs, const Tensor& rhs) -> bool {
+      // comparable to lexicographical sort
+      for (int i = 0; i < lhs.numel(); ++i) {
+        if ((bool)at::lt(lhs[i], rhs[i]).toCByte()) {
+          return true;
+        }
+        else if ((bool)at::gt(lhs[i], rhs[i]).toCByte()) {
+          return false;
+        }
+      }
+      return false;
+    });
+
+  auto last = std::unique(input_unbind.begin(), input_unbind.end(), [](Tensor& a, Tensor& b) {
+    return at::equal(a, b);
+  });
+  input_unbind.erase(last, input_unbind.end());
+
+  // reshape back
+  auto output_dim = at::stack(input_unbind, 0);
+  std::vector<int64_t> new_sizes(orig_sizes.begin(), orig_sizes.end());
+  new_sizes[0] = -1;
+  output_dim = output_dim.view(new_sizes);
+  output_dim = output_dim.transpose(0, dim);
+
+  Tensor inverse_indices_dim = at::empty({0}, self.type().toScalarType(kLong));
+  int64_t size = self.size(dim);
+  inverse_indices_dim.resize_(size);
+  std::vector<Tensor> self_unbind = at::unbind(self, dim);
+  std::vector<Tensor> output_unbind = at::unbind(output_dim, dim);
+  for (int i = 0; i < self_unbind.size(); ++i) {
+    for (int j = 0; j < output_unbind.size(); ++j) {
+      if (at::equal(self_unbind[i], output_unbind[j])) {
+        inverse_indices_dim[i] = j;
+      }
+    }
+  }
+  return std::make_tuple(output_dim, inverse_indices_dim);
+}
 } // namespace
 
 std::tuple<Tensor, Tensor>
 _unique_cpu(const Tensor& self, const bool sorted, const bool return_inverse) {
   return AT_DISPATCH_ALL_TYPES(self.type(), "unique", [&] {
     return _unique_cpu_template<scalar_t>(self, sorted, return_inverse);
+  });
+}
+
+std::tuple<Tensor, Tensor>
+_unique_dim_cpu(const Tensor& self, const int64_t dim, const bool sorted, const bool return_inverse) {
+  return AT_DISPATCH_ALL_TYPES(self.type(), "unique_dim", [&] {
+    // The current implementation using `dim` always sorts due to unhashable tensors
+    return _unique_dim_cpu_template<scalar_t>(self, dim, return_inverse);
   });
 }
 

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -59,46 +59,113 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
 
   input_flat = input_flat.contiguous().view({input_flat.size(0), -1});
 
-  // unbind to use in std::sort and sort
-  std::vector<Tensor> input_unbind = at::unbind(input_flat, 0);
-  std::sort(input_unbind.begin(), input_unbind.end(),
-    [](const Tensor& lhs, const Tensor& rhs) -> bool {
-      // comparable to lexicographical sort
-      for (int i = 0; i < lhs.numel(); ++i) {
-        if ((bool)at::lt(lhs[i], rhs[i]).toCByte()) {
+  // // unbind to use in std::sort and sort
+  // std::vector<Tensor> input_unbind = at::unbind(input_flat, 0);
+  // std::sort(input_unbind.begin(), input_unbind.end(),
+  //   [](const Tensor& lhs, const Tensor& rhs) -> bool {
+  //     // comparable to lexicographical sort
+  //     for (int i = 0; i < lhs.numel(); ++i) {
+  //       //if ((bool)at::lt(lhs[i], rhs[i]).toCByte()) {
+  //       if (lhs[i].toCFloat() < rhs[i].toCFloat()) {
+  //         return true;
+  //       }
+  //       //else if ((bool)at::gt(lhs[i], rhs[i]).toCByte()) {
+  //       else if (lhs[i].toCFloat() > rhs[i].toCFloat()) {
+  //         return false;
+  //       }
+  //     }
+  //     return false;
+  //   });
+
+  std::vector<int64_t> indices(input_flat.size(0)); //std::vector<int64_t>
+  std::iota(indices.begin(), indices.end(), 0);
+  int64_t numel = input_flat.size(1);
+  scalar_t* input_flat_ptr = ((scalar_t*)input_flat.data_ptr());
+  
+  std::sort(indices.begin(), indices.end(),
+    [&](int64_t a, int64_t b) -> bool {
+      for (int64_t i = 0; i < numel; ++i) {
+        scalar_t lhs = input_flat_ptr[i + a * input_flat.size(1)];
+        scalar_t rhs = input_flat_ptr[i + b * input_flat.size(1)];
+        //std::cout << "lhs :" << lhs << ", rhs: " << rhs << std::endl;
+        if (lhs < rhs) {
           return true;
         }
-        else if ((bool)at::gt(lhs[i], rhs[i]).toCByte()) {
+        else if (lhs > rhs) {
           return false;
         }
       }
       return false;
     });
+  
+  Tensor input_sorted = at::empty(input_flat.sizes(), input_flat.type());
+  for (int i = 0; i < indices.size(); ++i) {
+    input_sorted[i] = input_flat[indices[i]];
+    //std::cout << "sorted[" << i << "]: " << input_sorted[i] << std::endl;
+  } 
+  //std::cout << "sorted:\n" << input_sorted << std::endl;
 
-  auto last = std::unique(input_unbind.begin(), input_unbind.end(), [](Tensor& a, Tensor& b) {
+  // old
+  // std::vector<Tensor> input_unbind = at::unbind(input_sorted, 0);
+  // auto last = std::unique(input_unbind.begin(), input_unbind.end(), [](Tensor& a, Tensor& b) {
+  //   return at::equal(a, b);
+  // });
+  // input_unbind.erase(last, input_unbind.end());
+
+  // new
+  std::vector<Tensor> input_unbind = at::unbind(input_sorted, 0);
+  auto last = std::unique(input_unbind.begin(), input_unbind.end(), [&](Tensor a, Tensor b) {
     return at::equal(a, b);
   });
   input_unbind.erase(last, input_unbind.end());
-
+  // indices.erase(last, indices.end());
+  // std::cout << "indices erased: " << indices;
+  // Tensor input_unique = at::empty({indices.size(), input_flat.size(1)}, input_flat.type());
+  // for (int i = 0; i < indices.size(); ++i) {
+  //   input_unique[i] = input_sorted[indices[i]];
+  // }
+  // std::cout << input_unique << std::endl;
+  // std::vector<Tensor> input_unbind = at::unbind(input_unique, 0);
   // reshape back
   auto output_dim = at::stack(input_unbind, 0);
   std::vector<int64_t> new_sizes(orig_sizes.begin(), orig_sizes.end());
   new_sizes[0] = -1;
   output_dim = output_dim.view(new_sizes);
   output_dim = output_dim.transpose(0, dim);
+  //std::cout << "unique: " << output_dim << std::endl;
 
   Tensor inverse_indices_dim = at::empty({0}, self.type().toScalarType(kLong));
   int64_t size = self.size(dim);
   inverse_indices_dim.resize_(size);
-  std::vector<Tensor> self_unbind = at::unbind(self, dim);
-  std::vector<Tensor> output_unbind = at::unbind(output_dim, dim);
-  for (int i = 0; i < self_unbind.size(); ++i) {
-    for (int j = 0; j < output_unbind.size(); ++j) {
-      if (at::equal(self_unbind[i], output_unbind[j])) {
-        inverse_indices_dim[i] = j;
-      }
+  // std::vector<Tensor> self_unbind = at::unbind(self, dim);
+  // std::vector<Tensor> output_unbind = at::unbind(output_dim, dim);
+  // for (int i = 0; i < self_unbind.size(); ++i) {
+  //   for (int j = 0; j < output_unbind.size(); ++j) {
+  //     if (at::equal(self_unbind[i], output_unbind[j])) {
+  //       inverse_indices_dim[i] = j;
+  //     }
+  //   }
+  // }
+  // alternative
+  Tensor mask = at::empty(input_sorted.size(0), self.type().toScalarType(kLong));
+  mask[0] = 1;
+  for (int i = 0; i < input_sorted.size(0) - 1; ++i) {
+    if (!at::equal(input_sorted[i], input_sorted[i+1])) {
+      mask[i+1] = 1; 
+    }
+    else {
+      mask[i+1] = 0;
     }
   }
+  //std::cout << "mask: " << mask << std::endl;
+  Tensor imask = at::cumsum(mask, 0) - 1;
+  //std::cout << "imask: " << imask << std::endl;
+
+  for (int i = 0; i < indices.size(); ++i) {
+    inverse_indices_dim[indices[i]] = imask[i];
+  }
+  //std::cout << "inverse indices: " << inverse_indices_dim;
+
   return std::make_tuple(output_dim, inverse_indices_dim);
 }
 } // namespace

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -67,8 +67,8 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
   std::sort(indices.begin(), indices.end(),
     [&](int64_t a, int64_t b) -> bool {
       for (int64_t i = 0; i < numel; ++i) {
-        scalar_t lhs = input_flat_ptr[i + a * input_flat.size(1)];
-        scalar_t rhs = input_flat_ptr[i + b * input_flat.size(1)];
+        scalar_t lhs = input_flat_ptr[i + a * numel];
+        scalar_t rhs = input_flat_ptr[i + b * numel];
         if (lhs < rhs) {
           return true;
         }

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -55,7 +55,7 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
     const bool return_inverse) {
   // reshape tensor as [dim, -1]
   Tensor input_flat = self.transpose(dim, 0);
-  std::vector<int64_t> orig_sizes(input_flat.sizes());
+  std::vector<int64_t> orig_sizes(input_flat.sizes().begin(), input_flat.sizes().end());
 
   input_flat = input_flat.contiguous().view({input_flat.size(0), -1});
 

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -22,7 +22,7 @@ std::tuple<Tensor, Tensor> _unique_cpu_template(
   const scalar_t* input_data = input.data<scalar_t>();
   std::unordered_set<scalar_t> set(input_data, input_data + input.numel());
   Tensor output = at::empty({static_cast<int64_t>(set.size())}, input.type());
-  scalar_t* output_data = output.data<scalar_t>();  
+  scalar_t* output_data = output.data<scalar_t>();
 
   if (sorted) {
     std::vector<scalar_t> vec(set.begin(), set.end());

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -48,6 +48,31 @@ std::tuple<Tensor, Tensor> _unique_cpu_template(
   return std::make_tuple(output, inverse_indices);
 }
 
+template<class ForwardIt>
+ForwardIt _unique_dim_cpu_impl(ForwardIt first, ForwardIt last,
+  std::vector<int64_t>& indices, Tensor inverse_indices_vec) {
+    if (first == last) {
+      return last;
+    }
+    // save to calculate distance to iterators
+    ForwardIt begin = first;
+
+    // set first inverse index
+    inverse_indices_vec[indices[0]] = 0;
+
+    ForwardIt result = first;
+    while (++first != last) {
+      if (!at::equal(*result, *first) && ++result != first) {
+          *result = std::move(*first);
+      }
+      int64_t idx_result = std::distance(begin, result);
+      int64_t idx_first = std::distance(begin, first);
+      inverse_indices_vec[indices[idx_first]] = idx_result;
+    }
+
+    return ++result;
+  }
+
 template <typename scalar_t>
 std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
     const Tensor& self,
@@ -55,7 +80,7 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
     const bool return_inverse) {
   // reshape tensor as [dim, -1]
   Tensor input_flat = self.transpose(dim, 0);
-  std::vector<int64_t> orig_sizes(input_flat.sizes().begin(), input_flat.sizes().end());
+  auto orig_sizes = input_flat.sizes().vec();
   input_flat = input_flat.contiguous().view({input_flat.size(0), -1});
 
   std::vector<int64_t> indices(input_flat.size(0));
@@ -82,43 +107,19 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
   for (int i = 0; i < indices.size(); ++i) {
     input_sorted[i] = input_flat[indices[i]];
   }
- 
-  // pre-calculate mask for inverse_indices
-  Tensor mask = at::empty(input_sorted.size(0), self.type().toScalarType(kLong));
-  mask[0] = 1;
-  int mask_idx = 1;
 
+  Tensor inverse_indices = at::empty(indices.size(), self.type().toScalarType(kLong));
   std::vector<Tensor> input_unbind = at::unbind(input_sorted, 0);
-  auto last = std::unique(input_unbind.begin(), input_unbind.end(), [&](Tensor a, Tensor b) {
-    bool eq = at::equal(a, b);
-    if (return_inverse) {
-      if (!eq) {
-        mask[mask_idx++] = 1;
-      } else {
-        mask[mask_idx++] = 0;
-      }
-    }
-    return eq;
-  });
+  auto last = _unique_dim_cpu_impl(
+    input_unbind.begin(), input_unbind.end(), indices, inverse_indices);
   input_unbind.erase(last, input_unbind.end());
 
   // reshape back
   auto output = at::stack(input_unbind, 0);
-  std::vector<int64_t> new_sizes(orig_sizes.begin(), orig_sizes.end());
+  auto new_sizes = std::vector<int64_t>(orig_sizes);
   new_sizes[0] = -1;
   output = output.view(new_sizes);
   output = output.transpose(0, dim);
-
-  Tensor inverse_indices = at::empty({0}, self.type().toScalarType(kLong));
-  if (return_inverse) {
-    int64_t size = self.size(dim);
-    inverse_indices.resize_(size);
-
-    Tensor imask = at::cumsum(mask, 0) - 1;
-    for (int i = 0; i < indices.size(); ++i) {
-      inverse_indices[indices[i]] = imask[i];
-    }
-  }
 
   return std::make_tuple(output, inverse_indices);
 }

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -79,6 +79,51 @@ template <typename scalar_t>
     auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
     auto policy = thrust::cuda::par(allocator).on(stream);
 
+    // Tensor input_flat = self.transpose(dim, 0);
+    // std::vector<int64_t> orig_sizes(input_flat.sizes().begin(), input_flat.sizes().end());
+
+    // // unbind to use in thrust::sort
+    // std::vector<Tensor> input_unbind = at::unbind(input_flat, 0);
+    // thrust::sort(policy, input_unbind.begin(), input_unbind.end(),
+    //   [] __device__ (const Tensor& lhs, const Tensor& rhs) -> bool {
+    //     // compare to lexicographical sort
+    //     for (int i = 0; i < lhs.numel(); ++i) {
+    //       if (lhs[i].toCFloat() < rhs[i].toCFloat()) {
+    //         return true;
+    //       }
+    //       else if (lhs[i].toCFloat() > rhs[i].toCFloat()) {
+    //         return false;
+    //       }
+    //     }
+    //     return false;
+    //   });
+    
+    // auto last = thrust::unique(policy, input_unbind.begin(), input_unbind.end(),
+    //   [] __device __ (const Tensor& a, const Tensor& b) -> bool {
+    //     return at::equal(a, b);
+    // });
+    // input_unbind.erase(last, input_unbind.end());
+
+    // // reshape back
+    // auto output_dim = at::stack(input_unbind, 0);
+    // std::vector<int64_t> new_sizes(orig_sizes.begin(), orig_sizes.end());
+    // new_sizes[0] = -1;
+    // output_dim = output_dim.view(new_sizes);
+    // output_dim = output_dim.transpose(0, dim);
+
+    // Tensor inverse_indices_dim = at::empty({0}, self.type(.toScalarType(kLong)));
+    // int64_t size = self.size(dim);
+    // inverse_indices_dim.resize_(size);
+    // std::vector<Tensor> self_unbind = at::unbind(self, dim);
+    // std::vector<Tensor> output_unbind = at::unbind(output_dim,, dim);
+    // for (int i = 0; i < self_unbind.size(); ++i) {
+    //   for (int j = 0; j < output_unbind.size(); ++j) {
+    //     if (at::equal(self.unbind[i], output_unbind[j])) {
+    //       inverse_indices_dim[i] = j;
+    //     }
+    //   }
+    // }
+
     const Tensor& input = self.contiguous();
     int64_t num_inp = input.numel();
     const scalar_t* input_data = input.data<scalar_t>();

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -7,7 +7,6 @@
 #include <tuple>
 #include <thrust/unique.h>
 #include <thrust/sort.h>
-#include <thrust/device_vector.h>
 
 namespace at {
 namespace native{
@@ -126,8 +125,8 @@ template <typename scalar_t>
     input_sorted_indices.resize_(last - input_sorted_indices_ptr);
     Tensor output = input_sorted.index_select(0, input_sorted_indices);
 
-    // // reshape back
-    std::vector<int64_t> new_sizes(orig_sizes.begin(), orig_sizes.end());
+    // reshape back
+    auto new_sizes = std::vector<int64_t>(orig_sizes);
     new_sizes[0] = -1;
     output = output.view(new_sizes);
     output = output.transpose(0, dim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1634,6 +1634,11 @@
     CPU: _unique_cpu
     CUDA: _unique_cuda
 
+- func: _unique_dim(Tensor self, int64_t dim, bool sorted=false, bool return_inverse=false) -> (Tensor, Tensor)
+  dispatch:
+    CPU: _unique_dim_cpu
+    CUDA: _unique_dim_cuda
+
 - func: _unsafe_view(Tensor self, IntList size) -> Tensor
   variants: function
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8354,35 +8354,35 @@ class TestTorch(TestCase):
                                                   [2., 1.]]], dtype=dtype)
             expected_inverse_dim1 = torch.tensor([1, 0, 2, 0])
             expected_unique_dim2 = torch.tensor([[[1., 1.],
-                                                   [0., 1.],
-                                                   [2., 1.],
-                                                   [0., 1.]],
-                                                  [[1., 1.],
-                                                   [0., 1.],
-                                                   [2., 1.],
-                                                   [0., 1.]]], dtype=dtype)
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]],
+                                                 [[1., 1.],
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]]], dtype=dtype)
             expected_inverse_dim2 = torch.tensor([0, 1])
-    
+
             # dim0
             x_unique = torch.unique(x, dim=0)
             self.assertEqual(expected_unique_dim0, x_unique)
-    
+
             x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=0)
             self.assertEqual(expected_unique_dim0, x_unique)
             self.assertEqual(expected_inverse_dim0, x_inverse)
-    
+
             # dim1
             x_unique = torch.unique(x, dim=1)
             self.assertEqual(expected_unique_dim1, x_unique)
-    
+
             x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=1)
             self.assertEqual(expected_unique_dim1, x_unique)
             self.assertEqual(expected_inverse_dim1, x_inverse)
-    
+
             # dim2
             x_unique = torch.unique(x, dim=2)
             self.assertEqual(expected_unique_dim2, x_unique)
-    
+
             x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=2)
             self.assertEqual(expected_unique_dim2, x_unique)
             self.assertEqual(expected_inverse_dim2, x_inverse)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8331,6 +8331,67 @@ class TestTorch(TestCase):
         self.assertEqual(torch.ByteTensor([7, 42, 128, 133]), byte_unique)
         self.assertEqual(torch.LongTensor([3, 0, 0, 0, 1, 2]), byte_inverse)
 
+    def test_unique_dim(self):
+        def run_test(dtype=torch.float):
+            x = torch.tensor([[[1., 1.],
+                               [0., 1.],
+                               [2., 1.],
+                               [0., 1.]],
+                              [[1., 1.],
+                               [0., 1.],
+                               [2., 1.],
+                               [0., 1.]]], dtype=dtype)
+            expected_unique_dim0 = torch.tensor([[[1., 1.],
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]]], dtype=dtype)
+            expected_inverse_dim0 = torch.tensor([0, 0])
+            expected_unique_dim1 = torch.tensor([[[0., 1.],
+                                                  [1., 1.],
+                                                  [2., 1.]],
+                                                 [[0., 1.],
+                                                  [1., 1.],
+                                                  [2., 1.]]], dtype=dtype)
+            expected_inverse_dim1 = torch.tensor([1, 0, 2, 0])
+            expected_unique_dim2 = torch.tensor([[[1., 1.],
+                                                   [0., 1.],
+                                                   [2., 1.],
+                                                   [0., 1.]],
+                                                  [[1., 1.],
+                                                   [0., 1.],
+                                                   [2., 1.],
+                                                   [0., 1.]]], dtype=dtype)
+            expected_inverse_dim2 = torch.tensor([0, 1])
+    
+            # dim0
+            x_unique = torch.unique(x, dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+    
+            x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+            self.assertEqual(expected_inverse_dim0, x_inverse)
+    
+            # dim1
+            x_unique = torch.unique(x, dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+    
+            x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+            self.assertEqual(expected_inverse_dim1, x_inverse)
+    
+            # dim2
+            x_unique = torch.unique(x, dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+    
+            x_unique, x_inverse = torch.unique(x, return_inverse=True, dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+            self.assertEqual(expected_inverse_dim2, x_inverse)
+
+        run_test(torch.float)
+        run_test(torch.double)
+        run_test(torch.long)
+        run_test(torch.uint8)
+
     @staticmethod
     def _test_bincount(self, device):
         # negative input throws

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -314,7 +314,7 @@ def isnan(tensor):
     return tensor != tensor
 
 
-def unique(input, sorted=False, return_inverse=False):
+def unique(input, sorted=False, return_inverse=False, dim=None):
     r"""Returns the unique scalar elements of the input tensor as a 1-D tensor.
 
     Arguments:
@@ -356,11 +356,19 @@ def unique(input, sorted=False, return_inverse=False):
                 [ 1,  2]])
 
     """
-    output, inverse_indices = torch._unique(
-        input,
-        sorted=sorted,
-        return_inverse=return_inverse,
-    )
+    if dim is not None:
+        output, inverse_indices = torch._unique_dim(
+            input,
+            dim,
+            sorted=sorted,
+            return_inverse=return_inverse
+        )
+    else:
+        output, inverse_indices = torch._unique(
+            input,
+            sorted=sorted,
+            return_inverse=return_inverse,
+        )
     if return_inverse:
         return output, inverse_indices
     else:

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -305,13 +305,22 @@ class Tensor(torch._C._TensorBase):
     def masked_fill(self, mask, value):
         return self.clone().masked_fill_(mask, value)
 
-    def unique(self, sorted=False, return_inverse=False):
+    def unique(self, sorted=False, return_inverse=False, dim=None):
         r"""Returns the unique scalar elements of the tensor as a 1-D tensor.
 
         See :func:`torch.unique`
         """
-        output, inverse_indices = self._unique(
-            sorted=sorted, return_inverse=return_inverse)
+        if dim is not None:
+            output, inverse_indices = self._unique_dim(
+                sorted=sorted,
+                return_inverse=return_inverse,
+                dim=dim
+            )
+        else:
+            output, inverse_indices = self._unique(
+                sorted=sorted,
+                return_inverse=return_inverse
+            )
         if return_inverse:
             return output, inverse_indices
         else:


### PR DESCRIPTION
Initial version of `unique` supporting a `dim` argument.

As discussed in [this issue](https://github.com/pytorch/pytorch/issues/9997) I added the `dim` argument to `torch.unique` with the same behavior like [numpy](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.unique.html).

Since the implementation is based on `std/thrust::unique`, the `tensor` always needs to be sorted. The `sorted` argument in `torch.unique` does not have any function, as in the CUDA version of the plain `torch.unique`.

To check the performance and equal behavior between `torch.unique` and `np.unique`, I've used [this gist](https://gist.github.com/ptrblck/ac0dc862f4e1766f0e1036c252cdb105).

Currently we achieve the following timings for an input of `x = torch.randint(2, (1000, 1000))`:
(The values are calculated by taking the average of the times for both dimension)

| Device | PyTorch (return_inverse=False) | Numpy (return_inverse=False) | PyTorch (return_inverse=True) | Numpy (return_inverse=True) |
| --- | --- | --- | --- | --- |
| CPU | ~0.007331s | ~0.022452s | ~0.011139s | ~0.044800s |
| GPU | ~0.006154s | - | ~0.105373s | - |

Many thanks to @colesbury for the awesome mentoring and the valuable advices on the general implementation and performance issues!