### PR TITLE
[WIP][caffe2] Extend caffe2 FC/FCTranspose op to handle 2d bias.

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -691,8 +691,8 @@ Caffe2Ops Caffe2Backend::CreateGemm(
     const auto input_c_shape =
         input_c_vi_iter->second.type().tensor_type().shape();
 
-    if (input_c_shape.dim_size() != 1) {
-      return false;
+    if (input_c_shape.dim_size() == 2) {
+      return true;
     }
 
     // c is a scalar.


### PR DESCRIPTION
Currently, FC/FCTranspose only accepts 1d bias and broadcasts it to 2d matrix. If we have 2d bias, we could just bypass it to FC/FCTranspose op.

