### PR TITLE
Faster random number generation in fused_rowwise_random_quantization_ops

### DIFF
--- a/caffe2/operators/fused_rowwise_random_quantization_ops.cc
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.cc
@@ -1,7 +1,113 @@
 #include "caffe2/operators/fused_rowwise_random_quantization_ops.h"
 #include "caffe2/core/registry.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
+
+#define IS_LITTLE_ENDIAN                                      \
+  [] {                                                        \
+    const int32_t kValue = 1;                                 \
+    return reinterpret_cast<const uint8_t*>(&kValue)[0] == 1; \
+  }()
+
+template <class Context>
+bool FloatToFusedRandRowwiseQuantizedOp<Context>::RunOnDevice() {
+  CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+  const auto& input = Input(DATA_FLOAT);
+  auto* output = Output(DATA_FUSED_QUANTIZED);
+
+  CAFFE_ENFORCE_EQ(
+      input.ndim(),
+      2,
+      "Expect input to be a matrix. Reshape the input tensor to a matrix for usage.");
+
+  const auto input_rows = input.dim(0);
+  const auto input_columns = input.dim(1);
+
+  // The "fused" representation stores the [bitwidth][tail][min][max]
+  // with the row-wise quantized data in one tensor. Since we store 8/bitwidth
+  // quantized data in one byte, the last buckets of some bytes may have
+  // unused bits. There are totally tail buckets are unused.
+  // We encode *bitwidth* and *tail* at the beginning of
+  // each row, following by 32-bit floating data respresenting min and max.
+  // | bitwidth | tail | min | max | ... int8 data ... |
+  // |    1B    |  1B  |  4B |  4B | ...output_data....|
+  // In output_data: the b-th bucket of the i-th byte stores
+  // the i-th data of the b-th segment of input row
+  size_t data_per_byte = 8 / bitwidth_;
+  // How many bytes in the output
+  size_t segment_size = (input_columns + data_per_byte - 1) / data_per_byte;
+  const std::vector<TIndex> output_dimensions = {
+      input_rows, 10 + static_cast<TIndex>(segment_size)};
+  output->Resize(output_dimensions);
+
+  const auto* input_data = input.template data<float>();
+  auto* output_data = output->template mutable_data<uint8_t>();
+  const size_t output_columns = static_cast<size_t>(output->dim(1));
+  memset(output_data, 0, output->size());
+
+  if (random_) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    random_buffer_.resize(input_columns);
+#endif
+  }
+
+  for (size_t row = 0; row < input_rows; ++row) {
+    math::quantize_and_compress(
+        input_data + row * input_columns,
+        output_data + row * output_columns,
+        input_columns,
+        bitwidth_,
+        random_,
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+        vslStream_,
+        random_buffer_
+#else
+        dis_,
+        gen_
+#endif
+    );
+  }
+
+  return true;
+}
+
+template <class Context>
+bool FusedRandRowwiseQuantizedToFloatOp<Context>::RunOnDevice() {
+  CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
+
+  const auto& input = Input(DATA_FUSED_QUANTIZED);
+  auto* output = Output(DATA_FLOAT);
+  CAFFE_ENFORCE_EQ(input.ndim(), 2, "Expect input to be a matrix.");
+  CAFFE_ENFORCE_GE(
+      input.size(), 4, "Expect input to have size greater than or equal to 4.");
+
+  const auto input_rows = input.dim(0);
+  const auto input_columns = input.dim(1);
+  const auto* input_data = input.template data<uint8_t>();
+  const size_t bitwidth = input_data[0];
+  CAFFE_ENFORCE(
+      bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+      "Unsupported bitwidth");
+  const size_t tail = input_data[1];
+  const size_t output_columns = (input_columns - 10) * (8 / bitwidth) - tail;
+  const std::vector<TIndex> output_dimensions = {
+      input_rows, static_cast<TIndex>(output_columns)};
+  output->Resize(output_dimensions);
+  auto* output_data = output->template mutable_data<float>();
+  for (size_t row = 0; row < input_rows; ++row) {
+    math::decompress_and_dequantize(
+        input_data + row * input_columns,
+        output_data + row * output_columns,
+        input_columns);
+  }
+
+  return true;
+}
+
+#undef IS_LITTLE_ENDIAN
+
 REGISTER_CPU_OPERATOR(
     FloatToFusedRandRowwiseQuantized,
     FloatToFusedRandRowwiseQuantizedOp<CPUContext>);

--- a/caffe2/operators/fused_rowwise_random_quantization_ops.h
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.h
@@ -1,84 +1,16 @@
 #ifndef CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
 #define CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_
 
