### PR TITLE
Move all operator<< overloads out of the global namespace.

### DIFF
--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -30,12 +30,6 @@
 // is not fixed at the moment.
 
 namespace caffe2 {
-class TypeIdentifier;
-}
-
-std::ostream& operator<<(std::ostream& stream, caffe2::TypeIdentifier typeId);
-
-namespace caffe2 {
 
 class TypeMeta;
 
@@ -49,7 +43,7 @@ class TypeIdentifier final : public at::IdWrapper<TypeIdentifier, uint16_t> {
  public:
   static TypeIdentifier createTypeId();
 
-  friend std::ostream& ::operator<<(
+  friend std::ostream& operator<<(
       std::ostream& stream,
       TypeIdentifier typeId);
   friend bool operator<(TypeIdentifier lhs, TypeIdentifier rhs);
@@ -70,15 +64,15 @@ inline bool operator<(TypeIdentifier lhs, TypeIdentifier rhs) {
   return lhs.underlyingId() < rhs.underlyingId();
 }
 
-} // namespace caffe2
-
-AT_DEFINE_HASH_FOR_IDWRAPPER(caffe2::TypeIdentifier)
-
 inline std::ostream& operator<<(
     std::ostream& stream,
     caffe2::TypeIdentifier typeId) {
   return stream << typeId.underlyingId();
 }
+
+} // namespace caffe2
+
+AT_DEFINE_HASH_FOR_IDWRAPPER(caffe2::TypeIdentifier)
 
 namespace caffe2 {
 

--- a/caffe2/core/dispatch/DeviceId.h
+++ b/caffe2/core/dispatch/DeviceId.h
@@ -14,15 +14,15 @@ enum class DeviceTypeId : uint8_t {
     UNDEFINED
 };
 
-}
-
-inline std::ostream& operator<<(std::ostream& stream, c10::DeviceTypeId device_type_id) {
+inline std::ostream& operator<<(std::ostream& stream, DeviceTypeId device_type_id) {
     switch(device_type_id) {
         case c10::DeviceTypeId::CPU: return stream << "DeviceTypeId(CPU)";
         case c10::DeviceTypeId::CUDA: return stream << "DeviceTypeId(CUDA)";
         case c10::DeviceTypeId::UNDEFINED: return stream << "DeviceTypeId(UNDEFINED)";
     }
     throw std::logic_error("Unknown DeviceTypeId: " + c10::guts::to_string(static_cast<int>(device_type_id)));
+}
+
 }
 
 namespace std {

--- a/caffe2/core/dispatch/DispatchKey.h
+++ b/caffe2/core/dispatch/DispatchKey.h
@@ -12,6 +12,7 @@
 namespace c10 {
 
 namespace details {
+
 struct TensorParameterDispatchKey final {
   // note: This dispatch key structure is not final yet and will change. Don't rely on it.
   DeviceTypeId deviceTypeId;
@@ -22,12 +23,13 @@ struct TensorParameterDispatchKey final {
 inline constexpr bool operator==(const TensorParameterDispatchKey& lhs, const TensorParameterDispatchKey& rhs) {
   return lhs.deviceTypeId == rhs.deviceTypeId && lhs.layoutId == rhs.layoutId && lhs.dataType == rhs.dataType;
 }
-}  // namespace details
-}  // namespace c10
 
-inline std::ostream& operator<<(std::ostream& stream, const c10::details::TensorParameterDispatchKey& key) {
+inline std::ostream& operator<<(std::ostream& stream, const TensorParameterDispatchKey& key) {
   return stream << "TensorKey(" << key.deviceTypeId << ", " << key.layoutId.value() << ", " << key.dataType << ")";
 }
+
+}  // namespace details
+}  // namespace c10
 
 namespace std {
   template<>
@@ -64,10 +66,8 @@ inline constexpr bool operator==(const DispatchKey<num_dispatch_args> &lhs, cons
   return lhs.argTypes == rhs.argTypes;
 }
 
-}  // namespace c10
-
 template<size_t num_dispatch_args>
-inline std::ostream& operator<<(std::ostream& stream, const c10::DispatchKey<num_dispatch_args>& key) {
+inline std::ostream& operator<<(std::ostream& stream, const DispatchKey<num_dispatch_args>& key) {
   stream << "DispatchKey(";
   if (num_dispatch_args > 0) {
       stream << "DispatchKey(" << key.argTypes[0];
@@ -78,6 +78,8 @@ inline std::ostream& operator<<(std::ostream& stream, const c10::DispatchKey<num
   }
   return stream << ")";
 }
+
+}  // namespace c10
 
 namespace std {
   template<size_t num_dispatch_args>

--- a/caffe2/core/dispatch/DispatchTable.h
+++ b/caffe2/core/dispatch/DispatchTable.h
@@ -27,7 +27,6 @@ class ThreadsafeOperatorTable_ final {
     });
     if (!res) {
       std::ostringstream msg;
-      using ::operator<<;
       msg << "Tried to register conflicting kernels to the dispatcher: " << key;
       throw std::logic_error(msg.str());
     }

--- a/caffe2/core/logging_is_google_glog.h
+++ b/caffe2/core/logging_is_google_glog.h
@@ -14,6 +14,14 @@
 
 #if !defined(__CUDACC__) && !defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
 #include <glog/stl_logging.h>
+
+// Old versions of glog don't declare this using declaration, so help
+// them out.  Fortunately, C++ won't complain if you declare the same
+// using declaration multiple times.
+namespace std {
+  using ::operator<<;
+}
+
 #else // !defined(__CUDACC__) && !defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
 
 // here, we need to register a fake overload for vector/string - here,

--- a/caffe2/core/logging_is_not_google_glog.h
+++ b/caffe2/core/logging_is_not_google_glog.h
@@ -166,21 +166,26 @@ static_assert(CAFFE2_LOG_THRESHOLD <= FATAL,
 // These are adapted from glog to support a limited set of logging capability
 // for STL objects.
 
-namespace caffe2 {
+namespace std {
 // Forward declare these two, and define them after all the container streams
 // operators so that we can recurse from pair -> container -> container -> pair
 // properly.
 template<class First, class Second>
 std::ostream& operator<<(
     std::ostream& out, const std::pair<First, Second>& p);
+} // namespace std
+
+namespace caffe2 {
 template <class Iter>
 void PrintSequence(std::ostream& ss, Iter begin, Iter end);
+} // namespace caffe2
 
+namespace std {
 #define INSTANTIATE_FOR_CONTAINER(container) \
 template <class... Types> \
 std::ostream& operator<<( \
     std::ostream& out, const container<Types...>& seq) { \
-  PrintSequence(out, seq.begin(), seq.end()); \
+  caffe2::PrintSequence(out, seq.begin(), seq.end()); \
   return out; \
 }
 
@@ -195,7 +200,9 @@ inline std::ostream& operator<<(
   out << '(' << p.first << ", " << p.second << ')';
   return out;
 }
+} // namespace std
 
+namespace caffe2 {
 template <class Iter>
 inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
   // Output at most 100 elements -- appropriate if used for logging.


### PR DESCRIPTION
Summary:
Have you ever written an operator<< overload in the caffe2 namespace
in a core Caffe2 header, and then been stunned when some completely
unrelated code started breaking?  This diff fixes this problem!

The problem looks like this:
1. You're building against a really old version of glog (think 0.3.2,
   or something like that)
2. This version of glog defines operator<< overloads for std containers
   in the global namespace
3. You add a new overload in your current namespace (e.g., caffe2).
   Congratulations: this overload is *preferentially* chosen over
   the global namespace one for all calls to << in that namespace.
   And since it doesn't actually have std::vector overloads, unrelated
   Caffe2 code breaks.

Newer versions of glog have a fix for this: they have the line:

  namespace std { using ::operator<<; }

in their header.  So let's help old versions of glog out and do this ourselves.

In our new world order, operator<< overloads defined in the global namespace
won't work (unless they're for std containers, which work because of ADL).
So this diff also moves all those overloads to the correct namespace.

Differential Revision: D9344540
