### PR TITLE
Rename getType to getVariableTypeFromBaseType / getVariableType

### DIFF
--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -18,7 +18,7 @@ Type& TensorImpl::type() const {
   Backend backend = tensorTypeIdToBackend(type_id_);
   Type* base_type = &globalContext().getType(backend, scalar_type_);
   if (is_variable_) {
-    return detail::getVariableHooks().getVariableType(*base_type);
+    return detail::getVariableHooks().getVariableTypeFromBaseType(*base_type);
   } else {
     return *base_type;
   }

--- a/aten/src/ATen/detail/VariableHooksInterface.h
+++ b/aten/src/ATen/detail/VariableHooksInterface.h
@@ -25,8 +25,8 @@ struct AT_API VariableHooksInterface {
   // squelch -Werror=non-virtual-dtor
   virtual ~VariableHooksInterface() {}
 
-  virtual Type& getVariableType(const at::Type& baseType) const {
-    AT_ERROR("cannot getVariableType without libtorch");
+  virtual Type& getVariableTypeFromBaseType(const at::Type& baseType) const {
+    AT_ERROR("cannot getVariableTypeFromBaseType without libtorch");
   }
 
   virtual void registerVariableTypeFor(Context*, Backend backend, ScalarType scalar_type) const {

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -400,7 +400,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                         # The device actual is the corresponding AutoGPU index for the Device.
                         formal_args.append(parsed_type_args[1])
                         formal_args.append(device_type)
-                        actuals.append("torch::getType({}, {}, {})".format(parsed_type_args[0], layout, device))
+                        actuals.append("torch::getVariableType({}, {}, {})".format(parsed_type_args[0], layout, device))
                         actuals.append('{}.index()'.format(device))
 
                     has_device_bind = True

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -88,10 +88,10 @@ size_t VariableType::elementSizeInBytes() const {
   return baseType->elementSizeInBytes();
 }
 Type & VariableType::toBackend(Backend b) const {
-  return *getType(baseType->toBackend(b));
+  return *getVariableTypeFromBaseType(baseType->toBackend(b));
 }
 Type & VariableType::toScalarType(ScalarType s) const {
-  return *getType(baseType->toScalarType(s));
+  return *getVariableTypeFromBaseType(baseType->toScalarType(s));
 }
 TypeID VariableType::ID() const {
   return static_cast<TypeID>(id_);
@@ -130,7 +130,7 @@ struct VariableTypeRegistry {
 struct VariableHooks : public at::VariableHooksInterface {
   VariableHooks(at::VariableHooksArgs) {}
   void registerVariableTypeFor(at::Context*, at::Backend, at::ScalarType) const override;
-  at::Type& getVariableType(const at::Type&) const override;
+  at::Type& getVariableTypeFromBaseType(const at::Type&) const override;
 };
 
 // Sigh, the registry doesn't support namespaces :(
@@ -168,26 +168,19 @@ void VariableHooks::registerVariableTypeFor(at::Context* context, at::Backend ba
   register_variable_type_for(baseType);
 }
 
-at::Type& VariableHooks::getVariableType(const at::Type& baseType) const {
-  return *VariableType::getType(baseType);
+at::Type& VariableHooks::getVariableTypeFromBaseType(const at::Type& baseType) const {
+  return *VariableType::getVariableTypeFromBaseType(baseType);
 }
 
 bool VariableType::isVariableType(const at::Type& type) {
   return type.is_variable();
 }
 
-at::Type* VariableType::getType(const at::Type& baseType) {
+at::Type* VariableType::getVariableTypeFromBaseType(const at::Type& baseType) {
   auto id = static_cast<size_t>(baseType.ID());
   if(id >= type_to_variable_type.size())
     return nullptr;
   return type_to_variable_type[id].get();
-}
-
-at::Type* VariableType::getType(const at::Tensor& tensor) {
-  if (!tensor.defined()) {
-    throw std::runtime_error("tensor is undefined");
-  }
-  return getType(tensor.type());
 }
 
 namespace {
@@ -199,7 +192,7 @@ std::vector<at::Type*> allTypesForBackends(at::ArrayRef<at::Backend> backends) {
     for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); s++) {
       auto baseType = context.getNonVariableTypeRaw(static_cast<Backend>(p), static_cast<ScalarType>(s));
       if (baseType) {
-        res.emplace_back(VariableType::getType(*baseType));
+        res.emplace_back(VariableType::getVariableTypeFromBaseType(*baseType));
       }
     }
   }

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -51,8 +51,7 @@ struct TORCH_API VariableType final : public at::Type {
   virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual at::Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
-  static at::Type* getType(const at::Type& baseType);
-  static at::Type* getType(const at::Tensor& tensor);
+  static at::Type* getVariableTypeFromBaseType(const at::Type& baseType);
   static bool isVariableType(const at::Type& type);
   static std::vector<at::Type*> allCUDATypes();
   static std::vector<at::Type*> allCPUTypes();

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -50,7 +50,7 @@ static void check_out_type_matches(Tensor result,
   auto scalarType_arg = scalarType_is_none ? result.type().scalarType() : scalarType;
   auto layout_arg = layout_is_none ? *torch::getLayout(result.type().backend()) : layout;
   auto device_type_arg = device_is_none ? torch::getDeviceType(result.type()) : device.type();
-  const auto& type = torch::getType(scalarType_arg, layout_arg, device_type_arg);
+  const auto& type = torch::getVariableType(scalarType_arg, layout_arg, device_type_arg);
   if (result.type() != type) {
     AT_ERROR(
         "type corresponding to %s does not match type of out parameter (%s)",

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -507,7 +507,7 @@ static PyObject * THPVariable_to(PyObject* self, PyObject* args, PyObject* kwarg
     // device and maybe dtype are given
     auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
     auto& layout = *torch::getLayout(self_.type().backend());
-    auto& type = torch::getType(scalarType.value_or(self_.type().scalarType()), layout, device->type());
+    auto& type = torch::getVariableType(scalarType.value_or(self_.type().scalarType()), layout, device->type());
     const int32_t device_index = type.is_cuda() ? device->index() : -1;
     return THPVariable_Wrap(torch::utils::dispatch_type_conversion(self_, type, device_index, non_blocking));
   }
@@ -553,7 +553,7 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
     throw TypeError("dtype must be a type, str, or dtype object");
   }
   auto self_device_type = torch::getDeviceType(self_.type());
-  auto& type = is_dtype ? torch::getType(r.scalartype(0), *torch::getLayout(self_.type().backend()), self_device_type) :
+  auto& type = is_dtype ? torch::getVariableType(r.scalartype(0), *torch::getLayout(self_.type().backend()), self_device_type) :
                           torch::utils::type_from_string(type_name);
   return THPVariable_Wrap(torch::utils::dispatch_type_conversion(self_, type, at::nullopt, r.toBool(1)));
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -97,7 +97,7 @@ void registerLayoutObject(THPLayout *layout, at::Backend backend) {
   layout_registry[static_cast<int>(backend)] = layout;
 }
 
-at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
+at::Type& getVariableType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
   const at::Backend backend = get_backend(device.type() == at::Device::Type::CUDA, layout.layout == at::Layout::Sparse);
   auto baseType = at::globalContext().getNonVariableTypeOpt(backend, scalarType);
   if (!baseType) {
@@ -109,7 +109,7 @@ at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::
     }
     throw std::runtime_error(oss.str());
   }
-  return *torch::autograd::VariableType::getType(*baseType);
+  return *torch::autograd::VariableType::getVariableTypeFromBaseType(*baseType);
 }
 
 THPDtype* getDtype(at::ScalarType scalarType) {

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -34,6 +34,6 @@ bool isStorage(PyObject* obj);
 
 THPDtype* getDtype(at::ScalarType scalarType);
 THPLayout* getLayout(at::Backend backend);
-at::Type& getType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device);
+at::Type& getVariableType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device);
 at::Device::Type getDeviceType(const at::Type& type);
 }  // namespace torch

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -44,7 +44,7 @@ struct PyTensorType {
   at::Type* aten_type() {
     if (!aten_type_) {
       auto* baseType = globalContext().getNonVariableTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
-      aten_type_ = baseType ? torch::autograd::VariableType::getType(*baseType) : nullptr;
+      aten_type_ = baseType ? torch::autograd::VariableType::getVariableTypeFromBaseType(*baseType) : nullptr;
     }
     return aten_type_;
   }

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -3,16 +3,16 @@
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
-at::Type& getType(at::Backend backend, at::ScalarType type) {
-  return *autograd::VariableType::getType(at::getType(backend, type));
+at::Type& getVariableType(at::Backend backend, at::ScalarType type) {
+  return *autograd::VariableType::getVariableTypeFromBaseType(at::getType(backend, type));
 }
 
 at::Type& CPU(at::ScalarType type) {
-  return torch::getType(at::Backend::CPU, type);
+  return torch::getVariableType(at::Backend::CPU, type);
 }
 
 at::Type& CUDA(at::ScalarType type) {
-  return torch::getType(at::Backend::CUDA, type);
+  return torch::getVariableType(at::Backend::CUDA, type);
 }
 
 at::Tensor toTensor(const at::Scalar& scalar) {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -207,7 +207,7 @@ Tensor internal_new_from_data(const Type & type, at::optional<Device> device_opt
                                                                : torch::getDeviceType(var.type());
       // infer the scalar type and device type; it's not expected to infer the layout since these constructors
       // are defined per-layout-type (e.g. tensor vs sparse_coo_tensor).
-      const auto& type_inference_type = torch::getType(var.type().scalarType(),
+      const auto& type_inference_type = torch::getVariableType(var.type().scalarType(),
                                                        *torch::getLayout(type.backend()),
                                                        type_inference_device_type);
       const auto& type_to_use = type_inference ? type_inference_type : type;
@@ -320,7 +320,7 @@ const Type& typeWithDefault(PythonArgs& r, int64_t dtype_idx, int64_t device_idx
   const auto scalartype = r.scalartypeWithDefault(dtype_idx, type.scalarType());
   const Device types_device_type(type.device_type());
   const auto device_type = r.isNone(device_idx) ? types_device_type : r.device(device_idx).type();
-  return torch::getType(scalartype, *torch::getLayout(type.backend()), device_type);
+  return torch::getVariableType(scalartype, *torch::getLayout(type.backend()), device_type);
 }
 } // namespace
 

--- a/torch/csrc/variable_tensor_functions.h
+++ b/torch/csrc/variable_tensor_functions.h
@@ -15,14 +15,17 @@ namespace torch {
 
 /// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
 /// `ScalarType` (e.g. `at::kDouble`).
-THP_CLASS at::Type& getType(at::Backend backend, at::ScalarType type);
+/// TODO: Eliminate this function as much as possible
+THP_CLASS at::Type& getVariableType(at::Backend backend, at::ScalarType type);
 
 /// Returns a `Type` object for the CPU backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
+/// (e.g. `at::kDouble`). Equivalent to `getVariableType(kCPU, type)`.
+/// TODO: Eliminate this function as much as possible
 THP_CLASS at::Type& CPU(at::ScalarType type);
 
 /// Returns a `Type` object for the CUDA backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
+/// (e.g. `at::kDouble`). Equivalent to `getVariableType(kCUDA, type)`.
+/// TODO: Eliminate this function as much as possible
 THP_CLASS at::Type& CUDA(at::ScalarType type);
 
 /// Sets the `requires_grad` property of the given `Tensor`.


### PR DESCRIPTION
Rename getType to getVariableTypeFromBaseType / getVariableType

We used getType to mean a lot of things.

- getVariableTypeFromBaseType: given a base Type (non-Variable type)
  compute the Variable Type which corresponds to it.

- getVariableType: like at::getType, but return the Variable type
  rather than the plain type.

This rename makes it clearer at the use-site what things are what,
and will make a subsequent rename of at::getType easier.

Differential Revision: D9583630

Stacked on #11087