### PR TITLE
[Caffe2 multi-nodes] Enhance cpu support on gloo based multi-nodes mode.

### DIFF
--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -111,6 +111,8 @@ class C10_EXPORT IDEEPFallbackOp final : public IDEEPOperator {
       }
     }
 
+    // Some CPU ops inherited from OperatorBase directly might need this default
+    // input argument '0' like 'PrefetchOperator'.
     if (!base_op_->Run(0)) {
       LOG(ERROR) << "Base op run failed in IDEEPFallbackOp. Def: "
                  << ProtoDebugString(this->debug_def());

--- a/caffe2/image/image_input_op.cc
+++ b/caffe2/image/image_input_op.cc
@@ -1,5 +1,10 @@
 #include "caffe2/image/image_input_op.h"
 
+#ifdef CAFFE2_USE_MKLDNN
+#include <caffe2/ideep/operators/operator_fallback_ideep.h>
+#include <caffe2/ideep/utils/ideep_operator.h>
+#endif
+
 namespace caffe2 {
 
 template <>
@@ -111,5 +116,11 @@ The dimension of the output image will always be cropxcrop
             "Tensors read from the input TensorProtos");
 
 NO_GRADIENT(ImageInput);
+
+#ifdef CAFFE2_USE_MKLDNN
+REGISTER_IDEEP_OPERATOR(
+    ImageInput,
+    IDEEPFallbackOp<ImageInputOp<CPUContext>>);
+#endif
 
 }  // namespace caffe2

--- a/caffe2/python/predictor/predictor_exporter.py
+++ b/caffe2/python/predictor/predictor_exporter.py
@@ -189,8 +189,9 @@ def set_model_info(meta_net_def, project_str, model_class_str, version):
     meta_net_def.modelInfo.version = version
 
 
-def save_to_db(db_type, db_destination, predictor_export_meta):
+def save_to_db(db_type, db_destination, predictor_export_meta, use_ideep = False):
     meta_net_def = get_meta_net_def(predictor_export_meta)
+    device_type = caffe2_pb2.IDEEP if use_ideep else caffe2_pb2.CPU
     with core.DeviceScope(core.DeviceOption(caffe2_pb2.CPU)):
         workspace.FeedBlob(
             predictor_constants.META_NET_DEF,
@@ -202,6 +203,7 @@ def save_to_db(db_type, db_destination, predictor_export_meta):
     op = core.CreateOperator(
         "Save",
         blobs_to_save, [],
+        device_option = core.DeviceOption(device_type),
         absolute_path=True,
         db=db_destination, db_type=db_type)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -826,6 +826,7 @@ if(USE_GLOO)
     if(USE_CUDA)
       list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS gloo_cuda)
     endif()
+    add_compile_options(-DCAFFE2_USE_GLOO)
   endif()
 endif()
 


### PR DESCRIPTION
1. Add some gloo communication operators into related fallback list;
2. Work around to avoid compiling errors while using fallback operator whose CPU operator inherits from 'OperatorBase' directly like PrefetchOperator;
3. Add new cpu context support for some python module files and resnet50 training example file.