### PR TITLE
pybind conversion for IntList

### DIFF
--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -5,13 +5,13 @@
 #include "torch/csrc/jit/assertions.h"
 #include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/stack.h"
+#include "torch/csrc/jit/tracing_state.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/utils/functional.h"
 #include "torch/csrc/utils/functional.h"
 #include "torch/csrc/utils/variadic.h"
 #include "torch/csrc/utils/variadic.h"
 #include "torch/csrc/WindowsTorchApiMacro.h"
-
 #include <ATen/Backtrace.h>
 
 #include <memory>
@@ -28,75 +28,6 @@ using variable_list = std::vector<Variable>;
 
 TORCH_API void recordSourceLocation(Node* n);
 TORCH_API void setRecordSourceLocation(void (*v)(Node*));
-
-struct TORCH_API TracingState : public std::enable_shared_from_this<TracingState> {
-  TracingState();
-  ~TracingState();
-
-  using WeakTensor = at::WeakTensor;
-
-  struct WeakTensorHasher {
-    size_t operator()(const WeakTensor& t) const {
-      return std::hash<void*>()(t.unsafeGetTensorImpl());
-    }
-  };
-
-  struct WeakTensorEq {
-    bool operator()(const WeakTensor& t1, const WeakTensor& t2) const {
-      return t1.is_same(t2);
-    }
-  };
-
-  std::unordered_map<WeakTensor, Value*, WeakTensorHasher, WeakTensorEq> value_map;
-  std::shared_ptr<Graph> graph;
-  bool warn = true;
-};
-
-
-// This is meant to be used as a thread local place, where we can store extra
-// info that gets lost when we call into ATen from Python bindings. One example
-// for when this happens is when we get an IntList argument with e.g. sizes for
-// view. When tracing, those might be tensors, which let us encode extra data
-// dependencies, but once they get to the ATen call where we actually have the
-// tracing logic, they get converted into a raw IntList, and we loose all
-// information. To prevent this, we temporarily stash it in here.
-struct ArgumentStash {
-  struct IntListTrace : std::vector<Value*> {
-    IntListTrace(int size)
-      : std::vector<Value*>(size, nullptr) {}
-  };
-
-  static bool empty() {
-    return stash.intlists.empty();
-  }
-
-  TORCH_API static void stashIntListElem(const std::string& arg_name,
-                                         size_t size,
-                                         size_t idx,
-                                         const Variable& var);
-
-  static bool hasIntList(const std::string& arg_name) {
-    return stash.intlists.count(arg_name) > 0;
-  }
-
-  static IntListTrace popIntList(const std::string& arg_name) {
-    auto info = std::move(stash.intlists.at(arg_name));
-    stash.intlists.erase(arg_name);
-    return info;
-  }
-
-private:
-  static thread_local ArgumentStash stash;
-  std::unordered_map<std::string, IntListTrace> intlists;
-};
-
-// Retrieve or set the current tracing state. Returns a nullptr if tracing is disabled.
-TORCH_API const std::shared_ptr<TracingState>& getTracingState();
-TORCH_API void setTracingState(std::shared_ptr<TracingState> state);
-
-inline bool isTracing() {
-  return static_cast<bool>(getTracingState());
-}
 
 // Having finished adding a new 'node' to the graph IR 'setValueTrace' associates
 // this node with an output variable, so that further operations involving this
@@ -263,32 +194,5 @@ TORCH_API void addOutput(Node* node, const at::Tensor& tensor);
 TORCH_API void addOutput(Node* node, const std::vector<at::Tensor>& list);
 
 TORCH_API autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim);
-
-using warn_fn_type = void (*)(const std::string& msg);
-TORCH_API void _do_warn(const char * _reason);
-inline void warn(const char * _reason) {
-  if (auto state = getTracingState()) {
-    if (!state->warn) return;
-    _do_warn(_reason);
-  }
-}
-TORCH_API void setWarn(warn_fn_type fn);
-
-struct TORCH_API NoWarn {
-  NoWarn(): state(getTracingState()) {
-    if (state) {
-      prev = state->warn;
-      state->warn = false;
-    }
-  }
-  ~NoWarn() {
-    if (state) {
-      state->warn = prev;
-    }
-  }
-  std::shared_ptr<TracingState> state;
-  bool prev;
-};
-
 
 }}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/tracing_state.h
