### PR TITLE
add narrow() support for sparse tensors re: #8853

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -533,6 +533,7 @@ public:
   Tensor mv(const Tensor & vec) const;
   Tensor mvlgamma(int64_t p) const;
   Tensor & mvlgamma_(int64_t p);
+  Tensor narrow_copy(int64_t dim, int64_t start, int64_t length) const;
   Tensor narrow(int64_t dim, int64_t start, int64_t length) const;
   Tensor permute(IntList dims) const;
   Tensor pin_memory() const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -902,6 +902,9 @@ inline Tensor Tensor::mvlgamma(int64_t p) const {
 inline Tensor & Tensor::mvlgamma_(int64_t p) {
     return type().mvlgamma_(*this, p);
 }
+inline Tensor Tensor::narrow_copy(int64_t dim, int64_t start, int64_t length) const {
+    return type().narrow_copy(*this, dim, start, length);
+}
 inline Tensor Tensor::narrow(int64_t dim, int64_t start, int64_t length) const {
     return type().narrow(*this, dim, start, length);
 }

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -492,6 +492,7 @@ struct CAFFE2_API Type {
   virtual Tensor mv(const Tensor & self, const Tensor & vec) const = 0;
   virtual Tensor mvlgamma(const Tensor & self, int64_t p) const = 0;
   virtual Tensor & mvlgamma_(Tensor & self, int64_t p) const = 0;
+  virtual Tensor narrow_copy(const Tensor & self, int64_t dim, int64_t start, int64_t length) const = 0;
   virtual Tensor narrow(const Tensor & self, int64_t dim, int64_t start, int64_t length) const = 0;
   virtual Tensor permute(const Tensor & self, IntList dims) const = 0;
   virtual Tensor pin_memory(const Tensor & self) const = 0;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -149,13 +149,15 @@ Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
 }
 
 Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length){
-  AT_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
-  auto cur_size = self.size(dim);
-  AT_CHECK(length >= 0 && start <= cur_size - length,
-           "start (", start, ") + length (", length, ") exceeds dimension size (", cur_size, ").");
+  int64_t allDim = self.dim();
+  int64_t end = start+length;
+  AT_CHECK(allDim > 0, "narrow() cannot be applied to a 0-dim tensor.");
+  AT_CHECK(dim >= 0 && dim < allDim, 
+    "Dimension ", dim, " out of range. Expecting 0 <= dim < ", allDim, ".");
+  AT_CHECK(start >= 0 && length >= 0 && end <= self.size(dim),
+    "Invalid range to narrow. range(start, start+length) must be a subset of range(0, ", self.size(dim), ").")
   LongTensor indices = self._indices();
   int64_t sparseDims = self._sparseDims();
-  int64_t end = start+length;
   
   std::vector<int64_t> newSizes = self.sizes().vec();
   newSizes[dim]=length;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -176,7 +176,7 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_
     newValues = self._values().narrow_copy(ddim, start, length);
   }
 
-  SparseTensor newTensor = self.type().sparse_coo_tensor(newIndices, newValues, newSizes);
+  SparseTensor newTensor = at::sparse_coo_tensor(newIndices, newValues, newSizes, self.type().options());
   _get_sparse_impl(newTensor)->set_coalesced(self.is_coalesced());
   return newTensor;
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -148,6 +148,39 @@ Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
   return at::as_strided_(self, size, stride, self.storage_offset());
 }
 
+Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length){
+  AT_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
+  LongTensor indices = self._indices();
+  int64_t dims = indices.size(0);
+  int64_t sparseDims = self._sparseDims();
+  int64_t end = start+length;
+  
+  std::vector<int64_t> newSizes = self.sizes().vec();
+  newSizes[dim]=length;
+  
+  Tensor newValues;
+  LongTensor newIndices;
+  if(dim < sparseDims){
+    Tensor mask = (indices[dim] >= start).__and__((indices[dim] < end));
+    newIndices = indices.masked_select(mask).view({dims, -1});
+    newIndices[dim].add_(-start);
+    Tensor nzIndices = mask.nonzero().view(-1);
+    newValues = self._values().index_select(0, nzIndices);
+  }else{
+    newIndices = indices;
+    int64_t ddim = dim-sparseDims+1;
+    newValues = self._values().narrow_copy(ddim,start,length);
+  }
+  
+  SparseTensor newTensor = self.type().sparse_coo_tensor(newIndices, newValues, newSizes);
+  _get_sparse_impl(newTensor)->set_coalesced(self.is_coalesced());
+  return newTensor;
+}
+
+Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, int64_t length){
+    return self.narrow(dim,start,length).clone();
+}
+
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
   AT_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   auto cur_size = self.size(dim);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -150,8 +150,10 @@ Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
 
 Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length){
   AT_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
+  auto cur_size = self.size(dim);
+  AT_CHECK(length >= 0 && start <= cur_size - length,
+           "start (", start, ") + length (", length, ") exceeds dimension size (", cur_size, ").");
   LongTensor indices = self._indices();
-  int64_t dims = indices.size(0);
   int64_t sparseDims = self._sparseDims();
   int64_t end = start+length;
   
@@ -162,23 +164,25 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_
   LongTensor newIndices;
   if(dim < sparseDims){
     Tensor mask = (indices[dim] >= start).__and__((indices[dim] < end));
-    newIndices = indices.masked_select(mask).view({dims, -1});
+    newIndices = indices.masked_select(mask).view({sparseDims, -1});
     newIndices[dim].add_(-start);
     Tensor nzIndices = mask.nonzero().view(-1);
     newValues = self._values().index_select(0, nzIndices);
   }else{
+    /* This means we are narrowing on a dense dim, which is in effect just a
+        regular narrow on _values() */
     newIndices = indices;
-    int64_t ddim = dim-sparseDims+1;
-    newValues = self._values().narrow_copy(ddim,start,length);
+    int64_t ddim = dim - sparseDims + 1;
+    newValues = self._values().narrow_copy(ddim, start, length);
   }
-  
+
   SparseTensor newTensor = self.type().sparse_coo_tensor(newIndices, newValues, newSizes);
   _get_sparse_impl(newTensor)->set_coalesced(self.is_coalesced());
   return newTensor;
 }
 
 Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, int64_t length){
-    return self.narrow(dim,start,length).clone();
+    return self.narrow(dim, start, length).clone();
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1181,7 +1181,6 @@
     CUDA: narrow_copy_dense
     SparseCPU: narrow_copy_sparse
     SparseCUDA: narrow_copy_sparse
-    
 
 - func: narrow(Tensor self, int64_t dim, int64_t start, int64_t length) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1174,6 +1174,15 @@
 - func: mvlgamma_(Tensor self, int64_t p) -> Tensor
   variants: method
 
+- func: narrow_copy(Tensor self, int64_t dim, int64_t start, int64_t length) -> Tensor
+  variants: method
+  dispatch:
+    CPU: narrow_copy_dense
+    CUDA: narrow_copy_dense
+    SparseCPU: narrow_copy_sparse
+    SparseCUDA: narrow_copy_sparse
+    
+
 - func: narrow(Tensor self, int64_t dim, int64_t start, int64_t length) -> Tensor
   variants: function, method
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -110,6 +110,7 @@ An empty sparse tensor can be constructed by specifying its size:
     .. method:: mm
     .. method:: mul
     .. method:: mul_
+    .. method:: narrow_copy
     .. method:: resizeAs_
     .. method:: size
     .. method:: spadd

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1030,27 +1030,27 @@ class TestSparse(TestCase):
     def _all_narrow_combs(self, shape):
         for dim, dim_sz in enumerate(shape):
             for start in range(dim_sz):
-                for length in range(dim_sz-start):
+                for length in range(dim_sz - start):
                     yield [dim, start, length]
-       
+
     def test_narrow(self):
         shape = [3, 3, 4, 2]
         input, _, _ = self._gen_sparse(4, 19, shape)
         for narrow_args in self._all_narrow_combs(shape):
             self._test_narrow(input, narrow_args)
             self._test_narrow(input.coalesce(), narrow_args)
-	
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(-1, 0, 3)) # dim < 0
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3)) # dim > input.dim()
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, shape[0]+1, 3)) # start > size of dim
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, 2, shape[0])) # start+length > size of dim
+
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(-1, 0, 3))  # dim < 0
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3))  # dim > input.dim()
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, shape[0] + 1, 3))  # start > size of dim
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, 2, shape[0]))  # start+length > size of dim
 
         with_dense, _, _ = self._gen_sparse(2, 7, shape)
         for narrow_args in self._all_narrow_combs(shape):
             self._test_narrow(with_dense, narrow_args)
             self._test_narrow(with_dense, narrow_args)
 
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3)) # dim > sparseDim + denseDim
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3))  # dim > sparseDim + denseDim
 
     def _test_log1p_tensor(self, input, dense_tensor):
         expected_output = torch.tensor(dense_tensor).log1p_()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1023,51 +1023,34 @@ class TestSparse(TestCase):
         test_shape([0, 3, 4], [3, 4, 5, 6], [0])
         test_shape([2, 3, 4], [0, 4, 5, 6], [9, 12])
 
