### PR TITLE
ADD child module at ARBITRAY POSITION in current module

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -156,7 +156,7 @@ class Module(object):
         else:
             self._parameters[name] = param
 
-    def add_module(self, name, module):
+    def add_module(self, name, module, index=-1):
         r"""Adds a child module to the current module.
 
         The module can be accessed as an attribute using the given name.
@@ -178,7 +178,17 @@ class Module(object):
             raise KeyError("module name can't contain \".\"")
         elif name == '':
             raise KeyError("module name can't be empty string \"\"")
-        self._modules[name] = module
+        # Add child module at arbitary position of the current module
+        # user do not need specify the position if they add child module 
+        # like before.
+        if index == -1:
+            self._modules[name] = module
+        else:
+            temp_key = list(self._modules.keys())
+            temp_val = list(self._modules.values())
+            temp_key.insert(index, name)
+            temp_val.insert(index, module)
+            self._modules = OrderedDict({k: v for k, v in zip(temp_key, temp_val)})
 
     def _apply(self, fn):
         for module in self.children():


### PR DESCRIPTION
I revised member function add_module(...) of Module. I reinforce it by add child module to arbitary position of the current module.
Samples like this:

I revised member function `add_module(...)` of Module. I reinforce it by add child module to arbitary position of the current module.
Samples like this:
``` python
class Perceptron(nn.Module):

    def __init__(self, in_features, out_features, hidden_features):
        super(Perceptron, self).__init__()

        self.layer1 = nn.Linear(in_features, hidden_features)
        self.layer2 = nn.Linear(hidden_features, 4)
        self.layer3 = nn.Linear(4, out_features)



    def forward(self, x):

        x = self.layer1(x)
        x = self.layer2(x)
        x = self.layer3(x)

        return x
```
When we have a lot of module like this kind. if we need to add a child module to all of this kind of module.
We can easily specify the child module position via setting the parameter `index` to a number(default is -1, the same
as now PyTorcher's already define.)

It can easily use the following code to do add a specified child module between **model.layer2** and **model.layer3**:
``` python
class Perceptron_ADD(nn.Module):
    def __init__(self):
        super(Perceptron_ADD, self).__init__()
        model = Perceptron(10, 5, 4)

        model.add_module("arbitarylayer", nn.Linear(4, 4), index=2)

        self.model = model

    def forward(self, x):
        return self.model(x)

