### PR TITLE
[Caffe2] Delete copy constructor/assignment of class Observable explicitly.

### DIFF
--- a/caffe2/core/observer.h
+++ b/caffe2/core/observer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <unordered_set>
+
 #include "caffe2/core/logging.h"
 
 namespace caffe2 {
@@ -43,7 +44,15 @@ class ObserverBase {
 template <class T>
 class Observable {
  public:
-  virtual ~Observable(){};
+  Observable() = default;
+
+  Observable(Observable&&) = default;
+  Observable& operator =(Observable&&) = default;
+
+  virtual ~Observable() = default;
+
+  AT_DISABLE_COPY_AND_ASSIGN(Observable);
+
   using Observer = ObserverBase<T>;
 
   /* Returns a reference to the observer after addition. */


### PR DESCRIPTION
This should resolves "error C2280: 'std::unique_ptr<caffe2::ObserverBase<caffe2::OperatorBase>,std::default_delete<_Ty>> &std::unique_ptr<_Ty,std::default_delete<_Ty>>::operator =(const std::unique_ptr<_Ty,std::default_delete<_Ty>> &)': attempting to reference a deleted function" from Visual Studio.
It should also make error message more human-readable in case if something really messed up.

