### PR TITLE
Add .expand() method to distribution classes

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -812,6 +812,28 @@ class TestDistributions(TestCase):
                     self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
                     self.assertEqual(actual_shape, expected_shape)
 
+    def test_distribution_subclass_expand(self):
+        expand_by = torch.Size((2,))
+        for Dist, params in EXAMPLES:
+            if Dist.__name__ == "TransformedDistribution":
+                continue
+
+            class SubClass(Dist):
+                pass
+
+            for param in params:
+                d = SubClass(**param)
+                expanded_shape = expand_by + d.batch_shape
+                original_shape = d.batch_shape + d.event_shape
+                expected_shape = expand_by + original_shape
+                expanded = d.expand(batch_shape=expanded_shape)
+                sample = expanded.sample()
+                actual_shape = expanded.sample().shape
+                self.assertEqual(expanded.__class__, d.__class__)
+                self.assertEqual(d.sample().shape, original_shape)
+                self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
+                self.assertEqual(actual_shape, expected_shape)
+
     def test_bernoulli(self):
         p = torch.tensor([0.7, 0.2, 0.4], requires_grad=True)
         r = torch.tensor(0.3, requires_grad=True)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -807,6 +807,7 @@ class TestDistributions(TestCase):
                     expanded = d.expand(batch_shape=expanded_shape)
                     sample = expanded.sample()
                     actual_shape = expanded.sample().shape
+                    self.assertEqual(expanded.__class__, d.__class__)
                     self.assertEqual(d.sample().shape, original_shape)
                     self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
                     self.assertEqual(actual_shape, expected_shape)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2200,7 +2200,7 @@ class TestDistributions(TestCase):
         for Dist, params in EXAMPLES:
             if Dist.__name__ == "TransformedDistribution":
                 continue
-            for i, param in enumerate(params):
+            for param in params:
                 base_dist = Dist(**param)
                 for reinterpreted_batch_ndims in range(len(base_dist.batch_shape) + 1):
                     for s in [torch.Size(), torch.Size((2,)), torch.Size((2, 3))]:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -793,6 +793,24 @@ class TestDistributions(TestCase):
                 self.assertIn(Dist, distributions_with_examples,
                               "Please add {} to the EXAMPLES list in test_distributions.py".format(Dist.__name__))
 
+    def test_distribution_expand(self):
+        shapes = [torch.Size(), torch.Size((2,)), torch.Size((2, 1))]
+        for Dist, params in EXAMPLES:
+            if Dist.__name__ == "TransformedDistribution":
+                continue
+            for param in params:
+                for shape in shapes:
+                    d = Dist(**param)
+                    expanded_shape = shape + d.batch_shape
+                    original_shape = d.batch_shape + d.event_shape
+                    expected_shape = shape + original_shape
+                    expanded = d.expand(batch_shape=expanded_shape)
+                    sample = expanded.sample()
+                    actual_shape = expanded.sample().shape
+                    self.assertEqual(d.sample().shape, original_shape)
+                    self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
+                    self.assertEqual(actual_shape, expected_shape)
+
     def test_bernoulli(self):
         p = torch.tensor([0.7, 0.2, 0.4], requires_grad=True)
         r = torch.tensor(0.3, requires_grad=True)
@@ -2177,6 +2195,27 @@ class TestDistributions(TestCase):
                         self.assertEqual(indep_dist.entropy().shape, indep_log_prob_shape)
                     except NotImplementedError:
                         pass
+
+    def test_independent_expand(self):
+        for Dist, params in EXAMPLES:
+            if Dist.__name__ == "TransformedDistribution":
+                continue
+            for i, param in enumerate(params):
+                base_dist = Dist(**param)
+                for reinterpreted_batch_ndims in range(len(base_dist.batch_shape) + 1):
+                    for s in [torch.Size(), torch.Size((2,)), torch.Size((2, 3))]:
+                        indep_dist = Independent(base_dist, reinterpreted_batch_ndims)
+                        expanded_shape = s + indep_dist.batch_shape
+                        expanded = indep_dist.expand(expanded_shape)
+                        expanded_sample = expanded.sample()
+                        expected_shape = expanded_shape + indep_dist.event_shape
+                        self.assertEqual(expanded_sample.shape, expected_shape)
+                        self.assertEqual(expanded.log_prob(expanded_sample),
+                                         indep_dist.log_prob(expanded_sample))
+                        self.assertEqual(expanded.event_shape, indep_dist.event_shape)
+                        self.assertEqual(expanded.batch_shape, expanded_shape)
+
+
 
     def test_cdf_icdf_inverse(self):
         # Tests the invertibility property on the distributions
@@ -4032,5 +4071,5 @@ class TestValidation(TestCase):
         super(TestCase, self).tearDown()
         Distribution.set_default_validate_args(False)
 
-if __name__ == '__main__':
-    run_tests()
+# if __name__ == '__main__':
+#     run_tests()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -4071,5 +4071,5 @@ class TestValidation(TestCase):
         super(TestCase, self).tearDown()
         Distribution.set_default_validate_args(False)
 
-# if __name__ == '__main__':
-#     run_tests()
+if __name__ == '__main__':
+    run_tests()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2215,8 +2215,6 @@ class TestDistributions(TestCase):
                         self.assertEqual(expanded.event_shape, indep_dist.event_shape)
                         self.assertEqual(expanded.batch_shape, expanded_shape)
 
-
-
     def test_cdf_icdf_inverse(self):
         # Tests the invertibility property on the distributions
         for Dist, params in EXAMPLES:

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -48,7 +48,7 @@ class Bernoulli(ExponentialFamily):
 
     def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Bernoulli)
+        new = self.__new__(type(self))
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -46,8 +46,8 @@ class Bernoulli(ExponentialFamily):
             batch_shape = self._param.size()
         super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Bernoulli, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Bernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -46,6 +46,19 @@ class Bernoulli(ExponentialFamily):
             batch_shape = self._param.size()
         super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Bernoulli)
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(batch_shape)
+            new._param = new.probs
+        else:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
+        super(Bernoulli, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -47,10 +47,7 @@ class Bernoulli(ExponentialFamily):
         super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Bernoulli.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Bernoulli, instance)
         batch_shape = torch.Size(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -46,9 +46,12 @@ class Bernoulli(ExponentialFamily):
             batch_shape = self._param.size()
         super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Bernoulli.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(type(self))
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -46,7 +46,7 @@ class Bernoulli(ExponentialFamily):
             batch_shape = self._param.size()
         super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Bernoulli)
         if 'probs' in self.__dict__:

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -36,9 +36,12 @@ class Beta(ExponentialFamily):
         self._dirichlet = Dirichlet(concentration1_concentration0)
         super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Beta.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Beta)
         new._dirichlet = self._dirichlet.expand(batch_shape)
         super(Beta, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -37,10 +37,7 @@ class Beta(ExponentialFamily):
         super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Beta.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Beta, instance)
         batch_shape = torch.Size(batch_shape)
         new._dirichlet = self._dirichlet.expand(batch_shape)
         super(Beta, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -36,7 +36,7 @@ class Beta(ExponentialFamily):
         self._dirichlet = Dirichlet(concentration1_concentration0)
         super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Beta)
         new._dirichlet = self._dirichlet.expand(batch_shape)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -36,6 +36,14 @@ class Beta(ExponentialFamily):
         self._dirichlet = Dirichlet(concentration1_concentration0)
         super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Beta)
+        new._dirichlet = self._dirichlet.expand(batch_shape)
+        super(Beta, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def mean(self):
         return self.concentration1 / (self.concentration1 + self.concentration0)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -36,8 +36,8 @@ class Beta(ExponentialFamily):
         self._dirichlet = Dirichlet(concentration1_concentration0)
         super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Beta, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Beta, _instance)
         batch_shape = torch.Size(batch_shape)
         new._dirichlet = self._dirichlet.expand(batch_shape)
         super(Beta, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -51,7 +51,7 @@ class Binomial(Distribution):
             batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Binomial)
         new.total_count = self.total_count.expand(batch_shape)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -51,8 +51,8 @@ class Binomial(Distribution):
             batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Binomial, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Binomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -51,6 +51,20 @@ class Binomial(Distribution):
             batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Binomial)
