### PR TITLE
Tuples/Lists can now be inputs/outputs to script and other simple fixes.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2037,13 +2037,13 @@ class TestScript(JitTestCase):
             a, b = x
             return b, a
 
-        a = (torch.ones(3), torch.ones(3))
+        a = (torch.rand(3), torch.rand(3))
         self.checkScript(stuff, (a,))
 
     def test_tuple_create_return(self):
         def stuff2(x):
             # type: (int) -> Tuple[Tensor, Tensor]
-            a = (torch.ones(x), torch.ones(x))
+            a = (torch.ones(x), torch.zeros(x))
             return a
         self.checkScript(stuff2, (3,))
 
@@ -6796,9 +6796,10 @@ class TestCustomOperators(JitTestCase):
 
     def test_passing_and_returning_lists(self):
         # Replace with actual test once we support lists.
-        a, b = torch.ones(5), torch.ones(5)
+        a, b = torch.rand(5), torch.rand(5)
         output = torch.ops.aten.cat([a, b])
-        self.assertEqual(output, torch.ones(10))
+        output_ref = torch.cat([a, b])
+        self.assertEqual(output, output_ref)
 
     def test_script_graph_contains_custom_op(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5053,11 +5053,10 @@ a")
                 return x.splork(3)
 
     def test_return_tuple(self):
-        with self.assertRaisesRegex(RuntimeError, 'only supported return types'):
-            @torch.jit.script
-            def return_tuple(x):
-                a = (x, x)
-                return a, x
+        def return_tuple(x):
+            a = (x, x)
+            return a, x
+        self.checkScript(return_tuple, (torch.rand(4),))
 
     def test_method_no_self(self):
         with self.assertRaisesRegex(RuntimeError, 'methods must have a self argument'):
@@ -6741,24 +6740,21 @@ class TestCustomOperators(JitTestCase):
     def test_passing_too_many_args(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "Expected at most 1 argument\(s\) for operator 'aten::relu', " +
-            "but received 2 argument\(s\). " +
-            "Schema: aten::relu\(Tensor self\) -> Tensor",
+            "aten::relu\(\) expected at most 1 argument\(s\) but received 2 argument\(s\)"
         ):
             torch.ops.aten.relu(1, 2)
 
     def test_passing_too_few_args(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "Missing value for argument 'self' to operator 'aten::relu'. " +
-            "Schema: aten::relu\(Tensor self\) -> Tensor",
+            "aten::relu\(\) is missing value for argument 'self'."
         ):
             torch.ops.aten.relu()
 
     def test_passing_one_positional_but_not_the_second(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "Missing value for argument 'dim' to operator 'aten::log_softmax'"
+            "aten::log_softmax\(\) is missing value for argument 'dim'."
         ):
             torch.ops.aten.log_softmax(torch.ones(5))
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6466,8 +6466,6 @@ class TestPytorchExportModes(JitTestCase):
 EXCLUDE_TRACED = {
     'test_split_dim',
     'test_split_dim_neg0',
-    'test_gesv',
-    'test_inverse',
 
     # nn functional test
     # schema not found for onnx node

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -21,6 +21,7 @@
 #include "torch/csrc/jit/passes/constant_propagation.h"
 #include "torch/csrc/jit/passes/loop_unrolling.h"
 #include "torch/csrc/jit/passes/to_batch.h"
+#include "torch/csrc/jit/passes/lower_tuples.h"
 #include "torch/csrc/jit/passes/specialize_undef.h"
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/script/init.h"
@@ -67,6 +68,7 @@ void initJITBindings(PyObject *module) {
 
   m.def("_jit_init", loadPythonClasses)
    .def("_jit_pass_onnx", ToONNX)
+   .def("_jit_pass_lower_all_tuples", LowerAllTuples)
    .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)
    .def("_jit_pass_fuse", FuseGraph)
    .def("_jit_pass_dce", [](std::shared_ptr<Graph>& g) {

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -5,34 +5,150 @@
 
 namespace torch { namespace jit {
 
-static void LowerTuples(Block* block);
+// operators where we expect to find tuples as inputs/outputs
+// this is to assert we are only  doing modifications when we know
+// we can flatten tuples
+std::unordered_set<Symbol> white_list = {
+  prim::If,
+  prim::Loop,
+  prim::TupleUnpack,
+  prim::TupleConstruct,
+  prim::Param,
+  prim::Return,
+};
 
-static void VisitNode(Node* n) {
+
+static void LowerAllTuples(Block* block);
+
+static void VisitNode(Node* n, Node* insert_point) {
+  auto & graph = *n->owningGraph();
+
+  // tuple construction operators will become dead when the unpacks are replaced
+  if(n->kind() == prim::TupleConstruct) {
+    return;
+  }
+
   // make any TupleUnpack dead by undoing TupleUnpack(TupleConstruct())
   if(n->kind() == prim::TupleUnpack) {
     auto construct = n->input()->node();
-    if(construct->kind() == prim::TupleConstruct) {
-      for(size_t i = 0; i < n->outputs().size(); ++i) {
-        n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
+    // note: removing these asserts changes this pass from a complete lowering
+    // pass to one that removes tuples when possible. When tuples are first-class
+    // in the interpreter, we should still run this pass to remove extraneous uses
+    JIT_ASSERTM(construct->kind() == prim::TupleConstruct, "tuple unpack not matched to tuple construct");
+    for(size_t i = 0; i < n->outputs().size(); ++i) {
+      n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
+    }
+    return;
+  }
+  // flatten the input list  op(a, tup, b) --> op(a, t0, t1, b)
+  for(size_t i = 0; i < n->inputs().size();) {
+    auto input = n->inputs()[i];
+    if(TupleTypePtr tt = input->type()->cast<TupleType>()) {
+      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
+      JIT_ASSERTM(input->node()->kind() == prim::TupleConstruct, "tuple use not matched to tuple construct");
+      for(size_t j = 0; j < tt->elements().size(); ++j) {
+        n->insertInput(i + 1 + j, input->node()->inputs().at(j));
       }
-      // op is now dead let dce clean up
-      return;
+      n->removeInput(i);
+      // note: no update to i
+      // since tuples might be nested we need to recursively scan
+      // the new flattened inputs
+    } else {
+      ++i;
     }
   }
-
   for(auto b : n->blocks()) {
-    LowerTuples(b);
+    LowerAllTuples(b);
+  }
+
+  // flatten the outputs list
+  for(size_t i = 0; i < n->outputs().size();) {
+    Value * output = n->outputs()[i];
+    // (a, b, tup, c) -> (a, b, t0, t1, c)
+    // and:
+    //    tup = (t0, t1)
+    // is placed at the current insertion point
+    if(TupleTypePtr tt = output->type()->cast<TupleType>()) {
+      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
+      for(size_t j = 0; j < tt->elements().size(); j++) {
+        n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
+      }
+      auto new_tup = graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
+      new_tup->insertBefore(insert_point);
+      insert_point = new_tup;
+      output->replaceAllUsesWith(new_tup->output());
+      n->eraseOutput(i);
+      // note: no update to i to handle nested tuples
+    } else {
+      ++i;
+    }
   }
 }
 
-static void LowerTuples(Block* block) {
+static void LowerAllTuples(Block* block) {
+  // tuples in parameter lists of a block behave exactly the same as
+  // _outputs_ of normal instructions, since the param_node represents the
+  // parameters as outputs, we can handle it by simply visiting the node
+  VisitNode(block->param_node(), *block->nodes().begin());
+  for(auto it = block->nodes().begin(), end = block->nodes().end(); it != end;) {
+    auto n = *it++;
+    VisitNode(n, *it);
+  }
+  // tuples in return lists of blocks behave exactly the same as
+  // _inputs_ of normal instructions, so we can use VisitNode here as well
+  // insert_point is null because it will never be used since return nodes
+  // have no outputs
+  VisitNode(block->return_node(), nullptr);
+}
+
+
+static void EnsureNoTuples(ArrayRef<Value*> values) {
+  for (Value * v : values) {
+    JIT_ASSERTM(v->type()->kind() != TypeKind::TupleType,
+                "Couldn't lower all tuples.");
+  }
+}
+
+static void EnsureNoTuples(Block* block) {
+  for (Node* n : block->nodes()) {
+    for (Block* b : n->blocks()) {
+      EnsureNoTuples(b);
+    }
+    EnsureNoTuples(n->outputs());
+  }
+}
+
+void LowerAllTuples(std::shared_ptr<Graph>& graph) {
+  // we can't lower all tuples if are tuples in the input or outputs
+  // we need to check because LowerTuples will try to flatten them,
+  // editing the inputs/outputs to the graph in a way that is not desired
+  EnsureNoTuples(graph->inputs());
+  EnsureNoTuples(graph->outputs());
+
+  LowerAllTuples(graph->block());
+  EliminateDeadCode(graph);
+  EnsureNoTuples(graph->block());
+}
+
+static void LowerSimpleTuples(Block* block) {
   for(auto n : block->nodes()) {
-    VisitNode(n);
+    // make any TupleUnpack dead by undoing TupleUnpack(TupleConstruct())
+    if(n->kind() == prim::TupleUnpack) {
+      auto construct = n->input()->node();
+      if(construct->kind() == prim::TupleConstruct) {
+        for(size_t i = 0; i < n->outputs().size(); ++i) {
+          n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
+        }
+      }
+    }
+    for(auto b : n->blocks()) {
+      LowerSimpleTuples(b);
+    }
   }
 }
 
-void LowerTuples(std::shared_ptr<Graph>& graph) {
-  LowerTuples(graph->block());
+void LowerSimpleTuples(std::shared_ptr<Graph>& graph) {
+  LowerSimpleTuples(graph->block());
   EliminateDeadCode(graph);
 }
 

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -5,119 +5,35 @@
 
 namespace torch { namespace jit {
 
-// operators where we expect to find tuples as inputs/outputs
-// this is to assert we are only  doing modifications when we know
-// we can flatten tuples
-std::unordered_set<Symbol> white_list = {
-  prim::If,
-  prim::Loop,
-  prim::TupleUnpack,
-  prim::TupleConstruct,
-  prim::Param,
-  prim::Return,
-};
-
-
 static void LowerTuples(Block* block);
 
-static void VisitNode(Node* n, Node* insert_point) {
-  auto & graph = *n->owningGraph();
-
-  // tuple construction operators will become dead when the unpacks are replaced
-  if(n->kind() == prim::TupleConstruct) {
-    return;
-  }
-
+static void VisitNode(Node* n) {
   // make any TupleUnpack dead by undoing TupleUnpack(TupleConstruct())
   if(n->kind() == prim::TupleUnpack) {
     auto construct = n->input()->node();
-    // note: removing these asserts changes this pass from a complete lowering
-    // pass to one that removes tuples when possible. When tuples are first-class
-    // in the interpreter, we should still run this pass to remove extraneous uses
-    JIT_ASSERTM(construct->kind() == prim::TupleConstruct, "tuple unpack not matched to tuple construct");
-    for(size_t i = 0; i < n->outputs().size(); ++i) {
-      n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
-    }
-    return;
-  }
-  // flatten the input list  op(a, tup, b) --> op(a, t0, t1, b)
-  for(size_t i = 0; i < n->inputs().size();) {
-    auto input = n->inputs()[i];
-    if(TupleTypePtr tt = input->type()->cast<TupleType>()) {
-      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
-      JIT_ASSERTM(input->node()->kind() == prim::TupleConstruct, "tuple use not matched to tuple construct");
-      for(size_t j = 0; j < tt->elements().size(); ++j) {
-        n->insertInput(i + 1 + j, input->node()->inputs().at(j));
+    if(construct->kind() == prim::TupleConstruct) {
+      for(size_t i = 0; i < n->outputs().size(); ++i) {
+        n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
       }
-      n->removeInput(i);
-      // note: no update to i
-      // since tuples might be nested we need to recursively scan
-      // the new flattened inputs
-    } else {
-      ++i;
+      // op is now dead let dce clean up
+      return;
     }
-  }
-  for(auto b : n->blocks()) {
-    LowerTuples(b);
   }
 
-  // flatten the outputs list
-  for(size_t i = 0; i < n->outputs().size();) {
-    Value * output = n->outputs()[i];
-    // (a, b, tup, c) -> (a, b, t0, t1, c)
-    // and:
-    //    tup = (t0, t1)
-    // is placed at the current insertion point
-    if(TupleTypePtr tt = output->type()->cast<TupleType>()) {
-      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
-      for(size_t j = 0; j < tt->elements().size(); j++) {
-        n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
-      }
-      auto new_tup = graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
-      new_tup->insertBefore(insert_point);
-      insert_point = new_tup;
-      output->replaceAllUsesWith(new_tup->output());
-      n->eraseOutput(i);
-      // note: no update to i to handle nested tuples
-    } else {
-      ++i;
-    }
+  for(auto b : n->blocks()) {
+    LowerTuples(b);
   }
 }
 
 static void LowerTuples(Block* block) {
-  // tuples in parameter lists of a block behave exactly the same as
-  // _outputs_ of normal instructions, since the param_node represents the
-  // parameters as outputs, we can handle it by simply visiting the node
-  VisitNode(block->param_node(), *block->nodes().begin());
-  for(auto it = block->nodes().begin(), end = block->nodes().end(); it != end;) {
-    auto n = *it++;
-    VisitNode(n, *it);
-  }
-  // tuples in return lists of blocks behave exactly the same as
-  // _inputs_ of normal instructions, so we can use VisitNode here as well
-  // insert_point is null because it will never be used since return nodes
-  // have no outputs
-  VisitNode(block->return_node(), nullptr);
-}
-
-static void EnsureNoTuples(Block* block) {
-  for (Node* n : block->nodes()) {
-    for (Block* b : n->blocks()) {
-      EnsureNoTuples(b);
-    }
-    for (Value * o : n->outputs()) {
-      JIT_ASSERTM(o->type()->kind() != TypeKind::TupleType,
-                  "Couldn't lower all tuples. This is an error because "
-                  "they're not implemented in the interpreter just yet.");
-    }
+  for(auto n : block->nodes()) {
+    VisitNode(n);
   }
 }
 
 void LowerTuples(std::shared_ptr<Graph>& graph) {
   LowerTuples(graph->block());
   EliminateDeadCode(graph);
-  EnsureNoTuples(graph->block());
 }
 
 }}

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -119,12 +119,6 @@ static void EnsureNoTuples(Block* block) {
 }
 
 void LowerAllTuples(std::shared_ptr<Graph>& graph) {
-  // we can't lower all tuples if are tuples in the input or outputs
-  // we need to check because LowerTuples will try to flatten them,
-  // editing the inputs/outputs to the graph in a way that is not desired
-  EnsureNoTuples(graph->inputs());
-  EnsureNoTuples(graph->outputs());
-
   LowerAllTuples(graph->block());
   EliminateDeadCode(graph);
   EnsureNoTuples(graph->block());

--- a/torch/csrc/jit/passes/lower_tuples.h
+++ b/torch/csrc/jit/passes/lower_tuples.h
@@ -4,6 +4,14 @@
 
 namespace torch { namespace jit {
 
-TORCH_API void LowerTuples(std::shared_ptr<Graph>& graph);
+// removes tuples where TupleConstruct and TupleUnpack are matched
+// but leaves tuples in place across if statements, loops, and as inputs/outputs
+TORCH_API void LowerSimpleTuples(std::shared_ptr<Graph>& graph);
+
+// removes _all_ tuples and raises an error if some cannot be removed
+// this is used by ONNX to ensure there are not tuples before conversion,
+// but will not work on graphs whose inputs contain tuples.
+TORCH_API void LowerAllTuples(std::shared_ptr<Graph>& graph);
+
 
 }}

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -233,6 +233,7 @@ void PropagateCatShape(Node * cat_node) {
     }
     node->output()->setType(input_types[0]->withSizes(sizes));
     return true;
+<<<<<<< HEAD
   };
   static const auto propagate = [](Node * node, at::ArrayRef<Value*> tensors) -> bool {
     for (Value * v : tensors) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -145,7 +145,16 @@ bool isValidReturnForRunning(Value* v) {
       v->type()->isSubtypeOf(NumberType::get());
 }
 
+OperatorSet cannot_propagate_shape_by_running_it = {
+  "aten::gesv(Tensor self, Tensor A) -> (Tensor, Tensor)",
+  "aten::inverse(Tensor self) -> Tensor",
+};
+
 bool canPropagateShapeByRunningIt(Node* node) {
+  if(cannot_propagate_shape_by_running_it.find(node)) {
+    return false;
+  }
+
   bool valid_args = std::all_of(
       node->inputs().begin(), node->inputs().end(), isValidArgumentForRunning);
   if (!valid_args)
@@ -233,7 +242,6 @@ void PropagateCatShape(Node * cat_node) {
     }
     node->output()->setType(input_types[0]->withSizes(sizes));
     return true;
-<<<<<<< HEAD
   };
   static const auto propagate = [](Node * node, at::ArrayRef<Value*> tensors) -> bool {
     for (Value * v : tensors) {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -226,9 +226,8 @@ inline Stack evilDeprecatedBadCreateStackDoNotUse(const py::tuple& tuple, at::Ar
 
 inline py::object invokeScriptMethodFromPython(
     script::Method& method,
-    py::args args) {
-  auto relevant_inputs = method.graph()->inputs().slice(0, method.num_inputs());
-  auto stack = evilDeprecatedBadCreateStackDoNotUse(args, relevant_inputs);
+    py::args args, py::kwargs kwargs) {
+  auto stack = createStackForSchema(method.getSchema(), std::move(args), std::move(kwargs));
   method.run(stack);
   return createPyObjectForStack(std::move(stack));
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -707,30 +707,11 @@ Value* emitBuiltinCall(
                          << "for call at";
 }
 
-static Value* ensureTensor(const SourceRange& range, Value* v) {
-  if(!v->type()->isSubtypeOf(DynamicType::get())) {
-    throw ErrorReport(range) << "expected a tensor value but found a "
-                             << v->type()->str();
-  }
-  return v;
-}
-
 static Value* ensureInt(const SourceRange& range, Value* v) {
   if(!v->type()->isSubtypeOf(IntType::get())) {
     throw ErrorReport(range) << "expected a int but found a "
                              << v->type()->str();
   }
-  return v;
-}
-
-
-void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values) {
-  for(auto value : values) {
-    ensureTensor(range, value);
-  }
-}
-
-static Value* identity(const SourceRange& range, Value* v) {
   return v;
 }
 
@@ -814,7 +795,7 @@ struct to_ir {
     // outputs
     if (has_return) {
       auto return_stmt = Return(*stmts_end);
-      auto results = getValues(return_stmt.values(), true, identity);
+      auto results = getValues(return_stmt.values(), true);
       // a single return value that is a tuple expands in place:
       // return a
       if (return_stmt.values().size() == 1 && results.size() == 1) {
@@ -831,15 +812,6 @@ struct to_ir {
       auto range = return_stmt.range();
       size_t return_type_idx = 0;
       for (auto& r : results) {
-        // TODO: support tuples and lists as returns
-        auto return_kind = r->type()->kind();
-        if (return_kind != TypeKind::CompleteTensorType &&
-            return_kind != TypeKind::DynamicType &&
-            return_kind != TypeKind::IntType &&
-            return_kind != TypeKind::FloatType) {
-          throw ErrorReport(return_stmt.range()) << "The only supported return types "
-            << "are tensors, ints and floats";
-        }
         graph->registerOutput(r);
         TypePtr type = DynamicType::get();
         if (!schema.is_varret) {
@@ -970,7 +942,7 @@ private:
   }
 
   Value* emitCond(Expr cond) {
-    Value* v = emitExpr(cond, identity);
+    Value* v = emitExpr(cond);
     if(v->type()->isSubtypeOf(DynamicType::get())) {
       v = typeCast(cond.range(), v, IntType::get());
     }
@@ -1096,7 +1068,8 @@ private:
     {
       WithInsertPoint guard(n);
       if (max_trip_count) {
-        max_trip_count_val = emitExpr(max_trip_count.value(), ensureInt);
+        max_trip_count_val = ensureInt(
+            max_trip_count->range(), emitExpr(max_trip_count.value()));
       } else {
         max_trip_count_val =
             graph->insertConstant(INT_MAX,range);
@@ -1268,7 +1241,7 @@ private:
       Ident lhs = Var(stmt.lhs()[0]).name();
       Expr expr = BinOp::create(stmt.range(), stmt.reduction(),
                                 Var::create(lhs.range(), lhs), stmt.rhs());
-      environment_stack->setVar(lhs.range(), lhs.name(), emitExpr(expr, identity));
+      environment_stack->setVar(lhs.range(), lhs.name(), emitExpr(expr));
       return;
     }
 
@@ -1366,8 +1339,7 @@ private:
 
   std::vector<NamedValue> getNamedValues(
       TreeList trees,
-      bool maybe_unpack=false,
-      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
+      bool maybe_unpack) {
     std::vector<NamedValue> values;
     for (const auto& tree : trees) {
       if(maybe_unpack && tree->kind() == TK_STARRED) {
@@ -1375,35 +1347,30 @@ private:
         auto entries = emitSugaredExpr(starred.expr(), 1)->asTuple(starred.range(), method);
         for(auto entry : entries) {
           values.push_back(NamedValue(
-              tree->range(),
-              post_process(
-                  starred.range(), entry->asValue(starred.range(), method))));
+              tree->range(), entry->asValue(starred.range(), method)));
         }
       } else {
         values.push_back(NamedValue(
-            tree->range(), emitExpr(Expr(tree), post_process)));
+            tree->range(), emitExpr(Expr(tree))));
       }
     }
     return values;
   }
   std::vector<NamedValue> getNamedValues(
       List<Expr> trees,
-      bool maybe_unpack=false,
-      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
-    return getNamedValues(trees.tree()->trees(), maybe_unpack, post_process);
+      bool maybe_unpack) {
+    return getNamedValues(trees.tree()->trees(), maybe_unpack);
   }
 
   std::vector<Value*> getValues(
       TreeList trees,
-      bool maybe_unpack=false,
-      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
-    return toValues(*graph, getNamedValues(trees, maybe_unpack, post_process));
+      bool maybe_unpack) {
+    return toValues(*graph, getNamedValues(trees, maybe_unpack));
   }
   std::vector<Value*> getValues(
       List<Expr> trees,
-      bool maybe_unpack=false,
-      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
-    return getValues(trees.tree()->trees(), maybe_unpack, post_process);
+      bool maybe_unpack) {
+    return getValues(trees.tree()->trees(), maybe_unpack);
   }
 
   // special rules apply when we directly call foo(a,b) when foo is an ident
@@ -1425,8 +1392,8 @@ private:
     return sv->call(callee.range(), method, inputs, attributes, n_binders);
   }
 
-  Value* emitExpr(Expr tree, std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
-    return post_process(tree.range(), emitSugaredExpr(tree, 1)->asValue(tree.range(), method));
+  Value* emitExpr(Expr tree) {
+    return emitSugaredExpr(tree, 1)->asValue(tree.range(), method);
   }
 
   NodeKind reverseComparision(NodeKind kind) {
@@ -1455,9 +1422,9 @@ private:
       }
       case TK_APPLY: {
         auto apply = Apply(tree);
-        auto inputs = getNamedValues(apply.inputs(), true, identity);
+        auto inputs = getNamedValues(apply.inputs(), true);
         auto attributes = fmap(apply.attributes(), [&](const Attribute& attr) {
-          return NamedValue(attr.range(), attr.name().name(), emitExpr(attr.value(), identity));
+          return NamedValue(attr.range(), attr.name().name(), emitExpr(attr.value()));
         });
         // the apply is directly an identifier 'foo'
         if(apply.callee().kind() == TK_VAR) {
@@ -1491,7 +1458,7 @@ private:
       case TK_UNARY_MINUS: {
         const auto& inputs = tree->trees();
         auto kind = getNodeKind(tree->kind(), inputs.size());
-        auto named_values = getNamedValues(inputs, /*maybe_unpack=*/false, identity);
+        auto named_values = getNamedValues(inputs, /*maybe_unpack=*/false);
         return emitBuiltinCall(
                    tree->range(),
                    *method.graph(),
@@ -1536,7 +1503,7 @@ private:
       } break;
       case TK_LIST_LITERAL: {
         auto ll = ListLiteral(tree);
-        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
+        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true);
 
         // If this is an empty list literal `[]`, construct an empty Tensor[]
         const auto elem_type =
@@ -1553,7 +1520,7 @@ private:
       } break;
       case TK_TUPLE_LITERAL: {
         auto ll = TupleLiteral(tree);
-        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
+        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true);
         return graph->insertNode(graph->createTuple(values))->output();
       } break;
       default:
@@ -1666,7 +1633,6 @@ private:
     JIT_ASSERT(subscript.subscript_exprs().size() == 1);
     JIT_ASSERT(subscript.subscript_exprs()[0].kind() == TK_SLICE_EXPR);
     auto slice_exp = SliceExpr(subscript.subscript_exprs()[0]);
-
     auto * sliceable = emitExpr(subscript.value(), identity);
     at::optional<int64_t> maybe_dim;
     if (sliceable->type()->kind() == TypeKind::DynamicType) {
@@ -1683,8 +1649,7 @@ private:
     const auto applyInputs =
         Compound::create(TK_LIST, loc, std::move(inputs));
     auto input_values = getNamedValues(applyInputs->trees(),
-                                        /*maybe_unpack*/false,
-                                        identity);
+                                        /*maybe_unpack*/false);
     NamedValue gatherable = input_values[0];
     NamedValue idx = input_values[1];
     if (gatherable.value(*graph)->type()->kind() == TypeKind::ListType) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1577,10 +1577,10 @@ private:
       JIT_ASSERT(!input->type()->isSubtypeOf(DynamicType::get()));
     }
 
-    args.emplace_back(loc, "begin", emitExpr(Expr(slice.startOr(0)), identity));
+    args.emplace_back(loc, "begin", emitExpr(Expr(slice.startOr(0))));
     const auto has_end = slice.end().present();
     if (has_end) {
-      args.emplace_back(loc, "end", emitExpr(Expr(slice.end().get()), identity));
+      args.emplace_back(loc, "end", emitExpr(Expr(slice.end().get())));
     }
     NamedValue step = NamedValue(loc, "step", graph->insertConstant(1, loc));
     return emitBuiltinCall(loc, *graph, aten::slice, args, {step}, true);
@@ -1612,7 +1612,7 @@ private:
         ++dim;
         continue;
       }
-      auto index = emitExpr(subscript_expr, identity);
+      auto index = emitExpr(subscript_expr);
       if (index->type() == IntType::get()) {
         sliceable = emitSelect(loc, sliceable, dim, index);
         continue;
@@ -1633,7 +1633,7 @@ private:
     JIT_ASSERT(subscript.subscript_exprs().size() == 1);
     JIT_ASSERT(subscript.subscript_exprs()[0].kind() == TK_SLICE_EXPR);
     auto slice_exp = SliceExpr(subscript.subscript_exprs()[0]);
-    auto * sliceable = emitExpr(subscript.value(), identity);
+    auto * sliceable = emitExpr(subscript.value());
     at::optional<int64_t> maybe_dim;
     if (sliceable->type()->kind() == TypeKind::DynamicType) {
       // If the sliceable object is a tensor, specify a default dimension

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1763,6 +1763,13 @@ const std::unordered_map<std::string, std::function<TypePtr(Subscript)>> &subscr
       }
       return TupleType::create(subscript_expr_types);
     }},
+    {"List", [](Subscript subscript) -> TypePtr {
+      if (subscript.subscript_exprs().size() != 1) {
+        throw ErrorReport(subscript) << " expected exactly one element type but found " << subscript.subscript_exprs().size();
+      }
+      auto elem_type = parseTypeFromExpr(*subscript.subscript_exprs().begin());
+      return ListType::create(elem_type);
+    }},
   };
   return map;
 }
@@ -1782,7 +1789,7 @@ TypePtr parseTypeFromExpr(Expr expr) {
     }
     auto value_name = Var(subscript.value()).name().name();
     if (!subscript_to_type_fns().count(value_name)) {
-      throw ErrorReport(subscript.range()) << "Type " << value_name << " cannot be subscripted";
+      throw ErrorReport(subscript.range()) << "Unknown type constructor " << value_name;
     }
     return subscript_to_type_fns().at(value_name)(subscript);
   } else if (expr.kind() == '.') {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -576,7 +576,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       } else if(auto idx = findInputWithName(arg.name, kwargs))  {
         const NamedValue& nv = kwargs[*idx];
         if(used_kwarg[*idx]) {
-          err() << "argument " << nv.name() << " specified twice \n" << nv.locOr(loc);
+          err() << "argument " << nv.name() << " specified twice in schema, submit a bug report!\n" << nv.locOr(loc);
           return at::nullopt;
         }
         used_kwarg[*idx] = true;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -828,8 +828,8 @@ struct to_ir {
     }
 
     method.setSchema({def.name().name(), std::move(arguments), std::move(returns)});
-    // remove any uses of tuples that we inserted
-    LowerTuples(graph);
+    // remove any uses of tuples that we inserted that are not needed
+    LowerSimpleTuples(graph);
   }
 
 private:

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -552,11 +552,11 @@ void initJitScriptBindings(PyObject* module) {
           auto graph = tracer::createGraphByTracing(func, inputs, input_tuple.size());
           self.create_method(name, std::move(graph), std::move(parameters));
       })
-      .def("graph_for", [](Module& self, py::args args) {
+      .def("graph_for", [](Module& self, py::args args, py::kwargs kwargs) {
         if (self.find_method("forward")) {
           Method & m = self.get_method("forward");
           return m.graph_for(
-              evilDeprecatedBadCreateStackDoNotUse(args, m.graph()->inputs()));
+              createStackForSchema(m.getSchema(), std::move(args), std::move(kwargs)));
         }
         throw std::runtime_error("Attempted to call graph_for on a Module without a compiled forward()");
       })
@@ -567,14 +567,14 @@ void initJitScriptBindings(PyObject* module) {
         }
         throw std::runtime_error("Attempted to call get_debug_state on a Module without a compiled forward()");
       })
-      .def("forward", [](Module& self, py::args args) {
+      .def("forward", [](Module& self, py::args args, py::kwargs kwargs) {
         // We implement this in C++ to avoid incurring the pybind11 dispatch
         // overhead twice: once to call into the method lookup for "forward"
         // and once to actually invoke the method.
         //
         // There is a thin wrapper on top of this method in the C++ version of
         // ScriptModule.
-        return invokeScriptMethodFromPython(self.get_method("forward"), args);
+        return invokeScriptMethodFromPython(self.get_method("forward"), std::move(args), std::move(kwargs));
       });
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
@@ -588,14 +588,14 @@ void initJitScriptBindings(PyObject* module) {
     .def("propagate_shapes", &Method::propagate_shapes)
     .def("propagate_and_assign_input_and_output_shapes", &Method::propagate_and_assign_input_and_output_shapes)
     .def("params", &Method::params)
-    .def("graph_for", [](Method& self, py::args args) {
-      return self.graph_for(evilDeprecatedBadCreateStackDoNotUse(args, self.graph()->inputs()));
+    .def("graph_for", [](Method& self, py::args args, py::kwargs kwargs) {
+      return self.graph_for(createStackForSchema(self.getSchema(), std::move(args), std::move(kwargs)));
     })
     .def("forward_schema", [](Method &self, Def &def, bool is_method) {
       auto schema = extractSchemaFromDef(def, is_method);
       self.setSchema(schema);
     })
-    .def("pretty_print_schema", &Method::prettyPrintSchema);
+    .def("pretty_print_schema", &Method::pretty_print_schema);
 
   m.def("_jit_script_compile", [](const Def &def, ResolutionCallback rcb) {
     return compileFunction(def, pythonResolver(rcb));

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -149,12 +149,9 @@ struct Method {
     return *this;
   }
 
-  const FunctionSchema& getSchema() const {
-    AT_ASSERT(schema != nullptr);
-    return *schema;
-  }
+  const FunctionSchema& getSchema() const;
 
-  std::string prettyPrintSchema() const {
+  std::string pretty_print_schema() const {
     JIT_ASSERT(schema);
     std::stringstream ss;
     ss << *schema;
@@ -205,7 +202,9 @@ private:
   std::function<void(Method&)> method_creator;
 
   // if absent, then we generate a default schema based on the graph
-  std::unique_ptr<FunctionSchema> schema;
+  // mutable because getSchema caches the default schema if one is requested
+  // before a call to setSchema
+  mutable std::unique_ptr<FunctionSchema> schema;
 };
 
 struct Module;

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -131,6 +131,8 @@ def _optimize_graph(graph, operator_export_type):
 
     # onnx only supports tensors, so we turn all out number types into tensors
     torch._C._jit_pass_erase_number_types(graph)
+    # onnx does not support tuples, so try to remove them
+    torch._C._jit_pass_lower_all_tuples(graph)
     torch._C._jit_pass_peephole(graph)
     torch._C._jit_pass_lint(graph)
 


### PR DESCRIPTION
* Fix the necessary pathways so that tuples and lists can be inputs to the script.

* prevent linear algebra functions from being run in shape prop because
they frequently will error out for nonsense data.

* favor schema-driven python input conversion where possible.
remaining cases where we directly create Stacks without schema are
only for debugging

* Make the error messages when calling script/trace functions more pythonic

* Simplify FlattenTuples -- now that tuples are supported we can choose to only flatten tuples when needed. This may have to be revisited pending onnx test results, but is necessary for making tuple io work. 