### PR TITLE
Record tensor factory functions in trace

### DIFF
--- a/test/expect/TestJit.test_constant_prop_loop_constant.expect
+++ b/test/expect/TestJit.test_constant_prop_loop_constant.expect
@@ -1,0 +1,20 @@
+graph() {
+  %b.1 : int = prim::Constant[value=0]()
+  %1 : int = prim::Constant[value=2147483647]()
+  %2 : int = prim::Constant[value=1]()
+  %b.3 : int = prim::Loop(%1, %2, %b.1)
+    block0(%4 : int, %5 : int) {
+      %b.2 : int = prim::Constant[value=1]()
+      %7 : int = prim::Constant[value=1]()
+      -> (%7, %b.2)
+    }
+  %8 : int = prim::Constant[value=2147483647]()
+  %9 : int = prim::Constant[value=0]()
+  %b : int = prim::Loop(%8, %9, %b.3)
+    block0(%11 : int, %12 : int) {
+      %b.4 : int = prim::Constant[value=2]()
+      %14 : int = prim::Constant[value=0]()
+      -> (%14, %b.4)
+    }
+  return (%b);
+}

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,8 +1,14 @@
 graph(%x : Dynamic) {
-  %1 : Double(4, 3) = prim::Constant[value=<Tensor>]()
-  %2 : Double(3, 3) = aten::mm(%x, %1)
-  %3 : int = prim::Constant[value=1]()
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%2, %3, %4)
-  return (%5);
+  %1 : int = prim::Constant[value=4]()
+  %2 : int = prim::Constant[value=3]()
+  %3 : int[] = prim::ListConstruct(%1, %2)
+  %4 : int = prim::Constant[value=7]()
+  %5 : int = prim::Constant[value=0]()
+  %6 : int[] = prim::Constant[value=[0, -1]]()
+  %7 : Double(4, 3) = aten::zeros(%3, %4, %5, %6)
+  %8 : Double(3, 3) = aten::mm(%x, %7)
+  %9 : int = prim::Constant[value=1]()
+  %10 : int = prim::Constant[value=1]()
+  %11 : Dynamic = aten::add(%8, %9, %10)
+  return (%11);
 }

