### PR TITLE
Add `math` to scope when using inf in tests

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7621,7 +7621,6 @@ def create_script_fn(self, method_name, func_type, output_process_fn):
         formals = []
         tensors = []
         actuals = []
-        modules = set()
         for arg in args:
             if isinstance(arg, torch.Tensor):
                 name = 'i{}'.format(len(formals))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10,7 +10,7 @@ from torch.autograd import Variable, Function
 from torch.autograd.function import traceable
 from torch.testing import assert_allclose
 from torch.onnx import OperatorExportTypes
-from torch._six import inf
+from torch._six import inf, inf_str
 from common import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, skipIfRocm, suppress_warnings
 from textwrap import dedent
 import os
@@ -2588,11 +2588,9 @@ a")
         self.assertEqual(s + s + s, foo(s))
 
     def test_inf(self):
-        import math
-
         @torch.jit.script
         def foo(a):
-            return a < math.inf
+            return a < float('inf')
         s = torch.rand(1)
         self.assertTrue(foo(s))
 
@@ -7614,6 +7612,8 @@ def the_method({}):
 def get_constant(x):
     module = None
     if x == inf or x == -inf:
+        if PY2:
+            return (inf_str, None)
         module = 'math'
     return (str(x), module)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2588,6 +2588,8 @@ a")
         self.assertEqual(s + s + s, foo(s))
 
     def test_inf(self):
+        import math
+
         @torch.jit.script
         def foo(a):
             return a < math.inf

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2591,7 +2591,7 @@ a")
         @torch.jit.script
         def foo(a):
             return a < math.inf
-        s = Variable(torch.rand(1))
+        s = torch.rand(1)
         self.assertTrue(foo(s))
 
     def test_add(self):

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -28,12 +28,10 @@ PY3 = sys.version_info[0] == 3
 if PY2:
     inf = float('inf')
     nan = float('nan')
-    inf_str = 'float(\'inf\')'
 else:
     import math
     inf = math.inf
     nan = math.nan
-    inf_str = 'math.inf'
 
 if PY2:
     string_classes = basestring

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -28,10 +28,12 @@ PY3 = sys.version_info[0] == 3
 if PY2:
     inf = float('inf')
     nan = float('nan')
+    inf_str = 'float(\'inf\')'
 else:
     import math
     inf = math.inf
     nan = math.nan
