### PR TITLE
[JIT] Store schema in serialized modules and check arguments in function call

### DIFF
--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -41,6 +41,43 @@ void load_serialized_module_with_custom_op_and_execute(
   assert(output.allclose(torch::ones(5) + 1));
 }
 
+void test_argument_checking_for_serialized_modules(
+    const char* path_to_exported_script_module) {
+  std::shared_ptr<torch::jit::script::Module> module =
+      torch::jit::load(path_to_exported_script_module);
+  assert(module != nullptr);
+
+  try {
+    module->forward({torch::jit::IValue(1), torch::jit::IValue(2)});
+    assert(false);
+  } catch (const at::Error& error) {
+    assert(
+        std::string(error.what_without_backtrace())
+            .find("Expected at most 1 argument(s) for operator 'forward', "
+                  "but received 2 argument(s)") == 0);
+  }
+
+  try {
+    module->forward({torch::jit::IValue(5)});
+    assert(false);
+  } catch (const at::Error& error) {
+    assert(
+        std::string(error.what_without_backtrace())
+            .find("Expected value of type Dynamic for argument 'input' in "
+                  "position 0, but instead got value of type int") == 0);
+  }
+
+  try {
+    module->forward({});
+    assert(false);
+  } catch (const at::Error& error) {
+    std::cout << error.what_without_backtrace() << std::endl;
+    assert(
+        std::string(error.what_without_backtrace())
+            .find("custom::op() is missing value for argument 'tensor'") == 0);
+  }
+}
+
 int main(int argc, const char* argv[]) {
   if (argc != 2) {
     std::cerr << "usage: test_custom_ops <path-to-exported-script-module>\n";
@@ -48,5 +85,6 @@ int main(int argc, const char* argv[]) {
   }
   get_operator_from_registry_and_execute();
   load_serialized_module_with_custom_op_and_execute(argv[1]);
+  test_argument_checking_for_serialized_modules(argv[1]);
   std::cout << "ok\n";
 }

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -4,6 +4,7 @@
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/utils/functional.h"
 #include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/operator.h"
 
 #include <ATen/ATen.h>
 
@@ -371,6 +372,10 @@ ModuleDecoder::ModuleDecoder(
 
     auto graph = buildGraph(node_proto.attribute(0).g());
     parent_module->create_method(name, graph, member_inputs);
+    // We store the schema in the docstring so we can parse the schema and
+    // assign it to the method.
+    auto schema = parseSchema(node_proto.doc_string());
+    parent_module->get_method(name).setSchema(std::move(schema));
   }
 }
 

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -62,17 +62,40 @@ struct SchemaParser {
       throw ErrorReport(tok.range) << "unknown type specifier";
     return it->second;
   }
