### PR TITLE
Static assert GetMutable is not passed with Tensor argument

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -128,6 +128,9 @@ class CAFFE2_API Blob {
         std::is_default_constructible<T>::value,
         "GetMutable can't be called with non-default-constructible types. "
         "Try using specialized methods");
+    static_assert(
+        !std::is_same<T, Tensor>::value,
+        "Use GetMutableTensor(DeviceType) instead");
     if (IsType<T>()) {
       return static_cast<T*>(pointer_);
     } else {


### PR DESCRIPTION
Static assert GetMutable is not passed with Tensor argument

If you do pass it this, you'll get a pointer to
UndefinedTensor; probably not what you want!

Differential Revision: D9676205

