### PR TITLE
remove direct calls to graph executor

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -327,7 +327,7 @@ class TestJit(JitTestCase):
         m._create_method_from_graph("forward", graph)
         m_import = self.getExportImportCopy(m)
 
-        self.assertEqual(m.forward(*inputs), m_import.forward(*inputs))
+        self.assertEqual(m(*inputs), m_import(*inputs))
 
     def test_simple(self):
         x = torch.tensor([0.4], requires_grad=True)
@@ -1164,7 +1164,7 @@ class TestJit(JitTestCase):
         m._create_method_from_graph("forward", ge.graph())
         a, b = V(torch.rand(1), requires_grad=True), V(
             torch.rand(1), requires_grad=True)
-        r, = m.forward(a, b)
+        r, = m(a, b)
         da, db = torch.autograd.grad(r + 3, [a, b], create_graph=True)
 
         l2 = (da * db + db * db)
@@ -3445,12 +3445,12 @@ a")
         c = m2.weight.mm(input)
         d = m2.sub2.a.mm(input)
         ref = a + b + m2.bias + m2.sub.weight + a + c + d
-        self.assertEqual(ref, m2.forward(input))
+        self.assertEqual(ref, m2(input))
         m2.weight = nn.Parameter(torch.zeros_like(m2.weight))
         m2.bias = nn.Parameter(torch.zeros_like(m2.bias))
         m2.sub.weight = nn.Parameter(torch.zeros_like(m2.sub.weight))
         m2.sub2.a.data.zero_()
-        self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
+        self.assertEqual(torch.zeros(2, 2), m2(torch.randn(3, 2)))
 
     def test_script_module_call_noscript(self):
         class M(torch.jit.ScriptModule):
@@ -4391,7 +4391,7 @@ a")
         self.assertEqual(m_orig.doit(input), m_import.doit(input))
         self.assertEqual(m_orig.hi(input), m_import.hi(input))
         self.assertEqual(m_orig.doit3(input), m_import.doit3(input))
-        self.assertEqual(m_orig.forward(input), m_import.forward(input))
+        self.assertEqual(m_orig(input), m_import(input))
 
     @skipIfNoTorchVision
     def test_script_module_export_resnet18(self):

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -83,10 +83,12 @@ void initJITBindings(PyObject *module) {
    })
    .def("_jit_pass_lint", LintGraph)
    .def("_jit_pass_shape_analysis", [](Graph& graph, py::tuple inputs, bool with_grad) {
-     PropagateInputShapes(graph, ArgumentSpec(with_grad, evilDeprecatedBadCreateStackDoNotUse(inputs, graph.inputs())));
+     auto stack = createStackForGraph(graph, inputs);
+     PropagateInputShapes(graph, ArgumentSpec(with_grad, stack));
    })
    .def("_jit_pass_complete_shape_analysis", [](Graph& graph, py::tuple inputs, bool with_grad) {
-     PropagateInputShapes(graph, CompleteArgumentSpec(with_grad, evilDeprecatedBadCreateStackDoNotUse(inputs, graph.inputs())));
+     auto stack = createStackForGraph(graph, inputs);
+     PropagateInputShapes(graph, CompleteArgumentSpec(with_grad, stack));
    })
    .def("_jit_pass_remove_expands", RemoveExpands)
    .def("_jit_pass_erase_number_types", EraseNumberTypes)
@@ -198,7 +200,9 @@ void initJITBindings(PyObject *module) {
           py::arg("graph"),
           py::arg("optimize") = true)
       .def("graph_for", [](GraphExecutor& ge, py::args args) {
-        return ge.graphFor(evilDeprecatedBadCreateStackDoNotUse(args, ge.graph()->inputs()));
+        const auto & graph = ge.graph();
+        auto stack = createStackForGraph(*graph, args);
+        return ge.graphFor(stack);
       })
       .def_property_readonly("graph", [](GraphExecutor& ge) {
         return ge.graph();

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -205,7 +205,7 @@ void initJITBindings(PyObject *module) {
       })
      .def("get_debug_state", [](GraphExecutor& ge) {
         return ge.getDebugState();
-      })
+      });
 
     py::class_<PyTorchFileWriter>(m, "PyTorchFileWriter")
       .def(py::init<std::string>())

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -206,13 +206,6 @@ void initJITBindings(PyObject *module) {
      .def("get_debug_state", [](GraphExecutor& ge) {
         return ge.getDebugState();
       })
-      .def("__call__", [](GraphExecutor& ge, py::args args) -> py::object {
-        const auto & graph = ge.graph();
-        auto stack = evilDeprecatedBadCreateStackDoNotUse(args, graph->inputs());
-        ge.run(stack);
-        return createPyObjectForStack(std::move(stack));
-      });
-
 
     py::class_<PyTorchFileWriter>(m, "PyTorchFileWriter")
       .def(py::init<std::string>())

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -214,6 +214,15 @@ inline Stack createStackForSchema(
   return stack;
 }
 
+
+inline Stack createStackForGraph(const Graph& graph, py::args args) {
+  auto arguments = fmap(graph.inputs(), [](const Value *v) { return Argument(v->uniqueName(), v->type()); });
+  auto returns = fmap(graph.outputs(), [](const Value *v) { return Argument(v->uniqueName(), v->type()); });
+  auto schema = FunctionSchema("", arguments, returns);
+  auto stack = createStackForSchema(schema, args);
+  return stack;
+}
+
 inline py::object createPyObjectForStack(Stack&& stack) {
   if (stack.empty()) {
     return py::none();
@@ -232,20 +241,6 @@ inline py::object createPyObjectForStack(Stack&& stack) {
   }
 
   return return_values;
-}
-
-// TODO: Remove once we clean up the GraphExecutor usage.
-inline Stack evilDeprecatedBadCreateStackDoNotUse(const py::tuple& tuple, at::ArrayRef<Value*> inputs, size_t reserve_extra_space = 0) {
-  if (tuple.size() != inputs.size()) {
-    AT_ERROR("expected " + std::to_string(inputs.size()) +
-                             " inputs, but got " + std::to_string(tuple.size()));
-  }
-  Stack result;
-  result.reserve(tuple.size() + reserve_extra_space);
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    result.push_back(toIValue(std::move(tuple[i]), inputs[i]->type()));
-  }
-  return result;
 }
 
 inline py::object invokeScriptMethodFromPython(


### PR DESCRIPTION
Removing direct calls to graph executor, which uses "evilDeprecatedBadCreateStackDoNotUse"