### PR TITLE
proper sharing in ShareExternalPointer

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -196,6 +196,9 @@ TEST(TensorNonTypedTest, TensorChangeType) {
   EXPECT_TRUE(tensor.meta().Match<int>());
 
   // int and float are same size, so should retain the pointer
+  // NB: this is only true when the use_count of the underlying Storage is 1, if
+  // the underlying Storage is shared between multiple Tensors We'll create a
+  // new Storage when the data type changes
   EXPECT_TRUE(tensor.mutable_data<float>() == (float*)ptr);
   EXPECT_TRUE(tensor.data<float>() == (const float*)ptr);
   EXPECT_TRUE(tensor.meta().Match<float>());

--- a/caffe2/core/storage.h
+++ b/caffe2/core/storage.h
@@ -19,6 +19,9 @@
 namespace caffe2 {
 
 using DataType = TypeMeta;
+// TODO: changed to DataPtr in Aten when shared folder
+// is ready
+using DataPtr = std::shared_ptr<void>;
 
 class StorageImpl;
 using Storage = std::shared_ptr<StorageImpl>;
@@ -32,6 +35,29 @@ class StorageImpl {
   explicit StorageImpl(DeviceType device_type) : device_type_(device_type) {}
   StorageImpl(DeviceType device_type, TypeMeta data_type)
       : data_type_(data_type), device_type_(device_type) {}
+  template <typename Deleter = MemoryDeleter>
+  StorageImpl(
+      DeviceType device_type,
+      TypeMeta data_type,
+      void* src,
+      size_t capacity,
+      Deleter d = nullptr)
+      : data_type_(data_type), device_type_(device_type) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        data_type_.id() != TypeIdentifier::uninitialized(),
+        "To create storage with a raw external pointer you need to pass in an "
+        "initialized data_type(TypeMeta).");
+    // Check if the deleter is a MemoryDeleter and is a simple nullptr.
+    if (std::is_same<MemoryDeleter, Deleter>::value &&
+        reinterpret_cast<MemoryDeleter*>(static_cast<void*>(&d))[0] ==
+            nullptr) {
+      // Use aliasing constructor trick to avoid calling the destructor.
+      data_ptr_ = std::shared_ptr<void>(std::shared_ptr<void>(), src);
+    } else {
+      data_ptr_.reset(src, d);
+    }
+    capacity_ = capacity;
+  }
 
   void reset() {
     data_ptr_.reset();
@@ -43,12 +69,24 @@ class StorageImpl {
     return data_type_.Match<T>();
   }
 
-  const void* data_ptr() const {
+  const void* data() const {
     return data_ptr_.get();
   }
 
-  void* data_ptr() {
+  void* data() {
     return data_ptr_.get();
+  }
+
+  DataPtr& data_ptr() {
+    return data_ptr_;
+  }
+
+  const DataPtr& data_ptr() const {
+    return data_ptr_;
+  }
+
+  void set_dtype(const DataType& data_type) {
+    data_type_ = data_type;
   }
 
   const DataType& dtype() const {
@@ -63,8 +101,9 @@ class StorageImpl {
     return capacity_ / itemsize();
   }
 
-  inline void set_device_type(DeviceType device_type) {
-    device_type_ = device_type;
+  // TODO: remove later
+  void set_numel(int64_t numel) {
+    capacity_ = numel * itemsize();
   }
 
   inline DeviceType device_type() const {
@@ -80,13 +119,27 @@ class StorageImpl {
   ~StorageImpl() = default;
   StorageImpl& operator=(StorageImpl&&) = default;
 
- protected:
+  /**
+   * Can only be called when use_count is 1
+   */
   template <typename Deleter = MemoryDeleter>
-  void ShareExternalPointer(
+  void SingleUseStorageShareExternalPointer(
       void* src,
       const DataType& data_type,
-      size_t capacity = 0,
+      size_t capacity,
       Deleter d = nullptr) {
+    // TODO: this will be added in the intrusive_ptr diff
+    // CAFFE_ENFORCE_WITH_CALLER(
+    //     use_count() == 1,
+    //     "SingleUseStorageShareExternalPointer can only be called when
+    //     use_count == 1");
+    data_type_ = data_type;
+    CAFFE_ENFORCE_WITH_CALLER(
+        data_type_.id() != TypeIdentifier::uninitialized(),
+        "To share with a raw external pointer you need to have meta "
+        "already set.");
+    CAFFE_ENFORCE_WITH_CALLER(
+        capacity >= 0, "capacity must be valid for ShareExternalPointer");
     // Check if the deleter is a MemoryDeleter and is a simple nullptr.
     if (std::is_same<MemoryDeleter, Deleter>::value &&
         reinterpret_cast<MemoryDeleter*>(&d)[0] == nullptr) {
@@ -95,16 +148,10 @@ class StorageImpl {
     } else {
       data_ptr_.reset(src, d);
     }
-    // Sets capacity. If not specified, we will implicitly assume that
-    // the capacity is the current size.
-    if (capacity) {
-      capacity_ = capacity;
-    }
+    capacity_ = capacity;
   }
 
-  // TODO: changed to DataPtr in Aten when shared folder
-  // is ready
-  using DataPtr = std::shared_ptr<void>;
+ private:
   int64_t capacity_ = 0;
   DataType data_type_;
   DataPtr data_ptr_;
@@ -112,8 +159,32 @@ class StorageImpl {
   // Allocator* allocator_;
   DeviceType device_type_ = CPU;
 
-  friend class TensorImpl;
 };
+
+/**
+ * Create a Storage given an external pointer `src`.
+ * `device_type`: the device type of the storage
+ * `capacity`: the capacity of the Tensor
+ */
+template <typename T, typename Deleter = MemoryDeleter>
+Storage CreateStorage(
+    T* src,
+    DeviceType device_type,
+    size_t capacity = 0,
+    Deleter d = nullptr) {
+  return CreateStorage(src, device_type, TypeMeta::Make<T>(), capacity, d);
+}
+
+template <typename Deleter = MemoryDeleter>
+Storage CreateStorage(
+    void* src,
+    DeviceType device_type,
+    const TypeMeta& meta,
+    size_t capacity, /* need to specify capacity of the storage */
+    Deleter d = nullptr) {
+  // We include capacity here because this will be a public function.
+  return std::make_shared<StorageImpl>(device_type, meta, src, capacity, d);
+}
 
 } // namespace caffe2
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -205,7 +205,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if ((void*)&src == (void*)this) {
       return;
     }
-    storage_->data_type_ = src.storage()->dtype();
+    if (storage_->dtype() != src.meta()) {
+      storage_ = std::make_shared<StorageImpl>(GetDeviceType(), src.meta());
+    }
     if (src.size() == -1) {
       dims_.clear();
       size_ = -1;
@@ -277,7 +279,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
         "Can't call Extend on shared storage, please call Resize instead");
     auto newDims = dims_;
     newDims[0] += num;
-    if (!storage_->data_ptr()) {
+    if (!storage_->data()) {
       Resize(newDims);
       return;
     }
@@ -294,7 +296,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     auto newCapacity = dims_;
     newCapacity[0] = std::max<size_t>(
         newDims[0], std::ceil(dims_[0] * (growthPct + 100) / 100));
-    auto oldData = std::move(storage_->data_ptr_);
+    auto oldData = std::move(storage_->data_ptr());
     auto oldSize = size_;
     auto oldDims = dims_;
     Resize(newCapacity);
@@ -354,7 +356,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       return;
     }
     // Old data is discarded
-    storage_->data_ptr_.reset();
+    storage_->data_ptr().reset();
     auto oldSize = size_;
     auto oldDims = dims_;
     Resize(newCapacity);
@@ -486,10 +488,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * The source tensor should already have its data allocated.
    */
   void ShareData(const TensorImpl& src) {
-    CAFFE_ENFORCE(
-        storage_.use_count() == 1,
-        "Can't share data if underlying storage used by more than one tensor");
-    storage_->data_type_ = src.storage()->data_type_;
+    // Right now, we are assuming the device_type are the same, since it is
+    // inherently the same in the non-templatized code. We should probably add
+    // an ENFORCE here which might affect perf a little bit.
     CAFFE_ENFORCE_EQ_WITH_CALLER(
         src.size_,
         size_,
@@ -498,11 +499,13 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     // in which case ShareData() doesn't make much sense since we don't really
     // know what to share yet.
     CAFFE_ENFORCE_WITH_CALLER(
-        src.storage()->data_ptr() || src.size_ == 0,
+        src.storage()->data() || src.size_ == 0,
         "Source tensor has no content and has size > 0");
     // Finally, do sharing.
-    storage_->data_ptr_ = src.storage()->data_ptr_;
-    storage_->capacity_ = src.storage()->capacity_;
+    /* Since we create new Storage whenever we need to change data_type/capacity
+     * this still keeps the original semantics
+     */
+    storage_ = src.storage();
   }
 
   /**
@@ -514,16 +517,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * using it. If a Deleter object is passed in, when this tensor is reallocated
    * or freed, the deleter function is going to be called.
    */
-  // TODO: Change to ShareExternalStorage
   template <typename T, typename Deleter = MemoryDeleter>
   void ShareExternalPointer(T* src, size_t capacity = 0, Deleter d = nullptr) {
     ShareExternalPointer(src, TypeMeta::Make<T>(), capacity, d);
-    // Sets capacity. If not specified, we will implicitly assume that
-    // the capacity is the current size.
-    if (!capacity) {
-      capacity = size_ * storage_->itemsize();
-    }
-    storage_->capacity_ = capacity;
   }
 
   template <typename Deleter = MemoryDeleter>
@@ -532,18 +528,23 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       const TypeMeta& data_type,
       size_t capacity = 0,
       Deleter d = nullptr) {
-    CAFFE_ENFORCE(
-        storage_.use_count() == 1,
-        "Can't share external pointer if underlying storage used by more than one tensor");
-    storage_->data_type_ = data_type;
     CAFFE_ENFORCE_WITH_CALLER(
-        storage_->data_type_.id() != TypeIdentifier::uninitialized(),
-        "To share with a raw external pointer you need to have meta "
-        "already set.");
-    CAFFE_ENFORCE_WITH_CALLER(
-        size_ >= 0,
-        "To share data with a raw pointer, you need to set shape first.");
-    storage_->ShareExternalPointer(src, data_type, capacity, d);
+        data_type.id() != TypeIdentifier::uninitialized(),
+        "To share with a raw external pointer you need to pass in an "
+        "initialized data_type(TypeMeta).");
+    if (!capacity) {
+      capacity = size_ * data_type.itemsize();
+    }
+    if (storage_.use_count() == 1) {
+      CAFFE_ENFORCE_WITH_CALLER(
+          size_ >= 0,
+          "To share data with a raw pointer, you need to set shape first.");
+      storage_->SingleUseStorageShareExternalPointer(
+          src, data_type, capacity, d);
+    } else {
+      // Create a new Storage
+      storage_ = CreateStorage(src, GetDeviceType(), data_type, capacity, d);
+    }
   }
 
   /**
@@ -551,8 +552,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * or raw_mutable_data() must have been called prior to this function call.
    */
   inline const void* raw_data() const {
-    CAFFE_ENFORCE_WITH_CALLER(storage_->data_ptr() || size_ == 0);
-    return storage_->data_ptr();
+    CAFFE_ENFORCE_WITH_CALLER(storage_->data() || size_ == 0);
+    return storage_->data();
   }
 
   /**
@@ -564,7 +565,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   template <typename T>
   inline const T* data() const {
     CAFFE_ENFORCE_WITH_CALLER(
-        storage_->data_ptr() || size_ == 0,
+        storage_->data() || size_ == 0,
         "The tensor is of non-zero shape, but its data is not allocated yet. "
         "Caffe2 uses a lazy allocation, so you will need to call "
         "mutable_data() or raw_mutable_data() to actually allocate memory.");
@@ -574,7 +575,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
         TypeMeta::TypeName<T>(),
         " while tensor contains ",
         storage_->dtype().name());
-    return static_cast<T*>(storage_->data_ptr());
+    return static_cast<T*>(storage_->data());
   }
 
   /**
@@ -590,12 +591,20 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   inline void* raw_mutable_data(const TypeMeta& meta) {
     // For 0-size tensors it's fine to return any pointer (including nullptr)
-    if (storage_->dtype() == meta && (storage_->data_ptr() || size_ == 0)) {
-      return storage_->data_ptr();
+    if (storage_->dtype() == meta && (storage_->data() || size_ == 0)) {
+      return storage_->data();
     } else {
       bool had_special_dtor = storage_->dtype().dtor() != nullptr;
-      // TODO: we should create a new Storage here.
-      storage_->data_type_ = meta;
+      if (storage_.use_count() == 1) {
+        storage_->set_dtype(meta);
+        // TODO: recalcuate numel when we store numel instead of capacity in
+        // Storage
+      } else {
+        if (storage_->dtype() != meta) {
+          storage_ =
+              std::make_shared<StorageImpl>(storage_->device_type(), meta);
+        }
+      }
       CAFFE_ENFORCE_WITH_CALLER(
           size_ >= 0,
           "Tensor is not initialized. You probably need to call Resize() "
@@ -607,7 +616,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       if (size_ == 0 ||
           (meta.ctor() == nullptr && !had_special_dtor &&
            storage_->capacity() >= size_ * storage_->itemsize())) {
-        return storage_->data_ptr();
+        return storage_->data();
       }
       if (meta.ctor()) {
         // For types that need placement new, we will call it, as well as
@@ -618,21 +627,21 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
         auto ptr_and_deleter =
             GetStaticContext()->New(size_ * storage_->itemsize());
         auto deleter = ptr_and_deleter.second;
-        storage_->data_ptr_.reset(
+        storage_->data_ptr().reset(
             ptr_and_deleter.first, [size, dtor, deleter](void* ptr) -> void {
               dtor(ptr, size);
               deleter(ptr);
             });
-        storage_->dtype().ctor()(storage_->data_ptr(), size_);
+        storage_->dtype().ctor()(storage_->data(), size_);
       } else {
         // For fundamental type, new and delete is easier.
         auto ptr_and_deleter =
             GetStaticContext()->New(size_ * storage_->itemsize());
-        storage_->data_ptr_.reset(
+        storage_->data_ptr().reset(
             ptr_and_deleter.first, ptr_and_deleter.second);
       }
-      storage_->capacity_ = size_ * storage_->itemsize();
-      return storage_->data_ptr();
+      storage_->set_numel(size_);
+      return storage_->data();
     }
   }
 
@@ -661,8 +670,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline T* mutable_data() {
-    if ((size_ == 0 || storage_->data_ptr()) && IsType<T>()) {
-      return static_cast<T*>(storage_->data_ptr());
+    if ((size_ == 0 || storage_->data()) && IsType<T>()) {
+      return static_cast<T*>(storage_->data());
     }
     // Check it here statically - otherwise TypeMeta would throw the runtime
     // error in attempt to invoke TypeMeta::ctor()


### PR DESCRIPTION
Summary:
Make ShareData and ShareExternalPointer to create new storage when the old one is used by multiple tensors.
When we need to modify the field of storage, we'll create a new storage instead.

Differential Revision: D9350686
