### PR TITLE
Special case BatchGather and BatchGatherGradient for block_size=1.

### DIFF
--- a/caffe2/python/operator_test/gather_ops_test.py
+++ b/caffe2/python/operator_test/gather_ops_test.py
@@ -38,10 +38,11 @@ def _inputs(draw):
     rows_num = draw(st.integers(1, 100))
     index_num = draw(st.integers(1, 10))
     batch_size = draw(st.integers(2, 10))
+    block_size = draw(st.integers(1, 2))
     return (
         draw(hnp.arrays(
             np.float32,
-            (batch_size, rows_num, 2),
+            (batch_size, rows_num, block_size),
             elements=st.floats(-10.0, 10.0),
         )),
         draw(hnp.arrays(


### PR DESCRIPTION
Summary: Special case BatchGather and BatchGatherGradient for block_size=1. This makes BatchGather 3-4X faster and BatchGatherGradient 10X for this case.

Differential Revision: D7218043
