### PR TITLE
Fix EnsureCPUOutputOp

### DIFF
--- a/caffe2/operators/ensure_cpu_output_op.h
+++ b/caffe2/operators/ensure_cpu_output_op.h
@@ -40,7 +40,7 @@ class EnsureCPUOutputOp : public Operator<Context> {
         input.size(),
         input.raw_data(),
         output->raw_mutable_data(input.meta()));
-
+    context_.FinishDeviceComputation();
     return true;
   }
 };


### PR DESCRIPTION
Summary: EnsureCPUOutputOp will copy the input from another Context to CPU, but currently there is no guarantee that the Copy will be executed.

Differential Revision: D9390046
