### PR TITLE
Replace direct include of caffe2.pb.h with an intermediary header caffe2_pb.h

### DIFF
--- a/binaries/convert_caffe_image_db.cc
+++ b/binaries/convert_caffe_image_db.cc
@@ -16,7 +16,7 @@
 
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/proto/caffe2_legacy.pb.h"
 #include "caffe2/core/logging.h"
 

--- a/binaries/convert_db.cc
+++ b/binaries/convert_db.cc
@@ -16,7 +16,7 @@
 
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 
 CAFFE2_DEFINE_string(input_db, "", "The input db.");

--- a/binaries/convert_encoded_to_raw_leveldb.cc
+++ b/binaries/convert_encoded_to_raw_leveldb.cc
@@ -30,7 +30,7 @@
 #include <string>
 
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"

--- a/binaries/make_cifar_db.cc
+++ b/binaries/make_cifar_db.cc
@@ -30,7 +30,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 
 CAFFE2_DEFINE_string(input_folder, "", "The input folder name.");

--- a/binaries/make_image_db.cc
+++ b/binaries/make_image_db.cc
@@ -39,7 +39,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 
 CAFFE2_DEFINE_bool(shuffle, false,

--- a/binaries/make_mnist_db.cc
+++ b/binaries/make_mnist_db.cc
@@ -24,7 +24,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 
 CAFFE2_DEFINE_string(image_file, "", "The input image file name.");

--- a/binaries/print_core_object_sizes_gpu.cc
+++ b/binaries/print_core_object_sizes_gpu.cc
@@ -20,7 +20,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/context_gpu.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #define PRINT_SIZE(cls) \
   std::cout << "Size of " #cls ": " << sizeof(cls) << " bytes." \

--- a/binaries/run_plan.cc
+++ b/binaries/run_plan.cc
@@ -16,7 +16,7 @@
 
 #include "caffe2/core/init.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/core/logging.h"
 

--- a/binaries/run_plan_mpi.cc
+++ b/binaries/run_plan_mpi.cc
@@ -18,7 +18,7 @@
 
 #include "caffe2/core/init.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/core/logging.h"
 

--- a/binaries/speed_benchmark.cc
+++ b/binaries/speed_benchmark.cc
@@ -22,7 +22,7 @@
 #ifdef CAFFE2_OPTIMIZER
 #include "caffe2/opt/optimizer.h"
 #endif
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 

--- a/binaries/split_db.cc
+++ b/binaries/split_db.cc
@@ -19,7 +19,7 @@
 
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/logging.h"
 
 CAFFE2_DEFINE_string(input_db, "", "The input db.");

--- a/binaries/tsv_2_proto.cc
+++ b/binaries/tsv_2_proto.cc
@@ -21,7 +21,7 @@
 #include "caffe2/core/db.h"
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 CAFFE2_DEFINE_string(f_in, "", "The input data file name.");

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.h
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/workspace.h"
 #include "caffe2/onnx/onnx_exporter.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "onnx/onnx_pb.h"
 
 namespace caffe2 {

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -12,7 +12,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/typeid.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/blob_gpu_test.cc
+++ b/caffe2/core/blob_gpu_test.cc
@@ -3,7 +3,7 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/common_gpu.h"
 #include "caffe2/core/context_gpu.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include <gtest/gtest.h>
 
 namespace caffe2 {

--- a/caffe2/core/blob_serializer_base.h
+++ b/caffe2/core/blob_serializer_base.h
@@ -5,7 +5,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/registry.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -15,7 +15,7 @@
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 CAFFE2_DEFINE_int64(caffe2_test_big_tensor_size, 100000000, "");

--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -10,7 +10,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/types.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #ifndef CAFFE2_USE_CUDNN
 #error("This Caffe2 install is not built with cudnn, so you should not include this file.");

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -11,7 +11,7 @@
 #include "caffe2/core/event.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/typeid.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #include "ATen/core/ATenCoreTest.h"
 #include "ATen/core/ArrayRef.h"

--- a/caffe2/core/context_base.h
+++ b/caffe2/core/context_base.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/event.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/typeid.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -12,7 +12,7 @@
 #include "caffe2/core/numa.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 // Since we are using the macro CAFFE2_USE_CUDNN, we will need to include this
 // file after common.h is included.

--- a/caffe2/core/context_test.cc
+++ b/caffe2/core/context_test.cc
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 #include "caffe2/core/context.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -5,7 +5,7 @@
 
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/registry.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 namespace db {

--- a/caffe2/core/dispatch/OpSchema.h
+++ b/caffe2/core/dispatch/OpSchema.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "caffe2/core/dispatch/DispatchKey.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/Array.h"
 #include "caffe2/utils/Metaprogramming.h"
 

--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/graph.cc
+++ b/caffe2/core/graph.cc
@@ -3,7 +3,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/graph.h
+++ b/caffe2/core/graph.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "caffe2/core/common.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 

--- a/caffe2/core/hip/common_miopen.h
+++ b/caffe2/core/hip/common_miopen.h
@@ -23,7 +23,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/types.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #define MIOPEN_VERSION 1399
 

--- a/caffe2/core/hip/context_hip.h
+++ b/caffe2/core/hip/context_hip.h
@@ -12,7 +12,7 @@
 #include "caffe2/core/numa.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/hip/net_async_dag_hip.cc
+++ b/caffe2/core/hip/net_async_dag_hip.cc
@@ -24,7 +24,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 #include "caffe2/core/hip/context_hip.h"

--- a/caffe2/core/logging.h
+++ b/caffe2/core/logging.h
@@ -9,7 +9,7 @@
 
 #include <ATen/core/Error.h>
 #include "caffe2/core/flags.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 // CAFFE2_LOG_THRESHOLD is a compile time flag that would allow us to turn off
 // logging at compile time so no logging message below that level is produced

--- a/caffe2/core/memonger.h
+++ b/caffe2/core/memonger.h
@@ -5,7 +5,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 namespace memonger {

--- a/caffe2/core/net.cc
+++ b/caffe2/core/net.cc
@@ -8,7 +8,7 @@
 #include "caffe2/core/init.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 

--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -17,7 +17,7 @@
 #include "caffe2/core/registry.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/simple_queue.h"
 #include "caffe2/utils/thread_pool.h"
 

--- a/caffe2/core/net_async_base.h
+++ b/caffe2/core/net_async_base.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/stats.h"
 #include "caffe2/core/timer.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/thread_pool.h"
 

--- a/caffe2/core/net_async_dag_gpu.cc
+++ b/caffe2/core/net_async_dag_gpu.cc
@@ -8,7 +8,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 #include "caffe2/core/context_gpu.h"

--- a/caffe2/core/net_async_dag_gpu.h
+++ b/caffe2/core/net_async_dag_gpu.h
@@ -4,7 +4,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/net_dag.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/net_dag.cc
+++ b/caffe2/core/net_dag.cc
@@ -9,7 +9,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/thread_name.h"
 

--- a/caffe2/core/net_dag.h
+++ b/caffe2/core/net_dag.h
@@ -21,7 +21,7 @@
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/timer.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/simple_queue.h"
 
 namespace caffe2 {

--- a/caffe2/core/net_dag_utils.cc
+++ b/caffe2/core/net_dag_utils.cc
@@ -8,7 +8,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/core/net_dag_utils.h
+++ b/caffe2/core/net_dag_utils.h
@@ -19,7 +19,7 @@
 #include "caffe2/core/registry.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/simple_queue.h"
 
 namespace caffe2 {

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -9,7 +9,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 CAFFE2_DEFINE_bool(

--- a/caffe2/core/net_simple.h
+++ b/caffe2/core/net_simple.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/registry.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/net_simple_async.cc
+++ b/caffe2/core/net_simple_async.cc
@@ -9,7 +9,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/core/net_simple_async.h
+++ b/caffe2/core/net_simple_async.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/registry.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -10,7 +10,7 @@
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
 
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 #include "caffe2/utils/string_utils.h"
 

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -19,7 +19,7 @@
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/core/operator_gradient.h
+++ b/caffe2/core/operator_gradient.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/operator_schema.h"
 #include "caffe2/core/registry.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -12,7 +12,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/registry.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/filler.h"
 
 namespace caffe2 {

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -9,7 +9,7 @@
 
 #include "caffe2/core/timer.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 CAFFE2_DEFINE_bool(
     caffe2_handle_executor_threads_exceptions,

--- a/caffe2/core/tensor_int8.h
+++ b/caffe2/core/tensor_int8.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 namespace int8 {

--- a/caffe2/core/transform.cc
+++ b/caffe2/core/transform.cc
@@ -4,7 +4,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/transform.h
+++ b/caffe2/core/transform.h
@@ -3,7 +3,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/graph.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/core/types.h
+++ b/caffe2/core/types.h
@@ -8,7 +8,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/typeid.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/core/workspace.cc
+++ b/caffe2/core/workspace.cc
@@ -9,7 +9,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/plan_executor.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 CAFFE2_DEFINE_bool(
     caffe2_print_blob_sizes_at_exit,

--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -14,7 +14,7 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/registry.h"
 #include "caffe2/core/net.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/signal_handler.h"
 #include "caffe2/utils/threadpool/ThreadPool.h"
 

--- a/caffe2/db/db_test.cc
+++ b/caffe2/db/db_test.cc
@@ -6,7 +6,7 @@
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/db.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include <gtest/gtest.h>
 
 namespace caffe2 {

--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -4,7 +4,7 @@
 #include <caffe2/core/context.h>
 #include <caffe2/core/operator.h>
 #include <caffe2/ideep/ideep_utils.h>
-#include <caffe2/proto/caffe2.pb.h>
+#include <caffe2/proto/caffe2_pb.h>
 
 namespace caffe2 {
 

--- a/caffe2/ideep/utils/ideep_operator.h
+++ b/caffe2/ideep/utils/ideep_operator.h
@@ -2,7 +2,7 @@
 
 #include <ideep.hpp>
 #include <caffe2/core/operator.h>
-#include <caffe2/proto/caffe2.pb.h>
+#include <caffe2/proto/caffe2_pb.h>
 
 namespace caffe2 {
 

--- a/caffe2/ideep/utils/ideep_register.cc
+++ b/caffe2/ideep/utils/ideep_register.cc
@@ -1,6 +1,6 @@
 #include <caffe2/core/event_cpu.h>
 #include <caffe2/core/operator.h>
-#include <caffe2/proto/caffe2.pb.h>
+#include <caffe2/proto/caffe2_pb.h>
 #include <ideep_pin_singletons.hpp>
 #include "ideep_context.h"
 

--- a/caffe2/mkl/mkl_operator.cc
+++ b/caffe2/mkl/mkl_operator.cc
@@ -1,5 +1,5 @@
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 CAFFE2_DEFINE_bool(
     caffe2_mkl_memonger_in_use,

--- a/caffe2/mkl/mkl_utils_test.cc
+++ b/caffe2/mkl/mkl_utils_test.cc
@@ -2,7 +2,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/mkl/mkl_utils.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/math.h"
 
 #include <gtest/gtest.h>

--- a/caffe2/mkl/operators/operator_fallback_mkl.h
+++ b/caffe2/mkl/operators/operator_fallback_mkl.h
@@ -5,7 +5,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/mkl/mkl_utils.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #ifdef CAFFE2_HAS_MKL_DNN
 namespace caffe2 {

--- a/caffe2/mkl/utils/mkl_operator.h
+++ b/caffe2/mkl/utils/mkl_operator.h
@@ -4,7 +4,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/mkl/utils/mkl_dnn_cppwrapper.h"
 #include "caffe2/mkl/utils/mkl_memory.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 CAFFE2_DECLARE_bool(caffe2_mkl_memonger_in_use);
 

--- a/caffe2/mobile/contrib/arm-compute/core/net_gl.cc
+++ b/caffe2/mobile/contrib/arm-compute/core/net_gl.cc
@@ -10,7 +10,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/static_tracepoint.h"
 #include "caffe2/core/timer.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/mobile/contrib/arm-compute/core/net_gl.h
+++ b/caffe2/mobile/contrib/arm-compute/core/net_gl.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/registry.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/mobile/contrib/opengl/test/opengl_test.h
+++ b/caffe2/mobile/contrib/opengl/test/opengl_test.h
@@ -1,5 +1,5 @@
 
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 void testOpenGL();

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -3,7 +3,7 @@
 #include "caffe2/onnx/backend_rep.h"
 #include "caffe2/onnx/device.h"
 #include "caffe2/onnx/helper.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "onnx/onnx_pb.h"
 
 #include <functional>

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "caffe2/predictor/predictor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #include <memory>
 #include <string>

--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/onnx/helper.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "onnx/onnx_pb.h"
 
 #include <string>

--- a/caffe2/operators/create_scope_op.h
+++ b/caffe2/operators/create_scope_op.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 CAFFE2_DECLARE_bool(caffe2_workspace_stack_debug);
 

--- a/caffe2/operators/do_op.h
+++ b/caffe2/operators/do_op.h
@@ -10,7 +10,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/create_scope_op.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/flexible_top_k.cc
+++ b/caffe2/operators/flexible_top_k.cc
@@ -1,6 +1,6 @@
 #include "caffe2/operators/flexible_top_k.h"
 
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/operator_fallback_gpu.h
+++ b/caffe2/operators/operator_fallback_gpu.h
@@ -5,7 +5,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/text_file_reader_utils_test.cc
+++ b/caffe2/operators/text_file_reader_utils_test.cc
@@ -2,7 +2,7 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/math.h"
 #include <gtest/gtest.h>
 

--- a/caffe2/operators/top_k.cc
+++ b/caffe2/operators/top_k.cc
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {

--- a/caffe2/opt/backend_cutting.h
+++ b/caffe2/opt/backend_cutting.h
@@ -2,7 +2,7 @@
 
 
 #include "caffe2/core/common.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #include <functional>
 

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "nomnigraph/Graph/Graph.h"
 #include "nomnigraph/Representations/ControlFlow.h"
 #include "nomnigraph/Representations/NeuralNet.h"

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -11,7 +11,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/workspace.h"
 #include "caffe2/onnx/onnxifi_init.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 namespace onnx {

--- a/caffe2/opt/optimize_ideep.h
+++ b/caffe2/opt/optimize_ideep.h
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "nomnigraph/Representations/NeuralNet.h"
 
 namespace caffe2 {

--- a/caffe2/opt/optimizer.h
+++ b/caffe2/opt/optimizer.h
@@ -2,7 +2,7 @@
 #define CAFFE2_OPT_OPTIMIZER_H
 
 #include "caffe2/core/common.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/core/workspace.h"
 
 namespace caffe2 {

--- a/caffe2/opt/passes.h
+++ b/caffe2/opt/passes.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 #include "nomnigraph/Representations/NeuralNet.h"
 

--- a/caffe2/opt/sink.h
+++ b/caffe2/opt/sink.h
@@ -2,7 +2,7 @@
 #define CAFFE2_OPT_SINK_H_
 
 #include "caffe2/core/common.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "nomnigraph/Representations/NeuralNet.h"
 
 namespace caffe2 {

--- a/caffe2/predictor/predictor_utils.cc
+++ b/caffe2/predictor/predictor_utils.cc
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/blob.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/proto/predictor_consts.pb.h"
 #include "caffe2/utils/proto_utils.h"
 

--- a/caffe2/proto/caffe2_pb.h
+++ b/caffe2/proto/caffe2_pb.h
@@ -1,0 +1,2 @@
+#pragma once
+#include <caffe2/proto/caffe2.pb.h>

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -12,7 +12,7 @@
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/python/pybind_state_dlpack.h"
 
 #include <pybind11/pybind11.h>

--- a/caffe2/python/pybind_state_dlpack.h
+++ b/caffe2/python/pybind_state_dlpack.h
@@ -3,7 +3,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/types.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/python/dlpack.h"
 
 #include <pybind11/pybind11.h>

--- a/caffe2/share/contrib/zstd/quant_decomp_zstd_op.cc
+++ b/caffe2/share/contrib/zstd/quant_decomp_zstd_op.cc
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <zstd.h>
 #include "caffe2/core/tensor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/transforms/common_subexpression_elimination.cc
+++ b/caffe2/transforms/common_subexpression_elimination.cc
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/net.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/transforms/common_subexpression_elimination.h
+++ b/caffe2/transforms/common_subexpression_elimination.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/transform.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/transforms/conv_to_nnpack_transform.h
+++ b/caffe2/transforms/conv_to_nnpack_transform.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "caffe2/core/common.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/transforms/single_op_transform.h"
 #include "caffe2/utils/proto_utils.h"
 

--- a/caffe2/transforms/pattern_net_transform.cc
+++ b/caffe2/transforms/pattern_net_transform.cc
@@ -3,7 +3,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/transforms/pattern_net_transform.h
+++ b/caffe2/transforms/pattern_net_transform.h
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/transform.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/transforms/single_op_transform.cc
+++ b/caffe2/transforms/single_op_transform.cc
@@ -3,7 +3,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 

--- a/caffe2/transforms/single_op_transform.h
+++ b/caffe2/transforms/single_op_transform.h
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/transform.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/utils/hip/math_blas_hip_test.cc
+++ b/caffe2/utils/hip/math_blas_hip_test.cc
@@ -4,7 +4,7 @@
 #include "caffe2/core/hip/context_hip.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/operators/utility_ops.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/conversions.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -7,7 +7,7 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/conversions.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -9,7 +9,7 @@
 
 #include "caffe2/core/logging.h"
 #include "caffe2/utils/proto_wrap.h"
-#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 


### PR DESCRIPTION
Replace direct include of caffe2.pb.h with an intermediary header caffe2_pb.h

```
codemod -d . --extensions cc,cpp,cu,cuh,h caffe2/proto/caffe2.pb.h caffe2/proto/caffe2_pb.h
```

Differential Revision: D9539945

