### PR TITLE
Fix warning in Nomnigraph

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -399,7 +399,7 @@ class Graph {
     return result;
   }
 
-  const size_t getNodesCount() const {
+  size_t getNodesCount() const {
     return (size_t)nodes_.size();
   }
 


### PR DESCRIPTION
Summary: `const size_t` as return value doesn't make sense.

Differential Revision: D9281442
