### PR TITLE
Make profiler.build_table() O(n) rather than O(n^2)

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -554,11 +554,11 @@ def build_table(events, sort_by=None, header=None):
     header_sep = '-' * max_name_length + ('  ' + '-' * col_width) * 5
 
     # Have to use a list because nonlocal is Py3 only...
-    result = ['']
+    result = []
 
     def append(s):
-        result[0] += s
-        result[0] += '\n'
+        result.append(s)
+        result.append('\n')  # Yes, newline after the end as well
 
     # Actual printing
     if header is not None:
@@ -572,4 +572,4 @@ def build_table(events, sort_by=None, header=None):
         append(row_format.format(evt.key, evt.cpu_time_str, evt.cuda_time_str,
                                  evt.count, evt.cpu_time_total_str, evt.cuda_time_total_str))
 
-    return result[0]
+    return ''.join(result)


### PR DESCRIPTION
Fixes #10851

Speeds up profiling results dramatically.

For the following script:
```
import torch
import time

ITER = 2000

x = torch.randn(1, 1, requires_grad=True)

with torch.autograd.profiler.profile() as prof:
    y = x
    for i in range(ITER):
        y = 3 * y - 2 * y
    y.backward()

start = time.time()
print("Done running. Preparing prof")
x = str(prof)
print("Done preparing prof results")
end = time.time()
print("Elapsed: {}".format(end - start))
```

I get 7s before / 0.13s after these changes.

cc @apaszke 