### PR TITLE
Caffe2 Functional enforcing inplace output

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -324,6 +324,10 @@ class CAFFE2_API OpSchema {
     return std::numeric_limits<int>::max();
   }
 
+  bool inplace_enforced(int x, int y) const {
+    return inplace_enforced_(x, y);
+  }
+
   friend std::ostream& operator<<(std::ostream& out, const OpSchema& schema);
 
   const std::vector<Argument>& args() const {

--- a/caffe2/python/functional.py
+++ b/caffe2/python/functional.py
@@ -89,6 +89,13 @@ class _Functional(object):
                     output_prefix, max_output, max_output
                 )
 
+            # There could be input-output inplace enforcement; replace the
+            # output names with input ones if such enforcements exist
+            for i in range(len(input_names)):
+                for j in range(len(output_names)):
+                    if schema.inplace_enforced(i, j):
+                        output_names[j] = input_names[i]
+
             op = core.CreateOperator(
                 op_type, input_names, output_names, **args
             )

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -612,6 +612,7 @@ void addObjectMethods(py::module& m) {
       // protobuf objects.
       .def("infer_tensor", &OpSchema::InferTensor)
       .def("CalculateOutput", &OpSchema::CalculateOutput)
+      .def("inplace_enforced", &OpSchema::inplace_enforced)
       .def("num_inputs_allowed", &OpSchema::num_inputs_allowed)
       .def("num_outputs_allowed", &OpSchema::num_outputs_allowed)
       .def("num_inputs_outputs_allowed", &OpSchema::num_inputs_outputs_allowed)


### PR DESCRIPTION
Summary: A few operators enforces in-place output (e.g., running mean/var for SpatialBN). Functional right now doesn't follow the inplace_enforced_ rules in OpSchema and therefore, the RunNetOnce() will fail on OpSchema->Verify(). Edit the output_names in Functional following the rules to pass check.

Reviewed By: jerryzh168

Differential Revision: D9470582
