### PR TITLE
Nomnigraph - Refactor SubtreeMatchCriteria to become a Graph of MatchNode

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -181,6 +181,12 @@ void coalesceInsertedDataDependencies(repr::NNModule* m) {
   }
 }
 
+std::ostream& operator<<(
+    std::ostream& oss,
+    const NNNodeMatchCriteria& criteria) {
+  return oss << criteria.debugString;
+}
+
 bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
   auto nodeOutputs = nn::getOutputs(nodeRef);
   NOM_REQUIRE_OR_RET_FALSE(nodeOutputs.size() == 1);
@@ -189,7 +195,8 @@ bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
 }
 
 NNNodeMatchCriteria matchAnyNode() {
-  return [](NNGraph::NodeRef /* unused */) { return true; };
+  return NNNodeMatchCriteria(
+      [](NNGraph::NodeRef /* unused */) { return true; }, "matchAnyNode");
 }
 
 NNSubtree operatorTree(

--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -199,11 +199,12 @@ NNNodeMatchCriteria matchAnyNode() {
       [](NNGraph::NodeRef /* unused */) { return true; }, "matchAnyNode");
 }
 
-NNSubtree operatorTree(
+NNMatchGraph::NodeRef operatorTree(
+    NNMatchGraph& g,
     const NNNodeMatchCriteria& root,
-    const std::vector<NNSubtree>& childrenCriteria,
+    const std::vector<NNMatchGraph::NodeRef>& childrenCriteria,
     int count) {
-  return NNSubtree(matchAnyNode(), {NNSubtree(root, childrenCriteria)}, count);
+  return tree(g, matchAnyNode(), {tree(g, root, childrenCriteria)}, count);
 }
 
 } // namespace nn

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -438,7 +438,7 @@ std::ostream& operator<<(
     std::ostream& oss,
     const NNNodeMatchCriteria& criteria);
 
-using NNSubtree = nom::matcher::SubtreeMatchCriteria<NNNodeMatchCriteria>;
+using NNMatchGraph = nom::matcher::MatchGraph<NNNodeMatchCriteria>;
 
 bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef);
 
@@ -489,9 +489,10 @@ using NNSubgraphMatcher =
 // This helper method makes it easy to create matching criteria in NNGraph.
 // For example, operatorTree(opMatch, ...) will refer to a tree like this:
 // ... -> opMatch -> opMatch_Output
-NNSubtree operatorTree(
+NNMatchGraph::NodeRef operatorTree(
+    NNMatchGraph& g,
     const NNNodeMatchCriteria& root,
-    const std::vector<NNSubtree>& childrenCriteria = {},
+    const std::vector<NNMatchGraph::NodeRef>& childrenCriteria = {},
     int count = 1);
 
 } // namespace nn

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -19,6 +19,7 @@
 #include "nomnigraph/Support/Pointer.h"
 #include "nomnigraph/Transformations/SubgraphMatcher.h"
 
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -423,7 +424,20 @@ void coalesceInsertedDataDependencies(repr::NNModule* m);
 template <NNGraph* G>
 struct NodeHelper {};
 
-using NNNodeMatchCriteria = std::function<bool(NNGraph::NodeRef)>;
+struct NNNodeMatchCriteria {
+  const std::function<bool(NNGraph::NodeRef)> predicate;
+  const std::string debugString;
+
+  NNNodeMatchCriteria(
+      const std::function<bool(NNGraph::NodeRef)>& predicate,
+      const std::string& debugString = "No debug string specified")
+      : predicate(predicate), debugString(debugString){};
+};
+
+std::ostream& operator<<(
+    std::ostream& oss,
+    const NNNodeMatchCriteria& criteria);
+
 using NNSubtree = nom::matcher::SubtreeMatchCriteria<NNNodeMatchCriteria>;
 
 bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef);
