### PR TITLE
[do not merge] temporary fix: trying to patch generated headers to use const instead of constexpr

### DIFF
--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -11,6 +11,13 @@ string(
   content
   "${content}")
 
+string(
+  REPLACE
+  "constexpr"
+  "const"
+  content
+  "${content}")
+
 foreach(ns ${NAMESPACES})
   # Insert "const ::std::string& GetEmptyStringAlreadyInited();" within
   # the namespace and make sure we only do it once in the file. Unfortunately


### PR DESCRIPTION
This is an experiment to see if we can temporarily patch protobuf gen files to avoid having constexpr, which nvcc complains at this moment on windows machines (see https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-build/19383/console)