### PR TITLE
Import DistributedSampler in utils/data/__init__

### DIFF
--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,4 +1,5 @@
 
 from .sampler import Sampler, SequentialSampler, RandomSampler, SubsetRandomSampler, WeightedRandomSampler, BatchSampler
+from .distributed import DistributedSampler
 from .dataset import Dataset, TensorDataset, ConcatDataset, Subset, random_split
 from .dataloader import DataLoader


### PR DESCRIPTION
There is no reason that user should do an extra import to use DistributedSampler.