### PR TITLE
use py::str to remove deprecation warnings

### DIFF
--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -136,7 +136,7 @@ inline IValue argumentToIValue(
     return toIValue(object, argument.type);
   } catch (const py::cast_error& error) {
     AT_ERROR(
-        schema.name, "() expected value of type ", py::str(argument.type),
+        schema.name, "() expected value of type ", argument.type->str(),
         " for argument '", argument.name,
         "' in position ", argumentPosition,
         ", but instead got value of type ",

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -136,10 +136,11 @@ inline IValue argumentToIValue(
     return toIValue(object, argument.type);
   } catch (const py::cast_error& error) {
     AT_ERROR(
-        schema.name, "() expected value of type ", argument.type->str(),
+        schema.name, "() expected value of type ", py::str(argument.type),
         " for argument '", argument.name,
         "' in position ", argumentPosition,
-        ", but instead got value of type ", object.get_type().attr("__name__").str(),
+        ", but instead got value of type ",
+        py::str(object.get_type().attr("__name__")),
         ". Declaration: ", schema);
   }
 }


### PR DESCRIPTION
```
In file included from third-party-buck/gcc-5-glibc-2.23/build/pybind11/889256a/include/pybind11/cast.h:13:0,
                 from third-party-buck/gcc-5-glibc-2.23/build/pybind11/889256a/include/pybind11/attr.h:13,
                 from third-party-buck/gcc-5-glibc-2.23/build/pybind11/889256a/include/pybind11/pybind11.h:43,
                 from caffe2/torch/csrc/utils/pybind.h:6,
                 from caffe2/torch/csrc/jit/pybind.h:5,
                 from caffe2/torch/csrc/jit/script/init.h:3,
                 from caffe2/torch/csrc/jit/script/init.cpp:1:
third-party-buck/gcc-5-glibc-2.23/build/pybind11/889256a/include/pybind11/pytypes.h:118:19: note: declared here
In file included from caffe2/torch/csrc/jit/pybind.h:12:0,
                 from caffe2/torch/csrc/jit/python_ir.cpp:4:
caffe2/torch/csrc/jit/pybind_utils.h: In function 'torch::jit::IValue torch::jit::argumentToIValue(const torch::jit::FunctionSchema&, size_t, pybind11::handle)':
caffe2/torch/csrc/jit/pybind_utils.h:138:226: warning: 'pybind11::str pybind11::detail::object_api<Derived>::str() const [with Derived = pybind11::detail::accessor<pybind11::detail::accessor_policies::str_attr>]' is deprecated: Use py::str(obj) instead [-Wdeprecated-declarations]
```

@apaszke @zdevito @ezyang 