### PR TITLE
Re-sync with internal repository

### DIFF
--- a/submodules/nanopb-rev.txt
+++ b/submodules/nanopb-rev.txt
@@ -1,1 +1,0 @@
-Subproject commit 14efb1a47a496652ab08b1ebcefb0ea24ae4a5e4

--- a/submodules/nanopb-rev.txt
+++ b/submodules/nanopb-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 14efb1a47a496652ab08b1ebcefb0ea24ae4a5e4


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.