### PR TITLE
[Caffe2] Fix subgraph cutting wrt recent external_input change in nomnigraph

### DIFF
--- a/caffe2/opt/backend_cutting.cc
+++ b/caffe2/opt/backend_cutting.cc
@@ -1,6 +1,6 @@
 #include "caffe2/opt/backend_cutting.h"
-#include "caffe2/opt/converter.h"
 #include "caffe2/core/logging.h"
+#include "caffe2/opt/converter.h"
 #include "nomnigraph/Converters/Dot.h"
 #include "nomnigraph/Representations/NeuralNet.h"
 
@@ -57,12 +57,11 @@ void DumpGraph(NNGraph* g) {
     assert(node->data() && "Node doesn't have data, can't render it");
     if (isa<NeuralNetOperator>(node->data())) {
       auto* op = dyn_cast<NeuralNetOperator>(node->data().get());
-      labelMap["label"] =
-          op->getName() + " (" + caffe2::to_string((unsigned long long)node) + ")";
+      labelMap["label"] = op->getName() + " (" +
+          caffe2::to_string((unsigned long long)node) + ")";
       auto* annotation = op->getAnnotation();
       if (annotation && isa<Caffe2Annotation>(annotation)) {
-        auto device_annotation =
-            dyn_cast<Caffe2Annotation>(annotation);
+        auto device_annotation = dyn_cast<Caffe2Annotation>(annotation);
         labelMap["label"] += "\\n[" + device_annotation->getDevice() + "]";
         auto hash = std::hash<std::string>{}(device_annotation->getDevice());
         std::stringstream hex_stream;
@@ -104,8 +103,7 @@ void Explore(
 
     // Check if the node is supported, stop exploring further if not supported
     if (nn::is<NeuralNetOperator>(node)) {
-      const auto* nn_op =
-        nn::get<NeuralNetOperator>(node);
+      const auto* nn_op = nn::get<NeuralNetOperator>(node);
       const auto& op_def =
           dyn_cast<Caffe2Annotation>(nn_op->getAnnotation())->getOperatorDef();
       bool wanted = context->predicate(op_def);
@@ -190,7 +188,9 @@ caffe2::NetDef ConvertToC2Net(
   for (auto node : sub.nodes) {
     if (nn::is<NeuralNetOperator>(node)) {
       const auto* nn_op = nn::get<NeuralNetOperator>(node);
-      assert(isa<Caffe2Annotation>(nn_op->getAnnotation()) && "Cannot get caffe2 op from NNOp");
+      assert(
+          isa<Caffe2Annotation>(nn_op->getAnnotation()) &&
+          "Cannot get caffe2 op from NNOp");
       const auto& op_def =
           dyn_cast<Caffe2Annotation>(nn_op->getAnnotation())->getOperatorDef();
       net.add_op()->CopyFrom(op_def);
@@ -210,8 +210,9 @@ caffe2::NetDef ConvertToC2Net(
 
 void DetectBoundaryReferences(
     TransformSubgraph* subgraph,
-    const std::unordered_map<NodeRef, GroupAnnotation>& infos) {
-  for (auto node: subgraph->nodes) {
+    const std::unordered_map<NodeRef, GroupAnnotation>& infos,
+    const std::unordered_set<std::string>& original_external_output) {
+  for (auto node : subgraph->nodes) {
     // inputs
     for (auto in_edge : node->getInEdges()) {
       auto parent_node = in_edge->tail();
@@ -228,12 +229,20 @@ void DetectBoundaryReferences(
     if (!nn::is<NeuralNetData>(node)) {
       continue;
     }
-    for (auto child_node : nn::getConsumers(node)) {
-      const auto& info = infos.at(child_node);
-      if (info.group != subgraph->group_id) {
-        const auto* nn_tensor = nn::get<const NeuralNetData>(node);
-        subgraph->external_output_refs.emplace(nn_tensor->getName(), node);
-        break;
+    // Note that although matched subgraph won't contain external inputs as we
+    // skip the initial input tensor of matching, it is possible to contain
+    // external outputs. We will mark these external outputs as boundary outputs
+    // too.
+    auto name = nn::get<const NeuralNetData>(node)->getName();
+    if (original_external_output.count(name)) {
+      subgraph->external_output_refs.emplace(name, node);
+    } else {
+      for (auto child_node : nn::getConsumers(node)) {
+        const auto& info = infos.at(child_node);
+        if (info.group != subgraph->group_id) {
+          subgraph->external_output_refs.emplace(name, node);
+          break;
+        }
       }
     }
   }
@@ -247,9 +256,8 @@ void ReplaceSubgraph(
   // tensors
   for (auto node : subgraph.nodes) {
     if (nn::is<NeuralNetData>(node) &&
-        subgraph.external_output_refs.find(
-            nn::get<const NeuralNetData>(node)->getName()) !=
-            subgraph.external_output_refs.end()) {
+        subgraph.external_output_refs.count(
+            nn::get<const NeuralNetData>(node)->getName())) {
       VLOG(2) << "Keeping " << ShowNode(node);
       continue;
     }
@@ -259,10 +267,10 @@ void ReplaceSubgraph(
 
   // Convert new NetDef back to NNGraph
   std::unordered_map<std::string, NodeRef> tensor_map;
-  for (const auto kv: subgraph.external_input_refs) {
+  for (const auto kv : subgraph.external_input_refs) {
     tensor_map.emplace(kv.first, kv.second);
   }
-  for (const auto kv: subgraph.external_output_refs) {
+  for (const auto kv : subgraph.external_output_refs) {
     tensor_map.emplace(kv.first, kv.second);
   }
   for (auto& op : *net_opt.mutable_op()) {
@@ -294,8 +302,7 @@ void PruneUnrefereredNodes(NNModule* nn) {
   auto& g = nn->dataFlow;
   std::vector<NodeRef> to_delete;
   for (auto node : g.getMutableNodes()) {
-    if (!nn::hasProducer(node) &&
-        !nn::hasConsumer(node)) {
+    if (!nn::hasProducer(node) && !nn::hasConsumer(node)) {
       to_delete.push_back(node);
     }
   }
@@ -329,7 +336,7 @@ caffe2::NetDef OptimizeForBackend(
   // Initialize the group info and figure out the external/input output
   VisitorContext context(supports);
   std::vector<NodeRef> external_inputs;
-  std::vector<NodeRef> external_outputs;
+  std::unordered_set<std::string> external_outputs;
   for (auto node : dfg.getMutableNodes()) {
     context.infos.emplace(
         std::piecewise_construct,
@@ -341,7 +348,7 @@ caffe2::NetDef OptimizeForBackend(
         external_inputs.push_back(node);
       }
       if (!nn::hasConsumer(node)) {
-        external_outputs.push_back(node);
+        external_outputs.emplace(nn::get<const NeuralNetData>(node)->getName());
       }
     }
   }
@@ -357,11 +364,11 @@ caffe2::NetDef OptimizeForBackend(
        context.find_supported = !context.find_supported) {
     Explore(frontier, &context);
     if (context.find_supported) {
-    subs.emplace_back(
-        std::move(frontier),
-        std::move(context.current_group),
-        context.group,
-        context.find_supported);
+      subs.emplace_back(
+          std::move(frontier),
+          std::move(context.current_group),
+          context.group,
+          context.find_supported);
     }
 
     frontier.assign(context.frontier.begin(), context.frontier.end());
@@ -375,7 +382,7 @@ caffe2::NetDef OptimizeForBackend(
   opt_subnets.reserve(subs.size());
   for (auto& g : subs) {
     // Generate boundary input/output edges
-    DetectBoundaryReferences(&g, context.infos);
+    DetectBoundaryReferences(&g, context.infos, external_outputs);
 
     caffe2::NetDef subnet = ConvertToC2Net(g, context.infos);
     // Transform the subgraph protobuf def, note that we can have less external

--- a/caffe2/opt/backend_cutting_test.cc
+++ b/caffe2/opt/backend_cutting_test.cc
@@ -42,6 +42,21 @@ namespace {
   }
 }
 
+// N0 -> MyConv -> N1
+TEST(BackendCuttingTest, unit) {
+  caffe2::NetDef net;
+  AddConv(&net, 0);
+  net.add_external_input("N0");
+  net.add_external_input("W0");
+  net.add_external_input("b0");
+  net.add_external_output("N1");
+  auto net_opt = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  EXPECT_EQ(1, net_opt.op_size());
+  EXPECT_EQ(1, net_opt.external_input_size());
+  EXPECT_EQ(1, net_opt.external_output_size());
+}
+
+
 // X -> CopyIn -> MyConv -> MyConv -> CopyOut -> Y
 TEST(BackendCuttingTest, line) {
   caffe2::NetDef net;

--- a/caffe2/opt/backend_cutting_test.cc
+++ b/caffe2/opt/backend_cutting_test.cc
@@ -1,5 +1,6 @@
 #include "caffe2/core/common.h"
 #include "caffe2/opt/backend_cutting.h"
+#include "caffe2/core/logging.h"
 #include "caffe2/utils/string_utils.h"
 
 #include <gtest/gtest.h>
@@ -45,6 +46,11 @@ namespace {
 TEST(BackendCuttingTest, line) {
   caffe2::NetDef net;
   net.add_external_input("X");
+  // Adding weights as external intputs to test weight absorption
+  net.add_external_input("W0");
+  net.add_external_input("W1");
+  net.add_external_input("b0");
+  net.add_external_input("b1");
   net.add_external_output("Y");
   auto* op = net.add_op();
   op->set_type("CopyIn");

--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -297,11 +297,6 @@ repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::st
     currentBasicBlock->pushInstructionNode(opNode);
   }
 
-  CAFFE_ENFORCE(
-      externalInputNames.size() == 0,
-      "Attempting to convert an ill-formed network: \
-      external_input contains unused blobs");
-
   for (const auto& outputName : net.external_output()) {
     CAFFE_ENFORCE(
         blobMap.count(outputName), "NetDef has ill-formed external_output");


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/10100 recently take external input/output in nomnigraph. This PR makes adjust to 
0. Relax some of the conditions on external input
1. Update NNModule inputs/outputs when pruning the input/output. 
2. Avoiding copying external input/output as nomnigraph already takes care of it. 