### PR TITLE
Change Tensor/TensorImpl to use c10::intrusive_ptr

### DIFF
--- a/aten/src/ATen/Formatting.cpp
+++ b/aten/src/ATen/Formatting.cpp
@@ -244,7 +244,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
   if(!tensor_.defined()) {
     stream << "[ Tensor (undefined) ]";
   } else if (tensor_.is_sparse()) {
-    stream << "[ " << tensor_.pImpl->toString() << "{}\n";
+    stream << "[ " << tensor_.toString() << "{}\n";
     stream << "indices:\n" << tensor_._indices() << "\n";
     stream << "values:\n" << tensor_._values() << "\n";
     stream << "size:\n" << tensor_.sizes() << "\n";
@@ -254,7 +254,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     Tensor tensor = tensor_.toType(cpudouble).contiguous();
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
-      stream << "[ " << tensor_.pImpl->toString() << "{} ]";
+      stream << "[ " << tensor_.toString() << "{} ]";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
         double scale;
@@ -268,17 +268,17 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
         }
       }
-      stream << "[ " << tensor_.pImpl->toString() << "{" << tensor.size(0) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "} ]";
     } else if(tensor.ndimension() == 2) {
       if (tensor.numel() > 0) {
         __printMatrix(stream, tensor, linesize, 0);
       }
-      stream << "[ " << tensor_.pImpl->toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "} ]";
     } else {
       if (tensor.numel() > 0) {
         __printTensor(stream, tensor, linesize);
       }
-      stream << "[ " << tensor_.pImpl->toString() << "{" << tensor.size(0);
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0);
       for(int64_t i = 1; i < tensor.ndimension(); i++) {
         stream << "," << tensor.size(i);
       }

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -75,7 +75,7 @@ TensorImpl* SparseTensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
            " changing dimensionality via maybe_zero_dim");
   return this;
 }
