### PR TITLE
add caching to some cmake variables

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -455,30 +455,35 @@ if (BUILD_TEST)
 endif()
 
 if (BUILD_PYTHON)
-  # Python site-packages
-  # Get canonical directory for python site packages (relative to install
-  # location).  It varies from system to system.
-  pycmd(PYTHON_SITE_PACKAGES "
+  if (NOT PYTHON_LIB_REL_PATH)
+    # Python site-packages
+    # Get canonical directory for python site packages (relative to install
+    # location).  It varies from system to system.
+    pycmd(PYTHON_SITE_PACKAGES "
       from distutils import sysconfig
       print(sysconfig.get_python_lib(prefix=''))
   ")
-  SET(PYTHON_SITE_PACKAGES ${PYTHON_SITE_PACKAGES} PARENT_SCOPE) # for Summary
-  # ---[ Options.
-  SET(PYTHON_LIB_REL_PATH "${PYTHON_SITE_PACKAGES}" CACHE STRING "Python installation path (relative to CMake installation prefix)")
+    SET(PYTHON_SITE_PACKAGES ${PYTHON_SITE_PACKAGES} CACHE STRING "Python site packages dir, for summary" PARENT_SCOPE ) # for Summary
+    # ---[ Options.
+    SET(PYTHON_LIB_REL_PATH "${PYTHON_SITE_PACKAGES}" CACHE STRING "Python installation path (relative to CMake installation prefix)")
+  endif()
   message(STATUS "Using ${PYTHON_LIB_REL_PATH} as python relative installation path")
-  # Python extension suffix
-  # Try to get from python through sysconfig.get_env_var('EXT_SUFFIX') first,
-  # fallback to ".pyd" if windows and ".so" for all others.
-  pycmd(PY_EXT_SUFFIX "
+
+  if (NOT DEFINED PY_EXT_SUFFIX)
+    # Python extension suffix
+    # Try to get from python through sysconfig.get_env_var('EXT_SUFFIX') first,
+    # fallback to ".pyd" if windows and ".so" for all others.
+    pycmd(PY_EXT_SUFFIX "
       from distutils import sysconfig
       ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
       print(ext_suffix if ext_suffix else '')
   ")
-  if("${PY_EXT_SUFFIX}" STREQUAL "")
-    if (MSVC)
-      set(PY_EXT_SUFFIX ".pyd")
-    else()
-      set(PY_EXT_SUFFIX ".so")
+    if("${PY_EXT_SUFFIX}" STREQUAL "")
+      if (MSVC)
+	set(PY_EXT_SUFFIX ".pyd" CACHE STRING "Python expected extension suffix")
+      else()
+	set(PY_EXT_SUFFIX ".so" CACHE STRING "Python expected extension suffix")
+      endif()
     endif()
   endif()
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -11,30 +11,33 @@ include(CheckCXXCompilerFlag)
 include(CMakePushCheckState)
 
 # ---[ If running on Ubuntu, check system version and compiler version.
-if(EXISTS "/etc/os-release")
-  execute_process(COMMAND
-    "sed" "-ne" "s/^ID=\\([a-z]\\+\\)$/\\1/p" "/etc/os-release"
-    OUTPUT_VARIABLE OS_RELEASE_ID
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  execute_process(COMMAND
-    "sed" "-ne" "s/^VERSION_ID=\"\\([0-9\\.]\\+\\)\"$/\\1/p" "/etc/os-release"
-    OUTPUT_VARIABLE OS_RELEASE_VERSION_ID
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  if(OS_RELEASE_ID STREQUAL "ubuntu")
-    if(OS_RELEASE_VERSION_ID VERSION_GREATER "17.04")
-      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0")
-          message(FATAL_ERROR
-            "Please use GCC 6 or higher on Ubuntu 17.04 and higher. "
-            "For more information, see: "
-            "https://github.com/caffe2/caffe2/issues/1633"
-            )
-        endif()
+if (NOT CHECKED_GCCVER_UBUNTU_1704)
+  if(EXISTS "/etc/os-release")
+    execute_process(COMMAND
+      "sed" "-ne" "s/^ID=\\([a-z]\\+\\)$/\\1/p" "/etc/os-release"
+      OUTPUT_VARIABLE OS_RELEASE_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    execute_process(COMMAND
+      "sed" "-ne" "s/^VERSION_ID=\"\\([0-9\\.]\\+\\)\"$/\\1/p" "/etc/os-release"
+      OUTPUT_VARIABLE OS_RELEASE_VERSION_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(OS_RELEASE_ID STREQUAL "ubuntu")
+      if(OS_RELEASE_VERSION_ID VERSION_GREATER "17.04")
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+          if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0")
+            message(FATAL_ERROR
+              "Please use GCC 6 or higher on Ubuntu 17.04 and higher. "
+              "For more information, see: "
+              "https://github.com/caffe2/caffe2/issues/1633"
+              )
+          endif()
+	endif()
       endif()
     endif()
   endif()
+  set(CHECKED_GCCVER_UBUNTU_1704 CACHE INTERNAL "Check Ubuntu 17.04 gcc version")
 endif()
 
 # ---[ Check if the data type long and int32_t/int64_t overlap.
@@ -141,7 +144,7 @@ CHECK_CXX_SOURCE_COMPILES(
        return 0;
      }" CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
 if (CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
-  message(STATUS "Current compiler supports avx2 extention. Will build perfkernels.")
+  message(STATUS "Current compiler supports avx2 extension. Will build perfkernels.")
   # Currently MSVC seems to have a symbol not found error while linking (related
   # to source file order?). As a result we will currently disable the perfkernel
   # in msvc.


### PR DESCRIPTION
This PR brings caching to some uncached logic that was heavy (calling exec and/or executing python).

There isn't a big effective speedup on rebuild because the majority of time is spent on logic that cant be cached:
- `CUDA_ADD_LIBRARY` logic is pretty heavy (long story)
- generating build files -- for generating the `ninja` build files for `build_caffe2` takes ~10 seconds.

A subsequent PR will simply avoid a cmake re-run every rebuild, by introducing `python setup.py rebuild develop`