### PR TITLE
Use FULL_CAFFE2 to build caffe2 and python in one shot

### DIFF
--- a/scripts/onnx/install-develop.sh
+++ b/scripts/onnx/install-develop.sh
@@ -17,4 +17,4 @@ pip install -e "$tp2_dir/onnx"
 
 # Install pytorch
 pip install -r "$top_dir/requirements.txt"
-FULL_CAFFE2=1 python setup.py install
+FULL_CAFFE2=1 python setup.py build_deps develop 

--- a/scripts/onnx/install-develop.sh
+++ b/scripts/onnx/install-develop.sh
@@ -9,12 +9,10 @@ tp2_dir="$top_dir/third_party"
 
 pip install ninja
 
-# Install caffe2
-pip install -r "$top_dir/caffe2/requirements.txt"
-
 # Install onnx
 pip install -e "$tp2_dir/onnx"
 
-# Install pytorch
+# Install caffe2 and pytorch
+pip install -r "$top_dir/caffe2/requirements.txt"
 pip install -r "$top_dir/requirements.txt"
 FULL_CAFFE2=1 python setup.py build_deps develop 

--- a/scripts/onnx/install-develop.sh
+++ b/scripts/onnx/install-develop.sh
@@ -11,11 +11,10 @@ pip install ninja
 
 # Install caffe2
 pip install -r "$top_dir/caffe2/requirements.txt"
-python setup_caffe2.py develop
 
 # Install onnx
 pip install -e "$tp2_dir/onnx"
 
 # Install pytorch
 pip install -r "$top_dir/requirements.txt"
-python setup.py build develop
+FULL_CAFFE2=1 python setup.py install

--- a/scripts/onnx/install.sh
+++ b/scripts/onnx/install.sh
@@ -30,11 +30,10 @@ _pip_install() {
 }
 
 pip install -r "$top_dir/caffe2/requirements.txt"
-python setup_caffe2.py install
 
 # Install onnx
 _pip_install -b "$BUILD_DIR/onnx" "file://$tp2_dir/onnx#egg=onnx"
 
 # Install pytorch
 pip install -r "$top_dir/requirements.txt"
-_pip_install -b "$BUILD_DIR/pytorch" "file://$top_dir#egg=torch"
+FULL_CAFFE2=1 python setup.py install

--- a/scripts/onnx/install.sh
+++ b/scripts/onnx/install.sh
@@ -29,11 +29,10 @@ _pip_install() {
     fi
 }
 
-pip install -r "$top_dir/caffe2/requirements.txt"
-
 # Install onnx
 _pip_install -b "$BUILD_DIR/onnx" "file://$tp2_dir/onnx#egg=onnx"
 
-# Install pytorch
+# Install caffe2 and pytorch
+pip install -r "$top_dir/caffe2/requirements.txt"
 pip install -r "$top_dir/requirements.txt"
 FULL_CAFFE2=1 python setup.py install

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -23,7 +23,7 @@ do
 done
 set -- "${UNKNOWN[@]}" # leave UNKNOWN
 
-pip install pytest torchvision
+pip install pytest scipy torchvision
 if [[ $PARALLEL == 1 ]]; then
     pip install pytest-xdist
 fi


### PR DESCRIPTION
Building caffe2 and pytorch separately will end up duplicated symbols as they now share some basic libs. And it's especially bad for registry. This PR fixes our CI and build them in one shot with shared symbols. 