### PR TITLE
add a Float16UniformFill

### DIFF
--- a/caffe2/operators/half_float_ops.h
+++ b/caffe2/operators/half_float_ops.h
@@ -39,6 +39,37 @@ class Float16ConstantFillOp : public Operator<CPUContext> {
   vector<TIndex> shape_;
 };
 
+class Float16UniformFillOp : public Operator<CPUContext> {
+ public:
+  Float16UniformFillOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        shape_(this->template GetRepeatedArgument<int64_t>("shape")),
+        min_(this->template GetSingleArgument<float>("min", 0)),
+        max_(this->template GetSingleArgument<float>("max", 1)) {
+    if (InputSize() == 3) {
+      CAFFE_ENFORCE(
+          !this->template HasSingleArgumentOfType<float>("min"),
+          "Cannot set both min arg and min input blob");
+      CAFFE_ENFORCE(
+          !this->template HasSingleArgumentOfType<float>("max"),
+          "Cannot set both max arg and max input blob");
+    } else {
+      CAFFE_ENFORCE_LT(
+          min_, max_, "Max value should be bigger than min value.");
+    }
+  }
+
+  USE_OPERATOR_FUNCTIONS(CPUContext);
+  virtual ~Float16UniformFillOp() {}
+
+  bool RunOnDevice() override;
+
+ private:
+  vector<TIndex> shape_;
+  float min_;
+  float max_;
+};
+
 inline std::vector<TensorShape> Float16FillerTensorInference(
     const OperatorDef& def,
     const vector<TensorShape>& in) {


### PR DESCRIPTION
Summary:
this adds an operator that fills a tensor with a uniform(min, max)
the implementation is to use the fp32 generator and convert to fp16

if performance becomes an issue we could resort to intrinsics

Differential Revision: D9598142
