### PR TITLE
finishRun fix

### DIFF
--- a/caffe2/core/net_async_scheduling.cc
+++ b/caffe2/core/net_async_scheduling.cc
@@ -206,14 +206,12 @@ void AsyncSchedulingNet::pollAndSchedule(int task_id) {
 }
 
 void AsyncSchedulingNet::finishRun() {
-  {
-    std::unique_lock<std::mutex> lock(running_mutex_);
-    running_ = false;
-  }
+  std::unique_lock<std::mutex> lock(running_mutex_);
   // wait for scheduled ops and make sure all events are marked as finished
   finalizeEvents();
   // notify observers and waiters
   StopAllObservers();
+  running_ = false;
   running_cv_.notify_all();
 }
 


### PR DESCRIPTION
Summary:
Fixing a possible case when next iteration of a net may be started prematurely.
We have to ensure that resetting running_ flag is done *after* finalizeEvents
(e.g. waiting for the rest of net's event to be finished).

Differential Revision: D9545442
