### PR TITLE
Fix performance of WeightedRandomSampler

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -95,7 +95,7 @@ class WeightedRandomSampler(Sampler):
         self.replacement = replacement
 
     def __iter__(self):
-        return iter(torch.multinomial(self.weights, self.num_samples, self.replacement))
+        return iter(torch.multinomial(self.weights, self.num_samples, self.replacement).tolist())
 
     def __len__(self):
         return self.num_samples


### PR DESCRIPTION
Since https://github.com/pytorch/pytorch/pull/8958 was merged, the BatchSampler samples 0d tensors from WeightedRandomSampler instead of integers. It significantly reduces performance. This PR fix it the same way as https://github.com/pytorch/pytorch/pull/10361 fix DistributedSampler.