### PR TITLE
Conversions to and from complex numbers.

### DIFF
--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -86,13 +86,13 @@ struct alignas(4) ComplexHalf {
 };
 
 template <typename T>
-struct is_complex : public std::false_type {};
+struct is_complex_t : public std::false_type {};
 
 template <typename T>
-struct is_complex<std::complex<T>> : public std::true_type {};
+struct is_complex_t<std::complex<T>> : public std::true_type {};
 
 template <>
-struct is_complex<ComplexHalf> : public std::true_type {};
+struct is_complex_t<ComplexHalf> : public std::true_type {};
 
 // Extract double from std::complex<double>; is identity otherwise
 // TODO: Write in more idiomatic C++17
@@ -101,12 +101,12 @@ template <typename T> struct scalar_value_type<std::complex<T>> { typedef T type
 template <>           struct scalar_value_type<ComplexHalf>     { typedef Half type; };
 
 template <typename To, typename From>
-typename std::enable_if<c10::guts::negation<c10::guts::conjunction<is_complex<From>, c10::guts::negation<is_complex<To>>>>::value, To>::type convert(From f) {
+typename std::enable_if<c10::guts::negation<c10::guts::conjunction<is_complex_t<From>, c10::guts::negation<is_complex_t<To>>>>::value, To>::type convert(From f) {
   return static_cast<To>(f);
 }
 
 template <typename To, typename From>
-typename std::enable_if<c10::guts::conjunction<is_complex<From>, c10::guts::negation<is_complex<To>>>::value, To>::type convert(From f) {
+typename std::enable_if<c10::guts::conjunction<is_complex_t<From>, c10::guts::negation<is_complex_t<To>>>::value, To>::type convert(From f) {
   return static_cast<To>(f.real());
 }
 
@@ -140,16 +140,16 @@ typename std::enable_if<std::is_floating_point<From>::value, bool>::type overflo
 
 
 template <typename To, typename From>
-typename std::enable_if<is_complex<From>::value, bool>::type overflows(
+typename std::enable_if<is_complex_t<From>::value, bool>::type overflows(
     From f) {
   // casts from complex to real are considered to overflow if the
   // imaginary component is non-zero
-  if (!is_complex<To>::value && f.imag() != 0) {
+  if (!is_complex_t<To>::value && f.imag() != 0) {
     return true;
   }
   // Check for overflow componentwise
   // (Technically, the imag overflow check is guaranteed to be false
-  // when !is_complex<To>, but any optimizer worth its salt will be
+  // when !is_complex_t<To>, but any optimizer worth its salt will be
   // able to figure it out.)
   return overflows<typename scalar_value_type<To>::type, typename From::value_type>(f.real()) ||
          overflows<typename scalar_value_type<To>::type, typename From::value_type>(f.imag());

--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -101,12 +101,22 @@ template <typename T> struct scalar_value_type<std::complex<T>> { typedef T type
 template <>           struct scalar_value_type<ComplexHalf>     { typedef Half type; };
 
 template <typename To, typename From>
-typename std::enable_if<c10::guts::negation<c10::guts::conjunction<is_complex_t<From>, c10::guts::negation<is_complex_t<To>>>>::value, To>::type convert(From f) {
+typename std::enable_if<
+  c10::guts::negation<
+    c10::guts::conjunction<
+      is_complex_t<From>,
+      c10::guts::negation<is_complex_t<To>>
+    >
+  >::value, To>::type convert(From f) {
   return static_cast<To>(f);
 }
 
 template <typename To, typename From>
-typename std::enable_if<c10::guts::conjunction<is_complex_t<From>, c10::guts::negation<is_complex_t<To>>>::value, To>::type convert(From f) {
+typename std::enable_if<
+  c10::guts::conjunction<
+    is_complex_t<From>,
+    c10::guts::negation<is_complex_t<To>>
+  >::value, To>::type convert(From f) {
   return static_cast<To>(f.real());
 }
 

--- a/aten/src/ATen/core/Scalar.cpp
+++ b/aten/src/ATen/core/Scalar.cpp
@@ -3,11 +3,13 @@
 namespace at {
 
 Scalar Scalar::operator-() const {
- if (isFloatingPoint()) {
-   return Scalar(-v.d);
- } else {
-   return Scalar(-v.i);
- }
+  if (isFloatingPoint()) {
+    return Scalar(-v.d);
+  } else if (isComplex()) {
+    return Scalar(std::complex<double>(-v.z[0], -v.z[1]));
+  } else {
+    return Scalar(-v.i);
+  }
 }
 
 }  // namespace at

--- a/aten/src/ATen/core/Scalar.h
+++ b/aten/src/ATen/core/Scalar.h
@@ -20,7 +20,11 @@ public:
 
 #define DEFINE_IMPLICIT_CTOR(type,name,member) \
   Scalar(type vv) \
-  : tag(Tag::HAS_##member), v{ .member = convert<decltype(v.member),type>(vv) } {}
+  : tag(Tag::HAS_##member) { \
+    v . member = convert<decltype(v.member),type>(vv); \
+  }
+  // We can't set v in the initializer list using the
+  // syntax v{ .member = ... } because it doesn't work on MSVC
 
   AT_FORALL_SCALAR_TYPES(DEFINE_IMPLICIT_CTOR)
 

--- a/aten/src/ATen/core/Scalar.h
+++ b/aten/src/ATen/core/Scalar.h
@@ -32,7 +32,10 @@ public:
 
 #define DEFINE_IMPLICIT_CTOR(type,name,member) \
   Scalar(type vv) \
-  : tag(Tag::HAS_##member), v{ .member = { convert<double>(vv.real()), convert<double>(vv.imag()) } } {}
+  : tag(Tag::HAS_##member) { \
+    v . member[0] = convert<double>(vv.real()); \
+    v . member[1] = convert<double>(vv.imag()); \
+  }
 
   DEFINE_IMPLICIT_CTOR(at::ComplexHalf,ComplexHalf,z)
   DEFINE_IMPLICIT_CTOR(std::complex<float>,ComplexFloat,z)

--- a/aten/src/ATen/core/ScalarType.h
+++ b/aten/src/ATen/core/ScalarType.h
@@ -25,6 +25,21 @@ _(at::ComplexHalf,ComplexHalf,z)        /* 8 */ \
 _(std::complex<float>,ComplexFloat,z)   /* 9 */ \
 _(std::complex<double>,ComplexDouble,z) /* 10 */
 
+// If you want to support ComplexHalf for real, replace occurrences
+// of this macro with AT_FORALL_SCALAR_TYPES_WITH_COMPLEX.  But
+// beware: convert() doesn't work for all the conversions you need...
+#define AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(_) \
+_(uint8_t,Byte,i)  \
+_(int8_t,Char,i)   \
+_(int16_t,Short,i) \
+_(int,Int,i)       \
+_(int64_t,Long,i)  \
+_(at::Half,Half,d) \
+_(float,Float,d)   \
+_(double,Double,d) \
+_(std::complex<float>,ComplexFloat,z) \
+_(std::complex<double>,ComplexDouble,z)
+
 #define AT_FORALL_SCALAR_TYPES(_) \
 _(uint8_t,Byte,i)  \
 _(int8_t,Char,i)   \

--- a/aten/src/ATen/cuda/CUDAHalf.cu
+++ b/aten/src/ATen/cuda/CUDAHalf.cu
@@ -8,35 +8,35 @@
 namespace at {
 #if CUDA_VERSION < 9000 && !defined(__HIP_PLATFORM_HCC__)
 template <> AT_CUDA_API
-half convert(Half aten_half) {
+half convert<half, Half>(Half aten_half) {
   return half{aten_half.x};
 }
 
 template <> AT_CUDA_API
-half convert(double value) {
+half convert<half, double>(double value) {
   return half{Half(value).x};
 }
 
 template <> AT_CUDA_API
-Half convert(half cuda_half) {
+Half convert<Half, half>(half cuda_half) {
   return Half(cuda_half.x, Half::from_bits);
 }
 #else
 template <> AT_CUDA_API
-half convert(Half aten_half) {
+half convert<half, Half>(Half aten_half) {
   __half_raw x_raw;
   x_raw.x = aten_half.x;
   return half(x_raw);
 }
 
 template <> AT_CUDA_API
-Half convert(half cuda_half) {
+Half convert<Half, half>(half cuda_half) {
   __half_raw raw(cuda_half);
   return Half(raw.x, Half::from_bits);
 }
 
 template <> AT_CUDA_API
-half convert(double value) {
+half convert<half, double>(double value) {
   __half_raw raw;
   raw.x = Half(value).x;
   return half {raw};

--- a/aten/src/ATen/cuda/CUDAHalf.cuh
+++ b/aten/src/ATen/cuda/CUDAHalf.cuh
@@ -8,9 +8,9 @@
 #include <cuda_fp16.h>
 
 namespace at {
-template <> AT_CUDA_API half convert(Half aten_half);
-template <> AT_CUDA_API Half convert(half cuda_half);
-template <> AT_CUDA_API half convert(double value);
+template <> AT_CUDA_API half convert<half, Half>(Half aten_half);
+template <> AT_CUDA_API Half convert<Half, half>(half cuda_half);
+template <> AT_CUDA_API half convert<half, double>(double value);
 #if CUDA_VERSION >= 9000 || defined(__HIP_PLATFORM_HCC__)
 template <> __half HalfFix(Half h);
 template <> Half HalfFix(__half h);

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -13,6 +13,10 @@ bool is_distributed(const Tensor& self) {
   return self.type().is_distributed();
 }
 
+bool is_complex(const Tensor& self) {
+  return at::isComplexType(self.type().scalarType());
+}
+
 bool is_floating_point(const Tensor& self) {
   return at::isFloatingType(self.type().scalarType());
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -908,6 +908,9 @@
 - func: is_floating_point(Tensor self) -> bool
   device_guard: false
 
+- func: is_complex(Tensor self) -> bool
+  device_guard: false
+
 - func: is_nonzero(Tensor self) -> bool
   device_guard: false
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -194,12 +194,12 @@ struct AT_API Tensor {
   //toLongData(), toFloatData() etc.
   #define TO_TYPE_DATA(T,name,_) \
   T * to##name##Data() const;
-  AT_FORALL_SCALAR_TYPES(TO_TYPE_DATA)
+  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_TYPE_DATA)
   #undef TO_TYPE_DATA
 
   #define TO_C_TYPE(T,name,_) \
   T toC##name () const;
-  AT_FORALL_SCALAR_TYPES(TO_C_TYPE)
+  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_C_TYPE)
   #undef TO_C_TYPE
 
   template<typename T, size_t N>

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -101,13 +101,13 @@ ${tensor_method_definitions}
     return data<T>();                            \
   }
 
-AT_FORALL_SCALAR_TYPES(DEFINE_CAST)
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)
 #undef DEFINE_CAST
 
 #define DEFINE_TO_C_TYPE(T,name,_) \
 inline T Tensor::toC##name () const { return _local_scalar().to##name (); }
 
-AT_FORALL_SCALAR_TYPES(DEFINE_TO_C_TYPE)
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO_C_TYPE)
 #undef DEFINE_TO_C_TYPE
 
 } //namespace at

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -189,6 +189,7 @@ class TestTorch(TestCase):
                        'is_coalesced',
                        'is_distributed',
                        'is_floating_point',
+                       'is_complex',
                        'is_nonzero',
                        'is_same_size',
                        'is_signed',

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -159,6 +159,15 @@ static double dispatch_to_CDouble(const Tensor & self) {
   return self.toCDouble();
 }
 
+static std::complex<double> dispatch_to_CComplexDouble(const Tensor & self) {
+  AutoNoGIL no_gil;
+  DeviceGuard device_guard(self);
+  if (self.numel() != 1) {
+    throw ValueError("only one element tensors can be converted to Python scalars");
+  }
+  return self.toCComplexDouble();
+}
+
 static int64_t dispatch_to_CLong(const Tensor & self) {
   AutoNoGIL no_gil;
   DeviceGuard device_guard(self);
@@ -365,6 +374,8 @@ static PyObject * THPVariable_item(PyObject* self, PyObject* args)
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   if (self_.is_floating_point()) {
     return wrap(dispatch_to_CDouble(self_));
+  } else if (self_.is_complex()) {
+    return wrap(dispatch_to_CComplexDouble(self_));
   } else {
     return wrap(dispatch_to_CLong(self_));
   }

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -84,7 +84,7 @@ inline PyObject* wrap(double value) {
 inline PyObject* wrap(std::complex<double> value) {
   // I could probably also use FromComplex with a reinterpret cast,
   // but... eh.
-  return PyComplex_FromDoubles(value.real(), value.complex());
+  return PyComplex_FromDoubles(value.real(), value.imag());
 }
 
 inline PyObject* wrap(void* value) {

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -81,6 +81,12 @@ inline PyObject* wrap(double value) {
   return PyFloat_FromDouble(value);
 }
 
+inline PyObject* wrap(std::complex<double> value) {
+  // I could probably also use FromComplex with a reinterpret cast,
+  // but... eh.
+  return PyComplex_FromDoubles(value.real(), value.complex());
+}
+
 inline PyObject* wrap(void* value) {
   return THPUtils_packInt64(reinterpret_cast<intptr_t>(value));
 }


### PR DESCRIPTION
Surprisingly tricky!  Here are the major pieces:

- We grow a even yet more ludicrous macro
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF
  which does what it says on the tin.  This is because I was
  too lazy to figure out how to define the necessary conversions
  in and out of ComplexHalf without triggering ambiguity problems.
  It doesn't seem to be as simple as just Half.  Leave it for
  when someone actually wants this.

- Scalar now can hold std::complex<double>.  Internally, it is
  stored as double[2] because nvcc chokes on a non-POD type
  inside a union.

- overflow() checking is generalized to work with complex.
  When converting *to* std::complex<T>, all we need to do is check
  for overflow against T.  When converting *from* complex, we
  must check (1) if To is not complex, that imag() == 0
  and (2) for overflow componentwise.

- convert() is generalized to work with complex<->real conversions.
  Complex to real drops the imaginary component; we rely on
  overflow checking to tell if this actually loses fidelity.

- Complex scalars convert into Python complex numbers

- This probably fixes complex tensor printing, but there is no way
  to test this right now.

TODO: This somehow breaks the CUDA build.  Needs further investigating.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @Roger-luo
