### PR TITLE
Add registry to pybind_state

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -28,6 +28,7 @@
 #include "caffe2/opt/passes.h"
 #include "caffe2/opt/sink.h"
 #include "caffe2/predictor/predictor.h"
+#include "caffe2/python/pybind_state_registry.h"
 #include "caffe2/utils/cpuid.h"
 #include "caffe2/utils/string_utils.h"
 
@@ -1734,6 +1735,9 @@ PYBIND11_MODULE(caffe2_pybind11_state, m) {
 
   addGlobalMethods(m);
   addObjectMethods(m);
+  for (const auto& addition : PybindAdditionRegistry()->Keys()) {
+    PybindAdditionRegistry()->Create(addition, m);
+  }
 }
 
 } // namespace python

--- a/caffe2/python/pybind_state_registry.cc
+++ b/caffe2/python/pybind_state_registry.cc
@@ -1,0 +1,11 @@
+#include "caffe2/python/pybind_state_registry.h"
+
+namespace caffe2 {
+namespace python {
+
+namespace py = pybind11;
+
+CAFFE_DEFINE_REGISTRY(PybindAdditionRegistry, PybindAddition, py::module&);
+
+} // namespace python
+} // namespace caffe2

--- a/caffe2/python/pybind_state_registry.h
+++ b/caffe2/python/pybind_state_registry.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include "caffe2/core/registry.h"
+
+namespace caffe2 {
+namespace python {
+
+namespace py = pybind11;
+
+struct PybindAddition {
+  PybindAddition() {}
+  PybindAddition(py::module&) {}
+  virtual ~PybindAddition(){};
+};
+
+CAFFE_DECLARE_REGISTRY(PybindAdditionRegistry, PybindAddition, py::module&);
+
+#define REGISTER_PYBIND_ADDITION(funcname)        \
+  namespace {                                     \
+  struct funcname##Impl : public PybindAddition { \
+    funcname##Impl(py::module& m) {               \
+      funcname(m);                                \
+    }                                             \
+  };                                              \
+  CAFFE_REGISTER_CLASS(                           \
+      PybindAdditionRegistry,                     \
+      funcname##Impl,                             \
+      funcname##Impl);                            \
+  }
+
+} // namespace python
+} // namespace caffe2


### PR DESCRIPTION
Summary: Adding a basic registry pattern to pybindstate so that we can have separate 'cc' files register module updates.  This is substantially cleaner than using multiple pybind modules (which have been known to cause bugs)

Differential Revision: D9441878
