### PR TITLE
Nomnigraph - DAG matching

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -412,6 +412,10 @@ class Graph {
     return result;
   }
 
+  size_t getEdgesCount() const {
+    return (size_t)edges_.size();
+  }
+
  private:
   std::list<Node<T, U...>> nodes_;
   std::list<Edge<T, U...>> edges_;

--- a/caffe2/core/nomnigraph/tests/test_util.h
+++ b/caffe2/core/nomnigraph/tests/test_util.h
@@ -34,6 +34,23 @@ struct NNEquality {
   }
 };
 
+// Very simple random number generator used to generate platform independent
+// random test data.
+class TestRandom {
+ public:
+  TestRandom(unsigned int seed) : seed_(seed){};
+
+  unsigned int nextInt() {
+    seed_ = A * seed_ + C;
+    return seed_;
+  }
+
+ private:
+  static const unsigned int A = 1103515245;
+  static const unsigned int C = 12345;
+  unsigned int seed_;
+};
+
 /** Our test graph looks like this:
  *           +-------+
  *           | entry |


### PR DESCRIPTION
Summary:
Support dag matching in nomnigraph. This is done by maintaining a map from node in the MatchGraph to node in the input graph, and additionally enforce that same nodes in the MatchGraph must match to same nodes in the input graph (with the exception of multiplicity i.e. when count != 1 on the MatchGraph node).

In a follow up diff, I'll rename the API that refers to subtree as subgraph to improve clarity.

Differential Revision: D9347322
