### PR TITLE
State dict loading arguments were in the wrong order

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -650,7 +650,7 @@ class Module(object):
                     # local shape should match the one in checkpoint
                     error_msgs.append('size mismatch for {}: copying a param of {} from checkpoint, '
                                       'where the shape is {} in current model.'
-                                      .format(key, param.shape, input_param.shape))
+                                      .format(key, input_param.shape, param.shape))
                     continue
 
                 if isinstance(input_param, Parameter):


### PR DESCRIPTION
In the state dict loading code, it would print the error message referring to the shape of the loaded parameters and the parameters in the initialised model with the formatting in the wrong order. Swapped them round to fix.