### PR TITLE
Pass tensor object (self) to registered hook

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -413,7 +413,11 @@ class TestAutograd(TestCase):
         z.backward(torch.ones(5, 5), retain_graph=True)
         self.assertEqual(y.grad.data, (x.data + 1) * 2)
 
+        def bw_hook_tensor(tensor, grad):
+            self.assertIsInstance(tensor, torch.Tensor)
+
         y.register_hook(bw_hook_modify)
+        z.register_hook(bw_hook_tensor)
         y.grad.data.zero_()
         z.backward(torch.ones(5, 5))
         self.assertEqual(y.grad.data, (x.data + 1) * 4)


### PR DESCRIPTION
This PR addresses the issue #10683 and passes the tensor object itself to the registered hook function. To ensure backwards compatibility the tensor object is only passed if the signature of the hook function indicates two arguments. Otherwise the old behaviour works as expected.

Currently this PR fails for Python 2. How do you deal with this at the moment?