### PR TITLE
Refactor Device to not depend on Backend.

### DIFF
--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -23,7 +23,7 @@ private:
 public:
   // Choice of CPU here is arbitrary; if there's an "undefined" device
   // we could use that too
-  DataPtr() : ptr_(), device_(kCPU) {}
+  DataPtr() : ptr_(), device_(DeviceType::CPU) {}
   DataPtr(void* data, Device device)
     : ptr_(data), device_(device) {}
   DataPtr(void* data, void* ctx, DeleterFnPtr ctx_deleter, Device device)

--- a/aten/src/ATen/Backend.h
+++ b/aten/src/ATen/Backend.h
@@ -3,17 +3,24 @@
 #include <ATen/core/TensorTypeId.h>
 #include <ATen/core/TensorTypeIdRegistration.h>
 #include <ATen/core/Error.h>
+#include <ATen/core/DeviceType.h>
 
 #include <stdexcept>
 
 namespace at {
 
+/**
+ * This legacy enum class defines the set of backends supported by
+ * old school, code generated Type-based ATen.  The reason we are
+ * sunsetting this enum class is because it doesn't allow for
+ * open registration of backends.  TensorTypeId is the replacement
+ * for Backend which supports open registration.
+ *
+ * ARE YOU SURE YOU WANT TO USE THIS TYPE?  Think about if SparseCPU/SparseCUDA
+ * would make sense in your use case.  If it doesn't make sense, maybe
+ * you want DeviceType.
+ */
 enum class Backend { CPU, CUDA, SparseCPU, SparseCUDA, Undefined, NumOptions };
-
-constexpr Backend kCPU = Backend::CPU;
-constexpr Backend kCUDA = Backend::CUDA;
-constexpr Backend kSparseCPU = Backend::SparseCPU;
-constexpr Backend kSparseCUDA = Backend::SparseCUDA;
 
 static inline Backend toSparse(Backend b) {
   switch (b) {
@@ -77,6 +84,71 @@ static inline TensorTypeId backendToTensorTypeId(Backend b) {
       throw std::runtime_error("Unknown backend");
   }
 }
+
+static inline DeviceType backendToDeviceType(Backend b) {
+  switch (b) {
+    case Backend::CPU:
+      return DeviceType::CPU;
+    case Backend::CUDA:
+      return DeviceType::CUDA;
+    case Backend::SparseCPU:
+      return DeviceType::CPU;
+    case Backend::SparseCUDA:
+      return DeviceType::CUDA;
+    case Backend::Undefined:
+      AT_ERROR("Undefined backend is not a valid device type");
+    default:
+      AT_ERROR("Unknown backend");
+  }
+}
+
+static inline Backend deviceTypeToBackend(DeviceType d) {
+  switch (d) {
+    case DeviceType::CPU:
+      return Backend::CPU;
+    case DeviceType::CUDA:
+      return Backend::CUDA;
+    default:
+      AT_ERROR("Unknown device type ", d);
+  }
+}
+
+static inline Backend backendToCPU(Backend b) {
+  switch (b) {
+    case Backend::CPU:
+      return Backend::CPU;
+    case Backend::CUDA:
+      return Backend::CPU;
+    case Backend::SparseCPU:
+      return Backend::SparseCPU;
+    case Backend::SparseCUDA:
+      return Backend::SparseCPU;
+    case Backend::Undefined:
+      return Backend::Undefined;
+    default:
+      AT_ERROR("Unknown backend");
+  }
+}
+
+static inline Backend backendToCUDA(Backend b) {
+  switch (b) {
+    case Backend::CPU:
+      return Backend::CUDA;
+    case Backend::CUDA:
+      return Backend::CUDA;
+    case Backend::SparseCPU:
+      return Backend::SparseCUDA;
+    case Backend::SparseCUDA:
+      return Backend::SparseCUDA;
+    case Backend::Undefined:
+      return Backend::Undefined;
+    default:
+      AT_ERROR("Unknown backend");
+  }
+}
+
+constexpr DeviceType kCPU = DeviceType::CPU;
+constexpr DeviceType kCUDA = DeviceType::CUDA;
 
 static inline const char* toString(Backend b) {
   switch (b) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -32,7 +32,7 @@ Context::Context()
   THSetDefaultErrorHandler(errorHandler,nullptr);
   THSetDefaultArgErrorHandler(argErrorHandler,nullptr);
 
-  generator_registry[static_cast<int>(Backend::CPU)]
+  generator_registry[static_cast<int>(DeviceType::CPU)]
     .reset(new CPUGenerator(this));
   Type::registerCPU(this);
 }

--- a/aten/src/ATen/Device.h
+++ b/aten/src/ATen/Device.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <ATen/ScalarType.h>
+#include <ATen/ATenGeneral.h>
 #include <ATen/core/Error.h>
 #include <ATen/core/DeviceType.h>
 #include <ATen/core/Error.h>
+#include <ATen/Backend.h>
 
 #include <cstddef>
 #include <iosfwd>
@@ -23,21 +24,6 @@ namespace at {
 /// 2. When the device type is CPU, the device index must be zero.
 struct Device {
   using Type = at::DeviceType;
-
-  /// Converts a `Backend` to a `DeviceType` if possible.
-  static DeviceType backend_to_type(Backend backend) {
-    switch (backend) {
-      case kCPU:
-      case kSparseCPU:
-        return DeviceType::CPU;
-      case kCUDA:
-      case kSparseCUDA:
-        return DeviceType::CUDA;
-      default:
-        AT_ERROR(
-            "Invalid backend ", toString(backend), " for Device construction");
-    }
-  }
 
   /// Constructs a new `Device` from a `DeviceType` and an optional device
   /// index.
@@ -59,11 +45,6 @@ struct Device {
   /// where `cpu:` or `cuda:` specifies the device type, and
   /// `<device-index>` optionally specifies a device index.
   /* implicit */ Device(const std::string& device_string);
-
-  /// Constructs a new `Device` from a `Backend` (which is converted to a
-  /// `DeviceType`, if possible) and an optional device index.
-  /* implicit */ Device(Backend backend, int32_t index = -1)
-      : Device(backend_to_type(backend), index) {}
 
   /// Returns true if the type and index of this `Device` matches that of
   /// `other`.

--- a/aten/src/ATen/Formatting.cpp
+++ b/aten/src/ATen/Formatting.cpp
@@ -250,7 +250,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     stream << "size:\n" << tensor_.sizes() << "\n";
     stream << "]";
   } else {
-    Type& cpudouble = tensor_.type().toBackend(kCPU).toScalarType(kDouble);
+    Type& cpudouble = tensor_.type().toBackend(Backend::CPU).toScalarType(kDouble);
     Tensor tensor = tensor_.toType(cpudouble).contiguous();
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -293,7 +293,7 @@ CHECKED_CAST = {
             'Backend::${Backend}, ScalarType::${ScalarName})'),
     'THGenerator*':
         CodeTemplate(
-            'check_generator<${Backend}Generator>(${arg_name}, &globalContext().defaultGenerator(backend()))'),
+            'check_generator<${Backend}Generator>(${arg_name}, &globalContext().defaultGenerator(device_type()))'),
     # This is a cast done via direct-construction
     'IntListStride': CodeTemplate('at::IntList ${result_name} = get_intlist_stride_th(${arg_name});'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -28,7 +28,7 @@ Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar 
     AT_ERROR("add(sparse, dense) is not supported. Use add(dense, sparse) instead.");
   }
   auto iter = TensorIterator::binary_op(result, self, other);
-  add_stub(iter->backend(), *iter, alpha);
+  add_stub(iter->device_type(), *iter, alpha);
   return result;
 }
 
@@ -53,7 +53,7 @@ Tensor& div_out(Tensor& result, const Tensor& self, const Tensor& other) {
     return at::_sparse_div_out(result, self, Scalar(other));
   }
   auto iter = TensorIterator::binary_op(result, self, other);
-  div_stub(iter->backend(), *iter);
+  div_stub(iter->device_type(), *iter);
   return result;
 }
 
@@ -74,7 +74,7 @@ Tensor& mul_out(Tensor& result, const Tensor& self, const Tensor& other) {
     return at::_sparse_mul_out(result, self, other);
   }
   auto iter = TensorIterator::binary_op(result, self, other);
-  mul_stub(iter->backend(), *iter);
+  mul_stub(iter->device_type(), *iter);
   return result;
 }
 
@@ -105,7 +105,7 @@ Tensor& sub_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar 
     AT_ERROR("sub(sparse, dense) is not supported. Use sub(dense, sparse) instead.");
   }
   auto iter = TensorIterator::binary_op(result, self, other);
