### PR TITLE
Check for maximum numel in NCCL broadcasting

### DIFF
--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -72,6 +72,9 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
                    [&](const at::Tensor& t) { return t.get_device() == devices[0]; })) {
     throw std::runtime_error("all tensors must be on devices[0]");
   }
+#ifdef USE_NCCL
+  buffer_size = std::min(torch::cuda::nccl::get_max_count(), buffer_size);
+#endif
 
   tensor_list2d outputs(devices.size());
   outputs[0] = tensors.vec();

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -180,7 +180,7 @@ std::uint64_t version() {
 }
 
 namespace {
-  // NCCL changed the umerical type used for count between NCCL1 and NCCL2.
+  // NCCL changed the numerical type used for count between NCCL1 and NCCL2.
   // So we use the following struct, which gets the type of the second argument
   // of T, if T is a function type, with ncclBcast, to get that type statically
   // and programmatically.

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -216,7 +216,7 @@ void broadcast(TensorList tensors, const stream_list& streams, const comm_list& 
     device_guard.set_index(tensors[i].get_device());
     // TODO: use current stream
     const auto stream = (streams.empty() || !streams[i]) ? nullptr : THCStream_stream(streams[i]);
-    AT_CHECK(numel <= count_max,
+    AT_CHECK(static_cast<uint64_t>(numel) <= static_cast<uint64_t>(count_max),
              "Broadcast tensor has ", numel, " elements, which exceeds the "
              "maximum NCCL supports (", count_max, ")");
     CHECK(ncclBcast(tensors[i].data_ptr(), numel, data_type, 0, comms[i], stream));

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -5,6 +5,8 @@
 
 #include <unordered_map>
 #include <sstream>
+#include <limits>
+#include <type_traits>
 #include <ATen/ATen.h>
 #include <THC/THC.h>
 #include <THC/THCStream.h>
@@ -177,6 +179,28 @@ std::uint64_t version() {
 #endif
 }
 
+namespace {
+  // NCCL changed the umerical type used for count between NCCL1 and NCCL2.
+  // So we use the following struct, which gets the type of the second argument
+  // of T, if T is a function type, with ncclBcast, to get that type statically
+  // and programmatically.
+
+  template<typename T>
+  struct GetSecondArgType;
+
+  template<typename R, typename Arg0, typename Arg1, typename ...Args>
+  struct GetSecondArgType<R(Arg0, Arg1, Args...)> {
+    typedef typename std::decay<Arg1>::type type;
+  };
+
+  constexpr auto count_max = std::numeric_limits<GetSecondArgType<decltype(ncclBcast)>::type>::max();
+}
+
+size_t get_max_count() {
+  return count_max;
+}
+
+
 void broadcast(TensorList tensors, const stream_list& streams, const comm_list& user_comms) {
 #ifdef USE_NCCL
   using namespace torch::cuda::nccl::detail;
@@ -192,6 +216,9 @@ void broadcast(TensorList tensors, const stream_list& streams, const comm_list& 
     device_guard.set_index(tensors[i].get_device());
     // TODO: use current stream
     const auto stream = (streams.empty() || !streams[i]) ? nullptr : THCStream_stream(streams[i]);
+    AT_CHECK(numel <= count_max,
+             "Broadcast tensor has ", numel, " elements, which exceeds the "
+             "maximum NCCL supports (", count_max, ")");
     CHECK(ncclBcast(tensors[i].data_ptr(), numel, data_type, 0, comms[i], stream));
   }
 #else

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -47,4 +47,6 @@ void broadcast(at::TensorList tensors,
                const stream_list& streams = {},
                const comm_list& user_comms = {});
 
+size_t get_max_count();
+
 }}}


### PR DESCRIPTION
NCCL1 uses `int` as its numerical type for fields like `count`, which makes broadcasting tensors larger than `2 << 31 - 1` impossible, and raises opaque error `invalid arguments`. NCCL2 greatly increase the limit on many platforms by using `size_t`. This patch statically detects this type, and raises properly if the broadcast tensor exceeds the limit.

No test because I don't think our test suite should broadcast big tensors.