### PR TITLE
Logical short circuit

### DIFF
--- a/test/expect/TestScript.test_logical_short_circuit.expect
+++ b/test/expect/TestScript.test_logical_short_circuit.expect
@@ -1,0 +1,45 @@
+graph(%t : Dynamic) {
+  %c1.1 : int = prim::Constant[value=1]()
+  %2 : int = prim::Constant[value=0]()
+  %3 : int = prim::If(%2)
+    block0() {
+      %4 : int = prim::Constant[value=1]()
+      %5 : int = prim::Constant[value=0]()
+      %6 : Dynamic = aten::select(%t, %5, %4)
+      %7 : int = prim::TensorToNum(%6)
+      -> (%7)
+    }
+    block1() {
+      -> (%2)
+    }
+  %8 : int = aten::__not__(%3)
+  %9 : int = prim::If(%8)
+    block0() {
+      %10 : int = prim::Constant[value=1]()
+      %11 : int = aten::__not__(%10)
+      %12 : int = prim::If(%11)
+        block0() {
+          %13 : int = prim::Constant[value=1]()
+          %14 : int = prim::Constant[value=0]()
+          %15 : Dynamic = aten::select(%t, %14, %13)
+          %16 : int = prim::TensorToNum(%15)
+          -> (%16)
+        }
+        block1() {
+          -> (%10)
+        }
+      -> (%12)
+    }
+    block1() {
+      -> (%3)
+    }
+  %c1 : int = prim::If(%9)
+    block0() {
+      %c1.2 : int = prim::Constant[value=0]()
+      -> (%c1.2)
+    }
+    block1() {
+      -> (%c1.1)
+    }
+  return (%c1);
+}

