### PR TITLE
Rename getTypeOpt to getNonVariableTypeOpt

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -24,7 +24,7 @@ public:
   Type* getTypeRaw(Backend p, ScalarType s) {
     return type_registry[static_cast<int>(p)][static_cast<int>(s)].get();
   }
-  Type * getTypeOpt(Backend p, ScalarType s) {
+  Type * getNonVariableTypeOpt(Backend p, ScalarType s) {
     if (p != Backend::Undefined) initCUDAIfNeeded(backendToDeviceType(p));
     auto type = getTypeRaw(p, s);
 
@@ -38,7 +38,7 @@ public:
     return type;
   }
   Type & getType(Backend p, ScalarType s) {
-    auto* type = getTypeOpt(p, s);
+    auto* type = getNonVariableTypeOpt(p, s);
     if (!type) AT_ERROR(toString(p), toString(s), "Type is not enabled.");
     return *type;
   }

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -33,8 +33,8 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, at::ScalarType scal
     , size_{0}
     , sparseDims_(1)
     , denseDims_(0)
-    , indices_(globalContext().getTypeOpt(sparseTensorIdToDenseBackend(type_id), ScalarType::Long)->tensor({1, 0}))
-    , values_(globalContext().getTypeOpt(sparseTensorIdToDenseBackend(type_id), scalar_type)->tensor()) {}
+    , indices_(globalContext().getNonVariableTypeOpt(sparseTensorIdToDenseBackend(type_id), ScalarType::Long)->tensor({1, 0}))
+    , values_(globalContext().getNonVariableTypeOpt(sparseTensorIdToDenseBackend(type_id), scalar_type)->tensor()) {}
 
 IntList SparseTensorImpl::sizes() const {
   return size_;

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -69,7 +69,7 @@ at::Type* get_type(const std::string& name, bool is_cuda, bool is_sparse) {
 
 PyTypeObject* getPyTypeObject(const at::Storage& storage)
 {
-  auto attype = at::globalContext().getTypeOpt(
+  auto attype = at::globalContext().getNonVariableTypeOpt(
       deviceTypeToBackend(storage.device_type()),
       at::dataTypeToScalarType(storage.dtype()));
   auto it = attype_to_py_storage_type.find(attype);
@@ -99,7 +99,7 @@ void registerLayoutObject(THPLayout *layout, at::Backend backend) {
 
 at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
   const at::Backend backend = get_backend(device.type() == at::Device::Type::CUDA, layout.layout == at::Layout::Sparse);
-  auto baseType = at::globalContext().getTypeOpt(backend, scalarType);
+  auto baseType = at::globalContext().getNonVariableTypeOpt(backend, scalarType);
   if (!baseType) {
     std::ostringstream oss;
     oss << "Error attempting to use dtype " << getDtype(scalarType)->name << " with layout " << layout.name

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -43,7 +43,7 @@ struct PyTensorType {
   // Precondition: Access to this struct is protected by the GIL
   at::Type* aten_type() {
     if (!aten_type_) {
-      auto* baseType = globalContext().getTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
+      auto* baseType = globalContext().getNonVariableTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
       aten_type_ = baseType ? torch::autograd::VariableType::getType(*baseType) : nullptr;
     }
     return aten_type_;


### PR DESCRIPTION
Rename getTypeOpt to getNonVariableTypeOpt

getType now supports retrieving variable types, so make it clearer
when a getType function does NOT give you a variable type.

```
codemod -d . --extensions cc,cpp,cu,cuh,h getTypeOpt getNonVariableTypeOpt
```

Differential Revision: D9578398