+#include <chrono>
+
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/reducer_functors.h"
+#include "caffe2/perfkernels/math.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
-
-#define IS_LITTLE_ENDIAN                                      \
-  [] {                                                        \
-    const int32_t kValue = 1;                                 \
-    return reinterpret_cast<const uint8_t*>(&kValue)[0] == 1; \
-  }()
-
-#define QEPSILON 1e-8f
-// define a custom template unary functor
-// stochastic quantization
-template <typename Scalar>
-struct CwiseRandQuantizeOp {
-  CwiseRandQuantizeOp(
-      CPUContext::rand_gen_type& gen,
-      const uint8_t& bitwidth,
-      const bool& r,
-      const Scalar& minv,
-      const Scalar& maxv)
-      : gen_(gen),
-        bitwidth_(bitwidth),
-        random_(r),
-        min_(minv),
-        max_(maxv),
-        gap_((maxv - minv) / ((1 << bitwidth) - 1.f)),
-        maxq_((1 << bitwidth) - 1) {}
-  uint8_t operator()(const Scalar& fval) const {
-    Scalar thetimes = (fval - min_) / (gap_ + QEPSILON);
-    thetimes = thetimes < 0 ? 0 : (thetimes > maxq_ ? maxq_ : thetimes);
-    uint8_t floor_times = floor(thetimes);
-    // the probability of quantizing to the larger discrete level
-    Scalar p = thetimes - floor_times;
-    // generate Bernoulli distribution
-    std::bernoulli_distribution dist(p);
-    uint8_t q =
-        floor_times + (random_ ? dist(gen_) : p > 0.5); // quantized value
-    // (1 << bitwidth_) - 1 is to avoid contamination when q is dirty data
-    return (uint8_t)(maxq_ & q);
-  }
-
-  CPUContext::rand_gen_type& gen_;
-  const uint8_t bitwidth_; // bits per data
-  const bool random_; // false for unittest
-  const Scalar min_; // the minimum value
-  const Scalar max_; // the maximum value
-  const Scalar gap_; // the gap between two discrete levels
-  const uint8_t maxq_; // the max quantized value
-};
-
-// define a custom template binary functor
-// left shift and or
-template <typename T>
-struct CwiseLeftShiftOrOp {
-  CwiseLeftShiftOrOp(const size_t& s) : shift_(s) {}
-  const T operator()(const T& orval, const T& shiftval) const {
-    return (T)(orval | (shiftval << shift_));
-  }
-  const size_t shift_; // bits per data
-};
-
-// define a custom template unary functor
-// select [start, start+bitwidth) bits and convert to a value
-template <typename T, typename D>
-struct CwiseBitsValueOp {
-  CwiseBitsValueOp(const size_t& start, const size_t& bitwidth)
-      : start_(start), mask_((1 << bitwidth) - 1) {}
-  const T operator()(const D& bytes) const {
-    return (T)((bytes >> start_) & mask_);
-  }
-  const size_t start_; // start index of the bits
-  const D mask_;
-};
 
 template <class Context>
 class FloatToFusedRandRowwiseQuantizedOp : public Operator<Context> {
@@ -93,89 +25,34 @@ class FloatToFusedRandRowwiseQuantizedOp : public Operator<Context> {
     CAFFE_ENFORCE(
         bitwidth_ == 1 || bitwidth_ == 2 || bitwidth_ == 4 || bitwidth_ == 8,
         "Unsupported bitwidth");
-  }
-  ~FloatToFusedRandRowwiseQuantizedOp() {}
-
-  bool RunOnDevice() override {
-    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
-
-    const auto& input = Input(DATA_FLOAT);
-    auto* output = Output(DATA_FUSED_QUANTIZED);
-
-    CAFFE_ENFORCE_EQ(
-        input.ndim(),
-        2,
-        "Expect input to be a matrix. Reshape the input tensor to a matrix for usage.");
-
-    const auto input_rows = input.dim(0);
-    const auto input_columns = input.dim(1);
-
-    // The "fused" representation stores the [bitwidth][tail][min][max]
-    // with the row-wise quantized data in one tensor. Since we store 8/bitwidth
-    // quantized data in one byte, the last buckets of some bytes may have
-    // unused bits. There are totally tail buckets are unused.
-    // We encode *bitwidth* and *tail* at the beginning of
-    // each row, following by 32-bit floating data respresenting min and max.
-    // | bitwidth | tail | min | max | ... int8 data ... |
-    // |    1B    |  1B  |  4B |  4B | ...output_data....|
-    // In output_data: the b-th bucket of the i-th byte stores
-    // the i-th data of the b-th segment of input row
-    size_t data_per_byte = 8 / bitwidth_;
-    size_t tail = input_columns % data_per_byte;
-    tail = tail ? data_per_byte - tail : 0;
-    // How many bytes in the output
-    size_t segment_size = (input_columns + data_per_byte - 1) / data_per_byte;
-    const std::vector<TIndex> output_dimensions = {
-        input_rows, static_cast<TIndex>(10 + segment_size)};
-    output->Resize(output_dimensions);
-
-    const auto* input_data = input.template data<float>();
-    auto* output_data = output->template mutable_data<uint8_t>();
-    const auto output_columns = output->dim(1);
-    memset(output_data, 0, output->size());
-
-    for (size_t row = 0; row < input_rows; ++row) {
-      // memory pointers
-      ConstEigenVectorArrayMap<float> input_row(
-          input_data + row * input_columns, input_columns);
-      uint8_t* output_row = output_data + row * output_columns;
-      EigenVectorArrayMap<uint8_t> output_bitwidth_tail(output_row, 2);
-      EigenVectorArrayMap<float> output_row_min_max(
-          reinterpret_cast<float*>(output_row + 2), 2);
-
-      // basic info
-      const float minimum_element = input_row.minCoeff();
-      const float maximum_element = input_row.maxCoeff();
-      output_bitwidth_tail(0) = bitwidth_;
-      output_bitwidth_tail(1) = tail;
-      output_row_min_max(0) = minimum_element;
-      output_row_min_max(1) = maximum_element;
-
-      CwiseRandQuantizeOp<float> cwiserand(
-          context_.RandGenerator(),
-          bitwidth_,
-          random_,
-          minimum_element,
-          maximum_element);
-      size_t bit_start = 0;
-      for (int start = 0; start < input_columns; start += segment_size) {
-        CwiseLeftShiftOrOp<uint8_t> cwiseshftor(bit_start);
-        bit_start += bitwidth_;
-        size_t stride = start + segment_size <= input_columns
-            ? segment_size
-            : input_columns - start;
-        ConstEigenVectorArrayMap<float> sub_input_row(
-            input_data + row * input_columns + start, stride);
-        auto qvals = sub_input_row.unaryExpr(
-            cwiserand); // some last buckets may have unused data
-        EigenVectorArrayMap<uint8_t> output_seg(output_row + 10, stride);
-        // shift and concatenate current ones
-        output_seg = output_seg.binaryExpr(qvals.cast<uint8_t>(), cwiseshftor);
+    if (random_) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+      int status = vslNewStream(
+          &vslStream_,
+          VSL_BRNG_MT19937,
+          std::chrono::system_clock::now().time_since_epoch().count());
+      if (status != VSL_STATUS_OK) {
+        LOG(WARNING) << "vslNewStream returns " << status;
       }
+#else
+      gen_.seed(std::chrono::system_clock::now().time_since_epoch().count());
+      dis_.reset(new std::uniform_real_distribution<float>(0.0f, 1.0f));
+#endif
     }
-
-    return true;
   }
+
+  ~FloatToFusedRandRowwiseQuantizedOp() {
+    if (random_) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+      int status = vslDeleteStream(&vslStream_);
+      if (status != VSL_STATUS_OK) {
+        LOG(WARNING) << "vslDeleteStream returns " << status;
+      }
+#endif
+    }
+  }
+
+  bool RunOnDevice() override;
 
  private:
   INPUT_TAGS(DATA_FLOAT);
@@ -184,6 +61,13 @@ class FloatToFusedRandRowwiseQuantizedOp : public Operator<Context> {
  protected:
   size_t bitwidth_{8};
   bool random_{true};
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+  VSLStreamStatePtr vslStream_;
+  std::vector<float> random_buffer_;
+#else
+  std::unique_ptr<std::uniform_real_distribution<float>> dis_;
+  std::minstd_rand gen_;
+#endif
 };
 
 template <class Context>
@@ -192,80 +76,13 @@ class FusedRandRowwiseQuantizedToFloatOp : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(FusedRandRowwiseQuantizedToFloatOp)
 
-  bool RunOnDevice() override {
-    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
-
-    const auto& input = Input(DATA_FUSED_QUANTIZED);
-    auto* output = Output(DATA_FLOAT);
-    CAFFE_ENFORCE_EQ(input.ndim(), 2, "Expect input to be a matrix.");
-    CAFFE_ENFORCE_GE(
-        input.size(),
-        4,
-        "Expect input to have size greater than or equal to 4.");
-
-    const auto input_rows = input.dim(0);
-    const auto input_columns = input.dim(1);
-    const auto* input_data = input.template data<uint8_t>();
-    const size_t bitwidth = input_data[0];
-    CAFFE_ENFORCE(
-        bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
-        "Unsupported bitwidth");
-    const size_t tail = input_data[1];
-    const size_t output_columns = (input_columns - 10) * (8 / bitwidth) - tail;
-    const std::vector<TIndex> output_dimensions = {
-        input_rows, static_cast<TIndex>(output_columns)};
-    output->Resize(output_dimensions);
-    auto* output_data = output->template mutable_data<float>();
-    for (size_t row = 0; row < input_rows; ++row) {
-      // memory pointers
-      const uint8_t* input_row = input_data + row * input_columns;
-      ConstEigenVectorArrayMap<uint8_t> input_bitwidth_tail(input_row, 2);
-      ConstEigenVectorArrayMap<float> input_row_min_max(
-          reinterpret_cast<const float*>(input_row + 2), 2);
-      EigenVectorArrayMap<float> output_row(
-          output_data + row * output_columns, output_columns);
-
-      // basic info
-      const float minimum_element = input_row_min_max(0);
-      const float maximum_element = input_row_min_max(1);
-      const float gap =
-          (maximum_element - minimum_element) / ((1 << bitwidth) - 1.f) +
-          QEPSILON; // for exact recovering
-      CAFFE_ENFORCE_EQ(
-          bitwidth,
-          input_bitwidth_tail(0),
-          "Expect each row have the same bitwidth");
-      CAFFE_ENFORCE_EQ(
-          tail, input_bitwidth_tail(1), "Expect each row have the same tail");
-
-      // decoding
-      size_t bit_start = 0;
-      const size_t segment_size = input_columns - 10;
-      for (int start = 0; start < output_columns; start += segment_size) {
-        CwiseBitsValueOp<float, uint8_t> cwisedec(bit_start, bitwidth);
-        bit_start += bitwidth;
-        size_t stride = start + segment_size <= output_columns
-            ? segment_size
-            : output_columns - start;
-        EigenVectorArrayMap<float> sub_output_row(
-            output_data + row * output_columns + start, stride);
-        ConstEigenVectorArrayMap<uint8_t> input_seg(input_row + 10, stride);
-        sub_output_row = input_seg.unaryExpr(cwisedec).cast<float>();
-      }
-      // scaling and biasing
-      output_row = output_row * gap + minimum_element;
-    }
-
-    return true;
-  }
+  bool RunOnDevice() override;
 
  private:
   INPUT_TAGS(DATA_FUSED_QUANTIZED);
   OUTPUT_TAGS(DATA_FLOAT);
 };
 