@@ -431,8 +445,9 @@ bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef);
 template <typename NodeType>
 NNNodeMatchCriteria matchNodeTypeWithPredicate(
     const std::function<bool(NNGraph::NodeRef, const NodeType&)> predicate,
-    bool expectedSingleOutputAndConsumer = false) {
-  return
+    bool expectedSingleOutputAndConsumer = false,
+    const std::string& debugString = "matchNodeTypeWithPredicate") {
+  return NNNodeMatchCriteria(
       [&predicate, expectedSingleOutputAndConsumer](NNGraph::NodeRef nodeRef) {
         NOM_REQUIRE_OR_RET_FALSE(is<NodeType>(nodeRef));
         if (expectedSingleOutputAndConsumer) {
@@ -440,18 +455,22 @@ NNNodeMatchCriteria matchNodeTypeWithPredicate(
         }
         NodeType* node = get<NodeType>(nodeRef);
         return predicate(nodeRef, *node);
-      };
+      },
+      debugString);
 };
 
 template <typename NodeType>
 NNNodeMatchCriteria matchNodeType(
-    bool expectedSingleOutputAndConsumer = false) {
-  return [expectedSingleOutputAndConsumer](NNGraph::NodeRef nodeRef) {
-    if (expectedSingleOutputAndConsumer) {
-      NOM_REQUIRE_OR_RET_FALSE(hasSingleOutputAndConsumer(nodeRef));
-    }
-    return is<NodeType>(nodeRef);
-  };
+    bool expectedSingleOutputAndConsumer = false,
+    const std::string& debugString = "matchNodeType") {
+  return NNNodeMatchCriteria(
+      [expectedSingleOutputAndConsumer](NNGraph::NodeRef nodeRef) {
+        if (expectedSingleOutputAndConsumer) {
+          NOM_REQUIRE_OR_RET_FALSE(hasSingleOutputAndConsumer(nodeRef));
+        }
+        return is<NodeType>(nodeRef);
+      },
+      debugString);
 }
 
 NNNodeMatchCriteria matchAnyNode();
@@ -460,7 +479,7 @@ struct NNNodeMatch {
   static bool isMatch(
       const NNGraph::NodeRef& node,
       const NNNodeMatchCriteria& criteria) {
-    return criteria(node);
+    return criteria.predicate(node);
   }
 };
 

--- a/caffe2/core/nomnigraph/tests/neural_net_test.cc
+++ b/caffe2/core/nomnigraph/tests/neural_net_test.cc
@@ -42,12 +42,13 @@ TEST(NeuralNetGraph, ReplaceGraph) {
         reluOutput
   */
 
+  auto mg = NNMatchGraph();
   // clang-format off
-  auto pattern = NNSubtree(
+  auto pattern = tree(mg,
       matchNodeType<Relu>(), {
-          operatorTree(
+          operatorTree(mg,
               matchNodeType<Sum>(), {
-                NNSubtree::nonTerminal(matchNodeType<Tensor>(), 2)
+                tree(mg, matchNodeType<Tensor>(), {}, 2, true)
               }),
       });
   // clang-format on

--- a/caffe2/core/nomnigraph/tests/neural_net_test.cc
+++ b/caffe2/core/nomnigraph/tests/neural_net_test.cc
@@ -52,11 +52,12 @@ TEST(NeuralNetGraph, ReplaceGraph) {
       });
   // clang-format on
 
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern));
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern));
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern));
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern).isMatch());
+  EXPECT_FALSE(
+      NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern).isMatch());
+  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern).isMatch());
 
-  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern));
+  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern).isMatch());
 
   NNSubgraphMatcher::replaceSubtree(
       graph, pattern, [](NNGraph& g, NNGraph::NodeRef relu) {


### PR DESCRIPTION
Summary:
SubtreeMatchCriteria now becomes a graph of MatchNode

MatchNode consists of NodeMatchCriteria, nonTerminal and count. This is a cleaner internal representation of the data structure and will bring us much closer to DAG matching.

Note that I still keep the debugString method because convertToDotGraph doesn't currently work with Subgraph.

Differential Revision: D9321695