-  sub_stub(iter->backend(), *iter, alpha);
+  sub_stub(iter->device_type(), *iter, alpha);
   return result;
 }
 

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -50,17 +50,17 @@ struct AT_API DispatchStub {
   static_assert(std::is_pointer<FnPtr>::value, "FnPtr should be a pointer type");
 
   template <typename... ArgTypes>
-  void operator()(Backend backend, ArgTypes&&... args) {
-    if (backend == Backend::CPU) {
+  void operator()(DeviceType device_type, ArgTypes&&... args) {
+    if (device_type == DeviceType::CPU) {
       if (!cpu_dispatch_ptr) {
         cpu_dispatch_ptr = choose_cpu_impl();
       }
       (*cpu_dispatch_ptr)(std::forward<ArgTypes>(args)...);
-    } else if (backend == Backend::CUDA) {
+    } else if (device_type == DeviceType::CUDA) {
       AT_ASSERTM(cuda_dispatch_ptr, "DispatchStub: missing CUDA kernel");
       (*cuda_dispatch_ptr)(std::forward<ArgTypes>(args)...);
     } else {
-      AT_ERROR("DispatchStub: unsupported backend", backend);
+      AT_ERROR("DispatchStub: unsupported device type", device_type);
     }
   }
 

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -49,7 +49,7 @@ namespace {
  */
 
 THGenerator* get_generator(at::Generator* gen) {
-  auto default_gen = &at::globalContext().defaultGenerator(at::Backend::CPU);
+  auto default_gen = &at::globalContext().defaultGenerator(at::kCPU);
   auto gen_ = at::check_generator<at::CPUGenerator>(gen, default_gen);
   return gen_->generator;
 }

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -67,7 +67,7 @@ Tensor embedding_sparse_backward(
   int64_t num_features = grad_.size(-1);
   auto weight_size = std::array<int64_t, 2>{{ num_weights, num_features }};
   auto& dense_type = grad.type();
-  auto& sparse_type = dense_type.toBackend(grad.is_cuda() ? kSparseCUDA : kSparseCPU);
+  auto& sparse_type = dense_type.toBackend(grad.is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU);
 
   // check if all our grad come from padding_idx
   if (grad.numel() == 0) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -89,7 +89,7 @@ Tensor inverse(const Tensor& self) {
 }
 
 Tensor& inverse_out(Tensor &result, const Tensor &self) {
-  AT_CHECK(self.type().backend() == kCPU || self.type().backend() == kCUDA,
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "tensor should have CPU or CUDA backend");
   AT_CHECK(self.dim() == 2, "tensor should be 2 dimensional");
   AT_CHECK(self.size(0) == self.size(1), "tensor should be square");

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -364,8 +364,8 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntList input_le
 
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction) {
-  Tensor ilc = input_lengths.toType(kLong).toBackend(kCPU).contiguous();
-  Tensor tlc = target_lengths.toType(kLong).toBackend(kCPU).contiguous();
+  Tensor ilc = input_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
+  Tensor tlc = target_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
   IntList il(ilc.data<int64_t>(), ilc.numel());
   IntList tl(tlc.data<int64_t>(), tlc.numel());
   return at::native::ctc_loss(log_probs, targets, il, tl, BLANK, reduction);

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -7,7 +7,7 @@ namespace at {
 namespace native {
 
 Tensor pin_memory(const Tensor& self) {
-  if (self.type().backend() != kCPU) {
+  if (self.type().backend() != Backend::CPU) {
     AT_ERROR("cannot pin '", self.type().toString(), "' only CPU memory can be pinned");
   }
   auto* allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -519,7 +519,7 @@ std::tuple<Tensor, Tensor> NAME(                                               \
       int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) { \
   if (at::cudnn_is_acceptable(_input)) {                                       \
     Tensor output, hy;                                                         \
-    NAME##_cudnn_stub(_input.type().backend(), output, hy, _input, hx, _params, has_biases, \
+    NAME##_cudnn_stub(_input.type().device_type(), output, hy, _input, hx, _params, has_biases, \
             num_layers, dropout_p, train, bidirectional, batch_first);         \
     return std::make_tuple(output, hy);                                        \
   }                                                                            \
@@ -539,7 +539,7 @@ std::tuple<Tensor, Tensor> NAME(                                               \
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {  \
   if (at::cudnn_is_acceptable(data)) {                                         \
     Tensor output, hy;                                                         \
-    NAME##_packed_cudnn_stub(data.type().backend(), output, hy, data, batch_sizes, hx, \
+    NAME##_packed_cudnn_stub(data.type().device_type(), output, hy, data, batch_sizes, hx, \
             _params, has_biases, num_layers, dropout_p, train, bidirectional); \
     return std::make_tuple(output, hy);                                        \
   }                                                                            \
@@ -567,7 +567,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   AT_CHECK(hx.size() == 2, "lstm expects two hidden states");
   if (at::cudnn_is_acceptable(_input)) {
     Tensor output, hy, cy;
-    lstm_cudnn_stub(_input.type().backend(), output, hy, cy, _input, hx, _params, has_biases,
+    lstm_cudnn_stub(_input.type().device_type(), output, hy, cy, _input, hx, _params, has_biases,
             num_layers, dropout_p, train, bidirectional, batch_first);
     return std::make_tuple(output, hy, cy);
   }
@@ -588,7 +588,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   AT_CHECK(hx.size() == 2, "lstm expects two hidden states");
   if (at::cudnn_is_acceptable(data)) {
     Tensor output, hy, cy;
-    lstm_packed_cudnn_stub(data.type().backend(), output, hy, cy, data, batch_sizes, hx,
+    lstm_packed_cudnn_stub(data.type().device_type(), output, hy, cy, data, batch_sizes, hx,
             _params, has_biases, num_layers, dropout_p, train, bidirectional);
     return std::make_tuple(output, hy, cy);
   }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -413,7 +413,7 @@ void randperm_cpu(Tensor& result, int64_t n, THGenerator* generator) {
 
 
 THGenerator* get_generator(at::Generator* gen) {
-  auto default_gen = &at::globalContext().defaultGenerator(at::Backend::CPU);
+  auto default_gen = &at::globalContext().defaultGenerator(at::kCPU);
   auto gen_ = at::check_generator<at::CPUGenerator>(gen, default_gen);
   return gen_->generator;
 }
@@ -616,7 +616,7 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 
 template <typename T>
 Tensor tensor_cuda(ArrayRef<T> values, const TensorOptions& options) {
-  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(at::kCPU));
+  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(DeviceType::CPU));
   return cpu_tensor.to(options.device());
 }
 

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -97,7 +97,7 @@ void TensorIterator::compute_common_type() {
       op.type = &type;
       if (op.tensor->defined() && type != op.tensor->type()) {
         if (op.tensor->dim() == 0) {
-          if (type.backend() != at::kCUDA) {
+          if (type.backend() != at::Backend::CUDA) {
             *op.tensor = op.tensor->toType(type);
           }
         } else {
@@ -300,7 +300,7 @@ bool TensorIterator::is_scalar(int arg) const {
 }
 
 bool TensorIterator::is_cpu_scalar(int arg) const {
-  return is_scalar(arg) && operands_[arg].tensor->type().backend() == at::kCPU;
+  return is_scalar(arg) && operands_[arg].tensor->type().backend() == at::Backend::CPU;
 }
 
 void* TensorIterator::data_ptr(int arg) const {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -120,6 +120,7 @@ struct AT_API TensorIterator {
   }
   ScalarType dtype(int arg) const { return type(arg).scalarType(); }
   Backend backend(int arg=0) const { return type(arg).backend(); }
+  DeviceType device_type(int arg=0) const { return type(arg).device_type(); }
   bool is_scalar(int arg) const;
   bool is_cpu_scalar(int arg) const;
 

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -104,7 +104,7 @@ static void sigmoid_kernel(Tensor& result, const Tensor& self) {
 
 #define IMPLEMENT_FLOAT_KERNEL(dispatchtypes, op)                          \
   static void op##_kernel(Tensor& result, const Tensor& self) {            \
-    checkBackend(#op, {result}, kCPU);                                     \
+    checkBackend(#op, {result}, Backend::CPU);                             \
     AT_DISPATCH_##dispatchtypes##_TYPES(self.type(), #op, [&] {            \
       if (self.is_contiguous() && result.is_contiguous()) {                \
         vml::v##op(                                                        \

--- a/aten/src/ATen/native/cuda/Gesv.cu
+++ b/aten/src/ATen/native/cuda/Gesv.cu
@@ -75,7 +75,7 @@ template<class T>
 static inline std::unique_ptr<Storage> pin_memory(int64_t size, Tensor dummy) {
   int64_t adjusted_size = size * sizeof(T);
   auto* allocator = cuda::getPinnedMemoryAllocator();
-  auto& backend = dummy.type().toBackend(kCPU).toScalarType(kByte);
+  auto& backend = dummy.type().toBackend(Backend::CPU).toScalarType(kByte);
   return backend.storageWithAllocator(adjusted_size, allocator);
 }
 

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -249,7 +249,7 @@ Tensor _bincount_cuda_template(
   }
   if (self.dim() != 1 ||
       (!std::is_same<input_t, uint8_t>::value &&
-       *self.min().toBackend(kCPU).data<input_t>() < 0)) {
+       *self.min().cpu().data<input_t>() < 0)) {
     AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
   }
 
@@ -268,7 +268,7 @@ Tensor _bincount_cuda_template(
     auto ret = cuda::CUDA_tensor_histogram<weights_t, input_t, true>(
         output, self, weights, nbins, 1);
   } else {
-    output = native::zeros({nbins}, device(kCUDA).dtype(kLong));
+    output = native::zeros({nbins}, device(DeviceType::CUDA).dtype(kLong));
     auto ret = cuda::CUDA_tensor_histogram<int64_t, input_t, false>(
         output, self, weights, nbins, 1);
   }

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -49,7 +49,7 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
     result.copy_(randperm_out_cuda(result_float, n, generator));
   } else {
     if (n < 30000) {  // For small inputs, we offload it to CPU instead.
-      auto result_cpu = result.type().toBackend(kCPU).tensor({n});
+      auto result_cpu = result.type().cpu().tensor({n});
       randperm_out(result_cpu, n, generator);
       result.copy_(result_cpu);
     } else {

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -35,8 +35,8 @@ ScalarType ${Type}::scalarType() const {
 Backend ${Type}::backend() const {
   return Backend::${Backend};
 }
-bool ${Type}::is_cuda() const { return backend() == kCUDA || backend() == kSparseCUDA; }
-bool ${Type}::is_sparse() const { return backend() == kSparseCPU || backend() == kSparseCUDA; }
+bool ${Type}::is_cuda() const { return backend() == Backend::CUDA || backend() == Backend::SparseCUDA; }
+bool ${Type}::is_sparse() const { return backend() == Backend::SparseCPU || backend() == Backend::SparseCUDA; }
 bool ${Type}::is_distributed() const { return false; }
 
 std::unique_ptr<Storage> ${Type}::storage(bool resizable) const {

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -154,6 +154,9 @@ struct Tensor : public detail::TensorBase {
   Tensor operator[](Tensor index) const;
   Tensor operator[](int64_t index) const;
 
+  Tensor cpu() const;
+  Tensor cuda() const;
+
   // ~~~~~ Autograd API ~~~~~
 
   Tensor& set_requires_grad(bool requires_grad) {

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -19,6 +19,14 @@ inline Tensor Tensor::toType(const Type & t, bool non_blocking) const {
   return t.copy(*this, non_blocking);
 }
 
+inline Tensor Tensor::cpu() const {
+  return toType(type().cpu());
+}
+
+inline Tensor Tensor::cuda() const {
+  return toType(type().cuda());
+}
+
 inline Tensor & Tensor::copy_(const Tensor & src, bool non_blocking) {
   return type().copy_(*this, src, non_blocking);
 }

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -74,14 +74,25 @@ struct AT_API Type {
   Type & toDense() const {
     return this->toBackend(at::toDense(this->backend()));
   }
+  Type & cpu() const {
+    return this->toBackend(at::backendToCPU(this->backend()));
+  }
+  Type & cuda() const {
+    return this->toBackend(at::backendToCUDA(this->backend()));
+  }
   Context& get_context() const { return *context; }
 
-  // contingious IDs for all types in the system
+  // contiguous IDs for all types in the system
   // for external dispatch
   virtual TypeID ID() const = 0;
 
   // New-style TensorTypeId that supports open registration.
   TensorTypeId type_id() const { return type_id_; }
+
+  // NB: This will return DeviceType::CPU for Backend::SparseCPU
+  DeviceType device_type() const {
+    return backendToDeviceType(backend());
+  }
 
   Tensor copy(const Tensor & src, bool non_blocking=false) const;
   Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const;
@@ -121,7 +132,7 @@ inline Layout Tensor::layout() const noexcept {
 }
 
 inline Device Tensor::device() const {
-  return Device(type().backend(), type().is_cuda() ? get_device() : -1);
+  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
 }
 
 } // namespace at

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -46,8 +46,8 @@ ScalarType ${Type}::scalarType() const {
 Backend ${Type}::backend() const {
   return Backend::${Backend};
 }
-bool ${Type}::is_cuda() const { return backend() == kCUDA || backend() == kSparseCUDA; }
-bool ${Type}::is_sparse() const { return backend() == kSparseCPU || backend() == kSparseCUDA; }
+bool ${Type}::is_cuda() const { return backend() == Backend::CUDA || backend() == Backend::SparseCUDA; }
+bool ${Type}::is_sparse() const { return backend() == Backend::SparseCPU || backend() == Backend::SparseCUDA; }
 bool ${Type}::is_distributed() const { return false; }
 
 std::unique_ptr<Storage> ${Type}::storage(bool resizable) const {
@@ -80,9 +80,9 @@ std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, con
       ScalarType::${ScalarName},
       InefficientStdFunctionContext::makeDataPtr(data, deleter,
 #if ${isCUDA}
-      Device(kCUDA, getPointerDevice(data))
+      Device(DeviceType::CUDA, getPointerDevice(data))
 #else
-      kCPU
+      DeviceType::CPU
 #endif
       ),
       size,

--- a/aten/src/ATen/test/apply_utils_test.cpp
+++ b/aten/src/ATen/test/apply_utils_test.cpp
@@ -109,31 +109,31 @@ void test(Type& type, IntList shape, int64_t a = 0, int64_t b = 1) {
 }
 
 TEST_CASE("apply utils test 2-dim small contiguous", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {2, 1}, -1, -1);
 }
 
 TEST_CASE("apply utils test 2-dim small", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {2, 1});
 }
 
 TEST_CASE("apply utils test 2-dim", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {20, 10});
 }
 
 TEST_CASE("apply utils test 3-dim", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 4, 2});
 }
 
 TEST_CASE("apply utils test 3-dim medium", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 40, 2});
 }
 
 TEST_CASE("apply utils test 10-dim", "[cpu]") {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 4, 2, 5, 2, 1, 3, 4, 2, 3});
 }

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -24,8 +24,8 @@ void trace() {
 
 TEST_CASE( "atest", "[]" ) {
 
-  manual_seed(123, at::Backend::CPU);
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCPU);
+  manual_seed(123, at::kCUDA);
 
   auto foo = rand({12,6});
   REQUIRE(foo.data<float>() == foo.toFloatData());

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -57,7 +57,7 @@ static void test(Type & type) {
     REQUIRE(Scalar(z_sorted[0][0]).toFloat() < Scalar(z_sorted[0][1]).toFloat());
   }
 
-  if(type.backend() != kCUDA)
+  if(type.backend() != Backend::CUDA)
   SECTION( "randperm" ) {
     Tensor b = randperm(15, type);
     Tensor rv, ri;
@@ -277,13 +277,13 @@ static void test(Type & type) {
 }
 
 TEST_CASE( "basic tests CPU", "[cpu]" ) {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   test(CPU(kFloat));
 }
 
 TEST_CASE( "basic tests GPU", "[cuda]" ) {
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCUDA);
 
   if(at::hasCUDA()) {
     test(CUDA(kFloat));

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -8,7 +8,7 @@ using namespace at;
 
 TEST_CASE( "broadcast", "[]" ) {
 
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   Type & T = CPU(kFloat);
 

--- a/aten/src/ATen/test/cudnn_test.cpp
+++ b/aten/src/ATen/test/cudnn_test.cpp
@@ -10,7 +10,7 @@ using namespace at;
 using namespace at::native;
 
 TEST_CASE( "cudnn", "[cuda]" ) {
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCUDA);
 
 #if CUDNN_VERSION < 7000
   auto handle = getCudnnHandle();

--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -13,7 +13,7 @@ using namespace at;
 
 TEST_CASE( "dlconvertor", "[cpu]" ) {
 
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   INFO( "convert ATen to DLTensor" );
 

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -179,13 +179,13 @@ void test(Type & T, Type & AccT) {
 }
 
 TEST_CASE( "native test CPU", "[cpu]" ) {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   test(CPU(kFloat), CPU(kDouble));
 }
 
 TEST_CASE( "native test CUDA", "[cuda]" ) {
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCUDA);
 
   if (at::hasCUDA()) {
     test(CUDA(kFloat), CUDA(kDouble));

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -264,13 +264,13 @@ void test(Type &T) {
 }
 
 TEST_CASE( "scalar tensor test CPU", "[cpu]" ) {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   test(CPU(kFloat));
 }
 
 TEST_CASE( "scalar tensor test CUDA", "[cuda]" ) {
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCUDA);
 
   if (at::hasCUDA()) {
     test(CUDA(kFloat));

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -72,15 +72,15 @@ void test_overflow() {
 
 TEST_CASE( "scalar test", "[]" ) {
 
-  manual_seed(123, at::Backend::CPU);
-  manual_seed(123, at::Backend::CUDA);
+  manual_seed(123, at::kCPU);
+  manual_seed(123, at::kCUDA);
 
   Scalar what = 257;
   Scalar bar = 3.0;
   Half h = bar.toHalf();
   Scalar h2 = h;
   cout << "H2: " << h2.toDouble() << " " << what.toFloat() << " " << bar.toDouble() << " " << what.isIntegral() <<  "\n";
-  Generator & gen = at::globalContext().defaultGenerator(Backend::CPU);
+  Generator & gen = at::globalContext().defaultGenerator(at::kCPU);
   REQUIRE_NOTHROW(gen.seed());
   auto && C = at::globalContext();
   if(at::hasCUDA()) {

--- a/aten/src/ATen/test/tbb_init_test.cpp
+++ b/aten/src/ATen/test/tbb_init_test.cpp
@@ -23,7 +23,7 @@ void test(int given_num_threads) {
 }
 
 int main() {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   test(-1);
   std::thread t1(test, -1);

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -13,7 +13,7 @@ using namespace at;
 
 TEST_CASE( "parallel", "[cpu]" ) {
 
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
   set_num_threads(1);
 
   Tensor a = rand({1,3});

--- a/aten/src/ATen/test/test_seed.h
+++ b/aten/src/ATen/test/test_seed.h
@@ -2,12 +2,12 @@
 
 #include "ATen/ATen.h"
 
-void manual_seed(uint64_t seed, at::Backend backend) {
-  if (backend == at::Backend::CPU) {
-    at::Generator & cpu_gen = at::globalContext().defaultGenerator(at::Backend::CPU);
+void manual_seed(uint64_t seed, at::DeviceType backend) {
+  if (backend == at::kCPU) {
+    at::Generator & cpu_gen = at::globalContext().defaultGenerator(at::kCPU);
     cpu_gen.manualSeed(seed);
-  } else if (backend == at::Backend::CUDA && at::hasCUDA()) {
-    at::Generator & cuda_gen = at::globalContext().defaultGenerator(at::Backend::CUDA);
+  } else if (backend == at::kCUDA && at::hasCUDA()) {
+    at::Generator & cuda_gen = at::globalContext().defaultGenerator(at::kCUDA);
     cuda_gen.manualSeed(seed);
   }
 }

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -9,7 +9,7 @@
 using namespace at;
 
 TEST_CASE( "undefined tensor test", "[]" ) {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   // mainly test ops on undefined tensors don't segfault and give a reasonable errror message.
   Tensor und;

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -7,7 +7,7 @@
 using namespace at;
 
 TEST_CASE( "wrapdim test", "[]" ) {
-  manual_seed(123, at::Backend::CPU);
+  manual_seed(123, at::kCPU);
 
   Type & T = CPU(kFloat);
 

--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -22,7 +22,7 @@
 struct THDefaultAllocator final : public at::Allocator {
   at::DataPtr allocate(size_t size) const override {
     auto* ptr = THAlloc(size);
-    return {ptr, ptr, &THFree, at::kCPU};
+    return {ptr, ptr, &THFree, at::DeviceType::CPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THFree;
@@ -537,25 +537,25 @@ THRefcountedMapAllocator* THRefcountedMapAllocator::fromDataPtr(const at::DataPt
 at::DataPtr THMapAllocator::makeDataPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
   auto* context = new THMapAllocator(filename, flags, size);
   if (actual_size_out) *actual_size_out = context->size();
-  return {context->data(), context, &deleteTHMapAllocator, at::kCPU};
+  return {context->data(), context, &deleteTHMapAllocator, at::DeviceType::CPU};
 }
 
 at::DataPtr THMapAllocator::makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
   auto* context = new THMapAllocator(WITH_FD, filename, fd, flags, size);
   if (actual_size_out) *actual_size_out = context->size();
-  return {context->data(), context, &deleteTHMapAllocator, at::kCPU};
+  return {context->data(), context, &deleteTHMapAllocator, at::DeviceType::CPU};
 }
 
 at::DataPtr THRefcountedMapAllocator::makeDataPtr(const char *filename, int flags, size_t size, size_t* actual_size_out) {
   auto* context = new THRefcountedMapAllocator(filename, flags, size);
   if (actual_size_out) *actual_size_out = context->size() - TH_ALLOC_ALIGNMENT;
-  return {context->data(), context, &deleteTHRefcountedMapAllocator, at::kCPU};
+  return {context->data(), context, &deleteTHRefcountedMapAllocator, at::DeviceType::CPU};
 }
 
 at::DataPtr THRefcountedMapAllocator::makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out) {
   auto* context = new THRefcountedMapAllocator(WITH_FD, filename, fd, flags, size);
   if (actual_size_out) *actual_size_out = context->size() - TH_ALLOC_ALIGNMENT;
-  return {context->data(), context, &deleteTHRefcountedMapAllocator, at::kCPU};
+  return {context->data(), context, &deleteTHRefcountedMapAllocator, at::DeviceType::CPU};
 }
 
 void* THRefcountedMapAllocator::data() const {

--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -10,7 +10,7 @@ struct THCudaHostAllocator : public at::Allocator {
     if (size != 0) {
       THCudaCheck(cudaMallocHost(&ptr, size));
     }
-    return {ptr, ptr, &THCudaHostDeleter, at::kCPU};
+    return {ptr, ptr, &THCudaHostDeleter, at::DeviceType::CPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCudaHostDeleter;
@@ -34,7 +34,7 @@ struct THCUVAAllocator : public at::Allocator {
     if (size != 0) {
       THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
     }
-    return {ptr, ptr, &THCUVADeleter, at::kCPU};
+    return {ptr, ptr, &THCUVADeleter, at::DeviceType::CPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCUVADeleter;
@@ -64,5 +64,5 @@ at::DataPtr THCIpcDeleter::makeDataPtr(void* data, int device) {
   int cur_device;
   THCudaCheck(cudaGetDevice(&cur_device));
   auto* context = new THCIpcDeleter(data, device);
-  return {data, context, &deleteTHCIpcDeleter, at::Device(at::kCUDA, cur_device)};
+  return {data, context, &deleteTHCIpcDeleter, at::Device(at::DeviceType::CUDA, cur_device)};
 }

--- a/aten/src/THC/THCBlas.cu
+++ b/aten/src/THC/THCBlas.cu
@@ -2,6 +2,8 @@
 #include "THCGeneral.h"
 #include "THCHalf.h"
 
+#include <algorithm>
+
 float THCudaBlas_Sdot(THCState *state, int64_t n, float *x, int64_t incx, float *y, int64_t incy)
 {
   if (n == 1) {

--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -510,7 +510,7 @@ struct CudaCachingAllocator : public at::Allocator {
     if (size != 0) {
       AT_CUDA_CHECK(caching_allocator.malloc(&r, size, at::cuda::getCurrentCUDAStreamOnDevice(device)));
     }
-    return {r, r, &CudaCachingDeleter, at::Device(at::kCUDA, device)};
+    return {r, r, &CudaCachingDeleter, at::Device(at::DeviceType::CUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &CudaCachingDeleter;

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -269,7 +269,7 @@ struct THCCachingHostAllocator final : public at::Allocator {
     THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
-    return {ptr, ptr, &THCCachingHostDeleter, at::kCPU};
+    return {ptr, ptr, &THCCachingHostDeleter, at::DeviceType::CPU};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THCCachingHostDeleter;

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -49,7 +49,7 @@ struct THDefaultDeviceAllocator final : public at::Allocator {
     if (size != 0) THCudaCheck(cudaMalloc(&p, size));
     int device;
     THCudaCheck(cudaGetDevice(&device));
-    return {p, p, &THDefaultDeviceDeleter, at::Device(at::kCUDA, device)};
+    return {p, p, &THDefaultDeviceDeleter, at::Device(at::DeviceType::CUDA, device)};
   }
   at::DeleterFnPtr raw_deleter() const override {
     return &THDefaultDeviceDeleter;

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -22,7 +22,7 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
 
   if(size == 0)
   {
-    self->set_data_ptr(at::DataPtr(nullptr, at::Device(at::kCUDA, device)));
+    self->set_data_ptr(at::DataPtr(nullptr, at::Device(at::DeviceType::CUDA, device)));
     self->set_size(0);
   }
   else

--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -6,7 +6,7 @@ namespace caffe2 {
 REGISTER_CPU_OPERATOR(ATen, ATenOp<CPUContext>);
 template<>
 at::Backend ATenOp<CPUContext>::backend() const {
-  return at::kCPU;
+  return at::Backend::CPU;
 }
 
 OPERATOR_SCHEMA(ATen);

--- a/caffe2/contrib/aten/aten_op_cuda.cc
+++ b/caffe2/contrib/aten/aten_op_cuda.cc
@@ -6,7 +6,7 @@ namespace caffe2 {
 REGISTER_CUDA_OPERATOR(ATen, ATenOp<CUDAContext>);
 template<>
 at::Backend ATenOp<CUDAContext>::backend() const {
-  return at::kCUDA;
+  return at::Backend::CUDA;
 }
 
 namespace math {

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -163,7 +163,7 @@ bool test_mnist(
       }
     }
 
-    return data.toBackend(useGPU ? torch::kCUDA : torch::kCPU);
+    return data.toBackend(useGPU ? torch::Backend::CUDA : torch::Backend::CPU);
   };
 
   auto readLabels = [&](std::string fn) {
@@ -177,7 +177,7 @@ bool test_mnist(
     for (int i = 0; i < label_count; ++i) {
       a_data[i] = static_cast<int64_t>(rd.read_byte());
     }
-    return data.toBackend(useGPU ? torch::kCUDA : torch::kCPU);
+    return data.toBackend(useGPU ? torch::Backend::CUDA : torch::Backend::CPU);
   };
 
   auto trdata = readData("test/cpp/api/mnist/train-images-idx3-ubyte");

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -59,7 +59,7 @@ TEST_CASE("serialization") {
       }
 
       auto x = torch::ones(
-          {5, 5}, torch::getType(torch::kCPU, static_cast<torch::Dtype>(i)));
+          {5, 5}, torch::getType(torch::Backend::CPU, static_cast<torch::Dtype>(i)));
       auto y = torch::empty({});
 
       std::stringstream ss;

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -32,7 +32,7 @@ TEST_CASE("TensorOptions/DefaultsToTheRightValues") {
 
 TEST_CASE("TensorOptions/ReturnsTheCorrectType") {
   auto options = TensorOptions().device(kCPU).dtype(kInt).layout(kSparse);
-  REQUIRE(options.type() == getType(kSparseCPU, kInt));
+  REQUIRE(options.type() == getType(Backend::SparseCPU, kInt));
 }
 
 TEST_CASE("TensorOptions/UtilityFunctionsReturnTheRightTensorOptions") {
@@ -62,10 +62,10 @@ TEST_CASE("TensorOptions/ConstructsWellFromCPUTypes") {
   options = TensorOptions(kInt);
   REQUIRE_OPTIONS(kCPU, -1, kInt, kStrided);
 
-  options = TensorOptions(getType(kSparseCPU, kFloat));
+  options = TensorOptions(getType(Backend::SparseCPU, kFloat));
   REQUIRE_OPTIONS(kCPU, -1, kFloat, kSparse);
 
-  options = TensorOptions(getType(kSparseCPU, kByte));
+  options = TensorOptions(getType(Backend::SparseCPU, kByte));
   REQUIRE_OPTIONS(kCPU, -1, kByte, kSparse);
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("TensorOptions/ConstructsWellFromCPUTensors") {
   auto options = TensorOptions(empty(5, kDouble));
   REQUIRE_OPTIONS(kCPU, -1, kDouble, kStrided);
 
-  options = TensorOptions(empty(5, getType(kSparseCPU, kByte)));
+  options = TensorOptions(empty(5, getType(Backend::SparseCPU, kByte)));
   REQUIRE_OPTIONS(kCPU, -1, kByte, kSparse);
 }
 

--- a/test/cpp/api/tensor_options_cuda.cpp
+++ b/test/cpp/api/tensor_options_cuda.cpp
@@ -28,16 +28,16 @@ TEST_CASE("TensorOptions/ConstructsWellFromCUDATypes", "[cuda]") {
   options = TensorOptions(CUDA(kInt));
   REQUIRE_OPTIONS(kCUDA, -1, kInt, kStrided);
 
-  options = TensorOptions(getType(kSparseCUDA, kFloat));
+  options = TensorOptions(getType(Backend::SparseCUDA, kFloat));
   REQUIRE_OPTIONS(kCUDA, -1, kFloat, kSparse);
 
-  options = TensorOptions(getType(kSparseCUDA, kByte));
+  options = TensorOptions(getType(Backend::SparseCUDA, kByte));
   REQUIRE_OPTIONS(kCUDA, -1, kByte, kSparse);
 
   options = TensorOptions(CUDA(kFloat), /*device=*/5);
   REQUIRE_OPTIONS(kCUDA, 5, kFloat, kStrided);
 
-  options = TensorOptions(getType(kSparseCUDA, kFloat), /*device=*/5);
+  options = TensorOptions(getType(Backend::SparseCUDA, kFloat), /*device=*/5);
   REQUIRE_OPTIONS(kCUDA, 5, kFloat, kSparse);
 }
 
@@ -45,7 +45,7 @@ TEST_CASE("TensorOptions/ConstructsWellFromCUDATensors", "[multi-cuda]") {
   auto options = TensorOptions(empty(5, device(kCUDA).dtype(kDouble)));
   REQUIRE_OPTIONS(kCUDA, 0, kDouble, kStrided);
 
-  options = TensorOptions(empty(5, getType(kSparseCUDA, kByte)));
+  options = TensorOptions(empty(5, getType(Backend::SparseCUDA, kByte)));
   REQUIRE_OPTIONS(kCUDA, 0, kByte, kSparse);
 
   if (at::globalContext().getNumGPUs() > 1) {

--- a/test/cpp_extensions/cudnn_extension.cpp
+++ b/test/cpp_extensions/cudnn_extension.cpp
@@ -31,10 +31,10 @@ void cudnn_relu_check(const at::Tensor& inputs, const at::Tensor& outputs) {
   // TensorArgs.
   at::checkContiguous(cudnn_relu_name, arg_inputs);
   at::checkScalarType(cudnn_relu_name, arg_inputs, at::kFloat);
-  at::checkBackend(cudnn_relu_name, arg_inputs.tensor, at::kCUDA);
+  at::checkBackend(cudnn_relu_name, arg_inputs.tensor, at::Backend::CUDA);
   at::checkContiguous(cudnn_relu_name, arg_outputs);
   at::checkScalarType(cudnn_relu_name, arg_outputs, at::kFloat);
-  at::checkBackend(cudnn_relu_name, arg_outputs.tensor, at::kCUDA);
+  at::checkBackend(cudnn_relu_name, arg_outputs.tensor, at::Backend::CUDA);
   at::checkSameSize(cudnn_relu_name, arg_inputs, arg_outputs);
 }
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -255,7 +255,7 @@ static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwa
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
-  auto backend = self_.is_sparse() ? at::kSparseCUDA : at::kCUDA;
+  auto backend = self_.is_sparse() ? at::Backend::SparseCUDA : at::Backend::CUDA;
   auto& type = self_.type().toBackend(backend);
   auto device_obj = r.device(0);
   if (!r.isNone(0) && device_obj.is_cpu()) {

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -46,15 +46,15 @@ THPLayout* layout_registry
 at::Backend get_backend(bool is_cuda, bool is_sparse) {
   if (is_cuda) {
     if (is_sparse){
-      return at::kSparseCUDA;
+      return at::Backend::SparseCUDA;
     } else {
-      return at::kCUDA;
+      return at::Backend::CUDA;
     }
   } else {
     if (is_sparse){
-      return at::kSparseCPU;
+      return at::Backend::SparseCPU;
     } else {
-      return at::kCPU;
+      return at::Backend::CPU;
     }
   }
 }

--- a/torch/csrc/api/include/torch/serialization.h
+++ b/torch/csrc/api/include/torch/serialization.h
@@ -211,7 +211,7 @@ void save(Archive& archive, const torch::Tensor& tensor) {
   for (auto s : tensor.sizes()) {
     sizes.push_back(s);
   }
-  auto contig = tensor.toBackend(torch::kCPU).contiguous();
+  auto contig = tensor.cpu().contiguous();
   int32_t backend = ::torch::detail::backendId(tensor.type().backend());
 
   archive(CEREAL_NVP(backend), CEREAL_NVP(sizes));

--- a/torch/csrc/api/src/utils.cpp
+++ b/torch/csrc/api/src/utils.cpp
@@ -7,11 +7,11 @@
 namespace torch {
 void manual_seed(uint64_t seed) {
   // TODO: Move this to at::Context
-  at::globalContext().defaultGenerator(at::Backend::CPU).manualSeed(seed);
+  at::globalContext().defaultGenerator(at::kCPU).manualSeed(seed);
   // NB: Sometimes we build with CUDA, but we don't have any GPUs
   // available. In that case, we must not seed CUDA; it will fail!
   if (at::globalContext().hasCUDA() && at::globalContext().getNumGPUs() > 0) {
-    at::globalContext().defaultGenerator(at::Backend::CUDA).manualSeedAll(seed);
+    at::globalContext().defaultGenerator(at::kCUDA).manualSeedAll(seed);
   }
 }
 } // namespace torch

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -235,7 +235,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
       "can't assign Variable as its own grad");
 
   auto& grad = ((THPVariable*)py_grad)->cdata;
-  auto& sparseType = var.type().toBackend(var.is_cuda() ? kSparseCUDA : kSparseCPU);
+  auto& sparseType = var.type().toBackend(var.is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU);
 
   THPUtils_assertRet(-1, grad.type() == var.type() || grad.type() == sparseType,
       "assigned grad has data of a different type");

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -54,7 +54,7 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
 #else
   {
 #endif
-    auto & gpu_type = type.toBackend(type.is_sparse() ? at::kSparseCUDA : at::kCUDA);
+    auto & gpu_type = type.toBackend(type.is_sparse() ? at::Backend::SparseCUDA : at::Backend::CUDA);
     if (type.is_cuda()) {
       tensors.push_back(tensor);
     }
@@ -157,7 +157,7 @@ std::vector<at::Tensor> scatter(
       cuda_guard.set_stream(at::cuda::CUDAStream((*streams)[chunk]));
     }
     chunks[chunk] = chunks[chunk].contiguous().to(
-        {at::kCUDA, device_index}, /*non_blocking=*/true);
+        {at::DeviceType::CUDA, device_index}, /*non_blocking=*/true);
   }
   return chunks;
 }
@@ -186,9 +186,9 @@ at::Tensor gather(
     total_size += tensor.size(dim);
   }
   expected_size[dim] = total_size;
-  at::Device device(at::kCPU);
+  at::Device device(at::DeviceType::CPU);
   if (!destination_index || *destination_index != -1) {
-    device = at::Device(at::kCUDA, destination_index ? *destination_index : -1);
+    device = at::Device(at::DeviceType::CUDA, destination_index ? *destination_index : -1);
   }
   result = at::empty(expected_size, first.options().device(device));
 

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -72,7 +72,7 @@ ArrayRef<ncclComm_t> _get_communicators(TensorList inputs) {
 }
 
 ncclDataType_t _get_data_type(const Type& type) {
-  if (type.backend() != kCUDA) {
+  if (type.backend() != Backend::CUDA) {
     throw std::runtime_error("Unconvertible NCCL type");
   }
   switch (type.scalarType()) {

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -372,7 +372,7 @@ void GraphEncoder::EncodeTensor(
   }
   tensor_proto->set_data_type(ATenTypeToOnnxType(tensor.type().scalarType()));
   // CPU's HalfTensor doesn't have contiguous(), so first calling contiguous()
-  auto t = tensor.contiguous().toBackend(at::kCPU);
+  auto t = tensor.contiguous().cpu();
   // Add a buffer to the raw_data_export_map for the caller to dump into an
   // external data store. If external_ref is not specified, we instead dump
   // the contiguous data into the protobuf itself
@@ -623,7 +623,7 @@ void ModuleEncoder::EncodeTensor(
     tensor_proto->add_int64_data(dedup_it->second);
   } else {
     at::Tensor t = tensor;
-    if (at::detail::get_backend(tensor.storage()->pImpl()) == at::kCUDA) {
+    if (at::detail::get_backend(tensor.storage()->pImpl()) == at::Backend::CUDA) {
       // NB: This new tensor is created to support cuda tensors.
       // Storages can be mutated when converting tensors from cuda to cpu,
       // and we need a cpu tensor to copy data from.
@@ -632,7 +632,7 @@ void ModuleEncoder::EncodeTensor(
           /* storageOffset = */ 0,
           /* size = */ { static_cast<int64_t>(tensor.type().elementSizeInBytes() * tensor.storage()->pImpl()->size()) },
           /* strides = */ { 1 })
-        .toBackend(at::kCPU);
+        .cpu();
     }
 
     auto record_number = file_writer_.writeRecord(

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -685,7 +685,7 @@ void CompiledFusionFunction::launch_with_tensors(at::ArrayRef<at::Tensor> inputs
   // If the kernel call contains a random op, we need to pass in random seeds as
   // well.
   #ifdef USE_CUDA
-  if(has_random && this->backend() == at::kCUDA) {
+  if(has_random && this->backend() == at::Backend::CUDA) {
     auto gen_ = THCRandom_getGenerator(at::globalContext().getTHCState());
     uint64_t offset =
         gen_->state.philox_seed_offset.fetch_add(this->get_rand_offset(numel));
@@ -769,7 +769,7 @@ struct CUDAFusionFunction : public CompiledFusionFunction {
   }
 protected:
   virtual at::Backend backend() const override {
-    return at::kCUDA;
+    return at::Backend::CUDA;
   }
   virtual uint64_t get_rand_offset(uint32_t numel) override {
      int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
@@ -950,7 +950,7 @@ struct CPUFusionFunction : public CompiledFusionFunction {
   }
 protected:
   virtual at::Backend backend() const override {
-    return at::kCPU;
+    return at::Backend::CPU;
   }
   virtual uint64_t get_rand_offset(uint32_t numel) override {
      return numel;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -45,7 +45,7 @@ IValue representativeValue(Value* v) {
     return *iv;
   }
   if (TensorTypePtr type = type_->cast<TensorType>()) {
-    auto backend = type->device() == -1 ? at::kCPU : at::kCUDA;
+    auto backend = type->device() == -1 ? at::Backend::CPU : at::Backend::CUDA;
     at::DeviceGuard device_guard(type->device());
     auto& attype = at::getType(backend, type->scalarType());
     auto t = attype.tensor(type->sizes(), type->strides()).zero_();

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -62,7 +62,7 @@ struct IODescriptor {
 };
 
 static inline std::ostream& operator<<(std::ostream& out, const IODescriptor::VariableMetadata& meta) {
-  auto & t = at::getType(meta.device < 0 ? at::kCPU : at::kCUDA, meta.type);
+  auto & t = at::getType(meta.device < 0 ? at::Backend::CPU : at::Backend::CUDA, meta.type);
   out << t << "(requires_grad=" << meta.requires_grad;
   if (meta.device > 0) {
     out << ", device=" << meta.device;

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -171,10 +171,10 @@ static void py_initialize_tensor_type(PyTypeObject& type, const char* name, PyOb
 
 static const char* get_module(Backend backend) {
   switch (backend) {
-    case kCPU: return "torch";
-    case kCUDA: return "torch.cuda";
-    case kSparseCPU: return "torch.sparse";
-    case kSparseCUDA: return "torch.cuda.sparse";
+    case Backend::CPU: return "torch";
+    case Backend::CUDA: return "torch.cuda";
+    case Backend::SparseCPU: return "torch.sparse";
+    case Backend::SparseCUDA: return "torch.cuda.sparse";
     default: AT_ERROR("invalid backend: ", toString(backend));
   }
 }
@@ -389,8 +389,8 @@ at::Type& get_default_tensor_type() {
 
 Device getDevice(const at::Tensor& tensor) {
   if (tensor.type().is_cuda()) {
-    return at::Device(at::kCUDA, tensor.get_device());
+    return at::Device(at::DeviceType::CUDA, tensor.get_device());
   }
-  return at::Device(at::kCPU);
+  return at::Device(at::DeviceType::CPU);
 }
 }} // namespace torch::tensors

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -8,11 +8,11 @@ at::Type& getType(at::Backend backend, at::ScalarType type) {
 }
 
 at::Type& CPU(at::ScalarType type) {
-  return torch::getType(at::kCPU, type);
+  return torch::getType(at::Backend::CPU, type);
 }
 
 at::Type& CUDA(at::ScalarType type) {
-  return torch::getType(at::kCUDA, type);
+  return torch::getType(at::Backend::CUDA, type);
 }
 
 at::Tensor toTensor(const at::Scalar& scalar) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -346,7 +346,7 @@ static std::string cpu_prefix = "cpu:";
 inline at::Device PythonArgs::device(int i) {
   if (!args[i]) {
     const auto& default_tensor_type = torch::tensors::get_default_tensor_type();
-    return at::Device(default_tensor_type.backend());
+    return at::Device(default_tensor_type.device_type());
   }
   if (THPDevice_Check(args[i])) {
     const auto device = reinterpret_cast<THPDevice*>(args[i]);
@@ -355,21 +355,21 @@ inline at::Device PythonArgs::device(int i) {
   if (THPUtils_checkLong(args[i])) {
     const auto device_index = THPUtils_unpackLong(args[i]);
     AT_CHECK(device_index >= 0, "Device index must not be negative");
-    return at::Device(at::kCUDA, device_index);
+    return at::Device(at::DeviceType::CUDA, device_index);
   }
   const std::string device_str = THPUtils_unpackString(args[i]);
   if (device_str == cpu_str) {
-    return at::Device(at::kCPU);
+    return at::Device(at::DeviceType::CPU);
   } else if (device_str == cuda_str) {
-    return at::Device(at::kCUDA);
+    return at::Device(at::DeviceType::CUDA);
   } else if (device_str.compare(0, cpu_prefix.length(), cpu_prefix) == 0) {
     const auto device_index = std::stoi(device_str.substr(cpu_prefix.length()));
     AT_CHECK(device_index >= 0, "Device index must not be negative");
-    return at::Device(at::kCPU, device_index);
+    return at::Device(at::DeviceType::CPU, device_index);
   } else if (device_str.compare(0, cuda_prefix.length(), cuda_prefix) == 0) {
     const auto device_index = std::stoi(device_str.substr(cuda_prefix.length()));
     AT_CHECK(device_index >= 0, "Device index must not be negative");
-    return at::Device(at::kCUDA, device_index);
+    return at::Device(at::DeviceType::CUDA, device_index);
   }
   throw torch::TypeError("only \"cuda\" and \"cpu\" are valid device types, got %s", device_str.c_str());
 }

--- a/torch/csrc/utils/tensor_apply.cpp
+++ b/torch/csrc/utils/tensor_apply.cpp
@@ -54,7 +54,7 @@ static void recursive_apply(IntList sizes, ScalarType scalarType, int64_t dim,
 }
 
 Tensor & apply_(Tensor & self, PyObject* fn) {
-  if (self.type().backend() != kCPU) {
+  if (self.type().backend() != Backend::CPU) {
     throw TypeError("apply_ is only implemented on CPU tensors");
   }
   auto scalarType = self.type().scalarType();
@@ -63,7 +63,7 @@ Tensor & apply_(Tensor & self, PyObject* fn) {
 }
 
 Tensor & map_(Tensor & self, const Tensor & other_, PyObject* fn) {
-  if (self.type().backend() != kCPU) {
+  if (self.type().backend() != Backend::CPU) {
     throw TypeError("map_ is only implemented on CPU tensors");
   }
   if (other_.type() != self.type()) {
@@ -78,7 +78,7 @@ Tensor & map_(Tensor & self, const Tensor & other_, PyObject* fn) {
 }
 
 Tensor & map2_(Tensor & self, const Tensor & x_, const Tensor & y_, PyObject* fn) {
-  if (self.type().backend() != kCPU || x_.type().backend() != kCPU || y_.type().backend() != kCPU) {
+  if (self.type().backend() != Backend::CPU || x_.type().backend() != Backend::CPU || y_.type().backend() != Backend::CPU) {
     throw TypeError("map2_ is only implemented on CPU tensors");
   }
   if (x_.type() != self.type()) {

--- a/torch/csrc/utils/tensor_list.cpp
+++ b/torch/csrc/utils/tensor_list.cpp
@@ -30,9 +30,9 @@ static PyObject* recursive_to_list(
 
 PyObject* tensor_to_list(const Tensor& tensor) {
   Tensor data = tensor;
-  if (data.type().backend() != kCPU) {
+  if (data.type().backend() != Backend::CPU) {
     with_no_gil([&]() {
-      data = data.toBackend(kCPU);
+      data = data.toBackend(Backend::CPU);
     });
   }
   auto& type = data.type();

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -28,8 +28,6 @@ using at::IntList;
 using at::kCPU;
 using at::kCUDA;
 using at::kLong;
-using at::kSparseCPU;
-using at::kSparseCUDA;
 using at::optional;
 using at::Scalar;
 using at::ScalarType;
@@ -37,6 +35,7 @@ using at::Storage;
 using at::Tensor;
 using at::TensorOptions;
 using at::Type;
+using at::Backend;
 
 namespace torch { namespace utils {
 namespace {
@@ -319,7 +318,7 @@ Tensor legacy_sparse_tensor_new(const Type& type, PyObject* args, PyObject* kwar
 
 const Type& typeWithDefault(PythonArgs& r, int64_t dtype_idx, int64_t device_idx, const Type& type) {
   const auto scalartype = r.scalartypeWithDefault(dtype_idx, type.scalarType());
-  const Device types_device_type(toDense(type.backend()));
+  const Device types_device_type(type.device_type());
   const auto device_type = r.isNone(device_idx) ? types_device_type : r.device(device_idx).type();
   return torch::getType(scalartype, *torch::getLayout(type.backend()), device_type);
 }
@@ -410,7 +409,7 @@ Tensor legacy_new_from_data(const Type & type, at::optional<Device> device, PyOb
 }
 
 Tensor sparse_coo_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
-  const auto sparse_backend = type.is_cuda() ? kSparseCUDA : kSparseCPU;
+  const auto sparse_backend = type.is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU;
   const auto& default_sparse_type = type.toBackend(sparse_backend);
 
   static PythonArgParser parser({
@@ -423,23 +422,23 @@ Tensor sparse_coo_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs
   if (r.idx == 0) {
     bool type_inference = r.isNone(2);
     const auto& sparse_type = typeWithDefault(r, 2, 3, default_sparse_type);
-    const auto& dense_type = sparse_type.toBackend(sparse_type.is_cuda() ? kCUDA : kCPU);
+    const auto& dense_type = sparse_type.toBackend(sparse_type.is_cuda() ? Backend::CUDA : Backend::CPU);
     at::DeviceGuard device_guard(r.device(3));
     Tensor values = internal_new_from_data(dense_type, r.deviceOptional(3), r.pyobject(1), false, true, type_inference);
     // if no dtype provided, infer type based on value type.
     const auto& index_type = values.type().toScalarType(kLong);
     Tensor indices = internal_new_from_data(index_type, r.deviceOptional(3), r.pyobject(0), false, true, false);
-    const auto& sparse_type_to_use = values.type().toBackend(values.type().is_cuda() ? kSparseCUDA : kSparseCPU);
+    const auto& sparse_type_to_use = values.type().toBackend(values.type().is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU);
     return sparse_type_to_use.sparse_coo_tensor(indices, values).set_requires_grad(r.toBool(4));
   } else if (r.idx == 1) {
     bool type_inference = r.isNone(3);
     const auto& sparse_type = typeWithDefault(r, 3, 4, default_sparse_type);
-    const auto& dense_type = sparse_type.toBackend(sparse_type.is_cuda() ? kCUDA : kCPU);
+    const auto& dense_type = sparse_type.toBackend(sparse_type.is_cuda() ? Backend::CUDA : Backend::CPU);
     at::DeviceGuard device_guard(r.device(4));
     Tensor values = internal_new_from_data(dense_type, r.deviceOptional(4), r.pyobject(1), false, true, type_inference);
     const auto& index_type = values.type().toScalarType(kLong);
     Tensor indices = internal_new_from_data(index_type, r.deviceOptional(4), r.pyobject(0), false, true, false);
-    const auto& sparse_type_to_use = values.type().toBackend(values.type().is_cuda() ? kSparseCUDA : kSparseCPU);
+    const auto& sparse_type_to_use = values.type().toBackend(values.type().is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU);
     return sparse_type_to_use.sparse_coo_tensor(indices, values, r.intlist(2)).set_requires_grad(r.toBool(5));
   }
   throw std::runtime_error("sparse_coo_tensor(): invalid arguments");

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -140,7 +140,7 @@ static int aten_to_dtype(const at::Type& type) {
         "can't convert sparse tensor to numpy. Use Tensor.to_dense() to "
         "convert to a dense tensor first.");
   }
-  if (type.backend() == kCPU) {
+  if (type.backend() == Backend::CPU) {
     switch (type.scalarType()) {
       case kDouble: return NPY_DOUBLE;
       case kFloat: return NPY_FLOAT;

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -16,11 +16,11 @@ namespace torch { namespace utils {
 
 static const char* backend_to_string(const at::Type& type) {
   switch (type.backend()) {
-    case at::kCPU: return "torch";
-    case at::kCUDA: return "torch.cuda";
-    case at::kSparseCPU: return "torch.sparse";
-    case at::kSparseCUDA: return "torch.cuda.sparse";
-    default: throw std::runtime_error("Unimplemented backend");
+    case at::Backend::CPU: return "torch";
+    case at::Backend::CUDA: return "torch.cuda";
+    case at::Backend::SparseCPU: return "torch.sparse";
+    case at::Backend::SparseCUDA: return "torch.cuda.sparse";
+    default: AT_ERROR("Unimplemented backend ", type.backend());
   }
 }
 

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -322,7 +322,7 @@ void ProcessGroupGloo::createAllreduce(AlgorithmEntry& entry) {
   auto& context = contexts_[0];
   at::DeviceGuard guard(entry.src[0]);
 
-  if (backend == at::kCPU) {
+  if (backend == at::Backend::CPU) {
     if (getSize() < 16) {
       entry.algorithm = std::unique_ptr<::gloo::Algorithm>(
           new ::gloo::AllreduceRingChunked<T>(
@@ -341,7 +341,7 @@ void ProcessGroupGloo::createAllreduce(AlgorithmEntry& entry) {
     return;
   }
 
-  if (backend == at::kCUDA) {
+  if (backend == at::Backend::CUDA) {
     if (getSize() < 16) {
       entry.algorithm = std::unique_ptr<::gloo::Algorithm>(
           new ::gloo::CudaAllreduceRingChunked<T>(
@@ -373,7 +373,7 @@ void ProcessGroupGloo::createBroadcast(AlgorithmEntry& entry) {
   auto& context = contexts_[0];
   at::DeviceGuard guard(entry.src[0]);
 
-  if (backend == at::kCPU) {
+  if (backend == at::Backend::CPU) {
     entry.algorithm =
         std::unique_ptr<::gloo::Algorithm>(new ::gloo::BroadcastOneToAll<T>(
             context,
@@ -384,7 +384,7 @@ void ProcessGroupGloo::createBroadcast(AlgorithmEntry& entry) {
     return;
   }
 
-  if (backend == at::kCUDA) {
+  if (backend == at::Backend::CUDA) {
     entry.algorithm =
         std::unique_ptr<::gloo::Algorithm>(new ::gloo::CudaBroadcastOneToAll<T>(
             context,

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -69,7 +69,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
         numTensors_(numTensors),
         numDevices_(cudaNumDevices()),
         state_(::at::globalContext().lazyInitCUDA()) {
-    const auto& type = at::getType(at::kCUDA, at::kFloat);
+    const auto& type = at::getType(at::Backend::CUDA, at::kFloat);
 
     // Allocate inputs on available devices in a round robin fashion.
     inputs_.resize(numTensors_);
@@ -116,7 +116,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
 
     // Copy inputs to outputs
     for (auto i = 0; i < numTensors_; i++) {
-      outputs[i] = inputs_[i].toBackend(at::kCPU);
+      outputs[i] = inputs_[i].cpu();
     }
 
     return outputs;

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -141,7 +141,7 @@ std::vector<std::vector<at::Tensor>> copyTensors(
     const auto& input = inputs[i];
     std::vector<at::Tensor> output(input.size());
     for (size_t j = 0; j < input.size(); j++) {
-      output[j] = input[j].toBackend(at::kCPU);
+      output[j] = input[j].cpu();
     }
     outputs[i] = std::move(output);
   }
@@ -261,22 +261,22 @@ int main(int argc, char** argv) {
 
   {
     TemporaryFile file;
-    testAllreduce(file.path, at::kCPU);
+    testAllreduce(file.path, at::Backend::CPU);
   }
 
   {
     TemporaryFile file;
-    testAllreduce(file.path, at::kCUDA);
+    testAllreduce(file.path, at::Backend::CUDA);
   }
 
   {
     TemporaryFile file;
-    testBroadcast(file.path, at::kCPU);
+    testBroadcast(file.path, at::Backend::CPU);
   }
 
   {
     TemporaryFile file;
-    testBroadcast(file.path, at::kCUDA);
+    testBroadcast(file.path, at::Backend::CUDA);
   }
 
   return 0;

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -118,7 +118,7 @@ static void deleteTHManagedMapAllocator(void* ptr) {
 
 at::DataPtr THManagedMapAllocator::makeDataPtr(const char* manager_handle, const char* filename, int flags, ptrdiff_t size) {
   auto* context = new THManagedMapAllocator(manager_handle, filename, flags, size);
-  return {context->data(), context, &deleteTHManagedMapAllocator, at::kCPU};
+  return {context->data(), context, &deleteTHManagedMapAllocator, at::DeviceType::CPU};
 }
 
 THManagedMapAllocator* THManagedMapAllocator::fromDataPtr(const at::DataPtr& dptr) {


### PR DESCRIPTION
```
- Removed Backend constructor from Device, and fixed all
  use-sites to use DeviceType::CPU instead of kCPU, or
  use a new function backendToDeviceType to perform
  the conversion.
- New method device_type() on Type; it gives you the
  underlying device type, e.g., CPU for SparseCPU.
- We add backward compatibility for kCPU/kCUDA uses,
  by introducing a new special type which is implicitly
  convertible to both DeviceType and Backend.  As long as
  you don't define a function that's overloaded on both
  DeviceType and Backend (but not on BackendOrDeviceType),
  the implicit conversions will ensure that uses
  of at::Device(at::kCPU) keep working. We fixed use-sites in
  the library, but did NOT fix sites in the test code, so that
  we can exercise this BC code.
```

Differential Revision: D9301861