+++ b/torch/csrc/jit/tracing_state.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "torch/csrc/autograd/function_hook.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/constants.h"
+#include "torch/csrc/jit/stack.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/utils/variadic.h"
+#include "torch/csrc/utils/variadic.h"
+#include "torch/csrc/WindowsTorchApiMacro.h"
+
+#include <ATen/Backtrace.h>
+
+#include <memory>
+#include <mutex>
+#include <vector>
+#include <iostream>
+#include <cstdint>
+#include <unordered_map>
+
+namespace torch { namespace jit { namespace tracer {
+
+using torch::autograd::Variable;
+using variable_list = std::vector<Variable>;
+
+struct TORCH_API TracingState : public std::enable_shared_from_this<TracingState> {
+  TracingState();
+  ~TracingState();
+
+  using WeakTensor = at::WeakTensor;
+
+  struct WeakTensorHasher {
+    size_t operator()(const WeakTensor& t) const {
+      return std::hash<void*>()(t.unsafeGetTensorImpl());
+    }
+  };
+
+  struct WeakTensorEq {
+    bool operator()(const WeakTensor& t1, const WeakTensor& t2) const {
+      return t1.is_same(t2);
+    }
+  };
+
+  std::unordered_map<WeakTensor, Value*, WeakTensorHasher, WeakTensorEq> value_map;
+  std::shared_ptr<Graph> graph;
+  bool warn = true;
+};
+
+
+// This is meant to be used as a thread local place, where we can store extra
+// info that gets lost when we call into ATen from Python bindings. One example
+// for when this happens is when we get an IntList argument with e.g. sizes for
+// view. When tracing, those might be tensors, which let us encode extra data
+// dependencies, but once they get to the ATen call where we actually have the
+// tracing logic, they get converted into a raw IntList, and we loose all
+// information. To prevent this, we temporarily stash it in here.
+struct ArgumentStash {
+  struct IntListTrace : std::vector<Value*> {
+    IntListTrace(int size)
+      : std::vector<Value*>(size, nullptr) {}
+  };
+
+  static bool empty() {
+    return stash.intlists.empty();
+  }
+
+  TORCH_API static void stashIntListElem(const std::string& arg_name,
+                                         size_t size,
+                                         size_t idx,
+                                         const Variable& var);
+
+  static bool hasIntList(const std::string& arg_name) {
+    return stash.intlists.count(arg_name) > 0;
+  }
+
+  static IntListTrace popIntList(const std::string& arg_name) {
+    auto info = std::move(stash.intlists.at(arg_name));
+    stash.intlists.erase(arg_name);
+    return info;
+  }
+
+private:
+  static thread_local ArgumentStash stash;
+  std::unordered_map<std::string, IntListTrace> intlists;
+};
+
+// Retrieve or set the current tracing state. Returns a nullptr if tracing is disabled.
+TORCH_API const std::shared_ptr<TracingState>& getTracingState();
+TORCH_API void setTracingState(std::shared_ptr<TracingState> state);
+
+inline bool isTracing() {
+  return static_cast<bool>(getTracingState());
+}
+
+using warn_fn_type = void (*)(const std::string& msg);
+TORCH_API void _do_warn(const char * _reason);
+inline void warn(const char * _reason) {
+  if (auto state = getTracingState()) {
+    if (!state->warn) return;
+    _do_warn(_reason);
+  }
+}
+TORCH_API void setWarn(warn_fn_type fn);
+
+struct TORCH_API NoWarn {
+  NoWarn(): state(getTracingState()) {
+    if (state) {
+      prev = state->warn;
+      state->warn = false;
+    }
+  }
+  ~NoWarn() {
+    if (state) {
+      state->warn = prev;
+    }
+  }
+  std::shared_ptr<TracingState> state;
+  bool prev;
+};
+
+}}} // namespace torch::jit::tracer

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -8,6 +8,8 @@
 
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/utils/python_tuples.h"
+#include "torch/csrc/utils/python_numbers.h"
 
 #include <stdexcept>
 
@@ -55,6 +57,39 @@ public:
   static handle cast(torch::autograd::Variable src, return_value_policy /* policy */, handle /* parent */) {
     return handle(THPVariable_Wrap(src));
   }
+};
+
+template<> struct type_caster<at::IntList> {
+public:
+  PYBIND11_TYPE_CASTER(at::IntList, _("at::IntList"));
+
+  bool load(handle src, bool) {
+    PyObject *source = src.ptr();
+    auto tuple = PyTuple_Check(source);
+    if (tuple || PyList_Check(source)) {
+      auto size = tuple ? PyTuple_GET_SIZE(source) : PyList_GET_SIZE(source);
+      v_value.resize(size);
+      for (int idx = 0; idx < size; idx++) {
+	PyObject* obj = tuple ? PyTuple_GET_ITEM(source, idx) : PyList_GET_ITEM(source, idx);
+	if (THPVariable_Check(obj)) {
+	  v_value[idx] = THPVariable_Unpack(obj).toCLong();
+	} else if (PyLong_Check(obj)) {
+	  // use THPUtils_unpackLong after it is safe to include python_numbers.h
+	  v_value[idx] = THPUtils_unpackLong(obj);
+	} else {
+	  return false;
+	}
+      }
+      value = v_value;
+      return true;
+    }
+    return false;
+  }
+  static handle cast(at::IntList src, return_value_policy /* policy */, handle /* parent */) {
+    return handle(THPUtils_packInt64Array(src.size(), src.data()));
+  }
+private:
+  std::vector<int64_t> v_value;
 };
 
 // http://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/utils/tensor_numpy.h"
-#include "torch/csrc/jit/tracer.h"
+#include "torch/csrc/jit/tracing_state.h"
 
 // largest integer that can be represented consecutively in a double
 const int64_t DOUBLE_INT_MAX = 9007199254740992;


### PR DESCRIPTION
as discussed with @ezyang and @slayton58 , this might be a nice convenience to be able to use code in extensions just as in ATen.

also split off `tracing_state.h` from `torch/jit/tracer.h` fix #11204 to bee able to use the utility functions

@pytorchbot  it's not a jit patch per se.