### PR TITLE
Introducing python setup.py rebuild develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -467,6 +467,7 @@ class build_deps(PytorchCommand):
 
 
 build_dep_cmds = {}
+rebuild_dep_cmds = {}
 
 for lib in dep_libs:
     # wrap in function to capture lib
@@ -477,6 +478,16 @@ for lib in dep_libs:
             build_libs([self.lib])
     build_dep.lib = lib
     build_dep_cmds['build_' + lib.lower()] = build_dep
+
+    class rebuild_dep(build_deps):
+        description = 'Rebuild {} external library'.format(lib)
+
+        def run(self):
+            global RERUN_CMAKE
+            RERUN_CMAKE = False
+            build_libs([self.lib])
+    rebuild_dep.lib = lib
+    rebuild_dep_cmds['rebuild_' + lib.lower()] = rebuild_dep
 
 
 class build_module(PytorchCommand):
@@ -1143,6 +1154,7 @@ cmdclass = {
     'clean': clean,
 }
 cmdclass.update(build_dep_cmds)
+cmdclass.update(rebuild_dep_cmds)
 
 entry_points = {
     'console_scripts': [

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -22,8 +22,12 @@ USE_NNPACK=0
 USE_MKLDNN=0
 USE_GLOO_IBVERBS=0
 CAFFE2_STATIC_LINK_CUDA=0
+RERUN_CMAKE=1
 while [[ $# -gt 0 ]]; do
     case "$1" in
+      --dont-rerun-cmake)
+          RERUN_CMAKE=0
+          ;;
       --use-cuda)
           USE_CUDA=1
           ;;
@@ -152,46 +156,49 @@ function build() {
       THCS | THCUNN ) BUILD_C_FLAGS=$C_FLAGS;;
       *) BUILD_C_FLAGS=$C_FLAGS" -fexceptions";;
   esac
-  # TODO: The *_LIBRARIES cmake variables should eventually be
-  # deprecated because we are using .cmake files to handle finding
-  # installed libraries instead
-  ${CMAKE_VERSION} ../../$1 -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/Modules_CUDA_fix" \
-              ${CMAKE_GENERATOR} \
-              -DTorch_FOUND="1" \
-              -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-              -DCMAKE_C_FLAGS="$BUILD_C_FLAGS $USER_CFLAGS" \
-              -DCMAKE_CXX_FLAGS="$BUILD_C_FLAGS $CPP_FLAGS $USER_CFLAGS" \
-              -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
-              -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
-              -DCMAKE_INSTALL_LIBDIR="$INSTALL_DIR/lib" \
-              -DCUDA_NVCC_FLAGS="$CUDA_NVCC_FLAGS" \
-              -DCUDA_DEVICE_DEBUG=$CUDA_DEVICE_DEBUG \
-              -DCMAKE_PREFIX_PATH="$INSTALL_DIR" \
-              -Dcwrap_files="$CWRAP_FILES" \
-              -DTH_INCLUDE_PATH="$INSTALL_DIR/include" \
-              -DTH_LIB_PATH="$INSTALL_DIR/lib" \
-              -DTH_LIBRARIES="$INSTALL_DIR/lib/libTH$LD_POSTFIX" \
-              -DCAFFE2_LIBRARIES="$INSTALL_DIR/lib/libcaffe2$LD_POSTFIX" \
-              -DCAFFE2_STATIC_LINK_CUDA=$CAFFE2_STATIC_LINK_CUDA \
-              -DTHNN_LIBRARIES="$INSTALL_DIR/lib/libTHNN$LD_POSTFIX" \
-              -DTHCUNN_LIBRARIES="$INSTALL_DIR/lib/libTHCUNN$LD_POSTFIX" \
-              -DTHS_LIBRARIES="$INSTALL_DIR/lib/libTHS$LD_POSTFIX" \
-              -DTHC_LIBRARIES="$INSTALL_DIR/lib/libTHC$LD_POSTFIX" \
-              -DTHCS_LIBRARIES="$INSTALL_DIR/lib/libTHCS$LD_POSTFIX" \
-              -DTH_SO_VERSION=1 \
-              -DTHC_SO_VERSION=1 \
-              -DTHNN_SO_VERSION=1 \
-              -DTHCUNN_SO_VERSION=1 \
-              -DTHD_SO_VERSION=1 \
-              -DUSE_CUDA=$USE_CUDA \
-              -DBUILD_EXAMPLES=OFF \
-              -DBUILD_TEST=$BUILD_TEST \
-              -DNO_NNPACK=$((1-$USE_NNPACK)) \
-              -DNCCL_EXTERNAL=1 \
-              -DCMAKE_DEBUG_POSTFIX="" \
-              -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-              ${@:2} \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${CMAKE_ARGS[@]}
+  if [[ $RERUN_CMAKE -eq 1 ]] || [ ! -f CMakeCache.txt ]; then
+      # TODO: The *_LIBRARIES cmake variables should eventually be
+      # deprecated because we are using .cmake files to handle finding
+      # installed libraries instead
+      ${CMAKE_VERSION} ../../$1 -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/Modules_CUDA_fix" \
+		       ${CMAKE_GENERATOR} \
+		       -DCMAKE_INSTALL_MESSAGE="LAZY" \
+		       -DTorch_FOUND="1" \
+		       -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+		       -DCMAKE_C_FLAGS="$BUILD_C_FLAGS $USER_CFLAGS" \
+		       -DCMAKE_CXX_FLAGS="$BUILD_C_FLAGS $CPP_FLAGS $USER_CFLAGS" \
+		       -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
+		       -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
+		       -DCMAKE_INSTALL_LIBDIR="$INSTALL_DIR/lib" \
+		       -DCUDA_NVCC_FLAGS="$CUDA_NVCC_FLAGS" \
+		       -DCUDA_DEVICE_DEBUG=$CUDA_DEVICE_DEBUG \
+		       -DCMAKE_PREFIX_PATH="$INSTALL_DIR" \
+		       -Dcwrap_files="$CWRAP_FILES" \
+		       -DTH_INCLUDE_PATH="$INSTALL_DIR/include" \
+		       -DTH_LIB_PATH="$INSTALL_DIR/lib" \
+		       -DTH_LIBRARIES="$INSTALL_DIR/lib/libTH$LD_POSTFIX" \
+		       -DCAFFE2_LIBRARIES="$INSTALL_DIR/lib/libcaffe2$LD_POSTFIX" \
+		       -DCAFFE2_STATIC_LINK_CUDA=$CAFFE2_STATIC_LINK_CUDA \
+		       -DTHNN_LIBRARIES="$INSTALL_DIR/lib/libTHNN$LD_POSTFIX" \
+		       -DTHCUNN_LIBRARIES="$INSTALL_DIR/lib/libTHCUNN$LD_POSTFIX" \
+		       -DTHS_LIBRARIES="$INSTALL_DIR/lib/libTHS$LD_POSTFIX" \
+		       -DTHC_LIBRARIES="$INSTALL_DIR/lib/libTHC$LD_POSTFIX" \
+		       -DTHCS_LIBRARIES="$INSTALL_DIR/lib/libTHCS$LD_POSTFIX" \
+		       -DTH_SO_VERSION=1 \
+		       -DTHC_SO_VERSION=1 \
+		       -DTHNN_SO_VERSION=1 \
+		       -DTHCUNN_SO_VERSION=1 \
+		       -DTHD_SO_VERSION=1 \
+		       -DUSE_CUDA=$USE_CUDA \
+		       -DBUILD_EXAMPLES=OFF \
+		       -DBUILD_TEST=$BUILD_TEST \
+		       -DNO_NNPACK=$((1-$USE_NNPACK)) \
+		       -DNCCL_EXTERNAL=1 \
+		       -DCMAKE_DEBUG_POSTFIX="" \
+		       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+		       ${@:2} \
+		       -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${CMAKE_ARGS[@]}
+  fi
   ${CMAKE_INSTALL} -j"$MAX_JOBS"
   popd
 
@@ -216,15 +223,18 @@ function path_remove {
 function build_nccl() {
   mkdir -p build/nccl
   pushd build/nccl
-  ${CMAKE_VERSION} ../../nccl -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/Modules_CUDA_fix" \
-              ${CMAKE_GENERATOR} \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-              -DCMAKE_C_FLAGS="$C_FLAGS $USER_CFLAGS" \
-              -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS $USER_CFLAGS" \
-              -DCMAKE_SHARED_LINKER_FLAGS="$USER_LDFLAGS" \
-              -DCMAKE_UTILS_PATH="$BASE_DIR/cmake/public/utils.cmake" \
-              -DNUM_JOBS="$MAX_JOBS"
+  if [[ $RERUN_CMAKE -eq 1 ]] || [ ! -f CMakeCache.txt ]; then
+      ${CMAKE_VERSION} ../../nccl -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/Modules_CUDA_fix" \
+		       ${CMAKE_GENERATOR} \
+		       -DCMAKE_INSTALL_MESSAGE="LAZY" \
+		       -DCMAKE_BUILD_TYPE=Release \
+		       -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+		       -DCMAKE_C_FLAGS="$C_FLAGS $USER_CFLAGS" \
+		       -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS $USER_CFLAGS" \
+		       -DCMAKE_SHARED_LINKER_FLAGS="$USER_LDFLAGS" \
+		       -DCMAKE_UTILS_PATH="$BASE_DIR/cmake/public/utils.cmake" \
+		       -DNUM_JOBS="$MAX_JOBS"
+  fi
   ${CMAKE_INSTALL} -j"$MAX_JOBS"
   mkdir -p ${INSTALL_DIR}/lib
   $SYNC_COMMAND "lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so.1"
@@ -257,45 +267,48 @@ function build_caffe2() {
     EXTRA_CAFFE2_CMAKE_FLAGS+=("-DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH")
   fi
 
-  ${CMAKE_VERSION} $BASE_DIR \
-  ${CMAKE_GENERATOR} \
-      -DPYTHON_EXECUTABLE=$PYTORCH_PYTHON \
-      -DBUILDING_WITH_TORCH_LIBS=ON \
-      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-      -DBUILD_TORCH=$BUILD_TORCH \
-      -DBUILD_PYTHON=$BUILD_PYTHON \
-      -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
-      -DBUILD_BINARY=$BUILD_BINARY \
-      -DBUILD_TEST=$BUILD_TEST \
-      -DINSTALL_TEST=$INSTALL_TEST \
-      -DBUILD_CAFFE2_OPS=$BUILD_CAFFE2_OPS \
-      -DONNX_NAMESPACE=$ONNX_NAMESPACE \
-      -DUSE_CUDA=$USE_CUDA \
-      -DCAFFE2_STATIC_LINK_CUDA=$CAFFE2_STATIC_LINK_CUDA \
-      -DUSE_ROCM=$USE_ROCM \
-      -DUSE_NNPACK=$USE_NNPACK \
-      -DUSE_LEVELDB=$USE_LEVELDB \
-      -DUSE_LMDB=$USE_LMDB \
-      -DUSE_OPENCV=$USE_OPENCV \
-      -DUSE_GLOG=OFF \
-      -DUSE_GFLAGS=OFF \
-      -DUSE_SYSTEM_EIGEN_INSTALL=OFF \
-      -DCUDNN_INCLUDE_DIR=$CUDNN_INCLUDE_DIR \
-      -DCUDNN_LIB_DIR=$CUDNN_LIB_DIR \
-      -DCUDNN_LIBRARY=$CUDNN_LIBRARY \
-      -DUSE_MKLDNN=$USE_MKLDNN \
-      -DMKLDNN_INCLUDE_DIR=$MKLDNN_INCLUDE_DIR \
-      -DMKLDNN_LIB_DIR=$MKLDNN_LIB_DIR \
-      -DMKLDNN_LIBRARY=$MKLDNN_LIBRARY \
-      -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-      -DCMAKE_C_FLAGS="$USER_CFLAGS" \
-      -DCMAKE_CXX_FLAGS="$USER_CFLAGS" \
-      -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
-      -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" ${EXTRA_CAFFE2_CMAKE_FLAGS[@]}
+  if [[ $RERUN_CMAKE -eq 1 ]] || [ ! -f CMakeCache.txt ]; then
+      ${CMAKE_VERSION} $BASE_DIR \
+		       ${CMAKE_GENERATOR} \
+		       -DCMAKE_INSTALL_MESSAGE="LAZY" \
+		       -DPYTHON_EXECUTABLE=$PYTORCH_PYTHON \
+		       -DBUILDING_WITH_TORCH_LIBS=ON \
+		       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+		       -DBUILD_TORCH=$BUILD_TORCH \
+		       -DBUILD_PYTHON=$BUILD_PYTHON \
+		       -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
+		       -DBUILD_BINARY=$BUILD_BINARY \
+		       -DBUILD_TEST=$BUILD_TEST \
+		       -DINSTALL_TEST=$INSTALL_TEST \
+		       -DBUILD_CAFFE2_OPS=$BUILD_CAFFE2_OPS \
+		       -DONNX_NAMESPACE=$ONNX_NAMESPACE \
+		       -DUSE_CUDA=$USE_CUDA \
+		       -DCAFFE2_STATIC_LINK_CUDA=$CAFFE2_STATIC_LINK_CUDA \
+		       -DUSE_ROCM=$USE_ROCM \
+		       -DUSE_NNPACK=$USE_NNPACK \
+		       -DUSE_LEVELDB=$USE_LEVELDB \
+		       -DUSE_LMDB=$USE_LMDB \
+		       -DUSE_OPENCV=$USE_OPENCV \
+		       -DUSE_GLOG=OFF \
+		       -DUSE_GFLAGS=OFF \
+		       -DUSE_SYSTEM_EIGEN_INSTALL=OFF \
+		       -DCUDNN_INCLUDE_DIR=$CUDNN_INCLUDE_DIR \
+		       -DCUDNN_LIB_DIR=$CUDNN_LIB_DIR \
+		       -DCUDNN_LIBRARY=$CUDNN_LIBRARY \
+		       -DUSE_MKLDNN=$USE_MKLDNN \
+		       -DMKLDNN_INCLUDE_DIR=$MKLDNN_INCLUDE_DIR \
+		       -DMKLDNN_LIB_DIR=$MKLDNN_LIB_DIR \
+		       -DMKLDNN_LIBRARY=$MKLDNN_LIBRARY \
+		       -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+		       -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+		       -DCMAKE_C_FLAGS="$USER_CFLAGS" \
+		       -DCMAKE_CXX_FLAGS="$USER_CFLAGS" \
+		       -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
+		       -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" ${EXTRA_CAFFE2_CMAKE_FLAGS[@]}
       # STOP!!! Are you trying to add a C or CXX flag?  Add it
       # to CMakeLists.txt and aten/CMakeLists.txt, not here.
       # We need the vanilla cmake build to work.
+  fi
 
   # This is needed by the aten tests built with caffe2
   if [ -f "${INSTALL_DIR}/lib/libnccl.so" ] && [ ! -f "lib/libnccl.so.1" ]; then
@@ -363,7 +376,7 @@ if [ -d "$INSTALL_DIR/lib64/" ]; then
 fi
 $SYNC_COMMAND ../../aten/src/THNN/generic/THNN.h .
 $SYNC_COMMAND ../../aten/src/THCUNN/generic/THCUNN.h .
-$SYNC_COMMAND "$INSTALL_DIR/include" .
+$SYNC_COMMAND -r "$INSTALL_DIR/include" .
 if [ -d "$INSTALL_DIR/bin/" ]; then
     $SYNC_COMMAND -r "$INSTALL_DIR/bin/"/* .
 fi


### PR DESCRIPTION
This speeds up incremental builds by doing the following changes:

- Uses `rsync` instead of `cp` (when `rsync` is found) which is a bit smarter in doing "maybe copy"
- Introduces a `rebuild` mode which does not rerun `cmake` in `build_pytorch_libs.sh`.
   *Note: `rebuild` should only be used if you dont add / remove files to the build, as `cmake` is not rerun*

Current no-op rebuild speedup:
- 1m 15s -> 20s

There are some lingering bugs. No-op rebuilds rerun `cmake`  for two rebuilds (likely that cmake logic is dependent on the install folder, hence kicking off rebuild).

So what you see

```
# (with ccache)
python setup.py rebuild develop    # first time - ~5 mins  
python setup.py rebuild develop    # second time - ~3 mins
python setup.py rebuild develop    # third time - ~2 mins
python setup.py rebuild develop    # fourth time - ~20 seconds
python setup.py rebuild develop    # fifth time - ~20 seconds
```