### PR TITLE
[Caffe2] Search for CMake config files for pybind11.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -412,11 +412,18 @@ if(BUILD_PYTHON)
 endif()
 
 # ---[ pybind11
-find_package(pybind11)
-if(pybind11_FOUND)
-  include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
+find_package(pybind11 CONFIG)
+if((DEFINED pybind11_DIR) AND pybind11_DIR)
+  get_target_property(pybind11_INCLUDE_DIRS pybind11::pybind11 INTERFACE_INCLUDE_DIRECTORIES)
 else()
-  include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
+  message("pybind11 config not found. Fallback to legacy find.")
+  find_package(pybind11)
+endif()
+
+if(pybind11_FOUND)
+    include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
+else()
+    include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
 endif()
 
 # ---[ MPI


### PR DESCRIPTION
If pybind is build with cmake and installed, we should use config file instead of the Findpybind11 shipped with caffe2.