### PR TITLE
parallel norm operation for ATen on CPU

### DIFF
--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -21,7 +21,7 @@ namespace {
 // can just use the native mechanism straight.
 
 // TODO: Maybe the foo_ variants should call th_foo_
-
+/*
 Tensor norm(const Tensor & self, Scalar p) {
   if (_has_native(self)) {
     return native_norm(self, p);
@@ -29,7 +29,7 @@ Tensor norm(const Tensor & self, Scalar p) {
     return th_norm(self, p);
   }
 }
-
+*/
 Tensor clone(const Tensor& self) {
   if (_has_native(self)) {
     return native_clone(self);

--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -21,15 +21,7 @@ namespace {
 // can just use the native mechanism straight.
 
 // TODO: Maybe the foo_ variants should call th_foo_
-/*
-Tensor norm(const Tensor & self, Scalar p) {
-  if (_has_native(self)) {
-    return native_norm(self, p);
-  } else {
-    return th_norm(self, p);
-  }
-}
-*/
+
 Tensor clone(const Tensor& self) {
   if (_has_native(self)) {
     return native_clone(self);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -592,7 +592,7 @@ Tensor& _norm_out_cpu(Tensor& result, const Tensor& self, Scalar p, int64_t dim_
     return result;
   if (self.is_contiguous() && result.is_contiguous()) {
     _dimreduce_setup(result, self, dim);
-    norm_kernel(kCPU, result, self, p, dim, keepdim);
+    norm_kernel(kCPU, result, self, p, dim);
     if (!keepdim) {
       result.squeeze_(dim);
     }
@@ -602,12 +602,7 @@ Tensor& _norm_out_cpu(Tensor& result, const Tensor& self, Scalar p, int64_t dim_
   }
 }
 
-Tensor norm(const Tensor& self, Scalar p, int64_t dim, bool keepdim) {
-  Tensor result = self.type().tensor();
-  return at::native::norm_out(result, self, p, dim, keepdim);
-}
-
-Tensor &norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool keepdim) {
+Tensor& norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool keepdim) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "norm only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
@@ -625,6 +620,36 @@ Tensor &norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool
     return at::_th_norm_out(result, self, p, dim, keepdim);
 #endif
   }
+}
+
+Tensor _norm(const Tensor &self, Scalar p) {
+  AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
+           "norm only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
+  AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
+#if 1
+  if (self.is_cuda()) {
+    return at::th_norm(self, p);
+  } else {
+    if (self.is_contiguous()) {
+      Tensor result = at::zeros(1, self.type());
+      norm_kernel(kCPU, result, self, p, nullopt);
+      return result;
+    } else {
+      at::th_norm(self, p);
+    }
+  }
+#else
+  return at::th_norm(self, p);
+#endif
+}
+
+Tensor norm(const Tensor& self, Scalar p, int64_t dim, bool keepdim) {
+  Tensor result = self.type().tensor();
+  return at::native::norm_out(result, self, p, dim, keepdim);
+}
+
+Tensor norm(const Tensor& self, Scalar p) {
+  return at::native::_norm(self, p);;
 }
 
 Tensor all(const Tensor& self, int64_t dim, bool keepdim) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -586,7 +586,7 @@ Tensor& _sum_out(Tensor &result, const Tensor &self, IntList dims, bool keepdim)
 }
 
 Tensor& _norm_out_cpu(Tensor& result, const Tensor& self, Scalar p, int64_t dim_, bool keepdim) {
-  std::cout << "p = " << p << ", dim = " << dim_ << ", keepdim = " << keepdim << std::endl;
+  //std::cout << "p = " << p << ", dim = " << dim_ << ", keepdim = " << keepdim << std::endl;
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim))
     return result;
@@ -615,11 +615,15 @@ Tensor &norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
     return result;
   } else {
+#if 1
     if (self.is_cuda()) {
       return at::_th_norm_out(result, self, p, dim, keepdim);
     } else {
       return _norm_out_cpu(result, self, p, dim, keepdim);
     }
+#else
+    return at::_th_norm_out(result, self, p, dim, keepdim);
+#endif
   }
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -586,7 +586,6 @@ Tensor& _sum_out(Tensor &result, const Tensor &self, IntList dims, bool keepdim)
 }
 
 Tensor& _norm_out_cpu(Tensor& result, const Tensor& self, Scalar p, int64_t dim_, bool keepdim) {
-  //std::cout << "p = " << p << ", dim = " << dim_ << ", keepdim = " << keepdim << std::endl;
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim))
     return result;
