### PR TITLE
Use ATen native functions for THCTensor_cadd/cmul/cdiv/csub

### DIFF
--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -84,34 +84,6 @@ struct TensorSignOp<half> {
 };
 
 template <typename T>
-struct TensorAddOp {
-  __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out += *in;
-  }
-
-  __device__ __forceinline__ void operator()(T* out, T* in1, T* in2) {
-    *out = *in1 + *in2;
-  }
-};
-
-template <>
-struct TensorAddOp<half> {
-  __device__ __forceinline__ void operator()(half* out, half* in) {
-    float fout = __half2float(*out);
-    float fin = __half2float(*in);
-    fout += fin;
-    *out = __float2half(fout);
-  }
-
-  __device__ __forceinline__ void operator()(half* out, half* in1, half* in2) {
-    float fin1 = __half2float(*in1);
-    float fin2 = __half2float(*in2);
-    float fout = fin1 + fin2;
-    *out = __float2half(fout);
-  }
-};
-
-template <typename T>
 struct TensorCAddOp {
   TensorCAddOp(T v) : val(v) {}
 
@@ -149,34 +121,6 @@ struct TensorCAddOp<half> {
   }
 
   half val;
-};
-
-template <typename T>
-struct TensorSubOp {
-  __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out -= *in;
-  }
-
-  __device__ __forceinline__ void operator()(T* out, T* in1, T* in2) {
-    *out = *in1 - *in2;
-  }
-};
-
-template <>
-struct TensorSubOp<half> {
-  __device__ __forceinline__ void operator()(half* out, half* in) {
-    float fout = __half2float(*out);
-    float fin = __half2float(*in);
-    fout -= fin;
-    *out = __float2half(fout);
-  }
-
-  __device__ __forceinline__ void operator()(half* out, half* in1, half* in2) {
-    float fin1 = __half2float(*in1);
-    float fin2 = __half2float(*in2);
-    float fout = fin1 - fin2;
-    *out = __float2half(fout);
-  }
 };
 
 template <typename T>
@@ -332,40 +276,6 @@ struct TensorCPowOp<half> {
     float fin1 = __half2float(*in1);
     float fin2 = __half2float(*in2);
     float fout = powf(fin1, fin2);
-    *out = __float2half(fout);
-  }
-};
-
-template <typename T>
-struct TensorDivOp {
-  __device__ __forceinline__ void
-  operator()(T* out, T* in) {
-    *out /= *in;
-  }
-
-  __device__ __forceinline__ void
-  operator()(T* out, T* in1, T* in2) {
-    *out = *in1 / *in2;
-  }
-};
-
-template <>
-struct TensorDivOp<half> {
-  __device__ __forceinline__ void
-  operator()(half* out, half* in) {
-    // No fp16 div instruction yet
-    float fout = __half2float(*out);
-    float fin = __half2float(*in);
-    fout /= fin;
-    *out = __float2half(fout);
-  }
-
-  __device__ __forceinline__ void
-  operator()(half* out, half* in1, half* in2) {
-    // No fp16 div instruction yet
-    float fin1 = __half2float(*in1);
-    float fin2 = __half2float(*in2);
-    float fout = fin1 / fin2;
     *out = __float2half(fout);
   }
 };

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -231,105 +231,32 @@ THCTensor_(lerp)(THCState *state, THCTensor *result, THCTensor *a, THCTensor *b,
 THC_API void
 THCTensor_(cadd)(THCState *state, THCTensor *self_, THCTensor* src1, real value, THCTensor *src2)
 {
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    if (value == ScalarConvert<int, real>::to(1)) {
-      // self += src2
-      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorAddOp<real>())) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    } else {
-      // self += value * src2
-      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorCAddOp<real>(value))) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    if (value == ScalarConvert<int, real>::to(1)) {
-      // self = src1 + src2
-      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorAddOp<real>())) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    } else {
-      // self = src1 + value * src2
-      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorCAddOp<real>(value))) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
+  auto out = at::Tensor(self_, true);
+#ifdef THC_REAL_IS_HALF
+  auto alpha = at::Half(value);
+#else
+  auto alpha = value;
+#endif
+  at::add_out(out, at::Tensor(src1, true), at::Tensor(src2, true), alpha);
 }
 
 THC_API void
 THCTensor_(csub)(THCState *state, THCTensor *self_, THCTensor* src1, real value, THCTensor *src2)
 {
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    if (value == ScalarConvert<int, real>::to(1)) {
-      // self -= src2
-      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorSubOp<real>())) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    } else {
-      // self += -value * src2
-      if (!THC_pointwiseApply2<real, real>(state, self_, src2,
-                                   TensorCAddOp<real>(
-                                     ScalarNegate<real>::to(value)))) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    if (value == ScalarConvert<int, real>::to(1)) {
-      // self = src1 - src2
-      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorSubOp<real>())) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    } else {
-      // self = src1 - value * src2
-      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2,
-                                   TensorCAddOp<real>(
-                                     ScalarNegate<real>::to(value)))) {
-        THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-      }
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
+  auto out = at::Tensor(self_, true);
+#ifdef THC_REAL_IS_HALF
+  auto alpha = at::Half(value);
+#else
+  auto alpha = value;
+#endif
+  at::sub_out(out, at::Tensor(src1, true), at::Tensor(src2, true), alpha);
 }
 
 THC_API void
 THCTensor_(cmul)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    // self *= src2
