### PR TITLE
use batched gemm from mkl on torch.bmm when mkl is available

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2567,7 +2567,7 @@
         - THTensor* mat2
 ]]
 [[
-  name: bmm
+  name: _th_bmm
   cname: baddbmm
   variants:
     - method

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -347,5 +347,19 @@ Tensor& matmul_out(Tensor &result, const Tensor & tensor1, const Tensor & tensor
   return result;
 }
 
+Tensor bmm(const Tensor & self, const Tensor & tensor) {
+  Tensor result = self.type().tensor();
+  return at::native::bmm_out(result, self, tensor);
+}
+
+Tensor& bmm_out(Tensor &result, const Tensor & self, const Tensor & tensor) {
+  if (!self.is_cuda() && at::hasMKL()) {
+    result = at::bmm_mkl(self, tensor);
+    return result;
+  }
+  at::_th_bmm_out(result, self, tensor);
+  return result;
+}
+
 }
 }

--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -1,0 +1,105 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/Config.h"
+
+#if !AT_MKL_ENABLED()
+
+namespace at { namespace native {
+
+Tensor bmm_mkl(const Tensor& self, const Tensor& tensor) {
+  throw std::runtime_error("bmm: ATen not compiled with MKL support");
+}
+
+}}
+
+#else // AT_MKL_ENABLED
+
+#include "ATen/ATen.h"
+#include "ATen/Config.h"
+#include "ATen/Dispatch.h"
+#include "ATen/Utils.h"
+#include "ATen/NativeFunctions.h"
+
+#include <algorithm>
+#include <vector>
+#include <numeric>
+#include <cmath>
+
+#include <mkl.h>
+#include <ATen/mkl/Exceptions.h>
+#include <ATen/mkl/Descriptors.h>
+#include <ATen/mkl/Limits.h>
+
+namespace at { namespace native {
+
+static inline void gemm_batched(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int batch_size, const int M, const int N, const int K, const float alpha,
+  const float** A, const float** B, const float beta, float** C) {
+  const int lda = (trans_A == CblasNoTrans) ? K : M;
+  const int ldb = (trans_B == CblasNoTrans) ? N : K;
+  const int ldc = N;
+
+  cblas_sgemm_batch(CblasRowMajor, &trans_A, &trans_B, &M, &N, &K, &alpha,
+    A, &lda, B, &ldb, &beta, C, &ldc, 1, &batch_size);
+}
+
+static inline void gemm_batched(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int batch_size, const int M, const int N, const int K, const double alpha,
+  const double** A, const double** B, const double beta, double** C) {
+  const int lda = (trans_A == CblasNoTrans) ? K : M;
+  const int ldb = (trans_B == CblasNoTrans) ? N : K;
+  const int ldc = N;
+
+  cblas_dgemm_batch(CblasRowMajor, &trans_A, &trans_B, &M, &N, &K, &alpha,
+    A, &lda, B, &ldb, &beta, C, &ldc, 1, &batch_size);
+}
+
+template <typename scalar_t>
+static inline void _bmm_mkl(Tensor& res, const Tensor& mat1, const Tensor& mat2) {
+  auto is_transposed = [&](const Tensor& t) {
+    return t.stride(0) == 1 && t.stride(1) == t.size(0);
+  };
+  const CBLAS_TRANSPOSE trans_A = is_transposed(mat1[0]) ? CblasTrans : CblasNoTrans;
+  const CBLAS_TRANSPOSE trans_B = is_transposed(mat2[0]) ? CblasTrans : CblasNoTrans;
+
+  const int batch_size = mat1.size(0);
+  const int M = mat1.size(1);
+  const int N = mat2.size(2);
+  const int K = mat1.size(2);
+  scalar_t alpha = static_cast<scalar_t>(1.0);
+  scalar_t beta = static_cast<scalar_t>(0.0);
+
+  std::vector<const scalar_t*> A(batch_size);
+  std::vector<const scalar_t*> B(batch_size);
+  std::vector<scalar_t*> C(batch_size);
+  for (int64_t batch = 0; batch < batch_size; batch++) {
+    A[batch] = mat1[batch].data<scalar_t>();
+    B[batch] = mat2[batch].data<scalar_t>();
+    C[batch] = res[batch].data<scalar_t>();
+  }
+
+  gemm_batched(trans_A, trans_B, batch_size, M, N, K, alpha, A.data(), B.data(), beta, C.data());
+}
+
+// MKL BMM
+Tensor bmm_mkl(const Tensor& self, const Tensor& tensor) {
+  AT_CHECK(self.dim() == 3, "expected 3D tensor, got ", self.dim(), "D");
+  AT_CHECK(tensor.dim() == 3, "expected 3D tensor, got ", tensor.dim(), "D");
+  AT_CHECK(self.size(0) == tensor.size(0),
+          "equal number of batches expected, got ", self.size(0), ", ", tensor.size(0));
+  AT_CHECK(self.size(2) == tensor.size(1),
+          "wrong matrix size, batch1: ", self.size(1), "x", self.size(2),
+          ", batch2 ", tensor.size(1), "x", tensor.size(2));
+
+  std::vector<int64_t> output_sz{self.size(0), self.size(1), tensor.size(2)};
+  auto result = self.type().tensor(output_sz);
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "bmm_mkl", [&] {
+    _bmm_mkl<scalar_t>(result, self, tensor);
+  });
+
+  return result;
+}
+
+}} // namespace at::native
+
+#endif

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -281,6 +281,14 @@
 - func: blackman_window(int64_t window_length, bool periodic, TensorOptions options={}) -> Tensor
   variants: function
 
