### PR TITLE
[C++ API] Use ATen dropout implementation in Dropout module and add FeatureDropout

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -336,7 +336,7 @@ TEST_CASE("integration/mnist", "[cuda]") {
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto drop = Dropout(0.3);
-  auto drop2d = Dropout2d(0.3);
+  auto drop2d = FeatureDropout(0.3);
   auto linear1 = model->add(Linear(320, 50), "linear1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -9,10 +9,13 @@
 
 namespace torch {
 namespace nn {
+
+/// Options for `Dropout` and `FeatureDropout`.
 struct DropoutOptions {
   DropoutOptions(double rate);
   /// The probability with which a particular component of the input is set to
   /// zero.
+  /// Changes to this parameter at runtime are effective.
   TORCH_ARG(double, rate) = 0.5;
 };
 
@@ -26,14 +29,7 @@ class DropoutImplBase : public torch::nn::Cloneable<Derived> {
 
   void reset() override;
 
-  /// During training, applies a noise mask to the input tensor.
-  /// During evaluation, applies an identity function.
-  Tensor forward(Tensor input);
-
-  /// Returns a noise mask that can be applied to the given input tensor.
-  /// Used inside `forward()` to generate the noise mask for dropout.
-  virtual Tensor noise_mask(Tensor input) const = 0;
-
+  /// The options used to configure this `Dropout` module.
   DropoutOptions options;
 };
 } // namespace detail
@@ -45,18 +41,26 @@ class DropoutImplBase : public torch::nn::Cloneable<Derived> {
 class DropoutImpl : public detail::DropoutImplBase<DropoutImpl> {
  public:
   using detail::DropoutImplBase<DropoutImpl>::DropoutImplBase;
-  Tensor noise_mask(Tensor input) const override;
+  /// During training, applies a noise mask to the input tensor.
+  /// During evaluation, applies an identity function.
+  Tensor forward(Tensor input) const;
 };
 
-/// Applies [Dropout](https://arxiv.org/abs/1207.0580) to inputs with
-/// 2-dimensional features.
+/// Applies spatial [Dropout](https://arxiv.org/abs/1207.0580) to inputs with
+/// 2-D or 3-D features.
 ///
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout2d to learn more
-/// about the exact semantics of this module.
-class Dropout2dImpl : public detail::DropoutImplBase<Dropout2dImpl> {
+/// The equivalent in Python is
+/// [Dropout2d](https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout2d) for
+/// 2-D features and
+/// [Dropout3d](https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout3d) for
+/// 3-D features. This `FeatureDropout` module can instead deal with both 2-D
+/// and 3-D features.
+class FeatureDropoutImpl : public detail::DropoutImplBase<FeatureDropoutImpl> {
  public:
-  using detail::DropoutImplBase<Dropout2dImpl>::DropoutImplBase;
-  Tensor noise_mask(Tensor input) const override;
+  using detail::DropoutImplBase<FeatureDropoutImpl>::DropoutImplBase;
+  /// During training, applies a noise mask to the input tensor.
+  /// During evaluation, applies an identity function.
+  Tensor forward(Tensor input) const;
 };
 
 /// A `ModuleHolder` subclass for `DropoutImpl`.
@@ -65,10 +69,10 @@ class Dropout2dImpl : public detail::DropoutImplBase<Dropout2dImpl> {
 /// module storage semantics.
 TORCH_MODULE(Dropout);
 
-/// A `ModuleHolder` subclass for `Dropout2dImpl`.
-/// See the documentation for `Dropout2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
-/// module storage semantics.
-TORCH_MODULE(Dropout2d);
+/// A `ModuleHolder` subclass for `FeatureDropoutImpl`.
+/// See the documentation for `FeatureDropoutImpl` class to learn what methods
+/// it provides, or the documentation for `ModuleHolder` to learn about
+/// PyTorch's module storage semantics.
+TORCH_MODULE(FeatureDropout);
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -43,7 +43,7 @@ class DropoutImpl : public detail::DropoutImplBase<DropoutImpl> {
   using detail::DropoutImplBase<DropoutImpl>::DropoutImplBase;
   /// During training, applies a noise mask to the input tensor.
   /// During evaluation, applies an identity function.
-  Tensor forward(Tensor input) const;
+  Tensor forward(Tensor input);
 };
 
 /// Applies spatial [Dropout](https://arxiv.org/abs/1207.0580) to inputs with
@@ -60,7 +60,7 @@ class FeatureDropoutImpl : public detail::DropoutImplBase<FeatureDropoutImpl> {
   using detail::DropoutImplBase<FeatureDropoutImpl>::DropoutImplBase;
   /// During training, applies a noise mask to the input tensor.
   /// During evaluation, applies an identity function.
-  Tensor forward(Tensor input) const;
+  Tensor forward(Tensor input);
 };
 
 /// A `ModuleHolder` subclass for `DropoutImpl`.

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -26,11 +26,11 @@ template class DropoutImplBase<FeatureDropoutImpl>;
 
 DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
 
-Tensor DropoutImpl::forward(Tensor input) const {
+Tensor DropoutImpl::forward(Tensor input) {
   return torch::dropout(input, options.rate_, this->is_training());
 }
 
-Tensor FeatureDropoutImpl::forward(Tensor input) const {
+Tensor FeatureDropoutImpl::forward(Tensor input) {
   return torch::feature_dropout(input, options.rate_, this->is_training());
 }
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -20,31 +20,18 @@ DropoutImplBase<Derived>::DropoutImplBase(DropoutOptions options_)
 template <typename Derived>
 void DropoutImplBase<Derived>::reset() {}
 
-template <typename Derived>
-Tensor DropoutImplBase<Derived>::forward(Tensor input) {
-  if (options.rate_ == 0 || !this->is_training()) {
-    return input;
-  }
-
-  auto scale = 1.0f / (1.0f - options.rate_);
-  auto boolean_mask = noise_mask(input).uniform_(0, 1) > options.rate_;
-  auto noise = boolean_mask.to(input.dtype()).mul_(scale);
-
-  return input * noise;
-}
-
 template class DropoutImplBase<DropoutImpl>;
-template class DropoutImplBase<Dropout2dImpl>;
+template class DropoutImplBase<FeatureDropoutImpl>;
 } // namespace detail
 
 DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
 
-Tensor DropoutImpl::noise_mask(Tensor input) const {
-  return torch::empty_like(input);
+Tensor DropoutImpl::forward(Tensor input) const {
+  return torch::dropout(input, options.rate_, this->is_training());
 }
 
-Tensor Dropout2dImpl::noise_mask(Tensor input) const {
-  return torch::empty({input.size(0), input.size(1), 1, 1}, input.options());
+Tensor FeatureDropoutImpl::forward(Tensor input) const {
+  return torch::feature_dropout(input, options.rate_, this->is_training());
 }
 } // namespace nn
 } // namespace torch

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -662,6 +662,8 @@ def dropout3d(input, p=0.5, training=True, inplace=False):
         training: apply dropout if is ``True``. Defualt: ``True``
         inplace: If set to ``True``, will do this operation in-place. Default: ``False``
     """
+    # This is 100% the same code as dropout2d. We duplicate this code so that
+    # stack traces are not confusing.
     if p < 0 or p > 1:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))


### PR DESCRIPTION
This PR does two things:
1. Replaces the implementation of the `Dropout` module with a call to the ATen function,
2. Replaces `Dropout2d` with a new `FeatureDropout` module that shall take the place of `Dropout2d` and `Dropout3d`. I contemplated calling it `Dropout2d` and making `Dropout3d` an alias for it, but similar to our decision for `BatchNorm{1,2,3}d` (c.f. https://github.com/pytorch/pytorch/pull/9188), we can deviate from Python PyTorch in favor of the ideal-world solution, which is to have a single module, since both actually just call `feature_dropout`.

I also replaced the implementation of `dropout3d`  with a call to `dropout2d` in Python. The code is the same and it's easier for developers to parse than having to manually match the tokens to make sure it's really 100% the same code (which it is, if I matched the tokens correctly).

@ebetica @ezyang @SsnL 