### PR TITLE
Remove Tensor constructor of Scalar.

### DIFF
--- a/aten/src/ATen/Scalar.cpp
+++ b/aten/src/ATen/Scalar.cpp
@@ -36,7 +36,7 @@ Scalar Scalar::operator-() const {
  } else if (isIntegral()) {
    return Scalar(-v.i);
  } else {
-   return Scalar(-Tensor(t)._local_scalar());
+   return -Tensor(t)._local_scalar();
  }
 }
 

--- a/aten/src/ATen/Scalar.cpp
+++ b/aten/src/ATen/Scalar.cpp
@@ -36,7 +36,7 @@ Scalar Scalar::operator-() const {
  } else if (isIntegral()) {
    return Scalar(-v.i);
  } else {
-   return Scalar(-Tensor(t));
+   return Scalar(-Tensor(t)._local_scalar());
  }
 }
 

--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -19,12 +19,6 @@ class AT_API Scalar {
 public:
   Scalar() : Scalar(int64_t(0)) {}
 
-  explicit Scalar(const detail::TensorBase & t)
-  : tag(Tag::HAS_t), t(t) {
-    AT_CHECK(t.defined(), "Attempting to create a Scalar from an undefined tensor");
-    AT_CHECK(t.dim() == 0, "Attempting to create a Scalar from a ", t.dim(), " dim tensor");
-  }
-
 #define DEFINE_IMPLICIT_CTOR(type,name,member) \
   Scalar(type vv) \
   : tag(Tag::HAS_##member) { \

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -55,7 +55,7 @@ inline Tensor Tensor::operator[](Tensor index) const {
       index.dim() == 0,
       "Can only index with tensors that are scalars (zero-dim)");
   // The Scalar(Tensor) constructor is explicit, so we need to call it.
-  return this->operator[](Scalar(index));
+  return this->operator[](index._local_scalar());
 }
 inline Tensor Tensor::operator[](int64_t index) const {
   return select(0, index);

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1227,7 +1227,7 @@ def create_derived(backend_type_env, declarations):
         if broadcasts_arg:
             return []
         zero_dim_actuals = [arg['name']
-                            if arg['name'] != zero_dim_dispatch else "Scalar({})".format(arg['name'])
+                            if arg['name'] != zero_dim_dispatch else "{}._local_scalar()".format(arg['name'])
                             for arg in option['formals_list']]
         return [ZERO_DIM_CHECK.substitute(env, check_name=zero_dim_dispatch, zero_dim_actuals=zero_dim_actuals)]
 

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -50,7 +50,7 @@ Tensor& div_out(Tensor& result, const Tensor& self, const Tensor& other) {
       AT_ERROR("div(): sparse division only supports division by a scalar ",
         "(got shape ", other.sizes(), " for argument 'other')");
     }
-    return at::_sparse_div_out(result, self, Scalar(other));
+    return at::_sparse_div_zerodim_out(result, self, other);
   }
   auto iter = TensorIterator::binary_op(result, self, other);
   div_stub(iter->device_type(), *iter);

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -258,8 +258,7 @@ Tensor _bincount_cuda_template(
     AT_ERROR("input and weights should have the same length");
   }
 
-  auto maxScalarGpu = Scalar(self.max());
-  auto nbins = maxScalarGpu.local().to<int64_t>() + 1L;
+  auto nbins = self.max().toCLong() + 1L;
   nbins = std::max(nbins, minlength);
   // alloc output counter on GPU
   Tensor output;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1448,7 +1448,13 @@
     CPU: add_out_dense_sparse_cpu
     CUDA: add_out_dense_sparse_cuda
 
-- func: _sparse_div_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: _sparse_div_zerodim_out(Tensor result, Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    SparseCPU: div_out_sparse_zerodim
+    SparseCUDA: div_out_sparse_zerodim
+
+- func: _sparse_div_scalar_out(Tensor result, Tensor self, Scalar other) -> Tensor
   variants: function
   dispatch:
     SparseCPU: div_out_sparse_scalar
@@ -1459,6 +1465,12 @@
   dispatch:
     SparseCPU: mul_out_sparse_cpu
     SparseCUDA: mul_out_sparse_cuda
+
+- func: _sparse_mul_zerodim_out(Tensor result, Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    SparseCPU: mul_out_sparse_zerodim
+    SparseCUDA: mul_out_sparse_zerodim
 
 - func: _sparse_mul_scalar_out(Tensor result, Tensor self, Scalar other) -> Tensor
   variants: function

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -59,9 +59,10 @@ static Tensor scalar_tensor(Scalar s) {
   return tensor;
 }
 
-SparseTensor& mul_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scalar value) {
+SparseTensor& mul_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value) {
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());
+  AT_ASSERT(value.dim() == 0);
 
   if (isSameTensor(r, t)) {
     r._values().mul_(value);
@@ -70,11 +71,15 @@ SparseTensor& mul_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scal
     r._indices().resize_as_(t._indices());
     r._indices().copy_(t._indices());
     Tensor r_values = r._values(); // Sigh... needed because mul_out takes Tensor&
-    at::mul_out(r_values, t._values(), scalar_tensor(value));
+    at::mul_out(r_values, t._values(), value);
     _get_sparse_impl(r)->set_nnz_and_narrow(t._nnz());
     _get_sparse_impl(r)->set_coalesced(t.is_coalesced());
   }
   return r;
+}
+
+SparseTensor& mul_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scalar value) {
+  return mul_out_sparse_zerodim(r, t, scalar_tensor(value));
 }
 
 // --------------------------------------------------------------------
