### PR TITLE
[jit] Fix prim::FusedConcat bug

### DIFF
--- a/test/expect/TestJit.test_concat_fusion_invariant_cuda.expect
+++ b/test/expect/TestJit.test_concat_fusion_invariant_cuda.expect
@@ -1,0 +1,17 @@
+graph(%0 : Float(2, 2)
+      %1 : Float(2, 2)
+      %2 : Float(4, 2)) {
+  %3 : int = prim::Constant[value=1]()
+  %4 : Float(2, 2) = aten::sub(%0, %1, %3)
+  %5 : Float(4, 2) = prim::FusionGroup_0[device=0](%4, %0, %1)
+  %6 : Float(4, 2) = aten::add(%5, %2, %3)
+  return (%6);
+}
+with prim::FusionGroup_0 = graph(%1 : Float(2, 2)
+      %3 : Float(2, 2)
+      %4 : Float(2, 2)) {
+  %5 : int = prim::Constant[value=1]()
+  %6 : Float(2, 2) = aten::add(%3, %4, %5)
+  %2 : Float(4, 2) = prim::FusedConcat[dim=0](%6, %1)
+  return (%2);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -451,7 +451,6 @@ class TestJit(JitTestCase):
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     @skipIfRocm
-    @unittest.skipIf(TEST_WITH_ROCM, "test doesn't currently work on the ROCm stack")
     def test_concat_fusion_invariant_cuda(self):
         # Invariant: the output of prim::FusedConcat may
         # not be an input to any node inside the FusionGroup.

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -236,20 +236,10 @@ struct GraphFuser {
     return true;
   }
 
-  // XXX: this is O(n) where n is the number of outputs of the FusionGroup
   bool isFusedConcatOutput(Value * producer) {
     JIT_ASSERT(producer->node()->kind() == prim::FusionGroup);
-    auto * fusion_group = producer->node();
-
-    // Find the output index
-    auto outputs = fusion_group->outputs();
-    auto it = std::find(outputs.begin(), outputs.end(), producer);
-    JIT_ASSERT(it != outputs.end());
-    int64_t output_index = it - outputs.begin();
-
-    // Find the relevant node
-    auto subgraph = fusion_group->g(attr::Subgraph);
-    auto * value = subgraph->outputs()[output_index];
+    auto subgraph = producer->node()->g(attr::Subgraph);
+    auto * value = subgraph->outputs().at(producer->offset());
     return value->node()->kind() == prim::FusedConcat;
   }
 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -207,7 +207,11 @@ struct GraphFuser {
   // because it is not a simple map, can be put in a fusion group
   // as long as no items in the group read the output of concat
   bool isFusableAsExitNode(Node * node) {
-    return isFusable(node) || isFusableCatNode(node);
+    return isFusable(node) || isFusableOnlyAsExitNode(node);
+  }
+
+  bool isFusableOnlyAsExitNode(Node * node) {
+    return isFusableCatNode(node) || node->kind() == prim::FusedConcat;
   }
 
   // necessary condition for fusion. If all of the uses of producer are consumer
@@ -236,11 +240,13 @@ struct GraphFuser {
     return true;
   }
 
-  bool isFusedConcatOutput(Value * producer) {
-    JIT_ASSERT(producer->node()->kind() == prim::FusionGroup);
+  bool mustRemainAsFusionGroupOutput(Value * producer) {
+    if (producer->node()->kind() != prim::FusionGroup) {
+      return false;
+    }
     auto subgraph = producer->node()->g(attr::Subgraph);
-    auto * value = subgraph->outputs().at(producer->offset());
-    return value->node()->kind() == prim::FusedConcat;
+    auto * node = subgraph->outputs().at(producer->offset())->node();
+    return isFusableOnlyAsExitNode(node);
   }
 
   bool shouldFuse(Node * consumer, Value * producer) {
@@ -249,12 +255,6 @@ struct GraphFuser {
     // if the consumer allInputsAreThisProducer(consumer,producer)
     // we can move the consumer up into the producer.
     // but this requires better handling of merging fusion groups so it is not done now
-    bool producer_is_fusion_group = producer->node()->kind() == prim::FusionGroup;
-    if (producer_is_fusion_group && isFusedConcatOutput(producer)) {
-      // the output of a prim::FusedConcat node cannot be an input
-      // to any node inside a prim::FusionGroup.
-      return false;
-    }
     at::optional<int> consumer_device = getDevice(consumer);
     Node *real_consumer = consumer->kind() == aten::cat ? consumer->namedInput(attr::tensors)->node() : consumer;
     return isFusable(producer->node()) &&
@@ -572,6 +572,8 @@ struct GraphFuser {
       for(auto producer : inputs) {
         // Don't fuse accross stage boundaries
         if (producer->stage() != consumer->stage()) continue;
+        // Don't fuse if producer must come from a FusionGroup exit node
+        if (mustRemainAsFusionGroupOutput(producer)) continue;
         if(tryToMoveChunk(consumer,producer)) {
           // the chunk before this consumer was re-arranged to allow fusion,
           // we scan this consumer again to perform the fusion


### PR DESCRIPTION
Fixes #10456

The graph fuser was fusing together groups with prim::FusedConcat (the producer) with other ops (the consumer) if the consumer is fusable. For example,

```
import torch
@torch.jit.script
def fn(x, y, z):
    x1 = x + y
    y1 = x - y
    w = torch.cat([x1, y1])
    return w + z

x = torch.randn(2, 2, dtype=torch.float, device='cpu')
y = torch.randn(2, 2, dtype=torch.float, device='cpu')
z = torch.randn(4, 2, dtype=torch.float, device='cpu')
fn(x, y, z)
fn.graph_for(x, y, z)
```
produced the following graph:
```
graph(%x : Float(2, 2)
      %y : Float(2, 2)
      %z : Float(4, 2)) {
  %3 : int = prim::Constant[value=1]()
  %y1 : Float(2, 2) = aten::sub(%x, %y, %3)
  %8 : int = prim::Constant[value=0]()
  %14 : Float(4, 2) = prim::FusionGroup_0[device=-1](%z, %y1, %x, %y)
  return (%14);
}
with prim::FusionGroup_0 = graph(%1 : Float(4, 2)
      %5 : Float(2, 2)
      %7 : Float(2, 2)
      %8 : Float(2, 2)) {
  %11 : int = prim::Constant[value=1]()
  %9 : int = prim::Constant[value=1]()
  %x1 : Float(2, 2) = aten::add(%7, %8, %9)
  %w : Float(4, 2) = prim::FusedConcat[dim=0](%x1, %5)
  %2 : int = prim::Constant[value=1]()
  %3 : Float(4, 2) = aten::add(%w, %1, %2)
  return (%3);
}
```

this is a problem because it violates two invariants:
1) all inputs to the FusionGroup must have the same size
2) prim::FusedConcat's output must not be used inside the FusionGroup

This PR fixes this problem by checking if the output to a FusionGroup came from a prim::FusedConcat node when deciding whether to fuse the consumer and producer.
If the producer is a value that came from a prim::FusedConcat node in a FusionGroup, then consumer & producer do not get fused.

cc @apaszke @zdevito 