### PR TITLE
Fixed log message

### DIFF
--- a/caffe2/python/data_workers.py
+++ b/caffe2/python/data_workers.py
@@ -242,7 +242,7 @@ class BatchFeeder(State):
                 qsize = self._internal_queue.qsize()
                 if qsize < 2 and (time.time() - self._last_warning) > LOG_INT_SECS:
                     log.warning("Warning, data loading lagging behind: " +
-                                "name={}".format(qsize, self._input_source_name))
+                                "queue size={}, name={}".format(qsize, self._input_source_name))
                     self._last_warning = time.time()
                 self._counter += 1
                 self._internal_queue.put(chunk, block=True, timeout=0.5)


### PR DESCRIPTION
Summary: Fixes the log message "WARNING:data_workers:Warning, data loading lagging behind: name=0" where instead of source name the size of a queue is reported

Differential Revision: D9506606
