### PR TITLE
Eliminate use of getType from DLConvertor

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -71,7 +71,7 @@ static DeviceType getATenDeviceType(const DLContext& ctx) {
     default:
       throw std::logic_error("Unsupported device_type: " + std::to_string(ctx.device_type));
   }
-  __builtin_unreachable();
+  return DeviceType::CPU; // impossible
 }
 
 

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -169,6 +169,6 @@ Tensor fromDLPack(const DLManagedTensor* src) {
       IntList(src->dl_tensor.shape, src->dl_tensor.ndim),
       IntList(src->dl_tensor.strides, src->dl_tensor.ndim),
       deleter,
-      TensorOptions(device_type, stype));
+      at::device(device_type).dtype(stype));
 }
 } //namespace at

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -21,6 +21,10 @@ namespace at {
 /// `torch::TensorOptions` subclass of this `TensorOptions`, which changes
 /// `type()` to return a variable type instead of a tensor type, such that
 /// variables are created inside factory methods, instead of tensors.
+///
+/// Here are a number of common ways to use specify a TensorOptions (some
+/// of which may not be obvious, because many types are implicitly convertible
+/// to TensorOptions).
 struct AT_API TensorOptions {
   TensorOptions() : TensorOptions(/*use_thread_local_default_options=*/true) {}
 
@@ -94,6 +98,14 @@ struct AT_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given dtype.
   /* implicit */ TensorOptions(ScalarType dtype) : TensorOptions() {
+    this->dtype(dtype);
+  }
+
+  /// Constructs a `TensorOptions` object with a given `Device` and
+  /// `ScalarType` (we don't provide all of these multi-constructors,
+  /// but this particular one is used quite frequently.)
+  explicit TensorOptions(Device device, ScalarType dtype) : TensorOptions() {
+    this->device(device);
     this->dtype(dtype);
   }
 

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -97,14 +97,6 @@ struct AT_API TensorOptions {
     this->dtype(dtype);
   }
 
-  /// Constructs a `TensorOptions` object with a given `Device` and
-  /// `ScalarType` (we don't provide all of these multi-constructors,
-  /// but this particular one is used quite frequently.)
-  explicit TensorOptions(Device device, ScalarType dtype) : TensorOptions() {
-    this->device(device);
-    this->dtype(dtype);
-  }
-
   /// True if all elements of the `TensorOptions` match that of the other.
   bool operator==(const TensorOptions& other) const noexcept {
     return dtype_ == other.dtype_ && layout_ == other.layout_ &&

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -21,10 +21,6 @@ namespace at {
 /// `torch::TensorOptions` subclass of this `TensorOptions`, which changes
 /// `type()` to return a variable type instead of a tensor type, such that
 /// variables are created inside factory methods, instead of tensors.
-///
-/// Here are a number of common ways to use specify a TensorOptions (some
-/// of which may not be obvious, because many types are implicitly convertible
-/// to TensorOptions).
 struct AT_API TensorOptions {
   TensorOptions() : TensorOptions(/*use_thread_local_default_options=*/true) {}
 

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -34,6 +34,15 @@ inline Tensor from_blob(
 inline Tensor from_blob(
     void* data,
     IntList sizes,
+    IntList strides,
+    const std::function<void(void*)>& deleter,
+    const TensorOptions& options = {}) {
+  return options.type().tensorFromBlob(data, sizes, strides, deleter);
+}
+
+inline Tensor from_blob(
+    void* data,
+    IntList sizes,
     const TensorOptions& options = {}) {
   return native::from_blob(data, sizes, /*deleter=*/[](void*) {}, options);
 }


### PR DESCRIPTION
Eliminate use of getType from DLConvertor

- Add a new TensorOptions(Device, ScalarType) constructor,
  which serves roughly the same role as getType used to.
  We shouldn't get too wild with these constructors, but
  since this particular one was widely used by getType,
  it seems worth adding.
- Change DLPack DeviceType conversion to at::DeviceType,
  rather than at::Backend.  While I'm at, add a few more
  conversions that at::DeviceType understands.
- Add a new overload of from_blob which understands strides.

Differential Revision: D9578734

Stacked on #11078