### PR TITLE
nomnigraph - simplify core graph API and test

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -1,9 +1,5 @@
 //===- nomnigraph/Graph/Graph.h - Basic graph implementation ----*- C++ -*-===//
 //
-// TODO Licensing.
-//
-//===----------------------------------------------------------------------===//
-//
 // This file defines a basic graph API for generic and flexible use with
 // graph algorithms.
 //
@@ -248,27 +244,8 @@ class Graph {
     return createNodeInternal(Node<T, U...>());
   }
 
-  void importNode(NodeRef node, Graph<T, U...>& otherGraph) {
-    for (auto it = nodes_.begin(); it != nodes_.end(); ++it) {
-      if (&(*it) == node) {
-        std::list<Node<T, U...>>& otherNodes = otherGraph.nodes_;
-        otherNodes.splice(otherNodes.end(), nodes_, it, ++it);
-        otherGraph.nodeRefs_.insert(node);
-        break;
-      }
-    }
-  }
-
-  void importEdge(EdgeRef edge, Graph<T, U...>& otherGraph) {
-    std::list<Edge<T, U...>>& otherEdges = otherGraph.edges_;
-    for (auto it = edges_.begin(); it != edges_.end(); ++it) {
-      if (&(*it) == edge) {
-        otherEdges.splice(otherEdges.end(), edges_, it, ++it);
-        break;
-      }
-    }
-  }
-
+  // Swap two nodes.
+  // Any edge V -> N1 becomes V -> N2, and N1 -> V becomes N2 -> V.
   void swapNodes(NodeRef n1, NodeRef n2) {
     // First rectify the edges
     for (auto& inEdge : n1->getInEdges()) {
@@ -295,34 +272,14 @@ class Graph {
     n2->setInEdges(n1InEdges);
   }
 
-  /// \brief Replace a node in the graph with a generic
-  /// set of nodes.
+  /// \brief Replace a node in the graph with another node.
   /// \note The node replaced simply has its edges cut, but it not
   /// deleted from the graph.  Call Graph::deleteNode to delete it.
-  /// \p old A node to be replaced in the graph.
-  /// \p newTail The node that inherit the old node's in-edges
-  /// \p newHead (optional) The node that inherit the old node's out-edges
-  void replaceNode(
-      const NodeRef& old,
-      const NodeRef& newTail,
-      const NodeRef& newHead_ = nullptr) {
-    // If no newHead is specified, make the tail the head as well.
-    // We are effectively replacing the node with one node in this case.
-    const NodeRef newHead = newHead_ ? newHead_ : newTail;
-    const auto inEdges = old->getInEdges();
-    const auto outEdges = old->getOutEdges();
-
-    for (const auto& inEdge : inEdges) {
-      inEdge->setHead(newTail);
-      old->removeInEdge(inEdge);
-      newTail->addInEdge(inEdge);
-    }
-
-    for (const auto& outEdge : outEdges) {
-      outEdge->setTail(newHead);
-      old->removeOutEdge(outEdge);
-      newTail->addOutEdge(outEdge);
-    }
+  /// \p oldNode A node to be replaced in the graph.
+  /// \p newNode The node that inherit the old node's in-edges and out-edges.
+  void replaceNode(const NodeRef& oldNode, const NodeRef& newNode) {
+    replaceInEdges(oldNode, newNode);
+    replaceOutEdges(oldNode, newNode);
   }
 
   // All out-edges oldNode -> V will be replaced with newNode -> V
@@ -361,36 +318,46 @@ class Graph {
     return e;
   }
 
-  /// \brief Get a reference to the edge between two nodes if it exists.
-  /// note: will fail assertion if the edge does not exist.
-  EdgeRef getEdge(NodeRef tail, NodeRef head) const {
+  /// \brief Get a reference to the edge between two nodes if it exists. Returns
+  /// nullptr if the edge does not exist.
+  EdgeRef getEdgeIfExists(NodeRef tail, NodeRef head) const {
     for (auto& inEdge : head->getInEdges()) {
       if (inEdge->tail() == tail) {
         return inEdge;
       }
     }
-    assert(0 && "Edge doesn't exist.");
     return nullptr;
+  }
+
+  /// \brief Returns true if there is an edge between the given two nodes.
+  bool hasEdge(NodeRef tail, NodeRef head) const {
+    return getEdgeIfExists(tail, head);
+  }
+
+  /// \brief Get a reference to the edge between two nodes if it exists.
+  /// note: will fail assertion if the edge does not exist.
+  EdgeRef getEdge(NodeRef tail, NodeRef head) const {
+    auto result = getEdgeIfExists(tail, head);
+    assert(result && "Edge doesn't exist.");
+    return result;
   }
 
   /// \brief Deletes a node from the graph.
   /// \param n A reference to the node.
-  /// \param deleteEdges (optional) Whether or not to delete the edges
-  /// related to the node.
-  void deleteNode(NodeRef n, bool deleteEdges = true) {
+  void deleteNode(NodeRef n) {
     if (!hasNode(n)) {
       return;
     }
-    if (deleteEdges) {
-      auto inEdges = n->inEdges_;
-      for (auto& edge : inEdges) {
-        deleteEdge(edge);
-      }
-      auto outEdges = n->outEdges_;
-      for (auto& edge : outEdges) {
-        deleteEdge(edge);
-      }
+
+    auto inEdges = n->inEdges_;
+    for (auto& edge : inEdges) {
+      deleteEdge(edge);
     }
+    auto outEdges = n->outEdges_;
+    for (auto& edge : outEdges) {
+      deleteEdge(edge);
+    }
+
     for (auto i = nodes_.begin(); i != nodes_.end(); ++i) {
       if (&*i == n) {
         nodeRefs_.erase(n);
@@ -401,11 +368,9 @@ class Graph {
   }
 
   // Delete all nodes in the set.
-  void deleteNodes(
-      const std::unordered_set<NodeRef>& nodes,
-      bool deleteEdges = true) {
+  void deleteNodes(const std::unordered_set<NodeRef>& nodes) {
     for (auto node : nodes) {
-      deleteNode(node, deleteEdges);
+      deleteNode(node);
     }
   }
 
@@ -415,11 +380,9 @@ class Graph {
 
   /// \brief Deletes a edge from the graph.
   /// \p e A reference to the edge.
-  void deleteEdge(EdgeRef e, bool removeRef = true) {
-    if (removeRef) {
-      e->tail_->removeOutEdge(e);
-      e->head_->removeInEdge(e);
-    }
+  void deleteEdge(EdgeRef e) {
+    e->tail_->removeOutEdge(e);
+    e->head_->removeInEdge(e);
     for (auto i = edges_.begin(); i != edges_.end(); ++i) {
       if (&*i == e) {
         edges_.erase(i);

--- a/caffe2/core/nomnigraph/tests/basic_test.cc
+++ b/caffe2/core/nomnigraph/tests/basic_test.cc
@@ -3,28 +3,28 @@
 #include "nomnigraph/Converters/Dot.h"
 #include "nomnigraph/Graph/Algorithms.h"
 #include "nomnigraph/Graph/Graph.h"
-#include "nomnigraph/Transformations/Match.h"
 #include "nomnigraph/Support/Casting.h"
 
 #include <gtest/gtest.h>
 
+using TestGraph = nom::Graph<TestClass>;
+TestGraph::NodeRef createTestNode(TestGraph& g) {
+  return g.createNode(TestClass());
+}
+
 TEST(Basic, CreateNodeAndEdge) {
-  TestClass t1;
-  TestClass t2;
-  nom::Graph<TestClass> g;
-  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
-  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
   g.createEdge(n1, n2);
   EXPECT_TRUE(g.hasNode(n1));
   EXPECT_TRUE(g.hasNode(n2));
 }
 
 TEST(Basic, DeleteNode) {
-  TestClass t1;
-  TestClass t2;
-  nom::Graph<TestClass> g;
-  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
-  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
   g.createEdge(n1, n2);
   EXPECT_TRUE(g.hasNode(n1));
   g.deleteNode(n1);
@@ -32,23 +32,72 @@ TEST(Basic, DeleteNode) {
 }
 
 TEST(Basic, DeleteEdge) {
-  TestClass t1;
-  TestClass t2;
-  nom::Graph<TestClass> g;
-  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
-  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
-  nom::Graph<TestClass>::EdgeRef e = g.createEdge(n1, n2);
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto e = g.createEdge(n1, n2);
   g.deleteEdge(e);
 }
 
+TEST(Basic, ReplaceEdges) {
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto n3 = createTestNode(g);
+  auto n4 = createTestNode(g);
+  auto n5 = createTestNode(g);
+
+  g.createEdge(n1, n3);
+  g.createEdge(n2, n3);
+  g.createEdge(n3, n4);
+  /*
+       1     2        5
+          |
+          3
+          |
+          4
+   */
+
+  EXPECT_FALSE(g.hasEdge(n1, n5));
+  EXPECT_FALSE(g.hasEdge(n2, n5));
+  g.replaceInEdges(n3, n5);
+  /*
+       1     2        3
+          |           |
+          5           4
+   */
+  EXPECT_TRUE(g.hasEdge(n1, n5));
+  EXPECT_TRUE(g.hasEdge(n2, n5));
+
+  EXPECT_FALSE(g.hasEdge(n5, n4));
+  g.replaceOutEdges(n3, n5);
+  /*
+       1     2        3
+          |
+          5
+          |
+          4
+   */
+  EXPECT_TRUE(g.hasEdge(n5, n4));
+
+  g.replaceNode(n5, n3);
+  // Back to the original graph.
+  /*
+       1     2        5
+          |
+          3
+          |
+          4
+   */
+  EXPECT_TRUE(g.hasEdge(n1, n3));
+  EXPECT_TRUE(g.hasEdge(n2, n3));
+}
+
 TEST(Basic, HasNode) {
-  TestClass t1;
-  TestClass t2;
-  TestClass t3;
-  nom::Graph<TestClass> g;
-  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
-  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
-  nom::Graph<TestClass>::NodeRef n3 = g.createNode(std::move(t3));
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto n3 = createTestNode(g);
   g.createEdge(n1, n2);
   g.createEdge(n1, n3);
   // Current graph: 1 -> 2 -> 3
@@ -62,22 +111,10 @@ TEST(Basic, HasNode) {
   g.deleteNode(n1);
   // Current graph: 3 -> 2
   EXPECT_FALSE(g.hasNode(n1));
-  TestClass t4;
-  nom::Graph<TestClass>::NodeRef n4 = g.createNode(std::move(t4));
+  auto n4 = createTestNode(g);
   EXPECT_TRUE(g.hasNode(n4));
   g.replaceNode(n2, n4);
   // Current graph: 3 -> 4  ,   2
   // replaceNode doesn't delete n2.
   EXPECT_TRUE(g.hasNode(n2));
-
-  // Create a second graph g2, and import the nodes from g2 to g.
-  TestClass t5;
-  nom::Graph<TestClass> g2;
-  nom::Graph<TestClass>::NodeRef n5 = g2.createNode(std::move(t5));
-  EXPECT_TRUE(g2.hasNode(n5));
-
-  EXPECT_FALSE(g.hasNode(n5));
-  g2.importNode(n5, g);
-  // Current graph (g1): 3 -> 4, 2, 5
-  EXPECT_TRUE(g.hasNode(n5));
 }


### PR DESCRIPTION
Summary:
- in deleteNode method, remove optional deleteEdge flag as it's not used
- in deleteEdge method, remove optional removeRef flag as it's not used
- in replaceNode method, remove optional newHead_ parameter as it's not used - also simplifying the implementation by just calling replaceInEdges and replaceOutEdges
- remove importNode & importEdge as they're not in used
- add getEdgeIfExists that is like getEdge() but returns nullptr instead of throwing when the edge does not exist
- reduce verbosity in the basic graph unit test and add more test cases for ReplaceEdges

Differential Revision: D9650913
