### PR TITLE
[jit] Excluded tests changed to expected failures

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6343,12 +6343,6 @@ EXCLUDE_TRACED = {
     # nn functional test
     # schema not found for onnx node
     'test_nn_instance_norm',
-
-    # output no dependence with traced input, tracer confusion
-    'test_nn_rrelu',
-
-    # aten op has additional cudnn argument
-    'test_nn_group_norm',
 }
 
 # known to be failing in script


### PR DESCRIPTION
For JIT specific failures (i.e. in scripts/tracing):
- Run `test_jit.py` tests to see expected failures instead of silently excluding them
- `test_nn_group_norm` and `test_nn_rrelu` now succeed, removed them from exclude lists
