### PR TITLE
Add Workspace methods ws.feed_blob(name, arr) ws.remove_blob(name)

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -491,6 +491,11 @@ void addObjectMethods(py::module& m) {
             return py::cast(self->CreateBlob(name));
           },
           py::return_value_policy::reference_internal)
+      .def(
+          "_remove_blob",
+          [](Workspace* self, const std::string& name) -> py::bool_ {
+            return self->RemoveBlob(name);
+          })
       .def("fetch_blob", &python_detail::fetchBlob)
       .def(
           "has_blob",


### PR DESCRIPTION
Summary:
Workspace classes methods were missing on the Python side.

Being able to write the New Checkpoint Framework with more control of the workspace and cleaner implementation.

Added

- ws.feed_blob(name, arr)

- ws.remove_blob(name)

Differential Revision: D9486867
