### PR TITLE
 Minor cleanup for tracing

### DIFF
--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -46,8 +46,8 @@ BATCH_SIZE = 2
 
 class TestModels(TestCase):
     def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7):
-        trace = torch.onnx.utils._trace(model, inputs, OperatorExportTypes.ONNX)
-        torch._C._jit_pass_lint(trace.graph())
+        graph = torch.onnx.utils._trace(model, inputs, OperatorExportTypes.ONNX)
+        torch._C._jit_pass_lint(graph)
         verify(model, inputs, backend, rtol=rtol, atol=atol)
 
     def test_ops(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -211,7 +211,7 @@ class JitTestCase(TestCase):
         return imported
 
     def assertExpectedONNXGraph(self, trace, *args, **kwargs):
-        torch.onnx._optimize_trace(trace, operator_export_type=OperatorExportTypes.ONNX)
+        trace = torch.onnx._optimize_trace(trace, operator_export_type=OperatorExportTypes.ONNX)
         self.assertExpectedGraph(trace, *args, **kwargs)
 
     def assertExpectedGraph(self, trace, *args, **kwargs):
@@ -880,9 +880,9 @@ class TestJit(JitTestCase):
             y = RegularFn.apply(y)
             return y
 
-        trace, _ = torch.jit.get_trace_graph(fn, (x,))
-        self.run_pass('dce', trace)
-        ops = [n for n in trace.graph().nodes()]
+        graph, _ = torch.jit.get_trace_graph(fn, (x,))
+        self.run_pass('dce', graph)
+        ops = [n for n in graph.nodes()]
         for op in ops:
             self.assertTrue(op.hasAttribute('inplace'))
         inplace_flags = [False, True, True, False]
@@ -922,8 +922,8 @@ class TestJit(JitTestCase):
         self.assertEqual(traced_fn(x), fn(x))
 
         # Check that the trace looks ok
-        trace, _ = torch.jit.get_trace_graph(fn, (x,))
-        self.assertExpectedGraph(trace)
+        graph, _ = torch.jit.get_trace_graph(fn, (x,))
+        self.assertExpectedGraph(graph)
 
     def test_trace_size(self):
         self.do_trace_size(False)
@@ -939,6 +939,7 @@ class TestJit(JitTestCase):
 
         x, y = torch.randn(2, 2), (torch.ones(2, 2), torch.randn(2, 2))
         traced_fn = torch.jit.trace(x, y)(fn)
+        print(torch.jit.get_trace_graph(fn, (x, y))[0])
         self.assertEqual(traced_fn(x, y), fn(x, y))
         self.assertExpectedGraph(traced_fn.graph)
         self.assertExportImport(traced_fn.graph, (x, y))
@@ -998,10 +999,10 @@ class TestJit(JitTestCase):
         def doit(x, y):
             return torch.sigmoid(torch.tanh(x * (x + y)))
 
-        trace, _ = torch.jit.get_trace_graph(doit, (x, y))
-        self.run_pass('dce', trace)
-        self.run_pass('canonicalize', trace)
-        g = trace.graph()
+        graph, _ = torch.jit.get_trace_graph(doit, (x, y))
+        self.run_pass('dce', graph)
+        self.run_pass('canonicalize', graph)
+        g = graph
         g2 = torch._C.Graph()
         g_to_g2 = {}
         for node in g.inputs():
@@ -1097,7 +1098,7 @@ class TestJit(JitTestCase):
 
         m = MyModule()
         trace, _ = torch.jit.get_trace_graph(m, (torch.randn(2, 2),))
-        self.assertEqual(len(list(trace.graph().inputs())), 2)
+        self.assertEqual(len(list(trace.inputs())), 2)
         self.assertExpectedGraph(trace)
 
     def test_nested_inplace(self):

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -22,6 +22,7 @@
 #include "torch/csrc/jit/passes/loop_unrolling.h"
 #include "torch/csrc/jit/passes/to_batch.h"
 #include "torch/csrc/jit/passes/specialize_undef.h"
+#include "torch/csrc/jit/passes/lower_tuples.h"
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/script/init.h"
 #include "torch/csrc/jit/script/python_tree_views.h"
@@ -68,6 +69,7 @@ void initJITBindings(PyObject *module) {
   m.def("_jit_init", loadPythonClasses)
    .def("_jit_pass_onnx", ToONNX)
    .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)
+   .def("_jit_pass_lower_tuples", LowerTuples)
    .def("_jit_pass_fuse", FuseGraph)
    .def("_jit_pass_dce", [](std::shared_ptr<Graph>& g) {
      return EliminateDeadCode(g); // overload resolution

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -44,7 +44,7 @@ def load(filename):
     return m
 
 
-def get_trace_graph(f, args=(), kwargs=None):
+def get_trace_graph(f, args):
     """
     Trace a function or model, returning a tuple consisting of the both the
     *trace* of an execution, as well as the original return value.
@@ -58,19 +58,32 @@ def get_trace_graph(f, args=(), kwargs=None):
         args (tuple or Tensor): the positional arguments to pass to the
             function/module to be traced.  A non-tuple is assumed to
             be a single positional argument to be passed to the model.
-        kwargs (dict): the keyword arguments to pass to the function/module
-            to be traced.
 
     Example: Trace a cell.
 
         >>> trace, out = jit.trace(nn.LSTMCell(), (input, hidden))
         >>> print(trace)
     """
-    if kwargs is None:
-        kwargs = {}
     if not isinstance(args, tuple):
         args = (args,)
-    return LegacyTracedModule(f)(*args, **kwargs)
+
+    if isinstance(f, torch.nn.Module):
+        # NOTE: use full state, because we need it for BatchNorm export
+        # This differs from the compiler path, which doesn't support it at the moment.
+        module_state = list(_unique_state_dict(f, keep_vars=True).values())
+    else:
+        module_state = []
+
+    traced_args = list(args) + module_state
+    output = [None]
+    def traced_f(*all_trace_inputs):
+        f_inputs = all_trace_inputs[:len(args)]
+        out = output[0] = f(*f_inputs)
+        return out
+
+    graph = trace(*traced_args)(traced_f).graph
+    torch._C._jit_pass_lower_tuples(graph)
+    return graph, output[0]
 
 
 def _unique_state_dict(module, keep_vars=False):
@@ -83,31 +96,6 @@ def _unique_state_dict(module, keep_vars=False):
         seen_ids.add(id(v))
         filtered_dict[k] = v
     return filtered_dict
-
-
-class LegacyTracedModule(Module):
-    def __init__(self, inner):
-        super(LegacyTracedModule, self).__init__()
-        # inner may be a Module, or it may be an arbitrary callable
-        # If it's a Module, we get its parameters automatically, which lets
-        # us avoid a special casing functions versus modules.
-        self.inner = inner
-
-    def forward(self, *args):
-        in_vars, in_desc = _flatten(args)
-        # NOTE: use full state, because we need it for BatchNorm export
-        # This differs from the compiler path, which doesn't support it at the moment.
-        module_state = list(_unique_state_dict(self, keep_vars=True).values())
-        trace, all_trace_inputs = torch._C._tracer_enter(*(in_vars + module_state))
-        try:
-            trace_inputs = _unflatten(all_trace_inputs[:len(in_vars)], in_desc)
-            out = self.inner(*trace_inputs)
-            out_vars, _ = _flatten(out)
-            torch._C._tracer_exit(tuple(out_vars))
-        except Exception:
-            torch._C._tracer_abandon()
-            raise
-        return trace, out
 
 
 def _clone_inputs(args):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -76,6 +76,7 @@ def get_trace_graph(f, args):
 
     traced_args = list(args) + module_state
     output = [None]
+
     def traced_f(*all_trace_inputs):
         f_inputs = all_trace_inputs[:len(args)]
         out = output[0] = f(*f_inputs)

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -39,7 +39,7 @@ def _export_to_pretty_string(*args, **kwargs):
 
 def _optimize_trace(trace, operator_export_type):
     from torch.onnx import utils
-    trace.set_graph(utils._optimize_graph(trace.graph(), operator_export_type))
+    return utils._optimize_graph(trace, operator_export_type)
 
 
 def set_training(*args, **kwargs):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -153,11 +153,11 @@ def _trace(func, args, operator_export_type, return_outs=False):
     if isinstance(args, torch.Tensor):
         args = (args, )
 
-    trace, torch_out = torch.jit.get_trace_graph(func, args)
-    trace.set_graph(_optimize_graph(trace.graph(), operator_export_type))
+    graph, torch_out = torch.jit.get_trace_graph(func, args)
+    graph = _optimize_graph(graph, operator_export_type)
     if return_outs:
-        return trace, torch_out
-    return trace
+        return graph, torch_out
+    return graph
 
 
 def _trace_and_get_graph_from_model(model, args, training):
@@ -172,13 +172,13 @@ def _trace_and_get_graph_from_model(model, args, training):
     # can turn training=True (or None, to preserve whatever the original
     # training mode was.)
     with set_training(model, training):
-        trace, torch_out = torch.jit.get_trace_graph(model, args)
+        graph, torch_out = torch.jit.get_trace_graph(model, args)
 
     if orig_state_dict_keys != _unique_state_dict(model).keys():
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
-    return trace, torch_out
+    return graph, torch_out
 
 
 def _model_to_graph(model, args, f, verbose=False, training=False,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -178,7 +178,7 @@ def _trace_and_get_graph_from_model(model, args, training):
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
-    return trace.graph(), torch_out
+    return trace, torch_out
 
 
 def _model_to_graph(model, args, f, verbose=False, training=False,


### PR DESCRIPTION
Stacked on top of #10637.

`get_trace_graph` was the only place where we explicitly used the
tracer from Python, which was annoying during some refactors.
This patch implements it in terms of the usual `trace` function.

@zdevito 