### PR TITLE
Add "merge to master" step before build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ pytorch_linux_cpu_build_test_defaults: &pytorch_linux_cpu_build_test_defaults
         # This IAM user allows write access to S3 bucket for sccache
         export AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA
         export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}
-        git submodule update --init
+        git submodule sync && git submodule update --init
         .jenkins/pytorch/build.sh
         .jenkins/pytorch/test.sh
 
@@ -74,7 +74,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         # This IAM user allows write access to S3 bucket for sccache
         export AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA
         export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}
-        git submodule update --init || git submodule update --init || git submodule update --init
+        git submodule sync && git submodule update --init
         .jenkins/pytorch/build.sh
         mkdir -p pytorch-ci-env/
         cp -r /var/lib/jenkins/workspace pytorch-ci-env/build_workspace
@@ -151,9 +151,9 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
           docker cp "/opt/workspace/cpp-build" "$id:/var/lib/jenkins/cpp-build"
         fi
         if [ -n "${MULTI_GPU}" ]; then
-          (echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch && cd workspace && (git submodule update --init || git submodule update --init || git submodule update --init) && .jenkins/pytorch/multigpu-test.sh') | docker exec -u jenkins -i "$id" bash
+          (echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch && cd workspace && .jenkins/pytorch/multigpu-test.sh') | docker exec -u jenkins -i "$id" bash
         else
-          (echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch && cd workspace && (git submodule update --init || git submodule update --init || git submodule update --init) && .jenkins/pytorch/test.sh') | docker exec -u jenkins -i "$id" bash
+          (echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch && cd workspace && .jenkins/pytorch/test.sh') | docker exec -u jenkins -i "$id" bash
         fi
 
 caffe2_linux_build_defaults: &caffe2_linux_build_defaults
@@ -183,7 +183,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         cd third_party/onnx && git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/* && cd -
 
         # Reinitialize submodules
-        git submodule update --init --recursive
+        git submodule sync && git submodule update --init --recursive
 
         # Ensure jenkins can write to the ccache root dir.
         sudo chown jenkins:jenkins "${HOME}/.ccache"
@@ -359,7 +359,7 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
           brew install cmake
 
           # Reinitialize submodules
-          git submodule update --init --recursive
+          git submodule sync && git submodule update --init --recursive
 
           # Reinitialize path (see man page for path_helper(8))
           eval `/usr/libexec/path_helper -s`
@@ -579,7 +579,7 @@ jobs:
             export AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}
 
-            git submodule update --init
+            git submodule sync && git submodule update --init
             chmod a+x .jenkins/pytorch/macos-build.sh
             .jenkins/pytorch/macos-build.sh
 
@@ -610,7 +610,6 @@ jobs:
             # TODO: need to share source files from build to test, when macOS builds are enabled
             set -ex
             export IN_CIRCLECI=1
-            git submodule update --init
             chmod a+x .jenkins/pytorch/macos-test.sh
             .jenkins/pytorch/macos-test.sh
 
@@ -656,7 +655,7 @@ jobs:
             export AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}
 
-            git submodule update --init
+            git submodule sync && git submodule update --init
             chmod a+x .jenkins/pytorch/macos-build.sh
             .jenkins/pytorch/macos-build.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,13 @@ docker_config_defaults: &docker_config_defaults
     aws_access_key_id: AKIAJ2J6FIG5OSZTQ3IA
     aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_ECR_READ_ONLY}
 
+# NOTE: We only perform the merge in build step and not in test step, because
+# all source files will be shared from build to test
 merge_pull_request_onto_master: &merge_pull_request_onto_master
   name: Merge Onto Master
   no_output_timeout: "10h"
   command: |
+    # yf225 TODO: add `if [ -n "${CIRCLE_PULL_REQUEST}" ]; then` wrapper here
     git config --global user.email "circleci.ossci@gmail.com"
     git config --global user.name "CircleCI"
 
@@ -31,6 +34,8 @@ pytorch_linux_cpu_build_test_defaults: &pytorch_linux_cpu_build_test_defaults
   working_directory: /var/lib/jenkins/workspace
   steps:
   - checkout
+  - run:
+      <<: *merge_pull_request_onto_master
   - run:
       name: Build
       no_output_timeout: "10h"
@@ -58,8 +63,6 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
       name: Build
       no_output_timeout: "10h"
       command: |
-        git log -2
-
         export IN_CIRCLECI=1
         export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
         if [ -n "${CUDA_VERSION}" ]; then
@@ -74,6 +77,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         git submodule update --init || git submodule update --init || git submodule update --init
         .jenkins/pytorch/build.sh
         mkdir -p pytorch-ci-env/
+        cp -r /var/lib/jenkins/workspace pytorch-ci-env/build_workspace
         cp -r /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch pytorch-ci-env/torch
         cp -r build/bin pytorch-ci-env/cpp_test_bin
         if [ -d "../cpp-build" ]; then
@@ -88,7 +92,6 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
   machine:
     image: default
   steps:
-  - checkout
   - run:
       name: Prepare workspace
       command: |
@@ -138,9 +141,10 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
         # This IAM user allows write access to S3 bucket for sccache
         echo "declare -x AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA" >> /home/circleci/project/env
         echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}" >> /home/circleci/project/env
+
+        docker cp "/opt/workspace/build_workspace" "$id:/var/lib/jenkins/workspace"  # This copies all source files from build step to the current step
         mkdir -p /home/circleci/project/build
         cp -r /opt/workspace/cpp_test_bin /home/circleci/project/build/bin
-        docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
         echo "mkdir -p /opt/conda/lib/python${PYTHON_VERSION}/site-packages" | docker exec -u jenkins -i "$id" bash
         docker cp "/opt/workspace/torch" "$id:/opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch"
         if [ -d "/opt/workspace/cpp-build" ]; then
@@ -157,6 +161,8 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
   working_directory: /var/lib/jenkins/workspace
   steps:
   - checkout
+  - run:
+      <<: *merge_pull_request_onto_master
   - run:
       name: Build
       no_output_timeout: "10h"
@@ -215,6 +221,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
 
         # Copy all necessary binaries to shared workspace
         mkdir -p caffe2-ci-env
+        cp -r /var/lib/jenkins/workspace caffe2-ci-env/build_workspace
         cp -r third_party/onnx caffe2-ci-env/onnx
         if [ -d "/usr/local/caffe2" ]; then
           cp -r /usr/local/caffe2 caffe2-ci-env/caffe2
@@ -231,7 +238,6 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
   machine:
     image: default
   steps:
-  - checkout
   - run:
       name: Prepare workspace
       command: |
@@ -323,7 +329,7 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         # =================== The above code will be executed inside Docker container ===================
         EOL
         chmod +x /home/circleci/project/ci_build_script.sh
-        docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
+        docker cp "/opt/workspace/build_workspace" "$id:/var/lib/jenkins/workspace"  # This copies all source files from build step to the current step
         if [ -d "/opt/workspace/caffe2" ]; then
           echo "mkdir -p /usr/local/caffe2" | docker exec -u jenkins -i "$id" bash
           docker cp /opt/workspace/caffe2/. "$id:/usr/local/caffe2"
@@ -340,6 +346,8 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
     xcode: "9.0"
   steps:
     - checkout
+    - run:
+        <<: *merge_pull_request_onto_master
     - run:
         name: Build
         no_output_timeout: "10h"
@@ -551,6 +559,8 @@ jobs:
     steps:
       - checkout
       - run:
+          <<: *merge_pull_request_onto_master
+      - run:
           name: Build
           environment:
             BUILD_ENVIRONMENT: pytorch-macos-10.13-py3
@@ -572,6 +582,9 @@ jobs:
             git submodule update --init
             chmod a+x .jenkins/pytorch/macos-build.sh
             .jenkins/pytorch/macos-build.sh
+
+            # TODO: need to share source files from build to test, when macOS builds are enabled
+
       - persist_to_workspace:
           root: /Users/distiller/pytorch-ci-env
           paths:
@@ -581,7 +594,6 @@ jobs:
     macos:
       xcode: "9.0"
     steps:
-      - checkout
       - run:
           name: Prepare workspace
           command: |
@@ -595,6 +607,7 @@ jobs:
             BUILD_ENVIRONMENT: pytorch-macos-10.13-py3
           no_output_timeout: "10h"
           command: |
+            # TODO: need to share source files from build to test, when macOS builds are enabled
             set -ex
             export IN_CIRCLECI=1
             git submodule update --init
@@ -606,6 +619,8 @@ jobs:
       xcode: "9.0"
     steps:
       - checkout
+      - run:
+          <<: *merge_pull_request_onto_master
       - run:
           name: Build
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
       no_output_timeout: "10h"
       command: |
         # yf225 debug
+        printenv
+
         git config --global user.email "circleci.ossci@gmail.com"
         git config --global user.name "CircleCI"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,9 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
           id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         fi
         pwd
+
+        cp -r /opt/workspace/build_workspace/. /home/circleci/project  # This copies all source files from build step to the current step
+
         echo "declare -x IN_CIRCLECI=1" > /home/circleci/project/env
         echo "declare -x PYTHON_VERSION=${PYTHON_VERSION}" >> /home/circleci/project/env
         echo "declare -x SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> /home/circleci/project/env
@@ -143,9 +146,9 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
         echo "declare -x AWS_ACCESS_KEY_ID=AKIAJJZUW4G2ASX5W7KA" >> /home/circleci/project/env
         echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}" >> /home/circleci/project/env
 
-        docker cp "/opt/workspace/build_workspace" "$id:/var/lib/jenkins/workspace"  # This copies all source files from build step to the current step
         mkdir -p /home/circleci/project/build
         cp -r /opt/workspace/cpp_test_bin /home/circleci/project/build/bin
+        docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
         echo "mkdir -p /opt/conda/lib/python${PYTHON_VERSION}/site-packages" | docker exec -u jenkins -i "$id" bash
         docker cp "/opt/workspace/torch" "$id:/opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch"
         if [ -d "/opt/workspace/cpp-build" ]; then
@@ -283,6 +286,7 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
           id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         fi
         pwd
+        cp -r /opt/workspace/build_workspace/. /home/circleci/project  # This copies all source files from build step to the current step
         echo "declare -x IN_CIRCLECI=1" > /home/circleci/project/env
         echo "declare -x SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> /home/circleci/project/env
         # This IAM user allows write access to S3 bucket for sccache
@@ -331,7 +335,7 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         # =================== The above code will be executed inside Docker container ===================
         EOL
         chmod +x /home/circleci/project/ci_build_script.sh
-        docker cp "/opt/workspace/build_workspace" "$id:/var/lib/jenkins/workspace"  # This copies all source files from build step to the current step
+        docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
         if [ -d "/opt/workspace/caffe2" ]; then
           echo "mkdir -p /usr/local/caffe2" | docker exec -u jenkins -i "$id" bash
           docker cp /opt/workspace/caffe2/. "$id:/usr/local/caffe2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,15 +76,16 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET}
         git submodule sync && git submodule update --init
         .jenkins/pytorch/build.sh
-        mkdir -p pytorch-ci-env/
-        cp -r /var/lib/jenkins/workspace pytorch-ci-env/build_workspace  # This copies all source files from build step to the next step
-        cp -r /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch pytorch-ci-env/torch
-        cp -r build/bin pytorch-ci-env/cpp_test_bin
+        export PYTORCH_CI_ENV_DIR=/var/lib/jenkins/pytorch-ci-env
+        mkdir -p ${PYTORCH_CI_ENV_DIR}
+        cp -r /var/lib/jenkins/workspace ${PYTORCH_CI_ENV_DIR}/build_workspace  # This copies all source files from build step to the next step
+        cp -r /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch ${PYTORCH_CI_ENV_DIR}/torch
+        cp -r build/bin ${PYTORCH_CI_ENV_DIR}/cpp_test_bin
         if [ -d "../cpp-build" ]; then
-          cp -r ../cpp-build pytorch-ci-env/cpp-build
+          cp -r ../cpp-build ${PYTORCH_CI_ENV_DIR}/cpp-build
         fi
   - persist_to_workspace:
-      root: /var/lib/jenkins/workspace/pytorch-ci-env
+      root: /var/lib/jenkins/pytorch-ci-env
       paths:
         - "*"
 
@@ -220,17 +221,18 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         fi
 
         # Copy all necessary binaries to shared workspace
-        mkdir -p caffe2-ci-env
-        cp -r /var/lib/jenkins/workspace caffe2-ci-env/build_workspace  # This copies all source files from build step to the next step
-        cp -r third_party/onnx caffe2-ci-env/onnx
+        export CAFFE2_CI_ENV_DIR=/var/lib/jenkins/caffe2-ci-env
+        mkdir -p ${CAFFE2_CI_ENV_DIR}
+        cp -r /var/lib/jenkins/workspace ${CAFFE2_CI_ENV_DIR}/build_workspace  # This copies all source files from build step to the next step
+        cp -r third_party/onnx ${CAFFE2_CI_ENV_DIR}/onnx
         if [ -d "/usr/local/caffe2" ]; then
-          cp -r /usr/local/caffe2 caffe2-ci-env/caffe2
+          cp -r /usr/local/caffe2 ${CAFFE2_CI_ENV_DIR}/caffe2
         fi
         if [ -d "/opt/conda" ]; then
-          cp -r /opt/conda caffe2-ci-env/conda_env
+          cp -r /opt/conda ${CAFFE2_CI_ENV_DIR}/conda_env
         fi
   - persist_to_workspace:
-      root: /var/lib/jenkins/workspace/caffe2-ci-env
+      root: /var/lib/jenkins/caffe2-ci-env
       paths:
         - "*"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,27 @@ docker_config_defaults: &docker_config_defaults
     aws_access_key_id: AKIAJ2J6FIG5OSZTQ3IA
     aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_ECR_READ_ONLY}
 
+merge_pull_request_onto_master: &merge_pull_request_onto_master
+  name: Merge Onto Master
+  no_output_timeout: "10h"
+  command: |
+    git config --global user.email "circleci.ossci@gmail.com"
+    git config --global user.name "CircleCI"
+
+    git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
+    git config remote.origin.url https://github.com/pytorch/pytorch.git
+    git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+    git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
+
+    export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
+    echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
+    export GIT_COMMIT=${CIRCLE_SHA1}
+    echo "GIT_COMMIT: " ${GIT_COMMIT}
+
+    git checkout -f ${GIT_COMMIT}
+    git reset --hard ${GIT_COMMIT}
+    git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+
 pytorch_linux_cpu_build_test_defaults: &pytorch_linux_cpu_build_test_defaults
   resource_class: large
   working_directory: /var/lib/jenkins/workspace
@@ -32,33 +53,12 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
   steps:
   - checkout
   - run:
+      <<: *merge_pull_request_onto_master
+  - run:
       name: Build
       no_output_timeout: "10h"
       command: |
-        # yf225 debug
-        printenv
-
-        git config --global user.email "circleci.ossci@gmail.com"
-        git config --global user.name "CircleCI"
-
-        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
-        git config remote.origin.url https://github.com/pytorch/pytorch.git
-        git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
-
-        export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
-        echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-        export GIT_COMMIT=${CIRCLE_SHA1}
-        echo "GIT_COMMIT: " ${GIT_COMMIT}
-
-        git checkout -f ${GIT_COMMIT}
-        git reset --hard ${GIT_COMMIT}
-        git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
-
         git log -2
-
-        export GIT_MERGE_COMMIT=`git log -n 1 --pretty=format:"%H"`
-        git show --stat ${GIT_MERGE_COMMIT}
 
         export IN_CIRCLECI=1
         export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,29 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
       name: Build
       no_output_timeout: "10h"
       command: |
+        # yf225 debug
+        git config --global user.email "circleci.ossci@gmail.com"
+        git config --global user.name "CircleCI"
+
+        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
+        git config remote.origin.url https://github.com/pytorch/pytorch.git
+        git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
+
+        export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
+        echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
+        export GIT_COMMIT=${CIRCLE_SHA1}
+        echo "GIT_COMMIT: " ${GIT_COMMIT}
+
+        git checkout -f ${GIT_COMMIT}
+        git reset --hard ${GIT_COMMIT}
+        git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+
+        git log -2
+
+        export GIT_MERGE_COMMIT=`git log -n 1 --pretty=format:"%H"`
+        git show --stat ${GIT_MERGE_COMMIT}
+
         export IN_CIRCLECI=1
         export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
         if [ -n "${CUDA_VERSION}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         git submodule sync && git submodule update --init
         .jenkins/pytorch/build.sh
         mkdir -p pytorch-ci-env/
-        cp -r /var/lib/jenkins/workspace pytorch-ci-env/build_workspace
+        cp -r /var/lib/jenkins/workspace pytorch-ci-env/build_workspace  # This copies all source files from build step to the next step
         cp -r /opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch pytorch-ci-env/torch
         cp -r build/bin pytorch-ci-env/cpp_test_bin
         if [ -d "../cpp-build" ]; then
@@ -221,7 +221,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
 
         # Copy all necessary binaries to shared workspace
         mkdir -p caffe2-ci-env
-        cp -r /var/lib/jenkins/workspace caffe2-ci-env/build_workspace
+        cp -r /var/lib/jenkins/workspace caffe2-ci-env/build_workspace  # This copies all source files from build step to the next step
         cp -r third_party/onnx caffe2-ci-env/onnx
         if [ -d "/usr/local/caffe2" ]; then
           cp -r /usr/local/caffe2 caffe2-ci-env/caffe2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,24 @@ merge_pull_request_onto_master: &merge_pull_request_onto_master
   name: Merge Onto Master
   no_output_timeout: "10h"
   command: |
-    # yf225 TODO: add `if [ -n "${CIRCLE_PULL_REQUEST}" ]; then` wrapper here
-    git config --global user.email "circleci.ossci@gmail.com"
-    git config --global user.name "CircleCI"
+    if [[ "${CIRCLE_BRANCH}" != "master" ]]; then
+      git config --global user.email "circleci.ossci@gmail.com"
+      git config --global user.name "CircleCI"
 
-    git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
-    git config remote.origin.url https://github.com/pytorch/pytorch.git
-    git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-    git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
+      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
+      git config remote.origin.url https://github.com/pytorch/pytorch.git
+      git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
 
-    export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
-    echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-    export GIT_COMMIT=${CIRCLE_SHA1}
-    echo "GIT_COMMIT: " ${GIT_COMMIT}
+      export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
+      echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
+      export GIT_COMMIT=${CIRCLE_SHA1}
+      echo "GIT_COMMIT: " ${GIT_COMMIT}
 
-    git checkout -f ${GIT_COMMIT}
-    git reset --hard ${GIT_COMMIT}
-    git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+      git checkout -f ${GIT_COMMIT}
+      git reset --hard ${GIT_COMMIT}
+      git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+    fi
 
 pytorch_linux_cpu_build_test_defaults: &pytorch_linux_cpu_build_test_defaults
   resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,9 @@ merge_pull_request_onto_master: &merge_pull_request_onto_master
       git config --global user.email "circleci.ossci@gmail.com"
       git config --global user.name "CircleCI"
 
-      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* --depth=50 --quiet
       git config remote.origin.url https://github.com/pytorch/pytorch.git
-      git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* --depth=50 --quiet
+      git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
+      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=50 --quiet
 
       export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
       echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}


### PR DESCRIPTION
This PR adds the "merge to master" step before the build step in CircleCI, so that all PR commits are built against master instead of against the PR's branch. Note that all PRs still need to rebase to master to pick up this new config, so it won't apply to old PR branches retroactively.

To check in CI: make sure it's performing the git merge to master appropriately in "Merge Onto Master" step.