### PR TITLE
Move AT_HOST_DEVICE macro to Macros.h

### DIFF
--- a/aten/src/ATen/core/Half-inl.h
+++ b/aten/src/ATen/core/Half-inl.h
@@ -16,7 +16,7 @@ namespace at {
 
 /// Constructors
 
-inline AT_HOSTDEVICE Half::Half(float value) {
+inline AT_HOST_DEVICE Half::Half(float value) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   x = __half_as_short(__float2half(value));
 #else
@@ -26,7 +26,7 @@ inline AT_HOSTDEVICE Half::Half(float value) {
 
 /// Implicit conversions
 
-inline AT_HOSTDEVICE Half::operator float() const {
+inline AT_HOST_DEVICE Half::operator float() const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   return __half2float(*reinterpret_cast<const __half*>(&x));
 #else
@@ -35,10 +35,10 @@ inline AT_HOSTDEVICE Half::operator float() const {
 }
 
 #ifdef __CUDACC__
-inline AT_HOSTDEVICE Half::Half(const __half& value) {
+inline AT_HOST_DEVICE Half::Half(const __half& value) {
   x = *reinterpret_cast<const unsigned short*>(&value);
 }
-inline AT_HOSTDEVICE Half::operator __half() const {
+inline AT_HOST_DEVICE Half::operator __half() const {
   return *reinterpret_cast<const __half*>(&x);
 }
 #endif
@@ -53,140 +53,140 @@ inline __device__ Half __ldg(const Half* ptr) {
 
 /// Arithmetic
 
-inline AT_HOSTDEVICE Half operator+(const Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half operator+(const Half& a, const Half& b) {
   return static_cast<float>(a) + static_cast<float>(b);
 }
 
-inline AT_HOSTDEVICE Half operator-(const Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half operator-(const Half& a, const Half& b) {
   return static_cast<float>(a) - static_cast<float>(b);
 }
 
-inline AT_HOSTDEVICE Half operator*(const Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half operator*(const Half& a, const Half& b) {
   return static_cast<float>(a) * static_cast<float>(b);
 }
 
-inline AT_HOSTDEVICE Half operator/(const Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
   return static_cast<float>(a) / static_cast<float>(b);
 }
 
-inline AT_HOSTDEVICE Half operator-(const Half& a) {
+inline AT_HOST_DEVICE Half operator-(const Half& a) {
   return -static_cast<float>(a);
 }
 
-inline AT_HOSTDEVICE Half& operator+=(Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half& operator+=(Half& a, const Half& b) {
   a = a + b;
   return a;
 }
 
-inline AT_HOSTDEVICE Half& operator-=(Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half& operator-=(Half& a, const Half& b) {
   a = a - b;
   return a;
 }
 
-inline AT_HOSTDEVICE Half& operator*=(Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half& operator*=(Half& a, const Half& b) {
   a = a * b;
   return a;
 }
 
-inline AT_HOSTDEVICE Half& operator/=(Half& a, const Half& b) {
+inline AT_HOST_DEVICE Half& operator/=(Half& a, const Half& b) {
   a = a / b;
   return a;
 }
 
 /// Arithmetic with floats
 
-inline AT_HOSTDEVICE float operator+(Half a, float b) {
+inline AT_HOST_DEVICE float operator+(Half a, float b) {
   return static_cast<float>(a) + b;
 }
-inline AT_HOSTDEVICE float operator-(Half a, float b) {
+inline AT_HOST_DEVICE float operator-(Half a, float b) {
   return static_cast<float>(a) - b;
 }
-inline AT_HOSTDEVICE float operator*(Half a, float b) {
+inline AT_HOST_DEVICE float operator*(Half a, float b) {
   return static_cast<float>(a) * b;
 }
-inline AT_HOSTDEVICE float operator/(Half a, float b) {
+inline AT_HOST_DEVICE float operator/(Half a, float b) {
   return static_cast<float>(a) / b;
 }
 
-inline AT_HOSTDEVICE float operator+(float a, Half b) {
+inline AT_HOST_DEVICE float operator+(float a, Half b) {
   return a + static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float operator-(float a, Half b) {
+inline AT_HOST_DEVICE float operator-(float a, Half b) {
   return a - static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float operator*(float a, Half b) {
+inline AT_HOST_DEVICE float operator*(float a, Half b) {
   return a * static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float operator/(float a, Half b) {
+inline AT_HOST_DEVICE float operator/(float a, Half b) {
   return a / static_cast<float>(b);
 }
 
-inline AT_HOSTDEVICE float& operator+=(float& a, const Half& b) {
+inline AT_HOST_DEVICE float& operator+=(float& a, const Half& b) {
   return a += static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float& operator-=(float& a, const Half& b) {
+inline AT_HOST_DEVICE float& operator-=(float& a, const Half& b) {
   return a -= static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float& operator*=(float& a, const Half& b) {
+inline AT_HOST_DEVICE float& operator*=(float& a, const Half& b) {
   return a *= static_cast<float>(b);
 }
-inline AT_HOSTDEVICE float& operator/=(float& a, const Half& b) {
+inline AT_HOST_DEVICE float& operator/=(float& a, const Half& b) {
   return a /= static_cast<float>(b);
 }
 
 /// Arithmetic with doubles
 
-inline AT_HOSTDEVICE double operator+(Half a, double b) {
+inline AT_HOST_DEVICE double operator+(Half a, double b) {
   return static_cast<double>(a) + b;
 }
-inline AT_HOSTDEVICE double operator-(Half a, double b) {
+inline AT_HOST_DEVICE double operator-(Half a, double b) {
   return static_cast<double>(a) - b;
 }
-inline AT_HOSTDEVICE double operator*(Half a, double b) {
+inline AT_HOST_DEVICE double operator*(Half a, double b) {
   return static_cast<double>(a) * b;
 }
-inline AT_HOSTDEVICE double operator/(Half a, double b) {
+inline AT_HOST_DEVICE double operator/(Half a, double b) {
   return static_cast<double>(a) / b;
 }
 
-inline AT_HOSTDEVICE double operator+(double a, Half b) {
+inline AT_HOST_DEVICE double operator+(double a, Half b) {
   return a + static_cast<double>(b);
 }
-inline AT_HOSTDEVICE double operator-(double a, Half b) {
+inline AT_HOST_DEVICE double operator-(double a, Half b) {
   return a - static_cast<double>(b);
 }
-inline AT_HOSTDEVICE double operator*(double a, Half b) {
+inline AT_HOST_DEVICE double operator*(double a, Half b) {
   return a * static_cast<double>(b);
 }
-inline AT_HOSTDEVICE double operator/(double a, Half b) {
+inline AT_HOST_DEVICE double operator/(double a, Half b) {
   return a / static_cast<double>(b);
 }
 
 /// Arithmetic with ints
 
-inline AT_HOSTDEVICE Half operator+(Half a, int b) {
+inline AT_HOST_DEVICE Half operator+(Half a, int b) {
   return a + static_cast<Half>(b);
 }
-inline AT_HOSTDEVICE Half operator-(Half a, int b) {
+inline AT_HOST_DEVICE Half operator-(Half a, int b) {
   return a - static_cast<Half>(b);
 }
-inline AT_HOSTDEVICE Half operator*(Half a, int b) {
+inline AT_HOST_DEVICE Half operator*(Half a, int b) {
   return a * static_cast<Half>(b);
 }
-inline AT_HOSTDEVICE Half operator/(Half a, int b) {
+inline AT_HOST_DEVICE Half operator/(Half a, int b) {
   return a / static_cast<Half>(b);
 }
 
-inline AT_HOSTDEVICE Half operator+(int a, Half b) {
+inline AT_HOST_DEVICE Half operator+(int a, Half b) {
   return static_cast<Half>(a) + b;
 }
-inline AT_HOSTDEVICE Half operator-(int a, Half b) {
+inline AT_HOST_DEVICE Half operator-(int a, Half b) {
   return static_cast<Half>(a) - b;
 }
-inline AT_HOSTDEVICE Half operator*(int a, Half b) {
+inline AT_HOST_DEVICE Half operator*(int a, Half b) {
   return static_cast<Half>(a) * b;
 }
-inline AT_HOSTDEVICE Half operator/(int a, Half b) {
+inline AT_HOST_DEVICE Half operator/(int a, Half b) {
   return static_cast<Half>(a) / b;
 }
 

--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -30,14 +30,6 @@
 #include <hip/hip_fp16.h>
 #endif
 
-#ifndef AT_HOSTDEVICE
-#ifdef __CUDACC__
-#define AT_HOSTDEVICE __host__ __device__
-#else
-#define AT_HOSTDEVICE
-#endif
-#endif
-
 namespace at {
 
 namespace detail {
@@ -55,18 +47,18 @@ struct alignas(2) Half {
 
   // HIP wants __host__ __device__ tag, CUDA does not
 #ifdef __HIP_PLATFORM_HCC__
-  AT_HOSTDEVICE Half() = default;
+  AT_HOST_DEVICE Half() = default;
 #else
   Half() = default;
 #endif
 
-  constexpr AT_HOSTDEVICE Half(unsigned short bits, from_bits_t) : x(bits){};
-  inline AT_HOSTDEVICE Half(float value);
-  inline AT_HOSTDEVICE operator float() const;
+  constexpr AT_HOST_DEVICE Half(unsigned short bits, from_bits_t) : x(bits){};
+  inline AT_HOST_DEVICE Half(float value);
+  inline AT_HOST_DEVICE operator float() const;
 
 #ifdef __CUDACC__
-  inline AT_HOSTDEVICE Half(const __half& value);
-  inline AT_HOSTDEVICE operator __half() const;
+  inline AT_HOST_DEVICE Half(const __half& value);
+  inline AT_HOST_DEVICE operator __half() const;
 #endif
 };
 
@@ -191,5 +183,3 @@ AT_CORE_API std::ostream& operator<<(std::ostream& out, const Half& value);
 } // namespace at
 
 #include "ATen/core/Half-inl.h"
-
-#undef AT_HOSTDEVICE

--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -39,6 +39,14 @@
 #define AT_CORE_API AT_CORE_IMPORT
 #endif // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
 
+#ifdef __CUDACC__
+// Designates functions callable from the host (CPU) and the device (GPU)
+#define AT_HOST_DEVICE __host__ __device__
+#define AT_DEVICE __device__
+#else
+#define AT_HOST_DEVICE
+#endif
+
 // Disable the copy and assignment operator for a class. Note that this will
 // disable the usage of the class in std containers.
 #define AT_DISABLE_COPY_AND_ASSIGN(classname) \

--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -43,8 +43,11 @@
 // Designates functions callable from the host (CPU) and the device (GPU)
 #define AT_HOST_DEVICE __host__ __device__
 #define AT_DEVICE __device__
+#define AT_HOST __host__
 #else
 #define AT_HOST_DEVICE
+#define AT_HOST
+#define AT_DEVICE
 #endif
 
 // Disable the copy and assignment operator for a class. Note that this will


### PR DESCRIPTION
```
I'm using AT_HOST_DEVICE outside of Half.h in an upcoming PR. Since this
changes code without making any semantic changes, I wanted to make this
change in a separate PR.
```