### PR TITLE
allow spaces in filename for jit-compiled cpp_extensions

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -901,6 +901,7 @@ def _write_ninja_file(path,
         object_files.append(target)
         if sys.platform == 'win32':
             source_file = source_file.replace(':', '$:')
+        source_file = source_file.replace(" ", "$ ")
         build.append('build {}: {} {}'.format(target, rule, source_file))
 
     ext = '.pyd' if sys.platform == 'win32' else '.so'


### PR DESCRIPTION
Now, folder having spaces will not error out for `torch.utils.cpp_extensionload(name="xxx", sources=["xxx.cpp"], verbose=True)` calls.