### PR TITLE
Change torch.jit.trace to no longer be a decorator

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -409,7 +409,7 @@ class TestJit(JitTestCase):
             def f(x, y):
                 return x + y
 
-            self.assertIs(torch.jit.trace(torch.randn(2, 2), torch.randn(2, 2))(f), f)
+            self.assertIs(torch.jit.trace(f, (torch.randn(2, 2), torch.randn(2, 2))), f)
             self.assertIs(torch.jit.script(f), f)
 
             class MyModule(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -174,6 +174,13 @@ def backward_graph(script_module):
     return bwd_plan.graph.copy()
 
 
+# make it easy to quicky define/trace a function for these tests
+def _trace(*args, **kwargs):
+    def wrapper(func):
+        return torch.jit.trace(func, args, **kwargs)
+    return wrapper
+
+
 # Python equivalents for the empty list construction builtins. We need
 # these otherwise the tests won't execute in regular Python mode.
 def _construct_empty_int_list():
@@ -263,7 +270,7 @@ class JitTestCase(TestCase):
         if isinstance(func, torch._C.Graph):
             ge = torch._C.GraphExecutor(func, optimize)
         else:
-            ge = torch.jit.trace(*input_tensors, optimize=optimize, check_tolerance=check_tolerance)(func)
+            ge = torch.jit.trace(func, input_tensors, optimize=optimize, check_tolerance=check_tolerance)
 
         if verbose:
             print(ge.graph)
@@ -392,7 +399,7 @@ class TestJit(JitTestCase):
         def fn(x, y):
             return x[y]
 
-        fn_traced = torch.jit.trace(x, y)(fn)
+        fn_traced = torch.jit.trace(fn, (x, y,))
 
         self.assertEqual(fn(x, y), fn_traced(x, y))
 
@@ -434,7 +441,7 @@ class TestJit(JitTestCase):
             grad = torch.autograd.grad(y, x)[0].clone()
             return y, grad
 
-        traced_fn = torch.jit.trace(torch.ones(1))(fn)
+        traced_fn = torch.jit.trace(fn, torch.ones(1))
         self.assertEqual(run(fn), run(traced_fn))
 
     def test_scopes(self):
@@ -621,7 +628,7 @@ class TestJit(JitTestCase):
 
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')
         y = torch.randn(4, 4, dtype=torch.float, device='cuda')
-        traced_f = torch.jit.trace(x, y)(f)
+        traced_f = torch.jit.trace(f, (x, y,))
         self.assertEqual(traced_f(x.t().contiguous(), y), traced_f(x.t(), y))
 
     @staticmethod
@@ -714,7 +721,7 @@ class TestJit(JitTestCase):
             local_fusion_inputs = [t.clone().requires_grad_() for t in fusion_inputs]
 
             # Verifies outputs
-            fusion = torch.jit.trace(*local_fusion_inputs, optimize=True)(fn)
+            fusion = torch.jit.trace(fn, local_fusion_inputs, optimize=True)
             outputs = fn(*local_inputs)
             fusion_outputs = fusion(*local_fusion_inputs)
             outputs_half = [t.half() for t in outputs]
@@ -949,7 +956,7 @@ class TestJit(JitTestCase):
         y = torch.randn(4, 8, 4, requires_grad=requires_grad)
 
         # Check that it behaves as expected
-        traced_fn = torch.jit.trace(x)(fn)
+        traced_fn = torch.jit.trace(fn, x)
         self.assertEqual(traced_fn(y), fn(y))
         self.assertEqual(traced_fn(x), fn(x))
 
@@ -970,7 +977,7 @@ class TestJit(JitTestCase):
             return x, (x * y[1], x * y[0])
 
         x, y = torch.randn(2, 2), (torch.ones(2, 2), torch.randn(2, 2))
-        traced_fn = torch.jit.trace(x, y)(fn)
+        traced_fn = torch.jit.trace(fn, (x, y))
         self.assertEqual(traced_fn(x, y), fn(x, y))
         self.assertExpectedGraph(traced_fn.graph)
         self.assertExportImport(traced_fn.graph, (x, y))
@@ -984,7 +991,7 @@ class TestJit(JitTestCase):
             input = torch.ones(2, 3, **kwargs)
             self.checkTrace(fn, (input,), inputs_require_grads=inputs_require_grads)
             # check we recorded 'ones' and did not just record a constant
-            tfn = torch.jit.trace(input)(fn)
+            tfn = torch.jit.trace(fn, input)
             self.assertTrue("ones" in str(tfn.graph))
         run()
         run(dtype=torch.int, inputs_require_grads=False)
@@ -1221,7 +1228,7 @@ class TestJit(JitTestCase):
         self.assertEqual(g2result, g2result2)
 
     def test_trace_annotation(self):
-        @torch.jit.trace(torch.rand(1))
+        @_trace(torch.rand(1))
         def foo(a):
             return a + a + a
 
@@ -1247,7 +1254,7 @@ class TestJit(JitTestCase):
 
         model = Model(5, 3)
         x = torch.randn(2, 5)
-        traced_model = torch.jit.trace(x)(model)
+        traced_model = torch.jit.trace(model, x)
 
         # We're missing some attributes these modules had initially. Make sure we can
         # still get the __repr__()
@@ -1300,7 +1307,7 @@ class TestJit(JitTestCase):
             def backward(ctx, grad_output):
                 return grad_output
 
-        @torch.jit.trace(torch.zeros(2))
+        @_trace(torch.zeros(2))
         def fn(x):
             return MyFn.apply(x + 2) + 3
 
@@ -1341,7 +1348,7 @@ class TestJit(JitTestCase):
             ten[mask] = torch.ones(6)
             return ten
 
-        traced_test_fn = torch.jit.trace(ten, mask)(test_fn)
+        traced_test_fn = torch.jit.trace(test_fn, (ten, mask))
 
         ten = torch.rand(3, 3)
         self.assertEqual(test_fn(ten, mask), traced_test_fn(ten, mask))
@@ -2825,7 +2832,7 @@ a")
 
         eg = torch.zeros(1, 2, 3, requires_grad=True)
 
-        @torch.jit.trace(eg)
+        @_trace(eg)
         def foo(x):
             x = torch.neg(x)
             return F.dropout(x)
@@ -3543,7 +3550,7 @@ a")
         class M2(torch.jit.ScriptModule):
             def __init__(self):
                 super(M2, self).__init__(False)
-                self.m = torch.jit.trace(torch.zeros(4, 3), torch.zeros(4, 3))(M())
+                self.m = torch.jit.trace(M(), (torch.zeros(4, 3), torch.zeros(4, 3)))
 
             @torch.jit.script_method
             def forward(self, inp):
@@ -3805,9 +3812,9 @@ a")
         class M2(torch.jit.ScriptModule):
             def __init__(self):
                 super(M2, self).__init__(True)
-                self.m = torch.jit.trace(
-                    torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3))(TestScript.StarTestSumStarred())
-                self.g = torch.jit.trace(torch.ones(4, 3))(TestScript.StarTestReturnThree())
+                self.m = torch.jit.trace(TestScript.StarTestSumStarred(),
+                                         (torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3)))
+                self.g = torch.jit.trace(TestScript.StarTestReturnThree(), torch.ones(4, 3))
 
             @torch.jit.script_method
             def forward(self, rep):