@@ -610,15 +609,11 @@ Tensor& norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
     return result;
   } else {
-#if 1
     if (self.is_cuda()) {
       return at::_th_norm_out(result, self, p, dim, keepdim);
     } else {
       return _norm_out_cpu(result, self, p, dim, keepdim);
     }
-#else
-    return at::_th_norm_out(result, self, p, dim, keepdim);
-#endif
   }
 }
 
@@ -626,7 +621,6 @@ Tensor _norm(const Tensor &self, Scalar p) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "norm only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
   AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
-#if 1
   if (self.is_cuda()) {
     return at::th_norm(self, p);
   } else {
@@ -638,9 +632,6 @@ Tensor _norm(const Tensor &self, Scalar p) {
       at::th_norm(self, p);
     }
   }
-#else
-  return at::th_norm(self, p);
-#endif
 }
 
 Tensor norm(const Tensor& self, Scalar p, int64_t dim, bool keepdim) {

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -183,9 +183,31 @@ static void prod_kernel_impl(Tensor& result, const Tensor& self, at::optional<in
   });
 }
 
+template<typename scalar_t>
+struct NormReduction {
+  static void apply(Tensor& res, const Tensor& self, Scalar p, int64_t dim, bool keepdim) {
+    std::cout << "NormReduction called" << std::endl;
+    auto out_ = res.data<scalar_t>();
+    auto data_ = self.data<scalar_t>();
+    auto numel = self.numel();
+    //if (!dim.has_value()) {
+    //  std::cout << "dim has no value, not supported yet, TODO" << std::endl;
+    //  return;
+    //}
+    //int64_t n = self.size(*dim);
+  }
+};
+
+static void norm_kernel_impl(Tensor& result, const Tensor& self, Scalar p, int64_t dim, bool keepdim) {
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "norm", [&] {
+    NormReduction<scalar_t>::apply(result, self, p, dim, keepdim);
+  });
+}
+
 }  // anonymous namespace
 
 REGISTER_DISPATCH(sum_kernel, &sum_kernel_impl);
 REGISTER_DISPATCH(prod_kernel, &prod_kernel_impl);
+REGISTER_DISPATCH(norm_kernel, &norm_kernel_impl);
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -189,15 +189,14 @@ struct NormReduction {
     auto out_ = res.data<scalar_t>();
     auto data_ = self.data<scalar_t>();
     auto numel = self.numel();
-    auto pval = 0.0;
+    float pval = 0.0;
     if (p.isIntegral()){
       pval = p.to<int64_t>();
     } else if (p.isFloatingPoint()) {
       pval = p.to<float>();
     }
     if (!dim.has_value()) {
-      *out_ = reduce_all(data_, numel,  p);
-      //std::cout << "dim has no value, not supported yet, TODO" << std::endl;
+      *out_ = reduce_all(data_, numel,  pval);
       return;
     }
 
@@ -213,97 +212,17 @@ struct NormReduction {
       }
     }
     int64_t batch = numel / n;
