### PR TITLE
[Caffe2 Bug] Added missing "AT_" prefix to macro.

### DIFF
--- a/modules/rocksdb/rocksdb.cc
+++ b/modules/rocksdb/rocksdb.cc
@@ -67,7 +67,7 @@ class RocksDBTransaction : public Transaction {
   rocksdb::DB* db_;
   std::unique_ptr<rocksdb::WriteBatch> batch_;
 
-  DISABLE_COPY_AND_ASSIGN(RocksDBTransaction);
+  AT_DISABLE_COPY_AND_ASSIGN(RocksDBTransaction);
 };
 
 class RocksDB : public DB {


### PR DESCRIPTION
For issue #10435 