### PR TITLE
Allow restoring of Parameters with load_state_dict()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -654,8 +654,7 @@ class Module(object):
                     continue
 
                 if isinstance(input_param, Parameter):
-                    # backwards compatibility for serialized parameters
-                    input_param = input_param.data
+                    self._parameters[name] = input_param.to(param.device, param.dtype)
                 try:
                     param.copy_(input_param)
                 except Exception:


### PR DESCRIPTION
Extending from #8633, this allows `requires_grad` to be restored when serialized using `keep_vars=True`.
Potentially rename `keep_vars` as I am guessing this is a reference to the old `Variable` ?

