### PR TITLE
Remove tests from test_jit.py that are now passing

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7483,6 +7483,7 @@ EXCLUDE_SCRIPT = {
     'test_nn_adaptive_max_pool1d',
     'test_nn_adaptive_max_pool2d',
     'test_nn_adaptive_max_pool3d',
+    'test_nn_ctc_loss',
 
     # argument has custom behavior
     'test_nn_fractional_max_pool2d',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7473,6 +7473,7 @@ EXCLUDE_SCRIPT = {
     'test_renorm_norm_inf',
     'test_matrix_power_n=-1',  # involves inverse
     'test_matrix_power_n=-3',  # involves inverse
+
     # skipped nn functional tests
     # ops involves sampling which could not test
     'test_nn_dropout',
@@ -7485,7 +7486,6 @@ EXCLUDE_SCRIPT = {
     'test_nn_adaptive_max_pool2d',
     'test_nn_adaptive_max_pool3d',
     'test_nn_ctc_loss',
-
 
     # argument has custom behavior
     'test_nn_fractional_max_pool2d',
@@ -7518,7 +7518,6 @@ EXCLUDE_SCRIPT = {
     'test_nn_cosine_similarity',
     'test_nn_normalize',
     'test_nn_fold',
-    'test_nn_linear',
     'test_nn_max_unpool1d',
     'test_nn_lp_pool1d',
     'test_nn_lp_pool2d',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7961,10 +7961,11 @@ def add_autograd_test(
                 if run_magic_methods or not is_magic_method:
                     check_against_reference(
                         self,
-                        fn_creator(fn, name, "method", output_process_fn),
+                        fn_creator(self, fn, name, "method", output_process_fn),
                         fn,
                         (self_variable,) + args_variable,
                         kwargs_variable,
+                        check_types=check_types,
                     )
 
             # functional interface tests
@@ -7979,10 +7980,11 @@ def add_autograd_test(
                 if not is_inplace:
                     check_against_reference(
                         self,
-                        fn_creator(fn, name, "functional", output_process_fn),
+                        fn_creator(self, fn, name, "functional", output_process_fn),
                         fn,
                         f_args_variable,
                         kwargs_variable,
+                        check_types=check_types
                     )
 
         check(name)
@@ -8008,11 +8010,11 @@ def add_test(
     if variant_name != '':
         basic_test_name += '_' + variant_name
 
-    def script_fn_creator(fn, name, type, output_process_fn):
-        return create_script_fn(name, type, output_process_fn)
+    def script_fn_creator(self, fn, name, type, output_process_fn):
+        return create_script_fn(self, name, type, output_process_fn)
 
-    def traced_fn_creator(fn, name, type, output_process_fn):
-        return create_traced_fn(fn)
+    def traced_fn_creator(self, fn, name, type, output_process_fn):
+        return create_traced_fn(self, fn)
 
     for dim_perm in product([-1, 1], repeat=len(dim_args_idx)):
         test_name = basic_test_name
@@ -8071,19 +8073,12 @@ def add_nn_test(name, self_size, args, skipTestIf=(), output_process_fn=lambda x
         f_args_variable = (self_variable,) + args_variable
         f_args_tensor = (self_tensor,) + args_tensor
 
-<<<<<<< HEAD
-        if test_name not in EXCLUDE_SCRIPT:
-            check_against_reference(self,
-                                    create_script_fn(self, name, 'nn_functional', output_process_fn),
-                                    fn, f_args_variable, kwargs_variable)
-=======
         check_against_reference(self,
-                                create_script_fn(name, 'nn_functional', output_process_fn),
+                                create_script_fn(self, name, 'nn_functional', output_process_fn),
                                 fn, f_args_variable, kwargs_variable)
 
     if test_name in EXCLUDE_SCRIPT:
         do_test = unittest.expectedFailure(do_test)
->>>>>>> Mark failing tests as expected failures
 
     post_add_test(test_name, skipTestIf, do_test)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7471,8 +7471,6 @@ EXCLUDE_SCRIPT = {
     'test_var_dim_neg0',
     'test_norm_inf',
     'test_renorm_norm_inf',
-    'test_matrix_power_n=-1',  # involves inverse
-    'test_matrix_power_n=-3',  # involves inverse
 
     # skipped nn functional tests
     # ops involves sampling which could not test
@@ -7485,7 +7483,6 @@ EXCLUDE_SCRIPT = {
     'test_nn_adaptive_max_pool1d',
     'test_nn_adaptive_max_pool2d',
     'test_nn_adaptive_max_pool3d',
-    'test_nn_ctc_loss',
 
     # argument has custom behavior
     'test_nn_fractional_max_pool2d',
@@ -7993,6 +7990,9 @@ def add_autograd_test(
         broadcast_skip_inplace = 'broadcast_lhs' in test_name or 'broadcast_all' in test_name
         if hasattr(torch.ones(1), inplace_name) and not broadcast_skip_inplace:
             check(inplace_name)
+
+    if test_name in exclude_list:
+        do_test = unittest.expectedFailure(do_test)
 
     post_add_test(test_name + postfix, skipTestIf, do_test)
 


### PR DESCRIPTION
A bunch of the tests that were being excluded for tracing/script for
failing are now passing, so this PR takes them out of the list

@zdevito 