### PR TITLE
[c10d] Added PrefixStore, pybind, test for group backward compatibility 

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -110,11 +110,35 @@ class FileStoreTest(TestCase, StoreTestBase):
         return c10d.FileStore(self.file.name)
 
 
+class PrefixFileStoreTest(TestCase, StoreTestBase):
+    def setUp(self):
+        self.file = tempfile.NamedTemporaryFile()
+        self.filestore = c10d.FileStore(self.file.name)
+        self.prefix = "test_prefix"
+
+    def tearDown(self):
+        self.file.close()
+
+    def _create_store(self):
+        return c10d.PrefixStore(self.prefix, self.filestore)
+
+
 class TCPStoreTest(TestCase, StoreTestBase):
     def _create_store(self):
         addr = 'localhost'
         port = find_free_port()
         return c10d.TCPStore(addr, port, True)
+
+
+class PrefixTCPStoreTest(TestCase, StoreTestBase):
+    def setUp(self):
+        addr = 'localhost'
+        port = find_free_port()
+        self.tcpstore = c10d.TCPStore(addr, port, True)
+        self.prefix = "test_prefix"
+
+    def _create_store(self):
+        return c10d.PrefixStore(self.prefix, self.tcpstore)
 
 
 class RendezvousTest(TestCase):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <c10d/TCPStore.hpp>
+#include <c10d/PrefixStore.hpp>
 #include <gloo/transport/tcp/device.h>
 #include <pybind11/chrono.h>
 
