### PR TITLE
Move filler interface to operator schema

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -20,7 +20,6 @@
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
 #include "caffe2/proto/caffe2.pb.h"
-#include "caffe2/utils/filler.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {
@@ -604,76 +603,6 @@ class Operator : public OperatorBase {
   }
 
   void SyncDevice() final {}
-
-  virtual std::vector<TensorFiller<Context>> InputFillers(
-      const std::vector<std::vector<TIndex>>& shapes) {
-    CAFFE_ENFORCE(shapes.size() == Inputs().size());
-    std::vector<TensorFiller<Context>> fillers;
-    for (const auto& shape : shapes) {
-      fillers.emplace_back(shape, &context_);
-    }
-
-    return fillers;
-  }
-
-#define DISABLE_INPUT_FILLERS(Context)                                 \
-  std::vector<TensorFiller<Context>> InputFillers(                     \
-      const std::vector<std::vector<TIndex>>& /* unused */) override { \
-    throw UnsupportedOperatorFeature(                                  \
-        OperatorBase::type() + " does not have input fillers");        \
-  }
-
-  void SparseLengthsFillerHelper(
-      const std::vector<std::vector<TIndex>>& shapes,
-      size_t value_index,
-      size_t length_index,
-      std::vector<TensorFiller<Context>>* fillers) {
-    CAFFE_ENFORCE_EQ(shapes[length_index].size(), 1);
-    (*fillers)[length_index].SparseLengths(shapes[value_index].front());
-  }
-
-  void SparseSegmentsFillerHelper(
-      const std::vector<std::vector<TIndex>>& shapes,
-      size_t value_index,
-      size_t segment_index,
-      std::vector<TensorFiller<Context>>* fillers) {
-    CAFFE_ENFORCE_EQ(shapes[segment_index].size(), 1);
-    // TODO (mnaumov): distribution of value
-    (*fillers)[value_index].Min(0).Max(shapes[value_index].front() * 2);
-    (*fillers)[segment_index].SparseSegments(shapes[value_index].front() - 1);
-  }
-
-// The helper is build sparse input with values and lengths; e.g.:
-// values  = [1, 2, 3, 2, 4, 6, 7, 3, 6]
-//            \_____/  \________/  \__/
-// lengths =    [3,        4,       2]
-#define USE_VALUE_LENGTH_INPUT_FILLERS(Context, value_index, length_index) \
-  std::vector<TensorFiller<Context>> InputFillers(                         \
-      const std::vector<std::vector<TIndex>>& shapes) override {           \
-    CAFFE_ENFORCE_EQ(shapes.size(), Operator<Context>::Inputs().size());   \
-    auto fillers = Operator<Context>::InputFillers(shapes);                \
-    Operator<Context>::SparseLengthsFillerHelper(                          \
-        shapes, value_index, length_index, &fillers);                      \
-    return fillers;                                                        \
-  }
-
-  // The helper is build sparse input with values, keys, and lengths; e.g.:
-  // values  = [1, 2, 3, 2, 4, 6, 7, 3, 6]
-  // keys    = [0, 1, 4, 0, 1, 2, 5, 1, 2]
-  //            \_____/  \________/  \__/
-  // lengths =    [3,        4,       2]
-#define USE_VALUE_KEY_LENGTH_INPUT_FILLERS(                              \
-    Context, value_index, key_index, length_index)                       \
-  std::vector<TensorFiller<Context>> InputFillers(                       \
-      const std::vector<std::vector<TIndex>>& shapes) override {         \
-    CAFFE_ENFORCE_EQ(shapes.size(), Operator<Context>::Inputs().size()); \
-    auto fillers = Operator<Context>::InputFillers(shapes);              \
-    Operator<Context>::SparseLengthsFillerHelper(                        \
-        shapes, key_index, length_index, &fillers);                      \
-    Operator<Context>::SparseSegmentsFillerHelper(                       \
-        shapes, value_index, key_index, &fillers);                       \
-    return fillers;                                                      \
-  }
 
  protected:
   void RecordEvent(const char* err_msg = nullptr) final {

--- a/caffe2/core/operator_schema.cc
+++ b/caffe2/core/operator_schema.cc
@@ -330,6 +330,76 @@ int OpSchema::CalculateOutput(int num_input) const {
   }
 }
 
