### PR TITLE
nomnigraph - fix memory error in NN subgraph matchOp

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -481,7 +481,7 @@ NNNodeMatchCriteria matchOp(
     const std::function<bool(const NodeType&)> predicate,
     const std::string& debugString = "matchOpWithPredicate") {
   return NNNodeMatchCriteria(
-      [&predicate](NNGraph::NodeRef nodeRef) {
+      [predicate](NNGraph::NodeRef nodeRef) {
         NOM_REQUIRE_OR_RET_FALSE(is<NodeType>(nodeRef));
         NodeType* node = get<NodeType>(nodeRef);
         return predicate(*node);


### PR DESCRIPTION
Summary: it's invalid to capture `predicate` by reference as it's a local variable. capture it by value instead.

Differential Revision: D9600115