@@ -105,6 +106,9 @@ PyObject* c10d_init(PyObject* _unused) {
 
   shared_ptr_class_<::c10d::TCPStore>(module, "TCPStore", store)
       .def(py::init<const std::string&, int, bool>());
+
+  shared_ptr_class_<::c10d::PrefixStore>(module, "PrefixStore", store)
+      .def(py::init<const std::string&, ::c10d::Store&>());
 
   auto processGroup =
       shared_ptr_class_<::c10d::ProcessGroup>(module, "ProcessGroup")

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -73,6 +73,7 @@ set(C10D_SRCS
   FileStore.cpp
   ProcessGroup.cpp
   Store.cpp
+  PrefixStore.cpp
   TCPStore.cpp
   Utils.cpp
   ProcessGroupGloo.cpp
@@ -118,6 +119,7 @@ target_include_directories(c10d PUBLIC ${GLOO_INCLUDE_DIR})
 
 copy_header(CUDAUtils.hpp)
 copy_header(FileStore.hpp)
+copy_header(PrefixStore.hpp)
 copy_header(ProcessGroup.hpp)
 copy_header(Store.hpp)
 copy_header(TCPStore.hpp)

--- a/torch/lib/c10d/PrefixStore.cpp
+++ b/torch/lib/c10d/PrefixStore.cpp
@@ -1,0 +1,48 @@
+#include "PrefixStore.hpp"
+
+namespace c10d {
+
+PrefixStore::PrefixStore(const std::string& prefix, Store& store)
+    : prefix_(prefix), store_(store) {}
+
+std::string PrefixStore::joinKey(const std::string& key) {
+  return prefix_ + "/" + key;
+}
+
+std::vector<std::string> PrefixStore::joinKeys(
+    const std::vector<std::string>& keys) {
+  std::vector<std::string> joinedKeys;
+  joinedKeys.reserve(keys.size());
+  for (const auto& key : keys) {
+    joinedKeys.push_back(joinKey(key));
+  }
+  return joinedKeys;
+}
+
+void PrefixStore::set(
+    const std::string& key,
+    const std::vector<uint8_t>& value) {
+  store_.set(joinKey(key), value);
+}
+
+std::vector<uint8_t> PrefixStore::get(const std::string& key) {
+  return store_.get(joinKey(key));
+}
+
+int64_t PrefixStore::add(const std::string& key, int64_t value) {
+  return store_.add(joinKey(key), value);
+}
+
+bool PrefixStore::check(const std::vector<std::string>& keys) {
+  auto joinedKeys = joinKeys(keys);
+  return store_.check(joinedKeys);
+}
+
+void PrefixStore::wait(
+    const std::vector<std::string>& keys,
+    const std::chrono::milliseconds& timeout) {
+  auto joinedKeys = joinKeys(keys);
+  store_.wait(joinedKeys, timeout);
+}
+
+} // namespace c10d

--- a/torch/lib/c10d/PrefixStore.hpp
+++ b/torch/lib/c10d/PrefixStore.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <c10d/Store.hpp>
+
+namespace c10d {
+
+class PrefixStore : public Store {
+ public:
+  explicit PrefixStore(const std::string& prefix, Store& store);
+
+  virtual ~PrefixStore(){};
+
+  void set(const std::string& key, const std::vector<uint8_t>& value) override;
+
+  std::vector<uint8_t> get(const std::string& key) override;
+
+  int64_t add(const std::string& key, int64_t value) override;
+
+  bool check(const std::vector<std::string>& keys) override;
+
+  void wait(
+      const std::vector<std::string>& keys,
+      const std::chrono::milliseconds& timeout = kDefaultTimeout) override;
+
+ protected:
+  std::string prefix_;
+  Store& store_;
+
+  std::string joinKey(const std::string& key);
+  std::vector<std::string> joinKeys(const std::vector<std::string>& keys);
+};
+
+} // namespace c10d

--- a/torch/lib/c10d/test/FileStoreTest.cpp
+++ b/torch/lib/c10d/test/FileStoreTest.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include <c10d/FileStore.hpp>
+#include <c10d/PrefixStore.hpp>
 
 std::string tmppath() {
   const char* tmpdir = getenv("TMPDIR");
@@ -27,13 +28,14 @@ std::string tmppath() {
   return std::string(tmp.data(), tmp.size());
 }
 
-int main(int argc, char** argv) {
+void testHelper(const std::string prefix = "") {
   auto path = tmppath();
   std::cout << "Using temporary file: " << path << std::endl;
 
   // Basic set/get
   {
-    c10d::FileStore store(path);
+    c10d::FileStore fileStore(path);
+    c10d::PrefixStore store(prefix, fileStore);
     c10d::test::set(store, "key0", "value0");
     c10d::test::set(store, "key1", "value1");
     c10d::test::set(store, "key2", "value2");
@@ -44,7 +46,8 @@ int main(int argc, char** argv) {
 
   // Perform get on new instance
   {
-    c10d::FileStore store(path);
+    c10d::FileStore fileStore(path);
+    c10d::PrefixStore store(prefix, fileStore);
     c10d::test::check(store, "key0", "value0");
   }
 
@@ -55,7 +58,8 @@ int main(int argc, char** argv) {
   c10d::test::Semaphore sem1, sem2;
   for (auto i = 0; i < numThreads; i++) {
     threads.push_back(std::move(std::thread([&] {
-      c10d::FileStore store(path);
+      c10d::FileStore fileStore(path);
+      c10d::PrefixStore store(prefix, fileStore);
       sem1.post();
       sem2.wait();
       for (auto j = 0; j < numIterations; j++) {
@@ -71,12 +75,17 @@ int main(int argc, char** argv) {
 
   // Check that the counter has the expected value
   {
-    c10d::FileStore store(path);
+    c10d::FileStore fileStore(path);
+    c10d::PrefixStore store(prefix, fileStore);
     std::string expected = std::to_string(numThreads * numIterations);
     c10d::test::check(store, "counter", expected);
   }
 
   unlink(path.c_str());
+}
+
+int main(int argc, char** argv) {
+  testHelper();
+  testHelper("testPrefix");
   std::cout << "Test succeeded" << std::endl;
-  return 0;
 }

--- a/torch/lib/c10d/test/TCPStoreTest.cpp
+++ b/torch/lib/c10d/test/TCPStoreTest.cpp
@@ -4,11 +4,13 @@
 #include <iostream>
 #include <thread>
 
+#include <c10d/PrefixStore.hpp>
 #include <c10d/TCPStore.hpp>
 
-int main(int argc, char** argv) {
+void testHelper(const std::string& prefix = "") {
   // server store
-  c10d::TCPStore serverStore("127.0.0.1", 29500, true);
+  c10d::TCPStore serverTCPStore("127.0.0.1", 29500, true);
+  c10d::PrefixStore serverStore(prefix, serverTCPStore);
 
   // Basic set/get on the server store
   c10d::test::set(serverStore, "key0", "value0");
@@ -25,10 +27,13 @@ int main(int argc, char** argv) {
   c10d::test::Semaphore sem1, sem2;
 
   // Each thread will have a client store to send/recv data
-  std::vector<std::unique_ptr<c10d::TCPStore>> clientStores;
+  std::vector<std::unique_ptr<c10d::TCPStore>> clientTCPStores;
+  std::vector<std::unique_ptr<c10d::PrefixStore>> clientStores;
   for (auto i = 0; i < numThreads; i++) {
-    clientStores.push_back(std::unique_ptr<c10d::TCPStore>(
+    clientTCPStores.push_back(std::unique_ptr<c10d::TCPStore>(
         new c10d::TCPStore("127.0.0.1", 29500, false)));
+    clientStores.push_back(std::unique_ptr<c10d::PrefixStore>(
+        new c10d::PrefixStore(prefix, *clientTCPStores[i])));
   }
 
   std::string expectedCounterRes = std::to_string(numThreads * numIterations);
@@ -72,6 +77,7 @@ int main(int argc, char** argv) {
 
   // Clear the store to test that client disconnect won't shutdown the store
   clientStores.clear();
+  clientTCPStores.clear();
 
   // Check that the counter has the expected value
   c10d::test::check(serverStore, "counter", expectedCounterRes);
@@ -82,7 +88,10 @@ int main(int argc, char** argv) {
     std::string val = "thread_val_" + std::to_string(numIterations - 1);
     c10d::test::check(serverStore, key, val);
   }
-
+}
+int main(int argc, char** argv) {
+  testHelper();
+  testHelper("testPrefix");
   std::cout << "Test succeeded" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Added Prefix Store support.

This will make group be backward compatible.

Test is covered too.
```
tengli@devfair033:~/new_pytorch/pytorch/torch/lib/build/c10d/test$ ./FileStoreTest
Using temporary file: /tmp/testoglRl4
Using temporary file: /tmp/testepZIpB
Test succeeded
tengli@devfair033:~/new_pytorch/pytorch/torch/lib/build/c10d/test$ ./TCPStoreTest
Test succeeded
```