### PR TITLE
Optimize WeightedSumOp for two inputs

### DIFF
--- a/caffe2/operators/accumulate_op.h
+++ b/caffe2/operators/accumulate_op.h
@@ -25,7 +25,7 @@ class AccumulateOp final : public Operator<Context> {
       math::Set<T, Context>(
           output->size(), 0, output->template mutable_data<T>(), &context_);
     }
-    math::Axpby<T, Context>(
+    math::Axpby<T, T, Context>(
         input.size(),
         static_cast<T>(1),
         input.template data<T>(),

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -321,45 +321,70 @@ class WeightedSumOp : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(WeightedSumOp);
 
-  template <typename DstType>
+  bool RunOnDevice() override;
+
+  template <typename T>
   bool DoRunWithType() {
-    CAFFE_ENFORCE_EQ(InputSize() % 2, 0);
-    auto& X0 = Input(0);
-    auto& weight0 = Input(1);
+    const int input_size = InputSize();
+    CAFFE_ENFORCE_EQ(input_size % 2, 0);
+    const auto& X0 = Input(0);
+    const auto& weight0 = Input(1);
     CAFFE_ENFORCE_GT(X0.size(), 0);
     CAFFE_ENFORCE_EQ(weight0.size(), 1);
-    int size = X0.size();
-    auto* output = Output(0);
-    output->ResizeLike(X0);
-    math::Scale<float, DstType, Context>(
+    const int size = X0.size();
+    auto* Y = Output(0);
+    if (Y != &X0) {
+      Y->ResizeLike(X0);
+    }
+    T* Y_data = Y->template mutable_data<T>();
+    if (input_size == 2) {
+      math::Scale<float, T>(
+          size,
+          weight0.template data<float>(),
+          X0.template data<T>(),
+          Y_data,
+          &context_);
+      return true;
+    }
+    const auto& X1 = Input(2);
+    CAFFE_ENFORCE_NE(
+        &X1,
+        Y,
+        "Input #2 is the same as output. If you want to do in-place updates, "
+        "put the output as input #0.");
+    const auto& weight1 = Input(3);
+    CAFFE_ENFORCE_EQ(X1.size(), size);
+    CAFFE_ENFORCE_EQ(weight1.size(), 1);
+    if (Y != &X0) {
+      context_.template CopySameDevice<T>(size, X0.template data<T>(), Y_data);
+    }
+    math::Axpby<float, T, Context>(
         size,
+        weight1.template data<float>(),
+        X1.template data<T>(),
         weight0.template data<float>(),
-        X0.template data<DstType>(),
-        output->template mutable_data<DstType>(),
+        Y_data,
         &context_);
-    for (int i = 2; i < InputSize(); i += 2) {
-      auto& X = Input(i);
+    for (int i = 4; i < input_size; i += 2) {
+      const auto& Xi = Input(i);
       // Do a check: if the input is the same as output, we have a problem -
       // in-place update should always only happen with the zeroth input.
-      if (&X == output) {
-        LOG(ERROR) << "Input #" << i << " is the same as output. "
-                   << "If you want to do in-place updates, put the output as "
-                   << "input #0.";
-        return false;
-      }
-      auto& weight = Input(i + 1);
-      CAFFE_ENFORCE_EQ(X.size(), size);
-      CAFFE_ENFORCE_EQ(weight.size(), 1);
-      math::Axpy<DstType, Context>(
+      const std::string err_msg = "Input #" + to_string(i) +
+          " is the same as output. If you want to do in-place updates, "
+          "put the output as input #0.";
+      CAFFE_ENFORCE_NE(&Xi, Y, err_msg);
+      const auto& weighti = Input(i + 1);
+      CAFFE_ENFORCE_EQ(Xi.size(), size);
+      CAFFE_ENFORCE_EQ(weighti.size(), 1);
+      math::Axpy<T, Context>(
           size,
-          weight.template data<float>(),
-          X.template data<DstType>(),
-          output->template mutable_data<DstType>(),
+          weighti.template data<float>(),
+          Xi.template data<T>(),
+          Y_data,
           &context_);
     }
     return true;
   }
-  bool RunOnDevice() override;
 };
 
 template <class Context>
@@ -369,7 +394,8 @@ class WeightedSumGradientOp : public Operator<Context> {
 
   WeightedSumGradientOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        grad_on_w_(this->template GetSingleArgument<bool>("grad_on_w", false)) {}
+        grad_on_w_(this->template GetSingleArgument<bool>("grad_on_w", false)) {
+  }
 
   template <typename DstType>
   bool DoRunWithType() {
@@ -680,7 +706,8 @@ class CopyOp : public Operator<Context> {
 
   bool RunOnDevice() override {
     auto& input = this->template Input<Tensor>(0, SrcContext::GetDeviceType());
-    auto* output = this->template Output<Tensor>(0, DstContext::GetDeviceType());
+    auto* output =
+        this->template Output<Tensor>(0, DstContext::GetDeviceType());
     output->ResizeLike(input);
     this->context_.template CopyItems<SrcContext, DstContext>(
         input.meta(),

--- a/caffe2/operators/utility_ops_cudnn.cc
+++ b/caffe2/operators/utility_ops_cudnn.cc
@@ -1,0 +1,168 @@
+#include "caffe2/operators/utility_ops.h"
+
+#include <type_traits>
+
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/core/cudnn_wrappers.h"
+#include "caffe2/utils/conversions.h"
+
+namespace caffe2 {
+
+class CuDNNWeightedSumOp : public Operator<CUDAContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CUDAContext);
+
+  CuDNNWeightedSumOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CUDAContext>(operator_def, ws), cudnn_wrapper_(&context_) {
+    CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
+    CUDNN_ENFORCE(cudnnCreateOpTensorDescriptor(&add_desc_));
+    // Both float and float16 require opTensorCompType to be CUDNN_DATA_FLOAT.
+    CUDNN_ENFORCE(cudnnSetOpTensorDescriptor(
+        add_desc_, CUDNN_OP_TENSOR_ADD, CUDNN_DATA_FLOAT, CUDNN_PROPAGATE_NAN));
+  }
+
+  ~CuDNNWeightedSumOp() {
+    CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(data_desc_));
+    CUDNN_ENFORCE(cudnnDestroyOpTensorDescriptor(add_desc_));
+  }
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, float16>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    if (std::is_same<T, float16>::value) {
+      LOG(WARNING)
+          << "CuDNN only support same type for data and weight, "
+             "so the weight will be cast to float16 when data type is float16.";
+    }
+    const int num_inputs = InputSize();
+    CAFFE_ENFORCE_EQ(num_inputs % 2, 0);
+    const auto& X0 = Input(0);
+    const auto& weight0 = Input(1);
+    CAFFE_ENFORCE_GT(X0.size(), 0);
+    CAFFE_ENFORCE_EQ(weight0.size(), 1);
+    const int input_size = X0.size();
+    SetTensorDescriptor(cudnnTypeWrapper<T>::type, input_size);
+    auto* Y = Output(0);
+    if (Y != &X0) {
+      Y->ResizeLike(X0);
+    }
+    T* Y_data = Y->template mutable_data<T>();
+    T alpha = convert::To<float, T>(0.0f);
+    T beta = convert::To<float, T>(0.0f);
+    if (num_inputs == 2) {
+      CopyWeightToHost<T>(weight0.template data<float>(), &alpha);
+      CUDNN_ENFORCE(cudnnAddTensor(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          &alpha,
+          data_desc_,
+          X0.template data<T>(),
+          cudnnTypeWrapper<T>::kZero(),
+          data_desc_,
+          Y_data));
+      return true;
+    }
+    const auto& X1 = Input(2);
+    CAFFE_ENFORCE_NE(
+        &X1,
+        Y,
+        "Input #2 is the same as output. If you want to do in-place updates, "
+        "put the output as input #0.");
+    const auto& weight1 = Input(3);
+    CAFFE_ENFORCE_EQ(X1.size(), input_size);
+    CAFFE_ENFORCE_EQ(weight1.size(), 1);
+    CopyWeightToHost<T>(weight1.template data<float>(), &alpha);
+    CopyWeightToHost<T>(weight0.template data<float>(), &beta);
+    if (Y == &X0) {
+      CUDNN_ENFORCE(cudnnAddTensor(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          &alpha,
+          data_desc_,
+          X1.template data<T>(),
+          &beta,
+          data_desc_,
+          Y_data));
+    } else {
+      CUDNN_ENFORCE(cudnnOpTensor(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          add_desc_,
+          &alpha,
+          data_desc_,
+          X1.template data<T>(),
+          &beta,
+          data_desc_,
+          X0.template data<T>(),
+          cudnnTypeWrapper<T>::kZero(),
+          data_desc_,
+          Y_data));
+    }
+    for (int i = 4; i < num_inputs; i += 2) {
+      const auto& Xi = Input(i);
+      // Do a check: if the input is the same as output, we have a problem -
+      // in-place update should always only happen with the zeroth input.
+      const std::string err_msg = "Input #" + to_string(i) +
+          " is the same as output. If you want to do in-place updates, "
+          "put the output as input #0.";
+      CAFFE_ENFORCE_NE(&Xi, Y, err_msg);
+      const auto& weighti = Input(i + 1);
+      CAFFE_ENFORCE_EQ(Xi.size(), input_size);
+      CAFFE_ENFORCE_EQ(weighti.size(), 1);
+      CopyWeightToHost<T>(weighti.template data<float>(), &alpha);
+      CUDNN_ENFORCE(cudnnAddTensor(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          &alpha,
+          data_desc_,
+          Xi.template data<T>(),
+          cudnnTypeWrapper<T>::kOne(),
+          data_desc_,
+          Y_data));
+    }
+    return true;
+  }
+
+ private:
+  void SetTensorDescriptor(
+      const cudnnDataType_t data_type,
+      const int input_size) {
+    if (cached_input_size_ != input_size) {
+      cached_input_size_ = input_size;
+      // Since the best performance is obtained when the tesor is HW-packed, we
+      // put X.size() to W.
+      CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
+          data_desc_,
+          GetCudnnTensorFormat(StorageOrder::NCHW),
+          data_type,
+          1,
+          1,
+          1,
+          input_size));
+    }
+  }
+
+  template <typename T>
+  void CopyWeightToHost(const float* src, T* dst);
+
+  CuDNNWrapper cudnn_wrapper_;
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnOpTensorDescriptor_t add_desc_;
+
+  int cached_input_size_ = 0;
+};
+
+template <typename T>
+void CuDNNWeightedSumOp::CopyWeightToHost(const float* src, T* dst) {
+  float val;
+  context_.template CopyToCPU<float>(1, src, &val);
+  *dst = convert::To<float, T>(val);
+}
+
+template <>
+void CuDNNWeightedSumOp::CopyWeightToHost<float>(const float* src, float* dst) {
+  context_.CopyToCPU<float>(1, src, dst);
+}
+
+REGISTER_CUDNN_OPERATOR(WeightedSum, CuDNNWeightedSumOp);
+
+} // namespace caffe2

--- a/caffe2/python/operator_test/weighted_sum_test.py
+++ b/caffe2/python/operator_test/weighted_sum_test.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.python import core
+from hypothesis import given
+
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 import hypothesis.strategies as st
@@ -13,10 +15,12 @@ import numpy as np
 class TestWeightedSumOp(serial.SerializedTestCase):
 
     @serial.given_and_seeded(
-        n=st.integers(5, 8), m=st.integers(1, 1), d=st.integers(2, 4),
-        grad_on_w=st.booleans(), seed=st.integers(min_value=0, max_value=65535),
-        **hu.gcs_cpu_only)
-    def test_weighted_sum(self, n, m, d, grad_on_w, seed, gc, dc):
+        n=st.integers(1, 8), m=st.integers(1, 10), d=st.integers(1, 4),
+        in_place=st.booleans(), engine=st.sampled_from(["", "CUDNN"]),
+        seed=st.integers(min_value=0, max_value=65535),
+        **hu.gcs)
+    def test_weighted_sum(
+            self, n, m, d, in_place, engine, seed, gc, dc):
         input_names = []
         input_vars = []
         np.random.seed(seed)
@@ -41,8 +45,8 @@ class TestWeightedSumOp(serial.SerializedTestCase):
         op = core.CreateOperator(
             "WeightedSum",
             input_names,
-            ['Y'],
-            grad_on_w=grad_on_w,
+            [input_names[0]] if in_place else ['Y'],
+            engine=engine,
         )
 
         self.assertReferenceChecks(
@@ -51,8 +55,36 @@ class TestWeightedSumOp(serial.SerializedTestCase):
             inputs=input_vars,
             reference=weighted_sum_op_ref,
         )
+        self.assertDeviceChecks(dc, op, input_vars, [0])
 
-        output_to_check_grad = range(2 * m) if grad_on_w else range(0, 2 * m, 2)
+    @given(n=st.integers(1, 8), m=st.integers(1, 10), d=st.integers(1, 4),
+           grad_on_w=st.booleans(),
+           seed=st.integers(min_value=0, max_value=65535), **hu.gcs_cpu_only)
+    def test_weighted_sum_grad(
+            self, n, m, d, grad_on_w, seed, gc, dc):
+        input_names = []
+        input_vars = []
+        np.random.seed(seed)
+        for i in range(m):
+            X_name = 'X' + str(i)
+            w_name = 'w' + str(i)
+            input_names.extend([X_name, w_name])
+            var = np.random.rand(n, d).astype(np.float32)
+            vars()[X_name] = var
+            input_vars.append(var)
+            var = np.random.rand(1).astype(np.float32)
+            vars()[w_name] = var
+            input_vars.append(var)
+
+        op = core.CreateOperator(
+            "WeightedSum",
+            input_names,
+            ['Y'],
+            grad_on_w=grad_on_w,
+        )
+
+        output_to_check_grad = (
+            range(2 * m) if grad_on_w else range(0, 2 * m, 2))
         for i in output_to_check_grad:
             self.assertGradientChecks(
                 device_option=gc,

--- a/caffe2/utils/hip/math_hip.cc
+++ b/caffe2/utils/hip/math_hip.cc
@@ -1967,35 +1967,105 @@ void Axpy<float16, HIPContext>(
 }
 
 namespace {
-template <typename T>
-__global__ void
-AxpbyKernel(const int n, const T a, const T* x, const T b, T* y) {
-  HIP_1D_KERNEL_LOOP(index, n) {
-    y[index] = x[index] * a + y[index] * b;
+
+template <typename TCoeff, typename TData>
+__global__ void AxpbyKernel(
+    const int n,
+    const TCoeff a,
+    const TData* x,
+    const TCoeff b,
+    TData* y) {
+  HIP_1D_KERNEL_LOOP(i, n) {
+    y[i] = x[i] * a + y[i] * b;
   }
 }
-} // namespace
 
 template <>
-void Axpby<float, HIPContext>(
+__global__ void AxpbyKernel<float, float16>(
     const int n,
     const float a,
-    const float* x,
+    const float16* x,
     const float b,
-    float* y,
-    HIPContext* context) {
-  hipLaunchKernelGGL(
-      (AxpbyKernel<float>),
-      dim3(CAFFE_GET_BLOCKS(n)),
-      dim3(CAFFE_HIP_NUM_THREADS),
-      0,
-      context->hip_stream(),
-      n,
-      a,
-      x,
-      b,
-      y);
+    float16* y) {
+  HIP_1D_KERNEL_LOOP(i, n) {
+    y[i] = convert::To<float, float16>(
+        convert::To<float16, float>(x[i]) * a +
+        convert::To<float16, float>(y[i]) * b);
+  }
 }
+
+template <typename TCoeff, typename TData>
+__global__ void AxpbyKernel(
+    const int n,
+    const TCoeff* a,
+    const TData* x,
+    const TCoeff* b,
+    TData* y) {
+  HIP_1D_KERNEL_LOOP(i, n) {
+    y[i] = x[i] * *a + y[i] * *b;
+  }
+}
+
+template <>
+__global__ void AxpbyKernel<float, float16>(
+    const int n,
+    const float* a,
+    const float16* x,
+    const float* b,
+    float16* y) {
+  HIP_1D_KERNEL_LOOP(i, n) {
+    y[i] = convert::To<float, float16>(
+        convert::To<float16, float>(x[i]) * *a +
+        convert::To<float16, float>(y[i]) * *b);
+  }
+}
+
+} // namespace
+
+#define CAFFE2_SPECIALIZED_HIP_AXPBY(TCoeff, TData) \
+  template <>                                       \
+  void Axpby<TCoeff, TData, HIPContext>(            \
+      const int n,                                  \
+      const TCoeff a,                               \
+      const TData* x,                               \
+      const TCoeff b,                               \
+      TData* y,                                     \
+      HIPContext* context) {                        \
+    hipLaunchKernelGGL(                             \
+        (AxpbyKernel<TCoeff, TData>),               \
+        dim3(CAFFE_GET_BLOCKS(n)),                  \
+        dim3(CAFFE_HIP_NUM_THREADS),                \
+        0,                                          \
+        context->hip_stream(),                      \
+        n,                                          \
+        a,                                          \
+        x,                                          \
+        b,                                          \
+        y);                                         \
+  }                                                 \
+  template <>                                       \
+  void Axpby<TCoeff, TData, HIPContext>(            \
+      const int n,                                  \
+      const TCoeff* a,                              \
+      const TData* x,                               \
+      const TCoeff* b,                              \
+      TData* y,                                     \
+      HIPContext* context) {                        \
+    hipLaunchKernelGGL(                             \
+        (AxpbyKernel<TCoeff, TData>),               \
+        dim3(CAFFE_GET_BLOCKS(n)),                  \
+        dim3(CAFFE_HIP_NUM_THREADS),                \
+        0,                                          \
+        context->hip_stream(),                      \
+        n,                                          \
+        a,                                          \
+        x,                                          \
+        b,                                          \
+        y);                                         \
+  }
+CAFFE2_SPECIALIZED_HIP_AXPBY(float, float)
+CAFFE2_SPECIALIZED_HIP_AXPBY(float, float16)
+#undef CAFFE2_SPECIALIZED_HIP_AXPBY
 
 namespace {
 

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -490,13 +490,22 @@ template <typename T, class Context>
 CAFFE2_API void
 Axpy(const int N, const float* alpha, const T* x, T* y, Context* context);
 
-template <typename T, class Context>
+template <typename TCoeff, typename TData, class Context>
 CAFFE2_API void Axpby(
     const int N,
-    const float alpha,
-    const T* x,
-    const T b,
-    T* y,
+    const TCoeff alpha,
+    const TData* x,
+    const TCoeff b,
+    TData* y,
+    Context* context);
+
+template <typename TCoeff, typename TData, class Context>
+CAFFE2_API void Axpby(
+    const int N,
+    const TCoeff* alpha,
+    const TData* x,
+    const TCoeff* b,
+    TData* y,
     Context* context);
 
 // groups must be 1 for GPU


### PR DESCRIPTION
Summary: Optimize WeightedSumOp for four inputs (2 weighted inputs), just call one kernel instead of two kernels.

Differential Revision: D9566692
