### PR TITLE
Virtualize all methods on Type.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -72,7 +72,7 @@ virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals
 # 4. We have a few flavors of declaration, but the default template looks pretty
 # similar.
 TYPE_DERIVED_DEFINITION = CodeTemplate("""\
-${return_type} Type::${method_prefix_derived}${api_name}(${type_method_formals}) const {
+${return_type} ${Type}::${method_prefix_derived}${api_name}(${type_method_formals}) const {
     ${device_guard_declaration}
     ${type_definition_body}
 }

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -80,13 +80,7 @@ ${return_type} Type::${method_prefix_derived}${api_name}(${type_method_formals})
 
 # 5. Here are the various bodies which we might put in type_definition_body
 
-# 5a. Legacy methods on Type which forward to native functions
-DEPRECATED_TYPE_METHOD_DEFINITION = CodeTemplate("""\
-TensorOptions options(*this);
-return at::native::${api_name}(${type_method_actuals}, options);
-""")
-
-# 5b. Methods which broadcast, and then call the actual implementation with
+# 5a. Methods which broadcast, and then call the actual implementation with
 # the broadcasted inputs
 BROADCASTING_METHOD_DEFINITION = CodeTemplate("""\
 Tensor ${broadcast_returns};
@@ -94,7 +88,7 @@ std::tie(${broadcast_returns}) = ${broadcast_function}(${broadcast_actuals}, "${
 return ${method_prefix_derived}${api_name}(${broadcast_modified_actuals});
 """)
 
-# 5c. Methods which call to a native method
+# 5b. Methods which call to a native method
 # TODO: native_actuals???
 NATIVE_METHOD_DEFINITION = CodeTemplate("""\
 const auto& self_ty = *this;
@@ -989,6 +983,7 @@ def create_generic(top_env, declarations):
         dispatch = option['type_method_definition_dispatch']
         option['native_type_method_dispatch'] = dispatch
 
+        top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION.substitute(env))
         top_env['type_method_definitions'].append(TYPE_METHOD_DEFINITION.substitute(env))
 
         # generate the at::native function declarations (i.e. what the user will implement)

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -983,9 +983,6 @@ def create_generic(top_env, declarations):
         dispatch = option['type_method_definition_dispatch']
         option['native_type_method_dispatch'] = dispatch
 
-        top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION.substitute(env))
-        top_env['type_method_definitions'].append(TYPE_METHOD_DEFINITION.substitute(env))
-
         # generate the at::native function declarations (i.e. what the user will implement)
         if needs_native_definition:
             if isinstance(dispatch, dict):

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -72,7 +72,7 @@ virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals
 # 4. We have a few flavors of declaration, but the default template looks pretty
 # similar.
 TYPE_DERIVED_DEFINITION = CodeTemplate("""\
-${return_type} Type::${api_name}(${type_method_formals}) const {
+${return_type} Type::${method_prefix_derived}${api_name}(${type_method_formals}) const {
     ${device_guard_declaration}
     ${type_definition_body}
 }

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -62,7 +62,10 @@ def process_types_and_backends(option):
             pairs.discard(('CUDA', 'Half'))
 
     # special case remove Half for cpu unless it is explicitly enabled,
-    if not option.get('cpu_half', False):
+    # or we have a non-dispatching native function
+    if not (option.get('cpu_half', False) or
+            (option['mode'] == 'native' and
+             not isinstance(option['type_method_definition_dispatch'], dict))):
         pairs.discard(('CPU', 'Half'))
 
     # sort the result for easy reading

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -14,6 +14,7 @@
 #include "ATen/UndefinedTensor.h"
 #include "ATen/Utils.h"
 #include "ATen/WrapDimUtils.h"
+#include "ATen/ExpandUtils.h"
 #include "ATen/core/Half.h"
 #include "ATen/core/optional.h"
 

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -17,6 +17,7 @@ $storage_tensor_headers
 #include "ATen/UndefinedTensor.h"
 #include "ATen/Utils.h"
 #include "ATen/WrapDimUtils.h"
+#include "ATen/ExpandUtils.h"
 #include "ATen/core/Half.h"
 #include "ATen/core/optional.h"
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -108,7 +108,7 @@ grad_fn->set_next_edges(collect_next_edges( ${args_with_derivatives} ));
 """)
 
 CALL_VIA_TYPE = CodeTemplate("""\
-Type::${method_prefix_derived}${api_name}(${type_method_args})""")
+baseType->${method_prefix_derived}${api_name}(${type_method_args})""")
 
 CALL_VIA_DERIVED = CodeTemplate("""\
 baseType->${method_prefix_derived}${base_name}(${unpacked_args})""")

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -545,23 +545,19 @@ def dispatch_strategy(declaration):
     """How are we going to call the underlying implementation of a
     declaration?  There are two strategies:
 
