### PR TITLE
[Caffe2] GCC-7 doesn't like the original syntax.

### DIFF
--- a/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
+++ b/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
@@ -49,7 +49,7 @@ class GivenTensorByteStringToUInt8FillOp final : public FillerOp<Context> {
 
  private:
   void Extract() {
-    auto source_values = OperatorBase::GetRepeatedArgument<string>("values");
+    auto source_values = this->template GetRepeatedArgument<string>("values");
     DCHECK_EQ(source_values.size(), 1)
         << "expected size: 1 "
         << " given size: " << source_values.size();


### PR DESCRIPTION
Replace with "this->template f<T>()".

Fix #7881 