### PR TITLE
Call MPI_Finalize before global variable destructions

### DIFF
--- a/torch/distributed/deprecated/__init__.py
+++ b/torch/distributed/deprecated/__init__.py
@@ -101,7 +101,7 @@ def init_process_group(backend, init_method='env://', **kwargs):
                                       group_name, rank)
     _initialized = _INITIALIZED_PG
 
-    if _backend == dist_backend.NCCL:
+    if _backend in [dist_backend.MPI, dist_backend.NCCL]:
         atexit.register(destroy_process_group)
 
     if not torch._C._dist_init_extension(False, reduce_op, group):

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -85,7 +85,7 @@ DataChannelMPI::DataChannelMPI()
 {}
 
 
-DataChannelMPI::~DataChannelMPI() {
+void DataChannelMPI::destroy() {
   for (auto& group : _groups) {
     auto comm = group.second.first;
     if (comm != MPI_COMM_WORLD && comm != MPI_COMM_NULL)
@@ -94,9 +94,6 @@ DataChannelMPI::~DataChannelMPI() {
 
   MPI_Finalize();
 }
-
-
-void DataChannelMPI::destroy() {}
 
 
 bool DataChannelMPI::init() {

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
@@ -32,7 +32,7 @@ struct DataChannelMPI : DataChannel {
   };
 
   DataChannelMPI();
-  virtual ~DataChannelMPI();
+  virtual ~DataChannelMPI() = default;
 
   bool init() override;
   void destroy() override;


### PR DESCRIPTION
Several MPI implementations do not support calling "MPI_Finalize" in a
global variable destructor. The common workaround is to use atexit() to
finalize as soon as main() returns.

