### PR TITLE
Add apply_local_tensor() method to torch.nn.Module.

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -655,7 +655,8 @@ def _get_methods(cls):
 
 _compiled_methods_whitelist = {
     'forward', 'register_buffer', 'register_parameter', 'add_module',
-    '_apply', 'apply', 'cuda', 'cpu', 'type', 'float', 'double', 'half',
+    '_apply', 'apply', 'apply_local_tensors',
+    'cuda', 'cpu', 'type', 'float', 'double', 'half',
     'state_dict', 'load_state_dict', '_load_from_state_dict', 'parameters',
     'named_parameters', '_all_buffers', 'children', 'named_children', 'modules',
     'named_modules', 'zero_grad', 'share_memory', '_get_name', 'extra_repr',

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -108,8 +108,8 @@ class RNNBase(Module):
             self._param_buf_size = weight_buf.size(0)
             self._data_ptrs = list(p.data.data_ptr() for p in self.parameters())
 
-    def _apply(self, fn):
-        ret = super(RNNBase, self)._apply(fn)
+    def apply_local_tensors(self, fn):
+        ret = super(RNNBase, self).apply_local_tensors(fn)
         self.flatten_parameters()
         return ret
 


### PR DESCRIPTION
This commit adds the ``apply_local_tensor()`` method to torch.nn.Module.

``apply_local_tensor()`` is a nonrecursive version of the ``_apply()`` private method.

See https://github.com/pytorch/ELF/pull/78 for an example where the
non-recursive variant is needed.

