### PR TITLE
Support Weight Decay to adaptive Optimizers

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -511,7 +511,8 @@ class AdagradOptimizer(Optimizer):
     def __init__(self, alpha=0.01, epsilon=1e-4, decay=1, policy="fixed",
                  sparse_dedup_aggregator=None, rowWise=False, engine='',
                  lars=None, output_effective_lr=False,
-                 output_effective_lr_and_update=False, **kwargs):
+                 output_effective_lr_and_update=False,
+                 weight_decay=1.0, **kwargs):
         super(AdagradOptimizer, self).__init__()
         self.alpha = alpha
         self.epsilon = epsilon
@@ -523,6 +524,7 @@ class AdagradOptimizer(Optimizer):
         self.lars = lars
         self.output_effective_lr = output_effective_lr
         self.output_effective_lr_and_update = output_effective_lr_and_update
+        self.weight_decay = weight_decay
         self.init_kwargs = kwargs
 
     def _run(self, net, param_init_net, param_info):
@@ -624,6 +626,7 @@ class AdagradOptimizer(Optimizer):
                 [param, param_squared_sum],
                 epsilon=self.epsilon,
                 engine=self.engine,
+                weight_decay=self.weight_decay
             )
         else:
             output_args = [param, param_squared_sum]
@@ -638,7 +641,8 @@ class AdagradOptimizer(Optimizer):
                 output_args,
                 epsilon=self.epsilon,
                 decay=float(self.decay),
-                engine=self.engine
+                engine=self.engine,
+                weight_decay=self.weight_decay
             )
 
     def scale_learning_rate(self, scale):
@@ -903,7 +907,7 @@ class AdamOptimizer(Optimizer):
     def __init__(self, alpha=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
                  policy='fixed', use_lr_adaption=False, lr_alpha=0.01,
                  normalized_lr_adaption=True, sparse_dedup_aggregator=None,
-                 rowWise=False, engine='', **kwargs):
+                 rowWise=False, engine='', weight_decay=1.0, **kwargs):
         super(AdamOptimizer, self).__init__()
         self.alpha = alpha
         self.beta1 = beta1
@@ -916,6 +920,7 @@ class AdamOptimizer(Optimizer):
         self.sparse_dedup_aggregator = sparse_dedup_aggregator
         self.rowWise = rowWise
         self.engine = engine
+        self.weight_decay = weight_decay
         self.init_kwargs = kwargs
 
     def _run(self, net, param_init_net, param_info):
@@ -980,21 +985,22 @@ class AdamOptimizer(Optimizer):
                 output_blobs,
                 beta1=self.beta1,
                 beta2=self.beta2,
-                epsilon=self.epsilon)
+                epsilon=self.epsilon,
+                weight_decay=self.weight_decay)
             if self.use_lr_adaption:
                 net.LearningRateAdaption(
                     [lr, grad.values, effective_grad],
                     [lr],
                     lr_alpha=self.lr_alpha,
                     normalized_lr_adaption=self.normalized_lr_adaption)
-
         else:
             net.Adam(
                 [param, m1, m2, grad, lr, iteration],
                 output_blobs,
                 beta1=self.beta1,
                 beta2=self.beta2,
-                epsilon=self.epsilon)
+                epsilon=self.epsilon,
+                weight_decay=self.weight_decay)
             if self.use_lr_adaption:
                 net.LearningRateAdaption(
                     [lr, grad, effective_grad],

--- a/caffe2/sgd/adagrad_op.cc
+++ b/caffe2/sgd/adagrad_op.cc
@@ -16,7 +16,7 @@ computes
     new_moment = moment + square(grad)
     effective_lr = learning_rate / (sqrt(new_moment) + epsilon)
     update = learning_rate * grad / (sqrt(new_moment) + epsilon)
-    new_param = param + update
+    new_param = weight_decay * param + update
 and returns (new_param, new_moment).
 
 Optionally returns effective_lr and update as well.
@@ -35,7 +35,8 @@ Optionally returns effective_lr and update as well.
     .Arg(
         "decay",
         "Default 1. If it is in (0, 1), the gradient square sum "
-        "is decayed by this factor.");
+        "is decayed by this factor.")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay");
 
 static OpSchema::Cost CostInferenceForSparseAdagrad(
     const OperatorDef& /* unused */,
@@ -84,6 +85,7 @@ new_moment) as in the dense case.
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment_1", "Updated moment")
     .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay")
     .CostInferenceFunction(
         OpSchema::CostInferenceFunctionType(CostInferenceForSparseAdagrad));
 
@@ -112,9 +114,10 @@ also be a 1D tensor indexing into the rows of param.
     .Input(4, "lr", "learning rate")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment_1", "Updated moment")
-    .Arg("epsilon", "Default 1e-5");
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay");
 
 SHOULD_NOT_DO_GRADIENT(Adagrad);
 SHOULD_NOT_DO_GRADIENT(SparseAdagrad);
 SHOULD_NOT_DO_GRADIENT(RowWiseSparseAdagrad);
-}
+} // namespace caffe2

--- a/caffe2/sgd/adam_op.cc
+++ b/caffe2/sgd/adam_op.cc
@@ -20,7 +20,7 @@ input gradient and momentum parameters. Concretely, given inputs
     m2_o = (beta2 * m2) + (1 - beta2) * np.square(grad)
     grad_o = correction_multiplier * m1_o / \
         (sqrt(m2_o) + epsilon)
-    param_o = param + lr * grad_o
+    param_o = weight_decay * param + lr * grad_o
 
 and returns (param_o, m1_o, m2_o, grad_o), in which grad_o is an optional output
 
@@ -37,7 +37,8 @@ and returns (param_o, m1_o, m2_o, grad_o), in which grad_o is an optional output
     .Output(3, "output_grad", "Optional Effective gradient")
     .Arg("beta1", "Default 0.9")
     .Arg("beta2", "Default 0.999")
-    .Arg("epsilon", "Default 1e-5");
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay");
 
 REGISTER_CPU_OPERATOR(SparseAdam, SparseAdamOp<float, CPUContext>);
 OPERATOR_SCHEMA(SparseAdam)
@@ -65,7 +66,8 @@ OPERATOR_SCHEMA(SparseAdam)
     .Output(3, "output_grad", "Optional Effective gradient")
     .Arg("beta1", "Default 0.9")
     .Arg("beta2", "Default 0.999")
-    .Arg("epsilon", "Default 1e-5");
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay");
 
 REGISTER_CPU_OPERATOR(
     RowWiseSparseAdam,
@@ -99,7 +101,8 @@ OPERATOR_SCHEMA(RowWiseSparseAdam)
     .Output(3, "output_grad", "Optional Effective gradient")
     .Arg("beta1", "Default 0.9")
     .Arg("beta2", "Default 0.999")
-    .Arg("epsilon", "Default 1e-5");
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "in (0, 1], Default 1, meaning no weight decay");
 
 SHOULD_NOT_DO_GRADIENT(Adam);
 SHOULD_NOT_DO_GRADIENT(SparseAdam);


### PR DESCRIPTION
Summary:
as title.
AdamW (https://arxiv.org/abs/1711.05101) has shown some good result by applying weight decay to adaptive optimzers.
This diff deals with adagrad and adam.

Currently, only constant weight decay is supported. According to the paper, dynamic weight decay hyperparameters that change according to the # of batches should achieve even better results. We ll implement that in a seperate diff if weight decay techies will be demonstrate to have some early positive results. Also AdamWR is also not implemented.

Differential Revision: D9496208
