### PR TITLE
Assert that dtype does not change with ShareExternalPointer

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -524,6 +524,10 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
         data_type.id() != TypeIdentifier::uninitialized(),
         "To share with a raw external pointer you need to pass in an "
         "initialized data_type(TypeMeta).");
+    CAFFE_ENFORCE_WITH_CALLER(
+        data_type == storage_.dtype(),
+        "ShareExternalPointer is not permitted to change the dtype of "
+        "a tensor.");
     if (!capacity) {
       capacity = numel_ * data_type.itemsize();
     }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11400 Assert that dtype does not change with ShareExternalPointer**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9727532/)

This doesn't cause anything "bad", but we'd like to make sure
we don't start violating this invariant, as it will make it
harder to write core code.

Differential Revision: [D9727532](https://our.internmc.facebook.com/intern/diff/D9727532/)