### PR TITLE
Do not use PERSISTENT cudnn mode for spatialBN

### DIFF
--- a/caffe2/operators/spatial_batch_norm_op_cudnn.cu
+++ b/caffe2/operators/spatial_batch_norm_op_cudnn.cu
@@ -64,7 +64,12 @@ class CuDNNSpatialBNOp final : public SpatialBNOp<CUDAContext> {
       : SpatialBNOp<CUDAContext>(operator_def, ws),
         cudnn_wrapper_(&context_),
 #if CUDNN_VERSION_MIN(7, 0, 0)
-        mode_(CUDNN_BATCHNORM_SPATIAL_PERSISTENT) {
+        // TODO(T31829456): The new CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode was
+        // introduced in CuDNN 7 for performance optimization, but it results in
+        // accuracy losses in convolution models such as ResNeXt-101 and
+        // video R(2+1)D. We will fall back to the normal
+        // CUDNN_BATCHNORM_SPATIAL for now
+        mode_(CUDNN_BATCHNORM_SPATIAL) {
 #else
         mode_(CUDNN_BATCHNORM_SPATIAL) {
 #endif
@@ -225,7 +230,12 @@ class CuDNNSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
       : SpatialBNGradientOp<CUDAContext>(operator_def, ws),
         cudnn_wrapper_(&context_),
 #if CUDNN_VERSION_MIN(7, 0, 0)
-        mode_(CUDNN_BATCHNORM_SPATIAL_PERSISTENT) {
+        // TODO(T31829456): The new CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode was
+        // introduced in CuDNN 7 for performance optimization, but it results in
+        // accuracy losses in convolution models such as ResNeXt-101 and
+        // video R(2+1)D. We will fall back to the normal
+        // CUDNN_BATCHNORM_SPATIAL for now
+        mode_(CUDNN_BATCHNORM_SPATIAL) {
 #else
         mode_(CUDNN_BATCHNORM_SPATIAL) {
 #endif


### PR DESCRIPTION
Summary: We found this cudnn bug in S163230 that causes accuracy loss. We fix this in D9601217, but due to the reimplementation of spatialBN it's overwritten. Let's land this fix again.

Differential Revision: D9702347
