### PR TITLE
Add initial documentation for JIT

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -1,0 +1,539 @@
+Torch Script
+============
+
+.. automodule:: torch.jit
+.. currentmodule:: torch.jit
+
+Torch Script is a way to create serializable and optimizable models from PyTorch code.
+Anything code written in Torch Script can be saved from your Python
+process and loaded/run a process where there is no python dependency.
+
+We provide tools to incrementally transition a model from being a pure python program
+to a Torch Script program that can be run independently from python, for instance, in a standalone C++ process.
+This makes it possible to train models in PyTorch using familiar tools and then export
+the model to a production environment where it is not a good idea to run models as python programs
+for performance and multi-threading reasons.
+
+.. autoclass:: ScriptModule
+    :members:
+
+    .. method:: save(filename)
+
+       Save an offline version of this module for use in a separate process. The saved
+       module serializes all of the methods and parameters of this module. It can be
+       loaded into the C++ API using ``torch::jit::load(filename)`` or into the Python
+       API with ``torch.jit.load(filename)``.
+
+       To be able to save a module, it must not make any calls to native python functions.
+       This means that all submodules must be subclasses of ScriptModules as well.
+
+
+.. autofunction:: load
+
+.. autofunction:: trace
+
+
+Mixing Tracing and Scripting
+----------------------------
+
+In many cases either tracing or script is an easier approach for converting a model.
+We allow you to compose tracing and scripting to suite the particular requirements
+of a part of a model.
+
+Scripted functions can call traced ones. This is particularly useful when you need
+to use control-flow around a simple feed-forward model. For instance the beam search
+of a sequence to sequence model will typically be written in script but can call an
+encoder module generated using tracing.
+
+Example:
+
+::
+
+    import torch
+
+    def foo(x, y):
+        return 2*x + y
+    traced_foo = torch.jit.trace(foo, (torch.rand(3), torch.rand(3)))
+
+    @torch.jit.script
+    def bar(x):
+        return traced_foo(x, x)
+
+Traced functions can call script functions. This is useful when a small part of
+a model requires some control-flow even though most of the model is just a feed-forward
+network. Control-flow inside of a script function called by a traced function is
+preserved correctly:
+
+Example:
+
+::
+
+    import torch
+    @torch.jit.script
+    def foo(x, y):
+        if x.max() > y.max():
+            r = x
+        else:
+            r = y
+        return r
+
+
+    def bar(x, y, z):
+        return foo(x, y) + z
+
+    traced_bar = torch.jit.trace(bar, (torch.rand(3), torch.rand(3), torch.rand(3))
+
+This composition also works for modules as well, where it can be used to generate
+a submodule using tracing that can be called from the methods of a script module:
+
+Example:
+
+::
+
+    import torch
+    import torchvision
+
+    class MyScriptModule(torch.jit.ScriptModule):
+        def __init__(self):
+            super(MyScriptModule, self).__init__()
+            self.means = torch.nn.Parameter(torch.tensor([103.939, 116.779, 123.68])
+                                            .resize_(1, 3, 1, 1))
+            self.resnet = torch.jit.trace(torchvision.models.resnet18(),
+                                          torch.rand(1, 3, 224, 224))
+
+        @torch.jit.script_method
+        def forward(self, input):
+            return self.resnet(input - self.means)
+
+
+Torch Script Language Reference
+===============================
+
+Torch Script is a subset of Python that can either be written directly (using
+the @script annotations) or generated automatically from Python code via
+tracing. When using tracing, code is automatically converted into this subset of
+Python by recording only the actual operators on tensors and simply executing
+the other Python code.
+
+When writing Torch Script directly using @script annotations, the programmer must
+only use the subset of Python supported in Torch Script. This section documents
+what is supported in Torch Script as if it were a language reference for a stand
+alone language. Any features of Python not mentioned in this reference are not
+part of Torch Script.
+
+As a subset of Python any valid Torch Script function is also a valid Python
+function. This makes it possible to remove the @script annotations and debug the
+function using standard Python tools like pdb. The reverse is not true: there
+are many valid python programs that are not valid Torch Script programs.
+Instead, Torch Script focuses specifically on the features of Python that are
+needed to represent neural network models in Torch.
+
+.. envvar:: PYTORCH_JIT=1
+
+    Setting the environment variable ``PYTORCH_JIT=0`` will disable all script
+    and tracing annotations. If there is hard-to-debug error in one of your
+    ScriptModules, you can use this flag to force everything to run using native
+    Python. This allows the use of tools like ``pdb`` to debug code.
+
+
+Types
+-----
+
+The largest difference between Torch Script and the full Python language is that
+Torch Script only support a small set of types that are needed to express neural
+net models. In particular Torch Script supports:
+
+``Tensor``
+    A PyTorch tensor of any dtype, dimension, or backend.
+
+``Tuple[T0, T1, ...]``
+    A tuple containing subtypes ``T0``, ``T1``, etc. (e.g. ``Tuple[Tensor, Tensor]``)
+
+``int``
+    A scalar integer
+
+``float``
+    A scalar floating point number
+
+``List[T]``
+    A list of which all members are type ``T``
+
+Unlike Python, each variable in Torch Script function must have a single static type.
+This makes it easier to optimize Torch Script functions.
+
+Example::
+
+    @torch.jit.script
+    def an_error(x):
+        if x:
+            r = torch.rand(1)
+        else:
+            r = 4
+        return r # Type mismatch: r is set to type Tensor in the true branch
+                 # and type int in the false branch
+
+By default, all parameters to a Torch Script function are assumed to be Tensor
+because this is the most common type used in modules. To specify that an
+argument to a Torch Script function is another type, it is possible to use
+MyPy-style type annotations using the types listed above:
+
+Example::
+
+    @torch.jit.script
+    def foo(x, tup):
+        # type: (int, Tuple[Tensor, Tensor]) -> Tensor
+        t0, t1 = tup
+        return t0 + t1 + x
+
+    print(foo(3, (torch.rand(3), torch.rand(3))))
+
+Expressions
+-----------
+
+The following Python Expressions are supported
+
+Literals
+    ``True``, ``False``, ``None``, ``'string literals'``, ``"string literals"``,
+    number literals ``3`` (interpreted as int) ``3.4`` (interpreter as a float)
+
+Variables
+  ``a``
+
+  .. note::
+      See 'variable scoping rules' for how variables are resolved.
+
+Tuple Construction
+    ``(3, 4)``, ``(3,)``
+
+List Construction
+    ``[3, 4]``, ``[]``, ``[torch.rand(3), torch.rand(4)]``
+
+    .. note::
+        an empty list is assumed have type ``List[Tensor]``.
+        The types of other list literals are derived from the type of the members.
+
+Arithmetic Operators
+  ``a + b``
+  ``a - b``
+  ``a * b``
+  ``a / b``
+  ``a ^ b``
+  ``a @ b``
+
+Comparison Operators
+  ``a == b``
+  ``a != b``
+  ``a < b``
+  ``a > b``
+  ``a <= b``
+  ``a >= b``
+
+Logical Operators
+  ``a and b``
+  ``a or b``
+  ``not b``
+
+Subscripts
+  ``t[0]``
+  ``t[-1]``
+  ``t[0:2]``
+  ``t[1:]``
+  ``t[:1]``
+  ``t[:]``
+  ``t[0, 1]``
+  ``t[0, 1:2]``
+  ``t[0, :1]``
+  ``t[-1, 1:, 0]``
+  ``t[1:, -1, 0]``
+  ``t[i:j, i]``
+
+  .. note::
+    Torch Script currently does not support mutating tensors in place, so any
+    tensor indexing can only appear on the right-hand size of an expression.
+
+Function calls
+   Calls to built-in functions: ``torch.rand(3, dtype=torch.int)``
+
+   Calls to other script functions:
+
+   ::
+
+        import torch
+
+        @torch.jit.script
+        def foo(x):
+          return x + 1
+
+        @torch.jit.script
+        def bar(x):
+          return foo(x)
+
+Method calls
+    Calls to methods of builtin types like tensor: ``x.mm(y)``
+
+
+    Inside of a ``@script_method``, it is possible to call other methods, or methods on submodules
+
+    ::
+
+        import torch
+
+        class MyScriptModule(torch.jit.ScriptModule):
+            def __init__(self):
+                super(MyScriptModule, self).__init__()
+                self.means = torch.nn.Parameter(torch.tensor([103.939, 116.779, 123.68])
+                                                .resize_(1, 3, 1, 1))
+                self.resnet = torch.jit.trace(torchvision.models.resnet18(),
+                                              torch.rand(1, 3, 224, 224))
+
+            @torch.jit.script_method
+            def helper(self, input):
+              return self.resnet(input - self.means)
+
+            @torch.jit.script_method
+            def forward(self, input):
+                return self.helper(input)
+
+If expressions
+    ``x if x > y else y``
+
+Casts
+    ``float(ten)``, ``int(3.5)``, ``bool(ten)``
+
+Accessing Module Parameters
+    ``self.my_parameter`` ``self.my_submodule.my_parameter``
+
+
+Statements
+----------
+
+Torch Script supports the following types of statements:
+
+Simple Assignments
+
+    ::
+
+        a = b
+        a += b # short-hand for a = a + b, does not operator in-place on a
+        a -= b
+
+Pattern Matching Assignments
+
+    ::
+
+        a, b = tuple_or_list
+        a, b, *c = a_tuple
+
+Print Statements
+
+  ``print("the result of an add:", a + b)``
+
+If Statements
+
+    ::
+        if a < 4:
+            r = -a
+        elif a < 3:
+            r = a + a
+        else:
+            r = 3 * a
+
+While Loops
+
+  ::
+
+      a = 0
+      while a < 4:
+          print(a)
+          a += 1
+
+
+For loops with ``range``
+
+    ::
+
+        x = 0
+        for i in range(0, 10):
+            x *= i
+
+    .. note::
+      Script currently does not support iterating over generic iterable
+      objects like lists or tensors. This will be added in a future version.
+
+For loops over tuples:
+
+    ::
+
+        tup = (3, torch.rand(4))
+        for x in tup:
+            print(x)
+
+    .. note::
+      for loops over tuples will unroll the loop, generating a body for
+      each member of the tuple. The body must type-check correctly for each member.
+
+For loops over constant ``torch.nn.ModuleList``
+
+      ::
+
+          class SubModule(torch.jit.ScriptModule):
+              def __init__(self):
+                  super(Sub, self).__init__()
+                  self.weight = nn.Parameter(torch.randn(2))
+
+              @torch.jit.script_method
+              def forward(self, input):
+                  return self.weight + input
+
+          class MyModule(torch.jit.ScriptModule):
+              __constants__ = ['mods']
+
+              def __init__(self):
+                  super(MyModule, self).__init__()
+                  self.mods = torch.nn.ModuleList([SubModule() for i in range(10)])
+
+              @torch.jit.script_method
+              def forward(self, v):
+                  for module in self.mods:
+                      v = m(v)
+                  return v
+
+      .. note::
+          To use a module list inside a ``@script_method`` it must be marked
+          constant by adding the name of the attribute to the ``__constants__``
+          list for the type. For loops over a ModuleList will unroll the body of the
+          loop at compile time, with each member of the constant module list.
+
+Return
+    ``return a, b``
+
+    .. note::
+        there must be a return statement as the last member of the function
+        and return statements cannot appear anywhere else in the function. This
+        restriction will be removed in the future.
+
+Variable Resolution
+-------------------
+
+Torch Script supports a subset of Python's variable resolution (i.e. scoping)
+rules. Local variables behave the same as in Python, except for the restriction
+that a variable must have the same type along all paths through a function.
+If a variable has a different type on different sides of an if statement, it
+is an error to use it after the end of the if statement.
+
+Similarly, a variable is not allowed to be used if it is only *defined* along some
+paths through the function.
+
+Example::
+
+    @torch.jit.script
+    def foo(x):
+        if x < 0:
+            y = 4
+        print(y) # Error: undefined value y
+
+Non-local variables are resolved to Python values at compile time when the
+function is defined. These values are then converted into Torch Script values using
+the rules described in *Use of Python Values*.
+
+Use of Python Values
+--------------------
+
+To make writing Torch Script more convenient, we allow script code to refer
+to Python values in the surrounding scope. For instance, any time there is a
+reference to ``torch``, the Torch Script compiler is actually resolving it to the
+``torch`` Python module when the function is declared.  These Python values are
+not a first class part of Torch Script. Instead they are desugared at compile-time
+into the primitive types that Torch Script supports. This section describes the
+rules that are used when accessing Python values in Torch Script. They depend
+on the dynamic type of the python valued referenced.
+
+Functions
+  Torch Script can call python functions. This functionality is very useful when
+  incrementally converting a model into script. The model can be moved function-by-function
+  to script, leaving calls to Python functions in place. This way you can incrementally
+  check the correctness of the model as you go.
+
+  Example::
+
+      def foo(x):
+        print("I am called with {}".format(x))
+        import pdb; pdb.set_trace()
+        return x
+
+      @torch.jit.script
+      def bar(x)
+        return foo(x + 1)
+
+  .. note::
+    Attempting to call ``save`` on a ScriptModule that contains calls to Python
+    functions will fail. The intention is that this pathway is used for debugging
+    and the calls removed or turned into script functions before saving.
+
+
+Attribute Lookup On Python Modules
+    Torch Script can lookup attributes on modules. Builtin functions like ``torch.add``
+    are accessed this way. This allows Torch Script to call functions defined in
+    other modules.
+
+Python-defined Constants
+    Torch Script also provides a way to use constants that are defined in Python.
+    These can be used to hard-code hyper-parameters into the function, or to
+    define universal constants. There are two ways of specifying that a Python
+    value should be treated as a constant.
+
+    1. Values looked up as attributes of a module are assumed to be constant.
+       Example: ``math.pi``
+    2. Attributes of a ScriptModule can be marked constant by listing them
+       as a member of the ``__constants__`` property of the class:
+
+       Example::
+
+           class Foo(torch.jit.ScriptModule):
+               __constants__ = ['a']
+
+               def __init__(self):
+                   super(Foo, self).__init__(False)
+                   self.a = 1 + 4
+
+              @torch.jit.ScriptModule
+              def forward(self, input):
+                  return self.a + input
+
+    Supported constant Python Values are
+
+    * ``int``
+    * ``bool``
+    * ``torch.device``
+    * ``torch.layout``
+    * ``torch.dtype``
+    * tuples containing supported types
+    * ``torch.nn.ModuleList`` which can be used in a TorchScript for loop
+
+
+Debugging
+---------
+
+Print things
+
+Use ``USE_PYTHON=0`` to debug in normal python mode
+
+Look at the graph
+
+Pay attention to tracer warnings
+
+
+Builtin Functions
+-----------------
+
+Torch Script supports a subset of the builtin tensor and neural network functions that
+PyTorch provides. Most methods on Tensor as well as functions in the ``torch``
+namespace are available. Many functions in ``torch.nn.functional`` are also availiable.
+
+
+We currently do not provide any builtin ScriptModules e.g. a ``Linear`` or
+``Conv`` module. This functionality is something that will be developed in the future.
+For now we suggestion using ``torch.jit.trace`` to transform standard ``torch.nn``
+modules into ScriptModules on construction.
+
+.. automodule:: torch.jit.supported_ops

--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -1,6 +1,8 @@
 Torch Script
 ============
 
+.. contents:: :local:
+
 .. automodule:: torch.jit
 .. currentmodule:: torch.jit
 
@@ -8,11 +10,15 @@ Torch Script is a way to create serializable and optimizable models from PyTorch
 Anything code written in Torch Script can be saved from your Python
 process and loaded/run a process where there is no python dependency.
 
-We provide tools to incrementally transition a model from being a pure python program
+We provide tools to incrementally transition a model from being a pure Python program
 to a Torch Script program that can be run independently from python, for instance, in a standalone C++ process.
 This makes it possible to train models in PyTorch using familiar tools and then export
 the model to a production environment where it is not a good idea to run models as python programs
 for performance and multi-threading reasons.
+
+Creating Torch Script Code
+--------------------------
+
 
 .. autoclass:: ScriptModule
     :members:
@@ -52,7 +58,7 @@ Example:
     import torch
 
     def foo(x, y):
-        return 2*x + y
+        return 2 * x + y
     traced_foo = torch.jit.trace(foo, (torch.rand(3), torch.rand(3)))
 
     @torch.jit.script
@@ -107,13 +113,13 @@ Example:
 
 
 Torch Script Language Reference
-===============================
+-------------------------------
 
 Torch Script is a subset of Python that can either be written directly (using
 the @script annotations) or generated automatically from Python code via
 tracing. When using tracing, code is automatically converted into this subset of
-Python by recording only the actual operators on tensors and simply executing
-the other Python code.
+Python by recording only the actual operators on tensors and simply executing and
+discarding the other surrounding Python code.
 
 When writing Torch Script directly using @script annotations, the programmer must
 only use the subset of Python supported in Torch Script. This section documents
@@ -137,7 +143,7 @@ needed to represent neural network models in Torch.
 
 
 Types
------
+~~~~~
 
 The largest difference between Torch Script and the full Python language is that
 Torch Script only support a small set of types that are needed to express neural
@@ -187,8 +193,13 @@ Example::
 
     print(foo(3, (torch.rand(3), torch.rand(3))))
 
+.. note::
+  It is also possible to annotate types with Python 3 type annotations.
+  In our examples, we use comment-based annotations to ensure Python 2
+  compatibility as well.
+
 Expressions
------------
+~~~~~~~~~~~
 
 The following Python Expressions are supported
 
@@ -200,7 +211,7 @@ Variables
   ``a``
 
   .. note::
-      See 'variable scoping rules' for how variables are resolved.
+      See `Variable Resolution`_ for how variables are resolved.
 
 Tuple Construction
     ``(3, 4)``, ``(3,)``
@@ -272,7 +283,12 @@ Method calls
     Calls to methods of builtin types like tensor: ``x.mm(y)``
 
 
-    Inside of a ``@script_method``, it is possible to call other methods, or methods on submodules
+    When defining a Script method inside of a ScriptModule, the ``@script_method``
+    annotation is used. Inside of these methods it is possible to call other methods
+    of this class or access methods on the submodules.
+
+    Calling a submodule directly (e.g. ``self.resnet(input)``) is equivalent to
+    calling its ``forward`` method (e.g. ``self.resnet.forward(input)``)
 
     ::
 
@@ -305,7 +321,7 @@ Accessing Module Parameters
 
 
 Statements
-----------
+~~~~~~~~~~
 
 Torch Script supports the following types of statements:
 
@@ -314,7 +330,7 @@ Simple Assignments
     ::
 
         a = b
-        a += b # short-hand for a = a + b, does not operator in-place on a
+        a += b # short-hand for a = a + b, does not operate in-place on a
         a -= b
 
 Pattern Matching Assignments
@@ -331,6 +347,7 @@ Print Statements
 If Statements
 
     ::
+
         if a < 4:
             r = -a
         elif a < 3:
@@ -413,7 +430,7 @@ Return
         restriction will be removed in the future.
 
 Variable Resolution
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 Torch Script supports a subset of Python's variable resolution (i.e. scoping)
 rules. Local variables behave the same as in Python, except for the restriction
@@ -434,10 +451,10 @@ Example::
 
 Non-local variables are resolved to Python values at compile time when the
 function is defined. These values are then converted into Torch Script values using
-the rules described in *Use of Python Values*.
+the rules described in `Use of Python Values`_.
 
 Use of Python Values
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 To make writing Torch Script more convenient, we allow script code to refer
 to Python values in the surrounding scope. For instance, any time there is a
@@ -512,7 +529,7 @@ Python-defined Constants
 
 
 Debugging
----------
+~~~~~~~~~
 
 Print things
 
@@ -524,7 +541,7 @@ Pay attention to tracer warnings
 
 
 Builtin Functions
------------------
+~~~~~~~~~~~~~~~~~
 
 Torch Script supports a subset of the builtin tensor and neural network functions that
 PyTorch provides. Most methods on Tensor as well as functions in the ``torch``
@@ -533,7 +550,7 @@ namespace are available. Many functions in ``torch.nn.functional`` are also avai
 
 We currently do not provide any builtin ScriptModules e.g. a ``Linear`` or
 ``Conv`` module. This functionality is something that will be developed in the future.
-For now we suggestion using ``torch.jit.trace`` to transform standard ``torch.nn``
+For now we suggest using ``torch.jit.trace`` to transform standard ``torch.nn``
 modules into ScriptModules on construction.
 
 .. automodule:: torch.jit.supported_ops

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -254,6 +254,31 @@ void initJITBindings(PyObject *module) {
     }
   }, py::arg("qualified_name"));
 
