### PR TITLE
Ignore FuseGraph Call on Windows

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1422,7 +1422,10 @@ class TestJit(JitTestCase):
 
         a, b, c = [torch.tensor(e) for e in (1, [[2.]], [[3.]])]
         addmm(a, b, c)
-        self.assertExpectedGraph(addmm.graph_for(a, b, c))
+        graph = addmm.graph_for(a, b, c)
+        # graph fusion skipped in windows, which runs cse
+        self.run_pass('cse', graph)
+        self.assertExpectedGraph(graph)
 
     def test_index_put(self):
         ten = torch.zeros(3, 3)

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -882,9 +882,14 @@ struct GraphFuser {
 } // anonymous namespace
 
 void FuseGraph(std::shared_ptr<Graph>& graph) {
+  // NYI on Windows
+  #ifndef _WIN32
+
   GraphFuser(graph->block()).run();
   // After FuseGraph some common subexpressions may come back
   EliminateCommonSubexpression(graph);
+
+  #endif
 }
 
 }}

--- a/torch/csrc/jit/passes/graph_fuser.h
+++ b/torch/csrc/jit/passes/graph_fuser.h
@@ -6,6 +6,7 @@ namespace torch { namespace jit {
 
 // NB: Be sure to run DCE before fusion, because dead instructions
 // can prevent fusion opportunities from being exploited.
+// On Windows will noop, NYI
 TORCH_API void FuseGraph(std::shared_ptr<Graph>& graph);
 
 }}


### PR DESCRIPTION
Fusion is NYI implemented on Windows, so ignore FuseGraph call instead of failing.