### PR TITLE
Fix AT_CUDA_CHECK and AT_CUDNN_CHECK macros

### DIFF
--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -2,19 +2,25 @@
 
 #include "ATen/core/Error.h"
 
-#define AT_CUDNN_CHECK(STATUS)                                                 \
-  if (STATUS != CUDNN_STATUS_SUCCESS) {                                        \
-    if (STATUS == CUDNN_STATUS_NOT_SUPPORTED) {                                \
-      AT_ERROR(                                                                \
-          "CuDNN error: ",                                                     \
-          cudnnGetErrorString(STATUS),                                         \
-          ". This error may appear if you passed in a non-contiguous input."); \
-    } else {                                                                   \
-      AT_ERROR("CuDNN error: ", cudnnGetErrorString(STATUS));                  \
-    }                                                                          \
-  }
+#define AT_CUDNN_CHECK(EXPR)                                                     \
+  do {                                                                           \
+    cudnnStatus_t status = EXPR;                                                 \
+    if (status != CUDNN_STATUS_SUCCESS) {                                        \
+      if (status == CUDNN_STATUS_NOT_SUPPORTED) {                                \
+        AT_ERROR(                                                                \
+            "cuDNN error: ",                                                     \
+            cudnnGetErrorString(status),                                         \
+            ". This error may appear if you passed in a non-contiguous input."); \
+      } else {                                                                   \
+        AT_ERROR("cuDNN error: ", cudnnGetErrorString(status));                  \
+      }                                                                          \
+    }                                                                            \
+  } while (0)
 
-#define AT_CUDA_CHECK(STATUS)                             \
-  if (STATUS != cudaSuccess) {                            \
-    AT_ERROR("CUDA error: ", cudaGetErrorString(STATUS)); \
-  }
+#define AT_CUDA_CHECK(EXPR)                              \
+  do {                                                   \
+    cudaError_t err = EXPR;                              \
+    if (err != cudaSuccess) {                            \
+      AT_ERROR("CUDA error: ", cudaGetErrorString(err)); \
+    }                                                    \
+  } while (0)


### PR DESCRIPTION
Previously, the macros evaluated the expression multiple times on error.

For example:

```
AT_CUDA_CHECK(cudaStreamWaitEvent(ptr->stream, event, 0));
```

would previously expand to

```
if (cudaStreamWaitEvent(ptr->stream, event, 0) != cudaSuccess) {
    AT_ERROR("CUDA error: ", cudaGetErrorString(cudaStreamWaitEvent(ptr->stream, event, 0)));
}
```