### PR TITLE
Moving the operator argument to the front for kernelPointwiseApply.

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -123,10 +123,10 @@ void rearrangeDims(detail::TensorInfo<T1, IndexType>* aInfo,
 
 // Threads per block for our apply kernel
 // FIXME: use occupancy calculator instead
-// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 #define AT_APPLY_THREADS_PER_BLOCK 32 * 16
 #define AT_APPLY_BLOCKS_PER_SM 4
 
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 template <typename Op,
           typename scalar1,
           typename scalar2,

--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -123,6 +123,7 @@ void rearrangeDims(detail::TensorInfo<T1, IndexType>* aInfo,
 
 // Threads per block for our apply kernel
 // FIXME: use occupancy calculator instead
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 #define AT_APPLY_THREADS_PER_BLOCK 32 * 16
 #define AT_APPLY_BLOCKS_PER_SM 4
 
@@ -154,7 +155,7 @@ kernelPointwiseApply2(Op op,
   }
 }
 
-
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 template <typename Op,
           typename scalar1,
           typename scalar2,
@@ -189,6 +190,7 @@ kernelPointwiseApply3(Op op,
   }
 }
 
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 template <typename Op,
           typename scalar1,
           typename scalar2,

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -109,6 +109,7 @@ void rearrangeDims(TensorInfo<T1, IndexType>* aInfo,
 }
 
 // Threads per block for our apply kernel
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 // FIXME: use occupancy calculator instead
 #define THC_APPLY_THREADS_PER_BLOCK (32 * 16)
 #define THC_APPLY_BLOCKS_PER_SM 4
@@ -129,6 +130,7 @@ kernelPointwiseApply1(Op op,
   }
 }
 
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 template <typename Op,
           typename Ta, typename Tb,
           typename IndexType,
@@ -145,6 +147,7 @@ kernelPointwiseApply2(Op op,
   }
 }
 
+// Order for arguments to kernelPointwiseApply need to be changed due to bug in HCC compiler. See PR #10829
 template <typename Op,
           typename Ta, typename Tb, typename Tc,
           typename IndexType,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1474,6 +1474,7 @@ class TestAutograd(TestCase):
         self.assertEqual(dvar.grad, torch.ones_like(dvar))
         self.assertEqual(type(dvar.grad.data), type(dvar.data))
 
+    @skipIfRocm
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)


### PR DESCRIPTION
Currently on PyTorch AMD, memory accesses on the TensorInfo struct contained in the Operators passed into the kernelPointwiseApply kernel leads to hangs on the HCC runtime. Permuting the argument order such that the operator is first alleviates this issue and the kernel hangs disappear.  