### PR TITLE
Make Type a (mostly) pure virtual class; TypeDefault for impls (#11013)

### DIFF
--- a/aten/src/ATen/UndefinedType.cpp
+++ b/aten/src/ATen/UndefinedType.cpp
@@ -4,7 +4,7 @@
 namespace at {
 
 UndefinedType::UndefinedType()
-    : Type(UndefinedTensorId(), /*is_variable=*/false, /*is_undefined=*/true) {}
+    : TypeDefault(UndefinedTensorId(), /*is_variable=*/false, /*is_undefined=*/true) {}
 ScalarType UndefinedType::scalarType() const {
   return ScalarType::Undefined;
 }
@@ -50,13 +50,13 @@ size_t UndefinedType::elementSizeInBytes() const {
 
 Type & UndefinedType::toBackend(Backend b) const {
   if (b == Backend::Undefined) {
-    return Type::toBackend(b);
+    return TypeDefault::toBackend(b);
   }
   AT_ERROR("toBackend not implemented for UndefinedType to non-UndefinedType");
 }
 Type & UndefinedType::toScalarType(ScalarType s) const {
   if (s == ScalarType::Undefined) {
-    return Type::toScalarType(s);
+    return TypeDefault::toScalarType(s);
   }
   AT_ERROR("toScalarType not implemented for UndefinedType to non-UndefinedType");
 }

--- a/aten/src/ATen/UndefinedType.h
+++ b/aten/src/ATen/UndefinedType.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ATen/Type.h"
+#include "ATen/TypeDefault.h"
 #include "ATen/CheckGenerator.h"
 
 #ifdef _MSC_VER
@@ -11,7 +11,7 @@
 
 namespace at {
 
-struct UndefinedType final : public Type {
+struct UndefinedType final : public TypeDefault {
   explicit UndefinedType();
   virtual ScalarType scalarType() const override;
   virtual Backend backend() const override;

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -39,11 +39,11 @@ else:
 #    declaration under Type.h  (right now, we call this template
 #    BROADCAST but it also handles default arguments)
 TYPE_METHOD_DECLARATION_BROADCAST = CodeTemplate("""\
-${return_type} ${api_name}(${type_method_formals_with_defaults}) const;
+${return_type} ${api_name}(${type_method_formals_with_defaults}) const override;
 """)
 # 2. broadcasting functions are implemented in Type.cpp
 TYPE_METHOD_DEFINITION_BROADCAST = CodeTemplate("""\
-${return_type} Type::${api_name}(${type_method_formals}) const {
+${return_type} TypeDefault::${api_name}(${type_method_formals}) const {
     ${device_guard_declaration}
     Tensor ${broadcast_returns};
     std::tie(${broadcast_returns}) = ${broadcast_function}(${broadcast_actuals}, "${api_name}");
@@ -59,28 +59,36 @@ ${return_type} Type::${api_name}(${type_method_formals}) const {
 #    actual implementation.  At the moment, this situation *only* occurs
 #    for 'native' declarations (so the native dispatch is hardcoded into
 #    the template here.)
+PURE_VIRTUAL_TYPE_METHOD_DECLARATION = CodeTemplate("""\
+virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals_with_defaults}) const = 0;
+""")
+DEPRECATED_PURE_VIRTUAL_TYPE_METHOD_DECLARATION = CodeTemplate("""\
+AT_DEPRECATED(virtual ${return_type} \
+${method_prefix_derived}${api_name}(${type_method_formals_with_defaults}) const = 0);
+""")
+PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST = CodeTemplate("""\
+virtual ${return_type} ${api_name}(${type_method_formals_with_defaults}) const = 0;
+""")
+
 TYPE_METHOD_DECLARATION_ABSTRACT = CodeTemplate("""\
-virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals_with_defaults}) const;
+${return_type} ${method_prefix_derived}${api_name}(${type_method_formals_with_defaults}) const override;
 """)
 TYPE_METHOD_DEFINITION_ABSTRACT = CodeTemplate("""\
-${return_type} Type::${method_prefix_derived}${api_name}(${type_method_formals}) const {
+${return_type} TypeDefault::${method_prefix_derived}${api_name}(${type_method_formals}) const {
     AT_ERROR("${method_prefix_derived}${api_name} is not implemented for type ", toString());
 }
 """)
 TYPE_METHOD_DECLARATION_CONCRETE = CodeTemplate("""\
-virtual ${return_type} ${api_name}(${type_method_formals_with_defaults}) const;
-""")
-DEPRECATED_TYPE_METHOD_DECLARATION_CONCRETE = CodeTemplate("""\
-AT_DEPRECATED(virtual ${return_type} ${api_name}(${type_method_formals_with_defaults}) const);
+${return_type} ${api_name}(${type_method_formals_with_defaults}) const override;
 """)
 TYPE_METHOD_DEFINITION_CONCRETE = CodeTemplate("""\
-${return_type} Type::${api_name}(${type_method_formals}) const {
+${return_type} TypeDefault::${api_name}(${type_method_formals}) const {
     ${device_guard_declaration}
     ${type_definition_body}
 }
 """)
 DEPRECATED_TYPE_METHOD_DEFINITION_CONCRETE = CodeTemplate("""\
-${return_type} Type::${api_name}(${type_method_formals}) const {
+${return_type} TypeDefault::${api_name}(${type_method_formals}) const {
     TensorOptions options(*this);
     ${device_guard_declaration}
     return at::native::${api_name}(${type_method_actuals}, options);
@@ -88,7 +96,7 @@ ${return_type} Type::${api_name}(${type_method_formals}) const {
 """)
 # 4. add virtual override to TypeDerived.h
 TYPE_DERIVED_DECLARATION = CodeTemplate("""\
-virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals}) const override;
+${return_type} ${method_prefix_derived}${api_name}(${type_method_formals}) const override;
 """)
 # 5. add override definition to TypeDerived.cpp
 TYPE_DERIVED_DEFINITION = CodeTemplate("""\
@@ -382,6 +390,7 @@ Environment = TypedDict('Environment', {
 TopEnvironment = TypedDict('TopEnvironment', {
     'type_registrations': List[str],
     'type_headers': List[str],
+    'pure_virtual_type_method_declarations': List[str],
     'type_method_declarations': List[str],
     'type_method_definitions': List[str],
     'type_method_inline_definitions': List[str],
@@ -815,6 +824,8 @@ def create_generic(top_env, declarations):
             # NN function with no _forward/_backward suffix don't have cimpls.
             # They call the _forward function and discard any buffer returns
             abstract = False
+            top_env['pure_virtual_type_method_declarations'].append(
+                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
             body = emit_nn_body(option)
@@ -822,11 +833,17 @@ def create_generic(top_env, declarations):
                 TYPE_METHOD_DEFINITION_CONCRETE.substitute(
                     env, type_definition_body=body))
         elif broadcast_arg is None:
+            top_env['pure_virtual_type_method_declarations'].append(
+                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_ABSTRACT.substitute(env))
             top_env['type_method_definitions'].append(
                 TYPE_METHOD_DEFINITION_ABSTRACT.substitute(env))
         else:
+            top_env['pure_virtual_type_method_declarations'].append(
+                PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
+            top_env['pure_virtual_type_method_declarations'].append(
+                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
             top_env['type_method_declarations'].append(
@@ -1031,9 +1048,12 @@ def create_generic(top_env, declarations):
         # Factory methods are not dispatched over `Type`.
         if not is_factory_method:
             if option['deprecated']:
-                top_env['type_method_declarations'].append(DEPRECATED_TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
+                top_env['pure_virtual_type_method_declarations'].append(
+                    DEPRECATED_PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             else:
-                top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
+                top_env['pure_virtual_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
         dispatch = option['type_method_definition_dispatch']
         option['native_type_method_dispatch'] = dispatch
 

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -107,7 +107,8 @@ TYPE_DERIVED_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDerived.cpp")
 SPARSE_TYPE_DERIVED_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/SparseTypeDerived.cpp")
 TYPE_DERIVED_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDerived.h")
 TYPE_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.h")
-TYPE_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.cpp")
+TYPE_DEFAULT_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDefault.h")
+TYPE_DEFAULT_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDefault.cpp")
 
 REGISTER_CPU_H = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCPU.h")
 REGISTER_CPU_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCPU.cpp")
@@ -166,6 +167,7 @@ top_env = {
     'cpu_type_headers': [],
     'cuda_type_registrations': [],
     'cuda_type_headers': [],
+    'pure_virtual_type_method_declarations': [],
     'type_method_declarations': [],
     'type_method_definitions': [],
     'type_method_inline_definitions': [],
@@ -329,7 +331,7 @@ def iterate_types():
 # so that the script runs quickly when we are just querying the
 # outputs
 def declare_outputs():
-    files = ['Declarations.yaml', 'Type.h', 'Type.cpp', 'Tensor.h',
+    files = ['Declarations.yaml', 'Type.h', 'TypeDefault.cpp', 'TypeDefault.h', 'Tensor.h',
              'TensorMethods.h', 'Functions.h',
              'CPUCopy.cpp', 'NativeFunctions.h',
              'RegisterCPU.cpp', 'RegisterCPU.h']
@@ -399,7 +401,8 @@ def generate_outputs():
             backend, density, scalar_type, declarations))
 
     file_manager.write('Type.h', TYPE_H, top_env)
-    file_manager.write('Type.cpp', TYPE_CPP, top_env)
+    file_manager.write('TypeDefault.h', TYPE_DEFAULT_H, top_env)
+    file_manager.write('TypeDefault.cpp', TYPE_DEFAULT_CPP, top_env)
 
     file_manager.write('RegisterCPU.h', REGISTER_CPU_H, top_env)
     file_manager.write('RegisterCPU.cpp', REGISTER_CPU_CPP, top_env)

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -28,7 +28,7 @@ $extra_cuda_headers
 namespace at {
 
 ${Type}::${Type}()
-  : Type(${Backend}TensorId(), /*is_variable=*/false, /*is_undefined=*/false) {}
+  : TypeDefault(${Backend}TensorId(), /*is_variable=*/false, /*is_undefined=*/false) {}
 ScalarType ${Type}::scalarType() const {
   return ScalarType::${ScalarName};
 }

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -47,6 +47,7 @@ enum class TypeID {
 struct AT_API Type {
   explicit Type(TensorTypeId type_id, bool is_variable, bool is_undefined)
       : type_id_(type_id), is_variable_(is_variable), is_undefined_(is_undefined) {}
+
   virtual ~Type() {}
   virtual ScalarType scalarType() const = 0;
   virtual Backend backend() const = 0;
@@ -65,8 +66,8 @@ struct AT_API Type {
   virtual Storage unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
   virtual size_t elementSizeInBytes() const = 0;
-  virtual Type & toBackend(Backend b) const;
-  virtual Type & toScalarType(ScalarType s) const;
+  virtual Type & toBackend(Backend b) const = 0;
+  virtual Type & toScalarType(ScalarType s) const = 0;
   Type & toSparse() const {
     return this->toBackend(at::toSparse(this->backend()));
   }
@@ -91,23 +92,27 @@ struct AT_API Type {
     return backendToDeviceType(backend());
   }
 
-  Tensor copy(const Tensor & src, bool non_blocking=false) const;
-  Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const;
+  virtual Tensor copy(const Tensor & src, bool non_blocking=false) const = 0;
+  virtual Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const = 0;
   virtual Tensor & s_copy_(Tensor & self, const Tensor & src, bool non_blocking) const = 0;
   virtual Tensor & _s_copy_from(const Tensor & self, Tensor & dst, bool non_blocking) const = 0;
 
-  Tensor tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter=noop_deleter) const;
-  Tensor tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter=noop_deleter) const;
-  Tensor tensorWithAllocator(IntList sizes, Allocator* allocator) const;
-  Tensor tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const;
-  Tensor scalarTensor(Scalar s) const;
+  virtual Tensor tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
+  virtual Tensor tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
+  virtual Tensor tensorWithAllocator(IntList sizes, Allocator* allocator) const = 0;
+  virtual Tensor tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const = 0;
+  virtual Tensor scalarTensor(Scalar s) const = 0;
 
-  bool operator==(const Type& other) const;
-  bool operator!=(const Type& other) const;
+  bool operator==(const Type& other) const {
+    return this == &other;
+  }
+  bool operator!=(const Type& other) const {
+    return this != &other;
+  }
 
   // example
   // virtual Tensor * add(Tensor & a, Tensor & b) = 0;
-  ${type_method_declarations}
+  ${pure_virtual_type_method_declarations}
 protected:
   TensorTypeId type_id_;
   bool is_variable_;

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -1,4 +1,4 @@
-#include "ATen/Type.h"
+#include "ATen/TypeDefault.h"
 
 // ${generated_comment}
 
@@ -13,13 +13,13 @@
 
 namespace at {
 
-Tensor & Type::copy_(Tensor & self, const Tensor & src, bool non_blocking) const {
+Tensor & TypeDefault::copy_(Tensor & self, const Tensor & src, bool non_blocking) const {
   Tensor b_src;
   std::tie(b_src) = expand_inplace(self, src, "copy");
   return s_copy_(self, b_src, non_blocking);
 }
 
-Tensor Type::copy(const Tensor & src, bool non_blocking) const {
+Tensor TypeDefault::copy(const Tensor & src, bool non_blocking) const {
   // TODO(psag): have a DeviceGuard here
   AT_CHECK(src.defined(), "attempt to copy an undefined tensor");
   if (is_sparse()) {
@@ -37,10 +37,10 @@ Tensor Type::copy(const Tensor & src, bool non_blocking) const {
   }
 }
 
-Type & Type::toBackend(Backend b) const {
+Type & TypeDefault::toBackend(Backend b) const {
   return at::globalContext().getNonVariableType(b,scalarType());
 }
-Type & Type::toScalarType(ScalarType s) const {
+Type & TypeDefault::toScalarType(ScalarType s) const {
   return at::globalContext().getNonVariableType(backend(),s);
 }
 static std::vector<int64_t> defaultStrides(IntList sizes) {
@@ -64,29 +64,22 @@ static int64_t computeStorageSize(IntList sizes, IntList strides) {
   }
   return size;
 }
-Tensor Type::tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter) const {
+Tensor TypeDefault::tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter) const {
   return tensorFromBlob(data, sizes, defaultStrides(sizes), deleter);
 }
-Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter) const {
+Tensor TypeDefault::tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter) const {
   auto storage = storageFromBlob(data, computeStorageSize(sizes, strides), deleter);
   return tensor(storage, 0, sizes, strides);
 }
-Tensor Type::tensorWithAllocator(IntList sizes, Allocator* allocator) const {
+Tensor TypeDefault::tensorWithAllocator(IntList sizes, Allocator* allocator) const {
   return tensorWithAllocator(sizes, defaultStrides(sizes), std::move(allocator));
 }
-Tensor Type::tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const {
+Tensor TypeDefault::tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const {
   auto storage = storageWithAllocator(computeStorageSize(sizes, strides), std::move(allocator));
   return tensor(storage, 0, sizes, strides);
 }
-Tensor Type::scalarTensor(Scalar s) const {
+Tensor TypeDefault::scalarTensor(Scalar s) const {
   return tensor({}).fill_(s);
-}
-
-bool Type::operator==(const Type& other) const {
-  return this == &other;
-}
-bool Type::operator!=(const Type& other) const {
-  return this != &other;
 }
 
 ${type_method_definitions}

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// ${generated_comment}
+
+#include "ATen/Type.h"
+
+namespace at {
+
+struct AT_API TypeDefault : public Type {
+  explicit TypeDefault(TensorTypeId type_id, bool is_variable, bool is_undefined)
+      : Type(type_id, is_variable, is_undefined) {}
+
+  // Make sure overload resolution considers the nullary virtual method.
+  // (A single argument overload is generated in the list.)
+  bool is_cuda() const override = 0;
+  bool is_sparse() const override = 0;
+  bool is_distributed() const override = 0;
+
+  Type & toBackend(Backend b) const override;
+  Type & toScalarType(ScalarType s) const override;
+
+  Tensor copy(const Tensor & src, bool non_blocking=false) const override;
+  Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const override;
+
+  Tensor tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter=noop_deleter) const override;
+  Tensor tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter=noop_deleter) const override;
+  Tensor tensorWithAllocator(IntList sizes, Allocator* allocator) const override;
+  Tensor tensorWithAllocator(IntList sizes, IntList strides, Allocator* allocator) const override;
+  Tensor scalarTensor(Scalar s) const override;
+
+  // example
+  // virtual Tensor * add(Tensor & a, Tensor & b) = 0;
+  ${type_method_declarations}
+};
+
+} // namespace at

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -39,7 +39,7 @@ static int getPointerDevice(void* ptr) {
 #endif
 
 ${Type}::${Type}()
-  : Type(${Backend}TensorId(), /*is_variable=*/false, /*is_undefined=*/false) {}
+  : TypeDefault(${Backend}TensorId(), /*is_variable=*/false, /*is_undefined=*/false) {}
 ScalarType ${Type}::scalarType() const {
   return ScalarType::${ScalarName};
 }

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -2,7 +2,7 @@
 
 // ${generated_comment}
 
-#include "ATen/Type.h"
+#include "ATen/TypeDefault.h"
 #include "ATen/Context.h"
 #include "ATen/TensorMethods.h"
 #include "ATen/CheckGenerator.h"
@@ -15,7 +15,7 @@
 
 namespace at {
 
-struct ${Type} final : public Type {
+struct ${Type} final : public TypeDefault {
   explicit ${Type}();
   virtual ScalarType scalarType() const override;
   virtual Backend backend() const override;

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -108,7 +108,7 @@ grad_fn->set_next_edges(collect_next_edges( ${args_with_derivatives} ));
 """)
 
 CALL_VIA_TYPE = CodeTemplate("""\
-Type::${method_prefix_derived}${api_name}(${type_method_args})""")
+TypeDefault::${method_prefix_derived}${api_name}(${type_method_args})""")
 
 CALL_VIA_DERIVED = CodeTemplate("""\
 baseType->${method_prefix_derived}${base_name}(${unpacked_args})""")

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -43,7 +43,7 @@ using namespace torch::autograd::generated;
 namespace torch { namespace autograd {
 
 VariableType::VariableType(Context* context, Type* baseType)
-  : Type(baseType->type_id(), /*is_variable=*/true, /*is_undefined=*/false)
+  : TypeDefault(baseType->type_id(), /*is_variable=*/true, /*is_undefined=*/false)
   , baseType(baseType)
   , id_(context->freshTypeID()) {
   str = std::string("Variable[") + baseType->toString() + "]";

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -4,6 +4,8 @@
 
 #include <ATen/ATen.h>
 
+#include <ATen/TypeDefault.h>
+
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <cstdint> // for size_t
@@ -30,7 +32,7 @@ using at::optional;
 
 void register_variable_type_for(at::Type* baseType);
 
-struct TORCH_API VariableType final : public at::Type {
+struct TORCH_API VariableType final : public at::TypeDefault {
   VariableType(Context* context, at::Type* baseType);
   virtual at::ScalarType scalarType() const override;
   virtual at::Backend backend() const override;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/11013

Previously, the parent class Type also contained a large number
of implementations, for things like broadcasting and native
functions that didn't need dispatch.  We'd like to be able
to reference this interface from Tensor even when we don't
have any of these implementations are available.

To do this, we convert Type into a truly pure virtual interface,
and move all of the implementations to TypeDefault.

Differential Revision: D9561478
