### PR TITLE
Resolve builtins using a dict rather than by name

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2031,6 +2031,15 @@ class TestScript(JitTestCase):
 
         return ge
 
+    def test_robust_op_resolution(self):
+        neg = torch.add  # misleading name to make sure we resolve by function
+
+        def stuff(x):
+            return neg(x, x)
+
+        a = (torch.rand(3),)
+        self.checkScript(stuff, a)
+
     def test_tuple_io(self):
         def stuff(x):
             # type: (Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]
@@ -5246,12 +5255,12 @@ a")
 
     def test_python_val_doesnt_have_attr(self):
         with self.assertRaisesRegex(RuntimeError, 'object has no attribute abcd'):
-            def test_fn():
-                return 3
 
             @torch.jit.script
             def python_val_doesnt_have_attr():
-                return test_fn.abcd
+                # this has to be a module otherwise attr lookup would not be
+                # allowed in the first place
+                return shutil.abcd
 
     def test_wrong_module_attr_lookup(self):
         with self.assertRaisesRegex(RuntimeError, 'python value of type \'type\' cannot be used as a value:'):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -3,7 +3,8 @@ import torch._C
 import contextlib
 import ctypes
 import sys
-
+import types
+import torch.jit
 
 # Query `hasattr` only once.
 _SET_GLOBAL_FLAGS = hasattr(sys, 'getdlopenflags') and hasattr(sys, 'setdlopenflags')
@@ -23,7 +24,10 @@ def dl_open_guard():
         sys.setdlopenflags(old_flags)
 
 
-class _OpNamespace(object):
+# _OpNamespace is a subclass of ModuleType because the torch script
+# allows attribute lookups on modules only. Since we want torch.ops.foo.bar()
+# to work from script, we need to ensure ops and foo are modules
+class _OpNamespace(types.ModuleType):
     """
     An op namespace to dynamically bind Operators into Python.
 
@@ -44,18 +48,24 @@ class _OpNamespace(object):
         operation will already exist).
     """
     def __init__(self, name):
+        super(_OpNamespace, self).__init__('torch.ops.' + name)
         self.name = name
 
     def __getattr__(self, op_name):
         # Get the op `my_namespace::my_op` if available. This will also check
         # for overloads and raise an exception if there are more than one.
-        op = torch._C._jit_get_operation('{}::{}'.format(self.name, op_name))
+        qualified_op_name = '{}::{}'.format(self.name, op_name)
+        op = torch._C._jit_get_operation(qualified_op_name)
+        # let the script frontend know that op is identical to the builtin op
+        # with qualified_op_name
+        torch.jit._register_builtin(op, qualified_op_name)
         setattr(self, op_name, op)
         return op
 
 
-class _Ops(object):
+class _Ops(types.ModuleType):
     def __init__(self):
+        super(_Ops, self).__init__('torch.ops')
         self.loaded_libraries = set()
 
     def __getattr__(self, name):


### PR DESCRIPTION
Changes the approach for resolving builtin ops so that the following works

```
add = torch.add
@script
def foo(x):
  return add(x, x)
```

This handles cases when people alias torch and torch.nn.functional to
shorter names.

This works by building a table of id -> builtin name for the know builtin
ops in torch, torch.nn.functional, and for any user-defined
op created by accessing in torch.ops.foo.bar

This allows us to clean up many SugaredValue types in the compiler.

Notes:
* we now consider any attributes on python modules to be constants
(e.g. math.pi, and torch.double).
* fixes a bug where we incorrectly allowed attribute lookup on arbitrary
pyton objects. It is now restricted to modules only.