### PR TITLE
[jit][script] mutable lists, take 2

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2378,6 +2378,66 @@ a")
             return a[3:10] == [3, 4]
         self.checkScript(test_backward_slice, ())
 
+    def test_mutable_list(self):
+        def test_append():
+            a = [0, 1]
+            a.append(2)
+            a.append(3)
+            return a == [0, 1, 2, 3]
+        self.checkScript(test_append, ())
+
+        def test_append_2():
+            a = [0, 1]
+            a.append(2)
+            a = [1]
+            a.append(4)
+            return a == [1, 4]
+        self.checkScript(test_append_2, ())
+
+        def test_append_if():
+            a = [1]
+            if True:
+                a.append(4)
+            return a == [1, 4]
+        self.checkScript(test_append_if, ())
+
+        def test_append_if_else():
+            a = [1]
+            if False:
+                a.append(4)
+            else:
+                a.append(10)
+            return a == [1, 10]
+        self.checkScript(test_append_if_else, ())
+
+        def test_append_loop():
+            a = _construct_empty_int_list()
+            for i in range(5):
+                a.append(i)
+
+            return a == [0, 1, 2, 3, 4]
+        self.checkScript(test_append_loop, ())
+
+        def test_append_loop_if():
+            a = _construct_empty_int_list()
+            for i in range(5):
+                if i > 3:
+                    a.append(i)
+                else:
+                    a.append(0)
+
+            return a == [0, 0, 0, 0, 4]
+        self.checkScript(test_append_loop_if, ())
+
+        def test_nested_loop():
+            a = _construct_empty_int_list()
+            for i in range(2):
+                for j in range(2):
+                    a.append(i + j)
+
+            return a == [0, 1, 1, 2]
+        self.checkScript(test_append_loop_if, ())
+
     def test_func_call(self):
         script = '''
         def add(a, b):

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -145,6 +145,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/ivalue.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
   ${TORCH_SRC_DIR}/csrc/jit/operator.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/annotate_effects.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/canonicalize.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/constant_propagation.cpp

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/tracer.h"
+#include "torch/csrc/jit/passes/annotate_effects.h"
 #include "torch/csrc/jit/passes/batch_mm.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
 #include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
@@ -557,6 +558,9 @@ void runOptimization(std::shared_ptr<Graph> & graph, bool graphMustSupportVariab
     BatchMM(graph);
     FuseGraph(graph);
   }
+  // This must run last, since the effect annotations prevent other
+  // optimizations from reordering instructions
+  UnAnnotateEffects(graph);
 }
 
 }}

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -55,6 +55,7 @@ _(prim, AnyDefined) \
 _(prim, FusedConcat) \
 _(prim, ListSelect) \
 _(prim, ListSlice) \
+_(prim, append) \
 _(aten, __not__) \
 FORALL_ATEN_BASE_SYMBOLS(_) \
 _(onnx, Add) \

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -53,6 +53,8 @@ _(prim, AutogradAdd) \
 _(prim, GradOf) \
 _(prim, AnyDefined) \
 _(prim, FusedConcat) \
+_(prim, ListSelect) \
+_(prim, ListSlice) \
 _(aten, __not__) \
 FORALL_ATEN_BASE_SYMBOLS(_) \
 _(onnx, Add) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -244,6 +244,17 @@ public:
   //          %5 = h(%6, %6)
   void replaceAllUsesWith(Value * newValue);
 
+  // Removes all uses of this value.
+  //
+  // Given:   %3 = f(%1, %2)
+  //          %4 = g(%3, %5)
+  //          %5 = h(%3, %4)
+  // Execute: %3.removeAllUses()
+  // Result:  %3 = f(%1, %2)
+  //          %4 = g(%5)
+  //          %5 = h(%4)
+  void removeAllUses();
+
   Value* copyMetadata(Value * from) {
     setType(from->type());
     if (from->hasUniqueName())
@@ -544,7 +555,7 @@ public:
     return {blocks_.data(), blocks_.size()};
   }
 
-  // Insert unattached 'this' node after 'n' in the topological order.
+  // Insert unattached 'this' node before 'n' in the topological order.
   // Returns this (for chaining).
   //
   // Given:   %3 = f(%1, %2)
@@ -1229,6 +1240,13 @@ inline void Value::replaceAllUsesWith(Value * newValue) {
   while (!uses().empty()) {
     replaceFirstUseWith(newValue);
   }
+}
+
+inline void Value::removeAllUses() {
+  for (const auto& use : uses_) {
+    use.user->removeInput(use.offset);
+  }
+  uses_.clear();
 }
 
 inline Node::Node(Graph * graph_, NodeKind kind_) :

--- a/torch/csrc/jit/ivalue.cpp
+++ b/torch/csrc/jit/ivalue.cpp
@@ -3,7 +3,15 @@
 #include <ATen/ATen.h>
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
 
 namespace torch { namespace jit {
 std::ostream& operator<<(std::ostream & out, const IValue & v) {

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -102,12 +102,12 @@ struct ConstantString : at::Retainable {
 };
 
 template<typename T>
-struct ConstantList;
+struct List;
 struct IValue;
-using Tuple = ConstantList<IValue>;
-using IntList = ConstantList<int64_t>;
-using TensorList = ConstantList<at::Tensor>;
-using DoubleList = ConstantList<double>;
+using Tuple = List<IValue>;
+using IntList = List<int64_t>;
+using TensorList = List<at::Tensor>;
+using DoubleList = List<double>;
 
 // IValue is the generic tagged union used by the interpreter to hold
 // all value types.
@@ -117,7 +117,15 @@ using DoubleList = ConstantList<double>;
 // retain/release calls.
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) _(TensorList)
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
 
 struct IValue {
   IValue()
@@ -443,22 +451,27 @@ DEFINE_TO(std::vector<at::Tensor>, toTensorListRef)
 
 #undef DEFINE_TO
 
-// non-mutable list
-template<typename Elem>
-struct ConstantList : at::Retainable {
+
+template <typename Elem>
+struct List : at::Retainable {
  private:
-  ConstantList(std::vector<Elem> elements_)
-  : elements_(std::move(elements_)) {}
+  List(std::vector<Elem> elements_) : elements_(std::move(elements_)) {}
   std::vector<Elem> elements_;
+
  public:
-  static Shared<ConstantList<Elem>> create(std::vector<Elem> elements_) {
-    return Shared<ConstantList<Elem>>(
-        new ConstantList<Elem>(std::move(elements_)), false);
+  static Shared<List<Elem>> create(std::vector<Elem> elements_) {
+    return Shared<List<Elem>>(new List<Elem>(std::move(elements_)), false);
   }
   const std::vector<Elem>& elements() const {
     return elements_;
   }
   operator const std::vector<Elem>&() const {
+    return elements();
+  }
+  std::vector<Elem>& elements() {
+    return elements_;
+  }
+  operator std::vector<Elem>&() {
     return elements();
   }
 };

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -341,7 +341,18 @@ bool Operator::matches(const Node* node) const {
   if (node->kind().toQualString() != schema().name) {
     return false;
   }
-  at::ArrayRef<const Value*> actuals = node->inputs();
+  at::ArrayRef<const Value*> inputs = node->inputs();
+  std::vector<const Value*> actuals;
+
+  // TODO(suo): need to figure out a better way of ignoring world tokens here.
+  // We can't just specially mark mutating schemas, since any op that uses a
+  // mutable value needs to receive a world token as well.
+  std::copy_if(
+      inputs.begin(),
+      inputs.end(),
+      std::back_inserter(actuals),
+      [](const Value* input) { return input->type() != WorldType::get(); });
+
   const auto& formals = schema().arguments;
 
   // not enough inputs

--- a/torch/csrc/jit/passes/annotate_effects.cpp
+++ b/torch/csrc/jit/passes/annotate_effects.cpp
@@ -1,0 +1,226 @@
+#include "torch/csrc/jit/passes/annotate_effects.h"
+#include <set>
+
+namespace torch {
+namespace jit {
+namespace {
+
+// Ops with effects that we need to track through the passing of world tokens
+// e.g. mutation
+const std::unordered_set<Symbol> effectfulOps = {
+    prim::append,
+    // TODO(suo): need to support the following side-effecting ops. This will
+    // require that we know which value is being mutated. Probably the best
+    // place to put that is in the function schema?
+    //
+    // prim::Print,
+    // aten::permute,
+    // aten::rand,
+    // aten::rand_out,
+    // aten::rand_like,
+    // aten::randint,
+    // aten::randint_out,
+    // aten::randint_like,
+    // aten::randn,
+    // aten::randn_out,
+    // aten::randn_like,
+    // aten::randperm,
+    // aten::randperm_out,
+};
+
+/**
+ * AnnotateEffects
+ *
+ * This pass annotates effectful operations (such as ones that mutate existing
+ * values) to prevent subsequent passes from re-ordering ops in a way that
+ * changes the meaning of the program.
+ *
+ * It does this by threading a "world token" value through nodes that use
+ * mutable values. This models effects explicitly in the IR and forces all
+ * annotated nodes to be linearized during optimization.
+ *
+ * UnAnnotateEffects just does the opposite of annotate effects, removing all
+ * world tokens so that there's no effect on the runtime.
+ */
+class AnnotateEffectsImpl {
+ public:
+  void annotateEffects(Graph* g) {
+    // TODO(suo): We need to change this so that the world token is an input
+    // and output of the graph. That would require changing a bunch of interop
+    // and batching code, so leaving it out for now.
+    //
+    // auto curToken = g->addInput("world")->setType(WorldType::get());
+    // curToken = visitBlock(g->block(), curToken);
+    // g->registerOutput(curToken);
+
+    // Generate the first world token
+    const auto tokenGenerator = g->create(prim::Constant);
+    g->block()->prependNode(tokenGenerator);
+    auto curToken = tokenGenerator->output()->setType(WorldType::get());
+
+    visitBlock(g->block(), curToken);
+  }
+
+ private:
+  Value* visitBlock(Block* block, Value* curToken) {
+    for (auto* node : block->nodes()) {
+      curToken = visitNode(node, curToken);
+    }
+    return curToken;
+  }
+
+  // If a node uses a mutable variable (or mutates a previously constant
+  // variable), annotate it
+  //
+  // Returns the last world token emitted for subsequent annotations to use.
+  Value* visitNode(Node* node, Value* curToken) {
+    if (node->kind() == prim::If) {
+      JIT_ASSERT(node->blocks().size() == 2);
+
+      auto trueBlock = node->blocks().at(0);
+      auto falseBlock = node->blocks().at(1);
+
+      auto trueToken = visitBlock(trueBlock, curToken);
+      auto falseToken = visitBlock(falseBlock, curToken);
+
+      // If any branch has a mutating op, this node has to output a world token
+      if (trueToken != curToken || falseToken != curToken) {
+        trueBlock->registerOutput(trueToken);
+        falseBlock->registerOutput(falseToken);
+
+        return node->addOutput()->setType(WorldType::get());
+      }
+      return curToken;
+    }
+
+    if (node->kind() == prim::Loop) {
+      JIT_ASSERT(node->blocks().size() == 1);
+      auto block = node->blocks().at(0);
+      if (!shouldAnnotate(block)) {
+        // Bail out early if there's no mutable variables used inside
+        return curToken;
+      }
+
+      // Register the world token as a loop carried dependency
+      auto beginLoopToken = block->addInput()->setType(WorldType::get());
+      auto endLoopToken = visitBlock(block, beginLoopToken);
+      block->registerOutput(endLoopToken);
+
+      JIT_ASSERT(endLoopToken != beginLoopToken);
+
+      // Thread the world token through the loop node
+      return annotateNode(node, curToken);
+    }
+
+    JIT_ASSERT(node->blocks().size() == 0);
+
+    if (shouldAnnotate(node)) {
+      return annotateNode(node, curToken);
+    }
+
+    return curToken;
+  }
+
+  bool shouldAnnotate(Node* node) {
+    // Check if this node uses a known mutable value
+    for (auto* input : node->inputs()) {
+      if (mutableValues_.count(input) != 0) {
+        return true;
+      }
+    }
+
+    // Otherwise, check if this node is the first mutation of a value
+    if (effectfulOps.count(node->kind()) != 0) {
+      const auto inputs = node->inputs();
+      Value* mut = inputs.at(0);
+      JIT_ASSERT(mut->type()->kind() == TypeKind::ListType); // TODO
+
+      mutableValues_.insert(mut);
+      return true;
+    }
+
+    // Check that any sub-blocks
+    for (auto block : node->blocks()) {
+      if (shouldAnnotate(block)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool shouldAnnotate(Block* block) {
+    for (auto node : block->nodes()) {
+      if (shouldAnnotate(node)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Annotate a node by threading the world token through it.
+  // Input:
+  //   = prim::append(%list, %new_element)
+  //
+  // Output:
+  //  t.2 : World = prim::append(%list, %new_element, %t.1)
+  //
+  // Returns the new world token (%t.2).
+  Value* annotateNode(Node* node, Value* curToken) {
+    node->addInput(curToken);
+    return node->addOutput()->setType(WorldType::get());
+  }
+
+  std::set<Value*> mutableValues_;
+};
+
+void eraseTokens(Node* node);
+void eraseTokens(Block* block) {
+  for (Node* node : block->nodes()) {
+    eraseTokens(node);
+  }
+}
+void eraseTokens(Node* node) {
+  // Erase all uses of the world token this node outputs.
+  size_t i = 0;
+  for (auto output : node->outputs()) {
+    if (output->type() == WorldType::get()) {
+      for (const auto& use : output->uses()) {
+        eraseTokens(use.user);
+      }
+      output->removeAllUses();
+      break;
+    }
+    ++i;
+  }
+
+  // If this node outputs a world token, erase the output now that all that all
+  // uses are gone
+  if (i != node->outputs().size()) {
+    node->eraseOutput(i);
+  }
+
+  // Traverse sub-blocks if necessary
+  for (auto block : node->blocks()) {
+    eraseTokens(block);
+  }
+}
+} // namespace
+
+void AnnotateEffects(std::shared_ptr<Graph>& graph) {
+  AnnotateEffectsImpl impl;
+  impl.annotateEffects(graph.get());
+}
+
+void UnAnnotateEffects(std::shared_ptr<Graph>& graph) {
+  eraseTokens(graph->block());
+
+  // Special handling to delete the constant "token" generator node
+  for (auto node : graph->block()->nodes())
+    if (node->kind() == prim::Constant && node->outputs().size() == 0) {
+      node->destroy();
+      break;
+    }
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/annotate_effects.h
+++ b/torch/csrc/jit/passes/annotate_effects.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+
+TORCH_API void AnnotateEffects(std::shared_ptr<Graph>& graph);
+TORCH_API void UnAnnotateEffects(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -20,6 +20,9 @@ std::unordered_set<Symbol> skip_list = {
   //FIXME Same problem as in DCE - cpp & python PythonOp and CppOp should be
   //FIXME treated as having side effects but ONNX depends on them being removed
   prim::Print,
+  // TODO(suo): can remove this once world tokens are passed in and out of
+  // graphs correctly
+  prim::append,
   //all the rand functions from native_functions.yaml
   aten::permute,
   aten::rand,

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -64,6 +64,8 @@ inline IValue toIValue(py::object&& obj, const TypePtr& type) {
         AT_ERROR("Lists and tuples are not supported yet");
       case TypeKind::NumberType:
         AT_ERROR("Insufficient type information to convert input");
+      case TypeKind::WorldType:
+        AT_ERROR("World arguments should not be passed in by users");
     }
   AT_ERROR("Missing cases in toIValue! File a bug report.");
 }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -396,14 +396,20 @@ RegisterOperators reg({
             throw std::runtime_error(ss.str());
           }
         }),
+    // Select element in the `b`th position from list `a`
+    // Equivalent to `a[b]` in Python.
     Operator("prim::ListSelect(int[] a, int b) -> int", listSelect<Shared<IntList>>),
     Operator("prim::ListSelect(float[] a, int b) -> float", listSelect<Shared<DoubleList>>),
     Operator("prim::ListSelect(Tensor[] a, int b) -> Tensor", listSelect<Shared<TensorList>>),
 
+    // Return the size of list `a`
+    // Equivalent to `len(a)` in Python.
     Operator("prim::len(int[] a) -> int", listLen<Shared<IntList>>),
     Operator("prim::len(float[] a) -> int", listLen<Shared<DoubleList>>),
     Operator("prim::len(Tensor[] a) -> int", listLen<Shared<TensorList>>),
 
+    // Return a slice of list `l`, with a specified start, end, and step length
+    // Equivalent to `l[start:end:step]` in Python.
     Operator(
         "prim::ListSlice(int[] l, int start, int end=9223372036854775807, int step=1) -> int[]",
         listSlice<Shared<IntList>, int64_t>),
@@ -470,10 +476,14 @@ RegisterOperators reg({
     };                                                                 \
   }),
 RegisterOperators reg2({
+    // Return True iff lists `a` and `b` are elementwise equal
+    // Equivalent to `a == b` in Python.
     Operator("aten::eq(int[] a, int[] b) -> int", listEq<Shared<IntList>>),
     Operator("aten::eq(float[] a, float[] b) -> int", listEq<Shared<DoubleList>>),
     Operator("aten::eq(Tensor[] a, Tensor[] b) -> int", listEq<Shared<TensorList>>),
 
+    // Concatenate list `a` with list `b` and return the result.
+    // Equivalent to `a + b` in Python.
     Operator("aten::add(int[] a, int[] b) -> int[]", listAdd<Shared<IntList>, int64_t>),
     Operator("aten::add(float[] a, float[] b) -> float[]", listAdd<Shared<DoubleList>, double>),
     Operator("aten::add(Tensor[] a, Tensor[] b) -> Tensor[]", listAdd<Shared<TensorList>, at::Tensor>),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -173,9 +173,20 @@ Operation listSlice(Node* node) {
   };
 }
 
+template <typename TList, typename TElement>
+Operation listAppend(Node* node) {
+  return [](Stack& stack) {
+    TList a;
+    TElement el;
+    pop(stack, a, el);
+
+    a->elements().push_back(el);
+
+    return 0;
+  };
+}
 
 RegisterOperators reg({
-
     Operator(
         prim::FusionGroup,
         [](Node* node) {
@@ -419,6 +430,10 @@ RegisterOperators reg({
     Operator(
         "prim::ListSlice(Tensor[] l, int start, int end=9223372036854775807, int step=1) -> Tensor[]",
         listSlice<Shared<TensorList>, at::Tensor>),
+
+    Operator("prim::append(int[] list, int el) -> ()", listAppend<Shared<IntList>, int64_t>),
+    Operator("prim::append(float[] list, float el) -> ()", listAppend<Shared<DoubleList>, double>),
+    Operator("prim::append(Tensor[] list, Tensor el) -> ()", listAppend<Shared<TensorList>, at::Tensor>),
 });
 
 // define implementations for primitive number ops

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -42,6 +42,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "None";
   } else if(t.kind() == TypeKind::StringType) {
     out << "string";
+  } else if(t.kind() == TypeKind::WorldType) {
+    out << "World";
   } else {
     AT_ERROR("unknown type kind");
   }
@@ -66,6 +68,10 @@ FloatTypePtr FloatType::get() {
 }
 NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
+  return value;
+}
+WorldTypePtr WorldType::get() {
+  static auto value = WorldType::create();
   return value;
 }
 StringTypePtr StringType::get() {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -22,6 +22,7 @@ _(FloatType) \
 _(IntType) \
 _(NoneType) \
 _(StringType) \
+_(WorldType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -212,6 +213,32 @@ private:
   int device_;
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
+};
+
+// This type is a token used to represent effectful computation in the IR.
+// See the AnnotateEffects pass for how it is used.
+struct WorldType;
+using WorldTypePtr = std::shared_ptr<WorldType>;
+struct TORCH_API WorldType : public Type {
+  template <typename... T>
+  static WorldTypePtr create(T&&... all) {
+    return WorldTypePtr(new WorldType(std::forward<T>(all)...));
+  }
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return "world";
+  }
+  bool isSubtypeOf(const TypePtr rhs) const override {
+    return *this == *rhs;
+  }
+  static const TypeKind Kind = TypeKind::WorldType;
+  // global singleton
+  static WorldTypePtr get();
+
+ private:
+  WorldType() : Type(TypeKind::WorldType) {}
 };
 
 struct ListType;


### PR DESCRIPTION
Second pass at #10500; I opened a new PR since the approach is different.

This is also stacked on top of #10566, so only look at the last commit (@ezyang is there a better way to do this???)

This PR has the `AnnotateEffects` pass thread a world token directly through ops that use mutable values. It also includes an `UnAnnotateEffects` pass that erases all the annotations before starting graph execution.

I added a bunch of todos with things that need to be fixed or I wanted peoples' thoughts on.