### PR TITLE
[jit][script] mutable list support

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2429,6 +2429,15 @@ a")
             return a == [0, 0, 0, 0, 4]
         self.checkScript(test_append_loop_if, ())
 
+        def test_nested_loop():
+            a = _construct_empty_int_list()
+            for i in range(2):
+                for j in range(2):
+                    a.append(i + j)
+
+            return a == [0, 1, 1, 2]
+        self.checkScript(test_append_loop_if, ())
+
     def test_func_call(self):
         script = '''
         def add(a, b):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2378,6 +2378,57 @@ a")
             return a[3:10] == [3, 4]
         self.checkScript(test_backward_slice, ())
 
+    def test_mutable_list(self):
+        def test_append():
+            a = [0, 1]
+            a.append(2)
+            a.append(3)
+            return a == [0, 1, 2, 3]
+        self.checkScript(test_append, ())
+
+        def test_append_2():
+            a = [0, 1]
+            a.append(2)
+            a = [1]
+            a.append(4)
+            return a == [1, 4]
+        self.checkScript(test_append_2, ())
+
+        def test_append_if():
+            a = [1]
+            if True:
+                a.append(4)
+            return a == [1, 4]
+        self.checkScript(test_append_if, ())
+
+        def test_append_if_else():
+            a = [1]
+            if False:
+                a.append(4)
+            else:
+                a.append(10)
+            return a == [1, 10]
+        self.checkScript(test_append_if_else, ())
+
+        def test_append_loop():
+            a = _construct_empty_int_list()
+            for i in range(5):
+                a.append(i)
+
+            return a == [0, 1, 2, 3, 4]
+        self.checkScript(test_append_loop, ())
+
+        def test_append_loop_if():
+            a = _construct_empty_int_list()
+            for i in range(5):
+                if i > 3:
+                    a.append(i)
+                else:
+                    a.append(0)
+
+            return a == [0, 0, 0, 0, 4]
+        self.checkScript(test_append_loop_if, ())
+
     def test_func_call(self):
         script = '''
         def add(a, b):

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -145,6 +145,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/ivalue.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/annotate_effects.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/canonicalize.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/constant_propagation.cpp

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -88,6 +88,14 @@ RegisterOperators reg({
             push(stack, s);
             return 0;
           };
+        } else if (type == WorldType::get()) {
+          return [](Stack& stack) {
+            // World doesn't have an IValue equivalent since it's a dummy type.
+            // TODO(suo): We can write a pass to erase all World tokens, which
+            // would eliminate the runtime overhead here.
+            push(stack, 0);
+            return 0;
+          };
         } else {
           std::stringstream ss;
           ss << "constant literal not supported for: " << type->str();

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -53,7 +53,9 @@ _(prim, AutogradAdd) \
 _(prim, GradOf) \
 _(prim, AnyDefined) \
 _(prim, FusedConcat) \
+_(prim, MemoryFence) \
 _(aten, __not__) \
+_(aten, append) \
 FORALL_ATEN_BASE_SYMBOLS(_) \
 _(onnx, Add) \
 _(onnx, Concat) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -544,7 +544,7 @@ public:
     return {blocks_.data(), blocks_.size()};
   }
 
-  // Insert unattached 'this' node after 'n' in the topological order.
+  // Insert unattached 'this' node before 'n' in the topological order.
   // Returns this (for chaining).
   //
   // Given:   %3 = f(%1, %2)

