### PR TITLE
Re-purpose setup_caffe2.py for faster caffe2 build iterations

### DIFF
--- a/setup_caffe2.py
+++ b/setup_caffe2.py
@@ -131,7 +131,6 @@ class cmake_build(Caffe2Command):
             # configure
             cmake_args = [
                 find_executable('cmake'),
-                '-DUSE_ATEN=ON',
                 '-DBUILD_SHARED_LIBS=OFF',
                 '-DPYTHON_EXECUTABLE:FILEPATH={}'.format(sys.executable),
                 '-DPYTHON_INCLUDE_DIR={}'.format(sysconfig.get_python_inc()),


### PR DESCRIPTION
setup.py is the official install script, setup_caffe2.py is not used any more