### PR TITLE
remove unnecessary clone() when .grad is None

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2473,6 +2473,38 @@ class TestAutograd(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'backward without computing eigenvectors'):
             torch.autograd.backward([w, v], [torch.ones_like(w), torch.ones_like(v)])
 
+    def test_no_grad_copy(self):
+        # create autograd function that saves grad pointer as class static
+        class MyFunc(Function):
+            static_grad_ptr = None
+
+            @staticmethod
+            def forward(ctx, inp1, inp2):
+                return inp1 + inp2
+
+            @staticmethod
+            def backward(ctx, grad):
+                MyFunc.static_grad_ptr = grad.data_ptr()
+                return grad, grad
+
+        a = torch.randn(5, 6, requires_grad=True)
+        b = torch.randn(5, 6, requires_grad=True)
+        # sum should not trigger no copy since it produce non-contiguous grad
+        MyFunc.apply(a, b).sum().backward()
+        self.assertFalse(a.grad.data_ptr() == MyFunc.static_grad_ptr)
+        self.assertFalse(b.grad.data_ptr() == MyFunc.static_grad_ptr)
+        # manually setting .grad to None
+        a.grad = b.grad = None
+        # test case that should trigger no copy for one of a,b
+        MyFunc.apply(a, b)[1][0].backward()
+        p_g = MyFunc.static_grad_ptr
+        p_a = a.grad.data_ptr()
+        p_b = b.grad.data_ptr()
+        # check a,b uses different grad buffer
+        self.assertFalse(p_a == p_b)
+        # check one of them is using the computed buffer
+        self.assertTrue(p_a == p_g or p_b == p_g)
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -33,7 +33,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   if (!variable.requires_grad())
     return {};
 
-  auto new_grad = grads[0];
+  auto& new_grad = grads[0];
   for (auto& hook : variable.hooks()) {
     new_grad = (*hook)({new_grad})[0];
   }
@@ -44,12 +44,11 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     if (!GradMode::is_enabled()
         && !new_grad.type().is_sparse()
         && new_grad.is_contiguous()
-        && new_grad.use_count() == 2) {
+        && new_grad.use_count() == 1) {
       // first check it is in first-order grad only mode
       // then check not sparse before is_contiguous
       // then check contiguous, otherwise later in place accumulation may fail
       // and lastly, check it is the last reference before we grab it
-      // we created new_grad above so ref count should be 2
       variable.grad() = new_grad.detach();
     } else {
       variable.grad() = new_grad.clone();

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -33,7 +33,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   if (!variable.requires_grad())
     return {};
 
-  auto& new_grad = grads[0];
+  auto new_grad = std::move(grads[0]);
   for (auto& hook : variable.hooks()) {
     new_grad = (*hook)({new_grad})[0];
   }


### PR DESCRIPTION
Currently gradient is copied into .grad if it is None. This PR aim to remove the copy when it is not absolutely needed.

It is generally an improvement of speed and memory usage. And here is a case it may help a lot:
Normally, people do optimizer.zero_grad() every minibatch before backward. It will translate into a memset, and later a point-wise add.
When there is some large weight in the network, one optimization people can always do is set parameter.grad to None instead of zero_grad. This will remove memset and change point-wise add to a memcpy.
Here is result running following script on V100 GPU. It is 100 iterations of forward/backward/zero_grad on single 1-billion word benchmark size embedding.
`Zero grad: 2.123847723007202`
`None grad: 1.3342866897583008`

With the backend change of this PR, the unnecessary memcpy is removed, thus further speed up is achieved.
`Zero grad: 2.124978542327881`
`None grad: 0.4396955966949463`

[benchmark.txt](https://github.com/pytorch/pytorch/files/2341800/benchmark.txt)

Some details on the code change:
.detach() is used because we need to get rid of new_grad being a view without copy data. This should be safe in first-order only mode.
data need to be contiguous, otherwise `grad_variable.data() += new_grad.data();` below will fail.
Only the last variable that has reference to the temp gradient will grab its buffer.

@ngimel, @mcarilli  and @mruberry helped on finalizing this PR.