+        new.total_count = self.total_count.expand(batch_shape)
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(batch_shape)
+            new._param = new.probs
+        else:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
+        super(Binomial, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -51,9 +51,12 @@ class Binomial(Distribution):
             batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Binomial.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Binomial)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -52,10 +52,7 @@ class Binomial(Distribution):
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Binomial.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Binomial, instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -54,10 +54,7 @@ class Categorical(Distribution):
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Categorical.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Categorical, instance)
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
         if 'probs' in self.__dict__:

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -53,6 +53,21 @@ class Categorical(Distribution):
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        param_shape = batch_shape + torch.Size((self._num_events,))
+        new = self.__new__(Categorical)
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(param_shape)
+            new._param = new.probs
+        else:
+            new.logits = self.logits.expand(param_shape)
+            new._param = new.logits
+        new._num_events = self._num_events
+        super(Categorical, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -53,10 +53,13 @@ class Categorical(Distribution):
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Categorical.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
-        new = self.__new__(Categorical)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(param_shape)
             new._param = new.probs

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -53,8 +53,8 @@ class Categorical(Distribution):
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Categorical, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Categorical, _instance)
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
         if 'probs' in self.__dict__:

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -53,7 +53,7 @@ class Categorical(Distribution):
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
         new = self.__new__(Categorical)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,6 +36,15 @@ class Cauchy(Distribution):
             batch_shape = self.loc.size()
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Cauchy)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        super(Cauchy, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def mean(self):
         return self.loc.new_tensor(nan).expand(self._extended_shape())

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,9 +36,12 @@ class Cauchy(Distribution):
             batch_shape = self.loc.size()
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Cauchy.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Cauchy)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         super(Cauchy, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -37,10 +37,7 @@ class Cauchy(Distribution):
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Cauchy.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Cauchy, instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,7 +36,7 @@ class Cauchy(Distribution):
             batch_shape = self.loc.size()
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Cauchy)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,8 +36,8 @@ class Cauchy(Distribution):
             batch_shape = self.loc.size()
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Cauchy, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Cauchy, _instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -22,8 +22,13 @@ class Chi2(Gamma):
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        return super(Chi2, self).expand(batch_shape)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Chi2.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
+        return super(Chi2, self).expand(batch_shape, new)
 
     @property
     def df(self):

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -22,7 +22,7 @@ class Chi2(Gamma):
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         return super(Chi2, self).expand(batch_shape)
 
     @property

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -23,10 +23,7 @@ class Chi2(Gamma):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Chi2.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Chi2, instance)
         batch_shape = torch.Size(batch_shape)
         return super(Chi2, self).expand(batch_shape, new)
 

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -1,3 +1,4 @@
+import torch
 from torch.distributions import constraints
 from torch.distributions.gamma import Gamma
 