+  py::class_<FunctionSchema>(m, "FunctionSchema")
+  .def_property_readonly("name", [](FunctionSchema& self) { return self.name; })
+  .def_property_readonly("arguments", [](FunctionSchema& self) { return self.arguments; })
+  .def_property_readonly("returns", [](FunctionSchema& self) { return self.returns; });
+  py::class_<Argument>(m, "Argument")
+  .def_property_readonly("name", [](Argument& self) { return self.name; })
+  .def_property_readonly("type", [](Argument& self) { return self.type; })
+  .def_property_readonly("N", [](Argument& self) -> py::object {
+    return (self.N) ? py::cast(*self.N) :  py::none();
+  })
+  .def_property_readonly("default_value", [](Argument& self) -> py::object {
+    if(!self.default_value)
+      return py::none();
+    IValue v = *self.default_value;
+    return toPyObject(std::move(v));
+  });
+  m.def("_jit_get_schemas_for_operator", [](const std::string& qualified_name) {
+    auto symbol = Symbol::fromQualString(qualified_name);
+    auto operations = getAllOperatorsFor(std::move(symbol));
+    return fmap(operations, [](const std::shared_ptr<Operator>& op) {
+        return op->schema();
+      });
+  });
+
+
   initPythonIRBindings(module);
   tracer::initPythonTracerBindings(module);
   script::initTreeViewBindings(module);

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -78,6 +78,19 @@ inline IValue createGenericList(py::handle obj, const TypePtr& elem_type) {
   return ConstantList<IValue>::create(std::move(elems));
 }
 
