### PR TITLE
Print blob sizes on fatal signal

### DIFF
--- a/caffe2/core/workspace.cc
+++ b/caffe2/core/workspace.cc
@@ -308,4 +308,9 @@ ThreadPool* Workspace::GetThreadPool() {
   return thread_pool_.get();
 }
 
+std::shared_ptr<Workspace::Bookkeeper> Workspace::bookkeeper() {
+  static auto shared = std::make_shared<Workspace::Bookkeeper>();
+  return shared;
+}
+
 } // namespace caffe2

--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -52,7 +52,7 @@ class CAFFE2_API Workspace {
   /**
    * Initializes an empty workspace.
    */
-  Workspace() : root_folder_("."), shared_(nullptr) {}
+  Workspace() : Workspace(".", nullptr) {}
 
   /**
    * Initializes an empty workspace with the given root folder.
@@ -62,7 +62,7 @@ class CAFFE2_API Workspace {
    * by the workspace.
    */
   explicit Workspace(const string& root_folder)
-      : root_folder_(root_folder), shared_(nullptr) {}
+      : Workspace(root_folder, nullptr) {}
 
   /**
    * Initializes a workspace with a shared workspace.
@@ -73,8 +73,7 @@ class CAFFE2_API Workspace {
    * and is responsible for making sure that its lifetime is longer than the
    * created workspace.
    */
-  explicit Workspace(const Workspace* shared)
-      : root_folder_("."), shared_(shared) {}
+  explicit Workspace(const Workspace* shared) : Workspace(".", shared) {}
 
   /**
    * Initializes workspace with parent workspace, blob name remapping
@@ -84,7 +83,7 @@ class CAFFE2_API Workspace {
   Workspace(
       const Workspace* shared,
       const std::unordered_map<string, string>& forwarded_blobs)
-      : root_folder_("."), shared_(nullptr) {
+      : Workspace(".", nullptr) {
     CAFFE_ENFORCE(shared, "Parent workspace must be specified");
     for (const auto& forwarded : forwarded_blobs) {
       CAFFE_ENFORCE(
@@ -97,13 +96,20 @@ class CAFFE2_API Workspace {
   /**
    * Initializes a workspace with a root folder and a shared workspace.
    */
-  Workspace(const string& root_folder, Workspace* shared)
-      : root_folder_(root_folder), shared_(shared) {}
+  Workspace(const string& root_folder, const Workspace* shared)
+      : root_folder_(root_folder), shared_(shared), bookkeeper_(bookkeeper()) {
+    std::lock_guard<std::mutex> guard(bookkeeper_->wsmutex);
+    bookkeeper_->workspaces.insert(this);
+  }
 
   ~Workspace() {
     if (FLAGS_caffe2_print_blob_sizes_at_exit) {
       PrintBlobSizes();
     }
+    // This is why we have a bookkeeper_ shared_ptr instead of a naked static! A
+    // naked static makes us vulnerable to out-of-order static destructor bugs.
+    std::lock_guard<std::mutex> guard(bookkeeper_->wsmutex);
+    bookkeeper_->workspaces.erase(this);
   }
 
   /**
@@ -284,10 +290,32 @@ class CAFFE2_API Workspace {
   bool RunOperatorOnce(const OperatorDef& op_def);
   bool RunNetOnce(const NetDef& net_def);
 
+  /**
+   * Applies a function f on each workspace that currently exists.
+   *
+   * This function is thread safe and there is no race condition between
+   * workspaces being passed to f in this thread and destroyed in another.
+   */
+  template <typename F>
+  static void ForEach(F f) {
+    auto bk = bookkeeper();
+    std::lock_guard<std::mutex> guard(bk->wsmutex);
+    for (Workspace* ws : bk->workspaces) {
+      f(ws);
+    }
+  }
+
  public:
   std::atomic<int> last_failed_op_net_position;
 
  private:
+  struct Bookkeeper {
+    std::mutex wsmutex;
+    std::unordered_set<Workspace*> workspaces;
+  };
+
+  static std::shared_ptr<Bookkeeper> bookkeeper();
+
   BlobMap blob_map_;
   NetMap net_map_;
   const string root_folder_;
@@ -296,6 +324,7 @@ class CAFFE2_API Workspace {
       forwarded_blobs_;
   std::unique_ptr<ThreadPool> thread_pool_;
   std::mutex thread_pool_creation_mutex_;
+  std::shared_ptr<Bookkeeper> bookkeeper_;
 
   AT_DISABLE_COPY_AND_ASSIGN(Workspace);
 };

--- a/caffe2/utils/signal_handler.cc
+++ b/caffe2/utils/signal_handler.cc
@@ -21,6 +21,7 @@
 #include <unordered_set>
 
 #include "caffe2/core/init.h"
+#include "caffe2/core/workspace.h"
 
 #if CAFFE2_ANDROID
 #ifndef SYS_gettid
@@ -162,6 +163,11 @@ std::vector<uintptr_t> getBacktrace() {
   return pcs;
 }
 
+void printBlobSizes() {
+  ::caffe2::Workspace::ForEach(
+      [&](::caffe2::Workspace* ws) { ws->PrintBlobSizes(); });
+}
+
 void printStacktrace() {
   std::vector<uintptr_t> pcs = getBacktrace();
   Dl_info info;
@@ -276,6 +282,7 @@ void fatalSignalHandler(int signum) {
   } else {
     perror("Failed to open /proc/self/task");
   }
+  printBlobSizes();
   sigaction(signum, getPreviousSigaction(signum), nullptr);
   raise(signum);
 }


### PR DESCRIPTION
Summary:
Added a `Workspace::ForEach(...)` API for accessing the global set of
existing Workspace instances. This is used in the signal handler to print blob
info on the thread receiving a fatal signal.

Differential Revision: D9147768