@@ -139,9 +144,10 @@ SparseTensor pow_sparse_scalar(const SparseTensor& t, Scalar value) {
 // div(SparseTensor, Scalar)
 // --------------------------------------------------------------------
 
-SparseTensor& div_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scalar value) {
+SparseTensor& div_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value) {
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());
+  AT_ASSERT(value.dim() == 0);
 
   if (isSameTensor(r, t)) {
     r._values().div_(value);
@@ -150,11 +156,15 @@ SparseTensor& div_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scal
     r._indices().resize_as_(t._indices());
     r._indices().copy_(t._indices());
     Tensor r_values = r._values(); // Sigh... needed because div_out takes Tensor&
-    at::div_out(r_values, t._values(), scalar_tensor(value));
+    at::div_out(r_values, t._values(), value);
     _get_sparse_impl(r)->set_nnz_and_narrow(t._nnz());
     _get_sparse_impl(r)->set_coalesced(t.is_coalesced());
   }
   return r;
+}
+
+SparseTensor& div_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scalar value) {
+  return div_out_sparse_zerodim(r, t, scalar_tensor(value));
 }
 
 // --------------------------------------------------------------------
@@ -345,9 +355,9 @@ Tensor& add_out_dense_sparse_cpu(Tensor& r, const Tensor& dense, SparseTensorRef
 
 SparseTensor& mul_out_sparse_cpu(SparseTensor& r, const Tensor& t_, const Tensor& src_) {
   if (src_.dim() == 0) {
-    return mul_out_sparse_scalar(r, t_, Scalar(src_));
+    return mul_out_sparse_zerodim(r, t_, src_);
   } else if (t_.dim() == 0) {
-    return mul_out_sparse_scalar(r, src_, Scalar(t_));
+    return mul_out_sparse_zerodim(r, src_, t_);
   }
 
   AT_CHECK(t_.sizes().equals(src_.sizes()), "mul operands have incompatible sizes");

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -408,9 +408,9 @@ SparseTensor& add_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t, const
 SparseTensor& mul_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t_, const SparseTensor& src_) {
 #ifndef __HIP_PLATFORM_HCC__
   if (src_.dim() == 0) {
-    return mul_out_sparse_scalar(r_, t_, Scalar(src_));
+    return mul_out_sparse_zerodim(r_, t_, src_);
   } else if (t_.dim() == 0) {
-    return mul_out_sparse_scalar(r_, src_, Scalar(t_));
+    return mul_out_sparse_zerodim(r_, src_, t_);
   }
 
   AT_ASSERT(t_.is_cuda()); // dispatch argument

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -19,7 +19,7 @@ void trace() {
     trace += foo_a[i][i];
   }
 
-  REQUIRE(Scalar(foo.trace()).toFloat() == Approx(trace));
+  REQUIRE(foo.trace().toCFloat() == Approx(trace));
 }
 
 TEST_CASE( "atest", "[]" ) {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -54,7 +54,7 @@ static void test(Type & type) {
     auto z = b.sort(1);
     auto z_sorted = std::get<0>(z);
 
-    REQUIRE(Scalar(z_sorted[0][0]).toFloat() < Scalar(z_sorted[0][1]).toFloat());
+    REQUIRE(z_sorted[0][0].toCFloat() < z_sorted[0][1].toCFloat());
   }
 
   if(type.backend() != Backend::CUDA)
@@ -62,7 +62,7 @@ static void test(Type & type) {
     Tensor b = randperm(15, type);
     Tensor rv, ri;
     std::tie(rv, ri) = sort(b, 0);
-    REQUIRE(Scalar(rv[0]).toFloat() <= Scalar(rv[1]).toFloat());
+    REQUIRE(rv[0].toCFloat() <= rv[1].toCFloat());
   }
 
   SECTION( "context" ) {
@@ -154,7 +154,7 @@ static void test(Type & type) {
 
   SECTION( "abs(value)" ) {
     Tensor r = at::abs(type.scalarTensor(-3));
-    REQUIRE(Scalar(r).toInt() == 3);
+    REQUIRE(r.toCInt() == 3);
   }
 
 //TODO(zach): operator overloads
@@ -184,7 +184,6 @@ static void test(Type & type) {
   SECTION( "zero-dim" ) {
     Tensor a =  type.scalarTensor(4); //rand(type, {1});
 
-    REQUIRE_NOTHROW(Scalar(a));
     Tensor b = rand({3,4}, type);
     REQUIRE((a + a).dim() == 0);
     REQUIRE((1 + a).dim() == 0);
@@ -196,7 +195,7 @@ static void test(Type & type) {
     auto f = rand({3,4}, type);
     f[2] = zeros({4}, type);
     f[1][0] = -1;
-    REQUIRE(Scalar(f[2][0]).toDouble() == 0);
+    REQUIRE(f[2][0].toCDouble() == 0);
   }
 
   SECTION( "tensor from TH" ) {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -255,7 +255,7 @@ static void test(Type & type) {
     REQUIRE_THROWS_WITH(
         tensor[ones({}) * 3.14].equal(one),
         StartsWith(
-            "Can only index tensors with integral scalars (got CPUFloatType)"));
+            "Can only index tensors with integral scalars (got CPUDoubleType)"));
     REQUIRE_THROWS_WITH(
         tensor[Tensor()].equal(one),
         StartsWith("Can only index with tensors that are defined"));

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE( "scalar test", "[]" ) {
   // check Scalar.toTensor on Scalars backed by different data types
   REQUIRE(bar.toTensor().type().scalarType() == kDouble);
   REQUIRE(what.toTensor().type().scalarType() == kLong);
-  REQUIRE(ones({})._local_scalar().toTensor().type().scalarType() == kFloat);
+  REQUIRE(ones({})._local_scalar().toTensor().type().scalarType() == kDouble);
 
   if (x.type().scalarType() != ScalarType::Half) {
     AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -31,25 +31,6 @@ struct Foo<Half> {
   static void apply(Tensor a, Tensor b) {}
 };
 
-void test_ctors() {
-  // create scalars backed by tensors
-  auto s1 = Scalar(CPU(kFloat).scalarTensor(1));
-  auto s2 = Scalar(CPU(kFloat).scalarTensor(2));
-  Scalar{s1};
-  Scalar{std::move(s2)};
-  REQUIRE(s2.isBackedByTensor());
-  REQUIRE(!s2.toTensor().defined());
-  s2 = s1;
-  REQUIRE(s2.isBackedByTensor());
-  REQUIRE(s2.toFloat() == 1.0);
-  Scalar s3;
-  s3 = std::move(s2);
-  REQUIRE(s2.isBackedByTensor());
-  REQUIRE(!s2.toTensor().defined());
-  REQUIRE(s3.isBackedByTensor());
-  REQUIRE(s3.toFloat() == 1.0);
-}
-
 void test_overflow() {
   auto s1 = Scalar(M_PI);
   REQUIRE(s1.toFloat() == static_cast<float>(M_PI));
@@ -109,9 +90,8 @@ TEST_CASE( "scalar test", "[]" ) {
   Tensor next_h = i2h.add(h2h);
   next_h = next_h.tanh();
 
-  REQUIRE_THROWS(Scalar{Tensor{}});
+  REQUIRE_THROWS(Tensor{}._local_scalar());
 
-  test_ctors();
   test_overflow();
 
   if(at::hasCUDA()) {
@@ -123,7 +103,7 @@ TEST_CASE( "scalar test", "[]" ) {
   // check Scalar.toTensor on Scalars backed by different data types
   REQUIRE(bar.toTensor().type().scalarType() == kDouble);
   REQUIRE(what.toTensor().type().scalarType() == kLong);
-  REQUIRE(Scalar(ones({})).toTensor().type().scalarType() == kFloat);
+  REQUIRE(ones({})._local_scalar().toTensor().type().scalarType() == kFloat);
 
   if (x.type().scalarType() != ScalarType::Half) {
     AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -10,12 +10,12 @@
 
 template <typename T>
 bool exactly_equal(at::Tensor left, T right) {
-  return at::Scalar(left).to<T>() == right;
+  return left._local_scalar().to<T>() == right;
 }
 
 template <typename T>
 bool almost_equal(at::Tensor left, T right, T tolerance = 1e-4) {
-  return std::abs(at::Scalar(left).to<T>() - right) < tolerance;
+  return std::abs(left._local_scalar().to<T>() - right) < tolerance;
 }
 
 #define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)                \

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -135,12 +135,12 @@ void printAttributes(std::ostream & out, const Node * n, bool ignore_subgraph=fa
           at::Tensor t = n->t(name);
           // 1-elem tensors are usually boxed scalars, so print them like it
           if (t.numel() == 1) {
-            auto scalar = at::Scalar(t.view({})).local();
+            auto scalar_tensor = t.view({})._local_scalar();
             out << "{";
-            if (scalar.isFloatingPoint()) {
-              out << scalar.toDouble();
+            if (scalar_tensor.isFloatingPoint()) {
+              out << scalar_tensor.toDouble();
             } else {
-              out << scalar.toLong();
+              out << scalar_tensor.toLong();
             }
             out << "}";
           } else if (t.numel() <= max_tensor_display_size) {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -905,7 +905,7 @@ void testControlFlow() {
   };
 
   auto L = [](int64_t l) { return IValue(autograd::make_variable(at::Scalar(l).toTensor())); };
-  auto V = [](IValue t) { return at::Scalar(std::move(t).toTensor()).toLong(); };
+  auto V = [](IValue t) { return std::move(t).toTensor().toCLong(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
     return V(run(name, {L(a), L(b)})[0]);
   };

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -226,7 +226,7 @@ inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar
   // Zero-dim tensors are converted to Scalars as-is. Note this doesn't currently
   // handle most NumPy scalar types except np.float64.
   if (THPVariable_Check(args[i])) {
-    return at::Scalar(((THPVariable*)args[i])->cdata);
+    return ((THPVariable*)args[i])->cdata._local_scalar();
   }
   if (THPUtils_checkLong(args[i])) {
     return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));


### PR DESCRIPTION
This is along the way of removing Tensor as a member of the tagged union in Scalar.  This simplifies ordering dependencies, because currently Scalar and Tensor both depend on each other (so we introduce a TensorBase).  Also, this API isn't particularly useful publicly: we can't autograd through Scalars, so you still need a Tensor overload basically everywhere anyway.

I'm undecided what the final API should be here.  We could keep a Tensor constructor on Scalar, but have it generate a local scalar; this is convenient but given this API used to be non-synchronizing, it may not be the best.

For now, I'm just using _local_scalar, which is clear, although we should get rid of the prefix _ if that's the API we intend to promote.