### PR TITLE
[c10d] Full-fledged group testings and fixes for c10d frontend APIs

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -170,6 +170,12 @@ class _DistTestBase(object):
 
         return (group, group_id, rank)
 
+    def _init_full_group_test(self):
+        group = [i for i in range(0, dist.get_world_size())]
+        group_id = dist.new_group()
+        rank = dist.get_rank()
+        return (group, group_id, rank)
+
     def _init_global_test(self):
         group = [i for i in range(0, dist.get_world_size())]
         group_id = dist.group.WORLD
@@ -222,6 +228,45 @@ class _DistTestBase(object):
                 os.unlink(os.path.join(test_dir, f_name))
 
         self._barrier()
+
+    # GET default group
+    def test_get_default_group(self):
+        default_grp = dist.get_default_group()
+        self.assertNotEqual(default_grp, None)
+
+    # Test destroy
+    def test_destroy_group(self):
+        if dist.get_world_size() > 2:
+            group = [1, 2]
+        else:
+            group = [0, 1]
+        group_id = dist.new_group(group)
+        dist.destroy_process_group(group_id)
+
+    # Test get rank and size of group
+    def test_get_rank_size_group(self):
+        if dist.get_world_size() > 2:
+            group = [1, 2]
+        else:
+            group = [0, 1]
+        group_id = dist.new_group(group)
+        if dist.get_rank() in group:
+            self.assertEqual(dist.get_world_size(group_id), 2)
+            self.assertTrue(dist.get_rank(group_id) in list(range(2)))
+        else:
+            self.assertEqual(dist.get_world_size(group_id), -1)
+            self.assertEqual(dist.get_rank(group_id), -1)
+
+    # Test destroy full groups
+    def test_destroy_full_group(self):
+        _, group_id, _ = self._init_full_group_test()
+        dist.destroy_process_group(group_id)
+
+    # Test get rank and size of full group
+    def test_get_rank_size_full_group(self):
+        _, group_id, _ = self._init_full_group_test()
+        self.assertEqual(dist.get_world_size(group_id), dist.get_world_size())
+        self.assertEqual(dist.get_rank(group_id), dist.get_rank())
 
     # SEND RECV
     @unittest.skipIf(BACKEND == "gloo", "Gloo does not support send/recv")
@@ -370,6 +415,11 @@ class _DistTestBase(object):
         group, group_id, rank = self._init_group_test()
         self._test_broadcast_helper(group, group_id, rank)
 
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_broadcast_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_broadcast_helper(group, group_id, rank)
+
     # REDUCE
     def _test_reduce_helper(
         self,
@@ -498,6 +548,46 @@ class _DistTestBase(object):
     @skip_if_small_worldsize
     def test_reduce_group_max(self):
         group, group_id, rank = self._init_group_test()
+        self._test_reduce_helper(group, group_id, rank, dist.reduce_op.MAX, -1, 10, 10)
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_reduce_full_group_sum(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_reduce_helper(
+            group,
+            group_id,
+            rank,
+            dist.reduce_op.SUM,
+            2,
+            10,
+            2 + (10 * (len(group) - 1)),
+        )
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_reduce_full_group_product(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_reduce_helper(
+            group,
+            group_id,
+            rank,
+            dist.reduce_op.PRODUCT,
+            2,
+            10,
+            reduce((lambda x, y: x * y), [10] * (len(group) - 1), 2),
+        )
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_reduce_full_group_min(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_reduce_helper(group, group_id, rank, dist.reduce_op.MIN, 1010, 1, 1)
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_reduce_full_group_max(self):
+        group, group_id, rank = self._init_full_group_test()
         self._test_reduce_helper(group, group_id, rank, dist.reduce_op.MAX, -1, 10, 10)
 
     # ALL REDUCE
@@ -634,6 +724,46 @@ class _DistTestBase(object):
             group, group_id, rank, dist.reduce_op.MAX, -1, 10, 10
         )
 
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_all_reduce_full_group_sum(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_reduce_helper(
+            group,
+            group_id,
+            rank,
+            dist.reduce_op.SUM,
+            2,
+            10,
+            2 + (10 * (len(group) - 1)),
+        )
+
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_all_reduce_full_group_product(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_reduce_helper(
+            group,
+            group_id,
+            rank,
+            dist.reduce_op.PRODUCT,
+            2,
+            10,
+            reduce((lambda x, y: x * y), [10] * (len(group) - 1), 2),
+        )
+
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_all_reduce_full_group_min(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_reduce_helper(
+            group, group_id, rank, dist.reduce_op.MIN, 1010, 1, 1
+        )
+
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_all_reduce_full_group_max(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_reduce_helper(
+            group, group_id, rank, dist.reduce_op.MAX, -1, 10, 10
+        )
+
     # SCATTER
     def _test_scatter_helper(self, group, group_id, rank):
         for dest in group:
@@ -658,6 +788,12 @@ class _DistTestBase(object):
     @skip_if_small_worldsize
     def test_scatter_group(self):
         group, group_id, rank = self._init_group_test()
+        self._test_scatter_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support scatter")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support scatter")
+    def test_scatter_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
         self._test_scatter_helper(group, group_id, rank)
 
     # GATHER
@@ -686,6 +822,12 @@ class _DistTestBase(object):
     @skip_if_small_worldsize
     def test_gather_group(self):
         group, group_id, rank = self._init_group_test()
+        self._test_gather_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_gather_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
         self._test_gather_helper(group, group_id, rank)
 
     # ALL GATHER
@@ -727,6 +869,12 @@ class _DistTestBase(object):
         group, group_id, rank = self._init_group_test()
         self._test_all_gather_helper(group, group_id, rank)
 
+    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
+    def test_all_gather_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_gather_helper(group, group_id, rank)
+
     # BARRIER
     def _test_barrier_helper(self, group, group_id, rank):
         WAIT_TIME = 0.3  # seconds
@@ -754,6 +902,11 @@ class _DistTestBase(object):
     @unittest.skipIf(BACKEND != "mpi", "Only MPI supports barrier")
     def test_barrier_group(self):
         group, group_id, rank = self._init_group_test()
+        self._test_barrier_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports barrier")
+    def test_barrier_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
         self._test_barrier_helper(group, group_id, rank)
 
     def _test_broadcast_multigpu_helper(self, group, group_id, rank, rank_to_GPU):
@@ -1086,6 +1239,7 @@ if BACKEND == "gloo" or BACKEND == "nccl":
             # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
             # We're retreiving a corresponding test and executing it.
             getattr(self, self.id().split(".")[2])()
+            dist.destroy_process_group()
             sys.exit(0)
 
         def _join_and_reduce(self, fn):


### PR DESCRIPTION
Fixed a few bugs that were not tested in the c10d frontend APIs, including 
get_rank, get_world_size, and destroy_process_group of a given group.

These APIs are added to the CI tests.

Also added all the group related tests, including full-group, and partial groups (existing ones), since both will hit different code paths.

Also removed experimental APIs for c10d initially used in DDP, now we don't use it anyway.