--- a/test/expect/TestScript.test_logical_short_circuit.expect
+++ b/test/expect/TestScript.test_logical_short_circuit.expect
@@ -12,28 +12,26 @@ graph(%t : Dynamic) {
     block1() {
       -> (%2)
     }
-  %8 : int = aten::__not__(%3)
-  %9 : int = prim::If(%8)
+  %8 : int = prim::If(%3)
     block0() {
-      %10 : int = prim::Constant[value=1]()
-      %11 : int = aten::__not__(%10)
-      %12 : int = prim::If(%11)
-        block0() {
-          %13 : int = prim::Constant[value=1]()
-          %14 : int = prim::Constant[value=0]()
-          %15 : Dynamic = aten::select(%t, %14, %13)
-          %16 : int = prim::TensorToNum(%15)
-          -> (%16)
-        }
-        block1() {
-          -> (%10)
-        }
-      -> (%12)
-    }
-    block1() {
       -> (%3)
     }
-  %c1 : int = prim::If(%9)
+    block1() {
+      %9 : int = prim::Constant[value=1]()
+      %10 : int = prim::If(%9)
+        block0() {
+          -> (%9)
+        }
+        block1() {
+          %11 : int = prim::Constant[value=1]()
+          %12 : int = prim::Constant[value=0]()
+          %13 : Dynamic = aten::select(%t, %12, %11)
+          %14 : int = prim::TensorToNum(%13)
+          -> (%14)
+        }
+      -> (%10)
+    }
+  %c1 : int = prim::If(%8)
     block0() {
       %c1.2 : int = prim::Constant[value=0]()
       -> (%c1.2)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3121,7 +3121,6 @@ a")
             print(c0)
 
         t = torch.randn(0)
-        print(testNoThrows.graph)
         self.assertEqual(0, testNoThrows(torch.randn(0)))
         self.assertExpectedGraph(testNoThrows.graph)
         with self.assertRaises(RuntimeError):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3121,6 +3121,7 @@ a")
             print(c0)
 
         t = torch.randn(0)
+        print(testNoThrows.graph)
         self.assertEqual(0, testNoThrows(torch.randn(0)))
         self.assertExpectedGraph(testNoThrows.graph)
         with self.assertRaises(RuntimeError):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3123,9 +3123,9 @@ a")
         t = torch.randn(0)
         self.assertEqual(0, testNoThrows(torch.randn(0)))
         self.assertExpectedGraph(testNoThrows.graph)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "index 1 out of range for tensor of size"):
             throwsOr(t)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "index 1 out of range for tensor of size"):
             throwsAnd(t)
 
     def test_type_cast(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3102,6 +3102,32 @@ a")
         y = torch.arange(0., 8, 2, requires_grad=True)
         self.checkScript(func, [x, y], optimize=True, capture_output=True)
 
+    def test_logical_short_circuit(self):
+        @torch.jit.script
+        def testNoThrows(t):
+            c1 = 1
+            if (False and t[1]) or (True or t[1]):
+                c1 = 0
+            return c1
+
+        @torch.jit.script
+        def throwsOr(t):
+            c0 = False or t[1]
+            print(c0)
+
+        @torch.jit.script
+        def throwsAnd(t):
+            c0 = True and t[1]
+            print(c0)
+
+        t = torch.randn(0)
+        self.assertEqual(0, testNoThrows(torch.randn(0)))
+        self.assertExpectedGraph(testNoThrows.graph)
+        with self.assertRaises(RuntimeError):
+            throwsOr(t)
+        with self.assertRaises(RuntimeError):
+            throwsAnd(t)
+
     def test_type_cast(self):
         def test_int_to_float():
             b = float(2)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -908,16 +908,16 @@ private:
 
   Value* emitTernaryIf(const TernaryIf& expr) {
     Value* cond_value = emitCond(expr.cond());
-    auto first_expr = [&] {
+    auto true_expr = [&] {
       return emitExpr(expr.true_expr());
     };
-    auto second_expr = [&] {
+    auto false_expr  = [&] {
       return emitExpr(expr.false_expr());
     };
-    return emitIfExpr(expr.range(), cond_value, first_expr, second_expr);
+    return emitIfExpr(expr.range(), cond_value, true_expr, false_expr);
   }
 
-  Value * emitShortCircuitIf(
+  Value* emitShortCircuitIf(
       const SourceRange& loc,
       const TreeRef & first_expr,
       const TreeRef & second_expr,
@@ -940,7 +940,7 @@ private:
     }
   }
 
-  Value * emitIfExpr(const SourceRange& range, Value * cond_value,
+  Value* emitIfExpr(const SourceRange& range, Value * cond_value,
       std::function<Value*()> true_expr,  std::function<Value*()> false_expr) {
     Node* n = graph->insertNode(create(prim::If, range, 0));
 
@@ -948,7 +948,7 @@ private:
     auto* true_block = n->addBlock();
     auto* false_block = n->addBlock();
 
-    auto emit_if_expr = [this](Block* b, std::function<Value *()> expr_value) {
+    auto emit_if_expr = [this](Block* b, std::function<Value*()> expr_value) {
       pushFrame(b);
       WithInsertPoint guard(b);
       Value* out_val = expr_value();

--- a/torch/jit/batchop.py
+++ b/torch/jit/batchop.py
@@ -240,7 +240,7 @@ def batch_type_as(data, mask, dims, data1, mask1, dims1):
 
 @torch.jit.script
 def batch_gt(data, mask, dims, data1, mask1, dims1):
-    return torch.gt(data, data1), mask * mask1, dims or dims1
+    return torch.gt(data, data1), mask * mask1, dims.__or__(dims1)
 
 
 @torch.jit.script
@@ -256,12 +256,12 @@ def batch_gt_one_scalar(data, mask, dims, other_):
 
 @torch.jit.script
 def batch_lt(data, mask, dims, data1, mask1, dims1):
-    return torch.lt(data, data1), mask * mask1, dims or dims1
+    return torch.lt(data, data1), mask * mask1, dims.__or__(dims1)
 
 
 @torch.jit.script
 def batch_eq(data, mask, dims, data1, mask1, dims1):
-    return torch.eq(data, data1), mask * mask1, dims or dims1
+    return torch.eq(data, data1), mask * mask1, dims.__or__(dims1)
 
 
 @torch.jit.script

--- a/torch/jit/batchop.py
+++ b/torch/jit/batchop.py
@@ -38,7 +38,7 @@ def batch_add(data1, mask1, dims1, data2, mask2, dims2, alpha_):
     alpha = float(alpha_)
     data = torch.add(data1, data2, alpha=alpha)
     mask = mask1 * mask2
-    dims = dims1 or dims2
+    dims = dims1.__or__(dims2)
     return data, mask, dims
 
 
@@ -54,7 +54,7 @@ def batch_sub(data1, mask1, dims1, data2, mask2, dims2, alpha_):
     alpha = float(alpha_)
     data = torch.sub(data1, data2, alpha=alpha)
     mask = mask1 * mask2
-    dims = dims1 or dims2
+    dims = dims1.__or__(dims2)
     return data, mask, dims
 
 
@@ -67,7 +67,7 @@ def batch_sub_scalar(data1, data2):
 def batch_mul(data1, mask1, dims1, data2, mask2, dims2):
     data = torch.mul(data1, data2)
     mask = mask1 * mask2
-    dims = dims1 or dims2
+    dims = dims1.__or__(dims2)
     return data, mask, dims
 
 
@@ -209,7 +209,7 @@ def batch_where(data, mask, dims, data1, mask1, dims1, data2, mask2, dims2):
         cond_mask = data.expand_as(mask1)
     res_data = torch.where(cond_data, data1, data2)
     res_mask = torch.where(cond_mask, mask1, mask2)
-    res_dims = dims1 or dims2
+    res_dims = dims1.__or__(dims2)
     return res_data, res_mask, res_dims
 
 


### PR DESCRIPTION
Adding short circuit evaluation to AND or OR. The second expression of and AND or OR gets lifted into an if branch, which is conditionally evaluated. 

BatchOps was using the expression `dims = dims1 or dims2`, where dims is often an empty tensor. This nows throws an error, because dims1 gets cast to a boolean, and you can't convert an empty tensor to a scalar. It now matches the behavior of pytorch in python. 

One thing that came up is if the second expression in an and/or in python gets returned, it does not get coerced to a boolean. 

`tensor == (False or tensor)`
`tensor == (True and tensor)`

We do not currently support this. 

edit: wording

