### PR TITLE
Support load and store between Py_complex and std::complex

### DIFF
--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -126,3 +126,12 @@ inline double THPUtils_unpackDouble(PyObject* obj) {
   }
   return value;
 }
+
+inline std::complex<double> THPUtils_unpackComplexDouble(PyObject *obj) {
+  Py_complex value = PyComplex_AsCComplex(obj);
+  if (value.real == -1.0 && PyErr_Occurred()) {
+    throw python_error();
+  }
+
+  return std::complex<double>(value.real, value.imag);
+}

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -128,10 +128,6 @@ inline double THPUtils_unpackDouble(PyObject* obj) {
 }
 
 inline std::complex<double> THPUtils_unpackComplexDouble(PyObject *obj) {
-  if (!PyComplex_Check(obj)) {
-    throw python_error();
-  }
-
   Py_complex value = PyComplex_AsCComplex(obj);
   if (value.real == -1.0 && PyErr_Occurred()) {
     throw python_error();

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -128,6 +128,10 @@ inline double THPUtils_unpackDouble(PyObject* obj) {
 }
 
 inline std::complex<double> THPUtils_unpackComplexDouble(PyObject *obj) {
+  if (!PyComplex_Check(obj)) {
+    throw python_error();
+  }
+
   Py_complex value = PyComplex_AsCComplex(obj);
   if (value.real == -1.0 && PyErr_Occurred()) {
     throw python_error();

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -20,6 +20,8 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
       break;
     case at::kFloat: *(float*)data = (float)THPUtils_unpackDouble(obj); break;
     case at::kDouble: *(double*)data = THPUtils_unpackDouble(obj); break;
+    case at::kComplexFloat: *(std::complex<float>*)data = (std::complex<float>)THPUtils_unpackComplexDouble(obj); break;
+    case at::kComplexDouble: *(std::complex<double>*)data = THPUtils_unpackComplexDouble(obj); break;
     default: throw std::runtime_error("invalid type");
   }
 }
@@ -34,6 +36,8 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kHalf: return PyFloat_FromDouble(at::convert<double, at::Half>(*(at::Half*)data));
     case at::kFloat: return PyFloat_FromDouble(*(float*)data);
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
+    case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
+    case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
     default: throw std::runtime_error("invalid type");
   }
 }


### PR DESCRIPTION
Printing for complex numbers requires loading and storing between `Py_complex` and `std::complex`. This patch aims to support this for the plugin.

cc: @ezyang 