### PR TITLE
Remove caffe namespace GetEmptyStringAlreadyInited

### DIFF
--- a/caffe2/utils/proto_wrap.cc
+++ b/caffe2/utils/proto_wrap.cc
@@ -4,17 +4,6 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/generated_message_util.h>
 
-namespace caffe {
-
-// Caffe wrapper functions for protobuf's GetEmptyStringAlreadyInited() function
-// used to avoid duplicated global variable in the case when protobuf
-// is built with hidden visibility.
-CAFFE2_API const ::std::string& GetEmptyStringAlreadyInited() {
-  return ::google::protobuf::internal::GetEmptyStringAlreadyInited();
-}
-
-}  // namespace caffe
-
 namespace ONNX_NAMESPACE {
 
 // ONNX wrapper functions for protobuf's GetEmptyStringAlreadyInited() function


### PR DESCRIPTION
A followup cleanup of #10380 .