@@ -20,6 +21,9 @@ class Chi2(Gamma):
 
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        return super(Chi2, self).expand(batch_shape)
 
     @property
     def df(self):

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -22,8 +22,8 @@ class Chi2(Gamma):
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Chi2, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Chi2, _instance)
         batch_shape = torch.Size(batch_shape)
         return super(Chi2, self).expand(batch_shape, new)
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -58,7 +58,7 @@ class Dirichlet(ExponentialFamily):
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Dirichlet)
         new.concentration = self.concentration.expand(batch_shape + self.event_shape)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -58,9 +58,12 @@ class Dirichlet(ExponentialFamily):
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Dirichlet.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Dirichlet)
         new.concentration = self.concentration.expand(batch_shape + self.event_shape)
         super(Dirichlet, new).__init__(batch_shape, self.event_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -58,6 +58,14 @@ class Dirichlet(ExponentialFamily):
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Dirichlet)
+        new.concentration = self.concentration.expand(batch_shape + self.event_shape)
+        super(Dirichlet, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def rsample(self, sample_shape=()):
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -59,10 +59,7 @@ class Dirichlet(ExponentialFamily):
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Dirichlet.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Dirichlet, instance)
         batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape + self.event_shape)
         super(Dirichlet, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -58,8 +58,8 @@ class Dirichlet(ExponentialFamily):
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Dirichlet, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Dirichlet, _instance)
         batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape + self.event_shape)
         super(Dirichlet, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -250,7 +250,13 @@ class Distribution(object):
             raise ValueError('The value argument must be within the support')
 
     def _get_checked_instance(self, cls, instance=None):
-        if instance is None and self.__init__.__func__ is not cls.__init__:
+        def cons(cls_):
+            """
+            Returns the `__init__` function for a python 2.7 / 3 class.
+            """
+            return getattr(cls_.__init__, "__func__", cls_.__init__)
+
+        if instance is None and cons(type(self)) is not cons(cls):
             raise NotImplementedError("Subclass {} of {} that defines a custom __init__ method "
                                       "must also define a custom .expand() method.".
                                       format(self.__class__.__name__, cls.__name__))

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -35,6 +35,24 @@ class Distribution(object):
                 if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
+    def expand(self, batch_shape=torch.Size()):
+        """
+        Returns a new distribution instance with batch dimensions expanded
+        to `batch_shape`. This method calls :class:`~torch.Tensor.expand`
+        on the distribution's parameters. As such, this does not allocate
+        new memory for the expanded distribution instance. Additionally,
+        this does not repeat any args checking or parameter broadcasting
+        in `__init__.py`, when an instance is first created.
+
+        Args:
+            batch_shape (torch.Size): the desired expanded size
+
+        Returns:
+            New distribution instance with batch dimensions expanded to
+            `batch_size`.
+        """
+        raise NotImplementedError
+
     @property
     def batch_shape(self):
         """

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -35,7 +35,7 @@ class Distribution(object):
                 if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         """
         Returns a new distribution instance with batch dimensions expanded
         to `batch_shape`. This method calls :class:`~torch.Tensor.expand`

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -35,20 +35,20 @@ class Distribution(object):
                 if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
-    def expand(self, batch_shape, instance=None):
+    def expand(self, batch_shape, _instance=None):
         """
-        Returns a new distribution instance (or populates a provided instance)
-        with batch dimensions expanded to `batch_shape`. This method calls
-        :class:`~torch.Tensor.expand` on the distribution's parameters.
-        As such, this does not allocate new memory for the expanded distribution
-        instance. Additionally, this does not repeat any args checking or
-        parameter broadcasting in `__init__.py`, when an instance is first
-        created.
+        Returns a new distribution instance (or populates an existing instance
+        provided by a derived class) with batch dimensions expanded to
+        `batch_shape`. This method calls :class:`~torch.Tensor.expand` on
+        the distribution's parameters. As such, this does not allocate new
+        memory for the expanded distribution instance. Additionally,
+        this does not repeat any args checking or parameter broadcasting in
+        `__init__.py`, when an instance is first created.
 
         Args:
             batch_shape (torch.Size): the desired expanded size.
-            instance: new instance (e.g. provided by subclasses) to be
-                populated.
+            _instance: new instance provided by subclasses that
+                need to override `.expand`.
 
         Returns:
             New distribution instance with batch dimensions expanded to
@@ -249,18 +249,12 @@ class Distribution(object):
         if not self.support.check(value).all():
             raise ValueError('The value argument must be within the support')
 
-    def _get_checked_instance(self, cls, instance=None):
-        def cons(cls_):
-            """
-            Returns the `__init__` function for a python 2.7 / 3 class.
-            """
-            return getattr(cls_.__init__, "__func__", cls_.__init__)
-
-        if instance is None and cons(type(self)) is not cons(cls):
+    def _get_checked_instance(self, cls, _instance=None):
+        if _instance is None and type(self).__init__ != cls.__init__:
             raise NotImplementedError("Subclass {} of {} that defines a custom __init__ method "
                                       "must also define a custom .expand() method.".
                                       format(self.__class__.__name__, cls.__name__))
-        return self.__new__(type(self)) if not instance else instance
+        return self.__new__(type(self)) if _instance is None else _instance
 
     def __repr__(self):
         param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -35,17 +35,20 @@ class Distribution(object):
                 if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
         """
-        Returns a new distribution instance with batch dimensions expanded
-        to `batch_shape`. This method calls :class:`~torch.Tensor.expand`
-        on the distribution's parameters. As such, this does not allocate
-        new memory for the expanded distribution instance. Additionally,
-        this does not repeat any args checking or parameter broadcasting
-        in `__init__.py`, when an instance is first created.
+        Returns a new distribution instance (or populates a provided instance)
+        with batch dimensions expanded to `batch_shape`. This method calls
+        :class:`~torch.Tensor.expand` on the distribution's parameters.
+        As such, this does not allocate new memory for the expanded distribution
+        instance. Additionally, this does not repeat any args checking or
+        parameter broadcasting in `__init__.py`, when an instance is first
+        created.
 
         Args:
-            batch_shape (torch.Size): the desired expanded size
+            batch_shape (torch.Size): the desired expanded size.
+            instance: new instance (e.g. provided by subclasses) to be
+                populated.
 
         Returns:
             New distribution instance with batch dimensions expanded to

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -249,6 +249,13 @@ class Distribution(object):
         if not self.support.check(value).all():
             raise ValueError('The value argument must be within the support')
 
+    def _get_checked_instance(self, cls, instance=None):
+        if instance is None and self.__init__.__func__ is not cls.__init__.__func__:
+            raise NotImplementedError("Subclass {} of {} that defines a custom __init__ method "
+                                      "must also define a custom .expand() method.".
+                                      format(self.__class__.__name__, cls.__name__))
+        return self.__new__(cls) if not instance else instance
+
     def __repr__(self):
         param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]
         args_string = ', '.join(['{}: {}'.format(p, self.__dict__[p]

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -250,11 +250,11 @@ class Distribution(object):
             raise ValueError('The value argument must be within the support')
 
     def _get_checked_instance(self, cls, instance=None):
-        if instance is None and self.__init__.__func__ is not cls.__init__.__func__:
+        if instance is None and self.__init__.__func__ is not cls.__init__:
             raise NotImplementedError("Subclass {} of {} that defines a custom __init__ method "
                                       "must also define a custom .expand() method.".
                                       format(self.__class__.__name__, cls.__name__))
-        return self.__new__(cls) if not instance else instance
+        return self.__new__(type(self)) if not instance else instance
 
     def __repr__(self):
         param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -41,9 +41,12 @@ class Exponential(ExponentialFamily):
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Exponential.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Exponential)
+        new = self.__new__(type(self)) if not instance else instance
         new.rate = self.rate.expand(batch_shape)
         super(Exponential, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -41,8 +41,8 @@ class Exponential(ExponentialFamily):
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Exponential, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Exponential, _instance)
         batch_shape = torch.Size(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Exponential, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -41,7 +41,7 @@ class Exponential(ExponentialFamily):
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Exponential)
         new.rate = self.rate.expand(batch_shape)

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -45,8 +45,8 @@ class Exponential(ExponentialFamily):
         if not instance and type(self).__init__ is not Exponential.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Exponential, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -41,6 +41,14 @@ class Exponential(ExponentialFamily):
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Exponential)
+        new.rate = self.rate.expand(batch_shape)
+        super(Exponential, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         return self.rate.new(shape).exponential_() / self.rate

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -42,10 +42,7 @@ class Exponential(ExponentialFamily):
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Exponential.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Exponential, instance)
         batch_shape = torch.Size(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Exponential, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -37,9 +37,12 @@ class FisherSnedecor(Distribution):
             batch_shape = self.df1.size()
         super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not FisherSnedecor.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(FisherSnedecor)
+        new = self.__new__(type(self)) if not instance else instance
         new.df1 = self.df1.expand(batch_shape)
         new.df2 = self.df2.expand(batch_shape)
         new._gamma1 = self._gamma1.expand(batch_shape)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -38,10 +38,7 @@ class FisherSnedecor(Distribution):
         super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not FisherSnedecor.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(FisherSnedecor, instance)
         batch_shape = torch.Size(batch_shape)
         new.df1 = self.df1.expand(batch_shape)
         new.df2 = self.df2.expand(batch_shape)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -37,7 +37,7 @@ class FisherSnedecor(Distribution):
             batch_shape = self.df1.size()
         super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(FisherSnedecor)
         new.df1 = self.df1.expand(batch_shape)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -37,8 +37,8 @@ class FisherSnedecor(Distribution):
             batch_shape = self.df1.size()
         super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(FisherSnedecor, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(FisherSnedecor, _instance)
         batch_shape = torch.Size(batch_shape)
         new.df1 = self.df1.expand(batch_shape)
         new.df2 = self.df2.expand(batch_shape)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -37,6 +37,17 @@ class FisherSnedecor(Distribution):
             batch_shape = self.df1.size()
         super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(FisherSnedecor)
+        new.df1 = self.df1.expand(batch_shape)
+        new.df2 = self.df2.expand(batch_shape)
+        new._gamma1 = self._gamma1.expand(batch_shape)
+        new._gamma2 = self._gamma2.expand(batch_shape)
+        super(FisherSnedecor, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def mean(self):
         df2 = self.df2.clone()

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -41,8 +41,8 @@ class FisherSnedecor(Distribution):
         if not instance and type(self).__init__ is not FisherSnedecor.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         new.df1 = self.df1.expand(batch_shape)
         new.df2 = self.df2.expand(batch_shape)
         new._gamma1 = self._gamma1.expand(batch_shape)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -47,8 +47,8 @@ class Gamma(ExponentialFamily):
             batch_shape = self.concentration.size()
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Gamma, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Gamma, _instance)
         batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
         new.rate = self.rate.expand(batch_shape)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -52,8 +52,8 @@ class Gamma(ExponentialFamily):
         if not instance and type(self).__init__ is not Gamma.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Gamma, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -49,10 +49,7 @@ class Gamma(ExponentialFamily):
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Gamma.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Gamma, instance)
         batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
         new.rate = self.rate.expand(batch_shape)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -1,7 +1,6 @@
 from numbers import Number
 
 import torch
-from torch.autograd import Function
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import _finfo, broadcast_all, lazy_property

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -48,9 +48,12 @@ class Gamma(ExponentialFamily):
             batch_shape = self.concentration.size()
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Gamma.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Gamma)
+        new = self.__new__(type(self)) if not instance else instance
         new.concentration = self.concentration.expand(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Gamma, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -48,7 +48,7 @@ class Gamma(ExponentialFamily):
             batch_shape = self.concentration.size()
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Gamma)
         new.concentration = self.concentration.expand(batch_shape)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -48,6 +48,15 @@ class Gamma(ExponentialFamily):
             batch_shape = self.concentration.size()
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Gamma)
+        new.concentration = self.concentration.expand(batch_shape)
+        new.rate = self.rate.expand(batch_shape)
+        super(Gamma, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(shape)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -45,6 +45,17 @@ class Geometric(Distribution):
             batch_shape = probs_or_logits.size()
         super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Geometric)
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(batch_shape)
+        else:
+            new.logits = self.logits.expand(batch_shape)
+        super(Geometric, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def mean(self):
         return 1. / self.probs - 1.

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -45,8 +45,8 @@ class Geometric(Distribution):
             batch_shape = probs_or_logits.size()
         super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Geometric, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Geometric, _instance)
         batch_shape = torch.Size(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -45,7 +45,7 @@ class Geometric(Distribution):
             batch_shape = probs_or_logits.size()
         super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Geometric)
         if 'probs' in self.__dict__:

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -45,9 +45,12 @@ class Geometric(Distribution):
             batch_shape = probs_or_logits.size()
         super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Geometric.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Geometric)
