### PR TITLE
Remove Scalar.local().

### DIFF
--- a/aten/src/ATen/Formatting.h
+++ b/aten/src/ATen/Formatting.h
@@ -18,7 +18,6 @@ static inline void print(const Tensor & t, int64_t linesize=80) {
 }
 
 static inline std::ostream& operator<<(std::ostream & out, Scalar s) {
-  s = s.local();
   return out << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
 }
 

--- a/aten/src/ATen/Scalar.cpp
+++ b/aten/src/ATen/Scalar.cpp
@@ -21,10 +21,6 @@ Tensor Scalar::toTensor() const {
   }
 }
 
-Scalar Scalar::local() const {
-  return *this;
-}
-
 Scalar Scalar::operator-() const {
  if (isFloatingPoint()) {
    return Scalar(-v.d);

--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -28,9 +28,6 @@ public:
 
 #undef DEFINE_IMPLICIT_CTOR
 
-  // return a new scalar that is guarenteed to be not backed by a tensor.
-  Scalar local() const;
-
 #define DEFINE_ACCESSOR(type,name,member) \
   type to##name () const { \
     if (Tag::HAS_d == tag) { \

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -42,7 +42,7 @@ inline Tensor& Tensor::operator/=(Scalar other) {
 }
 inline Tensor Tensor::operator[](Scalar index) const {
   AT_CHECK(
-      index.local().isIntegral(),
+      index.isIntegral(),
       "Can only index tensors with integral scalars (got ",
       index.toTensor().type().toString(), ")");
   return select(0, index.toLong());

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -541,7 +541,7 @@ Tensor& s_addmm_out_sparse_dense_cpu(
   int64_t nnz        = sparse._nnz();
 
   if (nnz == 0) {
-    at::mul_out(r, t, r.type().scalarTensor(beta.local()));
+    at::mul_out(r, t, r.type().scalarTensor(beta));
     return r;
   }
 


### PR DESCRIPTION
It's a no-op now that Scalars don't store tensors.

