### PR TITLE
Using JIT IR with nomnigraph

### DIFF
--- a/caffe2/ir/nomni_ir.cc
+++ b/caffe2/ir/nomni_ir.cc
@@ -1,0 +1,42 @@
+#include "caffe2/ir/nomni_ir.h"
+
+IRNode::IRNode(IRNode&& other) : kind_(other.kind_) {
+  if (kind_ == IRNodeKind::Operator) {
+    new (&op_) torch::jit::Node(std::move(other.op_));
+  } else if (kind_ == IRNodeKind::Value) {
+    new (&value_) torch::jit::Value(std::move(other.value_));
+  }
+};
+
+IRNode::IRNode(torch::jit::Node&& node) : kind_(IRNodeKind::Operator) {
+  new (&op_) torch::jit::Node(std::move(node));
+}
+
+IRNode::IRNode(torch::jit::Value&& value) : kind_(IRNodeKind::Value) {
+  new (&value_) torch::jit::Value(std::move(value));
+}
+
+IRNodeKind IRNode::getKind() const {
+  return kind_;
+}
+const torch::jit::Node& IRNode::getOperator() const {
+  CAFFE_ENFORCE(kind_ == IRNodeKind::Operator);
+  return op_;
+}
+const torch::jit::Value& IRNode::getValue() const {
+  CAFFE_ENFORCE(kind_ == IRNodeKind::Value);
+  return value_;
+}
+
+IRNode::~IRNode() {
+  switch (kind_) {
+    case IRNodeKind::Operator:
+      op_.~Node();
+      break;
+    case IRNodeKind::Value:
+      value_.~Value();
+      break;
+      // Intentionally avoid default to raise compiler
+      // error if new types are added to this wrapper.
+  }
+}

--- a/caffe2/ir/nomni_ir.h
+++ b/caffe2/ir/nomni_ir.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "caffe2/core/logging.h"
+#include "nomnigraph/Graph/Graph.h"
+#include "nomnigraph/Representations/ControlFlow.h"
+#include "torch/csrc/jit/ir.h"
+
+enum class IRNodeKind { Operator, Value };
+
+// Purely moveable tagged union to wrap torch::jit::{Node,Value}
+struct IRNode {
+  IRNode() = delete;
+  IRNode(const IRNode&) = delete;
+  IRNode(IRNode&& other);
+
+  IRNode(torch::jit::Node&& node);
+  IRNode(torch::jit::Value&& value);
+
+  // If you aren't sure what is stored at a node,
+  // query this method first.
+  IRNodeKind getKind() const;
+
+  // These methods raise exceptions if miscalled.
+  const torch::jit::Node& getOperator() const;
+  const torch::jit::Value& getValue() const;
+
+  // Nontrivial destructor.
+  ~IRNode();
+
+ private:
+  const IRNodeKind kind_;
+  union {
+    torch::jit::Node op_;
+    torch::jit::Value value_;
+  };
+};
+
+namespace nom {
+
+using DFGraph = nom::Graph<IRNode>;
+using CFGraph = nom::repr::ControlFlowGraph<DFGraph>;
+struct NeuralNet {
+  DFGraph dataFlow;
+  CFGraph controlFlow;
+};
+
+} // namespace nom

--- a/caffe2/ir/nomni_ir_test.cc
+++ b/caffe2/ir/nomni_ir_test.cc
@@ -1,0 +1,33 @@
+#include "caffe2/ir/nomni_ir.h"
+
+#include <gtest/gtest.h>
+
+TEST(Types, VerifyTypes) {
+  torch::jit::Node node(torch::jit::Symbol::fromQualString("test::test"));
+  torch::jit::Value value;
+
+  nom::DFGraph dd;
+  auto operatorNode = dd.createNode(std::move(node));
+  auto valueNode = dd.createNode(torch::jit::Value());
+
+  ASSERT_NO_THROW({
+    auto& testOp = operatorNode->data().getOperator();
+    LOG(INFO) << (uint32_t)testOp.kind();
+  });
+  ASSERT_NO_THROW({
+    auto& testVal = valueNode->data().getValue();
+    LOG(INFO) << (uint32_t)testVal.isTensor();
+  });
+}
+
+TEST(Types, Errors) {
+  torch::jit::Node node(torch::jit::Symbol::fromQualString("test::test"));
+  torch::jit::Value value;
+
+  nom::DFGraph dd;
+  auto operatorNode = dd.createNode(std::move(node));
+  auto valueNode = dd.createNode(torch::jit::Value());
+
+  ASSERT_ANY_THROW(auto& testOp = operatorNode->data().getValue());
+  ASSERT_ANY_THROW(auto& testVal = valueNode->data().getOperator());
+}

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -170,7 +170,10 @@ using NodeKind = Symbol;
 struct Value {
   TH_DISALLOW_COPY_AND_ASSIGN(Value);
   Value(Node * node_, size_t offset_);
-private:
+  Value(Value&&) = default;
+  Value();
+
+ private:
   friend struct Node;
   friend struct Graph;
   Node * node_;
@@ -254,6 +257,8 @@ public:
 
 struct Node : public Attributes<Node> {
   TH_DISALLOW_COPY_AND_ASSIGN(Node);
+  Node(Node&&) = default;
+  Node(NodeKind);
   friend struct Graph;
   friend struct Block;
   friend struct Value;
@@ -1192,6 +1197,8 @@ inline Value::Value(Node * node_, size_t offset_)
   node_->graph_->all_values.emplace(this);
 }
 
+inline Value::Value() : node_(nullptr), offset_(0), type_(DynamicType::get()) {}
+
 inline Value* Value::setType(const TypePtr type) {
   JIT_ASSERT(type);
   type_ = type;
@@ -1232,6 +1239,14 @@ inline Node::Node(Graph * graph_, NodeKind kind_) :
   schema_(nullptr) {
   graph_->all_nodes.emplace(this);
 }
+
+inline Node::Node(NodeKind kind_)
+    : kind_(kind_),
+      graph_(nullptr),
+      owning_block_(nullptr),
+      stage_(0),
+      scope_(nullptr),
+      schema_(nullptr) {}
 
 inline void Node::eraseOutput(size_t i) {
   JIT_ASSERT(i < outputs_.size());


### PR DESCRIPTION
Summary: Wrapping JIT IR with nomnigraph to enable nomnigraph transforms on new IR and start migrating caffe2 over to it

Differential Revision: D9202320