--- a/test/expect/TestScript.test_onnx_export_speculate-f1.expect
+++ b/test/expect/TestScript.test_onnx_export_speculate-f1.expect
@@ -6,27 +6,28 @@ ModelProto {
     GraphProto {
       name: "torch-jit-export"
       inputs: [{name: "x.1", type:Tensor dims: 1 10}]
-      outputs: [{name: "6", type:Tensor dims: 10 1}]
+      outputs: [{name: "8", type:Tensor dims: 10 1}]
       initializers: []
       nodes: [
         Node {type: "Add", inputs: [x.1,x.1], outputs: [1], attributes: []},
-        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "Transpose", inputs: [1], outputs: [3], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
-        Node {type: "Transpose", inputs: [1], outputs: [4], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "ReduceSum", inputs: [1], outputs: [2], attributes: [{ name: 'keepdims', type: int, value: 0}]},
+        Node {type: "Constant", inputs: [], outputs: [3], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Greater", inputs: [2,3], outputs: [4], attributes: []},
         Node {type: "Transpose", inputs: [1], outputs: [5], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
-        Node {type: "If", inputs: [2], outputs: [6], attributes: [{ name: 'then_branch', type: graph, value:
+        Node {type: "Transpose", inputs: [1], outputs: [6], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "Transpose", inputs: [1], outputs: [7], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "If", inputs: [4], outputs: [8], attributes: [{ name: 'then_branch', type: graph, value:
             GraphProto {
               name: "torch-jit-export1"
               inputs: []
-              outputs: [{name: "8", type:Tensor dims: }]
+              outputs: [{name: "9", type:Tensor dims: }]
               initializers: []
               nodes: [
-                Node {type: "Constant", inputs: [], outputs: [7], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-                Node {type: "If", inputs: [7], outputs: [8], attributes: [{ name: 'then_branch', type: graph, value:
+                Node {type: "If", inputs: [4], outputs: [9], attributes: [{ name: 'then_branch', type: graph, value:
                     GraphProto {
                       name: "torch-jit-export2"
                       inputs: []
-                      outputs: [{name: "3", type:Tensor dims: }]
+                      outputs: [{name: "5", type:Tensor dims: }]
                       initializers: []
                       nodes: [
                         
@@ -37,7 +38,7 @@ ModelProto {
                     GraphProto {
                       name: "torch-jit-export3"
                       inputs: []
-                      outputs: [{name: "4", type:Tensor dims: }]
+                      outputs: [{name: "6", type:Tensor dims: }]
                       initializers: []
                       nodes: [
                         
@@ -52,7 +53,7 @@ ModelProto {
             GraphProto {
               name: "torch-jit-export4"
               inputs: []
-              outputs: [{name: "5", type:Tensor dims: }]
+              outputs: [{name: "7", type:Tensor dims: }]
               initializers: []
               nodes: [
                 

--- a/test/expect/TestScript.test_onnx_export_speculate-f2.expect
+++ b/test/expect/TestScript.test_onnx_export_speculate-f2.expect
@@ -6,27 +6,28 @@ ModelProto {
     GraphProto {
       name: "torch-jit-export"
       inputs: [{name: "x.1", type:Tensor dims: 1 10},{name: "1", type:Tensor dims: 20 10},{name: "2", type:Tensor dims: 20}]
-      outputs: [{name: "5", type:Tensor dims: 1 20}]
+      outputs: [{name: "7", type:Tensor dims: 1 20}]
       initializers: [TensorProto shape: [20 10],TensorProto shape: [20]]
       nodes: [
         Node {type: "Add", inputs: [x.1,x.1], outputs: [3], attributes: []},
-        Node {type: "Constant", inputs: [], outputs: [4], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "If", inputs: [4], outputs: [5], attributes: [{ name: 'then_branch', type: graph, value:
+        Node {type: "ReduceSum", inputs: [3], outputs: [4], attributes: [{ name: 'keepdims', type: int, value: 0}]},
+        Node {type: "Constant", inputs: [], outputs: [5], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Greater", inputs: [4,5], outputs: [6], attributes: []},
+        Node {type: "If", inputs: [6], outputs: [7], attributes: [{ name: 'then_branch', type: graph, value:
             GraphProto {
               name: "torch-jit-export1"
               inputs: []
-              outputs: [{name: "7", type:Tensor dims: 1 20}]
+              outputs: [{name: "8", type:Tensor dims: 1 20}]
               initializers: []
               nodes: [
-                Node {type: "Constant", inputs: [], outputs: [6], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-                Node {type: "If", inputs: [6], outputs: [7], attributes: [{ name: 'then_branch', type: graph, value:
+                Node {type: "If", inputs: [6], outputs: [8], attributes: [{ name: 'then_branch', type: graph, value:
                     GraphProto {
                       name: "torch-jit-export2"
                       inputs: []
-                      outputs: [{name: "8", type:Tensor dims: 1 20}]
+                      outputs: [{name: "9", type:Tensor dims: 1 20}]
                       initializers: []
                       nodes: [
-                        Node {type: "Gemm", inputs: [3,1,2], outputs: [8], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                        Node {type: "Gemm", inputs: [3,1,2], outputs: [9], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
                       ]
                     }
 
@@ -34,10 +35,10 @@ ModelProto {
                     GraphProto {
                       name: "torch-jit-export3"
                       inputs: []
-                      outputs: [{name: "9", type:Tensor dims: 1 20}]
+                      outputs: [{name: "10", type:Tensor dims: 1 20}]
                       initializers: []
                       nodes: [
-                        Node {type: "Gemm", inputs: [3,1,2], outputs: [9], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                        Node {type: "Gemm", inputs: [3,1,2], outputs: [10], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
                       ]
                     }
 
@@ -49,10 +50,10 @@ ModelProto {
             GraphProto {
               name: "torch-jit-export4"
               inputs: []
-              outputs: [{name: "10", type:Tensor dims: 1 20}]
+              outputs: [{name: "11", type:Tensor dims: 1 20}]
               initializers: []
               nodes: [
-                Node {type: "Gemm", inputs: [3,1,2], outputs: [10], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                Node {type: "Gemm", inputs: [3,1,2], outputs: [11], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
               ]
             }
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4710,7 +4710,10 @@ a")
             @torch.jit.script_method
             def forward(self, x):
                 x += x
-                c = sum(x) > 4  # can't be True, onnx export constant props
+                # because we are testing if we emit `if` statement correctly
+                # we cannot use `True` as the condition. Constant prop
+                # would remove the `if` statements.
+                c = sum(x) > 4
                 if c:
                     if c:
                         y = self.m(x)

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -5,11 +5,16 @@
 import re
 
 from .utils import CodeTemplate, write
+from .gen_variable_type import format_trace
+
 
 FUNCTION_TEMPLATE = CodeTemplate("""\
 inline at::Tensor ${name}(${formals}) {
+  ${pre_record_trace}
   at::Tensor tensor = at::${name}(${actuals});
-  return autograd::make_variable(tensor, /*requires_grad=*/${requires_grad});
+  auto result = autograd::make_variable(tensor, /*requires_grad=*/${requires_grad});
+  ${post_record_trace}
+  return result;
 }
 """)
 
@@ -53,6 +58,10 @@ def process_function(decl, has_tensor_options):
     requires_grad = "options.requires_grad()" if has_tensor_options else "false"
     if decl['name'].endswith('_like') and not has_tensor_options:
         actuals.append('at::TensorOptions({}, /*discard_runtime_type=*/true)'.format(actuals[0]))
+
+    pre_record_trace, post_record_trace = format_trace(decl)
+
     return FUNCTION_TEMPLATE.substitute(
-        name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad
+        name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad,
+        pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
     )

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -141,7 +141,7 @@ ADD_TRACE_INPUT = CodeTemplate("""jit::tracer::addInputs(node, "${input}", ${inp
 
 POST_RECORD_TRACE = CodeTemplate("""\
 if (jit::tracer::isTracing()) {
-  jit::tracer::postRecordTrace(node, ArrayRef<Variable>(${trace_outputs}) );
+  jit::tracer::postRecordTrace(node, at::ArrayRef<autograd::Variable>(${trace_outputs}) );
 }
 """)
 
@@ -181,6 +181,41 @@ def should_trace(declaration):
     if base_name == 'addmm' and overload == ['Tensor', 'Tensor', 'Tensor', 'Scalar', 'Scalar']:
         return False
     return True
+
+
+def get_trace_outputs(declaration):
+    if declaration['return_type'] == 'std::vector<Tensor>':
+        return 'flatten_tensor_args({})'.format(declaration['returns'][0]['name'])
+    elif declaration['name'].endswith('_out'):
+        output_args = [arg['name'] for arg in declaration['arguments']
+                       if arg.get('output', False)]
+        return '{' + ', '.join(output_args) + '}'
+    trace_outs = [r['name'] for r in declaration['returns']]
+    if any(ret['dynamic_type'] == 'TensorList' for ret in declaration['returns']):
+        return CodeTemplate("flatten_tensor_args( ${outs} )").substitute(outs=trace_outs)
+    else:
+        return CodeTemplate("{ ${outs} }").substitute(outs=trace_outs)
+
+
+def format_trace(declaration):
+    local = {}
+
+    add_trace_inputs = []
+    for argument in declaration['arguments']:
+        add_trace_inputs.append(ADD_TRACE_INPUT.substitute(input=argument['name']))
+    local['add_trace_inputs'] = '\n'.join(add_trace_inputs)
+
+    # Record inplace operations as out-of-place operations (e.g.,
+    # not add_ but add)
+    # TODO: Add a proper concept of side effects to the IR, and
+    # properly record inplace operations.
+    local['trace_name'] = uninplace_api_name(declaration['api_name'])
+    if local['trace_name'] in RENAME_TRACE:
+        local['trace_name'] = RENAME_TRACE[local['trace_name']]
+
+    local['trace_outputs'] = get_trace_outputs(declaration)
+
+    return (PRE_RECORD_TRACE.substitute(local), POST_RECORD_TRACE.substitute(local))
 
 
 def gen_variable_type(out, aten_declarations, template_path):
@@ -361,42 +396,10 @@ def emit_body(declaration):
                 res.append(arg['name'])
         return res
 
-    def get_trace_outputs(declaration):
-        if declaration['return_type'] == 'std::vector<Tensor>':
-            return 'flatten_tensor_args({})'.format(declaration['returns'][0]['name'])
-        elif name.endswith('_out'):
-            output_args = [arg['name'] for arg in arguments
-                           if arg.get('output', False)]
-            return '{' + ', '.join(output_args) + '}'
-        trace_outs = [r['name'] for r in declaration['returns']]
-        if any(ret['dynamic_type'] == 'TensorList' for ret in declaration['returns']):
-            return CodeTemplate("flatten_tensor_args( ${outs} )").substitute(outs=trace_outs)
-        else:
-            return CodeTemplate("{ ${outs} }").substitute(outs=trace_outs)
-
     def emit_record_trace(env):
         if not should_trace(declaration):
             return ('', '')
-
-        local = {}
-
-        add_trace_inputs = []
-        for argument in declaration['arguments']:
-            add_trace_inputs.append(ADD_TRACE_INPUT.substitute(input=argument['name']))
-        local['add_trace_inputs'] = '\n'.join(add_trace_inputs)
-
-        # Record inplace operations as out-of-place operations (e.g.,
-        # not add_ but add)
-        # TODO: Add a proper concept of side effects to the IR, and
-        # properly record inplace operations.
-        local['trace_name'] = uninplace_api_name(declaration['api_name'])
-        if local['trace_name'] in RENAME_TRACE:
-            local['trace_name'] = RENAME_TRACE[local['trace_name']]
-
-        local['trace_outputs'] = get_trace_outputs(declaration)
-
-        combined = nested_dict(local, nested_dict(env, declaration))
-        return (PRE_RECORD_TRACE.substitute(combined), POST_RECORD_TRACE.substitute(combined))
+        return format_trace(declaration)
 
     def declare_returned_variables():
         if modifies_arguments:

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -3,7 +3,7 @@
 // ${generated_comment}
 
 #include <torch/csrc/autograd/variable.h>
-
+#include <torch/csrc/jit/tracer.h>
 #include <ATen/ATen.h>
 #include <ATen/core/ArrayRef.h>
 

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -262,7 +262,8 @@ def gen_jit_dispatch(declarations, out, template_path):
                 arguments.extend([
                     # XXX - until we actually have first-class interpreter types for these
                     # concepts, the default values to be encoded in Tensors
-
+                    # If you change this, you also need to update [TensorOptions in script]
+                    # in the tracer code.
                     # dtype is specified as an int64_t of at::ScalarType
                     {'name': 'dtype', 'simple_type': 'ScalarType', 'default': 'float', 'kwarg_only': True},
                     # layout is specified as an int64_t of at::Layout

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -13,7 +13,9 @@ Value* insertConstant(
   Node * n = g.create(prim::Constant);
   if(val.isTensor()) {
     at::Tensor ref = std::move(val).toTensor();
-    JIT_ASSERT(ref.defined());
+    if(!ref.defined()) {
+      throw constant_not_supported_error("undefined tensors cannot become constants");
+    }
     n->output()->inferTypeFrom(ref); // note: before t_ because of std::move(ref)
     n->t_(attr::value, std::move(ref));
   } else if(val.isInt()) {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -44,9 +44,14 @@ std::vector<IValue> runNode(Node* n) {
     stack.push_back(*(toIValue(input)));
   }
   op(stack);
-  auto var_outputs = fmap(stack, [&](IValue v) {
+  auto var_outputs = fmap(stack, [&](IValue v) -> IValue {
     if (v.isTensor()) {
-      return IValue(autograd::as_variable_ref(v.toTensor()).data());
+      auto t = std::move(v).toTensor();
+      if(t.defined()) {
+        return IValue(autograd::as_variable_ref(t).data());
+      } else {
+        return t;
+      }
     } else {
       return v;
     }

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -132,7 +132,7 @@ void ConstantPropagation(Node* n, bool recurse) {
       std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
         return v->node()->kind() == prim::Constant;
       });
-  bool supported_node = skip_list.count(n->kind()) == 0;
+  bool supported_node = !n->kind().is_onnx() && skip_list.count(n->kind()) == 0;
   auto run_blocks = [&]() {
     if (recurse) {
       for (Block * block : n->blocks()) {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -31,6 +31,8 @@ std::unordered_set<Symbol> skip_list = {
   aten::randn_like,
   aten::randperm,
   aten::randperm_out,
+  // TODO (zach): we should consider skipping tensor factories in the cases
+  // where the constant tensor would be large but cheap to create.
  };
 
 std::vector<IValue> runNode(Node* n) {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -461,6 +461,8 @@ void initPythonIRBindings(PyObject * module_) {
           return "FloatType";
         case TypeKind::StringType:
           return "StringType";
+        case TypeKind::GeneratorType:
+          return "GeneratorType";
         }
         // not reachable, but some compilers complain
         AT_ERROR("Unknown Type Kind");

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -462,6 +462,8 @@ void initPythonIRBindings(PyObject * module_) {
         case TypeKind::StringType:
           return "StringType";
         }
+        // not reachable, but some compilers complain
+        AT_ERROR("Unknown Type Kind");
     })
     .def("sizes",[](Type& t) {
       return t.expect<CompleteTensorType>()->sizes();

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -443,13 +443,24 @@ void initPythonIRBindings(PyObject * module_) {
       switch(t->kind()) {
         case TypeKind::DynamicType:
           return "DynamicType";
+        case TypeKind::TensorType:
+          return "TensorType";
+        case TypeKind::NumberType:
+          return "NumberType";
+        case TypeKind::NoneType:
+          return "NoneType";
         case TypeKind::CompleteTensorType:
           return "CompleteTensorType";
         case TypeKind::TupleType:
           return "TupleType";
-        default:
-          AT_ERROR("unknown type kind");
-          return "";
+        case TypeKind::ListType:
+          return "ListType";
+        case TypeKind::IntType:
+          return "IntType";
+        case TypeKind::FloatType:
+          return "FloatType";
+        case TypeKind::StringType:
+          return "StringType";
         }
     })
     .def("sizes",[](Type& t) {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -48,6 +48,16 @@ void addInputs(Node *n, const char * name, at::TensorList value) {
   n->addInput(list_node->output());
 }
 
+void addInputs(Node* n, const char * name, const at::TensorOptions& options) {
+  // [TensorOptions in script] - update this when you change how we schematize TensorOptions
+  detail::genericAddInput(n, static_cast<int64_t>(options.dtype()));
+  detail::genericAddInput(n, static_cast<int64_t>(options.layout()));
+  std::vector<int64_t> device = {
+      static_cast<int64_t>(options.device().type()),
+      static_cast<int64_t>(options.device().index())};
+  detail::genericAddInput(n, std::move(device));
+}
+
 void addInputs(Node *n, const char * name, at::IntList value) {
   using ArgumentStash = jit::tracer::ArgumentStash;
   std::vector<Value*> info = ArgumentStash::hasIntList(name) ?

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -239,6 +239,7 @@ void addInputs(Node *n, const char * name, at::TensorList value);
 void addInputs(Node *n, const char * name, const ArrayRef<double>& value);
 void addInputs(Node *n, const char * name, const std::string& value);
 void addInputs(Node *n, const char * name, const at::SparseTensorRef& value);
+void addInputs(Node *n, const char * name, const at::TensorOptions& value);
 
 template<size_t N>
 void addInputs(Node *n, const char * name, std::array<bool, N> value) {

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -242,7 +242,7 @@ TORCH_API void addInputs(Node *n, const char * name, const at::SparseTensorRef& 
 TORCH_API void addInputs(Node *n, const char * name, const at::TensorOptions& value);
 
 template<size_t N>
-TORCH_API void addInputs(Node *n, const char * name, std::array<bool, N> value) {
+void addInputs(Node *n, const char * name, std::array<bool, N> value) {
   throw std::runtime_error("Found an unsupported argument type in the JIT tracer. File a bug report.");
 }
 

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -229,20 +229,20 @@ inline void abandon() {
 
 // NB: those serve both as an intermediate steps in addInputs below,
 // as well as the overloads that terminate template recursion
-void addInputs(Node *n, const char * name, int64_t value);
-void addInputs(Node *n, const char * name, bool value);
-void addInputs(Node *n, const char * name, double value);
-void addInputs(Node *n, const char * name, const at::Scalar& value);
-void addInputs(Node *n, const char * name, const at::Tensor& value);
-void addInputs(Node *n, const char * name, at::IntList value);
-void addInputs(Node *n, const char * name, at::TensorList value);
-void addInputs(Node *n, const char * name, const ArrayRef<double>& value);
-void addInputs(Node *n, const char * name, const std::string& value);
-void addInputs(Node *n, const char * name, const at::SparseTensorRef& value);
-void addInputs(Node *n, const char * name, const at::TensorOptions& value);
+TORCH_API void addInputs(Node *n, const char * name, int64_t value);
+TORCH_API void addInputs(Node *n, const char * name, bool value);
+TORCH_API void addInputs(Node *n, const char * name, double value);
+TORCH_API void addInputs(Node *n, const char * name, const at::Scalar& value);
+TORCH_API void addInputs(Node *n, const char * name, const at::Tensor& value);
+TORCH_API void addInputs(Node *n, const char * name, at::IntList value);
+TORCH_API void addInputs(Node *n, const char * name, at::TensorList value);
+TORCH_API void addInputs(Node *n, const char * name, const ArrayRef<double>& value);
+TORCH_API void addInputs(Node *n, const char * name, const std::string& value);
+TORCH_API void addInputs(Node *n, const char * name, const at::SparseTensorRef& value);
+TORCH_API void addInputs(Node *n, const char * name, const at::TensorOptions& value);
 
 template<size_t N>
-void addInputs(Node *n, const char * name, std::array<bool, N> value) {
+TORCH_API void addInputs(Node *n, const char * name, std::array<bool, N> value) {
   throw std::runtime_error("Found an unsupported argument type in the JIT tracer. File a bug report.");
 }
 

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -51,6 +51,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "None";
   } else if(t.kind() == TypeKind::StringType) {
     out << "string";
+  } else if(t.kind() == TypeKind::GeneratorType) {
+    out << "Generator";
   } else {
     AT_ERROR("unknown type kind");
   }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -966,12 +966,12 @@ def _get_builtin_table():
     return _builtin_table
 
 
-def _register_builtin(callable, op):
-    _get_builtin_table()[id(callable)] = op
+def _register_builtin(fn, op):
+    _get_builtin_table()[id(fn)] = op
 
 
-def _find_builtin(callable):
-    return _get_builtin_table().get(id(callable))
+def _find_builtin(fn):
+    return _get_builtin_table().get(id(fn))
 
 
 if not torch._C._jit_init():

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -19,6 +19,7 @@ from torch._six import string_classes
 from torch.autograd import Function, function
 from torch.jit import _unique_state_dict
 from torch.onnx import ONNX_ARCHIVE_MODEL_PROTO_NAME, ExportTypes, OperatorExportTypes
+from torch._C import ListType
 
 
 @contextlib.contextmanager
@@ -103,24 +104,32 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             operator_export_type=operator_export_type)
 
 
-def _list_constant_prop(g, block):
+# ONNX can't handle constants that are lists of tensors, which can
+# get generated in constant prop. So we split them back into prim::ListConstructs
+def _split_tensor_list_constants(g, block):
     for node in block.nodes():
         for subblock in node.blocks():
-            _list_constant_prop(g, subblock)
-        if node.kind() == "prim::ListConstruct":
-            input_nodes = [i.node() for i in node.inputs()]
-            if all(inode.kind() == "prim::Constant" and inode.kindOf("value") == "i" for inode in input_nodes):
-                input_values = [inode['value'] for inode in input_nodes]
-                const_node = g.create("prim::Constant")
-                const_node.insertBefore(node)
-                const_node.is_("value", input_values)
-                const_node.output().setType(torch._C.ListType.ofInts())
-                node.output().replaceAllUsesWith(const_node.output())
+            _split_tensor_list_constants(g, subblock)
+        if node.kind() == "prim::Constant":
+            output_type = node.output().type()
+            if output_type.isSubtypeOf(ListType.ofTensors()):
+                inputs = [g.create("prim::Constant").t_('value', t)
+                           .insertBefore(node).output()
+                          for t in node['value']]
+                lc = (g.create("prim::ListConstruct", inputs)
+                      .insertBefore(node)
+                      .output()
+                      .setType(ListType.ofTensors()))
+                node.output().replaceAllUsesWith(lc)
 
 
 def _optimize_graph(graph, operator_export_type):
-    _list_constant_prop(graph, graph)
-
+    # we record now record some ops like ones/zeros
+    # into a trace where we previously recorded constants
+    # use constant prop to maintain our current level of onnx support
+    # without implementing symbolics for all of them
+    torch._C._jit_pass_constant_propagation(graph)
+    _split_tensor_list_constants(graph, graph)
     # run dce to eliminate dead parts of the graph that might have been
     # left behind by things like symbolic_override
     torch._C._jit_pass_dce(graph)


### PR DESCRIPTION
Things like torch.zeros now appear in traces rather than constants.

To continue to support our current level of ONNX export, we run
constant prop to turn these back into constants where possible before
export.

