### PR TITLE
[wip] Implement convtbc depthwise

### DIFF
--- a/aten/src/ATen/native/ConvolutionTBC.cpp
+++ b/aten/src/ATen/native/ConvolutionTBC.cpp
@@ -5,6 +5,63 @@
 namespace at {
 namespace native {
 
+static Tensor view4d(const at::Tensor& tensor) {
+  if (tensor.ndimension() != 3) throw std::runtime_error("expected 3D tensor");
+  return tensor.unsqueeze(1);
+}
+
+// We currently only have depthwise support for the case where groups ==
+// nInputPlane and nInputPlane == nOutputPlane
+static bool is_depthwise(const at::Tensor& input, const at::Tensor& weight, int64_t groups) {
+  return input.type().is_cuda() &&
+         input.ndimension() == 4 &&
+         input.size(3) == groups &&
+         weight.size(3) % input.size(3) == 0; // output channels must be a multiple of input channels
+}
+
+Tensor conv_tbc_group(const Tensor& self, const Tensor& weight, const Tensor& bias, int64_t pad, int64_t groups) {
+  AT_CHECK(self.dim() == 3, "Input must have 3 dims: time, batch, in_channel");
+  AT_CHECK(weight.dim() == 3, "Weight tensor must have 3 dims: kernel_width,"
+      " in_channels / groups, out_channels.");
+  AT_CHECK(bias.dim() == 1, "Bias must be 1-D");
+
+  if (!self.is_cuda()) {
+    AT_ERROR("NYI: conv_tbc_group only supports CUDA tensors. "
+             "Please file a feature request.");
+  }
+
+  auto input = view4d(self);
+  auto weights = view4d(weight);
+
+  if (groups <= 0) {
+    AT_ERROR("Groups must be positive, got ", groups);
+  }
+
+  if (is_depthwise(input, weights, groups)) {
+    // NB: thnn_convtbc_depthwise2d, also known as SpatialDepthwiseConvolutionTBC,
+    // has only been tested for the input_channels = output_channels = groups 1D case.
+    // It probably works for the general output_channels = input_channels * depth case,
+    // as well as the 2D case, but that requires further testing.
+    if (weights.size(3) != input.size(3)) {
+      AT_ERROR("Input channels (", input.size(3), ") must be equal to output channels (",
+               weights.size(3), ")");
+    }
+    auto sizes = weights.sizes();
+    auto kernel_size = std::vector<int64_t>(sizes.begin(), sizes.begin() + 2);
+
+    // NB: This is not necessarily faster than performing a (transpose, conv1d, transpose).
+    auto output = at::thnn_convtbc_depthwise2d(
+        input, weights, kernel_size, bias,
+        /*stride=*/{1, 1},
+        /*padding=*/{pad, 0},
+        /*dilation=*/{1, 1});
+    return output.squeeze(1);
+  }
+
+  AT_ERROR("NYI: Only groups == input_channels == output_channels is supported. "
+           "Please file a feature request.");
+}
+
 Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, int64_t pad) {
   AT_CHECK(self.dim() == 3, "Input must have 3 dims: time, batch, "
       "in_channel");

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -386,6 +386,12 @@
 - func: conv_tbc_backward(Tensor self, Tensor input, Tensor weight, Tensor bias, int64_t pad) -> (Tensor, Tensor, Tensor)
   variants: function
 
+- func: conv_tbc_group(Tensor self, Tensor weight, Tensor bias, int64_t pad, int64_t groups) -> Tensor
+  variants: function
+
+  # func: conv_tbc_group_backward(Tensor self, Tensor input, Tensor weight, Tensor bias, int64_t pad, int64_t groups) -> (Tensor, Tensor, Tensor)
+  # variants: function
+
 # NB: we inherit the goofy argument order from PyTorch torch.nn.functional
 - func: conv_transpose1d(Tensor input, Tensor weight, Tensor bias={}, IntList[1] stride=1, IntList[1] padding=0, IntList[1] output_padding=0, int64_t groups=1, IntList[1] dilation=1) -> Tensor
   variants: function

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -258,6 +258,11 @@
   cname: SpatialDepthwiseConvolution
   buffers: []
 
+- name: thnn_convtbc_depthwise2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1)
+  cname: SpatialDepthwiseConvolutionTBC
+  buffers: []
+
+
 - name: thnn_conv3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0)
   cname: VolumetricConvolutionMM
   buffers: [finput, fgrad_input]

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -251,4 +251,259 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   THCudaCheck(cudaGetLastError());
 }
 
