### PR TITLE
keep net type info when generating model complete net

### DIFF
--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -465,6 +465,8 @@ class ModelHelper(object):
         for op in new_net.Proto().op:
             op.debug_info = op.debug_info + "/param_init_net"
         new_net.AppendNet(self.net)
+        # keep the execution optimization
+        new_net.Proto().type = self.net.Proto().type
         return new_net
 
     def ConstructInitTrainNetfromNet(self, net):

--- a/caffe2/python/model_helper_test.py
+++ b/caffe2/python/model_helper_test.py
@@ -8,6 +8,26 @@ from caffe2.python import brew, model_helper
 
 
 class ModelHelperTest(unittest.TestCase):
+    def test_get_complete_net_type(self):
+        model = model_helper.ModelHelper("test_orig")
+        brew.conv(
+            model,
+            "input",
+            "conv",
+            dim_in=3,
+            dim_out=16,
+            weight_init=("MSRAFill", {}),
+            kernel=3,
+            stride=1,
+            pad=0,
+        )
+        model.net.Proto().type = "async_scheduling"
+        net = model.GetCompleteNet()
+        model2 = model_helper.ModelHelper("test_new")
+        model2.ConstructInitTrainNetfromNet(net)
+        self.assertTrue(model2.net.Proto().type, "async_scheduling")
+        self.assertTrue(model2.param_init_net.Proto().type, "async_scheduling")
+
     def test_get_complete_net(self):
         model = model_helper.ModelHelper("test_orig")
         conv = brew.conv(


### PR DESCRIPTION
Summary: keep net type info when generating model complete net. This will keep the performance optimization option

Differential Revision: D9564125