+static void SparseLengthsFillerHelper(
+    const std::vector<std::vector<TIndex>>& shapes,
+    size_t value_index,
+    size_t length_index,
+    std::vector<TensorFiller>* fillers) {
+  CAFFE_ENFORCE_EQ(shapes[length_index].size(), 1);
+  (*fillers)[length_index].SparseLengths(shapes[value_index].front());
+}
+
+static void SparseSegmentsFillerHelper(
+    const std::vector<std::vector<TIndex>>& shapes,
+    size_t value_index,
+    size_t segment_index,
+    std::vector<TensorFiller>* fillers) {
+  CAFFE_ENFORCE_EQ(shapes[segment_index].size(), 1);
+  // TODO (mnaumov): distribution of value
+  (*fillers)[value_index].Min(0).Max(shapes[value_index].front() * 2);
+  (*fillers)[segment_index].SparseSegments(shapes[value_index].front() - 1);
+}
+
+OpSchema& OpSchema::ValueKeyLengthInputFillers(
+    size_t value_index,
+    size_t key_index,
+    size_t length_index) {
+  // TODO (mnaumov): distribution of value
+  filler_supplier_ = [this, value_index, key_index, length_index](
+                         const std::vector<std::vector<TIndex>>& shapes) {
+    auto fillers = SupplyDenseFillers(shapes);
+    SparseLengthsFillerHelper(shapes, key_index, length_index, &fillers);
+    SparseSegmentsFillerHelper(shapes, value_index, key_index, &fillers);
+    return fillers;
+  };
+  return *this;
+}
+
+OpSchema& OpSchema::ValueLengthInputFillers(
+    size_t value_index,
+    size_t length_index) {
+  filler_supplier_ = [this, value_index, length_index](
+                         const std::vector<std::vector<TIndex>>& shapes) {
+    auto fillers = SupplyDenseFillers(shapes);
+    SparseLengthsFillerHelper(shapes, value_index, length_index, &fillers);
+    return fillers;
+  };
+  return *this;
+}
+
+OpSchema& OpSchema::DisallowInputFillers() {
+  filler_supplier_ =
+      [this](const std::vector<std::vector<TIndex>>& /* unused */) {
+        throw std::invalid_argument(type_ + " does not have input fillers");
+        return std::vector<TensorFiller>();
+      };
+  return *this;
+}
+
+std::vector<TensorFiller> OpSchema::InputFillers(
+    const std::vector<std::vector<TIndex>>& shapes) const {
+  return filler_supplier_(shapes);
+}
+
+std::vector<TensorFiller> OpSchema::SupplyDenseFillers(
+    const std::vector<std::vector<TIndex>>& shapes) {
+  std::vector<TensorFiller> fillers;
+  for (const auto& shape : shapes) {
+    fillers.emplace_back(shape);
+  }
+  return fillers;
+}
+
 std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
   if (!schema.args().empty()) {
     out << "Arguments:" << std::endl;

--- a/caffe2/experiments/operators/sparse_funhash_op.cc
+++ b/caffe2/experiments/operators/sparse_funhash_op.cc
@@ -27,6 +27,7 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseFunHash)
     .NumInputs(4, 5)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 This layer compresses a fully-connected layer for sparse inputs
 via hashing.
@@ -65,7 +66,10 @@ randomly mapped from the weight vector, provided the input
     .Arg("num_outputs", "Number of outputs")
     .Arg("num_segments", "Number of segments");
 
-OPERATOR_SCHEMA(SparseFunHashGradient).NumInputs(5, 6).NumOutputs(2, 3);
+OPERATOR_SCHEMA(SparseFunHashGradient)
+    .NumInputs(5, 6)
+    .NumOutputs(2, 3)
+    .DisallowInputFillers();
 
 class GetSparseFunHashGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/experiments/operators/sparse_funhash_op.h
+++ b/caffe2/experiments/operators/sparse_funhash_op.h
@@ -47,9 +47,6 @@ class SparseFunHashOp : public Operator<Context> {
     adaptive_ = (InputSize() == 5);
   }
 
