### PR TITLE
[Caffe2] Remove weight from input of onnxifi backend op

### DIFF
--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -88,7 +88,7 @@ class OnnxifiTest(TestCase):
         model_def = make_model(graph_def, producer_name='conv-test')
         op = core.CreateOperator(
             "Onnxifi",
-            ["X", "W"],
+            ["X"],
             ["Y"],
             onnx_model=model_def.SerializeToString(),
             initializers=["W", "W"],


### PR DESCRIPTION
The ONNXIFI backend will absorb the constant weight in Conv, so we should not add it as an input. This is just a test artifacts. Note that Onnxifi transformer will do the right thing when cutting the graph to absorb the weights. 

@rdzhabarov 