### PR TITLE
Nomnigraph - rename some APIs that invole Subtree to Subgraph

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -199,12 +199,13 @@ NNNodeMatchCriteria matchAnyNode() {
       [](NNGraph::NodeRef /* unused */) { return true; }, "matchAnyNode");
 }
 
-NNMatchGraph::NodeRef operatorTree(
+NNMatchGraph::NodeRef operatorSubgraph(
     NNMatchGraph& g,
     const NNNodeMatchCriteria& root,
     const std::vector<NNMatchGraph::NodeRef>& childrenCriteria,
     int count) {
-  return tree(g, matchAnyNode(), {tree(g, root, childrenCriteria)}, count);
+  return subgraph(
+      g, matchAnyNode(), {subgraph(g, root, childrenCriteria)}, count);
 }
 
 } // namespace nn

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -412,6 +412,10 @@ class Graph {
     return result;
   }
 
+  size_t getEdgesCount() const {
+    return (size_t)edges_.size();
+  }
+
  private:
   std::list<Node<T, U...>> nodes_;
   std::list<Edge<T, U...>> edges_;

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -487,9 +487,9 @@ using NNSubgraphMatcher =
     nom::matcher::SubgraphMatcher<NNGraph, NNNodeMatchCriteria, NNNodeMatch>;
 
 // This helper method makes it easy to create matching criteria in NNGraph.
-// For example, operatorTree(opMatch, ...) will refer to a tree like this:
+// For example, operatorSubgraph(opMatch, ...) will refer to a tree like this:
 // ... -> opMatch -> opMatch_Output
