### PR TITLE
orthogonal_ norm conservation

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6185,12 +6185,10 @@ class TestNNInit(TestCase):
 
                 rows, cols = tensor_size[0], reduce(mul, tensor_size[1:])
                 flattened_tensor = input_tensor.view(rows, cols)
-                if rows > cols:
-                    self.assertEqual(torch.mm(flattened_tensor.t(), flattened_tensor),
-                                     torch.eye(cols) * gain ** 2, prec=1e-6)
-                else:
-                    self.assertEqual(torch.mm(flattened_tensor, flattened_tensor.t()),
-                                     torch.eye(rows) * gain ** 2, prec=1e-6)
+                identities = torch.mm(flattened_tensor, flattened_tensor.t())
+                for i in range(0, rows, cols):
+                    identity = identities[i:i+cols, i:i+cols]
+                    self.assertEqual(identity, torch.eye(identity.size(0)) * gain ** 2, prec=1e-6)
 
     def test_deprecation(self):
         x = torch.randn(3, 3)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6187,7 +6187,7 @@ class TestNNInit(TestCase):
                 flattened_tensor = input_tensor.view(rows, cols)
                 identities = torch.mm(flattened_tensor, flattened_tensor.t())
                 for i in range(0, rows, cols):
-                    identity = identities[i:i+cols, i:i+cols]
+                    identity = identities[i:i + cols, i:i + cols]
                     self.assertEqual(identity, torch.eye(identity.size(0)) * gain ** 2, prec=1e-6)
 
     def test_deprecation(self):

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -358,7 +358,7 @@ def orthogonal_(tensor, gain=1):
 
         with torch.no_grad():
             tensor[i:i + cols].view_as(q).copy_(q)
-            
+
     with torch.no_grad():
         tensor.mul_(gain)
     return tensor


### PR DESCRIPTION
I propose to modify `nn.init.orthogonal_` such that the variance is conserved.
In all the modules, `weight` has its first index as output index:

- `(out_features, in_features)` for `nn.Linear`
- `(out_channels, in_channels, kH, kW)` for `nn.Conv2d`

I propose to modify the behavior of `nn.init.orthogonal_` for the case `rows > cols` such that
```python
lin = nn.Linear(20, 5)  # rows > cols
nn.init.orthogonal_(lin.weight)
x = torch.randn(100, 20)
lin(x).std()  # is equal to 1 in expectancy
```

To do so I propose to split the matrix `rows x cols` into a pile of orthogonal square matrices of size `cols x cols`.