### PR TITLE
Tune minimal work size

### DIFF
--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -18,11 +18,7 @@ namespace caffe2 {
 
 // Default smallest amount of work that will be partitioned between
 // multiple threads; the runtime value is configurable
-#if CAFFE2_ANDROID
-constexpr size_t kDefaultMinWorkSize = 8;
-#else
-constexpr size_t kDefaultMinWorkSize = 80;
-#endif
+constexpr size_t kDefaultMinWorkSize = 1;
 
 std::unique_ptr<ThreadPool> ThreadPool::defaultThreadPool() {
   CAFFE_ENFORCE(cpuinfo_initialize(), "cpuinfo initialization failed");


### PR DESCRIPTION
Summary:
Reduce minimal work size to 1 and see what happens to performance.
I think that not spawing threads with spin-lock synchronization may be bad because they will switch to condvar wait, which increases wake-up latency next time they are needed.

Reviewed By: ajtulloch

Differential Revision: D9366664
