### PR TITLE
Fix warnings diagnosed in recent clang

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -288,7 +288,7 @@ struct FullBidirectionalLayer : Layer<Tensor, pair_of<dir_hidden_type>, pair_of<
 
   std::vector<Tensor> reverse(std::vector<Tensor>&& x) const {
     std::reverse(x.begin(), x.end());
-    return x;
+    return std::move(x);
   }
 
   FullLayer<dir_hidden_type> layer_;


### PR DESCRIPTION
Summary: Fix "missing std::move from the return value" warning diagnosed by recent clang compiler.

Reviewed By: DavidCallahan

Differential Revision: D9384692
