### PR TITLE
move instance_norm to aten

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -15,7 +15,7 @@ namespace {
              arg_name, " should contain ", expected, " elements not ", actual);
   }
 
-  Tensor repeat_if_defined(const Tensor& t, int64_t repeat) {
+  static inline Tensor repeat_if_defined(const Tensor& t, int64_t repeat) {
     if (t.defined()) {
       return t.repeat(repeat);
     }
@@ -91,9 +91,8 @@ Tensor instance_norm(
     const Tensor& input, const Tensor& weight /* optional */, const Tensor& bias /* optional */,
     const Tensor& running_mean /* optional */, const Tensor& running_var /* optional */,
     bool use_input_stats, double momentum, double eps, bool cudnn_enabled) {
-  if (!use_input_stats && (!running_mean.defined() || !running_var.defined())) {
-    throw std::runtime_error("Expected running_mean and running_var to be defined when use_input_stats is false");
-  }
+  AT_CHECK(use_input_stats || (running_mean.defined() && running_var.defined()),
+           "Expected running_mean and running_var to be defined when use_input_stats is false");
   std::vector<int64_t> shape = input.sizes().vec();
   int64_t b = input.size(0);
   int64_t c = input.size(1);

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -14,6 +14,13 @@ namespace {
     AT_CHECK(actual == expected,
              arg_name, " should contain ", expected, " elements not ", actual);
   }
+
+  Tensor repeat_if_defined(const Tensor& t, int64_t repeat) {
+    if (t.defined()) {
+      return t.repeat(repeat);
+    }
+    return t;
+  }
 }
 
 Tensor batch_norm(
@@ -78,6 +85,38 @@ Tensor batch_norm(
   return at::thnn_batch_norm(
             input.contiguous(), weight, bias,
             running_mean, running_var, training, momentum, eps);
+}
+
+Tensor instance_norm(
+    const Tensor& input, const Tensor& weight /* optional */, const Tensor& bias /* optional */,
+    const Tensor& running_mean /* optional */, const Tensor& running_var /* optional */,
+    bool use_input_stats, double momentum, double eps, bool cudnn_enabled) {
+  if (!use_input_stats && (!running_mean.defined() || !running_var.defined())) {
+    throw std::runtime_error("Expected running_mean and running_var to be defined when use_input_stats is false");
+  }
+  std::vector<int64_t> shape = input.sizes().vec();
+  int64_t b = input.size(0);
+  int64_t c = input.size(1);
+  shape[1] = b * c;
+  shape[0] = 1;
+
+  Tensor weight_ = repeat_if_defined(weight, b);
+  Tensor bias_ = repeat_if_defined(bias, b);
+  Tensor running_mean_ = repeat_if_defined(running_mean, b);
+  Tensor running_var_ = repeat_if_defined(running_var, b);
+
+  auto input_reshaped = input.contiguous().view(shape);
+  auto out = at::batch_norm(input_reshaped, weight_, bias_, running_mean_, running_var_,
+                            use_input_stats, momentum, eps, cudnn_enabled);
+
+  if (running_mean.defined()) {
+    at::alias(running_mean).copy_(running_mean_.view({ b, c }).mean(0, false));
+  }
+  if (running_var.defined()) {
+    at::alias(running_var).copy_(running_var_.view({ b, c }).mean(0, false));
+  }
+
+  return out.view(input.sizes());
 }
 
 Tensor layer_norm(const Tensor& input, IntList normalized_shape,

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -109,6 +109,7 @@ Tensor instance_norm(
   auto out = at::batch_norm(input_reshaped, weight_, bias_, running_mean_, running_var_,
                             use_input_stats, momentum, eps, cudnn_enabled);
 
+  // we alias running_mean and running_var because they are const but we want to modify their data
   if (running_mean.defined()) {
     at::alias(running_mean).copy_(running_mean_.view({ b, c }).mean(0, false));
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -873,6 +873,9 @@
 - func: index_put_(Tensor self, TensorList indices, Tensor values) -> Tensor
   variants: function, method
 
+- func: instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, double momentum, double eps, bool cudnn_enabled) -> Tensor
+  variants: function
+
 - func: inverse(Tensor self) -> Tensor
   variants: function, method
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6925,6 +6925,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
         # XXX: export_import on CUDA modules doesn't work (#11480)
         self._test_dcgan_models(self, device='cuda', check_export_import=False)
 
+    @staticmethod
     def _test_neural_style(self, device, check_export_import=True):
         class TransformerNet(torch.nn.Module):
             def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6928,9 +6928,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
         # XXX: export_import on CUDA modules doesn't work (#11480)
         self._test_dcgan_models(self, device='cuda', check_export_import=False)
 
-    # XXX: When this is fixed, write a CUDA test for this.
-    @unittest.skip('https://github.com/pytorch/pytorch/issues/8439 InstanceNormalization bug')
-    def test_neural_style(self):
+    def _test_neural_style(self, device, check_export_import=True):
         class TransformerNet(torch.nn.Module):
             def __init__(self):
                 super(TransformerNet, self).__init__()
@@ -7027,7 +7025,15 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                 out = self.conv2d(out)
                 return out
 
-        self.checkTrace(TransformerNet(), (torch.rand(5, 3, 224, 224),))
+        self.checkTrace(TransformerNet(), (torch.rand(5, 3, 64, 64),), export_import=check_export_import)
+
+    def test_neural_style(self):
+        self._test_neural_style(self, device='cpu')
+
+    @unittest.skipIf(not RUN_CUDA, "no CUDA")
+    def test_neural_style_cuda(self):
+        # XXX: export_import on CUDA modules doesn't work (#11480)
+        self._test_neural_style(self, device='cuda', check_export_import=False)
 
     @staticmethod
     def _test_mnist(self, device, check_export_import=True):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -297,9 +297,6 @@ class JitTestCase(TestCase):
         if export_import:
             ge = self.getExportImportCopy(ge)
 
-        if export_import:
-            ge = self.getExportImportCopy(ge)
-
         if verbose:
             print(ge.graph)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -297,6 +297,9 @@ class JitTestCase(TestCase):
         if export_import:
             ge = self.getExportImportCopy(ge)
 
+        if export_import:
+            ge = self.getExportImportCopy(ge)
+
         if verbose:
             print(ge.graph)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1348,6 +1348,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
         training, momentum, eps, torch.backends.cudnn.enabled
     )
 
+
 def instance_norm(input, running_mean=None, running_var=None, weight=None,
                   bias=None, use_input_stats=True, momentum=0.1, eps=1e-5):
     r"""Applies Instance Normalization for each channel in each data sample in a
@@ -1360,6 +1361,7 @@ def instance_norm(input, running_mean=None, running_var=None, weight=None,
         input, weight, bias, running_mean, running_var,
         use_input_stats, momentum, eps, torch.backends.cudnn.enabled
     )
+
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     r"""Applies Layer Normalization for last certain number of dimensions.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1348,7 +1348,6 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
         training, momentum, eps, torch.backends.cudnn.enabled
     )
 
-
 def instance_norm(input, running_mean=None, running_var=None, weight=None,
                   bias=None, use_input_stats=True, momentum=0.1, eps=1e-5):
     r"""Applies Instance Normalization for each channel in each data sample in a
@@ -1357,47 +1356,10 @@ def instance_norm(input, running_mean=None, running_var=None, weight=None,
     See :class:`~torch.nn.InstanceNorm1d`, :class:`~torch.nn.InstanceNorm2d`,
     :class:`~torch.nn.InstanceNorm3d` for details.
     """
-    if not use_input_stats and (running_mean is None or running_var is None):
-        raise ValueError('Expected running_mean and running_var to be not None when use_input_stats=False')
-
-    b, c = input.size(0), input.size(1)
-    if weight is not None:
-        weight = weight.repeat(b)
-    if bias is not None:
-        bias = bias.repeat(b)
-
-    import torch.onnx.symbolic
-
-    @torch.onnx.symbolic_override(torch.onnx.symbolic.instance_norm)
-    def _instance_norm(input, running_mean=None, running_var=None, weight=None,
-                       bias=None, use_input_stats=None, momentum=None, eps=None):
-        # Repeat stored stats and affine transform params if necessary
-        if running_mean is not None:
-            running_mean_orig = running_mean
-            running_mean = running_mean_orig.repeat(b)
-        if running_var is not None:
-            running_var_orig = running_var
-            running_var = running_var_orig.repeat(b)
-
-        # Apply instance norm
-        input_reshaped = input.contiguous().view(1, b * c, *input.size()[2:])
-
-        out = batch_norm(
-            input_reshaped, running_mean, running_var, weight=weight, bias=bias,
-            training=use_input_stats, momentum=momentum, eps=eps)
-
-        # Reshape and copy back
-        if running_mean is not None:
-            running_mean_orig.copy_(running_mean.view(b, c).mean(0, keepdim=False))
-        if running_var is not None:
-            running_var_orig.copy_(running_var.view(b, c).mean(0, keepdim=False))
-
-        return out.view(b, c, *input.size()[2:])
-    return _instance_norm(input, running_mean=running_mean,
-                          running_var=running_var, weight=weight, bias=bias,
-                          use_input_stats=use_input_stats, momentum=momentum,
-                          eps=eps)
-
+    return torch.instance_norm(
+        input, weight, bias, running_mean, running_var,
+        use_input_stats, momentum, eps, torch.backends.cudnn.enabled
+    )
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     r"""Applies Layer Normalization for last certain number of dimensions.

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -716,6 +716,11 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         return res
 
 
+@parse_args('v', 'v', 'v', 'v', 'v', 'i', 'f', 'f', 'i')
+def instance_norm(g, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled):
+    return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
+
+
 @parse_args('v', 'i', 'i', 'i')
 def unfold(g, input, dimension, size, step):
     return g.op("ATen", input, operator_s="unfold", dimension_i=dimension, size_i=size, step_i=step)
@@ -1020,22 +1025,6 @@ def repeat(g, self, repeats):
         if diff_dims > 0:
             self = view(g, self, [1] * diff_dims + sizes)
     return g.op("Tile", self, repeats)
-
-
-def instance_norm(g, input, **kwargs):
-    input_type = input.type().scalarType()
-    weight = kwargs.get("weight", None)
-    bias = kwargs.get("bias", None)
-    eps = kwargs.get("eps", 1e-5)
-    if weight is None:
-        weight = g.constant(1.0, [input.type().sizes()[1]], input_type)
-    else:
-        weight = g.op('Constant', value_t=weight)
-    if bias is None:
-        bias = g.constant(0.0, [input.type().sizes()[1]], input_type)
-    else:
-        bias = g.op('Constant', value_t=bias)
-    return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
 
 
 def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,


### PR DESCRIPTION
This also removes the usage of torch.onnx.symbolic_override in instance_norm. Fixes #8439. 