### PR TITLE
cudnn 7 upgrade with spatialBN fix

### DIFF
--- a/caffe2/operators/spatial_batch_norm_op_cudnn.cc
+++ b/caffe2/operators/spatial_batch_norm_op_cudnn.cc
@@ -26,7 +26,12 @@ class CudnnSpatialBNOp final : public SpatialBNOp<CUDAContext> {
     }
     epsilon_ = std::max(epsilon_, CUDNN_BN_MIN_EPSILON);
 #if CUDNN_VERSION_MIN(7,0,0)
-    mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+    // TODO(T31829456): The new CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode was
+    // introduced in CuDNN 7 for performance optimization, but it results in
+    // accuracy losses in convolution models such as ResNeXt-101 and
+    // video R(2+1)D. We will fall back to the normal CUDNN_BATCHNORM_SPATIAL
+    // for now
+    mode_ = CUDNN_BATCHNORM_SPATIAL;
 #else
     mode_ = CUDNN_BATCHNORM_SPATIAL;
 #endif
@@ -65,7 +70,12 @@ class CudnnSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
     }
     epsilon_ = std::max(epsilon_, CUDNN_BN_MIN_EPSILON);
 #if CUDNN_VERSION_MIN(7,0,0)
-    mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+    // TODO(T31829456): The new CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode was
+    // introduced in CuDNN 7 for performance optimization, but it results in
+    // accuracy losses in convolution models such as ResNeXt-101 and
+    // video R(2+1)D. We will fall back to the normal CUDNN_BATCHNORM_SPATIAL
+    // for now
+    mode_ = CUDNN_BATCHNORM_SPATIAL;
 #else
     mode_ = CUDNN_BATCHNORM_SPATIAL;
 #endif


### PR DESCRIPTION
Summary:
In S163230, we've found CuDNN 7 upgrade causes accuracy drop in training convolution network such as ResNeXt-101 (~0% accuracy), and video R(2+1)D (65 --> 63%).

Our current theory for this accuracy loss is because of the new "CUDNN_BATCHNORM_SPATIAL_PERSISTENT" in spatialBN operator. In Caffe 2, we've made this mode as default. According to CuDNN manual (https://fburl.com/z996mr13), this mode may introduce some limitation in the input data range and cause overflow (which outputs NaN). NaN is probably not the case, because we're seeing a few percent of accuracy drop but not gradient explosion or failure. However, this "performance-optimized" code path may introduce accuracy loss (which is not caught by our unit test case because the input data range is [-0.5-0.5].

Differential Revision: D9601217