-NNMatchGraph::NodeRef operatorTree(
+NNMatchGraph::NodeRef operatorSubgraph(
     NNMatchGraph& g,
     const NNNodeMatchCriteria& root,
     const std::vector<NNMatchGraph::NodeRef>& childrenCriteria = {},

--- a/caffe2/core/nomnigraph/tests/neural_net_test.cc
+++ b/caffe2/core/nomnigraph/tests/neural_net_test.cc
@@ -44,23 +44,23 @@ TEST(NeuralNetGraph, ReplaceGraph) {
 
   auto mg = NNMatchGraph();
   // clang-format off
-  auto pattern = tree(mg,
+  auto pattern = subgraph(mg,
       matchNodeType<Relu>(), {
-          operatorTree(mg,
+          operatorSubgraph(mg,
               matchNodeType<Sum>(), {
-                tree(mg, matchNodeType<Tensor>(), {}, 2, true)
+                subgraph(mg, matchNodeType<Tensor>(), {}, 2, true)
               }),
       });
   // clang-format on
 
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(sum, pattern).isMatch());
+  EXPECT_FALSE(NNSubgraphMatcher::isSubgraphMatch(sum, pattern).isMatch());
   EXPECT_FALSE(
-      NNSubgraphMatcher::isSubtreeMatch(reluOutput, pattern).isMatch());
-  EXPECT_FALSE(NNSubgraphMatcher::isSubtreeMatch(input1, pattern).isMatch());
+      NNSubgraphMatcher::isSubgraphMatch(reluOutput, pattern).isMatch());
+  EXPECT_FALSE(NNSubgraphMatcher::isSubgraphMatch(input1, pattern).isMatch());
 
-  EXPECT_TRUE(NNSubgraphMatcher::isSubtreeMatch(relu, pattern).isMatch());
+  EXPECT_TRUE(NNSubgraphMatcher::isSubgraphMatch(relu, pattern).isMatch());
 
-  NNSubgraphMatcher::replaceSubtree(
+  NNSubgraphMatcher::replaceSubgraph(
       graph, pattern, [](NNGraph& g, NNGraph::NodeRef relu) {
         auto sumOutput = getInputs(relu)[0];
         auto sum = getProducer(sumOutput);

--- a/caffe2/core/nomnigraph/tests/subgraph_matcher_test.cc
+++ b/caffe2/core/nomnigraph/tests/subgraph_matcher_test.cc
@@ -41,11 +41,11 @@ TestMatchGraph::NodeRef Tree(
     const Criteria& root,
     const std::vector<TestMatchGraph::NodeRef>& children = {},
     int count = 1) {
-  return tree(graph, root, children, count, false);
+  return subgraph(graph, root, children, count, false);
 }
 
 TestMatchGraph::NodeRef NonTerminal(const Criteria& root, int count = 1) {
-  return tree(graph, root, {}, count, true);
+  return subgraph(graph, root, {}, count, true);
 }
 
 Criteria any() {
@@ -202,11 +202,11 @@ TestGraph::NodeRef getInNode(TestGraph::NodeRef node, int index) {
   return node->getInEdges()[index]->tail();
 }
 
-bool isSubtreeMatch(
+bool isSubgraphMatch(
     TestGraph::NodeRef nodeRef,
     const TestMatchGraph::NodeRef& criteria,
     bool invertGraphTraversal = true) {
-  return TestMatcher::isSubtreeMatch(nodeRef, criteria, invertGraphTraversal)
+  return TestMatcher::isSubgraphMatch(nodeRef, criteria, invertGraphTraversal)
       .isMatch();
 }
 } // namespace matcher
@@ -254,32 +254,32 @@ TEST(SubgraphMatcher, IsSubtreeMatch) {
 
   reset();
   auto subtree = Tree(any(), {Tree(any()), Tree(any())});
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n4, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n4, subtree, false));
 
-  EXPECT_TRUE(isSubtreeMatch(n2, subtree, false));
-  EXPECT_TRUE(isSubtreeMatch(n5, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n2, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n5, subtree, false));
 
   reset();
   subtree = Tree(Criteria("5"), {Tree(any()), Tree(any())});
-  EXPECT_FALSE(isSubtreeMatch(n2, subtree, false));
-  EXPECT_TRUE(isSubtreeMatch(n5, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n2, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n5, subtree, false));
 
   reset();
   subtree = Tree(any(), {Tree(any()), Tree(Criteria("4"))});
-  EXPECT_TRUE(isSubtreeMatch(n2, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n5, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n2, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n5, subtree, false));
 
   reset();
   // Accepts non terminal node
   subtree = Tree(any(), {NonTerminal(any()), NonTerminal(any())});
-  EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
-  EXPECT_TRUE(isSubtreeMatch(n2, subtree, false));
-  EXPECT_TRUE(isSubtreeMatch(n5, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n3, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n4, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n6, subtree, false));
-  EXPECT_FALSE(isSubtreeMatch(n7, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n1, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n2, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n5, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n3, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n4, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n6, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n7, subtree, false));
 }
 
 // Test subtree matching in which * (repeated) matching of children is allowed.
@@ -304,11 +304,11 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
 
   reset();
   auto subtree = Tree(any(), {Tree(Criteria("2"))});
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {Tree(Criteria("2"), {}, TestMatchNode::kStarCount)});
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   // clang-format off
@@ -318,7 +318,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
     Tree(Criteria("4"), {}, 2),
     Tree(Criteria("5"), {}, 3)
   });
-  EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {
@@ -328,7 +328,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
     Tree(Criteria("5"), {}, 4)
   });
   // Failes because exepected 4 matches of n5 but found 3.
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {
@@ -337,7 +337,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
     Tree(Criteria("4"), {}, 2),
     Tree(Criteria("5"), {}, TestMatchNode::kStarCount)
   });
-  EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {
@@ -346,7 +346,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
     Tree(Criteria("4"), {}, 2),
     Tree(Criteria("5"), {}, TestMatchNode::kStarCount)
   });
-  EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_TRUE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {
@@ -354,7 +354,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
     Tree(Criteria("3"), {}, TestMatchNode::kStarCount),
   });
   // Fails because there are unmatched edges.
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
 
   reset();
   subtree = Tree(any(), {
@@ -365,7 +365,7 @@ TEST(SubgraphMatcher, IsSubtreeMatchRepeated) {
   });
   // Fails because the count is wrong; we have 2 edges to node N4 while
   // the pattern expects only 1.
-  EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+  EXPECT_FALSE(isSubgraphMatch(n1, subtree, false));
   // clang-format on
 }
 
