### PR TITLE
[Caffe2] Support new Reshape semantics

### DIFF
--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -87,7 +87,9 @@ class CAFFE2_API Workspace {
     CAFFE_ENFORCE(shared, "Parent workspace must be specified");
     for (const auto& forwarded : forwarded_blobs) {
       CAFFE_ENFORCE(
-          shared->HasBlob(forwarded.second), "Invalid parent workspace blob");
+          shared->HasBlob(forwarded.second),
+          "Invalid parent workspace blob: ",
+          forwarded.second);
       forwarded_blobs_[forwarded.first] =
           std::make_pair(shared, forwarded.second);
     }

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -825,8 +825,7 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
   if (has_axis) {
     axis = it->second->i();
   }
-  if ((legacy_mode_ && has_axis) ||
-      (!legacy_mode_ && x_shape.dims().size() > 2)) {
+  if (x_shape.dims().size() > 2) {
     // we need to reshape only when dimension is higher than 2
     auto outer = DimProd(x_shape, 0, axis);
     auto inner = DimProd(x_shape, axis, x_shape.dims().size());
@@ -843,8 +842,7 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
   if (it != args.end()) {
     axis_w = it->second->i();
   }
-  if ((legacy_mode_ && it != args.end()) ||
-      (!legacy_mode_ && w_shape.dims().size() > 2)) {
+  if (w_shape.dims().size() > 2) {
     // we need to reshape only when dimension is higher than 2
     auto outer = DimProd(w_shape, 0, axis_w);
     auto inner = DimProd(w_shape, axis_w, w_shape.dims().size());
@@ -858,9 +856,7 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
 
   auto gemm_y_output = (has_axis) ? dummy_->NewDummyName() : y;
   std::vector<AttributeProto> attrs = {MakeAttribute("transB", 1L)};
-  if (legacy_mode_) {
-    attrs.emplace_back(MakeAttribute("broadcast", 1));
-  }
+  attrs.emplace_back(MakeAttribute("broadcast", 1));
   nodes.emplace_back(MakeNode(
       "Gemm",
       {x, w, b},

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -856,7 +856,6 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
 
   auto gemm_y_output = (has_axis) ? dummy_->NewDummyName() : y;
   std::vector<AttributeProto> attrs = {MakeAttribute("transB", 1L)};
-  attrs.emplace_back(MakeAttribute("broadcast", 1));
   nodes.emplace_back(MakeNode(
       "Gemm",
       {x, w, b},

--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -35,8 +35,7 @@ class CAFFE2_API OnnxExporter {
       const std::unordered_map<std::string, caffe2::TensorShape>&);
 
  public:
-  OnnxExporter(DummyName* dummy = nullptr, bool legacy_mode = false)
-      : legacy_mode_(legacy_mode) {
+  OnnxExporter(DummyName* dummy = nullptr) {
     if (dummy) {
       dummy_ = std::shared_ptr<DummyName>(dummy, [](DummyName*) {});
     } else {
@@ -115,9 +114,6 @@ class CAFFE2_API OnnxExporter {
       get_per_op_renamed_attrs() const;
   const std::unordered_map<std::string, OnnxExporter::SpecialOpConverter>&
   get_special_operators() const;
-
-  // To generate onnx models with opset < 6
-  bool legacy_mode_{false};
 
   // Dummy name generator
   std::shared_ptr<DummyName> dummy_;

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -80,7 +80,7 @@ void FillModelInfo(::ONNX_NAMESPACE::ModelProto* model) {
   model->set_producer_name("caffe2");
   auto* opset_id = model->add_opset_import();
   opset_id->set_domain("");
-  opset_id->set_version(3);
+  opset_id->set_version(7);
 }
 } // namespace
 
@@ -148,6 +148,7 @@ OperatorDef OnnxifiTransformer::BuildOnnxifiOp(
 
 NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
     const caffe2::NetDef& net,
+    const Workspace& mapped_ws,
     Workspace* ws,
     onnx::OnnxExporter* exporter,
     std::unordered_map<std::string, TensorShape>* shape_hints) {
@@ -158,6 +159,7 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
   DeviceOption option;
   CPUContext context(option);
   context.SwitchToDevice();
+  std::vector<std::string> extra_weights;
   for (const auto& op : net.op()) {
     const auto results = exporter->Caffe2OpToOnnxNodes(op, *shape_hints);
     for (const auto& n : results.first) {
@@ -165,10 +167,6 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
     }
     for (const auto& t : results.second) {
       VLOG(2) << "Adding extra init tensor: " << t.name();
-      CAFFE_ENFORCE_EQ(
-          t.data_type(),
-          ::ONNX_NAMESPACE::TensorProto::FLOAT,
-          "Only supports conversion of float type for now");
       TensorShape shape;
       shape.mutable_dims()->CopyFrom(t.dims());
       shape_hints->emplace(t.name(), std::move(shape));
@@ -177,15 +175,28 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
       auto* blob = ws->CreateBlob(t.name());
       auto* cpu_tensor = blob->GetMutableTensor(CPU);
       std::vector<TIndex> dims;
-      std::copy(t.dims().begin(), t.dims().end(), dims.begin());
+      for(const auto& d : t.dims()) {
+        dims.push_back(d);
+      }
       cpu_tensor->Resize(dims);
-      context.CopyBytesSameDevice(
-          cpu_tensor->size() * sizeof(float),
-          static_cast<const void*>(t.raw_data().data()),
-          cpu_tensor->raw_mutable_data(TypeMeta::Make<float>()));
+      if (t.data_type() == ::ONNX_NAMESPACE::TensorProto::FLOAT) {
+        context.CopyBytesSameDevice(
+            cpu_tensor->size() * sizeof(float),
+            static_cast<const void*>(t.raw_data().data()),
+            cpu_tensor->raw_mutable_data(TypeMeta::Make<float>()));
+      } else if (t.data_type() == ::ONNX_NAMESPACE::TensorProto::INT64) {
+        context.CopyBytesSameDevice(
+            cpu_tensor->size() * sizeof(int64_t),
+            static_cast<const void*>(t.raw_data().data()),
+            cpu_tensor->raw_mutable_data(TypeMeta::Make<int64_t>()));
+      } else {
+        CAFFE_THROW(
+            "Unsupported tensor data type for conversion: ", t.data_type());
+      }
       context.FinishDeviceComputation();
 
       // Add mappings
+      extra_weights.emplace_back(t.name());
       CAFFE_ENFORCE(
           input_mapping_.emplace(t.name(), t.name()).second,
           MakeString("Tensor ", t.name(), " already exists in the workspace"));
@@ -216,7 +227,7 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
 
   // Convert inputs and figure out weights
   std::unordered_set<std::string> weights;
-  const std::vector<string>& ws_blobs = ws->Blobs();
+  const std::vector<string>& ws_blobs = mapped_ws.Blobs();
   for (const auto& s : ws_blobs) {
     VLOG(2) << "Add weights: " << s;
     weights.emplace(s);
@@ -227,10 +238,11 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
   std::vector<std::string> total_inputs_vec;
 
   // Extra intermediate weights created during conversion
-  for (const auto& extra_weight : onnx_model.graph().initializer()) {
-    if (total_inputs.emplace(extra_weight.name()).second) {
-      total_inputs_vec.emplace_back(extra_weight.name());
+  for (const auto& extra_weight : extra_weights) {
+    if (total_inputs.emplace(extra_weight).second) {
+      total_inputs_vec.emplace_back(extra_weight);
     }
+    initialization_list.emplace(extra_weight);
   }
   // Boundary inputs, should not be weights
   std::unordered_set<std::string> boundary_inputs;
@@ -319,7 +331,7 @@ void OnnxifiTransformer::Transform(
   auto shape_hints = InferShapes(&mapped_ws, pred_net, &shape_hints_ordered);
 
   CAFFE_ENFORCE(pred_net, "Predict net cannot be nullptr");
-  onnx::OnnxExporter exporter(nullptr, true);
+  onnx::OnnxExporter exporter(nullptr);
 
   // function to tell whether the ONNXIFI backend supports a given C2 op or not
   // TODO: choose backend id
@@ -356,15 +368,15 @@ void OnnxifiTransformer::Transform(
         }
       };
 
-  // function to convert runnbale subgraph into a trt op. Note that to keep the
+  // function to convert runnable subgraph into a trt op. Note that to keep the
   // interface clean, we do the double conversion from C2 op to Onnx ops here
   // but it should be OK as the cost is really small. We also need to keep the
   // same exporter throughout the process to avoid duplicated dummy name
   // generation
-  onnx::OnnxExporter exporter2(nullptr, true);
-  auto trt_converter = [this, &mapped_ws, &shape_hints, &exporter2](
+  onnx::OnnxExporter exporter2(nullptr);
+  auto trt_converter = [this, ws, &mapped_ws, &shape_hints, &exporter2](
                            const caffe2::NetDef& net) mutable {
-    return SubnetToOnnxifiOp(net, &mapped_ws, &exporter2, &shape_hints);
+    return SubnetToOnnxifiOp(net, mapped_ws, ws, &exporter2, &shape_hints);
   };
 
   NetDef net_opt = opt::OptimizeForBackend(*pred_net, supports, trt_converter);

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -28,8 +28,12 @@ class CAFFE2_API OnnxifiTransformer {
       const std::unordered_map<std::string, TensorShape>& shape_hints);
 
  private:
+  // Note that we have two workspaces here as inputs. The first mapped_ws is
+  // used to mapped SSA names back to c2 original names. The second one is
+  // actually used to inject more weights into the original workspace
   caffe2::NetDef SubnetToOnnxifiOp(
       const caffe2::NetDef& net,
+      const Workspace& mapped_ws,
       Workspace* ws,
       onnx::OnnxExporter* exporter,
       std::unordered_map<std::string, TensorShape>* shape_hints);

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -54,8 +54,8 @@ def onnxifi_caffe2_net(
     for k, v in input_shapes.items():
         shape_hints[k] = v
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
-                                       shape_hints,
-                                       debug)
+                             shape_hints,
+                             debug)
     pred_net_cut = caffe2_pb2.NetDef()
     pred_net_cut.ParseFromString(pred_net_str)
     return pred_net_cut


### PR DESCRIPTION
Since ONNX opset version >5, Reshape changed semantics to take a shape tensor as input instead of relying on `shape` attribute to decide what shape to reshape to. ONNXIFI op has been postponing this change as some of the backends such as TensorRT were not ready. Now that the backends have adopted this semantics, we can remove the legacy mode and output opset version 7 ONNX models. 

This change also flushes out some of the bugs and new requirement. 
- Converting shape info into int64 tensor
- Fix a bug when we output the shape tensor in the mapped workspace instead of the original workspace