### PR TITLE
Adding Pre and Post padding functionalities to pad_sequence function

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3719,6 +3719,11 @@ class TestNN(NNTestCase):
         padded = rnn_utils.pad_sequence([b, a, c], True, 1)
         self.assertEqual(padded, expected)
 
+        # padding_type = 'pre'
+        expected = torch.tensor([[0, 4, 5], [1, 2, 3], [0, 0, 6]])
+        padded = rnn_utils.pad_sequence([b, a, c], True, padding_type='pre')
+        self.assertEqual(padded, expected)
+
         # Test pad sorted sequence
         expected = torch.tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]])
         padded = rnn_utils.pad_sequence([a, b, c], True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3719,9 +3719,9 @@ class TestNN(NNTestCase):
         padded = rnn_utils.pad_sequence([b, a, c], True, 1)
         self.assertEqual(padded, expected)
 
-        # padding_type = 'pre'
+        # padding_type = "pre"
         expected = torch.tensor([[0, 4, 5], [1, 2, 3], [0, 0, 6]])
-        padded = rnn_utils.pad_sequence([b, a, c], True, padding_type='pre')
+        padded = rnn_utils.pad_sequence([b, a, c], True, padding_type="pre")
         self.assertEqual(padded, expected)
 
         # Test pad sorted sequence

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -271,7 +271,7 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
 pad_packed_sequence = torch.onnx.symbolic_override(_symbolic_pad_packed_sequence)(pad_packed_sequence)
 
 
-def pad_sequence(sequences, batch_first=False, value=0, padding='post'):
+def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='post'):
     r"""Pad a list of variable length Tensors with zero
 
     ``pad_sequence`` stacks a list of Tensors along a new dimension,
@@ -302,8 +302,8 @@ def pad_sequence(sequences, batch_first=False, value=0, padding='post'):
         sequences (list[Tensor]): list of variable length sequences.
         batch_first (bool, optional): output will be in ``B x T x *`` if True, or in
             ``T x B x *`` otherwise
-        value (float, optional): value for padded elements. Default: 0.
-        padding: (string, 'pre' or 'post'): pad either before or after each sequence. Default: 'post'.
+        padding_value (float, optional): value for padded elements. Default: 0.
+        padding_type: (string, 'pre' or 'post'): pad either before or after each sequence. Default: 'post'.
 
     Returns:
         Tensor of size ``T x B x *`` if batch_first is False
@@ -319,11 +319,11 @@ def pad_sequence(sequences, batch_first=False, value=0, padding='post'):
         out_dims = (len(sequences), max_len) + trailing_dims
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
-    out_tensor = sequences[0].data.new(*out_dims).fill_(value)
+    out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
 
-    if padding not in ['post', 'pre']:
-        raise ValueError("Padding must be 'post' or 'pre'")
-    if padding == 'post':
+    if padding_type not in ['post', 'pre']:
+        raise ValueError("Padding_type must be 'post' or 'pre'")
+    if padding_type == 'post':
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
             if batch_first:

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -340,6 +340,7 @@ def pad_sequence(sequences, batch_first=False, value=0, padding='post'):
 
     return out_tensor
 
+
 def pack_sequence(sequences):
     r"""Packs a list of variable length Tensors
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -271,7 +271,7 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
 pad_packed_sequence = torch.onnx.symbolic_override(_symbolic_pad_packed_sequence)(pad_packed_sequence)
 
 
