### PR TITLE
[Caffe2] Add AT_CORE_EXPORT and AT_CORE_IMPORT.

### DIFF
--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -7,22 +7,27 @@
 // static library (in which case, saying the symbol is coming
 // from a DLL would be incorrect).
 
-#ifdef _WIN32
-#if !defined(AT_CORE_STATIC_WINDOWS)
-// TODO: unfiy the controlling macros.
-#if defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#define AT_CORE_API __declspec(dllexport)
-#else // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#define AT_CORE_API __declspec(dllimport)
-#endif // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#else // !defined(AT_CORE_STATIC_WINDOWS)
+#define AT_CORE_EXPORT
+#define AT_CORE_IMPORT
 #define AT_CORE_API
-#endif // !defined(AT_CORE_STATIC_WINDOWS)
+
+#ifdef _WIN32
+  #ifndef AT_CORE_STATIC_WINDOWS
+    #define AT_CORE_EXPORT __declspec(dllexport)
+    #define AT_CORE_IMPORT __declspec(dllimport)
+  #endif // !defined(AT_CORE_STATIC_WINDOWS)
 #else  // _WIN32
-#if defined(__GNUC__)
-#define AT_CORE_API __attribute__((__visibility__("default")))
-#endif // defined(__GNUC__)
+  #if defined(__GNUC__) || defined(__llvm__)
+    #define AT_CORE_EXPORT __attribute__((__visibility__("default")))
+    #define AT_CORE_IMPORT AT_CORE_EXPORT
+  #endif // defined(__GNUC__)
 #endif  // _WIN32
+
+#if defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
+  #define AT_CORE_API AT_CORE_EXPORT
+#else // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
+  #define AT_CORE_API AT_CORE_IMPORT
+#endif // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
 
 // Disable the copy and assignment operator for a class. Note that this will
 // disable the usage of the class in std containers.

--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -9,18 +9,21 @@
 
 #define AT_CORE_EXPORT
 #define AT_CORE_IMPORT
-#define AT_CORE_API
 
 #ifdef _WIN32
   #ifndef AT_CORE_STATIC_WINDOWS
+    #undef AT_CORE_EXPORT
+    #undef AT_CORE_IMPORT
     #define AT_CORE_EXPORT __declspec(dllexport)
     #define AT_CORE_IMPORT __declspec(dllimport)
   #endif // !defined(AT_CORE_STATIC_WINDOWS)
 #else  // _WIN32
   #if defined(__GNUC__) || defined(__llvm__)
+    #undef AT_CORE_EXPORT
+    #undef AT_CORE_IMPORT
     #define AT_CORE_EXPORT __attribute__((__visibility__("default")))
     #define AT_CORE_IMPORT AT_CORE_EXPORT
-  #endif // defined(__GNUC__)
+  #endif // defined(__GNUC__) || defined(__llvm__)
 #endif  // _WIN32
 
 #if defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -391,33 +391,14 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
  *
  * NOTE: the macro needs to be invoked in ::caffe2 namespace
  */
-// Implementation note: in MSVC, we will need to prepend the AT_CORE_API
-// keyword in order to get things compiled properly. in Linux, gcc seems to
-// create attribute ignored error for explicit template instantiations, see
-//   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0537r0.html
-//   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51930
-// and as a result, we define these two macros slightly differently.
-// TODO(jiayq): AT_CORE_API below is not correct, because we may use the
-// definition in third party dependent libraries. The proper way is to use
-// CAFFE2_EXPORT (which explicitly requires dllexport). Marking this as a
-// todo item when the unified build is finished.
-#ifdef _MSC_VER
+
 #define CAFFE_KNOWN_TYPE(T)                                               \
   template <>                                                             \
-  AT_CORE_API TypeIdentifier TypeMeta::Id<T>() {                          \
+  AT_CORE_EXPORT TypeIdentifier TypeMeta::Id<T>() {                       \
     static const TypeIdentifier type_id = TypeIdentifier::createTypeId(); \
     static TypeNameRegisterer<T> registerer(type_id, #T);                 \
     return type_id;                                                       \
   }
-#else // _MSC_VER
-#define CAFFE_KNOWN_TYPE(T)                                               \
-  template <>                                                             \
-  TypeIdentifier TypeMeta::Id<T>() {                                      \
-    static const TypeIdentifier type_id = TypeIdentifier::createTypeId(); \
-    static TypeNameRegisterer<T> registerer(type_id, #T);                 \
-    return type_id;                                                       \
-  }
-#endif
 
 /**
  * CAFFE_DECLARE_KNOWN_TYPE and CAFFE_DEFINE_KNOWN_TYPE are used
@@ -425,19 +406,11 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
  * can be resolved at compile time. Please use CAFFE_KNOWN_TYPE() instead
  * for your own types to allocate dynamic ids for them.
  */
-#ifdef _MSC_VER
-#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)       \
-  template <>                                             \
-  inline AT_CORE_API TypeIdentifier TypeMeta::Id<T>() {   \
-    return TypeIdentifier(PreallocatedId);                \
+#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)                       \
+  template <>                                                             \
+  AT_CORE_EXPORT inline AT_CORE_API TypeIdentifier TypeMeta::Id<T>() {    \
+    return TypeIdentifier(PreallocatedId);                                \
   }
-#else // _MSC_VER
-#define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T) \
-  template <>                                       \
-  inline TypeIdentifier TypeMeta::Id<T>() {         \
-    return TypeIdentifier(PreallocatedId);          \
-  }
-#endif
 
 #define CONCAT_IMPL(x, y) x##y
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)


### PR DESCRIPTION
Fix "error LNK2019: unresolved external symbol" from "CAFFE_KNOWN_TYPE" in tests where we should use dllexport instead of AT_CORE_API(=dllimport).

