### PR TITLE
[JIT] Traceable explicit Variable instantiation

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1674,6 +1674,15 @@ class TestJit(JitTestCase):
             torch.randn(5, 3, 10), torch.LongTensor([3, 3, 2]), torch.randn(2, 3, 20), torch.randn(2, 3, 20)
         self.assertEqual(traced(x, lengths, (h0, c0)), imported(x, lengths, (h0, c0)))
 
+    def test_trace_variable_instantiation(self):
+        def random_foo(x):
+            return Variable(Variable(x) + 1.0)
+
+        random_foo_traced = torch.jit.trace(random_foo, (torch.rand(3, 4),))
+
+        x = torch.rand(5, 6)
+        self.assertEqual(random_foo(x), random_foo_traced(x))
+
 
 class TestBatched(TestCase):
     # generate random examples and create an batchtensor with them

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/autograd/python_function.h"
 #include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/tensor/python_tensor.h"
+#include "torch/csrc/jit/tracer.h"
 
 using namespace at;
 
@@ -65,6 +66,12 @@ static PyObject *THPVariable_pynew(PyTypeObject* type, PyObject *args, PyObject 
 
   if (name) {
     var.set_name(name);
+  }
+
+  if (jit::tracer::isTracing() && data && data != Py_None && THPVariable_Check(data)) {
+    if (auto *v = jit::tracer::getValueTrace(((THPVariable*)data)->cdata)) {
+      jit::tracer::setValueTrace(var, v);
+    }
   }
 
   return THPVariable_Wrap(std::move(var));


### PR DESCRIPTION
There's a bunch of legacy code where people are explicitly instantiating Variable, and these call-sites have thus far been untraceable (appearing as prim::Constant nodes with the tensor value at the time of tracing). This makes it so that the new variable inherits the traced Value* from the tensor it's being constructed from