### PR TITLE
Fix bugs in handling of negative slice + gather indices

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -627,7 +627,7 @@ Caffe2Ops Caffe2Backend::CreateGather(
     BuildOperator(c2_op, "BatchGather", inputs, outputs);
   } else {
     CAFFE_THROW(
-        "Caffe2 only supports Gather with axis being 1 or 2, ",
+        "Caffe2 only supports Gather with axis being 0 or 1, ",
         "whereas axis is ",
         axis);
   }
@@ -843,7 +843,7 @@ Caffe2Ops Caffe2Backend::CreateSlice(
   auto pos = args.find("starts");
   if (pos != args.end()) {
     for (auto i : pos->second->ints()) {
-      starts_vals.add_ints(i);
+      starts_vals.add_ints(i < 0 ? i - 1 : i);
     }
     args.erase(pos);
   }

--- a/caffe2/operators/gather_op.h
+++ b/caffe2/operators/gather_op.h
@@ -40,6 +40,9 @@ class GatherOp : public Operator<Context> {
 
     for (int i = 0; i < N; ++i) {
       auto idx = idxs[i];
+      if (idx < 0) {
+        idx = idx + data.dim(0);
+      }
       CAFFE_ENFORCE(
           0 <= idx && idx < data.dim(0),
           "INDICES element is out of DATA bounds, id=",

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -3,73 +3,59 @@ producer_name: "pytorch"
 producer_version: "0.4"
 graph {
   node {
-    input: "0"
     output: "1"
-    op_type: "Shape"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: INT64
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
   }
   node {
-    input: "1"
+    input: "0"
     output: "2"
-    op_type: "Slice"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-    attribute {
-      name: "ends"
-      ints: 1
-      type: INTS
-    }
-    attribute {
-      name: "starts"
-      ints: 0
-      type: INTS
-    }
+    op_type: "Shape"
   }
   node {
     input: "2"
+    input: "1"
     output: "3"
-    op_type: "Squeeze"
+    op_type: "Gather"
     attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    output: "4"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: INT64
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
     }
   }
   node {
     input: "0"
-    output: "4"
+    output: "5"
     op_type: "Shape"
   }
   node {
-    input: "4"
-    output: "5"
-    op_type: "Slice"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-    attribute {
-      name: "ends"
-      ints: 1
-      type: INTS
-    }
-    attribute {
-      name: "starts"
-      ints: 0
-      type: INTS
-    }
-  }
-  node {
     input: "5"
+    input: "4"
     output: "6"
-    op_type: "Squeeze"
+    op_type: "Gather"
     attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
+      name: "axis"
+      i: 0
+      type: INT
     }
   }
   node {

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -3,33 +3,26 @@ producer_name: "pytorch"
 producer_version: "0.4"
 graph {
   node {
-    input: "0"
     output: "1"
-    op_type: "Slice"
+    op_type: "Constant"
     attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-    attribute {
-      name: "ends"
-      ints: 1
-      type: INTS
-    }
-    attribute {
-      name: "starts"
-      ints: 0
-      type: INTS
+      name: "value"
+      t {
+        data_type: INT64
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
     }
   }
   node {
+    input: "0"
     input: "1"
     output: "2"
-    op_type: "Squeeze"
+    op_type: "Gather"
     attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
+      name: "axis"
+      i: 0
+      type: INT
     }
   }
   name: "torch-jit-export"

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -849,6 +849,30 @@ class TestCaffe2Backend(unittest.TestCase):
         model = c2.prepare_zip_archive(f)
         model.run(X)
 
+    def test_neg_slice(self):
+        class NegSlice(torch.nn.Module):
+            def forward(self, x):
+                return x[-1, :, :]
+
+        x = torch.randn(3, 4, 5)
+        self.run_model_test(NegSlice(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
+    def test_neg_slice_large(self):
+        class NegSlice(torch.nn.Module):
+            def forward(self, x):
+                return x[:, :, :, :, -3]
+
+        x = torch.randn(3, 4, 5, 6, 7)
+        self.run_model_test(NegSlice(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
+    @unittest.skip('https://github.com/pytorch/pytorch/issues/10984')
+    def test_neg_slice_large_negone(self):
+        class NegSlice(torch.nn.Module):
+            def forward(self, x):
+                return x[:, :, :, :, -1]
+
+        x = torch.randn(3, 4, 5, 6, 7)
+        self.run_model_test(NegSlice(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
 # a bit of metaprogramming to set up all the rnn tests
 


### PR DESCRIPTION
Summary: This fixes multiple bugs in the handling of negative indices in both slicing and gather operations. These were uncovered by @[1466077526:Elias Ellison]'s diff D9493614, which made it so that we actually emit negative indices when we see them in PyTorch code.

Differential Revision: D9546183
