### PR TITLE
 Optional expand=True kwarg in distribution.enumerate_support

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -900,9 +900,9 @@ class TestDistributions(TestCase):
         examples = [
             ({"probs": [0.1], "total_count": 2}, [[0], [1], [2]]),
             ({"probs": [0.1, 0.9], "total_count": 2}, [[0], [1], [2]]),
-            ({"probs": [[0.1, 0.2], [0.3, 0.4]], "total_count": 2}, [[[0]], [[1]], [[2]]]),
+            ({"probs": [[0.1, 0.2], [0.3, 0.4]], "total_count": 3}, [[[0]], [[1]], [[2]], [[3]]]),
         ]
-        self._check_enumerate_support(Bernoulli, examples)
+        self._check_enumerate_support(Binomial, examples)
 
     def test_binomial_extreme_vals(self):
         total_count = 100
@@ -929,13 +929,6 @@ class TestDistributions(TestCase):
         self.assertTrue((samples <= total_count.type_as(samples)).all())
         self.assertEqual(samples.mean(dim=0), bin1.mean, prec=0.02)
         self.assertEqual(samples.var(dim=0), bin1.variance, prec=0.02)
-
-    def test_binomial_enumerate_support(self):
-        set_rng_seed(0)
-        bin0 = Binomial(0, torch.tensor(1.))
-        self.assertEqual(bin0.enumerate_support(), torch.tensor([0.]))
-        bin1 = Binomial(torch.tensor(5), torch.tensor(0.5))
-        self.assertEqual(bin1.enumerate_support(), torch.arange(6))
 
     def test_negative_binomial(self):
         p = torch.tensor(torch.arange(0.05, 1, 0.1), requires_grad=True)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -82,11 +82,12 @@ class Bernoulli(ExponentialFamily):
     def entropy(self):
         return binary_cross_entropy_with_logits(self.logits, self.probs, reduction='none')
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         values = self._new((2,))
         torch.arange(2, out=values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
-        values = values.expand((-1,) + self._batch_shape)
+        if expand:
+            values = values.expand((-1,) + self._batch_shape)
         return values
 
     @property

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -100,12 +100,13 @@ class Binomial(Distribution):
                 value * self.logits + self.total_count * max_val -
                 self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         total_count = int(self.total_count.max())
         if not self.total_count.min() == total_count:
             raise NotImplementedError("Inhomogeneous total count not supported by `enumerate_support`.")
         values = self._new(1 + total_count,)
         torch.arange(1 + total_count, out=values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
-        values = values.expand((-1,) + self._batch_shape)
+        if expand:
+            values = values.expand((-1,) + self._batch_shape)
         return values

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -102,11 +102,12 @@ class Categorical(Distribution):
         p_log_p = self.logits * self.probs
         return -p_log_p.sum(-1)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         num_events = self._num_events
         values = torch.arange(num_events).long()
         values = values.view((-1,) + (1,) * len(self._batch_shape))
-        values = values.expand((-1,) + self._batch_shape)
+        if expand:
+            values = values.expand((-1,) + self._batch_shape)
         if self._param.is_cuda:
             values = values.cuda(self._param.get_device())
         return values

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -142,7 +142,7 @@ class Distribution(object):
         """
         raise NotImplementedError
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         """
         Returns tensor containing all values supported by a discrete
         distribution. The result will enumerate over dimension 0, so the shape
@@ -150,8 +150,15 @@ class Distribution(object):
         (where `event_shape = ()` for univariate distributions).
 
         Note that this enumerates over all batched tensors in lock-step
-        `[[0, 0], [1, 1], ...]`. To iterate over the full Cartesian product
-        use `itertools.product(m.enumerate_support())`.
+        `[[0, 0], [1, 1], ...]`. With `expand=False`, enumeration happens
+        only along the leftmost dimension, `[[0], [1], ..`.
+
+
+        To iterate over the full Cartesian product use
+        `itertools.product(m.enumerate_support())`.
+
+        Args:
+            expand (bool):
 
         Returns:
             Tensor iterating over dimension 0.

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -151,15 +151,15 @@ class Distribution(object):
 
         Note that this enumerates over all batched tensors in lock-step
         `[[0, 0], [1, 1], ...]`. With `expand=False`, enumeration happens
-        along the leftmost dimension, `[[0], [1], ..`, with the remaining
-        batch dimensions being collapsed.
-
+        along dim 0, but with the remaining batch dimensions being
+        singleton dimensions, `[[0], [1], ..`.
 
         To iterate over the full Cartesian product use
         `itertools.product(m.enumerate_support())`.
 
         Args:
-            expand (bool):
+            expand (bool): whether to expand the support over the
+                batch dims to match the distribution's `batch_shape`.
 
         Returns:
             Tensor iterating over dimension 0.

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -151,7 +151,8 @@ class Distribution(object):
 
         Note that this enumerates over all batched tensors in lock-step
         `[[0, 0], [1, 1], ...]`. With `expand=False`, enumeration happens
-        only along the leftmost dimension, `[[0], [1], ..`.
+        along the leftmost dimension, `[[0], [1], ..`, with the remaining
+        batch dimensions being collapsed.
 
 
         To iterate over the full Cartesian product use

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -82,7 +82,7 @@ class Independent(Distribution):
         entropy = self.base_dist.entropy()
         return _sum_rightmost(entropy, self.reinterpreted_batch_ndims)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         if self.reinterpreted_batch_ndims > 0:
             raise NotImplementedError("Enumeration over cartesian product is not implemented")
-        return self.base_dist.enumerate_support()
+        return self.base_dist.enumerate_support(expand=expand)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -78,9 +78,11 @@ class OneHotCategorical(Distribution):
     def entropy(self):
         return self._categorical.entropy()
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=True):
         n = self.event_shape[0]
         values = self._new((n, n))
         torch.eye(n, out=values)
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
-        return values.expand((n,) + self.batch_shape + (n,))
+        if expand:
+            values = values.expand((n,) + self.batch_shape + (n,))
+        return values


### PR DESCRIPTION
This adds an optional `expand=True` kwarg to the `distribution.expand_support()` method, to get a distribution's support without expanding the values over the distribution's `batch_shape`. 
 - The default `expand=True` preserves the current behavior, whereas `expand=False` collapses the batch dimensions.

e.g.
```python
In [47]: d = dist.OneHotCategorical(torch.ones(3, 5) * 0.5)

In [48]: d.batch_shape
Out[48]: torch.Size([3])

In [49]: d.enumerate_support()
Out[49]:
tensor([[[1., 0., 0., 0., 0.],
         [1., 0., 0., 0., 0.],
         [1., 0., 0., 0., 0.]],

        [[0., 1., 0., 0., 0.],
         [0., 1., 0., 0., 0.],
         [0., 1., 0., 0., 0.]],

        [[0., 0., 1., 0., 0.],
         [0., 0., 1., 0., 0.],
         [0., 0., 1., 0., 0.]],

        [[0., 0., 0., 1., 0.],
         [0., 0., 0., 1., 0.],
         [0., 0., 0., 1., 0.]],

        [[0., 0., 0., 0., 1.],
         [0., 0., 0., 0., 1.],
         [0., 0., 0., 0., 1.]]])

In [50]: d.enumerate_support().shape
Out[50]: torch.Size([5, 3, 5])

In [51]: d.enumerate_support(expand=False)
Out[51]:
tensor([[[1., 0., 0., 0., 0.]],

        [[0., 1., 0., 0., 0.]],

        [[0., 0., 1., 0., 0.]],

        [[0., 0., 0., 1., 0.]],

        [[0., 0., 0., 0., 1.]]])

In [52]: d.enumerate_support(expand=False).shape
Out[52]: torch.Size([5, 1, 5])
```

**Motivation:**
 - Currently `enumerate_support` builds up tensors of size `support + batch_shape + event_shape`, but the values are *repeated* over the `batch_shape` (adding little in the way of information). This can lead to expensive matrix operations over large tensors when `batch_shape` is large (see, example above), often leading to OOM issues. We use `expand=False` in Pyro for message passing inference. e.g. when enumerating over the state space in a Hidden Markov Model. This creates sparse tensors that capture the markov dependence, and allows for the possibility of using optimized matrix operations over these sparse tensors. `expand=True`, on the other hand, will create tensors that scale exponentially in size with the length of the Markov chain.
 - We have been using this in our [patch](https://github.com/uber/pyro/blob/dev/pyro/distributions/torch.py) of `torch.distributions` in Pyro. The interface has been stable, and it is already being used in a few Pyro algorithms. We think that this is more broadly applicable and will be of interest to the larger distributions community.

cc. @apaszke, @fritzo, @alicanb 