+- func: bmm(Tensor self, Tensor mat2) -> Tensor
+
+- func: bmm_out(Tensor result, Tensor self, Tensor mat2) -> Tensor
+  variants: function
+
+- func: bmm_mkl(Tensor self, Tensor mat2) -> Tensor
+  variants: function
+
 - func: broadcast_tensors(TensorList tensors) -> TensorList
   variants: function
 


### PR DESCRIPTION
This PR uses mkl batched gemm for `torch.bmm` when mkl is available. The current [logic ](https://github.com/pytorch/pytorch/blob/master/aten/src/TH/generic/THTensorMoreMath.cpp#L7)dealing with `torch.bmm` is to do `batch_size` iterations of gemm. From the performance point of view, this should be OK in case the gemm size is large enough. However, in many cases, the gemm size is relatively small and not efficient.

One scenario it [globalAttention](https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/modules/global_attention.py#L194) calculation of NMT, where
`mat1`: N * 1 * T
`mat2`: N * T * H
N refers to batch size, T refers to timestep and H is the hidden size.
there the gemm size is relatively small, MKL has batched gemm APIs which is beneficial in case dealing with batched small gemms.

The following script is used for benchmarking and testing the PR. On Xeon skylake 8180 (2 sockets * 28 cores), it runs `0.81ms` without the PR and `0.45ms` with the PR.
```python
import torch
from time import time
import os

N = 128
T = 30
H = 500
count = 1000

def bench_bmm():
    mat1 = torch.randn(N, 1, T)
    mat2 = torch.randn(N, T, H)

    tstart = time()
    for i in range(count):
        res = torch.bmm(mat1, mat2)
    tend = time()
    t = (tend-tstart)/count*1000
    flops = N*1*T*H*2 / t / 1000000
    print("run torch.bmm:")
    print("total time     : %.2f s" % (tend-tstart))
    print("each iteration : %.2f ms %.2f GFlops" % (t, flops))

def test_bmm(trans_A=False, trans_B=False):
    I = 10
    print("testing torch.bmm mat1: %s, mat2 %s" % ("T" if trans_A else "N", "T" if trans_B else "N"))
    mat1 = torch.randn(N, T, I).transpose(1, 2) if trans_A else torch.randn(N, I, T)
    mat2 = torch.randn(N, H, T).transpose(1, 2) if trans_B else torch.randn(N, T, H)
    mat1_ = mat1.clone()
    mat2_ = mat2.clone()

    res = torch.bmm(mat1, mat2)
    res_ = torch.Tensor(N, I, H)
    for i in range(N):
        res_[i] = mat1_[i].matmul(mat2_[i])

    for ii in range(N):
        for jj in range(I):
            for kk in range(H):
                val1 = res[ii][jj][kk]
                val2 = res_[ii][jj][kk]
                if abs(val1-val2) < 1e-5:
                    continue
                else:
                    print(res[ii][jj][kk], res_[ii][jj][kk], "not equal, case FAIL")
                    return

    print("PASS")

bench_bmm()
test_bmm(trans_A=False, trans_B=False)
test_bmm(trans_A=True, trans_B=False)
test_bmm(trans_A=False, trans_B=True)
test_bmm(trans_A=True, trans_B=True)
```