### PR TITLE
[jit][script] enable advanced indexing with tensors

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2341,16 +2341,16 @@ a")
         x = torch.rand(10, dtype=torch.float, requires_grad=True)
         self.checkScript(func, [x], optimize=True)
 
+    def _check_code(self, code_str, fn_name, inputs):
+        scope = {}
+        exec(code_str, globals(), scope)
+        cu = torch.jit.CompilationUnit(code_str)
+        self.assertEqual(cu.func(*inputs), scope[fn_name](*inputs))
+
     def test_index(self):
         def consec(size, start=0):
             numel = torch.tensor(size).prod().item()
             return torch.arange(numel).view(size)
-
-        def check_code(code_str, fn_name, inputs):
-            scope = {}
-            exec(code_str, globals(), scope)
-            cu = torch.jit.CompilationUnit(code_str)
-            self.assertEqual(cu.func(*inputs), scope['func'](*inputs))
 
         def check_indexing(indexing, tensor):
             template = dedent("""
@@ -2358,7 +2358,7 @@ a")
                 return x{}
             """)
 
-            check_code(template.format(indexing), "func", [tensor])
+            self._check_code(template.format(indexing), "func", [tensor])
 
         def check_dynamic_indexing(indexing, tensor, value1, value2):
             value1 = torch.tensor(value1)
