### PR TITLE
Rename getType to getNonVariableType

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -37,7 +37,7 @@ public:
 
     return type;
   }
-  Type & getType(Backend p, ScalarType s) {
+  Type & getNonVariableType(Backend p, ScalarType s) {
     auto* type = getNonVariableTypeOpt(p, s);
     if (!type) AT_ERROR(toString(p), toString(s), "Type is not enabled.");
     return *type;
@@ -59,8 +59,8 @@ public:
   int64_t current_device() const {
     return detail::getCUDAHooks().current_device();
   }
-  // defined in header so that getType has ability to inline
-  // call_once check. getType is called fairly frequently
+  // defined in header so that getNonVariableType has ability to inline
+  // call_once check. getNonVariableType is called fairly frequently
   THCState* lazyInitCUDA() {
     std::call_once(thc_init,[&] {
       thc_state = detail::getCUDAHooks().initCUDA();
@@ -130,20 +130,20 @@ static inline void init() {
   }
 }
 
-static inline Type& getType(Backend p, ScalarType s) {
-  return globalContext().getType(p, s);
+static inline Type& getNonVariableType(Backend p, ScalarType s) {
+  return globalContext().getNonVariableType(p, s);
 }
 
-static inline Type& getType(DeviceType p, ScalarType s) {
-  return globalContext().getType(deviceTypeToBackend(p), s);
+static inline Type& getNonVariableType(DeviceType p, ScalarType s) {
+  return globalContext().getNonVariableType(deviceTypeToBackend(p), s);
 }
 
 static inline Type& CPU(ScalarType s) {
-  return getType(Backend::CPU, s);
+  return getNonVariableType(Backend::CPU, s);
 }
 
 static inline Type& CUDA(ScalarType s) {
-  return getType(Backend::CUDA, s);
+  return getNonVariableType(Backend::CUDA, s);
 }
 
 static inline bool hasCUDA() {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -163,7 +163,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
   auto deleter = [src](void * self) {
     src->deleter(const_cast<DLManagedTensor*>(src));
   };
-  return getType(backend, stype).tensorFromBlob(
+  return getNonVariableType(backend, stype).tensorFromBlob(
       src->dl_tensor.data,
       IntList(src->dl_tensor.shape, src->dl_tensor.ndim),
       IntList(src->dl_tensor.strides, src->dl_tensor.ndim),

--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -16,7 +16,7 @@ Type& TensorImpl::type() const {
   // Select backend from the hard-coded ones that the legacy ATen dispatcher
   // knows about
   Backend backend = tensorTypeIdToBackend(type_id_);
-  Type* base_type = &globalContext().getType(backend, scalar_type_);
+  Type* base_type = &globalContext().getNonVariableType(backend, scalar_type_);
   if (is_variable_) {
     return detail::getVariableHooks().getVariableType(*base_type);
   } else {
@@ -64,7 +64,7 @@ TensorImpl::TensorImpl(TensorTypeId type_id, ScalarType scalar_type, bool is_var
   // UndefinedTensors and SparseTensors don't have storages.
   if (type_id != UndefinedTensorId() && scalar_type != ScalarType::Undefined
       && type_id != SparseCPUTensorId() && type_id != SparseCUDATensorId()) {
-    auto type = &globalContext().getType(tensorTypeIdToBackend(type_id), scalar_type);
+    auto type = &globalContext().getNonVariableType(tensorTypeIdToBackend(type_id), scalar_type);
     storage_ = type->storage(true);
   }
 }

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -181,7 +181,7 @@ struct AT_API TensorOptions {
     if (type_ != nullptr) {
       return *type_;
     }
-    return getType(backend(), dtype_);
+    return getNonVariableType(backend(), dtype_);
   }
 
  private:

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -90,7 +90,7 @@ void TensorIterator::compute_common_type() {
   AT_ASSERT(result_type != ScalarType::Undefined);
   AT_ASSERT(backend != Backend::Undefined);
 
-  auto& type = at::globalContext().getType(backend, result_type);
+  auto& type = at::globalContext().getNonVariableType(backend, result_type);
 
   for (auto& op : operands_) {
     if (!op.type) {

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -186,7 +186,7 @@ static inline Tensor _run_cufft(
   // set to current stream
   CUFFT_CHECK(cufftSetStream(plan, at::cuda::getCurrentCUDAStream()));
 
-  auto ws = ctx.getType(at::Backend::CUDA, at::ScalarType::Byte).tensor({ config.workspace_size() });
+  auto ws = ctx.getNonVariableType(at::Backend::CUDA, at::ScalarType::Byte).tensor({ config.workspace_size() });
   CUFFT_CHECK(cufftSetWorkArea(plan, ws.data_ptr()));
 
   // run

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -38,10 +38,10 @@ Tensor Type::copy(const Tensor & src, bool non_blocking) const {
 }
 
 Type & Type::toBackend(Backend b) const {
-  return context->getType(b,scalarType());
+  return context->getNonVariableType(b,scalarType());
 }
 Type & Type::toScalarType(ScalarType s) const {
-  return context->getType(backend(),s);
+  return context->getNonVariableType(backend(),s);
 }
 static std::vector<int64_t> defaultStrides(IntList sizes) {
   std::vector<int64_t> strides(sizes.size());

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -65,7 +65,7 @@ TEST_CASE( "scalar test", "[]" ) {
   REQUIRE_NOTHROW(gen.seed());
   auto && C = at::globalContext();
   if(at::hasCUDA()) {
-    auto & CUDAFloat = C.getType(Backend::CUDA,ScalarType::Float);
+    auto & CUDAFloat = C.getNonVariableType(Backend::CUDA,ScalarType::Float);
     auto t2 = zeros({4,4}, CUDAFloat);
     cout << &t2 << "\n";
     cout << "AFTER GET TYPE " << &CUDAFloat << "\n";

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -55,7 +55,7 @@ private:
   }
 
   at::Type& typeFor(const Tensor& ten) {
-    return at::getType(backend(), atScalarTypeFor(ten.meta()));
+    return at::getNonVariableType(backend(), atScalarTypeFor(ten.meta()));
   }
   at::Tensor tensorWrapping(const Tensor& ten_) {
     auto& ten = const_cast<Tensor&>(ten_);
@@ -215,7 +215,7 @@ private:
     CAFFE_THROW("unsupported type annotation: ", name);
   }
   at::Type & stringToType(const std::string & name) {
-    return at::getType(backend(), stringToScalarType(name));
+    return at::getNonVariableType(backend(), stringToScalarType(name));
   }
   at::Type * readTypeAttribute(const std::string & name) {
     CAFFE_ENFORCE(OperatorBase::HasSingleArgumentOfType<std::string>(name));

--- a/test/cpp/api/serialization.cpp
+++ b/test/cpp/api/serialization.cpp
@@ -59,7 +59,7 @@ TEST_CASE("serialization") {
       }
 
       auto x = torch::ones(
-          {5, 5}, torch::getType(torch::Backend::CPU, static_cast<torch::Dtype>(i)));
+          {5, 5}, torch::getNonVariableType(torch::Backend::CPU, static_cast<torch::Dtype>(i)));
       auto y = torch::empty({});
 
       std::stringstream ss;

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -32,7 +32,7 @@ TEST_CASE("TensorOptions/DefaultsToTheRightValues") {
 
 TEST_CASE("TensorOptions/ReturnsTheCorrectType") {
   auto options = TensorOptions().device(kCPU).dtype(kInt).layout(kSparse);
-  REQUIRE(options.type() == getType(Backend::SparseCPU, kInt));
+  REQUIRE(options.type() == getNonVariableType(Backend::SparseCPU, kInt));
 }
 
 TEST_CASE("TensorOptions/UtilityFunctionsReturnTheRightTensorOptions") {
@@ -62,10 +62,10 @@ TEST_CASE("TensorOptions/ConstructsWellFromCPUTypes") {
   options = TensorOptions(kInt);
   REQUIRE_OPTIONS(kCPU, -1, kInt, kStrided);
 
-  options = TensorOptions(getType(Backend::SparseCPU, kFloat));
+  options = TensorOptions(getNonVariableType(Backend::SparseCPU, kFloat));
   REQUIRE_OPTIONS(kCPU, -1, kFloat, kSparse);
 
-  options = TensorOptions(getType(Backend::SparseCPU, kByte));
+  options = TensorOptions(getNonVariableType(Backend::SparseCPU, kByte));
   REQUIRE_OPTIONS(kCPU, -1, kByte, kSparse);
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("TensorOptions/ConstructsWellFromCPUTensors") {
   auto options = TensorOptions(empty(5, kDouble));
   REQUIRE_OPTIONS(kCPU, -1, kDouble, kStrided);
 
-  options = TensorOptions(empty(5, getType(Backend::SparseCPU, kByte)));
+  options = TensorOptions(empty(5, getNonVariableType(Backend::SparseCPU, kByte)));
   REQUIRE_OPTIONS(kCPU, -1, kByte, kSparse);
 }
 

--- a/test/cpp/api/tensor_options_cuda.cpp
+++ b/test/cpp/api/tensor_options_cuda.cpp
@@ -28,16 +28,16 @@ TEST_CASE("TensorOptions/ConstructsWellFromCUDATypes", "[cuda]") {
   options = TensorOptions(CUDA(kInt));
   REQUIRE_OPTIONS(kCUDA, -1, kInt, kStrided);
 
-  options = TensorOptions(getType(Backend::SparseCUDA, kFloat));
+  options = TensorOptions(getNonVariableType(Backend::SparseCUDA, kFloat));
   REQUIRE_OPTIONS(kCUDA, -1, kFloat, kSparse);
 
-  options = TensorOptions(getType(Backend::SparseCUDA, kByte));
+  options = TensorOptions(getNonVariableType(Backend::SparseCUDA, kByte));
   REQUIRE_OPTIONS(kCUDA, -1, kByte, kSparse);
 
   options = TensorOptions(CUDA(kFloat), /*device=*/5);
   REQUIRE_OPTIONS(kCUDA, 5, kFloat, kStrided);
 
-  options = TensorOptions(getType(Backend::SparseCUDA, kFloat), /*device=*/5);
+  options = TensorOptions(getNonVariableType(Backend::SparseCUDA, kFloat), /*device=*/5);
   REQUIRE_OPTIONS(kCUDA, 5, kFloat, kSparse);
 }
 
@@ -45,7 +45,7 @@ TEST_CASE("TensorOptions/ConstructsWellFromCUDATensors", "[multi-cuda]") {
   auto options = TensorOptions(empty(5, device(kCUDA).dtype(kDouble)));
   REQUIRE_OPTIONS(kCUDA, 0, kDouble, kStrided);
 
-  options = TensorOptions(empty(5, getType(Backend::SparseCUDA, kByte)));
+  options = TensorOptions(empty(5, getNonVariableType(Backend::SparseCUDA, kByte)));
   REQUIRE_OPTIONS(kCUDA, 0, kByte, kSparse);
 
   if (at::globalContext().getNumGPUs() > 1) {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -51,8 +51,8 @@ struct TORCH_API VariableType final : public at::Type {
   virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual at::Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
-  static at::Type* getType(const at::Type& baseType);
-  static at::Type* getType(const at::Tensor& tensor);
+  static at::Type* getNonVariableType(const at::Type& baseType);
+  static at::Type* getNonVariableType(const at::Tensor& tensor);
   static bool isVariableType(const at::Type& type);
   static std::vector<at::Type*> allCUDATypes();
   static std::vector<at::Type*> allCPUTypes();

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -50,7 +50,7 @@ static void check_out_type_matches(Tensor result,
   auto scalarType_arg = scalarType_is_none ? result.type().scalarType() : scalarType;
   auto layout_arg = layout_is_none ? *torch::getLayout(result.type().backend()) : layout;
   auto device_type_arg = device_is_none ? torch::getDeviceType(result.type()) : device.type();
-  const auto& type = torch::getType(scalarType_arg, layout_arg, device_type_arg);
+  const auto& type = torch::getNonVariableType(scalarType_arg, layout_arg, device_type_arg);
   if (result.type() != type) {
     AT_ERROR(
         "type corresponding to %s does not match type of out parameter (%s)",

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -507,7 +507,7 @@ static PyObject * THPVariable_to(PyObject* self, PyObject* args, PyObject* kwarg
     // device and maybe dtype are given
     auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
     auto& layout = *torch::getLayout(self_.type().backend());
-    auto& type = torch::getType(scalarType.value_or(self_.type().scalarType()), layout, device->type());
+    auto& type = torch::getNonVariableType(scalarType.value_or(self_.type().scalarType()), layout, device->type());
     const int32_t device_index = type.is_cuda() ? device->index() : -1;
     return THPVariable_Wrap(torch::utils::dispatch_type_conversion(self_, type, device_index, non_blocking));
   }
@@ -553,7 +553,7 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
     throw TypeError("dtype must be a type, str, or dtype object");
   }
   auto self_device_type = torch::getDeviceType(self_.type());
-  auto& type = is_dtype ? torch::getType(r.scalartype(0), *torch::getLayout(self_.type().backend()), self_device_type) :
+  auto& type = is_dtype ? torch::getNonVariableType(r.scalartype(0), *torch::getLayout(self_.type().backend()), self_device_type) :
                           torch::utils::type_from_string(type_name);
   return THPVariable_Wrap(torch::utils::dispatch_type_conversion(self_, type, at::nullopt, r.toBool(1)));
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -64,7 +64,7 @@ at::Type* get_type(const std::string& name, bool is_cuda, bool is_sparse) {
     return nullptr;
   }
   at::Backend backend = get_backend(is_cuda, is_sparse);
-  return &at::getType(backend, attype_names.at(name));
+  return &at::getNonVariableType(backend, attype_names.at(name));
 }
 
 PyTypeObject* getPyTypeObject(const at::Storage& storage)
@@ -97,7 +97,7 @@ void registerLayoutObject(THPLayout *layout, at::Backend backend) {
   layout_registry[static_cast<int>(backend)] = layout;
 }
 
-at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
+at::Type& getNonVariableType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
   const at::Backend backend = get_backend(device.type() == at::Device::Type::CUDA, layout.layout == at::Layout::Sparse);
   auto baseType = at::globalContext().getNonVariableTypeOpt(backend, scalarType);
   if (!baseType) {
@@ -109,7 +109,7 @@ at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::
     }
     throw std::runtime_error(oss.str());
   }
-  return *torch::autograd::VariableType::getType(*baseType);
+  return *torch::autograd::VariableType::getNonVariableType(*baseType);
 }
 
 THPDtype* getDtype(at::ScalarType scalarType) {

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -34,6 +34,6 @@ bool isStorage(PyObject* obj);
 
 THPDtype* getDtype(at::ScalarType scalarType);
 THPLayout* getLayout(at::Backend backend);
-at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device);
+at::Type& getNonVariableType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device);
 at::Device::Type getDeviceType(const at::Type& type);
 }  // namespace torch

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -68,7 +68,7 @@ static PyObject * THPGenerator_getState(THPGenerator *self)
   using namespace torch::autograd;
   HANDLE_TH_ERRORS
   THGenerator *generator = THPGenerator_TH_CData(self);
-  Variable var = VariableType::getType(CPU(kByte))->tensor();
+  Variable var = VariableType::getNonVariableType(CPU(kByte))->tensor();
   THByteTensor_getRNGState(generator, (THByteTensor*)(var.data().unsafeGetTensorImpl()));
   return THPVariable_Wrap(std::move(var));
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/api/include/torch/serialization.h
+++ b/torch/csrc/api/include/torch/serialization.h
@@ -246,7 +246,7 @@ void load(Archive& archive, torch::Tensor& tensor) {
 
   at::Backend backend = ::torch::detail::backendFromId(backendId);
   if (!tensor.defined() || tensor.dtype() != type) {
-    tensor = torch::empty({}, torch::getType(backend, type));
+    tensor = torch::empty({}, torch::getNonVariableType(backend, type));
   }
   const auto required_grad = tensor.requires_grad();
   tensor.set_requires_grad(false);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -118,7 +118,7 @@ PyObject * THCPModule_getRNGState(PyObject *_unused)
   using namespace at;
   using namespace torch::autograd;
   HANDLE_TH_ERRORS
-  Variable var = VariableType::getType(CPU(kByte))->tensor();
+  Variable var = VariableType::getNonVariableType(CPU(kByte))->tensor();
   THCRandom_getRNGState(state, (THByteTensor*)(var.data().unsafeGetTensorImpl()));
   return THPVariable_Wrap(var);
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -47,7 +47,7 @@ IValue representativeValue(Value* v) {
   if (CompleteTensorTypePtr type = type_->cast<CompleteTensorType>()) {
     auto backend = type->device() == -1 ? at::Backend::CPU : at::Backend::CUDA;
     at::DeviceGuard device_guard(type->device());
-    auto& attype = at::getType(backend, type->scalarType());
+    auto& attype = at::getNonVariableType(backend, type->scalarType());
     auto t = attype.tensor(type->sizes(), type->strides()).zero_();
     return autograd::make_variable(t, /*requires_grad=*/false);
   } else if (type_->isSubtypeOf(FloatType::get())) {

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -62,7 +62,7 @@ struct IODescriptor {
 };
 
 static inline std::ostream& operator<<(std::ostream& out, const IODescriptor::VariableMetadata& meta) {
-  auto & t = at::getType(meta.device < 0 ? at::Backend::CPU : at::Backend::CUDA, meta.type);
+  auto & t = at::getNonVariableType(meta.device < 0 ? at::Backend::CPU : at::Backend::CUDA, meta.type);
   out << t << "(requires_grad=" << meta.requires_grad;
   if (meta.device > 0) {
     out << ", device=" << meta.device;

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -44,7 +44,7 @@ struct PyTensorType {
   at::Type* aten_type() {
     if (!aten_type_) {
       auto* baseType = globalContext().getNonVariableTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
-      aten_type_ = baseType ? torch::autograd::VariableType::getType(*baseType) : nullptr;
+      aten_type_ = baseType ? torch::autograd::VariableType::getNonVariableType(*baseType) : nullptr;
     }
     return aten_type_;
   }

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -3,16 +3,16 @@
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
-at::Type& getType(at::Backend backend, at::ScalarType type) {
-  return *autograd::VariableType::getType(at::getType(backend, type));
+at::Type& getNonVariableType(at::Backend backend, at::ScalarType type) {
+  return *autograd::VariableType::getNonVariableType(at::getNonVariableType(backend, type));
 }
 
 at::Type& CPU(at::ScalarType type) {
-  return torch::getType(at::Backend::CPU, type);
+  return torch::getNonVariableType(at::Backend::CPU, type);
 }
 
 at::Type& CUDA(at::ScalarType type) {
-  return torch::getType(at::Backend::CUDA, type);
+  return torch::getNonVariableType(at::Backend::CUDA, type);
 }
 
 at::Tensor toTensor(const at::Scalar& scalar) {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -207,7 +207,7 @@ Tensor internal_new_from_data(const Type & type, at::optional<Device> device_opt
                                                                : torch::getDeviceType(var.type());
       // infer the scalar type and device type; it's not expected to infer the layout since these constructors
       // are defined per-layout-type (e.g. tensor vs sparse_coo_tensor).
-      const auto& type_inference_type = torch::getType(var.type().scalarType(),
+      const auto& type_inference_type = torch::getNonVariableType(var.type().scalarType(),
                                                        *torch::getLayout(type.backend()),
                                                        type_inference_device_type);
       const auto& type_to_use = type_inference ? type_inference_type : type;
@@ -320,7 +320,7 @@ const Type& typeWithDefault(PythonArgs& r, int64_t dtype_idx, int64_t device_idx
   const auto scalartype = r.scalartypeWithDefault(dtype_idx, type.scalarType());
   const Device types_device_type(type.device_type());
   const auto device_type = r.isNone(device_idx) ? types_device_type : r.device(device_idx).type();
-  return torch::getType(scalartype, *torch::getLayout(type.backend()), device_type);
+  return torch::getNonVariableType(scalartype, *torch::getLayout(type.backend()), device_type);
 }
 } // namespace
 

--- a/torch/csrc/variable_tensor_functions.h
+++ b/torch/csrc/variable_tensor_functions.h
@@ -15,14 +15,14 @@ namespace torch {
 
 /// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
 /// `ScalarType` (e.g. `at::kDouble`).
-THP_CLASS at::Type& getType(at::Backend backend, at::ScalarType type);
+THP_CLASS at::Type& getNonVariableType(at::Backend backend, at::ScalarType type);
 
 /// Returns a `Type` object for the CPU backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
+/// (e.g. `at::kDouble`). Equivalent to `getNonVariableType(kCPU, type)`.
 THP_CLASS at::Type& CPU(at::ScalarType type);
 
 /// Returns a `Type` object for the CUDA backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
+/// (e.g. `at::kDouble`). Equivalent to `getNonVariableType(kCUDA, type)`.
 THP_CLASS at::Type& CUDA(at::ScalarType type);
 
 /// Sets the `requires_grad` property of the given `Tensor`.

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -69,7 +69,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
         numTensors_(numTensors),
         numDevices_(cudaNumDevices()),
         state_(::at::globalContext().lazyInitCUDA()) {
-    const auto& type = at::getType(at::Backend::CUDA, at::kFloat);
+    const auto& type = at::getNonVariableType(at::Backend::CUDA, at::kFloat);
 
     // Allocate inputs on available devices in a round robin fashion.
     inputs_.resize(numTensors_);

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -156,7 +156,7 @@ void testAllreduce(const std::string& path, const at::Backend b) {
   std::vector<std::vector<at::Tensor>> inputs(size);
   for (auto i = 0; i < size; i++) {
     auto tensor =
-        at::ones({16, 16}, at::TensorOptions(at::getType(b, at::kFloat))) * i;
+        at::ones({16, 16}, at::TensorOptions(at::getNonVariableType(b, at::kFloat))) * i;
     inputs[i] = std::vector<at::Tensor>({tensor});
   }
 
@@ -193,7 +193,7 @@ void testBroadcast(const std::string& path, const at::Backend b) {
   auto tests = CollectiveTest::initialize(path, size);
 
   std::vector<std::vector<at::Tensor>> inputs(size);
-  const auto& type = at::getType(b, at::kFloat);
+  const auto& type = at::getNonVariableType(b, at::kFloat);
 
   // Try every permutation of root rank and root tensoro
   for (auto i = 0; i < size; i++) {

--- a/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
@@ -45,7 +45,7 @@ class NCCLTest : public NCCLTestBase {
         numDevices_(cudaNumDevices()),
         state_(::at::globalContext().lazyInitCUDA()),
         worldSize_(worldSize) {
-    const auto& type = at::getType(at::kCUDA, at::kFloat);
+    const auto& type = at::getNonVariableType(at::kCUDA, at::kFloat);
 
     // Each device has a single tensor to perf the NCCL op
     inputs_.resize(numDevices_);


### PR DESCRIPTION
Rename getType to getNonVariableType

```
codemod -d . --extensions cc,cpp,cu,cuh,h "\bgetType\b" getNonVariableType
hg revert caffe2
codemod -d caffe2/contrib/aten/ --extensions cc,cpp,cu,cuh,h "\bgetType\b" getNonVariableType
```

Differential Revision: D9578397

Stacked on #11078