### PR TITLE
Treat numerical differences as warnings instead of errors when tracing

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -43,13 +43,15 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   auto max_error = atol + rtol * other.abs();
   auto close = actual_error <= max_error;
 
-  // Handle +/-inf
-  close.__ior__(self == other);
-  close.__iand__((self == INFINITY) == (other == INFINITY));
-  close.__iand__((self == -INFINITY) == (other == -INFINITY));
+  if (isFloatingType(self.type().scalarType()) && isFloatingType(other.type().scalarType())) {
+    // Handle +/-inf
+    close.__ior__(self == other);
+    close.__iand__((self == INFINITY) == (other == INFINITY));
+    close.__iand__((self == -INFINITY) == (other == -INFINITY));
 
-  if (equal_nan) {
-    close.__ior__((self != self).__and__((other != other)));
+    if (equal_nan) {
+      close.__ior__((self != self).__and__((other != other)));
+    }
   }
   return close;
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6314,10 +6314,14 @@ a")
 
     @suppress_warnings
     def test_trace_checker_dropout_train(self):
-        with self.assertRaisesRegex(torch.jit.TracingCheckError, r'Trace had nondeterministic nodes'):
-            @_trace(torch.rand(3, 4))
-            def foo(x):
-                return torch.dropout(x, p=0.5, train=True)
+        def foo(x):
+            return torch.dropout(x, p=0.5, train=True)
+
+        self.assertWarnsRegex(lambda: torch.jit.trace(foo, torch.rand(3, 4), check_inputs=[torch.rand(5, 6)]),
+                              'Output nr 1. of the traced function does not match the '
+                              'corresponding output of the Python function')
+        self.assertWarnsRegex(lambda: torch.jit.trace(foo, torch.rand(3, 4), check_inputs=[torch.rand(5, 6)]),
+                              'Trace had nondeterministic nodes')
 
     def test_trace_checker_dropout_notrain(self):
         input = torch.rand(3, 4)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6276,11 +6276,6 @@ a")
             self.assertIn("cause the trace to be incorrect", str(warn.message))
 
     def test_trace_checker_slice_lhs(self):
-        # def foo(x):
-            # for i in range(3):
-                # x[i, :] = torch.zeros(4)
-            # return x
-        # self.checkTracerWarning(foo, torch.rand(3, 4))
         def foo(x):
             for i in range(3):
                 x[i, :] = torch.zeros(4)
@@ -6291,11 +6286,6 @@ a")
                               'corresponding output of the Python function')
 
     def test_trace_checker_inplace_on_view(self):
-        # def foo(x):
-            # x.view(-1).add_(-x.view(-1))
-            # return x
-        # self.checkTracerWarning(foo, torch.rand(3, 4), check_trace=False)
-
         def foo(x):
             x.view(-1).add_(-x.view(-1))
             return x
@@ -6315,6 +6305,12 @@ a")
             y[...] = x
             return y
         self.checkTrace(foo, (torch.rand(3, 4), torch.rand(4)), inputs_require_grads=False)
+
+    def test_inplace_warn(self):
+        def foo(x):
+            x.view(-1).add_(-x.view(-1))
+            return x
+        self.checkTracerWarning(foo, torch.rand(3, 4))
 
     @suppress_warnings
     def test_trace_checker_dropout_train(self):
@@ -6536,9 +6532,6 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
 
     @skipIfRocm
     def test_snli(self):
-        # TODO:
-        #   1) nn.LSTM is called as a Python function https://github.com/pytorch/pytorch/issues/8449
-        #   2) Dropout is called as a Python function https://github.com/pytorch/pytorch/issues/8450
         class Bottle(nn.Module):
 
             def forward(self, input):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -381,7 +381,7 @@ def _check_trace(check_inputs, func, executor_options, module, check_tolerance):
                 nondeterministic_ops_warning += "\n".join([indent(str(op)) for op in nondeterm_ops][:20])
                 nondeterministic_ops_warning += "\nThis may cause errors in trace checking. To disable trace checking,"\
                                                 " pass disable_checks=True to torch.jit.trace()"
-            warnings.warn(nondeterministic_ops_warning, category=TracerWarning, stacklevel=5)
+                warnings.warn(nondeterministic_ops_warning, category=TracerWarning, stacklevel=5)
 
         def compare_outputs(original, reference, match_what):
             all_ok = True


### PR DESCRIPTION
Also, make `torch.isclose` work with integral tensors and refactor `_check_trace` a bit.

@zdevito 