### PR TITLE
Add strides to caffe2::Tensor

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -96,6 +96,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
       // TODO(jerryzh): We'll need to check device type in Get<T>() later
       // Get<T>() -> Get<T>(type)
       const auto& tensor = inputs_.at(idx)->template Get<T>();
+      CAFFE_ENFORCE(
+          tensor.is_contiguous(),
+          "Tensor must be contiguous for caffe2 operators");
       return tensor;
     } catch (::caffe2::EnforceNotMet& enf) {
       if (has_debug_def()) {
@@ -122,7 +125,11 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     static_assert(
         std::is_same<T, Tensor>::value,
         "Output(int, DeviceType) is only available for Tensor");
-    return outputs_.at(idx)->GetMutableTensor(type);
+    auto* tensor = outputs_.at(idx)->GetMutableTensor(type);
+    CAFFE_ENFORCE(
+        tensor->is_contiguous(),
+        "Tensor must be contiguous for caffe2 operators");
+    return tensor;
   }
 
   template <typename T>

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -17,6 +17,8 @@ CAFFE2_DECLARE_int64(caffe2_max_keep_on_shrink_memory);
 
 namespace caffe2 {
 
+using DimVector = std::vector<TIndex>;
+
 /**
  * A utility function to convert vector<int> to vector<TIndex>.
  */
@@ -206,11 +208,16 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if ((void*)&src == (void*)this) {
       return;
     }
+    CAFFE_ENFORCE_WITH_CALLER(
+        src.is_contiguous(),
+        "Source Tensor must be contiguous in order to be copied.");
     if (storage_->dtype() != src.meta()) {
       storage_ = std::make_shared<StorageImpl>(GetDeviceType(), src.meta());
     }
     if (src.size() == -1) {
       dims_.clear();
+      strides_.clear();
+      is_contiguous_ = true;
       size_ = -1;
       storage_->reset();
       return;
@@ -272,6 +279,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * complexity.
    */
   void Extend(TIndex num, float growthPct, BaseContext* context) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_, "Tensor must be contiguous in order to call Extend.");
     CAFFE_ENFORCE_GE_WITH_CALLER(dims_.size(), 1);
     CAFFE_ENFORCE_GE_WITH_CALLER(
         num, 0, "`num` must be non-negative for Extend");
@@ -318,6 +327,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * that the extra capacity after the end of the shurnk tensor is maintained.
    */
   void ShrinkTo(TIndex outer_dim) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_, "Tensor must be contiguous in order to call ShrinkTo.");
     CAFFE_ENFORCE_WITH_CALLER(dims_.size() >= 1, "Tensor must be at least 1D");
     CAFFE_ENFORCE_WITH_CALLER(
         outer_dim <= dims_[0],
@@ -341,6 +352,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <class T>
   void ReserveSpace(const T& outer_dim) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call ReserveSpace.");
     CAFFE_ENFORCE(
         size_ != -1, "size should be initialized before calling ReserveSpace");
     CAFFE_ENFORCE(
@@ -411,6 +425,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * sugar wrapper that essentially calls Resize(src_tensor.dims()).
    */
   inline void ResizeLike(const TensorImpl& src_tensor) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        src_tensor.is_contiguous(),
+        "Tensor must be contiguous in order to call ResizeLike.");
     // Note: need casting for different context types.
     if (static_cast<void*>(this) != static_cast<const void*>(&src_tensor)) {
       Resize(src_tensor.dims());
@@ -422,6 +439,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * This requires the total size of the tensor to remains constant.
    */
   inline void Reshape(const vector<TIndex>& dims) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_, "Tensor must be contiguous in order to call Reshape.");
     TIndex new_size = 1;
     for (auto d : dims) {
       CAFFE_ENFORCE_GE_WITH_CALLER(d, 0);
@@ -472,6 +491,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
 
   void swap(TensorImpl& other) noexcept {
     std::swap(dims_, other.dims_);
+    std::swap(strides_, other.strides_);
+    std::swap(is_contiguous_, other.is_contiguous_);
     std::swap(size_, other.size_);
     std::swap(storage_, other.storage_);
   }
@@ -530,6 +551,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       size_t capacity = 0,
       Deleter d = nullptr) {
     CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call ShareExternalPointer.");
+    CAFFE_ENFORCE_WITH_CALLER(
         data_type.id() != TypeIdentifier::uninitialized(),
         "To share with a raw external pointer you need to pass in an "
         "initialized data_type(TypeMeta).");
@@ -553,6 +577,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * or raw_mutable_data() must have been called prior to this function call.
    */
   inline const void* raw_data() const {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call raw_data()");
     CAFFE_ENFORCE_WITH_CALLER(storage_->data() || size_ == 0);
     return storage_->data();
   }
@@ -565,6 +592,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline const T* data() const {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_, "Tensor must be contiguous in order to call data()");
     CAFFE_ENFORCE_WITH_CALLER(
         storage_->data() || size_ == 0,
         "The tensor is of non-zero shape, but its data is not allocated yet. "
@@ -591,6 +620,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * and a new storage will be created.
    */
   inline void* raw_mutable_data(const TypeMeta& meta) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call raw_mutable_data()");
     // For 0-size tensors it's fine to return any pointer (including nullptr)
     if (storage_->dtype() == meta && (storage_->data() || size_ == 0)) {
       return storage_->data();
@@ -657,6 +689,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   inline void* raw_mutable_data() {
     CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call raw_mutable_data()");
+    CAFFE_ENFORCE_WITH_CALLER(
         storage_->dtype().id() != TypeIdentifier::uninitialized(),
         "Calling raw_mutable_data() without meta, but the current meta is "
         "of unknown type.");
@@ -671,6 +706,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline T* mutable_data() {
+    CAFFE_ENFORCE_WITH_CALLER(
+        is_contiguous_,
+        "Tensor must be contiguous in order to call mutable_data()");
     if ((size_ == 0 || storage_->data()) && IsType<T>()) {
       return static_cast<T*>(storage_->data());
     }
@@ -758,6 +796,25 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     return canonical_axis_index_(axis_index, ndim());
   }
 
+  inline int64_t stride(int64_t dim) const {
+#ifndef NDEBUG
+    // TODO: dim wrapping?
+    CAFFE_ENFORCE_LT_WITH_CALLER(dim, strides_.size(), "Exceeding ndim limit");
+    CAFFE_ENFORCE_GE_WITH_CALLER(
+        dim, 0, "Cannot have negative dimension index");
+#endif
+    return strides_[dim];
+  }
+
+  // TODO: Change to ArrayRef later
+  inline DimVector strides() {
+    return strides_;
+  }
+
+  inline bool is_contiguous() const {
+    return is_contiguous_;
+  }
+
   /**
    * Checks if the tensor content is of the given data type.
    */
@@ -806,9 +863,10 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
  protected:
-  using DimVector = std::vector<TIndex>;
   DimVector dims_; // sizes_
+  DimVector strides_;
   TIndex size_ = -1; // numel_
+  bool is_contiguous_ = true;
   // we decide to keep reserved_ and it will
   // live in Tensor after the split
   // The logic is that if Extend() or ReserveSpace() were ever called,
@@ -829,6 +887,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       new_size *= src[i];
       dims_[i] = src[i];
     }
+    update_strides();
     size_ = new_size;
     return size_ != old_size;
   }
@@ -836,6 +895,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   bool SetDims() {
     auto old_size = size_;
     dims_.resize(0);
+    update_strides();
     size_ = 1;
     return size_ != old_size;
   }
@@ -847,6 +907,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     auto old_size = size_;
     dims_.resize(1);
     dims_[0] = d0;
+    update_strides();
     size_ = d0;
     return size_ != old_size;
   }
@@ -856,6 +917,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     dims_.resize(2);
     dims_[0] = d0;
     dims_[1] = d1;
+    update_strides();
     size_ = d0 * d1;
     return size_ != old_size;
   }
@@ -866,6 +928,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     dims_[0] = d0;
     dims_[1] = d1;
     dims_[2] = d2;
+    update_strides();
     size_ = d0 * d1 * d2;
     return size_ != old_size;
   }
@@ -878,8 +941,20 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     dims_[1] = d1;
     dims_[2] = d2;
     dims_[3] = d3;
+    update_strides();
     size_ = d0 * d1 * d2 * d3;
     return size_ != old_size;
+  }
+  inline void update_strides() {
+    strides_.resize(dims_.size());
+    for (auto i = ndim() - 1; i >= 0; --i) {
+      if (i == ndim() - 1) {
+        strides_[i] = 1;
+      } else {
+        strides_[i] = strides_[i + 1] * std::max<int64_t>(dims_[i + 1], 1);
+      }
+    }
+    is_contiguous_ = true;
   }
 };
 
@@ -1107,6 +1182,18 @@ class CAFFE2_API Tensor final {
 
   inline int canonical_axis_index(int axis_index) const {
     return impl_.get()->canonical_axis_index(axis_index);
+  }
+
+  inline int64_t stride(int64_t dim) const {
+    return impl_.get()->stride(dim);
+  }
+
+  inline DimVector strides() {
+    return impl_.get()->strides();
+  }
+
+  inline bool is_contiguous() const {
+    return impl_.get()->is_contiguous();
   }
 
   template <typename T>


### PR DESCRIPTION
Summary: Add strides, and make sure the strides are consistent with sizes, and is_contiguous, for all the Caffe2 functions.

Differential Revision: D9354480