+struct ConvertError : public std::exception {
+    ConvertError(std::string msg)
+    : msg_(std::move(msg)) {}
+    const char* what() const noexcept override  {
+        return msg_.c_str();
+    }
+private:
+    std::string msg_;
+};
+
+#define TORCH_CONVERT_ERROR(...) \
+  throw ConvertError(at::str(__VA_ARGS__))
+
 inline IValue toIValue(py::handle obj, const TypePtr& type) {
     switch (type->kind()) {
       case TypeKind::DynamicType:
@@ -95,7 +108,7 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
         size_t tuple_size = tuple.size();
         const auto & elem_types = type->cast<TupleType>()->elements();
         if (elem_types.size() != tuple_size) {
-          AT_ERROR("Expected ", elem_types.size(), " tuple elements for argument, but got ", tuple_size);
+          TORCH_CONVERT_ERROR("Expected ", elem_types.size(), " tuple elements for argument, but got ", tuple_size);
         }
         std::vector<IValue> values;
         values.reserve(tuple_size);
@@ -121,9 +134,9 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
         }
       }
       case TypeKind::NumberType:
-        AT_ERROR("Insufficient type information to convert input");
+        TORCH_CONVERT_ERROR("Insufficient type information to convert input");
       case TypeKind::GeneratorType:
