### PR TITLE
[Caffe2] Resolving error C2487 "member of dll interface class may not be declared with dll interface" by removing nested CAFFE2_API.

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -206,7 +206,7 @@ class CAFFE2_API CPUStaticContext : public BaseStaticContext {
   }
 
  protected:
-  CAFFE2_API static MemoryAllocationReporter reporter_;
+  static MemoryAllocationReporter reporter_;
 
  private:
   static void ReportAndDelete(void* ptr) {

--- a/caffe2/core/context_base.h
+++ b/caffe2/core/context_base.h
@@ -167,8 +167,7 @@ class CAFFE2_API BaseContext {
     }
   }
 
-  CAFFE2_API static BaseStaticContext*
-      static_context_[COMPILE_TIME_MAX_DEVICE_TYPES];
+  static BaseStaticContext* static_context_[COMPILE_TIME_MAX_DEVICE_TYPES];
 
   template <int d>
   friend struct StaticContextFunctionRegisterer;

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -263,8 +263,8 @@ class CAFFE2_API OpSchema {
   Arg(const char* name, const char* description, bool required = false);
 
 #define DECLARE_STANDARD_ARG(name, str)     \
-  CAFFE2_API static const char* Arg_##name; \
-  CAFFE2_API OpSchema& Arg##name(const char* description);
+  static const char* Arg_##name; \
+  OpSchema& Arg##name(const char* description);
 
   DECLARE_STANDARD_ARG(IsTest, is_test)
 


### PR DESCRIPTION
For #10570 
