### PR TITLE
set coalesced=false at sparse transpose() and removed transpose invariants

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -6,6 +6,7 @@
 #include "ATen/WrapDimUtils.h"
 #include "ATen/core/Error.h"
 #include "ATen/core/optional.h"
+#include <ATen/native/sparse/SparseUtils.h>
 
 #include <algorithm>
 #include <vector>
@@ -388,6 +389,8 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
     tmp.copy_(row0);
     row0.copy_(row1);
     row1.copy_(tmp);
+
+    _get_sparse_impl(self)->set_coalesced(false);
 
     auto sizes = self.sizes().vec();
     std::swap(sizes[dim0], sizes[dim1]);

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -367,28 +367,23 @@ class TestSparse(TestCase):
             y = y.transpose(i, j)
             self.assertEqual(self.safeToDense(x), y)
 
-    def test_transpose_coalesce_invariant(self):
-        # If a sparse tensor is coalesced, its transpose should be the same
-        # If a sparse tensor is uncoalesed, its transpose should be the same
-        x_coalesced = self._gen_sparse(2, 3, 4)[0].coalesce()
-        x_indices = x_coalesced._indices()
-        x_values = x_coalesced._values()
+    @cpu_only
+    def test_coalesce_transpose_mm(self):
+        def test_shape(di, dj, dk):
+            x, _, _ = self._gen_sparse(2, 20, [dj, di])
+            y = torch.randn(dj, dk)
 
-        y_uncoalesced = self.SparseTensor(
-            torch.cat([x_indices, x_indices], dim=1),
-            torch.cat([x_values, x_values]),
-            x_coalesced.size())
+            x_coalesced = x.coalesce()
+            self.assertTrue(x_coalesced.is_coalesced())
 
-        self.assertTrue(x_coalesced.is_coalesced())
-        self.assertFalse(y_uncoalesced.is_coalesced())
+            x_coalesced_t = x.t()
+            self.assertFalse(x_coalesced_t.is_coalesced())
 
-        self.assertTrue(x_coalesced.transpose(0, 1).is_coalesced())
-        self.assertFalse(y_uncoalesced.transpose(0, 1).is_coalesced())
+            res = torch.mm(x_coalesced_t, y)
+            expected = torch.mm(self.safeToDense(x_coalesced_t), y)
+            self.assertEqual(res, expected)
 
-        x_coalesced.transpose_(0, 1)
-        y_uncoalesced.transpose_(0, 1)
-        self.assertTrue(x_coalesced.is_coalesced())
-        self.assertFalse(y_uncoalesced.is_coalesced())
+        test_shape(10, 20, 30)
 
     def test_t_empty(self):
         x = self.SparseTensor(2, 3)


### PR DESCRIPTION
- fixes https://github.com/pytorch/pytorch/issues/6219
- removed invariants at https://github.com/pytorch/pytorch/pull/4707
- assume a sparse tensor with coalesced=true when:
1. its elements are unique and
2. the indices are in sorted order

