### PR TITLE
Don't convert TensorOptions to type before printing.

### DIFF
--- a/aten/src/ATen/TensorOptions.cpp
+++ b/aten/src/ATen/TensorOptions.cpp
@@ -19,14 +19,15 @@ TensorOptions::TensorOptions(bool use_thread_local_default_options) {
     this->requires_grad(DefaultTensorOptions::get().requires_grad());
   }
 }
-} // namespace at
 
 std::ostream& operator<<(
     std::ostream& stream,
-    const at::TensorOptions& options) {
+    const TensorOptions& options) {
   return stream << "TensorOptions(dtype=" << options.dtype()
                 << ", device=" << options.device()
                 << ", layout=" << options.layout()
                 << ", requires_grad=" << std::boolalpha
                 << options.requires_grad() << ")";
 }
+
+} // namespace at

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -201,8 +201,8 @@ inline TensorOptions requires_grad(bool requires_grad = true) {
   return TensorOptions().requires_grad(requires_grad);
 }
 
-} // namespace at
-
 std::ostream& operator<<(
     std::ostream& stream,
-    const at::TensorOptions& options);
+    const TensorOptions& options);
+
+} // namespace at

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -30,12 +30,12 @@ void window_function_checks(
       options.layout() != kSparse,
       function_name,
       " is not implemented for sparse types, got: ",
-      options.type().toString());
+      options);
   AT_CHECK(
       at::isFloatingType(options.dtype()),
       function_name,
       " expects floating point dtypes, got: ",
-      options.type().toString());
+      options);
   AT_CHECK(
       window_length >= 0,
       function_name,


### PR DESCRIPTION
Don't convert TensorOptions to type before printing.



Differential Revision: D9613897

Stacked on #11144