### PR TITLE
[build] Remove setup_requires and tests_require from setup.py for FULL_CAFFE2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1046,8 +1046,6 @@ install_requires = [
     'six',
 ] if FULL_CAFFE2 else []
 
-tests_require = ['pytest-cov', 'hypothesis'] if FULL_CAFFE2 else []
-
 entry_points = {}
 if FULL_CAFFE2:
     entry_points = {
@@ -1101,5 +1099,4 @@ if __name__ == '__main__':
             ]
         },
         install_requires=install_requires,
-        tests_require=tests_require,
     )

--- a/setup.py
+++ b/setup.py
@@ -1046,7 +1046,6 @@ install_requires = [
     'six',
 ] if FULL_CAFFE2 else []
 
-setup_requires = ['pytest-runner'] if FULL_CAFFE2 else []
 tests_require = ['pytest-cov', 'hypothesis'] if FULL_CAFFE2 else []
 
 entry_points = {}
@@ -1102,6 +1101,5 @@ if __name__ == '__main__':
             ]
         },
         install_requires=install_requires,
-        setup_requires=setup_requires,
         tests_require=tests_require,
     )


### PR DESCRIPTION
In my environment, it looks like setup.py hangs when running

```
FULL_CAFFE2=1 python setup.py build_deps
```

Removing this fixes things, but we might also want to look at `tests_require`, which came over from `setup_caffe2.py`.

cc @pjh5 