### PR TITLE
Open source multithreaded predictor bench utils

### DIFF
--- a/caffe2/predictor/emulator/benchmark.cc
+++ b/caffe2/predictor/emulator/benchmark.cc
@@ -1,0 +1,84 @@
+#include "caffe2/core/init.h"
+#include "caffe2/predictor/emulator/std_output_formatter.h"
+
+#include "benchmark.h"
+
+// Basic benchmark params
+C10_DEFINE_int(warmup, 10000, "The number of iterations to warm up.");
+C10_DEFINE_int(iter, 10000000, "The number of iterations to run.");
+C10_DEFINE_int(threads, 32, "The number of threads to run.");
+C10_DEFINE_int(runs, 10, "The number of independent runs.");
+
+// Benchmark setup params
+C10_DEFINE_int(
+    num_loading_threads,
+    56,
+    "The number of threads to build predictors.");
+
+// Benchmark model params
+C10_DEFINE_string(run_net, "", "The given net to benchmark.");
+C10_DEFINE_string(init_net, "", "The given net to initialize.");
+C10_DEFINE_string(data_net, "", "The given net to get input data.");
+C10_DEFINE_string(
+    input_dims,
+    "",
+    "The path of the file that "
+    "stores input dimesions of all the operators in the run net. "
+    "Each element of the array is a mapping from "
+    "operator index to its input dimension.");
+C10_DEFINE_string(
+    input_types,
+    "",
+    "The path of the file that "
+    "stores input types of all the operators in the run net. "
+    "Each element of the array is a mapping from "
+    "operator index to its input types.");
+
+// aysnc net related params
+C10_DEFINE_string(
+    mutating_net_type,
+    "",
+    "If used, we will use async_scheduling instead simple net for predict net");
+
+C10_DEFINE_bool(
+    mutating_net_async_deferrable_mode,
+    true,
+    "If used, use deferrable_mode for DFS scheduling in async_scheduling net");
+
+C10_DEFINE_int(
+    mutating_net_async_workers,
+    -1,
+    "Set number of worker threads for the thread pool in asyn_scheduling net");
+
+namespace caffe2 {
+namespace emulator {
+
+void BenchmarkRunner::benchmark(const BenchmarkParam& param) {
+  param.emulator->init();
+  std::vector<float> durations_ms;
+  for (size_t run = 0; run < FLAGS_runs; ++run) {
+    LOG(WARNING) << "Starting run " << run + 1;
+    LOG(INFO) << "Warming up " << FLAGS_threads << " threads with "
+              << FLAGS_warmup << " iterations...";
+    param.emulator->run(FLAGS_warmup);
+
+    LOG(INFO) << "Starting benchmark with " << FLAGS_iter << " iterations...";
+    pre_benchmark_setup();
+    const auto duration_ms =
+        param.profiler->profile([&]() { param.emulator->run(FLAGS_iter); });
+
+    durations_ms.emplace_back(duration_ms);
+    auto throughput = FLAGS_iter / (duration_ms / MS_IN_SECOND);
+    LOG(INFO) << "Benchmark run finished in " << duration_ms / MS_IN_SECOND
+              << " seconds.\n"
+              << "Throughput:\t\t" << throughput << " iterations/s\n";
+
+    post_benchmark_cleanup();
+    LOG(INFO) << "Run " << run + 1 << " finished";
+  }
+  LOG(WARNING) << param.formatter->format(
+      durations_ms, FLAGS_threads, FLAGS_iter);
+}
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/benchmark.h
+++ b/caffe2/predictor/emulator/benchmark.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "caffe2/core/logging.h"
+#include "caffe2/predictor/emulator/emulator.h"
+#include "caffe2/predictor/emulator/output_formatter.h"
+#include "caffe2/predictor/emulator/profiler.h"
+
+C10_DECLARE_int(warmup);
+C10_DECLARE_int(iter);
+C10_DECLARE_int(threads);
+C10_DECLARE_int(runs);
+C10_DECLARE_string(run_net);
+C10_DECLARE_string(init_net);
+C10_DECLARE_string(data_net);
+C10_DECLARE_string(input_dims);
+C10_DECLARE_string(input_types);
+
+namespace caffe2 {
+namespace emulator {
+
+struct BenchmarkParam {
+  std::unique_ptr<Profiler> profiler;
+  std::unique_ptr<Emulator> emulator;
+  std::unique_ptr<OutputFormatter> formatter;
+};
+
+/*
+ * benchmark runner takes an @emulator to run nets.
+ * The runtime will be measured by @profiler.
+ * The output will be formatted by @formatter
+ */
+class BenchmarkRunner {
+ public:
+  void benchmark(const BenchmarkParam& param);
+
+  virtual ~BenchmarkRunner() noexcept {}
+
+ protected:
+  virtual void pre_benchmark_setup() {}
+
+  virtual void post_benchmark_cleanup() {}
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -1,0 +1,149 @@
+#include "caffe2/predictor/emulator/data_filler.h"
+#include "caffe2/predictor/emulator/utils.h"
+
+namespace caffe2 {
+namespace emulator {
+
+void DataNetFiller::fill_parameter(Workspace* ws) const {
+  // As we use initial parameter initialization for this BenchmarkState,
+  // we can just run the init_net
+  CAFFE_ENFORCE(
+      ws->RunNetOnce(init_net_),
+      "Failed running the init_net: ",
+      ProtoDebugString(init_net_));
+}
+
+void DataNetFiller::fill_input_internal(TensorList_t* input_data) const {
+  Workspace ws;
+  CAFFE_ENFORCE(ws.RunNetOnce(data_net_));
+  for (const auto& name : input_names_) {
+    input_data->emplace_back(
+        BlobGetMutableTensor(ws.GetBlob(name), CPU)->Clone());
+  }
+}
+
+static void fill_with_type(
+    const TensorFiller& filler,
+    const std::string& type,
+    TensorCPU* output) {
+  CPUContext context;
+  if (type == "float") {
+    filler.Fill<float>(output, &context);
+  } else if (type == "double") {
+    filler.Fill<double>(output, &context);
+  } else if (type == "uint8_t" || type == "unsigned char") {
+    filler.Fill<uint8_t>(output, &context);
+  } else if (type == "uint16_t") {
+    filler.Fill<uint16_t>(output, &context);
+  } else if (type == "int8_t") {
+    filler.Fill<int8_t>(output, &context);
+  } else if (type == "int16_t") {
+    filler.Fill<int16_t>(output, &context);
+  } else if (type == "int32_t" || type == "int") {
+    filler.Fill<int32_t>(output, &context);
+  } else if (type == "int64_t" || type == "long") {
+    filler.Fill<int64_t>(output, &context);
+  } else if (type == "bool") {
+    auto mutable_filler = filler;
+    mutable_filler.Min(0).Max(2).Fill<uint8_t>(output, &context);
+  } else {
+    throw std::invalid_argument("filler does not support type " + type);
+  }
+}
+
+DataRandomFiller::DataRandomFiller(
+    const NetDef& run_net,
+    const std::vector<std::vector<std::vector<int64_t>>>& input_dims,
+    const std::vector<std::vector<std::string>>& input_types) {
+  // parse dimensions
+  CAFFE_ENFORCE_EQ(input_dims.size(), run_net.op_size());
+  CAFFE_ENFORCE_EQ(input_types.size(), run_net.op_size());
+
+  // load op inputs and outputs
+  std::unordered_set<std::string> output_names;
+  for (size_t i = 0; i < run_net.op_size(); ++i) {
+    const auto& op = run_net.op(i);
+    const auto& op_dims = input_dims[i];
+    const auto& op_types = input_types[i];
+    CAFFE_ENFORCE(
+        op_dims.size() == op.input_size(),
+        op.name() + " has " + caffe2::to_string(op.input_size()) +
+            " inputs; while the input dimension size is " +
+            caffe2::to_string(op_dims.size()));
+    CAFFE_ENFORCE(
+        op_types.size() == op.input_size(),
+        op.name() + " has " + caffe2::to_string(op.input_size()) +
+            " inputs; while the input type size is " +
+            caffe2::to_string(op_types.size()));
+
+    for (size_t j = 0; j < op.input_size(); ++j) {
+      inputs_.emplace(
+          op.input(j),
+          std::make_pair(get_tensor_filler(op, j, op_dims), op_types[j]));
+    }
+
+    for (size_t j = 0; j < op.output_size(); ++j) {
+      output_names.emplace(op.output(j));
+    }
+  }
+
+  // load parameters
+  std::unordered_set<std::string> parameters;
+  for (size_t i = 0; i < run_net.arg_size(); ++i) {
+    const auto& arg = run_net.arg(i);
+    // TODO: replace "PredictorParameters" with the constant in OSS bbp
+    if (arg.has_name() && arg.name() == "PredictorParameters") {
+      parameters.reserve(arg.strings_size());
+      for (size_t j = 0; j < arg.strings_size(); ++j) {
+        parameters.emplace(arg.strings(j));
+      }
+      break;
+    }
+  }
+  if (parameters.size() == 0) {
+    VLOG(1) << "Fail to find any parameters";
+  }
+  for (const auto& param : parameters) {
+    // remove unused parameters
+    if (inputs_.find(param) != inputs_.end()) {
+      // inputs_[param] will be erase from inputs_ in the next step
+      parameters_.emplace(param, inputs_[param]);
+    }
+  }
+
+  for (const auto& param : parameters_) {
+    inputs_.erase(param.first);
+  }
+  for (const auto& name : output_names) {
+    inputs_.erase(name);
+  }
+  CAFFE_ENFORCE(inputs_.size() > 0, "Empty input for run net");
+
+  // generate input names
+  for (const auto& input : inputs_) {
+    input_names_.push_back(input.first);
+  }
+}
+
+void DataRandomFiller::fill_parameter(Workspace* ws) const {
+  for (auto& param : parameters_) {
+    Blob* blob = ws->CreateBlob(param.first);
+    fill_with_type(
+        param.second.first,
+        param.second.second,
+        BlobGetMutableTensor(blob, CPU));
+    CAFFE_ENFORCE(ws->GetBlob(param.first)->GetRaw());
+  }
+}
+
+void DataRandomFiller::fill_input_internal(TensorList_t* input_data) const {
+  for (auto& name : input_names_) {
+    input_data->emplace_back(CPU);
+    const auto& it = inputs_.find(name);
+    CAFFE_ENFORCE(it != inputs_.end());
+    fill_with_type(it->second.first, it->second.second, &input_data->back());
+  }
+}
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/data_filler.h
+++ b/caffe2/predictor/emulator/data_filler.h
@@ -1,0 +1,122 @@
+#pragma once
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/predictor/predictor.h"
+#include "caffe2/utils/filler.h"
+
+namespace caffe2 {
+namespace emulator {
+
+typedef caffe2::Predictor::TensorList TensorList_t;
+
+/*
+ * A filler to initialize the parameters and inputs of a predictor
+ */
+class Filler {
+ protected:
+  virtual void fill_input_internal(TensorList_t* input_data) const = 0;
+
+ public:
+  // initialize the workspace with parameter
+  virtual void fill_parameter(Workspace* ws) const = 0;
+
+  // generate input data and return input data size
+  size_t fill_input(TensorList_t* input_data) const {
+    CAFFE_ENFORCE(input_data, "input_data is null");
+    input_data->clear();
+
+    fill_input_internal(input_data);
+
+    uint64_t bytes = 0;
+    for (const auto& item : *input_data) {
+      bytes += item.nbytes();
+    }
+    CAFFE_ENFORCE(bytes > 0, "input bytes should be positive");
+
+    return bytes;
+  }
+
+  std::vector<std::string> get_input_names() const {
+    CAFFE_ENFORCE(!input_names_.empty(), "input names is not initialized");
+    return input_names_;
+  }
+
+  virtual ~Filler() noexcept {}
+
+ protected:
+  std::vector<std::string> input_names_;
+};
+
+/*
+ * @init_net: a reader net to generate parameters
+ * @data_net: a reader net to generate inputs
+ */
+class DataNetFiller : public Filler {
+ public:
+  DataNetFiller(const NetDef&& init_net, const NetDef&& data_net)
+      : init_net_(init_net), data_net_(data_net) {
+    // The output of the data_net_ will be served as the input
+    int op_size = data_net_.op_size();
+    for (int i = 0; i < op_size; ++i) {
+      OperatorDef op_def = data_net_.op(i);
+      // We rely on Fill op to generate inputs
+      CAFFE_ENFORCE(op_def.type().find("Fill") != std::string::npos);
+      int output_size = op_def.output_size();
+      for (int j = 0; j < output_size; ++j) {
+        input_names_.push_back(op_def.output(j));
+      }
+    }
+  }
+
+  void fill_input_internal(TensorList_t* input_data) const override;
+
+  void fill_parameter(Workspace* ws) const override;
+
+ private:
+  const NetDef init_net_;
+  const NetDef data_net_;
+};
+
+/*
+ * @run_net: the predict net with parameter and input names
+ * @input_dims: the input dimentions of all operator inputs of run_net
+ * @input_types: the input types of all operator inputs of run_net
+ */
+class DataRandomFiller : public Filler {
+ public:
+  DataRandomFiller(
+      const NetDef& run_net,
+      const std::vector<std::vector<std::vector<int64_t>>>& input_dims,
+      const std::vector<std::vector<std::string>>& input_types);
+
+  void fill_input_internal(TensorList_t* input_data) const override;
+
+  void fill_parameter(Workspace* ws) const override;
+
+ private:
+  TensorFiller get_tensor_filler(
+      const OperatorDef& op_def,
+      int input_index,
+      const std::vector<std::vector<int64_t>>& input_dims) {
+    Workspace ws;
+    for (size_t i = 0; i < op_def.input_size(); ++i) {
+      // CreateOperator requires all input blobs present
+      ws.CreateBlob(op_def.input(i));
+    }
+    CAFFE_ENFORCE(op_def.has_type());
+    const OpSchema* schema = caffe2::OpSchemaRegistry::Schema(op_def.type());
+    if (schema == nullptr) {
+      throw std::invalid_argument(
+          op_def.type() + " does not have input fillers");
+    }
+    auto filler = schema->InputFillers(input_dims)[input_index];
+    return filler;
+  }
+
+  using filler_type_pair_t = std::pair<TensorFiller, std::string>;
+  std::unordered_map<std::string, filler_type_pair_t> parameters_;
+  std::unordered_map<std::string, filler_type_pair_t> inputs_;
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/emulator.h
+++ b/caffe2/predictor/emulator/emulator.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "caffe2/core/logging.h"
+
+namespace caffe2 {
+namespace emulator {
+
+/*
+ * A net emulator. In short, it can run nets with given @iterations.
+ */
+class Emulator {
+ public:
+  virtual void init() = 0;
+
+  virtual void run(const uint64_t iterations) = 0;
+
+  virtual ~Emulator() noexcept {}
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/net_supplier.h
+++ b/caffe2/predictor/emulator/net_supplier.h
@@ -1,0 +1,90 @@
+#pragma once
+#include "caffe2/predictor/emulator/data_filler.h"
+#include "caffe2/predictor/emulator/utils.h"
+
+C10_DECLARE_string(mutating_net_type);
+C10_DECLARE_bool(mutating_net_async_deferrable_mode);
+C10_DECLARE_int(mutating_net_async_workers);
+
+namespace caffe2 {
+namespace emulator {
+
+struct RunnableNet {
+  const caffe2::NetDef& netdef;
+  const Filler* filler;
+
+  RunnableNet(const caffe2::NetDef& netdef_, const Filler* filler_)
+      : netdef(netdef_), filler(filler_) {}
+};
+
+/*
+ * An interface to supplier a pair of net and its filler.
+ * The net should be able to run once the filler fills the workspace.
+ * The supplier should take the ownership of both net and filler.
+ */
+class NetSupplier {
+ public:
+  // next() should be thread-safe
+  virtual RunnableNet next() = 0;
+
+  virtual ~NetSupplier() noexcept {}
+};
+
+/*
+ * A simple net supplier that always return the same net and filler pair.
+ */
+class SingleNetSupplier : public NetSupplier {
+ public:
+  SingleNetSupplier(unique_ptr<Filler> filler, caffe2::NetDef netdef)
+      : filler_(std::move(filler)), netdef_(netdef) {}
+
+  RunnableNet next() override {
+    return RunnableNet(netdef_, filler_.get());
+  }
+
+ private:
+  const unique_ptr<Filler> filler_;
+  const caffe2::NetDef netdef_;
+};
+
+class MutatingNetSupplier : public NetSupplier {
+ public:
+  MutatingNetSupplier(std::unique_ptr<NetSupplier>&& core)
+      : core_(std::move(core)) {}
+
+  RunnableNet next() override {
+    RunnableNet orig = core_->next();
+    NetDef* new_net = nullptr;
+    {
+      std::lock_guard<std::mutex> guard(lock_);
+      nets_.push_back(orig.netdef);
+      new_net = &nets_.back();
+    }
+    mutate(new_net);
+    return RunnableNet(*new_net, orig.filler);
+  }
+
+ protected:
+  virtual void mutate(NetDef* net) {
+    // Using async scheduling net if specified
+    if (!FLAGS_mutating_net_type.empty()) {
+      net->set_type(FLAGS_mutating_net_type);
+      if (FLAGS_mutating_net_async_workers > 0) {
+        net->set_num_workers(FLAGS_mutating_net_async_workers);
+      }
+      if (FLAGS_mutating_net_async_deferrable_mode) {
+        auto* arg = net->add_arg();
+        arg->set_name("deferrable_mode");
+        arg->set_i(1);
+      }
+    }
+  }
+
+ private:
+  std::mutex lock_;
+  std::unique_ptr<NetSupplier> core_;
+  std::vector<NetDef> nets_;
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/output_formatter.h
+++ b/caffe2/predictor/emulator/output_formatter.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "caffe2/core/logging.h"
+
+namespace caffe2 {
+namespace emulator {
+
+/*
+ * An interface that formats the output of the emulator runs.
+ */
+class OutputFormatter {
+ public:
+  virtual std::string format(
+      const std::vector<float>& durations_ms,
+      uint64_t threads,
+      uint64_t iterations) = 0;
+
+  virtual ~OutputFormatter() noexcept {}
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/profiler.h
+++ b/caffe2/predictor/emulator/profiler.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "caffe2/core/logging.h"
+#include "caffe2/core/timer.h"
+
+namespace caffe2 {
+namespace emulator {
+
+/*
+ * An interface to profile the metrics of a @runnable.
+ * It should return execution walltime in milliseconds.
+ */
+class Profiler {
+ public:
+  virtual float profile(std::function<void()> runnable) = 0;
+
+  virtual ~Profiler() noexcept {}
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/std_output_formatter.h
+++ b/caffe2/predictor/emulator/std_output_formatter.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "output_formatter.h"
+
+namespace caffe2 {
+namespace emulator {
+
+const uint64_t MS_IN_SECOND = 1000;
+
+/*
+ * Print the output of the emulator run to stdout.
+ */
+class StdOutputFormatter : public OutputFormatter {
+ private:
+  template <typename T>
+  static float get_mean(const std::vector<T>& values) {
+    float sum = std::accumulate(values.begin(), values.end(), 0.0);
+    return sum / values.size();
+  }
+
+  template <typename T>
+  static float get_stdev(const std::vector<T>& values) {
+    auto mean = get_mean(values);
+    double sq_sum =
+        std::inner_product(values.begin(), values.end(), values.begin(), 0.0);
+    return std::sqrt(sq_sum / values.size() - mean * mean);
+  }
+
+ public:
+  std::string format(
+      const std::vector<float>& durations_ms,
+      uint64_t threads,
+      uint64_t iterations) override {
+    auto mean = get_mean(durations_ms);
+    auto throughput = iterations / (mean / MS_IN_SECOND);
+    return std::string("\n\n====================================\n") +
+        "Predictor benchmark finished with " + caffe2::to_string(threads) +
+        " threads.\nThroughput:\t\t" + caffe2::to_string(throughput) +
+        " iterations/s\nVariation:\t\t" +
+        caffe2::to_string(get_stdev(durations_ms) * 100 / mean) +
+        "%\n====================================";
+  }
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/time_profiler.h
+++ b/caffe2/predictor/emulator/time_profiler.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "profiler.h"
+
+namespace caffe2 {
+namespace emulator {
+
+/*
+ * An profiler that measures the walltime of a @runnable
+ */
+class TimeProfiler : public Profiler {
+ public:
+  float profile(std::function<void()> runnable) override {
+    Timer timer;
+    runnable();
+    return timer.MilliSeconds();
+  }
+};
+
+} // namespace emulator
+} // namespace caffe2

--- a/caffe2/predictor/emulator/utils.h
+++ b/caffe2/predictor/emulator/utils.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <fstream>
+
+#include "caffe2/core/logging.h"
+
+namespace caffe2 {
+namespace emulator {
+
+/*
+ * Replace a @substring in a given @line with @target
+ */
+inline std::string replace(
+    std::string line,
+    const std::string& substring,
+    const std::string& target) {
+  size_t index = 0;
+  while (true) {
+    index = line.find(substring, index);
+    if (index == std::string::npos) {
+      break;
+    }
+    line.replace(index, substring.length(), target);
+    index += substring.length();
+  }
+  return line;
+}
+
+/*
+ * Split given @str into a vector of strings delimited by @delim
+ */
+inline std::vector<std::string> split(const string& str, const string& delim) {
+  std::vector<std::string> tokens;
+  size_t prev = 0, pos = 0;
+  do {
+    pos = str.find(delim, prev);
+    if (pos == std::string::npos) {
+      pos = str.length();
+    }
+    std::string token = str.substr(prev, pos - prev);
+    if (!token.empty()) {
+      tokens.push_back(token);
+    }
+    prev = pos + delim.length();
+  } while (pos < str.length() && prev < str.length());
+  return tokens;
+}
+
+/*
+ * Check if the given @path is valid.
+ * Remove the file/folder if @remove is specified
+ */
+inline bool check_path_valid(std::string path, bool remove = true) {
+  CAFFE_ENFORCE(!path.empty());
+  std::ifstream file(path.c_str());
+  // The file should exist or the path is valid
+  if (!file.good() && !static_cast<bool>(std::ofstream(path).put('t'))) {
+    return false;
+  }
+  file.close();
+  if (remove) {
+    std::remove(path.c_str());
+  }
+  return true;
+}
+
+} // namespace emulator
+} // namespace caffe2


### PR DESCRIPTION
Summary:
This diff does not have any logic change; it simply move files/functions/classes around.
Open source (almost all) necessary dependency for multithreaded predictor bench.
The benchmark itself can be open sourced once the predictor is open sourced.

Differential Revision: D9602006
