### PR TITLE
[build] Completely remove the nanopb submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/catch"]
 	path = third_party/catch
 	url = https://github.com/catchorg/Catch2.git
-[submodule "third_party/nanopb"]
-	path = third_party/nanopb
-	url = https://github.com/nanopb/nanopb.git
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
 	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
After making changes internally, really remove the nanopb submodule.

Finalizes https://github.com/pytorch/pytorch/pull/10772

cc @pjh5 @ezyang 