-#undef IS_LITTLE_ENDIAN
-#undef QEPSILON
 } // namespace caffe2
 
 #endif // CAFFE2_OPERATORS_FUSED_ROWWISE_RAND_CONVERSION_OPS_H_

--- a/caffe2/perfkernels/math.h
+++ b/caffe2/perfkernels/math.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#ifdef CAFFE2_USE_MKL
+#include <mkl.h>
+#endif // CAFFE2_USE_MKL
+
+#include <random>
+
+namespace caffe2 {
+
+namespace math {
+
+// Returns the quantized and compressed values of floating inputs
+// The "fused" representation stores the [bitwidth][tail][min][max]
+// with the quantized data in one array. Since we store 8/bitwidth
+// quantized data in one byte, the last buckets of some bytes may have
+// unused bits. There are totally tail buckets are unused.
+// We encode *bitwidth* and *tail* at the beginning,
+// following by 32-bit floating data respresenting min and max.
+// | bitwidth | tail | min | max | ... int8 data ... |
+// |    1B    |  1B  |  4B |  4B | ...output_data....|
+// In output_data: the b-th bucket of the i-th byte stores
+// the i-th data of the b-th segment of input row
+#ifdef CAFFE2_USE_MKL
+#define FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+#endif
+void quantize_and_compress(
+    const float* input_data,
+    uint8_t* output_data,
+    size_t input_size,
+    size_t bitwidth,
+    bool random,
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    VSLStreamStatePtr& vslStream,
+    std::vector<float>& random_buffer
+#else
+    std::unique_ptr<std::uniform_real_distribution<float>>& dis,
+    std::minstd_rand& gen
+#endif
+);
+void decompress_and_dequantize(
+    const uint8_t* input_data,
+    float* output_data,
+    size_t input_size);
+
+} // namespace math
+} // namespace caffe2