+        new = self.__new__(type(self)) if not instance else instance
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
         else:

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -49,8 +49,8 @@ class Geometric(Distribution):
         if not instance and type(self).__init__ is not Geometric.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
         else:

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -46,10 +46,7 @@ class Geometric(Distribution):
         super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Geometric.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Geometric, instance)
         batch_shape = torch.Size(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -39,10 +39,7 @@ class Gumbel(TransformedDistribution):
         super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Gumbel.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Gumbel, instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         transforms = self.transforms

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -38,7 +38,7 @@ class Gumbel(TransformedDistribution):
                             ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
         super(Gumbel, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(Gumbel)
         new._base_dist = self._base_dist.expand(batch_shape)
         new._transforms = self._transforms

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -38,8 +38,8 @@ class Gumbel(TransformedDistribution):
                       ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
         super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Gumbel, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Gumbel, _instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         transforms = self.transforms

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -31,18 +31,18 @@ class Gumbel(TransformedDistribution):
         self.loc, self.scale = broadcast_all(loc, scale)
         finfo = _finfo(self.loc)
         if isinstance(loc, Number) and isinstance(scale, Number):
-            self._base_dist = Uniform(finfo.tiny, 1 - finfo.eps)
+            base_dist = Uniform(finfo.tiny, 1 - finfo.eps)
         else:
-            self._base_dist = Uniform(self.loc.new(self.loc.size()).fill_(finfo.tiny), 1 - finfo.eps)
-        self._transforms = [ExpTransform().inv, AffineTransform(loc=0, scale=-torch.ones_like(self.scale)),
-                            ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
-        super(Gumbel, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
+            base_dist = Uniform(self.loc.new(self.loc.size()).fill_(finfo.tiny), 1 - finfo.eps)
+        transforms = [ExpTransform().inv, AffineTransform(loc=0, scale=-torch.ones_like(self.scale)),
+                      ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
+        super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(Gumbel)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        new._transforms = self._transforms
-        super(Gumbel, new).__init__(new._base_dist, new._transforms, validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        transforms = self.transforms
+        super(Gumbel, new).__init__(base_dist, transforms, validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -42,8 +42,8 @@ class Gumbel(TransformedDistribution):
         if not instance and type(self).__init__ is not Gumbel.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         transforms = self.transforms
         super(Gumbel, new).__init__(base_dist, transforms, validate_args=False)

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -31,14 +31,20 @@ class Gumbel(TransformedDistribution):
         self.loc, self.scale = broadcast_all(loc, scale)
         finfo = _finfo(self.loc)
         if isinstance(loc, Number) and isinstance(scale, Number):
-            batch_shape = torch.Size()
-            base_dist = Uniform(finfo.tiny, 1 - finfo.eps)
+            self._base_dist = Uniform(finfo.tiny, 1 - finfo.eps)
         else:
-            batch_shape = self.scale.size()
-            base_dist = Uniform(self.loc.new(self.loc.size()).fill_(finfo.tiny), 1 - finfo.eps)
-        transforms = [ExpTransform().inv, AffineTransform(loc=0, scale=-torch.ones_like(self.scale)),
-                      ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
-        super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
+            self._base_dist = Uniform(self.loc.new(self.loc.size()).fill_(finfo.tiny), 1 - finfo.eps)
+        self._transforms = [ExpTransform().inv, AffineTransform(loc=0, scale=-torch.ones_like(self.scale)),
+                            ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
+        super(Gumbel, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(Gumbel)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        new._transforms = self._transforms
+        super(Gumbel, new).__init__(new._base_dist, new._transforms, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def mean(self):

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -38,8 +38,12 @@ class Gumbel(TransformedDistribution):
                       ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
         super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(Gumbel)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Gumbel.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         transforms = self.transforms
         super(Gumbel, new).__init__(base_dist, transforms, validate_args=False)

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -33,7 +33,7 @@ class HalfCauchy(TransformedDistribution):
         super(HalfCauchy, self).__init__(self._base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(HalfCauchy)
         new._base_dist = self._base_dist.expand(batch_shape)
         super(HalfCauchy, new).__init__(new._base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -34,10 +34,7 @@ class HalfCauchy(TransformedDistribution):
                                          validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not HalfCauchy.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(HalfCauchy, instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -33,8 +33,12 @@ class HalfCauchy(TransformedDistribution):
         super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(HalfCauchy)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not HalfCauchy.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -1,5 +1,6 @@
 import math
 
+import torch
 from torch._six import inf
 from torch.distributions import constraints
 from torch.distributions.transforms import AbsTransform
@@ -28,8 +29,16 @@ class HalfCauchy(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):
-        super(HalfCauchy, self).__init__(Cauchy(0, scale), AbsTransform(),
+        self._base_dist = Cauchy(0, scale)
+        super(HalfCauchy, self).__init__(self._base_dist, AbsTransform(),
                                          validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(HalfCauchy)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        super(HalfCauchy, new).__init__(new._base_dist, AbsTransform(), validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def scale(self):

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -29,14 +29,14 @@ class HalfCauchy(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):
-        self._base_dist = Cauchy(0, scale)
-        super(HalfCauchy, self).__init__(self._base_dist, AbsTransform(),
+        base_dist = Cauchy(0, scale)
+        super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(HalfCauchy)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        super(HalfCauchy, new).__init__(new._base_dist, AbsTransform(), validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -37,8 +37,8 @@ class HalfCauchy(TransformedDistribution):
         if not instance and type(self).__init__ is not HalfCauchy.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -33,8 +33,8 @@ class HalfCauchy(TransformedDistribution):
         super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(HalfCauchy, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(HalfCauchy, _instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -33,7 +33,7 @@ class HalfNormal(TransformedDistribution):
         super(HalfNormal, self).__init__(self._base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(HalfNormal)
         new._base_dist = self._base_dist.expand(batch_shape)
         super(HalfNormal, new).__init__(new._base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -33,8 +33,12 @@ class HalfNormal(TransformedDistribution):
         super(HalfNormal, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(HalfNormal)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not HalfNormal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -29,14 +29,14 @@ class HalfNormal(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):
-        self._base_dist = Normal(0, scale)
-        super(HalfNormal, self).__init__(self._base_dist, AbsTransform(),
+        base_dist = Normal(0, scale)
+        super(HalfNormal, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(HalfNormal)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        super(HalfNormal, new).__init__(new._base_dist, AbsTransform(), validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -33,8 +33,8 @@ class HalfNormal(TransformedDistribution):
         super(HalfNormal, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(HalfNormal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(HalfNormal, _instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -1,5 +1,6 @@
 import math
 
+import torch
 from torch._six import inf
 from torch.distributions import constraints
 from torch.distributions.transforms import AbsTransform
@@ -28,8 +29,16 @@ class HalfNormal(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):
-        super(HalfNormal, self).__init__(Normal(0, scale), AbsTransform(),
+        self._base_dist = Normal(0, scale)
+        super(HalfNormal, self).__init__(self._base_dist, AbsTransform(),
                                          validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(HalfNormal)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        super(HalfNormal, new).__init__(new._base_dist, AbsTransform(), validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def scale(self):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -37,8 +37,8 @@ class HalfNormal(TransformedDistribution):
         if not instance and type(self).__init__ is not HalfNormal.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -34,10 +34,7 @@ class HalfNormal(TransformedDistribution):
                                          validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not HalfNormal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(HalfNormal, instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -46,9 +46,12 @@ class Independent(Distribution):
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
         super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Independent.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Independent)
+        new = self.__new__(type(self)) if not instance else instance
         new.base_dist = self.base_dist.expand(batch_shape +
                                               self.event_shape[:self.reinterpreted_batch_ndims])
         new.reinterpreted_batch_ndims = self.reinterpreted_batch_ndims

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -46,7 +46,7 @@ class Independent(Distribution):
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
         super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Independent)
         new.base_dist = self.base_dist.expand(batch_shape +

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -50,8 +50,8 @@ class Independent(Distribution):
         if not instance and type(self).__init__ is not Independent.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         new.base_dist = self.base_dist.expand(batch_shape +
                                               self.event_shape[:self.reinterpreted_batch_ndims])
         new.reinterpreted_batch_ndims = self.reinterpreted_batch_ndims

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -47,10 +47,7 @@ class Independent(Distribution):
         super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Independent.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Independent, instance)
         batch_shape = torch.Size(batch_shape)
         new.base_dist = self.base_dist.expand(batch_shape +
                                               self.event_shape[:self.reinterpreted_batch_ndims])

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -46,8 +46,8 @@ class Independent(Distribution):
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
         super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Independent, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Independent, _instance)
         batch_shape = torch.Size(batch_shape)
         new.base_dist = self.base_dist.expand(batch_shape +
                                               self.event_shape[:self.reinterpreted_batch_ndims])

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -46,6 +46,16 @@ class Independent(Distribution):
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
         super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Independent)
+        new.base_dist = self.base_dist.expand(batch_shape +
+                                              self.event_shape[:self.reinterpreted_batch_ndims])
+        new.reinterpreted_batch_ndims = self.reinterpreted_batch_ndims
+        super(Independent, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def has_rsample(self):
         return self.base_dist.has_rsample

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -44,10 +44,7 @@ class Laplace(Distribution):
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Laplace.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Laplace, instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -43,9 +43,12 @@ class Laplace(Distribution):
             batch_shape = self.loc.size()
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Laplace.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Laplace)
+        new = self.__new__(type(self)) if not instance else instance
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         super(Laplace, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -43,6 +43,15 @@ class Laplace(Distribution):
             batch_shape = self.loc.size()
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Laplace)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        super(Laplace, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         u = self.loc.new(shape).uniform_(_finfo(self.loc).eps - 1, 1)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -43,7 +43,7 @@ class Laplace(Distribution):
             batch_shape = self.loc.size()
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Laplace)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -43,8 +43,8 @@ class Laplace(Distribution):
             batch_shape = self.loc.size()
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Laplace, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Laplace, _instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -47,8 +47,8 @@ class Laplace(Distribution):
         if not instance and type(self).__init__ is not Laplace.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         super(Laplace, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -28,13 +28,13 @@ class LogNormal(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, loc, scale, validate_args=None):
-        self._base_dist = Normal(loc, scale)
-        super(LogNormal, self).__init__(self._base_dist, ExpTransform(), validate_args=validate_args)
+        base_dist = Normal(loc, scale)
+        super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(LogNormal)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        super(LogNormal, new).__init__(new._base_dist, ExpTransform(), validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -31,8 +31,8 @@ class LogNormal(TransformedDistribution):
         base_dist = Normal(loc, scale)
         super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(LogNormal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(LogNormal, _instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -31,7 +31,7 @@ class LogNormal(TransformedDistribution):
         self._base_dist = Normal(loc, scale)
         super(LogNormal, self).__init__(self._base_dist, ExpTransform(), validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(LogNormal)
         new._base_dist = self._base_dist.expand(batch_shape)
         super(LogNormal, new).__init__(new._base_dist, ExpTransform(), validate_args=False)

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -35,8 +35,8 @@ class LogNormal(TransformedDistribution):
         if not instance and type(self).__init__ is not LogNormal.__init__:
             raise NotImplementedError("Subclasses that define a custom __init__ method "
                                       "must also define a custom .expand() method")
-        batch_shape = torch.Size(batch_shape)
         new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -31,8 +31,12 @@ class LogNormal(TransformedDistribution):
         base_dist = Normal(loc, scale)
         super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(LogNormal)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not LogNormal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -32,10 +32,7 @@ class LogNormal(TransformedDistribution):
         super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not LogNormal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(LogNormal, instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)
         super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -32,8 +32,8 @@ class LogisticNormal(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, loc, scale, validate_args=None):
-        self._base_dist = Normal(loc, scale)
-        super(LogisticNormal, self).__init__(self._base_dist,
+        base_dist = Normal(loc, scale)
+        super(LogisticNormal, self).__init__(base_dist,
                                              StickBreakingTransform(),
                                              validate_args=validate_args)
         # Adjust event shape since StickBreakingTransform adds 1 dimension
@@ -41,8 +41,8 @@ class LogisticNormal(TransformedDistribution):
 
     def expand(self, batch_shape):
         new = self.__new__(LogisticNormal)
-        new._base_dist = self._base_dist.expand(batch_shape + self._base_dist.batch_shape[-1:])
-        super(LogisticNormal, new).__init__(new._base_dist,
+        base_dist = self.base_dist.expand(batch_shape + self.base_dist.batch_shape[-1:])
+        super(LogisticNormal, new).__init__(base_dist,
                                             StickBreakingTransform(),
                                             validate_args=False)
         new._event_shape = self._event_shape

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -39,7 +39,7 @@ class LogisticNormal(TransformedDistribution):
         # Adjust event shape since StickBreakingTransform adds 1 dimension
         self._event_shape = torch.Size([s + 1 for s in self._event_shape])
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(LogisticNormal)
         new._base_dist = self._base_dist.expand(batch_shape + self._base_dist.batch_shape[-1:])
         super(LogisticNormal, new).__init__(new._base_dist,

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -39,8 +39,8 @@ class LogisticNormal(TransformedDistribution):
         # Adjust event shape since StickBreakingTransform adds 1 dimension
         self._event_shape = torch.Size([s + 1 for s in self._event_shape])
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(LogisticNormal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(LogisticNormal, _instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape + self.base_dist.batch_shape[-1:])
         super(LogisticNormal, new).__init__(base_dist,

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -39,8 +39,12 @@ class LogisticNormal(TransformedDistribution):
         # Adjust event shape since StickBreakingTransform adds 1 dimension
         self._event_shape = torch.Size([s + 1 for s in self._event_shape])
 
-    def expand(self, batch_shape):
-        new = self.__new__(LogisticNormal)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not LogisticNormal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
+        batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape + self.base_dist.batch_shape[-1:])
         super(LogisticNormal, new).__init__(base_dist,
                                             StickBreakingTransform(),

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -32,11 +32,22 @@ class LogisticNormal(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, loc, scale, validate_args=None):
-        super(LogisticNormal, self).__init__(
-            Normal(loc, scale), StickBreakingTransform(),
-            validate_args=validate_args)
+        self._base_dist = Normal(loc, scale)
+        super(LogisticNormal, self).__init__(self._base_dist,
+                                             StickBreakingTransform(),
+                                             validate_args=validate_args)
         # Adjust event shape since StickBreakingTransform adds 1 dimension
         self._event_shape = torch.Size([s + 1 for s in self._event_shape])
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(LogisticNormal)
+        new._base_dist = self._base_dist.expand(batch_shape + self._base_dist.batch_shape[-1:])
+        super(LogisticNormal, new).__init__(new._base_dist,
+                                            StickBreakingTransform(),
+                                            validate_args=False)
+        new._event_shape = self._event_shape
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def loc(self):

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -40,10 +40,7 @@ class LogisticNormal(TransformedDistribution):
         self._event_shape = torch.Size([s + 1 for s in self._event_shape])
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not LogisticNormal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(LogisticNormal, instance)
         batch_shape = torch.Size(batch_shape)
         base_dist = self.base_dist.expand(batch_shape + self.base_dist.batch_shape[-1:])
         super(LogisticNormal, new).__init__(base_dist,

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -117,10 +117,7 @@ class LowRankMultivariateNormal(Distribution):
                                                         validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not LowRankMultivariateNormal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(LowRankMultivariateNormal, instance)
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         new.loc = self.loc.expand(loc_shape)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -116,7 +116,7 @@ class LowRankMultivariateNormal(Distribution):
         super(LowRankMultivariateNormal, self).__init__(batch_shape, event_shape,
                                                         validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         new = self.__new__(LowRankMultivariateNormal)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -126,7 +126,7 @@ class LowRankMultivariateNormal(Distribution):
         new.loc = self.loc.expand(loc_shape)
         new.cov_diag = self.cov_diag.expand(loc_shape)
         new.cov_factor = self.cov_factor.expand(loc_shape + self.cov_factor.shape[-1:])
-        new._capacitance_tril = self._capacitance_tril
+        new._capacitance_tril = self._capacitance_tril.expand(batch_shape + self._capacitance_tril.shape[-2:])
         super(LowRankMultivariateNormal, new).__init__(batch_shape,
                                                        self.event_shape,
                                                        validate_args=False)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -116,6 +116,20 @@ class LowRankMultivariateNormal(Distribution):
         super(LowRankMultivariateNormal, self).__init__(batch_shape, event_shape,
                                                         validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        loc_shape = batch_shape + self.event_shape
+        new = self.__new__(LowRankMultivariateNormal)
+        new.loc = self.loc.expand(loc_shape)
+        new.cov_diag = self.cov_diag.expand(loc_shape)
+        new.cov_factor = self.cov_factor.expand(loc_shape + self.cov_factor.shape[-1:])
+        new._capacitance_tril = self._capacitance_tril
+        super(LowRankMultivariateNormal, new).__init__(batch_shape,
+                                                       self.event_shape,
+                                                       validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @property
     def mean(self):
         return self.loc

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -116,8 +116,8 @@ class LowRankMultivariateNormal(Distribution):
         super(LowRankMultivariateNormal, self).__init__(batch_shape, event_shape,
                                                         validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(LowRankMultivariateNormal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(LowRankMultivariateNormal, _instance)
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         new.loc = self.loc.expand(loc_shape)

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -116,10 +116,13 @@ class LowRankMultivariateNormal(Distribution):
         super(LowRankMultivariateNormal, self).__init__(batch_shape, event_shape,
                                                         validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not LowRankMultivariateNormal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
-        new = self.__new__(LowRankMultivariateNormal)
         new.loc = self.loc.expand(loc_shape)
         new.cov_diag = self.cov_diag.expand(loc_shape)
         new.cov_factor = self.cov_factor.expand(loc_shape + self.cov_factor.shape[-1:])

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -58,8 +58,8 @@ class Multinomial(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Multinomial, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Multinomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count
         new._categorical = self._categorical.expand(batch_shape)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -58,7 +58,7 @@ class Multinomial(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Multinomial)
         new.total_count = self.total_count

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -58,9 +58,12 @@ class Multinomial(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Multinomial.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Multinomial)
         new.total_count = self.total_count
         new._categorical = self._categorical.expand(batch_shape)
         super(Multinomial, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -59,10 +59,7 @@ class Multinomial(Distribution):
         super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Multinomial.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Multinomial, instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count
         new._categorical = self._categorical.expand(batch_shape)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -58,6 +58,15 @@ class Multinomial(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Multinomial)
+        new.total_count = self.total_count
+        new._categorical = self._categorical.expand(batch_shape)
+        super(Multinomial, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._categorical._new(*args, **kwargs)
 

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -147,10 +147,7 @@ class MultivariateNormal(Distribution):
         super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not MultivariateNormal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(MultivariateNormal, instance)
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         cov_shape = batch_shape + self.event_shape + self.event_shape

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -146,6 +146,25 @@ class MultivariateNormal(Distribution):
         batch_shape, event_shape = self.loc.shape[:-1], self.loc.shape[-1:]
         super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        loc_shape = batch_shape + self.event_shape
+        cov_shape = batch_shape + self.event_shape + self.event_shape
+        new = self.__new__(MultivariateNormal)
+        new.loc = self.loc.expand(loc_shape)
+        new._unbroadcasted_scale_tril = self._unbroadcasted_scale_tril.expand(cov_shape)
+        if 'covariance_matrix' in self.__dict__:
+            new.covariance_matrix = self.covariance_matrix.expand(cov_shape)
+        if 'scale_tril' in self.__dict__:
+            new.scale_tril = self.scale_tril.expand(cov_shape)
+        if 'precision_matrix' in self.__dict__:
+            new.precision_matrix = self.precision_matrix.expand(cov_shape)
+        super(MultivariateNormal, new).__init__(batch_shape,
+                                                self.event_shape,
+                                                validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @lazy_property
     def scale_tril(self):
         return self._unbroadcasted_scale_tril.expand(

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -146,7 +146,7 @@ class MultivariateNormal(Distribution):
         batch_shape, event_shape = self.loc.shape[:-1], self.loc.shape[-1:]
         super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         cov_shape = batch_shape + self.event_shape + self.event_shape

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -146,11 +146,14 @@ class MultivariateNormal(Distribution):
         batch_shape, event_shape = self.loc.shape[:-1], self.loc.shape[-1:]
         super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not MultivariateNormal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         cov_shape = batch_shape + self.event_shape + self.event_shape
-        new = self.__new__(MultivariateNormal)
         new.loc = self.loc.expand(loc_shape)
         new._unbroadcasted_scale_tril = self._unbroadcasted_scale_tril.expand(cov_shape)
         if 'covariance_matrix' in self.__dict__:

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -146,8 +146,8 @@ class MultivariateNormal(Distribution):
         batch_shape, event_shape = self.loc.shape[:-1], self.loc.shape[-1:]
         super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(MultivariateNormal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(MultivariateNormal, _instance)
         batch_shape = torch.Size(batch_shape)
         loc_shape = batch_shape + self.event_shape
         cov_shape = batch_shape + self.event_shape + self.event_shape

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -39,10 +39,7 @@ class NegativeBinomial(Distribution):
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not NegativeBinomial.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(NegativeBinomial, instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -38,6 +38,20 @@ class NegativeBinomial(Distribution):
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(NegativeBinomial)
+        new.total_count = self.total_count.expand(batch_shape)
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(batch_shape)
+            new._param = new.probs
+        else:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
+        super(NegativeBinomial, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -38,9 +38,12 @@ class NegativeBinomial(Distribution):
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not NegativeBinomial.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(NegativeBinomial)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -38,7 +38,7 @@ class NegativeBinomial(Distribution):
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(NegativeBinomial)
         new.total_count = self.total_count.expand(batch_shape)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -38,8 +38,8 @@ class NegativeBinomial(Distribution):
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(NegativeBinomial, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(NegativeBinomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
         if 'probs' in self.__dict__:

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -48,6 +48,15 @@ class Normal(ExponentialFamily):
             batch_shape = self.loc.size()
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Normal)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        super(Normal, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -48,9 +48,12 @@ class Normal(ExponentialFamily):
             batch_shape = self.loc.size()
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Normal.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Normal)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         super(Normal, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -48,8 +48,8 @@ class Normal(ExponentialFamily):
             batch_shape = self.loc.size()
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Normal, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Normal, _instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -48,7 +48,7 @@ class Normal(ExponentialFamily):
             batch_shape = self.loc.size()
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Normal)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -49,10 +49,7 @@ class Normal(ExponentialFamily):
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Normal.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Normal, instance)
         batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -39,10 +39,7 @@ class OneHotCategorical(Distribution):
         super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not OneHotCategorical.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(OneHotCategorical, instance)
         batch_shape = torch.Size(batch_shape)
         new._categorical = self._categorical.expand(batch_shape)
         super(OneHotCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -38,9 +38,12 @@ class OneHotCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not OneHotCategorical.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(OneHotCategorical)
         new._categorical = self._categorical.expand(batch_shape)
         super(OneHotCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -38,7 +38,7 @@ class OneHotCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(OneHotCategorical)
         new._categorical = self._categorical.expand(batch_shape)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -38,6 +38,14 @@ class OneHotCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(OneHotCategorical)
+        new._categorical = self._categorical.expand(batch_shape)
+        super(OneHotCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._categorical._new(*args, **kwargs)
 

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -38,8 +38,8 @@ class OneHotCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(OneHotCategorical, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(OneHotCategorical, _instance)
         batch_shape = torch.Size(batch_shape)
         new._categorical = self._categorical.expand(batch_shape)
         super(OneHotCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -32,7 +32,7 @@ class Pareto(TransformedDistribution):
         self._transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
         super(Pareto, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(Pareto)
         new._base_dist = self._base_dist.expand(batch_shape)
         new._transforms = self._transforms

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -28,15 +28,14 @@ class Pareto(TransformedDistribution):
 
     def __init__(self, scale, alpha, validate_args=None):
         self.scale, self.alpha = broadcast_all(scale, alpha)
-        self._base_dist = Exponential(self.alpha)
-        self._transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
-        super(Pareto, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
+        base_dist = Exponential(self.alpha)
+        transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
+        super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(Pareto)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        new._transforms = self._transforms
-        super(Pareto, new).__init__(new._base_dist, new._transforms, validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        super(Pareto, new).__init__(base_dist, self.transforms, validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -28,9 +28,17 @@ class Pareto(TransformedDistribution):
 
     def __init__(self, scale, alpha, validate_args=None):
         self.scale, self.alpha = broadcast_all(scale, alpha)
-        base_dist = Exponential(self.alpha)
-        transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
-        super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
+        self._base_dist = Exponential(self.alpha)
+        self._transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
+        super(Pareto, self).__init__(self._base_dist, self._transforms, validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(Pareto)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        new._transforms = self._transforms
+        super(Pareto, new).__init__(new._base_dist, new._transforms, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def mean(self):

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -1,7 +1,3 @@
-from numbers import Number
-
-import math
-
 import torch
 from torch.distributions import constraints
 from torch.distributions.exponential import Exponential
@@ -32,8 +28,8 @@ class Pareto(TransformedDistribution):
         transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
         super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Pareto, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Pareto, _instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(Pareto, new).__init__(base_dist, self.transforms, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -32,8 +32,11 @@ class Pareto(TransformedDistribution):
         transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
         super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(Pareto)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Pareto.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(Pareto, new).__init__(base_dist, self.transforms, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -33,10 +33,7 @@ class Pareto(TransformedDistribution):
         super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Pareto.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Pareto, instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(Pareto, new).__init__(base_dist, self.transforms, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -43,9 +43,12 @@ class Poisson(ExponentialFamily):
             batch_shape = self.rate.size()
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Poisson.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Poisson)
         new.rate = self.rate.expand(batch_shape)
         super(Poisson, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -44,10 +44,7 @@ class Poisson(ExponentialFamily):
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Poisson.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Poisson, instance)
         batch_shape = torch.Size(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Poisson, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -43,8 +43,8 @@ class Poisson(ExponentialFamily):
             batch_shape = self.rate.size()
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Poisson, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Poisson, _instance)
         batch_shape = torch.Size(batch_shape)
         new.rate = self.rate.expand(batch_shape)
         super(Poisson, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -43,6 +43,14 @@ class Poisson(ExponentialFamily):
             batch_shape = self.rate.size()
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Poisson)
+        new.rate = self.rate.expand(batch_shape)
+        super(Poisson, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -43,7 +43,7 @@ class Poisson(ExponentialFamily):
             batch_shape = self.rate.size()
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Poisson)
         new.rate = self.rate.expand(batch_shape)

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -46,6 +46,20 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = self._param.size()
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(LogitRelaxedBernoulli)
+        new.temperature = self.temperature
+        if 'probs' in self.__dict__:
+            new.probs = self.probs.expand(batch_shape)
+            new._param = new.probs
+        else:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
+        super(LogitRelaxedBernoulli, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
@@ -99,8 +113,17 @@ class RelaxedBernoulli(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
-        super(RelaxedBernoulli, self).__init__(LogitRelaxedBernoulli(temperature, probs, logits),
-                                               SigmoidTransform(), validate_args=validate_args)
+        self._base_dist = LogitRelaxedBernoulli(temperature, probs, logits)
+        super(RelaxedBernoulli, self).__init__(self._base_dist,
+                                               SigmoidTransform(),
+                                               validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(RelaxedBernoulli)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        super(RelaxedBernoulli, new).__init__(new._base_dist, SigmoidTransform(), validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def temperature(self):

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -46,8 +46,8 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = self._param.size()
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(LogitRelaxedBernoulli, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(LogitRelaxedBernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
         if 'probs' in self.__dict__:
@@ -118,8 +118,8 @@ class RelaxedBernoulli(TransformedDistribution):
                                                SigmoidTransform(),
                                                validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(RelaxedBernoulli, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(RelaxedBernoulli, _instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedBernoulli, new).__init__(base_dist, SigmoidTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -46,9 +46,12 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = self._param.size()
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not LogitRelaxedBernoulli.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(LogitRelaxedBernoulli)
         new.temperature = self.temperature
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
@@ -118,8 +121,11 @@ class RelaxedBernoulli(TransformedDistribution):
                                                SigmoidTransform(),
                                                validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(RelaxedBernoulli)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not RelaxedBernoulli.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedBernoulli, new).__init__(base_dist, SigmoidTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -47,10 +47,7 @@ class LogitRelaxedBernoulli(Distribution):
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not LogitRelaxedBernoulli.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(LogitRelaxedBernoulli, instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
         if 'probs' in self.__dict__:
@@ -122,10 +119,7 @@ class RelaxedBernoulli(TransformedDistribution):
                                                validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not RelaxedBernoulli.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(RelaxedBernoulli, instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedBernoulli, new).__init__(base_dist, SigmoidTransform(), validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -118,7 +118,7 @@ class RelaxedBernoulli(TransformedDistribution):
                                                SigmoidTransform(),
                                                validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(RelaxedBernoulli)
         new._base_dist = self._base_dist.expand(batch_shape)
         super(RelaxedBernoulli, new).__init__(new._base_dist, SigmoidTransform(), validate_args=False)

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -113,15 +113,15 @@ class RelaxedBernoulli(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
-        self._base_dist = LogitRelaxedBernoulli(temperature, probs, logits)
-        super(RelaxedBernoulli, self).__init__(self._base_dist,
+        base_dist = LogitRelaxedBernoulli(temperature, probs, logits)
+        super(RelaxedBernoulli, self).__init__(base_dist,
                                                SigmoidTransform(),
                                                validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(RelaxedBernoulli)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        super(RelaxedBernoulli, new).__init__(new._base_dist, SigmoidTransform(), validate_args=False)
+        base_dist = self.base_dist.expand(batch_shape)
+        super(RelaxedBernoulli, new).__init__(base_dist, SigmoidTransform(), validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -46,7 +46,7 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = self._param.size()
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(LogitRelaxedBernoulli)
         new.temperature = self.temperature

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -41,7 +41,7 @@ class ExpRelaxedCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(ExpRelaxedCategorical)
         new.temperature = self.temperature

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -41,9 +41,12 @@ class ExpRelaxedCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not ExpRelaxedCategorical.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(ExpRelaxedCategorical)
         new.temperature = self.temperature
         new._categorical = self._categorical.expand(batch_shape)
         super(ExpRelaxedCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)
@@ -114,8 +117,11 @@ class RelaxedOneHotCategorical(TransformedDistribution):
                                                        ExpTransform(),
                                                        validate_args=validate_args)
 
-    def expand(self, batch_shape):
-        new = self.__new__(RelaxedOneHotCategorical)
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not RelaxedOneHotCategorical.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedOneHotCategorical, new).__init__(base_dist,
                                                       ExpTransform(),

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -114,7 +114,7 @@ class RelaxedOneHotCategorical(TransformedDistribution):
                                                        ExpTransform(),
                                                        validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         new = self.__new__(RelaxedOneHotCategorical)
         new._base_dist = self._base_dist.expand(batch_shape)
         super(RelaxedOneHotCategorical, new).__init__(new._base_dist,

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -41,6 +41,15 @@ class ExpRelaxedCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(ExpRelaxedCategorical)
+        new.temperature = self.temperature
+        new._categorical = self._categorical.expand(batch_shape)
+        super(ExpRelaxedCategorical, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def _new(self, *args, **kwargs):
         return self._categorical._new(*args, **kwargs)
 
@@ -100,8 +109,19 @@ class RelaxedOneHotCategorical(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
-        super(RelaxedOneHotCategorical, self).__init__(ExpRelaxedCategorical(temperature, probs, logits),
-                                                       ExpTransform(), validate_args=validate_args)
+        self._base_dist = ExpRelaxedCategorical(temperature, probs, logits)
+        super(RelaxedOneHotCategorical, self).__init__(self._base_dist,
+                                                       ExpTransform(),
+                                                       validate_args=validate_args)
+
+    def expand(self, batch_shape=torch.Size()):
+        new = self.__new__(RelaxedOneHotCategorical)
+        new._base_dist = self._base_dist.expand(batch_shape)
+        super(RelaxedOneHotCategorical, new).__init__(new._base_dist,
+                                                      ExpTransform(),
+                                                      validate_args=False)
+        new._validate_args = self._validate_args
+        return new
 
     @property
     def temperature(self):

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -42,10 +42,7 @@ class ExpRelaxedCategorical(Distribution):
         super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not ExpRelaxedCategorical.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(ExpRelaxedCategorical, instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
         new._categorical = self._categorical.expand(batch_shape)
@@ -118,10 +115,7 @@ class RelaxedOneHotCategorical(TransformedDistribution):
                                                        validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not RelaxedOneHotCategorical.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(RelaxedOneHotCategorical, instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedOneHotCategorical, new).__init__(base_dist,
                                                       ExpTransform(),

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -41,8 +41,8 @@ class ExpRelaxedCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(ExpRelaxedCategorical, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(ExpRelaxedCategorical, _instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
         new._categorical = self._categorical.expand(batch_shape)
@@ -114,8 +114,8 @@ class RelaxedOneHotCategorical(TransformedDistribution):
                                                        ExpTransform(),
                                                        validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(RelaxedOneHotCategorical, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(RelaxedOneHotCategorical, _instance)
         base_dist = self.base_dist.expand(batch_shape)
         super(RelaxedOneHotCategorical, new).__init__(base_dist,
                                                       ExpTransform(),

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -109,15 +109,15 @@ class RelaxedOneHotCategorical(TransformedDistribution):
     has_rsample = True
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
-        self._base_dist = ExpRelaxedCategorical(temperature, probs, logits)
-        super(RelaxedOneHotCategorical, self).__init__(self._base_dist,
+        base_dist = ExpRelaxedCategorical(temperature, probs, logits)
+        super(RelaxedOneHotCategorical, self).__init__(base_dist,
                                                        ExpTransform(),
                                                        validate_args=validate_args)
 
     def expand(self, batch_shape):
         new = self.__new__(RelaxedOneHotCategorical)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        super(RelaxedOneHotCategorical, new).__init__(new._base_dist,
+        base_dist = self.base_dist.expand(batch_shape)
+        super(RelaxedOneHotCategorical, new).__init__(base_dist,
                                                       ExpTransform(),
                                                       validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -46,10 +46,7 @@ class StudentT(Distribution):
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not StudentT.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(StudentT, instance)
         batch_shape = torch.Size(batch_shape)
         new.df = self.df.expand(batch_shape)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -45,9 +45,12 @@ class StudentT(Distribution):
         batch_shape = torch.Size() if isinstance(df, Number) else self.df.size()
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not StudentT.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(StudentT)
         new.df = self.df.expand(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -45,7 +45,7 @@ class StudentT(Distribution):
         batch_shape = torch.Size() if isinstance(df, Number) else self.df.size()
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(StudentT)
         new.df = self.df.expand(batch_shape)

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -45,6 +45,17 @@ class StudentT(Distribution):
         batch_shape = torch.Size() if isinstance(df, Number) else self.df.size()
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(StudentT)
+        new.df = self.df.expand(batch_shape)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        new._chi2 = self._chi2.expand(batch_shape)
+        super(StudentT, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     def rsample(self, sample_shape=torch.Size()):
         # NOTE: This does not agree with scipy implementation as much as other distributions.
         # (see https://github.com/fritzo/notebooks/blob/master/debug-student-t.ipynb). Using DoubleTensor

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -45,8 +45,8 @@ class StudentT(Distribution):
         batch_shape = torch.Size() if isinstance(df, Number) else self.df.size()
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(StudentT, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(StudentT, _instance)
         batch_shape = torch.Size(batch_shape)
         new.df = self.df.expand(batch_shape)
         new.loc = self.loc.expand(batch_shape)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -50,7 +50,7 @@ class Uniform(Distribution):
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Uniform)
         new.low = self.low.expand(batch_shape)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -51,10 +51,7 @@ class Uniform(Distribution):
             raise ValueError("Uniform is not defined when low>= high")
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Uniform.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Uniform, instance)
         batch_shape = torch.Size(batch_shape)
         new.low = self.low.expand(batch_shape)
         new.high = self.high.expand(batch_shape)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -1,4 +1,3 @@
-import math
 from numbers import Number
 
 import torch
@@ -50,8 +49,8 @@ class Uniform(Distribution):
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Uniform, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Uniform, _instance)
         batch_shape = torch.Size(batch_shape)
         new.low = self.low.expand(batch_shape)
         new.high = self.high.expand(batch_shape)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -50,9 +50,12 @@ class Uniform(Distribution):
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Uniform.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Uniform)
         new.low = self.low.expand(batch_shape)
         new.high = self.high.expand(batch_shape)
         super(Uniform, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -50,6 +50,15 @@ class Uniform(Distribution):
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")
 
+    def expand(self, batch_shape=torch.Size()):
+        batch_shape = torch.Size(batch_shape)
+        new = self.__new__(Uniform)
+        new.low = self.low.expand(batch_shape)
+        new.high = self.high.expand(batch_shape)
+        super(Uniform, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @constraints.dependent_property
     def support(self):
         return constraints.interval(self.low, self.high)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -36,9 +36,12 @@ class Weibull(TransformedDistribution):
                                       transforms,
                                       validate_args=validate_args)
 
-    def expand(self, batch_shape):
+    def expand(self, batch_shape, instance=None):
+        if not instance and type(self).__init__ is not Weibull.__init__:
+            raise NotImplementedError("Subclasses that define a custom __init__ method "
+                                      "must also define a custom .expand() method")
+        new = self.__new__(type(self)) if not instance else instance
         batch_shape = torch.Size(batch_shape)
-        new = self.__new__(Weibull)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
         base_dist = self.base_dist.expand(batch_shape)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -29,11 +29,11 @@ class Weibull(TransformedDistribution):
     def __init__(self, scale, concentration, validate_args=None):
         self.scale, self.concentration = broadcast_all(scale, concentration)
         self.concentration_reciprocal = self.concentration.reciprocal()
-        self._base_dist = Exponential(self.scale.new(self.scale.size()).fill_(1.0))
-        self._transforms = [PowerTransform(exponent=self.concentration_reciprocal),
-                            AffineTransform(loc=0, scale=self.scale)]
-        super(Weibull, self).__init__(self._base_dist,
-                                      self._transforms,
+        base_dist = Exponential(self.scale.new(self.scale.size()).fill_(1.0))
+        transforms = [PowerTransform(exponent=self.concentration_reciprocal),
+                      AffineTransform(loc=0, scale=self.scale)]
+        super(Weibull, self).__init__(base_dist,
+                                      transforms,
                                       validate_args=validate_args)
 
     def expand(self, batch_shape):
@@ -41,10 +41,9 @@ class Weibull(TransformedDistribution):
         new = self.__new__(Weibull)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
-        new._base_dist = self._base_dist.expand(batch_shape)
-        new._transforms = self._transforms
-        super(Weibull, new).__init__(new._base_dist,
-                                     new._transforms,
+        base_dist = self.base_dist.expand(batch_shape)
+        super(Weibull, new).__init__(base_dist,
+                                     self.transforms,
                                      validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -1,5 +1,3 @@
-from numbers import Number
-import math
 import torch
 from torch.distributions import constraints
 from torch.distributions.exponential import Exponential
@@ -36,8 +34,8 @@ class Weibull(TransformedDistribution):
                                       transforms,
                                       validate_args=validate_args)
 
-    def expand(self, batch_shape, instance=None):
-        new = self._get_checked_instance(Weibull, instance)
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(Weibull, _instance)
         batch_shape = torch.Size(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -36,7 +36,7 @@ class Weibull(TransformedDistribution):
                                       self._transforms,
                                       validate_args=validate_args)
 
-    def expand(self, batch_shape=torch.Size()):
+    def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         new = self.__new__(Weibull)
         new.scale = self.scale.expand(batch_shape)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -37,10 +37,7 @@ class Weibull(TransformedDistribution):
                                       validate_args=validate_args)
 
     def expand(self, batch_shape, instance=None):
-        if not instance and type(self).__init__ is not Weibull.__init__:
-            raise NotImplementedError("Subclasses that define a custom __init__ method "
-                                      "must also define a custom .expand() method")
-        new = self.__new__(type(self)) if not instance else instance
+        new = self._get_checked_instance(Weibull, instance)
         batch_shape = torch.Size(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)


### PR DESCRIPTION
This adds a `.expand` method for distributions that is akin to the `torch.Tensor.expand` method for tensors. It returns a new distribution instance with batch dimensions expanded to the desired `batch_shape`. Since this calls `torch.Tensor.expand` on the distribution's parameters, it does not allocate new memory for the expanded distribution instance's parameters. 

e.g.
```python
>>> d = dist.Normal(torch.zeros(100, 1), torch.ones(100, 1))
>>> d.sample().shape
  torch.Size([100, 1])
>>> d.expand([100, 10]).sample().shape
  torch.Size([100, 10])
```

### Motivation

We have already been using the `.expand` method in Pyro in our [patch](https://github.com/uber/pyro/blob/dev/pyro/distributions/torch.py#L10) of `torch.distributions`. We use this in our models to enable dynamic broadcasting. This has also been requested by a few users on the distributions slack, and we believe will be useful to the larger community. 

Note that currently, there is no convenient and efficient way to expand distribution instances:
 - Many distributions use `TransformedDistribution` (or wrap over another distribution instance. e.g. `OneHotCategorical` uses a `Categorical` instance) under the hood, or have lazy parameters. This makes it difficult to collect all the relevant parameters, broadcast them and construct new instances.
 - In the few cases where this is even possible, the resulting implementation would be inefficient since we will go through a lot of broadcasting and args validation logic in `__init__.py` that can be avoided.

The `.expand` method allows for a safe and efficient way to expand distribution instances. Additionally, this bypasses `__init__.py` (using `__new__` and populating relevant attributes) since we do not need to do any broadcasting or args validation (which was already done when the instance was first created). This can result in significant savings as compared to constructing new instances via `__init__` (that said, the `sample` and `log_prob` methods will probably be the rate determining steps in many applications).

e.g.
```python
>>> a = dist.Bernoulli(torch.ones([10000, 1]), validate_args=True)

>>> %timeit a.expand([10000, 100])
15.2 µs ± 224 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

>>> %timeit dist.Bernoulli(torch.ones([10000, 100]), validate_args=True)
11.8 ms ± 153 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

cc. @fritzo, @apaszke, @vishwakftw, @alicanb 