### PR TITLE
Fix cuDNN dropout state cache

### DIFF
--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -57,10 +57,6 @@ struct CUDAEvent {
     return *this;
   }
 
-  explicit operator bool() const noexcept {
-    return internals_ != nullptr;
-  }
-
   operator cudaEvent_t() const { return detail::CUDAEvent_event(internals_); }
 
   // Less than operator (to allow use in sets)


### PR DESCRIPTION
Minor fix for the cuDNN cache. Previously we would skip the event reinitialization when an RNN function would be called on GPU 0, and then on GPU 1, but it would be in eval mode on GPU1. That would cause us to skip event re-initialization, and cause an incorrect resource handle error when trying to record the event.

@soumith 