### PR TITLE
Add AVX optimizations for pdist

### DIFF
--- a/aten/src/ATen/cpu/vec256/functional.h
+++ b/aten/src/ATen/cpu/vec256/functional.h
@@ -68,8 +68,8 @@ template <typename scalar_t, typename MapOp, typename ReduceOp>
 inline scalar_t map2_reduce_all(
     const MapOp& map_fun,
     const ReduceOp& red_fun,
-    scalar_t* data,
-    scalar_t* data2,
+    const scalar_t* data,
+    const scalar_t* data2,
     int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   if (size < Vec::size) {

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -84,6 +84,13 @@ public:
     }
     return ret;
   }
+  Vec256<T> map2(const Vec256<T> other, T (*f)(T, T)) const {
+    Vec256<T> ret;
+    for (int64_t i = 0; i != size; i++) {
+      ret[i] = f(values[i], other[i]);
+    }
+    return ret;
+  }
   Vec256<T> abs() const {
     Vec256<T> ret;
     for (int64_t i = 0; i < size; i++) {
@@ -166,46 +173,33 @@ public:
   Vec256<T> rsqrt() const {
     return map([](T x) { return 1 / std::sqrt(x); });
   }
+  Vec256<T> pow(const Vec256<T> &b) const {
+    return map2(b, [](T x, T y)->T{ return std::pow(x, y); });
+  }
 };
 
 template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size; i++) {
-    c[i] = a[i] + b[i];
-  }
-  return c;
+  return a.map2(b, [](T x, T y)->T{ return x + y; });
 }
 
 template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size; i++) {
-    c[i] = a[i] - b[i];
-  }
-  return c;
+  return a.map2(b, [](T x, T y)->T{ return x - y; });
 }
 
 template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size; i++) {
-    c[i] = a[i] * b[i];
-  }
-  return c;
+  return a.map2(b, [](T x, T y)->T{ return x * y; });
 }
 
 template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) __ubsan_ignore_float_divide_by_zero__ {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size; i++) {
-    c[i] = a[i] / b[i];
-  }
-  return c;
+  return a.map2(b, [](T x, T y)->T{ return x / y; });
 }
 
 template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size; i++) {
-    c[i] = std::max(a[i], b[i]);
-  }
-  return c;
+  return a.map2(b, [](T x, T y)->T{ return std::max(x, y); });
+}
+
+template <class T> Vec256<T> min(const Vec256<T> &a, const Vec256<T> &b) {
+  return a.map2(b, [](T x, T y)->T{ return std::min(x, y); });
 }
 
 template <typename T>

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -84,13 +84,6 @@ public:
     }
     return ret;
   }
-  Vec256<T> map2(const Vec256<T> other, T (*f)(T, T)) const {
-    Vec256<T> ret;
-    for (int64_t i = 0; i != size; i++) {
-      ret[i] = f(values[i], other[i]);
-    }
-    return ret;
-  }
   Vec256<T> abs() const {
     Vec256<T> ret;
     for (int64_t i = 0; i < size; i++) {
@@ -173,33 +166,61 @@ public:
   Vec256<T> rsqrt() const {
     return map([](T x) { return 1 / std::sqrt(x); });
   }
-  Vec256<T> pow(const Vec256<T> &b) const {
-    return map2(b, [](T x, T y)->T{ return std::pow(x, y); });
+  Vec256<T> pow(const Vec256<T> &exp) const {
+    Vec256<T> ret;
+    for (int64_t i = 0; i < size; i++) {
+      ret[i] = std::pow(values[i], exp[i]);
+    }
+    return ret;
   }
 };
 
 template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
-  return a.map2(b, [](T x, T y)->T{ return x + y; });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = a[i] + b[i];
+  }
+  return c;
 }
 
 template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
-  return a.map2(b, [](T x, T y)->T{ return x - y; });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = a[i] - b[i];
+  }
+  return c;
 }
 
 template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
-  return a.map2(b, [](T x, T y)->T{ return x * y; });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = a[i] * b[i];
+  }
+  return c;
 }
 
 template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) __ubsan_ignore_float_divide_by_zero__ {
-  return a.map2(b, [](T x, T y)->T{ return x / y; });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = a[i] / b[i];
+  }
+  return c;
 }
 
 template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
-  return a.map2(b, [](T x, T y)->T{ return std::max(x, y); });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = std::max(a[i], b[i]);
+  }
+  return c;
 }
 
 template <class T> Vec256<T> min(const Vec256<T> &a, const Vec256<T> &b) {
-  return a.map2(b, [](T x, T y)->T{ return std::min(x, y); });
+  Vec256<T> c = Vec256<T>();
+  for (int i = 0; i != Vec256<T>::size; i++) {
+    c[i] = std::min(a[i], b[i]);
+  }
+  return c;
 }
 
 template <typename T>

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -151,6 +151,9 @@ public:
   Vec256<double> rsqrt() const {
     return _mm256_div_pd(_mm256_set1_pd(1), _mm256_sqrt_pd(values));
   }