-  // TODO: enable the filler
-  DISABLE_INPUT_FILLERS(Context)
-
   bool RunOnDevice() override {
     const auto& val = Input(0);
     const auto& key = Input(1);
@@ -153,9 +150,6 @@ class SparseFunHashGradientOp : public Operator<Context> {
         seed_(OperatorBase::GetSingleArgument<uint64_t>("seed", 0)) {
     adaptive_ = (InputSize() == 6);
   }
-
-  // TODO: enable the filler
-  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     const auto& grad_out = Input(0);

--- a/caffe2/experiments/operators/sparse_matrix_reshape_op.cc
+++ b/caffe2/experiments/operators/sparse_matrix_reshape_op.cc
@@ -24,6 +24,7 @@ REGISTER_CPU_OPERATOR(SparseMatrixReshape, SparseMatrixReshapeOp<CPUContext>);
 OPERATOR_SCHEMA(SparseMatrixReshape)
     .NumInputs(2)
     .NumOutputs(2)
+    .DisallowInputFillers() // TODO: enable the filler
     .AllowInplace({{0, 0}, {1, 1}})
     .SetDoc(R"DOC(
 Compute the indices of the reshaped sparse matrix.

--- a/caffe2/experiments/operators/sparse_matrix_reshape_op.h
+++ b/caffe2/experiments/operators/sparse_matrix_reshape_op.h
@@ -91,9 +91,6 @@ class SparseMatrixReshapeOp : public Operator<Context> {
     new_stride_ = new_shape[1];
   }
 
-  // TODO: enable the filler
-  DISABLE_INPUT_FILLERS(Context)
-
   bool RunOnDevice() override {
     auto& old_col = Input(0);
     CAFFE_ENFORCE(old_col.ndim() == 1, "Row index tensor must be 1-D.");

--- a/caffe2/operators/batch_sparse_to_dense_op.cc
+++ b/caffe2/operators/batch_sparse_to_dense_op.cc
@@ -108,6 +108,7 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(BatchSparseToDense)
     .NumInputs(3, 4)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Convert sparse matrix representation into dense matrix.
 

--- a/caffe2/operators/batch_sparse_to_dense_op.h
+++ b/caffe2/operators/batch_sparse_to_dense_op.h
@@ -19,9 +19,6 @@ class BatchSparseToDenseOp : public Operator<Context> {
         OP_SINGLE_ARG(T, "default_value", default_value_, static_cast<T>(0)) {}
   bool RunOnDevice() override;
 
-  // TODO: enable the filler
-  DISABLE_INPUT_FILLERS(Context)
-
  private:
   TIndex dense_last_dim_;
   T default_value_;

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
@@ -9,6 +9,10 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseLengthsSumFused8BitRowwise)
     .NumInputs(3)
     .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFused8BitRowwiseOp<CPUContext>::DATA,
+        SparseLengthsFused8BitRowwiseOp<CPUContext>::INDICES,
+        SparseLengthsFused8BitRowwiseOp<CPUContext>::LENGTHS)
     .SetDoc(R"DOC(
 Performs the same operation as SparseLengthsSum, but operating on
 8-bit rowwise quantized matrices with fused storage (where each row
@@ -37,6 +41,7 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseLengthsWeightedSumFused8BitRowwise)
     .NumInputs(4)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: Enable the fillers
     .SetDoc(R"DOC(
 Performs the same operation as SparseLengthsWeightedSum,
 but operating on 8-bit rowwise quantized matrices with fused storage
@@ -73,6 +78,10 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseLengthsMeanFused8BitRowwise)
     .NumInputs(3)
     .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFused8BitRowwiseOp<CPUContext, false, true>::DATA,
+        SparseLengthsFused8BitRowwiseOp<CPUContext, false, true>::INDICES,
+        SparseLengthsFused8BitRowwiseOp<CPUContext, false, true>::LENGTHS)
     .SetDoc(R"DOC(
 Performs the same operation as SparseLengthsMean, but
 operating on 8-bit rowwise quantized matrices with fused storage

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -68,23 +68,6 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     return true;
   }
 
-  std::vector<TensorFiller<Context>> InputFillers(
-      const std::vector<std::vector<TIndex>>& shapes) override {
-    CAFFE_ENFORCE_EQ(shapes.size(), Operator<Context>::Inputs().size());
-    auto fillers = Operator<Context>::InputFillers(shapes);
-    if (with_weights) {
-      // TODO: enable the fillers
-      throw UnsupportedOperatorFeature(
-          OperatorBase::type() + " does not have input fillers");
-    }
-    Operator<Context>::SparseLengthsFillerHelper(
-        shapes, INDICES, LENGTHS, &fillers);
-    Operator<Context>::SparseSegmentsFillerHelper(
-        shapes, DATA, INDICES, &fillers);
-    return fillers;
-  }
-
- private:
   enum {
     DATA = 0,
     WEIGHTS = 1,

--- a/caffe2/operators/lengths_reducer_ops.cc
+++ b/caffe2/operators/lengths_reducer_ops.cc
@@ -1,6 +1,7 @@
 #include "caffe2/operators/lengths_reducer_ops.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/operators/segment_reduction_op.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -9,15 +10,15 @@ namespace caffe2 {
 // generic fashion. Otherwise it'd break schema declaration check.
 // TODO(dzhulgakov): remove _STR when all lengths ops are off generic version.
 
-REGISTER_CPU_OPERATOR_STR(
-    "SparseLengthsSum",
-    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 0, 0>);
-REGISTER_CPU_OPERATOR_STR(
-    "SparseLengthsWeightedSum",
-    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 1, 0>);
-REGISTER_CPU_OPERATOR_STR(
-    "SparseLengthsMean",
-    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 0, 1>);
+using SparseLengthsSumOp =
+    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 0, 0>;
+using SparseLengthsWeightedSumOp =
+    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 1, 0>;
+using SparseLengthsMeanOp =
+    CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 0, 1>;
+REGISTER_CPU_OPERATOR(SparseLengthsSum, SparseLengthsSumOp);
+REGISTER_CPU_OPERATOR(SparseLengthsWeightedSum, SparseLengthsWeightedSumOp);
+REGISTER_CPU_OPERATOR(SparseLengthsMean, SparseLengthsMeanOp);
 
 OPERATOR_SCHEMA(SparseLengthsPositionalWeightedSum)
     .NumInputs(4)
@@ -53,4 +54,87 @@ REGISTER_CPU_OPERATOR_STR(
     "SparseLengthsPositionalWeightedSum",
     CPUSparseLengthsReductionOp<float, TensorTypes<float, float16>, 1, 0, 1>);
 
+template <typename Def>
+string FormatDoc() {
+  string doc = Def::doc;
+  ReplaceAll(doc, "{op}", Def::OpDef::name);
+  ReplaceAll(doc, "{op_doc}", Def::OpDef::doc);
+  auto replaced = ReplaceAll(doc, "{extra}", "");
+  CAFFE_ENFORCE_EQ(replaced, 0);
+  return doc;
+}
+
+using SparseLengthsSumDef = AbstractSparseLengthsDef<
+    float,
+    int,
+    CPUContext,
+    SumReducerDef,
+    true /*GradientNeedIndices*/>;
+OPERATOR_SCHEMA(SparseLengthsSum)
+    .NumInputs(SparseLengthsSumDef::ForwardOp::kNumInputs)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsSumOp::DATA,
+        SparseLengthsSumOp::INDICES,
+        SparseLengthsSumOp::LENGTHS)
+    .SetDoc(FormatDoc<SparseLengthsSumDef>())
+    .Output(0, "OUTPUT", "Aggregated tensor")
+    .FillUsing(SparseLengthsSumDef::PopulateSchema);
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSumGradient,
+    SparseLengthsSumDef::BackwardOp);
+OPERATOR_SCHEMA(SparseLengthsSumGradient)
+    .NumInputs(SparseLengthsSumDef::BackwardOp::kNumInputs)
+    .NumOutputs(1)
+    .DisallowInputFillers();
+REGISTER_GRADIENT(SparseLengthsSum, SparseLengthsSumDef::GetGradient)
+
+using SparseLengthsWeightedSumDef = AbstractSparseLengthsDef<
+    float,
+    int,
+    CPUContext,
+    WeightedSumReducerDef,
+    true /*GradientNeedIndices*/>;
+OPERATOR_SCHEMA(SparseLengthsWeightedSum)
+    .NumInputs(SparseLengthsWeightedSumDef::ForwardOp::kNumInputs)
+    .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable input fillers
+    .SetDoc(FormatDoc<SparseLengthsWeightedSumDef>())
+    .Output(0, "OUTPUT", "Aggregated tensor")
+    .FillUsing(SparseLengthsWeightedSumDef::PopulateSchema);
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSumGradient,
+    SparseLengthsWeightedSumDef::BackwardOp);
+OPERATOR_SCHEMA(SparseLengthsWeightedSumGradient)
+    .NumInputs(SparseLengthsWeightedSumDef::BackwardOp::kNumInputs)
+    .NumOutputs(1)
+    .DisallowInputFillers();
+REGISTER_GRADIENT(
+    SparseLengthsWeightedSum,
+    SparseLengthsWeightedSumDef::GetGradient)
+
+using SparseLengthsMeanDef = AbstractSparseLengthsDef<
+    float,
+    int,
+    CPUContext,
+    MeanReducerDef,
+    true /*GradientNeedIndices*/>;
+OPERATOR_SCHEMA(SparseLengthsMean)
+    .NumInputs(SparseLengthsMeanDef::ForwardOp::kNumInputs)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsMeanOp::DATA,
+        SparseLengthsMeanOp::INDICES,
+        SparseLengthsMeanOp::LENGTHS)
+    .SetDoc(FormatDoc<SparseLengthsMeanDef>())
+    .Output(0, "OUTPUT", "Aggregated tensor")
+    .FillUsing(SparseLengthsMeanDef::PopulateSchema);
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMeanGradient,
+    SparseLengthsMeanDef::BackwardOp);
+OPERATOR_SCHEMA(SparseLengthsMeanGradient)
+    .NumInputs(SparseLengthsMeanDef::BackwardOp::kNumInputs)
+    .NumOutputs(1)
+    .DisallowInputFillers();
+REGISTER_GRADIENT(SparseLengthsMean, SparseLengthsMeanDef::GetGradient)
 } // namespace caffe2

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -92,23 +92,6 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
     return true;
   }
 