-  void parseType(Argument& arg) {
-    arg.type = parseBaseType();
-    if(L.nextIf('[')) {
-      arg.type = ListType::create(arg.type);
-      if(L.cur().kind == TK_NUMBER) {
-        arg.N = std::stoll(L.next().text());
+  void parseType(std::vector<TypePtr>& types) {
+    TypePtr type;
+    if (L.cur().kind == '(') {
+      std::vector<TypePtr> nestedTypes;
+      parseList('(', ',', ')', nestedTypes, &SchemaParser::parseType);
+      type = TupleType::create(std::move(nestedTypes));
+    } else {
+      type = parseBaseType();
+      if(L.nextIf('[')) {
+        type = ListType::create(type);
+        if(L.cur().kind == TK_NUMBER) {
+          L.next(); // Discard
+        }
+        L.expect(']');
       }
-      L.expect(']');
+    }
+    types.push_back(std::move(type));
+  }
+  void parseArgumentType(Argument& arg) {
+    if (L.cur().kind == '(') {
+      std::vector<TypePtr> types;
+      parseList('(', ',', ')', types, &SchemaParser::parseType);
+      arg.type = TupleType::create(std::move(types));
+    } else {
+      arg.type = parseBaseType();
+      if(L.nextIf('[')) {
+        arg.type = ListType::create(arg.type);
+        if(L.cur().kind == TK_NUMBER) {
+          arg.N = std::stoll(L.next().text());
+        }
+        L.expect(']');
+      }
     }
   }
-
   void parseArgument(std::vector<Argument>& arguments) {
     // varargs
     if(L.nextIf('*')) {
@@ -80,7 +103,7 @@ struct SchemaParser {
       return;
     }
     Argument arg;
-    parseType(arg);
+    parseArgumentType(arg);
 
     // nullability is ignored for now, since the JIT never cares about it
     L.nextIf('?');
@@ -93,7 +116,7 @@ struct SchemaParser {
   }
   void parseReturn(std::vector<Argument>& args) {
     Argument arg("ret" + std::to_string(args.size()));
-    parseType(arg);
+    parseArgumentType(arg);
     args.push_back(std::move(arg));
   }
   IValue parseSingleConstant(TypeKind kind) {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -178,7 +178,7 @@ inline Stack createStackForSchema(
       args.size() + kwargs.size() <= schema.arguments.size(),
       schema.name, "() expected at most ", schema.arguments.size(),
       " argument(s) but received ",
-      args.size(), " argument(s). Declaration: ", schema);
+      args.size() + kwargs.size(), " argument(s). Declaration: ", schema);
 
   Stack stack;
   stack.reserve(schema.arguments.size());

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -61,6 +61,7 @@ struct Method {
   }
 
   IValue operator()(std::vector<IValue> stack) {
+    checkInputsAgainstSchema(stack);
     run(stack);
     if (stack.size() != 1) {
       return Tuple::create(std::move(stack));
@@ -172,6 +173,34 @@ private:
       executor = GraphExecutor(graph(), optimize);
     });
     return executor;
+  }
+
+  void checkInputsAgainstSchema(std::vector<IValue>& inputs) {
+    const auto& schema = getSchema();
+    // Do we have more inputs than the schema accepts?
+    AT_CHECK(
+        inputs.size() <= schema.arguments.size(),
+        "Expected at most ", schema.arguments.size(),
+        " argument(s) for operator '", schema.name, "', but received ",
+        inputs.size(), " argument(s). Declaration: ", schema);
+
+    for (size_t pos = 0; pos < schema.arguments.size(); ++pos) {
+      const auto& argument = schema.arguments[pos];
+      if (pos < inputs.size()) {
+        const TypePtr inputType = inferTypeFrom(inputs[pos]);
+        AT_CHECK(inputType->isSubtypeOf(argument.type),
+              "Expected value of type ", *argument.type,
+              " for argument '", argument.name,
+              "' in position ", pos,
+              ", but instead got value of type ", *inputType,
+              ". Declaration: ", schema);
+      } else if (argument.default_value) {
+        inputs.push_back(*argument.default_value);
+      } else {
+        AT_ERROR(schema.name, "() is missing value for argument '",
+                argument.name, "'. Declaration: ", schema);
+      }
+    }
   }
 
   GraphExecutor executor; // for execution

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -351,8 +351,8 @@ struct TORCH_API TupleType : public Type {
   static constexpr bool is_singleton = false;
   friend struct Type;
   template<typename ... T>
-  static TupleTypePtr create( T&& ... all ) {
-    return TupleTypePtr(new TupleType( std::forward<T>(all)... ));
+  static TupleTypePtr create(std::vector<TypePtr> types) {
+    return TupleTypePtr(new TupleType( std::move(types) ));
   }
   at::ArrayRef<TypePtr> elements() const {
     return elements_;


### PR DESCRIPTION
This PR adds argument checking for script method invocation from C++. For this I had to:
1. The schema of a method is currently not serialized in script modules, so we now store the function schema in the `doc_string` field of the ONNX proto. Upon loading of a serialized script module, we parse the schema into the structured C++ form and assign it to the loaded method,
2. Inside `Method::operator()`, we now verify the number and types of arguments.

CC @li-roy 

@zdevito 