@@ -2371,7 +2371,7 @@ a")
                 return x{}
             """)
 
-            check_code(template.format(indexing), "func", [tensor, value1, value2])
+            self._check_code(template.format(indexing), "func", [tensor, value1, value2])
 
         # basic slices
         check_indexing('[0]', consec((3, 3)))
@@ -2469,6 +2469,93 @@ a")
         for tensor in tensors:
             for i in range(len(script_funs)):
                 self.assertEqual(test_func(script_funs[i], x, tensor), test_func(funs[i], x, tensor))
+
+    def test_advancedindex(self):
+        def consec(size, start=0):
+            numel = torch.tensor(size).prod().item()
+            return torch.arange(numel).view(size)
+
+        def check_indexing(indexing, tensor, **kwargs):
+            indices_dict = kwargs
+
+            template = dedent("""
+            def func(x{formals}):
+                return x{expr}
+            """)
+
+            formals = []
+            values = []
+            for formal, value in indices_dict.items():
+                formals.append(formal)
+                values.append(value)
+
+            formals = ''.join(map(', {}'.format, formals))
+            inputs = [tensor] + values
+
+            self._check_code(template.format(formals=formals, expr=indexing),
+                             "func", inputs)
+
+        # Indexing with tensor (basic)
+        check_indexing('[i]', consec((3, 3)), i=torch.tensor([0]))
+        check_indexing('[i]', consec((3, 3)), i=torch.tensor(1))
+        check_indexing('[i]', consec((3, 3)), i=torch.tensor([-2]))
+        check_indexing('[i]', consec((3, 3), 2), i=torch.tensor([0, 0]))
+        check_indexing('[i]', consec((3, 3, 2, 2)), i=torch.tensor([0, -2, 1]))
+
+        # NB: indexing with tensors and indexing with sequences can be implemented
+        # in a very similar way (sequences are converted to tensors), so only one
+        # case needs to be tested extensively.
+        # XXX: When we can index with sequences, replace these cases with
+        # sequence indexing expressions; those are much easier to read.
+
+        # Misc sequence advanced indexing
+        inp = consec((4, 8, 5))
+        to_check = [
+            # [[0, 2], [1, 3]]
+            ['[i, j]', dict(i=[0, 2], j=[1, 3])],
+            # [[0, 2], [1, 3], [1, 1]]
+            ['[i, j, k]', dict(i=[0, 2], j=[1, 3], k=[1, 1])],
+            # [[0, 2], 1, [1, 1]]
+            ['[i, j, k]', dict(i=[0, 2], j=1, k=[1, 1])],
+            # [:, :, [0, 3, 4]]
+            ['[:, :, i]', dict(i=[0, 3, 4])],
+            # [:, [2, 4, 5, 7], 2:4]
+            ['[:, i, 2:4]', dict(i=[0, 2, 3])],
+            # [[2, 3], :, :]
+            ['[i, :, :]', dict(i=[2, 3])],
+            # [:, [0, 2, 3], [1, 3, 4]]
+            ['[:, i, j]', dict(i=[0, 2, 3], j=[1, 3, 4])],
+            # [:, [0], [1, 2, 4]]
+            ['[:, i, j]', dict(i=[0], j=[1, 2, 4])],
+            # [:, [0, 1, 3], [4]]
+            ['[:, i, j]', dict(i=[0, 1, 3], j=[4])],
+            # [:, [[0, 1], [1, 0]], [[2, 3]]]
+            ['[:, i, j]', dict(i=[[0, 1], [1, 0]], j=[[2, 3]])],
+            # [:, [[0, 1], [2, 3]], [[0]]]
+            ['[:, i, j]', dict(i=[[0, 1], [2, 3]], j=[[0]])],
+            # [:, [[5, 6]], [[0, 3], [4, 4]]]
+            ['[:, i, j]', dict(i=[[5, 6]], j=[[0, 3], [4, 4]])],
+            # [[0, 2, 3], [1, 3, 4], :]
+            ['[i, j, :]', dict(i=[0, 2, 3], j=[1, 3, 4])],
+            # [0, [1, 2, 4], :]
+            ['[i, j, :]', dict(i=0, j=[1, 2, 4])],
+            # [[0, 1, 3], 4, :]
+            ['[i, j, :]', dict(i=[0, 1, 3], j=4)],
+            # [[[0, 1], [1, 0]], [[2, 1], [3, 5]], :]
+            ['[i, j, :]', dict(i=[[0, 1], [1, 0]], j=[[2, 1], [3, 5]])],
+            # [[[0, 1], [1, 0]], [[2, 3]], :]
+            ['[i, j, :]', dict(i=[[0, 1], [1, 0]], j=[[2, 3]])],
+            # [[[0, 1], [2, 3]], [[0]], :]
+            ['[i, j, :]', dict(i=[[0, 1], [2, 3]], j=[[0]])],
+            # [[[2, 1]], [[0, 3], [4, 4]], :]
+            ['[i, j, :]', dict(i=[[2, 1]], j=[[0, 3], [4, 4]])],
+            # [[[2]], [[0, 3], [4, 1]], 0:2]
+            ['[i, j, 0:2]', dict(i=[[2]], j=[[0, 3], [4, 1]])],
+        ]
+
+        for expr, argdict in to_check:
+            tensordict = {k: torch.tensor(v) for (k, v) in argdict.items()}
+            check_indexing(expr, inp, **tensordict)
 
     def test_keyword(self):
         @torch.jit.script

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1525,8 +1525,7 @@ private:
         if (slice_exprs[0].kind() == TK_SLICE_EXPR) {
           return emitBasicSlice(subscript);
         } else {
-          return emitBasicGather(
-              subscript.range(), TreeList{subscript.value(), slice_exprs[0]});
+          return emitBasicGather(subscript);
         }
       } break;
       case TK_IF_EXPR: {
@@ -1629,31 +1628,20 @@ private:
     return emitBuiltinCall(loc, *graph, aten::index, {input, index}, {}, true);
   }
 
-  // Desugars multidim slicing into aten::slice / aten::select calls.
-  //
-  // XXX: Errors in user code are not elegantly reported.
-  // Let's say someone were to do the following:
-  //   @torch.jit.script
-  //   def fn(x):
-  //       return x[0, 1]
-  //   fn(torch.randn(5))
-  // Because we desugar this into two aten::select ops, the error message
-  // complains about aten::select failing rather than there "not being
-  // enough dimensions to index".
-  Value * emitMultidimSlicing(const Subscript& subscript) {
-    const auto& loc = subscript.range();
-    auto * sliceable = emitExpr(subscript.value());
-    if (!sliceable->type()->isSubtypeOf(DynamicType::get())) {
-      throw ErrorReport(loc)
-        << "Unsupported operation: attempted to use multidimensional "
-        << "indexing on a non-tensor type.";
-    }
+  // Emits multidimensional slicing with int and slice indices.
+  // Returns:
+  // - Value*: the input after it has been indexed by int and slice indices.
+  // - vector<Value*>: A list of tensor Value* indices that have not been applied yet.
+  //   Should be NULL at indices where sliceable (post-slicing) isn't indexed by a tensor.
+  std::pair<Value*, std::vector<Value*>> emitIntAndSliceIndexing(
+      const SourceRange& loc,
+      Value* sliceable,
+      const Subscript& subscript) {
+    std::vector<Value*> tensor_indices;
     size_t dim = 0;
 
-    // Accumulate tensor Values here; call aten::index on them later.
-    std::vector<Value*> tensor_indices;
-
     auto handle_tensor = [&](Value* tensor) {
+      // NB: tensor_indices can have NULL holes because of how at::index works.
       tensor_indices.resize(dim + 1);
       tensor_indices[dim] = tensor;
       dim++;
@@ -1674,10 +1662,24 @@ private:
         continue;
       }
       throw ErrorReport(loc)
-        << "Unsupported operation: attempted to use multidimensional "
-        << "indexing with unsupported index type " << index->type()->str()
-        << ". Only ints, slices, and tensors are supported.";
+        << "Unsupported operation: indexing tensor with unsupported index type "
+        << index->type()->str() << ". Only ints, slices, and tensors are supported.";
     }
+    return std::make_pair(sliceable, tensor_indices);
+  }
+
+  // The strategy is to slice and select the tensor for int and slices first
+  // in one pass and then apply at::index on the result of the slicing/selecting.
+  // Call the tensor after we've applied slice / select the `sliced`.
+  // tensor_indices should have the same size as sliced.dim():
+  // - tensor_indices[i] = NULL if we should not index `sliced` at dim i
+  // - tensor_indices[i] = t if we should index `sliced` at dim i with tensor t.
+  Value* emitMultidimSlicing(
+      const SourceRange& loc,
+      Value* sliceable,
+      const Subscript& subscript) {
+    std::vector<Value*> tensor_indices;
+    std::tie(sliceable, tensor_indices) = emitIntAndSliceIndexing(loc, sliceable, subscript);
 
     if (tensor_indices.empty()) {
       // XXX: Might need to at::alias this when we support mutability
@@ -1685,15 +1687,35 @@ private:
     }
 
     // at::index takes in a TensorList where some tensors can be undefined.
-    // Add undefined tensors for NULL tensor_indices so at::index is happy.
+    // Convert NULL tensor_indices to undefined tensors to pass to at::index.
     for (auto& index : tensor_indices) {
       if (index == nullptr) {
         index = graph->insertNode(graph->createUndefined())->output();
       }
     }
-
-    // Handle tensors by calling aten::index
     return emitIndex(loc, sliceable, tensor_indices);
+  }
+
+  // Desugars multidim slicing into slice/select/index calls.
+  //
+  // XXX: Errors in user code are not elegantly reported.
+  // Let's say someone were to do the following:
+  //   @torch.jit.script
+  //   def fn(x):
+  //       return x[0, 1]
+  //   fn(torch.randn(5))
+  // Because we desugar this into two aten::select ops, the error message
+  // complains about aten::select failing rather than there "not being
+  // enough dimensions to index".
+  Value* emitMultidimSlicing(const Subscript& subscript) {
+    const auto& loc = subscript.range();
+    auto* sliceable = emitExpr(subscript.value());
+    if (!sliceable->type()->isSubtypeOf(DynamicType::get())) {
+      throw ErrorReport(loc)
+        << "Unsupported operation: attempted to use multidimensional "
+        << "indexing on a non-tensor type.";
+    }
+    return emitMultidimSlicing(loc, sliceable, subscript);
   }
 
   // Desugars slice syntactic sugar tensor[begin:end] -> tensor.slice(begin,
@@ -1713,31 +1735,19 @@ private:
   }
 
   // Desugars gather syntactic sugar foo[i]
-  Value* emitBasicGather(
-      const SourceRange& loc,
-      TreeList&& inputs) {
-    const auto applyInputs =
-        Compound::create(TK_LIST, loc, std::move(inputs));
-    auto input_values = getNamedValues(applyInputs->trees(),
-                                        /*maybe_unpack*/false);
-    NamedValue gatherable = input_values[0];
-    NamedValue idx = input_values[1];
-    if (gatherable.value(*graph)->type()->kind() == TypeKind::ListType) {
+  Value* emitBasicGather(const Subscript& subscript) {
+    const auto& loc = subscript.range();
+    JIT_ASSERT(subscript.subscript_exprs().size() == 1);
+    auto* gatherable = emitExpr(subscript.value(), identity);
+
+    if (gatherable->type()->kind() == TypeKind::ListType) {
       // if it's a list, emit a regular index selection op
+      auto* idx = emitExpr(subscript.subscript_exprs()[0], identity);
       return emitBuiltinCall(
                  loc, *graph, aten::select, {gatherable, idx}, {}, true);
     } else {
-      JIT_ASSERT(gatherable.value(*graph)->type()->isSubtypeOf(DynamicType::get()));
-      auto * index = idx.value(*graph);
-      const auto index_type = index->type();
-      if (index_type->isSubtypeOf(DynamicType::get())) {
-        return emitIndex(loc, gatherable.value(*graph), {index});
-      } else if (index_type == IntType::get()) {
-        return emitSelect(
-            loc, gatherable.value(*graph), /*dim=*/0, index);
-      }
-      throw ErrorReport(loc)
-        << "Cannot index tensor with value of type " << index_type->str();
+      JIT_ASSERT(gatherable->type()->isSubtypeOf(DynamicType::get()));
+      return emitMultidimSlicing(loc, gatherable, subscript);
     }
   }
 };

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1738,11 +1738,11 @@ private:
   Value* emitBasicGather(const Subscript& subscript) {
     const auto& loc = subscript.range();
     JIT_ASSERT(subscript.subscript_exprs().size() == 1);
-    auto* gatherable = emitExpr(subscript.value(), identity);
+    auto* gatherable = emitExpr(subscript.value());
 
     if (gatherable->type()->kind() == TypeKind::ListType) {
       // if it's a list, emit a regular index selection op
-      auto* idx = emitExpr(subscript.subscript_exprs()[0], identity);
+      auto* idx = emitExpr(subscript.subscript_exprs()[0]);
       return emitBuiltinCall(
                  loc, *graph, aten::select, {gatherable, idx}, {}, true);
     } else {


### PR DESCRIPTION
On the way to #10774

This PR adds advanced indexing with tensors.
The approach is to desugar advanced indexing into an at::index op.
This is exactly how normal pytorch does it.
[(I used this code as reference)](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/python_variable_indexing.cpp)

Supporting sequences is a little tricky because JIT script doesn't have
an easy way to turn arbitrary n-dimensional python lists into a tensor
(it would be easy if we supported `torch.tensor`), so that'll come
in a future PR.

cc @jamesr66a @zdevito 