-
-#if 1
-    if (stride == 1) {
-      parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
-        for (int64_t b = begin; b < end; b++) {
-          const scalar_t* data = &data_[b * n];
-          scalar_t result = 0.0;
-          if (pval == 0) {
-            for (int64_t k = 0; k < n; k++) {
-              result += (data[k] != 0.0);
-            }
-            out_[b] = result;
-          } else if (pval == 1) {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::abs(data[k]);
-            }
-            out_[b] = result;
-          } else if (pval == 2) {
-            for (int64_t k = 0; k < n; k++) {
-              result += data[k] * data[k];
-            }
-            out_[b] = std::sqrt(result);
-          } else if (pval == 3) {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::abs(data[k] * data[k] * data[k]);
-            }
-            out_[b] = std::pow(result, 1.0/3);
-          } else if (std::isinf(pval)) {
-            for (int64_t k = 0; k < n; k++) {
-              result = std::abs(data[k]) > result ? std::abs(data[k]) : result;
-            }
-            out_[b] = result;
-          } else {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::pow(std::abs(data[k]), pval);
-            }
-            out_[b] = std::pow(result, 1.0/pval);
-          }
-        }
-      });
-    } else {
-      parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
-        for (int64_t bi = begin; bi < end; bi++) {
-          int64_t b = bi / stride;
-          int64_t i = bi % stride;
-          const scalar_t* data = &data_[b * n * stride + i];
-          scalar_t result = 0.0;
-          if (pval == 0) {
-            for (int64_t k = 0; k < n; k++) {
-              result += (data[k * stride] != 0.0);
-            }
-            out_[bi] = result;
-          } else if (pval == 1) {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::abs(data[k * stride]);
-            }
-            out_[bi] = result;
-          } else if (pval == 2) {
-            for (int64_t k = 0; k < n; k++) {
-              result += data[k * stride] * data[k * stride];
-            }
-            out_[bi] = std::sqrt(result);
-          } else if (pval == 3) {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
-            }
-            out_[bi] = std::pow(result, 1.0/3);
-          } else if (std::isinf(pval)) {
-            for (int64_t k = 0; k < n; k++) {
-              result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
-            }
-            out_[bi] = result;
-          } else {
-            for (int64_t k = 0; k < n; k++) {
-              result += std::pow(std::abs(data[k * stride]), pval);
-            }
-            out_[bi] = std::pow(result, 1.0/pval);
-          }
-        }
-      });
-    }
-#endif
+    parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
+      for (int64_t bi = begin; bi < end; bi++) {
+        int64_t b = bi / stride;
+        int64_t i = bi % stride;
+        const scalar_t* data = &data_[b * n * stride + i];
+        out_[bi] = norm_calc(data, n, stride, pval);
+      }
+    });
   }
 
-  static scalar_t reduce_all(const scalar_t* data_, int64_t size,  Scalar p) {
-    auto pval = 0.0;
-    if (p.isIntegral()){
-      pval = p.to<int64_t>();
-    } else if (p.isFloatingPoint()) {
-      pval = p.to<float>();
-    }
+  static scalar_t reduce_all(const scalar_t* data_, int64_t size,  float pval) {
     scalar_t sum = parallel_reduce(
       0,
       size,
@@ -312,39 +231,45 @@ struct NormReduction {
       [=](int64_t begin, int64_t end, scalar_t init) {
         const scalar_t* data = &data_[begin];
         int64_t n = end - begin;
-        scalar_t result = 0.0;
-        if (pval == 0) {
-          for (int64_t k = 0; k < n; k++) {
-            result += (data[k] != 0.0);
-          }
-        } else if (pval == 1) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k]);
-          }
-        } else if (pval == 2) {
-          for (int64_t k = 0; k < n; k++) {
-            result += data[k] * data[k];
-          }
-          result = std::sqrt(result);
-        } else if (pval == 3) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k] * data[k] * data[k]);
-          }
-          result = std::pow(result, 1.0/3);
-        } else if (std::isinf(pval)) {
-          for (int64_t k = 0; k < n; k++) {
-            result = std::abs(data[k]) > result ? std::abs(data[k]) : result;
-          }
-        } else {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::pow(std::abs(data[k]), pval);
-          }
-          result = std::pow(result, 1.0/pval);
-        }
+        scalar_t result = norm_calc(data, n, 1, pval);
         return result;
       },
       std::plus<scalar_t>());
     return sum;
