### PR TITLE
Convert from pytorch jit IR to nomnigraph graph

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -96,8 +96,8 @@ static std::unordered_set<repr::NNGraph::NodeRef> getTrackedNodes(
     repr::NNCFGraph& cf) {
   std::unordered_set<repr::NNGraph::NodeRef> cfTrackedNodes;
   for (const auto& bbNode : cf.getMutableNodes()) {
-    auto bb = repr::nn::get<repr::BasicBlockType<repr::NNGraph>>(bbNode);
-    for (const auto node : bb->getInstructions()) {
+    auto bb = bbNode->data();
+    for (const auto node : bb.getInstructions()) {
       cfTrackedNodes.insert(node);
     }
   }
@@ -107,8 +107,8 @@ static std::unordered_set<repr::NNGraph::NodeRef> getTrackedNodes(
 static size_t coalesceInsertedDataDependenciesHelper(repr::NNModule* m) {
   auto cfTrackedNodes = getTrackedNodes(m->controlFlow);
 
-  for (auto& bbNode : m->controlFlow.getMutableNodes()) {
-    auto bb = repr::nn::get<repr::BasicBlockType<repr::NNGraph>>(bbNode);
+  for (auto* bbNode : m->controlFlow.getMutableNodes()) {
+    auto bb = bbNode->mutableData();
     // We mutate the instructions of the bb, so we copy here.
     // TODO make this an iterator and simply promote it on insertion.
     auto instrsCopy = bb->getInstructions();
@@ -148,13 +148,13 @@ void coalesceInsertedDataDependencies(repr::NNModule* m) {
     }
   }
 
-  auto newBbNode = m->controlFlow.createNode(
-      util::make_unique<repr::BasicBlockType<repr::NNGraph>>());
+  auto newBbNode =
+      m->controlFlow.createNode(repr::BasicBlockType<repr::NNGraph>());
   auto sccs = algorithm::tarjans(&m->dataFlow);
   for (auto iter = sccs.rbegin(); iter != sccs.rend(); ++iter) {
     for (auto node : iter->getNodes()) {
       if (dfNodes.count(node)) {
-        auto currentBasicBlock = newBbNode->mutableData()->get();
+        auto currentBasicBlock = newBbNode->mutableData();
         currentBasicBlock->pushInstructionNode(node);
       }
     }
@@ -162,7 +162,7 @@ void coalesceInsertedDataDependencies(repr::NNModule* m) {
 
   // Finally we reconcile any data dependency issues (if we can).
   for (auto& bbNode : m->controlFlow.getMutableNodes()) {
-    auto bb = bbNode->mutableData()->get();
+    auto bb = bbNode->mutableData();
     std::unordered_set<repr::NNGraph::NodeRef> seen;
     for (auto instr_iter = bb->getInstructions().begin();
          instr_iter != bb->getInstructions().end();

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
@@ -39,9 +39,6 @@ class BasicBlock {
   }
 
   void pushInstructionNode(NodeRef node) {
-    assert(
-        isa<Instruction>(node->data()) &&
-        "Cannot push non-instruction node to basic block.");
     Instructions.emplace_back(node);
     trackNode(node);
   }
@@ -102,7 +99,7 @@ struct ControlFlowGraphImpl {
 
 template <typename T, typename... U>
 struct ControlFlowGraphImpl<Graph<T, U...>> {
-  using type = Graph<std::unique_ptr<BasicBlock<T, U...>>, int>;
+  using type = Graph<BasicBlock<T, U...>, int>;
   using bbType = BasicBlock<T, U...>;
 };
 

--- a/caffe2/core/nomnigraph/tests/test_util.cc
+++ b/caffe2/core/nomnigraph/tests/test_util.cc
@@ -63,11 +63,9 @@ nom::Graph<std::string> createGraphWithCycle() {
 
 std::map<std::string, std::string> BBPrinter(typename nom::repr::NNCFGraph::NodeRef node) {
   std::map<std::string, std::string> labelMap;
-  assert(node->data() && "Node doesn't have data, can't render it");
-  auto *bb = dyn_cast<nom::repr::BasicBlockType<nom::repr::NNGraph>>(
-      node->data().get());
+  auto bb = node->data();
   labelMap["label"] = to_string((unsigned long long)node) + "\\n";
-  for (const auto &instr : bb->getInstructions()) {
+  for (const auto& instr : bb.getInstructions()) {
     assert(isa<nom::repr::NeuralNetOperator>(instr->data()) &&
            "Invalid instruction.");
     auto *op = dyn_cast<nom::repr::NeuralNetOperator>(instr->data().get());

--- a/caffe2/ir/nomni_ir.cc
+++ b/caffe2/ir/nomni_ir.cc
@@ -1,0 +1,42 @@
+#include "caffe2/ir/nomni_ir.h"
+
+IRNode::IRNode(IRNode&& other) : kind_(other.kind_) {
+  if (kind_ == IRNodeKind::Operator) {
+    new (&op_) torch::jit::Node(std::move(other.op_));
+  } else if (kind_ == IRNodeKind::Value) {
+    new (&value_) torch::jit::Value(std::move(other.value_));
+  }
+};
+
+IRNode::IRNode(torch::jit::Node&& node) : kind_(IRNodeKind::Operator) {
+  new (&op_) torch::jit::Node(std::move(node));
+}
+
+IRNode::IRNode(torch::jit::Value&& value) : kind_(IRNodeKind::Value) {
+  new (&value_) torch::jit::Value(std::move(value));
+}
+
+IRNodeKind IRNode::getKind() const {
+  return kind_;
+}
+const torch::jit::Node& IRNode::getOperator() const {
+  CAFFE_ENFORCE(kind_ == IRNodeKind::Operator);
+  return op_;
+}
+const torch::jit::Value& IRNode::getValue() const {
+  CAFFE_ENFORCE(kind_ == IRNodeKind::Value);
+  return value_;
+}
+
+IRNode::~IRNode() {
+  switch (kind_) {
+    case IRNodeKind::Operator:
+      op_.~Node();
+      break;
+    case IRNodeKind::Value:
+      value_.~Value();
+      break;
+      // Intentionally avoid default to raise compiler
+      // error if new types are added to this wrapper.
+  }
+}

--- a/caffe2/ir/nomni_ir.h
+++ b/caffe2/ir/nomni_ir.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "caffe2/core/logging.h"
+#include "nomnigraph/Graph/Graph.h"
+#include "nomnigraph/Representations/ControlFlow.h"
+#include "torch/csrc/jit/ir.h"
+
+enum class IRNodeKind { Operator, Value };
+
+// Purely moveable tagged union to wrap torch::jit::{Node,Value}
+struct IRNode {
+  IRNode() = delete;
+  IRNode(const IRNode&) = delete;
+  IRNode(IRNode&& other);
+
+  IRNode(torch::jit::Node&& node);
+  IRNode(torch::jit::Value&& value);
+
+  // If you aren't sure what is stored at a node,
+  // query this method first.
+  IRNodeKind getKind() const;
+
+  // These methods raise exceptions if miscalled.
+  const torch::jit::Node& getOperator() const;
+  const torch::jit::Value& getValue() const;
+
+  // Nontrivial destructor.
+  ~IRNode();
+
+ private:
+  const IRNodeKind kind_;
+  union {
+    torch::jit::Node op_;
+    torch::jit::Value value_;
+  };
+};
+
+namespace nom {
+
+using DFGraph = nom::Graph<IRNode>;
+using CFGraph = nom::repr::ControlFlowGraph<DFGraph>;
+struct NeuralNet {
+  DFGraph dataFlow;
+  CFGraph controlFlow;
+};
+
+} // namespace nom

--- a/caffe2/ir/nomni_ir.h
+++ b/caffe2/ir/nomni_ir.h
@@ -44,4 +44,6 @@ struct NeuralNet {
   CFGraph controlFlow;
 };
 
+void convert(torch::jit::Graph&, NeuralNet*);
+
 } // namespace nom

--- a/caffe2/ir/nomni_ir_test.cc
+++ b/caffe2/ir/nomni_ir_test.cc
@@ -1,0 +1,33 @@
+#include "caffe2/ir/nomni_ir.h"
+
+#include <gtest/gtest.h>
+
+TEST(Types, VerifyTypes) {
+  torch::jit::Node node(torch::jit::Symbol::fromQualString("test::test"));
+  torch::jit::Value value;
+
+  nom::DFGraph dd;
+  auto operatorNode = dd.createNode(std::move(node));
+  auto valueNode = dd.createNode(torch::jit::Value());
+
+  ASSERT_NO_THROW({
+    auto& testOp = operatorNode->data().getOperator();
+    LOG(INFO) << (uint32_t)testOp.kind();
+  });
+  ASSERT_NO_THROW({
+    auto& testVal = valueNode->data().getValue();
+    LOG(INFO) << (uint32_t)testVal.isTensor();
+  });
+}
+
+TEST(Types, Errors) {
+  torch::jit::Node node(torch::jit::Symbol::fromQualString("test::test"));
+  torch::jit::Value value;
+
+  nom::DFGraph dd;
+  auto operatorNode = dd.createNode(std::move(node));
+  auto valueNode = dd.createNode(torch::jit::Value());
+
+  ASSERT_ANY_THROW(auto& testOp = operatorNode->data().getValue());
+  ASSERT_ANY_THROW(auto& testVal = valueNode->data().getOperator());
+}

--- a/caffe2/ir/nomni_ir_test.cc
+++ b/caffe2/ir/nomni_ir_test.cc
@@ -1,4 +1,10 @@
 #include "caffe2/ir/nomni_ir.h"
+#include "nomnigraph/Converters/Dot.h"
+
+#include "torch/csrc/jit/script/compiler.h"
+#include "torch/csrc/jit/script/module.h"
+
+#include "torch/csrc/jit/symbolic_variable.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +36,96 @@ TEST(Types, Errors) {
 
   ASSERT_ANY_THROW(auto& testOp = operatorNode->data().getValue());
   ASSERT_ANY_THROW(auto& testVal = valueNode->data().getOperator());
+}
+
+std::string getDotString(nom::NeuralNet& nn) {
+  return nom::converters::convertToDotString(
+      &nn.dataFlow, [](nom::DFGraph::NodeRef node) {
+        std::map<std::string, std::string> labels;
+        if (node->data().getKind() == IRNodeKind::Operator) {
+          std::ostringstream os;
+          // os << node->data().getOperator();
+          os << node->data().getOperator().kind().toDisplayString();
+          labels["label"] = os.str();
+        } else {
+          std::ostringstream os;
+          os << *node->data().getValue().type();
+          labels["label"] = os.str();
+        }
+        return labels;
+      });
+}
+
+const static auto jit_example = R"JIT(
+  def simple_test(a, b):
+      c = a * b
+      d = c * c
+      return d
+)JIT";
+
+TEST(GraphInjestion, ConvertScript) {
+  torch::jit::script::Module cu;
+  torch::jit::script::defineMethodsInModule(
+      cu, jit_example, torch::jit::script::Resolver(), nullptr);
+
+  auto graph = cu.get_method("simple_test").graph();
+
+  nom::NeuralNet nn;
+  nom::convert(*graph, &nn);
+
+  LOG(ERROR) << getDotString(nn);
+  EXPECT_EQ(nn.dataFlow.getMutableNodes().size(), 6);
+}
+
+using namespace torch::jit;
+using Var = SymbolicVariable;
+
+std::tuple<Var, Var>
+build_lstm_body(Graph& g, Var input, Var hx, Var cx, Var w_ih, Var w_hh) {
+  auto gates = input.mm(w_ih);
+  gates = gates + hx.mm(w_hh);
+  auto outputs = gates.chunk(4, 1);
+  auto ingate = outputs[0];
+  auto forgetgate = outputs[1];
+  auto cellgate = outputs[2];
+  auto outgate = outputs[3];
+  ingate = ingate.sigmoid();
+  outgate = outgate.sigmoid();
+  cellgate = cellgate.tanh();
+  forgetgate = forgetgate.sigmoid();
+
+  auto cy = forgetgate * cx;
+  cy = cy + ingate * cellgate;
+  auto hy = outgate * cy.tanh();
+
+  return std::make_tuple(hy, cy);
+}
+
+std::shared_ptr<Graph> build_lstm() {
+  auto r = std::make_shared<Graph>();
+  auto& g = *r;
+  Value* input = g.addInput();
+  Value* hx = g.addInput();
+  Value* cx = g.addInput();
+  Value* w_ih = g.addInput();
+  Value* w_hh = g.addInput();
+
+  Var hy;
+  Var cy;
+  std::tie(hy, cy) = build_lstm_body(g, input, hx, cx, w_ih, w_hh);
+
+  hy.addAsOutput();
+  cy.addAsOutput();
+  g.lint();
+
+  return r;
+}
+
+TEST(GraphInjestion, ConvertCpp) {
+  auto graph = build_lstm();
+  nom::NeuralNet nn;
+  nom::convert(*graph, &nn);
+
+  LOG(ERROR) << getDotString(nn);
+  EXPECT_EQ(nn.dataFlow.getMutableNodes().size(), 42);
 }

--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -254,9 +254,7 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
   /// \brief For the construction of the control flow graph we keep track
   /// of a current basic block, which we split up as we come accross control
   /// flow operations such as if and while.
-  // std::unique_ptr<repr::BasicBlockType<repr::NNGraph>> currentBasicBlock =
-  auto bbNode =
-      cfg.createNode(util::make_unique<repr::BasicBlockType<repr::NNGraph>>());
+  auto bbNode = cfg.createNode(repr::BasicBlockType<repr::NNGraph>());
 
   for (auto &op : *net.mutable_op()) {
     auto opNode = dfg.createNode(); // Create an empty node for the operator.
@@ -283,7 +281,7 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
     }
 
     opNode->resetData(convertToNeuralNetOperator(op));
-    auto currentBasicBlock = bbNode->mutableData()->get();
+    auto currentBasicBlock = bbNode->mutableData();
     currentBasicBlock->pushInstructionNode(opNode);
   }
 
@@ -343,8 +341,8 @@ caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m, const caffe2::NetDef& old
     if (bbNode->getOutEdges().size() > 1) {
       CAFFE_THROW("Control flow not yet supported in Caffe2 converter.");
     }
-    auto bb = bbNode->data().get();
-    for (const auto &instrNode : bb->getInstructions()) {
+    auto bb = bbNode->data();
+    for (const auto& instrNode : bb.getInstructions()) {
       caffe2::OperatorDef op = convertToOperatorDef(instrNode);
 
       for (const auto &inEdge : instrNode->getInEdges()) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -170,7 +170,10 @@ using NodeKind = Symbol;
 struct Value {
   TH_DISALLOW_COPY_AND_ASSIGN(Value);
   Value(Node * node_, size_t offset_);
-private:
+  Value(Value&&) = default;
+  Value();
+
+ private:
   friend struct Node;
   friend struct Graph;
   Node * node_;
@@ -254,6 +257,8 @@ public:
 
 struct Node : public Attributes<Node> {
   TH_DISALLOW_COPY_AND_ASSIGN(Node);
+  Node(Node&&) = default;
+  Node(NodeKind);
   friend struct Graph;
   friend struct Block;
   friend struct Value;
@@ -1192,6 +1197,8 @@ inline Value::Value(Node * node_, size_t offset_)
   node_->graph_->all_values.emplace(this);
 }
 
+inline Value::Value() : node_(nullptr), offset_(0), type_(DynamicType::get()) {}
+
 inline Value* Value::setType(const TypePtr type) {
   JIT_ASSERT(type);
   type_ = type;
@@ -1232,6 +1239,14 @@ inline Node::Node(Graph * graph_, NodeKind kind_) :
   schema_(nullptr) {
   graph_->all_nodes.emplace(this);
 }
+
+inline Node::Node(NodeKind kind_)
+    : kind_(kind_),
+      graph_(nullptr),
+      owning_block_(nullptr),
+      stage_(0),
+      scope_(nullptr),
+      schema_(nullptr) {}
 
 inline void Node::eraseOutput(size_t i) {
   JIT_ASSERT(i < outputs_.size());


### PR DESCRIPTION
Summary: more progress on using pytorch JIT IR instead of nomnigraph IR at node level

Differential Revision: D9202326
