### PR TITLE
nomnigraph - Improvements to subgraph matching APIs

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -216,17 +216,14 @@ NNNodeMatchCriteria criteriaSingleConsumer() {
       "Single consumer");
 }
 
-NNNodeMatchCriteria matchTensor() {
-  return matchOp<nom::repr::Tensor>("matchTensor");
+NNNodeMatchCriteria matchTensor(const std::string& debugString) {
+  return matchOp<nom::repr::Tensor>(debugString);
 }
 
-NNMatchGraph::NodeRef operatorSubgraph(
-    NNMatchGraph& g,
-    const NNNodeMatchCriteria& root,
-    const std::vector<NNMatchGraph::NodeRef>& childrenCriteria,
-    int count) {
-  return subgraph(
-      g, matchTensor(), {subgraph(g, root, childrenCriteria)}, count);
+NNMatchNode matchExternalTensorNode(const std::string& debugString) {
+  return NNMatchNode(matchTensor(debugString))
+      .nonTerminal()
+      .excludeFromSubgraph();
 }
 
 } // namespace nn

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -474,8 +474,6 @@ NNNodeMatchCriteria matchOp(const std::string& debugString = "matchOp") {
       debugString);
 }
 
-CAFFE2_API NNNodeMatchCriteria matchTensor();
-
 template <typename NodeType>
 NNNodeMatchCriteria matchOp(
     const std::function<bool(const NodeType&)> predicate,
@@ -489,6 +487,12 @@ NNNodeMatchCriteria matchOp(
       debugString);
 };
 