+  }
+
+  static scalar_t norm_calc(const scalar_t* data, int64_t n, int64_t stride, float pval) {
+        scalar_t result = 0.0;
+        if (pval == 0) {
+          for (int64_t k = 0; k < n; k++) {
+            result += (data[k * stride] != 0.0);
+          }
+        } else if (pval == 1) {
+          for (int64_t k = 0; k < n; k++) {
+            result += std::abs(data[k * stride]);
+          }
+        } else if (pval == 2) {
+          for (int64_t k = 0; k < n; k++) {
+            result += data[k * stride] * data[k * stride];
+          }
+          result = std::sqrt(result);
+        } else if (pval == 3) {
+          for (int64_t k = 0; k < n; k++) {
+            result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
+          }
+          result = std::pow(result, 1.0/3);
+        } else if (std::isinf(pval)) {
+          for (int64_t k = 0; k < n; k++) {
+            result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
+          }
+          result = result;
+        } else {
+          for (int64_t k = 0; k < n; k++) {
+            result += std::pow(std::abs(data[k * stride]), pval);
+          }
+          result = std::pow(result, 1.0/pval);
+        }
+        return result;
   }
 
 };

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -185,20 +185,22 @@ static void prod_kernel_impl(Tensor& result, const Tensor& self, at::optional<in
 
 template<typename scalar_t>
 struct NormReduction {
-  static void apply(Tensor& res, const Tensor& self, Scalar p, at::optional<int64_t> dim, bool keepdim) {
+  static void apply(Tensor& res, const Tensor& self, Scalar p, at::optional<int64_t> dim) {
     auto out_ = res.data<scalar_t>();
     auto data_ = self.data<scalar_t>();
     auto numel = self.numel();
-    if (!dim.has_value()) {
-      std::cout << "dim has no value, not supported yet, TODO" << std::endl;
-      return;
-    }
     auto pval = 0.0;
     if (p.isIntegral()){
       pval = p.to<int64_t>();
     } else if (p.isFloatingPoint()) {
       pval = p.to<float>();
     }
+    if (!dim.has_value()) {
+      *out_ = reduce_all(data_, numel,  p);
+      //std::cout << "dim has no value, not supported yet, TODO" << std::endl;
+      return;
+    }
+
     int64_t n = self.size(*dim);
     int64_t stride = self.stride(*dim);
     //std::cout << "NormReduction called, p = " << p << ", pval = " << pval << ", stride = " << stride << std::endl;
@@ -212,52 +214,144 @@ struct NormReduction {
     }
     int64_t batch = numel / n;
 
-    parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
-      for (int64_t bi = begin; bi < end; bi++) {
-        int64_t b = bi / stride;
-        int64_t i = bi % stride;
-        const scalar_t* data = &data_[b * n * stride + i];
+#if 1
+    if (stride == 1) {
+      parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
+        for (int64_t b = begin; b < end; b++) {
+          const scalar_t* data = &data_[b * n];
+          scalar_t result = 0.0;
+          if (pval == 0) {
+            for (int64_t k = 0; k < n; k++) {
+              result += (data[k] != 0.0);
+            }
+            out_[b] = result;
+          } else if (pval == 1) {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::abs(data[k]);
+            }
+            out_[b] = result;
+          } else if (pval == 2) {
+            for (int64_t k = 0; k < n; k++) {
+              result += data[k] * data[k];
+            }
+            out_[b] = std::sqrt(result);
+          } else if (pval == 3) {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::abs(data[k] * data[k] * data[k]);
+            }
+            out_[b] = std::pow(result, 1.0/3);
+          } else if (std::isinf(pval)) {
+            for (int64_t k = 0; k < n; k++) {
+              result = std::abs(data[k]) > result ? std::abs(data[k]) : result;
+            }
+            out_[b] = result;
+          } else {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::pow(std::abs(data[k]), pval);
+            }
+            out_[b] = std::pow(result, 1.0/pval);
+          }
+        }
+      });
+    } else {
+      parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
+        for (int64_t bi = begin; bi < end; bi++) {
+          int64_t b = bi / stride;
+          int64_t i = bi % stride;
+          const scalar_t* data = &data_[b * n * stride + i];
+          scalar_t result = 0.0;
+          if (pval == 0) {
+            for (int64_t k = 0; k < n; k++) {
+              result += (data[k * stride] != 0.0);
+            }
+            out_[bi] = result;
+          } else if (pval == 1) {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::abs(data[k * stride]);
+            }
+            out_[bi] = result;
+          } else if (pval == 2) {
+            for (int64_t k = 0; k < n; k++) {
+              result += data[k * stride] * data[k * stride];
+            }
+            out_[bi] = std::sqrt(result);
+          } else if (pval == 3) {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
+            }
+            out_[bi] = std::pow(result, 1.0/3);
+          } else if (std::isinf(pval)) {
+            for (int64_t k = 0; k < n; k++) {
+              result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
+            }
+            out_[bi] = result;
+          } else {
+            for (int64_t k = 0; k < n; k++) {
+              result += std::pow(std::abs(data[k * stride]), pval);
+            }
+            out_[bi] = std::pow(result, 1.0/pval);
+          }
+        }
+      });
+    }
+#endif
+  }
+
+  static scalar_t reduce_all(const scalar_t* data_, int64_t size,  Scalar p) {
+    auto pval = 0.0;
+    if (p.isIntegral()){
+      pval = p.to<int64_t>();
+    } else if (p.isFloatingPoint()) {
+      pval = p.to<float>();
+    }
+    scalar_t sum = parallel_reduce(
+      0,
+      size,
+      internal::GRAIN_SIZE,
+      (scalar_t)0,
+      [=](int64_t begin, int64_t end, scalar_t init) {
+        const scalar_t* data = &data_[begin];
+        int64_t n = end - begin;
         scalar_t result = 0.0;
         if (pval == 0) {
           for (int64_t k = 0; k < n; k++) {
-            result += (data[k * stride] != 0.0);
+            result += (data[k] != 0.0);
           }
-          out_[bi] = result;
         } else if (pval == 1) {
           for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride]);
+            result += std::abs(data[k]);
           }
-          out_[bi] = result;
         } else if (pval == 2) {
           for (int64_t k = 0; k < n; k++) {
-            result += data[k * stride] * data[k * stride];
+            result += data[k] * data[k];
           }
-          out_[bi] = std::sqrt(result);
+          result = std::sqrt(result);
         } else if (pval == 3) {
           for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
+            result += std::abs(data[k] * data[k] * data[k]);
           }
