### PR TITLE
Kill the dummy TaskOutput when task.get_step()

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -162,10 +162,10 @@ print("Y:", workspace.FetchBlob("Y"))
         "length as number of output blobs.");
 
 OPERATOR_SCHEMA(Save)
-    .NumInputs(1, INT_MAX)
+    .NumInputs(0, INT_MAX)
     .NumOutputs(0)
     .SetDoc(R"DOC(
-Saves a set of blobs to a db. It takes $[1, \infty)$ number of inputs and has
+Saves a set of blobs to a db. It takes $[0, \infty)$ number of inputs and has
 no output. The contents of the inputs are written into the db using the
 settings specified by the arguments.
 

--- a/caffe2/python/checkpoint_test.py
+++ b/caffe2/python/checkpoint_test.py
@@ -161,9 +161,9 @@ class TestCheckpoint(TestCase):
                     num_epochs = job_runner.train(session)
                 self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
 
-                # There are 17 global blobs after finishing up the job runner.
+                # There are 15 global blobs after finishing up the job runner.
                 # (only blobs on init_group are checkpointed)
-                self.assertEquals(len(ws.blobs), 17)
+                self.assertEquals(len(ws.blobs), 15)
 
             ws = workspace.C.Workspace()
             session = LocalSession(ws)

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -533,8 +533,8 @@ class TestCreatePlan(test_util.TestCase):
 
         self.assertEqual(len(plan.Steps()), 1)
         self.assertEqual(len(test_plan.Steps()), 1)
-        self.assertEqual(len(plan.Proto().network), 9)
-        self.assertEqual(len(test_plan.Proto().network), 9)
+        self.assertEqual(len(plan.Proto().network), 8)
+        self.assertEqual(len(test_plan.Proto().network), 8)
         self.assertEqual(len(plan.Proto().execution_step), 1)
         self.assertEqual(len(test_plan.Proto().execution_step), 1)
         self.assertEqual(plan.Steps()[0].Name(), test_plan.Steps()[0].Name())

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -497,6 +497,11 @@ void addObjectMethods(py::module& m) {
             return self->HasBlob(name);
           })
       .def(
+          "remove_blob",
+          [](Workspace* self, const std::string& name) -> py::bool_ {
+            return self->RemoveBlob(name);
+          })
+      .def(
           "_run_net",
           [](Workspace* self, py::bytes def) {
             caffe2::NetDef proto;

--- a/caffe2/python/task.py
+++ b/caffe2/python/task.py
@@ -582,11 +582,6 @@ class Task(object):
             Task.TASK_SETUP, [self._step] + report_steps, self)
         instance_init_nets, instance_exit_nets = get_setup_nets(
             Task.TASK_INSTANCE_SETUP, [self._step] + report_steps, self)
-        if len(self._outputs) == 0:
-            output_net = core.Net('%s:output' % self.name)
-            self.add_output(output_net.ConstantFill(
-                [], 1, dtype=core.DataType.INT32, value=0))
-            task_exit_nets.append(output_net)
 
         # Add instance-level report steps
         body = self._step if not report_steps else core.execution_step(


### PR DESCRIPTION
Summary:
I wanted to assert that the blobs in the workspace blobs after loading checkpoint are exactly the same as the blobs in the work save before saving to a checkpoint.

But I found that when calling `task.get_step()`, a dummy task output blob, `task:output/ConstIntFill:0`, is added. Also a dummy net "task:output" was also added along.

This makes it hard to assert "Equal", forcing me to assert "LessThan" or "GreaterThan".

ZMQ socket can't send empty list.
As a result, if the Task on the Worker had no output,
The master would never stop waiting and hang forever.

So a dummy TaskOutput was added when `task.get_step()` to work around it.

After thinking it twice, I think this should be fixed.

Because TaskOuput is at User layer. The issued shouldn't have been solved by adding a TaskOuput.

Instead, we should move the creating of the placeholder blob to some deeper layer,
and remove the placeholder blob in the workspace afterwards to avoid polluting user workspace.
After this change, the workaround becomes totally transparent and no side-effect to users.

Differential Revision: D9413150