-  std::vector<TensorFiller<CPUContext>> InputFillers(
-      const std::vector<std::vector<TIndex>>& shapes) override {
-    CAFFE_ENFORCE_EQ(shapes.size(), Operator<CPUContext>::Inputs().size());
-    auto fillers = Operator<CPUContext>::InputFillers(shapes);
-    if (USE_WEIGHT) {
-      // TODO: enable the fillers
-      throw UnsupportedOperatorFeature(
-          OperatorBase::type() + " does not have input fillers");
-    }
-    Operator<CPUContext>::SparseLengthsFillerHelper(
-        shapes, INDICES, LENGTHS, &fillers);
-    Operator<CPUContext>::SparseSegmentsFillerHelper(
-        shapes, DATA, INDICES, &fillers);
-    return fillers;
-  }
-
- private:
   enum {
     DATA = 0, // Data input.
     WEIGHT = 1, // Weight input used in SparseLengthsWeightedSum

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.cc
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.cc
@@ -29,6 +29,9 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseLengthsSum8BitsRowwise)
     .NumInputs(4)
     .NumOutputs(1)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext>::LENGTHS)
     .SetDoc(R"DOC(
 Variation of SparseLengthsSum operator, where DATA is
 stored using 8bits. DATA was quantized with 8Bit row-wise
@@ -61,6 +64,9 @@ and biases.
 OPERATOR_SCHEMA(SparseLengthsWeightedSum8BitsRowwise)
     .NumInputs(5)
     .NumOutputs(1)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext, 1>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext, 1>::LENGTHS)
     .SetDoc(R"DOC(
 Variation of SparseLengthsWeightedSum operator, where
 DATA is stored using 8bits. DATA was quantized with 8Bit row-wise
@@ -97,6 +103,9 @@ and biases.
 OPERATOR_SCHEMA(SparseLengthsMean8BitsRowwise)
     .NumInputs(4)
     .NumOutputs(1)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext, 0, 1>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext, 0, 1>::LENGTHS)
     .SetDoc(R"DOC(
 Variation of SparseLengthsMean operator, where DATA is
 stored using 8bits. DATA was quantized with 8Bit row-wise
@@ -129,6 +138,9 @@ and biases.
 OPERATOR_SCHEMA(SparseLengthsWeightedMean8BitsRowwise)
     .NumInputs(5)
     .NumOutputs(1)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext, 1, 1>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext, 1, 1>::LENGTHS)
     .SetDoc(R"DOC(
 Variation of SparseLengthsWeightedMean operator, where
 DATA is stored using 8bits. DATA was quantized with 8Bit row-wise
@@ -165,6 +177,9 @@ and biases.
 OPERATOR_SCHEMA(FloatToRowwiseQuantized8Bits)
     .NumInputs(1)
     .NumOutputs(2)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext>::LENGTHS)
     .SetDoc(R"DOC(
 This operator applies 8Bit row-wise quantization to
 input tensor and returns quantized tensor. Row wise quantization of
@@ -189,6 +204,9 @@ restore input tensor (with losses).
 OPERATOR_SCHEMA(Rowwise8BitQuantizedToFloat)
     .NumInputs(2)
     .NumOutputs(1)
+    .ValueLengthInputFillers(
+        SparseLengths8BitsRowwiseOp<CPUContext>::DATA,
+        SparseLengths8BitsRowwiseOp<CPUContext>::LENGTHS)
     .SetDoc(R"DOC(
 Given uint8 tensor, quantized using 8bit row-wise
 quantization, and auxiliary scales and biases, this operator

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
@@ -87,8 +87,6 @@ class SparseLengths8BitsRowwiseOp : public Operator<Context> {
     return true;
   }
 
-  USE_VALUE_LENGTH_INPUT_FILLERS(Context, DATA, LENGTHS)
-
   enum {
     DATA = 0,
     WEIGHTS = 1,

--- a/caffe2/operators/one_hot_ops.cc
+++ b/caffe2/operators/one_hot_ops.cc
@@ -172,9 +172,6 @@ class SegmentOneHotOp : public Operator<CPUContext> {
   SegmentOneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator(operator_def, ws) {}
 
-  // TODO: enable input filler
-  DISABLE_INPUT_FILLERS(CPUContext)
-
   bool RunOnDevice() override {
     auto& lengths = Input(0);
     auto& indices = Input(1);
@@ -216,6 +213,7 @@ REGISTER_CPU_OPERATOR(SegmentOneHot, SegmentOneHotOp);
 OPERATOR_SCHEMA(BatchBucketOneHot)
     .NumInputs(3)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Input is a matrix tensor. Its first dimension is the batch
 size. For each column, bucketize it based on the boundary values and then do
@@ -247,6 +245,10 @@ For example
 OPERATOR_SCHEMA(BatchOneHot)
     .NumInputs(3)
     .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        BatchOneHotOp<CPUContext>::X,
+        BatchOneHotOp<CPUContext>::VALS,
+        BatchOneHotOp<CPUContext>::LENS)
     .SetDoc(R"DOC(
 Input is a matrix tensor. Its first dimension is the batch
 size. Expand each column of it using one hot encoding. The `lengths` specifies
@@ -272,6 +274,7 @@ of one-hot encoding for each column. For example
 OPERATOR_SCHEMA(OneHot)
     .NumInputs(2)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 The *OneHot* op accepts two inputs *indices* and *index_size_tensor*, and produces a single output *one_hots*.  For each index in *indices* the op creates a one-hot row in *one_hots* of length *index_size_tensor* where all entries are zero except the entry at the index is 1. The size of *one_hots* is *len(indices)* x *index_size_tensor*.
 
@@ -338,6 +341,7 @@ one_hots:
 OPERATOR_SCHEMA(SegmentOneHot)
     .NumInputs(3)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Given a sequence of indices, segmented by the lengths tensor, returns a matrix
 that has the elements in each sequence set to 1.0, and 0.0 everywhere else.

--- a/caffe2/operators/one_hot_ops.h
+++ b/caffe2/operators/one_hot_ops.h
@@ -13,9 +13,6 @@ class OneHotOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  // TODO: enable input filler
-  DISABLE_INPUT_FILLERS(Context)
-
   OneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {}
 
@@ -61,8 +58,6 @@ class BatchOneHotOp final : public Operator<Context> {
   BatchOneHotOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {}
 
-  USE_VALUE_KEY_LENGTH_INPUT_FILLERS(Context, X, VALS, LENS)
-
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(X));
   }
@@ -70,8 +65,9 @@ class BatchOneHotOp final : public Operator<Context> {
   template <typename T>
   bool DoRunWithType();
 
- protected:
   INPUT_TAGS(X, LENS, VALS);
+
+ protected:
   OUTPUT_TAGS(ONE_HOT);
 
  private:
@@ -87,9 +83,6 @@ class BatchBucketOneHotOp final : public Operator<Context> {
       : Operator<Context>(operator_def, ws) {}
 
   bool RunOnDevice() override;
-
-  // TODO: enable input filler
-  DISABLE_INPUT_FILLERS(Context)
 
  protected:
   INPUT_TAGS(X, LENS, BOUNDARIES);

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -367,6 +367,7 @@ constexpr bool equal(
 
 // Helper macro when the main op is defined elsewhere, and we only need to
 // define the schema, and the gradient op.
+// TODO: enable input fillers
 #define REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                            \
     segment_name, gradient_name, ...)                                         \
   static_assert(                                                              \
@@ -382,13 +383,15 @@ constexpr bool equal(
   OPERATOR_SCHEMA(segment_name)                                               \
       .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                          \
       .NumOutputs(1)                                                          \
+      .DisallowInputFillers()                                                 \
       .SetDoc(FormatDoc<__VA_ARGS__>())                                       \
       .Output(0, "OUTPUT", "Aggregated tensor")                               \
       .FillUsing(__VA_ARGS__::PopulateSchema);                                \
   REGISTER_CPU_OPERATOR_STR(string(#gradient_name), __VA_ARGS__::BackwardOp); \
   OPERATOR_SCHEMA(gradient_name)                                              \
       .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                         \
-      .NumOutputs(1);                                                         \
+      .NumOutputs(1)                                                          \
+      .DisallowInputFillers();                                                \
   REGISTER_GRADIENT_STR(string(#segment_name), __VA_ARGS__::GetGradient)
 
 #define REGISTER_SEGMENT_DEF(segment_name, gradient_name, ...)               \
@@ -504,37 +507,6 @@ REGISTER_SEGMENT_DEF(
     LengthsWeightedSum,
     LengthsWeightedSumGradient,
     AbstractLengthsDef<float, int, CPUContext, WeightedSumReducerDef, false>);
-
-// SparseLengths[Sum,WeightedSum,Mean] are now implemented separately,
-// so we only rely to the historical implementation for the backward + schema.
-REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    SparseLengthsSum,
-    SparseLengthsSumGradient,
-    AbstractSparseLengthsDef<
-        float,
-        int,
-        CPUContext,
-        SumReducerDef,
-        true /*GradientNeedIndices*/>)
-REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    SparseLengthsWeightedSum,
-    SparseLengthsWeightedSumGradient,
-    AbstractSparseLengthsDef<
-        float,
-        int,
-        CPUContext,
-        WeightedSumReducerDef,
-        true /*GradientNeedIndices*/>)
-
-REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    SparseLengthsMean,
-    SparseLengthsMeanGradient,
-    AbstractSparseLengthsDef<
-        float,
-        int,
-        CPUContext,
-        MeanReducerDef,
-        true /*GradientNeedIndices*/>)
 
 // Auxiliary output gradients are currently implemented only for Lengths version
 #define REGISTER_GRADIENT_WITH_MAIN_INPUT(gradient_name, ...)        \

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -9,6 +9,7 @@ REGISTER_CPU_OPERATOR(SliceGradient, SliceGradientOp<int, CPUContext>);
 OPERATOR_SCHEMA(Slice)
     .NumInputs(1, 3)
     .NumOutputs(1)
+    .DisallowInputFillers() // the filler cannot be enabled without output dims
     .SetDoc(R"DOC(
 Produces a slice of the input tensor.
 
@@ -63,8 +64,14 @@ Y:
 
 )DOC")
     .Input(0, "X", "(*Tensor*): tensor to extract slices from")
-    .Input(1, "starts", "(*Tensor`<int>`*): 1D tensor of start-indices for each dimension of data")
-    .Input(2, "ends", "(*Tensor`<int>`*): 1D tensor of end-indices for each dimension of data")
+    .Input(
+        1,
+        "starts",
+        "(*Tensor`<int>`*): 1D tensor of start-indices for each dimension of data")
+    .Input(
+        2,
+        "ends",
+        "(*Tensor`<int>`*): 1D tensor of end-indices for each dimension of data")
     .Arg("starts", "(*Tuple(int)*): list of starting indices")
     .Arg("ends", "(*Tuple(int)*): list of ending indices")
     .TensorInferenceFunction([](const OperatorDef& def,

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -212,9 +212,6 @@ class SliceOp : public Operator<Context> {
     return RunOnDeviceImpl(Input(0), Output(0));
   }
 
-  // This cannot be enabled given the output dims depends on the input
-  DISABLE_INPUT_FILLERS(Context)
-
  protected:
   bool RunOnDeviceImpl(const Tensor& data, Tensor* output) {
     if (InputSize() > 1) {

--- a/caffe2/operators/sparse_to_dense_mask_op.cc
+++ b/caffe2/operators/sparse_to_dense_mask_op.cc
@@ -11,6 +11,7 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseToDenseMask)
     .NumInputs(3, 4)
     .NumOutputs(1, 2)
+    .DisallowInputFillers() // TODO: enable the filler
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       ArgumentHelper helper(def);
@@ -94,6 +95,7 @@ of size `len(lengths) X len(mask)`
 OPERATOR_SCHEMA(SparseToDenseMaskGradient)
     .NumInputs(2, 3)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 The output is the gradient of the input value from SparseToDenseMask. The
 gradient for default_value has not been implemented.

--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -37,9 +37,6 @@ class SparseToDenseMaskBase : public Operator<Context> {
     }
   }
 
-  // TODO: enable the filler
-  DISABLE_INPUT_FILLERS(Context)
-
  protected:
   const int64_t kMaxDenseSize = 1024 * 128;
 

--- a/caffe2/operators/utility_ops.cc
+++ b/caffe2/operators/utility_ops.cc
@@ -694,6 +694,7 @@ Example:
 OPERATOR_SCHEMA(LengthsToSegmentIds)
     .NumInputs(1)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Given a vector of segment lengths (*lengths*) the *LengthsToSegmentIds* op returns a zero-based, consecutive vector of segment ids (*segment_ids*). For example, *lengths=[1, 3, 0, 2]* will produce *segment_ids=[0, 1, 1, 1, 3, 3]*. In general, the inverse operation is *SegmentIdsToLengths*. Notice though that trailing empty sequence lengths can't be properly recovered from segment ids.
 
@@ -770,6 +771,7 @@ For example, `[1, 3, 0, 2]` transforms into `[[0, 1], [1, 3], [4, 0], [4, 2]]`.
 OPERATOR_SCHEMA(SegmentIdsToLengths)
     .NumInputs(1, 2)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Transfers a vector of segment ids to a vector of segment lengths. This operation
 supports non-consecutive segment ids. Segments not appearing in the input vector
@@ -791,6 +793,7 @@ cannot represent empty segments at the end (if the second input is absent).
 OPERATOR_SCHEMA(SegmentIdsToRanges)
     .NumInputs(1, 2)
     .NumOutputs(1)
+    .DisallowInputFillers() // TODO: enable the filler
     .SetDoc(R"DOC(
 Transfers a vector of segment ids to a vector of segment ranges. This operation
 supports non-consecutive segment ids. Segments not appearing in the input vector

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -704,9 +704,6 @@ class LengthsToSegmentIdsOp : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(LengthsToSegmentIdsOp);
 
-  // TODO: enable the InputFillers
-  DISABLE_INPUT_FILLERS(Context)
-
   bool RunOnDevice() override {
     auto& input = Input(0);
     auto* output = Output(0);
@@ -761,9 +758,6 @@ class SegmentIdsToLengthsOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(SegmentIdsToLengthsOp);
-
-  // TODO: enable the InputFillers
-  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(0));
@@ -821,9 +815,6 @@ class SegmentIdsToRangesOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(SegmentIdsToRangesOp);
-
-  // TODO: enable the InputFillers
-  DISABLE_INPUT_FILLERS(Context)
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(0));


### PR DESCRIPTION
Summary:
Move filler interface to operator schema to avoid extra code for
caffe2 mobile.

Differential Revision: D9312940
