### PR TITLE
ATen layer norm symbolic

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -688,6 +688,20 @@ class TestCaffe2Backend(unittest.TestCase):
             x = Variable(torch.randn(*shape))
             self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_layer_norm(self):
+        shape = (20, 5, 10, 10)
+
+        class MyModel(torch.nn.Module):
+            def __init__(self):
+                super(MyModel, self).__init__()
+                self.ln = torch.nn.LayerNorm([5, 10, 10])
+
+            def forward(self, x):
+                return self.ln(x)
+
+        x = torch.randn(*shape)
+        self.run_model_test(MyModel(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
     def test_repeat(self):
         class MyModel(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -710,6 +710,12 @@ def type_as(g, self, other):
         return g.op("ATen", self, other, operator_s="type_as")
 
 
+@parse_args('v', 'is', 'v', 'v', 'f', 'i')
+def layer_norm(g, self, normalized_shape, weight, bias, eps, cudnn_enable):
+    return g.op("ATen", self, weight, bias, normalized_shape_i=normalized_shape,
+                eps_f=eps, cudnn_enable_i=cudnn_enable, operator_s="layer_norm")
+
+
 # ignore clone operators that are inserted by PyTorch autograd
 def clone(g, input):
     return input


### PR DESCRIPTION
We can't rely on the ATen fallback pathway here because we need to parse out the constant attributes explicitly