### PR TITLE
[Ready] Vectorize grid sample 2d CPU kernels

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -27,7 +27,7 @@ inline void parallel_for(
     const int64_t grain_size,
     const F& f) {
 #ifdef _OPENMP
-#pragma omp parallel if ((end - begin) >= grain_size)
+#pragma omp parallel if (!omp_in_parallel() && ((end - begin) >= grain_size))
   {
     int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();

--- a/aten/src/ATen/TensorGeometry.cpp
+++ b/aten/src/ATen/TensorGeometry.cpp
@@ -1,4 +1,5 @@
 #include <ATen/TensorGeometry.h>
+#include <ATen/TensorUtils.h>
 
 #include <ATen/ATen.h>
 
@@ -8,15 +9,7 @@ bool TensorGeometry::is_contiguous() const {
   if (numel_ == 0) {
     return true;
   }
-  int64_t dim = sizes_.size();
-  int64_t expected_stride = 1;
-  for (int64_t i = dim - 1; i >= 0; i--) {
-    if (sizes_[i] != 1 && strides_[i] != expected_stride) {
-      return false;
-    }
-    expected_stride *= sizes_[i];
-  }
-  return true;
+  return at::geometry_is_contiguous(sizes_, strides_);
 }
 
 Tensor TensorGeometry::zeros_with_stride(const Type& type) const {

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -215,4 +215,19 @@ void * maybe_data_ptr(const Tensor& tensor) {
 void * maybe_data_ptr(const TensorArg& tensor) {
   return tensor->defined() ? (void *)tensor->data_ptr() : nullptr;
 }
+
+bool geometry_is_contiguous(IntList sizes, IntList strides) {
+  int64_t dim = sizes.size();
+  int64_t expected_stride = 1;
+  for (int64_t i = dim - 1; i >= 0; i--) {
+    if (sizes[i] == 0) {
+      return true;
+    } else if (sizes[i] != 1 && strides[i] != expected_stride) {
+      return false;
+    }
+    expected_stride *= sizes[i];
+  }
+  return true;
+}
+
 }

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -219,15 +219,19 @@ void * maybe_data_ptr(const TensorArg& tensor) {
 bool geometry_is_contiguous(IntList sizes, IntList strides) {
   int64_t dim = sizes.size();
   int64_t expected_stride = 1;
+  bool contig_if_nonempty = true;
   for (int64_t i = dim - 1; i >= 0; i--) {
     if (sizes[i] == 0) {
       return true;
-    } else if (sizes[i] != 1 && strides[i] != expected_stride) {
-      return false;
     }
-    expected_stride *= sizes[i];
+    if (contig_if_nonempty) {
+      if (sizes[i] != 1 && strides[i] != expected_stride) {
+        contig_if_nonempty = false;
+      }
+      expected_stride *= sizes[i];
+    }
   }
-  return true;
+  return contig_if_nonempty;
 }
 
 }

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -216,6 +216,7 @@ void * maybe_data_ptr(const TensorArg& tensor) {
   return tensor->defined() ? (void *)tensor->data_ptr() : nullptr;
 }
 
+// See TensorUtils.h on why this is useful now that we cache is_contiguous.
 bool geometry_is_contiguous(IntList sizes, IntList strides) {
   int64_t dim = sizes.size();
   int64_t expected_stride = 1;

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -78,4 +78,7 @@ AT_API void checkBackend(CheckedFrom c, at::ArrayRef<Tensor> t, at::Backend back
 AT_API void * maybe_data_ptr(const Tensor& tensor);
 AT_API void * maybe_data_ptr(const TensorArg& tensor);
 
+// Return if the tensor geometry represented by `sizes` and `strides` is contiguous
+AT_API bool geometry_is_contiguous(IntList sizes, IntList strides);
+
 }

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -79,6 +79,10 @@ AT_API void * maybe_data_ptr(const Tensor& tensor);
 AT_API void * maybe_data_ptr(const TensorArg& tensor);
 
 // Return if the tensor geometry represented by `sizes` and `strides` is contiguous
+// Although we cache is_contiguous in tensor now, this is till useful because it
+// allows checking if a particular geometry is contiguous without explicitly
+// constructing a tensor, e.g., when you want to choose a kernel strategy based
+// on whether a subgeometry is contiguous.
 AT_API bool geometry_is_contiguous(IntList sizes, IntList strides);
 
 }

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -44,14 +44,14 @@ public:
 
   AT_HOSTDEVICE TensorAccessorBase(PtrType data_, const int64_t * sizes_, const int64_t * strides_)
   : data_(data_), sizes_(sizes_), strides_(strides_) {}
-  AT_HOST IntList sizes() {
+  AT_HOST IntList sizes() const {
     return IntList(sizes_,N);
   }
-  AT_HOST IntList strides() {
+  AT_HOST IntList strides() const {
     return IntList(strides_,N);
   }
-  AT_HOSTDEVICE int64_t stride(int64_t i) { return strides_[i]; }
-  AT_HOSTDEVICE int64_t size(int64_t i) { return sizes_[i]; }
+  AT_HOSTDEVICE int64_t stride(int64_t i) const { return strides_[i]; }
+  AT_HOSTDEVICE int64_t size(int64_t i) const { return sizes_[i]; }
   AT_HOSTDEVICE T *data() { return data_; }
   AT_HOSTDEVICE const T *data() const { return data_; }
 protected:
@@ -76,7 +76,7 @@ public:
     return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i,this->sizes_+1,this->strides_+1);
   }
 
-  const TensorAccessor<T,N-1> operator[](int64_t i) const {
+  AT_HOSTDEVICE const TensorAccessor<T,N-1> operator[](int64_t i) const {
     return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i,this->sizes_+1,this->strides_+1);
   }
 };
@@ -112,8 +112,8 @@ public:
     std::copy(sizes_, sizes_ + N, std::begin(this->sizes_));
     std::copy(strides_, strides_ + N, std::begin(this->strides_));
   }
-  AT_HOSTDEVICE int64_t stride(int64_t i) { return strides_[i]; }
-  AT_HOSTDEVICE int64_t size(int64_t i) { return sizes_[i]; }
+  AT_HOSTDEVICE int64_t stride(int64_t i) const { return strides_[i]; }
+  AT_HOSTDEVICE int64_t size(int64_t i) const { return sizes_[i]; }
 protected:
   PtrType data_;
   int64_t sizes_[N];
@@ -133,6 +133,12 @@ public:
     int64_t* new_strides = this->strides_+1;
     return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i, new_sizes, new_strides);
   }
+
+  AT_DEVICE const TensorAccessor<T,N-1> operator[](int64_t i) const {
+    int64_t* new_sizes = this->sizes_+1;
+    int64_t* new_strides = this->strides_+1;
+    return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i, new_sizes, new_strides);
+  }
 };
 
 template<typename T, template <typename U> class PtrTraits>
@@ -145,7 +151,7 @@ public:
   AT_DEVICE T & operator[](int64_t i) {
     return this->data_[this->strides_[0]*i];
   }
-  const T& operator[](int64_t i) const {
+  AT_DEVICE const T& operator[](int64_t i) const {
     return this->data_[this->strides_[0]*i];
   }
 };

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -52,6 +52,8 @@ public:
   }
   AT_HOSTDEVICE int64_t stride(int64_t i) { return strides_[i]; }
   AT_HOSTDEVICE int64_t size(int64_t i) { return sizes_[i]; }
+  AT_HOSTDEVICE T *data() { return data_; }
+  AT_HOSTDEVICE const T *data() const { return data_; }
 protected:
   PtrType data_;
   const int64_t* sizes_;
@@ -73,6 +75,10 @@ public:
   AT_HOSTDEVICE TensorAccessor<T,N-1> operator[](int64_t i) {
     return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i,this->sizes_+1,this->strides_+1);
   }
+
+  const TensorAccessor<T,N-1> operator[](int64_t i) const {
+    return TensorAccessor<T,N-1>(this->data_ + this->strides_[0]*i,this->sizes_+1,this->strides_+1);
+  }
 };
 
 template<typename T, template <typename U> class PtrTraits>
@@ -89,7 +95,7 @@ public:
 
 
 // PackedTensorAccessorBase and PackedTensorAccessor are used on for CUDA `Tensor`s on the host
-// and as 
+// and as
 // In contrast to `TensorAccessor`s, they copy the strides and sizes on instantiation (on the host)
 // in order to transfer them on the device when calling kernels.
 // On the device, indexing of multidimensional tensors gives to `TensorAccessor`s.
@@ -137,6 +143,9 @@ public:
   : PackedTensorAccessorBase<T,1,PtrTraits>(data_, sizes_, strides_) {};
 
   AT_DEVICE T & operator[](int64_t i) {
+    return this->data_[this->strides_[0]*i];
+  }
+  const T& operator[](int64_t i) const {
     return this->data_[this->strides_[0]*i];
   }
 };

--- a/aten/src/ATen/cpu/vec256/intrinsics.h
+++ b/aten/src/ATen/cpu/vec256/intrinsics.h
@@ -19,7 +19,7 @@
 /* GCC-compatible compiler, targeting ARM with WMMX */
 #include <mmintrin.h>
 #elif (defined(__GNUC__) || defined(__xlC__)) &&                               \
-    (defined(__VEC__) || defined(__ALTIVEC__))
+	(defined(__VEC__) || defined(__ALTIVEC__))
 /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
 #include <altivec.h>
 #elif defined(__GNUC__) && defined(__SPE__)

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -32,4 +32,145 @@ std::ostream& operator<<(std::ostream& stream, const Vec256<T>& vec) {
   return stream;
 }
 
