### PR TITLE
[build] Disable smart_tensor_printer_test without glog

### DIFF
--- a/caffe2/utils/smart_tensor_printer_test.cc
+++ b/caffe2/utils/smart_tensor_printer_test.cc
@@ -39,6 +39,9 @@ void printTensorAndCheck(const std::vector<T>& values) {
   expect_stderr_contains(values);
 }
 
+// We need real glog for this test to pass
+#ifdef CAFFE2_USE_GOOGLE_GLOG
+
 #if !(__APPLE__) // TODO(janusz): thread_local does not work under mac.
 
 TEST(SmartTensorPrinterTest, SimpleTest) {
@@ -47,5 +50,7 @@ TEST(SmartTensorPrinterTest, SimpleTest) {
 }
 
 #endif // !(__APPLE__)
+
+#endif // CAFFE2_USE_GOOGLE_GLOG
 
 } // namespace caffe2


### PR DESCRIPTION
Breaking out of https://github.com/pytorch/pytorch/pull/8338

This test fails once we start building with `-DUSE_GLOG=OFF` since the non-glog logging case doesn't support flushing or streaming to the right location. For now, we just disable this test in that case.

cc @Yangqing @mingzhe09088 