### PR TITLE
Remove protobuf require and use requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+future
+numpy
 pyyaml
+setuptools
+six
 typing

--- a/setup.py
+++ b/setup.py
@@ -1064,7 +1064,6 @@ cmdclass = {
 cmdclass.update(build_dep_cmds)
 
 install_requires = [
-    'protobuf',
     'pyyaml',
     'numpy',
     'future',

--- a/setup.py
+++ b/setup.py
@@ -1063,14 +1063,6 @@ cmdclass = {
 }
 cmdclass.update(build_dep_cmds)
 
-install_requires = [
-    'pyyaml',
-    'numpy',
-    'future',
-    'setuptools',
-    'six',
-] if FULL_CAFFE2 else []
-
 entry_points = {}
 if FULL_CAFFE2:
     entry_points = {
@@ -1123,5 +1115,4 @@ if __name__ == '__main__':
                 'lib/include/torch/torch.h',
             ]
         },
-        install_requires=install_requires,
     )


### PR DESCRIPTION
In prep for making FULL_CAFFE2 default, users shouldn't be required to have protobuf installed.

cc @pjh5 