### PR TITLE
Remove MetaNetDef test case in Predictor

### DIFF
--- a/caffe2/predictor/predictor_test.cc
+++ b/caffe2/predictor/predictor_test.cc
@@ -209,33 +209,4 @@ TEST_F(PredictorTest, SimpleBatchSizedMapInput) {
   EXPECT_NEAR(output.front().data<float>()[4], 0.1209, 1E-4);
 }
 
-class PredictorMetaNetDefTest : public testing::Test {
- public:
-  void SetUp() override {
-    DeviceOption op;
-    op.set_random_seed(1701);
-    ctx_ = caffe2::make_unique<CPUContext>(op);
-    p_ = caffe2::make_unique<Predictor>(
-        makePredictorConfig(parseMetaNetDef(metaSpec)));
-  }
-
-  std::unique_ptr<CPUContext> ctx_;
-  std::unique_ptr<Predictor> p_;
-};
-
-TEST_F(PredictorMetaNetDefTest, SimpleMetaNetDefInitializer) {
-  auto inputData = randomTensor({1, 4}, ctx_.get());
-  Predictor::TensorMap input;
-  auto iter = input.emplace("data", Tensor(CPU));
-  auto tensor = inputData->GetMutableTensor(CPU);
-  iter.first->second.ResizeLike(*tensor);
-  iter.first->second.ShareData(*tensor);
-  Predictor::TensorList output;
-  (*p_)(input, &output);
-  EXPECT_EQ(output.size(), 1);
-  EXPECT_EQ(output.front().dims().size(), 2);
-  EXPECT_EQ(output.front().dim(0), 1);
-  EXPECT_EQ(output.front().dim(1), 10);
-  EXPECT_NEAR(output.front().data<float>()[4], 0.1209, 1E-4);
-}
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Delete the test case for Predictor with constructing by MetaNetDef since the constructor
actually has been deprecated. The broken PR is for construcing predictor from DB instance.

Reviewed By: highker

Differential Revision: D9566935