+void THNN_(SpatialDepthwiseConvolutionTBC_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  THCTensor *weight,
+                  THCTensor *bias,
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH)
+{
+  THCUNN_assertSameGPU(state, 3, input, output, weight);
+
+  // Only handle 4D Input Tensors for now
+  THAssert(!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4);
+  THAssert(!weight->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, weight) == 4);
+
+  // We assume that the input and weight Tensors are shaped properly by
+  // the caller, so we verify that here to some extent
+
+  // Weight Tensor is shape (kH, kW, 1, output_channels)
+  THAssert(weight->size(2) == 1);
+
+  // Input Tensor is shape (H, W, N, input_channels)
+  // We verify that the # of output_channels is a multiple of input_channels
+  THAssert(weight->size(3) % input->size(3) == 0);
+
+  // Bias has same # of channels as output
+  if (bias) {
+    THAssert(THTensor_sizeLegacyNoScalars(bias, 0) == weight->size(3));
+  }
+
+  input = THCTensor_(newContiguous)(state, input);
+  weight = THCTensor_(newContiguous)(state, weight);
+  bias = bias ? THCTensor_(newContiguous)(state, bias) : bias;
+
+  // Following the behvaior of other THCUNN functions, we shape the output
+  // Tensor ourselves
+
+  int batchSize = input->size(2);
+  int height = input->size(0);
+  int width = input->size(1);
+  int outputHeight = (height + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
+  int outputWidth = (width + 2 * padW - (dilationW * (kW - 1) + 1)) / dW + 1;
+  int outputChannels = weight->size(3);
+
+  THCTensor_(resize4d)(state, output, outputHeight, outputWidth, batchSize, outputChannels);
+
+  // Create THCDeviceTensor
+  // Kernel currently relies upon all the Tensors to be contiguous, but we made
+  // them contiguous above
+  THCDeviceTensor<scalar_t, 4> dInput = toDeviceTensor<scalar_t, 4>(state, input);
+  THCDeviceTensor<scalar_t, 4> dWeight = toDeviceTensor<scalar_t, 4>(state, weight);
+  THCDeviceTensor<scalar_t, 4> dOutput = toDeviceTensor<scalar_t, 4>(state, output);
+  THCDeviceTensor<scalar_t, 1> dBias;
+  if (bias) {
+    dBias = toDeviceTensor<scalar_t, 1>(state, bias);
+  }
+
+  int inputChannels = input->size(3);
+  int depthwiseMultiplier = outputChannels / inputChannels;
+
+  // One thread per output value
+  int n = THCTensor_(nElement)(state, output);
+  int blocks = GET_BLOCKS(n);
+  dim3 grid(blocks);
+  dim3 block(CUDA_NUM_THREADS);
+  if (kW == 3 && kH == 3) {
+  spatialDepthwiseConvolutionTBCUpdateOutput<scalar_t, accreal, unsigned int, 3><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+    width, height, outputWidth, outputHeight,
+    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  } else if (kW == 1 && kH == 1) {
+  spatialDepthwiseConvolutionTBCUpdateOutput<scalar_t, accreal, unsigned int, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+    width, height, outputWidth, outputHeight,
+    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  } else {
+  spatialDepthwiseConvolutionTBCUpdateOutput<scalar_t, accreal, unsigned int, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+    width, height, outputWidth, outputHeight,
+    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  }
+
+  THCudaCheck(cudaGetLastError());
+
+  THCTensor_(free)(state, input);
+  THCTensor_(free)(state, weight);
+  if (bias) THCTensor_(free)(state, bias);
+}
+
+void THNN_(SpatialDepthwiseConvolutionTBC_updateGradInput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  THCTensor *weight,
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH)
+{
+  THCUNN_assertSameGPU(state, 3, gradOutput, gradInput, weight);
+
+  // Only handle 4D Input Tensors for now
+  THAssert(!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4);
+  THAssert(!weight->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, weight) == 4);
+  THAssert(!gradOutput->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, gradOutput) == 4);
+
+  // input :  H,  W, N, iC
+  // output: oH, oW, N, oC
+  // weight: kH, kW, 1, oC
+  // bias  : oC
+
+  // Minimal shape checking, as above
+  // Same # of elements in batch
+  THAssert(input->size(2) == gradOutput->size(2));
+  // Same # of filters as outputChannels
+  THAssert(weight->size(3) == gradOutput->size(3));
+
+  // Resize GradInput
+  THCTensor_(resizeAs)(state, gradInput, input);
+
+  int inputChannels = input->size(3);
+  int height = input->size(0);
+  int width = input->size(1);
+
+  int outputChannels = gradOutput->size(3);
+  int outputHeight = gradOutput->size(0);
+  int outputWidth = gradOutput->size(1);
+
+  int depthwiseMultiplier = outputChannels / inputChannels;
+
+  THCDeviceTensor<scalar_t, 4> dGradOutput = toDeviceTensor<scalar_t, 4>(state, gradOutput);
+  THCDeviceTensor<scalar_t, 4> dGradInput = toDeviceTensor<scalar_t, 4>(state, gradInput);
+  THCDeviceTensor<scalar_t, 4> dWeight = toDeviceTensor<scalar_t, 4>(state, weight);
+
+  // Kernel currently relies upon all the Tensors to be contiguous
+  THAssert(dGradOutput.isContiguous());
+  THAssert(dGradInput.isContiguous());
+  THAssert(dWeight.isContiguous());
+
+  // One thread per gradInput value
+  int n = THCTensor_(nElement)(state, gradInput);
+  int blocks = GET_BLOCKS(n);
+  dim3 grid(blocks);
+  dim3 block(CUDA_NUM_THREADS);
+  if (kW == 3 && kH == 3)
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 3, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 3, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 3, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+  else if (kW == 1 && kH == 1)
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 1, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 1, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 1, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+  else
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 0, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 0, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionTBCUpdateGradInput<scalar_t, accreal, unsigned int, 0, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+
+
+  THCudaCheck(cudaGetLastError());
+}
+
+void THNN_(SpatialDepthwiseConvolutionTBC_accGradParameters)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradWeight,
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH)
+{
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradWeight);
+
+  // input :  H,  W, N, iC
+  // output: oH, oW, N, oC
+  // weight: kH, kW, 1, oC
+  // bias  : oC
+
+  // Only handle 4D Input Tensors for now
+  THAssert(!input->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, input) == 4);
+  THAssert(!gradOutput->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, gradOutput) == 4);
+  THAssert(!gradWeight->is_empty() && THCTensor_(nDimensionLegacyNoScalars)(state, gradWeight) == 4);
+
+  // Minimal shape checking as above
+  // Same # of elements in batch
+  THAssert(input->size(2) == gradOutput->size(2));
+  // Same # of filters as outputChannels
+  THAssert(gradWeight->size(3) == gradOutput->size(3));
+
+  int batchSize = input->size(2);
+  int inputChannels = input->size(3);
+  int height = input->size(0);
+  int width = input->size(1);
+
+  int outputChannels = gradOutput->size(3);
+  int outputHeight = gradOutput->size(0);
+  int outputWidth = gradOutput->size(1);
+
+  int depthwiseMultiplier = outputChannels / inputChannels;
+
+  THCDeviceTensor<scalar_t, 4> dGradOutput = toDeviceTensor<scalar_t, 4>(state, gradOutput);
+  THCDeviceTensor<scalar_t, 4> dInput = toDeviceTensor<scalar_t, 4>(state, input);
+  THCDeviceTensor<scalar_t, 4> dGradWeight = toDeviceTensor<scalar_t, 4>(state, gradWeight);
+
+  // Kernel currently relies upon all the Tensors to be contiguous
+  THAssert(dGradOutput.isContiguous());
+  THAssert(dInput.isContiguous());
+  THAssert(dGradWeight.isContiguous());
+
+  // One thread per gradWeight value
+  int n = THCTensor_(nElement)(state, gradWeight);
+  int blocks = GET_BLOCKS(n);
+  dim3 grid(blocks);
+  dim3 block(CUDA_NUM_THREADS);
+
+  spatialDepthwiseConvolutionTBCAccGradParameters<scalar_t, accreal, unsigned int><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dInput, dGradWeight, batchSize, inputChannels, outputChannels, depthwiseMultiplier,
+      width, height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+
+  THCudaCheck(cudaGetLastError());
+}
+
 #endif

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -694,6 +694,38 @@ THC_API void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
                   int padW, int padH,
                   int dilationW, int dilationH);
 