-def pad_sequence(sequences, batch_first=False, padding_value=0):
+def pad_sequence(sequences, batch_first=False, value=0, padding='post'):
     r"""Pad a list of variable length Tensors with zero
 
     ``pad_sequence`` stacks a list of Tensors along a new dimension,
@@ -302,7 +302,8 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
         sequences (list[Tensor]): list of variable length sequences.
         batch_first (bool, optional): output will be in ``B x T x *`` if True, or in
             ``T x B x *`` otherwise
-        padding_value (float, optional): value for padded elements. Default: 0.
+        value (float, optional): value for padded elements. Default: 0.
+        padding: (string, 'pre' or 'post'): pad either before or after each sequence. Default: 'post'.
 
     Returns:
         Tensor of size ``T x B x *`` if batch_first is False
@@ -318,18 +319,26 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
         out_dims = (len(sequences), max_len) + trailing_dims
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
+    out_tensor = sequences[0].data.new(*out_dims).fill_(value)
 
-    out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
-    for i, tensor in enumerate(sequences):
-        length = tensor.size(0)
-        # use index notation to prevent duplicate references to the tensor
-        if batch_first:
-            out_tensor[i, :length, ...] = tensor
-        else:
-            out_tensor[:length, i, ...] = tensor
+    if padding not in ['post', 'pre']:
+        raise ValueError("Padding must be 'post' or 'pre'")
+    if padding == 'post':
+        for i, tensor in enumerate(sequences):
+            length = tensor.size(0)
+            if batch_first:
+                out_tensor[i, :length, ...] = tensor
+            else:
+                out_tensor[:length, i, ...] = tensor
+    else:
+        for i, tensor in enumerate(sequences):
+            length = tensor.size(0)
+            if batch_first:
+                out_tensor[i, -length:, ...] = tensor
+            else:
+                out_tensor[-length:, i, ...] = tensor
 
     return out_tensor
-
 
 def pack_sequence(sequences):
     r"""Packs a list of variable length Tensors

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -319,8 +319,10 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
         out_dims = (len(sequences), max_len) + trailing_dims
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
-
     out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
+
+    if not isinstance(padding_type, str):
+        raise TypeError("Expected padding_type to be str type but {} found".format(type(padding_type)))
     if padding_type == 'post':
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
@@ -336,7 +338,7 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
             else:
                 out_tensor[-length:, i, ...] = tensor
     else:
-        raise ValueError("Padding_type must be 'post' or 'pre'")
+        raise ValueError("Padding_type must be 'post' or 'pre' but '{}' found".format(padding_type))
 
     return out_tensor
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -319,10 +319,8 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
         out_dims = (len(sequences), max_len) + trailing_dims
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
-    out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
 
-    if padding_type not in ['post', 'pre']:
-        raise ValueError("Padding_type must be 'post' or 'pre'")
+    out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
     if padding_type == 'post':
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
@@ -330,13 +328,15 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
                 out_tensor[i, :length, ...] = tensor
             else:
                 out_tensor[:length, i, ...] = tensor
-    else:
+    elif padding_type == 'pre':
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
             if batch_first:
                 out_tensor[i, -length:, ...] = tensor
             else:
                 out_tensor[-length:, i, ...] = tensor
+    else:
+        raise ValueError("Padding_type must be 'post' or 'pre'")
 
     return out_tensor
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -320,9 +320,7 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type="po
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
     out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
-
-    if not isinstance(padding_type, str):
-        raise TypeError("Expected padding_type to be str type but {} found".format(type(padding_type)))
+    
     if padding_type == "post":
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -271,7 +271,7 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
 pad_packed_sequence = torch.onnx.symbolic_override(_symbolic_pad_packed_sequence)(pad_packed_sequence)
 
 
-def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='post'):
+def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type="post"):
     r"""Pad a list of variable length Tensors with zero
 
     ``pad_sequence`` stacks a list of Tensors along a new dimension,
@@ -303,7 +303,7 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
         batch_first (bool, optional): output will be in ``B x T x *`` if True, or in
             ``T x B x *`` otherwise
         padding_value (float, optional): value for padded elements. Default: 0.
-        padding_type: (string, 'pre' or 'post'): pad either before or after each sequence. Default: 'post'.
+        padding_type: (string, "pre" or "post"): pad either before or after each sequence. Default: "post".
 
     Returns:
         Tensor of size ``T x B x *`` if batch_first is False
@@ -323,14 +323,14 @@ def pad_sequence(sequences, batch_first=False, padding_value=0, padding_type='po
 
     if not isinstance(padding_type, str):
         raise TypeError("Expected padding_type to be str type but {} found".format(type(padding_type)))
-    if padding_type == 'post':
+    if padding_type == "post":
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
             if batch_first:
                 out_tensor[i, :length, ...] = tensor
             else:
                 out_tensor[:length, i, ...] = tensor
-    elif padding_type == 'pre':
+    elif padding_type == "pre":
         for i, tensor in enumerate(sequences):
             length = tensor.size(0)
             if batch_first:


### PR DESCRIPTION
Fixes #10536 
For the function `torch.nn.utils.rnn.pad_sequence` :
* Add another argument `padding_type`(string, 'pre' or 'post') to indicate padding either before or after each sequence