--- a/caffe2/perfkernels/math_cpu_avx2.cc
+++ b/caffe2/perfkernels/math_cpu_avx2.cc
@@ -1,0 +1,287 @@
+// Implements the math functions for CPU.
+// The implementation in this file allows us to route the underlying numerical
+// computation library to different compiler options (-mno-avx2 or -mavx2).
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "caffe2/core/context.h"
+#include "caffe2/perfkernels/math.h"
+#include "caffe2/utils/cpu_neon.h"
+#include "caffe2/utils/cpuid.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+#include "Eigen/Core"
+#include "Eigen/Dense"
+
+#ifdef CAFFE2_USE_MKL
+#include <mkl.h>
+#endif // CAFFE2_USE_MKL
+
+#ifdef CAFFE2_USE_HPTT
+#include <hptt.h>
+#endif // CAFFE2_USE_HPTT
+
+#if defined(_MSC_VER)
+#include <process.h>
+#endif
+
+namespace caffe2 {
+
+namespace math {
+#define QEPSILON 1e-8
+
+void quantize_and_compress__avx2(
+    const float* input_data,
+    uint8_t* output_data,
+    size_t input_size,
+    size_t bitwidth,
+    bool random,
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    VSLStreamStatePtr& vslStream,
+    std::vector<float>& random_buffer
+#else
+    std::unique_ptr<std::uniform_real_distribution<float>>& dis,
+    std::minstd_rand& gen
+#endif
+) {
+  CAFFE_ENFORCE(
+      bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+      "Unsupported bitwidth");
+
+#ifdef __AVX2__
+  __m256i shuffle_mask_v = _mm256_set_epi8(
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x0c,
+      0x08,
+      0x04,
+      0x00,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x0c,
+      0x08,
+      0x04,
+      0x00);
+  __m256i permute_mask_v =
+      _mm256_set_epi32(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00);
+#endif // __AVX2__
+
+  // memory pointers
+  ConstEigenVectorArrayMap<float> input_row(input_data, input_size);
+  uint8_t* output_row = output_data;
+  EigenVectorArrayMap<uint8_t> output_bitwidth_tail(output_row, 2);
+  EigenVectorArrayMap<float> output_row_min_max(
+      reinterpret_cast<float*>(output_row + 2), 2);
+
+  size_t data_per_byte = 8 / bitwidth;
+  size_t tail = input_size % data_per_byte;
+  tail = tail ? data_per_byte - tail : 0;
+  size_t segment_size = (input_size + data_per_byte - 1) / data_per_byte;
+
+  // basic info
+  const float minimum_element = input_row.minCoeff();
+  const float maximum_element = input_row.maxCoeff();
+  output_bitwidth_tail(0) = bitwidth;
+  output_bitwidth_tail(1) = tail;
+  output_row_min_max(0) = minimum_element;
+  output_row_min_max(1) = maximum_element;
+
+  float gap = (maximum_element - minimum_element) / ((1 << bitwidth) - 1.0f);
+  float gap_inverse = 1. / (gap + QEPSILON);
+  uint8_t max_q = (1 << bitwidth) - 1;
+  size_t bit_start = 0;
+  if (random) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    int status = vsRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD,
+        vslStream,
+        input_size,
+        random_buffer.data(),
+        0.0f,
+        1.0f);
+    if (status != VSL_ERROR_OK) {
+      LOG(WARNING) << "vsRngUniform returns " << status;
+    }
+#endif
+    for (int start = 0; start < input_size; start += segment_size) {
+      size_t stride = start + segment_size <= input_size ? segment_size
+                                                         : input_size - start;
+      int i = 0;
+#ifdef __AVX2__
+      constexpr int VLEN = 8;
+      for (; i < stride / VLEN * VLEN; i += VLEN) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+        __m256 r_v = _mm256_loadu_ps(&random_buffer[start + i]);
+#else
+        float random_buffer[VLEN];
+        for (int j = 0; j < VLEN; ++j) {
+          random_buffer[j] = (*dis)(gen);
+        }
+        __m256 r_v = _mm256_loadu_ps(random_buffer);
+#endif
+        __m256 fval_v = _mm256_loadu_ps(input_data + start + i);
+        __m256 thetimes_v = _mm256_mul_ps(
+            _mm256_sub_ps(fval_v, _mm256_set1_ps(minimum_element)),
+            _mm256_set1_ps(gap_inverse));
+        __m256 rounded_v = _mm256_floor_ps(_mm256_add_ps(thetimes_v, r_v));
+        rounded_v = _mm256_max_ps(
+            _mm256_setzero_ps(),
+            _mm256_min_ps(_mm256_set1_ps(max_q), rounded_v));
+        __m256i qval_v = _mm256_cvtps_epi32(rounded_v);
+        __m256i orval_v = _mm256_cvtepu8_epi32(_mm_lddqu_si128(
+            reinterpret_cast<const __m128i*>(output_row + 10 + i)));
+        orval_v =
+            _mm256_or_si256(orval_v, _mm256_slli_epi32(qval_v, bit_start));
+        orval_v = _mm256_shuffle_epi8(orval_v, shuffle_mask_v);
+        orval_v = _mm256_permutevar8x32_epi32(orval_v, permute_mask_v);
+        *reinterpret_cast<int64_t*>(output_row + 10 + i) =
+            _mm256_extract_epi64(orval_v, 0);
+      }
+#endif // __AVX2__
+      for (; i < stride; ++i) {
+        float fval = input_data[start + i];
+        float thetimes = (fval - minimum_element) * gap_inverse;
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+        float rounded = floor(thetimes + random_buffer[start + i]);
+#else
+        float rounded = floor(thetimes + (*dis)(gen));
+#endif
+        rounded = std::max(0.0f, std::min(static_cast<float>(max_q), rounded));
+        uint8_t qval = rounded;
+
+        uint8_t orval = output_row[10 + i];
+        output_row[10 + i] = orval | static_cast<uint8_t>(qval << bit_start);
+      }
+      bit_start += bitwidth;
+    }
+  } else {
+    for (int start = 0; start < input_size; start += segment_size) {
+      size_t stride = start + segment_size <= input_size ? segment_size
+                                                         : input_size - start;
+      int i = 0;
+#ifdef __AVX2__
+      constexpr int VLEN = 8;
+      for (; i < stride / VLEN * VLEN; i += VLEN) {
+        __m256 fval_v = _mm256_loadu_ps(input_data + start + i);
+        __m256 thetimes_v = _mm256_mul_ps(
+            _mm256_sub_ps(fval_v, _mm256_set1_ps(minimum_element)),
+            _mm256_set1_ps(gap_inverse));
+        thetimes_v = _mm256_max_ps(
+            _mm256_setzero_ps(),
+            _mm256_min_ps(_mm256_set1_ps(max_q), thetimes_v));
+        __m256i qval_v = _mm256_cvtps_epi32(_mm256_round_ps(
+            thetimes_v, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+        __m256i orval_v = _mm256_cvtepu8_epi32(_mm_lddqu_si128(
+            reinterpret_cast<const __m128i*>(output_row + 10 + i)));
+        orval_v =
+            _mm256_or_si256(orval_v, _mm256_slli_epi32(qval_v, bit_start));
+        orval_v = _mm256_shuffle_epi8(orval_v, shuffle_mask_v);
+        orval_v = _mm256_permutevar8x32_epi32(orval_v, permute_mask_v);
+        *reinterpret_cast<int64_t*>(output_row + 10 + i) =
+            _mm256_extract_epi64(orval_v, 0);
+      }
+#endif // __AVX2__
+      for (; i < stride; ++i) {
+        float fval = input_data[start + i];
+        float thetimes = (fval - minimum_element) * gap_inverse;
+        thetimes =
+            std::max(0.0f, std::min(static_cast<float>(max_q), thetimes));
+        uint8_t qval = nearbyint(thetimes);
+
+        uint8_t orval = output_row[10 + i];
+        output_row[10 + i] = orval | static_cast<uint8_t>(qval << bit_start);
+      }
+      bit_start += bitwidth;
+    }
+  }
+}
+
+void decompress_and_dequantize__avx2(
+    const uint8_t* input_data,
+    float* output_data,
+    size_t input_size) {
+  ConstEigenVectorArrayMap<float> input_row_min_max(
+      reinterpret_cast<const float*>(input_data + 2), 2);
+
+  // basic info
+  const float minimum_element = input_row_min_max(0);
+  const float maximum_element = input_row_min_max(1);
+  const size_t bitwidth = input_data[0];
+  const float gap =
+      (maximum_element - minimum_element) / ((1 << bitwidth) - 1.f) +
+      QEPSILON; // for exact recovering
+
+  CAFFE_ENFORCE(
+      bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+      "Unsupported bitwidth");
+  const size_t tail = input_data[1];
+
+  const size_t output_size = (input_size - 10) * (8 / bitwidth) - tail;
+  EigenVectorArrayMap<float> output_row(output_data, output_size);
+  // decoding
+  size_t bit_start = 0;
+  const size_t segment_size = input_size - 10;
+  for (int start = 0; start < output_size; start += segment_size) {
+    size_t stride = start + segment_size <= output_size ? segment_size
+                                                        : output_size - start;
+    uint8_t mask = (1 << bitwidth) - 1;
+    int i = 0;
+#ifdef __AVX2__
+    // Can process 8 elements at a time because we need to expand uint8_t
+    // to int32_t to use epi32 vector instructions.
+    constexpr int VLEN = 8;
+    for (; i < stride / VLEN * VLEN; i += VLEN) {
+      __m128i in_v = _mm_lddqu_si128(
+          reinterpret_cast<const __m128i*>(input_data + 10 + i));
+      __m256i out_epi32_v = _mm256_and_si256(
+          _mm256_srli_epi32(_mm256_cvtepu8_epi32(in_v), bit_start),
+          _mm256_set1_epi32(mask));
+      _mm256_storeu_ps(
+          output_data + start + i, _mm256_cvtepi32_ps(out_epi32_v));
+    }
+#endif
+    for (; i < stride; ++i) {
+      output_data[start + i] = ((input_data[10 + i] >> bit_start) & mask);
+    }
+    bit_start += bitwidth;
+  }
+  // scaling and biasing
+  output_row = output_row * gap + minimum_element;
+}
+
+#undef QEPSILON
+} // namespace math
+} // namespace caffe2