-    def _test_narrow(self, input, narrow_args, dense=None):
-        if dense is None:
-            dense = input.to_dense()
-        expected = dense.narrow(*narrow_args)
+    def _test_narrow(self, input, narrow_args):
+        expected = input.to_dense().narrow(*narrow_args)
         self.assertEqual(expected, input.narrow_copy(*narrow_args).to_dense())
 
+    def _all_narrow_combs(self, shape):
+        for dim, dim_sz in enumerate(shape):
+            for start in range(dim_sz):
+                for length in range(dim_sz-start):
+                    yield [dim, start, length]
+       
     def test_narrow(self):
-        input = self.SparseTensor(
-            self.IndexTensor([[0], [1], [2]]).transpose(1, 0),
-            self.ValueTensor([3, 4, 5]),
-            torch.Size([3]))
+        shape = [3, 3, 4, 2]
+        input, _, _ = self._gen_sparse(4, 19, shape)
+        for narrow_args in self._all_narrow_combs(shape):
+            self._test_narrow(input, narrow_args)
+            self._test_narrow(input.coalesce(), narrow_args)
+	
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(-1, 0, 3)) # dim < 0
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3)) # dim > input.dim()
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, shape[0]+1, 3)) # start > size of dim
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(0, 2, shape[0])) # start+length > size of dim
 
-        narrow_args = [0, 0, 2]
+        with_dense, _, _ = self._gen_sparse(2, 7, shape)
+        for narrow_args in self._all_narrow_combs(shape):
+            self._test_narrow(with_dense, narrow_args)
+            self._test_narrow(with_dense, narrow_args)
 
-        self._test_narrow(input, narrow_args)
-        self._test_narrow(input.coalesce(), narrow_args)
-
-        uncoalesced = self.SparseTensor(
-            self.IndexTensor([[0], [1], [2], [0], [1], [2]]).transpose(1, 0),
-            self.ValueTensor([2, 3, 4, 1, 1, 1]),
-            torch.Size([3]))
-
-        self._test_narrow(uncoalesced, narrow_args)
-        self._test_narrow(uncoalesced.coalesce(), narrow_args)
-
-    def test_narrow_hybrid(self):
-        input = self.SparseTensor(
-            self.IndexTensor([[0, 2, 0], [0, 2, 1]]),
-            self.ValueTensor([[1, 2], [3, 4], [5, 6]]),
-            torch.Size([3, 3, 2]))
-
-        dense = torch.DoubleTensor([[[1., 2.],
-                                    [5., 6.],
-                                    [0., 0.]],
-
-                                    [[0., 0.],
-                                    [0., 0.],
-                                    [0., 0.]],
-
-                                    [[0., 0.],
-                                    [0., 0.],
-                                    [3., 4.]]])
-
-        self._test_narrow(input, [0, 0, 2], dense)
-        self._test_narrow(input, [2, 1, 1], dense)
+        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3)) # dim > sparseDim + denseDim
 
     def _test_log1p_tensor(self, input, dense_tensor):
         expected_output = torch.tensor(dense_tensor).log1p_()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1024,7 +1024,7 @@ class TestSparse(TestCase):
         test_shape([2, 3, 4], [0, 4, 5, 6], [9, 12])
 
     def _test_narrow(self, input, narrow_args, dense=None):
