### PR TITLE
[Caffe2] Should not use CAFFE2_API when definition is already in header.

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -43,7 +43,7 @@ class Node;
 
 // \brief Edge within a Graph.
 template <typename T, typename... U>
-class CAFFE2_API Edge : public StorageType<U...> {
+class Edge : public StorageType<U...> {
  public:
   using NodeRef = typename Graph<T, U...>::NodeRef;
   Edge(NodeRef tail, NodeRef head, U... args)
@@ -77,7 +77,7 @@ class CAFFE2_API Edge : public StorageType<U...> {
 
 // \brief Node within a Graph.
 template <typename T, typename... U>
-class CAFFE2_API Node : public StorageType<T>, public Notifier<Node<T, U...>> {
+class Node : public StorageType<T>, public Notifier<Node<T, U...>> {
  public:
   using NodeRef = typename Graph<T, U...>::NodeRef;
   using EdgeRef = typename Graph<T, U...>::EdgeRef;
@@ -156,7 +156,7 @@ class CAFFE2_API Node : public StorageType<T>, public Notifier<Node<T, U...>> {
 /// for example.
 ///
 template <typename T, typename... U>
-class CAFFE2_API Subgraph {
+class Subgraph {
  public:
   Subgraph() {
     DEBUG_PRINT("Creating instance of Subgraph: %p\n", this);
@@ -223,7 +223,7 @@ class CAFFE2_API Subgraph {
 /// Everything is owned by the graph to simplify storage concerns.
 ///
 template <typename T, typename... U>
-class CAFFE2_API Graph {
+class Graph {
  public:
   using SubgraphType = Subgraph<T, U...>;
   using NodeRef = Node<T, U...>*;

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/Compiler.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/Compiler.h
@@ -8,7 +8,7 @@
 namespace nom {
 namespace repr {
 
-class CAFFE2_API Value {
+class Value {
  public:
   enum class ValueKind { Value, Instruction, Data };
   Value(ValueKind K) : kind_(K) {}
@@ -22,7 +22,7 @@ class CAFFE2_API Value {
   const ValueKind kind_;
 };
 
-class CAFFE2_API Data : public Value {
+class Data : public Value {
  public:
   Data() : Value(ValueKind::Data) {}
   static bool classof(const Value* V) {
@@ -41,7 +41,7 @@ class CAFFE2_API Data : public Value {
   size_t version_ = 0;
 };
 
-class CAFFE2_API Instruction : public Value {
+class Instruction : public Value {
  public:
   /// \brief All the different types of execution.
   enum class Opcode {
@@ -66,7 +66,7 @@ class CAFFE2_API Instruction : public Value {
   Opcode op_;
 };
 
-class CAFFE2_API Terminator : public Instruction {
+class Terminator : public Instruction {
  public:
   Terminator(Instruction::Opcode op) : Instruction(op) {}
 
@@ -80,17 +80,17 @@ class CAFFE2_API Terminator : public Instruction {
   }
 };
 
-class CAFFE2_API Branch : public Terminator {
+class Branch : public Terminator {
  public:
   Branch() : Terminator(Instruction::Opcode::Branch) {}
 };
 
-class CAFFE2_API Return : public Terminator {
+class Return : public Terminator {
  public:
   Return() : Terminator(Instruction::Opcode::Return) {}
 };
 
-class CAFFE2_API Phi : public Instruction {
+class Phi : public Instruction {
  public:
   Phi() : Instruction(Instruction::Opcode::Phi) {}
 };

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
@@ -14,7 +14,7 @@ namespace repr {
 /// of the data flow graph as well as an ordering on instruction
 /// execution.  Basic blocks are used for control flow analysis.
 template <typename T, typename... U>
-class CAFFE2_API BasicBlock {
+class BasicBlock {
  public:
   using NodeRef = typename Subgraph<T, U...>::NodeRef;
   BasicBlock() {}
@@ -92,7 +92,7 @@ class CAFFE2_API BasicBlock {
 using Program = Graph<Value>;
 
 template <typename G>
-struct CAFFE2_API ControlFlowGraphImpl {
+struct ControlFlowGraphImpl {
   // Hack to help debugging in case this class is misused.
   static_assert(
       sizeof(ControlFlowGraphImpl),
@@ -102,7 +102,7 @@ struct CAFFE2_API ControlFlowGraphImpl {
 };
 
 template <typename T, typename... U>
-struct CAFFE2_API ControlFlowGraphImpl<Graph<T, U...>> {
+struct ControlFlowGraphImpl<Graph<T, U...>> {
   using type = Graph<std::unique_ptr<BasicBlock<T, U...>>, int>;
   using bbType = BasicBlock<T, U...>;
 };
@@ -112,7 +112,7 @@ struct CAFFE2_API ControlFlowGraphImpl<Graph<T, U...>> {
 ///
 /// \note G Must be of type Graph<T, U...>.
 template <typename G>
-class CAFFE2_API ControlFlowGraph : public ControlFlowGraphImpl<G>::type {
+class ControlFlowGraph : public ControlFlowGraphImpl<G>::type {
  public:
   // This is for C++11 compatibility, otherwise we could use "using"
   ControlFlowGraph() {}
@@ -131,7 +131,7 @@ using BasicBlockType = typename ControlFlowGraphImpl<G>::bbType;
 /// \brief Converts graph to SSA representation.  Modifies the graph
 /// by inserting versions and phi nodes.
 template <typename Phi, typename G>
-CAFFE2_EXPORT void addSSA(G* dfg, ControlFlowGraph<G>* cfg) {
+void addSSA(G* dfg, ControlFlowGraph<G>* cfg) {
   static_assert(
       std::is_base_of<Instruction, Phi>::value,
       "Phi type must be derived from Instruction.");

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -41,7 +41,7 @@ class NeuralNetData;
 /// a saved void* pointer for external use.  Derived classes
 /// add richer semantics to the annotation and it is encouraged
 /// to use them.
-class CAFFE2_API Annotation {
+class Annotation {
  public:
   enum class AnnotationKind { Generic, Caffe2 };
 
@@ -60,7 +60,7 @@ class CAFFE2_API Annotation {
   const AnnotationKind kind_;
 };
 
-class CAFFE2_API NeuralNetOperator : public Instruction {
+class NeuralNetOperator : public Instruction {
  public:
   /// Discriminator for LLVM-style RTTI (isa<>)
   enum class NNKind {
@@ -135,7 +135,7 @@ class CAFFE2_API NeuralNetOperator : public Instruction {
   std::unique_ptr<Annotation> extraAnnotation_;
 };
 
-class CAFFE2_API NeuralNetData : public Data {
+class NeuralNetData : public Data {
  public:
   /// Discriminator for LLVM-style RTTI (isa<>)
   enum class NNDataKind { Generic, Tensor };
@@ -159,7 +159,7 @@ class CAFFE2_API NeuralNetData : public Data {
   size_t version_ = 0;
 };
 
-class CAFFE2_API Tensor : public NeuralNetData {
+class Tensor : public NeuralNetData {
  public:
   enum class DataType { Generic, Float, Half, Int8 };
   enum class Layout { Generic, NCHW, NHWC };
@@ -207,21 +207,21 @@ class CAFFE2_API Tensor : public NeuralNetData {
 
 #include "nomnigraph/Generated/OpClasses.h"
 
-class CAFFE2_API While : public NeuralNetOperator {
+class While : public NeuralNetOperator {
  public:
   While() : NeuralNetOperator(NNKind::While, Opcode::Branch) {}
   NOMNIGRAPH_DEFINE_NN_RTTI(While);
   ~While() {}
 };
 
-class CAFFE2_API NNPhi : public NeuralNetOperator {
+class NNPhi : public NeuralNetOperator {
  public:
   NNPhi() : NeuralNetOperator(NNKind::NNPhi, Opcode::Phi) {}
   NOMNIGRAPH_DEFINE_NN_RTTI(NNPhi);
   ~NNPhi() {}
 };
 
-class CAFFE2_API GenericOperator : public NeuralNetOperator {
+class GenericOperator : public NeuralNetOperator {
  public:
   GenericOperator() : NeuralNetOperator(NNKind::GenericOperator) {}
   GenericOperator(std::string name)
@@ -243,7 +243,7 @@ using NNGraph = nom::Graph<std::unique_ptr<nom::repr::Value>>;
 using NNSubgraph = nom::Subgraph<std::unique_ptr<nom::repr::Value>>;
 using NNCFGraph = nom::repr::ControlFlowGraph<NNGraph>;
 
-struct CAFFE2_API NNModule {
+struct NNModule {
   NNGraph dataFlow;
   NNCFGraph controlFlow;
   std::unordered_set<NNGraph::NodeRef> inputs;
@@ -262,7 +262,7 @@ template <bool B, class T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
 template <typename T, typename U>
-struct CAFFE2_API inheritedFrom {
+struct inheritedFrom {
   static constexpr bool value =
       std::is_base_of<U, T>::value && !std::is_same<U, T>::value;
 };
@@ -270,14 +270,14 @@ struct CAFFE2_API inheritedFrom {
 // This is just a way to fix issues when the isa<> implementation
 // can't automatically downcast.
 template <typename T, typename N, typename = void>
-struct CAFFE2_API is_impl {
+struct is_impl {
   inline static bool impl(N n) {
     return isa<T>(n->data());
   }
 };
 
 template <typename T, typename N>
-struct CAFFE2_API is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
+struct is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
   inline static bool impl(N n) {
     if (!isa<NeuralNetOperator>(n->data().get())) {
       return false;
@@ -288,7 +288,7 @@ struct CAFFE2_API is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>:
 };
 
 template <typename T, typename N>
-struct CAFFE2_API is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
+struct is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
   inline static bool impl(N n) {
     if (!isa<NeuralNetData>(n->data().get())) {
       return false;
@@ -306,14 +306,14 @@ inline bool is(N n) {
 // This is just a way to fix issues when the dyn_cast<> implementation
 // can't automatically downcast.
 template <typename T, typename N, typename = void>
-struct CAFFE2_API get_impl {
+struct get_impl {
   inline static T* impl(N n) {
     return dyn_cast<T>(n->data().get());
   }
 };
 
 template <typename T, typename N>
-struct CAFFE2_API get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
+struct get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
   inline static T* impl(N n) {
     if (!is<T>(n)) {
       assert(0 && "Cannot get type from node");
@@ -325,7 +325,7 @@ struct CAFFE2_API get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>
 };
 
 template <typename T, typename N>
-struct CAFFE2_API get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
+struct get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
   inline static T* impl(N n) {
     if (!is<T>(n)) {
       assert(0 && "Cannot get type from node");
@@ -425,9 +425,9 @@ CAFFE2_API std::vector<NNGraph::NodeRef> getOutputs(NNGraph::NodeRef n);
 CAFFE2_API void coalesceInsertedDataDependencies(repr::NNModule* m);
 
 template <NNGraph* G>
-struct CAFFE2_API NodeHelper {};
+struct NodeHelper {};
 
-struct CAFFE2_API NNNodeMatchCriteria {
+struct NNNodeMatchCriteria {
   std::function<bool(NNGraph::NodeRef)> predicate;
   std::string debugString;
 
@@ -489,7 +489,7 @@ NNNodeMatchCriteria matchOp(
       debugString);
 };
 
-struct CAFFE2_API NNNodeMatch {
+struct NNNodeMatch {
   static bool isMatch(
       const NNGraph::NodeRef& node,
       const NNNodeMatchCriteria& criteria) {
@@ -503,7 +503,7 @@ using NNSubgraphMatcher =
 // This helper method makes it easy to create matching criteria in NNGraph.
 // For example, operatorSubgraph(opMatch, ...) will refer to a tree like this:
 // ... -> opMatch -> opMatch_Output
-CAFFE2_API NNMatchGraph::NodeRef operatorSubgraph(
+NNMatchGraph::NodeRef operatorSubgraph(
     NNMatchGraph& g,
     const NNNodeMatchCriteria& root,
     const std::vector<NNMatchGraph::NodeRef>& childrenCriteria = {},

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -12,7 +12,7 @@
 
 namespace caffe2 {
 
-class CAFFE2_API Caffe2Annotation : public nom::repr::Annotation {
+class Caffe2Annotation : public nom::repr::Annotation {
 public:
   Caffe2Annotation() : Annotation(AnnotationKind::Caffe2) {}
   Caffe2Annotation(std::string device)
@@ -75,7 +75,7 @@ CAFFE2_API caffe2::OperatorDef convertToOperatorDef(
 
 class CAFFE2_API Converter {
  public:
-  explicit Converter() {}
+  explicit Converter() = default;
   virtual std::unique_ptr<nom::repr::NeuralNetOperator>
   convertToNeuralNetOperator(const OperatorDef&) = 0;
   virtual OperatorDef convertToOperatorDef(const nom::repr::NeuralNetOperator*);

--- a/caffe2/opt/fusion.h
+++ b/caffe2/opt/fusion.h
@@ -37,7 +37,7 @@ CAFFE2_API void fuseConvBN(repr::NNModule* nn, caffe2::Workspace* ws);
 // \param postprocess Functor to postprocess the conv node,
 // attaching additional attributes if necessary
 template <typename OperationT, typename ActivationT>
-CAFFE2_API void fuseActivation(
+void fuseActivation(
     repr::NNModule* nn,
     std::function<bool(const OperationT& conv)> should_fuse,
     std::function<void(repr::NNGraph::NodeRef conv_node)> postprocess) {

--- a/caffe2/opt/onnx_convert.h
+++ b/caffe2/opt/onnx_convert.h
@@ -1,4 +1,4 @@
-class CAFFE2_API OnnxAnnotation : public nom::repr::Annotation {
+class OnnxAnnotation : public nom::repr::Annotation {
 public:
   OnnxAnnotation() : Annotation(AnnotationKind::Onnx) {}
   OnnxAnnotation(std::string device)

--- a/caffe2/opt/passes.h
+++ b/caffe2/opt/passes.h
@@ -25,7 +25,7 @@ class CAFFE2_API OptimizationPass {
  public:
   OptimizationPass(NNModule* nn) : nn_(nn) {}
   virtual void run() = 0;
-  virtual ~OptimizationPass(){}
+  virtual ~OptimizationPass() {}
 
  protected:
   NNModule* nn_;
@@ -34,7 +34,7 @@ class CAFFE2_API OptimizationPass {
 class CAFFE2_API WorkspaceOptimizationPass : public OptimizationPass {
  public:
   WorkspaceOptimizationPass(NNModule* nn, Workspace* ws) : OptimizationPass(nn), ws_(ws) {}
-  virtual ~WorkspaceOptimizationPass(){}
+  virtual ~WorkspaceOptimizationPass() {}
 
  protected:
   Workspace* ws_;


### PR DESCRIPTION
Remove or use CAFFE2_EXPORT.
Fix #11108 