+CAFFE2_API NNNodeMatchCriteria
+matchTensor(const std::string& debugString = "matchTensor");
+
+CAFFE2_API NNMatchNode
+matchExternalTensorNode(const std::string& debugString = "matchExternalTensor");
+
 struct CAFFE2_API NNNodeMatch {
   static bool isMatch(
       const NNGraph::NodeRef& node,
@@ -499,15 +503,6 @@ struct CAFFE2_API NNNodeMatch {
 
 using NNSubgraphMatcher =
     nom::matcher::SubgraphMatcher<NNGraph, NNNodeMatchCriteria, NNNodeMatch>;
-
-// This helper method makes it easy to create matching criteria in NNGraph.
-// For example, operatorSubgraph(opMatch, ...) will refer to a tree like this:
-// ... -> opMatch -> opMatch_Output
-CAFFE2_API NNMatchGraph::NodeRef operatorSubgraph(
-    NNMatchGraph& g,
-    const NNNodeMatchCriteria& root,
-    const std::vector<NNMatchGraph::NodeRef>& childrenCriteria = {},
-    int count = 1);
 
 } // namespace nn
 

--- a/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
@@ -32,15 +32,8 @@ template <typename NodeMatchCriteria>
 class CAFFE2_API MatchNode {
  public:
   static const int kStarCount = -1;
-  MatchNode(
-      const NodeMatchCriteria& criteria,
-      bool includeInSubgraph = true,
-      int count = 1,
-      bool nonTerminal = false)
-      : criteria_(criteria),
-        includeInSubgraph_(includeInSubgraph),
-        count_(count),
-        nonTerminal_(nonTerminal) {}
+
+  MatchNode(const NodeMatchCriteria& criteria) : criteria_(criteria) {}
 
   MatchNode() = default;
   MatchNode(const MatchNode&) = default;
@@ -55,6 +48,25 @@ class CAFFE2_API MatchNode {
     return count_;
   }
 
+  MatchNode<NodeMatchCriteria>& count(int count) {
+    count_ = count;
+    return *this;
+  }
+
+  MatchNode<NodeMatchCriteria>& starCount() {
+    return count(kStarCount);
+  }
+
+  MatchNode<NodeMatchCriteria>& nonTerminal() {
+    nonTerminal_ = true;
+    return *this;
+  }
+
+  MatchNode<NodeMatchCriteria>& excludeFromSubgraph() {
+    includeInSubgraph_ = false;
+    return *this;
+  }
+
   bool isNonTerminal() const {
     return nonTerminal_;
   }
@@ -65,9 +77,9 @@ class CAFFE2_API MatchNode {
 
  private:
   NodeMatchCriteria criteria_;
-  bool includeInSubgraph_;
-  int count_;
-  bool nonTerminal_;
+  int count_ = 1;
+  bool includeInSubgraph_ = true;
+  bool nonTerminal_ = false;
 };
 
 template <typename NodeMatchCriteria>
@@ -76,38 +88,12 @@ using MatchGraph = Graph<MatchNode<NodeMatchCriteria>>;
 template <typename NodeMatchCriteria>
 using MatchNodeRef = typename MatchGraph<NodeMatchCriteria>::NodeRef;
 
-template <typename NodeMatchCriteria>
-MatchNodeRef<NodeMatchCriteria> subgraph(
-    MatchGraph<NodeMatchCriteria>& graph,
-    const NodeMatchCriteria& root,
-    const std::vector<MatchNodeRef<NodeMatchCriteria>>& children,
-    int count = 1,
-    bool includeInSubgraph = true) {
-  auto result = graph.createNode(
-      MatchNode<NodeMatchCriteria>(root, includeInSubgraph, count, false));
-  for (auto child : children) {
-    graph.createEdge(result, child);
-  }
-  return result;
-}
-
-// Note that for nonTerminalSubgraph, the default value for includeInSubgraph
-// is false since we typically do not want to include a nonTerminal node
-// in the matched subgraph.
-template <typename NodeMatchCriteria>
-MatchNodeRef<NodeMatchCriteria> nonTerminalSubgraph(
-    MatchGraph<NodeMatchCriteria>& graph,
-    const NodeMatchCriteria& root,
-    int count = 1,
-    bool includeInSubgraph = false) {
-  return graph.createNode(
-      MatchNode<NodeMatchCriteria>(root, includeInSubgraph, count, true));
-}
-
 // TODO: Reuse convertToDotString once convertToDotString can work
 // with subgraph.
 template <typename NodeMatchCriteria>
-std::string debugString(MatchNodeRef<NodeMatchCriteria> rootCriteriaRef) {
+std::string debugString(
+    MatchNodeRef<NodeMatchCriteria> rootCriteriaRef,
+    bool invertGraphTraversal) {
   std::ostringstream out;
   auto rootNode = rootCriteriaRef->data();
   out << "{rootCriteria = '" << rootNode.getCriteria() << "'";
@@ -117,11 +103,14 @@ std::string debugString(MatchNodeRef<NodeMatchCriteria> rootCriteriaRef) {
   if (rootNode.isNonTerminal()) {
     out << ", nonTerminal = " << rootNode.isNonTerminal();
   }
-  auto outEdges = rootCriteriaRef->getOutEdges();
-  if (!outEdges.empty()) {
+  auto edges = invertGraphTraversal ? rootCriteriaRef->getInEdges()
+                                    : rootCriteriaRef->getOutEdges();
+  if (!edges.empty()) {
     out << ", childrenCriteria = [";
-    for (auto& child : outEdges) {
-      out << debugString<NodeMatchCriteria>(child->head()) << ", ";
+    for (auto& child : edges) {
+      auto nextNode = invertGraphTraversal ? child->tail() : child->head();
+      out << debugString<NodeMatchCriteria>(nextNode, invertGraphTraversal)
+          << ", ";
     }
     out << "]";
   }
@@ -294,7 +283,8 @@ struct SubgraphMatcher {
           std::ostringstream debugMessage;
           debugMessage << "Subgraph root at " << root << " is not the same as "
                        << matchedNode << " which previously matched criteria "
-                       << debugString<NodeMatchCriteria>(rootCriteriaRef);
+                       << debugString<NodeMatchCriteria>(
+                              rootCriteriaRef, invertGraphTraversal);
           return SubgraphMatchResultType::notMatched(debugMessage.str());
         } else {
           return SubgraphMatchResultType::notMatched();
@@ -307,7 +297,8 @@ struct SubgraphMatcher {
         std::ostringstream debugMessage;
         debugMessage << "Subgraph root at " << root
                      << " does not match criteria "
-                     << debugString<NodeMatchCriteria>(rootCriteriaRef);
+                     << debugString<NodeMatchCriteria>(
+                            rootCriteriaRef, invertGraphTraversal);
         return SubgraphMatchResultType::notMatched(debugMessage.str());
       } else {
         return SubgraphMatchResultType::notMatched();
@@ -326,8 +317,10 @@ struct SubgraphMatcher {
         invertGraphTraversal ? root->getInEdges() : root->getOutEdges();
 
     int numEdges = edges.size();
-    const auto outEdges = rootCriteriaRef->getOutEdges();
-    int numChildrenCriteria = outEdges.size();
+    const auto criteriaEdges = invertGraphTraversal
+        ? rootCriteriaRef->getInEdges()
+        : rootCriteriaRef->getOutEdges();
+    int numChildrenCriteria = criteriaEdges.size();
 
     // The current algorithm implies that the ordering of the children is
     // important. The children nodes will be matched with the children subgraph
@@ -336,7 +329,9 @@ struct SubgraphMatcher {
     int currentEdgeIdx = 0;
     for (int criteriaIdx = 0; criteriaIdx < numChildrenCriteria;
          criteriaIdx++) {
-      auto childrenCriteriaRef = outEdges[criteriaIdx]->head();
+      auto childrenCriteriaRef = invertGraphTraversal
+          ? criteriaEdges[criteriaIdx]->tail()
+          : criteriaEdges[criteriaIdx]->head();
 
       int expectedCount = childrenCriteriaRef->data().getCount();
       bool isStarCount =
@@ -374,7 +369,7 @@ struct SubgraphMatcher {
               debugMessage << "Child node at " << child
                            << " does not match child criteria "
                            << debugString<NodeMatchCriteria>(
-                                  childrenCriteriaRef)
+                                  childrenCriteriaRef, invertGraphTraversal)
                            << ". We expected " << expectedCount
                            << " matches but only found " << countMatch << ".";
               return SubgraphMatchResultType::notMatched(debugMessage.str());
@@ -399,7 +394,8 @@ struct SubgraphMatcher {
           std::ostringstream debugMessage;
           debugMessage << "Expected " << expectedCount
                        << " matches for child criteria "
-                       << debugString<NodeMatchCriteria>(childrenCriteriaRef)
+                       << debugString<NodeMatchCriteria>(
+                              childrenCriteriaRef, invertGraphTraversal)
                        << " but only found " << countMatch;
           return SubgraphMatchResultType::notMatched(debugMessage.str());
         } else {

--- a/caffe2/python/pybind_state_nomni.cc
+++ b/caffe2/python/pybind_state_nomni.cc
@@ -233,9 +233,11 @@ void addNomnigraphMethods(pybind11::module& m) {
                   auto nnOp = nn::get<NeuralNetOperator>(node);
                   return opName == nnOp->getName();
                 });
-            return g->createNode(
-                nom::matcher::MatchNode<nn::NNNodeMatchCriteria>(
-                    match, true, 1, !strict));
+            auto node = nom::matcher::MatchNode<nn::NNNodeMatchCriteria>(match);
+            if (!strict) {
+              node.nonTerminal();
+            }
+            return g->createNode(std::move(node));
           },
           py::return_value_policy::reference_internal,
           py::arg("node"),
@@ -243,9 +245,11 @@ void addNomnigraphMethods(pybind11::module& m) {
       .def(
           "createNode",
           [](nn::NNMatchGraph* g, nom::repr::Tensor& tensor, bool strict) {
-            return g->createNode(
-                nom::matcher::MatchNode<nn::NNNodeMatchCriteria>(
-                    nn::matchTensor(), true, 1, !strict));
+            auto node = nn::NNMatchNode(nn::matchTensor());
+            if (!strict) {
+              node.nonTerminal();
+            }
+            return g->createNode(std::move(node));
           },
           py::return_value_policy::reference_internal,
           py::arg("tensor"),
@@ -255,9 +259,11 @@ void addNomnigraphMethods(pybind11::module& m) {
           [](nn::NNMatchGraph* g, bool strict) {
             auto match = nn::NNNodeMatchCriteria(
                 [](NNGraph::NodeRef node) { return true; });
-            return g->createNode(
-                nom::matcher::MatchNode<nn::NNNodeMatchCriteria>(
-                    match, true, 1, !strict));
+            auto node = nom::matcher::MatchNode<nn::NNNodeMatchCriteria>(match);
+            if (!strict) {
+              node.nonTerminal();
+            }
+            return g->createNode(std::move(node));
           },
           py::return_value_policy::reference_internal,
           py::arg("strict") = false)


### PR DESCRIPTION
Summary:
Several improvements that aim to make the APIs more straightforward to use

- Get rid of helper methods subgraph and nonTerminal . Users now should create a NNMatchGraph directly via graph's createNode and createEdge API

- Get rid of operatorSubgraph helper method

- invertGraphTraversal flag applies to both the match graph and the scanned graph. This allows user to create match graph in the same direction as the scanned graph, thus reduce confusion.

- additional parameters of matchNode (count, includeInSubgraph, nonTerminal) are removed from the constructors and moved into setter methods. (We no longer enforce that MatchNode is immutable but this helps improve code clarity).

- Tests are updated to reflect the changes

Follow up changes:
- Possibly clean up the tests further. This change aims to minimally modify the unit tests.
- Help a validity check that enforce the current limitation of the match graph (single source node), and throws if the match graph does not satisfy the criteria.
- Have the single source node be detected automatically and callers just need to pass in the matchGraph instead of the source node reference.

Differential Revision: D9732565