-          out_[bi] = std::pow(result, 1.0/3);
+          result = std::pow(result, 1.0/3);
         } else if (std::isinf(pval)) {
           for (int64_t k = 0; k < n; k++) {
-            result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
+            result = std::abs(data[k]) > result ? std::abs(data[k]) : result;
           }
-          out_[bi] = result;
         } else {
           for (int64_t k = 0; k < n; k++) {
-            result += std::pow(std::abs(data[k * stride]), pval);
+            result += std::pow(std::abs(data[k]), pval);
           }
-          out_[bi] = std::pow(result, 1.0/pval);
+          result = std::pow(result, 1.0/pval);
         }
-      }
-    });
+        return result;
+      },
+      std::plus<scalar_t>());
+    return sum;
   }
 
 };
 
-static void norm_kernel_impl(Tensor& result, const Tensor& self, Scalar p, at::optional<int64_t> dim, bool keepdim) {
+static void norm_kernel_impl(Tensor& result, const Tensor& self, Scalar p, at::optional<int64_t> dim) {
   AT_DISPATCH_FLOATING_TYPES(self.type(), "norm", [&] {
-    NormReduction<scalar_t>::apply(result, self, p, dim, keepdim);
+    NormReduction<scalar_t>::apply(result, self, p, dim);
   });
 }
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -185,6 +185,10 @@ static void prod_kernel_impl(Tensor& result, const Tensor& self, at::optional<in
 
 template<typename scalar_t>
 struct NormReduction {
+  // reduction width in number of scalar elements
+  static constexpr int WIDTH = 128 / sizeof(scalar_t);
+  using Vec = Vec256<scalar_t>;
+
   static void apply(Tensor& res, const Tensor& self, Scalar p, at::optional<int64_t> dim) {
     auto out_ = res.data<scalar_t>();
     auto data_ = self.data<scalar_t>();
@@ -215,7 +219,7 @@ struct NormReduction {
         int64_t b = bi / stride;
         int64_t i = bi % stride;
         const scalar_t* data = &data_[b * n * stride + i];
-        out_[bi] = norm_calc(data, n, stride, pval);
+        out_[bi] = norm_reduce(data, n, stride, pval);
       }
     });
   }
@@ -229,45 +233,100 @@ struct NormReduction {
       [=](int64_t begin, int64_t end, scalar_t init) {
         const scalar_t* data = &data_[begin];
         int64_t n = end - begin;
-        scalar_t result = norm_calc(data, n, 1, pval);
+        scalar_t result = norm_reduce(data, n, 1, pval);
         return result;
       },
       std::plus<scalar_t>());
     return sum;
   }
 
