### PR TITLE
Kill the dummy TaskOutput when task.get_step() (#10739)

### DIFF
--- a/caffe2/python/checkpoint_test.py
+++ b/caffe2/python/checkpoint_test.py
@@ -161,9 +161,9 @@ class TestCheckpoint(TestCase):
                     num_epochs = job_runner.train(session)
                 self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
 
-                # There are 17 global blobs after finishing up the job runner.
+                # There are 15 global blobs after finishing up the job runner.
                 # (only blobs on init_group are checkpointed)
-                self.assertEquals(len(ws.blobs), 17)
+                self.assertEquals(len(ws.blobs), 15)
 
             ws = workspace.C.Workspace()
             session = LocalSession(ws)

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -533,8 +533,8 @@ class TestCreatePlan(test_util.TestCase):
 
         self.assertEqual(len(plan.Steps()), 1)
         self.assertEqual(len(test_plan.Steps()), 1)
-        self.assertEqual(len(plan.Proto().network), 9)
-        self.assertEqual(len(test_plan.Proto().network), 9)
+        self.assertEqual(len(plan.Proto().network), 8)
+        self.assertEqual(len(test_plan.Proto().network), 8)
         self.assertEqual(len(plan.Proto().execution_step), 1)
         self.assertEqual(len(test_plan.Proto().execution_step), 1)
         self.assertEqual(plan.Steps()[0].Name(), test_plan.Steps()[0].Name())

--- a/caffe2/python/task.py
+++ b/caffe2/python/task.py
@@ -150,7 +150,7 @@ def add_setup_steps(step, init_nets, exit_nets, name):
     if init_nets:
         steps.append(core.execution_step('%s:init' % name, init_nets))
     steps.append(step)
-    if len(exit_nets) > 0:
+    if exit_nets:
         steps.append(core.execution_step('%s:exit' % name, exit_nets))
     return core.execution_step(name, steps)
 
@@ -215,10 +215,11 @@ class TaskGroup(object):
         self._tasks.append(task)
 
     def tasks(self):
-        for task in self._tasks_to_add:
-            self.add(task)
-        self._tasks_to_add = []
-        self._already_used = True
+        if not self._already_used:
+            for task in self._tasks_to_add:
+                self.add(task)
+            self._tasks_to_add = []
+            self._already_used = True
         return self._tasks
 
     def num_registered_tasks(self):
@@ -259,9 +260,8 @@ class TaskGroup(object):
         # tasks_by_node can't be called twice because the setup won't
         # work properly a second time.
         node_map = {}
-        for task in self.tasks():
-            node_map[task.node] =\
-                node_remap(task.node) if node_remap else task.node
+        for node in self.used_nodes():
+            node_map[node] = node_remap(node) if node_remap else node
         if self._tasks_by_node is not None:
             tasks_by_node, prev_node_map = self._tasks_by_node
             assert prev_node_map == node_map, (
@@ -285,11 +285,7 @@ class TaskGroup(object):
         grouped_by_node = TaskGroup()
         for node, tasks in viewitems(tasks_by_node):
             report_steps = report_steps_by_node[node]
-            node_inits, node_exits = get_setup_nets(
-                TaskGroup.LOCAL_SETUP,
-                [t.get_step() for t in tasks] + report_steps,
-                self)
-            # shortcut for single task with no queue
+
             steps = report_steps
             outputs = []
             grouped_workspace_type = WorkspaceType.PRIVATE
@@ -311,16 +307,15 @@ class TaskGroup(object):
             else:
                 step = core.execution_step(
                     '%s:body' % node, steps, concurrent_substeps=True)
-            if len(node_inits) > 0 or len(node_exits) > 0:
-                steps = []
-                if len(node_inits) > 0:
-                    steps.append(
-                        core.execution_step('%s:init' % node, node_inits))
-                steps.append(step)
-                if len(node_exits) > 0:
-                    steps.append(
-                        core.execution_step('%s:exit' % node, node_exits))
-                step = core.execution_step(node, steps)
+
+            # Prepend and append setup nets.
+            node_inits, node_exits = get_setup_nets(
+                TaskGroup.LOCAL_SETUP,
+                [t.get_step() for t in tasks] + report_steps,
+                self,
+            )
+            step = add_setup_steps(step, node_inits, node_exits, node)
+
             Task(
                 node=node, step=step, outputs=outputs,
                 name='grouped_by_node',
@@ -582,11 +577,6 @@ class Task(object):
             Task.TASK_SETUP, [self._step] + report_steps, self)
         instance_init_nets, instance_exit_nets = get_setup_nets(
             Task.TASK_INSTANCE_SETUP, [self._step] + report_steps, self)
-        if len(self._outputs) == 0:
-            output_net = core.Net('%s:output' % self.name)
-            self.add_output(output_net.ConstantFill(
-                [], 1, dtype=core.DataType.INT32, value=0))
-            task_exit_nets.append(output_net)
 
         # Add instance-level report steps
         body = self._step if not report_steps else core.execution_step(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/10739

I wanted to assert that the blobs in the workspace of the new session after loading checkpoint are exactly the same as the blobs in the workspace of the old session before saving to a checkpoint.

But I found that when calling `task.get_step()`, a dummy task output blob, `task:output/ConstIntFill:0`, is added. Also a dummy net `task:output` was also added along with it. See https://fburl.com/937lf2yk

This makes it hard to assert "Equal", forcing me to assert "LessThan" or "GreaterThan".

This adding a dummy TaskOutput when user specifies no TaskOutput is a hack.
The reason for this is that ZMQ socket can't send empty blob list.
As a result, if the Task on the Worker had no output,
The master would never stop waiting and hang forever. See https://fburl.com/rd7fhy6p and imagine `socket.recv(net, 0)`.

TaskOuput is at user layer. The hack shouldn't be exposed to user layer, polluting user workspaces.

Instead, we should move the creating of the dummy blob to some deeper layer,
and remove the dummy blob in the workspace afterwards to avoid polluting user workspaces.
After this change, the workaround becomes totally transparent and no side-effect to users.

Differential Revision: D9566744