+THC_API void THNN_(SpatialDepthwiseConvolutionTBC_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  THCTensor *weight,
+                  THCTensor *bias,              // [OPTIONAL]
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH);
+
+THC_API void THNN_(SpatialDepthwiseConvolutionTBC_updateGradInput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  THCTensor *weight,
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH);
+
+THC_API void THNN_(SpatialDepthwiseConvolutionTBC_accGradParameters)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradWeight,
+                  int kW, int kH,
+                  int dW, int dH,
+                  int padW, int padH,
+                  int dilationW, int dilationH);
+
 THC_API void THNN_(SpatialCrossMapLRN_updateOutput)(
                   THCState *state,
                   THCTensor *input,

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -973,6 +973,10 @@
   self, weight: thnn_conv_depthwise2d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
   bias: grad.contiguous().view({grad.size(0), grad.size(1), -1}).sum(0).sum(1)
 
+- name: thnn_convtbc_depthwise2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight: thnn_convtbc_depthwise2d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
+  bias: grad.contiguous().view({-1, grad.size(2), grad.size(3)}).sum(1).sum(0)
+
 - name: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, std::array<bool,2> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], {}, grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, self.size(1), false, false, false, grad_input_mask)
 


### PR DESCRIPTION
Added `torch.conv_tbc_groups`. It works with the following restrictions:
- CUDA only
- groups == in_channels == out_channels must be true.

The input/weight/output formats are as follows:
- input: (iL, B, iC).
- weight: (oL, iC / G, oC).
- output: (oL, B, oC).
- bias: (oC,)

NB: This is not faster than a (transpose, conv1d+groups, transpose) for some
cases. Depthwise conv1d has a nice strided access pattern that the kernels in
this PR cannot exploit.

