### PR TITLE
Support Loading to GPU

### DIFF
--- a/caffe2/python/checkpoint.py
+++ b/caffe2/python/checkpoint.py
@@ -217,7 +217,9 @@ class CheckpointManager(object):
                     [], self._blob_names,
                     db=full_db_name,
                     db_type=db_type,
-                    absolute_path=True)
+                    absolute_path=True,
+                    keep_device=True,
+                )
         self._names_output = task.outputs()[0]
         return task
 
@@ -280,7 +282,9 @@ class CheckpointManager(object):
                 self.blob_list(),
                 db=self._current_db_name,
                 db_type=db_type,
-                absolute_path=True)
+                absolute_path=True,
+                keep_device=True,
+            )
 
         return self._timed_task('checkpoint_load', add_op)
 


### PR DESCRIPTION
Summary:
Can't resume from checkpoint for workflows that use GPU.

The problem is just we didn't leverage the already-provided GPU deserialization of Caffe2.

`keep_device` arg of LoadOp. See https://fburl.com/y27ltaxw

How a serialized BlobProto (contraining TensorProto) is loaded into GPU memory?
- Load BlobProto from DB. https://fburl.com/pe1qaeyf
- Deserialize the BlobProto into a Blob instance. https://fburl.com/5dirjuuh and https://fburl.com/stoho0x1
- Call Blob->Deserialized. https://fburl.com/bnureu32
- Deserializer Registration. https://fburl.com/wbu95ry7 https://fburl.com/ycetud8u
- Create TensorCUDA Deserializer. https://fburl.com/2lirfuqj
- Create Tensor on GPU and get TensorProto of BlobProto. https://fburl.com/7dre82zg
- Copy TensorProto in CPU to Tensor on GPU. https://fburl.com/fr0qk2oe

Cloned the GPU workflows for testing in D9125520.

Differential Revision: D9372950