+  Vec256<double> pow(const Vec256<double> &b) const {
+    return Vec256<double>(Sleef_powd4_u10(values, b));
+  }
 };
 
 template <>
@@ -176,6 +179,11 @@ Vec256<double> inline operator/(const Vec256<double>& a, const Vec256<double>& b
 template <>
 Vec256<double> inline max(const Vec256<double>& a, const Vec256<double>& b) {
   return _mm256_max_pd(a, b);
+}
+
+template <>
+Vec256<double> inline min(const Vec256<double>& a, const Vec256<double>& b) {
+  return _mm256_min_pd(a, b);
 }
 
 #ifdef __AVX2__

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -156,6 +156,9 @@ public:
   Vec256<float> rsqrt() const {
     return _mm256_div_ps(_mm256_set1_ps(1), _mm256_sqrt_ps(values));
   }
+  Vec256<float> pow(const Vec256<float> &b) const {
+    return Vec256<float>(Sleef_powf8_u10(values, b));
+  }
 };
 
 template <>
@@ -181,6 +184,11 @@ Vec256<float> inline operator/(const Vec256<float>& a, const Vec256<float>& b) {
 template <>
 Vec256<float> inline max(const Vec256<float>& a, const Vec256<float>& b) {
   return _mm256_max_ps(a, b);
+}
+
+template <>
+Vec256<float> inline min(const Vec256<float>& a, const Vec256<float>& b) {
+  return _mm256_min_ps(a, b);
 }
 
 #ifdef __AVX2__

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -1,8 +1,8 @@
-#include "ATen/ATen.h"
-#include "ATen/Dispatch.h"
-#include "ATen/NativeFunctions.h"
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/NativeFunctions.h>
 
-#include "Distance.h"
+#include <ATen/native/Distance.h>
 
 namespace at { namespace native {
 


### PR DESCRIPTION
Added AVX optimizations for pdist using Vec256. This brings single threaded performance up to speed with scipy, but the current implementation greatly hurts performance without AVX enabled. Is there a way to special case out AVX on dispatch and call the non Vec256 code? Or is the way I used Vec256 completely wrong?

Single threaded comparison to scipy
============================

This is the time to compute the pdist of a 2048 x 2048 float matrix with only one thread for various values of p between torch and scipy. p = 3 is the code path for arbitrary p, and so is much slower than the other values.

p | torch | scipy
-----|-----------|------
0 | 6.27 s ± 393 ms | 7.23 s ± 498 ms
1 | 5.49 s ± 201 ms | 43.4 s ± 1.09 s
2 | 5.74 s ± 474 ms | 53.8 s ± 3.52 s
∞ | 5.59 s ± 292 ms | 47.4 s ± 2.03 s
3 | really slow | gave up

Result by AVX support
================

This is the time to compute the distance and gradient of a 2048 x 2048 float matrix with all threads by AVX support. `before` is the old code, `default` is no AVX support, etc. Interestingly the AVX optimizations provided a great benefit over the old unoptimized code, but drastically hurt performance when compiled without AVX optimizations. p = 3 is the code path for arbitrary p, and so is much slower than the other values.

Results for p = 0
----------------

avx | dist | grad
----|------|-----
before | 514 ms ± 87.5 ms | 191 µs ± 35 µs
default | 3.47 s ± 183 ms | 201 µs ± 24.6 µs
avx | 123 ms ± 18.2 ms | 281 µs ± 130 µs
avx2 | 103 ms ± 11.4 ms | 216 µs ± 74.4 µs

Results for p = 1
----------------

avx | dist | grad
----|------|-----
before | 426 ms ± 35 ms | 6.21 s ± 187 ms
default | 2.6 s ± 123 ms | 5.62 s ± 273 ms
avx | 104 ms ± 6.37 ms | 833 ms ± 44.3 ms
avx2 | 106 ms ± 3.59 ms | 924 ms ± 86.2 ms

Results for p = 2
-----------------

avx | dist | grad
----|------|-----
before | 425 ms ± 45.4 ms | 6.31 s ± 125 ms
default | 3.04 s ± 187 ms | 3.55 s ± 242 ms
avx | 110 ms ± 3.66 ms | 896 ms ± 21.8 ms
avx2 | 113 ms ± 4.68 ms | 934 ms ± 25.2 ms

Results for p = ∞
------------------

avx | dist | grad
----|------|-----
before | 501 ms ± 39.5 ms | 6.64 s ± 321 ms
default | 2.15 s ± 92.9 ms | 8.43 s ± 355 ms
avx | 104 ms ± 5.52 ms | 835 ms ± 36.7 ms
avx2 | 100 ms ± 3.41 ms | 864 ms ± 67 ms

Results for p = 3
-----------------

avx | dist | grad
----|------|-----
before | 22.6 s ± 413 ms | 11.1 s ± 242 ms
default | 24.9 s ± 1 s | 11.2 s ± 293 ms
avx | 2.69 s ± 148 ms | 5.63 s ± 88.4 ms
avx2 | 2.48 s ± 31.8 ms | 5.61 s ± 114 ms