+
+#if defined(__AVX__) && !defined(_MSC_VER)
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CAST (AVX) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template<>
+Vec256<float> cast<float, double>(const Vec256<double>& src) {
+  return _mm256_castpd_ps(src);
+}
+
+template<>
+Vec256<double> cast<double, float>(const Vec256<float>& src) {
+  return _mm256_castps_pd(src);
+}
+
+#if defined(__AVX2__)
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CAST (AVX2) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#define DEFINE_FLOAT_INT_CAST(int_t, float_t, float_ch)            \
+template<>                                                         \
+Vec256<int_t> cast<int_t, float_t>(const Vec256<float_t>& src) {   \
+  return _mm256_castp ## float_ch ## _si256(src);                  \
+}                                                                  \
+template<>                                                         \
+Vec256<float_t> cast<float_t, int_t>(const Vec256<int_t>& src) {   \
+  return _mm256_castsi256_p ## float_ch (src);                     \
+}
+
+DEFINE_FLOAT_INT_CAST(int64_t, double, d)
+DEFINE_FLOAT_INT_CAST(int32_t, double, d)
+DEFINE_FLOAT_INT_CAST(int16_t, double, d)
+DEFINE_FLOAT_INT_CAST(int64_t, float, s)
+DEFINE_FLOAT_INT_CAST(int32_t, float, s)
+DEFINE_FLOAT_INT_CAST(int16_t, float, s)
+
+#undef DEFINE_FLOAT_INT_CAST
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template<int64_t scale = 1>
+c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<double>>
+inline gather(const double* base_addr, const Vec256<int64_t>& vindex) {
+  return _mm256_i64gather_pd(base_addr, vindex, scale);
+}
+
+template<int64_t scale = 1>
+c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<float>>
+inline gather(const float* base_addr, const Vec256<int64_t>& vindex) {
+  return _mm256_i32gather_ps(base_addr, vindex, scale);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MASK GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template<int64_t scale = 1>
+c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<double>>
+inline mask_gather(const Vec256<double>& src, const double* base_addr,
+                   const Vec256<int64_t>& vindex, Vec256<double>& mask) {
+  return _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale);
+}
+
+template<int64_t scale = 1>
+c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<float>>
+inline mask_gather(const Vec256<float>& src, const float* base_addr,
+                   const Vec256<int32_t>& vindex, Vec256<float>& mask) {
+  return _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CONVERT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Only works for inputs in the range: [-2^51, 2^51]
+// From: https://stackoverflow.com/a/41148578
+template<>
+Vec256<int64_t>
+inline convert_to_int_of_same_size<double>(const Vec256<double> &src) {
+  auto x = _mm256_add_pd(src, _mm256_set1_pd(0x0018000000000000));
+  return _mm256_sub_epi64(
+      _mm256_castpd_si256(x),
+      _mm256_castpd_si256(_mm256_set1_pd(0x0018000000000000))
+  );
+}
+
+template<>
+Vec256<int32_t>
+inline convert_to_int_of_same_size<float>(const Vec256<float> &src) {
+  return _mm256_cvttps_epi32(src);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ DEINTERLEAVE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <>
+std::pair<Vec256<double>, Vec256<double>>
+inline deinterleave2<double>(const Vec256<double>& a, const Vec256<double>& b) {
+  // inputs:
+  //   a = {a0, b0, a1, b1}
+  //   b = {a2, b2, a3, b3}
+
+  // group cols crossing lanes:
+  //   a_grouped = {a0, a1, b0, b1}
+  //   b_grouped = {a2, a3, b2, b3}
+  static constexpr int group_ctrl = 0 | (2 << 2) | (1 << 4) | (3 << 6);  // 0, 2, 1, 3
+  auto a_grouped = _mm256_permute4x64_pd(a, group_ctrl);
+  auto b_grouped = _mm256_permute4x64_pd(b, group_ctrl);
+
+  // swap lanes:
+  //   return {a0, a1, a3, a3}
+  //          {b0, b1, b2, b3}
+  static constexpr int swap_ctrl_a = 0 | (2 << 4);  // 0, 2.   4 bits apart
+  static constexpr int swap_ctrl_b = 1 | (3 << 4);  // 1, 3.   4 bits apart
+  return std::make_pair(_mm256_permute2f128_pd(a_grouped, b_grouped, swap_ctrl_a),
+                        _mm256_permute2f128_pd(a_grouped, b_grouped, swap_ctrl_b));
+}
+
+template <>
+std::pair<Vec256<float>, Vec256<float>>
+inline deinterleave2<float>(const Vec256<float>& a, const Vec256<float>& b) {
+  // inputs:
+  //   a = {a0, b0, a1, b1, a2, b2, a3, b3}
+  //   b = {a4, b4, a5, b5, a6, b6, a7, b7}
+
+  // group cols crossing lanes:
+  //   a_grouped = {a0, a1, a2, a3, b0, b1, b2, b3}
+  //   b_grouped = {a4, a5, a6, a7, b4, b5, b6, b7}
+  // TODO: can we support caching this?
+  const __m256i group_ctrl = _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7);
+  auto a_grouped = _mm256_permutevar8x32_ps(a, group_ctrl);
+  auto b_grouped = _mm256_permutevar8x32_ps(b, group_ctrl);
+
+  // swap lanes:
+  //   return {a0, a1, a2, a3, a4, a5, a6, a7}
+  //          {b0, b1, b2, b3, b4, b5, b6, b7}
+  static constexpr int swap_ctrl_a = 0 | (2 << 4);  // 0, 2.   4 bits apart
+  static constexpr int swap_ctrl_b = 1 | (3 << 4);  // 1, 3.   4 bits apart
+  return std::make_pair(_mm256_permute2f128_ps(a_grouped, b_grouped, swap_ctrl_a),
+                        _mm256_permute2f128_ps(a_grouped, b_grouped, swap_ctrl_b));
+}
+
+#endif  // defined(__AVX2__)
+
+#endif // defined(__AVX__) && !defined(_MSC_VER)
+
 }}}

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -120,6 +120,55 @@ inline convert_to_int_of_same_size<float>(const Vec256<float> &src) {
   return _mm256_cvttps_epi32(src);
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ INTERLEAVE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+template <>
+std::pair<Vec256<double>, Vec256<double>>
+inline interleave2<double>(const Vec256<double>& a, const Vec256<double>& b) {
+  // inputs:
+  //   a = {a0, a1, a3, a3}
+  //   b = {b0, b1, b2, b3}
+
+  // swap lanes:
+  //   a_swapped = {a0, a1, b0, b1}
+  //   b_swapped = {a2, a3, b2, b3}
+  static constexpr int swap_ctrl_a = 0 | (2 << 4);  // 0, 2.   4 bits apart
+  static constexpr int swap_ctrl_b = 1 | (3 << 4);  // 1, 3.   4 bits apart
+  auto a_swapped = _mm256_permute2f128_pd(a, b, swap_ctrl_a);
+  auto b_swapped = _mm256_permute2f128_pd(a, b, swap_ctrl_b);
+
+  // group cols crossing lanes:
+  //   return {a0, b0, a1, b1}
+  //          {a2, b2, a3, b3}
+  static constexpr int group_ctrl = 0 | (2 << 2) | (1 << 4) | (3 << 6);  // 0, 2, 1, 3
+  return std::make_pair(_mm256_permute4x64_pd(a_swapped, group_ctrl),
+                        _mm256_permute4x64_pd(b_swapped, group_ctrl));
+}
+
+template <>
+std::pair<Vec256<float>, Vec256<float>>
+inline interleave2<float>(const Vec256<float>& a, const Vec256<float>& b) {
+  // inputs:
+  //   a = {a0, a1, a2, a3, a4, a5, a6, a7}
+  //   b = {b0, b1, b2, b3, b4, b5, b6, b7}
+
+  // swap lanes:
+  //   a_swapped = {a0, a1, a2, a3, b0, b1, b2, b3}
+  //   b_swapped = {a4, a5, a6, a7, b4, b5, b6, b7}
+  // TODO: can we support caching this?
+  static constexpr int swap_ctrl_a = 0 | (2 << 4);  // 0, 2.   4 bits apart
+  static constexpr int swap_ctrl_b = 1 | (3 << 4);  // 1, 3.   4 bits apart
+  auto a_swapped = _mm256_permute2f128_ps(a, b, swap_ctrl_a);
+  auto b_swapped = _mm256_permute2f128_ps(a, b, swap_ctrl_b);
+
+  // group cols crossing lanes:
+  //   return {a0, b0, a1, b1, a2, b2, a3, b3}
+  //          {a4, b4, a5, b5, a6, b6, a7, b7}
+  const __m256i group_ctrl = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+  return std::make_pair(_mm256_permutevar8x32_ps(a_swapped, group_ctrl),
+                        _mm256_permutevar8x32_ps(b_swapped, group_ctrl));
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ DEINTERLEAVE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <>
@@ -137,7 +186,7 @@ inline deinterleave2<double>(const Vec256<double>& a, const Vec256<double>& b) {
   auto b_grouped = _mm256_permute4x64_pd(b, group_ctrl);
 
   // swap lanes:
-  //   return {a0, a1, a3, a3}
+  //   return {a0, a1, a2, a3}
   //          {b0, b1, b2, b3}
   static constexpr int swap_ctrl_a = 0 | (2 << 4);  // 0, 2.   4 bits apart
   static constexpr int swap_ctrl_b = 1 | (3 << 4);  // 1, 3.   4 bits apart

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -73,30 +73,30 @@ DEFINE_FLOAT_INT_CAST(int16_t, float, s)
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template<int64_t scale = 1>
-c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<double>>
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<double>>
 inline gather(const double* base_addr, const Vec256<int64_t>& vindex) {
   return _mm256_i64gather_pd(base_addr, vindex, scale);
 }
 
 template<int64_t scale = 1>
-c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<float>>
-inline gather(const float* base_addr, const Vec256<int64_t>& vindex) {
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<float>>
+inline gather(const float* base_addr, const Vec256<int32_t>& vindex) {
   return _mm256_i32gather_ps(base_addr, vindex, scale);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MASK GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template<int64_t scale = 1>
-c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<double>>
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<double>>
 inline mask_gather(const Vec256<double>& src, const double* base_addr,
-                   const Vec256<int64_t>& vindex, Vec256<double>& mask) {
+                   const Vec256<int64_t>& vindex, const Vec256<double>& mask) {
   return _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale);
 }
 
 template<int64_t scale = 1>
-c10::guts::enable_if_t<scale == 1 || scale == 2 ||scale == 4 || scale == 8, Vec256<float>>
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<float>>
 inline mask_gather(const Vec256<float>& src, const float* base_addr,
-                   const Vec256<int32_t>& vindex, Vec256<float>& mask) {
+                   const Vec256<int32_t>& vindex, const Vec256<float>& mask) {
   return _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale);
 }
 

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -271,6 +271,7 @@ template <class T> Vec256<T> inline operator/(const Vec256<T> &a, const Vec256<T
   return c;
 }
 
+
 template <class T> Vec256<T> inline max(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -287,7 +287,7 @@ template <class T> Vec256<T> inline min(const Vec256<T> &a, const Vec256<T> &b) 
   return c;
 }
 
-#define DEFINE_LOGICAL_OP(op)                                               \
+#define DEFINE_BITWISE_OP(op)                                               \
 template <class T>                                                          \
 Vec256<T> inline operator op(const Vec256<T> &a, const Vec256<T> &b) {      \
   using iT = int_same_size_t<T>;                                            \
@@ -301,10 +301,10 @@ Vec256<T> inline operator op(const Vec256<T> &a, const Vec256<T> &b) {      \
   }                                                                         \
   return Vec256<T>::loadu(buffer);                                          \
 }
-DEFINE_LOGICAL_OP(&)
-DEFINE_LOGICAL_OP(|)
-DEFINE_LOGICAL_OP(^)
-#undef DEFINE_LOGICAL_OP
+DEFINE_BITWISE_OP(&)
+DEFINE_BITWISE_OP(|)
+DEFINE_BITWISE_OP(^)
+#undef DEFINE_BITWISE_OP
 
 template <typename T>
 inline T fmadd(const T& a, const T& b, const T& c) {

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -218,8 +218,8 @@ public:
     }
     return ret;
   }
-#define DEFINE_COMP(name, binary_pred)                                        \
-  Vec256<T> name(const Vec256<T> &other) const {                              \
+#define DEFINE_COMP(binary_pred)                                              \
+  Vec256<T> operator binary_pred(const Vec256<T> &other) const {              \
     Vec256<T> vec;                                                            \
     for (int64_t i = 0; i != size; i++) {                                     \
       if (values[i] binary_pred other.values[i]) {                            \
@@ -230,12 +230,12 @@ public:
     }                                                                         \
     return vec;                                                               \
   }
-  DEFINE_COMP(eq, ==)
-  DEFINE_COMP(ne, !=)
-  DEFINE_COMP(ge, >=)
-  DEFINE_COMP(le, <=)
-  DEFINE_COMP(gt, >)
-  DEFINE_COMP(lt, <)
+  DEFINE_COMP(==)
+  DEFINE_COMP(!=)
+  DEFINE_COMP(>=)
+  DEFINE_COMP(<=)
+  DEFINE_COMP(>)
+  DEFINE_COMP(<)
 #undef DEFINE_COMP
 };
 

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -70,6 +70,21 @@ public:
     }
     return vec;
   }
+  static Vec256<T> blendv(const Vec256<T>& a, const Vec256<T>& b,
+                          const Vec256<T>& mask) {
+    Vec256 vec;
+    int_same_size_t<T> buffer[size];
+    mask.store(buffer);
+    for (int64_t i = 0; i < size; i++) {
+      if (buffer[i] & 0x01)
+       {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+    }
+    return vec;
+  }
   static Vec256<T> arange(T base = static_cast<T>(0), T step = static_cast<T>(1)) {
     Vec256 vec;
     for (int64_t i = 0; i < size; i++) {
@@ -275,11 +290,16 @@ template <class T> Vec256<T> inline min(const Vec256<T> &a, const Vec256<T> &b) 
 #define DEFINE_LOGICAL_OP(op)                                               \
 template <class T>                                                          \
 Vec256<T> inline operator op(const Vec256<T> &a, const Vec256<T> &b) {      \
-  Vec256<T> vec = Vec256<T>();                                              \
+  using iT = int_same_size_t<T>;                                            \
+  iT buffer[Vec256<T>::size];                                               \
   for (int64_t i = 0; i != Vec256<T>::size; i++) {                          \
-    vec[i] = a[i] op b[i];                                                  \
+    auto a_val = a[i];                                                      \
+    auto b_val = b[i];                                                      \
+    iT *i_a_ptr = reinterpret_cast<iT*>(&a_val);                            \
+    iT *i_b_ptr = reinterpret_cast<iT*>(&b_val);                            \
+    buffer[i] = *i_a_ptr op *i_b_ptr;                                       \
   }                                                                         \
-  return vec;                                                               \
+  return Vec256<T>::loadu(buffer);                                          \
 }
 DEFINE_LOGICAL_OP(&)
 DEFINE_LOGICAL_OP(|)
@@ -307,7 +327,7 @@ inline gather(T const* base_addr, const Vec256<int_same_size_t<T>>& vindex) {
 template <int64_t scale = 1, typename T = void>
 c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<T>>
 inline mask_gather(const Vec256<T>& src, T const* base_addr,
-            const Vec256<int_same_size_t<T>>& vindex, Vec256<T>& mask) {
+                   const Vec256<int_same_size_t<T>>& vindex, Vec256<T>& mask) {
   static constexpr int size = Vec256<T>::size;
   T src_arr[size];
   int_same_size_t<T> mask_arr[size];  // use int type so we can logical and
@@ -326,7 +346,6 @@ inline mask_gather(const Vec256<T>& src, T const* base_addr,
   mask = Vec256<T>();  // "zero out" mask
   return Vec256<T>::loadu(static_cast<void*>(buffer));
 }
-
 
 // Cast a given vector to another type without changing the bits representation.
 // So a Vec<double> of 256 bits containing all ones can be cast to a
@@ -370,6 +389,32 @@ deinterleave2(const Vec256<T>& a, const Vec256<T>& b) {
     buffer1[half_size + i] = b_arr[i * 2];
     buffer2[i] = a_arr[i * 2 + 1];
     buffer2[half_size + i] = b_arr[i * 2 + 1];
+  }
+  return std::make_pair(Vec256<T>::loadu(static_cast<void*>(buffer1)),
+                        Vec256<T>::loadu(static_cast<void*>(buffer2)));
+}
+
+// inverse operation of deinterleave2
+// E.g., inputs: a           Vec256<float>   = {a0, a1, a2, a3, a4, a5, a6, a7}
+//               b           Vec256<float>   = {b0, b1, b2, b3, b4, b5, b6, b7}
+//       returns:            Vec256<float>   = {a0, b0, a1, b1, a2, b2, a3, b3}
+//                           Vec256<float>   = {a4, b4, a5, b5, a6, b6, a7, b7}
+template <typename T>
+inline c10::guts::enable_if_t<Vec256<T>::size % 2 == 0, std::pair<Vec256<T>, Vec256<T>>>
+interleave2(const Vec256<T>& a, const Vec256<T>& b) {
+  static constexpr int size = Vec256<T>::size;
+  static constexpr int half_size = size / 2;
+  T a_arr[size];
+  T b_arr[size];
+  T buffer1[size];
+  T buffer2[size];
+  a.store(static_cast<void*>(a_arr));
+  b.store(static_cast<void*>(b_arr));
+  for (int64_t i = 0; i < half_size; i++) {
+    buffer1[i * 2] = a_arr[i];
+    buffer1[i * 2 + 1] = b_arr[i];
+    buffer2[i * 2] = a_arr[half_size + i];
+    buffer2[i * 2 + 1] = b_arr[half_size + i];
   }
   return std::make_pair(Vec256<T>::loadu(static_cast<void*>(buffer1)),
                         Vec256<T>::loadu(static_cast<void*>(buffer2)));

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -3,8 +3,11 @@
 #include <cstring>
 #include <functional>
 #include <cmath>
+#include <type_traits>
+#include <bitset>
 
 #include "ATen/Utils.h"
+#include "ATen/core/C++17.h"
 
 #if defined(__GNUC__)
 #define __at_align32__ __attribute__((aligned(32)))
@@ -17,6 +20,21 @@
 namespace at {
 namespace vec256 {
 namespace {
+
+template<size_t n> struct int_of_size;
+
+#define DEFINE_INT_OF_SIZE(int_t) \
+template<> struct int_of_size<sizeof(int_t)> { using type = int_t; }
+
+DEFINE_INT_OF_SIZE(int64_t);
+DEFINE_INT_OF_SIZE(int32_t);
+DEFINE_INT_OF_SIZE(int16_t);
+DEFINE_INT_OF_SIZE(int8_t);
+
+#undef DEFINE_INT_OF_SIZE
+
+template <typename T>
+using int_same_size_t = typename int_of_size<sizeof(T)>::type;
 
 // NOTE: If you specialize on a type, you must define all operations!
 
@@ -33,8 +51,13 @@ public:
       values[i] = val;
     }
   }
+  template<typename... Args,
+           typename = c10::guts::enable_if_t<(sizeof...(Args) == size)>>
+  Vec256(Args... vals) {
+    values = { vals... };
+  }
   template <int64_t mask_>
-  static Vec256<T> blend(Vec256<T> a, Vec256<T> b) {
+  static Vec256<T> blend(const Vec256<T>& a, const Vec256<T>& b) {
     int64_t mask = mask_;
     Vec256 vec;
     for (int64_t i = 0; i < size; i++) {
@@ -47,7 +70,14 @@ public:
     }
     return vec;
   }
-  static Vec256<T> set(Vec256<T> a, Vec256<T> b, int64_t count = size) {
+  static Vec256<T> arange(T base = static_cast<T>(0), T step = static_cast<T>(1)) {
+    Vec256 vec;
+    for (int64_t i = 0; i < size; i++) {
+      vec.values[i] = base + i * step;
+    }
+    return vec;
+  }
+  static Vec256<T> set(const Vec256<T>& a, const Vec256<T>& b, int64_t count = size) {
     Vec256 vec;
     for (int64_t i = 0; i < size; i++) {
       if (i < count) {
@@ -173,9 +203,28 @@ public:
     }
     return ret;
   }
+#define DEFINE_COMP(name, binary_pred)                                        \
+  Vec256<T> name(const Vec256<T> &other) const {                              \
+    Vec256<T> vec;                                                            \
+    for (int64_t i = 0; i != size; i++) {                                     \
+      if (values[i] binary_pred other.values[i]) {                            \
+        std::memset(static_cast<void*>(vec.values + i), 0xFF, sizeof(T));     \
+      } else {                                                                \
+        std::memset(static_cast<void*>(vec.values + i), 0, sizeof(T));        \
+      }                                                                       \
+    }                                                                         \
+    return vec;                                                               \
+  }
+  DEFINE_COMP(eq, ==)
+  DEFINE_COMP(ne, !=)
+  DEFINE_COMP(ge, >=)
+  DEFINE_COMP(le, <=)
+  DEFINE_COMP(gt, >)
+  DEFINE_COMP(lt, <)
+#undef DEFINE_COMP
 };
 
-template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T> Vec256<T> inline operator+(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = a[i] + b[i];
@@ -183,7 +232,7 @@ template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T> Vec256<T> inline operator-(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = a[i] - b[i];
@@ -191,7 +240,7 @@ template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T> Vec256<T> inline operator*(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = a[i] * b[i];
@@ -199,7 +248,7 @@ template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) __ubsan_ignore_float_divide_by_zero__ {
+template <class T> Vec256<T> inline operator/(const Vec256<T> &a, const Vec256<T> &b) __ubsan_ignore_float_divide_by_zero__ {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = a[i] / b[i];
@@ -207,7 +256,7 @@ template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) _
   return c;
 }
 
-template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T> Vec256<T> inline max(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = std::max(a[i], b[i]);
@@ -215,7 +264,7 @@ template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-template <class T> Vec256<T> min(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T> Vec256<T> inline min(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
     c[i] = std::min(a[i], b[i]);
@@ -223,9 +272,107 @@ template <class T> Vec256<T> min(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
+#define DEFINE_LOGICAL_OP(op)                                               \
+template <class T>                                                          \
+Vec256<T> inline operator op(const Vec256<T> &a, const Vec256<T> &b) {      \
+  Vec256<T> vec = Vec256<T>();                                              \
+  for (int64_t i = 0; i != Vec256<T>::size; i++) {                          \
+    vec[i] = a[i] op b[i];                                                  \
+  }                                                                         \
+  return vec;                                                               \
+}
+DEFINE_LOGICAL_OP(&)
+DEFINE_LOGICAL_OP(|)
+DEFINE_LOGICAL_OP(^)
+#undef DEFINE_LOGICAL_OP
+
 template <typename T>
-T fmadd(const T& a, const T& b, const T& c) {
+inline T fmadd(const T& a, const T& b, const T& c) {
   return a * b + c;
+}
+
+template <int64_t scale = 1, typename T = void>
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<T>>
+inline gather(T const* base_addr, const Vec256<int_same_size_t<T>>& vindex) {
+  static constexpr int size = Vec256<T>::size;
+  int_same_size_t<T> index_arr[size];
+  vindex.store(static_cast<void*>(index_arr));
+  T buffer[size];
+  for (int64_t i = 0; i < size; i++) {
+    buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
+  }
+  return Vec256<T>::loadu(static_cast<void*>(buffer));
+}
+
+template <int64_t scale = 1, typename T = void>
+c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<T>>
+inline mask_gather(const Vec256<T>& src, T const* base_addr,
+            const Vec256<int_same_size_t<T>>& vindex, Vec256<T>& mask) {
+  static constexpr int size = Vec256<T>::size;
+  T src_arr[size];
+  int_same_size_t<T> mask_arr[size];  // use int type so we can logical and
+  int_same_size_t<T> index_arr[size];
+  src.store(static_cast<void*>(src_arr));
+  mask.store(static_cast<void*>(mask_arr));
+  vindex.store(static_cast<void*>(index_arr));
+  T buffer[size];
+  for (int64_t i = 0; i < size; i++) {
+    if (mask_arr[i] & 0x01) {  // check highest bit
+      buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
+    } else {
+      buffer[i] = src_arr[i];
+    }
+  }
+  mask = Vec256<T>();  // "zero out" mask
+  return Vec256<T>::loadu(static_cast<void*>(buffer));
+}
+
+
+// Cast a given vector to another type without changing the bits representation.
+// So a Vec<double> of 256 bits containing all ones can be cast to a
+// Vec<int64_t> of 256 bits containing all ones (i.e., four negative 1s).
+template<typename dst_t, typename src_t>
+Vec256<dst_t> cast(const Vec256<src_t>& src) {
+  src_t src_arr[Vec256<src_t>::size];
+  src.store(static_cast<void*>(src_arr));
+  return Vec256<dst_t>::loadu(static_cast<const void*>(src_arr));
+}
+
+template <typename T>
+inline Vec256<int_same_size_t<T>> convert_to_int_of_same_size(const Vec256<T>& src) {
+  static constexpr int size = Vec256<T>::size;
+  T src_arr[size];
+  src.store(static_cast<void*>(src_arr));
+  int_same_size_t<T> buffer[size];
+  for (int64_t i = 0; i < size; i++) {
+    buffer[i] = static_cast<int_same_size_t<T>>(src_arr[i]);
+  }
+  return Vec256<int_same_size_t<T>>::loadu(static_cast<void*>(buffer));
+}
+
+// E.g., inputs: a           Vec256<float>   = {a0, b0, a1, b1, a2, b2, a3, b3}
+//               b           Vec256<float>   = {a4, b4, a5, b5, a6, b6, a7, b7}
+//       returns:            Vec256<float>   = {a0, a1, a2, a3, a4, a5, a6, a7}
+//                           Vec256<float>   = {b0, b1, b2, b3, b4, b5, b6, b7}
+template <typename T>
+inline c10::guts::enable_if_t<Vec256<T>::size % 2 == 0, std::pair<Vec256<T>, Vec256<T>>>
+deinterleave2(const Vec256<T>& a, const Vec256<T>& b) {
+  static constexpr int size = Vec256<T>::size;
+  static constexpr int half_size = size / 2;
+  T a_arr[size];
+  T b_arr[size];
+  T buffer1[size];
+  T buffer2[size];
+  a.store(static_cast<void*>(a_arr));
+  b.store(static_cast<void*>(b_arr));
+  for (int64_t i = 0; i < half_size; i++) {
+    buffer1[i] = a_arr[i * 2];
+    buffer1[half_size + i] = b_arr[i * 2];
+    buffer2[i] = a_arr[i * 2 + 1];
+    buffer2[half_size + i] = b_arr[i * 2 + 1];
+  }
+  return std::make_pair(Vec256<T>::loadu(static_cast<void*>(buffer1)),
+                        Vec256<T>::loadu(static_cast<void*>(buffer2)));
 }
 
 }}}

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -168,27 +168,27 @@ public:
   // Comparison using the _CMP_**_OQ predicate.
   //   `O`: get false if an operand is NaN
   //   `Q`: do not raise if an operand is NaN
-  Vec256<double> eq(const Vec256<double>& other) const {
+  Vec256<double> operator==(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_EQ_OQ);
   }
 
-  Vec256<double> ne(const Vec256<double>& other) const {
+  Vec256<double> operator!=(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_NEQ_OQ);
   }
 
-  Vec256<double> lt(const Vec256<double>& other) const {
+  Vec256<double> operator<(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_LT_OQ);
   }
 
-  Vec256<double> le(const Vec256<double>& other) const {
+  Vec256<double> operator<=(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_LE_OQ);
   }
 
-  Vec256<double> gt(const Vec256<double>& other) const {
+  Vec256<double> operator>(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_GT_OQ);
   }
 
-  Vec256<double> ge(const Vec256<double>& other) const {
+  Vec256<double> operator>=(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_GE_OQ);
   }
 };

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -32,6 +32,10 @@ public:
   static Vec256<double> blend(const Vec256<double>& a, const Vec256<double>& b) {
     return _mm256_blend_pd(a.values, b.values, mask);
   }
+  static Vec256<double> blendv(const Vec256<double>& a, const Vec256<double>& b,
+                               const Vec256<double>& mask) {
+    return _mm256_blendv_pd(a.values, b.values, mask.values);
+  }
   static Vec256<double> arange(double base = 0., double step = 1.) {
     return Vec256<double>(base, base + step, base + 2 * step, base + 3 * step);
   }
@@ -63,7 +67,7 @@ public:
   void store(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_pd(reinterpret_cast<double*>(ptr), values);
-    } else {
+    } else if (count > 0) {
       double tmp_values[size];
       _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
       std::memcpy(ptr, tmp_values, count * sizeof(double));

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -22,14 +22,21 @@ public:
   Vec256(double val) {
     values = _mm256_set1_pd(val);
   }
+  Vec256(double val1, double val2, double val3, double val4) {
+    values = _mm256_setr_pd(val1, val2, val3, val4);
+  }
   operator __m256d() const {
     return values;
   }
   template <int64_t mask>
-  static Vec256<double> blend(Vec256<double> a, Vec256<double> b) {
+  static Vec256<double> blend(const Vec256<double>& a, const Vec256<double>& b) {
     return _mm256_blend_pd(a.values, b.values, mask);
   }
-  static Vec256<double> set(Vec256<double> a, Vec256<double> b, int64_t count = size) {
+  static Vec256<double> arange(double base = 0., double step = 1.) {
+    return Vec256<double>(base, base + step, base + 2 * step, base + 3 * step);
+  }
+  static Vec256<double> set(const Vec256<double>& a, const Vec256<double>& b,
+                            int64_t count = size) {
     switch (count) {
       case 0:
         return a;
@@ -154,6 +161,32 @@ public:
   Vec256<double> pow(const Vec256<double> &b) const {
     return Vec256<double>(Sleef_powd4_u10(values, b));
   }
+  // Comparison using the _CMP_**_OQ predicate.
+  //   `O`: get false if an operand is NaN
+  //   `Q`: do not raise if an operand is NaN
+  Vec256<double> eq(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_EQ_OQ);
+  }
+
+  Vec256<double> ne(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_NEQ_OQ);
+  }
+
+  Vec256<double> lt(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_LT_OQ);
+  }
+
+  Vec256<double> le(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_LE_OQ);
+  }
+
+  Vec256<double> gt(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_GT_OQ);
+  }
+
+  Vec256<double> ge(const Vec256<double>& other) const {
+    return _mm256_cmp_pd(values, other.values, _CMP_GE_OQ);
+  }
 };
 
 template <>
@@ -186,9 +219,24 @@ Vec256<double> inline min(const Vec256<double>& a, const Vec256<double>& b) {
   return _mm256_min_pd(a, b);
 }
 
+template <>
+Vec256<double> inline operator&(const Vec256<double>& a, const Vec256<double>& b) {
+  return _mm256_and_pd(a, b);
+}
+
+template <>
+Vec256<double> inline operator|(const Vec256<double>& a, const Vec256<double>& b) {
+  return _mm256_or_pd(a, b);
+}
+
+template <>
+Vec256<double> inline operator^(const Vec256<double>& a, const Vec256<double>& b) {
+  return _mm256_xor_pd(a, b);
+}
+
 #ifdef __AVX2__
 template <>
-Vec256<double> fmadd(const Vec256<double>& a, const Vec256<double>& b, const Vec256<double>& c) {
+Vec256<double> inline fmadd(const Vec256<double>& a, const Vec256<double>& b, const Vec256<double>& c) {
   return _mm256_fmadd_pd(a, b, c);
 }
 #endif

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -16,20 +16,30 @@ template <> class Vec256<float> {
 private:
   __m256 values;
 public:
-  static constexpr int64_t size = 8;
+  static constexpr int size = 8;
   Vec256() {}
   Vec256(__m256 v) : values(v) {}
   Vec256(float val) {
     values = _mm256_set1_ps(val);
   }
+  Vec256(float val1, float val2, float val3, float val4,
+         float val5, float val6, float val7, float val8) {
+    values = _mm256_setr_ps(val1, val2, val3, val4, val5, val6, val7, val8);
+  }
   operator __m256() const {
     return values;
   }
   template <int64_t mask>
-  static Vec256<float> blend(Vec256<float> a, Vec256<float> b) {
+  static Vec256<float> blend(const Vec256<float>& a, const Vec256<float>& b) {
     return _mm256_blend_ps(a.values, b.values, mask);
   }
-  static Vec256<float> set(Vec256<float> a, Vec256<float> b, int64_t count = size) {
+  static Vec256<float> arange(float base = 0.f, float step = 1.f) {
+    return Vec256<float>(
+      base,            base +     step, base + 2 * step, base + 3 * step,
+      base + 4 * step, base + 5 * step, base + 6 * step, base + 7 * step);
+  }
+  static Vec256<float> set(const Vec256<float>& a, const Vec256<float>& b,
+                           int64_t count = size) {
     switch (count) {
       case 0:
         return a;
@@ -159,6 +169,32 @@ public:
   Vec256<float> pow(const Vec256<float> &b) const {
     return Vec256<float>(Sleef_powf8_u10(values, b));
   }
+  // Comparison using the _CMP_**_OQ predicate.
+  //   `O`: get false if an operand is NaN
+  //   `Q`: do not raise if an operand is NaN
+  Vec256<float> eq(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_EQ_OQ);
+  }
+
+  Vec256<float> ne(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_NEQ_OQ);
+  }
+
+  Vec256<float> lt(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_LT_OQ);
+  }
+
+  Vec256<float> le(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_LE_OQ);
+  }
+
+  Vec256<float> gt(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_GT_OQ);
+  }
+
+  Vec256<float> ge(const Vec256<float>& other) const {
+    return _mm256_cmp_ps(values, other.values, _CMP_GE_OQ);
+  }
 };
 
 template <>
@@ -191,9 +227,24 @@ Vec256<float> inline min(const Vec256<float>& a, const Vec256<float>& b) {
   return _mm256_min_ps(a, b);
 }
 
+template <>
+Vec256<float> inline operator&(const Vec256<float>& a, const Vec256<float>& b) {
+  return _mm256_and_ps(a, b);
+}
+
+template <>
+Vec256<float> inline operator|(const Vec256<float>& a, const Vec256<float>& b) {
+  return _mm256_or_ps(a, b);
+}
+
+template <>
+Vec256<float> inline operator^(const Vec256<float>& a, const Vec256<float>& b) {
+  return _mm256_xor_ps(a, b);
+}
+
 #ifdef __AVX2__
 template <>
-Vec256<float> fmadd(const Vec256<float>& a, const Vec256<float>& b, const Vec256<float>& c) {
+Vec256<float> inline fmadd(const Vec256<float>& a, const Vec256<float>& b, const Vec256<float>& c) {
   return _mm256_fmadd_ps(a, b, c);
 }
 #endif

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -176,27 +176,27 @@ public:
   // Comparison using the _CMP_**_OQ predicate.
   //   `O`: get false if an operand is NaN
   //   `Q`: do not raise if an operand is NaN
-  Vec256<float> eq(const Vec256<float>& other) const {
+  Vec256<float> operator==(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_EQ_OQ);
   }
 
-  Vec256<float> ne(const Vec256<float>& other) const {
+  Vec256<float> operator!=(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_NEQ_OQ);
   }
 
-  Vec256<float> lt(const Vec256<float>& other) const {
+  Vec256<float> operator<(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_LT_OQ);
   }
 
-  Vec256<float> le(const Vec256<float>& other) const {
+  Vec256<float> operator<=(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_LE_OQ);
   }
 
-  Vec256<float> gt(const Vec256<float>& other) const {
+  Vec256<float> operator>(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_GT_OQ);
   }
 
-  Vec256<float> ge(const Vec256<float>& other) const {
+  Vec256<float> operator>=(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_GE_OQ);
   }
 };

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -33,6 +33,10 @@ public:
   static Vec256<float> blend(const Vec256<float>& a, const Vec256<float>& b) {
     return _mm256_blend_ps(a.values, b.values, mask);
   }
+  static Vec256<float> blendv(const Vec256<float>& a, const Vec256<float>& b,
+                              const Vec256<float>& mask) {
+    return _mm256_blendv_ps(a.values, b.values, mask.values);
+  }
   static Vec256<float> arange(float base = 0.f, float step = 1.f) {
     return Vec256<float>(
       base,            base +     step, base + 2 * step, base + 3 * step,
@@ -71,7 +75,7 @@ public:
   void store(void* ptr, int64_t count = size) const {
     if (count == size) {
       _mm256_storeu_ps(reinterpret_cast<float*>(ptr), values);
-    } else {
+    } else if (count > 0) {
       float tmp_values[size];
       _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
       std::memcpy(ptr, tmp_values, count * sizeof(float));

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -26,6 +26,9 @@ struct Vec256<int64_t> : public Vec256i {
   using Vec256i::Vec256i;
   Vec256() {}
   Vec256(int64_t v) { values = _mm256_set1_epi64x(v); }
+  Vec256(int64_t val1, int64_t val2, int64_t val3, int64_t val4) {
+    values = _mm256_setr_epi64x(val1, val2, val3, val4);
+  }
   template <int64_t mask>
   static Vec256<int64_t> blend(Vec256<int64_t> a, Vec256<int64_t> b) {
     __at_align32__ int64_t tmp_values[size];
@@ -39,6 +42,9 @@ struct Vec256<int64_t> : public Vec256i {
     if (mask & 0x08)
       tmp_values[3] = _mm256_extract_epi64(b.values, 3);
     return loadu(tmp_values);
+  }
+  static Vec256<int64_t> arange(int64_t base = 0, int64_t step = 1) {
+    return Vec256<int64_t>(base, base + step, base + 2 * step, base + 3 * step);
   }
   static Vec256<int64_t>
   set(Vec256<int64_t> a, Vec256<int64_t> b, int64_t count = size) {
@@ -79,6 +85,30 @@ struct Vec256<int64_t> : public Vec256i {
     auto inverse = _mm256_xor_si256(values, is_larger);
     return _mm256_sub_epi64(inverse, is_larger);
   }
+  Vec256<int64_t> eq(const Vec256<int64_t>& other) const {
+    return _mm256_cmpeq_epi64(values, other.values);
+  }
+  Vec256<int64_t> ne(const Vec256<int64_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto eq = _mm256_cmpeq_epi64(values, other.values);
+    return _mm256_xor_si256(zero, eq);  // invert
+  }
+  Vec256<int64_t> lt(const Vec256<int64_t>& other) const {
+    return _mm256_cmpgt_epi64(other.values, values);
+  }
+  Vec256<int64_t> le(const Vec256<int64_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto gt = _mm256_cmpgt_epi64(values, other.values);
+    return _mm256_xor_si256(zero, gt);  // invert
+  }
+  Vec256<int64_t> gt(const Vec256<int64_t>& other) const {
+    return _mm256_cmpgt_epi64(values, other.values);
+  }
+  Vec256<int64_t> ge(const Vec256<int64_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto lt = _mm256_cmpgt_epi64(other.values, values);
+    return _mm256_xor_si256(zero, lt);  // invert
+  }
 };
 
 template <>
@@ -87,9 +117,18 @@ struct Vec256<int32_t> : public Vec256i {
   using Vec256i::Vec256i;
   Vec256() {}
   Vec256(int32_t v) { values = _mm256_set1_epi32(v); }
+  Vec256(int32_t val1, int32_t val2, int32_t val3, int32_t val4,
+         int32_t val5, int32_t val6, int32_t val7, int32_t val8) {
+    values = _mm256_setr_epi32(val1, val2, val3, val4, val5, val6, val7, val8);
+  }
   template <int64_t mask>
   static Vec256<int32_t> blend(Vec256<int32_t> a, Vec256<int32_t> b) {
     return _mm256_blend_epi32(a, b, mask);
+  }
+  static Vec256<int32_t> arange(int32_t base = 0, int32_t step = 1) {
+    return Vec256<int32_t>(
+      base,            base +     step, base + 2 * step, base + 3 * step,
+      base + 4 * step, base + 5 * step, base + 6 * step, base + 7 * step);
   }
   static Vec256<int32_t>
   set(Vec256<int32_t> a, Vec256<int32_t> b, int32_t count = size) {
@@ -135,6 +174,30 @@ struct Vec256<int32_t> : public Vec256i {
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
   }
+  Vec256<int32_t> eq(const Vec256<int32_t>& other) const {
+    return _mm256_cmpeq_epi32(values, other.values);
+  }
+  Vec256<int32_t> ne(const Vec256<int32_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto eq = _mm256_cmpeq_epi32(values, other.values);
+    return _mm256_xor_si256(zero, eq);  // invert
+  }
+  Vec256<int32_t> lt(const Vec256<int32_t>& other) const {
+    return _mm256_cmpgt_epi32(other.values, values);
+  }
+  Vec256<int32_t> le(const Vec256<int32_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto gt = _mm256_cmpgt_epi32(values, other.values);
+    return _mm256_xor_si256(zero, gt);  // invert
+  }
+  Vec256<int32_t> gt(const Vec256<int32_t>& other) const {
+    return _mm256_cmpgt_epi32(values, other.values);
+  }
+  Vec256<int32_t> ge(const Vec256<int32_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto lt = _mm256_cmpgt_epi32(other.values, values);
+    return _mm256_xor_si256(zero, lt);  // invert
+  }
 };
 
 template <>
@@ -143,6 +206,13 @@ struct Vec256<int16_t> : public Vec256i {
   using Vec256i::Vec256i;
   Vec256() {}
   Vec256(int16_t v) { values = _mm256_set1_epi16(v); }
+  Vec256(int16_t val1, int16_t val2, int16_t val3, int16_t val4,
+         int16_t val5, int16_t val6, int16_t val7, int16_t val8,
+         int16_t val9, int16_t val10, int16_t val11, int16_t val12,
+         int16_t val13, int16_t val14, int16_t val15, int16_t val16) {
+    values = _mm256_setr_epi16(val1, val2, val3, val4, val5, val6, val7, val8,
+                               val9, val10, val11, val12, val13, val14, val15, val16);
+  }
   template <int64_t mask>
   static Vec256<int16_t> blend(Vec256<int16_t> a, Vec256<int16_t> b) {
     __at_align32__ int16_t tmp_values[size];
@@ -180,6 +250,13 @@ struct Vec256<int16_t> : public Vec256i {
     if (mask & 0x8000)
       tmp_values[15] = _mm256_extract_epi16(b.values, 15);
     return loadu(tmp_values);
+  }
+  static Vec256<int16_t> arange(int16_t base = 0, int16_t step = 1) {
+    return Vec256<int16_t>(
+      base,             base +      step, base +  2 * step, base +  3 * step,
+      base +  4 * step, base +  5 * step, base +  6 * step, base +  7 * step,
+      base +  8 * step, base +  9 * step, base + 10 * step, base + 11 * step,
+      base + 12 * step, base + 13 * step, base + 14 * step, base + 15 * step);
   }
   static Vec256<int16_t>
   set(Vec256<int16_t> a, Vec256<int16_t> b, int16_t count = size) {
@@ -241,6 +318,30 @@ struct Vec256<int16_t> : public Vec256i {
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
   }
+  Vec256<int16_t> eq(const Vec256<int16_t>& other) const {
+    return _mm256_cmpeq_epi16(values, other.values);
+  }
+  Vec256<int16_t> ne(const Vec256<int16_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto eq = _mm256_cmpeq_epi16(values, other.values);
+    return _mm256_xor_si256(zero, eq);  // invert
+  }
+  Vec256<int16_t> lt(const Vec256<int16_t>& other) const {
+    return _mm256_cmpgt_epi16(other.values, values);
+  }
+  Vec256<int16_t> le(const Vec256<int16_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto gt = _mm256_cmpgt_epi16(values, other.values);
+    return _mm256_xor_si256(zero, gt);  // invert
+  }
+  Vec256<int16_t> gt(const Vec256<int16_t>& other) const {
+    return _mm256_cmpgt_epi16(values, other.values);
+  }
+  Vec256<int16_t> ge(const Vec256<int16_t>& other) const {
+    auto zero = _mm256_set1_epi64x(0);
+    auto lt = _mm256_cmpgt_epi16(other.values, values);
+    return _mm256_xor_si256(zero, lt);  // invert
+  }
 };
 
 template <>
@@ -256,6 +357,21 @@ Vec256<int32_t> inline operator+(const Vec256<int32_t>& a, const Vec256<int32_t>
 template <>
 Vec256<int16_t> inline operator+(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
   return _mm256_add_epi16(a, b);
+}
+
+template <>
+Vec256<int64_t> inline operator-(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {
+  return _mm256_sub_epi64(a, b);
+}
+
+template <>
+Vec256<int32_t> inline operator-(const Vec256<int32_t>& a, const Vec256<int32_t>& b) {
+  return _mm256_sub_epi32(a, b);
+}
+
+template <>
+Vec256<int16_t> inline operator-(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
+  return _mm256_sub_epi16(a, b);
 }
 
 // AVX2 has no intrinsic for int64_t multiply so it needs to be emulated
@@ -292,8 +408,28 @@ Vec256<int16_t> inline operator*(const Vec256<int16_t>& a, const Vec256<int16_t>
   return _mm256_mullo_epi16(a, b);
 }
 
+/* TODO:
+ * From Agner Fog's vectorclass:
+ *
+ * Mathematical formula, used for signed division with fixed or variable divisor:
+ * (From T. Granlund and P. L. Montgomery: Division by Invariant Integers Using Multiplication,
+ * Proceedings of the SIGPLAN 1994 Conference on Programming Language Design and Implementation.
+ * http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1.2556 )
+ * x = dividend
+ * d = abs(divisor)
+ * w = integer word size, bits
+ * L = ceil(log2(d)) = bit_scan_reverse(d-1)+1
+ * L = max(L,1)
+ * m = 1 + 2^(w+L-1)/d - 2^w                      [division should overflow to 0 if d = 1]
+ * sh1 = L-1
+ * q = x + (m*x >> w)                             [high part of signed multiplication with 2w bits]
+ * q = (q >> sh1) - (x<0 ? -1 : 0)
+ * if (divisor < 0) q = -q
+ * result trunc(x/d) = q
+ */
+
 template <typename T>
-Vec256<T> intdiv_256(const Vec256<T>& a, const Vec256<T>& b) {
+Vec256<T> inline intdiv_256(const Vec256<T>& a, const Vec256<T>& b) {
   T values_a[Vec256<T>::size];
   T values_b[Vec256<T>::size];
   a.store(values_a);
@@ -304,20 +440,26 @@ Vec256<T> intdiv_256(const Vec256<T>& a, const Vec256<T>& b) {
   return Vec256<T>::loadu(values_a);
 }
 
-template <>
-Vec256<int64_t> inline operator/(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {
-  return intdiv_256(a, b);
+#define DEFINE_WIDTH_IGNOSTIC_BINARY_OP(op, func)                                         \
+template <>                                                                               \
+Vec256<int64_t> inline operator op(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {  \
+  return func(a, b);                                                                      \
+}                                                                                         \
+template <>                                                                               \
+Vec256<int32_t> inline operator op(const Vec256<int32_t>& a, const Vec256<int32_t>& b) {  \
+  return func(a, b);                                                                      \
+}                                                                                         \
+template <>                                                                               \
+Vec256<int16_t> inline operator op(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {  \
+  return func(a, b);                                                                      \
 }
 
-template <>
-Vec256<int32_t> inline operator/(const Vec256<int32_t>& a, const Vec256<int32_t>& b) {
-  return intdiv_256(a, b);
-}
+DEFINE_WIDTH_IGNOSTIC_BINARY_OP(/, intdiv_256)
+DEFINE_WIDTH_IGNOSTIC_BINARY_OP(&, _mm256_and_si256)
+DEFINE_WIDTH_IGNOSTIC_BINARY_OP(|, _mm256_or_si256)
+DEFINE_WIDTH_IGNOSTIC_BINARY_OP(^, _mm256_xor_si256)
 
-template <>
-Vec256<int16_t> inline operator/(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
-  return intdiv_256(a, b);
-}
+#undef DEFINE_WITDTH_IGNOSTIC_BINARY_OP
 
 #endif
 

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -89,26 +89,26 @@ struct Vec256<int64_t> : public Vec256i {
     auto inverse = _mm256_xor_si256(values, is_larger);
     return _mm256_sub_epi64(inverse, is_larger);
   }
-  Vec256<int64_t> eq(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator==(const Vec256<int64_t>& other) const {
     return _mm256_cmpeq_epi64(values, other.values);
   }
-  Vec256<int64_t> ne(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator!=(const Vec256<int64_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto eq = _mm256_cmpeq_epi64(values, other.values);
     return _mm256_xor_si256(zero, eq);  // invert
   }
-  Vec256<int64_t> lt(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator<(const Vec256<int64_t>& other) const {
     return _mm256_cmpgt_epi64(other.values, values);
   }
-  Vec256<int64_t> le(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator<=(const Vec256<int64_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto gt = _mm256_cmpgt_epi64(values, other.values);
     return _mm256_xor_si256(zero, gt);  // invert
   }
-  Vec256<int64_t> gt(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator>(const Vec256<int64_t>& other) const {
     return _mm256_cmpgt_epi64(values, other.values);
   }
-  Vec256<int64_t> ge(const Vec256<int64_t>& other) const {
+  Vec256<int64_t> operator>=(const Vec256<int64_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto lt = _mm256_cmpgt_epi64(other.values, values);
     return _mm256_xor_si256(zero, lt);  // invert
@@ -182,26 +182,26 @@ struct Vec256<int32_t> : public Vec256i {
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
   }
-  Vec256<int32_t> eq(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator==(const Vec256<int32_t>& other) const {
     return _mm256_cmpeq_epi32(values, other.values);
   }
-  Vec256<int32_t> ne(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator!=(const Vec256<int32_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto eq = _mm256_cmpeq_epi32(values, other.values);
     return _mm256_xor_si256(zero, eq);  // invert
   }
-  Vec256<int32_t> lt(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator<(const Vec256<int32_t>& other) const {
     return _mm256_cmpgt_epi32(other.values, values);
   }
-  Vec256<int32_t> le(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator<=(const Vec256<int32_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto gt = _mm256_cmpgt_epi32(values, other.values);
     return _mm256_xor_si256(zero, gt);  // invert
   }
-  Vec256<int32_t> gt(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator>(const Vec256<int32_t>& other) const {
     return _mm256_cmpgt_epi32(values, other.values);
   }
-  Vec256<int32_t> ge(const Vec256<int32_t>& other) const {
+  Vec256<int32_t> operator>=(const Vec256<int32_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto lt = _mm256_cmpgt_epi32(other.values, values);
     return _mm256_xor_si256(zero, lt);  // invert
@@ -330,26 +330,26 @@ struct Vec256<int16_t> : public Vec256i {
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
   }
-  Vec256<int16_t> eq(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator==(const Vec256<int16_t>& other) const {
     return _mm256_cmpeq_epi16(values, other.values);
   }
-  Vec256<int16_t> ne(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator!=(const Vec256<int16_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto eq = _mm256_cmpeq_epi16(values, other.values);
     return _mm256_xor_si256(zero, eq);  // invert
   }
-  Vec256<int16_t> lt(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator<(const Vec256<int16_t>& other) const {
     return _mm256_cmpgt_epi16(other.values, values);
   }
-  Vec256<int16_t> le(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator<=(const Vec256<int16_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto gt = _mm256_cmpgt_epi16(values, other.values);
     return _mm256_xor_si256(zero, gt);  // invert
   }
-  Vec256<int16_t> gt(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator>(const Vec256<int16_t>& other) const {
     return _mm256_cmpgt_epi16(values, other.values);
   }
-  Vec256<int16_t> ge(const Vec256<int16_t>& other) const {
+  Vec256<int16_t> operator>=(const Vec256<int16_t>& other) const {
     auto zero = _mm256_set1_epi64x(0);
     auto lt = _mm256_cmpgt_epi16(other.values, values);
     return _mm256_xor_si256(zero, lt);  // invert

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -43,6 +43,10 @@ struct Vec256<int64_t> : public Vec256i {
       tmp_values[3] = _mm256_extract_epi64(b.values, 3);
     return loadu(tmp_values);
   }
+  static Vec256<int64_t> blendv(const Vec256<int64_t>& a, const Vec256<int64_t>& b,
+                                const Vec256<int64_t>& mask) {
+    return _mm256_blendv_epi8(a.values, b.values, mask.values);
+  }
   static Vec256<int64_t> arange(int64_t base = 0, int64_t step = 1) {
     return Vec256<int64_t>(base, base + step, base + 2 * step, base + 3 * step);
   }
@@ -71,7 +75,7 @@ struct Vec256<int64_t> : public Vec256i {
   void store(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
-    } else {
+    } else if (count > 0) {
       __at_align32__ int64_t tmp_values[size];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
       std::memcpy(ptr, tmp_values, count * sizeof(int64_t));
@@ -125,6 +129,10 @@ struct Vec256<int32_t> : public Vec256i {
   static Vec256<int32_t> blend(Vec256<int32_t> a, Vec256<int32_t> b) {
     return _mm256_blend_epi32(a, b, mask);
   }
+  static Vec256<int32_t> blendv(const Vec256<int32_t>& a, const Vec256<int32_t>& b,
+                                const Vec256<int32_t>& mask) {
+    return _mm256_blendv_epi8(a.values, b.values, mask.values);
+  }
   static Vec256<int32_t> arange(int32_t base = 0, int32_t step = 1) {
     return Vec256<int32_t>(
       base,            base +     step, base + 2 * step, base + 3 * step,
@@ -163,7 +171,7 @@ struct Vec256<int32_t> : public Vec256i {
   void store(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
-    } else {
+    } else if (count > 0) {
       __at_align32__ int32_t tmp_values[size];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
       std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
@@ -251,6 +259,10 @@ struct Vec256<int16_t> : public Vec256i {
       tmp_values[15] = _mm256_extract_epi16(b.values, 15);
     return loadu(tmp_values);
   }
+  static Vec256<int16_t> blendv(const Vec256<int16_t>& a, const Vec256<int16_t>& b,
+                                const Vec256<int16_t>& mask) {
+    return _mm256_blendv_epi8(a.values, b.values, mask.values);
+  }
   static Vec256<int16_t> arange(int16_t base = 0, int16_t step = 1) {
     return Vec256<int16_t>(
       base,             base +      step, base +  2 * step, base +  3 * step,
@@ -307,7 +319,7 @@ struct Vec256<int16_t> : public Vec256i {
   void store(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
-    } else {
+    } else if (count > 0) {
       __at_align32__ int16_t tmp_values[size];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
       std::memcpy(ptr, tmp_values, count * sizeof(int16_t));

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -420,26 +420,6 @@ Vec256<int16_t> inline operator*(const Vec256<int16_t>& a, const Vec256<int16_t>
   return _mm256_mullo_epi16(a, b);
 }
 
-/* TODO:
- * From Agner Fog's vectorclass:
- *
- * Mathematical formula, used for signed division with fixed or variable divisor:
- * (From T. Granlund and P. L. Montgomery: Division by Invariant Integers Using Multiplication,
- * Proceedings of the SIGPLAN 1994 Conference on Programming Language Design and Implementation.
- * http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1.2556 )
- * x = dividend
- * d = abs(divisor)
- * w = integer word size, bits
- * L = ceil(log2(d)) = bit_scan_reverse(d-1)+1
- * L = max(L,1)
- * m = 1 + 2^(w+L-1)/d - 2^w                      [division should overflow to 0 if d = 1]
- * sh1 = L-1
- * q = x + (m*x >> w)                             [high part of signed multiplication with 2w bits]
- * q = (q >> sh1) - (x<0 ? -1 : 0)
- * if (divisor < 0) q = -q
- * result trunc(x/d) = q
- */
-
 template <typename T>
 Vec256<T> inline intdiv_256(const Vec256<T>& a, const Vec256<T>& b) {
   T values_a[Vec256<T>::size];
@@ -452,7 +432,7 @@ Vec256<T> inline intdiv_256(const Vec256<T>& a, const Vec256<T>& b) {
   return Vec256<T>::loadu(values_a);
 }
 
-#define DEFINE_WIDTH_IGNOSTIC_BINARY_OP(op, func)                                         \
+#define DEFINE_INTEGER_BINARY_OP(op, func)                                                \
 template <>                                                                               \
 Vec256<int64_t> inline operator op(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {  \
   return func(a, b);                                                                      \
@@ -466,12 +446,12 @@ Vec256<int16_t> inline operator op(const Vec256<int16_t>& a, const Vec256<int16_
   return func(a, b);                                                                      \
 }
 
-DEFINE_WIDTH_IGNOSTIC_BINARY_OP(/, intdiv_256)
-DEFINE_WIDTH_IGNOSTIC_BINARY_OP(&, _mm256_and_si256)
-DEFINE_WIDTH_IGNOSTIC_BINARY_OP(|, _mm256_or_si256)
-DEFINE_WIDTH_IGNOSTIC_BINARY_OP(^, _mm256_xor_si256)
+DEFINE_INTEGER_BINARY_OP(/, intdiv_256)
+DEFINE_INTEGER_BINARY_OP(&, _mm256_and_si256)
+DEFINE_INTEGER_BINARY_OP(|, _mm256_or_si256)
+DEFINE_INTEGER_BINARY_OP(^, _mm256_xor_si256)
 
-#undef DEFINE_WITDTH_IGNOSTIC_BINARY_OP
+#undef DEFINE_INTEGER_BINARY_OP
 
 #endif
 

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -22,7 +22,10 @@
 //   DEFINE_DISPATCH(stub);
 //
 // In native/cpu/MyKernel.cpp:
-//   void kernel(const Tensor& x) { ... }
+//   namespace {
+//     // use anonymous namespace so that different cpu versions won't conflict
+//     void kernel(const Tensor& x) { ... }
+//   }
 //   REGISTER_DISPATCH(stub, &kernel);
 //
 // To call:
@@ -46,19 +49,22 @@ enum class CPUCapability {
 CPUCapability get_cpu_capability();
 
 template <typename FnPtr, typename T>
-struct AT_API DispatchStub {
-  static_assert(std::is_pointer<FnPtr>::value, "FnPtr should be a pointer type");
+struct AT_API DispatchStub;
+
+template <typename rT, typename T, typename... Args>
+struct AT_API DispatchStub<rT (*) (Args...), T> {
+  using FnPtr = rT (*) (Args...);
 
   template <typename... ArgTypes>
-  void operator()(DeviceType device_type, ArgTypes&&... args) {
+  rT operator()(DeviceType device_type, ArgTypes&&... args) {
     if (device_type == DeviceType::CPU) {
       if (!cpu_dispatch_ptr) {
         cpu_dispatch_ptr = choose_cpu_impl();
       }
-      (*cpu_dispatch_ptr)(std::forward<ArgTypes>(args)...);
+      return (*cpu_dispatch_ptr)(std::forward<ArgTypes>(args)...);
     } else if (device_type == DeviceType::CUDA) {
       AT_ASSERTM(cuda_dispatch_ptr, "DispatchStub: missing CUDA kernel");
-      (*cuda_dispatch_ptr)(std::forward<ArgTypes>(args)...);
+      return (*cuda_dispatch_ptr)(std::forward<ArgTypes>(args)...);
     } else {
       AT_ERROR("DispatchStub: unsupported device type", device_type);
     }

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -111,8 +111,8 @@ struct RegisterDispatch {
 
 // Compiler will complain if you put things like std::tuple<Tensor, Tensor> in
 // the `fn` argument of DECLARE_DISPATCH. Some possible workarounds, e.g.,
-// adding parentheses and using helper struct to get rid of the parentheses do
-// not work with MSVC. So use a `using`-declaration if you need to pass in such
+// adding parentheses and using helper struct to get rid of the parentheses, do
+// not work with MSVC. So do a `using`-declaration if you need to pass in such
 // `fn`, e.g., grid_sampler_2d_backward_cpu_kernel in GridSampleKernel.h.
 #define DECLARE_DISPATCH(fn, name) \
   struct name : DispatchStub<fn, name> {}; \

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -109,8 +109,17 @@ struct RegisterDispatch {
 };
 } // anonymous namespace
 
+namespace {
+  // These are used to resolve template arguement in `fn` of DECLARE_DISPATCH.
+  // e.g., function with return/argument type of std::tuple<Tensor, Tensor>.
+  // From https://stackoverflow.com/a/13842784
+
+  template<typename T> struct argument_type;
+  template<typename T, typename U> struct argument_type<T(U)> { typedef U type; };
+}
+
 #define DECLARE_DISPATCH(fn, name) \
-  struct name : DispatchStub<fn, name> {}; \
+  struct name : DispatchStub<argument_type<void(fn)>::type, name> {}; \
   extern AT_API struct name name
 
 #define DEFINE_DISPATCH(name) struct name name

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -109,17 +109,13 @@ struct RegisterDispatch {
 };
 } // anonymous namespace
 
-namespace {
-  // These are used to resolve template arguement in `fn` of DECLARE_DISPATCH.
-  // e.g., function with return/argument type of std::tuple<Tensor, Tensor>.
-  // From https://stackoverflow.com/a/13842784
-
-  template<typename T> struct argument_type;
-  template<typename T, typename U> struct argument_type<T(U)> { typedef U type; };
-}
-
+// Compiler will complain if you put things like std::tuple<Tensor, Tensor> in
+// the `fn` argument of DECLARE_DISPATCH. Some possible workarounds, e.g.,
+// adding parentheses and using helper struct to get rid of the parentheses do
+// not work with MSVC. So use a `using`-declaration if you need to pass in such
+// `fn`, e.g., grid_sampler_2d_backward_cpu_kernel in GridSampleKernel.h.
 #define DECLARE_DISPATCH(fn, name) \
-  struct name : DispatchStub<argument_type<void(fn)>::type, name> {}; \
+  struct name : DispatchStub<fn, name> {}; \
   extern AT_API struct name name
 
 #define DEFINE_DISPATCH(name) struct name name

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -3,8 +3,9 @@
 #include "ATen/Device.h"
 #include "ATen/Error.h"
 #include "ATen/NativeFunctions.h"
-#include "ATen/detail/CUDAHooksInterface.h"
 #include "ATen/native/GridSampler.h"
+#include "ATen/native/cpu/GridSamplerKernel.h"
+#include "ATen/cpu/vml.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -16,6 +17,7 @@ using at::native::detail::GridSamplerInterpolation;
 using at::native::detail::GridSamplerPadding;
 
 namespace {
+
   template<typename scalar_t>
   static inline scalar_t clip_coordinates(scalar_t in, int64_t clip_limit) {
     return std::min(static_cast<scalar_t>(clip_limit - 1), std::max(in, static_cast<scalar_t>(0)));
@@ -118,120 +120,9 @@ namespace {
   }
 
   template<typename scalar_t>
-  Tensor grid_sampler_2d_cpu_impl(const Tensor& input, const Tensor& grid,
-                                 GridSamplerInterpolation interpolation_mode,
-                                 GridSamplerPadding padding_mode) {
-    int64_t N = input.size(0);
-    int64_t C = input.size(1);
-    int64_t inp_H = input.size(2);
-    int64_t inp_W = input.size(3);
-    int64_t out_H = grid.size(1);
-    int64_t out_W = grid.size(2);
-    auto output = at::empty({N, C, out_H, out_W}, input.options());
-    int64_t inp_sN = input.stride(0);
-    int64_t inp_sC = input.stride(1);
-    int64_t inp_sH = input.stride(2);
-    int64_t inp_sW = input.stride(3);
-    int64_t grid_sN = grid.stride(0);
-    int64_t grid_sH = grid.stride(1);
-    int64_t grid_sW = grid.stride(2);
-    int64_t grid_sCoor = grid.stride(3);
-    int64_t out_sN = output.stride(0);
-    int64_t out_sC = output.stride(1);
-    int64_t out_sH = output.stride(2);
-    int64_t out_sW = output.stride(3);
-    scalar_t *inp_ptr = input.data<scalar_t>();
-    scalar_t *out_ptr = output.data<scalar_t>();
-    scalar_t *grid_ptr = grid.data<scalar_t>();
-    // loop over each output pixel
-    #ifdef _OPENMP
-    #pragma omp parallel for
-    #endif
-    for (int64_t n = 0; n < N; ++n) {
-      scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
-      scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-      for (int64_t h = 0; h < out_H; ++h) {
-        for (int64_t w = 0; w < out_W; ++w) {
-          // get the corresponding input x, y co-ordinates from grid
-          scalar_t ix = grid_ptr_N[h * grid_sH + w * grid_sW];
-          scalar_t iy = grid_ptr_N[h * grid_sH + w * grid_sW + grid_sCoor];
-
-          // normalize ix, iy from [-1, 1] to [0, inp_W-1] & [0, inp_H-1]
-          ix = ((ix + 1) / 2) * (inp_W - 1);
-          iy = ((iy + 1) / 2) * (inp_H - 1);
-
-          if (padding_mode == GridSamplerPadding::Border) {
-            // clip coordinates to image borders
-            ix = clip_coordinates(ix, inp_W);
-            iy = clip_coordinates(iy, inp_H);
-          } else if (padding_mode == GridSamplerPadding::Reflection) {
-            // reflect coordinates by image borders
-            ix = reflect_coordinates(ix, inp_W);
-            iy = reflect_coordinates(iy, inp_H);
-          }
-
-          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-            // get NE, NW, SE, SW pixel values from (x, y)
-            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-            int64_t ix_ne = ix_nw + 1;
-            int64_t iy_ne = iy_nw;
-            int64_t ix_sw = ix_nw;
-            int64_t iy_sw = iy_nw + 1;
-            int64_t ix_se = ix_nw + 1;
-            int64_t iy_se = iy_nw + 1;
-
-            // get surfaces to each neighbor:
-            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
-
-            // calculate bilinear weighted pixel value and set output pixel
-            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-            scalar_t *inp_ptr_NC = inp_ptr_N;
-            for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
-              //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
-              // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
-              *out_ptr_NCHW = static_cast<scalar_t>(0);
-              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-                *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
-              }
-              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-                *out_ptr_NCHW += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
-              }
-              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-                *out_ptr_NCHW += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
-              }
-              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-                *out_ptr_NCHW += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
-              }
-            }
-          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-            int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
-            int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
-
-            // assign nearest neighor pixel value to output pixel
-            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-            scalar_t *inp_ptr_NC = inp_ptr_N;
-            for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
-              if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
-                *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
-              } else {
-                *out_ptr_NCHW = static_cast<scalar_t>(0);
-              }
-            }
-          }
-        }
-      }
-    }
-    return output;
-  }
-
-  template<typename scalar_t>
   Tensor grid_sampler_3d_cpu_impl(const Tensor& input, const Tensor& grid,
-                                 GridSamplerInterpolation interpolation_mode,
-                                 GridSamplerPadding padding_mode) {
+                                  GridSamplerInterpolation interpolation_mode,
+                                  GridSamplerPadding padding_mode) {
     int64_t N = input.size(0);
     int64_t C = input.size(1);
     int64_t inp_D = input.size(2);
@@ -398,9 +289,9 @@ namespace {
   template<typename scalar_t>
   std::tuple<Tensor, Tensor>
   grid_sampler_2d_backward_cpu_impl(const Tensor& grad_output,
-                                   const Tensor& input, const Tensor& grid,
-                                   GridSamplerInterpolation interpolation_mode,
-                                   GridSamplerPadding padding_mode) {
+                                    const Tensor& input, const Tensor& grid,
+                                    GridSamplerInterpolation interpolation_mode,
+                                    GridSamplerPadding padding_mode) {
     auto grad_input = at::zeros_like(input);
     auto grad_grid = at::empty_like(grid);
     // If interpolation mode is Nearest, then grad_grid is not filled in the
@@ -553,9 +444,9 @@ namespace {
   template<typename scalar_t>
   std::tuple<Tensor, Tensor>
   grid_sampler_3d_backward_cpu_impl(const Tensor& grad_output,
-                                   const Tensor& input, const Tensor& grid,
-                                   GridSamplerInterpolation interpolation_mode,
-                                   GridSamplerPadding padding_mode) {
+                                    const Tensor& input, const Tensor& grid,
+                                    GridSamplerInterpolation interpolation_mode,
+                                    GridSamplerPadding padding_mode) {
     auto grad_input = at::zeros_like(input);
     auto grad_grid = at::empty_like(grid);
     // If interpolation mode is Nearest, then grad_grid is not filled in the
@@ -783,17 +674,17 @@ namespace {
     }
     return std::make_tuple(grad_input, grad_grid);
   }
-}
+
+}  // namespace
 
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
                            int64_t interpolation_mode, int64_t padding_mode) {
-  return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler2d_cpu", [&] {
-    return grid_sampler_2d_cpu_impl<scalar_t>(
-      input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
-      static_cast<GridSamplerPadding>(padding_mode));
-  });
+  return grid_sampler_2d_cpu_kernel(kCPU, input, grid, interpolation_mode, padding_mode);
 }
+
+DEFINE_DISPATCH(grid_sampler_2d_cpu_kernel);
+
 
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -288,161 +288,6 @@ namespace {
 
   template<typename scalar_t>
   std::tuple<Tensor, Tensor>
-  grid_sampler_2d_backward_cpu_impl(const Tensor& grad_output,
-                                    const Tensor& input, const Tensor& grid,
-                                    GridSamplerInterpolation interpolation_mode,
-                                    GridSamplerPadding padding_mode) {
-    auto grad_input = at::zeros_like(input);
-    auto grad_grid = at::empty_like(grid);
-    // If interpolation mode is Nearest, then grad_grid is not filled in the
-    // loop below.
-    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-      grad_grid.zero_();
-    }
-    int64_t N = input.size(0);
-    int64_t C = input.size(1);
-    int64_t inp_H = input.size(2);
-    int64_t inp_W = input.size(3);
-    int64_t out_H = grid.size(1);
-    int64_t out_W = grid.size(2);
-    int64_t inp_sN = input.stride(0);
-    int64_t inp_sC = input.stride(1);
-    int64_t inp_sH = input.stride(2);
-    int64_t inp_sW = input.stride(3);
-    int64_t grid_sN = grid.stride(0);
-    int64_t grid_sH = grid.stride(1);
-    int64_t grid_sW = grid.stride(2);
-    int64_t grid_sCoor = grid.stride(3);
-    int64_t gOut_sN = grad_output.stride(0);
-    int64_t gOut_sC = grad_output.stride(1);
-    int64_t gOut_sH = grad_output.stride(2);
-    int64_t gOut_sW = grad_output.stride(3);
-    int64_t gInp_sN = grad_input.stride(0);
-    int64_t gInp_sC = grad_input.stride(1);
-    int64_t gInp_sH = grad_input.stride(2);
-    int64_t gInp_sW = grad_input.stride(3);
-    int64_t gGrid_sN = grad_grid.stride(0);
-    int64_t gGrid_sW = grad_grid.stride(2);
-    scalar_t *inp_ptr = input.data<scalar_t>();
-    scalar_t *grid_ptr = grid.data<scalar_t>();
-    scalar_t *gOut_ptr = grad_output.data<scalar_t>();
-    scalar_t *gInp_ptr = grad_input.data<scalar_t>();
-    scalar_t *gGrid_ptr = grad_grid.data<scalar_t>();
-    // loop over each output pixel
-    #ifdef _OPENMP
-    #pragma omp parallel for
-    #endif
-    for (int64_t n = 0; n < N; ++n) {
-      scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
-      scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-      scalar_t *gGrid_ptr_NHW = gGrid_ptr + n * gGrid_sN;
-      for (int64_t h = 0; h < out_H; ++h) {
-        for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NHW += gGrid_sW /* grad_grid is contiguous */ ) {
-          // get the corresponding input x, y co-ordinates from grid
-          scalar_t ix = grid_ptr_N[h * grid_sH + w * grid_sW];
-          scalar_t iy = grid_ptr_N[h * grid_sH + w * grid_sW + grid_sCoor];
-
-          // normalize ix, iy from [-1, 1] to [0, inp_W-1] & [0, inp_H-1]
-          ix = ((ix + 1) / 2) * (inp_W - 1);
-          iy = ((iy + 1) / 2) * (inp_H - 1);
-
-          // multipliers for gradients on ix and iy
-          // E.g.,  0 for out-of-bound indices when GridSamplerPadding::Border
-          scalar_t gix_mult, giy_mult;
-          if (padding_mode == GridSamplerPadding::Border) {
-            // clip coordinates to image borders
-            ix = clip_coordinates_set_grad(ix, inp_W, &gix_mult);
-            iy = clip_coordinates_set_grad(iy, inp_H, &giy_mult);
-          } else if (padding_mode == GridSamplerPadding::Reflection) {
-            // reflect coordinates by image borders
-            ix = reflect_coordinates_set_grad(ix, inp_W, &gix_mult);
-            iy = reflect_coordinates_set_grad(iy, inp_H, &giy_mult);
-          } else {  // padding_mode == GridSamplerPadding::Zeros
-            gix_mult = static_cast<scalar_t>(1);
-            giy_mult = static_cast<scalar_t>(1);
-          }
-
-          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-            // get NE, NW, SE, SW pixel values from (x, y)
-            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-            int64_t ix_ne = ix_nw + 1;
-            int64_t iy_ne = iy_nw;
-            int64_t ix_sw = ix_nw;
-            int64_t iy_sw = iy_nw + 1;
-            int64_t ix_se = ix_nw + 1;
-            int64_t iy_se = iy_nw + 1;
-
-            // get surfaces to each neighbor:
-            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
-
-            scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
-            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-            scalar_t *inp_ptr_NC = inp_ptr_N;
-            // calculate bilinear weighted pixel value and set output pixel
-            for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
-              scalar_t gOut = *gOut_ptr_NCHW;
-
-              // calculate and set grad_input
-              safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-              safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-              safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-              safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
-
-              // calculate grad_grid
-              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-                scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
-                gix -= nw_val * (iy_se - iy) * gOut;
-                giy -= nw_val * (ix_se - ix) * gOut;
-              }
-              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-                scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
-                gix += ne_val * (iy_sw - iy) * gOut;
-                giy -= ne_val * (ix - ix_sw) * gOut;
-              }
-              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-                scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
-                gix -= sw_val * (iy - iy_ne) * gOut;
-                giy += sw_val * (ix_ne - ix) * gOut;
-              }
-              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-                scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
-                gix += se_val * (iy - iy_nw) * gOut;
-                giy += se_val * (ix - ix_nw) * gOut;
-              }
-            }
-
-            // un-normalize grad_grid values back to [-1, 1] constraints
-            gix = gix * (inp_W - 1) / 2;
-            giy = giy * (inp_H - 1) / 2;
-
-            // assuming grad_grid is contiguous
-            gGrid_ptr_NHW[0] = gix_mult * gix;
-            gGrid_ptr_NHW[1] = giy_mult * giy;
-          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-            int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
-            int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
-
-            // assign nearest neighor pixel value to output pixel
-            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-            for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
-              // calculate and set grad_input
-              safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW);
-            }
-          }
-        }
-      }
-    }
-    return std::make_tuple(grad_input, grad_grid);
-  }
-
-  template<typename scalar_t>
-  std::tuple<Tensor, Tensor>
   grid_sampler_3d_backward_cpu_impl(const Tensor& grad_output,
                                     const Tensor& input, const Tensor& grid,
                                     GridSamplerInterpolation interpolation_mode,
@@ -700,13 +545,10 @@ Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
 std::tuple<Tensor, Tensor>
 grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
                              int64_t interpolation_mode, int64_t padding_mode) {
-  return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_2d_backward_cpu", [&] {
-    return grid_sampler_2d_backward_cpu_impl<scalar_t>(
-      grad_output, input, grid,
-      static_cast<GridSamplerInterpolation>(interpolation_mode),
-      static_cast<GridSamplerPadding>(padding_mode));
-  });
+  return grid_sampler_2d_backward_cpu_kernel(kCPU, grad_output, input, grid, interpolation_mode, padding_mode);
 }
+
+DEFINE_DISPATCH(grid_sampler_2d_backward_cpu_kernel);
 
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 std::tuple<Tensor, Tensor>

--- a/aten/src/ATen/native/GridSampler.h
+++ b/aten/src/ATen/native/GridSampler.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
 

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -1,0 +1,450 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/core/C++17.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/native/GridSampler.h>
+#include <ATen/native/cpu/GridSamplerKernel.h>
+#include <ATen/cpu/vml.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include <algorithm>
+#include <cstring>
+#include <type_traits>
+#include <iostream>
+#include <bitset>
+
+namespace at { namespace native { namespace {
+
+using at::native::detail::GridSamplerInterpolation;
+using at::native::detail::GridSamplerPadding;
+using namespace at::vec256;
+
+// clip_coordinates_set_grad works similarly to clip_coordinates except that
+// it also returns the `d output / d input` via pointer argument `grad_in`.
+// This is useful in the backward pass of grid_sampler.
+template<typename scalar_t>
+struct ApplyPaddingBase {
+  const Vec256<scalar_t> half_max_val;
+  const Vec256<scalar_t> zeros = Vec256<scalar_t>(0);
+
+  ApplyPaddingBase(int64_t size)
+    : half_max_val(static_cast<scalar_t>(size - 1) / 2) {}
+
+  inline Vec256<scalar_t> unnormalize(const Vec256<scalar_t> &in) const {
+    return (in + Vec256<scalar_t>(1)) * half_max_val;
+  }
+};
+
+template<typename scalar_t, GridSamplerPadding padding>
+struct ApplyPadding;
+
+template<typename scalar_t>
+struct ApplyPadding<scalar_t, GridSamplerPadding::Zeros>
+  : ApplyPaddingBase<scalar_t> {
+
+  using ApplyPaddingBase<scalar_t>::ApplyPaddingBase;
+
+  inline Vec256<scalar_t> apply(const Vec256<scalar_t> &in) const {
+    return this->unnormalize(in);
+  }
+
+  inline std::pair<Vec256<scalar_t>, Vec256<scalar_t>> apply_get_grad(const Vec256<scalar_t> &in) const {
+    return std::make_pair(this->unnormalize(in), this->half_max_val);
+  }
+};
+
+template<typename scalar_t>
+struct ApplyPadding<scalar_t, GridSamplerPadding::Border>
+  : ApplyPaddingBase<scalar_t> {
+
+  const Vec256<scalar_t> max_val;
+
+  ApplyPadding(int64_t size)
+    : ApplyPaddingBase<scalar_t>(size)
+    , max_val(static_cast<scalar_t>(size - 1)) {}
+
+  inline Vec256<scalar_t> apply(const Vec256<scalar_t> &in) const {
+    return min(this->max_val, max(this->unnormalize(in), this->zeros));
+  }
+  inline std::pair<Vec256<scalar_t>, Vec256<scalar_t>> apply_get_grad(const Vec256<scalar_t> &in) const {
+    AT_ERROR("FIXME: NYI");
+    return std::make_pair(apply(in), this->zeros);
+  }
+};
+
+template<typename scalar_t>
+struct ApplyPadding<scalar_t, GridSamplerPadding::Reflection>
+  : ApplyPaddingBase<scalar_t> {
+
+  bool unit_size;  // whether size == 1, just return 0 in this case
+  const Vec256<scalar_t> double_max_val;
+
+  ApplyPadding(int64_t size)
+    : ApplyPaddingBase<scalar_t>(size)
+    , unit_size(size == 1)
+    , double_max_val(static_cast<scalar_t>((size - 1) * 2)) {}
+
+  inline Vec256<scalar_t> apply(const Vec256<scalar_t> &in) const {
+    if (unit_size) {
+      return this->zeros;
+    }
+    auto abs_in = this->unnormalize(in).abs();
+    auto fdouble_flips = abs_in / double_max_val;
+    auto double_flips = fdouble_flips.trunc();
+    auto extra = abs_in - double_flips * double_max_val;
+    return min(extra, double_max_val - extra);
+  }
+
+  inline std::pair<Vec256<scalar_t>, Vec256<scalar_t>> apply_get_grad(const Vec256<scalar_t> &in) const {
+    AT_ERROR("FIXME: NYI");
+    return std::make_pair(this->unnormalize(in), this->zeros);
+  }
+};
+
+
+template<typename scalar_t, int dim, GridSamplerInterpolation interp>
+struct ApplyInterpolation;
+
+template<typename scalar_t>
+struct ApplyInterpolation<scalar_t, 2, GridSamplerInterpolation::Bilinear> {
+  using Vec = Vec256<scalar_t>;
+  using iVec = Vec256<int_same_size_t<scalar_t>>;
+
+  const iVec i_H;
+  const iVec i_W;
+  const iVec i_inp_sH;
+  const iVec i_inp_sW;
+  const iVec i_neg1s = iVec(-1);
+  const iVec i_ones = iVec(1);
+  const Vec ones = Vec(1);
+  const Vec zeros = Vec(0);
+  int64_t C;
+  int64_t inp_sC;
+
+  ApplyInterpolation(const TensorAccessor<scalar_t, 4>& input)
+    : i_H(iVec(input.size(2))), i_W(iVec(input.size(3)))
+    , i_inp_sH(input.stride(2)), i_inp_sW(input.stride(3))
+    , C(input.size(1)), inp_sC(input.stride(1)) {}
+
+  inline void apply(scalar_t *out_ptr, const scalar_t *inp_slice_ptr,
+                    int64_t out_sC, const Vec& x, const Vec& y,
+                    bool must_in_bound, int64_t len) const {
+    // get NE, NW, SE, SW pixel values from (x, y)
+    // assuming we get exact integer representation and just use scalar_t
+    // if we don't, the weights will be garbage anyways.
+    auto x_w = x.floor();
+    auto y_n = y.floor();
+    auto x_e = x_w + ones;
+    auto y_s = y_n + ones;
+
+    // get surfaces to each neighbor:
+    auto nw = (x_e - x)   * (y_s - y);
+    auto ne = (x   - x_w) * (y_s - y);
+    auto sw = (x_e - x)   * (y   - y_n);
+    auto se = (x   - x_w) * (y   - y_n);
+
+    auto i_x_w = convert_to_int_of_same_size(x_w);
+    auto i_y_n = convert_to_int_of_same_size(y_n);
+    // int addition is faster than float -> int conversion
+    auto i_x_e = i_x_w + i_ones;
+    auto i_y_s = i_y_n + i_ones;
+
+    // Use int comparison because it is much faster than float comp with AVX2
+    // (latency 1 cyc vs. 4 cyc on skylake)
+    // Avoid using the le and ge because those are not implemented in AVX2 and
+    // are actually simulated using multiple instructions.
+    auto w_mask = must_in_bound ? i_neg1s  // true = all ones
+                                : i_x_w.gt(i_neg1s) & i_x_w.lt(i_W);
+    auto n_mask = must_in_bound ? i_neg1s  // true = all ones
+                                : i_y_n.gt(i_neg1s) & i_y_n.lt(i_H);
+    auto e_mask = must_in_bound ? i_x_e.lt(i_W)
+                                : i_x_e.gt(i_neg1s) & i_x_e.lt(i_W);
+    auto s_mask = must_in_bound ? i_y_s.lt(i_H)
+                                : i_y_s.gt(i_neg1s) & i_y_s.lt(i_H);
+    auto nw_mask = cast<scalar_t>(must_in_bound ? i_neg1s : (w_mask & n_mask));
+    auto sw_mask = cast<scalar_t>(w_mask & s_mask);
+    auto ne_mask = cast<scalar_t>(e_mask & n_mask);
+    auto se_mask = cast<scalar_t>(e_mask & s_mask);
+
+    auto i_nw_offset = i_y_n * i_inp_sH + i_x_w * i_inp_sW;
+    auto i_ne_offset = i_nw_offset + i_inp_sW;
+    auto i_sw_offset = i_nw_offset + i_inp_sH;
+    auto i_se_offset = i_sw_offset + i_inp_sW;
+
+    #pragma unroll
+    for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
+      // mask_gather zeros out the mask, so we need to make copies
+      Vec nw_mask_copy = nw_mask;
+      Vec ne_mask_copy = ne_mask;
+      Vec sw_mask_copy = sw_mask;
+      Vec se_mask_copy = se_mask;
+      auto nw_inp_val = mask_gather<sizeof(scalar_t)>(zeros, inp_slice_ptr, i_nw_offset, nw_mask_copy);
+      auto ne_inp_val = mask_gather<sizeof(scalar_t)>(zeros, inp_slice_ptr, i_ne_offset, ne_mask_copy);
+      auto sw_inp_val = mask_gather<sizeof(scalar_t)>(zeros, inp_slice_ptr, i_sw_offset, sw_mask_copy);
+      auto se_inp_val = mask_gather<sizeof(scalar_t)>(zeros, inp_slice_ptr, i_se_offset, se_mask_copy);
+      auto interpolated = (nw_inp_val * nw) + (ne_inp_val * ne) +
+                          (sw_inp_val * sw) + (se_inp_val * se);
+      interpolated.store(static_cast<void*>(out_ptr), len);
+    }
+  }
+};
+
+template<typename scalar_t>
+struct ApplyInterpolation<scalar_t, 2, GridSamplerInterpolation::Nearest> {
+  using Vec = Vec256<scalar_t>;
+  using iVec = Vec256<int_same_size_t<scalar_t>>;
+
+  const iVec i_H;
+  const iVec i_W;
+  const iVec i_inp_sH;
+  const iVec i_inp_sW;
+  const iVec i_neg1s = iVec(-1);
+  const iVec i_ones = iVec(-1);
+  const Vec ones = Vec(1);
+  const Vec zeros = Vec(0);
+  int64_t C;
+  int64_t inp_sC;
+
+  ApplyInterpolation(const TensorAccessor<scalar_t, 4>& input)
+    : i_H(iVec(input.size(2))), i_W(iVec(input.size(3)))
+    , i_inp_sH(input.stride(2)), i_inp_sW(input.stride(3))
+    , C(input.size(1)), inp_sC(input.stride(1)) {}
+
+  inline void apply(scalar_t *out_ptr, const scalar_t *inp_slice_ptr,
+                    int64_t out_sC, const Vec& x, const Vec& y,
+                    bool must_in_bound, int64_t len) const {
+    auto x_nearest = x.round();
+    auto y_nearest = y.round();
+
+    auto i_x_nearest = convert_to_int_of_same_size(x_nearest);
+    auto i_y_nearest = convert_to_int_of_same_size(y_nearest);
+
+    auto i_mask = must_in_bound ? i_neg1s
+                                : (i_x_nearest.gt(i_neg1s) & i_x_nearest.lt(i_W) &
+                                   i_y_nearest.gt(i_neg1s) & i_y_nearest.lt(i_H));
+    auto mask = cast<scalar_t>(i_mask);
+
+    auto i_offset = i_y_nearest * i_inp_sH + i_x_nearest * i_inp_sW;
+
+    #pragma unroll
+    for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
+      // mask_gather zeros out the mask, so we need to make a copy
+      auto mask_copy = mask;
+      auto inp_val = mask_gather<sizeof(scalar_t)>(zeros, inp_slice_ptr, i_offset, mask_copy);
+      inp_val.store(static_cast<void*>(out_ptr), len);
+    }
+  }
+};
+
+template<typename scalar_t,
+         GridSamplerInterpolation interp_mode,
+         GridSamplerPadding padding_mode>
+struct ApplyForward2d {
+  ApplyPadding<scalar_t, padding_mode> &padH;
+  ApplyPadding<scalar_t, padding_mode> &padW;
+  ApplyInterpolation<scalar_t, 2, interp_mode> &interp;
+
+  const int64_t out_sC;
+  const scalar_t *inp_slice_ptr;
+  scalar_t *out_slice_ptr;
+
+  ApplyForward2d(ApplyPadding<scalar_t, padding_mode> &padH,
+                 ApplyPadding<scalar_t, padding_mode> &padW,
+                 ApplyInterpolation<scalar_t, 2, interp_mode> &interp,
+                 const TensorAccessor<scalar_t, 3> inp_slice,
+                 TensorAccessor<scalar_t, 3> out_slice)
+    : padH(padH)
+    , padW(padW)
+    , interp(interp)
+    , out_sC(out_slice.stride(0))
+    , inp_slice_ptr(inp_slice.data())
+    , out_slice_ptr(out_slice.data()) {}
+
+  inline void operator()(const Vec256<scalar_t>& grid_ix,
+                         const Vec256<scalar_t>& grid_iy,
+                         int64_t spatial_offset, int64_t len) {
+    auto fix = padW.apply(grid_ix);
+    auto fiy = padH.apply(grid_iy);
+    auto always_in_bound = padding_mode != GridSamplerPadding::Zeros;
+    interp.apply(out_slice_ptr + spatial_offset,
+                inp_slice_ptr, out_sC, fix, fiy, always_in_bound, len);
+  }
+};
+
+template<typename scalar_t, typename GetApply2d>
+static inline void grid_sample_2d_grid_iterator (
+    const TensorAccessor<scalar_t, 4>& grid, const GetApply2d &get_apply_fn) {
+  int64_t N = grid.size(0);
+  int64_t out_H = grid.size(1);
+  int64_t out_W = grid.size(2);
+  int64_t grid_sN = grid.stride(0);
+  int64_t grid_sH = grid.stride(1);
+  int64_t grid_sW = grid.stride(2);
+  int64_t grid_sCoor = grid.stride(3);
+  auto grid_ptr = grid.data();
+
+  using Vec = Vec256<scalar_t>;
+  using iVec = Vec256<int_same_size_t<scalar_t>>;
+  const int64_t step = Vec::size;
+
+  // loop over each output pixel
+  #ifdef _OPENMP
+  #pragma parallel for if (N > 1)
+  #endif
+  for (int64_t n = 0; n < N; ++n) {
+    const scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
+
+    auto apply_fn = get_apply_fn(n);
+
+    // For the three tensors we work with, input, grid, output, we know output
+    // is contiguous, and we need to do random read for input anyways. So we
+    // base our iterating strategy on the geometry of grid. We consider the
+    // following three cases (after slicing out the batch dimension).
+    // See detailed discussions under each if-case.
+
+    if (at::geometry_is_contiguous({out_H, out_W, 2}, {grid_sH, grid_sW, grid_sCoor})) {
+      // Case 1:
+      // Grid is contiguous.
+      // Strategy: Sequentially load two vectors at the same time, and get,
+      //           e.g.,  {x0, y0, x1, y1}, {x2, y2, x3, y3}. Then we use
+      //           at::vec256::deinterleave2 to get x and y vectors.
+      auto total_size = out_H * out_W;
+      for (int64_t offset = 0; offset < total_size; offset += step) {
+        auto grid_offset = offset * 2;
+        auto len = std::min(step, total_size - offset);
+        auto vec1 = Vec::loadu(grid_ptr_N + grid_offset,
+                               std::min(step, len * 2));
+        auto vec2 = Vec::loadu(grid_ptr_N + grid_offset + step,
+                               std::max(static_cast<int64_t>(0), len * 2 - step));
+        auto vec_xy_pair = deinterleave2(vec1, vec2);
+        apply_fn(std::get<0>(vec_xy_pair), std::get<1>(vec_xy_pair),
+                 offset, len);
+      }
+    } else if (grid_sW == 1 || out_W == 1) {
+      // Case 2:
+      // The W dimension is contiguous.
+      // This can be common, e.g., grid is from a conv net output of shape
+      // [N, 2, H, W].
+      // Strategy: Divide into two contiguous slices each of shape [H, W], and
+      //           each containing x and y vectors. So we sequentially load a
+      //           vector from each of them to get x and y vector
+
+      // Function to apply along a contiguous W dimension (or flattened H x W).
+      auto line_fn = [&](const scalar_t *grid_ptr_x, const scalar_t *grid_ptr_y,
+                         int64_t out_base_offset, int64_t total_size) {
+        for (int64_t i = 0; i < total_size; i += step) {
+          auto len = std::min(step, total_size - i);
+          apply_fn(Vec::loadu(grid_ptr_x + i, len),
+                   Vec::loadu(grid_ptr_y + i, len),
+                   out_base_offset + i, len);
+        }
+      };
+
+      if (at::geometry_is_contiguous({out_H, out_W}, {grid_sH, grid_sW})) {
+        // If [H, W] is contiguous, apply line_fn once.
+        line_fn(grid_ptr_N, grid_ptr_N + grid_sCoor, 0, out_H * out_W);
+      } else {
+        // If only [W] is contiguous, apply line_fn once for each h slice.
+        auto grid_ptr_NH = grid_ptr_N;
+        for (int64_t h = 0; h < out_H; h++) {
+          line_fn(grid_ptr_NH, grid_ptr_NH + grid_sCoor, h * grid_sH, out_W);
+          grid_ptr_NH += grid_sH;
+        }
+      }
+    } else {
+      // Case 3:
+      // General case.
+      // Strategy: Do a for-loop over H, for each W slice, use
+      //           at::vec256::gather to load the x and y vectors.
+      auto i_zeros = iVec(0);
+      auto spatial_offset = 0;
+      auto i_offsets_delta = iVec(grid_sW * step);
+
+      #pragma unroll
+      for (int64_t h = 0; h < out_H; h++) {
+        auto grid_ptr_x = grid_ptr_N + h * grid_sH;
+        auto grid_ptr_y = grid_ptr_x + grid_sCoor;
+        auto i_offsets = iVec::arange(0, grid_sW);
+        #pragma unroll
+        for (int64_t w = 0; w < out_W; w += step) {
+          auto len = std::min(step, out_W - w);
+          if (len < step) {
+            // prevents illegal memory access, sets the exceeding offsets to zero
+            i_offsets = iVec::set(i_zeros, i_offsets, len);
+          }
+
+          apply_fn(gather<sizeof(scalar_t)>(grid_ptr_x, i_offsets),
+                   gather<sizeof(scalar_t)>(grid_ptr_y, i_offsets),
+                   spatial_offset, len);
+
+          i_offsets = i_offsets + i_offsets_delta;
+          spatial_offset += len;
+        }
+      }
+    }
+  }
+}
+
+template<typename scalar_t,
+         GridSamplerInterpolation interp_mode,
+         GridSamplerPadding padding_mode>
+static inline
+void grid_sample_2d_vec_kernel(Tensor& output, const Tensor& input, const Tensor& grid) {
+
+  auto inp_acc = input.accessor<scalar_t, 4>();
+  auto grid_acc = grid.accessor<scalar_t, 4>();
+  auto out_acc = output.accessor<scalar_t, 4>();
+
+  ApplyPadding<scalar_t, padding_mode> padH(inp_acc.size(2));
+  ApplyPadding<scalar_t, padding_mode> padW(inp_acc.size(3));
+  ApplyInterpolation<scalar_t, 2, interp_mode> interp(inp_acc);
+
+  grid_sample_2d_grid_iterator(
+    grid_acc,
+    [&](int64_t n) {
+      return ApplyForward2d<scalar_t, interp_mode, padding_mode>(
+          padH, padW, interp, inp_acc[n], out_acc[n]);
+    });
+}
+
+Tensor grid_sampler_2d_cpu_kernel_impl(const Tensor& input, const Tensor& grid,
+               int64_t interpolation_mode, int64_t padding_mode) {
+  auto output = at::empty({input.size(0), input.size(1), grid.size(1), grid.size(2)}, input.options());
+
+#define HANDLE_CASE(interp, padding)                                            \
+  case padding: {                                                               \
+    grid_sample_2d_vec_kernel<scalar_t, interp, padding>(output, input, grid);  \
+    return;                                                                     \
+  }
+
+#define HANDLE_INTERP(interp)                                          \
+  case interp: {                                                       \
+    switch (static_cast<GridSamplerPadding>(padding_mode)) {           \
+      HANDLE_CASE(interp, GridSamplerPadding::Zeros);                  \
+      HANDLE_CASE(interp, GridSamplerPadding::Border);                 \
+      HANDLE_CASE(interp, GridSamplerPadding::Reflection);             \
+    }                                                                  \
+  }
+
+  AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
+    switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
+      HANDLE_INTERP(GridSamplerInterpolation::Bilinear);
+      HANDLE_INTERP(GridSamplerInterpolation::Nearest);
+    }
+  });
+#undef HANDLE_CASE
+#undef HANDLE_INTERP
+
+  return output;
+}
+
+}
+
+REGISTER_DISPATCH(grid_sampler_2d_cpu_kernel, &grid_sampler_2d_cpu_kernel_impl);
+
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -86,7 +86,7 @@ namespace at { namespace native { namespace {
  *                      const TensorAccessor<scalar_t, 3>& inp_slice,
  *                      int64_t offset, const Vec& grid_x, const Vec& grid_y,
  *                      int64_t len) const;
- *      }
+ *      };
  *
  *   3. `grid_sample_2d_grid_slice_iterator` function
  *      Among the tensors we work with, we know that the output tensors are

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.h
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "ATen/ATen.h"
+#include "ATen/Dispatch.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/native/DispatchStub.h"
+#include "ATen/cpu/vml.h"
+
+namespace at { namespace native {
+
+DECLARE_DISPATCH(Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t), grid_sampler_2d_cpu_kernel);
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.h
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.h
@@ -6,8 +6,11 @@
 #include "ATen/native/DispatchStub.h"
 #include "ATen/cpu/vml.h"
 
+#include <tuple>
+
 namespace at { namespace native {
 
 DECLARE_DISPATCH(Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t), grid_sampler_2d_cpu_kernel);
+DECLARE_DISPATCH((std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t)), grid_sampler_2d_backward_cpu_kernel);
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.h
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.h
@@ -10,9 +10,9 @@
 
 namespace at { namespace native {
 
-using forward_fn = Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t);
-using backward_fn = std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t);
-DECLARE_DISPATCH(forward_fn, grid_sampler_2d_cpu_kernel);
-DECLARE_DISPATCH(backward_fn, grid_sampler_2d_backward_cpu_kernel);
+using forward_2d_fn = Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t);
+using backward_2d_fn = std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t);
+DECLARE_DISPATCH(forward_2d_fn, grid_sampler_2d_cpu_kernel);
+DECLARE_DISPATCH(backward_2d_fn, grid_sampler_2d_backward_cpu_kernel);
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.h
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.h
@@ -10,7 +10,9 @@
 
 namespace at { namespace native {
 
-DECLARE_DISPATCH(Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t), grid_sampler_2d_cpu_kernel);
-DECLARE_DISPATCH((std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t)), grid_sampler_2d_backward_cpu_kernel);
+using forward_fn = Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t);
+using backward_fn = std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t);
+DECLARE_DISPATCH(forward_fn, grid_sampler_2d_cpu_kernel);
+DECLARE_DISPATCH(backward_fn, grid_sampler_2d_backward_cpu_kernel);
 
 }}  // namespace at::native

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5097,34 +5097,55 @@ class TestNN(NNTestCase):
     def test_grid_sample(self):
         def test(N, C, H, W, mode, padding_mode):
             def test_shape(N, C, IH, IW, H, W, mode, padding_mode):
-                input_cpu = torch.randn(C, N, IH, IW).transpose(0, 1).requires_grad_()
-                grid_cpu = torch.randn(H, N, W, 2).transpose(0, 1).requires_grad_()
-                out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
-                self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
+                for grid_dim_contig_order in [(0, 1, 2, 3), (0, 3, 1, 2), (3, 0, 1, 2), (0, 2, 1, 3)]:
+                    # grid_dim_contig_order specifies the dimension order that can
+                    # make grid to be contiguous.
+                    # i.e., grid.permute(grid_dim_contig_order) is contiguous.
+                    # e.g., with grid_dim_contig_order=[0, 3, 1, 2], grid should be
+                    #       initialized with contiguous tensor of shape [N, 2, H, W]
+                    #       and permuted to [N, H, W, 2] afterwards.
+                    grid_shape = [N, H, W, 2]
+                    grid_init_shape = [grid_shape[d] for d in grid_dim_contig_order]
+                    grid_fwd_permute = [None, None, None, None]
+                    for i, d in enumerate(grid_dim_contig_order):
+                        grid_fwd_permute[d] = i
 
-                gradients = torch.randn_like(out_cpu)
-                out_cpu.backward(gradients)
+                    def get_grid(device='cpu', data=None):
+                        if data is not None:
+                            assert list(data.shape) == grid_shape
+                            data = data.permute(grid_dim_contig_order).to(device)
+                        else:
+                            data = torch.randn(grid_init_shape, device=device)
+                        grid = data.permute(grid_fwd_permute)
+                        assert grid.permute(grid_dim_contig_order).is_contiguous()
+                        return grid
 
-                if TEST_CUDA:
-                    input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                    grid_cuda = grid_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
-                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                    self.assertEqual(out_cpu, out_cuda)
-
-                    out_cuda.backward(gradients.cuda())
-                    self.assertEqual(input_cpu.grad, input_cuda.grad)
-                    self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
-
-                    # check that zero-dimensional input strides don't error out
-                    base_input = torch.randn(N, C, 1, IW)
-                    input_cpu = base_input.expand_as(input_cuda).requires_grad_()
-                    grid_cpu = torch.randn(N, H, W, 2, requires_grad=True)
+                    input_cpu = torch.randn(C, N, IH, IW).transpose(0, 1).requires_grad_()
+                    grid_cpu = get_grid().requires_grad_()
                     out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+                    self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
 
-                    input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
-                    grid_cuda = grid_cpu.detach().cuda().requires_grad_()
-                    out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
-                    self.assertEqual(out_cpu, out_cuda)
+                    gradients = torch.randn_like(out_cpu)
+                    out_cpu.backward(gradients)
+
+                    if TEST_CUDA:
+                        input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                        grid_cuda = get_grid('cuda', grid_cpu.detach()).requires_grad_()
+                        out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                        self.assertEqual(out_cpu, out_cuda)
+
+                        out_cuda.backward(gradients.cuda())
+                        self.assertEqual(input_cpu.grad, input_cuda.grad)
+                        self.assertEqual(grid_cpu.grad, grid_cuda.grad, prec=5e-5)
+
+                        # check that zero-dimensional input strides don't error out
+                        base_input = torch.randn(N, C, 1, IW)
+                        input_cpu = base_input.expand_as(input_cuda).requires_grad_()
+                        out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode)
+
+                        input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
+                        out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode)
+                        self.assertEqual(out_cpu, out_cuda)
 
             # test same size output
             test_shape(N, C, H, W, H, W, mode, padding_mode)
@@ -5182,15 +5203,11 @@ class TestNN(NNTestCase):
 
         for mode in ('bilinear', 'nearest'):
             for padding_mode in ('zeros', 'border', 'reflection'):
-
                 # test known input on CPU
                 input = torch.arange(1., 11).view(1, 1, 2, 5)
                 grid = torch.tensor(
-                    [[-0.9, -4.1, 0, 0.2, 1],
-                     [-1, -0.333, 0, 0.5, 1],
-                     [-1, -0.5, 0, 0.3333, 1],
-                     [-1, -0.2, 0, 1.5, 0.5]]).view(1, 2, 5, 2)
-                output = F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode)
+                    [[[-0.9, -4.1], [0, 0.2000], [1, -1], [-0.333, 1e-10], [0.5, 1.0]],
+                     [[-1.0, -0.5], [0, 0.3333], [1, -1], [-0.200, 1e-10], [1.5, 0.5]]]).view(1, 2, 5, 2)
                 if mode == 'bilinear':
                     if padding_mode == 'zeros':
                         groundtruth = torch.tensor(
@@ -5223,7 +5240,10 @@ class TestNN(NNTestCase):
                         assert False, "missing groundtruth test for padding mode '{}'".format(padding_mode)
                 else:
                     assert False, "missing groundtruth test for interpolation mode '{}'".format(mode)
-                self.assertEqual(output, groundtruth)
+                output = F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode)
+                self.assertEqual(output, groundtruth,
+                                 "groundtruth comparison failed for mode={}, "
+                                 "padding_mode={}".format(mode, padding_mode))
 
                 # do gradcheck
                 N = random.randint(2, 8)


### PR DESCRIPTION
This PR vectorizes the CPU grid sample 2d forward and backward kernels. Specifically, 



 1. add `.data()` in `TensorAccessor`
 2. support non-void return value for declaring CPU kernel stub
 2. add `bool at:: geometry_is_contiguous(IntList sizes, IntList strides)`
1. The following vectorized CPU primitives are added: 

    + `gather<scale>(baseaddr, vindex)`: `result[i] = baseaddr[vindex[i] * scale]`
    + `mask_gather<scale>(src, baseaddr, vindex, mask)`: `result[i] = mask[i] ? baseaddr[vindex[i] * scale] : src[i]`. 
    + comparison ops
    + binary logical ops
    + `min(a, b)`
    + `cast<dst_t, src_t>(src_vec)`: changing dtype but keeping the bit representation
    + `blendv(a, b, mask)`: `result[i] = mask[i] ? b[i] : a[i]`.
    + ctor with multiple values (i.e., `setr`)
    + `arange(start = 0, step = 1)`: constructs a vector with values specified by the arange parameters
    + `convert_to_int_of_same_size(vec)`: convert floating point vector to corresponding integral type of same size
    + `interleave2(a, b)` & `deinterleave2(x, y)`: interleave or deinterleaves two vectors. E.g., for `interleave`:
        ```
        inputs:
          {a0, a1, a2, a3, a4, a5, a6, a7}
          {b0, b1, b2, b3, b4, b5, b6, b7}
        outputs:
          {a0, b0, a1, b1, a2, b2, a3, b3}
          {a4, b4, a5, b5, a6, b6, a7, b7}
        ```

  2. Grid sample CPU kernel implementations are described in the following note (also in `GridSampleKernel.cpp`:

  ```
   NOTE [ Grid Sample CPU Kernels ]
  
   Implementation of vectorized grid sample CPU kernels is divided into three
   parts:
  
   1. `ComputeLocation` struct
      Transforms grid values into interpolation locations of the input tensor
      for a particular spatial dimension, basing on the size of that dimension
      in input tensor, and the padding mode.
```
```cpp
      template<typename scalar_t, GridSamplerPadding padding>
      struct ComputeLocation {
        using Vec = Vec256<scalar_t>;
  
        // ctor
        ComputeLocation(int64_t size);
  
        // Given grid values `in`, return the interpolation locations after
        // un-normalization and padding mechanism (elementwise).
        Vec apply(const Vec &in) const;
  
        // Similar to `apply`, but also returns `d apply(in) / d in`
        // (elementwise).
        // this is often used in gradient computation.
        std::pair<Vec, Vec> apply_get_grad(const Vec &in) const;
      };
```
```
   2. `ApplyGridSample` struct
      Owns N `ComputeLocation` structs, where N is the number of spatial
      dimensions. Given N input grid vectors (one for each spatial dimension)
      and spatial offset, it gets the interpolation locations from
      `ComputeLocation`s, applies interpolation procedure, and then writes to
      the output (or grad_input & grad_grid in backward).
```
```cpp
      template<typename scalar_t, int spatial_dim,
               GridSamplerInterpolation interp,
               GridSamplerPadding padding>
      struct ApplyGridSample {
  
        // ctor
        ApplyGridSample(const TensorAccessor<scalar_t, 4>& input);
  
        // Applies grid sampling (forward) procedure:
        //   1. computes interpolation locations from grid values `grid_x` and
        //      `grid_y`,
        //   2. interpolates output values using the locations and input data
        //      in `inp_slice`, and
        //   3. writes the first `len` values in the interpolated vector to
        //      `out_slice` with spatial offset being `offset`.
        //
        // This assimes that `grid_x` and `grid_y` all contain valid grid
        // values \in [-1, 1], even at indices greater than `len`.
        //
        // The `*_slice` argument namess mean samples within a batch (i.e.,
        // with the batch dimension sliced out).
        void forward(TensorAccessor<scalar_t, 3>& out_slice,
                     const TensorAccessor<scalar_t, 3>& inp_slice,
                     int64_t offset, const Vec& grid_x, const Vec& grid_y,
                     int64_t len) const;
  
        // Applies grid sampling (backward) procedure. Arguments semantics
        // and strategy are similar to those of `forward`.
        void backward(TensorAccessor<scalar_t, 3>& gInp_slice,
                      TensorAccessor<scalar_t, 3>& gGrid_slice,
                      const TensorAccessor<scalar_t, 3>& gOut_slice,
                      const TensorAccessor<scalar_t, 3>& inp_slice,
                      int64_t offset, const Vec& grid_x, const Vec& grid_y,
                      int64_t len) const;
      }
```
```
   3. `grid_sample_2d_grid_slice_iterator` function
      Among the tensors we work with, we know that the output tensors are
      contiguous (i.e., `output` in forward, and `grad_input` & `grad_grid` in
      backward), we need to randomly read `input` anyways, and `grad_output`
      usually comes from autograd and is often contiguous. So we base our
      iterating strategy on the geometry of grid.
      `grid_sample_2d_grid_slice_iterator` function provides an abstract to
      efficiently iterates through a `grid` slice (without batch dimension).
      See comments of that function on the specific cases and strategies used.
```
```cpp
      template<typename scalar_t, typename ApplyFn>
      void grid_sample_2d_grid_slice_iterator(
        const TensorAccessor<scalar_t, 3>& grid_slice,
        const ApplyFn &apply_fn);

      // `apply_fn` is a function/lambda that can be called as if it has
      // declaration:
      //   void apply_fn(const Vec256<scalar_t>& grid_x,
      //                 const Vec256<scalar_t>& grid_y,
      //                 int64_t spatial_offset, int64_t len);
```
```
      `apply_fn` will be called multiple times, and together cover the entire
      output spatial space. Therefore, e.g., to implement forward 2d grid
      sample, we can do
```
```cpp
      ApplyGridSample<scalar_t, 2, interp, padding> grid_sample(input_accessor);
  
      for (int n = 0; n < input_accessor.size(0); n++) {
        grid_sample_2d_grid_slice_iterator(
          grid_accessor[n],
          [&](const Vec256<scalar_t>& grid_x, const Vec256<scalar_t>& grid_y,
              int64_t spatial_offset, int64_t len) {
            grid_sample.forward(out_accessor[n], input_accessor[n],
                                spatial_offset, grid_x, grid_y, len);
          });
      }
   ```