### PR TITLE
Fix a bug in constant prop

### DIFF
--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -34,7 +34,7 @@ Value* insertConstant(
     n->s_(attr::string, val.toString()->string());
     n->output()->setType(StringType::get());
   } else {
-    throw std::runtime_error("Unsupported value kind: " + val.tagKind());
+    throw constant_not_supported_error("Unsupported value kind: " + val.tagKind());
   }
   if(loc)
     n->setSourceLocation(std::make_shared<SourceRange>(*loc));

--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -11,6 +11,11 @@ namespace torch { namespace jit {
 struct Graph;
 struct Value;
 
+// thrown when insertConstant cannot encode the IValue into a graph
+struct TORCH_API constant_not_supported_error : public std::runtime_error {
+  using runtime_error::runtime_error;
+};
+
 // note: prefer g.insertConsant(val, loc) which does exactly the same thing
 // this function is only declared/defined here because its implementation is
 // closely related to the implementation of prim::Constant that is also in constants.cpp

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -55,8 +55,13 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-    auto new_output = graph->insertConstant(outputs[i]);
-    n->outputs()[i]->replaceAllUsesWith(new_output);
+    try {
+      auto new_output = graph->insertConstant(outputs[i]);
+      n->outputs()[i]->replaceAllUsesWith(new_output);
+    } catch(constant_not_supported_error& err) {
+      // we cannot actually represent the IValue as a constant node,
+      // so we give up replacing it
+    }
     // let dce elimination remove n
   }
 }


### PR DESCRIPTION
More support for tuples has uncovered a bug in constant prop where
it assumed it can create constant nodes of tuples, even though we
cannot easily create a single prim::Constant to represent a tuples.
This fix checks when we cannot represent an IValue as a prim::Constant
and then stops propagating the node.