-const Storage& SparseTensorImpl::storage() {
+const Storage& SparseTensorImpl::storage() const {
   AT_ERROR("sparse tensors do not have storage");
 }
 int64_t SparseTensorImpl::storage_offset() const {

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -57,7 +57,7 @@ public:
 
   int64_t dim() const override;
   TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override;
-  const Storage& storage() override;
+  const Storage& storage() const override;
   int64_t storage_offset() const override;
 
   // WARNING: This function does NOT preserve invariants of sparseDims/denseDims with

--- a/aten/src/ATen/StorageImpl.h
+++ b/aten/src/ATen/StorageImpl.h
@@ -18,7 +18,7 @@ namespace at {
 
 struct Type;
 
-struct AT_API StorageImpl : public c10::raw_intrusive_ptr_target<StorageImpl> {
+struct AT_API StorageImpl : public c10::intrusive_ptr_target {
  public:
   StorageImpl() = delete;
   virtual ~StorageImpl() {};

--- a/aten/src/ATen/TensorBase.h
+++ b/aten/src/ATen/TensorBase.h
@@ -2,107 +2,52 @@
 
 #include "ATen/TensorImpl.h"
 #include "ATen/UndefinedTensor.h"
+#include "ATen/core/Error.h"
 
 namespace at { namespace detail {
 
-// TensorBaseImpl is the base class for Tensor which handles the reference counting
-template<bool is_strong>
-struct TensorBaseImpl {
-  TensorBaseImpl(): TensorBaseImpl(UndefinedTensor::singleton(), false) {}
-  TensorBaseImpl(TensorImpl * self, bool should_retain)
-  : pImpl(self) {
-    if (pImpl == nullptr) {
+// TensorBase is the base class for Tensor.
+// TODO: Eliminate this, once we remove TensorBase from Scalar.  At
+// the moment it's only used to break an include cycle for Scalar
+struct TensorBase {
+  TensorBase() {}
+  TensorBase(TensorImpl * tensor_impl, bool retain) : tensor_impl_(c10::intrusive_ptr<TensorImpl, UndefinedTensor>::reclaim(tensor_impl)) {
+    if (tensor_impl == nullptr) {
       throw std::runtime_error("TensorBaseImpl with nullptr not supported");
     }
-    if(should_retain && pImpl != UndefinedTensor::singleton()) {
-      retain();
+    if (retain && tensor_impl != UndefinedTensor::singleton()) {
+      c10::raw::intrusive_ptr::incref(tensor_impl);
     }
   }
-  TensorBaseImpl(const TensorBaseImpl & rhs)
-  : pImpl(rhs.pImpl) {
-    if (pImpl != UndefinedTensor::singleton()) {
-      retain();
-    }
-  }
-  TensorBaseImpl(TensorBaseImpl && rhs) noexcept
-  : pImpl(rhs.pImpl) {
-    rhs.pImpl = UndefinedTensor::singleton();
-  }
-  ~TensorBaseImpl() {
-    if (pImpl != UndefinedTensor::singleton()) {
-      release();
-    }
-  }
-  TensorBaseImpl & operator=(TensorBaseImpl && rhs) & {
-    rhs.swap(*this);
-    return *this;
-  }
-  TensorBaseImpl & operator=(TensorBaseImpl const & rhs) & {
-    //TensorBaseImpl ctor retains original rhs.pImpl
-    //then rhs.pImpl is swapped with this->pImpl
-    //finally TensorBaseImpl dtor releases rhs.pImpl, which was originally this->pImpl
-    TensorBaseImpl(rhs).swap(*this);
-    return *this;
-  }
+  TensorBase(c10::intrusive_ptr<TensorImpl, UndefinedTensor>&& ptr) : tensor_impl_(std::move(ptr)) {}
+  TensorBase(const c10::intrusive_ptr<TensorImpl, UndefinedTensor>& ptr) : tensor_impl_(ptr) {}
+
   int64_t dim() const {
-    if (is_strong) {
-      return pImpl->dim();
-    } else {
-      AT_ERROR("Can't call dim() on a WeakTensor");
-    }
+    return tensor_impl_->dim();
   }
-  void reset() {
-    TensorBaseImpl().swap(*this);
+
+  TensorImpl * unsafeGetTensorImpl() const {
+    return tensor_impl_.get();
   }
-  void reset(TensorImpl * rhs) {
-    TensorBaseImpl(rhs, true).swap(*this);
+  TensorImpl * unsafeReleaseTensorImpl() {
+    return tensor_impl_.release();
   }
-  void reset(TensorImpl * rhs, bool should_retain) {
-    TensorBaseImpl(rhs, should_retain).swap(*this );
-  }
-  void swap(TensorBaseImpl & rhs) {
-    TensorImpl * tmp = pImpl;
-    pImpl = rhs.pImpl;
-    rhs.pImpl = tmp;
-  }
-  TensorImpl * get() const {
-    return pImpl;
-  }
-  TensorImpl * detach() {
-    TensorImpl * ret = pImpl;
-    pImpl = UndefinedTensor::singleton();
-    return ret;
+  const c10::intrusive_ptr<TensorImpl, UndefinedTensor>& getIntrusivePtr() const {
+    return tensor_impl_;
   }
 
   bool defined() const {
-    return pImpl != UndefinedTensor::singleton();
+    return tensor_impl_;
   }
 
-  friend struct at::Type;
-
-  //TODO(zach): sort out friend structes
-public:
-  TensorImpl * pImpl;
-
-private:
-  void retain() {
-    if (is_strong) {
-      pImpl->retain();
-    } else {
-      pImpl->weak_retain();
-    }
+  void reset() {
+    tensor_impl_.reset();
   }
 
-  void release() {
-    if (is_strong) {
-      pImpl->release();
-    } else {
-      pImpl->weak_release();
-    }
-  }
+  friend struct WeakTensor;
+
+protected:
+  c10::intrusive_ptr<TensorImpl, UndefinedTensor> tensor_impl_;
 };
-
-using TensorBase = TensorBaseImpl<true>;
-using WeakTensorBase = TensorBaseImpl<false>;
 
 }} // namespace at::detail

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -56,7 +56,7 @@ void Tensor::backward(
     at::optional<Tensor> gradient,
     bool keep_graph,
     bool create_graph) {
-  pImpl->backward(std::move(gradient), keep_graph, create_graph);
+  tensor_impl_->backward(std::move(gradient), keep_graph, create_graph);
 }
 
 TensorImpl::TensorImpl(TensorTypeId type_id, ScalarType scalar_type, bool is_variable)
@@ -137,7 +137,7 @@ TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
   return this;
 }
 
-const Storage& TensorImpl::storage() {
+const Storage& TensorImpl::storage() const {
   return storage_;
 }
 

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -20,7 +20,7 @@ struct Tensor;
 } // namespace at
 
 namespace at {
-struct AT_API TensorImpl : public Retainable {
+struct AT_API TensorImpl : public c10::intrusive_ptr_target {
   TensorImpl() = delete;
   TensorImpl(TensorTypeId type_id, ScalarType scalar_type, bool is_variable);
   TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable);
@@ -32,11 +32,12 @@ struct AT_API TensorImpl : public Retainable {
   // TODO: This really really needs to be inlined.
   Type & type() const;
 
+  TensorTypeId type_id() const { return type_id_; }
   const char * toString() const;
   virtual IntList sizes() const;
   virtual IntList strides() const;
   virtual int64_t dim() const;
-  virtual const Storage& storage();
+  virtual const Storage& storage() const;
   friend struct Type;
 
   virtual int64_t numel() const {

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -9,7 +9,12 @@
 
 namespace at {
 
-
+inline Tensor & Tensor::operator=(Tensor const & rhs) && {
+  return copy_(rhs);
+}
+inline Tensor & Tensor::operator=(Tensor && rhs) && {
+  return copy_(rhs);
+}
 inline Tensor & Tensor::operator=(Scalar v) && {
   return fill_(v);
 }

--- a/aten/src/ATen/UndefinedTensor.cpp
+++ b/aten/src/ATen/UndefinedTensor.cpp
@@ -25,7 +25,7 @@ int64_t UndefinedTensor::dim() const {
   AT_ERROR("dim() called on undefined Tensor");
 }
 
-const Storage& UndefinedTensor::storage() {
+const Storage& UndefinedTensor::storage() const {
   AT_ERROR("storage() called on undefined Tensor");
 }
 

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -6,7 +6,15 @@ namespace at {
 
 struct AT_API UndefinedTensor final : public TensorImpl {
 public:
-  static inline UndefinedTensor * singleton() {
+  // Without this, we get:
+  //  error: identifier "at::UndefinedTensor::_singleton" is undefined in device code
+  // (ostensibly because the constexpr tricks MSVC into trying to compile this
+  // function for device as well).
+#ifdef _WIN32
+  static inline TensorImpl * singleton() {
+#else
+  static constexpr inline TensorImpl * singleton() {
+#endif
     return &_singleton;
   }
   IntList sizes() const override;
@@ -14,7 +22,7 @@ public:
   int64_t size(int64_t d) const override;
   int64_t stride(int64_t d) const override;
   int64_t dim() const override;
-  const Storage& storage() override;
+  const Storage& storage() const override;
   int64_t storage_offset() const override;
 private:
   UndefinedTensor();

--- a/aten/src/ATen/copy_wrapper.py
+++ b/aten/src/ATen/copy_wrapper.py
@@ -33,15 +33,15 @@ CUDA_INCLUDES = """\
 
 COPY = CodeTemplate("""\
 ${THTensor}_copy${cuda}${src_scalar_name}(${state,}\
-static_cast<TensorImpl*>(dst.pImpl), \
-static_cast<TensorImpl*>(src.pImpl));
+dst.unsafeGetTensorImpl(), \
+src.unsafeGetTensorImpl());
 """)
 
 COPY_ASYNC_CPU = CodeTemplate("""\
 if (non_blocking) {
     ${THTensor}_copyAsyncCPU(${state,}\
-static_cast<TensorImpl*>(dst.pImpl), \
-static_cast<TensorImpl*>(src.pImpl));
+dst.unsafeGetTensorImpl(), \
+src.unsafeGetTensorImpl());
     break;
 }
 """)
@@ -49,8 +49,8 @@ static_cast<TensorImpl*>(src.pImpl));
 COPY_ASYNC_CUDA = CodeTemplate("""\
 if (non_blocking) {
     ${THTensor}_copyAsyncCuda(${state,}\
-static_cast<TensorImpl*>(dst.pImpl), \
-static_cast<TensorImpl*>(src.pImpl));
+dst.unsafeGetTensorImpl(), \
+src.unsafeGetTensorImpl());
     break;
 }
 """)
@@ -70,7 +70,7 @@ Tensor & ${Type}::s_copy_(Tensor & dst, const Tensor & src, bool non_blocking) c
     default:
       ${function_fallthrough}
   }
-  dst.pImpl->maybe_zero_dim(src.pImpl->dim() == 0);
+  dst.unsafeGetTensorImpl()->maybe_zero_dim(src.dim() == 0);
   return dst;
 }
 """)
@@ -91,7 +91,7 @@ Tensor & ${Type}::_s_copy_from(const Tensor & src, Tensor & dst, bool non_blocki
       AT_ERROR("copy does not support ", toString(), " to ", dst.type().toString(), " copy.");
       break;
   }
-  dst.pImpl->maybe_zero_dim(src.pImpl->dim() == 0);
+  dst.unsafeGetTensorImpl()->maybe_zero_dim(src.dim() == 0);
   return dst; // NB! dst
 }
 """)
@@ -160,7 +160,7 @@ def create_one_copy(dst_type, all_types):
     checked_cast_dst = ''
     if dst_type['Density'] == 'Dense':
         checked_cast_dst = \
-            'checked_cast_tensor<TensorImpl>(dst.pImpl, "dst", 0, false, Backend::{}, ScalarType::{});' \
+            'checked_tensor_unwrap(dst, "dst", 0, false, Backend::{}, ScalarType::{});' \
             .format(dst_type['Backend'],
                     dst_type['ScalarName'])
 
@@ -212,7 +212,7 @@ def create_one_copy_from(src_type, all_types):
     checked_cast_src = ''
     if src_type['Density'] != 'Sparse':
         checked_cast_src = \
-            'checked_cast_tensor<TensorImpl>(src.pImpl, "src", 0, false, Backend::{}, ScalarType::{});' \
+            'checked_tensor_unwrap(src, "src", 0, false, Backend::{}, ScalarType::{});' \
             .format(src_type['Backend'], src_type['ScalarName'])
 
     return FUNCTION_FROM.substitute(src_type, copy_body=copy_body, checked_cast_src=checked_cast_src)

--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -246,9 +246,11 @@ class intrusive_ptr final {
         NullType::singleton() == FromNullType::singleton(),
         "NullType mismatch. intrusive_ptr move assignment got pointer with differing null value.");
 #endif
-    reset_();
-    target_ = rhs.target_;
-    rhs.target_ = FromNullType::singleton();
+    if (static_cast<const void*>(&this->target_) != static_cast<const void*>(&rhs.target_)) {
+      reset_();
+      target_ = rhs.target_;
+      rhs.target_ = FromNullType::singleton();
+    }
     return *this;
   }
 
@@ -268,9 +270,11 @@ class intrusive_ptr final {
         NullType::singleton() == FromNullType::singleton(),
         "NullType mismatch. intrusive_ptr copy assignment got pointer with differing null value.");
 #endif
-    reset_();
-    target_ = rhs.target_;
-    retain_();
+    if (static_cast<const void*>(&this->target_) != static_cast<const void*>(&rhs.target_)) {
+      reset_();
+      target_ = rhs.target_;
+      retain_();
+    }
     return *this;
   }
 
@@ -320,6 +324,13 @@ class intrusive_ptr final {
     return target_->refcount_.load();
   }
 
+  size_t weak_use_count() const noexcept {
+    if (target_ == NullType::singleton()) {
+      return 0;
+    }
+    return target_->weakcount_.load();
+  }
+
   bool unique() const noexcept {
     return use_count() == 1;
   }
@@ -346,7 +357,7 @@ class intrusive_ptr final {
   static intrusive_ptr reclaim(TTarget* owning_ptr) {
     // See Note [Stack allocated intrusive_ptr_target safety]
     AT_ASSERTM(
-        owning_ptr->refcount_.load() > 0,
+        owning_ptr == NullType::singleton() || owning_ptr->refcount_.load() > 0,
         "intrusive_ptr: Can only intrusive_ptr::reclaim() owning pointers that were created using intrusive_ptr::release().");
     return intrusive_ptr(owning_ptr);
   }
@@ -516,9 +527,11 @@ class weak_intrusive_ptr final {
         NullType::singleton() == FromNullType::singleton(),
         "NullType mismatch. weak_intrusive_ptr move assignment got pointer with differing null value.");
 #endif
-    reset_();
-    target_ = rhs.target_;
-    rhs.target_ = FromNullType::singleton();
+    if (static_cast<const void*>(&this->target_) != static_cast<const void*>(&rhs.target_)) {
+      reset_();
+      target_ = rhs.target_;
+      rhs.target_ = FromNullType::singleton();
+    }
     return *this;
   }
 
@@ -539,9 +552,11 @@ class weak_intrusive_ptr final {
         NullType::singleton() == FromNullType::singleton(),
         "NullType mismatch. weak_intrusive_ptr copy assignment got pointer with differing null value.");
 #endif
-    reset_();
-    target_ = rhs.target_;
-    retain_();
+    if (static_cast<const void*>(&this->target_) != static_cast<const void*>(&rhs.target_)) {
+      reset_();
+      target_ = rhs.target_;
+      retain_();
+    }
     return *this;
   }
 
@@ -587,6 +602,13 @@ class weak_intrusive_ptr final {
     return target_->refcount_.load(); // refcount, not weakcount!
   }
 
+  size_t weak_use_count() const noexcept {
+    if (target_ == NullType::singleton()) {
+      return 0;
+    }
+    return target_->weakcount_.load();
+  }
+
   bool expired() const noexcept {
     return use_count() == 0;
   }
@@ -630,6 +652,7 @@ class weak_intrusive_ptr final {
     // see weak counting explanation at top of this file.
     // if refcount == 0, weakcount only must be >0.
     AT_ASSERTM(
+        owning_weak_ptr == NullType::singleton() ||
         owning_weak_ptr->weakcount_.load() > 1 ||
             (owning_weak_ptr->refcount_.load() == 0 &&
              owning_weak_ptr->weakcount_.load() > 0),
@@ -676,93 +699,97 @@ inline bool operator!=(
   return !operator==(lhs, rhs);
 }
 
-// This target lets your provide some public methods for working with
-// raw pointers to subclasses intrusive_ptr_target.  They are not provided
-// by default, because ideally you would not need these methods at all
-// (use smart pointers), but if you are dealing with legacy code that
-// still needs to pass around raw pointers, you may find these quite useful.
-// Inherit from this publically.
+// Alias for documentary purposes, to more easily distinguish
+// weak raw intrusive pointers from intrusive pointers.
+using weak_intrusive_ptr_target = intrusive_ptr_target;
+
+// This namespace provides some methods for working with
+// raw pointers that subclass intrusive_ptr_target.  They are not provided
+// as methods on intrusive_ptr_target, because ideally you would not need these
+// methods at all (use smart pointers), but if you are dealing with legacy code
+// that still needs to pass around raw pointers, you may find these quite
+// useful.
 //
 // An important usage note: some functions are only valid if you have a
 // strong raw pointer to the object, while others are only valid if you
-// have a weak raw pointer to the object.  ONLY call _raw_weak_* methods
-// on weak pointers, and _raw_* methods on strong pointers.  If you mix
-// it up, you may get an assert failure.  We also use 'weakref' to refer
-// to weak references, and 'ref' to refer to strong references.
-template <typename T> // CRTP
-class raw_intrusive_ptr_target : public intrusive_ptr_target {
+// have a weak raw pointer to the object.  ONLY call intrusive_ptr namespace
+// functions on strong pointers, and weak_intrusive_ptr namespace functions
+// on weak pointers.  If you mix it up, you may get an assert failure.
+namespace raw {
 
-public:
+namespace intrusive_ptr {
 
-  // ------------------------------------------------------------------
-  // STRONG pointer functions
-  // Call this only if you got T* from intrusive_ptr<T>::release()
-
-  void _raw_incref() {
-    auto ptr = c10::intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+  // WARNING: Unlike the reclaim() API, it is NOT valid to pass
+  // NullType::singleton to this function
+  inline void incref(intrusive_ptr_target* self) {
+    auto ptr = c10::intrusive_ptr<intrusive_ptr_target>::reclaim(self);
     auto ptr_copy = ptr;
     ptr_copy.release();
     ptr.release();
   }
 
-  void _raw_decref() {
+  // WARNING: Unlike the reclaim() API, it is NOT valid to pass
+  // NullType::singleton to this function
+  inline void decref(intrusive_ptr_target* self) {
     // Let it die
-    c10::intrusive_ptr<T>::reclaim(static_cast<T*>(this));
-    // NB: You still "have" a pointer, but it's now invalid.
+    c10::intrusive_ptr<intrusive_ptr_target>::reclaim(self);
+    // NB: Caller still has 'self' pointer, but it's now invalid.
     // If you want more safety, used the actual c10::intrusive_ptr class
   }
 
-  T* _raw_make_weak() {
+  template <typename T>
+  inline T* make_weak(T* self) {
     // NB: 'this' is a strong pointer, but we return a weak pointer
-    auto ptr = c10::intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+    auto ptr = c10::intrusive_ptr<T>::reclaim(self);
     c10::weak_intrusive_ptr<T> wptr(ptr);
     ptr.release();
     return wptr.release();
   }
 
-  // This gives the STRONG refcount of a STRONG pointer
-  uint32_t _raw_use_count() {
-    auto ptr = c10::intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+  inline uint32_t use_count(intrusive_ptr_target* self) {
+    auto ptr = c10::intrusive_ptr<intrusive_ptr_target>::reclaim(self);
     auto r = ptr.use_count();
     ptr.release();
     return r;
   }
 
-  // ------------------------------------------------------------------
-  // WEAK pointer functions
-  // Call this only if you got T* from weak_intrusive_ptr<T>::release()
+} // namespace intrusive_ptr_target
 
-  void _raw_weak_incweakref() {
-    // NB: 'this' is a weak pointer
-    auto wptr = c10::weak_intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+namespace weak_intrusive_ptr {
+
+  inline void incref(weak_intrusive_ptr_target* self) {
+    auto wptr = c10::weak_intrusive_ptr<weak_intrusive_ptr_target>::reclaim(self);
     auto wptr_copy = wptr;
     wptr_copy.release();
     wptr.release();
   }
 
-  void _raw_weak_decweakref() {
-    // NB: 'this' is a weak pointer
+  inline void decref(weak_intrusive_ptr_target* self) {
     // Let it die
-    c10::weak_intrusive_ptr<T>::reclaim(static_cast<T*>(this));
-    // NB: You still "have" a pointer, but it's now invalid.
+    c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
+    // NB: You still "have" the 'self' pointer, but it's now invalid.
     // If you want more safety, used the actual c10::weak_intrusive_ptr class
   }
 
-  T* _raw_weak_lock() {
-    auto wptr = c10::weak_intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+  template <typename T>
+  inline T* lock(T* self) {
+    auto wptr = c10::weak_intrusive_ptr<T>::reclaim(self);
     auto ptr = wptr.lock();
     wptr.release();
     return ptr.release();
   }
 
   // This gives the STRONG refcount of a WEAK pointer
-  uint32_t _raw_weak_use_count() {
-    auto wptr = c10::weak_intrusive_ptr<T>::reclaim(static_cast<T*>(this));
+  inline uint32_t use_count(weak_intrusive_ptr_target* self) {
+    auto wptr = c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
     auto r = wptr.use_count();
     wptr.release();
     return r;
   }
-};
+
+} // namespace weak_intrusive_ptr_target
+
+} // namespace raw
 
 } // namespace c10
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -180,7 +180,8 @@ if(${check_name}.type().is_sparse()) {
 }""")
 
 BUFFER_DEFINITION = CodeTemplate("""\
-auto ${name}_ = new TensorImpl(${Backend}TensorId(), ScalarType::${ScalarName}, ${THTensor}_new(), false);
+auto ${name}_ = c10::make_intrusive<TensorImpl, UndefinedTensor>(
+    ${Backend}TensorId(), ScalarType::${ScalarName}, ${THTensor}_new(), false).release();
 auto ${name} = Tensor(${name}_, false);""")
 
 CONDITIONAL_INITIALIZER = CodeTemplate("""\
@@ -253,38 +254,38 @@ TYPE_RETURN = {
 CHECKED_CAST = {
     'THTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${Backend}, ScalarType::${ScalarName})'),
     'THSTensor*':
         CodeTemplate(
-            'checked_cast_tensor<Sparse${Tensor}>('
-            '${arg_name}.tref.pImpl,"${arg_name}",${arg_pos},false, '
+            'checked_tensor_unwrap('
+            '${arg_name}.tref,"${arg_name}",${arg_pos},false, '
             'Backend::${Backend}, ScalarType::${ScalarName})'),
     'THBoolTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${Backend}, ScalarType::Byte)'),
     'THIndexTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${Backend}, ScalarType::Long)'),
     'THIntegerTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${Backend}, ScalarType::Int)'),
     'THDenseTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${DenseBackend}, ScalarType::${ScalarName})'),
     'THDenseIndexTensor*':
         CodeTemplate(
-            'checked_cast_tensor<TensorImpl>('
-            '${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay}, '
+            'checked_tensor_unwrap('
+            '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${DenseBackend}, ScalarType::Long)'),
     'THStorage*':
         CodeTemplate(
@@ -301,8 +302,7 @@ CHECKED_CAST = {
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate(
-            'tensor_list_checked_cast<TensorImpl, Tensor, '
-            '${THTensor}>(${arg_name},"${arg_name}",${arg_pos}, '
+            'checked_tensor_list_unwrap(${arg_name},"${arg_name}",${arg_pos}, '
             'Backend::${Backend}, ScalarType::${ScalarName})'),
     'IntList': CodeTemplate('check_intlist<${size}>(${arg_name}, "${arg_name}", ${arg_pos}${,default_init})')
 }
@@ -323,13 +323,18 @@ CHECKED_USE = {
 CHECKED_USE_NULLABLE = CodeTemplate('${arg_name}_ ? ${usage} : NULL')
 
 ALLOC_NOARGS_WRAP = {
-    'THTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::${ScalarName}, false)',
-    'THBoolTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::Byte, false)',
-    'THIndexTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::Long, false)',
-    'THIntegerTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::Int, false)',
-    'THSTensor*': 'detail::new_Sparse${Tensor}()',
-    'THDenseTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::${ScalarName}, false)',
-    'THDenseIndexTensor*': 'new TensorImpl(${Backend}TensorId(), ScalarType::Long, false)'
+    'THTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                 '(${Backend}TensorId(), ScalarType::${ScalarName}, false).release()',
+    'THBoolTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                     '(${Backend}TensorId(), ScalarType::Byte, false).release()',
+    'THIndexTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                      '(${Backend}TensorId(), ScalarType::Long, false).release()',
+    'THIntegerTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                        '(${Backend}TensorId(), ScalarType::Int, false).release()',
+    'THDenseTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                      '(${Backend}TensorId(), ScalarType::${ScalarName}, false).release()',
+    'THDenseIndexTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensor>'
+                           '(${Backend}TensorId(), ScalarType::Long, false).release()'
 }
 
 ALLOC_WRAP = {
@@ -337,7 +342,6 @@ ALLOC_WRAP = {
     'THBoolTensor*': '${arguments}',
     'THIndexTensor*': '${arguments}',
     'THIntegerTensor*': '${arguments}',
-    'THSTensor*': 'new Sparse${Tensor}(${arguments})',
     'THDenseTensor*': '${arguments}',
     'THDenseIndexTensor*': '${arguments}',
 }

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -124,7 +124,7 @@ Tensor& sub_(Tensor& self, const Tensor& other, Scalar alpha) {
 
 static Tensor scalar_tensor(Scalar scalar) {
   auto tensor = scalar.toTensor();
-  tensor.get()->set_wrapped_number(true);
+  tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
   return tensor;
 }
 

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -78,7 +78,7 @@ void TensorIterator::compute_common_type() {
   });
   if (result_type == ScalarType::Undefined) {
     std::tie(result_type, backend) = compute_result_type(operands_, [](const Tensor& t) {
-      return !t.get()->is_wrapped_number();
+      return !t.unsafeGetTensorImpl()->is_wrapped_number();
     });
   }
   if (result_type == ScalarType::Undefined) {
@@ -339,7 +339,7 @@ void TensorIterator::mark_outputs() {
     // check if output is also an input
     for (int arg = num_outputs_; arg < ntensors(); arg++) {
       auto input = *operands_[arg].tensor;
-      if (output.get() == input.get()) {
+      if (output.is_same(input)) {
         operands_[i].is_read_write = true;
       }
     }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -593,7 +593,7 @@ Tensor view_as(const Tensor& self, const Tensor& other) {
 }
 
 int64_t numel(const Tensor& self) {
-  return self.pImpl->numel();
+  return self.unsafeGetTensorImpl()->numel();
 }
 
 std::vector<Tensor> unbind(const Tensor &self, int64_t dim) {

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -68,7 +68,7 @@ SparseTensor new_sparse(const SparseType& dtype) {
   } else {
     type_id = SparseCPUTensorId();
   }
-  return SparseTensor(new SparseTensorImpl(type_id, dtype.scalarType()), /* retain */ false);
+  return SparseTensor(c10::make_intrusive<SparseTensorImpl>(type_id, dtype.scalarType()).release(), /* retain */ false);
 }
 
 /*** Helper methods ***/

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -55,7 +55,7 @@ SparseTensor& zero_sparse_(SparseTensor& self) {
 
 static Tensor scalar_tensor(Scalar s) {
   auto tensor = s.toTensor();
-  tensor.get()->set_wrapped_number(true);
+  tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
   return tensor;
 }
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -18,9 +18,6 @@ struct Generator;
 struct Type;
 struct Tensor;
 struct TensorOptions;
-namespace detail {
-void set_data(Tensor& tensor, Tensor new_data);
-} // namespace detail
 } // namespace at
 
 namespace at {
@@ -45,42 +42,88 @@ struct AT_API Tensor : public detail::TensorBase {
   using TensorBase = detail::TensorBase;
   Tensor() : TensorBase() {}
   Tensor(TensorImpl * self, bool retain) : TensorBase(self, retain) {}
-  Tensor(const TensorBase & rhs) : TensorBase(rhs) {}
-  Tensor(const Tensor & rhs) = default;
-  Tensor(Tensor && rhs) noexcept = default;
+  Tensor(const c10::intrusive_ptr<TensorImpl, UndefinedTensor>& ptr) : TensorBase(ptr) {}
+  Tensor(c10::intrusive_ptr<TensorImpl, UndefinedTensor>&& ptr) : TensorBase(std::move(ptr)) {}
 
-  // reimplemented from TensorBase so the return type is Tensor rather than TensorBase
-  Tensor & operator=(Tensor && rhs) & {
-    rhs.swap(*this);
+  Tensor(const Tensor&) = default;
+  Tensor(Tensor&&) = default;
+
+  // The following overloads are very intruiging.  Consider the following
+  // program:
+  //
+  //    x[1] = 3;
+  //
+  // We would expect that the first entry of x is written to 3.  But how can we
+  // actually achieve this?  x[1] evaluates to a tensor...
+  //
+  // The answer is, using a ref-qualifier.  x[1] is an rvalue, which cannot be
+  // (profitably) assigned to in the traditional sense, so we overload
+  // assignment to mean, "Actually, copy 3 into the tensor data."  This is done
+  // with an rvalue-reference ref-qualified overload (the methods with && at the
+  // end of their type.)
+  //
+  // There's one more fly in the ointment: We also want
+  //
+  //    Tensor x = y;
+  //
+  // to work, and we want it NOT to copy.  So we need a traditional operator=
+  // overload.  But we MUST specify a mutable lvalue ref-qualifier, to
+  // disambiguate the traditional overload from the rvalue-reference
+  // ref-qualified overload.  Otherwise, it will be ambiguous, because
+  // a non ref-qualified method is eligible for all situations.
+
+  // Unfortunately, we have to write these constructors out manually
+  // to work around an MSVC bug:
+  //    error C2580: 'at::Tensor &at::Tensor::operator =(const at::Tensor &) &':
+  //    multiple versions of a defaulted special member functions are not allowed
+  // Tensor& operator=(const Tensor&) & = default;
+  // Tensor& operator=(Tensor&&) & = default;
+  Tensor& operator=(const Tensor& x) & {
+    tensor_impl_ = x.tensor_impl_;
     return *this;
   }
-  Tensor & operator=(Tensor const & rhs) & {
-      //Tensor ctor retains original rhs.pImpl
-      //then rhs.pImpl is swapped with this->pImpl
-      //finally Tensor dtor releases rhs.pImpl, which was originally this->pImpl
-      Tensor(rhs).swap(*this);
-      return *this;
+  Tensor& operator=(Tensor&& x) & {
+    tensor_impl_ = std::move(x.tensor_impl_);
+    return *this;
   }
 
-  inline Tensor & operator=(Tensor const & rhs) &&;
-  Tensor & operator=(Scalar v) &&;
+  Tensor& operator=(Scalar v) &&;
+  Tensor& operator=(const Tensor&) &&;
+  Tensor& operator=(Tensor&&) &&;
+
+  bool is_same(const Tensor& other) const noexcept {
+    return tensor_impl_ == other.tensor_impl_;
+  }
+  size_t use_count() const noexcept {
+    return tensor_impl_.use_count();
+  }
+  size_t weak_use_count() const noexcept {
+    return tensor_impl_.weak_use_count();
+  }
+
   const char * toString() const {
-    return pImpl->toString();
+    return tensor_impl_->toString();
   }
   IntList sizes() const {
-    return pImpl->sizes();
+    return tensor_impl_->sizes();
   }
   IntList strides() const {
-    return pImpl->strides();
+    return tensor_impl_->strides();
   }
   int64_t ndimension() const {
     return dim();
   }
   Type & type() const {
-    return pImpl->type();
+    return tensor_impl_->type();
+  }
+  TensorTypeId type_id() const {
+    return tensor_impl_->type_id();
+  }
+  ScalarType scalar_type() const {
+    return tensor_impl_->scalar_type();
   }
   const Storage& storage() const {
-    return pImpl->storage();
+    return tensor_impl_->storage();
   }
   inline Tensor toType(const Type & t, bool non_blocking=false) const;
   inline Tensor & copy_(const Tensor & src, bool non_blocking=false);
@@ -112,11 +155,6 @@ struct AT_API Tensor : public detail::TensorBase {
 
   template<typename T>
   T * data() const;
-
-  // non-retaining
-  TensorImpl * unsafeGetTensorImpl() const {
-    return pImpl;
-  }
 
   // Purposely not defined here to avoid inlining
   void print() const;
@@ -160,25 +198,29 @@ struct AT_API Tensor : public detail::TensorBase {
   // ~~~~~ Autograd API ~~~~~
 
   Tensor& set_requires_grad(bool requires_grad) {
-    pImpl->set_requires_grad(requires_grad);
+    tensor_impl_->set_requires_grad(requires_grad);
     return *this;
   }
   bool requires_grad() const {
-    return pImpl->requires_grad();
+    return tensor_impl_->requires_grad();
   }
 
   Tensor& grad() {
-    return pImpl->grad();
+    return tensor_impl_->grad();
   }
   const Tensor& grad() const {
-    return pImpl->grad();
+    return tensor_impl_->grad();
   }
 
   Tensor detach() const {
-    return pImpl->detach();
+    return tensor_impl_->detach();
   }
   void detach_() {
-    pImpl->detach_();
+    tensor_impl_->detach_();
+  }
+
+  void set_data(Tensor new_data) {
+    tensor_impl_->set_data(new_data);
   }
 
   /// Computes the gradient of current tensor w.r.t. graph leaves.
@@ -186,8 +228,6 @@ struct AT_API Tensor : public detail::TensorBase {
       at::optional<Tensor> gradient = at::nullopt,
       bool keep_graph = false,
       bool create_graph = false);
-
-  friend void detail::set_data(Tensor& tensor, Tensor new_data);
 
   // STOP.  Thinking of adding a method here, which only makes use
   // of other ATen methods?  Define it in native_functions.yaml.
@@ -204,47 +244,31 @@ struct AT_API Tensor : public detail::TensorBase {
   friend struct WeakTensor;
 };
 
-struct AT_API WeakTensor : public detail::WeakTensorBase {
-  using WeakTensorBase = detail::WeakTensorBase;
-  WeakTensor() : WeakTensorBase() {}
-  WeakTensor(TensorImpl * self, bool retain) : WeakTensorBase(self, retain) {}
-  WeakTensor(const WeakTensor & rhs) = default;
-  WeakTensor(WeakTensor && rhs) noexcept = default;
-  WeakTensor(const Tensor& t) : WeakTensorBase(t.pImpl, true) {}
-
-  // reimplemented from TensorBase so the return type is WeakTensor rather than TensorBase
-  WeakTensor & operator=(WeakTensor && rhs) & {
-    rhs.swap(*this);
-    return *this;
-  }
-  WeakTensor & operator=(WeakTensor const & rhs) & {
-    //Tensor ctor retains original rhs.pImpl
-    //then rhs.pImpl is swapped with this->pImpl
-    //finally Tensor dtor releases rhs.pImpl, which was originally this->pImpl
-    WeakTensor(rhs).swap(*this);
-    return *this;
-  }
-
-  WeakTensor & operator=(const Tensor& t) {
-    WeakTensor(t.pImpl, true).swap(*this);
-    return *this;
-  }
-
-  // non-retaining
-  TensorImpl * unsafeGetTensorImpl() const {
-    return pImpl;
-  }
+struct AT_API WeakTensor {
+  WeakTensor(const Tensor& t) : weak_tensor_impl_(t.tensor_impl_) {}
 
   // XXX: this can return undefined tensors
   // Ideally it would be at::optional<Tensor>, but MSVC is too cool for that
   Tensor lock() const {
-    return pImpl->weak_lock() ? Tensor(pImpl, false) : Tensor();
+    return Tensor(weak_tensor_impl_.lock());
   }
-};
 
-namespace detail {
-inline void set_data(Tensor& tensor, Tensor new_data) {
-  tensor.pImpl->set_data(new_data);
-}
-} // namespace detail
+  bool is_same(const WeakTensor& other) const noexcept {
+    return weak_tensor_impl_ == other.weak_tensor_impl_;
+  }
+
+  size_t use_count() const noexcept {
+    return weak_tensor_impl_.use_count();
+  }
+  size_t weak_use_count() const noexcept {
+    return weak_tensor_impl_.weak_use_count();
+  }
+
+  TensorImpl* unsafeGetTensorImpl() const {
+    return weak_tensor_impl_._unsafe_get_target();
+  }
+
+private:
+  c10::weak_intrusive_ptr<TensorImpl, UndefinedTensor> weak_tensor_impl_;
+};
 } // namespace at

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -9,10 +9,6 @@
 
 namespace at {
 
-inline Tensor & Tensor::operator=(Tensor const & rhs) && {
-  return copy_(rhs);
-}
-
 inline Tensor Tensor::toType(const Type & t, bool non_blocking) const {
   if(type() == t)
     return *this;

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -91,11 +91,7 @@ Storage ${Type}::storageWithAllocator(int64_t size, Allocator* allocator) const 
     return Storage(ScalarType::${ScalarName}, size, allocator);
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
-  TensorImpl* pimpl = (TensorImpl*)(th_pointer);
-  if (retain) {
-    pimpl->retain();
-  }
-  return Tensor(pimpl, false);
+  return Tensor(static_cast<TensorImpl*>(th_pointer), retain);
 }
 Storage ${Type}::unsafeStorageFromTH(void * th_pointer, bool retain) const {
   if (retain)

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       auto aScalar = ones({1}, T);
-      aScalar.get()->maybe_zero_dim(true);
+      aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
       auto b = randn({3, 5}, T);
       REQUIRE((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
     }
@@ -60,7 +60,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       auto aTensorScalar = ones({1}, T);
-      aTensorScalar.get()->maybe_zero_dim(true);
+      aTensorScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
       auto b = randn({3, 2, 1}, T);
       auto c = randn({1, 2, 5}, T);
       std::vector<int64_t> expanded_sizes = {3, 2, 5};
@@ -93,7 +93,7 @@ TEST_CASE( "broadcast", "[]" ) {
     SECTION( "with scalar" ) {
       auto a = randn({3, 5}, T);
       auto bScalar = ones({1}, T);
-      bScalar.get()->maybe_zero_dim(true);
+      bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
       REQUIRE((a + bScalar).equal(a + bScalar.expand(a.sizes())));
     }
 
@@ -118,7 +118,7 @@ TEST_CASE( "broadcast", "[]" ) {
     SECTION( "with scalar" ) {
       auto aClone = a.clone();
       auto bScalar = ones({1}, T);
-      bScalar.get()->maybe_zero_dim(true);
+      bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
       REQUIRE(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
     }
 
@@ -142,7 +142,7 @@ TEST_CASE( "broadcast", "[]" ) {
 
     SECTION( "with scalar" ) {
       Tensor aScalar = ones({1}, T);
-      aScalar.get()->maybe_zero_dim(true);
+      aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
       REQUIRE(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
     }
 

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -48,5 +48,5 @@ TEST_CASE( "undefined tensor test", "[]" ) {
   Tensor to_move = ones({1}, CPU(kFloat));
   Tensor m(std::move(to_move));
   REQUIRE(!to_move.defined());
-  REQUIRE(to_move.get() == UndefinedTensor::singleton());
+  REQUIRE(to_move.unsafeGetTensorImpl() == UndefinedTensor::singleton());
 }

--- a/aten/src/ATen/test/weakref_test.cpp
+++ b/aten/src/ATen/test/weakref_test.cpp
@@ -32,33 +32,31 @@ TEST_CASE( "Weak pointer tests", "" ) {
 
   SECTION("updates refcounts correctly") {
     Tensor a = at::ones({2, 2});
-    auto ai = a.unsafeGetTensorImpl();
-    REQUIRE(ai->use_count() == 1);
-    REQUIRE(ai->weak_use_count() == 1);
+    REQUIRE(a.use_count() == 1);
+    REQUIRE(a.weak_use_count() == 1);
     {
       WeakTensor b = a;
-      REQUIRE(ai->use_count() == 1);
-      REQUIRE(ai->weak_use_count() == 2);
+      REQUIRE(a.use_count() == 1);
+      REQUIRE(a.weak_use_count() == 2);
     }
-    REQUIRE(ai->use_count() == 1);
-    REQUIRE(ai->weak_use_count() == 1);
+    REQUIRE(a.use_count() == 1);
+    REQUIRE(a.weak_use_count() == 1);
     {
       WeakTensor b = a;
-      REQUIRE(ai->use_count() == 1);
+      REQUIRE(a.use_count() == 1);
       auto locked = b.lock();
       REQUIRE(locked.defined());
-      REQUIRE(ai->use_count() == 2);
+      REQUIRE(a.use_count() == 2);
     }
-    REQUIRE(ai->use_count() == 1);
-    REQUIRE(ai->weak_use_count() == 1);
+    REQUIRE(a.use_count() == 1);
+    REQUIRE(a.weak_use_count() == 1);
     {
       WeakTensor b = a;
-      REQUIRE(ai->use_count() == 1);
-      REQUIRE(ai->weak_use_count() == 2);
+      REQUIRE(a.use_count() == 1);
+      REQUIRE(a.weak_use_count() == 2);
       a.reset();
-      auto bi = b.unsafeGetTensorImpl();
-      REQUIRE(bi->use_count() == 0);
-      REQUIRE(bi->weak_use_count() == 1);
+      REQUIRE(b.use_count() == 0);
+      REQUIRE(b.weak_use_count() == 1);
     }
   }
 }

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE( "wrapdim test", "[]" ) {
 
     // can unsqueeze scalar
     auto b = randn(1, T);
-    b.get()->maybe_zero_dim(true);
+    b.unsafeGetTensorImpl()->maybe_zero_dim(true);
     REQUIRE(b.unsqueeze(0).equal(b.unsqueeze(-1)));
   }
 
@@ -36,8 +36,8 @@ TEST_CASE( "wrapdim test", "[]" ) {
   SECTION( "scalar vs 1-dim, 1-size" ) {
     auto a = randn(1, T);
     REQUIRE(a.prod(0).equal(a.prod(-1)));
-    a.get()->maybe_zero_dim(true);
-    REQUIRE(a.get()->dim() == 0);
+    a.unsafeGetTensorImpl()->maybe_zero_dim(true);
+    REQUIRE(a.dim() == 0);
     REQUIRE(a.prod(0).equal(a.prod(-1)));
   }
 }

--- a/aten/src/TH/THStorageFunctions.cpp
+++ b/aten/src/TH/THStorageFunctions.cpp
@@ -29,7 +29,7 @@ void THStorage_free(THStorage* storage) {
   if (!storage) {
     return;
   }
-  storage->_raw_decref();
+  c10::raw::intrusive_ptr::decref(storage);
 }
 
 ptrdiff_t THStorage_size(const THStorage *self)
@@ -40,7 +40,7 @@ ptrdiff_t THStorage_size(const THStorage *self)
 void THStorage_retain(THStorage *storage)
 {
   if (storage) {
-    storage->_raw_incref();
+    c10::raw::intrusive_ptr::incref(storage);
   }
 }
 

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -8,10 +8,11 @@
 
 #include <numeric>
 
+// NB: This is NOT valid on UndefinedTensor
 void THTensor_free(THTensor *self)
 {
   if (!self) return;
-  self->release();
+  c10::raw::intrusive_ptr::decref(self);
 }
 
 void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntList size_, at::IntList stride_) {
@@ -41,7 +42,7 @@ void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storage
     auto scalar_type = THTensor_getStoragePtr(self)->scalar_type();
     if(storage)
     {
-      storage->_raw_incref();
+      c10::raw::intrusive_ptr::incref(storage);
       THTensor_stealAndSetStoragePtr(self, storage);
     }
     else {

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -54,13 +54,13 @@ real *THTensor_(data)(const THTensor *self) {
 /* Empty init */
 THTensor *THTensor_(new)(void)
 {
-  return new THTensor(THStorage_(new)(), at::CPUTensorId(), false);
+  return c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THStorage_(new)(), at::CPUTensorId(), false).release();
 }
 
 /* Pointer-copy init */
 THTensor *THTensor_(newWithTensor)(THTensor *tensor)
 {
-  THTensor *self = new THTensor(THStorage_(new)(), at::CPUTensorId(), false);
+  THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THStorage_(new)(), at::CPUTensorId(), false).release();
   THTensor_(setStorageNd)(self,
                           THTensor_getStoragePtr(tensor),
                           tensor->storage_offset(),
@@ -75,7 +75,7 @@ THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
   if (strides.data()) {
     AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
-  THTensor *self = new THTensor(THStorage_(new)(), at::CPUTensorId(), false);
+  THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THStorage_(new)(), at::CPUTensorId(), false).release();
   THTensor_(setStorageNd)(self, storage, storageOffset, sizes.size(),
                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
 
@@ -547,9 +547,10 @@ ptrdiff_t THTensor_(nElement)(const THTensor *self)
   }
 }
 
+// NB: It is INVALID to call this on an UndefinedTensor
 void THTensor_(retain)(THTensor *self)
 {
-  self->retain();
+  c10::raw::intrusive_ptr::incref(self);
 }
 
 void THTensor_(free)(THTensor *self)

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -192,7 +192,7 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
     auto scalar_type = THTensor_getStoragePtr(self)->scalar_type();
 
     if (storage) {
-      storage->_raw_incref();
+      c10::raw::intrusive_ptr::incref(storage);
       THTensor_stealAndSetStoragePtr(self, storage);
     } else {
       THTensor_stealAndSetStoragePtr(self, THCStorage_new(state, scalar_type));
@@ -273,8 +273,9 @@ ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self) {
   }
 }
 
+// NB: It is INVALID to call this on an UndefinedTensor
 void THCTensor_retain(THCState *state, THCTensor *self) {
-  self->retain();
+  c10::raw::intrusive_ptr::incref(self);
 }
 
 void THCTensor_free(THCState *state, THCTensor *self) {

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -63,13 +63,13 @@ real *THCTensor_(data)(THCState *state, const THCTensor *self)
 /* Empty init */
 THCTensor *THCTensor_(new)(THCState *state)
 {
-  return new THCTensor(THCStorage_(new)(state), at::CUDATensorId(), false);
+  return c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THCStorage_(new)(state), at::CUDATensorId(), false).release();
 }
 
 /* Pointer-copy init */
 THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
 {
-  THCTensor *self = new THCTensor(THCStorage_(new)(state), at::CUDATensorId(), false);
+  THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THCStorage_(new)(state), at::CUDATensorId(), false).release();
   THCTensor_(setStorageNd)(state,
                            self,
                            THTensor_getStoragePtr(tensor),
@@ -85,7 +85,7 @@ THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrd
   if (strides.data()) {
     AT_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
-  THCTensor *self = new THCTensor(THCStorage_(new)(state), at::CUDATensorId(), false);
+  THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensor>(THCStorage_(new)(state), at::CUDATensorId(), false).release();
   THCTensor_(setStorageNd)(state, self, storage, storageOffset, sizes.size(),
                            const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
 

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -59,7 +59,7 @@ static void check_out_type_matches(Tensor result,
   }
 }
 
-inline Tensor & dispatch_arange(Scalar end, Tensor result) {
+inline Tensor dispatch_arange(Scalar end, Tensor result) {
   AutoNoGIL no_gil;
   return at::arange_out(result, end);
 }
@@ -70,7 +70,7 @@ inline Tensor dispatch_arange(Scalar end, const TensorOptions& options) {
   return torch::arange(end, options);
 }
 
-inline Tensor & dispatch_arange(Scalar start, Scalar end, Scalar step, Tensor result) {
+inline Tensor dispatch_arange(Scalar start, Scalar end, Scalar step, Tensor result) {
   AutoNoGIL no_gil;
   return at::arange_out(result, start, end, step);
 }
@@ -140,7 +140,7 @@ static PyObject * THPVariable_arange(PyObject* self, PyObject* args, PyObject* k
   END_HANDLE_TH_ERRORS
 }
 
-inline Tensor & dispatch_range(Scalar start, Scalar end, Scalar step, Tensor result) {
+inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, Tensor result) {
   AutoNoGIL no_gil;
   DeviceGuard device_guard(result);
   return at::range_out(result, start, end, step);

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -58,9 +58,7 @@ class Cloneable : public virtual Module {
         copy->parameters_[parameter.key].copy_(
             *parameter, /*non_blocking=*/true);
       } else {
-        at::detail::set_data(
-            copy->parameters_[parameter.key],
-            autograd::Variable(*parameter).data().clone());
+        copy->parameters_[parameter.key].set_data(autograd::Variable(*parameter).data().clone());
       }
     }
     AT_CHECK(
@@ -73,9 +71,7 @@ class Cloneable : public virtual Module {
       if (device) {
         copy->buffers_[buffer.key].copy_(*buffer, /*non_blocking=*/true);
       } else {
-        at::detail::set_data(
-            copy->buffers_[buffer.key],
-            autograd::Variable(*buffer).data().clone());
+        copy->buffers_[buffer.key].set_data(autograd::Variable(*buffer).data().clone());
       }
     }
     AT_CHECK(

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -223,12 +223,11 @@ void Module::to_impl(Ts&&... ts) {
   }
   // Then move every parameter to the new dtype/device.
   for (auto& parameter : parameters_) {
-    at::detail::set_data(
-        *parameter, autograd::Variable(*parameter).data().to(ts...));
+    parameter->set_data(autograd::Variable(*parameter).data().to(ts...));
   }
   // Then move every buffer to the new dtype/device.
   for (auto& buffer : buffers_) {
-    at::detail::set_data(*buffer, autograd::Variable(*buffer).data().to(ts...));
+    buffer->set_data(autograd::Variable(*buffer).data().to(ts...));
   }
 }
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -208,7 +208,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   if (!THPVariable_Check(data)) {
     throw torch::TypeError("Variable data has to be a tensor, but got %s", Py_TYPE(data)->tp_name);
   }
-  at::detail::set_data(self->cdata, THPVariable_UnpackData(data));
+  self->cdata.set_data(THPVariable_UnpackData(data));
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -89,7 +89,7 @@ const char* Variable::Impl::typeString() {
   return "VariableType";
 }
 
-const at::Storage& Variable::Impl::storage() {
+const at::Storage& Variable::Impl::storage() const {
   return data_.storage();
 }
 

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -294,7 +294,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 static PyObject * THPStorage_(weakRef)(THPStorage *self, PyObject *args) {
   HANDLE_TH_ERRORS
   THStorage* storage = self->cdata;
-  return PyLong_FromVoidPtr(storage->_raw_make_weak());
+  return PyLong_FromVoidPtr(c10::raw::intrusive_ptr::make_weak(storage));
   END_HANDLE_TH_ERRORS
 }
 
@@ -304,7 +304,7 @@ PyObject * THPStorage_(newWithWeakPtr)(PyObject *_unused, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg),
       "_new_with_weak_ptr(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  if (auto* storage = weak_storage->_raw_weak_lock()) {
+  if (auto* storage = c10::raw::weak_intrusive_ptr::lock(weak_storage)) {
     return THPStorage_(New)(storage);
   }
   Py_RETURN_NONE;
@@ -320,7 +320,7 @@ PyObject * THPStorage_(freeWeakRef)(PyObject *_unused, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg),
       "_free_weak_ref(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  weak_storage->_raw_weak_decweakref();
+  c10::raw::weak_intrusive_ptr::decref(weak_storage);
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -331,7 +331,7 @@ PyObject * THPStorage_(expired)(PyObject *_unused, PyObject *arg)
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "_expired(): arg must be an 'int'");
   THStorage *weak_storage = (THStorage*)PyLong_AsVoidPtr(arg);
-  return PyBool_FromLong(weak_storage->_raw_weak_use_count() == 0);
+  return PyBool_FromLong(c10::raw::weak_intrusive_ptr::use_count(weak_storage) == 0);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -349,7 +349,7 @@ public:
   virtual int64_t dim() const override {
     throw std::runtime_error("dim() on ContainerTensor");
   }
-  virtual const at::Storage& storage() override {
+  virtual const at::Storage& storage() const override {
     throw std::runtime_error("storage() on ContainerTensor");
   }
 };

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -911,23 +911,23 @@ void testControlFlow() {
 
 void testIValue() {
   Shared<IntList> foo = IntList::create({3, 4, 5});
-  JIT_ASSERT(foo->use_count() == 1);
+  JIT_ASSERT(foo.use_count() == 1);
   IValue bar(foo);
-  JIT_ASSERT(foo->use_count() == 2);
+  JIT_ASSERT(foo.use_count() == 2);
   auto baz = bar;
-  JIT_ASSERT(foo->use_count() == 3);
+  JIT_ASSERT(foo.use_count() == 3);
   auto foo2 = std::move(bar);
-  JIT_ASSERT(foo->use_count() == 3);
+  JIT_ASSERT(foo.use_count() == 3);
   JIT_ASSERT(foo2.isIntList());
   JIT_ASSERT(bar.isNone());
   foo2 = IValue(4.0);
   JIT_ASSERT(foo2.isDouble());
   JIT_ASSERT(foo2.toDouble() == 4.0);
-  JIT_ASSERT(foo->use_count() == 2);
+  JIT_ASSERT(foo.use_count() == 2);
   JIT_ASSERT(ArrayRef<int64_t>(baz.toIntList()->elements()).equals({3,4,5}));
 
   auto move_it = std::move(baz).toIntList();
-  JIT_ASSERT(foo->use_count() == 2);
+  JIT_ASSERT(foo.use_count() == 2);
   JIT_ASSERT(baz.isNone());
   IValue i(4);
   JIT_ASSERT(i.isInt() && i.toInt() == 4);
@@ -940,18 +940,18 @@ void testIValue() {
   dlist = IValue(DoubleList::create({3.4}));
   JIT_ASSERT(ArrayRef<double>(dlist.toDoubleList()->elements()).equals({3.4}));
   IValue the_list(Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));
-  JIT_ASSERT(foo->use_count() == 3);
+  JIT_ASSERT(foo.use_count() == 3);
   JIT_ASSERT(the_list.isTuple());
   auto first = std::move(the_list).toTuple()->elements().at(1);
   JIT_ASSERT(first.toInt() == 4);
   at::Tensor tv = at::rand({3,4});
   IValue ten(tv);
-  JIT_ASSERT(tv.get()->use_count() == 2);
+  JIT_ASSERT(tv.use_count() == 2);
   auto ten2 = ten;
-  JIT_ASSERT(tv.get()->use_count() == 3);
+  JIT_ASSERT(tv.use_count() == 3);
   JIT_ASSERT(ten2.toTensor().equal(ten.toTensor()));
   std::move(ten2).toTensor();
-  JIT_ASSERT(tv.get()->use_count() == 2);
+  JIT_ASSERT(tv.use_count() == 2);
 }
 
 void testProto() {

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -40,7 +40,7 @@ struct TORCH_API TracingState : public std::enable_shared_from_this<TracingState
 
   struct WeakTensorEq {
     bool operator()(const WeakTensor& t1, const WeakTensor& t2) const {
-      return t1.unsafeGetTensorImpl() == t2.unsafeGetTensorImpl();
+      return t1.is_same(t2);
     }
   };
 

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -211,7 +211,7 @@ inline at::Tensor PythonArgs::tensor(int i) {
           Py_TYPE(obj)->tp_name);
     }
     auto tensor = scalar.toTensor();
-    tensor.get()->set_wrapped_number(true);
+    tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
     return autograd::make_variable(tensor);
   }
   return reinterpret_cast<THPVariable*>(obj)->cdata;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/10824

API additions:
- Tensor(c10::intrusive_ptr<TensorImpl,UndefinedTensor>&&)
- Tensor(const c10::intrusive_ptr<TensorImpl,UndefinedTensor>&)
- Tensor::operator=(Tensor&&) && (for completeness sake)
- TensorBase::unsafeGetTensorImpl()
- TensorBase::unsafeReleaseTensorImpl()
- TensorBase::getIntrusivePtr()
- TensorImpl::type_id()
- Tensor::set_data()
- Tensor::is_same(Tensor)
- Tensor::use_count()
- Tensor::type_id()
- Tensor::scalar_type()
- WeakTensor::is_same(WeakTensor)
- intrusive_ptr::weak_use_count()
- weak_intrusive_ptr::weak_use_count()
- c10::raw::intrusive_ptr::{incref,decref,make_weak}
- c10::raw::weak_intrusive_ptr::{incref,decref,lock}

API changes:
- Tensor::pImpl is no longer public (and now named tensor_impl_)
    - Most methods accessed this way are now accessible on Tensor
      maybe_zero_dim() and set_wrapped_number() being prominent exceptions
      (they are now accessed through unsafeGetTensorImpl())
- Type is no longer friend of Tensor
- TensorBase::reset(TensorImpl*) is deleted
- TensorBase::reset(TensorImpl*, bool should_retain) is deleted
- TensorBase::swap(TensorBaseImpl&) is deleted; use std::swap instead
- TensorBase::get() is deleted; use unsafeGetTensorImpl() instead
- TensorBase::detach() is deleted; use unsafeReleaseTensorImpl() instead
- TensorBase::retain() is deleted; use _raw_incref() instead
- TensorBase::release() is deleted; use _raw_decref() instead
- WeakTensor lost most of its methods (it no longer inherits from
  TensorBase)
- TensorImpl::storage() is now a const method
- Tensor(TensorBase) constructor removed, instead
  we go through getIntrusivePtr().  I'm not sure about
  this change; I happened to have accidentally removed the
  TensorBase constructor and decided to fix call sites,
  but I could go the other way.
- detail::set_data() is deleted; use Tensor::set_data() instead
- c10::raw_intrusive_ptr_target removed; use the functions in c10::raw instead.
  (The reason for this change, is that it is invalid to cast an intrusive_ptr_target*
  to a raw_intrusive_ptr_target* to take advantage of the methods. But there is
  no reason the incref/decref methods shouldn't also work on intrusive_ptr_target;
  it is primarily an API consideration. We can be more standards compliant by
  keeping them as functions, which are universally applicable.)
- intrusive_ptr::reclaim() and weak_intrusive_ptr::reclaim() now work on
  pointers of the NullType. (This counts as a bug fix, because the documentation
  specified that pointers produced by release() are valid to reclaim(), and
  a release() on a null intrusive_ptr produces the NullType::singleton())

Bug fixes:
- Dispatch code for mutable references incorrectly returned
  a reference to a value argument (which would immediately
  go out of scope).  They now correctly return a tensor by
  value.
- intrusive_ptr copy/move assignment did not work correctly when
  an object was assigned to itself. We now check for this case and
  no-op if so. (This bug manifested itself as a Tensor mysteriously
  becoming an UndefinedTensor after lines of code like
  'x = x.mul_(y)'

Other changes:
- The checked cast functions in Utils.h have now been
  renamed and detemplatized into checked unwrap functions.
- Added type_id() and scalar_type() methods to Tensor
- pImpl is no longer public
- Documented what the && overloads are doing
- All occurrences of 'new TensorImpl' (and similar spellings, like 'new THTensor')
  have been expunged. This is NO LONGER a valid way to create a new
  tensor, and if you do this, upon your first incref, you will catch an ASSERT
  failure saying that only tensors created by intrusive_ptr::release() are valid
  to reclaim(). Use c10::make_intrusive instead in this situation.
- IValue is adjusted to use intrusive_ptr instead of Retainable, and all
  other sub-classes of Retainable were modified to use intrusive_ptr.
  When doing this, I had to make the constructors of sub-classes like
  ConstantList public, so that c10::make_intrusive could invoke them.  Fortunately,
  if you incorrectly stack allocate a ConstantList, and then try to get an
  intrusive_ptr to it, it will fail, as stack allocated ConstantLists have refcount 0.
- IValue very narrowly sidesteps the problem of handling NullType, as it
  considers intrusive_ptr<TensorImpl> identical to intrusive_ptr<TensorImpl, UndefinedTensor>
  which is not always true. This was always the case, but there's now a comment
  explaining what's going on.

Some MSVC bugs were uncovered during the preparation of this patch.
They are documented as comments in the code.

Differential Revision: D9481140