### PR TITLE
fix nested no_grad decorator and with-statement

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -724,7 +724,7 @@ class TestAutograd(TestCase):
         self.assertRaises(RuntimeError, lambda: z.backward(torch.ones(5, 5)))
         self.assertIsNone(z.grad_fn)
 
-        # test nested decorator and with-statement
+        # test nested decorator and with-statement on no_grad
         with torch.no_grad():
             self.assertFalse(torch.is_grad_enabled())
             w = adder(x, y)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -724,6 +724,12 @@ class TestAutograd(TestCase):
         self.assertRaises(RuntimeError, lambda: z.backward(torch.ones(5, 5)))
         self.assertIsNone(z.grad_fn)
 
+        # test nested decorator and with-statement
+        with torch.no_grad():
+            self.assertFalse(torch.is_grad_enabled())
+            w = adder(x, y)
+            self.assertFalse(torch.is_grad_enabled())
+
     def test_no_grad_python_function(self):
         """Python Functions should respect grad mode."""
         x = torch.ones(5, 5, requires_grad=True)

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -42,7 +42,7 @@ class no_grad(object):
     def __call__(self, func):
         @functools.wraps(func)
         def decorate_no_grad(*args, **kwargs):
-            with self:
+            with torch.no_grad():
                 return func(*args, **kwargs)
         return decorate_no_grad
 
@@ -89,7 +89,7 @@ class enable_grad(object):
     def __call__(self, func):
         @functools.wraps(func)
         def decorate_enable_grad(*args, **kwargs):
-            with self:
+            with torch.no_grad():
                 return func(*args, **kwargs)
         return decorate_enable_grad
 

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -28,11 +28,8 @@ class no_grad(object):
         >>> z.requires_grad
         False
     """
-
-    def __init__(self):
-        self.prev = torch.is_grad_enabled()
-
     def __enter__(self):
+        self.prev = torch.is_grad_enabled()
         torch._C.set_grad_enabled(False)
 
     def __exit__(self, *args):
@@ -42,7 +39,7 @@ class no_grad(object):
     def __call__(self, func):
         @functools.wraps(func)
         def decorate_no_grad(*args, **kwargs):
-            with torch.no_grad():
+            with self:
                 return func(*args, **kwargs)
         return decorate_no_grad
 
@@ -75,11 +72,8 @@ class enable_grad(object):
         True
 
     """
-
-    def __init__(self):
-        self.prev = torch.is_grad_enabled()
-
     def __enter__(self):
+        self.prev = torch.is_grad_enabled()
         torch._C.set_grad_enabled(True)
 
     def __exit__(self, *args):
@@ -89,7 +83,7 @@ class enable_grad(object):
     def __call__(self, func):
         @functools.wraps(func)
         def decorate_enable_grad(*args, **kwargs):
-            with torch.no_grad():
+            with self:
                 return func(*args, **kwargs)
         return decorate_enable_grad
 


### PR DESCRIPTION
- fixes https://github.com/pytorch/pytorch/issues/10858
- allow `no_grad` decorator to apply `with torch.no_grad()` at the correct context
- current behavior:
```
import torch

@torch.no_grad()
def nothing(x):
    return x

testin = torch.Tensor([0])
with torch.no_grad():
    print(torch.is_grad_enabled()) # False
    testout = nothing(testin)
    print(torch.is_grad_enabled()) # False
```