### PR TITLE
[c10d] bumping up the default store timeout

### DIFF
--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -11,7 +11,7 @@ namespace c10d {
 class Store {
  public:
   static constexpr std::chrono::milliseconds kDefaultTimeout =
-      std::chrono::seconds(30);
+      std::chrono::seconds(300);
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 


### PR DESCRIPTION
to 300 seconds to be safe. It used to be no timeout in THD