### PR TITLE
Desugar `ListConstruct + aten::index` into a series of `index_select` ops for ONNX export

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -702,6 +702,15 @@ class TestCaffe2Backend(unittest.TestCase):
         x = torch.randn(*shape)
         self.run_model_test(MyModel(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_index_desugar(self):
+        class TestIndexing(torch.nn.Module):
+            def forward(self, x, y):
+                return x[y, y]
+
+        x = torch.rand(3, 4, 5)
+        y = torch.arange(2)
+        self.run_model_test(TestIndexing(), train=False, input=(x,y), batch_size=BATCH_SIZE, use_gpu=False)
+
     def test_repeat(self):
         class MyModel(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -688,6 +688,20 @@ class TestCaffe2Backend(unittest.TestCase):
             x = Variable(torch.randn(*shape))
             self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_layer_norm(self):
+        shape = (20, 5, 10, 10)
+
+        class MyModel(torch.nn.Module):
+            def __init__(self):
+                super(MyModel, self).__init__()
+                self.ln = torch.nn.LayerNorm([5, 10, 10])
+
+            def forward(self, x):
+                return self.ln(x)
+
+        x = torch.randn(*shape)
+        self.run_model_test(MyModel(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
     def test_repeat(self):
         class MyModel(torch.nn.Module):
             def __init__(self):

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -158,6 +158,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/passes/loop_unrolling.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/lower_grad_of.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/lower_tuples.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/eliminate_index_lists.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/peephole.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/remove_expands.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/shape_analysis.cpp

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -11,6 +11,7 @@
 #include "torch/csrc/jit/passes/onnx.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/erase_number_types.h"
+#include "torch/csrc/jit/passes/eliminate_index_lists.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
 #include "torch/csrc/jit/passes/peephole.h"
 #include "torch/csrc/jit/passes/canonicalize.h"
@@ -82,6 +83,7 @@ void initJITBindings(PyObject *module) {
    .def("_jit_pass_constant_propagation", [](std::shared_ptr<Graph>& g) {
      return ConstantPropagation(g);
    })
+   .def("_jit_pass_eliminate_index_lists", eraseIndexWithLists)
    .def("_jit_run_cpp_tests", [] {
      // We have to release the GIL inside this method, because if we happen to
      // initialize the autograd engine in these tests, the newly spawned worker threads will

--- a/torch/csrc/jit/passes/eliminate_index_lists.cpp
+++ b/torch/csrc/jit/passes/eliminate_index_lists.cpp
@@ -1,0 +1,41 @@
+#include "torch/csrc/jit/passes/eliminate_index_lists.h"
+
+namespace torch { namespace jit {
+
+void eraseIndexWithLists(Block* block) {
+  auto g = block->owningGraph();
+  for (auto it = block->nodes().begin(), end = block->nodes().end();
+        it != end;) {
+    Node * n = *it;
+    ++it;
+
+    for (auto b : n->blocks()) {
+      eraseIndexWithLists(b);
+    }
+
+    // Replace a sequence of ListConstruct -> Index with a series of index_select
+    // ops, one for each dimension in the list specification.
+    if (n->kind() == prim::ListConstruct && n->output()->uses().size() == 1
+        && n->output()->uses()[0].user->kind() == aten::index) {
+      Node *index_node = n->output()->uses()[0].user;
+      WithInsertPoint guard(n);
+      Value *self = index_node->inputs()[0]; // Note this is carried across iterations
+      for (size_t dim = 0; dim < n->inputs().size(); ++dim) {
+        at::ArrayRef<NamedValue> input_args = {
+          /*self=*/NamedValue(self),
+          /*dim=*/NamedValue(g->insertConstant((int64_t)dim)),
+          /*index=*/NamedValue(n->inputs()[dim])
+        };
+        self = g->insert(aten::index_select, input_args);
+      } //  for (size_t dim = 0; ...
+      index_node->output()->replaceAllUsesWith(self);
+      // Let DCE clean up the original nodes.
+    } //  if (n->kind() == prim::ListConstruct ...
+  }
+}
+
+void eraseIndexWithLists(Graph* graph) {
+  eraseIndexWithLists(graph->block());
+}
+
+}} // namespace torch::jit

--- a/torch/csrc/jit/passes/eliminate_index_lists.cpp
+++ b/torch/csrc/jit/passes/eliminate_index_lists.cpp
@@ -21,7 +21,7 @@ void eraseIndexWithLists(Block* block) {
       WithInsertPoint guard(n);
       Value *self = index_node->inputs()[0]; // Note this is carried across iterations
       for (size_t dim = 0; dim < n->inputs().size(); ++dim) {
-        at::ArrayRef<NamedValue> input_args = {
+        std::vector<NamedValue> input_args = {
           /*self=*/NamedValue(self),
           /*dim=*/NamedValue(g->insertConstant((int64_t)dim)),
           /*index=*/NamedValue(n->inputs()[dim])

--- a/torch/csrc/jit/passes/eliminate_index_lists.h
+++ b/torch/csrc/jit/passes/eliminate_index_lists.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+TORCH_API void eraseIndexWithLists(Graph* graph);
+
+
+}}  // namespace torch::jit

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -710,6 +710,12 @@ def type_as(g, self, other):
         return g.op("ATen", self, other, operator_s="type_as")
 
 
+@parse_args('v', 'is', 'v', 'v', 'f', 'i')
+def layer_norm(g, self, normalized_shape, weight, bias, eps, cudnn_enable):
+    return g.op("ATen", self, weight, bias, normalized_shape_i=normalized_shape,
+                eps_f=eps, cudnn_enable_i=cudnn_enable, operator_s="layer_norm")
+
+
 # ignore clone operators that are inserted by PyTorch autograd
 def clone(g, input):
     return input

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -120,6 +120,10 @@ def _optimize_graph(graph, operator_export_type):
     torch._C._jit_pass_peephole(graph)
     torch._C._jit_pass_lint(graph)
 
+    torch._C._jit_pass_eliminate_index_lists(graph)
+    torch._C._jit_pass_dce(graph)
+    torch._C._jit_pass_lint(graph)
+
     # onnx only supports tensors, so we turn all out number types into tensors
     torch._C._jit_pass_erase_number_types(graph)
     torch._C._jit_pass_peephole(graph)


### PR DESCRIPTION
Using lists previously broke export for these indexing operations, this is an attempt to fix it. Mostly publishing this to get CI signal