### PR TITLE
Move RNN implementations to C++

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -543,7 +543,7 @@ LayerOutput<Tensor, hidden_type> _cudnn_impl(
   int64_t hidden_size = hx.size(2);
 
   AT_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
-  IntList batch_sizes { _batch_sizes.data<int64_t>(), _batch_sizes.size(0) };
+  IntList batch_sizes { _batch_sizes.data<int64_t>(), static_cast<size_t>(_batch_sizes.size(0)) };
   // cudnn_output = std::tuple<output, hy, cy, reserve, new_weight_buf>
   auto cudnn_output = at::_cudnn_rnn(
       input, params, has_biases ? 4 : 2, weight_buf,

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -5,6 +5,10 @@ namespace at { namespace native {
 
 namespace {
 
+// Windows doesn't like passing those addresses directly to templates, but this is fine...
+constexpr static auto tanh_ptr = &at::tanh;
+constexpr static auto relu_ptr = &at::relu;
+
 template<typename T>
 using pair_of = std::pair<T, T>;
 
@@ -620,8 +624,8 @@ std::tuple<Tensor, Tensor> NAME(                                               \
 }
 
 ONE_HIDDEN_RNN(gru, GRUCell)
-ONE_HIDDEN_RNN(rnn_tanh, SimpleCell<at::tanh>)
-ONE_HIDDEN_RNN(rnn_relu, SimpleCell<at::relu>)
+ONE_HIDDEN_RNN(rnn_tanh, SimpleCell<tanh_ptr>)
+ONE_HIDDEN_RNN(rnn_relu, SimpleCell<relu_ptr>)
 
 std::tuple<Tensor, Tensor, Tensor> lstm(
       const Tensor& _input, TensorList hx,
@@ -679,13 +683,13 @@ Tensor gru_cell(
 Tensor rnn_tanh_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
-  return SimpleCell<at::tanh>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+  return SimpleCell<tanh_ptr>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
 }
 
 Tensor rnn_relu_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
-  return SimpleCell<at::relu>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+  return SimpleCell<relu_ptr>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -350,7 +350,7 @@ struct ReversedPackedLayer : Layer<PackedSequence, hidden_type, CellParams> {
       int64_t batch_size = batch_sizes[i];
       int64_t inc = batch_size - last_batch_size;
       if (inc > 0) {
-        hidden = hidden_concat({hidden, hidden_slice(input_hidden, last_batch_size, batch_size)});
+        hidden = hidden_concat(ArrayRef<hidden_type>{hidden, hidden_slice(input_hidden, last_batch_size, batch_size)});
       }
 
       auto step_input = input.data.narrow(0, input_offset - batch_size, batch_size);

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -148,6 +148,7 @@ Tensor linear(const Tensor& input, const Tensor& weight, /* optional */ const Te
 template<typename hidden_type_tmpl>
 struct Cell {
   using hidden_type = hidden_type_tmpl;
+  virtual ~Cell() {} // This is really dumb, but enables projects with -Wnon-virtual-dtor to compile...
   virtual hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const = 0;
 };
 
@@ -230,6 +231,7 @@ struct LayerOutput {
 template<typename io_type, typename hidden_type, typename param_type>
 struct Layer {
   using output_type = LayerOutput<io_type, hidden_type>;
+  virtual ~Layer() {} // This is really dumb, but enables projects with -Wnon-virtual-dtor to compile...
   virtual output_type operator()(const io_type& input, const hidden_type& input_hidden, const param_type& params) const = 0;
 };
 

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -423,7 +423,7 @@ apply_layer_stack(const Layer<io_type, hidden_type, weight_type>& layer, const i
 // HELPERS SIMPLIFYING DISPATCH TO FUNCTIONS ABOVE
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename CellType, template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+template<typename CellType, template<typename> class LayerT, template<typename> class BidirLayerT, typename io_type>
 LayerOutput<io_type, std::vector<typename CellType::hidden_type>> _rnn_impl(
       const io_type& input,
       const std::vector<CellParams>& params,
@@ -440,7 +440,7 @@ LayerOutput<io_type, std::vector<typename CellType::hidden_type>> _rnn_impl(
   }
 }
 
-template<typename CellType, template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+template<typename CellType, template<typename> class LayerT, template<typename> class BidirLayerT, typename io_type>
 std::tuple<io_type, Tensor> _rnn_impl_with_concat(
       const io_type& input,
       const std::vector<CellParams>& params,
@@ -450,7 +450,7 @@ std::tuple<io_type, Tensor> _rnn_impl_with_concat(
   return std::make_tuple(result.outputs, at::stack(result.final_hidden, 0));
 }
 
-template<template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+template<template<typename> class LayerT, template<typename> class BidirLayerT, typename io_type>
 std::tuple<io_type, Tensor, Tensor> _lstm_impl(
       const io_type& input,
       const std::vector<CellParams>& params, const Tensor& hx, const Tensor& cx,

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -496,7 +496,10 @@ std::tuple<Tensor, Tensor> unpack_hidden(const tpair_of<Tensor>& hidden) {
 }
 
 template<typename hidden_type>
-hidden_type pack_hidden(const Tensor& hx, const Tensor& cx) = delete;
+hidden_type pack_hidden(const Tensor& hx, const Tensor& cx) {
+  static_assert(std::is_same<hidden_type, void>::value, "pack_hidden not implemented for this type");
+  AT_ERROR("NOT IMPLEMENTED");
+}
 
 template<>
 Tensor pack_hidden<Tensor>(const Tensor& hx, const Tensor& cx) {

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1,0 +1,688 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+
+namespace at { namespace native {
+
+namespace {
+
+template<typename T>
+using pair_of = std::pair<T, T>;
+
+template<typename T>
+using tpair_of = std::tuple<T, T>;
+
+struct PackedSequence {
+  PackedSequence() = default;
+  PackedSequence(Tensor _data, Tensor _batch_sizes)
+    : data(std::move(_data)), batch_sizes(std::move(_batch_sizes)) {}
+
+  Tensor data;
+  Tensor batch_sizes;
+};
+
+// Pretty much all cells we support take the same set of arguments, but threading those
+// 4 arguments manually is really annoying. Their lifetime is externally managed, so we only
+// pass this struct of references around.
+struct CellParams {
+  CellParams(const Tensor& _w_ih, const Tensor& _w_hh, const Tensor& _b_ih, const Tensor& _b_hh)
+    : w_ih(_w_ih), w_hh(_w_hh), b_ih(_b_ih), b_hh(_b_hh) {};
+
+  const Tensor& w_ih;
+  const Tensor& w_hh;
+  const Tensor& b_ih; /* optional */
+  const Tensor& b_hh; /* optional */
+};
+
+// Gathers every two elements of a vector in a vector of pairs
+template<typename T>
+static std::vector<pair_of<T>> pair_vec(const std::vector<T>& vals) {
+  AT_CHECK(vals.size() % 2 == 0, "Odd number of params or hiddens given to a bidirectional RNN");
+  std::vector<pair_of<T>> result;
+  result.reserve(vals.size() / 2);
+  for (int64_t i = 0; i < vals.size(); i += 2) {
+    result.emplace_back(vals[i], vals[i + 1]);
+  }
+  return result;
+}
+
+// Flattens a vector of pairs
+template<typename T>
+static std::vector<T> unpair_vec(std::vector<pair_of<T>>&& vals) {
+  std::vector<T> result;
+  result.reserve(vals.size() * 2);
+  for (int64_t i = 0; i < vals.size(); i++) {
+    result.push_back(std::move(vals[i].first));
+    result.push_back(std::move(vals[i].second));
+  }
+  return result;
+}
+
+// Parses a flat list of parameter tensors into a list of CellParams
+static std::vector<CellParams> gather_params(TensorList params, bool has_biases) {
+  static at::Tensor undefined;
+  std::vector<CellParams> result;
+  if (has_biases) {
+    AT_CHECK(params.size() % 4 == 0, "got an incorrect number of RNN parameters");
+    for (size_t i = 0; i < params.size(); i += 4) {
+      result.emplace_back(params[i], params[i + 1], params[i + 2], params[i + 3]);
+    }
+  } else {
+    AT_CHECK(params.size() % 2 == 0, "got an incorrect number of RNN parameters");
+    for (size_t i = 0; i < params.size(); i += 2) {
+      result.emplace_back(params[i], params[i + 1], undefined, undefined);
+    }
+  }
+  return result;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// HIDDEN STATE FUNCTIONS
+//
+// Functions implemented below are implemented as templates based on hidden type,
+// because they need to work both with simple RNNs and GRU (which use a single Tensor),
+// as well as with LSTM (or possibly more complicated architectures in the future).
+// Still, there are some operations that need to be performed on the hidden states
+// alone, and for this purpose we provide an overloaded set of functions below.
+
+Tensor hidden_as_output(const Tensor& t) { return t; }
+Tensor hidden_as_output(const tpair_of<Tensor>& t) { return std::get<0>(t); }
+
+template<size_t index>
+std::vector<Tensor> project(at::ArrayRef<tpair_of<Tensor>> tuples) {
+  std::vector<Tensor> result;
+  result.reserve(tuples.size());
+  for (auto & t : tuples) {
+    result.push_back(std::get<index>(t));
+  }
+  return result;
+}
+
+Tensor hidden_concat(at::ArrayRef<Tensor> hiddens) { return at::cat(hiddens, 0); }
+tpair_of<Tensor> hidden_concat(at::ArrayRef<tpair_of<Tensor>> hiddens) {
+  return std::make_tuple(hidden_concat(project<0>(hiddens)), hidden_concat(project<1>(hiddens)));
+}
+
+Tensor hidden_slice(const Tensor& t, int64_t start, int64_t end) {
+  return t.narrow(0, start, end - start);
+}
+tpair_of<Tensor> hidden_slice(const tpair_of<Tensor>& t, int64_t start, int64_t end) {
+  return std::make_tuple(hidden_slice(std::get<0>(t), start, end),
+                         hidden_slice(std::get<1>(t), start, end));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CELL IMPLEMENTATIONS
+//
+// Cell is a basic component of an RNN, representing a single application of the
+// recurrent function. You can think of it as a function of signature
+//
+// (Tensor input, hidden_type hidden, CellParams) -> hidden_type
+//
+// which means that it consumes an input tensor, and updates the previous hidden state.
+// It's a struct only because functional programming in C++ is a pain, and it's easier
+// to pass around "vtable pointers" than actual function pointers.
+
+Tensor linear(const Tensor& input, const Tensor& weight, /* optional */ const Tensor& bias={}) {
+  if (input.dim() == 2 && bias.defined()) {
+    // fused op is marginally faster
+    return at::addmm(bias, input, weight.t());
+  }
+
+  auto output = at::matmul(input, weight.t());
+  if (bias.defined()) {
+    output.add_(bias);
+  }
+  return output;
+}
+
+template<typename hidden_type_tmpl>
+struct Cell {
+  using hidden_type = hidden_type_tmpl;
+  virtual hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const = 0;
+};
+
+template<Tensor (*nonlinearity)(const Tensor&)>
+struct SimpleCell : Cell<Tensor> {
+  hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const override {
+    return nonlinearity(linear(input, params.w_ih, params.b_ih) + linear(hidden, params.w_hh, params.b_hh));
+  }
+};
+
+// TODO: can use inplace ops?
+struct LSTMCell : Cell<std::tuple<Tensor, Tensor>> {
+  hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const override {
+    auto hx = std::get<0>(hidden);
+    auto cx = std::get<1>(hidden);
+
+    if (input.is_cuda()) {
+      auto igates = at::matmul(input, params.w_ih.t());
+      auto hgates = at::matmul(hx, params.w_hh.t());
+      auto result = at::_thnn_fused_lstm_cell(igates, hgates, cx, params.b_ih, params.b_hh);
+      // Slice off the workspace argument (it's needed only for AD).
+      return std::make_tuple(std::get<0>(result), std::get<1>(result));
+    }
+
+    auto gates = linear(input, params.w_ih, params.b_ih) + linear(hx, params.w_hh, params.b_hh);
+    auto chunked_gates = gates.chunk(4, 1);
+
+    auto ingate = chunked_gates[0].sigmoid();
+    auto forgetgate = chunked_gates[1].sigmoid();
+    auto cellgate = chunked_gates[2].tanh();
+    auto outgate = chunked_gates[3].sigmoid();
+
+    auto cy = (forgetgate * cx) + (ingate * cellgate);
+    auto hy = outgate * cy.tanh();
+
+    return std::make_tuple(hy, cy);
+  }
+};
+
+struct GRUCell : Cell<Tensor> {
+  hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const override {
+    if (input.is_cuda()) {
+      auto igates = at::matmul(input, params.w_ih.t());
+      auto hgates = at::matmul(hidden, params.w_hh.t());
+      auto result = at::_thnn_fused_gru_cell(igates, hgates, hidden, params.b_ih, params.b_hh);
+      // Slice off the workspace argument (it's needed only for AD).
+      return std::get<0>(result);
+    }
+
+    auto igates = linear(input, params.w_ih, params.b_ih);
+    auto hgates = linear(hidden, params.w_hh, params.b_hh);
+    auto chunked_igates = igates.chunk(3, 1);
+    auto chunked_hgates = hgates.chunk(3, 1);
+
+    auto reset_gate = at::sigmoid(chunked_igates[0] + chunked_hgates[0]);
+    auto input_gate = at::sigmoid(chunked_igates[1] + chunked_hgates[1]);
+    auto new_gate = at::tanh(chunked_igates[2] + reset_gate * chunked_hgates[2]);
+
+    return new_gate + input_gate * (hidden - new_gate);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// LAYER IMPLEMENTATIONS
+//
+// Layers are scan-like higher-order functions, which take in cells, and
+// transform them to fuctions of signature
+//
+// (io_type input, hidden_type hidden, param_type params) -> (io_type, hidden_type)
+//
+// which can apply the cell over a sequence of inputs, and produce both a new set
+// of hidden states, as well as a concatenated output of each step.
+
+template<typename output_type, typename hidden_type>
+struct LayerOutput {
+  output_type outputs;
+  hidden_type final_hidden;
+};
+
+template<typename io_type, typename hidden_type, typename param_type>
+struct Layer {
+  using output_type = LayerOutput<io_type, hidden_type>;
+  virtual output_type operator()(const io_type& input, const hidden_type& input_hidden, const param_type& params) const = 0;
+};
+
+template<typename hidden_type>
+struct FullLayer : Layer<Tensor, hidden_type, CellParams> {
+  using output_type = typename Layer<Tensor, hidden_type, CellParams>::output_type;
+  using unstacked_output_type = LayerOutput<std::vector<Tensor>, hidden_type>;
+
+  FullLayer(Cell<hidden_type>& cell)
+    : cell_(cell) {};
+
+  unstacked_output_type operator()(std::vector<Tensor> step_inputs, const hidden_type& input_hidden, const CellParams& params) const {
+    std::vector<Tensor> step_outputs;
+    auto hidden = input_hidden;
+    for (size_t i = 0; i < step_inputs.size(); i++) {
+      hidden = cell_(step_inputs[i], hidden, params);
+      step_outputs.push_back(hidden_as_output(hidden));
+    }
+    return {step_outputs, hidden};
+  }
+
+  output_type operator()(const Tensor& inputs, const hidden_type& input_hidden, const CellParams& params) const override {
+    auto unstacked_output = (*this)(inputs.unbind(0), input_hidden, params);
+    return {at::stack(unstacked_output.outputs, 0), unstacked_output.final_hidden};
+  }
+
+  Cell<hidden_type>& cell_;
+};
+
+template<typename dir_hidden_type>
+struct FullBidirectionalLayer : Layer<Tensor, pair_of<dir_hidden_type>, pair_of<CellParams>> {
+  using hidden_type = pair_of<dir_hidden_type>;
+  using param_type = pair_of<CellParams>;
+  using output_type = typename Layer<Tensor, hidden_type, param_type>::output_type;
+
+  FullBidirectionalLayer(Cell<dir_hidden_type>& cell)
+    : layer_(cell) {};
+
+  output_type operator()(const Tensor& input, const hidden_type& input_hidden, const param_type& params) const override {
+    auto step_inputs = input.unbind(0);
+    auto fw_result = layer_(step_inputs, input_hidden.first, params.first);
+    auto fw_output = at::stack(fw_result.outputs, 0);
+
+    auto rev_step_inputs = reverse(std::move(step_inputs));
+    auto rev_result = layer_(rev_step_inputs, input_hidden.second, params.second);
+    std::reverse(rev_result.outputs.begin(), rev_result.outputs.end());
+    auto rev_output = at::stack(rev_result.outputs, 0);
+
+    return {at::cat({fw_output, rev_output}, fw_output.dim() - 1),
+            std::make_pair(fw_result.final_hidden, rev_result.final_hidden)};
+  }
+
+  std::vector<Tensor> reverse(std::vector<Tensor>&& x) const {
+    std::reverse(x.begin(), x.end());
+    return x;
+  }
+
+  FullLayer<dir_hidden_type> layer_;
+};
+
+template<typename hidden_type>
+struct PackedLayer : Layer<PackedSequence, hidden_type, CellParams> {
+  using output_type = typename Layer<PackedSequence, hidden_type, CellParams>::output_type;
+
+  PackedLayer(Cell<hidden_type>& cell)
+    : cell_(cell) {};
+
+  output_type operator()(const PackedSequence& input, const hidden_type& input_hidden, const CellParams& params) const override {
+    std::vector<at::Tensor> step_outputs;
+    std::vector<hidden_type> hiddens;
+    int64_t input_offset = 0;
+    int64_t num_steps = input.batch_sizes.size(0);
+    int64_t* batch_sizes = input.batch_sizes.data<int64_t>();
+    int64_t last_batch_size = batch_sizes[0];
+
+    // TODO: use split with sizes?
+    auto hidden = input_hidden;
+    for (int64_t i = 0; i < num_steps; ++i) {
+      int64_t batch_size = batch_sizes[i];
+      auto step_input = input.data.narrow(0, input_offset, batch_size);
+      input_offset += batch_size;
+
+      int64_t dec = last_batch_size - batch_size;
+      if (dec > 0) {
+        hiddens.push_back(hidden_slice(hidden, last_batch_size - dec, last_batch_size));
+        hidden = hidden_slice(hidden, 0, last_batch_size - dec);
+      }
+
+      last_batch_size = batch_size;
+      hidden = cell_(step_input, hidden, params);
+      step_outputs.push_back(hidden_as_output(hidden));
+    }
+    hiddens.push_back(hidden);
+    std::reverse(hiddens.begin(), hiddens.end());
+
+    return { PackedSequence{ at::cat(step_outputs, 0), input.batch_sizes }, hidden_concat(hiddens) };
+  }
+
+  Cell<hidden_type>& cell_;
+};
+
+template<typename hidden_type>
+struct ReversedPackedLayer : Layer<PackedSequence, hidden_type, CellParams> {
+  using output_type = typename Layer<PackedSequence, hidden_type, CellParams>::output_type;
+
+  ReversedPackedLayer(Cell<hidden_type>& cell)
+    : cell_(cell) {};
+
+  output_type operator()(const PackedSequence& input, const hidden_type& input_hidden, const CellParams& params) const override {
+    std::vector<at::Tensor> step_outputs;
+    int64_t input_offset = input.data.size(0);
+    int64_t num_steps = input.batch_sizes.size(0);
+    int64_t* batch_sizes = input.batch_sizes.data<int64_t>();
+    int64_t last_batch_size = batch_sizes[num_steps - 1];
+
+    auto hidden = hidden_slice(input_hidden, 0, batch_sizes[num_steps - 1]);
+    for (int64_t i = num_steps - 1; i >= 0; --i) {
+      int64_t batch_size = batch_sizes[i];
+      int64_t inc = batch_size - last_batch_size;
+      if (inc > 0) {
+        hidden = hidden_concat({hidden, hidden_slice(input_hidden, last_batch_size, batch_size)});
+      }
+
+      auto step_input = input.data.narrow(0, input_offset - batch_size, batch_size);
+      input_offset -= batch_size;
+
+      last_batch_size = batch_size;
+      hidden = cell_(step_input, hidden, params);
+      step_outputs.push_back(hidden_as_output(hidden));
+    }
+    std::reverse(step_outputs.begin(), step_outputs.end());
+    return { PackedSequence{ at::cat(step_outputs, 0), input.batch_sizes }, hidden };
+  }
+
+  Cell<hidden_type>& cell_;
+};
+
+template<typename dir_hidden_type>
+struct PackedBidirectionalLayer : Layer<PackedSequence, pair_of<dir_hidden_type>, pair_of<CellParams>> {
+  using hidden_type = pair_of<dir_hidden_type>;
+  using param_type = pair_of<CellParams>;
+  using output_type = typename Layer<PackedSequence, hidden_type, param_type>::output_type;
+
+  PackedBidirectionalLayer(Cell<dir_hidden_type>& cell)
+    : layer_(cell), rev_layer_(cell) {};
+
+  output_type operator()(const PackedSequence& input, const hidden_type& input_hidden, const param_type& params) const override {
+    auto fw_result = layer_(input, input_hidden.first, params.first);
+    auto rev_result = rev_layer_(input, input_hidden.second, params.second);
+    PackedSequence output { at::cat({fw_result.outputs.data, rev_result.outputs.data}, -1), input.batch_sizes };
+    return { output, std::make_pair(fw_result.final_hidden, rev_result.final_hidden) };
+  }
+
+  PackedLayer<dir_hidden_type> layer_;
+  ReversedPackedLayer<dir_hidden_type> rev_layer_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_layer_stack
+//
+// layers are convenient, but in reality we often want to stack them. this little
+// helper manages slicing of all inputs and parameters, and repeatedly feeds them
+// into the given layer. returns the last layer's outputs, and a vector of final
+// hidden states produced at each level.
+
+Tensor dropout(const Tensor& input, double p) {
+  return at::dropout(input, p, /*train=*/true);
+}
+
+PackedSequence dropout(const PackedSequence& input, double p) {
+  return {at::dropout(input.data, p, /*train=*/true), input.batch_sizes};
+}
+
+template<typename io_type, typename hidden_type, typename weight_type>
+LayerOutput<io_type, std::vector<hidden_type>>
+apply_layer_stack(const Layer<io_type, hidden_type, weight_type>& layer, const io_type& input,
+                  const std::vector<hidden_type>& hiddens, const std::vector<weight_type>& weights,
+                  int64_t num_layers, double dropout_p, bool train) {
+  AT_CHECK(num_layers == hiddens.size(), "Expected more hidden states in stacked_rnn");
+  AT_CHECK(num_layers == weights.size(), "Expected more weights in stacked_rnn");
+
+  auto layer_input = input;
+  auto hidden_it = hiddens.begin();
+  auto weight_it = weights.begin();
+  std::vector<hidden_type> final_hiddens;
+  for (int64_t l = 0; l < num_layers; ++l) {
+    auto layer_output = layer(layer_input, *(hidden_it++), *(weight_it++));
+    final_hiddens.push_back(layer_output.final_hidden);
+    layer_input = layer_output.outputs;
+
+    if (dropout_p != 0 && train && l < num_layers - 1) {
+      layer_input = dropout(layer_input, dropout_p);
+    }
+  }
+
+  return {layer_input, final_hiddens};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// HELPERS SIMPLIFYING DISPATCH TO FUNCTIONS ABOVE
+////////////////////////////////////////////////////////////////////////////////
+
+template<typename CellType, template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+LayerOutput<io_type, std::vector<typename CellType::hidden_type>> _rnn_impl(
+      const io_type& input,
+      const std::vector<CellParams>& params,
+      const std::vector<typename CellType::hidden_type>& hiddens,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
+  using hidden_type = typename CellType::hidden_type;
+  CellType cell;
+  if (bidirectional) {
+    using BidirLayer = BidirLayerT<hidden_type>;
+    auto bidir_result = apply_layer_stack(BidirLayer{cell}, input, pair_vec(hiddens), pair_vec(params), num_layers, dropout_p, train);
+    return {bidir_result.outputs, unpair_vec(std::move(bidir_result.final_hidden))};
+  } else {
+    return apply_layer_stack(LayerT<hidden_type>{cell}, input, hiddens, params, num_layers, dropout_p, train);
+  }
+}
+
+template<typename CellType, template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+std::tuple<io_type, Tensor> _rnn_impl_with_concat(
+      const io_type& input,
+      const std::vector<CellParams>& params,
+      const std::vector<typename CellType::hidden_type>& hiddens,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
+  auto result = _rnn_impl<CellType, LayerT, BidirLayerT>(input, params, hiddens, num_layers, dropout_p, train, bidirectional);
+  return std::make_tuple(result.outputs, at::stack(result.final_hidden, 0));
+}
+
+template<template<typename> typename LayerT, template<typename> typename BidirLayerT, typename io_type>
+std::tuple<io_type, Tensor, Tensor> _lstm_impl(
+      const io_type& input,
+      const std::vector<CellParams>& params, const Tensor& hx, const Tensor& cx,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
+  // It's much more useful for us to work on lists of pairs of hx and cx for each layer, so we need
+  // to transpose a pair of those tensors.
+  auto layer_hx = hx.unbind(0);
+  auto layer_cx = cx.unbind(0);
+  int64_t total_layers = layer_hx.size();
+  std::vector<LSTMCell::hidden_type> hiddens;
+  hiddens.reserve(total_layers);
+  for (int64_t i = 0; i < total_layers; ++i) {
+    hiddens.emplace_back(std::move(layer_hx[i]), std::move(layer_cx[i]));
+  }
+
+  auto result = _rnn_impl<LSTMCell, LayerT, BidirLayerT>(input, params, hiddens, num_layers, dropout_p, train, bidirectional);
+
+  // Now, we need to reverse the transposed we performed above.
+  std::vector<Tensor> hy, cy;
+  hy.reserve(total_layers); cy.reserve(total_layers);
+  for (auto & hidden : result.final_hidden) {
+    hy.push_back(std::move(std::get<0>(hidden)));
+    cy.push_back(std::move(std::get<1>(hidden)));
+  }
+
+  return std::make_tuple(result.outputs, at::stack(hy, 0), at::stack(cy, 0));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CUDNN BINDINGS
+////////////////////////////////////////////////////////////////////////////////
+
+// These must line up with the CUDNN mode codes:
+// https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnRNNMode_t
+enum class CuDNNMode { rnn_relu = 0, rnn_tanh = 1, lstm = 2, gru = 3 };
+
+std::tuple<Tensor, Tensor> unpack_hidden(const Tensor& hidden) {
+  return std::make_tuple(hidden, at::Tensor{});
+}
+
+std::tuple<Tensor, Tensor> unpack_hidden(const tpair_of<Tensor>& hidden) {
+  return hidden;
+}
+
+template<typename hidden_type>
+hidden_type pack_hidden(const Tensor& hx, const Tensor& cx) = delete;
+
+template<>
+Tensor pack_hidden<Tensor>(const Tensor& hx, const Tensor& cx) {
+  AT_ASSERT(cx.numel() == 0);
+  return hx;
+}
+
+template<>
+tpair_of<Tensor> pack_hidden<tpair_of<Tensor>>(const Tensor& hx, const Tensor& cx) {
+  return std::make_tuple(hx, cx);
+}
+
+const char * WEIGHT_FORMAT_WARN = "RNN module weights are not part of single contiguous "
+                                  "chunk of memory. This means they need to be compacted "
+                                  "at every call, possibly greatly increasing memory usage. "
+                                  "To compact weights again call flatten_parameters().";
+
+template<typename hidden_type>
+LayerOutput<Tensor, hidden_type> _cudnn_impl(
+      const Tensor& input, const Tensor& _batch_sizes,
+      const hidden_type& hidden,
+      TensorList params, bool has_biases,
+      CuDNNMode cudnn_mode, const Tensor& weight_buf, const Tensor& dropout_state,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
+  if (!weight_buf.defined()) {
+    AT_WARN(WEIGHT_FORMAT_WARN);
+  }
+
+  Tensor hx, cx;
+  std::tie(hx, cx) = unpack_hidden(hidden);
+
+  int64_t hidden_size = hx.size(2);
+
+  AT_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  IntList batch_sizes { _batch_sizes.data<int64_t>(), _batch_sizes.size(0) };
+  // cudnn_output = std::tuple<output, hy, cy, reserve, new_weight_buf>
+  auto cudnn_output = at::_cudnn_rnn(
+      input, params, has_biases ? 4 : 2, weight_buf,
+      hx, cx, static_cast<int>(cudnn_mode), hidden_size,
+      num_layers, /*batch_first=*/false, dropout_p, train, bidirectional,
+      batch_sizes, dropout_state);
+
+  return {std::get<0>(cudnn_output),
+          pack_hidden<hidden_type>(std::get<1>(cudnn_output), std::get<2>(cudnn_output))};
+}
+
+template<typename hidden_type>
+LayerOutput<Tensor, hidden_type> _cudnn_impl(
+      const Tensor& input,
+      const hidden_type& hidden,
+      TensorList params, bool has_biases,
+      CuDNNMode cudnn_mode, const Tensor& weight_buf, const Tensor& dropout_state,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
+  if (!weight_buf.defined()) {
+    AT_WARN(WEIGHT_FORMAT_WARN);
+  }
+
+  Tensor hx, cx;
+  std::tie(hx, cx) = unpack_hidden(hidden);
+
+  int64_t hidden_size = hx.size(2);
+
+  // cudnn_output = std::tuple<output, hy, cy, reserve, new_weight_buf>
+  auto cudnn_output = at::_cudnn_rnn(
+      input, params, has_biases ? 4 : 2, weight_buf,
+      hx, cx, static_cast<int>(cudnn_mode), hidden_size,
+      num_layers, batch_first, dropout_p, train, bidirectional,
+      /*batch_sizes=*/{}, dropout_state);
+
+  return {std::get<0>(cudnn_output),
+          pack_hidden<hidden_type>(std::get<1>(cudnn_output), std::get<2>(cudnn_output))};
+}
+
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+// PUBLIC FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////
+
+#define ONE_HIDDEN_RNN(NAME, CELL)                                             \
+std::tuple<Tensor, Tensor> NAME(                                               \
+      const Tensor& _input, const Tensor& hx,                                  \
+      TensorList _params, bool has_biases,                                     \
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first, \
+      const Tensor& cudnn_weight_buf, const Tensor& cudnn_dropout_state) {     \
+  if (at::cudnn_is_acceptable(_input)) {                                       \
+    auto result = _cudnn_impl(_input, hx, _params, has_biases,                 \
+        CuDNNMode::NAME, cudnn_weight_buf, cudnn_dropout_state,                \
+        num_layers, dropout_p, train, bidirectional, batch_first);             \
+    return std::make_tuple(result.outputs, result.final_hidden);               \
+  }                                                                            \
+  auto input = batch_first ? _input.transpose(0, 1) : _input;                  \
+  auto params = gather_params(_params, has_biases);                            \
+  auto results = _rnn_impl_with_concat<CELL, FullLayer, FullBidirectionalLayer>( \
+          input, params, hx.unbind(0), num_layers, dropout_p, train, bidirectional); \
+  if (batch_first) {                                                           \
+    std::get<0>(results) = std::get<0>(results).transpose(0, 1);               \
+  }                                                                            \
+  return results;                                                              \
+}                                                                              \
+                                                                               \
+std::tuple<Tensor, Tensor> NAME(                                               \
+      const Tensor& data, const Tensor& batch_sizes, const Tensor& hx,         \
+      TensorList _params, bool has_biases,                                     \
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional,    \
+      const Tensor& cudnn_weight_buf, const Tensor& cudnn_dropout_state) {     \
+  if (at::cudnn_is_acceptable(data)) {                                         \
+    auto result = _cudnn_impl(data, batch_sizes, hx, _params, has_biases,      \
+        CuDNNMode::NAME, cudnn_weight_buf, cudnn_dropout_state, num_layers, dropout_p, train, bidirectional); \
+    return std::make_tuple(result.outputs, result.final_hidden);               \
+  }                                                                            \
+  PackedSequence input { data, batch_sizes };                                  \
+  auto params = gather_params(_params, has_biases);                            \
+  auto result = _rnn_impl_with_concat<CELL, PackedLayer, PackedBidirectionalLayer>( \
+          input, params, hx.unbind(0), num_layers, dropout_p, train, bidirectional); \
+  auto & packed_output = std::get<0>(result);                                  \
+  return std::make_tuple(packed_output.data, std::get<1>(result));             \
+}
+
+ONE_HIDDEN_RNN(gru, GRUCell)
+ONE_HIDDEN_RNN(rnn_tanh, SimpleCell<at::tanh>)
+ONE_HIDDEN_RNN(rnn_relu, SimpleCell<at::relu>)
+
+std::tuple<Tensor, Tensor, Tensor> lstm(
+      const Tensor& _input, TensorList hx,
+      TensorList _params, bool has_biases,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first,
+      const Tensor& cudnn_weight_buf, const Tensor& cudnn_dropout_state) {
+  AT_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  if (at::cudnn_is_acceptable(_input)) {
+    auto result = _cudnn_impl(_input, std::make_tuple(hx[0], hx[1]), _params, has_biases,
+        CuDNNMode::lstm, cudnn_weight_buf, cudnn_dropout_state, num_layers, dropout_p, train, bidirectional, batch_first);
+    return std::make_tuple(result.outputs, std::get<0>(result.final_hidden), std::get<1>(result.final_hidden));
+  }
+  auto input = batch_first ? _input.transpose(0, 1) : _input;
+  auto params = gather_params(_params, has_biases);
+  auto results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
+      input, params, hx[0], hx[1], num_layers, dropout_p, train, bidirectional);
+  if (batch_first) {
+    std::get<0>(results) = std::get<0>(results).transpose(0, 1);
+  }
+  return results;
+}
+
+std::tuple<Tensor, Tensor, Tensor> lstm(
+      const Tensor& data, const Tensor& batch_sizes, TensorList hx,
+      TensorList _params, bool has_biases,
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional,
+      const Tensor& cudnn_weight_buf, const Tensor& cudnn_dropout_state) {
+  AT_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  if (at::cudnn_is_acceptable(data)) {
+    auto result = _cudnn_impl(data, batch_sizes, std::make_tuple(hx[0], hx[1]), _params, has_biases,
+        CuDNNMode::lstm, cudnn_weight_buf, cudnn_dropout_state, num_layers, dropout_p, train, bidirectional);
+    return std::make_tuple(result.outputs, std::get<0>(result.final_hidden), std::get<1>(result.final_hidden));
+  }
+  PackedSequence input { data, batch_sizes };
+  auto params = gather_params(_params, has_biases);
+  auto result = _lstm_impl<PackedLayer, PackedBidirectionalLayer>(
+      input, params, hx[0], hx[1], num_layers, dropout_p, train, bidirectional);
+  auto & packed_output = std::get<0>(result);
+  return std::make_tuple(packed_output.data, std::get<1>(result), std::get<2>(result));
+}
+
+std::tuple<Tensor, Tensor> lstm_cell(
+    const Tensor& input, TensorList hx,
+    const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
+  AT_CHECK(hx.size() == 2, "lstm_cell expects two hidden states");
+  return LSTMCell{}(input, std::make_tuple(hx[0], hx[1]), CellParams{w_ih, w_hh, b_ih, b_hh});
+}
+
+Tensor gru_cell(
+    const Tensor& input, const Tensor& hx,
+    const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
+  return GRUCell{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+}
+
+Tensor rnn_tanh_cell(
+    const Tensor& input, const Tensor& hx,
+    const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
+  return SimpleCell<at::tanh>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+}
+
+Tensor rnn_relu_cell(
+    const Tensor& input, const Tensor& hx,
+    const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
+  return SimpleCell<at::relu>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -5,10 +5,6 @@ namespace at { namespace native {
 
 namespace {
 
-// Windows doesn't like passing those addresses directly to templates, but this is fine...
-constexpr static auto tanh_ptr = &at::tanh;
-constexpr static auto relu_ptr = &at::relu;
-
 template<typename T>
 using pair_of = std::pair<T, T>;
 
@@ -624,8 +620,8 @@ std::tuple<Tensor, Tensor> NAME(                                               \
 }
 
 ONE_HIDDEN_RNN(gru, GRUCell)
-ONE_HIDDEN_RNN(rnn_tanh, SimpleCell<tanh_ptr>)
-ONE_HIDDEN_RNN(rnn_relu, SimpleCell<relu_ptr>)
+ONE_HIDDEN_RNN(rnn_tanh, SimpleCell<&at::tanh>)
+ONE_HIDDEN_RNN(rnn_relu, SimpleCell<&at::relu>)
 
 std::tuple<Tensor, Tensor, Tensor> lstm(
       const Tensor& _input, TensorList hx,
@@ -683,13 +679,13 @@ Tensor gru_cell(
 Tensor rnn_tanh_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
-  return SimpleCell<tanh_ptr>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+  return SimpleCell<&at::tanh>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
 }
 
 Tensor rnn_relu_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
-  return SimpleCell<relu_ptr>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
+  return SimpleCell<&at::relu>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh});
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2048,3 +2048,40 @@
   dispatch:
     CUDA: _thnn_fused_gru_cell_backward_cuda
   variants: function
+
+# RNN cells and layers
+- func: lstm(Tensor input, TensorList hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, bool batch_first, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor, Tensor)
+  variants: function
+
+- func: lstm(Tensor data, Tensor batch_sizes, TensorList hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor, Tensor)
+  variants: function
+
+- func: gru(Tensor input, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, bool batch_first, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: gru(Tensor data, Tensor batch_sizes, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: rnn_tanh(Tensor input, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, bool batch_first, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: rnn_tanh(Tensor data, Tensor batch_sizes, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: rnn_relu(Tensor input, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, bool batch_first, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: rnn_relu(Tensor data, Tensor batch_sizes, Tensor hx, TensorList params, bool has_biases, int64_t num_layers, double dropout, bool train, bool bidirectional, Tensor? cudnn_weight_buf={}, Tensor? cudnn_dropout_state={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: lstm_cell(Tensor input, TensorList hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih={}, Tensor? b_hh={}) -> (Tensor, Tensor)
+  variants: function
+
+- func: gru_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih={}, Tensor? b_hh={}) -> Tensor
+  variants: function
+
+- func: rnn_tanh_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih={}, Tensor? b_hh={}) -> Tensor
+  variants: function
+
+- func: rnn_relu_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih={}, Tensor? b_hh={}) -> Tensor
+  variants: function

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3946,7 +3946,7 @@ class TestNN(NNTestCase):
             self.assertEqual(output_cuda, output_cpu)
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    @repeat_test_for_types(ALL_TENSORTYPES)
+    @repeat_test_for_types(NO_HALF_TENSORTYPES)
     def test_cuda_rnn_fused(self, dtype=torch.float):
 
         def copy_rnn(rnn1, rnn2):
@@ -3964,14 +3964,14 @@ class TestNN(NNTestCase):
         num_layers = 2
         seq_length = 7
         batch = 6
-        input_val = torch.randn(seq_length, batch, input_size, device="cuda", dtype=dtype)
-        grad_output = torch.randn(seq_length, batch, hidden_size, device="cuda", dtype=dtype)
-        hx_val = torch.randn(num_layers, batch, hidden_size, device="cuda", dtype=dtype)
-        grad_hy = torch.randn(num_layers, batch, hidden_size, device="cuda", dtype=dtype)
+        input_val = torch.randn(seq_length, batch, input_size, dtype=dtype)
+        grad_output = torch.randn(seq_length, batch, hidden_size, dtype=dtype)
+        hx_val = torch.randn(num_layers, batch, hidden_size, dtype=dtype)
+        grad_hy = torch.randn(num_layers, batch, hidden_size, dtype=dtype)
         with torch.backends.cudnn.flags(enabled=False):
             for module in (nn.GRU, nn.LSTM):
                 for bias in (True, False):
-                    rnn = module(input_size, hidden_size, num_layers, bias=bias).to("cuda", dtype)
+                    rnn = module(input_size, hidden_size, num_layers, bias=bias).to(dtype)
                     rnn_cuda = module(input_size, hidden_size, num_layers, bias=bias).to("cuda", dtype)
                     copy_rnn(rnn, rnn_cuda)
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -41,7 +41,8 @@ MANUAL_IMPLEMENTATIONS = {
 # NO EFFECT otherwise.
 DONT_RECORD_TRACE = {
     'convolution', 'conv1d', 'conv2d', 'conv3d', 'conv_transpose1d',
-    'conv_transpose2d', 'conv_transpose3d',
+    'conv_transpose2d', 'conv_transpose3d', 'lstm_cell', 'gru_cell',
+    'rnn_tanh_cell', 'rnn_relu_cell',
 }
 
 # These functions have their names recorded under trace renamed,

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -6,302 +6,50 @@ import torch
 import itertools
 from functools import partial
 
-_cuda_fused_lstm_cell = torch._C._VariableFunctions._thnn_fused_lstm_cell
-_cuda_fused_gru_cell = torch._C._VariableFunctions._thnn_fused_gru_cell
-
 try:
     import torch.backends.cudnn.rnn
 except ImportError:
     pass
 
 
-def RNNReLUCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
-    hy = F.relu(F.linear(input, w_ih, b_ih) + F.linear(hidden, w_hh, b_hh))
-    return hy
-
-
-def RNNTanhCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
-    hy = torch.tanh(F.linear(input, w_ih, b_ih) + F.linear(hidden, w_hh, b_hh))
-    return hy
-
-
-def LSTMCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
-    if input.is_cuda:
-        igates = F.linear(input, w_ih)
-        hgates = F.linear(hidden[0], w_hh)
-        # Slice off the workspace arg (used only for backward)
-        return _cuda_fused_lstm_cell(igates, hgates, hidden[1], b_ih, b_hh)[:2]
-
-    hx, cx = hidden
-    gates = F.linear(input, w_ih, b_ih) + F.linear(hx, w_hh, b_hh)
-
-    ingate, forgetgate, cellgate, outgate = gates.chunk(4, 1)
-
-    ingate = torch.sigmoid(ingate)
-    forgetgate = torch.sigmoid(forgetgate)
-    cellgate = torch.tanh(cellgate)
-    outgate = torch.sigmoid(outgate)
-
-    cy = (forgetgate * cx) + (ingate * cellgate)
-    hy = outgate * torch.tanh(cy)
-
-    return hy, cy
-
-
-def GRUCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
-    if input.is_cuda:
-        gi = F.linear(input, w_ih)
-        gh = F.linear(hidden, w_hh)
-        return _cuda_fused_gru_cell(gi, gh, hidden, b_ih, b_hh)[0]
-
-    gi = F.linear(input, w_ih, b_ih)
-    gh = F.linear(hidden, w_hh, b_hh)
-    i_r, i_i, i_n = gi.chunk(3, 1)
-    h_r, h_i, h_n = gh.chunk(3, 1)
-
-    resetgate = torch.sigmoid(i_r + h_r)
-    inputgate = torch.sigmoid(i_i + h_i)
-    newgate = torch.tanh(i_n + resetgate * h_n)
-    hy = newgate + inputgate * (hidden - newgate)
-
-    return hy
-
-
-def StackedRNN(inners, num_layers, lstm=False, dropout=0, train=True):
-
-    num_directions = len(inners)
-    total_layers = num_layers * num_directions
-
-    def forward(input, hidden, weight, batch_sizes):
-        assert(len(weight) == total_layers)
-        next_hidden = []
-
-        if lstm:
-            hidden = list(zip(*hidden))
-
-        for i in range(num_layers):
-            all_output = []
-            for j, inner in enumerate(inners):
-                l = i * num_directions + j
-
-                hy, output = inner(input, hidden[l], weight[l], batch_sizes)
-                next_hidden.append(hy)
-                all_output.append(output)
-
-            input = torch.cat(all_output, input.dim() - 1)
-
-            if dropout != 0 and i < num_layers - 1:
-                input = F.dropout(input, p=dropout, training=train, inplace=False)
-
-        if lstm:
-            next_h, next_c = zip(*next_hidden)
-            next_hidden = (
-                torch.cat(next_h, 0).view(total_layers, *next_h[0].size()),
-                torch.cat(next_c, 0).view(total_layers, *next_c[0].size())
-            )
-        else:
-            next_hidden = torch.cat(next_hidden, 0).view(
-                total_layers, *next_hidden[0].size())
-
-        return next_hidden, input
-
-    return forward
-
-
-def Recurrent(inner, reverse=False):
-    def forward(input, hidden, weight, batch_sizes):
-        output = []
-        steps = range(input.size(0) - 1, -1, -1) if reverse else range(input.size(0))
-        for i in steps:
-            hidden = inner(input[i], hidden, *weight)
-            # hack to handle LSTM
-            output.append(hidden[0] if isinstance(hidden, tuple) else hidden)
-
-        if reverse:
-            output.reverse()
-        output = torch.cat(output, 0).view(input.size(0), *output[0].size())
-
-        return hidden, output
-
-    return forward
-
-
-def variable_recurrent_factory(inner, reverse=False):
-    if reverse:
-        return VariableRecurrentReverse(inner)
-    else:
-        return VariableRecurrent(inner)
-
-
-def VariableRecurrent(inner):
-    def forward(input, hidden, weight, batch_sizes):
-
-        output = []
-        input_offset = 0
-        last_batch_size = batch_sizes[0]
-        hiddens = []
-        flat_hidden = not isinstance(hidden, tuple)
-        if flat_hidden:
-            hidden = (hidden,)
-        for batch_size in batch_sizes:
-            step_input = input[input_offset:input_offset + batch_size]
-            input_offset += batch_size
-
-            dec = last_batch_size - batch_size
-            if dec > 0:
-                hiddens.append(tuple(h[-dec:] for h in hidden))
-                hidden = tuple(h[:-dec] for h in hidden)
-            last_batch_size = batch_size
-
-            if flat_hidden:
-                hidden = (inner(step_input, hidden[0], *weight),)
-            else:
-                hidden = inner(step_input, hidden, *weight)
-
-            output.append(hidden[0])
-        hiddens.append(hidden)
-        hiddens.reverse()
-
-        hidden = tuple(torch.cat(h, 0) for h in zip(*hiddens))
-        assert hidden[0].size(0) == batch_sizes[0]
-        if flat_hidden:
-            hidden = hidden[0]
-        output = torch.cat(output, 0)
-
-        return hidden, output
-
-    return forward
-
-
-def VariableRecurrentReverse(inner):
-    def forward(input, hidden, weight, batch_sizes):
-        output = []
-        input_offset = input.size(0)
-        last_batch_size = batch_sizes[-1]
-        initial_hidden = hidden
-        flat_hidden = not isinstance(hidden, tuple)
-        if flat_hidden:
-            hidden = (hidden,)
-            initial_hidden = (initial_hidden,)
-        hidden = tuple(h[:batch_sizes[-1]] for h in hidden)
-        for i in reversed(range(len(batch_sizes))):
-            batch_size = batch_sizes[i]
-            inc = batch_size - last_batch_size
-            if inc > 0:
-                hidden = tuple(torch.cat((h, ih[last_batch_size:batch_size]), 0)
-                               for h, ih in zip(hidden, initial_hidden))
-            last_batch_size = batch_size
-            step_input = input[input_offset - batch_size:input_offset]
-            input_offset -= batch_size
-
-            if flat_hidden:
-                hidden = (inner(step_input, hidden[0], *weight),)
-            else:
-                hidden = inner(step_input, hidden, *weight)
-            output.append(hidden[0])
-
-        output.reverse()
-        output = torch.cat(output, 0)
-        if flat_hidden:
-            hidden = hidden[0]
-        return hidden, output
-
-    return forward
-
-
-def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
+def _select_rnn_impl(mode, input_size, hidden_size, num_layers=1, batch_first=False,
                 dropout=0, train=True, bidirectional=False, variable_length=False,
                 dropout_state=None, flat_weight=None):
-
+    hidden_is_tensor = True
     if mode == 'RNN_RELU':
-        cell = RNNReLUCell
+        impl = torch._C._VariableFunctions.rnn_relu
     elif mode == 'RNN_TANH':
-        cell = RNNTanhCell
+        impl = torch._C._VariableFunctions.rnn_tanh
     elif mode == 'LSTM':
-        cell = LSTMCell
+        hidden_is_tensor = False
+        impl = torch._C._VariableFunctions.lstm
     elif mode == 'GRU':
-        cell = GRUCell
+        impl = torch._C._VariableFunctions.gru
     else:
         raise Exception('Unknown mode: {}'.format(mode))
 
-    rec_factory = variable_recurrent_factory if variable_length else Recurrent
-
-    if bidirectional:
-        layer = (rec_factory(cell), rec_factory(cell, reverse=True))
-    else:
-        layer = (rec_factory(cell),)
-
-    func = StackedRNN(layer,
-                      num_layers,
-                      (mode == 'LSTM'),
-                      dropout=dropout,
-                      train=train)
-
     def forward(input, weight, hidden, batch_sizes):
-        if batch_first and not variable_length:
-            input = input.transpose(0, 1)
-
-        nexth, output = func(input, hidden, weight, batch_sizes)
-
-        if batch_first and not variable_length:
-            output = output.transpose(0, 1)
-
-        return output, nexth
+        has_biases = len(weight[0]) == 4
+        weight = sum(weight, [])
+        if cudnn.is_acceptable(input):
+            dropout_seed = int(torch.IntTensor(1).random_())
+            with torch.cuda.device(input.get_device()):
+                dropout_ts = cudnn.rnn.init_dropout_state(dropout, train, dropout_seed, dropout_state)
+        else:
+            dropout_ts = None
+        if not variable_length:
+            result = impl(input, hidden, weight, has_biases, num_layers, dropout, train, bidirectional, batch_first, flat_weight, dropout_ts)
+        else:
+            result = impl(input, batch_sizes, hidden, weight, has_biases, num_layers, dropout, train, bidirectional, flat_weight, dropout_ts)
+        return result[0], (result[1] if hidden_is_tensor else result[1:])
 
     return forward
 
 
-def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
-             batch_first=False, dropout=0, train=True, bidirectional=False,
-             variable_length=False, dropout_state=None, flat_weight=None):
-    if dropout_state is None:
-        dropout_state = {}
-    mode = cudnn.rnn.get_cudnn_mode(mode)
-    # TODO: This is really goofy way of using the Torch RNG to get a random number
-    dropout_seed = int(torch.IntTensor(1).random_())
-    if flat_weight is None:
-        warnings.warn("RNN module weights are not part of single contiguous "
-                      "chunk of memory. This means they need to be compacted "
-                      "at every call, possibly greatly increasing memory usage. "
-                      "To compact weights again call flatten_parameters().", stacklevel=5)
-
-    def forward(input, weight, hx, batch_sizes):
-        if mode == cudnn.CUDNN_LSTM:
-            hx, cx = hx
-        else:
-            cx = None
-
-        handle = cudnn.get_handle()
-        with torch.cuda.device(input.get_device()):
-            dropout_ts = cudnn.rnn.init_dropout_state(dropout, train, dropout_seed, dropout_state)
-
-        weight_arr = list(itertools.chain.from_iterable(weight))
-        weight_stride0 = len(weight[0])
-
-        output, hy, cy, reserve, new_weight_buf = torch._cudnn_rnn(
-            input, weight_arr, weight_stride0,
-            flat_weight,
-            hx, cx,
-            mode, hidden_size, num_layers,
-            batch_first, dropout, train, bool(bidirectional),
-            list(batch_sizes.data) if variable_length else (),
-            dropout_ts)
-
-        if cx is not None:
-            return (output, (hy, cy))
-        else:
-            return (output, hy)
-
-    return forward
-
-
-def RNN(*args, **kwargs):
+def get_rnn_impl(*args, **kwargs):
 
     def forward(input, *fargs, **fkwargs):
-        if cudnn.is_acceptable(input.data):
-            func = CudnnRNN(*args, **kwargs)
-        else:
-            func = AutogradRNN(*args, **kwargs)
+        func = _select_rnn_impl(*args, **kwargs)
 
         # Hack for the tracer that allows us to represent RNNs as single
         # nodes and export them to ONNX in this form
@@ -309,13 +57,12 @@ def RNN(*args, **kwargs):
         # the lambda. We need special handling here because the forward()
         # function gets reconstructed each and every time when RNN() is invoked
         # and we don't want to pay the cost of decorator invocation
-        import torch
         if torch._C._get_tracing_state():
-            import torch.onnx.symbolic
-            sym = torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)
+            from torch.onnx import symbolic
+            sym = symbolic.RNN_symbolic_builder(*args, **kwargs)
             cell_type = args[0]
 
-            bound_symbolic = partial(torch.onnx.symbolic.rnn_trace_override_symbolic,
+            bound_symbolic = partial(symbolic.rnn_trace_override_symbolic,
                                      cell_type, func, sym)
 
             decorator = torch.onnx.symbolic_override(bound_symbolic)

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -13,8 +13,8 @@ except ImportError:
 
 
 def _select_rnn_impl(mode, input_size, hidden_size, num_layers=1, batch_first=False,
-                dropout=0, train=True, bidirectional=False, variable_length=False,
-                dropout_state=None, flat_weight=None):
+                     dropout=0, train=True, bidirectional=False, variable_length=False,
+                     dropout_state=None, flat_weight=None):
     hidden_is_tensor = True
     if mode == 'RNN_RELU':
         impl = torch._C._VariableFunctions.rnn_relu
@@ -30,7 +30,7 @@ def _select_rnn_impl(mode, input_size, hidden_size, num_layers=1, batch_first=Fa
 
     def forward(input, weight, hidden, batch_sizes):
         has_biases = len(weight[0]) == 4
-        weight = sum(weight, [])
+        weight = sum(weight, type(weight[0])())
         if cudnn.is_acceptable(input):
             dropout_seed = int(torch.IntTensor(1).random_())
             with torch.cuda.device(input.get_device()):
@@ -38,9 +38,11 @@ def _select_rnn_impl(mode, input_size, hidden_size, num_layers=1, batch_first=Fa
         else:
             dropout_ts = None
         if not variable_length:
-            result = impl(input, hidden, weight, has_biases, num_layers, dropout, train, bidirectional, batch_first, flat_weight, dropout_ts)
+            result = impl(input, hidden, weight, has_biases, num_layers, dropout, train, bidirectional,
+                          batch_first, flat_weight, dropout_ts)
         else:
-            result = impl(input, batch_sizes, hidden, weight, has_biases, num_layers, dropout, train, bidirectional, flat_weight, dropout_ts)
+            result = impl(input, batch_sizes, hidden, weight, has_biases, num_layers, dropout, train,
+                          bidirectional, flat_weight, dropout_ts)
         return result[0], (result[1] if hidden_is_tensor else result[1:])
 
     return forward

--- a/torch/nn/backends/thnn.py
+++ b/torch/nn/backends/thnn.py
@@ -20,14 +20,6 @@ def _get_thnn_function_backend():
 
 def _initialize_backend():
     from .._functions.thnn import _all_functions as _thnn_functions
-    from .._functions.rnn import RNN, \
-        RNNTanhCell, RNNReLUCell, GRUCell, LSTMCell
-
-    backend.register_function('RNN', RNN)
-    backend.register_function('RNNTanhCell', RNNTanhCell)
-    backend.register_function('RNNReLUCell', RNNReLUCell)
-    backend.register_function('LSTMCell', LSTMCell)
-    backend.register_function('GRUCell', GRUCell)
     for cls in _thnn_functions:
         name = cls.__name__
         backend.register_function(name, cls)


### PR DESCRIPTION
This is the first of two changes that are supposed to improve how we handle RNNs in the JIT. They still get traced as `PythonOp`s, but now it will be much easier to actually expose them to the JIT as e.g. `aten::lstm`, and ignore the Python interpreter entirely. This needs some symbolic adjustments that will be part of a second PR.

Even when we fix symbolics, there will still be a bit of a problem with statefulness of the cuDNN API (we need a mutable cache for the dropout state, but our IR has no way of representing that).

@zdevito @ezyang 