--- a/caffe2/perfkernels/math_cpu_base.cc
+++ b/caffe2/perfkernels/math_cpu_base.cc
@@ -1,0 +1,248 @@
+// Implements the math functions for CPU.
+// The implementation in this file allows us to route the underlying numerical
+// computation library to different compiler options (-mno-avx2 or -mavx2).
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "caffe2/core/context.h"
+#include "caffe2/perfkernels/common.h"
+#include "caffe2/perfkernels/math.h"
+#include "caffe2/utils/cpu_neon.h"
+#include "caffe2/utils/cpuid.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+#include "Eigen/Core"
+#include "Eigen/Dense"
+
+#ifdef CAFFE2_USE_MKL
+#include <mkl.h>
+#endif // CAFFE2_USE_MKL
+
+#ifdef CAFFE2_USE_HPTT
+#include <hptt.h>
+#endif // CAFFE2_USE_HPTT
+
+#if defined(_MSC_VER)
+#include <process.h>
+#endif
+
+namespace caffe2 {
+
+namespace math {
+#define QEPSILON 1e-8
+
+void quantize_and_compress__base(
+    const float* input_data,
+    uint8_t* output_data,
+    size_t input_size,
+    size_t bitwidth,
+    bool random,
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    VSLStreamStatePtr& vslStream,
+    std::vector<float>& random_buffer
+#else
+    std::unique_ptr<std::uniform_real_distribution<float>>& dis,
+    std::minstd_rand& gen
+#endif
+) {
+  CAFFE_ENFORCE(
+      bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+      "Unsupported bitwidth");
+
+  // memory pointers
+  ConstEigenVectorArrayMap<float> input_row(input_data, input_size);
+  uint8_t* output_row = output_data;
+  EigenVectorArrayMap<uint8_t> output_bitwidth_tail(output_row, 2);
+  EigenVectorArrayMap<float> output_row_min_max(
+      reinterpret_cast<float*>(output_row + 2), 2);
+
+  size_t data_per_byte = 8 / bitwidth;
+  size_t tail = input_size % data_per_byte;
+  tail = tail ? data_per_byte - tail : 0;
+  size_t segment_size = (input_size + data_per_byte - 1) / data_per_byte;
+
+  // basic info
+  const float minimum_element = input_row.minCoeff();
+  const float maximum_element = input_row.maxCoeff();
+  output_bitwidth_tail(0) = bitwidth;
+  output_bitwidth_tail(1) = tail;
+  output_row_min_max(0) = minimum_element;
+  output_row_min_max(1) = maximum_element;
+
+  float gap = (maximum_element - minimum_element) / ((1 << bitwidth) - 1.0f);
+  float gap_inverse = 1. / (gap + QEPSILON);
+  uint8_t max_q = (1 << bitwidth) - 1;
+  size_t bit_start = 0;
+  if (random) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    int status = vsRngUniform(
+        VSL_RNG_METHOD_UNIFORM_STD,
+        vslStream,
+        input_size,
+        random_buffer.data(),
+        0.0f,
+        1.0f);
+    if (status != VSL_ERROR_OK) {
+      LOG(WARNING) << "vsRngUniform returns " << status;
+    }
+#endif
+    for (int start = 0; start < input_size; start += segment_size) {
+      size_t stride = start + segment_size <= input_size ? segment_size
+                                                         : input_size - start;
+      int i = 0;
+      for (; i < stride; ++i) {
+        float fval = input_data[start + i];
+        float thetimes = (fval - minimum_element) * gap_inverse;
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+        float rounded = floor(thetimes + random_buffer[start + i]);
+#else
+        float rounded = floor(thetimes + (*dis)(gen));
+#endif
+        rounded = std::max(0.0f, std::min(static_cast<float>(max_q), rounded));
+        uint8_t qval = rounded;
+
+        uint8_t orval = output_row[10 + i];
+        output_row[10 + i] = orval | static_cast<uint8_t>(qval << bit_start);
+      }
+      bit_start += bitwidth;
+    }
+  } else {
+    for (int start = 0; start < input_size; start += segment_size) {
+      size_t stride = start + segment_size <= input_size ? segment_size
+                                                         : input_size - start;
+      int i = 0;
+      for (; i < stride; ++i) {
+        float fval = input_data[start + i];
+        float thetimes = (fval - minimum_element) * gap_inverse;
+        thetimes =
+            std::max(0.0f, std::min(static_cast<float>(max_q), thetimes));
+        uint8_t qval = nearbyint(thetimes);
+
+        uint8_t orval = output_row[10 + i];
+        output_row[10 + i] = orval | static_cast<uint8_t>(qval << bit_start);
+      }
+      bit_start += bitwidth;
+    }
+  }
+}
+
+void quantize_and_compress(
+    const float* input_data,
+    uint8_t* output_data,
+    size_t input_size,
+    size_t bitwidth,
+    bool random,
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+    VSLStreamStatePtr& vslStream,
+    std::vector<float>& random_buffer
+#else
+    std::unique_ptr<std::uniform_real_distribution<float>>& dis,
+    std::minstd_rand& gen
+#endif
+) {
+#ifdef FUSED_ROWWISE_RANDOM_QUANTIZATION_USE_MKL
+  AVX2_DO(
+      quantize_and_compress,
+      input_data,
+      output_data,
+      input_size,
+      bitwidth,
+      random,
+      vslStream,
+      random_buffer);
+  BASE_DO(
+      quantize_and_compress,
+      input_data,
+      output_data,
+      input_size,
+      bitwidth,
+      random,
+      vslStream,
+      random_buffer);
+#else
+  AVX2_DO(
+      quantize_and_compress,
+      input_data,
+      output_data,
+      input_size,
+      bitwidth,
+      random,
+      dis,
+      gen);
+  BASE_DO(
+      quantize_and_compress,
+      input_data,
+      output_data,
+      input_size,
+      bitwidth,
+      random,
+      dis,
+      gen);
+#endif
+}
+
+void decompress_and_dequantize__base(
+    const uint8_t* input_data,
+    float* output_data,
+    size_t input_size) {
+  // memory pointers ///
+  ConstEigenVectorArrayMap<uint8_t> input_bitwidth_tail(input_data, 2);
+  ConstEigenVectorArrayMap<float> input_row_min_max(
+      reinterpret_cast<const float*>(input_data + 2), 2);
+
+  // basic info
+  const float minimum_element = input_row_min_max(0);
+  const float maximum_element = input_row_min_max(1);
+  const size_t bitwidth = input_data[0];
+  const float gap =
+      (maximum_element - minimum_element) / ((1 << bitwidth) - 1.f) +
+      QEPSILON; // for exact recovering
+
+  CAFFE_ENFORCE(
+      bitwidth == 1 || bitwidth == 2 || bitwidth == 4 || bitwidth == 8,
+      "Unsupported bitwidth");
+  const size_t tail = input_data[1];
+
+  const size_t output_size = (input_size - 10) * (8 / bitwidth) - tail;
+  EigenVectorArrayMap<float> output_row(output_data, output_size);
+  // decoding
+  size_t bit_start = 0;
+  const size_t segment_size = input_size - 10;
+  for (int start = 0; start < output_size; start += segment_size) {
+    size_t stride = start + segment_size <= output_size ? segment_size
+                                                        : output_size - start;
+    uint8_t mask = (1 << bitwidth) - 1;
+    int i = 0;
+    for (; i < stride; ++i) {
+      output_data[start + i] = ((input_data[10 + i] >> bit_start) & mask);
+    }
+    bit_start += bitwidth;
+  }
+  // scaling and biasing
+  output_row = output_row * gap + minimum_element;
+}
+
+void decompress_and_dequantize(
+    const uint8_t* input_data,
+    float* output_data,
+    size_t input_size) {
+  AVX2_DO(decompress_and_dequantize, input_data, output_data, input_size);
+  BASE_DO(decompress_and_dequantize, input_data, output_data, input_size);
+}
+
+#undef QEPSILON
+} // namespace math
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Depends on D8745940

```
Trying example: test_speed_of_rand_quantization(self=<caffe2.caffe2.fb.net_transforms.tests.rand_quantization_op_speed_test.TestSpeedFloatToFusedRandRowwiseQuantized testMethod=test_speed_of_rand_quantization>, bitwidth_=2, random_=True
, data_shape_=array([1024, 1224]), gc=, dc=[])
Sub+Scale+Sum time: 1.28631591796875 ms
Quantizing time: 1.3524532318115234 ms (1.0514160735468565X)
De-quantizing time: 0.43795108795166016 ms (0.34046930604982206X)
```

Differential Revision: D8849770
