### PR TITLE
Add entry for torch/lib/pythonX.Y in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ torch/lib/pkgconfig
 torch/lib/protoc
 torch/lib/tmp_install
 torch/lib/torch_shm_manager
+torch/lib/python*
 torch/version.py
 
 # IPython notebook checkpoints


### PR DESCRIPTION
I've had `torch/lib/python3.6` show up as part of the build for some time now. It's not ignored which means I need to be extra careful about checking in files, or I end up with a thousand of them in my index.