### PR TITLE
Use intrusive_ptr in Storage; replace unique_ptr<Storage> with Storage

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -50,7 +50,7 @@
         - THTensor* self
         - THStorage* source
         - CONSTANT 0
-        - CONSTANT {static_cast<int64_t>(source.pImpl()->size())}
+        - CONSTANT {static_cast<int64_t>(source.size())}
         - CONSTANT {}
     - cname: setStorage
       arguments:

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -62,10 +62,7 @@ TensorImpl* SparseTensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
            " changing dimensionality via maybe_zero_dim");
   return this;
 }
-std::unique_ptr<Storage> SparseTensorImpl::storage() {
-  AT_ERROR("sparse tensors do not have storage");
-}
-at::StorageImpl* SparseTensorImpl::storageImpl() const {
+const Storage& SparseTensorImpl::storage() {
   AT_ERROR("sparse tensors do not have storage");
 }
 int64_t SparseTensorImpl::storage_offset() const {

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -64,8 +64,7 @@ public:
 
   int64_t dim() const override;
   TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override;
-  std::unique_ptr<Storage> storage() override;
-  at::StorageImpl* storageImpl() const override;
+  const Storage& storage() override;
   int64_t storage_offset() const override;
 
   // Some ops do some manual size fiddling.

--- a/aten/src/ATen/Storage.cpp
+++ b/aten/src/ATen/Storage.cpp
@@ -8,7 +8,7 @@ Storage::Storage(
     size_t size,
     Allocator* allocator,
     bool resizable)
-    : storage_impl_(new StorageImpl(scalar_type, size, allocator, resizable)) {}
+    : storage_impl_(c10::make_intrusive<StorageImpl>(scalar_type, size, allocator, resizable)) {}
 
 Storage::Storage(
     at::ScalarType scalar_type,
@@ -16,18 +16,11 @@ Storage::Storage(
     size_t size,
     const std::function<void(void*)>& deleter,
     bool resizable)
-    : storage_impl_(new StorageImpl(
+    : storage_impl_(c10::make_intrusive<StorageImpl>(
           scalar_type,
           size,
           std::move(data_ptr),
           /* allocator */ nullptr,
           resizable)) {}
-
-Storage::~Storage() {
-  if (!storage_impl_) {
-    return;
-  }
-  storage_impl_->release();
-}
 
 } // namespace at

--- a/aten/src/ATen/StorageImpl.cpp
+++ b/aten/src/ATen/StorageImpl.cpp
@@ -28,12 +28,4 @@ StorageImpl::StorageImpl(
           allocator,
           resizable) {}
 
-namespace detail {
-Backend get_backend(StorageImpl* storage_impl) {
-  if (storage_impl->data_ptr().device().is_cuda()) {
-    return Backend::CUDA;
-  }
-  return Backend::CPU;
-}
-} // namespace detail
 } // namespace at

--- a/aten/src/ATen/StorageImpl.h
+++ b/aten/src/ATen/StorageImpl.h
@@ -3,30 +3,11 @@
 #include <ATen/Allocator.h>
 #include <ATen/ScalarType.h>
 #include <ATen/ScalarTypeUtils.h>
-#include <ATen/Retainable.h>
 #include <TH/THTypeConversion.hpp>
-#include <atomic>
 
-// Note [Weak references for intrusive refcounting]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// Here's the scheme:
-//
-//  - refcount == number of strong references to the object
-//    weakcount == number of weak references to the object,
-//      plus one more if refcount > 0
-//
-//  - the underlying object stays live as long as there are any strong
-//    or weak pointers to it (weakcount > 0, since strong
-//    references count as a +1 to weakcount)
-//
-//  - underlying_object::release_resources() is called when refcount == 0
-//
-//  - the underlying object is destructed when weakcount == 0 (which implies
-//  refcount == 0)
-//
-//  - Once refcount == 0, it can never again be > 0 (the transition
-//    from > 0 to == 0 is monotonic)
-//
+#include <ATen/core/intrusive_ptr.h>
+
+#include <atomic>
 
 struct THFinalizer {
   virtual void operator()() = 0;
@@ -37,7 +18,7 @@ namespace at {
 
 struct Type;
 
-struct AT_API StorageImpl : public Retainable {
+struct AT_API StorageImpl : public c10::intrusive_ptr_target {
  public:
   StorageImpl() = delete;
   virtual ~StorageImpl() {};
@@ -55,9 +36,8 @@ struct AT_API StorageImpl : public Retainable {
   StorageImpl(StorageImpl&) = delete;
   StorageImpl(const StorageImpl&) = delete;
   // NB: Don't move ref count!
-  StorageImpl(StorageImpl&& other) = delete;
-  StorageImpl(const StorageImpl&&) = delete;
-  StorageImpl& operator=(StorageImpl&& other) = delete;
+  StorageImpl(StorageImpl&& other) = default;
+  StorageImpl& operator=(StorageImpl&& other) = default;
 
   // TODO: Rename this into th_data, and move it out of the class;
   // the real data shouldn't call th::from_type
@@ -79,7 +59,7 @@ struct AT_API StorageImpl : public Retainable {
     return static_cast<T*>(this->data_ptr_.get());
   }
 
-  void release_resources() {
+  void release_resources() override {
     if (finalizer_) {
       (*finalizer_)();
     }
@@ -89,7 +69,7 @@ struct AT_API StorageImpl : public Retainable {
 
   void operator=(const StorageImpl&) = delete;
 
-  virtual size_t elementSize() const {
+  size_t elementSize() const {
     return at::elementSize(scalar_type_);
   }
 
@@ -108,8 +88,13 @@ struct AT_API StorageImpl : public Retainable {
   at::DataPtr& data_ptr() {
     return data_ptr_;
   };
-  void set_data_ptr(at::DataPtr&& data_ptr) {
-    data_ptr_ = std::move(data_ptr);
+  const at::DataPtr& data_ptr() const {
+    return data_ptr_;
+  };
+  // Returns the previous data_ptr
+  at::DataPtr set_data_ptr(at::DataPtr&& data_ptr) {
+    std::swap(data_ptr_, data_ptr);
+    return std::move(data_ptr);
   };
   void* data() {
     return data_ptr_.get();
@@ -117,20 +102,89 @@ struct AT_API StorageImpl : public Retainable {
   const void* data() const {
     return data_ptr_.get();
   };
+  at::DeviceType device_type() const {
+    return data_ptr_.device().type();
+  }
   at::Allocator* allocator() {
     return allocator_;
   };
-  at::ScalarType& scalar_type() {
+  at::ScalarType scalar_type() const {
     return scalar_type_;
   };
   const at::Allocator* allocator() const {
     return allocator_;
   };
-  int getDevice() const {
-    return data_ptr_.device().index();
+  // You generally shouldn't use this method, but it is occasionally
+  // useful if you want to override how a tensor will be reallocated,
+  // after it was already allocated (and its initial allocator was
+  // set)
+  void set_allocator(at::Allocator* allocator) {
+    allocator_ = allocator;
+  }
+  Device device() const {
+    return data_ptr_.device();
   }
   void set_resizable(bool resizable) {
     resizable_ = resizable;
+  }
+
+  // You should only call these functions if you have a raw StorageImpl*
+  // pointer; if you have intrusive_ptr<StorageImpl> this will be
+  // handled automatically.
+  //
+  // TODO: Eliminate as many uses of these functions as humanly possible
+  void _raw_incref() {
+    auto ptr = c10::intrusive_ptr<StorageImpl>::reclaim(this);
+    auto ptr_copy = ptr;
+    ptr_copy.release();
+    ptr.release();
+  }
+  void _raw_decref() {
+    // Let it die
+    c10::intrusive_ptr<StorageImpl>::reclaim(this);
+    // NB: You still "have" a pointer, but it's now invalid.
+    // If you want more safety, used the actual c10::intrusive_ptr class
+  }
+  StorageImpl* _raw_make_weak() {
+    // NB: this is a strong reference
+    auto ptr = c10::intrusive_ptr<StorageImpl>::reclaim(this);
+    c10::weak_intrusive_ptr<StorageImpl> wptr(ptr);
+    ptr.release();
+    return wptr.release();
+  }
+  void _raw_weak_incweakref() {
+    // NB: this is a weak reference
+    auto wptr = c10::weak_intrusive_ptr<StorageImpl>::reclaim(this);
+    auto wptr_copy = wptr;
+    wptr_copy.release();
+    wptr.release();
+  }
+  void _raw_weak_decweakref() {
+    // NB: this is a weak reference
+    // Let it die
+    c10::weak_intrusive_ptr<StorageImpl>::reclaim(this);
+    // NB: You still "have" a pointer, but it's now invalid.
+    // If you want more safety, used the actual c10::weak_intrusive_ptr class
+  }
+  StorageImpl* _raw_weak_lock() {
+    auto wptr = c10::weak_intrusive_ptr<StorageImpl>::reclaim(this);
+    auto ptr = wptr.lock();
+    wptr.release();
+    return ptr.release();
+  }
+  // This gives the STRONG refcount of a STRONG pointer
+  uint32_t _raw_use_count() {
+    auto ptr = c10::intrusive_ptr<StorageImpl>::reclaim(this);
+    auto r = ptr.use_count();
+    ptr.release();
+    return r;
+  }
+  // This gives the STRONG refcount of a WEAK pointer
+  uint32_t _raw_weak_use_count() {
+    auto wptr = c10::weak_intrusive_ptr<StorageImpl>::reclaim(this);
+    auto r = wptr.use_count();
+    wptr.release();
+    return r;
   }
 
  private:
@@ -138,13 +192,7 @@ struct AT_API StorageImpl : public Retainable {
   at::DataPtr data_ptr_;
   ptrdiff_t size_;
   bool resizable_;
-
- public:
   at::Allocator* allocator_;
   std::unique_ptr<THFinalizer> finalizer_;
 };
-
-namespace detail {
-AT_API Backend get_backend(StorageImpl* storage_impl);
-}
 } // namespace at

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -60,35 +60,26 @@ void Tensor::backward(
 }
 
 TensorImpl::TensorImpl(TensorTypeId type_id, ScalarType scalar_type, bool is_variable)
-    : TensorImpl(nullptr, type_id, scalar_type, is_variable) {
+    : TensorImpl({}, type_id, scalar_type, is_variable) {
   // UndefinedTensors and SparseTensors don't have storages.
   if (type_id != UndefinedTensorId() && scalar_type != ScalarType::Undefined
       && type_id != SparseCPUTensorId() && type_id != SparseCUDATensorId()) {
     auto type = &globalContext().getType(tensorTypeIdToBackend(type_id), scalar_type);
-    auto storage = type->storage(true);
-    storage_ = storage->pImpl();
-    storage_->retain();
+    storage_ = type->storage(true);
   }
 }
 
-TensorImpl::TensorImpl(StorageImpl* storage, TensorTypeId type_id, bool is_variable)
-    : TensorImpl(storage, type_id, storage->scalar_type(), is_variable) {}
+TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable)
+    : TensorImpl(std::move(storage), type_id, storage.scalar_type(), is_variable) {}
 
-TensorImpl::TensorImpl(StorageImpl* storage, TensorTypeId type_id, ScalarType scalar_type, bool is_variable)
-    : storage_(storage),
+TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, ScalarType scalar_type, bool is_variable)
+    : storage_(std::move(storage)),
       storage_offset_(0),
       sizes_{0},
       strides_{1},
       type_id_(type_id),
       scalar_type_(scalar_type),
       is_variable_(is_variable) {}
-
-TensorImpl::~TensorImpl() {
-  if (storage_) {
-    storage_->release();
-    storage_ = nullptr;
-  }
-}
 
 IntList TensorImpl::sizes() const {
   return sizes_;
@@ -100,8 +91,7 @@ IntList TensorImpl::strides() const {
 
 void TensorImpl::release_resources() {
   if (storage_) {
-    storage_->release();
-    storage_ = nullptr;
+    storage_ = {};
   }
 }
 
@@ -127,9 +117,8 @@ TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
   return this;
 }
 
-std::unique_ptr<Storage> TensorImpl::storage() {
-  storage_->retain();
-  return std::unique_ptr<Storage>(new Storage(storage_));
+const Storage& TensorImpl::storage() {
+  return storage_;
 }
 
 } // namespace at

--- a/aten/src/ATen/UndefinedTensor.cpp
+++ b/aten/src/ATen/UndefinedTensor.cpp
@@ -25,12 +25,8 @@ int64_t UndefinedTensor::dim() const {
   AT_ERROR("dim() called on undefined Tensor");
 }
 
-std::unique_ptr<Storage> UndefinedTensor::storage() {
+const Storage& UndefinedTensor::storage() {
   AT_ERROR("storage() called on undefined Tensor");
-}
-
-at::StorageImpl* UndefinedTensor::storageImpl() const {
-  AT_ERROR("storageImpl() called on an undefined Tensor");
 }
 
 int64_t UndefinedTensor::storage_offset() const {

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -14,8 +14,7 @@ public:
   int64_t size(int64_t d) const override;
   int64_t stride(int64_t d) const override;
   int64_t dim() const override;
-  std::unique_ptr<Storage> storage() override;
-  at::StorageImpl* storageImpl() const override;
+  const Storage& storage() override;
   int64_t storage_offset() const override;
 private:
   UndefinedTensor();

--- a/aten/src/ATen/UndefinedType.cpp
+++ b/aten/src/ATen/UndefinedType.cpp
@@ -15,19 +15,19 @@ bool UndefinedType::is_cuda() const { return false; }
 bool UndefinedType::is_sparse() const { return false; }
 bool UndefinedType::is_distributed() const { return false; }
 
-std::unique_ptr<Storage> UndefinedType::storage(bool resizable) const {
+Storage UndefinedType::storage(bool resizable) const {
   AT_ERROR("storage not defined for UndefinedType");
 }
-std::unique_ptr<Storage> UndefinedType::storage(size_t size, bool resizable) const {
+Storage UndefinedType::storage(size_t size, bool resizable) const {
   AT_ERROR("storage(size_t) not defined for UndefinedType");
 }
-std::unique_ptr<Storage> UndefinedType::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
+Storage UndefinedType::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
   AT_ERROR("storageFromBlob not defined for UndefinedType");
 }
-std::unique_ptr<Storage> UndefinedType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
+Storage UndefinedType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   AT_ERROR("unsafeStorageFromTH not defined for UndefinedType");
 }
-std::unique_ptr<Storage> UndefinedType::storageWithAllocator(int64_t size, Allocator* allocator) const {
+Storage UndefinedType::storageWithAllocator(int64_t size, Allocator* allocator) const {
   AT_ERROR("storageWithAllocator not defined for UndefinedType");
 }
 Tensor UndefinedType::unsafeTensorFromTH(void * th_pointer, bool retain) const {

--- a/aten/src/ATen/UndefinedType.h
+++ b/aten/src/ATen/UndefinedType.h
@@ -19,10 +19,10 @@ struct UndefinedType final : public Type {
   virtual bool is_cuda() const override;
   virtual bool is_sparse() const override;
   virtual bool is_distributed() const override;
-  virtual std::unique_ptr<Storage> storage(bool resizable = false) const override;
-  virtual std::unique_ptr<Storage> storage(size_t size, bool resizable = false) const override;
-  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const override;
+  virtual Storage storage(bool resizable = false) const override;
+  virtual Storage storage(size_t size, bool resizable = false) const override;
+  virtual Storage storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
+  virtual Storage storageWithAllocator(int64_t size, Allocator* allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
   virtual size_t elementSizeInBytes() const override;
@@ -30,7 +30,7 @@ struct UndefinedType final : public Type {
   virtual Type & toScalarType(ScalarType s) const override;
   virtual TypeID ID() const override;
   static const char * typeString();
-  virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const override;
+  virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
   virtual Tensor & s_copy_(Tensor & self, const Tensor & src, bool non_blocking) const override;

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -26,17 +26,16 @@ namespace at {
 
 AT_API int _crash_if_asan(int);
 
-template <typename T>
-static inline T* checked_cast_storage(Storage* expr, const char * name, int pos, Backend backend, ScalarType scalar_type) {
-  if (at::detail::get_backend(expr->pImpl()) != backend) {
-    AT_ERROR("Expected object of backend ", backend, " but got backend ", at::detail::get_backend(expr->pImpl()),
+static inline const Storage& checked_storage(const Storage& expr, const char * name, int pos, DeviceType device_type, ScalarType scalar_type) {
+  if (expr.device_type() != device_type) {
+    AT_ERROR("Expected object of device type ", device_type, " but got device type ", expr.data_ptr().device().type(),
              " for argument #", pos, " '", name, "'");
   }
-  if (expr->pImpl()->scalar_type() != scalar_type) {
-    AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr->pImpl()->scalar_type(),
+  if (expr.scalar_type() != scalar_type) {
+    AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr.scalar_type(),
              " for argument #", pos, " '", name, "'");
   }
-  return static_cast<T*>(expr);
+  return expr;
 }
 
 template <typename T, typename Base>

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -208,7 +208,7 @@ TYPE_FORMAL_GENERIC = {
     'THIntegerTensor*': 'Tensor &',
     'THDenseTensor*': 'Tensor &',
     'THDenseIndexTensor*': 'Tensor &',
-    'THStorage*': 'Storage &',
+    'THStorage*': 'Storage',
     'THGenerator*': 'Generator *',
     'IntListSize': 'IntList',
     'accreal': 'Scalar',
@@ -288,9 +288,11 @@ CHECKED_CAST = {
             'Backend::${DenseBackend}, ScalarType::Long)'),
     'THStorage*':
         CodeTemplate(
-            'checked_cast_storage<Storage>('
-            '&${arg_name},"${arg_name}",${arg_pos}, '
-            'Backend::${Backend}, ScalarType::${ScalarName})'),
+            'checked_storage('
+            '${arg_name},"${arg_name}",${arg_pos}, '
+            # We're punning here (Backend and DeviceType constructors coincide)
+            # but DeviceType is the correct way to classify storages
+            'DeviceType::${Backend}, ScalarType::${ScalarName})'),
     'THGenerator*':
         CodeTemplate(
             'check_generator<${Backend}Generator>(${arg_name}, &globalContext().defaultGenerator(device_type()))'),
@@ -313,7 +315,7 @@ CHECKED_USE = {
     'THIntegerTensor*': '{}_',
     'THDenseTensor*': '{}_',
     'THDenseIndexTensor*': '{}_',
-    'THStorage*': '{}_->pImpl()',
+    'THStorage*': '{}_.unsafeGetStorageImpl()',
     'THGenerator*': '{}_->generator',
     'TensorList': "{0}_.data(), {0}_.size()",
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -139,11 +139,11 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  return self.type().tensor().set_(*self.storage(), storage_offset, size, stride);
+  return self.type().tensor().set_(self.storage(), storage_offset, size, stride);
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  return self.set_(*self.storage(), storage_offset, size, stride);
+  return self.set_(self.storage(), storage_offset, size, stride);
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride) {

--- a/aten/src/ATen/native/cuda/Gesv.cu
+++ b/aten/src/ATen/native/cuda/Gesv.cu
@@ -72,7 +72,7 @@ static inline magma_int_t magma_int_cast(int64_t value, const char* varname) {
 // Creates an array of size elements of type T, backed by pinned memory
 // wrapped in a Storage
 template<class T>
-static inline std::unique_ptr<Storage> pin_memory(int64_t size, Tensor dummy) {
+static inline Storage pin_memory(int64_t size, Tensor dummy) {
   int64_t adjusted_size = size * sizeof(T);
   auto* allocator = cuda::getPinnedMemoryAllocator();
   auto& backend = dummy.type().toBackend(Backend::CPU).toScalarType(kByte);
@@ -81,7 +81,7 @@ static inline std::unique_ptr<Storage> pin_memory(int64_t size, Tensor dummy) {
 
 #define ALLOCATE_ARRAY(name, type, size, dummy_tensor) \
   auto storage_##name = pin_memory<type>(size, dummy_tensor); \
-  name = reinterpret_cast<type*>(storage_##name->pImpl()->data());
+  name = static_cast<type*>(storage_##name.data());
 
 template <typename scalar_t>
 static void applyGesv(Tensor& b, Tensor& A, std::vector<int64_t> infos) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -459,7 +459,7 @@ namespace {
               mat_numel * num_linear_layers / 2, 1};
             // Generate a new parameter tensor which is a view into the
             // weight_buf.
-            Tensor param = weight_buf.type().tensor().set_(*weight_buf.storage(), offset, size);
+            Tensor param = weight_buf.type().tensor().set_(weight_buf.storage(), offset, size);
             params.emplace_back(std::move(param));
             layer_params_count++;
           } else {
@@ -1148,7 +1148,7 @@ Tensor try_get_weight_buf(
   // Try to get parameter storage
   auto & any_param = parameters.at(0);
   auto param_storage = any_param.storage();
-  auto weight_buf = any_param.type().tensor().set_(*param_storage);
+  auto weight_buf = any_param.type().tensor().set_(param_storage);
   if (weight_buf.size(0) < num_params) {
     return {};
   } else if (weight_buf.size(0) > num_params) {

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -39,22 +39,22 @@ bool ${Type}::is_cuda() const { return backend() == Backend::CUDA || backend() =
 bool ${Type}::is_sparse() const { return backend() == Backend::SparseCPU || backend() == Backend::SparseCUDA; }
 bool ${Type}::is_distributed() const { return false; }
 
-std::unique_ptr<Storage> ${Type}::storage(bool resizable) const {
+Storage ${Type}::storage(bool resizable) const {
   AT_ERROR("storage not supported on sparse");
 }
-std::unique_ptr<Storage> ${Type}::storage(size_t size, bool resizable) const {
+Storage ${Type}::storage(size_t size, bool resizable) const {
   AT_ERROR("storage not supported on sparse");
 }
-std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
+Storage ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
   AT_ERROR("storage not supported on sparse");
 }
-std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
+Storage ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
   AT_ERROR("storage not supported on sparse");
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   AT_ERROR("unsafeTensorFromTH not supported on sparse");
 }
-std::unique_ptr<Storage> ${Type}::unsafeStorageFromTH(void * th_pointer, bool retain) const {
+Storage ${Type}::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   AT_ERROR("unsafeTensorFromTH not supported on sparse");
 }
 std::unique_ptr<Generator> ${Type}::generator() const {

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -79,7 +79,7 @@ struct AT_API Tensor : public detail::TensorBase {
   Type & type() const {
     return pImpl->type();
   }
-  std::unique_ptr<Storage> storage() const {
+  const Storage& storage() const {
     return pImpl->storage();
   }
   inline Tensor toType(const Type & t, bool non_blocking=false) const;

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -81,14 +81,14 @@ Tensor Type::tensorFromBlob(void * data, IntList sizes, const std::function<void
 }
 Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter) const {
   auto storage = storageFromBlob(data, computeStorageSize(sizes, strides), deleter);
-  return tensor(*storage, 0, sizes, strides);
+  return tensor(storage, 0, sizes, strides);
 }
 Tensor Type::tensorWithAllocator(IntList sizes, Allocator* allocator) const {
   return tensorWithAllocator(sizes, defaultStrides(sizes), std::move(allocator));
 }
 Tensor Type::tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const {
   auto storage = storageWithAllocator(computeStorageSize(sizes, strides), std::move(allocator));
-  return tensor(*storage, 0, sizes, strides);
+  return tensor(storage, 0, sizes, strides);
 }
 Tensor Type::scalarTensor(Scalar s) const {
   if(s.isBackedByTensor())

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -57,13 +57,13 @@ struct AT_API Type {
   bool is_variable() const noexcept { return is_variable_; }
   bool is_undefined() const noexcept { return is_undefined_; }
   static void registerCPU(Context * context);
-  virtual std::unique_ptr<Storage> storage(bool resizable = false) const = 0;
-  virtual std::unique_ptr<Storage> storage(size_t size, bool resizable = false) const = 0;
-  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const = 0;
+  virtual Storage storage(bool resizable = false) const = 0;
+  virtual Storage storage(size_t size, bool resizable = false) const = 0;
+  virtual Storage storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
+  virtual Storage storageWithAllocator(int64_t size, Allocator* allocator) const = 0;
   virtual std::unique_ptr<Generator> generator() const = 0;
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
-  virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
+  virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
   virtual size_t elementSizeInBytes() const = 0;
   virtual Type & toBackend(Backend b) const;

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -50,8 +50,8 @@ bool ${Type}::is_cuda() const { return backend() == Backend::CUDA || backend() =
 bool ${Type}::is_sparse() const { return backend() == Backend::SparseCPU || backend() == Backend::SparseCUDA; }
 bool ${Type}::is_distributed() const { return false; }
 
-std::unique_ptr<Storage> ${Type}::storage(bool resizable) const {
-  return std::unique_ptr<Storage>(new Storage(
+Storage ${Type}::storage(bool resizable) const {
+  return Storage(
       ScalarType::${ScalarName},
       0,
 #if ${isCUDA}
@@ -60,10 +60,10 @@ std::unique_ptr<Storage> ${Type}::storage(bool resizable) const {
       getTHDefaultAllocator(),
 #endif
       resizable
-  ));
+  );
 }
-std::unique_ptr<Storage> ${Type}::storage(size_t size, bool resizable) const {
-  return std::unique_ptr<Storage>(new Storage(
+Storage ${Type}::storage(size_t size, bool resizable) const {
+  return Storage(
       ScalarType::${ScalarName},
       size,
 #if ${isCUDA}
@@ -72,25 +72,23 @@ std::unique_ptr<Storage> ${Type}::storage(size_t size, bool resizable) const {
       getTHDefaultAllocator(),
 #endif
       resizable
-  ));
+  );
 }
-std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
-    return std::unique_ptr<Storage>(
-      new Storage(
+Storage ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
+    return Storage(
       ScalarType::${ScalarName},
       InefficientStdFunctionContext::makeDataPtr(data, deleter,
 #if ${isCUDA}
-      Device(DeviceType::CUDA, getPointerDevice(data))
+        Device(DeviceType::CUDA, getPointerDevice(data))
 #else
-      DeviceType::CPU
+        DeviceType::CPU
 #endif
       ),
       size,
-      deleter));
+      deleter);
 }
-std::unique_ptr<Storage> ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
-    return std::unique_ptr<Storage>(
-        new Storage(ScalarType::${ScalarName}, size, allocator));
+Storage ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const {
+    return Storage(ScalarType::${ScalarName}, size, allocator);
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   TensorImpl* pimpl = (TensorImpl*)(th_pointer);
@@ -99,10 +97,10 @@ Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   }
   return Tensor(pimpl, false);
 }
-std::unique_ptr<Storage> ${Type}::unsafeStorageFromTH(void * th_pointer, bool retain) const {
+Storage ${Type}::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   if (retain)
     ${THStorage}_retain(${state,} (${THStorage}*) th_pointer);
-  return std::unique_ptr<Storage>(new Storage((${THStorage}*) th_pointer));
+  return Storage((${THStorage}*) th_pointer);
 }
 std::unique_ptr<Generator> ${Type}::generator() const {
   return std::unique_ptr<Generator>(new ${Generator}(context));

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -22,16 +22,16 @@ struct ${Type} final : public Type {
   virtual bool is_cuda() const override;
   virtual bool is_sparse() const override;
   virtual bool is_distributed() const override;
-  virtual std::unique_ptr<Storage> storage(bool resizable = false) const override;
-  virtual std::unique_ptr<Storage> storage(size_t size, bool resizable = false) const override;
-  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, Allocator* allocator) const override;
+  virtual Storage storage(bool resizable = false) const override;
+  virtual Storage storage(size_t size, bool resizable = false) const override;
+  virtual Storage storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
+  virtual Storage storageWithAllocator(int64_t size, Allocator* allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
   virtual size_t elementSizeInBytes() const override;
   virtual TypeID ID() const override;
   static const char * typeString();
-  virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const override;
+  virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
   // example

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -190,7 +190,7 @@ void test(Type &T) {
             auto lhs = ones(*lhs_it, T);
             auto rhs = ones(*rhs_it, T);
             auto storage = T.storage(rhs.numel(), false);
-            lhs.set_(*storage);
+            lhs.set_(storage);
             // should not be dim 0 because an empty storage is dim 1; all other storages aren't scalars
             REQUIRE(lhs.dim() != 0);
           }
@@ -199,7 +199,7 @@ void test(Type &T) {
             auto lhs = ones(*lhs_it, T);
             auto rhs = ones(*rhs_it, T);
             auto storage = T.storage(rhs.numel(), false);
-            lhs.set_(*storage, rhs.storage_offset(), rhs.sizes(), rhs.strides());
+            lhs.set_(storage, rhs.storage_offset(), rhs.sizes(), rhs.strides());
             require_equal_size_dim(lhs, rhs);
           }
         }

--- a/aten/src/TH/THStorageFunctions.cpp
+++ b/aten/src/TH/THStorageFunctions.cpp
@@ -1,4 +1,5 @@
 #include <climits>
+#include <ATen/core/intrusive_ptr.h>
 
 #include "THStorageFunctions.hpp"
 
@@ -15,11 +16,11 @@
 #include "THGenerateHalfType.h"
 
 THStorage* THStorage_new(at::ScalarType scalar_type) {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       scalar_type,
       0,
       getTHDefaultAllocator(),
-      true);
+      true).release();
   return storage;
 }
 
@@ -28,25 +29,7 @@ void THStorage_free(THStorage* storage) {
   if (!storage) {
     return;
   }
-  storage->release();
-}
-
-// Manually retains a weak reference
-void THStorage_weakRetain(THStorage *weak_storage) {
-  weak_storage->weak_retain();
-}
-
-// Releases a weak reference
-void THStorage_weakFree(THStorage *weak_storage) {
-  weak_storage->weak_release();
-}
-
-// Given a weak reference, returns a strong reference to a storage (which must
-// be freed when done) or null if the storage is already dead.
-THStorage* THStorage_weakLock(THStorage *weak_storage) {
-  if (weak_storage->weak_lock())
-    return weak_storage;
-  return nullptr;
+  storage->_raw_decref();
 }
 
 ptrdiff_t THStorage_size(const THStorage *self)
@@ -57,20 +40,19 @@ ptrdiff_t THStorage_size(const THStorage *self)
 void THStorage_retain(THStorage *storage)
 {
   if (storage) {
-    storage->retain();
+    storage->_raw_incref();
   }
 }
 
 void THStorage_resize(THStorage* storage, ptrdiff_t size) {
   if (storage->resizable()) {
     /* case when the allocator does not have a realloc defined */
-    at::DataPtr old_data;
-    std::swap(old_data, storage->data_ptr());
-    ptrdiff_t old_size = storage->size();
+    at::DataPtr new_data;
     if (size != 0) {
-      storage->set_data_ptr(
-          storage->allocator()->allocate(storage->elementSize() * size));
+      new_data = storage->allocator()->allocate(storage->elementSize() * size);
     }
+    at::DataPtr old_data = storage->set_data_ptr(std::move(new_data));
+    ptrdiff_t old_size = storage->size();
     storage->set_size(size);
     if (old_data != nullptr) {
       ptrdiff_t copy_size = old_size;

--- a/aten/src/TH/THStorageFunctions.h
+++ b/aten/src/TH/THStorageFunctions.h
@@ -19,4 +19,3 @@
 
 // This exists to have a data-type independent way of freeing (necessary for THPPointer).
 TH_API void THStorage_free(THStorage *storage);
-TH_API void THStorage_weakFree(THStorage *storage);

--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -38,6 +38,3 @@ TH_API ptrdiff_t THStorage_size(const THStorage *self);
 
 TH_API void THStorage_retain(THStorage *storage);
 TH_API void THStorage_resize(THStorage *storage, ptrdiff_t size);
-
-TH_API void THStorage_weakRetain(THStorage *weak_storage);
-TH_API THStorage* THStorage_weakLock(THStorage *weak_storage);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -30,7 +30,7 @@ inline THStorage* THTensor_getStoragePtr(const THTensor* tensor) {
   AT_CHECK(tensor->storage_, "Cannot use PyTorch operations on a half-constructed "
            "tensor.  If this tensor came from Caffe2, please call GetMutableData on "
            "it first; otherwise, this is a bug, please report it.");
-  return tensor->storage_;
+  return tensor->storage_.unsafeGetStorageImpl();
 }
 
 inline void THTensor_resizeDim(THTensor* tensor, int64_t ndim) {
@@ -127,12 +127,7 @@ inline void THTensor_setStorageOffset(THTensor* tensor, ptrdiff_t storage_offset
 }
 
 // NB: Steals ownership of storage
-inline void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
-  // Caffe2 might have tensors whose storages are null, but we
-  // don't allow it in PyTorch.
-  AT_ASSERT(storage);
-  tensor->storage_ = storage;
-}
+TH_API void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage);
 
 TH_API void THTensor_free(THTensor *self);
 TH_API void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride);

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -26,22 +26,22 @@ THStorage* THStorage_(new)(void)
 
 THStorage* THStorage_(newWithSize)(ptrdiff_t size)
 {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<th::from_type<real>>::to(),
       size,
       getTHDefaultAllocator(),
-      true);
+      true).release();
   return storage;
 }
 
 THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                         at::Allocator *allocator)
 {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<th::from_type<real>>::to(),
       size,
       allocator,
-      true);
+      true).release();
   return storage;
 }
 
@@ -50,13 +50,13 @@ THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int 
 {
   auto scalar_type = at::CTypeToScalarType<th::from_type<real>>::to();
   size_t actual_size = -1;
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       scalar_type,
       size,
       THMapAllocator::makeDataPtr(
           filename, flags, size * at::elementSize(scalar_type), &actual_size),
       /* allocator */ nullptr,
-      false);
+      false).release();
 
   if (size <= 0) {
     storage->set_size(actual_size / at::elementSize(scalar_type));
@@ -115,12 +115,12 @@ void THStorage_(free)(THStorage *storage)
 
 THStorage* THStorage_(newWithDataAndAllocator)(at::DataPtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<th::from_type<real>>::to(),
       size,
       std::move(data),
       allocator,
-      true);
+      true).release();
   return storage;
 }
 
@@ -150,16 +150,7 @@ real THStorage_(get)(const THStorage *self, ptrdiff_t idx)
 
 void THStorage_(swap)(THStorage *storage1, THStorage *storage2)
 {
-  std::swap(storage1->scalar_type(), storage2->scalar_type());
-  std::swap(storage1->data_ptr(), storage2->data_ptr());
-  ptrdiff_t tmp_size = storage1->size();
-  storage1->set_size(storage2->size());
-  storage2->set_size(tmp_size);
-  bool tmp_bool = storage1->resizable();
-  storage1->set_resizable(storage2->resizable());
-  storage2->set_resizable(tmp_bool);
-  std::swap(storage1->allocator_, storage2->allocator_);
-  std::swap(storage1->finalizer_, storage2->finalizer_);
+  std::swap(*storage1, *storage2);
 }
 
 #endif

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -8,6 +8,8 @@
 #include "generic/THCStorage.cpp"
 #include "THCGenerateAllTypes.h"
 
+#include <ATen/core/intrusive_ptr.h>
+
 void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
 {
   THArgCheck(size >= 0, 2, "invalid size");
@@ -48,16 +50,16 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
 }
 
 int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
-  return storage->getDevice();
+  return storage->device().index();
 }
 
 THC_API THCStorage* THCStorage_new(
     THCState* state,
     at::ScalarType scalar_type) {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       scalar_type,
       0,
       state->cudaDeviceAllocator,
-      true);
+      true).release();
   return storage;
 }

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -190,11 +190,10 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
       THError("Tensor: invalid null storage");
     }
     auto scalar_type = THTensor_getStoragePtr(self)->scalar_type();
-    THStorage_free(THTensor_getStoragePtr(self));
 
     if (storage) {
+      storage->_raw_incref();
       THTensor_stealAndSetStoragePtr(self, storage);
-      THStorage_retain(THTensor_getStoragePtr(self));
     } else {
       THTensor_stealAndSetStoragePtr(self, THCStorage_new(state, scalar_type));
     }

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/THCStorage.cpp"
 #else
 
+#include <ATen/core/intrusive_ptr.h>
+
 real* THCStorage_(data)(THCState *state, const THCStorage *self)
 {
   return self->data<real>();
@@ -40,32 +42,32 @@ real THCStorage_(get)(THCState *state, const THCStorage *self, ptrdiff_t index)
 
 THCStorage* THCStorage_(new)(THCState *state)
 {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<real>::to(),
       0,
       state->cudaDeviceAllocator,
-      true);
+      true).release();
   return storage;
 }
 
 THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<real>::to(),
       size,
       state->cudaDeviceAllocator,
-      true);
+      true).release();
   return storage;
 }
 
 THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
                                           at::Allocator* allocator)
 {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<real>::to(),
       size,
       allocator,
-      true);
+      true).release();
   return storage;
 }
 
@@ -114,12 +116,12 @@ THCStorage* THCStorage_(newWithDataAndAllocator)(
     at::DataPtr&& data,
     ptrdiff_t size,
     at::Allocator* allocator) {
-  THStorage* storage = new THStorage(
+  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
       at::CTypeToScalarType<real>::to(),
       size,
       std::move(data),
       allocator,
-      true);
+      true).release();
   return storage;
 }
 

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -110,7 +110,7 @@ TEST_CASE("rnn") {
     LSTM model(2, 2);
     for (auto& v : model->parameters()) {
       float size = v->numel();
-      auto p = static_cast<float*>(v->storage()->pImpl()->data());
+      auto p = static_cast<float*>(v->storage().data());
       for (size_t i = 0; i < size; i++) {
         p[i] = i / size;
       }
@@ -118,7 +118,7 @@ TEST_CASE("rnn") {
 
     auto x = torch::empty({3, 4, 2}, torch::requires_grad());
     float size = x.numel();
-    auto p = static_cast<float*>(x.storage()->pImpl()->data());
+    auto p = static_cast<float*>(x.storage().data());
     for (size_t i = 0; i < size; i++) {
       p[i] = (size - i) / size;
     }

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -321,8 +321,6 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 body.append('auto {} = {};'.format(name, expr))
                 expr = name
 
-            if typename == 'Storage &':
-                expr = '*' + expr
             if typename == 'SparseTensorRef':
                 expr = 'SparseTensorRef({})'.format(expr)
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -59,19 +59,19 @@ bool VariableType::is_cuda() const { return baseType->is_cuda(); }
 bool VariableType::is_sparse() const { return baseType->is_sparse(); }
 bool VariableType::is_distributed() const { return baseType->is_distributed(); }
 
-std::unique_ptr<Storage> VariableType::storage(bool resizable) const {
+Storage VariableType::storage(bool resizable) const {
   return baseType->storage();
 }
-std::unique_ptr<Storage> VariableType::storage(size_t size, bool resizable) const {
+Storage VariableType::storage(size_t size, bool resizable) const {
   return baseType->storage(size);
 }
-std::unique_ptr<Storage> VariableType::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
+Storage VariableType::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
   return baseType->storageFromBlob(data, size, deleter);
 }
-std::unique_ptr<Storage> VariableType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
+Storage VariableType::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   return baseType->unsafeStorageFromTH(th_pointer, retain);
 }
-std::unique_ptr<Storage> VariableType::storageWithAllocator(int64_t size, Allocator* allocator) const {
+Storage VariableType::storageWithAllocator(int64_t size, Allocator* allocator) const {
   return baseType->storageWithAllocator(size, allocator);
 }
 Tensor VariableType::unsafeTensorFromTH(void * th_pointer, bool retain) const {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -37,10 +37,10 @@ struct TORCH_API VariableType final : public at::Type {
   virtual bool is_cuda() const override;
   virtual bool is_sparse() const override;
   virtual bool is_distributed() const override;
-  virtual std::unique_ptr<at::Storage> storage(bool resizable = false) const override;
-  virtual std::unique_ptr<at::Storage> storage(size_t size, bool resizable = false) const override;
-  virtual std::unique_ptr<at::Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
-  virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, at::Allocator* allocator) const override;
+  virtual Storage storage(bool resizable = false) const override;
+  virtual Storage storage(size_t size, bool resizable = false) const override;
+  virtual Storage storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
+  virtual Storage storageWithAllocator(int64_t size, at::Allocator* allocator) const override;
   virtual std::unique_ptr<at::Generator> generator() const override;
   virtual const char * toString() const override;
   virtual at::TypeID ID() const override;
@@ -48,7 +48,7 @@ struct TORCH_API VariableType final : public at::Type {
   virtual at::Type & toBackend(at::Backend b) const override;
   virtual at::Type & toScalarType(at::ScalarType s) const override;
   static const char * typeString();
-  virtual std::unique_ptr<at::Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const override;
+  virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual at::Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
   static at::Type* getType(const at::Type& baseType);

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -476,7 +476,7 @@ static PyObject * THPVariable_storage(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  return createPyObject(*self_.storage());
+  return createPyObject(self_.storage());
   END_HANDLE_TH_ERRORS
 }
 
@@ -484,7 +484,7 @@ static PyObject * THPVariable_storage_type(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  auto storage = THPObjectPtr(createPyObject(*self_.storage()));
+  auto storage = THPObjectPtr(createPyObject(self_.storage()));
   auto storage_type = (PyObject*)Py_TYPE(storage);
   Py_INCREF(storage_type);
   return storage_type;

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -70,7 +70,7 @@ at::Type* get_type(const std::string& name, bool is_cuda, bool is_sparse) {
 PyTypeObject* getPyTypeObject(const at::Storage& storage)
 {
   auto attype = at::globalContext().getTypeOpt(
-      at::detail::get_backend(storage.pImpl()), storage.pImpl()->scalar_type());
+      deviceTypeToBackend(storage.device_type()), storage.scalar_type());
   auto it = attype_to_py_storage_type.find(attype);
   if (it != attype_to_py_storage_type.end()) {
     return it->second;
@@ -136,7 +136,7 @@ PyObject* createPyObject(const at::Storage& storage)
   auto type = getPyTypeObject(storage);
   auto obj = THPObjectPtr(type->tp_alloc(type, 0));
   if (!obj) throw python_error();
-  ((THPVoidStorage*)obj.get())->cdata = (THVoidStorage *)storage.retained_pImpl();
+  ((THPVoidStorage*)obj.get())->cdata = (THVoidStorage *)at::Storage(/* copy */ storage).unsafeReleaseStorageImpl();
   return obj.release();
 }
 
@@ -144,7 +144,7 @@ bool isStorage(PyObject* obj)
 {
   return py_storage_type_to_attype.count(Py_TYPE(obj));
 }
-std::unique_ptr<at::Storage> createStorage(PyObject* obj)
+at::Storage createStorage(PyObject* obj)
 {
   auto it = py_storage_type_to_attype.find(Py_TYPE(obj));
   if (it == py_storage_type_to_attype.end()) {

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -29,7 +29,7 @@ void registerDtypeObject(THPDtype *dtype, at::ScalarType scalarType);
 void registerLayoutObject(THPLayout *layout, at::Backend backend);
 
 PyObject* createPyObject(const at::Storage& storage);
-std::unique_ptr<at::Storage> createStorage(PyObject* obj);
+at::Storage createStorage(PyObject* obj);
 bool isStorage(PyObject* obj);
 
 THPDtype* getDtype(at::ScalarType scalarType);

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -64,12 +64,8 @@ const char* Variable::Impl::typeString() {
   return "VariableType";
 }
 
-std::unique_ptr<at::Storage> Variable::Impl::storage() {
+const at::Storage& Variable::Impl::storage() {
   return data_.storage();
-}
-
-at::StorageImpl* Variable::Impl::storageImpl() const {
-  return data_.unsafeGetTensorImpl()->storageImpl();
 }
 
 int64_t Variable::Impl::storage_offset() const {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -273,8 +273,7 @@ struct Variable::Impl : public at::TensorImpl {
   int64_t stride(int64_t d) const override;
 
   int64_t dim() const override;
-  std::unique_ptr<at::Storage> storage() override;
-  at::StorageImpl* storageImpl() const override;
+  const at::Storage& storage() override;
   int64_t storage_offset() const override;
 
   static const char* typeString();

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -215,9 +215,9 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
-  at::DeviceGuard device_guard(storage->getDevice());
+  at::DeviceGuard device_guard(storage->device());
   THPObjectPtr tuple(PyTuple_New(4));
-  THPObjectPtr device(PyLong_FromLong(storage->getDevice()));
+  THPObjectPtr device(PyLong_FromLong(storage->device().index()));
   THPObjectPtr _handle(Py_None);
   Py_INCREF(Py_None);
   THPObjectPtr size(PyLong_FromLong(storage->size()));
@@ -294,8 +294,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 static PyObject * THPStorage_(weakRef)(THPStorage *self, PyObject *args) {
   HANDLE_TH_ERRORS
   THStorage* storage = self->cdata;
-  THStorage_weakRetain(storage);
-  return PyLong_FromVoidPtr(storage);
+  return PyLong_FromVoidPtr(storage->_raw_make_weak());
   END_HANDLE_TH_ERRORS
 }
 
@@ -305,7 +304,7 @@ PyObject * THPStorage_(newWithWeakPtr)(PyObject *_unused, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg),
       "_new_with_weak_ptr(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  if (auto* storage = THStorage_weakLock(weak_storage)) {
+  if (auto* storage = weak_storage->_raw_weak_lock()) {
     return THPStorage_(New)(storage);
   }
   Py_RETURN_NONE;
@@ -321,7 +320,7 @@ PyObject * THPStorage_(freeWeakRef)(PyObject *_unused, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg),
       "_free_weak_ref(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  THStorage_weakFree(weak_storage);
+  weak_storage->_raw_weak_decweakref();
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -332,7 +331,7 @@ PyObject * THPStorage_(expired)(PyObject *_unused, PyObject *arg)
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "_expired(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  return PyBool_FromLong(weak_storage->use_count() == 0);
+  return PyBool_FromLong(weak_storage->_raw_weak_use_count() == 0);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -617,26 +617,26 @@ void ModuleEncoder::EncodeTensor(
     onnx::TensorProto *tensor_proto,
     const at::Tensor &tensor,
     const at::optional<std::string> external_ref = {}) {
-  auto storage_ptr = tensor.storage()->pImpl();
+  auto storage_ptr = tensor.storage().unsafeGetStorageImpl();
   auto dedup_it = storage_dedup_map_.find(storage_ptr);
   if (dedup_it != storage_dedup_map_.end()) {
     tensor_proto->add_int64_data(dedup_it->second);
   } else {
     at::Tensor t = tensor;
-    if (at::detail::get_backend(tensor.storage()->pImpl()) == at::Backend::CUDA) {
+    if (tensor.storage().device_type() == at::DeviceType::CUDA) {
       // NB: This new tensor is created to support cuda tensors.
       // Storages can be mutated when converting tensors from cuda to cpu,
       // and we need a cpu tensor to copy data from.
       t = tensor.type().tensor(
-          *tensor.storage(),
+          tensor.storage(),
           /* storageOffset = */ 0,
-          /* size = */ { static_cast<int64_t>(tensor.type().elementSizeInBytes() * tensor.storage()->pImpl()->size()) },
+          /* size = */ { static_cast<int64_t>(tensor.type().elementSizeInBytes() * tensor.storage().size()) },
           /* strides = */ { 1 })
         .cpu();
     }
 
     auto record_number = file_writer_.writeRecord(
-      static_cast<char*>(t.storage()->pImpl()->data()), t.type().elementSizeInBytes() * t.numel());
+      static_cast<char*>(t.storage().data()), t.type().elementSizeInBytes() * t.numel());
     tensor_proto->add_int64_data(record_number);
     storage_dedup_map_[storage_ptr] = record_number;
   }

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -67,8 +67,8 @@ at::Tensor DecoderBase::buildTensor(const onnx::TensorProto& tensor_proto) {
   tensor.resize_(sizes);
 
   JIT_ASSERT(
-      tensor.storage()->pImpl()->size() *
-          tensor.storage()->pImpl()->elementSize() ==
+      tensor.storage().size() *
+          tensor.storage().elementSize() ==
       tensor_proto.raw_data().size());
 
   std::memcpy(tensor.data_ptr(), tensor_proto.raw_data().data(), tensor_proto.raw_data().size());
@@ -301,7 +301,7 @@ at::Tensor ModuleDecoder::buildTensorCommon(
     auto storage = std::make_shared<at::Tensor>(at::CPU(type).tensor());
     auto record = file_reader_.getRecordWithKey(record_number);
     storage->resize_({ static_cast<int64_t>(std::get<1>(record)) });
-    std::memcpy(storage->storage()->pImpl()->data(), std::get<0>(record).get(), std::get<1>(record));
+    std::memcpy(storage->storage().data(), std::get<0>(record).get(), std::get<1>(record));
     storage_map_.insert(std::make_pair(record_number, storage));
     storage_tensor = storage.get();
   } else {
@@ -309,7 +309,7 @@ at::Tensor ModuleDecoder::buildTensorCommon(
   }
 
   return at::CPU(onnxTypeToATenType(tensor_proto.data_type())).tensor(
-      *storage_tensor->storage().get(), storage_offset, dims, strides);
+      storage_tensor->storage(), storage_offset, dims, strides);
 }
 
 // Given a full name of a parameter or method,

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -349,7 +349,7 @@ public:
   virtual int64_t dim() const override {
     throw std::runtime_error("dim() on ContainerTensor");
   }
-  virtual std::unique_ptr<at::Storage> storage() override {
+  virtual const at::Storage& storage() override {
     throw std::runtime_error("storage() on ContainerTensor");
   }
 };

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -120,7 +120,7 @@ struct PythonArgs {
   inline std::vector<int64_t> intlist(int i);
   inline std::vector<int64_t> intlistWithDefault(int i, std::vector<int64_t> default_intlist);
   inline at::Generator* generator(int i);
-  inline std::unique_ptr<at::Storage> storage(int i);
+  inline at::Storage storage(int i);
   inline at::ScalarType scalartype(int i);
   inline at::ScalarType scalartypeWithDefault(int i, at::ScalarType default_scalartype);
   inline at::optional<at::ScalarType> scalartypeOptional(int i);
@@ -428,7 +428,7 @@ inline at::Generator* PythonArgs::generator(int i) {
   return reinterpret_cast<THPGenerator*>(args[i])->cdata;
 }
 
-inline std::unique_ptr<at::Storage> PythonArgs::storage(int i) {
+inline at::Storage PythonArgs::storage(int i) {
   if (!args[i]) return nullptr;
   return createStorage(args[i]);
 }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -71,7 +71,7 @@ Tensor new_with_sizes(const Type& type, int32_t device_index, IntList sizes) {
   return torch::empty(sizes, TensorOptions(type, device_index));
 }
 
-Tensor new_with_storage(const Type& type, Storage& storage) {
+Tensor new_with_storage(const Type& type, Storage storage) {
   auto tensor = at::empty({}, type);
   tensor.set_(storage);
   return tensor;
@@ -344,7 +344,7 @@ Tensor legacy_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
     at::DeviceGuard device_guard(r.device(0));
     return type.tensor();
   } else if (r.idx == 1) {
-    return new_with_storage(type, *r.storage(0));
+    return new_with_storage(type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return type.unsafeTensorFromTH(cdata, true);
@@ -384,7 +384,7 @@ Tensor legacy_tensor_new(const Type& type, PyObject* args, PyObject* kwargs) {
     at::DeviceGuard device_guard(r.device(0));
     return type.tensor();
   } else if (r.idx == 1) {
-    return new_with_storage(type, *r.storage(0));
+    return new_with_storage(type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return type.unsafeTensorFromTH(cdata, true);

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -79,7 +79,8 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   if (PyArray_SetBaseObject((PyArrayObject*)array.get(), py_tensor) == -1) {
     return NULL;
   }
-  tensor.storage()->pImpl()->set_resizable(false);
+  // Use the private storage API
+  tensor.storage().unsafeGetStorageImpl()->set_resizable(false);
 
   return array.release();
 }

--- a/torch/lib/THD/master_worker/worker/Dispatch.cpp
+++ b/torch/lib/THD/master_worker/worker/Dispatch.cpp
@@ -31,8 +31,8 @@ at::Tensor& unpackRetrieveTensor(rpc::RPCMessage& message) {
   return workerTensors.at(unpackTensor(message));
 }
 
-at::Storage* unpackRetrieveStorage(rpc::RPCMessage& message) {
-  return workerStorages.at(unpackStorage(message)).get();
+at::Storage& unpackRetrieveStorage(rpc::RPCMessage& message) {
+  return workerStorages.at(unpackStorage(message));
 }
 
 at::Generator* unpackRetrieveGenerator(rpc::RPCMessage& message) {

--- a/torch/lib/THD/master_worker/worker/Worker.cpp
+++ b/torch/lib/THD/master_worker/worker/Worker.cpp
@@ -12,7 +12,7 @@ namespace worker {
 
 std::unique_ptr<WorkerCommandChannel> workerCommandChannel;
 std::unordered_map<object_id_type, at::Tensor> workerTensors;
-std::unordered_map<object_id_type, std::unique_ptr<at::Storage>> workerStorages;
+std::unordered_map<object_id_type, at::Storage> workerStorages;
 std::unordered_map<object_id_type, std::unique_ptr<at::Generator>> workerGenerators;
 
 } // namespace worker

--- a/torch/lib/THD/master_worker/worker/Worker.hpp
+++ b/torch/lib/THD/master_worker/worker/Worker.hpp
@@ -9,7 +9,7 @@ namespace thd { namespace worker {
 extern std::unique_ptr<WorkerCommandChannel> workerCommandChannel;
 extern std::unordered_map<object_id_type, at::Tensor>
   workerTensors;
-extern std::unordered_map<object_id_type, std::unique_ptr<at::Storage>>
+extern std::unordered_map<object_id_type, at::Storage>
   workerStorages;
 extern std::unordered_map<object_id_type, std::unique_ptr<at::Generator>>
   workerGenerators;

--- a/torch/lib/THD/master_worker/worker/dispatch/Storage.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/Storage.cpp
@@ -1,4 +1,4 @@
-static std::unique_ptr<at::Storage> createStorage(RPCType type) {
+static at::Storage createStorage(RPCType type) {
   if (type == RPCType::UCHAR)
     return at::getType(at::Backend::CPU, at::ScalarType::Byte).storage();
   else if (type == RPCType::CHAR)
@@ -16,14 +16,14 @@ static std::unique_ptr<at::Storage> createStorage(RPCType type) {
   throw std::invalid_argument("passed character doesn't represent a storage type");
 }
 
-static std::unique_ptr<at::Storage> createStorage(RPCType type, size_t size) {
-  std::unique_ptr<at::Storage> storage = createStorage(type);
+static at::Storage createStorage(RPCType type, size_t size) {
+  at::Storage storage = createStorage(type);
   storage->resize(size);
   return storage;
 }
 
 static void storageSet(rpc::RPCMessage& raw_message) {
-  at::Storage *storage = unpackRetrieveStorage(raw_message);
+  at::Storage& storage = unpackRetrieveStorage(raw_message);
   ptrdiff_t offset = unpackInteger(raw_message);
   RPCType type = peekType(raw_message);
   if (isInteger(type)) {
@@ -40,7 +40,7 @@ static void storageSet(rpc::RPCMessage& raw_message) {
 }
 
 static void storageGet(rpc::RPCMessage& raw_message) {
-  at::Storage *storage = unpackRetrieveStorage(raw_message);
+  at::Storage& storage = unpackRetrieveStorage(raw_message);
   ptrdiff_t offset = unpackInteger(raw_message);
   RPCType type = unpackType(raw_message);
   finalize(raw_message);
@@ -79,7 +79,7 @@ static void storageNewWithSize(rpc::RPCMessage& raw_message) {
 static void storageNewWithSizeN(rpc::RPCMessage& raw_message, size_t size) {
   RPCType storage_type = unpackType(raw_message);
   object_id_type storage_id = unpackStorage(raw_message);
-  std::unique_ptr<at::Storage> storage = createStorage(storage_type, size);
+  at::Storage storage = createStorage(storage_type, size);
   RPCType value_type = peekType(raw_message);
   if (isInteger(value_type)) {
     int64_t values[size];
@@ -128,7 +128,7 @@ static void storageFree(rpc::RPCMessage& raw_message) {
 }
 
 static void storageResize(rpc::RPCMessage& raw_message) {
-  at::Storage *storage = unpackRetrieveStorage(raw_message);
+  at::Storage& storage = unpackRetrieveStorage(raw_message);
   int64_t new_size = unpackInteger(raw_message);
   finalize(raw_message);
   storage->resize(new_size);

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -96,7 +96,7 @@ inline std::vector<int> getDevices(const std::vector<at::Tensor>& tensors) {
   std::vector<int> devices(tensors.size(), -1);
   if (tensors[0].type().is_cuda()) {
     for (size_t i = 0; i < tensors.size(); i++) {
-      devices[i] = tensors[i].storage()->pImpl()->getDevice();
+      devices[i] = tensors[i].storage().device().index();
     }
   }
   return devices;
@@ -106,7 +106,8 @@ template <typename T>
 std::vector<T*> getDataPointers(const std::vector<at::Tensor>& tensors) {
   std::vector<T*> ptrs(tensors.size());
   for (size_t i = 0; i < tensors.size(); i++) {
-    ptrs[i] = static_cast<T*>(tensors[i].storage()->pImpl()->data());
+    // NB: This does NOT respect storage_offset from the tensor
+    ptrs[i] = static_cast<T*>(tensors[i].storage().data());
   }
   return ptrs;
 }


### PR DESCRIPTION
```
Use intrusive_ptr in Storage; replace unique_ptr<Storage> with Storage

This patch does two major changes:

- It replaces the use of Retainable in Storage with a new implementation
  based on intrusive_ptr.  This will be necessary because Caffe2 will
  be using this class to implement intrusive_ptrs, and we need to
  line these up for the merge.  One good thing about the new implementation is
  that the default copy/move constructors/assignment operators and destructor
  work automatically, instead of needing to be hardcoded into Storage/Tensor.

- It replaces all places where we returned std::unique_ptr<Storage> with
  Storage, collapsing an unnecessary double indirection that is no longer
  necessary now that we have correctly working copy/move constructors.

I didn't initially want to do step (2), but it was very important to
eliminate all bare uses of new Storage and new StorageImpl, and this making
the API change was the most straightforward way to do this.

HOW TO FIX YOUR CODE IN THE NEW API

- You no longer need to dereference the result of tensor.storage() to pass
  it to set.  So, instead of:

      x.set_(*y.storage());

  just write:

      x.set_(y.storage());

- If you were accessing methods on StorageImpl via the pImpl() method, you
  must use the dot operator to run pImpl().  Even better; just drop pImpl,
  we now have method forwarding.  So, instead of:

      storage->pImpl()->data();

  just do:

      storage->data();
      // storage.pImpl()->data() works too but is not as recommended

MISC CODE UPDATES

- retain, release, weak_retain, weak_release and weak_lock are now
  reimplemented using the "blessed API"

- nvcc OS X and general OS X portability improvements to intrusive_ptr

- A new comment in intrusive_ptr describing how stack allocated
  intrusive_ptr_targets work differently than heap allocated ones
  from c10::make_intrusive

CAVEAT EMPTOR

- THStorage_weakRetain used to work on strong pointers, but it NO LONGER
  works with intrusive_ptr.  You must reclaim the strong pointer into a
  real strong pointer, construct a weak pointer from it, and then release
  the strong and weak pointers.  See StorageSharing.cpp for an example.
```