### PR TITLE
[lint] end macros with a semicolon guard

### DIFF
--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -146,6 +146,26 @@ using std::vector;
 #define CAFFE2_OBSERVER_API CAFFE2_IMPORT
 #endif
 
+/**
+ * CAFFE_ANONYMOUS_VARIABLE(str) introduces an identifier starting with
+ * str and ending with a number that varies with the line.
+ * Pretty much a copy from 'folly/Preprocessor.h'
+ */
+#define CAFFE_CONCATENATE_IMPL(s1, s2) s1##s2
+#define CAFFE_CONCATENATE(s1, s2) CAFFE_CONCATENATE_IMPL(s1, s2)
+#ifdef __COUNTER__
+#define CAFFE_ANONYMOUS_VARIABLE(str) CAFFE_CONCATENATE(str, __COUNTER__)
+#else
+#define CAFFE_ANONYMOUS_VARIABLE(str) CAFFE_CONCATENATE(str, __LINE__)
+#endif
+/**
+ * A helper line in macro definition that would allow one to force a macro
+ * to end with a semicolon, when the macro is used outside a function. It is
+ * similar to the equivalent of the "do {} while(0)" trick in in-function
+ * macros.
+ */
+#define MACRO_SEMICOLON_GUARD                                                  \
+  extern void CAFFE_ANONYMOUS_VARIABLE(macros_should_end_with_semicolon)()
 
 #if defined(_MSC_VER)
 #define NOMINMAX

--- a/caffe2/core/registry.h
+++ b/caffe2/core/registry.h
@@ -133,19 +133,6 @@ class Registerer {
 };
 
 /**
- * CAFFE_ANONYMOUS_VARIABLE(str) introduces an identifier starting with
- * str and ending with a number that varies with the line.
- * Pretty much a copy from 'folly/Preprocessor.h'
- */
-#define CAFFE_CONCATENATE_IMPL(s1, s2) s1##s2
-#define CAFFE_CONCATENATE(s1, s2) CAFFE_CONCATENATE_IMPL(s1, s2)
-#ifdef __COUNTER__
-#define CAFFE_ANONYMOUS_VARIABLE(str) CAFFE_CONCATENATE(str, __COUNTER__)
-#else
-#define CAFFE_ANONYMOUS_VARIABLE(str) CAFFE_CONCATENATE(str, __LINE__)
-#endif
-
-/**
  * CAFFE_DECLARE_TYPED_REGISTRY is a macro that expands to a function
  * declaration, as well as creating a convenient typename for its corresponding
  * registerer.

--- a/caffe2/core/typeid.h
+++ b/caffe2/core/typeid.h
@@ -87,8 +87,8 @@ static const char* DemangleType() {
 #endif // __GXX_RTTI
 }
 
-// A utility function to return an exception std::string by prepending its exception
-// type before its what() content.
+// A utility function to return an exception std::string by prepending its
+// exception type before its what() content.
 std::string GetExceptionString(const std::exception& e);
 
 std::mutex& gTypeRegistrationMutex();
@@ -141,7 +141,8 @@ class TypeMeta {
    * type, use TypeMeta::Make<T>().
    */
   TypeMeta() noexcept
-      : id_(TypeIdentifier::uninitialized()), itemsize_(0), ctor_(nullptr), copy_(nullptr), dtor_(nullptr) {}
+      : id_(TypeIdentifier::uninitialized()), itemsize_(0), ctor_(nullptr),
+        copy_(nullptr), dtor_(nullptr) {}
 
   /**
    * Copy constructor.
@@ -391,21 +392,23 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
 // and as a result, we define these two macros slightly differently.
 
 #ifdef _MSC_VER
-#define CAFFE_KNOWN_TYPE(T)                                                        \
-  template <>                                                                      \
-  CAFFE2_EXPORT TypeIdentifier TypeMeta::Id<T>() {                                    \
-    static const TypeIdentifier type_id = TypeIdentifier::createTypeId();                \
-    static TypeNameRegisterer<T> registerer(type_id, #T);                          \
-    return type_id;                                                                \
-  }
+#define CAFFE_KNOWN_TYPE(T)                                                    \
+  template <>                                                                  \
+  CAFFE2_EXPORT TypeIdentifier TypeMeta::Id<T>() {                             \
+    static const TypeIdentifier type_id = TypeIdentifier::createTypeId();      \
+    static TypeNameRegisterer<T> registerer(type_id, #T);                      \
+    return type_id;                                                            \
+  }                                                                            \
+  MACRO_SEMICOLON_GUARD
 #else // _MSC_VER
-#define CAFFE_KNOWN_TYPE(T)                                                        \
-  template <>                                                                      \
-  TypeIdentifier TypeMeta::Id<T>() {                                                  \
-    static const TypeIdentifier type_id = TypeIdentifier::createTypeId();                \
-    static TypeNameRegisterer<T> registerer(type_id, #T);                          \
-    return type_id;                                                                \
-  }
+#define CAFFE_KNOWN_TYPE(T)                                                    \
+  template <>                                                                  \
+  TypeIdentifier TypeMeta::Id<T>() {                                           \
+    static const TypeIdentifier type_id = TypeIdentifier::createTypeId();      \
+    static TypeNameRegisterer<T> registerer(type_id, #T);                      \
+    return type_id;                                                            \
+  }                                                                            \
+  MACRO_SEMICOLON_GUARD
 #endif
 
 /**
@@ -415,28 +418,31 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
  * for your own types to allocate dynamic ids for them.
  */
 #ifdef _MSC_VER
-#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)              \
-  template <>                                                    \
-  inline CAFFE2_EXPORT TypeIdentifier TypeMeta::Id<T>() { \
-    return TypeIdentifier(PreallocatedId);                          \
-  }
+#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)                            \
+  template <>                                                                  \
+  inline CAFFE2_EXPORT TypeIdentifier TypeMeta::Id<T>() {                      \
+    return TypeIdentifier(PreallocatedId);                                     \
+  }                                                                            \
+  MACRO_SEMICOLON_GUARD
 #else // _MSC_VER
-#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T) \
-  template <>                                       \
-  inline TypeIdentifier TypeMeta::Id<T>() {  \
-    return TypeIdentifier(PreallocatedId);             \
-  }
+#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)                            \
+  template <>                                                                  \
+  inline TypeIdentifier TypeMeta::Id<T>() {                                    \
+    return TypeIdentifier(PreallocatedId);                                     \
+  }                                                                            \
+  MACRO_SEMICOLON_GUARD
 #endif
 
 #define CONCAT_IMPL(x, y) x##y
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
 
-#define CAFFE_DEFINE_KNOWN_TYPE(T)                             \
-  namespace {                                                  \
-  TypeNameRegisterer<T> MACRO_CONCAT(registerer, __COUNTER__)( \
-      TypeMeta::Id<T>(),                                       \
-      #T);                                                     \
-  }
+#define CAFFE_DEFINE_KNOWN_TYPE(T)                                             \
+  namespace {                                                                  \
+  TypeNameRegisterer<T> MACRO_CONCAT(registerer, __COUNTER__)(                 \
+      TypeMeta::Id<T>(),                                                       \
+      #T);                                                                     \
+  }                                                                            \
+  MACRO_SEMICOLON_GUARD
 
 class Tensor;
 


### PR DESCRIPTION
For the type id related masters, -Wpedantic will give a warning that an unnecessary semicolon is being added to the macro invocation. This is a linting change to make sure that we are properly swallowing the macro, and also, explicitly require this macro to also end with a semicolon as other macros in PT1 do.