-        - use_derived: we want to call the implementation on CPUDoubleType
-          (or a similar, derived Type instance).  Because these derived
-          instances deal in Tensors, not Variables (it's a completely different
-          object, so it doesn't dispatch back to VariableType), code on
-          this dispatch path needs to wrap/unwrap tensors.  If the
-          derived implementation takes and returns tensors, the
-          implementation is usually differentiable (although we also use
-          the derived dispatch path for non-differentiable functions
-          that we still want to dispatch on the derived Type instance;
+        - use_derived: we want to call the implementation after
+          wrapping/unwrapping tensors.  If the derived implementation takes and
+          returns tensors, the implementation is usually differentiable
+          (although we also use the derived dispatch path for non-differentiable
+          functions that we still want to dispatch on the derived Type instance;
           e.g., size())
 
         - use_type: we want to call the implementation on Type, because
-          it is implemented concretely, and the functions it invokes will
-          get dispatched back to VariableType (which will ensure that they
-          are differentiable.)
+          the functions it invokes will get dispatched back to VariableType
+          (which will ensure that they are differentiable.)
     """
-    if declaration['derivative'] is not None or \
+    if declaration['abstract'] or \
+            declaration['derivative'] is not None or \
             any(arg.get('is_type_dispatched') for arg in declaration['arguments']):
         # If the function is abstract (not implemented on at::Type), we must
         # call the implementation on the derived type with unpacked tensors.

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -561,8 +561,8 @@ def dispatch_strategy(declaration):
           get dispatched back to VariableType (which will ensure that they
           are differentiable.)
     """
-    if (declaration['abstract'] or declaration['derivative'] is not None or
-            any(arg.get('is_type_dispatched') for arg in declaration['arguments'])):
+    if declaration['derivative'] is not None or
+            any(arg.get('is_type_dispatched') for arg in declaration['arguments']):
         # If the function is abstract (not implemented on at::Type), we must
         # call the implementation on the derived type with unpacked tensors.
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -561,7 +561,7 @@ def dispatch_strategy(declaration):
           get dispatched back to VariableType (which will ensure that they
           are differentiable.)
     """
-    if declaration['derivative'] is not None or
+    if declaration['derivative'] is not None or \
             any(arg.get('is_type_dispatched') for arg in declaration['arguments']):
         # If the function is abstract (not implemented on at::Type), we must
         # call the implementation on the derived type with unpacked tensors.


### PR DESCRIPTION
Virtualize all methods on Type.

Previously, we had a mixture of virtual and non-virtual methods on Type,
skipping virtual dispatch when we knew that dispatch could not matter.  This
patch removes this entirely, so we can treat Type as a purely virtual interface.
This simplifies function_wrapper.py a fair amount.

The underlying motivation for this change is to give us a way to generate
substantially the same Tensor header on mobile, without forcing the mobile
build to link against a ton of code it isn't interested in.  Instead,
mobile code that invokes the Type interface will go to a stub that
raises an error; kernels can then be slowly added on a case-by-case basis.

A legitimate alternate plan would have been to ifdef Type so that it compiles
differently on mobile.  But this seemed hackier, so we went the "make
Type pure virtual" plan instead.

Differential Revision: D9545248

