### PR TITLE
Add complex hooks for out of tree complex implementation.

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -9,6 +9,7 @@
 #include "ATen/core/Error.h"
 #include "ATen/detail/CUDAHooksInterface.h"
 #include "ATen/detail/VariableHooksInterface.h"
+#include "ATen/detail/ComplexHooksInterface.h"
 
 // This is temporary
 #include "ATen/core/ATenCoreTest.h"
@@ -26,7 +27,10 @@ public:
     return type_registry[static_cast<int>(p)][static_cast<int>(s)].get();
   }
   Type * getNonVariableTypeOpt(Backend p, ScalarType s) {
-    if (p != Backend::Undefined) initCUDAIfNeeded(backendToDeviceType(p));
+    if (p != Backend::Undefined) {
+      initCUDAIfNeeded(backendToDeviceType(p));
+      initComplexIfNeeded(s);
+    }
     auto type = getNonVariableTypeRaw(p, s);
 
     if(!type) {
@@ -53,6 +57,10 @@ public:
     } else {
       return getNonVariableType(p, s);
     }
+  }
+  void registerType(Backend b, ScalarType s, Type* t) {
+    type_registry[static_cast<int>(b)][static_cast<int>(s)].reset(t);
+    detail::getVariableHooks().registerVariableTypeFor(this, b, s);
   }
 
   Generator & defaultGenerator(DeviceType device_type) {
@@ -86,6 +94,11 @@ public:
       detail::getCUDAHooks().registerCUDATypes(this);
     });
     return thc_state.get();
+  }
+  void lazyInitComplex() {
+    std::call_once(complex_init_, [&] {
+      detail::getComplexHooks().registerComplexTypes(this);
+    });
   }
 
   THCState* getTHCState() {
@@ -124,7 +137,13 @@ private:
       lazyInitCUDA();
     }
   }
+  void initComplexIfNeeded(ScalarType s) {
+    if (isComplexType(s)) {
+      lazyInitComplex();
+    }
+  }
   std::once_flag thc_init;
+  std::once_flag complex_init_;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
   bool benchmark_cudnn = false;

--- a/aten/src/ATen/core/Storage.h
+++ b/aten/src/ATen/core/Storage.h
@@ -8,6 +8,8 @@ struct AT_API Storage {
 public:
   Storage() {}
   Storage(StorageImpl* storage_impl) : storage_impl_(c10::intrusive_ptr<StorageImpl>::reclaim(storage_impl)) {}
+  Storage(const c10::intrusive_ptr<StorageImpl>& ptr) : storage_impl_(ptr) {}
+  Storage(c10::intrusive_ptr<StorageImpl>&& ptr) : storage_impl_(std::move(ptr)) {}
   Storage(
       at::ScalarType,
       size_t size,

--- a/aten/src/ATen/detail/ComplexHooksInterface.cpp
+++ b/aten/src/ATen/detail/ComplexHooksInterface.cpp
@@ -1,0 +1,25 @@
+#include <ATen/detail/ComplexHooksInterface.h>
+
+namespace at {
+
+namespace detail {
+const ComplexHooksInterface& getComplexHooks() {
+  static std::unique_ptr<ComplexHooksInterface> complex_hooks;
+  // NB: The once_flag here implies that if you try to call any Complex
+  // functionality before you load the complex library, you're toast.
+  // Same restriction as in getCUDAHooks()
+  static std::once_flag once;
+  std::call_once(once, [] {
+    complex_hooks = ComplexHooksRegistry()->Create("ComplexHooks", ComplexHooksArgs{});
+    if (!complex_hooks) {
+      complex_hooks =
+          std::unique_ptr<ComplexHooksInterface>(new ComplexHooksInterface());
+    }
+  });
+  return *complex_hooks;
+}
+} // namespace detail
+
+AT_DEFINE_REGISTRY(ComplexHooksRegistry, ComplexHooksInterface, ComplexHooksArgs)
+
+}

--- a/aten/src/ATen/detail/ComplexHooksInterface.h
+++ b/aten/src/ATen/detail/ComplexHooksInterface.h
@@ -5,7 +5,7 @@
 
 namespace at {
 
-struct Context;
+class Context;
 
 struct AT_API ComplexHooksInterface {
   virtual ~ComplexHooksInterface() {}

--- a/aten/src/ATen/detail/ComplexHooksInterface.h
+++ b/aten/src/ATen/detail/ComplexHooksInterface.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ATen/Registry.h>
+#include <ATen/Error.h>
+
+namespace at {
+
+struct Context;
+
+struct AT_API ComplexHooksInterface {
+  virtual ~ComplexHooksInterface() {}
+
+  virtual void registerComplexTypes(Context*) const {
+    AT_ERROR("Cannot register complex types without loading a library with complex support");
+  }
+};
+
+struct AT_API ComplexHooksArgs {};
+AT_DECLARE_REGISTRY(ComplexHooksRegistry, ComplexHooksInterface, ComplexHooksArgs)
+#define REGISTER_COMPLEX_HOOKS(clsname) \
+  AT_REGISTER_CLASS(ComplexHooksRegistry, clsname, clsname)
+
+namespace detail {
+AT_API const ComplexHooksInterface& getComplexHooks();
+}
+
+}

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -52,9 +52,9 @@ struct AT_API Tensor {
     }
   }
   Tensor(const c10::intrusive_ptr<TensorImpl, UndefinedTensor>& ptr)
-      : tensor_impl_(std::move(ptr)) {}
-  Tensor(c10::intrusive_ptr<TensorImpl, UndefinedTensor>&& ptr)
       : tensor_impl_(ptr) {}
+  Tensor(c10::intrusive_ptr<TensorImpl, UndefinedTensor>&& ptr)
+      : tensor_impl_(std::move(ptr)) {}
 
   Tensor(const Tensor&) = default;
   Tensor(Tensor&&) = default;

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -41,6 +41,10 @@ static inline void noop_deleter(void*) {}
 
 enum class TypeID {
   ${type_ids}
+  CPUComplexFloat,
+  CPUComplexDouble,
+  CUDAComplexFloat,
+  CUDAComplexDouble,
   Undefined,
   NumOptions
 };

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -313,8 +313,15 @@ class TestCppExtension(common.TestCase):
             for (auto s : size) {
               numel *= s;
             }
-            Storage s{c10::make_intrusive<StorageImpl>(scalarTypeToDataType(ScalarType::ComplexFloat), numel, getCPUAllocator(), /* resizable */ true)};
-            Tensor t{c10::make_intrusive<TensorImpl, UndefinedTensor>(std::move(s), at::CPUTensorId(), /* is_variable */ false)};
+            Storage s{c10::make_intrusive<StorageImpl>(
+                scalarTypeToDataType(ScalarType::ComplexFloat),
+                numel,
+                getCPUAllocator(),
+                /* resizable */ true)};
+            Tensor t{c10::make_intrusive<TensorImpl, UndefinedTensor>(
+                std::move(s),
+                at::CPUTensorId(),
+                /* is_variable */ false)};
             return t;
           }
         };


### PR DESCRIPTION
This PR adds a hooks interface for registering types for complex
scalar types, and a sample implementation of the hook in
test_cpp_extensions.

The hook registration is patterned off of the existing CUDA hooks.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @Roger-luo