### PR TITLE
[build] Support environments with no libprotobuf

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -45,27 +45,36 @@ if (@USE_GLOG@)
 endif()
 
 # Protobuf
-include("${CMAKE_CURRENT_LIST_DIR}/public/protobuf.cmake")
-if (NOT TARGET protobuf::libprotobuf)
-  message(FATAL_ERROR
-      "Your installed Caffe2 version uses protobuf but the protobuf library "
-      "cannot be found. Did you accidentally remove it, or have you set "
-      "the right CMAKE_PREFIX_PATH? If you do not have protobuf, you will "
-      "need to install protobuf and set the library path accordingly.")
-endif()
-message(STATUS "Caffe2: Protobuf version " ${Protobuf_VERSION})
-# If during build time we know the protobuf version, we will also do a sanity
-# check to ensure that the protobuf library that Caffe2 found is consistent with
-# the compiled version.
-if (@CAFFE2_KNOWN_PROTOBUF_VERSION@)
-  if (NOT (${Protobuf_VERSION} VERSION_EQUAL @Protobuf_VERSION@))
+if (@CAFFE2_LINK_LOCAL_PROTOBUF@)
+  if (NOT TARGET protobuf::libprotobuf)
+    # Define protobuf::libprotobuf as a dummy target to resolve references to
+    # protobuf::libprotobuf in Caffe2Targets.cmake.
+    add_library(dummy INTERFACE)
+    add_library(protobuf::libprotobuf ALIAS dummy)
+  endif()
+else()
+  include("${CMAKE_CURRENT_LIST_DIR}/public/protobuf.cmake")
+  if (NOT TARGET protobuf::libprotobuf)
     message(FATAL_ERROR
-        "Your installed Caffe2 is built with protobuf "
-        "@Protobuf_VERSION@"
-        ", while your current cmake setting discovers protobuf version "
-        ${Protobuf_VERSION}
-        ". Please specify a protobuf version that is the same as the built "
-        "version.")
+        "Your installed Caffe2 version uses protobuf but the protobuf library "
+        "cannot be found. Did you accidentally remove it, or have you set "
+        "the right CMAKE_PREFIX_PATH? If you do not have protobuf, you will "
+        "need to install protobuf and set the library path accordingly.")
+  endif()
+  message(STATUS "Caffe2: Protobuf version " ${Protobuf_VERSION})
+  # If during build time we know the protobuf version, we will also do a sanity
+  # check to ensure that the protobuf library that Caffe2 found is consistent
+  # with the compiled version.
+  if (@CAFFE2_KNOWN_PROTOBUF_VERSION@)
+    if (NOT (${Protobuf_VERSION} VERSION_EQUAL @Protobuf_VERSION@))
+      message(FATAL_ERROR
+          "Your installed Caffe2 is built with protobuf "
+          "@Protobuf_VERSION@"
+          ", while your current cmake setting discovers protobuf version "
+          ${Protobuf_VERSION}
+          ". Please specify a protobuf version that is the same as the built "
+          "version.")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Just pulling this out of https://github.com/pytorch/pytorch/pull/10611

Make sure we can support environments where we don't have libprotobuf installed when we link-local protobuf.

cc @goldsborough @Yangqing 