### PR TITLE
[jit] Add resolver for 'torch' module

### DIFF
--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <string>
+#include <catch.hpp>
+
+#include <torch/jit.h>
+#include <torch/tensor.h>
+
+TEST_CASE("torch script") {
+  SECTION("multiple functions") {
+    auto module = torch::jit::compile(R"JIT(
+      def test_mul(a, b):
+        return a * b
+      def test_relu(a, b):
+        return torch.relu(a + b)
+      def test_while(a, i):
+        while i < 10:
+          a += a
+          i += 1
+        return a
+    )JIT");
+    auto a = torch::ones(1);
+    auto b = torch::ones(1);
+
+    REQUIRE(1 == torch::jit::run(
+      module, "test_mul", a, b)[0].toTensor().toCLong());
+
+    REQUIRE(2 == torch::jit::run(
+      module, "test_relu", a, b)[0].toTensor().toCLong());
+
+    REQUIRE(0x200 == torch::jit::run(
+      module, "test_while", a, b)[0].toTensor().toCLong());
+  }
+}

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -1,9 +1,9 @@
-#include <iostream>
-#include <string>
 #include <catch.hpp>
 
 #include <torch/jit.h>
 #include <torch/tensor.h>
+
+#include <string>
 
 TEST_CASE("torch script") {
   SECTION("multiple functions") {
@@ -21,13 +21,11 @@ TEST_CASE("torch script") {
     auto a = torch::ones(1);
     auto b = torch::ones(1);
 
-    REQUIRE(1 == torch::jit::run(
-      module, "test_mul", a, b)[0].toTensor().toCLong());
+    REQUIRE(1 == module->run_method("test_mul", a, b).toTensor().toCLong());
 
-    REQUIRE(2 == torch::jit::run(
-      module, "test_relu", a, b)[0].toTensor().toCLong());
+    REQUIRE(2 == module->run_method("test_relu", a, b).toTensor().toCLong());
 
-    REQUIRE(0x200 == torch::jit::run(
-      module, "test_while", a, b)[0].toTensor().toCLong());
+    REQUIRE(
+        0x200 == module->run_method("test_while", a, b).toTensor().toCLong());
   }
 }

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -209,6 +209,7 @@ if (NOT NO_API AND NOT USE_ROCM)
     ${TORCH_SRC_DIR}/csrc/api/src/optim/lbfgs.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/optim/rmsprop.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/optim/sgd.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
     )
 
 endif()
@@ -433,6 +434,7 @@ if (BUILD_TORCH_TEST AND NOT NO_API AND NOT USE_ROCM)
     ${TORCH_API_TEST_DIR}/static.cpp
     ${TORCH_API_TEST_DIR}/tensor_cuda.cpp
     ${TORCH_API_TEST_DIR}/tensor.cpp
+    ${TORCH_API_TEST_DIR}/jit.cpp
     # Temporary until ATen tests are built with Caffe2
     ${TORCH_API_TEST_DIR}/tensor_options.cpp
     ${TORCH_API_TEST_DIR}/tensor_options_cuda.cpp

