### PR TITLE
Small fixes to cppdocs for sync script

### DIFF
--- a/docs/cpp/conf.py
+++ b/docs/cpp/conf.py
@@ -23,7 +23,6 @@
 import sys
 import textwrap
 
-import torch
 import sphinx_rtd_theme
 
 # -- General configuration ------------------------------------------------
@@ -109,7 +108,7 @@ author = 'Torch Contributors'
 #
 # The short X.Y version.
 # TODO: change to [:2] at v1.0
-version = 'master (' + torch.__version__ + ' )'
+version = 'master'
 # The full version, including alpha/beta/rc tags.
 # TODO: verify this works as expected
 release = 'master'

--- a/docs/cpp/requirements.txt
+++ b/docs/cpp/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=1.7.5
--e git://github.com/snide/sphinx_rtd_theme.git#egg=sphinx_rtd_theme
+sphinx_rtd_theme
 breathe
 exhale


### PR DESCRIPTION
I'm setting up an automatic sync job for cppdocs and need two fixes to the cpp docs config:

1. Right now the cppdocs use the `torch` package to figure out the version. For C++ docs all I really need from the built package are the generated Tensor.h and Functions.h files. I can actually generate those directly via `aten/src/ATen/gen.py`, so I can skip building PyTorch altogether and save 10 minutes in the sync job! For this I need to avoid using the torch package in the docs.
2. Internal proxy issues prevent using the git link for sphinx_rtd_theme. We can just use the pip package for the cppdocs (not for the normal PyTorch docs)

@soumith @ezyang 