-  static scalar_t norm_calc(const scalar_t* data, int64_t n, int64_t stride, float pval) {
-        scalar_t result = 0.0;
-        if (pval == 0) {
-          for (int64_t k = 0; k < n; k++) {
-            result += (data[k * stride] != 0.0);
-          }
-        } else if (pval == 1) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride]);
-          }
-        } else if (pval == 2) {
-          for (int64_t k = 0; k < n; k++) {
-            result += data[k * stride] * data[k * stride];
-          }
-          result = std::sqrt(result);
-        } else if (pval == 3) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
-          }
-          result = std::pow(result, 1.0/3);
-        } else if (std::isinf(pval)) {
-          for (int64_t k = 0; k < n; k++) {
-            result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
-          }
-          result = result;
-        } else {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::pow(std::abs(data[k * stride]), pval);
-          }
-          result = std::pow(result, 1.0/pval);
+  static scalar_t norm_reduce(const scalar_t* data, int64_t n, int64_t stride, float pval) {
+    scalar_t result = 0.0;
+    if (stride == 1 && (pval == 1 || pval == 2 || pval == 3) && n >= WIDTH) {
+      int64_t n_rounded = round_down(n, WIDTH);
+      scalar_t result1 = norm_reduce128(data, n_rounded, pval);
+      scalar_t result2 = norm_reduce_sequential(data + n_rounded, n - n_rounded, stride, pval);
+      result = std::pow(std::pow(result1, pval) + std::pow(result2, pval), 1.0/pval);
+    } else {
+      result = norm_reduce_sequential(data, n, stride, pval);
+    }
+    return result;
+  }
+
+  static scalar_t norm_reduce_sequential(const scalar_t* data, int64_t n, int64_t stride, float pval) {
+    scalar_t result = 0.0;
+    if (pval == 0) {
+      for (int64_t k = 0; k < n; k++) {
+        result += (data[k * stride] != 0.0);
+      }
+    } else if (pval == 1) {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::abs(data[k * stride]);
+      }
+    } else if (pval == 2) {
+      for (int64_t k = 0; k < n; k++) {
+        result += data[k * stride] * data[k * stride];
+      }
+      result = std::sqrt(result);
+    } else if (pval == 3) {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
+      }
+      result = std::pow(result, 1.0/3);
+    } else if (std::isinf(pval)) {
+      for (int64_t k = 0; k < n; k++) {
+        result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
+      }
+      result = result;
+    } else {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::pow(std::abs(data[k * stride]), pval);
+      }
+      result = std::pow(result, 1.0/pval);
+    }
+    return result;
+  }
+
+  // Reduce down a column of WIDTH elements (128 bytes) with the given number n
+  // n is already rounded by 128
+  static scalar_t norm_reduce128(const scalar_t* data, int64_t n, float pval) {
+    scalar_t result = 0.0;
+    Vec acc[4] = {0.0, 0.0, 0.0, 0.0};  // 128 bytes (two cache lines)
+    static_assert(sizeof(acc) == 128, "accumulator should be 128 bytes");
+    int64_t rows = n / WIDTH;
+    if (pval == 1){
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + val.abs();
         }
-        return result;
+      }
+    }
+    else if (pval == 2) {
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + val * val;
+        }
+      }
+    }
+    else if (pval == 3) {
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + (val * val * val).abs();
+        }
+      }
+    }
+    scalar_t buf[WIDTH] = {0};
+    for (int j = 0; j != 4; j++) {
+      acc[j].store(&buf[j * Vec::size]);
+    }
+    for (int i = 0; i < WIDTH; i++) {
+      result += buf[i];
+    }
+    result = std::pow(result, 1.0/pval);
+    return result;
   }
 };
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -199,10 +199,8 @@ struct NormReduction {
       *out_ = reduce_all(data_, numel,  pval);
       return;
     }
