### PR TITLE
Fix out-of-boundary conversion issue

### DIFF
--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -18,8 +18,12 @@ class TensorFiller {
   void Fill(Tensor* tensor, Context* context) const {
     CAFFE_ENFORCE(context, "context is null");
     CAFFE_ENFORCE(tensor, "tensor is null");
-    auto min = static_cast<Type>(min_);
-    auto max = static_cast<Type>(max_);
+    auto min = (min_ < std::numeric_limits<Type>::min())
+        ? std::numeric_limits<Type>::min()
+        : static_cast<Type>(min_);
+    auto max = (max_ > std::numeric_limits<Type>::max())
+        ? std::numeric_limits<Type>::max()
+        : static_cast<Type>(max_);
     CAFFE_ENFORCE_LE(min, max);
 
     Tensor temp_tensor(shape_, Context::GetDeviceType());


### PR DESCRIPTION
Summary: The `min_` and `max_` value of the filler is in `double` format but when we are filling a specific type of tensor, their value can exceed the type limits, resulting in crash. This diff checks the type limits first and if `min_`/`max_` is out of the limits, it will clip it.

Differential Revision: D9684455
