### PR TITLE
Remove Node::invalidateSchema

### DIFF
--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -686,10 +686,6 @@ public:
     return *schema_;
   }
 
-  void invalidateSchema() {
-    schema_ = nullptr;
-  }
-
   void dump() const;
 
   virtual ~Node() = default;

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -467,7 +467,6 @@ static void speculateOps(Block* block) {
 }
 
 static void replaceInputWithList(Node *node, size_t i, ArrayRef<Value*> to) {
-  node->invalidateSchema();
   node->removeInput(i);
   for (auto* to_val : to) {
     JIT_ASSERT(to_val->owningGraph() == node->owningGraph());


### PR DESCRIPTION
The schema_ field is a private and internal cache for nodes, and no
methods meant to manipulate it should be publicly visible. This call
wasn't even necessary at its call site, since removeInput will reset the
schema by itself.

@zdevito @jamesr66a 
