### PR TITLE
Optimize LengthsTileOp on GPU to run a kernel instead of a sequence of memcopies

### DIFF
--- a/caffe2/operators/lengths_tile_op.cc
+++ b/caffe2/operators/lengths_tile_op.cc
@@ -1,6 +1,50 @@
 #include "caffe2/operators/lengths_tile_op.h"
 
 namespace caffe2 {
+
+template <>
+bool LengthsTileOp<CPUContext>::RunOnDevice() {
+  auto& data = Input(DATA);
+  auto& lengths = Input(LENGTHS);
+  auto* output = Output(0);
+
+  CAFFE_ENFORCE_EQ(lengths.ndim(), 1, "LENGTHS must be 1-D");
+  CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+  CAFFE_ENFORCE_EQ(lengths.size(), data.dim(0));
+
+  // Context::CopyFrom and math::Sum need the same context to avoid race
+  // conditions
+  // why? CPUContext is not used in Sum
+  lengths_host_.CopyFrom(lengths, &context_);
+  context_.FinishDeviceComputation();
+  auto lengths_size = lengths_host_.size();
+  auto* lengths_data = lengths_host_.data<int32_t>();
+
+  int32_t total_length = 0;
+  CPUContext cpuContext;
+  math::Sum<int32_t, CPUContext>(
+      lengths_size, lengths_data, &total_length, &cpuContext);
+
+  auto shape = data.dims();
+  shape[0] = total_length;
+  output->Resize(shape);
+
+  auto block_bytesize = data.size_from_dim(1) * data.meta().itemsize();
+  auto src = static_cast<const char*>(data.raw_data());
+  auto out = static_cast<char*>(output->raw_mutable_data(data.meta()));
+
+  for (TIndex i = 0; i < lengths_size; ++i) {
+    auto length = lengths_data[i];
+    CAFFE_ENFORCE_GE(length, 0);
+    for (int32_t j = 0; j < length; ++j) {
+      context_.CopyBytesSameDevice(block_bytesize, src, out);
+      out += block_bytesize;
+    }
+    src += block_bytesize;
+  }
+  return true;
+}
+
 REGISTER_CPU_OPERATOR(LengthsTile, LengthsTileOp<CPUContext>);
 
 OPERATOR_SCHEMA(LengthsTile)

--- a/caffe2/operators/lengths_tile_op.cu
+++ b/caffe2/operators/lengths_tile_op.cu
@@ -1,0 +1,110 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/lengths_tile_op.h"
+
+namespace caffe2 {
+
+template <typename T>
+__global__ void lengthsTileKernel(
+    int numElements,
+    int rowSize,
+    const T* input,
+    T* output,
+    const int32_t* inputRowOffsets) {
+  CUDA_1D_KERNEL_LOOP(i, numElements) {
+    auto outputRowIndex = i / rowSize;
+    auto inputBlockOffset = inputRowOffsets[outputRowIndex];
+    auto indexInRow = i - outputRowIndex * rowSize;
+    output[i] = input[inputBlockOffset + indexInRow];
+  }
+}
+
+template <>
+bool LengthsTileOp<CUDAContext>::RunOnDevice() {
+  auto& data = Input(DATA);
+  auto& lengths = Input(LENGTHS);
+  auto* output = Output(0);
+
+  CAFFE_ENFORCE_EQ(lengths.ndim(), 1, "LENGTHS must be 1-D");
+  CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+  CAFFE_ENFORCE_EQ(lengths.size(), data.dim(0));
+
+  lengths_host_.CopyFrom(lengths, &context_);
+  context_.FinishDeviceComputation();
+  auto lengths_size = lengths_host_.size();
+  auto* lengths_data = lengths_host_.data<int32_t>();
+
+  int32_t total_length = 0;
+  CPUContext cpuContext;
+  math::Sum<int32_t, CPUContext>(
+      lengths_size, lengths_data, &total_length, &cpuContext);
+
+  auto shape = data.dims();
+  shape[0] = total_length;
+  output->Resize(shape);
+
+  auto numElementsPerRow = data.size_from_dim(1);
+  auto numElements = total_length * numElementsPerRow;
+  auto numBlocks = CAFFE_GET_BLOCKS(numElements);
+
+  rowMappingHost_.Resize(total_length);
+  rowMappingDevice_.Resize(total_length);
+  auto* rowOffsets = rowMappingHost_.mutable_data<int32_t>();
+  int32_t outputRow = 0;
+  for (TIndex i = 0; i < lengths_size; i++) {
+    auto length = lengths_data[i];
+    for (int32_t j = 0; j < length; j++) {
+      rowOffsets[outputRow++] = i * numElementsPerRow;
+    }
+  }
+
+  context_.CopyFromCPU<int32_t>(
+      total_length,
+      rowMappingHost_.data<int32_t>(),
+      rowMappingDevice_.mutable_data<int32_t>());
+  context_.FinishDeviceComputation();
+
+  if (data.template IsType<float>()) {
+    lengthsTileKernel<<<
+        numBlocks,
+        CAFFE_CUDA_NUM_THREADS,
+        0,
+        context_.cuda_stream()>>>(
+        numElements,
+        numElementsPerRow,
+        data.data<float>(),
+        output->mutable_data<float>(),
+        rowMappingDevice_.data<int32_t>());
+  } else if (data.template IsType<int>()) {
+    lengthsTileKernel<<<
+        numBlocks,
+        CAFFE_CUDA_NUM_THREADS,
+        0,
+        context_.cuda_stream()>>>(
+        numElements,
+        numElementsPerRow,
+        data.data<int>(),
+        output->mutable_data<int>(),
+        rowMappingDevice_.data<int32_t>());
+  } else if (data.template IsType<int64_t>()) {
+    lengthsTileKernel<<<
+        numBlocks,
+        CAFFE_CUDA_NUM_THREADS,
+        0,
+        context_.cuda_stream()>>>(
+        numElements,
+        numElementsPerRow,
+        data.data<int64_t>(),
+        output->mutable_data<int64_t>(),
+        rowMappingDevice_.data<int32_t>());
+  } else {
+    CAFFE_THROW(
+        "LengthsTile operator only supports 32-bit float, int and int64_t"
+        " types but input was of type ",
+        data.meta().name());
+  }
+  return true;
+}
+
+REGISTER_CUDA_OPERATOR(LengthsTile, LengthsTileOp<CUDAContext>);
+
+} // namespace caffe2

--- a/caffe2/operators/lengths_tile_op.h
+++ b/caffe2/operators/lengths_tile_op.h
@@ -13,44 +13,6 @@ class LengthsTileOp : public Operator<Context> {
   USE_SIMPLE_CTOR_DTOR(LengthsTileOp);
 
   bool RunOnDevice() override {
-    auto& data = Input(DATA);
-    auto& lengths = Input(LENGTHS);
-    auto* output = Output(0);
-
-    CAFFE_ENFORCE_EQ(lengths.ndim(), 1, "LENGTHS must be 1-D");
-    CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
-    CAFFE_ENFORCE_EQ(lengths.size(), data.dim(0));
-
-    // Context::CopyFrom and math::Sum need the same context to avoid race
-    // conditions
-    // why? CPUContext is not used in Sum
-    lengths_host_.CopyFrom(lengths, &context_);
-    context_.FinishDeviceComputation();
-    auto lengths_size = lengths_host_.size();
-    auto* lengths_data = lengths_host_.data<int32_t>();
-
-    int32_t total_length = 0;
-    CPUContext cpuContext;
-    math::Sum<int32_t, CPUContext>(
-        lengths_size, lengths_data, &total_length, &cpuContext);
-
-    auto shape = data.dims();
-    shape[0] = total_length;
-    output->Resize(shape);
-
-    auto block_bytesize = data.size_from_dim(1) * data.meta().itemsize();
-    auto src = static_cast<const char*>(data.raw_data());
-    auto out = static_cast<char*>(output->raw_mutable_data(data.meta()));
-
-    for (TIndex i = 0; i < lengths_size; ++i) {
-      auto length = lengths_data[i];
-      CAFFE_ENFORCE_GE(length, 0);
-      for (int32_t j = 0; j < length; ++j) {
-        context_.CopyBytesSameDevice(block_bytesize, src, out);
-        out += block_bytesize;
-      }
-      src += block_bytesize;
-    }
     return true;
   }
 
@@ -58,6 +20,8 @@ class LengthsTileOp : public Operator<Context> {
 
  private:
   Tensor lengths_host_{CPU};
+  Tensor rowMappingHost_{CPU};
+  Tensor rowMappingDevice_{Context::GetDeviceType()};
 };
 
 } // namespace caffe2

--- a/caffe2/operators/lengths_tile_op_gpu.cc
+++ b/caffe2/operators/lengths_tile_op_gpu.cc
@@ -1,6 +1,0 @@
-#include "caffe2/core/context_gpu.h"
-#include "caffe2/operators/lengths_tile_op.h"
-
-namespace caffe2 {
-REGISTER_CUDA_OPERATOR(LengthsTile, LengthsTileOp<CUDAContext>);
-} // namespace caffe2

--- a/caffe2/python/operator_test/lengths_tile_op_test.py
+++ b/caffe2/python/operator_test/lengths_tile_op_test.py
@@ -15,7 +15,7 @@ class TestLengthsTileOp(hu.HypothesisTestCase):
     @given(
         inputs=st.integers(min_value=1, max_value=20).flatmap(
             lambda size: st.tuples(
-                hu.arrays([size]),
+                hu.arrays([size], dtype=np.float32),
                 hu.arrays([size], dtype=np.int32,
                           elements=st.integers(min_value=0, max_value=20)),
             )
@@ -32,7 +32,7 @@ class TestLengthsTileOp(hu.HypothesisTestCase):
         op = core.CreateOperator(
             "LengthsTile",
             ["data", "lengths"],
-            ["output"]
+            ["output"],
         )
 
         self.assertReferenceChecks(


### PR DESCRIPTION
Summary: LengthsTileOp was implemented using a sequence of device memcopies initiated on the CPU. This was very slow. I changed it to use a kernel. TUM benchmark QPS improved from 13k QPS to 20k QPS as a result.

Differential Revision: D9724988
