### PR TITLE
[jit] Fix scalar tensor assert in fusion compiler

### DIFF
--- a/test/expect/TestScript.test_scalar_fusion.expect
+++ b/test/expect/TestScript.test_scalar_fusion.expect
@@ -4,9 +4,9 @@ graph(%x : Float()
   return (%2);
 }
 with prim::FusionGroup_0 = graph(%0 : Float()
-      %4 : Float()) {
-  %5 : Float() = aten::type_as(%4, %0)
-  %2 : int = prim::Constant[value=1]()
-  %3 : Float() = aten::add(%0, %5, %2)
-  return (%3);
+      %1 : Float()) {
+  %2 : Float() = aten::type_as(%1, %0)
+  %3 : int = prim::Constant[value=1]()
+  %4 : Float() = aten::add(%0, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestScript.test_scalar_fusion.expect
+++ b/test/expect/TestScript.test_scalar_fusion.expect
@@ -1,0 +1,12 @@
+graph(%x : Float()
+      %y : Float()) {
+  %2 : Float() = prim::FusionGroup_0[device=-1](%x, %y)
+  return (%2);
+}
+with prim::FusionGroup_0 = graph(%0 : Float()
+      %4 : Float()) {
+  %5 : Float() = aten::type_as(%4, %0)
+  %2 : int = prim::Constant[value=1]()
+  %3 : Float() = aten::add(%0, %5, %2)
+  return (%3);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2925,7 +2925,8 @@ a")
 
         x = torch.tensor(0.1, dtype=torch.float, device='cpu')
         y = torch.tensor(1, dtype=torch.float, device='cpu')
-        self.checkScript(fn, (x, y))
+        ge = self.checkScript(fn, (x, y))
+        self.assertExpectedGraph(ge.graph_for(x, y))
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2921,6 +2921,17 @@ a")
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     @skipIfRocm
+    def test_scalar_fusion_cuda(self):
+        def fn(x, y):
+            return x + y.type_as(x)
+
+        x = torch.tensor(0.1, dtype=torch.float, device='cuda')
+        y = torch.tensor(1, dtype=torch.float, device='cuda')
+        self.checkScript(fn, (x, y))
+
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    @skipIfRocm
     def test_lstm_fusion_cuda(self):
         inputs = get_lstm_inputs('cuda', training=True)
         module = self.checkScript(LSTMCellS, inputs)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2919,14 +2919,12 @@ a")
         self.assertEqual(cu.test_fuser_multiple_blocks(*inputs), outputs)
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
-    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
-    @skipIfRocm
-    def test_scalar_fusion_cuda(self):
+    def test_scalar_fusion(self):
         def fn(x, y):
             return x + y.type_as(x)
 
-        x = torch.tensor(0.1, dtype=torch.float, device='cuda')
-        y = torch.tensor(1, dtype=torch.float, device='cuda')
+        x = torch.tensor(0.1, dtype=torch.float, device='cpu')
+        y = torch.tensor(1, dtype=torch.float, device='cpu')
         self.checkScript(fn, (x, y))
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -170,15 +170,17 @@ typedef long long int int64_t;
 ${HalfHeader}
 ${RandHeader}
 #endif
-#define MIN_ONE(N) (N == 0 ? 1 : N)
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {
   T * data;
-  IndexType sizes[MIN_ONE(N)];
-  IndexType strides[MIN_ONE(N)];
+  IndexType sizes[N];
+  IndexType strides[N];
 };
-#undef MIN_ONE
+template<typename T>
+struct TensorInfo<T, 0> {
+  T * data;
+};
 )");
 
 // We rewrite the code for philox RNG from curand as nvrtc couldn't resolve the
@@ -793,9 +795,7 @@ void FusedKernel::launch_with_tensors(at::ArrayRef<at::Tensor> inputs, at::Array
 
   // Compute the storage needed to store TensorInfo structs for inputs and outputs.
   size_t uncompressedDim = input_desc.at(0).contiguity.size();
-  // Avoid allocating no memory for TensorInfo when we have a 0-dim tensor
-  size_t maxPossibleDims = uncompressedDim == 0 ? 1 : uncompressedDim;
-  size_t maxPossibleTensorInfoSize = sizeof(TensorInfo) + 2 * sizeof(uint32_t) * maxPossibleDims;
+  size_t maxPossibleTensorInfoSize = sizeof(TensorInfo) + 2 * sizeof(uint32_t) * uncompressedDim;
   size_t maxPossibleBufferSize = maxPossibleTensorInfoSize * (flat_inputs_size + flat_outputs_size);
   std::vector<char> buffer(maxPossibleBufferSize);
   char * buffer_next = buffer.data();
@@ -804,7 +804,7 @@ void FusedKernel::launch_with_tensors(at::ArrayRef<at::Tensor> inputs, at::Array
   arguments.reserve(3 + flat_inputs_size + flat_outputs_size);
   auto addTensorInfoRaw = [&](TensorDesc & desc, void* data_ptr, at::IntList sizes, at::IntList strides) {
     size_t nDim = desc.nDim(); // NOTE: this is the compressed dim
-    JIT_ASSERT(nDim <= maxPossibleDims); // We'd overflow the space otherwise
+    JIT_ASSERT(nDim <= uncompressedDim); // We'd overflow the space otherwise
     auto ti = reinterpret_cast<TensorInfo*>(buffer_next);
     ti->data = data_ptr;
     compressContiguous(sizes, strides, desc.contiguity, ti->sizes(nDim), ti->strides(nDim));

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -734,7 +734,9 @@ void compressContiguous(
     c_strides[compressed_dims] = strides[cur-1];
     compressed_dims++;
   }
-  JIT_ASSERT(!cont.back() || strides.back() == 1);
+  if (ndim > 0) {
+    JIT_ASSERT(!cont.back() || strides.back() == 1);
+  }
 }
 
 } // anonymous namespace

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -29,7 +29,11 @@ struct TensorDesc {
 
   TensorDesc(const at::ScalarType& type, const std::vector<bool>& contiguity)
   : scalar_type(type), contiguity(contiguity) {
-    nDim_ = std::count(contiguity.begin(), contiguity.end(), false) + (lastIsContiguous() ? 1 : 0);
+    if (contiguity.size() == 0) {
+      nDim_ = 0;
+    } else {
+      nDim_ = std::count(contiguity.begin(), contiguity.end(), false) + (lastIsContiguous() ? 1 : 0);
+    }
   }
 
   TensorDesc(const at::ScalarType& type, const at::IntList& sizes, const at::IntList& strides)
@@ -46,8 +50,7 @@ struct TensorDesc {
 
   // do we have inner stride == 1?
   bool lastIsContiguous() const {
-    // NB: A scalar tensor does not have a "last dimension" because it has 0 dims.
-    return contiguity.size() != 0 && contiguity.back();
+    return contiguity.size() == 0 || contiguity.back();
   }
 
   static std::vector<bool> findContiguous(

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -46,7 +46,8 @@ struct TensorDesc {
 
   // do we have inner stride == 1?
   bool lastIsContiguous() const {
-    return contiguity.size() == 0 || contiguity.back();
+    // NB: A scalar tensor does not have a "last dimension" because it has 0 dims.
+    return contiguity.size() != 0 && contiguity.back();
   }
 
   static std::vector<bool> findContiguous(


### PR DESCRIPTION
Fixes #8560.
Unblocks #10715.

The assert (nDim <= uncompressedDims) was being triggered for a scalar
tensor because we compute nDim to be 1 for a scalar tensor but
uncompressedDim = 0.

This PR changes it so that we compute nDim to be 0 for a scalar tensor. This
works because indexing in a kernel depends on nDim. If nDim = 0, then
offset is always 0, which is what we want.

Some other (small) changes were necessary to make this work:
- One cannot define a 0-length array `IndexType arr[0]` so the code
  guards against that
- Needed to change some of the maxTensorInfoSize logic to handle the
  case when uncompressedDim == 0.

cc @apaszke @zdevito 