@@ -3821,9 +3828,9 @@ a")
         class M2(torch.jit.ScriptModule):
             def __init__(self):
                 super(M2, self).__init__(True)
-                self.m = torch.jit.trace(
-                    torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3))(TestScript.StarTestSumStarred())
-                self.g = torch.jit.trace(torch.ones(4, 3))(TestScript.StarTestReturnThree())
+                self.m = torch.jit.trace(TestScript.StarTestSumStarred(),
+                                         (torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3)))
+                self.g = torch.jit.trace(TestScript.StarTestReturnThree(), torch.ones(4, 3))
 
                 self.define('''
             def forward(self, rep):
@@ -3848,7 +3855,7 @@ a")
         class M2(torch.jit.ScriptModule):
             def __init__(self):
                 super(M2, self).__init__(True)
-                self.g = torch.jit.trace(torch.ones(4, 3))(TestScript.StarTestSumAndReturnThree())
+                self.g = torch.jit.trace(TestScript.StarTestSumAndReturnThree(), torch.ones(4, 3))
                 self.define('''
             def forward(self, rep):
                 head, *tail = self.g(rep)
@@ -3863,10 +3870,8 @@ a")
             def __init__(self):
                 super(M2, self).__init__(True)
                 self.g = torch.jit.trace(
-                    torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3)
-                )(
-                    TestScript.StarTestSumAndReturnThree()
-                )
+                    TestScript.StarTestSumAndReturnThree(),
+                    (torch.ones(4, 3), torch.ones(4, 3), torch.ones(4, 3)))
                 self.define('''
             def forward(self, rep):
                 *head, tail = self.g(rep, rep, rep)
@@ -3933,7 +3938,7 @@ a")
         x = torch.autograd.Variable(torch.from_numpy(x), requires_grad=True)
 
         m = PadPackedWrapper()
-        m_traced = torch.jit.trace(x, seq_lens)(m)
+        m_traced = torch.jit.trace(m, (x, seq_lens,))
 
         y = m(x, seq_lens)
         loss = torch.sum(y)
@@ -4031,7 +4036,7 @@ a")
             seq_lens = torch.from_numpy(np.array([11, 3, 2, 2, 1], dtype=np.int32))
 
             m = RNNTraceWrapper(cell_type)
-            m_traced = torch.jit.trace(x, seq_lens)(m)
+            m_traced = torch.jit.trace(m, (x, seq_lens,))
 
             y = m(x, seq_lens)
             loss = torch.sum(y)
@@ -4339,7 +4344,7 @@ a")
 
         a = torch.ones(1, dtype=torch.float)
 
-        @torch.jit.trace(torch.zeros(1, dtype=torch.float))
+        @_trace(torch.zeros(1, dtype=torch.float))
         def use(b):
             return foo(b - 1.0, a) + 1.0
 
@@ -4436,7 +4441,7 @@ a")
     @skipIfNoTorchVision
     def test_script_module_export_resnet18(self):
         x = torch.ones(1, 3, 224, 224)
-        m_orig = torch.jit.trace(torch.ones(1, 3, 224, 224))(torchvision.models.resnet18())
+        m_orig = torch.jit.trace(torchvision.models.resnet18(), torch.ones(1, 3, 224, 224))
         m_import = self.getExportImportCopy(m_orig)
 
         input = torch.randn(1, 3, 224, 224, requires_grad=True)
@@ -4559,7 +4564,7 @@ a")
         class ModuleToExport(torch.jit.ScriptModule):
             def __init__(self):
                 super(ModuleToExport, self).__init__()
-                self.mod = torch.jit.trace(torch.zeros(1, 2, 3))(ModuleToInline())
+                self.mod = torch.jit.trace(ModuleToInline(), torch.zeros(1, 2, 3))
 
             @torch.jit.script_method
             def forward(self, x):
@@ -4662,7 +4667,7 @@ a")
             example_outputs=result, propagate=True))
 
     def test_trace_with_size(self):
-        @torch.jit.trace(torch.zeros(1, 1))
+        @_trace(torch.zeros(1, 1))
         def foo(x):
             return x + 1
 
@@ -4676,7 +4681,7 @@ a")
         self.assertEqual(8, bar(torch.ones(1, 1)))
 
     def test_tracing_slicing(self):
-        @torch.jit.trace(torch.zeros(10))
+        @_trace(torch.zeros(10))
         def foo_trace(x):
             return x[-5:-3]
 
@@ -4694,7 +4699,7 @@ a")
         self.assertNotEqual(foo_trace(a), foo_trace(b))
 
     def test_tracing_indexing(self):
-        @torch.jit.trace(torch.zeros(10))
+        @_trace(torch.zeros(10))
         def foo_trace(x):
             return x[-2]
 
@@ -4745,7 +4750,7 @@ a")
                     y = self.m(x)
                 return y
 
-        linear = torch.jit.trace(torch.zeros(1, 10, dtype=torch.float))(nn.Linear(10, 20).float())
+        linear = torch.jit.trace(nn.Linear(10, 20).float(), torch.zeros(1, 10, dtype=torch.float))
 
         @torch.jit.script
         def transpose(x):
@@ -4776,7 +4781,7 @@ a")
                 reshaped = torch.onnx.operators.reshape_from_tensor_shape(x, shape)
                 return reshaped
 
-        foo = torch.jit.trace(torch.zeros(1, 2, 3))(Foo())
+        foo = torch.jit.trace(Foo(), torch.zeros(1, 2, 3))
         outputs = foo(torch.zeros(1, 2, 3))
         f = io.BytesIO()
         s = torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f,
@@ -4819,7 +4824,7 @@ a")
 
     def test_wrong_implicit_expand(self):
 
-        @torch.jit.trace(torch.zeros(3), torch.zeros(1))
+        @_trace(torch.zeros(3), torch.zeros(1))
         def foo(a, b):
             return a + b
 
@@ -5347,7 +5352,7 @@ a")
 
     def test_call_ge(self):
         with self.assertRaisesRegex(RuntimeError, 'expected at most 1 arguments but found 3'):
-            @torch.jit.trace(torch.zeros(1, 2, 3))
+            @_trace(torch.zeros(1, 2, 3))
             def foo(x):
                 return x
 
@@ -5370,7 +5375,7 @@ a")
         def python_fn(x):
             return torch.neg(x)
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return python_fn(x) + 1
 
@@ -5389,7 +5394,7 @@ a")
 
         pm = PythonMod()
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return pm(x) + 1.0
 
@@ -5398,11 +5403,11 @@ a")
         self.assertExpected(canonical(traced_fn.graph))
 
     def test_call_traced_fn_from_tracing_fn(self):
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn1(x):
             return torch.neg(x)
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return traced_fn1(x) + 1
 
@@ -5417,9 +5422,9 @@ a")
             def forward(self, x):
                 return torch.mm(x, self.param)
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return tm(x) + 1.0
 
@@ -5432,7 +5437,7 @@ a")
         def script_fn(x):
             return torch.neg(x)
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return script_fn(x) + 1
 
@@ -5450,7 +5455,7 @@ a")
 
         sm = ScriptMod()
 
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return sm(x) + 1.0
 
@@ -5468,7 +5473,7 @@ a")
             def forward(self, x):
                 return torch.mm(python_fn(x), self.param)
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
         # Note: parameter self.param from the traced module should appear as
         # an input to the graph and the neg op from the Python function should
@@ -5493,14 +5498,14 @@ a")
             def forward(self, x):
                 return self.mod(torch.mm(x, self.param)) + 1.0
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
         self.assertExpected(canonical(tm.graph))
 
     def test_call_traced_fn_from_traced_module(self):
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return torch.neg(x)
 
@@ -5512,7 +5517,7 @@ a")
             def forward(self, x):
                 return traced_fn(torch.mm(x, self.param))
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
         # Note: neg op from the traced function should be properly inlined
         self.assertExpected(canonical(tm.graph))
 
@@ -5529,12 +5534,12 @@ a")
             def __init__(self):
                 super(TracedModule, self).__init__()
                 self.param = torch.nn.Parameter(torch.rand(4, 5))
-                self.mod = torch.jit.trace(torch.rand(3, 5))(TracedModule1())
+                self.mod = torch.jit.trace(TracedModule1(), torch.rand(3, 5))
 
             def forward(self, x):
                 return self.mod(torch.mm(x, self.param)) + 1.0
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
@@ -5553,7 +5558,7 @@ a")
             def forward(self, x):
                 return traced_fn(torch.mm(x, self.param))
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
         # Note: neg op from the script function should be properly inlined
         self.assertExpected(canonical(tm.graph))
 
@@ -5576,7 +5581,7 @@ a")
             def forward(self, x):
                 return self.mod(torch.mm(x, self.param)) + 1.0
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
         # Note: the parameters from both modules should appear in the flattened
         # inputs of the graph. All ops from both modules should be inlined.
@@ -5614,7 +5619,7 @@ a")
         self.assertExpected(str(script_fn.graph))
 
     def test_call_traced_fn_from_script_fn(self):
-        @torch.jit.trace(torch.rand(3, 4))
+        @_trace(torch.rand(3, 4))
         def traced_fn(x):
             return torch.neg(x)
 
@@ -5634,7 +5639,7 @@ a")
             def forward(self, x):
                 return torch.mm(x, torch.zeros(4, 3))
 
-        tm = torch.jit.trace(torch.rand(3, 4))(TracedModule())
+        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
         @torch.jit.script
         def script_fn(x):
@@ -5713,7 +5718,7 @@ a")
         self.assertExpected(str(sm.graph))
 
     def test_call_tracing_fn_from_script_module(self):
-        @torch.jit.trace(torch.rand(3, 3))
+        @_trace(torch.rand(3, 3))
         def traced_fn(x):
             return torch.neg(x)
 
@@ -5742,7 +5747,7 @@ a")
             def __init__(self):
                 super(ScriptMod, self).__init__()
                 self.param = torch.nn.Parameter(torch.rand(4, 3))
-                self.tm = torch.jit.trace(torch.rand(3, 3))(TracedMod())
+                self.tm = torch.jit.trace(TracedMod(), torch.rand(3, 3))
 
             @torch.jit.script_method
             def forward(self, x):
@@ -5816,7 +5821,7 @@ a")
                 return sm(x)
 
     def test_index_put_trace_with_view(self):
-        @torch.jit.trace(torch.rand(100), torch.tensor([1, 2, 3, 4]), torch.rand(1, 1, 1, 4))
+        @_trace(torch.rand(100), torch.tensor([1, 2, 3, 4]), torch.rand(1, 1, 1, 4))
         def test_index_put(target, indices, rhs):
             target[indices] = rhs
             return target
@@ -5824,7 +5829,7 @@ a")
         self.assertExpected(str(test_index_put.graph))
 
     def test_index_put_trace_without_view(self):
-        @torch.jit.trace(torch.rand(100), torch.tensor([1, 2, 3, 4]), torch.rand(4))
+        @_trace(torch.rand(100), torch.tensor([1, 2, 3, 4]), torch.rand(4))
         def test_index_put(target, indices, rhs):
             target[indices] = rhs
             return target
@@ -6104,7 +6109,7 @@ a")
 
     def test_trace_checker_arange_as_constant(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Graphs differed across invocations!'):
-            @torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(4, 5),)])
+            @_trace(torch.rand(3, 4), check_inputs=[(torch.rand(4, 5),)])
             def foo(x):
                 y = torch.arange(0, x.shape[0]).double()
                 return x + y.unsqueeze(1)
@@ -6112,14 +6117,14 @@ a")
     def test_trace_checker_dot_data(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Tensor-valued Constant nodes differed in value '
                                                                  r'across invocations'):
-            @torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
+            @_trace(torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
             def foo(x):
                 y = x.data
                 return x + y
 
     def test_trace_checker_control_flow(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Graphs differed across invocations!'):
-            @torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(4, 4),)])
+            @_trace(torch.rand(3, 4), check_inputs=[(torch.rand(4, 4),)])
             def foo(x):
                 for _ in range(x.size(0)):
                     x = torch.neg(x)
@@ -6132,12 +6137,12 @@ a")
                     foo.cache = torch.neg(x)
                 return x + foo.cache
 
-            traced = torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])(foo)
+            traced = torch.jit.trace(foo, torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
 
     def test_trace_checker_slice_lhs(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Traced function outputs do not match the Python'
                                                                  r' function outputs'):
-            @torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
+            @_trace(torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
             def foo(x):
                 for i in range(3):
                     x[i, :] = torch.zeros(4)
@@ -6146,21 +6151,21 @@ a")
     def test_trace_checker_inplace_on_view(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Traced function outputs do not match the Python'
                                                                  r' function outputs'):
-            @torch.jit.trace(torch.rand(3, 4), check_inputs=[(torch.rand(5, 6),)])
+            @_trace(torch.rand(3, 4), check_inputs=[(torch.rand(5, 6),)])
             def foo(x):
                 x.view(-1).add_(-x.view(-1))
                 return x
 
     def test_trace_checker_dropout_train(self):
         with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Trace had nondeterministic nodes'):
-            @torch.jit.trace(torch.rand(3, 4))
+            @_trace(torch.rand(3, 4))
             def foo(x):
                 return torch.dropout(x, p=0.5, train=True)
 
     def test_trace_checker_dropout_notrain(self):
         input = torch.rand(3, 4)
 
-        @torch.jit.trace(input)
+        @_trace(input)
         def foo(x):
             return torch.dropout(x, p=0.5, train=False)
 
@@ -6765,7 +6770,7 @@ def partial_apply_nontensors(fn, args, **kwargs):
 def create_traced_fn(fn):
     def traced_fn(*inputs, **kwargs):
         fn_tensors, inputs_tensors = partial_apply_nontensors(fn, inputs, **kwargs)
-        traced = torch.jit.trace(*inputs_tensors)(fn_tensors)
+        traced = torch.jit.trace(fn_tensors, inputs_tensors)
         return traced(*inputs_tensors)
     return traced_fn
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -298,7 +298,7 @@ class TracingCheckError(Exception):
 # Check the traced module against a set of user-provided validation inputs
 def _check_trace(check_inputs, func, executor_options, module, check_tolerance):
     for inputs in check_inputs:
-        check_mod = torch.jit.trace(*_clone_inputs(inputs), disable_checks=True, **executor_options)(func)
+        check_mod = torch.jit.trace(func, _clone_inputs(inputs), check_trace=False, **executor_options)
 
         def graph_diagnostic_info():
             mod_canonicalized = torch._C._jit_pass_canonicalize(module.graph)
@@ -408,7 +408,7 @@ def _check_trace(check_inputs, func, executor_options, module, check_tolerance):
             raise TracingCheckError(*graph_diagnostic_info())
 
 
-def trace(*args, **kwargs):
+def trace(func, example_inputs, optimize=True, check_trace=True, check_inputs=None, check_tolerance=1e-5):
     """
     Trace a function and return an executable trace that will be optimized
     using just-in-time compilation.
@@ -423,13 +423,20 @@ def trace(*args, **kwargs):
         invocations of the model.
 
     Arg:
-        *args - a list of example tensors that will be passed to the function
-                as inputs while tracing. The resulting trace can be run with
-                inputs of different types and shapes assuming the traced operations
-                support those types and shapes.
+        example_inputs - a tuple of example inputs that will be passed to the function
+                         while tracing. The resulting trace can be run with
+                         inputs of different types and shapes assuming the traced operations
+                         support those types and shapes. example_inputs may also be a single
+                         Tensor in which case it is automatically wrapped in a tuple
 
     Keyword arguments:
         optimize (bool, optional): whether or not to apply optimizations.  Default: ``True``.
+        check_trace (bool, optional): check if the same inputs run through
+                                      traced code produce the same outputs. Default: ``True``. You might want
+                                      to disable this if, for example, your network contains non-
+                                      deterministic ops or if you are sure that the network is correct despite
+                                      a checker failure.
+
         check_inputs (list of tuples. optional): A list of tuples of input arguments that should be used
                                                  to check the trace against what is expected. Each tuple
                                                  is equivalent to a seet of input arguments that would
@@ -437,10 +444,6 @@ def trace(*args, **kwargs):
                                                  set of checking inputs representative of the space of
                                                  shapes and types of inputs you expect the network to see.
                                                  If not specified, the original `args` is used for checking
-        disable_checks (bool, optional): Pass bool True to disable the aforementioned checking. You might
-                                         want to do this if, for example, your network contains non-
-                                         deterministic ops or if you are sure that the network is
-                                         correct despite a checker failure.
         check_tolerance (float, optional): Floating-point comparison tolerance to use in the checker procedure.
                                            This can be used to relax the checker strictness in the event that
                                            results diverge numerically for a known reason, such as operator fusion.
@@ -449,32 +452,26 @@ def trace(*args, **kwargs):
         ... def f(x):
         ...     return x * 2
     """
-    def wrapper(func):
-        if not _enabled:
-            return func
-        executor_options = {'optimize': True}
-        for name in executor_options:
-            executor_options[name] = kwargs.pop(name, executor_options[name])
+    if not _enabled:
+        return func
+    executor_options = {'optimize': bool(optimize)}
+    # Special case for common case of passing a single Variable
+    if isinstance(example_inputs, torch.Tensor):
+        example_inputs = (example_inputs,)
+    # done primarily so that weird iterables fail here and not pybind11 code
+    if not isinstance(example_inputs, tuple):
+        example_inputs = tuple(e for e in example_inputs)
+    module = TopLevelTracedModule(func, **executor_options)
+    module._create_method_from_trace('forward', func, example_inputs)
 
-        check_inputs = kwargs.pop('check_inputs', None)
-        disable_checks = kwargs.pop('disable_checks', False)
-        check_tolerance = kwargs.pop('check_tolerance', 1e-5)
-
-        if len(kwargs) != 0:
-            raise TypeError("got unexpected keyword arguments: {}".format(", ".join(kwargs.keys())))
-
-        module = TopLevelTracedModule(func, **executor_options)
-        module._create_method_from_trace('forward', func, tuple(args))
-
-        # Check the trace against new traces created from user-specified inputs
+    # Check the trace against new traces created from user-specified inputs
+    if check_trace:
         if check_inputs is not None:
             _check_trace(check_inputs, func, executor_options, module, check_tolerance)
-        elif not disable_checks:
-            _check_trace([args], func, executor_options, module, check_tolerance)
+        else:
+            _check_trace([example_inputs], func, executor_options, module, check_tolerance)
 
-        return module
-
-    return wrapper
+    return module
 
 
 def createResolutionCallback(frames_up=0):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -196,7 +196,7 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
                     input_names=None, output_names=None,
                     operator_export_type=OperatorExportTypes.ONNX,
                     example_outputs=None, propagate=False):
-    # Special case for common case of passing a single Variable
+    # Special case for common case of passing a single Tensor
     if isinstance(args, torch.Tensor):
         args = (args, )
 


### PR DESCRIPTION
This was done because it surprising for a decorator to run a function
rather than wrap it, and not simplify the syntax for tracing modules.

