### PR TITLE
[build] re-enable USE_MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ option(USE_IDEEP "Use IDEEP interface in MKL BLAS" ON)
 option(USE_MKLML "Use MKLML interface in MKL BLAS" ON)
 option(USE_DISTRIBUTED "Use distributed" ON)
 cmake_dependent_option(
-    USE_MPI "Use MPI for Caffe2. Only available if USE_DISTRIBUTED is on." OFF
+    USE_MPI "Use MPI for Caffe2. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
 cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -430,6 +430,9 @@ if (BUILD_TEST)
   # For special tests that explicitly uses dependencies, we add them here
   if (USE_MPI)
     target_link_libraries(mpi_test ${MPI_CXX_LIBRARIES})
+    if (USE_CUDA)
+      target_link_libraries(mpi_gpu_test ${MPI_CXX_LIBRARIES})
+    endif()
   endif()
 endif()
 

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -427,6 +427,10 @@ if (BUILD_TEST)
     endforeach()
   endif()
 
+  # For special tests that explicitly uses dependencies, we add them here
+  if (USE_MPI)
+    target_link_libraries(mpi_test ${MPI_CXX_LIBRARIES})
+  endif()
 endif()
 
 if (BUILD_PYTHON)


### PR DESCRIPTION
The previous error was caused by mpi_test not depending on MPI_CXX_LIBRARIES. This might solve the problem. 

Not tested locally - waiting for CI test.