### PR TITLE
[Caffe2] fix mobile exportor kTypeNameMapper miss float64 bug

### DIFF
--- a/caffe2/python/predictor/mobile_exporter.py
+++ b/caffe2/python/predictor/mobile_exporter.py
@@ -16,6 +16,7 @@ def add_tensor(net, name, blob):
         uint8 is stored as an array of string with one element.
     '''
     kTypeNameMapper = {
+        np.dtype('float64'): "GivenTensorDoubleFill",
         np.dtype('float32'): "GivenTensorFill",
         np.dtype('int32'): "GivenTensorIntFill",
         np.dtype('int64'): "GivenTensorInt64Fill",


### PR DESCRIPTION
Summary:
File "convert_onnx_to_caffe2.py", line 27, in <module>
  inin_net, predict_net = mobile_exporter.Export(workspace, model, model.external_input)
File "/usr/local/lib/python3.6/dist-packages/caffe2/python/predictor/mobile_exporter.py", line 76, in Export
  add_tensor(init_net, blob_name, blob)
File "/usr/local/lib/python3.6/dist-packages/caffe2/python/predictor/mobile_exporter.py", line 41, in add_tensor
  kTypeNameMapper[blob.dtype],
KeyError: dtype("float64")

