### PR TITLE
[jit][easy] Relax RHS type assert for augassign

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3041,6 +3041,14 @@ def func4():
             self.assertEqual(cu.func3(), scope['func3']())
             self.assertEqual(cu.func4(), scope['func4']())
 
+    def test_number_augassign(self):
+        def func():
+            z = 1
+            z += 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
     def test_number_neg(self):
         # int -> int
         def func1():

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1104,7 +1104,7 @@ private:
       Ident lhs = Var(stmt.lhs()[0]).name();
       Expr expr = BinOp::create(stmt.range(), stmt.reduction(),
                                 Var::create(lhs.range(), lhs), stmt.rhs());
-      environment_stack->setVar(lhs.range(), lhs.name(), emitExpr(expr));
+      environment_stack->setVar(lhs.range(), lhs.name(), emitExpr(expr, identity));
       return;
     }
 


### PR DESCRIPTION
Augassign (i.e., `x += 1`) gets desugared to an assignment of a binop (`x = x + 1`).
Right now we assert that the RHS of the binop is a tensor,
but it really doesn't have to be because we support scalar/scalar ops and also
list-list ops (i.e., `[1, 2] + [2, 3]`).