-        AT_ERROR("Generators are not supported yet.");
+        TORCH_CONVERT_ERROR("Generators are not supported yet.");
     }
   AT_ERROR("Missing cases in toIValue! File a bug report.");
 }
@@ -142,7 +155,15 @@ inline IValue argumentToIValue(
         "' in position ", argumentPosition,
         ", but instead got value of type ",
         py::str(object.get_type().attr("__name__")),
-        ". Declaration: ", schema);
+        ".\nDeclaration: ", schema);
+  } catch (const ConvertError& error) {
+    AT_ERROR(
+        schema.name, "(): ", error.what(),
+        "\n for argument '", argument.name,
+        "' in position ", argumentPosition,
+        ", but instead got value of type ",
+        py::str(object.get_type().attr("__name__")),
+        ".\nDeclaration: ", schema);
   }
 }
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -438,7 +438,7 @@ void initPythonIRBindings(PyObject * module_) {
 
   py::class_<Type,std::shared_ptr<Type>>(m,"Type")
     .def("__repr__",[](Type & t) {
-      return t.str();
+      return t.python_str();
     })
     .def("kind",[](Type& t_) {
       Type * t = &t_;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -71,9 +71,15 @@ public:
   virtual bool isSubtypeOf(const TypePtr rhs) const {
     return *this == *rhs;
   }
-  // user-friendly form of the type, separate from
-  // operator<< which is verbose and unambiguous
+
+  // How this type will appear in FunctionSchema declarations
   virtual std::string str() const = 0;
+
+  // How this type will appear as if it were a type annotation in Python
+  // which is sometimes different than how it appears in declarations (e.g. int[] vs List[int])
+  virtual std::string python_str() const {
+    return str();
+  }
 
   TypeKind kind() const {
     return kind_;
@@ -331,6 +337,11 @@ struct TORCH_API ListType : public Type {
     ss << getElementType()->str() << "[]";
     return ss.str();
   }
+  std::string python_str() const override {
+    std::stringstream ss;
+    ss << "List[" << getElementType()->python_str() << "]";
+    return ss.str();
+  }
   TypePtr getElementType() const {
     return elem;
   }
@@ -377,6 +388,17 @@ struct TORCH_API TupleType : public Type {
       ss << elements()[i]->str();
     }
     ss << ")";
+    return ss.str();
+  }
+  std::string python_str() const override {
+    std::stringstream ss;
+    ss << "Tuple[";
+    for(size_t i = 0; i < elements().size(); ++i) {
+      if(i > 0)
+        ss << ", ";
+      ss << elements()[i]->python_str();
+    }
+    ss << "]";
     return ss.str();
   }
 private:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -59,6 +59,15 @@ def scope(scope_name):
 
 
 def load(filename):
+    r"""
+        Load a ``ScriptModule`` previously saved with :func:`save <torch.jit.ScriptModule.save>`
+
+        Arguments:
+            filename (string): the file to load
+
+        Returns:
+            A ``ScriptModule`` object.
+    """
     m = ScriptModule()
     m._load(filename)
     return m
@@ -436,15 +445,17 @@ def trace(func, example_inputs, optimize=True, check_trace=True, check_inputs=No
         models, you will silently get incorrect results on subsequent
         invocations of the model.
 
-    Arg:
-        func - a python function or torch.nn.Module that will be run with example_inputs.
-               arguments and returns to func must be Tensors or (possibly nested) tuples that
-               contain tensors.
-        example_inputs - a tuple of example inputs that will be passed to the function
-                         while tracing. The resulting trace can be run with
-                         inputs of different types and shapes assuming the traced operations
-                         support those types and shapes. example_inputs may also be a single
-                         Tensor in which case it is automatically wrapped in a tuple
+    Arguments:
+        func (callable or torch.nn.Module):  a python function or torch.nn.Module
+                                             that will be run with example_inputs.
+                                             arguments and returns to func must be Tensors
+                                             or (possibly nested) tuples that
+                                             contain tensors.
+        example_inputs (tuple):  a tuple of example inputs that will be passed to the function
+                                 while tracing. The resulting trace can be run with
+                                 inputs of different types and shapes assuming the traced operations
+                                 support those types and shapes. example_inputs may also be a single
+                                 Tensor in which case it is automatically wrapped in a tuple
 
     Keyword arguments:
         optimize (bool, optional): whether or not to apply optimizations.  Default: ``True``.
@@ -454,20 +465,20 @@ def trace(func, example_inputs, optimize=True, check_trace=True, check_inputs=No
                                       deterministic ops or if you are sure that the network is correct despite
                                       a checker failure.
 
-        check_inputs (list of tuples. optional): A list of tuples of input arguments that should be used
+        check_inputs (list of tuples, optional): A list of tuples of input arguments that should be used
                                                  to check the trace against what is expected. Each tuple
                                                  is equivalent to a seet of input arguments that would
-                                                 be specified in `args`. For best results, pass in a
+                                                 be specified in ``args``. For best results, pass in a
                                                  set of checking inputs representative of the space of
                                                  shapes and types of inputs you expect the network to see.
-                                                 If not specified, the original `args` is used for checking
+                                                 If not specified, the original ``args`` is used for checking
         check_tolerance (float, optional): Floating-point comparison tolerance to use in the checker procedure.
                                            This can be used to relax the checker strictness in the event that
                                            results diverge numerically for a known reason, such as operator fusion.
 
     Returns:
-        A torch.jit.ScriptModule object with a single forward() method containing the traced code.
-        When func in s a torch.nn.Module, the returned ScriptModule will have the same set of
+        A ``ScriptModule`` object with a single ``forward()`` method containing the traced code.
+        When func is a ``torch.nn.Module``, the returned ``ScriptModule`` will have the same set of
         sub-modules and parameters as func.
 
     Example:
@@ -790,6 +801,7 @@ class ScriptMeta(type(torch._C.ScriptModule)):
         super_constants = getattr(super(cls), '_constants_set', set())
         cls._constants_set = set(getattr(cls, '__constants__', ())).union(super_constants)
 
+        @functools.wraps(original_init)
         def init_then_register(self, *args, **kwargs):
             # ensure even if the user forgets to call super that
             # the pybind object is initialized so it will not segfault
@@ -807,6 +819,102 @@ class ScriptMeta(type(torch._C.ScriptModule)):
 
 if _enabled:
     class ScriptModule(with_metaclass(ScriptMeta, torch._C.ScriptModule, Module)):
+        r"""
+        The core data structure in Torch Script is the ``ScriptModule``. It is an analogue
+        of torch's nn.Module and represents an entire model as a tree of submodules.
+        Like normal modules, each individual module in a ScriptModule can have submodules,
+        parameters, and methods. In nn.Modules methods are implemented as Python functions,
+        but in ScriptModules methods are actually *Torch Script* functions, a statically-typed subset
+        of Python that contains all of PyTorch's built-in Tensor operations. This difference
+        allows your ScriptModules code to run without the need for a Python interpreter.
+
+        ScriptModules and the Torch Script functions inside of them can be created in
+        two ways:
+
+        tracing
+            Using ``torch.jit.trace``, you can take an existing module or python
+            function, provide example inputs, and we run the function, recording the
+            operations performed on all the tensors. We turn the resulting recording
+            into a Torch Script method that is installed as the ``forward`` method of a
+            ScriptModule. This module also contains any parameters that the original
+            module had as well.
+
+            Example::
+
+                import torch
+                def foo(x, y):
+                    return 2*x + y
+                traced_foo = torch.jit.trace(foo, (torch.rand(3), torch.rand(3)))
+
+            Example::
+
+                import torch
+                import torchvision
+                traced_net = torch.jit.trace(torchvision.models.resnet18(),
+                                             torch.rand(1, 3, 224, 224))
+
+        scripting
+            You can write Torch Script code directly using Python syntax. You do this
+            using the ``torch.jit.script`` annotation (for functions) or
+            ``torch.jit.script_method`` annotation (for methods) on subclasses of
+            ScriptModule. With this annotation the body of the annotated function is
+            directly translated into Torch Script. Torch Script itself is a subset of
+            the Python language, so not all features in python work, but we provide
+            enough functionality to compute on tensors and do control-dependent
+            operations.
+
+            Example::
+
+                import torch
+                @torch.jit.script
+                def foo(x, y):
+                    if x.max() > y.max():
+                        r = x
+                    else:
+                        r = y
+                    return r
+
+            Example::
+
+              import torch
+              class MyModule(torch.jit.ScriptModule):
+                  def __init__(self, N, M):
+                      super(MyModule, self).__init__()
+                      self.weight = torch.nn.Parameter(torch.rand(N, M))
+
+                  @torch.jit.script_method
+                  def forward(self, input):
+                      return self.weight.mv(input)
+
+            Example::
+
+                import torch
+                import torch.nn as nn
+                import torch.nn.functional as F
+                from torch.jit import ScriptModule, script_method, trace
+
+                class MyScriptModule(ScriptModule):
+                    def __init__(self):
+                        super(MyScriptModule, self).__init__()
+                        # trace produces a ScriptModule's conv1 and conv2
+                        self.conv1 = trace(nn.Conv2d(1, 20, 5), torch.rand(1, 1, 16, 16))
+                        self.conv2 = trace(nn.Conv2d(20, 20, 5), torch.rand(1, 20, 16, 16))
+
+                    @script_method
+                    def forward(self, input):
+                      input = F.relu(self.conv1(input))
+                      input = F.relu(self.conv2(input))
+                      return input
+
+        Since tracing only records operations on tensors, it will not record any
+        control-flow operations like if statements or loops. When this control-flow is
+        constant across your module, this is fine and it often just inlines
+        configuration decisions. But sometimes the control-flow is actually part of the
+        model itself. For instance, a beam search in sequence-to-sequence translation is
+        a loop over the (varying) sequence length of inputs. In this case tracing would
+        not be appropriate and the beam search should be written using scripting.
+        """
+
         def __init__(self, optimize=True):
             # must be before Module.init since the field is used in __getattr__
             Module.__init__(self)
@@ -999,6 +1107,8 @@ class _ConstSequential(_ConstModuleList):
 
 _builtin_table = None
 
+_modules_containing_builtins = (torch, torch.nn.functional)
+
 
 # lazily built to ensure the correct initialization order
 def _get_builtin_table():
@@ -1012,8 +1122,9 @@ def _get_builtin_table():
             v = getattr(mod, name)
             if callable(v):
                 _builtin_table[id(v)] = "aten::" + name
-    register_all(torch)
-    register_all(torch.nn.functional)
+    for mod in _modules_containing_builtins:
+        register_all(mod)
+
     return _builtin_table
 
 

--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -1,0 +1,86 @@
+import torch.jit
+# this file is for generating documentation using sphinx autodoc
+# > help(torch.jit.supported_ops) will also give a nice listed of the
+# supported ops programmatically
+
+
+def _list_supported_ops():
+    def emit_type(type):
+        return str(type)
+
+    def emit_arg(indent, i, arg):
+        v = "{} : {}".format(arg.name, emit_type(arg.type))
+        default = arg.default_value
+        if default is not None:
+            v = "{}={}".format(v, str(default))
+        if i > 0:
+            v = "\n{}{}".format(" " * indent, v)
+        return v
+
+    def emit_args(indent, arguments):
+        return ",".join(emit_arg(indent, i, arg) for i, arg in enumerate(arguments))
+
+    def emit_ret(ret):
+        return emit_type(ret.type)
+
+    def emit_rets(returns):
+        if len(returns) == 1:
+            return emit_ret(returns[0])
+        return "Tuple[{}]".format(", ".join(emit_ret(r) for r in returns))
+
+    def emit_schema(mod, name, schema, arg_start=0):
+        qualified_name = "{}.{}".format(mod, name)
+        schema = "{}({}) -> {}".format(qualified_name,
+                                       emit_args(len(qualified_name) + 1 + 4, schema.arguments[arg_start:]),
+                                       emit_rets(schema.returns))
+        return schema
+
+    def hidden(name):
+        return name.startswith('_') and not name.startswith('__')
+
+    functions = []
+
+    for mod in torch.jit._modules_containing_builtins:
+        name = mod.__name__
+        for elem in dir(mod):
+            builtin = torch.jit._find_builtin(getattr(mod, elem))
+            if builtin is not None:
+                schemas = torch._C._jit_get_schemas_for_operator(builtin)
+                for schema in schemas:
+                    # remove _tan but not __and__
+                    if not hidden(elem):
+                        functions.append(emit_schema(name, elem, schema))
+
+    def is_tensor_method(schema):
+        if len(schema.arguments) == 0:
+            return False
+        self = schema.arguments[0]
+        if self.name != 'self':
+            return False
+        if not self.type.isSubtypeOf(torch._C.DynamicType.get()):
+            return False
+        return True
+
+    methods = []
+    # discover methods
+    for elem in dir(torch.Tensor):
+        if not hidden(elem):
+            schemas = torch._C._jit_get_schemas_for_operator("aten::" + elem)
+            for schema in schemas:
+                if is_tensor_method(schema):
+                    methods.append(emit_schema('Tensor', elem, schema, arg_start=1))
+
+    def emit_block(decls):
+        return '\n::\n\n{}\n'.format(''.join('    {}\n\n'.format(d) for d in decls))
+    body = """
+Supported Functions
+~~~~~~~~~~~~~~~~~~~
+{}
+
+Supported Methods
+~~~~~~~~~~~~~~~~~
+{}
+"""
+    return body.format(emit_block(functions), emit_block(methods))
+
+__doc__ = _list_supported_ops()


### PR DESCRIPTION
In addition to documentation, this cleans up a few error message formats. 
It also adds infra to find which operators are supported by the JIT automatically, which is then used in the generation of the docs. 

The wording and formatting of the docs is not yet polished, but having this will allow our document writers to make faster progress.

Followup PRs will polish the docs and fix formatting issues.
