### PR TITLE
[Caffe2] Bugfix in slice op

### DIFF
--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -36,6 +36,7 @@ bool SliceImpl(
     if (i >= starts.size()) {
       starts_idx[i] = 0;
       ends_idx[i] = data.dims()[i];
+      dst_sizes[i] = data.dims()[i];
       continue;
     }
     if (data.dims()[i] > 0) {


### PR DESCRIPTION
The code forget to set dst_sizes when there is no slicing on a dimension where the dimension index is greater than or equal to the length of starts and ends.