+    inf_str = 'math.inf'
 
 if PY2:
     string_classes = basestring

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -559,6 +559,8 @@ void ModuleEncoder::EncodeTypeInfo(
     type_proto->set_denotation("NoneType");
   } else if (kind == TypeKind::GeneratorType) {
     type_proto->set_denotation("GeneratorType");
+  } else if (kind == TypeKind::StringType) {
+    type_proto->set_denotation("StringType");
   } else {
     throw std::runtime_error("unexpected type kind");
   }

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -260,6 +260,8 @@ TypePtr ModuleDecoder::buildType(const onnx::TypeProto& type_proto) {
     return NoneType::get();
   } else if (kind == "GeneratorType") {
     return GeneratorType::get();
+  }else if (kind == "StringType") {
+    return StringType::get();
   } else {
     throw std::runtime_error("unexpected string for type kind");
   }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -51,6 +51,7 @@ namespace torch { namespace jit {
   _(prim, ImplicitTensorToNum)     \
   _(prim, IntToFloat)              \
   _(prim, FloatToInt)              \
+  _(prim, Infinity)                \
   _(prim, AutogradAdd)             \
   _(prim, GradOf)                  \
   _(prim, AnyDefined)              \

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -51,7 +51,7 @@ namespace torch { namespace jit {
   _(prim, ImplicitTensorToNum)     \
   _(prim, IntToFloat)              \
   _(prim, FloatToInt)              \
-  _(prim, Infinity)                \
+  _(prim, StringToFloat)           \
   _(prim, AutogradAdd)             \
   _(prim, GradOf)                  \
   _(prim, AnyDefined)              \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1066,6 +1066,12 @@ public:
     result->output()->setType(IntType::get());
     return result;
   }
+  Node* createFloatInfinity(Value* value) {
+    JIT_ASSERT(*value->type() == *StringType::get());
+    auto* result = create(prim::Infinity, {value});
+    result->output()->setType(FloatType::get());
+    return result;
+  }
   Node* createPythonOp(
       THPObjectPtr&& pyobj,
       const std::string& cconv,

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1066,9 +1066,9 @@ public:
     result->output()->setType(IntType::get());
     return result;
   }
-  Node* createFloatInfinity(Value* value) {
+  Node* createStringToFloat(Value* value) {
     JIT_ASSERT(*value->type() == *StringType::get());
-    auto* result = create(prim::Infinity, {value});
+    auto* result = create(prim::StringToFloat, {value});
     result->output()->setType(FloatType::get());
     return result;
   }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -143,7 +143,7 @@ RegisterOperators reg({
             auto s = pop(stack).toString();
             if (s->string() != "inf") {
               AT_ERROR(
-                  "Expected 'inf' when casting to float, but got '",
+                  "Only 'inf' can be cast to a float, but got '",
                   s->string(),
                   "'");
             }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -13,10 +13,12 @@
 
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <ostream>
 #include <stdexcept>
+#include <string>
 #include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
@@ -131,6 +133,18 @@ RegisterOperators reg({
             double d;
             pop(stack, d);
             push(stack, (int64_t)d);
+            return 0;
+          };
+        }),
+    Operator(
+        prim::Infinity,
+        [](Node* node) -> Operation {
+          return [](Stack& stack) {
+            auto s = pop(stack).toString();
+            if (s->string() != "inf") {
+              AT_ERROR("Expected 'inf', but got '", s->string(), "'");
+            }
+            push(stack, std::numeric_limits<double>::infinity());
             return 0;
           };
         }),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -137,12 +137,15 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::Infinity,
+        prim::StringToFloat,
         [](Node* node) -> Operation {
           return [](Stack& stack) {
             auto s = pop(stack).toString();
             if (s->string() != "inf") {
-              AT_ERROR("Expected 'inf', but got '", s->string(), "'");
+              AT_ERROR(
+                  "Expected 'inf' when casting to float, but got '",
+                  s->string(),
+                  "'");
             }
             push(stack, std::numeric_limits<double>::infinity());
             return 0;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -76,6 +76,8 @@ static Value* typeCast(const SourceRange& loc, Value* value, TypePtr dst) {
     n = graph.createFloatToInt(value);
   } else if(dst->isSubtypeOf(FloatType::get()) && orig->isSubtypeOf(IntType::get())) {
     n = graph.createIntToFloat(value);
+  } else if(dst->isSubtypeOf(FloatType::get()) && orig->isSubtypeOf(StringType::get())) {
+    n = graph.createFloatInfinity(value);
   } else {
     throw ErrorReport(loc) << "Cannot cast type '" << orig->str() << "' to type '"
       << dst->str() << "'.";

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -77,7 +77,7 @@ static Value* typeCast(const SourceRange& loc, Value* value, TypePtr dst) {
   } else if(dst->isSubtypeOf(FloatType::get()) && orig->isSubtypeOf(IntType::get())) {
     n = graph.createIntToFloat(value);
   } else if(dst->isSubtypeOf(FloatType::get()) && orig->isSubtypeOf(StringType::get())) {
-    n = graph.createFloatInfinity(value);
+    n = graph.createStringToFloat(value);
   } else {
     throw ErrorReport(loc) << "Cannot cast type '" << orig->str() << "' to type '"
       << dst->str() << "'.";


### PR DESCRIPTION
This fixes #8515 which was mostly issues in the test themselves. As long
as `math` is imported in the scope in which the script runs it resolves
to a `prim::Constant` with value `inf` correctly. This PR adds this to
the `test_jit.py` tests involving `inf` and adds a test to demonstrate
`inf` in a non-generated test.
