### PR TITLE
fix #10838 incorrect bidirectional output format

### DIFF
--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -518,7 +518,7 @@ class Caffe2Backend(Backend):
                 pred_mh.net.VariableLengthSequencePadding(
                     [concatted_output, sequence_lens], [concatted_output])
             reshaped_output, _ = pred_mh.net.Reshape(concatted_output, [cls.dummy_name(), cls.dummy_name()], shape=[0,0,-1,2])
-            pred_mh.net.Transpose(reshaped_output, n.outputs[0], axes=[0,3,1,2])
+            pred_mh.net.Transpose(reshaped_output, n.outputs[0], axes=[0,2,1,3])
             for i in range(1, len(n.outputs)):
                 pred_mh.net.Concat([outputs_f[i], outputs_b[i]],
                                    [n.outputs[i], cls.dummy_name()], axis=0)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1097,11 +1097,11 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             # The ONNX RNN/GRU/LSTM produce an output of dimensions
             #   seq_len, num_directions, batch, hidden_size
             # We have to convert to match pytorch's expected
-            #   seq_len, batch, hidden_size * num_directions
+            #   seq_len, batch, num_directions * hidden_size
             # by first moving num_directions to the end with
             # Transpose, and then combining it with hidden_size
             # with Reshape.
-            prev_output = g.op('Transpose', prev_output, perm_i=[0, 2, 3, 1])
+            prev_output = g.op('Transpose', prev_output, perm_i=[0, 2, 1, 3])
             prev_output = g.op('Reshape', prev_output, g.op('Constant', value_t=torch.LongTensor([0, 0, -1])))
         else:
             prev_output = g.op('Squeeze', prev_output, axes_i=[1])

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1098,7 +1098,7 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             #   seq_len, num_directions, batch, hidden_size
             # We have to convert to match pytorch's expected
             #   seq_len, batch, num_directions * hidden_size
-            # by first moving num_directions to the end with
+            # by first moving num_directions before hidden_size with
             # Transpose, and then combining it with hidden_size
             # with Reshape.
             prev_output = g.op('Transpose', prev_output, perm_i=[0, 2, 1, 3])


### PR DESCRIPTION
Fixes the issue discussed in #10838. `hidden_size` should be the last dimension regardless if we're in ONNX or PyTorch.