-
     int64_t n = self.size(*dim);
     int64_t stride = self.stride(*dim);
-    //std::cout << "NormReduction called, p = " << p << ", pval = " << pval << ", stride = " << stride << std::endl;
     // A contiguous tensor does not need to hold a meaningful stride
     // if the corresponding size is 1
     if (n == 1) {
@@ -271,7 +269,6 @@ struct NormReduction {
         }
         return result;
   }
-
 };
 
 static void norm_kernel_impl(Tensor& result, const Tensor& self, Scalar p, at::optional<int64_t> dim) {

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -11,4 +11,7 @@ using reduce_fn = void(*)(Tensor &, const Tensor &, at::optional<int64_t>);
 DECLARE_DISPATCH(reduce_fn, sum_kernel);
 DECLARE_DISPATCH(reduce_fn, prod_kernel);
 
+using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, int64_t, bool);
+DECLARE_DISPATCH(reduce_norm_fn, norm_kernel);
+
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -11,7 +11,7 @@ using reduce_fn = void(*)(Tensor &, const Tensor &, at::optional<int64_t>);
 DECLARE_DISPATCH(reduce_fn, sum_kernel);
 DECLARE_DISPATCH(reduce_fn, prod_kernel);
 
-using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, int64_t, bool);
+using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, at::optional<int64_t>, bool);
 DECLARE_DISPATCH(reduce_norm_fn, norm_kernel);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -11,7 +11,7 @@ using reduce_fn = void(*)(Tensor &, const Tensor &, at::optional<int64_t>);
 DECLARE_DISPATCH(reduce_fn, sum_kernel);
 DECLARE_DISPATCH(reduce_fn, prod_kernel);
 
-using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, at::optional<int64_t>, bool);
+using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, at::optional<int64_t>);
 DECLARE_DISPATCH(reduce_norm_fn, norm_kernel);
 
 }} // namespace at::native


### PR DESCRIPTION
optimize norm operation for ATen CPU path. 
norm is a very heavy operation in RNN related workloads, see OpenNMT-py [example](https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/utils/optimizers.py#L227).
Our profiling show that norm takes about 8% in OpenNMT-py training time, which is not acceptable.

currently, the code path from TH module runs in sequential on CPU, see [link](https://github.com/pytorch/pytorch/blob/master/aten/src/TH/generic/THTensorMoreMath.cpp#L1937).
The norm performance data compare before and after our optimization:


norm size | SKX6148 OOB | SKX6148 OPT | speedup
-- | -- | -- | --
[35820, 500] | 19.9693 | 0.6204 | 32.19
[24997,   500] | 13.8752 | 0.4370 | 31.75
[2000, 1000] | 2.1803 | 0.0926 | 23.53
[2000,   500] | 1.0949 | 0.0508 | 21.55
[500, 1000] | 0.5483 | 0.0494 | 11.10
[500,   500] | 0.2758 | 0.0494 | 5.58



norm size | i7 OOB | i7 OPT | speedup
-- | -- | -- | --
[35820, 500] | 18.0185 | 3.8186 | 4.72
[24997,   500] | 12.5457 | 2.5238 | 4.97
[2000, 1000] | 1.8258 | 0.4204 | 4.34
[2000,   500] | 0.9252 | 0.2391 | 3.87
[500, 1000] | 0.4696 | 0.1129 | 4.16
[500,   500] | 0.2380 | 0.0650 | 3.66