--- a/torch/csrc/api/include/torch/jit.h
+++ b/torch/csrc/api/include/torch/jit.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <string>
+#include <torch/csrc/jit/script/module.h>
+#include <torch/csrc/jit/script/compiler.h>
+#include <torch/csrc/jit/stack.h>
+
+namespace torch {
+namespace jit {
+
+/// Compiles Python JIT code into a graph that can be executed.
+///
+/// For example:
+/// ```
+/// auto module = torch::jit::compile(R"JIT(
+///   def relu_script(a, b):
+///     return torch.relu(a + b)
+///   def test_while(a, i):
+///     while i < 10:
+///       a += a
+///       i += 1
+///     return a
+/// )JIT");
+/// auto output = torch::jit::run(module, "relu_script", a, b);
+/// auto output = torch::jit::run(module, "test_while", a, b);
+/// ```
+///
+/// @param source A JIT string containing functions that are valid under the
+///               scope of the script compiler
+/// @return A module containing the compiled functions
+std::shared_ptr<script::Module> compile(const std::string& source);
+
+/// Run a method from a module and get a list of the returns.
+///
+/// For example:
+/// ```
+/// auto output = torch::jit::run(module, "relu_script", a, b);
+/// std::cout << output[0].toTensor().toCLong() << std::endl;
+/// ```
+///
+///
+/// @param module A module containing the method `method_name` (see torch::jit::compile)
+/// @param method_name The name of the method to run
+/// @param args Arguments to be passed to the method
+/// @return A vector of `IValue`s that contain the results of the method
+template<typename... Types>
+Stack run(std::shared_ptr<script::Module> module, const std::string& method_name, Types&... args) {
+  // Marhsal arguments into stack of IValues
+  Stack stack;
+  std::initializer_list<int>{ (stack.push_back(IValue(args)), 0)... };
+
+  // Interpret graph and run computation
+  module->get_method(method_name).run(stack);
+  return stack;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/api/include/torch/jit.h
+++ b/torch/csrc/api/include/torch/jit.h
@@ -1,9 +1,9 @@
 #pragma once
+#include <torch/csrc/jit/script/compiler.h>
+#include <torch/csrc/jit/script/module.h>
+#include <torch/csrc/jit/stack.h>
 
 #include <string>
-#include <torch/csrc/jit/script/module.h>
-#include <torch/csrc/jit/script/compiler.h>
-#include <torch/csrc/jit/stack.h>
 
 namespace torch {
 namespace jit {
@@ -11,48 +11,23 @@ namespace jit {
 /// Compiles Python JIT code into a graph that can be executed.
 ///
 /// For example:
-/// ```
-/// auto module = torch::jit::compile(R"JIT(
-///   def relu_script(a, b):
-///     return torch.relu(a + b)
-///   def test_while(a, i):
-///     while i < 10:
-///       a += a
-///       i += 1
-///     return a
-/// )JIT");
-/// auto output = torch::jit::run(module, "relu_script", a, b);
-/// auto output = torch::jit::run(module, "test_while", a, b);
-/// ```
+/// @code
+///   auto module = torch::jit::compile(R"JIT(
+///     def relu_script(a, b):
+///       return torch.relu(a + b)
+///     def test_while(a, i):
+///       while i < 10:
+///         a += a
+///         i += 1
+///       return a
+///   )JIT");
+///   IValue output = module->run_method("relu_script", a, b);
+/// @endcode
 ///
-/// @param source A JIT string containing functions that are valid under the
-///               scope of the script compiler
+/// @param source A string containing functions containing script code to
+/// compile
 /// @return A module containing the compiled functions
 std::shared_ptr<script::Module> compile(const std::string& source);
-
-/// Run a method from a module and get a list of the returns.
-///
-/// For example:
-/// ```
-/// auto output = torch::jit::run(module, "relu_script", a, b);
-/// std::cout << output[0].toTensor().toCLong() << std::endl;
-/// ```
-///
-///
-/// @param module A module containing the method `method_name` (see torch::jit::compile)
-/// @param method_name The name of the method to run
-/// @param args Arguments to be passed to the method
-/// @return A vector of `IValue`s that contain the results of the method
-template<typename... Types>
-Stack run(std::shared_ptr<script::Module> module, const std::string& method_name, Types&... args) {
-  // Marhsal arguments into stack of IValues
-  Stack stack;
-  std::initializer_list<int>{ (stack.push_back(IValue(args)), 0)... };
-
-  // Interpret graph and run computation
-  module->get_method(method_name).run(stack);
-  return stack;
-}
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/api/include/torch/jit.h
+++ b/torch/csrc/api/include/torch/jit.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/stack.h>
 
 #include <string>
+#include <memory>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -3,6 +3,9 @@
 #include <torch/csrc/jit/script/compiler.h>
 #include <torch/csrc/jit/stack.h>
 
+#include <memory>
+#include <string>
+
 namespace torch {
 namespace jit {
 

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,7 @@ namespace jit {
 
 std::shared_ptr<script::Module> compile(const std::string& source) {
   auto module = std::make_shared<script::Module>();
-  defineMethodsInModule(*module, source, script::nativeResolver, nullptr);
+  defineMethodsInModule(*module, source, script::nativeResolver, /*self=*/nullptr);
   return module;
 }
 

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -1,0 +1,16 @@
+#include <torch/jit.h>
+
+#include <torch/csrc/jit/script/compiler.h>
+#include <torch/csrc/jit/stack.h>
+
+namespace torch {
+namespace jit {
+
+std::shared_ptr<script::Module> compile(const std::string& source) {
+  auto module = std::make_shared<script::Module>();
+  defineMethodsInModule(*module, source, script::nativeResolver, nullptr);
+  return module;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1906,12 +1906,6 @@ std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver) {
   return m.get_method(def.name().name()).graph();
 }
 
-std::shared_ptr<Graph> compileFunction(const std::string& source) {
-  Parser p(source);
-  auto def = Def(p.parseFunction(true));
-  return compileFunction(def, nativeResolver);
-}
-
 std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(SourceRange loc, Method& m, at::optional<size_t> size_hint) {
   static const auto make_simple_value = [](Value* v) -> std::shared_ptr<SugaredValue> {
     return std::make_shared<SimpleValue>(v);

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -122,8 +122,23 @@ struct TORCH_API BuiltinFunction : public SugaredValue {
       size_t n_binders) override;
 };
 
+struct TORCH_API BuiltinModule : public SugaredValue {
+  BuiltinModule(const std::string& name)
+    : name(name) {}
+  std::string name;
+
+  virtual std::string kind() const override {
+    return "builtin module";
+  }
+
+  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
+    return std::make_shared<BuiltinFunction>(Symbol::aten(field), at::nullopt);
+  }
+};
+
 using Resolver = std::function<std::shared_ptr<
     SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
+
 TORCH_API void defineMethodsInModule(
   Module & m,
   const std::vector<Def>& definitions,
@@ -134,6 +149,7 @@ TORCH_API void defineMethodsInModule(
 // same as above but parse the definitions from source
 TORCH_API void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
 TORCH_API std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
+TORCH_API std::shared_ptr<Graph> compileFunction(const std::string& source);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -127,11 +127,11 @@ struct TORCH_API BuiltinModule : public SugaredValue {
     : name(name) {}
   std::string name;
 
-  virtual std::string kind() const override {
+  std::string kind() const override {
     return "builtin module";
   }
 
-  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
+  std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
     return std::make_shared<BuiltinFunction>(Symbol::aten(field), at::nullopt);
   }
 };

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -139,6 +139,8 @@ struct TORCH_API BuiltinModule : public SugaredValue {
 using Resolver = std::function<std::shared_ptr<
     SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
 
+std::shared_ptr<SugaredValue> nativeResolver(const std::string& name, Method& m, const SourceRange& loc);
+
 TORCH_API void defineMethodsInModule(
   Module & m,
   const std::vector<Def>& definitions,
@@ -149,7 +151,6 @@ TORCH_API void defineMethodsInModule(
 // same as above but parse the definitions from source
 TORCH_API void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
 TORCH_API std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
-TORCH_API std::shared_ptr<Graph> compileFunction(const std::string& source);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -352,6 +352,24 @@ struct Module {
     return nullptr;
   }
 
+  /// Run a method from this module.
+  ///
+  /// For example:
+  /// @code
+  ///   IValue output = module->run("relu_script", a, b);
+  /// @endcode
+  ///
+  /// To get a compile a module from a source string, see torch::jit::compile
+  ///
+  /// @param method_name The name of the method to run
+  /// @param args Arguments to be passed to the method
+  /// @return An IValue containing the return value (or values if it is a tuple)
+  /// from the method
+  template <typename... Types>
+  IValue run_method(const std::string& method_name, Types&&... args) {
+    return get_method(method_name)({IValue(std::forward<Types>(args))...});
+  }
+
   void save(const std::string& filename);
 
  private:

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -871,12 +871,7 @@ void testControlFlow() {
     return stack;
   };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   auto L = [](int64_t l) { return IValue(autograd::make_variable(scalar_to_tensor(at::Scalar(l)))); };
-=======
-  auto L = [](int64_t l) { return IValue(autograd::make_variable(at::Scalar(l).toTensor())); };
->>>>>>> Add JIT to C++ API
   auto V = [](IValue t) { return std::move(t).toTensor().toCLong(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
     return V(run(name, {L(a), L(b)})[0]);
@@ -886,23 +881,6 @@ void testControlFlow() {
   REQUIRE(2 == run_binary("if_one", 2, 3));
   REQUIRE(2 == run_binary("if_one", 3, 2));
   REQUIRE(256 == run_binary("while_test",2,0));
-<<<<<<< HEAD
-=======
-const static auto script_example = R"JIT(
-  def relu_test(a, b):
-    c = a
-    if a < b:
-      c = b
-    else:
-      c = a
-    return torch.relu(c)
-)JIT";
-void testModuleResolver() {
-  auto graph = script::compileFunction(script_example);
-  REQUIRE(2 == run_graph(graph, 1, 2));
->>>>>>> [jit] Add resolver for 'torch' module
-=======
->>>>>>> Add JIT to C++ API
 }
 
 void testIValue() {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -838,6 +838,23 @@ void testBlocks(std::ostream & out) {
   out << *g2 << "\n";
 }
 
+static std::vector<IValue> run(std::shared_ptr<Graph> graph, std::vector<IValue> stack) {
+  Code code(graph);
+  InterpreterState interp(code);
+  interp.runOneStage(stack);
+  return stack;
+};
+
+static IValue L(int64_t l) { return IValue(autograd::make_variable(at::Scalar(l).toTensor())); };
+static long V(IValue t) { return std::move(t).toTensor().toCLong(); };
+
+static long run_graph(std::shared_ptr<Graph> graph, int64_t a, int64_t b) {
+  return V(run(graph, {L(a), L(b)})[0]);
+};
+
+static long run_method(script::Module& cu, const std::string & name, int64_t a, int64_t b) {
+  return run_graph(cu.get_method(name).graph(), a, b);
+};
 
 const static auto cf_examples = R"JIT(
   def if_test(a, b):
@@ -863,14 +880,14 @@ const static auto cf_examples = R"JIT(
 void testControlFlow() {
   script::Module cu;
   script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver(), nullptr);
-  auto run = [&](const std::string & name, std::vector<IValue> stack) {
-    auto graph = cu.get_method(name).graph();
-    Code code(graph);
-    InterpreterState interp(code);
-    interp.runOneStage(stack);
-    return stack;
-  };
+  REQUIRE(2 == run_method(cu, "if_test", 1, 2));
+  REQUIRE(3 == run_method(cu, "if_test", 3, 2));
+  REQUIRE(2 == run_method(cu, "if_one", 2, 3));
+  REQUIRE(2 == run_method(cu, "if_one", 3, 2));
+  REQUIRE(256 == run_method(cu, "while_test",2,0));
+}
 
+<<<<<<< HEAD
   auto L = [](int64_t l) { return IValue(autograd::make_variable(scalar_to_tensor(at::Scalar(l)))); };
   auto V = [](IValue t) { return std::move(t).toTensor().toCLong(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
@@ -881,6 +898,20 @@ void testControlFlow() {
   REQUIRE(2 == run_binary("if_one", 2, 3));
   REQUIRE(2 == run_binary("if_one", 3, 2));
   REQUIRE(256 == run_binary("while_test",2,0));
+=======
+const static auto script_example = R"JIT(
+  def relu_test(a, b):
+    c = a
+    if a < b:
+      c = b
+    else:
+      c = a
+    return torch.relu(c)
+)JIT";
+void testModuleResolver() {
+  auto graph = script::compileFunction(script_example);
+  REQUIRE(2 == run_graph(graph, 1, 2));
+>>>>>>> [jit] Add resolver for 'torch' module
 }
 
 void testIValue() {
@@ -1178,6 +1209,8 @@ TEST_CASE( "jit test CPU", "[cpu]" ) {
     internedStringsTests();
   SECTION( "custom operators" )
     testCustomOperators();
+  SECTION( "torch module" )
+    testModuleResolver();
 }
 
 TEST_CASE( "jit test CUDA", "[cuda]" ) {


### PR DESCRIPTION
This lets you compile builtin functions from C++ without having a dependence on Python

```cpp
auto module = torch::jit::compile(JIT"(
def my_script_method(x, y):
    return torch.relu(x) + y
)");
IValue result = module->run_method("my_script_method", 1, 2);
```

@goldsborough @zdevito @apaszke