-    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorMulOp<real>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    // self = src1 * src2
-    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorMulOp<real>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
+  auto out = at::Tensor(self_, true);
+  at::mul_out(out, at::Tensor(src1, true), at::Tensor(src2, true));
 }
 
 THC_API void
@@ -443,25 +370,8 @@ void THCTensor_(tpow)(THCState *state, THCTensor *self_, real value, THCTensor *
 THC_API void
 THCTensor_(cdiv)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    // self /= src2
-    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorDivOp<real>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    // self = src1 / src2
-    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorDivOp<real>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
+  auto out = at::Tensor(self_, true);
+  at::div_out(out, at::Tensor(src1, true), at::Tensor(src2, true));
 }
 
 THC_API void

--- a/aten/src/THCUNN/generic/PReLU.cu
+++ b/aten/src/THCUNN/generic/PReLU.cu
@@ -133,7 +133,7 @@ void THNN_(PReLU_accGradParameters)(
 
       if (ndim == 2)
       {
-        THCTensor_(sum)(state, gradWeightBuf, gradInput, 0, 1);
+        THCTensor_(sum)(state, gradWeightBuf, gradInput, 0, 0);
         THCTensor_(cadd)(state, gradWeight, gradWeight, scale, gradWeightBuf);
       }
       else
@@ -146,8 +146,8 @@ void THNN_(PReLU_accGradParameters)(
         }
         THCTensor_(resize3d)(state, buffer, input->size(0), nOutputPlane, size3);
         THCTensor_(resize2d)(state, sumbuf, input->size(0), nOutputPlane);
-        THCTensor_(sum)(state, sumbuf, buffer, 2, 1);
-        THCTensor_(sum)(state, gradWeightBuf, sumbuf, 0, 1);
+        THCTensor_(sum)(state, sumbuf, buffer, 2, 0);
+        THCTensor_(sum)(state, gradWeightBuf, sumbuf, 0, 0);
         THCTensor_(cadd)(state, gradWeight, gradWeight, scale, gradWeightBuf);
         THCTensor_(free)(state, buffer);
         THCTensor_(free)(state, sumbuf);


### PR DESCRIPTION
This seems to save a few percent in binary size in libcaffe2_gpu.so, but
the effect may not be real. In fact, deleting some functions can cause
the binary size to increase (perhaps due to alignment issues).

cc @orionr 