-        if dense is None: 
+        if dense is None:
             dense = input.to_dense()
         expected = dense.narrow(*narrow_args)
         self.assertEqual(expected, input.narrow_copy(*narrow_args).to_dense())
@@ -1065,7 +1065,7 @@ class TestSparse(TestCase):
                                     [[0., 0.],
                                     [0., 0.],
                                     [3., 4.]]])
-        
+
         self._test_narrow(input, [0, 0, 2], dense)
         self._test_narrow(input, [2, 1, 1], dense)
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1038,7 +1038,6 @@ class TestSparse(TestCase):
         input, _, _ = self._gen_sparse(4, 19, shape)
         for narrow_args in self._all_narrow_combs(shape):
             self._test_narrow(input, narrow_args)
-            self._test_narrow(input.coalesce(), narrow_args)
 
         self.assertRaises(RuntimeError, lambda: input.narrow_copy(-1, 0, 3))  # dim < 0
         self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3))  # dim > input.dim()
@@ -1048,9 +1047,8 @@ class TestSparse(TestCase):
         with_dense, _, _ = self._gen_sparse(2, 7, shape)
         for narrow_args in self._all_narrow_combs(shape):
             self._test_narrow(with_dense, narrow_args)
-            self._test_narrow(with_dense, narrow_args)
 
-        self.assertRaises(RuntimeError, lambda: input.narrow_copy(10, 0, 3))  # dim > sparseDim + denseDim
+        self.assertRaises(RuntimeError, lambda: with_dense.narrow_copy(10, 0, 3))  # dim > sparseDim + denseDim
 
     def _test_log1p_tensor(self, input, dense_tensor):
         expected_output = torch.tensor(dense_tensor).log1p_()

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1459,8 +1459,8 @@ narrow_copy(dimension, start, length) -> Tensor
 
 Same as :meth:`Tensor.narrow` except returning a copy rather
 than shared storage.  This is primarily for sparse tensors, which
-do not have a shared-storage narrow method.  Calling ```narrow_copy`` 
-with ```dimemsion > self._sparseDims()``` will return a copy with the 
+do not have a shared-storage narrow method.  Calling ```narrow_copy``
+with ```dimemsion > self._sparseDims()``` will return a copy with the
 relevant dense dimension narrowed, and ```self.shape``` updated accordingly.
 """)
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1459,7 +1459,9 @@ narrow_copy(dimension, start, length) -> Tensor
 
 Same as :meth:`Tensor.narrow` except returning a copy rather
 than shared storage.  This is primarily for sparse tensors, which
-do not have a shared-storage narrow method.
+do not have a shared-storage narrow method.  Calling ```narrow_copy`` 
+with ```dimemsion > self._sparseDims()``` will return a copy with the 
+relevant dense dimension narrowed, and ```self.shape``` updated accordingly.
 """)
 
 add_docstr_all('ndimension',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1453,6 +1453,15 @@ Example::
             [ 8,  9]])
 """)
 
+add_docstr_all('narrow_copy',
+               r"""
+narrow_copy(dimension, start, length) -> Tensor
+
+Same as :meth:`Tensor.narrow` except returning a copy rather
+than shared storage.  This is primarily for sparse tensors, which
+do not have a shared-storage narrow method.
+""")
+
 add_docstr_all('ndimension',
                r"""
 ndimension() -> int


### PR DESCRIPTION
Couple questions:

1) I used the log1p implementation in #8969 as a guide especially for testing.  I'm not sure what the ```@skipIfROCM``` annotation is for, so unsure if i need it for my test.

2) I implemented the branching logic in the narrow function itself; is this the right place to do so?  I noticed that there a number of places where sparse-specific logic is handled with just an if statement in this file.  Or should I implement a separate dispatch in native_functions.yml as in the log1p?

And of course, happy to make any any other updates/changes that I may have missed as well.  This is my first PR to the project.