### PR TITLE
Set the BUILD_ENVIRONMENT variable before installing sccache.

### DIFF
--- a/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
@@ -5,6 +5,10 @@ ARG EC2
 ADD ./install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh
 
+# Include BUILD_ENVIRONMENT environment variable in image
+ARG BUILD_ENVIRONMENT
+ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
+
 # Install Python
 ARG PYTHON_VERSION
 ADD ./install_python.sh install_python.sh
@@ -70,7 +74,3 @@ ARG JENKINS_GID
 ADD ./add_jenkins_user.sh add_jenkins_user.sh
 RUN if [ -n "${JENKINS}" ]; then bash ./add_jenkins_user.sh ${JENKINS_UID} ${JENKINS_GID}; fi
 RUN rm add_jenkins_user.sh
-
-# Include BUILD_ENVIRONMENT environment variable in image
-ARG BUILD_ENVIRONMENT
-ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}


### PR DESCRIPTION
Set the build environment before installing sccache in order to make sure the docker images have the links set up. 