### PR TITLE
Erase ListConstruct nodes for ONNX export

### DIFF
--- a/test/expect/TestScript.test_listconstruct_erasure.expect
+++ b/test/expect/TestScript.test_listconstruct_erasure.expect
@@ -1,0 +1,19 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "0", type:Tensor dims: 3 4}]
+      outputs: [{name: "4", type:Tensor dims: 0}]
+      initializers: []
+      nodes: [
+        Node {type: "Constant", inputs: [], outputs: [1], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Less", inputs: [0,1], outputs: [2], attributes: []},
+        Node {type: "Cast", inputs: [2], outputs: [3], attributes: [{ name: 'to', type: int, value: 2}]},
+        Node {type: "ATen", inputs: [0,3], outputs: [4], attributes: [{ name: 'operator', type: string, value: 'index'}]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5764,6 +5764,18 @@ def func(t):
             reference = getattr(x, cast_type)()
             self.assertEqual(cu_result, reference)
 
+    def test_listconstruct_erasure(self):
+        class FooMod(torch.nn.Module):
+            def forward(self, x):
+                mask = x < 0.0
+                return x[mask]
+
+        import io
+        f = io.BytesIO()
+        self.assertExpected(torch.onnx.export_to_pretty_string(
+            FooMod(), (torch.rand(3, 4),), f,
+            operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK))
+
 
 class TestEndToEndHybridFrontendModels(JitTestCase):
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -499,15 +499,6 @@ public:
     }
   }
 
-  void replaceInputWithList(size_t i, ArrayRef<Value*> to) {
-    schema_ = nullptr;
-    removeInput(i);
-    for (auto* to_val : to) {
-      JIT_ASSERT(to_val->owningGraph() == graph_);
-      insertInput(i++, to_val);
-    }
-  }
-
   Value* addOutput() {
     outputs_.push_back(new Value(this, outputs_.size()));
     schema_ = nullptr;
@@ -693,6 +684,10 @@ public:
     if (!schema_)
       findSchema();
     return *schema_;
+  }
+
+  void invalidateSchema() {
+    schema_ = nullptr;
   }
 
   void dump() const;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -499,6 +499,15 @@ public:
     }
   }
 
+  void replaceInputWithList(size_t i, ArrayRef<Value*> to) {
+    schema_ = nullptr;
+    removeInput(i);
+    for (auto* to_val : to) {
+      JIT_ASSERT(to_val->owningGraph() == graph_);
+      insertInput(i++, to_val);
+    }
+  }
+
   Value* addOutput() {
     outputs_.push_back(new Value(this, outputs_.size()));
     schema_ = nullptr;

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -466,6 +466,15 @@ static void speculateOps(Block* block) {
   }
 }
 
+static void replaceInputWithList(Node *node, size_t i, ArrayRef<Value*> to) {
+  node->invalidateSchema();
+  node->removeInput(i);
+  for (auto* to_val : to) {
+    JIT_ASSERT(to_val->owningGraph() == node->owningGraph());
+    node->insertInput(i++, to_val);
+  }
+}
+
 static void eraseListConstruct(Block* block) {
   for (auto it = block->nodes().begin(), end = block->nodes().end();
        it != end;) {
@@ -492,7 +501,7 @@ static void eraseListConstruct(Block* block) {
 
     for (auto ritr = replacements.rbegin(); ritr != replacements.rend();
          ++ritr) {
-      n->replaceInputWithList(std::get<0>(*ritr), std::get<1>(*ritr));
+      replaceInputWithList(n, std::get<0>(*ritr), std::get<1>(*ritr));
     }
   }
 }


### PR DESCRIPTION
ONNX doesn't support this. Instead flatten the inputs to the ListConstruct op and inline it into the subsequent usage