### PR TITLE
[pt1][tensor] caffe2::DeviceType -> at::DeviceType

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -68,7 +68,7 @@ bool backendCudaSet(const string& backend) {
 void setDeviceType(caffe2::NetDef* net_def, caffe2::DeviceType& run_dev) {
   for (int j = 0; j < net_def->op_size(); j++) {
     caffe2::OperatorDef* op = net_def->mutable_op(j);
-    op->mutable_device_option()->set_device_type(run_dev);
+    op->mutable_device_option()->set_device_type(caffe2::TypeToProto(run_dev));
   }
 }
 

--- a/binaries/core_overhead_benchmark_gpu.cc
+++ b/binaries/core_overhead_benchmark_gpu.cc
@@ -167,7 +167,7 @@ static void BM_OperatorCreationCPU(benchmark::State& state) {
   OperatorDef def;
   Workspace ws;
   def.set_type("DummyEmpty");
-  def.mutable_device_option()->set_device_type(CPU);
+  def.mutable_device_option()->set_device_type(PROTO_CPU);
   while (state.KeepRunning()) {
     op = CreateOperator(def, &ws);
   }
@@ -180,7 +180,7 @@ static void BM_OperatorCreationCUDA(benchmark::State& state) {
   OperatorDef def;
   Workspace ws;
   def.set_type("DummyEmpty");
-  def.mutable_device_option()->set_device_type(CUDA);
+  def.mutable_device_option()->set_device_type(PROTO_CUDA);
   while (state.KeepRunning()) {
     op = CreateOperator(def, &ws);
   }

--- a/binaries/print_registered_core_operators.cc
+++ b/binaries/print_registered_core_operators.cc
@@ -52,8 +52,8 @@ int main(int argc, char** argv) {
   for (const auto& pair : *caffe2::gDeviceTypeRegistry()) {
     std::cout << "Device type " << pair.first
 #ifndef CAFFE2_USE_LITE_PROTO
-              << " (" << caffe2::DeviceType_Name(
-                             static_cast<caffe2::DeviceType>(pair.first))
+              << " ("
+              << at::DeviceTypeName(static_cast<caffe2::DeviceType>(pair.first))
               << ")"
 #endif
               << std::endl;

--- a/caffe2/contrib/nervana/nervana_fc_op_gpu_test.cc
+++ b/caffe2/contrib/nervana/nervana_fc_op_gpu_test.cc
@@ -19,7 +19,7 @@ namespace {
 static void AddConstInput(const std::vector<int>& shape, const float value,
                           const string& name, Workspace* ws) {
   DeviceOption option;
-  option.set_device_type(CUDA);
+  option.set_device_type(PROTO_CUDA);
   CUDAContext context(option);
   Blob* blob = ws->CreateBlob(name);
   auto* tensor = blob->GetMutableTensor(CUDA);
@@ -43,7 +43,7 @@ TEST(NervanaFullyConnectedTest, Test) {
   def.add_input("W");
   def.add_input("B");
   def.add_output("Y");
-  def.mutable_device_option()->set_device_type(CUDA);
+  def.mutable_device_option()->set_device_type(PROTO_CUDA);
   def.set_engine("NERVANA");
   AddConstInput(std::vector<int>{5, 10}, 1., "X", &ws);
   AddConstInput(std::vector<int>{6, 10}, 1., "W", &ws);

--- a/caffe2/contrib/opencl/context.h
+++ b/caffe2/contrib/opencl/context.h
@@ -36,7 +36,7 @@ class OpenCLContext final {
  public:
   explicit OpenCLContext();
   explicit OpenCLContext(const DeviceOption& option) {
-    DCHECK_EQ(option.device_type(), OPENCL);
+    DCHECK_EQ(option.device_type(), PROTO_OPENCL);
     OpenCLContext();
   }
   ~OpenCLContext() {}

--- a/caffe2/core/blob_gpu_test.cc
+++ b/caffe2/core/blob_gpu_test.cc
@@ -193,7 +193,7 @@ TEST(TensorTest, TensorSerializationMultiDevices) {
       EXPECT_EQ(tensor_proto.float_data(i), i);
     }
     EXPECT_TRUE(tensor_proto.has_device_detail());
-    EXPECT_EQ(tensor_proto.device_detail().device_type(), CUDA);
+    EXPECT_EQ(tensor_proto.device_detail().device_type(), PROTO_CUDA);
     EXPECT_EQ(tensor_proto.device_detail().cuda_gpu_id(), gpu_id);
     // Test if the restored blob is still of the same device.
     blob.Reset();

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -883,7 +883,7 @@ TYPED_TEST(TypedTensorTest, BigTensorSerialization) {
 
   {
     DeviceOption option;
-    option.set_device_type(CPU);
+    option.set_device_type(PROTO_CPU);
     Argument db_type_arg = MakeArgument<string>("db_type", "vector_db");
     Argument absolute_path_arg = MakeArgument<bool>("absolute_path", true);
     Argument db_source_arg = MakeArgument<string>("db", db_source);
@@ -996,7 +996,7 @@ TEST(ContentChunks, Serialization) {
 
   {
     DeviceOption option;
-    option.set_device_type(CPU);
+    option.set_device_type(PROTO_CPU);
     Argument db_type_arg = MakeArgument<string>("db_type", "vector_db");
     Argument absolute_path_arg = MakeArgument<bool>("absolute_path", true);
     Argument db_source_arg = MakeArgument<string>("db", db_source);

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -48,7 +48,7 @@ class CAFFE2_API CPUContext final : public BaseContext {
       : random_seed_(
             option.has_random_seed() ? option.random_seed()
                                      : RandomNumberSeed()) {
-    CAFFE_ENFORCE_EQ(option.device_type(), CPU);
+    CAFFE_ENFORCE_EQ(option.device_type(), PROTO_CPU);
   }
 
   ~CPUContext() noexcept override {}

--- a/caffe2/core/context_base.cc
+++ b/caffe2/core/context_base.cc
@@ -3,20 +3,20 @@
 namespace caffe2 {
 
 // TODO: rename context.h -> context_cpu.h & context_base.h -> context.h
-std::array<BaseStaticContext*, COMPILE_TIME_MAX_DEVICE_TYPES>&
-GetStaticContexts() {
-  static std::array<BaseStaticContext*, COMPILE_TIME_MAX_DEVICE_TYPES>
-      static_contexts;
+StaticContextMap& GetStaticContexts() {
+  static StaticContextMap static_contexts;
   return static_contexts;
 }
 
-void set_static_context(int d, BaseStaticContext* ptr) {
+void set_static_context(DeviceType t, BaseStaticContext* ptr) {
   auto& static_contexts = GetStaticContexts();
-  static_contexts[d] = ptr;
+  static_contexts[t] = ptr;
 }
 
-BaseStaticContext* get_static_context(int d) {
-  return GetStaticContexts()[d];
+BaseStaticContext* get_static_context(DeviceType t) {
+  auto* ptr = GetStaticContexts()[t];
+  CAFFE_ENFORCE(ptr, "StaticContext is not registered yet.");
+  return ptr;
 }
 
 } // namespace caffe2

--- a/caffe2/core/context_base.h
+++ b/caffe2/core/context_base.h
@@ -86,7 +86,7 @@ class CAFFE2_API BaseContext {
       const void* src,
       void* dst,
       DeviceType type) {
-    if (type == DeviceType::CPU) {
+    if (type == CPU) {
       CopyBytesToCPU(nbytes, src, dst);
     } else if (type == GetDevicetype()) {
       CopyBytesSameDevice(nbytes, src, dst);

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -257,7 +257,7 @@ CUDAContext::CUDAContext(const DeviceOption& option)
           option.has_random_seed() ? option.random_seed()
                                    : RandomNumberSeed()) {
   static Caffe2CudaInitializerHelper g_cuda_initializer_;
-  DCHECK_EQ(option.device_type(), CUDA);
+  DCHECK_EQ(option.device_type(), PROTO_CUDA);
 }
 
 // shared mutex to lock out alloc / free during NCCL launches

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -403,7 +403,7 @@ class CAFFE2_API CUDAStaticContext final : public BaseStaticContext {
   }
 
   void ExtractDeviceOption(DeviceOption* device, const void* data) override {
-    device->set_device_type(GetDeviceType());
+    device->set_device_type(TypeToProto(GetDeviceType()));
     device->set_cuda_gpu_id(GetGPUIDForPointer(data));
   }
 

--- a/caffe2/core/dispatch/OpSchema.h
+++ b/caffe2/core/dispatch/OpSchema.h
@@ -23,9 +23,9 @@ using is_tensor_arg = std::
 
 inline DeviceTypeId to_device_type_id(caffe2::DeviceType device_type) {
   switch (device_type) {
-    case caffe2::CPU:
+    case caffe2::DeviceType::CPU:
       return DeviceTypeId::CPU;
-    case caffe2::CUDA:
+    case caffe2::DeviceType::CUDA:
       return DeviceTypeId::CUDA;
     default:
       return DeviceTypeId::UNDEFINED;

--- a/caffe2/core/dispatch/OpSchema.h
+++ b/caffe2/core/dispatch/OpSchema.h
@@ -23,9 +23,9 @@ using is_tensor_arg = std::
 
 inline DeviceTypeId to_device_type_id(caffe2::DeviceType device_type) {
   switch (device_type) {
-    case caffe2::DeviceType::CPU:
+    case caffe2::CPU:
       return DeviceTypeId::CPU;
-    case caffe2::DeviceType::CUDA:
+    case caffe2::CUDA:
       return DeviceTypeId::CUDA;
     default:
       return DeviceTypeId::UNDEFINED;

--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -1,13 +1,15 @@
 #ifndef CAFFE2_CORE_EVENT_H_
 #define CAFFE2_CORE_EVENT_H_
 
+#include <ATen/core/DeviceType.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/proto/caffe2_pb.h"
 
 namespace caffe2 {
 
-constexpr int MaxDeviceTypes = DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES;
+constexpr int MaxDeviceTypes =
+    DeviceTypeProto::PROTO_COMPILE_TIME_MAX_DEVICE_TYPES;
 class Event;
 
 enum EventStatus {
@@ -65,20 +67,22 @@ class CAFFE2_API Event {
   ~Event() {}
 
   void Record(
-      int recorder_type,
+      DeviceType recorder_type,
       const void* context,
       const char* err_msg = nullptr) {
+    auto recorder_index = TypeToProto(recorder_type);
     CAFFE_ENFORCE_EQ(
-        recorder_type,
+        recorder_index,
         type_,
         "You are trying to record with a wrong device type.");
-    CAFFE_ENFORCE(event_recorder_[recorder_type]);
-    event_recorder_[recorder_type](this, context, err_msg);
+    CAFFE_ENFORCE(event_recorder_[recorder_index]);
+    event_recorder_[recorder_index](this, context, err_msg);
   }
 
-  void Wait(int waiter_type, void* context) const {
-    CAFFE_ENFORCE(event_waiter_[waiter_type][type_]);
-    event_waiter_[waiter_type][type_](this, context);
+  void Wait(DeviceType waiter_type, void* context) const {
+    auto waiter_index = TypeToProto(waiter_type);
+    CAFFE_ENFORCE(event_waiter_[waiter_index][type_]);
+    event_waiter_[waiter_index][type_](this, context);
   }
 
   void Finish() const {
@@ -185,57 +189,57 @@ class CAFFE2_API Event {
 
   static EventSetCallbackFunction event_callback_setter_[MaxDeviceTypes];
 
-  template <int d>
+  template <DeviceType t>
   friend struct EventCreateFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventRecordFunctionRegisterer;
-  template <int w, int d>
+  template <DeviceType w, DeviceType d>
   friend struct EventWaitFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventFinishFunctionRegisterer;
 
-  template <int d>
+  template <DeviceType t>
   friend struct EventQueryFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventErrorMessageFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventSetFinishedFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventSetCallbackFunctionRegisterer;
-  template <int d>
+  template <DeviceType t>
   friend struct EventResetFunctionRegisterer;
 };
 
-template <int d>
+template <DeviceType t>
 struct EventCreateFunctionRegisterer {
   explicit EventCreateFunctionRegisterer(EventCreateFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_creator_[d] = f;
   }
 };
-#define REGISTER_EVENT_CREATE_FUNCTION(d, f)                     \
+#define REGISTER_EVENT_CREATE_FUNCTION(t, f)                     \
   namespace {                                                    \
-  static EventCreateFunctionRegisterer<d> g_event_create_##d(f); \
+  static EventCreateFunctionRegisterer<t> g_event_create_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventRecordFunctionRegisterer {
   explicit EventRecordFunctionRegisterer(EventRecordFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_recorder_[d] = f;
   }
 };
-#define REGISTER_EVENT_RECORD_FUNCTION(d, f)                     \
+#define REGISTER_EVENT_RECORD_FUNCTION(t, f)                     \
   namespace {                                                    \
-  static EventRecordFunctionRegisterer<d> g_event_record_##d(f); \
+  static EventRecordFunctionRegisterer<t> g_event_record_##d(f); \
   }
 
-template <int waiter_type, int event_type>
+template <DeviceType waiter_type, DeviceType event_type>
 struct EventWaitFunctionRegisterer {
   explicit EventWaitFunctionRegisterer(EventWaitFunction f) {
-    static_assert(waiter_type < MaxDeviceTypes, "");
-    static_assert(event_type < MaxDeviceTypes, "");
-    Event::event_waiter_[waiter_type][event_type] = f;
+    auto waiter_index = TypeToProto(waiter_type);
+    auto event_index = TypeToProto(event_type);
+    Event::event_waiter_[waiter_index][event_index] = f;
   }
 };
 #define REGISTER_EVENT_WAIT_FUNCTION(w, d, f)                         \
@@ -243,76 +247,76 @@ struct EventWaitFunctionRegisterer {
   static EventWaitFunctionRegisterer<w, d> g_event_wait_##w##_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventQueryFunctionRegisterer {
   explicit EventQueryFunctionRegisterer(EventQueryFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_querier_[d] = f;
   }
 };
-#define REGISTER_EVENT_QUERY_FUNCTION(d, f)                    \
+#define REGISTER_EVENT_QUERY_FUNCTION(t, f)                    \
   namespace {                                                  \
-  static EventQueryFunctionRegisterer<d> g_event_query_##d(f); \
+  static EventQueryFunctionRegisterer<t> g_event_query_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventErrorMessageFunctionRegisterer {
   explicit EventErrorMessageFunctionRegisterer(EventErrorMessageFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_err_msg_getter_[d] = f;
   }
 };
-#define REGISTER_EVENT_ERROR_MESSAGE_FUNCTION(d, f)                     \
+#define REGISTER_EVENT_ERROR_MESSAGE_FUNCTION(t, f)                     \
   namespace {                                                           \
-  static EventErrorMessageFunctionRegisterer<d> g_event_err_msg_##d(f); \
+  static EventErrorMessageFunctionRegisterer<t> g_event_err_msg_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventSetFinishedFunctionRegisterer {
   explicit EventSetFinishedFunctionRegisterer(EventSetFinishedFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_finished_setter_[d] = f;
   }
 };
-#define REGISTER_EVENT_SET_FINISHED_FUNCTION(d, f)                          \
+#define REGISTER_EVENT_SET_FINISHED_FUNCTION(t, f)                          \
   namespace {                                                               \
-  static EventSetFinishedFunctionRegisterer<d> g_event_set_finished_##d(f); \
+  static EventSetFinishedFunctionRegisterer<t> g_event_set_finished_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventSetCallbackFunctionRegisterer {
   explicit EventSetCallbackFunctionRegisterer(EventSetCallbackFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_callback_setter_[d] = f;
   }
 };
-#define REGISTER_EVENT_SET_CALLBACK_FUNCTION(d, f)                          \
+#define REGISTER_EVENT_SET_CALLBACK_FUNCTION(t, f)                          \
   namespace {                                                               \
-  static EventSetCallbackFunctionRegisterer<d> g_event_set_callback_##d(f); \
+  static EventSetCallbackFunctionRegisterer<t> g_event_set_callback_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventFinishFunctionRegisterer {
   explicit EventFinishFunctionRegisterer(EventFinishFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_finisher_[d] = f;
   }
 };
-#define REGISTER_EVENT_FINISH_FUNCTION(d, f)                     \
+#define REGISTER_EVENT_FINISH_FUNCTION(t, f)                     \
   namespace {                                                    \
-  static EventFinishFunctionRegisterer<d> g_event_finish_##d(f); \
+  static EventFinishFunctionRegisterer<t> g_event_finish_##d(f); \
   }
 
-template <int d>
+template <DeviceType t>
 struct EventResetFunctionRegisterer {
   explicit EventResetFunctionRegisterer(EventResetFunction f) {
-    static_assert(d < MaxDeviceTypes, "");
+    auto d = TypeToProto(t);
     Event::event_resetter_[d] = f;
   }
 };
-#define REGISTER_EVENT_RESET_FUNCTION(d, f)                    \
+#define REGISTER_EVENT_RESET_FUNCTION(t, f)                    \
   namespace {                                                  \
-  static EventResetFunctionRegisterer<d> g_event_reset_##d(f); \
+  static EventResetFunctionRegisterer<t> g_event_reset_##d(f); \
   }
 
 } // namespace caffe2

--- a/caffe2/core/event_cpu.h
+++ b/caffe2/core/event_cpu.h
@@ -9,8 +9,9 @@ struct CPUEventWrapper {
   explicit CPUEventWrapper(const DeviceOption& option)
       : status_(EventStatus::EVENT_INITIALIZED) {
     CAFFE_ENFORCE(
-        option.device_type() == CPU || option.device_type() == MKLDNN ||
-            option.device_type() == IDEEP,
+        option.device_type() == PROTO_CPU ||
+            option.device_type() == PROTO_MKLDNN ||
+            option.device_type() == PROTO_IDEEP,
         "Expected CPU/MKLDNN/IDEEP device type");
   }
   ~CPUEventWrapper() {}

--- a/caffe2/core/event_gpu.cc
+++ b/caffe2/core/event_gpu.cc
@@ -11,7 +11,7 @@ struct CudaEventWrapper {
       : cuda_stream_(nullptr),
         cuda_gpu_id_(option.cuda_gpu_id()),
         status_(EventStatus::EVENT_INITIALIZED) {
-    CAFFE_ENFORCE(option.device_type(), CUDA);
+    CAFFE_ENFORCE(option.device_type(), PROTO_CUDA);
     DeviceGuard g(cuda_gpu_id_);
     CUDA_ENFORCE(cudaEventCreate(
         &cuda_event_, cudaEventDefault | cudaEventDisableTiming));

--- a/caffe2/core/event_gpu_test.cc
+++ b/caffe2/core/event_gpu_test.cc
@@ -9,9 +9,9 @@ TEST(EventCUDATest, EventBasics) {
   if (!HasCudaGPU())
     return;
   DeviceOption device_cpu;
-  device_cpu.set_device_type(CPU);
+  device_cpu.set_device_type(PROTO_CPU);
   DeviceOption device_cuda;
-  device_cuda.set_device_type(CUDA);
+  device_cuda.set_device_type(PROTO_CUDA);
 
   CPUContext context_cpu(device_cpu);
   CUDAContext context_cuda(device_cuda);

--- a/caffe2/core/event_test.cc
+++ b/caffe2/core/event_test.cc
@@ -6,7 +6,7 @@ namespace caffe2 {
 
 TEST(EventCPUTest, EventBasics) {
   DeviceOption device_option;
-  device_option.set_device_type(CPU);
+  device_option.set_device_type(PROTO_CPU);
   Event event(device_option);
   CPUContext context;
 

--- a/caffe2/core/hip/context_hip.cc
+++ b/caffe2/core/hip/context_hip.cc
@@ -263,7 +263,7 @@ HIPContext::HIPContext(const DeviceOption& option)
           option.has_random_seed() ? option.random_seed()
                                    : RandomNumberSeed()) {
   static Caffe2HipInitializerHelper g_hip_initializer_;
-  DCHECK_EQ(option.device_type(), HIP);
+  DCHECK_EQ(option.device_type(), PROTO_HIP);
 }
 
 // shared mutex to lock out alloc / free during NCCL launches

--- a/caffe2/core/hip/context_hip.h
+++ b/caffe2/core/hip/context_hip.h
@@ -392,7 +392,7 @@ class HIPStaticContext final : public BaseStaticContext {
   }
 
   void ExtractDeviceOption(DeviceOption* device, const void* data) override {
-    device->set_device_type(GetDeviceType());
+    device->set_device_type(TypeToProto(GetDeviceType()));
     device->set_hip_gpu_id(GetGPUIDForPointer(data));
   }
 

--- a/caffe2/core/hip/event_hip.cc
+++ b/caffe2/core/hip/event_hip.cc
@@ -13,9 +13,10 @@ struct HipEventWrapper
           hip_gpu_id_(option.hip_gpu_id()),
           status_(EventStatus::EVENT_INITIALIZED)
     {
-        CAFFE_ENFORCE(option.device_type(), HIP);
-        DeviceGuard g(hip_gpu_id_);
-        HIP_ENFORCE(hipEventCreate(&hip_event_ /*, hipEventDefault | hipEventDisableTiming*/));
+      CAFFE_ENFORCE(option.device_type(), PROTO_HIP);
+      DeviceGuard g(hip_gpu_id_);
+      HIP_ENFORCE(hipEventCreate(
+          &hip_event_ /*, hipEventDefault | hipEventDisableTiming*/));
     }
     ~HipEventWrapper()
     {

--- a/caffe2/core/hip/net_async_dag_hip.cc
+++ b/caffe2/core/hip/net_async_dag_hip.cc
@@ -88,20 +88,18 @@ AsyncDAGNet::AsyncDAGNet(const std::shared_ptr<const NetDef>& net_def, Workspace
 int AsyncDAGNet::stream(const DeviceOption& device_option)
 {
     int stream_id = 0;
-    if(device_option.device_type() == PROTO_HIP)
-    {
-        int gpu_id = device_option.hip_gpu_id();
-        CAFFE_ENFORCE_GE(gpu_id, 0, "Invalid gpu id: " + caffe2::to_string(gpu_id));
-        if((unsigned)gpu_id >= stream_counters_.size())
-        {
-            stream_counters_.resize(gpu_id + 1, 0);
-        }
-        do
-        {
-            stream_id = stream_counters_[gpu_id]++;
-            stream_counters_[gpu_id] %= FLAGS_caffe2_streams_per_gpu;
-        } while(FLAGS_caffe2_net_async_check_stream_status &&
-                !HIPContext::IsStreamFree(device_option, stream_id));
+    if (device_option.device_type() == PROTO_HIP) {
+      int gpu_id = device_option.hip_gpu_id();
+      CAFFE_ENFORCE_GE(
+          gpu_id, 0, "Invalid gpu id: " + caffe2::to_string(gpu_id));
+      if ((unsigned)gpu_id >= stream_counters_.size()) {
+        stream_counters_.resize(gpu_id + 1, 0);
+      }
+      do {
+        stream_id = stream_counters_[gpu_id]++;
+        stream_counters_[gpu_id] %= FLAGS_caffe2_streams_per_gpu;
+      } while (FLAGS_caffe2_net_async_check_stream_status &&
+               !HIPContext::IsStreamFree(device_option, stream_id));
     }
     return stream_id;
 }

--- a/caffe2/core/hip/net_async_dag_hip.cc
+++ b/caffe2/core/hip/net_async_dag_hip.cc
@@ -88,7 +88,7 @@ AsyncDAGNet::AsyncDAGNet(const std::shared_ptr<const NetDef>& net_def, Workspace
 int AsyncDAGNet::stream(const DeviceOption& device_option)
 {
     int stream_id = 0;
-    if(device_option.device_type() == HIP)
+    if(device_option.device_type() == PROTO_HIP)
     {
         int gpu_id = device_option.hip_gpu_id();
         CAFFE_ENFORCE_GE(gpu_id, 0, "Invalid gpu id: " + caffe2::to_string(gpu_id));

--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -136,13 +136,13 @@ TaskThreadPool* AsyncNetBase::pool_getter(
 
 TaskThreadPool* AsyncNetBase::pool(const DeviceOption& device_option) {
   if (use_single_pool_) {
-    return pool_getter(cpu_pools_, CPU, -1, num_workers_);
+    return pool_getter(cpu_pools_, PROTO_CPU, -1, num_workers_);
   }
   static const std::unordered_set<int> cpu_types{
-      CPU,
-      MKLDNN,
-      IDEEP,
-      ONLY_FOR_TEST,
+      PROTO_CPU,
+      PROTO_MKLDNN,
+      PROTO_IDEEP,
+      PROTO_ONLY_FOR_TEST,
   };
   if (cpu_types.find(device_option.device_type()) != cpu_types.end()) {
     auto numa_node_id = -1;
@@ -155,13 +155,13 @@ TaskThreadPool* AsyncNetBase::pool(const DeviceOption& device_option) {
         FLAGS_caffe2_net_async_max_numa_nodes,
         "Invalid NUMA node id: ",
         numa_node_id);
-    return pool_getter(cpu_pools_, CPU, numa_node_id, num_workers_);
-  } else if (device_option.device_type() == CUDA) {
+    return pool_getter(cpu_pools_, PROTO_CPU, numa_node_id, num_workers_);
+  } else if (device_option.device_type() == PROTO_CUDA) {
     auto gpu_id = device_option.cuda_gpu_id();
     CAFFE_ENFORCE(
         gpu_id >= 0 && gpu_id < FLAGS_caffe2_net_async_max_gpus,
         "Invalid GPU id: " + caffe2::to_string(gpu_id));
-    return pool_getter(gpu_pools_, CUDA, gpu_id, num_workers_);
+    return pool_getter(gpu_pools_, PROTO_CUDA, gpu_id, num_workers_);
   } else {
     CAFFE_THROW(
         "Unsupported device type " +
@@ -172,7 +172,7 @@ TaskThreadPool* AsyncNetBase::pool(const DeviceOption& device_option) {
 int AsyncNetBase::stream(int task_id) {
   const auto& device_option = event(task_id).GetDeviceOption();
   int stream_id = 0;
-  if (device_option.device_type() == CUDA) {
+  if (device_option.device_type() == PROTO_CUDA) {
     int gpu_id = device_option.cuda_gpu_id();
     CAFFE_ENFORCE_GE(gpu_id, 0, "Invalid gpu id: " + caffe2::to_string(gpu_id));
     if ((unsigned)gpu_id >= getStreamCounters().size()) {

--- a/caffe2/core/net_async_dag_gpu.cc
+++ b/caffe2/core/net_async_dag_gpu.cc
@@ -111,7 +111,7 @@ AsyncDAGNet::AsyncDAGNet(
 
 int AsyncDAGNet::stream(const DeviceOption& device_option) {
   int stream_id = 0;
-  if (device_option.device_type() == CUDA) {
+  if (device_option.device_type() == PROTO_CUDA) {
     int gpu_id = device_option.cuda_gpu_id();
     CAFFE_ENFORCE_GE(gpu_id, 0, "Invalid gpu id: " + caffe2::to_string(gpu_id));
     if ((unsigned)gpu_id >= stream_counters_.size()) {

--- a/caffe2/core/net_async_polling.cc
+++ b/caffe2/core/net_async_polling.cc
@@ -16,10 +16,9 @@ AsyncPollingNet::AsyncPollingNet(
     task_timers_[task_id] = caffe2::make_unique<Timer>();
   }
 
-  stats_.reserve(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
-  for (auto device_idx = 0;
-       device_idx < DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES;
-       ++device_idx) {
+  auto MAX_DEVICE_TYPES = DeviceTypeProto::PROTO_COMPILE_TIME_MAX_DEVICE_TYPES;
+  stats_.reserve(MAX_DEVICE_TYPES);
+  for (auto device_idx = 0; device_idx < MAX_DEVICE_TYPES; ++device_idx) {
     stats_.emplace_back(
         "async_net/stats/" + net_def->name() + "/" +
         caffe2::DeviceTypeName(device_idx));
@@ -38,7 +37,7 @@ bool AsyncPollingNet::DoRunAsync() {
   Timer timer;
   bool success = pollAndSchedule();
   if (FLAGS_caffe2_dag_net_collect_stats) {
-    CAFFE_EVENT(stats_[CPU], poll_time_ms, timer.MilliSeconds());
+    CAFFE_EVENT(stats_[PROTO_CPU], poll_time_ms, timer.MilliSeconds());
   }
   if (!success) {
     finalizeEvents();
@@ -133,7 +132,7 @@ bool AsyncPollingNet::pollAndSchedule() {
     }
     if (FLAGS_caffe2_dag_net_collect_stats) {
       CAFFE_EVENT(
-          stats_[CPU], poll_status_update_time_us, timer.MicroSeconds());
+          stats_[PROTO_CPU], poll_status_update_time_us, timer.MicroSeconds());
     }
 
     std::unordered_set<int> visited_children;

--- a/caffe2/core/net_dag.cc
+++ b/caffe2/core/net_dag.cc
@@ -72,10 +72,10 @@ DAGNetBase::DAGNetBase(
       task_timers_[idx] = caffe2::make_unique<Timer>();
     }
   }
-  stats_.reserve(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
-  for (auto device_idx = 0;
-       device_idx < DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES;
-       ++device_idx) {
+  constexpr auto MAX_DEVICE_TYPES =
+      DeviceTypeProto::PROTO_COMPILE_TIME_MAX_DEVICE_TYPES;
+  stats_.reserve(MAX_DEVICE_TYPES);
+  for (auto device_idx = 0; device_idx < MAX_DEVICE_TYPES; ++device_idx) {
     stats_.emplace_back(
         "dag_net/stats/" + net_def->name() + "/" +
         caffe2::DeviceTypeName(device_idx));

--- a/caffe2/core/net_gpu_test.cc
+++ b/caffe2/core/net_gpu_test.cc
@@ -34,11 +34,11 @@ class NetTestDummyOp final : public OperatorBase {
 
   // Simulate CUDA operator behavior
   bool HasAsyncPart() const override {
-    return debug_def().device_option().device_type() == CUDA;
+    return debug_def().device_option().device_type() == PROTO_CUDA;
   }
 
   bool SupportsAsyncScheduling() const override {
-    return debug_def().device_option().device_type() == CUDA;
+    return debug_def().device_option().device_type() == PROTO_CUDA;
   }
 
  protected:

--- a/caffe2/core/net_test.cc
+++ b/caffe2/core/net_test.cc
@@ -36,11 +36,11 @@ class NetTestDummyOp final : public OperatorBase {
 
   // Simulate CUDA operator behavior
   bool HasAsyncPart() const override {
-    return debug_def().device_option().device_type() == CUDA;
+    return debug_def().device_option().device_type() == PROTO_CUDA;
   }
 
   bool SupportsAsyncScheduling() const override {
-    return debug_def().device_option().device_type() == CUDA;
+    return debug_def().device_option().device_type() == PROTO_CUDA;
   }
 
  protected:

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -72,8 +72,8 @@ PerOpEnginePrefType& g_per_op_engine_pref() {
 }
 
 GlobalEnginePrefType& g_global_engine_pref() {
-  static auto* g_global_engine_pref_ = new GlobalEnginePrefType{
-      {DeviceType::CUDA, {"CUDNN"}}, {DeviceType::HIP, {"MIOPEN"}}};
+  static auto* g_global_engine_pref_ =
+      new GlobalEnginePrefType{{CUDA, {"CUDNN"}}, {HIP, {"MIOPEN"}}};
   return *g_global_engine_pref_;
 }
 
@@ -321,21 +321,21 @@ CAFFE_DEFINE_REGISTRY(
     OperatorBase,
     const OperatorDef&,
     Workspace*);
-CAFFE_REGISTER_DEVICE_TYPE(DeviceType::CPU, CPUOperatorRegistry);
+CAFFE_REGISTER_DEVICE_TYPE(CPU, CPUOperatorRegistry);
 
 CAFFE_DEFINE_REGISTRY(
     CUDAOperatorRegistry,
     OperatorBase,
     const OperatorDef&,
     Workspace*);
-CAFFE_REGISTER_DEVICE_TYPE(DeviceType::CUDA, CUDAOperatorRegistry);
+CAFFE_REGISTER_DEVICE_TYPE(CUDA, CUDAOperatorRegistry);
 
 CAFFE_DEFINE_REGISTRY(
     HIPOperatorRegistry,
     OperatorBase,
     const OperatorDef&,
     Workspace*);
-CAFFE_REGISTER_DEVICE_TYPE(DeviceType::HIP, HIPOperatorRegistry);
+CAFFE_REGISTER_DEVICE_TYPE(HIP, HIPOperatorRegistry);
 
 CAFFE_DEFINE_REGISTRY(
     GradientRegistry,

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -806,12 +806,12 @@ typedef Registry<
     std::unique_ptr<OperatorBase>,
     const OperatorDef&,
     Workspace*>* (*RegistryFunction)();
-CAFFE2_API std::map<int32_t, OperatorRegistry*>* gDeviceTypeRegistry();
+CAFFE2_API std::map<DeviceType, OperatorRegistry*>* gDeviceTypeRegistry();
 
 struct CAFFE2_API DeviceTypeRegisterer {
-  explicit DeviceTypeRegisterer(int32_t type, RegistryFunction func) {
+  explicit DeviceTypeRegisterer(DeviceType type, RegistryFunction func) {
     if (gDeviceTypeRegistry()->count(type)) {
-      std::cerr << "Device type " << type
+      std::cerr << "Device type " << DeviceTypeName(type)
                 << "registered twice. This should not happen. Did you have "
                    "duplicated numbers assigned to different devices?";
       std::exit(1);
@@ -967,9 +967,9 @@ CAFFE2_API const std::string OpRegistryKey(
 using EnginePrefType = std::vector<std::string>;
 // {device_type -> {operator_name -> EnginePrefType}}
 using PerOpEnginePrefType =
-    CaffeMap<int, CaffeMap<std::string, EnginePrefType>>;
+    CaffeMap<DeviceType, CaffeMap<std::string, EnginePrefType>>;
 // {device_type -> EnginePrefType}
-using GlobalEnginePrefType = CaffeMap<int, EnginePrefType>;
+using GlobalEnginePrefType = CaffeMap<DeviceType, EnginePrefType>;
 CAFFE2_API void SetPerOpEnginePref(const PerOpEnginePrefType& per_op_engine_pref);
 CAFFE2_API void SetGlobalEnginePref(const GlobalEnginePrefType& global_engine_pref);
 CAFFE2_API void SetEnginePref(
@@ -977,7 +977,7 @@ CAFFE2_API void SetEnginePref(
     const GlobalEnginePrefType& global_engine_pref);
 CAFFE2_API void SetOpEnginePref(
     const std::string& op_type,
-    const CaffeMap<int, EnginePrefType>& op_pref);
+    const CaffeMap<DeviceType, EnginePrefType>& op_pref);
 
 CAFFE2_API TensorShape GetTensorShapeOfBlob(const Blob* b);
 

--- a/caffe2/core/operator_gpu_test.cc
+++ b/caffe2/core/operator_gpu_test.cc
@@ -48,7 +48,7 @@ TEST(EnginePrefTest, GPUDeviceDefaultPreferredEngines) {
     return;
   OperatorDef op_def;
   Workspace ws;
-  op_def.mutable_device_option()->set_device_type(CUDA);
+  op_def.mutable_device_option()->set_device_type(PROTO_CUDA);
   op_def.set_type("JustTest");
 
   {

--- a/caffe2/core/operator_test.cc
+++ b/caffe2/core/operator_test.cc
@@ -70,7 +70,7 @@ REGISTER_CUDA_OPERATOR(JustTest, JustTest);
 REGISTER_CPU_OPERATOR(JustTestWithSomeOutput, JustTestWithSomeOutput);
 
 TEST(OperatorTest, DeviceTypeRegistryWorks) {
-  EXPECT_EQ(gDeviceTypeRegistry()->count(DeviceType::CPU), 1);
+  EXPECT_EQ(gDeviceTypeRegistry()->count(CPU), 1);
 }
 
 TEST(OperatorTest, RegistryWorks) {
@@ -366,7 +366,7 @@ TEST(EnginePrefTest, PerOpEnginePref) {
   Workspace ws;
   op_def.set_type("JustTest");
 
-  SetPerOpEnginePref({{DeviceType::CPU, {{"JustTest", {"BAR"}}}}});
+  SetPerOpEnginePref({{CPU, {{"JustTest", {"BAR"}}}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -377,8 +377,7 @@ TEST(EnginePrefTest, PerOpEnginePref) {
 
   // Invalid operator type
   ASSERT_THROW(
-      SetPerOpEnginePref({{DeviceType::CPU, {{"NO_EXIST", {"BAR"}}}}}),
-      EnforceNotMet);
+      SetPerOpEnginePref({{CPU, {{"NO_EXIST", {"BAR"}}}}}), EnforceNotMet);
 }
 
 TEST(EnginePrefTest, GlobalEnginePref) {
@@ -386,7 +385,7 @@ TEST(EnginePrefTest, GlobalEnginePref) {
   Workspace ws;
   op_def.set_type("JustTest");
 
-  SetGlobalEnginePref({{DeviceType::CPU, {"FOO", "BAR"}}});
+  SetGlobalEnginePref({{CPU, {"FOO", "BAR"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -395,7 +394,7 @@ TEST(EnginePrefTest, GlobalEnginePref) {
   // clear
   SetGlobalEnginePref({});
 
-  SetGlobalEnginePref({{DeviceType::CPU, {"FOO"}}});
+  SetGlobalEnginePref({{CPU, {"FOO"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -414,8 +413,8 @@ TEST(EnginePrefTest, GlobalEnginePrefAndPerOpEnginePref) {
   Workspace ws;
   op_def.set_type("JustTest");
 
-  SetPerOpEnginePref({{DeviceType::CPU, {{"JustTest", {"BAR"}}}}});
-  SetGlobalEnginePref({{DeviceType::CPU, {"BAZ"}}});
+  SetPerOpEnginePref({{CPU, {{"JustTest", {"BAR"}}}}});
+  SetGlobalEnginePref({{CPU, {"BAZ"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -433,8 +432,8 @@ TEST(EnginePrefTest, GlobalEnginePrefAndPerOpEnginePrefAndOpDef) {
   op_def.set_type("JustTest");
   op_def.set_engine("BAR");
 
-  SetPerOpEnginePref({{DeviceType::CPU, {{"JustTest", {"BAZ"}}}}});
-  SetGlobalEnginePref({{DeviceType::CPU, {"BAZ"}}});
+  SetPerOpEnginePref({{CPU, {{"JustTest", {"BAZ"}}}}});
+  SetGlobalEnginePref({{CPU, {"BAZ"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -451,8 +450,8 @@ TEST(EnginePrefTest, SetOpEnginePref) {
   Workspace ws;
   op_def.set_type("JustTest");
 
-  SetPerOpEnginePref({{DeviceType::CPU, {{"JustTest", {"BAZ"}}}}});
-  SetOpEnginePref("JustTest", {{DeviceType::CPU, {"BAR"}}});
+  SetPerOpEnginePref({{CPU, {{"JustTest", {"BAZ"}}}}});
+  SetOpEnginePref("JustTest", {{CPU, {"BAR"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
@@ -469,8 +468,8 @@ TEST(EnginePrefTest, SetDefaultEngine) {
   Workspace ws;
   op_def.set_type("JustTest");
 
-  SetPerOpEnginePref({{DeviceType::CPU, {{"JustTest", {"DEFAULT"}}}}});
-  SetGlobalEnginePref({{DeviceType::CPU, {"BAR"}}});
+  SetPerOpEnginePref({{CPU, {{"JustTest", {"DEFAULT"}}}}});
+  SetGlobalEnginePref({{CPU, {"BAR"}}});
   {
     const auto op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());

--- a/caffe2/core/operator_test.cc
+++ b/caffe2/core/operator_test.cc
@@ -83,7 +83,7 @@ TEST(OperatorTest, RegistryWorks) {
   // as it needs to instantiate an Event object with CUDAContext. Thus we will
   // guard this test below.
   if (HasCudaRuntime()) {
-    op_def.mutable_device_option()->set_device_type(CUDA);
+    op_def.mutable_device_option()->set_device_type(PROTO_CUDA);
     op = CreateOperator(op_def, &ws);
     EXPECT_NE(nullptr, op.get());
   }
@@ -93,7 +93,7 @@ TEST(OperatorTest, RegistryWrongDevice) {
   OperatorDef op_def;
   Workspace ws;
   op_def.set_type("JustTypeCPUOnly");
-  op_def.mutable_device_option()->set_device_type(CUDA);
+  op_def.mutable_device_option()->set_device_type(PROTO_CUDA);
   try {
     CreateOperator(op_def, &ws);
     LOG(FATAL) << "No exception was thrown";
@@ -333,7 +333,7 @@ REGISTER_GRADIENT(Foo, GetFooGradient);
 TEST(OperatorGradientRegistryTest, GradientSimple) {
   Argument arg = MakeArgument<int>("arg", 1);
   DeviceOption option;
-  option.set_device_type(CPU);
+  option.set_device_type(PROTO_CPU);
   OperatorDef def = CreateOperatorDef(
       "Foo", "", std::vector<string>{"in"}, std::vector<string>{"out"},
       std::vector<Argument>{arg}, option, "DUMMY_ENGINE");
@@ -351,7 +351,7 @@ TEST(OperatorGradientRegistryTest, GradientSimple) {
   EXPECT_EQ(grad_op.output(0), "in_grad");
   // Checks the engine, device option and arguments.
   EXPECT_EQ(grad_op.engine(), "DUMMY_ENGINE");
-  EXPECT_EQ(grad_op.device_option().device_type(), CPU);
+  EXPECT_EQ(grad_op.device_option().device_type(), PROTO_CPU);
   EXPECT_EQ(grad_op.arg_size(), 1);
   EXPECT_EQ(grad_op.arg(0).SerializeAsString(),
             MakeArgument<int>("arg", 1).SerializeAsString());
@@ -405,7 +405,8 @@ TEST(EnginePrefTest, GlobalEnginePref) {
   SetGlobalEnginePref({});
 
   // Invalid device type
-  ASSERT_THROW(SetGlobalEnginePref({{8888, {"FOO"}}}), EnforceNotMet);
+  // This check is no longer necessary with the enum class
+  // ASSERT_THROW(SetGlobalEnginePref({{8888, {"FOO"}}}), EnforceNotMet);
 }
 
 TEST(EnginePrefTest, GlobalEnginePrefAndPerOpEnginePref) {

--- a/caffe2/core/storage.h
+++ b/caffe2/core/storage.h
@@ -16,14 +16,15 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/typeid.h"
 
+#include <ATen/core/Device.h>
+#include <ATen/core/DeviceType.h>
 #include <ATen/core/intrusive_ptr.h>
 
 namespace caffe2 {
 
 using DataType = TypeMeta;
-// TODO: changed to DataPtr in Aten when shared folder
-// is ready
 using DataPtr = std::shared_ptr<void>;
+using at::DeviceType;
 
 class CAFFE2_API StorageImpl : public c10::intrusive_ptr_target {
  public:
@@ -150,7 +151,6 @@ class CAFFE2_API StorageImpl : public c10::intrusive_ptr_target {
   // allocator_ takes precedence over StaticContext from device_type_
   // Allocator* allocator_;
   DeviceType device_type_ = CPU;
-
 };
 
 class CAFFE2_API Storage {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -222,18 +222,17 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if (size() > 0) {
       if (storage_.dtype().copy()) {
         CAFFE_ENFORCE(
-            GetDeviceType() == DeviceType::CPU,
+            GetDeviceType() == CPU,
             "In CopyFrom source and dest tensors must both be CPU for meta copy");
         CAFFE_ENFORCE(
-            src.GetDeviceType() == DeviceType::CPU,
+            src.GetDeviceType() == CPU,
             "In CopyFrom source and dest tensors must both be CPU for meta copy");
         storage_.dtype().copy()(src.raw_data(), raw_mutable_data(), size());
       } else {
         // We'll need to use a non-CPU context to perform the copy if
         // one of the context is not CPU since only non-CPU context
         // knows how to copy between CPU and that context
-        if (src.GetDeviceType() != DeviceType::CPU ||
-            GetDeviceType() == DeviceType::CPU) {
+        if (src.GetDeviceType() != CPU || GetDeviceType() == CPU) {
           if (!context) {
             src.CreateContext()->CopyBytesToDevice(
                 nbytes(), src.raw_data(), raw_mutable_data(), GetDeviceType());

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -97,12 +97,12 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   // and immediately discard it in Resize() since
   // reset_tensor will be true and FreeMemory will be called,
   // we might want to avoid creating Storage twice?
-  explicit TensorImpl(const vector<TIndex>& dims, DeviceType device_type)
+  explicit TensorImpl(const vector<TIndex>& dims, at::DeviceType device_type)
       : storage_(device_type) {
     Resize(dims);
   }
 
-  explicit TensorImpl(const vector<int>& dims, DeviceType device_type)
+  explicit TensorImpl(const vector<int>& dims, at::DeviceType device_type)
       : storage_(device_type) {
     Resize(dims);
   }
@@ -113,16 +113,16 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   TensorImpl(
       const TensorImpl& src,
       BaseContext* context_for_copy,
-      DeviceType device_type)
+      at::DeviceType device_type)
       : storage_(device_type) {
     CopyFrom(src, context_for_copy);
   }
 
   /**
-   * @brief: Create a Tensor of DeviceType `type` and initialize it with
+   * @brief: Create a Tensor of at::DeviceType `type` and initialize it with
    * src Tensor
    */
-  TensorImpl(const TensorImpl& src, DeviceType device_type)
+  TensorImpl(const TensorImpl& src, at::DeviceType device_type)
       : storage_(device_type) {
     CopyFrom(src);
   }
@@ -192,7 +192,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     return GetStaticContext()->CreateContext();
   }
 
-  DeviceType GetDeviceType() const {
+  at::DeviceType GetDeviceType() const {
     return storage_.device_type();
   }
 
@@ -222,17 +222,18 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if (size() > 0) {
       if (storage_.dtype().copy()) {
         CAFFE_ENFORCE(
-            GetDeviceType() == CPU,
+            GetDeviceType() == DeviceType::CPU,
             "In CopyFrom source and dest tensors must both be CPU for meta copy");
         CAFFE_ENFORCE(
-            src.GetDeviceType() == CPU,
+            src.GetDeviceType() == DeviceType::CPU,
             "In CopyFrom source and dest tensors must both be CPU for meta copy");
         storage_.dtype().copy()(src.raw_data(), raw_mutable_data(), size());
       } else {
         // We'll need to use a non-CPU context to perform the copy if
         // one of the context is not CPU since only non-CPU context
         // knows how to copy between CPU and that context
-        if (src.GetDeviceType() != CPU || GetDeviceType() == CPU) {
+        if (src.GetDeviceType() != DeviceType::CPU ||
+            GetDeviceType() == DeviceType::CPU) {
           if (!context) {
             src.CreateContext()->CopyBytesToDevice(
                 nbytes(), src.raw_data(), raw_mutable_data(), GetDeviceType());

--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -43,12 +43,12 @@ class IDEEPFallbackOp final : public IDEEPOperator {
 
   IDEEPFallbackOp(const OperatorDef& def, Workspace* ws)
       : IDEEPOperator(def, ws) {
-    CAFFE_ENFORCE_EQ(def.device_option().device_type(), IDEEP);
+    CAFFE_ENFORCE_EQ(def.device_option().device_type(), PROTO_IDEEP);
     base_def_.CopyFrom(def);
     // base_def_ runs on CPU, so we will set its device option to CPU.
     // Copy to allow random_seed to be correctly propagated.
     base_def_.mutable_device_option()->CopyFrom(def.device_option());
-    base_def_.mutable_device_option()->set_device_type(CPU);
+    base_def_.mutable_device_option()->set_device_type(PROTO_CPU);
     // Create output blobs in parent workspace,
     // then forward output blobs to local workspace.
     std::unordered_map<string, string> forwarded_output_blobs;

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -18,7 +18,7 @@ class IDEEPContext final : public BaseContext {
       : random_seed_(
             option.has_random_seed() ? option.random_seed()
                                      : RandomNumberSeed()) {
-    CAFFE_ENFORCE_EQ(option.device_type(), IDEEP);
+    CAFFE_ENFORCE_EQ(option.device_type(), PROTO_IDEEP);
   }
 
   ~IDEEPContext() noexcept override {}

--- a/caffe2/mkl/mklmemory_serialization.cc
+++ b/caffe2/mkl/mklmemory_serialization.cc
@@ -26,7 +26,7 @@ class MKLMemorySerializer : public BlobSerializerBase {
     blob_proto.set_type(kTensorBlobType);
     TensorProto* proto = blob_proto.mutable_tensor();
     auto* device_detail = proto->mutable_device_detail();
-    device_detail->set_device_type(MKLDNN);
+    device_detail->set_device_type(PROTO_MKLDNN);
     proto->set_name(name);
     if (blob.IsType<MKLMemory<float>>()) {
       const MKLMemory<float>& src = blob.Get<MKLMemory<float>>();

--- a/caffe2/mkl/operators/operator_fallback_mkl.h
+++ b/caffe2/mkl/operators/operator_fallback_mkl.h
@@ -44,12 +44,12 @@ class MKLFallbackOp final : public Operator<MKLContext> {
   USE_OPERATOR_FUNCTIONS(MKLContext);
   MKLFallbackOp(const OperatorDef& def, Workspace* ws)
       : Operator<MKLContext>(def, ws) {
-    CAFFE_ENFORCE_EQ(def.device_option().device_type(), MKLDNN);
+    CAFFE_ENFORCE_EQ(def.device_option().device_type(), PROTO_MKLDNN);
     OperatorDef base_def_(def);
     // base_def_ runs on CPU, so we will set its device option to CPU.
     // Copy to allow random_seed to be correctly propagated.
     base_def_.mutable_device_option()->CopyFrom(def.device_option());
-    base_def_.mutable_device_option()->set_device_type(CPU);
+    base_def_.mutable_device_option()->set_device_type(PROTO_CPU);
     // Set up the symbols for the local workspace.
     for (const string& name : def.input()) {
       local_input_blobs_.push_back(local_ws_.CreateBlob(name));

--- a/caffe2/mkl/utils/mkl_context.h
+++ b/caffe2/mkl/utils/mkl_context.h
@@ -27,7 +27,7 @@ class MKLContext : public BaseContext {
       : random_seed_(
             option.has_random_seed() ? option.random_seed()
                                      : RandomNumberSeed()) {
-    CAFFE_ENFORCE_EQ(option.device_type(), MKLDNN);
+    CAFFE_ENFORCE_EQ(option.device_type(), PROTO_MKLDNN);
   }
 
   ~MKLContext() override {}

--- a/caffe2/mkl/utils/mkl_memory.cc
+++ b/caffe2/mkl/utils/mkl_memory.cc
@@ -25,7 +25,7 @@ static vector<TIndex> GetMKLTensorInfo(
     DeviceOption* device) {
   const mkl::MKLMemory<T>* tc = static_cast<const mkl::MKLMemory<T>*>(c);
   *capacity = tc->size() * sizeof(T);
-  device->set_device_type(MKLDNN);
+  device->set_device_type(PROTO_MKLDNN);
   device->set_cuda_gpu_id(0);
   return tc->dims();
 }

--- a/caffe2/mobile/contrib/arm-compute/core/context.h
+++ b/caffe2/mobile/contrib/arm-compute/core/context.h
@@ -44,7 +44,7 @@ public:
   static bool initialized;
   explicit GLContext();
   explicit GLContext(const DeviceOption &option) {
-    DCHECK_EQ(option.device_type(), OPENGL);
+    DCHECK_EQ(option.device_type(), PROTO_OPENGL);
     GLContext();
   }
   ~GLContext() {}

--- a/caffe2/mobile/contrib/arm-compute/core/rewrite_net.cc
+++ b/caffe2/mobile/contrib/arm-compute/core/rewrite_net.cc
@@ -230,7 +230,7 @@ NetDef rewritePredictNetForOpenGL(const NetDef& predictNet, bool runFusion, std:
   for (auto i = 0; i < net.op().size(); ++i) {
     auto op = net.mutable_op(i);
     if (std::find(cpuOps.begin(), cpuOps.end(), op->type()) == cpuOps.end()) {
-      op->mutable_device_option()->set_device_type(OPENGL);
+      op->mutable_device_option()->set_device_type(PROTO_OPENGL);
     }
   }
 

--- a/caffe2/mobile/contrib/arm-compute/test/gl_model_test.h
+++ b/caffe2/mobile/contrib/arm-compute/test/gl_model_test.h
@@ -51,7 +51,7 @@ namespace caffe2 {
   for (auto i = 0; i < predict_net_def.op().size(); ++i) {
     auto op = predict_net_def.mutable_op(i);
     if (std::find(cpu_ops.begin(), cpu_ops.end(), op->type()) == cpu_ops.end()) {
-      op->mutable_device_option()->set_device_type(CPU);
+      op->mutable_device_option()->set_device_type(PROTO_CPU);
     }
   }
   predict_net_def.set_type("simple");

--- a/caffe2/mobile/contrib/arm-compute/test/gl_operator_test.h
+++ b/caffe2/mobile/contrib/arm-compute/test/gl_operator_test.h
@@ -7,12 +7,12 @@
 
 namespace caffe2 {
 
-#define DECLARE_OPENGL_OPERATOR(_name)                                         \
-  OperatorDef _name;                                                           \
-  _name.mutable_device_option()->set_device_type(OPENGL);
+#define DECLARE_OPENGL_OPERATOR(_name) \
+  OperatorDef _name;                   \
+  _name.mutable_device_option()->set_device_type(PROTO_OPENGL);
 
-#define MAKE_OPENGL_OPERATOR(_op)                                              \
-  _op->mutable_device_option()->set_device_type(OPENGL);
+#define MAKE_OPENGL_OPERATOR(_op) \
+  _op->mutable_device_option()->set_device_type(PROTO_OPENGL);
 
 #define ADD_ARG(_op, _name, _type, _val)                                       \
   {                                                                            \

--- a/caffe2/operators/batch_matmul_op_gpu_test.cc
+++ b/caffe2/operators/batch_matmul_op_gpu_test.cc
@@ -15,14 +15,14 @@ class BatchMatMulOpGPUTest : public testing::Test {
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     def_.set_name("test");
     def_.set_type("BatchMatMul");
     def_.add_input("A");
     def_.add_input("B");
     def_.add_output("Y");
-    def_.mutable_device_option()->set_device_type(CUDA);
+    def_.mutable_device_option()->set_device_type(PROTO_CUDA);
   }
 
   void AddConstInput(

--- a/caffe2/operators/elementwise_op_gpu_test.cc
+++ b/caffe2/operators/elementwise_op_gpu_test.cc
@@ -13,7 +13,7 @@ void CopyVector<caffe2::CUDAContext>(const int N, const bool* x, bool* y) {
 template <>
 caffe2::OperatorDef CreateOperatorDef<caffe2::CUDAContext>() {
   caffe2::OperatorDef def;
-  def.mutable_device_option()->set_device_type(caffe2::CUDA);
+  def.mutable_device_option()->set_device_type(caffe2::PROTO_CUDA);
   return def;
 }
 

--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -5,7 +5,8 @@ namespace caffe2 {
 template <>
 void LoadOp<CPUContext>::SetCurrentDevice(BlobProto* proto) {
   if (proto->has_tensor()) {
-    proto->mutable_tensor()->mutable_device_detail()->set_device_type(CPU);
+    proto->mutable_tensor()->mutable_device_detail()->set_device_type(
+        PROTO_CPU);
   }
 }
 

--- a/caffe2/operators/load_save_op_gpu.cc
+++ b/caffe2/operators/load_save_op_gpu.cc
@@ -7,7 +7,7 @@ template <>
 void LoadOp<CUDAContext>::SetCurrentDevice(BlobProto* proto) {
   if (proto->has_tensor()) {
     auto* device_detail = proto->mutable_tensor()->mutable_device_detail();
-    device_detail->set_device_type(CUDA);
+    device_detail->set_device_type(PROTO_CUDA);
     device_detail->set_cuda_gpu_id(CaffeCudaGetDevice());
   }
 }

--- a/caffe2/operators/operator_fallback_gpu.h
+++ b/caffe2/operators/operator_fallback_gpu.h
@@ -42,11 +42,11 @@ class GPUFallbackOp final : public Operator<CUDAContext> {
   USE_OPERATOR_FUNCTIONS(CUDAContext);
   GPUFallbackOp(const OperatorDef& def, Workspace* ws)
       : Operator<CUDAContext>(def, ws) {
-    CAFFE_ENFORCE_EQ(def.device_option().device_type(), CUDA);
+    CAFFE_ENFORCE_EQ(def.device_option().device_type(), PROTO_CUDA);
     OperatorDef base_def_(def);
     // base_def_ runs on CPU, so we will set its device option to CPU.
     base_def_.clear_device_option();
-    base_def_.mutable_device_option()->set_device_type(CPU);
+    base_def_.mutable_device_option()->set_device_type(PROTO_CPU);
     // Set up the symbols for the local workspace.
     for (const string& name : def.input()) {
       local_input_blobs_.push_back(local_ws_.CreateBlob(name));

--- a/caffe2/operators/operator_fallback_gpu_test.cc
+++ b/caffe2/operators/operator_fallback_gpu_test.cc
@@ -59,7 +59,7 @@ TEST(OperatorFallbackTest, GPUIncrementByOneOp) {
   OperatorDef op_def = CreateOperatorDef(
       "IncrementByOne", "", vector<string>{"X"},
       vector<string>{"X"});
-  op_def.mutable_device_option()->set_device_type(CUDA);
+  op_def.mutable_device_option()->set_device_type(PROTO_CUDA);
   Workspace ws;
   Tensor source_tensor(vector<TIndex>{2, 3}, CPU);
   for (int i = 0; i < 6; ++i) {

--- a/caffe2/operators/reshape_op_gpu_test.cc
+++ b/caffe2/operators/reshape_op_gpu_test.cc
@@ -17,7 +17,7 @@ static void AddConstInput(
     const string& name,
     Workspace* ws) {
   DeviceOption option;
-  option.set_device_type(CUDA);
+  option.set_device_type(PROTO_CUDA);
   CUDAContext context(option);
   Blob* blob = ws->CreateBlob(name);
   auto* tensor = blob->GetMutableTensor(CUDA);
@@ -38,7 +38,7 @@ TEST(ReshapeOpGPUTest, testReshapeWithScalar) {
   def.add_output("XNew");
   def.add_output("OldShape");
   def.add_arg()->CopyFrom(MakeArgument("shape", vector<int64_t>{1}));
-  def.mutable_device_option()->set_device_type(CUDA);
+  def.mutable_device_option()->set_device_type(PROTO_CUDA);
   AddConstInput(vector<TIndex>(), 3.14, "X", &ws);
   // execute the op
   unique_ptr<OperatorBase> op(CreateOperator(def, &ws));

--- a/caffe2/operators/rnn/recurrent_network_executor_gpu.cc
+++ b/caffe2/operators/rnn/recurrent_network_executor_gpu.cc
@@ -69,7 +69,9 @@ void CUDARecurrentNetworkExecutor::_ExecRange(int from, int to) {
         continue;
       }
 
-      if (gpu_id == -1 && rnn_op.op->device_option().device_type() == DeviceType::CUDA) {
+      if (gpu_id == -1 &&
+          rnn_op.op->device_option().device_type() ==
+              DeviceTypeProto::PROTO_CUDA) {
         gpu_id = rnn_op.op->device_option().cuda_gpu_id();
       } else {
         CAFFE_ENFORCE(

--- a/caffe2/operators/roi_align_op_gpu_test.cc
+++ b/caffe2/operators/roi_align_op_gpu_test.cc
@@ -136,7 +136,8 @@ void CreateAndRun(
     def.add_input("X");
     def.add_input("R");
     def.add_output("Y");
-    def.mutable_device_option()->set_device_type(GetDeviceType<Context>());
+    def.mutable_device_option()->set_device_type(
+        TypeToProto(GetDeviceType<Context>()));
     def.add_arg()->CopyFrom(MakeArgument("spatial_scale", 1.0f / 16.0f));
     def.add_arg()->CopyFrom(MakeArgument("pooled_h", 6));
     def.add_arg()->CopyFrom(MakeArgument("pooled_w", 8));
@@ -151,7 +152,7 @@ void CreateAndRun(
     def_roialign.add_input("R");
     def_roialign.add_output("Y_NHWC");
     def_roialign.mutable_device_option()->set_device_type(
-        GetDeviceType<Context>());
+        TypeToProto(GetDeviceType<Context>()));
     def_roialign.add_arg()->CopyFrom(
         MakeArgument("spatial_scale", 1.0f / 16.0f));
     def_roialign.add_arg()->CopyFrom(MakeArgument("pooled_h", 6));
@@ -164,14 +165,16 @@ void CreateAndRun(
     def_x.set_type("NCHW2NHWC");
     def_x.add_input("X");
     def_x.add_output("X_NHWC");
-    def_x.mutable_device_option()->set_device_type(GetDeviceType<Context>());
+    def_x.mutable_device_option()->set_device_type(
+        TypeToProto(GetDeviceType<Context>()));
 
     OperatorDef def_y;
     def_y.set_name("test_y");
     def_y.set_type("NHWC2NCHW");
     def_y.add_input("Y_NHWC");
     def_y.add_output("Y");
-    def_y.mutable_device_option()->set_device_type(GetDeviceType<Context>());
+    def_y.mutable_device_option()->set_device_type(
+        TypeToProto(GetDeviceType<Context>()));
 
     ops.push_back(CreateOperator(def_x, &ws));
     ops.push_back(CreateOperator(def_roialign, &ws));

--- a/caffe2/operators/utility_ops_gpu_test.cc
+++ b/caffe2/operators/utility_ops_gpu_test.cc
@@ -16,7 +16,7 @@ static void AddConstInput(
     const string& name,
     Workspace* ws) {
   DeviceOption option;
-  option.set_device_type(CUDA);
+  option.set_device_type(PROTO_CUDA);
   CUDAContext context(option);
   Blob* blob = ws->CreateBlob(name);
   auto* tensor = blob->GetMutableTensor(CUDA);
@@ -37,7 +37,7 @@ TEST(UtilityOpGPUTest, testReshapeWithScalar) {
   def.add_output("XNew");
   def.add_output("OldShape");
   def.add_arg()->CopyFrom(MakeArgument("shape", vector<int64_t>{1}));
-  def.mutable_device_option()->set_device_type(CUDA);
+  def.mutable_device_option()->set_device_type(PROTO_CUDA);
   AddConstInput(vector<TIndex>(), 3.14, "X", &ws);
   // execute the op
   unique_ptr<OperatorBase> op(CreateOperator(def, &ws));

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -54,7 +54,7 @@ private:
   std::string Device = "";
   caffe2::OperatorDef OpDef;
   bool OpDefExists = false;
-  int DeviceType = caffe2::DeviceType::CPU;
+  int DeviceType = caffe2::DeviceTypeProto::PROTO_CPU;
 };
 
 CAFFE2_API nom::repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<std::string, nom::repr::NNGraph::NodeRef>* blobMapOut = nullptr);

--- a/caffe2/opt/device_test.cc
+++ b/caffe2/opt/device_test.cc
@@ -27,13 +27,13 @@ TEST(DeviceTest, InsertCopies) {
       ADD_ARG(def, "pad", i, 0);
       ADD_ARG(def, "order", s, "NCHW");
       def->add_output("X");
-      def->mutable_device_option()->set_device_type(caffe2::CPU);
+      def->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
     } else {
       caffe2::OperatorDef* def = net.add_op();
       def->set_type("Relu");
       def->add_input("X");
       def->add_output("X");
-      def->mutable_device_option()->set_device_type(caffe2::CPU);
+      def->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
     }
   }
   auto nn = caffe2::convertToNNModule(net);
@@ -42,7 +42,7 @@ TEST(DeviceTest, InsertCopies) {
     if (nn::is<Relu>(node)) {
       auto annot = nn::get<NeuralNetOperator>(node)->getMutableAnnotation();
       auto c2_annot = dyn_cast<caffe2::Caffe2Annotation>(annot);
-      c2_annot->setDeviceType(caffe2::OPENCL);
+      c2_annot->setDeviceType(caffe2::PROTO_OPENCL);
     }
   }
 
@@ -57,7 +57,7 @@ TEST(DeviceTest, InsertCopies) {
         NOM_REQUIRE_OR_RET_FALSE(annot);
         auto c2_annot = dyn_cast<caffe2::Caffe2Annotation>(annot);
         NOM_REQUIRE_OR_RET_FALSE(c2_annot);
-        return c2_annot->getDeviceType() == caffe2::OPENCL;
+        return c2_annot->getDeviceType() == caffe2::PROTO_OPENCL;
       },
       [](NNGraph& g) {
         return g.createNode(nom::util::make_unique<GenericOperator>());

--- a/caffe2/opt/optimize_ideep.cc
+++ b/caffe2/opt/optimize_ideep.cc
@@ -56,7 +56,7 @@ caffe2::OperatorDef* getMutableOpDef(repr::NeuralNetOperator& nnOp) {
 bool isOnIdeepDevice(const repr::NeuralNetOperator& nnOp) {
   // We only want to fuse for IDEEP convs
   const auto& op = getOpDef(nnOp);
-  return op.device_option().device_type() == DeviceType::IDEEP;
+  return op.device_option().device_type() == DeviceTypeProto::PROTO_IDEEP;
 }
 
 bool shouldFuseConv(const repr::Conv& conv) {

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -111,17 +111,17 @@ message Argument {
 // Note: if you add a device type, make sure you add the corresponding device
 // line in the DeviceTypeName() function in caffe2/utils/proto_utils.cc
 // and update ATen/core/DeviceType.h
-enum DeviceType {
-  CPU = 0;                    // In default, we will use CPU.
-  CUDA = 1;                   // CUDA.
-  MKLDNN = 2;                 // Reserved for explicit MKLDNN
-  OPENGL = 3;                 // OpenGL
-  OPENCL = 4;                 // OpenCL
-  IDEEP = 5;                  // IDEEP.
-  HIP = 6;                    // AMD HIP
+enum DeviceTypeProto {
+  PROTO_CPU = 0;                    // In default, we will use CPU.
+  PROTO_CUDA = 1;                   // CUDA.
+  PROTO_MKLDNN = 2;                 // Reserved for explicit MKLDNN
+  PROTO_OPENGL = 3;                 // OpenGL
+  PROTO_OPENCL = 4;                 // OpenCL
+  PROTO_IDEEP = 5;                  // IDEEP.
+  PROTO_HIP = 6;                    // AMD HIP
   // Change the following number if you add more devices in the code.
-  COMPILE_TIME_MAX_DEVICE_TYPES = 7;
-  ONLY_FOR_TEST = 20901701;   // This device type is only for test.
+  PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = 7;
+  PROTO_ONLY_FOR_TEST = 20901701;   // This device type is only for test.
 }
 
 // Device-specific options. We do not distinguish DeviceOption protos for

--- a/caffe2/proto/caffe2_pb.h
+++ b/caffe2/proto/caffe2_pb.h
@@ -1,2 +1,86 @@
 #pragma once
+#include <ATen/core/DeviceType.h>
+#include <ATen/core/Error.h>
 #include <caffe2/proto/caffe2.pb.h>
+
+namespace caffe2 {
+
+using DeviceType = at::DeviceType;
+constexpr DeviceType CPU = DeviceType::CPU;
+constexpr DeviceType CUDA = DeviceType::CUDA;
+constexpr DeviceType OPENGL = DeviceType::OPENGL;
+constexpr DeviceType OPENCL = DeviceType::OPENCL;
+constexpr DeviceType MKLDNN = DeviceType::MKLDNN;
+constexpr DeviceType IDEEP = DeviceType::IDEEP;
+constexpr DeviceType HIP = DeviceType::HIP;
+constexpr DeviceType COMPILE_TIME_MAX_DEVICE_TYPES =
+    DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES;
+constexpr DeviceType ONLY_FOR_TEST = DeviceType::ONLY_FOR_TEST;
+
+inline CAFFE2_API DeviceType ProtoToType(const caffe2::DeviceTypeProto p) {
+  switch (p) {
+    case caffe2::PROTO_CPU:
+      return DeviceType::CPU;
+    case caffe2::PROTO_CUDA:
+      return DeviceType::CUDA;
+    case caffe2::PROTO_OPENGL:
+      return DeviceType::OPENGL;
+    case caffe2::PROTO_OPENCL:
+      return DeviceType::OPENCL;
+    case caffe2::PROTO_MKLDNN:
+      return DeviceType::MKLDNN;
+    case caffe2::PROTO_IDEEP:
+      return DeviceType::IDEEP;
+    case caffe2::PROTO_HIP:
+      return DeviceType::HIP;
+    case caffe2::PROTO_COMPILE_TIME_MAX_DEVICE_TYPES:
+      return DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES;
+    case caffe2::PROTO_ONLY_FOR_TEST:
+      return DeviceType::ONLY_FOR_TEST;
+    default:
+      AT_ERROR(
+          "Unknown device:",
+          static_cast<int32_t>(p),
+          ". If you have recently updated the caffe2.proto file to add a new "
+          "device type, did you forget to update the ProtoToType() and TypeToProto"
+          "function to reflect such recent changes?");
+      // The below code won't run but is needed to suppress some compiler
+      // warnings.
+      return DeviceType::ONLY_FOR_TEST;
+  }
+}
+
+inline CAFFE2_API DeviceTypeProto TypeToProto(const DeviceType& t) {
+  switch (t) {
+    case DeviceType::CPU:
+      return caffe2::PROTO_CPU;
+    case DeviceType::CUDA:
+      return caffe2::PROTO_CUDA;
+    case DeviceType::OPENGL:
+      return caffe2::PROTO_OPENGL;
+    case DeviceType::OPENCL:
+      return caffe2::PROTO_OPENCL;
+    case DeviceType::MKLDNN:
+      return caffe2::PROTO_MKLDNN;
+    case DeviceType::IDEEP:
+      return caffe2::PROTO_IDEEP;
+    case DeviceType::HIP:
+      return caffe2::PROTO_HIP;
+    case DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES:
+      return caffe2::PROTO_COMPILE_TIME_MAX_DEVICE_TYPES;
+    case DeviceType::ONLY_FOR_TEST:
+      return caffe2::PROTO_ONLY_FOR_TEST;
+    default:
+      AT_ERROR(
+          "Unknown device:",
+          static_cast<int32_t>(t),
+          ". If you have recently updated the caffe2.proto file to add a new "
+          "device type, did you forget to update the ProtoToType() and TypeToProto"
+          "function to reflect such recent changes?");
+      // The below code won't run but is needed to suppress some compiler
+      // warnings.
+      return PROTO_ONLY_FOR_TEST;
+  }
+}
+
+} // namespace caffe2

--- a/caffe2/python/__init__.py
+++ b/caffe2/python/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from caffe2.proto import caffe2_pb2
+# TODO: refactor & remove the following alias
+caffe2_pb2.CPU = caffe2_pb2.PROTO_CPU
+caffe2_pb2.CUDA = caffe2_pb2.PROTO_CUDA
+caffe2_pb2.MKLDNN = caffe2_pb2.PROTO_MKLDNN
+caffe2_pb2.OPENGL = caffe2_pb2.PROTO_OPENGL
+caffe2_pb2.OPENCL = caffe2_pb2.PROTO_OPENCL
+caffe2_pb2.IDEEP = caffe2_pb2.PROTO_IDEEP
+caffe2_pb2.HIP = caffe2_pb2.PROTO_HIP
+caffe2_pb2.COMPILE_TIME_MAX_DEVICE_TYPES = caffe2_pb2.PROTO_COMPILE_TIME_MAX_DEVICE_TYPES
+caffe2_pb2.ONLY_FOR_TEST = caffe2_pb2.PROTO_ONLY_FOR_TEST

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -59,7 +59,7 @@ CAFFE_DEFINE_TYPED_REGISTRY(
     std::unique_ptr);
 CAFFE_DEFINE_TYPED_REGISTRY(
     BlobFeederRegistry,
-    int,
+    caffe2::DeviceType,
     BlobFeederBase,
     std::unique_ptr);
 
@@ -368,7 +368,7 @@ void addObjectMethods(py::module& m) {
           [](DLPackWrapper<CPUContext>* t) -> py::object {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                CPU,
+                PROTO_CPU,
                 "Expected CPU device option for CPU tensor");
             return t->data();
           },
@@ -378,7 +378,7 @@ void addObjectMethods(py::module& m) {
           [](DLPackWrapper<CPUContext>* t, py::object obj) {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                CPU,
+                PROTO_CPU,
                 "Expected CPU device option for CPU tensor");
             t->feed(obj);
           },
@@ -985,7 +985,7 @@ void addGlobalMethods(py::module& m) {
   m.def(
       "set_op_engine_pref",
       [](const std::string& op_type,
-         const CaffeMap<int, EnginePrefType>& op_pref) -> void {
+         const CaffeMap<DeviceType, EnginePrefType>& op_pref) -> void {
         caffe2::SetOpEnginePref(op_type, op_pref);
       });
 

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -73,13 +73,14 @@ inline unique_ptr<BlobFetcherBase> CreateFetcher(TypeIdentifier id) {
 
 CAFFE_DECLARE_TYPED_REGISTRY(
     BlobFeederRegistry,
-    int,
+    DeviceType,
     BlobFeederBase,
     std::unique_ptr);
 #define REGISTER_BLOB_FEEDER(device_type, ...) \
   CAFFE_REGISTER_TYPED_CLASS(BlobFeederRegistry, device_type, __VA_ARGS__)
 inline unique_ptr<BlobFeederBase> CreateFeeder(int device_type) {
-  return BlobFeederRegistry()->Create(device_type);
+  return BlobFeederRegistry()->Create(
+      caffe2::ProtoToType(static_cast<DeviceTypeProto>(device_type)));
 }
 
 static_assert(
@@ -311,7 +312,7 @@ class PythonOpBase : public Operator<Context> {
       py::gil_scoped_acquire g;
 
       DeviceOption cpu_option;
-      cpu_option.set_device_type(CPU);
+      cpu_option.set_device_type(PROTO_CPU);
 
       std::vector<py::object> inputs;
       inputs.reserve(InputSize());

--- a/caffe2/python/pybind_state_dlpack.cc
+++ b/caffe2/python/pybind_state_dlpack.cc
@@ -7,8 +7,8 @@ namespace py = pybind11;
 
 const DLDeviceType* CaffeToDLDeviceType(int device_type) {
   static std::map<int, DLDeviceType> dl_device_type_map{
-      {CPU, kCPU},
-      {CUDA, kGPU},
+      {PROTO_CPU, kCPU},
+      {PROTO_CUDA, kGPU},
   };
   const auto it = dl_device_type_map.find(device_type);
   return it == dl_device_type_map.end() ? nullptr : &it->second;

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -121,7 +121,7 @@ void addCUDAObjectMethods(py::module& m) {
           [](DLPackWrapper<CUDAContext>* t) -> py::object {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                CUDA,
+                PROTO_CUDA,
                 "Expected CUDA device option for CUDA tensor");
 
             return t->data();
@@ -132,7 +132,7 @@ void addCUDAObjectMethods(py::module& m) {
           [](DLPackWrapper<CUDAContext>* t, py::object obj) {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                CUDA,
+                PROTO_CUDA,
                 "Expected CUDA device option for CUDA tensor");
             t->feed(obj);
           },

--- a/caffe2/python/pybind_state_hip.cc
+++ b/caffe2/python/pybind_state_hip.cc
@@ -53,7 +53,7 @@ void addHIPObjectMethods(py::module& m) {
           [](DLPackWrapper<HIPContext>* t) -> py::object {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                HIP,
+                PROTO_HIP,
                 "Expected HIP device option for HIP tensor");
 
             return t->data();
@@ -64,7 +64,7 @@ void addHIPObjectMethods(py::module& m) {
           [](DLPackWrapper<HIPContext>* t, py::object obj) {
             CAFFE_ENFORCE_EQ(
                 t->device_option.device_type(),
-                HIP,
+                PROTO_HIP,
                 "Expected HIP device option for HIP tensor");
             t->feed(obj);
           },

--- a/caffe2/python/pybind_state_ideep.cc
+++ b/caffe2/python/pybind_state_ideep.cc
@@ -161,7 +161,7 @@ public:
         FeedTensor(option, original_array, blob->GetMutable<itensor>());
       } else {
         DeviceOption cpu_option(option);
-        cpu_option.set_device_type(DeviceType::CPU);
+        cpu_option.set_device_type(DeviceTypeProto::PROTO_CPU);
         TensorFeeder<CPUContext> cpu_tensor_feeder;
         cpu_tensor_feeder.FeedTensor(cpu_option, original_array,
                                      blob->GetMutableTensor(CPU));

--- a/caffe2/transforms/conv_to_nnpack_transform.h
+++ b/caffe2/transforms/conv_to_nnpack_transform.h
@@ -12,7 +12,7 @@ class CAFFE2_API ConvToNNPackTransform : public SingleOpTransform {
   // Specify what the op needs to be to match the pattern.
   bool MatchOperator(const OperatorDef& op) override {
     return (
-        op.type() == "Conv" && op.device_option().device_type() == CPU &&
+        op.type() == "Conv" && op.device_option().device_type() == PROTO_CPU &&
         op.engine() != "NNPACK");
   }
 

--- a/caffe2/transforms/conv_to_nnpack_transform_test.cc
+++ b/caffe2/transforms/conv_to_nnpack_transform_test.cc
@@ -15,7 +15,7 @@ TEST(ConvToNNPackTest, TestSimple) {
   op = AddOp(&netdef, "Conv", {"in"}, {"out"});
   op = AddOp(&netdef, "Relu", {"out"}, {"out"});
   op = AddOp(&netdef, "Conv", {"out"}, {"out"}); // if not CPU, won't transform
-  op->mutable_device_option()->set_device_type(CUDA);
+  op->mutable_device_option()->set_device_type(PROTO_CUDA);
   op = AddOp(&netdef, "Relu", {"out"}, {"out"});
   op = AddOp(&netdef, "Conv", {"out"}, {"out"});
   op->set_engine("NNPACK"); // does not need to be transformed
@@ -28,7 +28,7 @@ TEST(ConvToNNPackTest, TestSimple) {
 
   int nnpack_count = 0;
   for (auto& op : transformed_netdef.op()) {
-    if (op.type() == "Conv" && op.device_option().device_type() == CPU) {
+    if (op.type() == "Conv" && op.device_option().device_type() == PROTO_CPU) {
       EXPECT_EQ(op.engine(), "NNPACK");
       nnpack_count++;
     }

--- a/caffe2/transforms/pattern_net_transform_test.cc
+++ b/caffe2/transforms/pattern_net_transform_test.cc
@@ -250,19 +250,19 @@ TEST(PatternNetTransformTest, TestDeviceOptionMatching) {
 
   NetDef pdef;
   auto op = AddOp(&pdef, "DummyOp1", {"in"}, {"out"});
-  op->mutable_device_option()->set_device_type(CPU);
+  op->mutable_device_option()->set_device_type(PROTO_CPU);
 
   NetDef rdef;
   op = AddOp(&rdef, "DummyOp1", {"in"}, {"out"});
-  op->mutable_device_option()->set_device_type(CUDA);
+  op->mutable_device_option()->set_device_type(PROTO_CUDA);
 
   NetDef netdef;
   op = AddOp(&netdef, "DummyOp1", {"in"}, {"mid"});
-  op->mutable_device_option()->set_device_type(CPU);
+  op->mutable_device_option()->set_device_type(PROTO_CPU);
   op = AddOp(&netdef, "DummyOp1", {"mid"}, {"mid"}); // should not match
-  op->mutable_device_option()->set_device_type(CUDA);
+  op->mutable_device_option()->set_device_type(PROTO_CUDA);
   op = AddOp(&netdef, "DummyOp1", {"mid"}, {"out"});
-  op->mutable_device_option()->set_device_type(CPU);
+  op->mutable_device_option()->set_device_type(PROTO_CPU);
 
   PatternNetTransform t(pdef, rdef);
   transform::Graph g(netdef);
@@ -272,7 +272,7 @@ TEST(PatternNetTransformTest, TestDeviceOptionMatching) {
   NetDef transformed_net = t.ApplyTo(netdef);
   for (const auto& opdef : transformed_net.op()) {
     EXPECT_TRUE(opdef.has_device_option());
-    EXPECT_EQ(opdef.device_option().device_type(), CUDA);
+    EXPECT_EQ(opdef.device_option().device_type(), PROTO_CUDA);
   }
 }
 

--- a/caffe2/utils/hip/math_blas_hip_test.cc
+++ b/caffe2/utils/hip/math_blas_hip_test.cc
@@ -15,7 +15,7 @@ TEST(MathROCBLASTest, GemmNoTransNoTrans) {
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(HIP);
+  option.set_device_type(PROTO_HIP);
   HIPContext context(option);
 
   Blob* blobX = ws.CreateBlob("X");
@@ -115,7 +115,7 @@ TEST(MathROCBLASTest, GemmNoTransTrans) {
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(HIP);
+  option.set_device_type(PROTO_HIP);
   HIPContext context(option);
 
   Blob* blobX = ws.CreateBlob("X");
@@ -214,7 +214,7 @@ TEST(MathROCBLASTest, GemvNoTrans) {
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(HIP);
+  option.set_device_type(PROTO_HIP);
   HIPContext context(option);
 
   Blob* blobA = ws.CreateBlob("A");
@@ -304,7 +304,7 @@ TEST(MathROCBLASTest, GemvTrans) {
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(HIP);
+  option.set_device_type(PROTO_HIP);
   HIPContext context(option);
 
   Blob* blobA = ws.CreateBlob("A");

--- a/caffe2/utils/math_gpu_test.cc
+++ b/caffe2/utils/math_gpu_test.cc
@@ -33,7 +33,7 @@ void executeGpuBinaryOpTest(
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(CUDA);
+  option.set_device_type(PROTO_CUDA);
   CUDAContext context(option);
 
   Blob* blobx0 = ws.CreateBlob("X0");
@@ -85,7 +85,7 @@ TEST(MathUtilGPUTest, testAddStripedBatch) {
     return;
   Workspace ws;
   DeviceOption option;
-  option.set_device_type(CUDA);
+  option.set_device_type(PROTO_CUDA);
   CUDAContext context(option);
   Blob* blobx = ws.CreateBlob("X");
   Blob* bloby = ws.CreateBlob("Y");
@@ -253,7 +253,7 @@ class GemmBatchedGPUTest
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     Blob* X_blob = ws_.CreateBlob("X");
     Blob* W_blob = ws_.CreateBlob("W");
@@ -377,7 +377,7 @@ class ReduceTensorGPUTest : public testing::Test {
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     Blob* blob_x = ws_.CreateBlob("X");
     Blob* blob_y = ws_.CreateBlob("Y");
@@ -660,7 +660,7 @@ class BroadcastGPUTest : public testing::Test {
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     Blob* blob_x = ws_.CreateBlob("X");
     Blob* blob_y = ws_.CreateBlob("Y");
@@ -736,7 +736,7 @@ class MomentsGPUTest : public testing::Test {
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     Blob* blob_x = ws_.CreateBlob("X");
     Blob* blob_mean = ws_.CreateBlob("mean");
@@ -864,7 +864,7 @@ class TransposeGPUTest : public testing::Test {
     if (!HasCudaGPU()) {
       return;
     }
-    option_.set_device_type(CUDA);
+    option_.set_device_type(PROTO_CUDA);
     cuda_context_ = make_unique<CUDAContext>(option_);
     Blob* blob_x = ws_.CreateBlob("X");
     Blob* blob_y = ws_.CreateBlob("Y");

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -27,13 +27,13 @@ CAFFE2_EXPORT std::string DeviceTypeName(const int32_t& d) {
 
 CAFFE2_EXPORT int DeviceId(const DeviceOption& option) {
   switch (option.device_type()) {
-    case CPU:
+    case PROTO_CPU:
       return option.numa_node_id();
-    case CUDA:
+    case PROTO_CUDA:
       return option.cuda_gpu_id();
-    case MKLDNN:
+    case PROTO_MKLDNN:
       return option.numa_node_id();
-    case HIP:
+    case PROTO_HIP:
       return option.hip_gpu_id();
     default:
       CAFFE_THROW("Unknown device id for device type: ", option.device_type());

--- a/caffe2/utils/proto_utils_test.cc
+++ b/caffe2/utils/proto_utils_test.cc
@@ -15,8 +15,8 @@ TEST(ProtoUtilsTest, IsSameDevice) {
   EXPECT_FALSE(IsSameDevice(a, b));
   a.set_cuda_gpu_id(2);
   EXPECT_TRUE(IsSameDevice(a, b));
-  a.set_device_type(DeviceType::CUDA);
-  b.set_device_type(DeviceType::CPU);
+  a.set_device_type(DeviceTypeProto::PROTO_CUDA);
+  b.set_device_type(DeviceTypeProto::PROTO_CPU);
   EXPECT_FALSE(IsSameDevice(a, b));
 }
 


### PR DESCRIPTION
[pt1][tensor] caffe2::DeviceType -> at::DeviceType

Previously we use DeviceType in caffe2.proto directly, but it's an `enum` and have implicit conversion to int, which does not have type safety, e.g. we have to explicitly check for a device type is valid in event.h:
```
template <int d>
struct EventCreateFunctionRegisterer {
  explicit EventCreateFunctionRegisterer(EventCreateFunction f) {
    static_assert(d < MaxDeviceTypes, "");
    Event::event_creator_[d] = f;
  }
};
```
at::DeviceType is an `enum class`, and it does not have implicit conversion to int, and provides better type safety guarantees. In this diff we have done the following refactor(taking CPU as an example):

    1. caffe2::DeviceType → caffe2::DeviceTypeProto
    2. caffe2::CPU → caffe2::PROTO_CPU
    3. caffe2::DeviceType = at::DeviceType
    4. caffe2::CPU = at::DeviceType::CPU

codemod -d caffe2/caffe2 --extensions h,cc,cpp 'device_type\(\), ' 'device_type(), PROTO_'
+ some manual changes

In short, after this diff, in c++, caffe2::CPU refers to the at::DeviceType::CPU and the old proto caffe2::CPU will be caffe2::PROTO_CPU.
In python side, we have a temporary workaround that alias `caffe2_pb2.CPU = caffe2_pb2.PROOT_CPU` to make the change easier to review and this will be removed later.

Differential Revision: D9545704

