### PR TITLE
add persistent rnns with conservative criteria

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -291,7 +291,7 @@ struct AT_CUDA_API RNNDescriptor
   DropoutDescriptor dropout_desc_;
   void set(cudnnHandle_t handle, int hidden_size, int num_layers, DropoutDescriptor&& dropout_desc,
            cudnnRNNInputMode_t input_mode, cudnnDirectionMode_t bidirectional,
-           cudnnRNNMode_t mode, cudnnDataType_t datatype) {
+           cudnnRNNMode_t mode, cudnnDataType_t datatype, cudnnRNNAlgo_t algo) {
     dropout_desc_ = std::move(dropout_desc);
     AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v6(
           handle,
@@ -302,7 +302,7 @@ struct AT_CUDA_API RNNDescriptor
           input_mode,
           bidirectional,
           mode,
-          CUDNN_RNN_ALGO_STANDARD,
+          algo,
           datatype));
 #if CUDNN_VERSION >= 7000 && CUDA_VERSION >= 9000
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -98,7 +98,7 @@ namespace {
     cudnnDirectionMode_t bidirectional;
     cudnnRNNMode_t mode;
     cudnnDataType_t datatype;
-
+    cudnnRNNAlgo_t algo = CUDNN_RNN_ALGO_STANDARD;
     cudnnRNNInputMode_t input_mode = CUDNN_LINEAR_INPUT;
 
     int64_t num_directions() const {
@@ -131,6 +131,10 @@ namespace {
     void set_bidirectional(bool fn_bidirectional) {
       bidirectional = fn_bidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL;
     }
+     
+    void set_algo(cudnnRNNAlgo_t algo){
+      this->algo = algo;
+    }
 
     void set(int64_t mode, int64_t hidden_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype) {
       this->set_mode(mode);
@@ -143,7 +147,7 @@ namespace {
 
     RNNDescriptor descriptor(cudnnHandle_t handle, DropoutDescriptor&& dropout_desc) const {
       RNNDescriptor rnn_desc;
-      rnn_desc.set(handle, hidden_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype);
+      rnn_desc.set(handle, hidden_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, algo);
       return rnn_desc;
     }
 
@@ -557,6 +561,29 @@ namespace {
     }
   }
 
+  cudnnRNNAlgo_t get_algo(const RNNDescriptorParams& rnn, const TensorDescriptorListParams& tensors){
+#if CUDNN_VERSION < 7200 || CUDA_VERSION < 9010
+      return CUDNN_RNN_ALGO_STANDARD;
+#else
+      cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
+      const int64_t bsize = tensors.mini_batch;
+      if (prop->major == 7 && rnn.datatype == CUDNN_DATA_HALF && !tensors.is_input_packed()) {
+          if (rnn.num_layers == 1 && rnn.hidden_size <= 1024 && tensors.input_size <=1024 && rnn.num_directions() == 1){
+              //technically, batch size should be multiple of 8, but there are quite a few multiple-of-8 batchsizes that give bad perf, 
+              //weed them out
+              if ((bsize % 16 == 0 && bsize != 80 && bsize !=112) || bsize == 8){
+                  if ((tensors.seq_length >=40 && bsize <=128) ||
+                     (tensors.seq_length >=20 && bsize <=96) ||
+                     (tensors.seq_length >=10 && bsize <=32)) {
+                     return CUDNN_RNN_ALGO_PERSIST_STATIC;
+                  }
+              }    
+          } 
+      } 
+      return CUDNN_RNN_ALGO_STANDARD;
+#endif          
+  }
+
 } // anonymous namespace
 
 // NB: does inplace update into TensorList
@@ -676,6 +703,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   auto y = output;
 
   auto handle = getCudnnHandle();
+  cudnnRNNAlgo_t algo = get_algo(fn.rnn, fn.tensors);
+  fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
   FilterDescriptor w_desc;
@@ -858,6 +887,8 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
     throw std::runtime_error("Gradients aren't CUDA tensors");
   }
 
+  cudnnRNNAlgo_t algo = get_algo(fn.rnn, fn.tensors);
+  fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
   FilterDescriptor w_desc;
@@ -968,6 +999,8 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
   const auto& y = output;
   auto dw = weight_buf.type().tensor(weight_buf.sizes()).zero_();
 
+  cudnnRNNAlgo_t algo = get_algo(fn.rnn, fn.tensors);
+  fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
   FilterDescriptor w_desc;

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -568,7 +568,8 @@ namespace {
       cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
       const int64_t bsize = tensors.mini_batch;
       if (prop->major == 7 && rnn.datatype == CUDNN_DATA_HALF && !tensors.is_input_packed()) {
-          if (rnn.num_layers == 1 && rnn.hidden_size <= 1024 && tensors.input_size <=1024 && rnn.num_directions() == 1){
+          if (rnn.num_layers == 1 && rnn.hidden_size <= 1024 && tensors.input_size <=1024 && rnn.num_directions() == 1 &&
+                  rnn.hidden_size % 128 == 0 && tensors.input_size % 128 == 0){
               //technically, batch size should be multiple of 8, but there are quite a few multiple-of-8 batchsizes that give bad perf, 
               //weed them out
               if ((bsize % 16 == 0 && bsize != 80 && bsize !=112) || bsize == 8){
@@ -577,11 +578,11 @@ namespace {
                      (tensors.seq_length >=10 && bsize <=32)) {
                      return CUDNN_RNN_ALGO_PERSIST_STATIC;
                   }
-              }    
-          } 
-      } 
+              }
+          }
+      }
       return CUDNN_RNN_ALGO_STANDARD;
-#endif          
+#endif
   }
 
 } // anonymous namespace


### PR DESCRIPTION
Persistent rnns provide much better performance on V100 with half input data for a variety of cases. 