### PR TITLE
Fix negative indices in tracer

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4596,7 +4596,6 @@ def func(t):
         self.assertEqual(foo_trace(a), foo(a))
         self.assertNotEqual(foo_trace(a), foo_trace(b))
 
-
     def test_index_select_shape_prop(self):
 
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4572,6 +4572,17 @@ def func(t):
         a = torch.arange(0, 8)
         self.assertEqual(foo_script(a), foo_trace(a))
 
+    def test_tracing_indexing(self):
+        @torch.jit.trace(torch.zeros(10))
+        def foo_trace(x):
+            return x[-2]
+
+        @torch.jit.script
+        def foo_script(x):
+            return x[-2]
+
+        a = torch.arange(0, 8)
+        self.assertEqual(foo_script(a), foo_trace(a))
 
     def test_index_select_shape_prop(self):
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4563,14 +4563,20 @@ def func(t):
     def test_tracing_slicing(self):
         @torch.jit.trace(torch.zeros(10))
         def foo_trace(x):
-            return x[-1:-3]
+            return x[-5:-3]
 
         @torch.jit.script
         def foo_script(x):
-            return x[-1:-3]
+            return x[-5:-3]
+
+        def foo(x):
+            return x[-5:-3]
 
         a = torch.arange(0, 8)
-        self.assertEqual(foo_script(a), foo_trace(a))
+        b = torch.arange(0, 20)
+        self.assertEqual(foo_trace(a), foo_script(a))
+        self.assertEqual(foo_trace(a), foo(a))
+        self.assertNotEqual(foo_trace(a), foo_trace(b))
 
     def test_tracing_indexing(self):
         @torch.jit.trace(torch.zeros(10))
@@ -4581,8 +4587,15 @@ def func(t):
         def foo_script(x):
             return x[-2]
 
+        def foo(x):
+            return x[-2]
+
         a = torch.arange(0, 8)
+        b = torch.arange(0, 20)
         self.assertEqual(foo_script(a), foo_trace(a))
+        self.assertEqual(foo_trace(a), foo(a))
+        self.assertNotEqual(foo_trace(a), foo_trace(b))
+
 
     def test_index_select_shape_prop(self):
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4560,6 +4560,19 @@ def func(t):
 
         self.assertEqual(8, bar(torch.ones(1, 1)))
 
+    def test_tracing_slicing(self):
+        @torch.jit.trace(torch.zeros(10))
+        def foo_trace(x):
+            return x[-1:-3]
+
+        @torch.jit.script
+        def foo_script(x):
+            return x[-1:-3]
+
+        a = torch.arange(0, 8)
+        self.assertEqual(foo_script(a), foo_trace(a))
+
+
     def test_index_select_shape_prop(self):
 
         @torch.jit.script

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -67,9 +67,9 @@ static void invalid_index(PyObject* obj) {
 }
 
 static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, bool ensure_view=false) {
-  Py_ssize_t start, stop, step, slicelength;
+  Py_ssize_t start, stop, step;
   auto length = self.size(dim);
-  if (!THPUtils_parseSlice(slice, length, &start, &stop, &step, &slicelength)) {
+  if (!THPUtils_unpackSlice(slice, &start, &stop, &step)) {
     throw python_error();
   }
   if (step == 0) {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -98,9 +98,9 @@ static Variable applySelect(const Variable& self, int64_t dim, int64_t index) {
     throw IndexError("index %lld is out of bounds for dimension %lld with size %lld",
       index, dim, size);
   }
-  if (index < 0) {
-    index += size;
-  }
+  // if the index is negative, do not normalize it because that would fix the index
+  // on the current tensor size in the tracer.
+  // aten::select also works on negative indices
   return self.select(dim, index);
 }
 

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -2,15 +2,71 @@
 
 #include "torch/csrc/python_headers.h"
 
+#if PY_VERSION_HEX < 0x03060100
+
+// PySlice_Unpack not introduced till python 3.6.1
+// included here for backwards compatibility
+// https://docs.python.org/3/c-api/slice.html#c.PySlice_Unpack
+// https://github.com/python/cpython/blob/master/Objects/sliceobject.c#L196
+
+inline int
+__PySlice_Unpack(PyObject *_r,
+               Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step)
+{
+    PySliceObject *r = (PySliceObject*)_r;
+    /* this is harder to get right than you might think */
+
+    // Py_BUILD_ASSERT replaced because it is not available in all versions
+    static_assert(PY_SSIZE_T_MIN + 1 <= -PY_SSIZE_T_MAX, "Build failed");
+
+    if (r->step == Py_None) {
+        *step = 1;
+    }
+    else {
+        if (!_PyEval_SliceIndex(r->step, step)) return -1;
+        if (*step == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "slice step cannot be zero");
+            return -1;
+        }
+        /* Here *step might be -PY_SSIZE_T_MAX-1; in this case we replace it
+         * with -PY_SSIZE_T_MAX.  This doesn't affect the semantics, and it
+         * guards against later undefined behaviour resulting from code that
+         * does "step = -step" as part of a slice reversal.
+         */
+        if (*step < -PY_SSIZE_T_MAX)
+            *step = -PY_SSIZE_T_MAX;
+    }
+
+    if (r->start == Py_None) {
+        *start = *step < 0 ? PY_SSIZE_T_MAX : 0;
+    }
+    else {
+        if (!_PyEval_SliceIndex(r->start, start)) return -1;
+    }
+
+    if (r->stop == Py_None) {
+        *stop = *step < 0 ? PY_SSIZE_T_MIN : PY_SSIZE_T_MAX;
+    }
+    else {
+        if (!_PyEval_SliceIndex(r->stop, stop)) return -1;
+    }
+
+    return 0;
+}
+
+#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
+  (__PySlice_Unpack(SLICE, START, STOP, STEP) == 0)
+#else
+#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
+  (PySlice_Unpack(SLICE, START, STOP, STEP) == 0)
+#endif
+
 // https://bugsfiles.kde.org/attachment.cgi?id=61186
 #if PY_VERSION_HEX >= 0x03020000
 #define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
   (PySlice_GetIndicesEx(SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
-#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
-  (PySlice_Unpack(SLICE, START, STOP, STEP) == 0)
 #else
 #define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
   (PySlice_GetIndicesEx((PySliceObject*)SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
-#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
-  (PySlice_Unpack((PySliceObject*)SLICE, START, STOP, STEP) == 0)
 #endif

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -6,7 +6,11 @@
 #if PY_VERSION_HEX >= 0x03020000
 #define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
   (PySlice_GetIndicesEx(SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
+  (PySlice_Unpack(SLICE, START, STOP, STEP) == 0)
 #else
 #define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
   (PySlice_GetIndicesEx((PySliceObject*)SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#define THPUtils_unpackSlice(SLICE, START, STOP, STEP) \
+  (PySlice_Unpack((PySliceObject*)SLICE, START, STOP, STEP) == 0)
 #endif


### PR DESCRIPTION
Previously when tracing slicing & select negative indices would get normalized, fixing the index to the size of the traced tensor. This makes the behavior the same as script so aten::select with negative indices is emitted. 