### PR TITLE
Back out "[pytorch][PR] Create at::linear"

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -1,27 +1,10 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/WrapDimUtilsMulti.h"
-
-#include <array>
 #include <cctype>
-#include <cstddef>
-#include <sstream>
-#include <string>
-#include <vector>
 
 namespace at { namespace native {
 
-Tensor linear(const Tensor& input, const Tensor& weight, const Tensor& bias) {
-  if (input.dim() == 2 && bias.defined()) {
-    // Fused op is marginally faster.
-    return at::addmm(bias, input, weight.t());
-  }
-  auto output = at::matmul(input, weight.t());
-  if (bias.defined()) {
-    output.add_(bias);
-  }
-  return output;
-}
 
 // sumproduct_pair computes `(left*right).sum(sumdims)` by means of permutation and
 // batch matrix multiplication
@@ -316,7 +299,7 @@ Tensor einsum(std::string eqn, TensorList tensors) {
       }
     }
     preprocessed_op = preprocessed_op.permute(permutation);
-    // finally, we insert dimensions for idxes not in the operand
+    // finally, we insert dimensions for idxes not in the operand 
     for (size_t dim = 0; dim < idx_to_dim.size(); dim++) {
       if (idx_to_dim[dim] == -1) {
         preprocessed_op = preprocessed_op.unsqueeze(dim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -928,9 +928,6 @@
 - func: layer_norm(Tensor input, IntList normalized_shape, Tensor? weight={}, Tensor? bias={}, double eps=1e-5, bool cudnn_enable=True) -> Tensor
   variants: function
 
-- func: linear(Tensor input, Tensor weight, Tensor bias={}) -> Tensor
-  variants: function
-
 - func: linspace(Scalar start, Scalar end, TensorOptions options={}) -> Tensor
   variants: function
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -28,7 +28,7 @@ SKIP_PYTHON_BINDINGS = [
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',
     'arange.*', 'range.*', '_gesv.*', '_getri.*', 'slice',
     '_local_scalar', '_local_scalar_dense',
-    'max_pool1d', 'max_pool2d', 'max_pool3d', 'linear'
+    'max_pool1d', 'max_pool2d', 'max_pool3d'
 ]
 
 # These function signatures are not exposed to Python. Note that this signature

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -22,15 +22,24 @@ void LinearImpl::reset() {
   }
 
   const auto stdv = 1.0 / std::sqrt(weight.size(1));
-  NoGradGuard no_grad;
+  NoGradGuard no_grad;;
   for (auto& p : parameters()) {
     p->uniform_(-stdv, stdv);
   }
 }
 
 Tensor LinearImpl::forward(Tensor input) {
-  AT_ASSERT(!options.with_bias_ || bias.defined());
-  return torch::linear(input, weight, bias);
+  if (input.ndimension() == 2 && options.with_bias_) {
+    // Fused op is marginally faster
+    AT_ASSERT(input.size(1) == weight.size(1));
+    return {torch::addmm(bias, input, weight.t())};
+  }
+
+  auto output = input.matmul(weight.t());
+  if (options.with_bias_) {
+    output += bias;
+  }
+  return output;
 }
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -20,6 +20,22 @@
 
 namespace torch {
 namespace nn {
+namespace {
+Tensor linear(Tensor x, Tensor w, Tensor b) {
+  if (x.ndimension() == 2 && b.defined()) {
+    // Fused op is marginally faster
+    assert(x.size(1) == w.size(1));
+    return torch::addmm(b, x, w.t());
+  }
+
+  auto output = x.matmul(w.t());
+  if (b.defined()) {
+    output += b;
+  }
+  return output;
+}
+} // namespace
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNNOptionsBase ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 namespace detail {
@@ -74,7 +90,7 @@ void RNNImplBase<Derived>::reset() {
   }
 
   const auto stdv = 1.0 / std::sqrt(options.hidden_size_);
-  NoGradGuard no_grad;
+  NoGradGuard no_grad;;
   for (auto& p : this->parameters()) {
     p->uniform_(-stdv, stdv);
   }
@@ -182,7 +198,7 @@ void RNNImplBase<Derived>::flatten_parameters_for_cudnn() {
   }
 
   {
-    NoGradGuard no_grad;
+    NoGradGuard no_grad;;
     flat_weights_ = torch::_cudnn_rnn_flatten_weight(
         flat_weights(),
         /*weight_stride=*/options.with_bias_ ? 4 : 2,
@@ -321,8 +337,8 @@ Tensor RNNImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
       ? state
       : torch::zeros({input.size(0), options.hidden_size_}, input.options());
 
-  auto h = torch::linear(input, w_ih[layer], b_ih[layer]) +
-      torch::linear(hx, w_hh[layer], b_hh[layer]);
+  auto h = linear(input, w_ih[layer], b_ih[layer]) +
+      linear(hx, w_hh[layer], b_hh[layer]);
 
   return torch::stack(activation_function_(h));
 }
@@ -343,8 +359,8 @@ Tensor LSTMImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
   auto hx = hid[0];
   auto cx = hid[1];
 
-  auto gates = torch::linear(input, w_ih[layer], b_ih[layer]) +
-      torch::linear(hx, w_hh[layer], b_hh[layer]);
+  auto gates = linear(input, w_ih[layer], b_ih[layer]) +
+      linear(hx, w_hh[layer], b_hh[layer]);
 
   auto chunked = gates.chunk(4, 1);
   auto in_gate = chunked[0].sigmoid();
@@ -371,8 +387,8 @@ Tensor GRUImpl::cell_forward(Tensor input, Tensor state, int64_t layer) {
       ? state
       : torch::zeros({input.size(0), options.hidden_size_}, input.options());
 
-  auto gi = torch::linear(input, w_ih[layer], b_ih[layer]);
-  auto gh = torch::linear(input, w_hh[layer], b_hh[layer]);
+  auto gi = linear(input, w_ih[layer], b_ih[layer]);
+  auto gh = linear(input, w_hh[layer], b_hh[layer]);
   auto gic = gi.chunk(3, 1);
   auto ghc = gh.chunk(3, 1);
 


### PR DESCRIPTION
Summary:
Multiple failing external and internal CI signals were ignored when this commit
was landed. goldsborough please fix the text failures and resubmit this change as a
new PR

Differential Revision: D9466791
