### PR TITLE
nomnigraph - isSubgraphMatch returns the matched Subgraph & map from MatchNodes to graph nodes

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -187,16 +187,37 @@ std::ostream& operator<<(
   return oss << criteria.debugString;
 }
 
-bool hasSingleOutputAndConsumer(NNGraph::NodeRef nodeRef) {
-  auto nodeOutputs = nn::getOutputs(nodeRef);
-  NOM_REQUIRE_OR_RET_FALSE(nodeOutputs.size() == 1);
-  auto nodeConsumers = nn::getConsumers(nodeOutputs.front());
-  return nodeConsumers.size() == 1;
+NNNodeMatchCriteria criteriaSingleOutputAndConsumer() {
+  return NNNodeMatchCriteria(
+      [](NNGraph::NodeRef nodeRef) {
+        auto nodeOutputs = nn::getOutputs(nodeRef);
+        NOM_REQUIRE_OR_RET_FALSE(nodeOutputs.size() == 1);
+        auto nodeConsumers = nn::getConsumers(nodeOutputs.front());
+        return nodeConsumers.size() == 1;
+      },
+      "Single output and consumer");
 }
 
-NNNodeMatchCriteria matchAnyNode() {
+NNNodeMatchCriteria criteriaSingleConsumer() {
   return NNNodeMatchCriteria(
-      [](NNGraph::NodeRef /* unused */) { return true; }, "matchAnyNode");
+      [](NNGraph::NodeRef nodeRef) {
+        auto nodeOutputs = nn::getOutputs(nodeRef);
+        NNGraph::NodeRef nodeConsumer = nullptr;
+        for (auto nodeOutput : nodeOutputs) {
+          for (auto consumer : nn::getConsumers(nodeOutput)) {
+            if (nodeConsumer && consumer && consumer != nodeConsumer) {
+              return false;
+            }
+            nodeConsumer = consumer;
+          }
+        }
+        return true;
+      },
+      "Single consumer");
+}
+
+NNNodeMatchCriteria matchTensor() {
+  return matchOp<nom::repr::Tensor>("matchTensor");
 }
 
 NNMatchGraph::NodeRef operatorSubgraph(
@@ -205,7 +226,7 @@ NNMatchGraph::NodeRef operatorSubgraph(
     const std::vector<NNMatchGraph::NodeRef>& childrenCriteria,
     int count) {
   return subgraph(
-      g, matchAnyNode(), {subgraph(g, root, childrenCriteria)}, count);
+      g, matchTensor(), {subgraph(g, root, childrenCriteria)}, count);
 }
 
 } // namespace nn

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -321,6 +321,28 @@ class Graph {
     }
   }
 
+  // All out-edges oldNode -> V will be replaced with newNode -> V
+  void replaceOutEdges(const NodeRef& oldNode, const NodeRef& newNode) {
+    const auto edges = oldNode->getOutEdges();
+
+    for (const auto& edge : edges) {
+      edge->setTail(newNode);
+      oldNode->removeOutEdge(edge);
+      newNode->addOutEdge(edge);
+    }
+  }
+
+  // All in-edges V -> oldNode  will be replaced with V -> newNode
+  void replaceInEdges(const NodeRef& oldNode, const NodeRef& newNode) {
+    const auto edges = oldNode->getInEdges();
+
+    for (const auto& edge : edges) {
+      edge->setHead(newNode);
+      oldNode->removeInEdge(edge);
+      newNode->addInEdge(edge);
+    }
+  }
+
   /// \brief Creates a directed edge and retains ownership of it.
   /// \p tail The node that will have this edge as an out-edge.
   /// \p head The node that will have this edge as an in-edge.
@@ -352,6 +374,9 @@ class Graph {
   /// \param deleteEdges (optional) Whether or not to delete the edges
   /// related to the node.
   void deleteNode(NodeRef n, bool deleteEdges = true) {
+    if (!hasNode(n)) {
+      return;
+    }
     if (deleteEdges) {
       auto inEdges = n->inEdges_;
       for (auto& edge : inEdges) {
@@ -368,6 +393,15 @@ class Graph {
         nodes_.erase(i);
         break;
       }
+    }
+  }
+
+  // Delete all nodes in the set.
+  void deleteNodes(
+      const std::unordered_set<NodeRef>& nodes,
+      bool deleteEdges = true) {
+    for (auto node : nodes) {
+      deleteNode(node, deleteEdges);
     }
   }
 


### PR DESCRIPTION
Summary:
Make isSubgraphMatch returns a subgraph and map from MatchNodes to graph nodes in the result, which makes it easier to write graph fusion logic. Also include some more helper methods for NN subgraph matcher.

Differential Revision: D9374931
