### PR TITLE
typo/grammar fixes

### DIFF
--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -273,7 +273,7 @@ class CAFFE2_API DBReader {
     for (uint32_t s = 0; s < shard_id_; s++) {
       cursor_->Next();
       CAFFE_ENFORCE(
-          cursor_->Valid(), "Db has less rows than shard id: ", s, shard_id_);
+          cursor_->Valid(), "Db has fewer rows than shard id: ", s, shard_id_);
     }
   }
 

--- a/torch/csrc/api/src/nn/init.cpp
+++ b/torch/csrc/api/src/nn/init.cpp
@@ -20,7 +20,7 @@ struct Fan {
     const auto dimensions = tensor.ndimension();
     AT_CHECK(
         dimensions >= 2,
-        "Fan in and fan out can not be computed for tensor with less than 2 dimensions");
+        "Fan in and fan out can not be computed for tensor with fewer than 2 dimensions");
 
     if (dimensions == 2) {
       in = tensor.size(1);

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -178,7 +178,7 @@ def dirac_(tensor):
 def _calculate_fan_in_and_fan_out(tensor):
     dimensions = tensor.ndimension()
     if dimensions < 2:
-        raise ValueError("Fan in and fan out can not be computed for tensor with less than 2 dimensions")
+        raise ValueError("Fan in and fan out can not be computed for tensor with fewer than 2 dimensions")
 
     if dimensions == 2:  # Linear
         fan_in = tensor.size(1)

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -25,7 +25,7 @@ class AdaptiveLogSoftmaxWithLoss(Module):
     Adaptive softmax partitions the labels into several clusters, according to
     their frequency. These clusters may contain different number of targets
     each.
-    Additionally, clusters containig less frequent labels assign lower
+    Additionally, clusters containing less frequent labels assign lower
     dimensional embeddings to those labels, which speeds up the computation.
     For each minibatch, only clusters for which at least one target is
     present are evaluated.


### PR DESCRIPTION
Fixes some minor grammar issues in the code base.

PS: I was actually looking for the following one but couldn't find it via grepping in this repo:

![screen shot 2018-09-06 at 3 27 39 pm](https://user-images.githubusercontent.com/5618407/45184280-1e16a980-b1ec-11e8-9cb1-87a96738bdd1.png)

Any idea in which file this issue is raised?