### PR TITLE
[pytorch][PR] Generate Type::registerCPU as we do register_cuda_types.

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 
 #include "ATen/CPUGenerator.h"
+#include "ATen/RegisterCPU.h"
 
 #ifdef USE_SSE3
 #include <pmmintrin.h>
@@ -34,7 +35,7 @@ Context::Context()
 
   generator_registry[static_cast<int>(DeviceType::CPU)]
     .reset(new CPUGenerator(this));
-  Type::registerCPU(this);
+  register_cpu_types(this);
 }
 
 // TODO: This could be bad juju if someone calls globalContext() in the

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -114,6 +114,7 @@ private:
   std::atomic<size_t> next_id;
   std::unique_ptr<THCState, void(*)(THCState*)> thc_state;
   friend struct Type;
+  friend void register_cpu_types(Context * context);
   friend void register_cuda_types(Context * context);
 };
 

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -109,6 +109,9 @@ TYPE_DERIVED_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDerived.h")
 TYPE_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.h")
 TYPE_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.cpp")
 
+REGISTER_CPU_H = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCPU.h")
+REGISTER_CPU_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCPU.cpp")
+
 REGISTER_CUDA_H = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCUDA.h")
 REGISTER_CUDA_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCUDA.cpp")
 
@@ -340,7 +343,8 @@ def iterate_types():
 def declare_outputs():
     files = ['Declarations.yaml', 'Type.h', 'Type.cpp', 'Tensor.h',
              'TensorMethods.h', 'Functions.h',
-             'CPUCopy.cpp', 'NativeFunctions.h']
+             'CPUCopy.cpp', 'NativeFunctions.h',
+             'RegisterCPU.cpp', 'RegisterCPU.h']
     for f in files:
         file_manager.will_write(f)
     cuda_files = ['CUDACopy.cpp', 'RegisterCUDA.cpp', 'RegisterCUDA.h']
@@ -408,6 +412,9 @@ def generate_outputs():
 
     file_manager.write('Type.h', TYPE_H, top_env)
     file_manager.write('Type.cpp', TYPE_CPP, top_env)
+
+    file_manager.write('RegisterCPU.h', REGISTER_CPU_H, top_env)
+    file_manager.write('RegisterCPU.cpp', REGISTER_CPU_CPP, top_env)
 
     cuda_file_manager.write('RegisterCUDA.h', REGISTER_CUDA_H, top_env)
     cuda_file_manager.write('RegisterCUDA.cpp', REGISTER_CUDA_CPP, top_env)

--- a/aten/src/ATen/templates/RegisterCPU.cpp
+++ b/aten/src/ATen/templates/RegisterCPU.cpp
@@ -1,0 +1,17 @@
+#include <ATen/RegisterCPU.h>
+
+// ${generated_comment}
+
+#include <ATen/Type.h>
+#include <ATen/Context.h>
+#include <ATen/detail/VariableHooksInterface.h>
+
+${cpu_type_headers}
+
+namespace at {
+
+void register_cpu_types(Context * context) {
+  ${cpu_type_registrations}
+}
+
+} // namespace at

--- a/aten/src/ATen/templates/RegisterCPU.cpp
+++ b/aten/src/ATen/templates/RegisterCPU.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/Type.h>
 #include <ATen/Context.h>
+#include <ATen/UndefinedType.h>
 #include <ATen/detail/VariableHooksInterface.h>
 
 ${cpu_type_headers}
@@ -12,6 +13,8 @@ namespace at {
 
 void register_cpu_types(Context * context) {
   ${cpu_type_registrations}
+  context->type_registry[static_cast<int>(Backend::Undefined)]
+                        [static_cast<int>(ScalarType::Undefined)].reset(new UndefinedType(context));
 }
 
 } // namespace at

--- a/aten/src/ATen/templates/RegisterCPU.h
+++ b/aten/src/ATen/templates/RegisterCPU.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// ${generated_comment}
+
+namespace at {
+
+class Context;
+void register_cpu_types(Context * context);
+
+} // namespace at

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -9,21 +9,9 @@
 #include "ATen/Storage.h"
 #include "ATen/Tensor.h"
 #include "ATen/TensorOptions.h"
-#include "ATen/UndefinedType.h"
 #include "ATen/DeviceGuard.h"
 
-#include <ATen/detail/VariableHooksInterface.h>
-
-#include <iostream>
-${cpu_type_headers}
-
 namespace at {
-
-void Type::registerCPU(Context * context) {
-  ${cpu_type_registrations}
-  context->type_registry[static_cast<int>(Backend::Undefined)]
-                        [static_cast<int>(ScalarType::Undefined)].reset(new UndefinedType(context));
-}
 
 Tensor & Type::copy_(Tensor & self, const Tensor & src, bool non_blocking) const {
   Tensor b_src;

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -56,7 +56,6 @@ struct AT_API Type {
   virtual bool is_distributed() const = 0;
   bool is_variable() const noexcept { return is_variable_; }
   bool is_undefined() const noexcept { return is_undefined_; }
-  static void registerCPU(Context * context);
   virtual Storage storage(bool resizable = false) const = 0;
   virtual Storage storage(size_t size, bool resizable = false) const = 0;
   virtual Storage storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter=noop_deleter) const = 0;


### PR DESCRIPTION
[pytorch][PR] Generate Type::registerCPU as we do register_cuda_types.

The goal here is to separate out the base Type into core; as it was done previously we need all derived Types to be defined when we compile the base Type.
GitHub Author: Gregory Chanan <gchanan@fb.com>

Differential Revision: D9540025

