### PR TITLE
[c10d] Working pybind version of MPI process group and abort() pybind

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -236,21 +236,23 @@ PyObject* c10d_init(PyObject* _unused) {
               &::c10d::ProcessGroup::recv,
               py::call_guard<py::gil_scoped_release>())
 
-         .def(
+          .def(
               "recv_anysource",
               [](::c10d::ProcessGroup& pg,
                  std::vector<at::Tensor>& input,
                  at::Tensor& srcRankTensor) {
                 if (srcRankTensor.type().scalarType() != at::kInt) {
-                  throw std::runtime_error("source rank tensor needs to be "
-                                           "CPU int tensor");
+                  throw std::runtime_error(
+                      "source rank tensor needs to be "
+                      "CPU int tensor");
                 }
                 if (srcRankTensor.numel() != 1) {
-                  throw std::runtime_error("source rank tensor needs to "
-                                           "contain only one element");
+                  throw std::runtime_error(
+                      "source rank tensor needs to "
+                      "contain only one element");
                 }
-                return pg.recvAnysource(input,
-                    static_cast<int *>(srcRankTensor.data_ptr()));
+                return pg.recvAnysource(
+                    input, static_cast<int*>(srcRankTensor.data_ptr()));
               },
               py::arg("tensors"),
               py::arg("src_rank"),

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -236,9 +236,29 @@ PyObject* c10d_init(PyObject* _unused) {
               &::c10d::ProcessGroup::recv,
               py::call_guard<py::gil_scoped_release>())
 
-          .def(
+         .def(
               "recv_anysource",
-              &::c10d::ProcessGroup::recvAnysource,
+              [](::c10d::ProcessGroup& pg,
+                 std::vector<at::Tensor>& input,
+                 at::Tensor& srcRankTensor) {
+                if (srcRankTensor.type().scalarType() != at::kInt) {
+                  throw std::runtime_error("source rank tensor needs to be "
+                                           "CPU int tensor");
+                }
+                if (srcRankTensor.numel() != 1) {
+                  throw std::runtime_error("source rank tensor needs to "
+                                           "contain only one element");
+                }
+                return pg.recvAnysource(input,
+                    static_cast<int *>(srcRankTensor.data_ptr()));
+              },
+              py::arg("tensors"),
+              py::arg("src_rank"),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "abort",
+              &::c10d::ProcessGroup::barrier,
               py::call_guard<py::gil_scoped_release>())
 
           .def(

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -298,16 +298,16 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
   checkSingleTensor(tensors);
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
-    [opts](std::unique_ptr<WorkEntry>& entry) {
-      auto data = (entry->src)[0];
-      MPI_CHECK(MPI_Allreduce(
+      [opts](std::unique_ptr<WorkEntry>& entry) {
+        auto data = (entry->src)[0];
+        MPI_CHECK(MPI_Allreduce(
             MPI_IN_PLACE,
             data.data_ptr(),
             data.numel(),
             mpiDatatype.at(data.type().scalarType()),
             mpiOp.at(opts.reduceOp),
             MPI_COMM_WORLD));
-    };
+      };
   auto entry = std::unique_ptr<WorkEntry>(
       new WorkEntry(&tensors, nullptr, std::move(runFunc)));
   return enqueue(std::move(entry));

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -279,7 +279,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::broadcast(
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
+        auto data = (entry->src)[0];
         MPI_CHECK(MPI_Bcast(
             data.data_ptr(),
             data.numel(),
@@ -296,17 +296,18 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   checkSingleTensor(tensors);
+
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
-      [opts](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
-        MPI_CHECK(MPI_Allreduce(
+    [opts](std::unique_ptr<WorkEntry>& entry) {
+      auto data = (entry->src)[0];
+      MPI_CHECK(MPI_Allreduce(
             MPI_IN_PLACE,
             data.data_ptr(),
             data.numel(),
             mpiDatatype.at(data.type().scalarType()),
             mpiOp.at(opts.reduceOp),
             MPI_COMM_WORLD));
-      };
+    };
   auto entry = std::unique_ptr<WorkEntry>(
       new WorkEntry(&tensors, nullptr, std::move(runFunc)));
   return enqueue(std::move(entry));
@@ -319,8 +320,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce(
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
-        auto dataPtr = (*entry->src)[0].data_ptr();
+        auto data = (entry->src)[0];
+        auto dataPtr = (entry->src)[0].data_ptr();
         void* sendbuf = (rank_ == opts.rootRank) ? MPI_IN_PLACE : dataPtr;
         void* recvbuf = (rank_ == opts.rootRank) ? dataPtr : nullptr;
 
@@ -357,8 +358,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
-        std::vector<at::Tensor>& outputDataVec = *(entry->dst);
+        auto data = (entry->src)[0];
+        std::vector<at::Tensor>& outputDataVec = entry->dst;
         auto flatOutputTensor = newLikeFlat(outputDataVec);
 
         MPI_CHECK(MPI_Allgather(
@@ -405,14 +406,12 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
+        auto data = (entry->src)[0];
         void* recvbuf = nullptr;
         at::Tensor flatOutputTensor;
-        std::vector<at::Tensor>* outputDataVec = nullptr;
 
         if (rank_ == opts.rootRank) {
-          outputDataVec = entry->dst;
-          flatOutputTensor = newLikeFlat(*outputDataVec);
+          flatOutputTensor = newLikeFlat(entry->dst);
           recvbuf = flatOutputTensor.data_ptr();
         }
         MPI_CHECK(MPI_Gather(
@@ -426,9 +425,10 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
             MPI_COMM_WORLD));
 
         if (rank_ == opts.rootRank) {
+          std::vector<at::Tensor>& outputDataVec = entry->dst;
           // copy the flattened output tensors to the outputs
-          for (size_t i = 0; i < outputDataVec->size(); ++i) {
-            outputDataVec->at(i).copy_(flatOutputTensor[i]);
+          for (size_t i = 0; i < outputDataVec.size(); ++i) {
+            outputDataVec.at(i).copy_(flatOutputTensor[i]);
           }
         }
       };
@@ -470,19 +470,18 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
 
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [opts, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->dst)[0];
+        auto data = (entry->dst)[0];
         void* sendbuf = nullptr;
         at::Tensor flatInputTensor;
-        std::vector<at::Tensor>* inputDataVec;
 
         if (rank_ == opts.rootRank) {
-          inputDataVec = entry->src;
-          flatInputTensor = newLikeFlat(*inputDataVec);
+          std::vector<at::Tensor>& inputDataVec = entry->src;
+          flatInputTensor = newLikeFlat(inputDataVec);
           sendbuf = flatInputTensor.data_ptr();
 
           // copy the input tensors to the flatten large send buffer
-          for (size_t i = 0; i < inputDataVec->size(); ++i) {
-            flatInputTensor[i].copy_(inputDataVec->at(i));
+          for (size_t i = 0; i < inputDataVec.size(); ++i) {
+            flatInputTensor[i].copy_(inputDataVec.at(i));
           }
         }
 
@@ -514,7 +513,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [dstRank](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
+        auto data = (entry->src)[0];
         MPI_CHECK(MPI_Send(
             data.data_ptr(),
             data.numel(),
@@ -534,7 +533,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [srcRank](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
+        auto data = (entry->src)[0];
         MPI_CHECK(MPI_Recv(
             data.data_ptr(),
             data.numel(),
@@ -555,7 +554,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
       [srcRank](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (*entry->src)[0];
+        auto data = (entry->src)[0];
         MPI_Status status;
         MPI_CHECK(MPI_Recv(
             data.data_ptr(),

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -23,13 +23,13 @@ struct WorkEntry {
       std::vector<at::Tensor>* dstPtr,
       std::function<void(std::unique_ptr<WorkEntry>&)> run)
       : run(run) {
-        if (srcPtr) {
-          src = *srcPtr;
-        }
-        if (dstPtr) {
-          dst = *dstPtr;
-        }
-      }
+    if (srcPtr) {
+      src = *srcPtr;
+    }
+    if (dstPtr) {
+      dst = *dstPtr;
+    }
+  }
 
   // Not copyable
   WorkEntry(const WorkEntry&) = delete;

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -19,10 +19,17 @@ namespace c10d {
 // The actual run function that will operate either on src or dst or both.
 struct WorkEntry {
   explicit WorkEntry(
-      std::vector<at::Tensor>* src,
-      std::vector<at::Tensor>* dst,
+      std::vector<at::Tensor>* srcPtr,
+      std::vector<at::Tensor>* dstPtr,
       std::function<void(std::unique_ptr<WorkEntry>&)> run)
-      : src(src), dst(dst), run(run) {}
+      : run(run) {
+        if (srcPtr) {
+          src = *srcPtr;
+        }
+        if (dstPtr) {
+          dst = *dstPtr;
+        }
+      }
 
   // Not copyable
   WorkEntry(const WorkEntry&) = delete;
@@ -30,10 +37,10 @@ struct WorkEntry {
   WorkEntry& operator=(const WorkEntry&) = delete;
 
   // For input and output tensors (in-place), we will always use src
-  std::vector<at::Tensor>* src;
-  std::vector<at::Tensor>* dst;
+  std::vector<at::Tensor> src;
+  std::vector<at::Tensor> dst;
   // src rank returned, for recv only
-  int* srcRank;
+  int* srcRank = nullptr;
   std::function<void(std::unique_ptr<WorkEntry>&)> run;
 };
 

--- a/torch/lib/c10d/test/ProcessGroupMPITest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupMPITest.cpp
@@ -342,6 +342,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
       } else {
         std::shared_ptr<::c10d::ProcessGroup::Work> work =
             pg->recvAnysource(tensors, &srcRanks[i]);
+        works.push_back(std::move(work));
       }
       ++i;
     }


### PR DESCRIPTION
This will make pybind version of MPI PG work. The issue is the scope of the tensor list won't be available for the MPI worker thread. So we pass the vector by value instead.

Also added recv_anysource pybind to make it work. The front-end API will wrap one level up with an int for this function. So taking a tensor should be the easiest way for now.

Also added abort pybind and fixed the flaky test.
```
tengli@devfair033:~/new_pytorch/pytorch/torch/lib/build/c10d/test$ mpirun -np 8 ProcessGroupMPITest
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
Test successful
```