### PR TITLE
Fix bug with pickling optimizers and then adding param groups

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,4 +1,5 @@
 import math
+import os
 import unittest
 import functools
 from copy import deepcopy
@@ -235,6 +236,19 @@ class TestOptim(TestCase):
 
     def _build_params_dict_single(self, weight, bias, **kwargs):
         return [dict(params=bias, **kwargs)]
+
+    def test_save_optim_defaults(self):
+        weight = torch.randn(2, 2)
+        default = torch.randn(2)
+        opt = optim.Optimizer([weight], {'test_default': default})
+        filename = 'test_save_optim.pth'
+        torch.save(opt, filename)
+
+        if os.path.exists(filename):
+            loaded_opt = torch.load(filename)
+            self.assertEqual(loaded_opt.param_groups[0]['params'][0], weight)
+            self.assertEqual(loaded_opt.defaults['test_default'], default)
+            os.remove(filename)
 
     def test_sgd(self):
         self._test_rosenbrock(

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -46,6 +46,7 @@ class Optimizer(object):
         return {
             'state': self.state,
             'param_groups': self.param_groups,
+            'defaults': self.defaults,
         }
 
     def __setstate__(self, state):


### PR DESCRIPTION
__setstate__ in optimizer doesn't save self.defaults, and so this field does not persist through pickling.  This causes add_param_group to fail on optimizers which have been pickled and unpickled.  This should fix that.