### PR TITLE
Fill eigenvector with zeros if not required

### DIFF
--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -235,7 +235,12 @@ THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
     else if (info < 0)
       THError("MAGMA syev : Argument %d : illegal value", -info);
   }
-  THCTensor_(freeCopyTo)(state, input, rv_);
+  if (jobzs[0] != 'N') {
+    THCTensor_(freeCopyTo)(state, input, rv_);
+  } else  {
+    // If eigenvector is not needed, fill the result with zeros.
+    THCTensor_(zero)(state, rv_);
+  }
 #else
   THError(NoMagma(syev));
 #endif

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -238,7 +238,8 @@ THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
   if (jobzs[0] == 'N') {
     // If eigenvector is not needed, fill the result with zeros.
     THCTensor_(zero)(state, rv_);
-  } else  {
+    THCTensor_(free)(state, input);
+  } else {
     THCTensor_(freeCopyTo)(state, input, rv_);
   }
 #else

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -235,11 +235,11 @@ THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
     else if (info < 0)
       THError("MAGMA syev : Argument %d : illegal value", -info);
   }
-  if (jobzs[0] != 'N') {
-    THCTensor_(freeCopyTo)(state, input, rv_);
-  } else  {
+  if (jobzs[0] == 'N') {
     // If eigenvector is not needed, fill the result with zeros.
     THCTensor_(zero)(state, rv_);
+  } else  {
+    THCTensor_(freeCopyTo)(state, input, rv_);
   }
 #else
   THError(NoMagma(syev));

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1730,17 +1730,7 @@ class TestCuda(TestCase):
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_symeig(self):
-        # Small case
-        tensor = torch.randn(3, 3).cuda()
-        tensor = torch.mm(tensor, tensor.t())
-        eigval, eigvec = torch.symeig(tensor, eigenvectors=True)
-        self.assertEqual(tensor, torch.mm(torch.mm(eigvec, eigval.diag()), eigvec.t()))
-
-        # Large case
-        tensor = torch.randn(257, 257).cuda()
-        tensor = torch.mm(tensor, tensor.t())
-        eigval, eigvec = torch.symeig(tensor, eigenvectors=True)
-        self.assertEqual(tensor, torch.mm(torch.mm(eigvec, eigval.diag()), eigvec.t()))
+        TestTorch._test_symeig(self, lambda t: t.cuda())
 
     def test_arange(self):
         for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4297,6 +4297,14 @@ class TestTorch(TestCase):
         ahat = torch.mm(torch.mm(resv, torch.diag(rese)), resv.t())
         self.assertEqual(cov, ahat, 1e-8, 'VeV\' wrong')
 
+        # test eigenvectors=False
+        rese2 = torch.zeros(3)
+        resv2 = torch.randn(3, 3)
+        expected_resv2 = torch.zeros(3, 3)
+        torch.symeig(cov.clone(), False, out=(rese2, resv2))
+        self.assertEqual(rese, rese2)
+        self.assertEqual(resv2, expected_resv2)
+
         # test non-contiguous
         X = torch.rand(5, 5)
         X = X.t() * X

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4298,8 +4298,9 @@ class TestTorch(TestCase):
         self.assertEqual(cov, ahat, 1e-8, 'VeV\' wrong')
 
         # test eigenvectors=False
-        rese2 = torch.zeros(3)
-        resv2 = torch.randn(3, 3)
+        cov = cov.cuda()
+        rese2 = torch.zeros(3).cuda()
+        resv2 = torch.randn(3, 3).cuda()
         expected_resv2 = torch.zeros(3, 3)
         torch.symeig(cov.clone(), False, out=(rese2, resv2))
         self.assertEqual(rese, rese2)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4404,6 +4404,15 @@ Args:
     upper(boolean, optional): controls whether to consider upper-triangular or lower-triangular region
     out (tuple, optional): the output tuple of (Tensor, Tensor)
 
+Returns:
+    (Tensor, Tensor): A tuple containing
+
+        - **e** (*Tensor*): Shape :math:`(m)`. Each element is an eigenvalue of ``input``,
+            The eigenvalues are in ascending order.
+        - **V** (*Tensor*): Shape :math:`(m \times m)`.
+            If ``eigenvectors=False``, it's a tensor filled with zeros.
+            Otherwise, this tensor contains the orthonormal eigenvectors of the ``input``.
+
 Examples::
 
 


### PR DESCRIPTION
Fix #10345, which only happens in CUDA case. 

* Instead of returning some random buffer, we fill it with zeros.

* update torch.symeig doc.