### PR TITLE
Constexpr std::move / std::forward for C++11

### DIFF
--- a/aten/src/ATen/core/C++17.h
+++ b/aten/src/ATen/core/C++17.h
@@ -23,7 +23,7 @@ namespace c10 { namespace guts {
 template <typename T, typename... Args>
 typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
 make_unique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  return std::unique_ptr<T>(new T(forward<Args>(args)...));
 }
 // Allows 'make_unique<T[]>(10)'. (N3690 s20.9.1.4 p3-4)
 template <typename T>
@@ -37,6 +37,7 @@ typename std::enable_if<std::extent<T>::value != 0, std::unique_ptr<T>>::type
 make_unique(Args&&...) = delete;
 
 #endif
+
 
 
 #ifdef __cpp_lib_integer_sequence
@@ -148,12 +149,29 @@ template<typename... Ts> using void_t = typename make_void<Ts...>::type;
 #endif
 
 
+// C++11 doesn't have constexpr std::move / std::forward.
+// Implementation taken from libc++.
+template<class T>
+constexpr inline guts::remove_reference_t<T>&& move(T&& t) noexcept {
+  return static_cast<guts::remove_reference_t<T>&&>(t);
+}
+template <class T>
+constexpr inline T&& forward(guts::remove_reference_t<T>& t) noexcept {
+    return static_cast<T&&>(t);
+}
+template <class T>
+constexpr inline T&& forward(guts::remove_reference_t<T>&& t) noexcept {
+    static_assert(!std::is_lvalue_reference<T>::value,
+                  "can not forward an rvalue as an lvalue.");
+    return static_cast<T&&>(t);
+}
+
 
 #ifdef __cpp_lib_apply
 
 template <class F, class Tuple>
 inline constexpr decltype(auto) apply(F&& f, Tuple&& t) {
-  return std::apply(std::forward<F>(f), std::forward<Tuple>(t));
+  return std::apply(forward<F>(f), forward<Tuple>(t));
 }
 
 #else
@@ -162,19 +180,19 @@ inline constexpr decltype(auto) apply(F&& f, Tuple&& t) {
 // TODO This is an incomplete implementation of std::apply, not working for member functions.
 namespace detail {
 template <class F, class Tuple, std::size_t... I>
-constexpr auto apply_impl(F&& f, Tuple&& t, guts::index_sequence<I...>) -> decltype(std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...))
+constexpr auto apply_impl(F&& f, Tuple&& t, guts::index_sequence<I...>) -> decltype(forward<F>(f)(std::get<I>(forward<Tuple>(t))...))
 {
-    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+    return forward<F>(f)(std::get<I>(forward<Tuple>(t))...);
 }
 }  // namespace detail
 
 template <class F, class Tuple>
 constexpr auto apply(F&& f, Tuple&& t) -> decltype(detail::apply_impl(
-    std::forward<F>(f), std::forward<Tuple>(t),
+    forward<F>(f), forward<Tuple>(t),
     guts::make_index_sequence<std::tuple_size<guts::remove_reference_t<Tuple>>::value>{}))
 {
     return detail::apply_impl(
-        std::forward<F>(f), std::forward<Tuple>(t),
+        forward<F>(f), forward<Tuple>(t),
         guts::make_index_sequence<std::tuple_size<guts::remove_reference_t<Tuple>>::value>{});
 }
 

--- a/caffe2/utils/Array.h
+++ b/caffe2/utils/Array.h
@@ -259,7 +259,7 @@ template<std::size_t _Int, typename _Tp, std::size_t _Nm>
 constexpr _Tp&& get(array<_Tp, _Nm>&& __arr) noexcept
 {
   static_assert(_Int < _Nm, "array index is within bounds");
-  return std::move(get<_Int>(__arr));
+  return guts::move(get<_Int>(__arr));
 }
 
 template<std::size_t _Int, typename _Tp, std::size_t _Nm>
@@ -292,12 +292,12 @@ constexpr inline array<T, N-1> tail(const array<T, N>& arg) {
 namespace detail {
 template<class T, size_t N, size_t... I>
 constexpr inline array<T, N+1> prepend_(T&& head, const array<T, N>& tail, guts::index_sequence<I...>) {
-  return {{std::forward<T>(head), get<I>(tail)...}};
+  return {{guts::forward<T>(head), get<I>(tail)...}};
 }
 }
 template<class T, size_t N>
 constexpr inline array<T, N+1> prepend(T&& head, const array<T, N>& tail) {
-  return detail::prepend_(std::forward<T>(head), tail, guts::make_index_sequence<N>());
+  return detail::prepend_(guts::forward<T>(head), tail, guts::make_index_sequence<N>());
 }
 
 /**

--- a/caffe2/utils/Array_test.cpp
+++ b/caffe2/utils/Array_test.cpp
@@ -78,11 +78,9 @@ namespace test_tail {
     static_assert(array < int, 0 > {{}} == tail(array < int, 1 > {{3}}), "");
 }
 
-TEST(ArrayTest, TestPrepend) {
-  // Some compilers can't handle move results as constexpr, so use
-  // gtest assert for this test
-  ASSERT_EQ((array<int, 3> {{2, 3, 4}}), (prepend(2, array<int, 2> {{3, 4}})));
-  ASSERT_EQ((array<int, 1> {{3}}), (prepend(3, array<int, 0> {{}})));
+namespace test_prepend {
+    static_assert(array < int, 3 > {{2, 3, 4}} == prepend(2, array < int, 2 > {{3, 4}}), "");
+    static_assert(array < int, 1 > {{3}} == prepend(3, array < int, 0 > {{}}), "");
 }
 
 namespace test_to_std_array {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11407 Constexpr std::move / std::forward for C++11**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9724805/)

std::move and std::forward in C++11 aren't constexpr (they are in C++14).
This caused a build issue @orionr was working on.
It should be fixed by this diff

Differential Revision: [D9724805](https://our.internmc.facebook.com/intern/diff/D9724805/)