### PR TITLE
Create at::linear

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -134,19 +134,6 @@ tpair_of<Tensor> hidden_slice(const tpair_of<Tensor>& t, int64_t start, int64_t 
 // It's a struct only because functional programming in C++ is a pain, and it's easier
 // to pass around "vtable pointers" than actual function pointers.
 
-Tensor linear(const Tensor& input, const Tensor& weight, /* optional */ const Tensor& bias={}) {
-  if (input.dim() == 2 && bias.defined()) {
-    // fused op is marginally faster
-    return at::addmm(bias, input, weight.t());
-  }
-
-  auto output = at::matmul(input, weight.t());
-  if (bias.defined()) {
-    output.add_(bias);
-  }
-  return output;
-}
-
 template<typename hidden_type_tmpl>
 struct Cell {
   using hidden_type = hidden_type_tmpl;
@@ -157,7 +144,7 @@ struct Cell {
 template<typename nonlinearity>
 struct SimpleCell : Cell<Tensor> {
   hidden_type operator()(const Tensor& input, const hidden_type& hidden, const CellParams& params) const override {
-    return nonlinearity{}(linear(input, params.w_ih, params.b_ih) + linear(hidden, params.w_hh, params.b_hh));
+    return nonlinearity{}(at::linear(input, params.w_ih, params.b_ih) + at::linear(hidden, params.w_hh, params.b_hh));
   }
 };
 
@@ -175,7 +162,7 @@ struct LSTMCell : Cell<std::tuple<Tensor, Tensor>> {
       return std::make_tuple(std::get<0>(result), std::get<1>(result));
     }
 
-    auto gates = linear(input, params.w_ih, params.b_ih) + linear(hx, params.w_hh, params.b_hh);
+    auto gates = at::linear(input, params.w_ih, params.b_ih) + at::linear(hx, params.w_hh, params.b_hh);
     auto chunked_gates = gates.chunk(4, 1);
 
     auto ingate = chunked_gates[0].sigmoid();
@@ -200,8 +187,8 @@ struct GRUCell : Cell<Tensor> {
       return std::get<0>(result);
     }
 
-    auto igates = linear(input, params.w_ih, params.b_ih);
-    auto hgates = linear(hidden, params.w_hh, params.b_hh);
+    auto igates = at::linear(input, params.w_ih, params.b_ih);
+    auto hgates = at::linear(hidden, params.w_hh, params.b_hh);
     auto chunked_igates = igates.chunk(3, 1);
     auto chunked_hgates = hgates.chunk(3, 1);
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -928,6 +928,9 @@
 - func: layer_norm(Tensor input, IntList normalized_shape, Tensor? weight={}, Tensor? bias={}, double eps=1e-5, bool cudnn_enable=True) -> Tensor
   variants: function
 
+- func: linear(Tensor input, Tensor weight, Tensor bias={}) -> Tensor
+  variants: function
+
 - func: linspace(Scalar start, Scalar end, TensorOptions options={}) -> Tensor
   variants: function
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -28,7 +28,7 @@ SKIP_PYTHON_BINDINGS = [
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',
     'arange.*', 'range.*', '_gesv.*', '_getri.*', 'slice',
     '_local_scalar', '_local_scalar_dense',
-    'max_pool1d', 'max_pool2d', 'max_pool3d'
+    'max_pool1d', 'max_pool2d', 'max_pool3d', 'linear'
 ]
 
 # These function signatures are not exposed to Python. Note that this signature


### PR DESCRIPTION
The optimized code for `linear()` which uses `addmm` when a bias is given was duplicated three times in the ATen and the C++ API. Let's just have `at::linear` and use that everywhere.

@apaszke @ezyang (who mentioned this in #10481)