### PR TITLE
Split Type into TypeInternalInterface and Type.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -107,6 +107,10 @@ ${return_type} ${Type}::${method_prefix_derived}${api_name}(${type_method_formal
 # NB: As far as ezyang can tell, we don't *have* to codegen this,
 # because we will inherit it from the TYPE_METHOD_DEFINITION_CONCRETE in
 # the superclass.  But it doesn't seem to be harmful.
+#
+# self_ty is a hack to make things work for native methods which need to
+# take a dtype, but also need to dispatch differently for different types.
+# Eliminate it at some point.
 TYPE_DERIVED_DEFINITION_NATIVE = CodeTemplate("""\
 ${return_type} ${Type}::${api_name}(${type_method_formals}) const {
     ${device_guard_declaration}
@@ -173,7 +177,7 @@ static inline ${return_type} ${api_name}(${formals}) {
 # the same name (but different signature) already
 ZERO_DIM_CHECK = CodeTemplate("""\
 if (${check_name}.dim() == 0) {
-    return static_cast<const Type*>(this)->${api_name}(${zero_dim_actuals});
+    return static_cast<const TypeInternalInterface*>(this)->${api_name}(${zero_dim_actuals});
 }""")
 
 ZERO_DIM_ONLY = CodeTemplate("""\
@@ -183,7 +187,7 @@ AT_ERROR("${api_name} only supports a 0-dimensional ${check_name} tensor, but go
 
 SPARSE_CHECK = CodeTemplate("""\
 if(${check_name}.type().is_sparse()) {
-    return static_cast<const Type*>(this)->${api_name}(${sparse_actuals});
+    return static_cast<const TypeInternalInterface*>(this)->${api_name}(${sparse_actuals});
 }""")
 
 BUFFER_DEFINITION = CodeTemplate("""\
@@ -390,6 +394,7 @@ TopEnvironment = TypedDict('TopEnvironment', {
     'type_registrations': List[str],
     'type_headers': List[str],
     'pure_virtual_type_method_declarations': List[str],
+    'pure_virtual_internal_type_method_declarations': List[str],
     'type_method_declarations': List[str],
     'type_method_definitions': List[str],
     'type_method_inline_definitions': List[str],
@@ -490,6 +495,9 @@ FunctionOption = TypedDict('FunctionOption', {
     'formals': List[str],
     'inferred_type': str,
     'inplace': bool,
+    # This controls whether or not we generate the interface in Type or
+    # TypeInternalInterface
+    'internal_method': bool,
     'method_actuals': List[str],
     'method_formals_with_defaults': List[str],
     'method_formals': List[str],
@@ -836,8 +844,12 @@ def create_generic(top_env, declarations):
             # NN function with no _forward/_backward suffix don't have cimpls.
             # They call the _forward function and discard any buffer returns
             abstract = False
-            top_env['pure_virtual_type_method_declarations'].append(
-                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            if option['internal_method']:
+                top_env['pure_virtual_internal_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            else:
+                top_env['pure_virtual_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
             body = emit_nn_body(option)
@@ -845,17 +857,27 @@ def create_generic(top_env, declarations):
                 TYPE_METHOD_DEFINITION_CONCRETE.substitute(
                     env, type_definition_body=body))
         elif broadcast_arg is None:
-            top_env['pure_virtual_type_method_declarations'].append(
-                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            if option['internal_method']:
+                top_env['pure_virtual_internal_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            else:
+                top_env['pure_virtual_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_ABSTRACT.substitute(env))
             top_env['type_method_definitions'].append(
                 TYPE_METHOD_DEFINITION_ABSTRACT.substitute(env))
         else:
-            top_env['pure_virtual_type_method_declarations'].append(
-                PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
-            top_env['pure_virtual_type_method_declarations'].append(
-                PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+            if option['internal_method']:
+                top_env['pure_virtual_internal_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+                top_env['pure_virtual_internal_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
+            else:
+                top_env['pure_virtual_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+                top_env['pure_virtual_type_method_declarations'].append(
+                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
             top_env['type_method_declarations'].append(
@@ -1060,11 +1082,16 @@ def create_generic(top_env, declarations):
         # Factory methods are not dispatched over `Type`.
         if not is_factory_method:
             if option['deprecated']:
+                # Deprecated functions are always non-internal
                 top_env['pure_virtual_type_method_declarations'].append(
                     DEPRECATED_PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             else:
-                top_env['pure_virtual_type_method_declarations'].append(
-                    PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+                if option['internal_method']:
+                    top_env['pure_virtual_internal_type_method_declarations'].append(
+                        PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
+                else:
+                    top_env['pure_virtual_type_method_declarations'].append(
+                        PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
         dispatch = option['type_method_definition_dispatch']
         option['native_type_method_dispatch'] = dispatch
@@ -1116,12 +1143,12 @@ def create_generic(top_env, declarations):
 
         if is_namespace_function:
             if dispatch_type:
-                option['inferred_type'] = dispatch_type['name']
+                option['inferred_type'] = 'static_cast<const TypeInternalInterface&>({})'.format(dispatch_type['name'])
             elif dispatch_tensor:
                 option['inferred_type'] = 'infer_type({})'.format(dispatch_tensor)
             else:
                 # doesn't depend on a specific type, use undefined float
-                option['inferred_type'] = 'at::getNonVariableType(at::Backend::Undefined, at::ScalarType::Float)'
+                option['inferred_type'] = 'non_specific_type()'
             declaration = DEPRECATED_FUNCTION_DECLARATION if option['deprecated'] else FUNCTION_DECLARATION
             top_env['function_declarations'].append(declaration.substitute(env))
             if is_factory_method:

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -107,6 +107,7 @@ TYPE_DERIVED_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDerived.cpp")
 SPARSE_TYPE_DERIVED_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/SparseTypeDerived.cpp")
 TYPE_DERIVED_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDerived.h")
 TYPE_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.h")
+TYPE_INTERNAL_INTERFACE_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeInternalInterface.h")
 TYPE_DEFAULT_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDefault.h")
 TYPE_DEFAULT_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/TypeDefault.cpp")
 
@@ -165,6 +166,7 @@ top_env = {
     'cuda_type_registrations': [],
     'cuda_type_headers': [],
     'pure_virtual_type_method_declarations': [],
+    'pure_virtual_internal_type_method_declarations': [],
     'type_method_declarations': [],
     'type_method_definitions': [],
     'type_method_inline_definitions': [],
@@ -330,7 +332,7 @@ def iterate_types():
 # so that the script runs quickly when we are just querying the
 # outputs
 def declare_outputs():
-    files = ['Declarations.yaml', 'Type.h', 'TypeDefault.cpp', 'TypeDefault.h', 'Tensor.h',
+    files = ['Declarations.yaml', 'Type.h', 'TypeInternalInterface.h', 'TypeDefault.cpp', 'TypeDefault.h', 'Tensor.h',
              'TensorMethods.h', 'Functions.h',
              'CPUCopy.cpp', 'NativeFunctions.h',
              'RegisterCPU.cpp', 'RegisterCPU.h']
@@ -400,6 +402,7 @@ def generate_outputs():
             backend, density, scalar_type, declarations))
 
     file_manager.write('Type.h', TYPE_H, top_env)
+    file_manager.write('TypeInternalInterface.h', TYPE_INTERNAL_INTERFACE_H, top_env)
     file_manager.write('TypeDefault.h', TYPE_DEFAULT_H, top_env)
     file_manager.write('TypeDefault.cpp', TYPE_DEFAULT_CPP, top_env)
 

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -67,18 +67,17 @@ Tensor embedding_sparse_backward(
   int64_t num_features = grad_.size(-1);
   auto weight_size = std::array<int64_t, 2>{{ num_weights, num_features }};
   auto& dense_type = grad.type();
-  auto& sparse_type = dense_type.toBackend(grad.is_cuda() ? Backend::SparseCUDA : Backend::SparseCPU);
 
   // check if all our grad come from padding_idx
   if (grad.numel() == 0) {
-    return sparse_type._sparse_coo_tensor_unsafe(indices_.type().tensor({1, 0}),
-                                                 dense_type.tensor({0, num_features}),
-                                                 weight_size);
+    return at::_sparse_coo_tensor_unsafe(indices_.type().tensor({1, 0}),
+                                         dense_type.tensor({0, num_features}),
+                                         weight_size);
   }
 
   auto index = indices.reshape({1, -1});
   auto values = grad.reshape({-1, num_features});
-  return sparse_type._sparse_coo_tensor_unsafe(index, values, weight_size);
+  return at::_sparse_coo_tensor_unsafe(index, values, weight_size);
 }
 
 Tensor embedding_dense_backward_cpu(

--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -144,34 +144,34 @@ Tensor& addmm_(Tensor& self, const Tensor& mat1, const Tensor& mat2, Scalar beta
 
 Tensor tensor(const Type& dtype) {
   if (_type_has_native(dtype)) {
-    return dtype.native_tensor();
+    return static_cast<const TypeInternalInterface&>(dtype).native_tensor();
   } else {
-    return dtype.th_tensor();
+    return static_cast<const TypeInternalInterface&>(dtype).th_tensor();
   }
 }
 
 Tensor tensor(const Type& dtype, ArrayRef<int64_t> size) {
   if (_type_has_native(dtype)) {
-    return dtype.native_tensor(size);
+    return static_cast<const TypeInternalInterface&>(dtype).native_tensor(size);
   } else {
-    return dtype.th_tensor(size);
+    return static_cast<const TypeInternalInterface&>(dtype).th_tensor(size);
   }
 }
 
 Tensor sparse_coo_tensor(const Type& dtype, ArrayRef<int64_t> size) {
-  return dtype.toSparse().native_sparse_coo_tensor(size);
+  return static_cast<const TypeInternalInterface&>(dtype.toSparse()).native_sparse_coo_tensor(size);
 }
 
 Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values) {
-  return values.type().toSparse().native_sparse_coo_tensor(indices, values);
+  return static_cast<const TypeInternalInterface&>(values.type().toSparse()).native_sparse_coo_tensor(indices, values);
 }
 
 Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values, ArrayRef<int64_t> size) {
-  return values.type().toSparse().native_sparse_coo_tensor(indices, values, size);
+  return static_cast<const TypeInternalInterface&>(values.type().toSparse()).native_sparse_coo_tensor(indices, values, size);
 }
 
 Tensor _sparse_coo_tensor_unsafe(const Tensor& indices, const Tensor& values, ArrayRef<int64_t> size) {
-  return values.type().toSparse()._native_sparse_coo_tensor_unsafe(indices, values, size);
+  return static_cast<const TypeInternalInterface&>(values.type().toSparse())._native_sparse_coo_tensor_unsafe(indices, values, size);
 }
 
 int64_t get_device(const Tensor& self) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -169,14 +169,14 @@ Tensor mm(const Tensor& self, const Tensor& mat2) {
   if (self.is_sparse()) {
     return mat2.type().addmm(at::zeros({}, mat2.type()), self, mat2, 0, 1);
   }
-  return self.type()._mm(self, mat2);
+  return at::_mm(self, mat2);
 }
 
 Tensor& mm_out(Tensor& result, const Tensor& self, const Tensor& mat2) {
   if (self.is_sparse()) {
-    return mat2.type().addmm_out(result, at::zeros({}, mat2.type()), self, mat2, 0, 1);
+    return at::addmm_out(result, at::zeros({}, mat2.options()), self, mat2, 0, 1);
   }
-  return self.type()._mm_out(result, self, mat2);
+  return at::_mm_out(result, self, mat2);
 }
 
 Tensor mv(const Tensor& self, const Tensor& vec) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -59,6 +59,10 @@ void window_function_checks(
       window_length);
 }
 
+const TypeInternalInterface& getFactoryType(const TensorOptions& options) {
+  return static_cast<const TypeInternalInterface&>(at::getType(options));
+}
+
 } // namespace
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ arange ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,7 +77,7 @@ Tensor arange(
     Scalar step,
     const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
-  return at::getType(options)._arange(start, end, step);
+  return getFactoryType(options)._arange(start, end, step);
 }
 
 Tensor& arange_out(Tensor& result, Scalar start, Scalar end) {
@@ -86,7 +90,7 @@ Tensor& arange_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
 
 Tensor arange(Scalar end, const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
-  return at::getType(options)._arange(end);
+  return getFactoryType(options)._arange(end);
 }
 
 Tensor& arange_out(Tensor& result, Scalar end) {
@@ -94,7 +98,7 @@ Tensor& arange_out(Tensor& result, Scalar end) {
 }
 
 Tensor _dim_arange(const Tensor& like, int64_t dim) {
-  return like.type().toScalarType(at::kLong)._arange(like.size(dim));
+  return static_cast<const TypeInternalInterface&>(like.type().toScalarType(at::kLong))._arange(like.size(dim));
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -102,7 +106,7 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 Tensor empty(IntList size, const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
   // Can't call a factory function, because the buck stops with us!
-  return at::getType(options).tensor(size);
+  return getFactoryType(options).tensor(size);
 }
 
 Tensor& empty_out(Tensor& result, IntList size) {
@@ -218,7 +222,7 @@ Tensor linspace(
     int64_t steps,
     const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
-  return at::getType(options)._linspace(start, end, steps);
+  return getFactoryType(options)._linspace(start, end, steps);
 }
 
 Tensor& linspace_out(Tensor& result, Scalar start, Scalar end) {
@@ -241,7 +245,7 @@ Tensor logspace(
     int64_t steps,
     const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
-  return at::getType(options)._logspace(start, end, steps);
+  return getFactoryType(options)._logspace(start, end, steps);
 }
 
 Tensor& logspace_out(Tensor& result, Scalar start, Scalar end) {
@@ -475,7 +479,7 @@ Tensor range(
     Scalar step,
     const TensorOptions& options) {
   // Note [Native bindings for legacy TH factory functions]
-  return at::getType(options)._range(start, end, step);
+  return getFactoryType(options)._range(start, end, step);
 }
 
 Tensor& range_out(Tensor& result, Scalar start, Scalar end) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -206,7 +206,7 @@ Tensor repeat(const Tensor& self, IntList repeats) {
   Tensor xtensor = self.expand(padded_size);
 
   Tensor result = self.type().tensor(target_size);
-  Tensor urtensor = result.type().alias(result);
+  Tensor urtensor = at::alias(result);
   for (int64_t i = 0; i < xtensor.dim(); ++i) {
     // can't unfold with step 0, so make sure step is at least 1
     // (it doesn't matter what it is in that case, because the size is 0).

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1061,7 +1061,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
 
   auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output);
   auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx);
-  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx) : grad_cy_r;
+  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx)) : grad_cy_r;
 
   Tensor dx, dhx, dcx;
   // NB: unconditionally compute this gradient, because it mutates reserve

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1059,9 +1059,9 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
     std::array<bool, 4> output_mask
     ) {
 
-  auto grad_output = grad_output_r.defined() ? grad_output_r : output.type().zeros_like(output);
-  auto grad_hy = grad_hy_r.defined() ? grad_hy_r : hx.type().zeros_like(hx);
-  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : cx.type().zeros_like(cx)) : grad_cy_r;
+  auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output);
+  auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx);
+  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx) : grad_cy_r;
 
   Tensor dx, dhx, dcx;
   // NB: unconditionally compute this gradient, because it mutates reserve

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -784,7 +784,7 @@ Tensor& _sspaddmm_out_only_sparse(Tensor& result, const Tensor& self,
 // sparse, dense -> sparse
 Tensor smm(const Tensor& self, const Tensor& mat2) {
   auto result = self.type().tensor();
-  self.type().sspaddmm_out(result, result, self, mat2, 0.0, 1.0);
+  at::sspaddmm_out(result, result, self, mat2, 0.0, 1.0);
   return result;
 }
 
@@ -792,7 +792,7 @@ Tensor smm(const Tensor& self, const Tensor& mat2) {
 Tensor sspaddmm(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
     Scalar beta, Scalar alpha) {
   auto result = self.type().tensor();
-  self.type().sspaddmm_out(result, self, mat1, mat2, beta, alpha);
+  at::sspaddmm_out(result, self, mat1, mat2, beta, alpha);
   return result;
 }
 

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -4,6 +4,7 @@
 
 #include "ATen/core/Scalar.h"
 #include "ATen/Type.h"
+#include "ATen/TypeInternalInterface.h"
 #include "ATen/Tensor.h"
 #include "ATen/core/Storage.h"
 #include "ATen/core/Generator.h"
@@ -20,13 +21,16 @@ using native::tensor;
 
 ${function_declarations}
 
-static inline Type & infer_type(const Tensor & t) {
+static inline TypeInternalInterface & infer_type(const Tensor & t) {
   AT_CHECK(t.defined(), "undefined Tensor");
-  return t.type();
+  return static_cast<TypeInternalInterface&>(t.type());
 }
-static inline Type & infer_type(const TensorList & tl) {
+static inline TypeInternalInterface & infer_type(const TensorList & tl) {
   AT_CHECK(tl.size() > 0, "expected a non-empty list of Tensors");
-  return tl[0].type();
+  return static_cast<TypeInternalInterface&>(tl[0].type());
+}
+static inline TypeInternalInterface & non_specific_type() {
+  return static_cast<TypeInternalInterface&>(at::getNonVariableType(at::Backend::Undefined, at::ScalarType::Float));
 }
 // function definitions are all static inline because
 // they are one-line statically dispatched functions that

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -2,13 +2,13 @@
 
 // ${generated_comment}
 
-#include "ATen/Type.h"
+#include "ATen/TypeInternalInterface.h"
 
 namespace at {
 
-struct AT_API TypeDefault : public Type {
+struct AT_API TypeDefault : public TypeInternalInterface {
   explicit TypeDefault(TensorTypeId type_id, bool is_variable, bool is_undefined)
-      : Type(type_id, is_variable, is_undefined) {}
+      : TypeInternalInterface(type_id, is_variable, is_undefined) {}
 
   // Make sure overload resolution considers the nullary virtual method.
   // (A single argument overload is generated in the list.)

--- a/aten/src/ATen/templates/TypeInternalInterface.h
+++ b/aten/src/ATen/templates/TypeInternalInterface.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <ATen/Type.h>
+
+namespace at {
+
+struct AT_API TypeInternalInterface : public Type {
+  explicit TypeInternalInterface(TensorTypeId type_id, bool is_variable, bool is_undefined)
+      : Type(type_id, is_variable, is_undefined) {}
+  ${pure_virtual_internal_type_method_declarations}
+};
+
+} // namespace at

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -214,10 +214,10 @@ private:
     DEFINE_IF(int64, Long)
     CAFFE_THROW("unsupported type annotation: ", name);
   }
-  at::Type & stringToType(const std::string & name) {
-    return at::getNonVariableType(backend(), stringToScalarType(name));
+  at::TypeInternalInterface & stringToType(const std::string & name) {
+    return static_cast<at::TypeInternalInterface&>(at::getNonVariableType(backend(), stringToScalarType(name)));
   }
-  at::Type * readTypeAttribute(const std::string & name) {
+  at::TypeInternalInterface * readTypeAttribute(const std::string & name) {
     CAFFE_ENFORCE(OperatorBase::HasSingleArgumentOfType<std::string>(name));
     return &stringToType(OperatorBase::GetSingleArgument<std::string>(name, ""));
   }

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
                     # first tensor input is used to define the output type.
                     defined_inferred_type = True
                     env['statements'].append(
-                        'auto inferred_type = &({}.type());'.format(
+                        'auto inferred_type = &(static_cast<at::TypeInternalInterface&>({}.type()));'.format(
                             arg['name']))
             else:
                 init = CT(ARGUMENT_MAP[arg['type']]).substitute(env, arg=arg['name'])

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -44,7 +44,7 @@ namespace torch { namespace autograd {
 
 VariableType::VariableType(Context* context, Type* baseType)
   : TypeDefault(baseType->type_id(), /*is_variable=*/true, /*is_undefined=*/false)
-  , baseType(baseType)
+  , baseType(static_cast<TypeInternalInterface*>(baseType))
   , id_(context->freshTypeID()) {
   str = std::string("Variable[") + baseType->toString() + "]";
 }

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -68,7 +68,7 @@ private:
   static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);
   static std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos);
 
-  at::Type* baseType;
+  at::TypeInternalInterface* baseType;
   std::string str;
   size_t id_;
 };

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -87,7 +87,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
   outputs.reserve(tensors.size());
   auto & type = tensors[0].type();
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
-    outputs.emplace_back(type._sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
+    outputs.emplace_back(at::_sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
   return outputs;
 }
 

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -85,7 +85,6 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
 
   std::vector<at::Tensor> outputs;
   outputs.reserve(tensors.size());
-  auto & type = tensors[0].type();
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
     outputs.emplace_back(at::_sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
   return outputs;


### PR DESCRIPTION
Previously, we had Type which was a catch all interface for all
functions and methods we could possibly want to do dynamic dispatch
on.  However, we want to check in a non-autogenerated Tensor class
to ATen/core, and to do this, we must also check in a non-autogenerated
Type class which we can do dispatch on.  In principle, we could
put the *full* Type interface in ATen/core, but this would be
a bad developer experience, since any time you add a new free
function, you'd have to regenerate the checked in Type header.

For a better dev experience, we split Type into a two parts,
Type, which will be checked in (though not in this diff), and
TypeInternalInterface, which will NOT be checked in.  Type contains
just enough methods to let Tensor be defined, and leaves the
rest to TypeInternalInterface.

Some complications:

- We (very unfortunately) have overloaded virtual methods.  Because
  of C++'s rules, we cannot move one overload without doing some
  extra work to make sure that overload in a superclass and an
  overload in a subclass resolve together.  I've chosen to resolve
  this problem simply by moving ALL overloads of a method which
  occurs in Tensor to Type.

- There are some places where we take a type() object and call
  a method on it, which is not a Tensor base method.  I've eliminated
  some where possible, but in other cases calling the method on type
  is the ONLY way to invoke it; in that case, I've just inserted
  a cast.  Further refactoring is necessary.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

