### PR TITLE
remove implicit conversion from gpu to cpu

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1891,7 +1891,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             a = alpha.view(-1)[idx].detach()
             b = beta.view(-1)[idx].detach()
-            expected = scipy.stats.gamma.logpdf(x, a, scale=1 / b)
+            expected = scipy.stats.gamma.logpdf(x.cpu(), a, scale=1 / b)
             self.assertAlmostEqual(log_prob, expected, places=3)
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1889,8 +1889,8 @@ class TestDistributions(TestCase):
         self.assertEqual(Gamma(0.5, 0.5).sample((1,)).size(), (1,))
 
         def ref_log_prob(idx, x, log_prob):
-            a = alpha.view(-1)[idx].detach()
-            b = beta.view(-1)[idx].detach()
+            a = alpha.view(-1)[idx].detach().cpu()
+            b = beta.view(-1)[idx].detach().cpu()
             expected = scipy.stats.gamma.logpdf(x.cpu(), a, scale=1 / b)
             self.assertAlmostEqual(log_prob, expected, places=3)
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -409,9 +409,9 @@ class Tensor(torch._C._TensorBase):
 
     def __array__(self, dtype=None):
         if dtype is None:
-            return self.cpu().numpy()
+            return self.numpy()
         else:
-            return self.cpu().numpy().astype(dtype, copy=False)
+            return self.numpy().astype(dtype, copy=False)
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`


### PR DESCRIPTION
Resubmit #10416 with fixed tests . This is to remove implicit conversion from gpu to cpu in when calling numpy to keep behavior match others. 

It requires users to move the tensor back to cpu() before call numpy functions on it. 