### PR TITLE
[C++ API] Document BatchNorm and update default behavior

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -281,8 +281,8 @@ TEST_CASE("integration/cartpole") {
     for (auto i = 0U; i < saved_log_probs.size(); i++) {
       auto r = rewards[i] - saved_values[i].toCFloat();
       policy_loss.push_back(-r * saved_log_probs[i]);
-      value_loss.push_back(torch::smooth_l1_loss(
-          saved_values[i], torch::ones(1) * rewards[i]));
+      value_loss.push_back(
+          torch::smooth_l1_loss(saved_values[i], torch::ones(1) * rewards[i]));
     }
 
     auto loss =
@@ -370,12 +370,10 @@ TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   torch::manual_seed(0);
   auto model = std::make_shared<SimpleContainer>();
   auto conv1 = model->add(Conv2d(1, 10, 5), "conv1");
-  auto batchnorm2d =
-      model->add(BatchNorm(BatchNormOptions(10).stateful(true)), "batchnorm2d");
+  auto batchnorm2d = model->add(BatchNorm(10), "batchnorm2d");
   auto conv2 = model->add(Conv2d(10, 20, 5), "conv2");
   auto linear1 = model->add(Linear(320, 50), "linear1");
-  auto batchnorm1 =
-      model->add(BatchNorm(BatchNormOptions(50).stateful(true)), "batchnorm1");
+  auto batchnorm1 = model->add(BatchNorm(50), "batchnorm1");
   auto linear2 = model->add(Linear(50, 10), "linear2");
 
   auto forward = [&](torch::Tensor x) {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -12,6 +12,8 @@
 
 #include <test/cpp/api/util.h>
 
+using Catch::StartsWith;
+
 using namespace torch::nn;
 using namespace torch::test;
 
@@ -238,8 +240,65 @@ TEST_CASE("modules") {
       REQUIRE(functional(torch::ones({}) * -1).toCFloat() == 0);
     }
     {
-      auto functional = Functional(torch::elu, /*alpha=*/1, /*scale=*/0, /*input_scale=*/1);
+      auto functional =
+          Functional(torch::elu, /*alpha=*/1, /*scale=*/0, /*input_scale=*/1);
       REQUIRE(functional(torch::ones({})).toCFloat() == 0);
+    }
+  }
+
+  SECTION("batchnorm") {
+    {
+      BatchNorm bn(5);
+
+      // Is stateful by default.
+      REQUIRE(bn->options.stateful());
+
+      REQUIRE(bn->running_mean.defined());
+      REQUIRE(bn->running_mean.dim() == 1);
+      REQUIRE(bn->running_mean.size(0) == 5);
+
+      REQUIRE(bn->running_variance.defined());
+      REQUIRE(bn->running_variance.dim() == 1);
+      REQUIRE(bn->running_variance.size(0) == 5);
+
+      // Is affine by default.
+      REQUIRE(bn->options.affine());
+
+      REQUIRE(bn->weight.defined());
+      REQUIRE(bn->weight.dim() == 1);
+      REQUIRE(bn->weight.size(0) == 5);
+
+      REQUIRE(bn->bias.defined());
+      REQUIRE(bn->bias.dim() == 1);
+      REQUIRE(bn->bias.size(0) == 5);
+    }
+    {
+      BatchNorm bn(BatchNormOptions(5).stateful(false).affine(false));
+
+      REQUIRE(!bn->running_mean.defined());
+      REQUIRE(!bn->running_variance.defined());
+      REQUIRE(!bn->weight.defined());
+      REQUIRE(!bn->bias.defined());
+
+      REQUIRE_THROWS_WITH(
+          bn->forward(torch::ones({2, 5})),
+          StartsWith("Calling BatchNorm::forward is only permitted "
+                     "when the 'stateful' option is true (was false). "
+                     "Use BatchNorm::pure_forward instead."));
+    }
+    {
+      BatchNorm bn(BatchNormOptions(5).affine(false));
+      bn->eval();
+
+      // Want to make sure we use the supplied values in `pure_forward` even if
+      // we are stateful.
+      auto input = torch::randn({2, 5});
+      auto mean = torch::randn(5);
+      auto variance = torch::rand(5);
+      auto output = bn->pure_forward(input, mean, variance);
+      auto expected =
+          (input - mean) / torch::sqrt(variance + bn->options.eps());
+      REQUIRE(output.allclose(expected));
     }
   }
 }

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -8,15 +8,43 @@
 
 namespace torch {
 namespace nn {
+
+/// Options for the `BatchNorm` module.
 struct BatchNormOptions {
   /* implicit */ BatchNormOptions(int64_t features);
+  /// The number of features of the input tensor.
+  /// Changing this parameter after construction __has no effect__.
   TORCH_ARG(int64_t, features);
+  /// Whether to learn a scale and bias that are applied in an affine
+  /// transformation on the input.
+  /// Changing this parameter after construction __has no effect__.
   TORCH_ARG(bool, affine) = true;
-  TORCH_ARG(bool, stateful) = false;
+  /// Whether to store and update batch statistics (mean and variance) in the
+  /// module. If `false`, you should call `pure_forward` and supply those batch
+  /// statistics yourself.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(bool, stateful) = true;
+  /// The epsilon value added for numerical stability.
+  /// Changing this parameter after construction __is effective__.
   TORCH_ARG(double, eps) = 1e-5;
+  /// A momentum multiplier for the mean and variance.
+  /// Changing this parameter after construction __is effective__.
   TORCH_ARG(double, momentum) = 0.1;
 };
 
+/// Applies [Batch Normalization](https://arxiv.org/abs/1502.03167) to an input.
+///
+/// Refer to the documentation for
+/// [`BatchNorm1d`](https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm1d)
+/// in PyTorch to learn more about the exact semantics of this module, __but see
+/// the note below regarding differences between the Python and C++ API__.
+///
+/// \rst
+/// .. attention::
+///   In the Python API, there are separate implementations for 1-D, 2-D and 3-D
+///   BatchNorm. In C++, there is only one `BatchNorm` module, which works for
+///   any of these dimensions.
+/// \endrst
 class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
  public:
   explicit BatchNormImpl(int64_t features)
@@ -25,16 +53,42 @@ class BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
 
   void reset() override;
 
+  /// Applies batch normalization on the `input` using the stored mean and
+  /// variance.
+  ///
+  /// The module must be constructed with `stateful = true` when calling this
+  /// method, as the module will otherwise not store running statistics. If you
+  /// want to supply the mean and variance yourself, use `pure_forward`.
   Tensor forward(Tensor input);
+
+  /// Applies batch normalization on the `input` using the given `mean` and
+  /// `variance` statistics.
   Tensor pure_forward(Tensor input, Tensor mean, Tensor variance);
 
+  /// The options with which this module was constructed.
   BatchNormOptions options;
+
+  /// The learned weight.
+  /// Only defined if the `affine` option was `true` upon construction.
   Tensor weight;
+
+  /// The learned bias.
+  /// Only defined if the `affine` option was `true` upon construction.
   Tensor bias;
+
+  /// The running mean.
+  /// Only defined if the `stateful` option was `true` upon construction.
   Tensor running_mean;
+
+  /// The running variance.
+  /// Only defined if the `stateful` option was `true` upon construction.
   Tensor running_variance;
 };
 
+/// A `ModuleHolder` subclass for `BatchNormImpl`.
+/// See the documentation for `BatchNormImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(BatchNorm);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -27,9 +27,10 @@ struct BatchNormOptions {
   /// The epsilon value added for numerical stability.
   /// Changing this parameter after construction __is effective__.
   TORCH_ARG(double, eps) = 1e-5;
-  /// A momentum multiplier for the mean and variance.
-  /// Changing this parameter after construction __is effective__.
-  TORCH_ARG(double, momentum) = 0.1;
+  /// A multiplier to exponentially decay the running mean and variance
+  /// (`momentum` in PyTorch). Changing this parameter after construction __is
+  /// effective__.
+  TORCH_ARG(double, exp_avg_factor) = 0.1;
 };
 
 /// Applies [Batch Normalization](https://arxiv.org/abs/1502.03167) to an input.

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -27,10 +27,9 @@ struct BatchNormOptions {
   /// The epsilon value added for numerical stability.
   /// Changing this parameter after construction __is effective__.
   TORCH_ARG(double, eps) = 1e-5;
-  /// A multiplier to exponentially decay the running mean and variance
-  /// (`momentum` in PyTorch). Changing this parameter after construction __is
-  /// effective__.
-  TORCH_ARG(double, exp_avg_factor) = 0.1;
+  /// A momentum multiplier for the mean and variance.
+  /// Changing this parameter after construction __is effective__.
+  TORCH_ARG(double, momentum) = 0.1;
 };
 
 /// Applies [Batch Normalization](https://arxiv.org/abs/1502.03167) to an input.

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -10,6 +10,7 @@
 
 namespace torch {
 namespace nn {
+/// Options for the `Linear` module.
 struct LinearOptions {
   LinearOptions(int64_t in, int64_t out);
   /// The number of input features (columns of the input matrix).

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -57,7 +57,7 @@ Tensor BatchNormImpl::pure_forward(Tensor input, Tensor mean, Tensor variance) {
       mean,
       variance,
       is_training(),
-      options.momentum_,
+      options.exp_avg_factor_,
       options.eps_,
       torch::cuda::cudnn_is_available());
 }

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -57,7 +57,7 @@ Tensor BatchNormImpl::pure_forward(Tensor input, Tensor mean, Tensor variance) {
       mean,
       variance,
       is_training(),
-      options.exp_avg_factor_,
+      options.momentum_,
       options.eps_,
       torch::cuda::cudnn_is_available());
 }


### PR DESCRIPTION
This PR:

1. Documents `BatchNorm`,
2. Makes a number of API changes after reconsidering some quirks:
    1. The default value for the `stateful` parameter used to be `false`, but the most common usage of `BatchNorm` out of the wild is certainly stateful, and the default in Python is also statefulness. So we change the default to stateful.
    2. The `pure_forward` function used to use the internal running mean and variance variables instead of the ones supplied to that function call when `stateful` was true, which certainly seems odd. When you call `pure_forward` you would certainly expect the values you pass explicitly to be used. This is now fixed.
3. Adds tests for `BatchNorm`, finally.

@ebetica @apaszke @ezyang 