### PR TITLE
Fixes errors when linking caffe2 statically

### DIFF
--- a/aten/src/ATen/core/IdWrapper.h
+++ b/aten/src/ATen/core/IdWrapper.h
@@ -22,7 +22,7 @@ namespace at {
  * for you, given the underlying type supports it.
  */
 template <class ConcreteType, class UnderlyingType>
-class AT_CORE_API IdWrapper {
+class AT_CORE_EXPORT IdWrapper {
  public:
   using underlying_type = UnderlyingType;
   using concrete_type = ConcreteType;

--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -33,7 +33,7 @@ namespace c10 {
 // tells us if the object was allocated by us.  If it wasn't, no
 // intrusive_ptr for you!
 
-class AT_CORE_API intrusive_ptr_target {
+class intrusive_ptr_target {
   // Note [Weak references for intrusive refcounting]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Here's the scheme:

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -42,7 +42,7 @@ class TypeMeta;
  */
 class TypeIdentifier final : public at::IdWrapper<TypeIdentifier, uint16_t> {
  public:
-  static TypeIdentifier createTypeId();
+  AT_CORE_API static TypeIdentifier createTypeId();
 
   friend std::ostream& operator<<(
       std::ostream& stream,

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -236,7 +236,7 @@ class TypeMeta {
    * is generated during run-time. Do NOT serialize the id for storage.
    */
   template <typename T>
-  AT_CORE_API static TypeIdentifier Id();
+  static TypeIdentifier Id();
 
   /**
    * Returns the item size of the type. This is equivalent to sizeof(T).


### PR DESCRIPTION
Fixes #10746 and #10902.
The linking error is caused by the wrong usage of dllexport/dllimport. We don't need them if the implementation of the function is available from the external side.