--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -3,7 +3,15 @@
 #include <ATen/ATen.h>
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
 
 namespace torch { namespace jit {
 std::ostream& operator<<(std::ostream & out, const IValue & v) {

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -102,12 +102,12 @@ struct ConstantString : at::Retainable {
 };
 
 template<typename T>
-struct ConstantList;
+struct List;
 struct IValue;
-using Tuple = ConstantList<IValue>;
-using IntList = ConstantList<int64_t>;
-using TensorList = ConstantList<at::Tensor>;
-using DoubleList = ConstantList<double>;
+using Tuple = List<IValue>;
+using IntList = List<int64_t>;
+using TensorList = List<at::Tensor>;
+using DoubleList = List<double>;
 
 // IValue is the generic tagged union used by the interpreter to hold
 // all value types.
@@ -117,7 +117,15 @@ using DoubleList = ConstantList<double>;
 // retain/release calls.
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
 
 struct IValue {
   IValue()
@@ -443,22 +451,27 @@ DEFINE_TO(std::vector<at::Tensor>, toTensorListRef)
 
 #undef DEFINE_TO
 
-// non-mutable list
-template<typename Elem>
-struct ConstantList : at::Retainable {
+
+template <typename Elem>
+struct List : at::Retainable {
  private:
-  ConstantList(std::vector<Elem> elements_)
-  : elements_(std::move(elements_)) {}
+  List(std::vector<Elem> elements_) : elements_(std::move(elements_)) {}
   std::vector<Elem> elements_;
+
  public:
-  static Shared<ConstantList<Elem>> create(std::vector<Elem> elements_) {
-    return Shared<ConstantList<Elem>>(
-        new ConstantList<Elem>(std::move(elements_)), false);
+  static Shared<List<Elem>> create(std::vector<Elem> elements_) {
+    return Shared<List<Elem>>(new List<Elem>(std::move(elements_)), false);
   }
   const std::vector<Elem>& elements() const {
     return elements_;
   }
   operator const std::vector<Elem>&() const {
+    return elements();
+  }
+  std::vector<Elem>& elements() {
+    return elements_;
+  }
+  operator std::vector<Elem>&() {
     return elements();
   }
 };

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -54,6 +54,7 @@ struct SchemaParser {
       {"float", FloatType::get() },
       {"int", IntType::get() },
       {"bool", IntType::get() }, // TODO: add separate bool type
+      {"World", WorldType::get() },
     };
     auto tok = L.expect(TK_IDENT);
     auto text = tok.text();

--- a/torch/csrc/jit/passes/annotate_effects.cpp
+++ b/torch/csrc/jit/passes/annotate_effects.cpp
@@ -1,0 +1,162 @@
+#include "torch/csrc/jit/passes/annotate_effects.h"
+#include <set>
+
+namespace torch {
+namespace jit {
+namespace {
+
+// Ops with effects that we need to track through the passing of world tokens
+// e.g. mutation
+const std::unordered_set<Symbol> effectfulOps = {
+    aten::append,
+};
+
+/**
+ * AnnotateEffects
+ *
+ * This pass annotates effectful operations (such as ones that mutate existing
+ * values) to prevent subsequent passes from re-ordering ops in a way that
+ * changes the meaning of the program.
+ *
+ * It does this by adding primitive memory fence ops around nodes that use
+ * mutable values. The memory fences input and output a "World" token, which
+ * expresses effects explicitly in the IR and forces all fenced nodes to be
+ * linearized.
+ */
+class AnnotateEffectsImpl {
+ public:
+  void annotateEffects(Graph* g) {
+    // Generate the first world token
+    const auto tokenGenerator = g->create(prim::Constant);
+    g->block()->prependNode(tokenGenerator);
+    auto curToken = tokenGenerator->output()->setType(WorldType::get());
+
+    visitBlock(g->block(), curToken);
+  }
+
+ private:
+  Value* visitBlock(Block* block, Value* curToken) {
+    for (auto* node : block->nodes()) {
+      curToken = visitNode(node, curToken);
+    }
+    return curToken;
+  }
+
+  // If a node uses a mutable variable (or mutates a previously constant
+  // variable), create a memory fence around the node.
+  //
+  // Returns the last world token emitted for subsequent memory fences to use.
+  Value* visitNode(Node* node, Value* curToken) {
+    if (node->kind() == prim::If) {
+      JIT_ASSERT(node->blocks().size() == 2);
+
+      auto trueBlock = node->blocks().at(0);
+      auto falseBlock = node->blocks().at(1);
+
+      auto trueToken = visitBlock(trueBlock, curToken);
+      auto falseToken = visitBlock(falseBlock, curToken);
+
+      // If any branch has a mutating op, this node has to output a world token
+      if (trueToken != curToken || falseToken != curToken) {
+        trueBlock->registerOutput(trueToken);
+        falseBlock->registerOutput(falseToken);
+
+        return node->addOutput()->setType(WorldType::get());
+      }
+      return curToken;
+    }
+
+    if (node->kind() == prim::Loop) {
+      JIT_ASSERT(node->blocks().size() == 1);
+      auto block = node->blocks().at(0);
+      auto newToken = visitBlock(block, curToken);
+
+      if (newToken != curToken) {
+        // Register the world token as a loop-carried dependency
+        block->addInput()->setType(WorldType::get());
+        block->registerOutput(curToken);
+
+        // Thread the world token through the loop node.
+        node->addInput(curToken);
+        return node->addOutput()->setType(WorldType::get());
+      }
+      return curToken;
+    }
+
+    if (shouldAddFence(node)) {
+      return addFenceForNode(node, curToken);
+    }
+
+    return curToken;
+  }
+
+  bool shouldAddFence(Node* node) {
+    // Check if this node uses a known mutable value
+    for (auto* input : node->inputs()) {
+      if (mutableValues_.count(input) != 0) {
+        return true;
+      }
+    }
+
+    // Otherwise, check if this node is the first mutation of a value
+    if (effectfulOps.count(node->kind()) != 0) {
+      const auto inputs = node->inputs();
+      Value* mut = inputs.at(0);
+      JIT_ASSERT(mut->type()->kind() == TypeKind::ListType); // TODO
+
+      mutableValues_.insert(mut);
+      return true;
+    }
+
+    return false;
+  }
+
+  // Create a memory fence around a node, using the world token
+  // Input:
+  //   = aten::append(%list, %new_element)
+  //
+  // Output:
+  //  %t.1 : World, %list.2 : int[] = prim::MemoryFence(%curToken, %list)
+  //   = aten::append(%list.2, %new_element)
+  //  %t.2 : World, %list.3 : int[] = prim::MemoryFence(%t.1, %list2)
+  //
+  // Returns the new world token (%t.2) for subsequent fences to use.
+  Value* addFenceForNode(Node* node, Value* curToken) {
+    auto mut = node->inputs().at(0);
+
+    // Add a start fence
+    auto startFence =
+        node->owningGraph()->create(prim::MemoryFence, /*outputs=*/2);
+    startFence->addInput(curToken);
+    startFence->addInput(mut);
+    curToken = startFence->outputs()[0]->setType(WorldType::get());
+    mut = startFence->outputs()[1]->setType(ListType::ofInts());
+    startFence->insertBefore(node);
+
+    // modify the node to take in the start fence's output list
+    node->replaceInput(0, mut);
+
+    // Add an end fence
+    auto endFence =
+        node->owningGraph()->create(prim::MemoryFence, /*outputs=*/2);
+    endFence->addInput(curToken);
+    endFence->addInput(mut);
+    curToken = endFence->outputs()[0]->setType(WorldType::get());
+    mut = endFence->outputs()[1]->setType(ListType::ofInts());
+    endFence->insertAfter(node);
+
+    return curToken;
+  }
+
+  std::set<Value*> mutableValues_;
+};
+
+} // namespace
+
+void AnnotateEffects(std::shared_ptr<Graph>& graph) {
+  AnnotateEffectsImpl impl;
+  impl.annotateEffects(graph.get());
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/annotate_effects.h
+++ b/torch/csrc/jit/passes/annotate_effects.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+
+TORCH_API void AnnotateEffects(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -20,6 +20,11 @@ std::unordered_set<Symbol> skip_list = {
   //FIXME Same problem as in DCE - cpp & python PythonOp and CppOp should be
   //FIXME treated as having side effects but ONNX depends on them being removed
   prim::Print,
+  // A memory fence implies a value is being mutated, so constant propagation
+  // must be disallowed.
+  // TODO(suo): we could allow constants to propagated for the first mutable
+  // use of a given value.
+  prim::MemoryFence,
   //all the rand functions from native_functions.yaml
   aten::permute,
   aten::rand,

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -14,6 +14,7 @@ bool hasSideEffects(Node * node, bool_memo_type& memo) {
   if (it != memo.end())
     return it->second;
   bool has_side_effects = node->kind() == prim::Print ||
+    node->kind() == aten::append ||
     std::any_of(node->blocks().begin(), node->blocks().end(),
                 [&](Block *b) {
                   return std::any_of(b->nodes().begin(), b->nodes().end(),

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -64,6 +64,8 @@ inline IValue toIValue(py::object&& obj, const TypePtr& type) {
         AT_ERROR("Lists and tuples are not supported yet");
       case TypeKind::NumberType:
         AT_ERROR("Insufficient type information to convert input");
+      case TypeKind::WorldType:
+        AT_ERROR("World arguments should not be passed in by users");
     }
   AT_ERROR("Missing cases in toIValue! File a bug report.");
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1,5 +1,6 @@
 #include "torch/csrc/jit/script/compiler.h"
 #include "torch/csrc/jit/passes/lower_tuples.h"
+#include "torch/csrc/jit/passes/annotate_effects.h"
 #include "torch/csrc/jit/operator.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/ir.h"
@@ -718,6 +719,7 @@ struct to_ir {
     }
 
     method.setSchema({def.name().name(), std::move(arguments), std::move(returns)});
+    AnnotateEffects(graph);
     // remove any uses of tuples that we inserted
     LowerTuples(graph);
   }

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -42,6 +42,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "None";
   } else if(t.kind() == TypeKind::StringType) {
     out << "string";
+  } else if(t.kind() == TypeKind::WorldType) {
+    out << "World";
   } else {
     AT_ERROR("unknown type kind");
   }
@@ -66,6 +68,10 @@ FloatTypePtr FloatType::get() {
 }
 NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
+  return value;
+}
+WorldTypePtr WorldType::get() {
+  static auto value = WorldType::create();
   return value;
 }
 StringTypePtr StringType::get() {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -22,6 +22,7 @@ _(FloatType) \
 _(IntType) \
 _(NoneType) \
 _(StringType) \
+_(WorldType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -212,6 +213,32 @@ private:
   int device_;
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
+};
+
+// This type is a token used to represent effectful computation in the IR.
+// See the AnnotateEffects pass for how it is used.
+struct WorldType;
+using WorldTypePtr = std::shared_ptr<WorldType>;
+struct TORCH_API WorldType : public Type {
+  template <typename... T>
+  static WorldTypePtr create(T&&... all) {
+    return WorldTypePtr(new WorldType(std::forward<T>(all)...));
+  }
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return "world";
+  }
+  bool isSubtypeOf(const TypePtr rhs) const override {
+    return *this == *rhs;
+  }
+  static const TypeKind Kind = TypeKind::WorldType;
+  // global singleton
+  static WorldTypePtr get();
+
+ private:
+  WorldType() : Type(TypeKind::WorldType) {}
 };
 
 struct ListType;


### PR DESCRIPTION
Basic support for token-based modeling of effects. The comments are pretty self explanatory, but the tldr is that there's a pass that annotates the IR to make effectful ops explicit. I also added an `append()` builtin to demonstrate how it might be used.

Some notes:
1. Instead of transforming a mutating op directly to do the return/bind, there's a primitive `MemoryFence` that wraps the op. This is to preserve the original function schema of the op (otherwise, optimizations have to know how to emit world tokens).
2. Right now, world token handling spills into the interpreter. It's not a very significant cost, but I plan to write a pass to erase all the annotation so that there's no runtime overhead to all the token passing.