@@ -376,7 +376,7 @@ TEST(SubgraphMatcher, DagMatching) {
   auto n4match = Tree(Criteria("4"), {
     Tree(Criteria("5"))
   });
-  auto subtree = Tree(Criteria("1"), {
+  auto subgraph = Tree(Criteria("1"), {
     Tree(Criteria("2"), {
       n4match
     }),
@@ -409,7 +409,7 @@ TEST(SubgraphMatcher, DagMatching) {
              N5
     */
 
-    EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
+    EXPECT_TRUE(isSubgraphMatch(n1, subgraph, false));
   }
 
   {
@@ -438,7 +438,7 @@ TEST(SubgraphMatcher, DagMatching) {
     */
 
     // This should fail because n4A and n4B are not the same node.
-    EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+    EXPECT_FALSE(isSubgraphMatch(n1, subgraph, false));
   }
 }
 
@@ -447,7 +447,7 @@ TEST(SubgraphMatcher, DagMatchingMultiEdges) {
 
   // clang-format off
   auto n2match = Tree(Criteria("2"));
-  auto subtree = Tree(Criteria("1"), {
+  auto subgraph = Tree(Criteria("1"), {
     n2match,
     n2match
   });
@@ -461,7 +461,7 @@ TEST(SubgraphMatcher, DagMatchingMultiEdges) {
     graph.createEdge(n1, n2);
     graph.createEdge(n1, n2);
 
-    EXPECT_TRUE(isSubtreeMatch(n1, subtree, false));
+    EXPECT_TRUE(isSubgraphMatch(n1, subgraph, false));
   }
 
   {
@@ -473,7 +473,7 @@ TEST(SubgraphMatcher, DagMatchingMultiEdges) {
     graph.createEdge(n1, n2A);
     graph.createEdge(n1, n2B);
 
-    EXPECT_FALSE(isSubtreeMatch(n1, subtree, false));
+    EXPECT_FALSE(isSubgraphMatch(n1, subgraph, false));
   }
 }
 
@@ -533,7 +533,7 @@ TEST(SubgraphMatcher, DagMatchingRandomLargeGraph) {
 
   int countMatch = 0;
   for (auto node : graph.getMutableNodes()) {
-    if (isSubtreeMatch(node, subtree, false)) {
+    if (isSubgraphMatch(node, subtree, false)) {
       countMatch++;
     }
   }
@@ -545,12 +545,12 @@ TEST(SubgraphMatcher, IsSubtreeMatchRealistic) {
   auto graph = DataFlowTestGraph();
   auto subtree = DataFlowTestGraphCriteria();
 
-  EXPECT_FALSE(isSubtreeMatch(graph.opF, subtree));
-  EXPECT_FALSE(isSubtreeMatch(graph.opC, subtree));
-  EXPECT_FALSE(isSubtreeMatch(graph.opB, subtree));
-  EXPECT_FALSE(isSubtreeMatch(graph.dataOut, subtree));
+  EXPECT_FALSE(isSubgraphMatch(graph.opF, subtree));
+  EXPECT_FALSE(isSubgraphMatch(graph.opC, subtree));
+  EXPECT_FALSE(isSubgraphMatch(graph.opB, subtree));
+  EXPECT_FALSE(isSubgraphMatch(graph.dataOut, subtree));
 
-  EXPECT_TRUE(isSubtreeMatch(graph.opG, subtree));
+  EXPECT_TRUE(isSubgraphMatch(graph.opG, subtree));
 }
 
 TEST(SubgraphMatcher, ReplaceSubtreeRealistic) {
@@ -558,7 +558,7 @@ TEST(SubgraphMatcher, ReplaceSubtreeRealistic) {
   auto graph = DataFlowTestGraph();
   auto subtree = DataFlowTestGraphCriteria();
 
-  TestMatcher::replaceSubtree(
+  TestMatcher::replaceSubgraph(
       graph.graph, subtree, [](TestGraph& g, TestGraph::NodeRef opG) {
         auto opFused = g.createNode("opFused");
 

--- a/caffe2/core/nomnigraph/tests/test_util.h
+++ b/caffe2/core/nomnigraph/tests/test_util.h
@@ -34,6 +34,23 @@ struct NNEquality {
   }
 };
 
+// Very simple random number generator used to generate platform independent
+// random test data.
+class TestRandom {
+ public:
+  TestRandom(unsigned int seed) : seed_(seed){};
+
+  unsigned int nextInt() {
+    seed_ = A * seed_ + C;
+    return seed_;
+  }
+
+ private:
+  static const unsigned int A = 1103515245;
+  static const unsigned int C = 12345;
+  unsigned int seed_;
+};
+
 /** Our test graph looks like this:
  *           +-------+
  *           | entry |


### PR DESCRIPTION
Summary:
Renaming from "subtree" -> "subgraph" to improve clarity of subgraph matcher APIs since it now supports DAG

This is pure renaming, no functionalities change.

Differential Revision: D9348311
