### PR TITLE
Add demo_graph, hack to make IR scopes work again (fixing JIT passes)

### DIFF
--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -19,6 +19,11 @@ TORCH_API Value* insertConstant(
     IValue val,
     at::optional<SourceRange> loc = at::nullopt);
 
+TORCH_API Value* insertConstantWithScope(
+    Graph& g,
+    IValue val,
+    std::string scopeName,
+    at::optional<SourceRange> loc = at::nullopt);
 
 //////////////////////////////////////////////////////////////////////////////////
 // Helper for retrieving constants

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -948,8 +948,8 @@ public:
   void set_current_scope(Scope* scope) {
     std::string name1 = scope->getRoot()->name().toDisplayString();
     std::string name2 = scope_root_.get()->name().toDisplayString();
-    if (name1.find(name2) < 0 &&
-        name2.find(name1) < 0 &&
+    if (!(name1.find(name2) == 0) &&
+        !(name2.find(name1) == 0) &&
         scope->getRoot() != scope_root_.get()) {
       throw std::runtime_error("trying to set a scope as current that does not belong to the Graph's scope trie");
     }
@@ -1089,13 +1089,6 @@ public:
       IValue val,
       at::optional<SourceRange> loc = at::nullopt) {
     return jit::insertConstant(*this, std::move(val), loc);
-  }
-
-  Value* insertConstantWithScope(
-      IValue val,
-      std::string scopeName = std::string(),
-      at::optional<SourceRange> loc = at::nullopt) {
-    return jit::insertConstantWithScope(*this, std::move(val), scopeName, loc);
   }
 
   // schema-driven insert

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -16,7 +16,8 @@ static void EraseNumberTypesOnBlock(Block* block) {
         if(it->output()->type()->isSubtypeOf(NumberType::get())) {
           auto s = *constant_as<at::Scalar>(it->output());
           WithInsertPoint guard(*it);
-          Value* r = block->owningGraph()->insertConstantWithScope(s.toTensor(), it->scopeName());
+          Value * r = block->owningGraph()->insertConstantWith(s.toTensor());
+          r->node()->setScope(it->scope());
           it->output()->replaceAllUsesWith(r);
         }
       } break;

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -16,7 +16,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
         if(it->output()->type()->isSubtypeOf(NumberType::get())) {
           auto s = *constant_as<at::Scalar>(it->output());
           WithInsertPoint guard(*it);
-          Value* r = block->owningGraph()->insertConstant(s.toTensor());
+          Value* r = block->owningGraph()->insertConstantWithScope(s.toTensor(), it->scopeName());
           it->output()->replaceAllUsesWith(r);
         }
       } break;

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -63,7 +63,7 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
         // Copy over source location information to all nodes created by
         // the symbolic
         outputs[i]->node()->setSourceLocation(node->getSourceLocation());
-        outputs[i]->node()->setScopeFromString(node->scopeName());
+        outputs[i]->node()->setScope(node->scope());
         env[old] = outputs[i];
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
@@ -84,7 +84,7 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
   // Clone the node and add it to the new graph
   auto cloneNode = [&](Node * node) {
     auto n_ = ctx.block->appendNode(ctx.block->owningGraph()->createClone(node, envFn));
-    n_->setScopeFromString(node->scopeName());
+    n_->setScope(node->scope());
     for(size_t i = 0; i < node->outputs().size(); i++) {
       // n_->outputs()[i]->setType(node->outputs()[i]->type());
       env[node->outputs()[i]] = n_->outputs()[i];

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -52,6 +52,7 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
       ss << num_old_outputs << ", but got " << outputs.size() << ")";
       throw std::runtime_error(ss.str());
     }
+
     for (size_t i = 0; i < num_old_outputs; ++i) {
       auto old = old_outputs[i];
       if (outputs[i]) {
@@ -62,6 +63,7 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
         // Copy over source location information to all nodes created by
         // the symbolic
         outputs[i]->node()->setSourceLocation(node->getSourceLocation());
+        outputs[i]->node()->setScopeFromString(node->scopeName());
         env[old] = outputs[i];
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
@@ -82,6 +84,7 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
   // Clone the node and add it to the new graph
   auto cloneNode = [&](Node * node) {
     auto n_ = ctx.block->appendNode(ctx.block->owningGraph()->createClone(node, envFn));
+    n_->setScopeFromString(node->scopeName());
     for(size_t i = 0; i < node->outputs().size(); i++) {
       // n_->outputs()[i]->setType(node->outputs()[i]->type());
       env[node->outputs()[i]] = n_->outputs()[i];

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -327,6 +327,7 @@ void initPythonIRBindings(PyObject * module_) {
     .NS(hasUses)
     .NS(eraseOutput)
     .NS(addOutput)
+    .NS(setScopeFromString)
     .NS(scopeName)
     .def("blocks", [](Node& n) {
       return py::make_iterator(n.blocks().begin(), n.blocks().end());


### PR DESCRIPTION
Summary:
Added a demo_graph so that users can try out writing model graph visualization for TensorboardX with various models (VGG, ResNet, DenseNet, and some other toy examples).

Working implementation that generates the graph correctly without extraneous information. It's pretty hacky and I'm trying to clean it up, any comments on the code are appreciated!

The problem was that the JIT passes weren't preserving scopes when they were creating new nodes so nodes were ending up without scope names and this caused us to lose valuable information in visualization.

Sample graph visualization (ResNet model) generated below:

{F136387033}

Differential Revision: D9389809
