### PR TITLE
Add padding as an option to torch.cat

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3303,5 +3303,6 @@
       output: True
     - TensorList tensors
     - arg: int64_t dim
-      default: 0
+    - arg: bool pad
+    - arg: real pad_value
 ]]

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -28,13 +28,27 @@ static void check_cat_no_zero_dim(TensorList tensors) {
 Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim) {
   check_cat_no_zero_dim(tensors);
   dim = legacy_cat_wrap_dim(dim, tensors);
-  return at::_cat_out(result, tensors, dim);
+  return at::_cat_out(result, tensors, dim, false, 0);
 }
 
 Tensor cat(TensorList tensors, int64_t dim) {
   check_cat_no_zero_dim(tensors);
   dim = legacy_cat_wrap_dim(dim, tensors);
-  return at::_cat(tensors, dim);
+  return at::_cat(tensors, dim, false, 0);
+}
+
+Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim, Scalar pad_value) {
+  if (pad_value.isFloatingPoint() && std::isnan(pad_value.toFloat())){
+    return at::cat_out(result, tensors, dim);
+  }
+  return at::_cat_out(result, tensors, dim, true, pad_value);
+}
+
+Tensor cat(TensorList tensors, int64_t dim, Scalar pad_value) {
+  if (pad_value.isFloatingPoint() && std::isnan(pad_value.toFloat())){
+    return at::cat(tensors, dim);
+  }
+  return at::_cat(tensors, dim, true, pad_value);
 }
 
 std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -31,12 +31,6 @@ Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim) {
   return at::_cat_out(result, tensors, dim, false, 0);
 }
 
-Tensor cat(TensorList tensors, int64_t dim) {
-  check_cat_no_zero_dim(tensors);
-  dim = legacy_cat_wrap_dim(dim, tensors);
-  return at::_cat(tensors, dim, false, 0);
-}
-
 Tensor& cat_out(
     Tensor& result,
     TensorList tensors,
@@ -46,6 +40,12 @@ Tensor& cat_out(
     return at::cat_out(result, tensors, dim);
   }
   return at::_cat_out(result, tensors, dim, true, pad_value);
+}
+
+Tensor cat(TensorList tensors, int64_t dim) {
+  check_cat_no_zero_dim(tensors);
+  dim = legacy_cat_wrap_dim(dim, tensors);
+  return at::_cat(tensors, dim, false, 0);
 }
 
 Tensor cat(TensorList tensors, int64_t dim, Scalar pad_value) {
@@ -170,16 +170,16 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_
   int64_t allDim = self.dim();
   int64_t end = start+length;
   AT_CHECK(allDim > 0, "narrow() cannot be applied to a 0-dim tensor.");
-  AT_CHECK(dim >= 0 && dim < allDim, 
+  AT_CHECK(dim >= 0 && dim < allDim,
     "Dimension ", dim, " out of range. Expecting 0 <= dim < ", allDim, ".");
   AT_CHECK(start >= 0 && length >= 0 && end <= self.size(dim),
     "Invalid range to narrow. range(start, start+length) must be a subset of range(0, ", self.size(dim), ").")
   LongTensor indices = self._indices();
   int64_t sparseDims = self._sparseDims();
-  
+
   std::vector<int64_t> newSizes = self.sizes().vec();
   newSizes[dim]=length;
-  
+
   Tensor newValues;
   LongTensor newIndices;
   if(dim < sparseDims){

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -37,8 +37,12 @@ Tensor cat(TensorList tensors, int64_t dim) {
   return at::_cat(tensors, dim, false, 0);
 }
 
-Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim, Scalar pad_value) {
-  if (pad_value.isFloatingPoint() && std::isnan(pad_value.toFloat())){
+Tensor& cat_out(
+    Tensor& result,
+    TensorList tensors,
+    int64_t dim,
+    Scalar pad_value) {
+  if (pad_value.isFloatingPoint() && std::isnan(pad_value.toFloat())) {
     return at::cat_out(result, tensors, dim);
   }
   return at::_cat_out(result, tensors, dim, true, pad_value);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -321,6 +321,10 @@
 
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
 
+- func: cat(TensorList tensors, int64_t dim, Scalar pad_value) -> Tensor
+
+- func: cat_out(Tensor result, TensorList tensors, int64_t dim, Scalar pad_value) -> Tensor
+
 - func: ceil(Tensor self) -> Tensor
   variants: function, method
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -322,8 +322,14 @@
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
 
 - func: cat(TensorList tensors, int64_t dim, Scalar pad_value) -> Tensor
+  python_default_init:
+    pad_value: NAN
+    dim: 0
 
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim, Scalar pad_value) -> Tensor
+  python_default_init:
+    pad_value: NAN
+    dim: 0
 
 - func: ceil(Tensor self) -> Tensor
   variants: function, method

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -106,8 +106,8 @@ TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int d
 TH_API void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted);
 TH_API void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k);
 TH_API void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k);
-TH_API void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension);
-TH_API void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int dimension);
+TH_API void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension, int pad, scalar_t pad_value);
+TH_API void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int dimension, int pad, scalar_t pad_value);
 
 TH_API int THTensor_(equal)(THTensor *ta, THTensor *tb);
 

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1290,29 +1290,14 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   }
 }
 
-void THTensor_(cat)(
-    THTensor* r_,
-    THTensor* ta,
-    THTensor* tb,
-    int dimension,
-    int pad,
-    scalar_t pad_value) {
+void THTensor_(cat)(THTensor* r_, THTensor* ta, THTensor* tb, int dimension, int pad, scalar_t pad_value) {
   THTensor* inputs[2];
   inputs[0] = ta;
   inputs[1] = tb;
   THTensor_(catArray)(r_, inputs, 2, dimension, pad, pad_value);
 }
 
-void THTensor_(check_shape_except_dim)(
-    THTensor* first,
-    THTensor* second,
-    int dimension,
-    bool pad);
-inline void THTensor_(check_shape_except_dim)(
-    THTensor* first,
-    THTensor* second,
-    int dimension,
-    bool pad) {
+inline void THTensor_(check_shape_except_dim)(THTensor* first, THTensor* second, int dimension, bool pad) {
   int first_dims = first->dim();
   int second_dims = second->dim();
   THArgCheck(
@@ -1342,13 +1327,7 @@ inline void THTensor_(check_shape_except_dim)(
   }
 }
 
-void THTensor_(catArray)(
-    THTensor* result,
-    THTensor** inputs,
-    int numInputs,
-    int dimension,
-    int pad,
-    scalar_t pad_value) {
+void THTensor_(catArray)(THTensor* result, THTensor** inputs, int numInputs, int dimension, int pad, scalar_t pad_value) {
   // previously, size [0] tensors were the only possible empty tensors; thus, it
   // wasn't possible to cat empty tensors unless all the other tensors were
   // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1353,7 +1353,8 @@ void THTensor_(catArray)(
   // wasn't possible to cat empty tensors unless all the other tensors were
   // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain
   // this behavior for backwards compatibility, but only for this specific size
-  // (i.e. other empty sizes are not skipped).
+  // (i.e. other empty sizes are not skipped). In addition, if pad is true, no
+  // tensor will be skipped.
   // FIXME: warn if this is the case
   bool allSkipped = true;
   int64_t nDims = 0;

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1290,22 +1290,37 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   }
 }
 
-void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension, int pad, scalar_t pad_value)
-{
+void THTensor_(cat)(
+    THTensor* r_,
+    THTensor* ta,
+    THTensor* tb,
+    int dimension,
+    int pad,
+    scalar_t pad_value) {
   THTensor* inputs[2];
   inputs[0] = ta;
   inputs[1] = tb;
   THTensor_(catArray)(r_, inputs, 2, dimension, pad, pad_value);
 }
 
-void THTensor_(check_shape_except_dim)(THTensor *first, THTensor *second, int dimension, bool pad);
-inline void THTensor_(check_shape_except_dim)(THTensor *first, THTensor *second, int dimension, bool pad)
-{
+void THTensor_(check_shape_except_dim)(
+    THTensor* first,
+    THTensor* second,
+    int dimension,
+    bool pad);
+inline void THTensor_(check_shape_except_dim)(
+    THTensor* first,
+    THTensor* second,
+    int dimension,
+    bool pad) {
   int first_dims = first->dim();
   int second_dims = second->dim();
-  THArgCheck(first_dims == second_dims, 0,
+  THArgCheck(
+      first_dims == second_dims,
+      0,
       "Tensors must have same number of dimensions: got %d and %d",
-      first_dims, second_dims);
+      first_dims,
+      second_dims);
 
   // Without padding, sizes of tensors must match except in dimension
   if (!pad) {
@@ -1315,24 +1330,37 @@ inline void THTensor_(check_shape_except_dim)(THTensor *first, THTensor *second,
       }
       int64_t first_dim_size = first->size(dim);
       int64_t second_dim_size = second->size(dim);
-      THArgCheck(first_dim_size == second_dim_size, 0,
+      THArgCheck(
+          first_dim_size == second_dim_size,
+          0,
           "Sizes of tensors must match except in dimension %d. Got %lld and %lld in dimension %d",
-          dimension, (long long)first_dim_size, (long long)second_dim_size, dim);
-      }
+          dimension,
+          (long long)first_dim_size,
+          (long long)second_dim_size,
+          dim);
     }
+  }
 }
 
-void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int dimension, int pad, scalar_t pad_value)
-{
-  // previously, size [0] tensors were the only possible empty tensors; thus, it wasn't possible
-  // to cat empty tensors unless all the other tensors were 1-dimensional, so we allowed these tensors
-  // to be "skipped".  We maintain this behavior for backwards compatibility, but only for this specific
-  // size (i.e. other empty sizes are not skipped).
+void THTensor_(catArray)(
+    THTensor* result,
+    THTensor** inputs,
+    int numInputs,
+    int dimension,
+    int pad,
+    scalar_t pad_value) {
+  // previously, size [0] tensors were the only possible empty tensors; thus, it
+  // wasn't possible to cat empty tensors unless all the other tensors were
+  // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain
+  // this behavior for backwards compatibility, but only for this specific size
+  // (i.e. other empty sizes are not skipped).
   // FIXME: warn if this is the case
-  bool allSkipped= true;
+  bool allSkipped = true;
   int64_t nDims = 0;
-  THTensor *notSkippedTensor;  // non-owning reference
-  auto should_skip = [](THTensor *t, bool pad) { return t->is_empty() && t->dim() == 1 && !pad; };
+  THTensor* notSkippedTensor; // non-owning reference
+  auto should_skip = [](THTensor* t, bool pad) {
+    return t->is_empty() && t->dim() == 1 && !pad;
+  };
   for (int i = 0; i < numInputs; i++) {
     if (should_skip(inputs[i], pad)) {
       continue;
@@ -1351,10 +1379,10 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   THArgCheck(dimension < nDims, 4, "invalid dimension %d", dimension);
   THArgCheck(numInputs > 0, 3, "invalid number of inputs %d", numInputs);
 
-    // Compute size of the result in the cat dimension
+  // Compute size of the result in the cat dimension
   int64_t cat_dim_size = 0;
   for (int i = 0; i < numInputs; i++) {
-    THTensor *tensor = inputs[i];
+    THTensor* tensor = inputs[i];
     if (should_skip(tensor, pad)) {
       continue;
     }
@@ -1387,7 +1415,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   // Check contiguity of all inputs and result
   bool allContiguous = true;
   for (int i = 0; i < numInputs; i++) {
-    if(!should_skip(inputs[i], pad)) {
+    if (!should_skip(inputs[i], pad)) {
       allContiguous = allContiguous && THTensor_(isContiguous)(inputs[i]);
     }
   }
@@ -1397,16 +1425,23 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   // Second path for non-contiguous
   int64_t offset;
   if (dimension == 0 && allContiguous && !pad) {
-    scalar_t* result_data = THStorage_(data)(THTensor_getStoragePtr(result)) + result->storage_offset();
+    scalar_t* result_data = THStorage_(data)(THTensor_getStoragePtr(result)) +
+        result->storage_offset();
     offset = 0;
     for (int j = 0; j < numInputs; j++) {
       if (!should_skip(inputs[j], pad)) {
         THTensor* input0 = inputs[j];
-        scalar_t* input0_data = THStorage_(data)(THTensor_getStoragePtr(input0)) + input0->storage_offset();
+        scalar_t* input0_data =
+            THStorage_(data)(THTensor_getStoragePtr(input0)) +
+            input0->storage_offset();
         int64_t input0_size = THTensor_(nElement)(input0);
-        // C standard says you can't pass nullptrs to memcpy, even if the size is 0; ubsan checks this.
+        // C standard says you can't pass nullptrs to memcpy, even if the size
+        // is 0; ubsan checks this.
         if (input0_size != 0) {
-          memcpy(result_data + offset, input0_data, input0_size*sizeof(scalar_t));
+          memcpy(
+              result_data + offset,
+              input0_data,
+              input0_size * sizeof(scalar_t));
         }
         offset += input0_size;
       }
@@ -1416,10 +1451,10 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
     for (int j = 0; j < numInputs; j++) {
       if (!should_skip(inputs[j], pad)) {
         int64_t dimSize = inputs[j]->size(dimension);
-        THTensor *nt = THTensor_(newWithTensor)(result);
+        THTensor* nt = THTensor_(newWithTensor)(result);
         if (pad) {
           for (int dim = 0; dim < nDims; dim++) {
-            if (dimension==dim) {
+            if (dimension == dim) {
               THTensor_(narrow)(nt, NULL, dimension, offset, dimSize);
             } else {
               THTensor_(narrow)(nt, NULL, dim, 0, inputs[j]->size(dim));

--- a/aten/src/THC/THCTensorMath.cuh
+++ b/aten/src/THC/THCTensorMath.cuh
@@ -89,40 +89,41 @@ __global__ void CatArrayBatchedCopy(
        linearIndex < nElementsOutput;
        linearIndex += (IndexType)gridDim.x * blockDim.x) {
     if (pad) {
+      IndexType tid = linearIndex;
       IndexType inputOffset = 0;
       IndexType outputOffset = 0;
       bool inbound = true;
       for (int i = Dims - 1; i >= 1; --i) {
         IndexType inputDimSize = inputs[blockIdx.y].inputParam.tensorSize[i];
         IndexType curDimSize = i == concatDim ? inputDimSize : os.tensorSize[i];
-        IndexType nextDimIndex = linearIndex / curDimSize;
-        IndexType curDimIndex = linearIndex - curDimSize * nextDimIndex;
+        IndexType nextDimIndex = tid / curDimSize;
+        IndexType curDimIndex = tid - curDimSize * nextDimIndex;
         inbound = inbound && curDimIndex < inputDimSize;
         inputOffset +=
             curDimIndex * inputs[blockIdx.y].inputParam.tensorStride[i];
         outputOffset += curDimIndex * os.tensorStride[i];
-        linearIndex = nextDimIndex;
+        tid = nextDimIndex;
       }
-      inbound = inbound && linearIndex < inputs[blockIdx.y].inputParam.tensorSize[0];
-      inputOffset += linearIndex * inputs[blockIdx.y].inputParam.tensorStride[0];
-      outputOffset += linearIndex * os.tensorStride[0];
+      inbound = inbound && tid < inputs[blockIdx.y].inputParam.tensorSize[0];
+      inputOffset += tid * inputs[blockIdx.y].inputParam.tensorStride[0];
+      outputOffset += tid * os.tensorStride[0];
       if (inbound) {
         output[dataOffset + outputOffset] = data[inputOffset];
       } else {
         output[dataOffset + outputOffset] = pad_value;
       }
     }else{
+      IndexType tid = linearIndex;
       IndexType inputOffset = linearIndex;
       IndexType outputOffset = 0;
-      bool inbound = true;
       for (int i = Dims - 1; i >= 1; --i) {
         IndexType curDimSize = inputs[blockIdx.y].inputParam.tensorSize[i];;
-        IndexType nextDimIndex = linearIndex / curDimSize;
-        IndexType curDimIndex = linearIndex - curDimSize * nextDimIndex;
+        IndexType nextDimIndex = tid / curDimSize;
+        IndexType curDimIndex = tid - curDimSize * nextDimIndex;
         outputOffset += curDimIndex * os.tensorStride[i];
-        linearIndex = nextDimIndex;
+        tid = nextDimIndex;
       }
-      outputOffset += linearIndex * os.tensorStride[0];
+      outputOffset += tid * os.tensorStride[0];
       output[dataOffset + outputOffset] = data[inputOffset];
     }
   }

--- a/aten/src/THC/THCTensorMath.cuh
+++ b/aten/src/THC/THCTensorMath.cuh
@@ -45,77 +45,87 @@ inline bool getCatGrid(THCState* state, ptrdiff_t nTensors, dim3& grid) {
 }
 
 template<typename IndexType, unsigned int MaxDims>
-struct OutputTensorSizeStride {
-  IndexType outputSize[MaxDims];
-  IndexType outputStride[MaxDims];
-};
-
-template<typename IndexType, unsigned int MaxDims>
-struct InputTensorSize {
-  IndexType inputSize[MaxDims];
-  IndexType inputStride[MaxDims];
+struct TensorSizeStride {
+  IndexType tensorSize[MaxDims];
+  IndexType tensorStride[MaxDims];
 };
 
 template <typename T, typename IndexType, unsigned int MaxDims>
 struct CatArrInputTensor {
   T* input;
   IndexType offset;
-  InputTensorSize<IndexType, CAT_ARRAY_MAX_INPUT_DIMS> inputParam;
+  TensorSizeStride<IndexType, CAT_ARRAY_MAX_INPUT_DIMS> inputParam;
   IndexType nElements;
   IndexType nElementsOutput;
 };
 
 /**
-  * Kernel used to concatenated grimDim.y tensors into an output tensor. Uses a grid-stride loop based off of
-  * the blockIdx.x, threadIdx.x for each input to copy each element from each input tensor into the output.
-  *
-  * output: base pointer to the storage associated with the output tensor
-  * inputs: GPU-allocated array of input metadata for each input to concatenate in the kernel
-  * os: the size/stride vectors for the output tensor
-  * concatDim: dimension along which we are concatenating
-  * dimStride: the stride of the output tensor at the concatDim
-  *
-  * The most important assumption made is that the input tensors are contiguous.
-  */
+ * Kernel used to concatenated grimDim.y tensors into an output tensor. Uses a
+ * grid-stride loop based off of the blockIdx.x, threadIdx.x for each input to
+ * copy each element from each input tensor into the output.
+ *
+ * output: base pointer to the storage associated with the output tensor
+ * inputs: GPU-allocated array of input metadata for each input to concatenate
+ * in the kernel os: the size/stride vectors for the output tensor concatDim:
+ * dimension along which we are concatenating dimStride: the stride of the
+ * output tensor at the concatDim
+ *
+ * The most important assumption made is that the input tensors are contiguous.
+ */
 template <typename T, typename IndexType, int Dims>
 __global__ void CatArrayBatchedCopy(
     T* output,
     CatArrInputTensor<T, IndexType, CAT_ARRAY_MAX_INPUT_DIMS>* inputs,
-    OutputTensorSizeStride<IndexType, CAT_ARRAY_MAX_INPUT_DIMS> os,
+    TensorSizeStride<IndexType, CAT_ARRAY_MAX_INPUT_DIMS> os,
     const int concatDim,
+    const int pad,
     T pad_value) {
+  IndexType nElementsOutput = inputs[blockIdx.y].nElementsOutput;
+  T* data = inputs[blockIdx.y].input;
+  IndexType dimOffset = inputs[blockIdx.y].offset;
+  IndexType dataOffset = dimOffset * os.tensorStride[concatDim];
 
-    IndexType nElementsOutput = inputs[blockIdx.y].nElementsOutput;
-    T* data = inputs[blockIdx.y].input;
-    IndexType dimOffset = inputs[blockIdx.y].offset;
-    IndexType dataOffset = dimOffset * os.outputStride[concatDim];
-
-    for (IndexType linearIndex = (IndexType) blockIdx.x * blockDim.x + threadIdx.x;
-      linearIndex < nElementsOutput;
-      linearIndex += (IndexType) gridDim.x * blockDim.x) {
+  for (IndexType linearIndex = (IndexType)blockIdx.x * blockDim.x + threadIdx.x;
+       linearIndex < nElementsOutput;
+       linearIndex += (IndexType)gridDim.x * blockDim.x) {
+    if (pad) {
       IndexType inputOffset = 0;
       IndexType outputOffset = 0;
       bool inbound = true;
       for (int i = Dims - 1; i >= 1; --i) {
-        IndexType inputDimSize = inputs[blockIdx.y].inputParam.inputSize[i];
-        IndexType curDimSize = i == concatDim ? inputDimSize : os.outputSize[i];
+        IndexType inputDimSize = inputs[blockIdx.y].inputParam.tensorSize[i];
+        IndexType curDimSize = i == concatDim ? inputDimSize : os.tensorSize[i];
         IndexType nextDimIndex = linearIndex / curDimSize;
         IndexType curDimIndex = linearIndex - curDimSize * nextDimIndex;
-        if (curDimIndex >= inputDimSize && inbound) {
-          inbound = false;
-        }
-        inputOffset += curDimIndex * inputs[blockIdx.y].inputParam.inputStride[i];
-        outputOffset += curDimIndex * os.outputStride[i];
+        inbound = inbound && curDimIndex < inputDimSize;
+        inputOffset +=
+            curDimIndex * inputs[blockIdx.y].inputParam.tensorStride[i];
+        outputOffset += curDimIndex * os.tensorStride[i];
         linearIndex = nextDimIndex;
       }
-      inputOffset += linearIndex * inputs[blockIdx.y].inputParam.inputStride[0];
-      outputOffset += linearIndex * os.outputStride[0];
+      inbound = inbound && linearIndex < inputs[blockIdx.y].inputParam.tensorSize[0];
+      inputOffset += linearIndex * inputs[blockIdx.y].inputParam.tensorStride[0];
+      outputOffset += linearIndex * os.tensorStride[0];
       if (inbound) {
         output[dataOffset + outputOffset] = data[inputOffset];
       } else {
         output[dataOffset + outputOffset] = pad_value;
       }
+    }else{
+      IndexType inputOffset = linearIndex;
+      IndexType outputOffset = 0;
+      bool inbound = true;
+      for (int i = Dims - 1; i >= 1; --i) {
+        IndexType curDimSize = inputs[blockIdx.y].inputParam.tensorSize[i];;
+        IndexType nextDimIndex = linearIndex / curDimSize;
+        IndexType curDimIndex = linearIndex - curDimSize * nextDimIndex;
+        outputOffset += curDimIndex * os.tensorStride[i];
+        linearIndex = nextDimIndex;
+      }
+      outputOffset += linearIndex * os.tensorStride[0];
+      output[dataOffset + outputOffset] = data[inputOffset];
     }
+  }
 }
 
 #endif

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -117,7 +117,8 @@ void THCTensor_(catArray)(
   // wasn't possible to cat empty tensors unless all the other tensors were
   // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain
   // this behavior for backwards compatibility, but only for this specific size
-  // (i.e. other empty sizes are not skipped).
+  // (i.e. other empty sizes are not skipped). In addition, if pad is true, no
+  // tensor will be skipped.
   // FIXME: warn if this is the case
   int i, j, cohortMax;
   int64_t offset;
@@ -311,8 +312,9 @@ void THCTensor_(catArray)(
     }
     offset = 0;
     for (j = 0; j < numInputs; j++) {
-      if (should_skip(inputs[j], pad))
+      if (should_skip(inputs[j], pad)){
         continue;
+      }
       int64_t dimSize = THCTensor_(size)(state, inputs[j], dimension);
       THCTensor* nt = THCTensor_(newWithTensor)(state, result);
       if (pad) {

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -53,31 +53,14 @@ THCTensor_(numel)(THCState *state, THCTensor *t)
   return THCTensor_(nElement)(state, t);
 }
 
-void THCTensor_(cat)(
-    THCState* state,
-    THCTensor* result,
-    THCTensor* ta,
-    THCTensor* tb,
-    int dimension,
-    int pad,
-    scalar_t pad_value) {
+void THCTensor_(cat)(THCState* state, THCTensor* result, THCTensor* ta, THCTensor* tb, int dimension, int pad, scalar_t pad_value) {
   THCTensor* inputs[2];
   inputs[0] = ta;
   inputs[1] = tb;
   THCTensor_(catArray)(state, result, inputs, 2, dimension, pad, pad_value);
 }
 
-void THCTensor_(check_shape_except_dim)(
-    THCState* state,
-    THCTensor* first,
-    THCTensor* second,
-    int dimension);
-inline void THCTensor_(check_shape_except_dim)(
-    THCState* state,
-    THCTensor* first,
-    THCTensor* second,
-    int dimension,
-    int pad) {
+inline void THCTensor_(check_shape_except_dim)(THCState* state, THCTensor* first, THCTensor* second, int dimension, int pad) {
   int first_dims = first->dim();
   int second_dims = second->dim();
   THArgCheck(
@@ -105,14 +88,7 @@ inline void THCTensor_(check_shape_except_dim)(
   }
 }
 
-void THCTensor_(catArray)(
-    THCState* state,
-    THCTensor* result,
-    THCTensor** inputs,
-    int numInputs,
-    int dimension,
-    int pad,
-    scalar_t pad_value) {
+void THCTensor_(catArray)(THCState* state, THCTensor* result, THCTensor** inputs, int numInputs, int dimension, int pad, scalar_t pad_value) {
   // previously, size [0] tensors were the only possible empty tensors; thus, it
   // wasn't possible to cat empty tensors unless all the other tensors were
   // 1-dimensional, so we allowed these tensors to be "skipped".  We maintain

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -206,12 +206,12 @@ void THCTensor_(catArray)(
         CatArrInputTensor<scalar_t, unsigned int, CAT_ARRAY_MAX_INPUT_DIMS>*>(
         THCudaMalloc(state, tensorMetadataSize));
 
-    OutputTensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> param;
+    TensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> param;
 
     // Next, let's initialize the size, stride arrays for the output Tensor.
     for (i = 0; i < nDims; ++i) {
-      param.outputSize[i] = THCTensor_(size)(state, result, i);
-      param.outputStride[i] = THCTensor_(stride)(state, result, i);
+      param.tensorSize[i] = THCTensor_(size)(state, result, i);
+      param.tensorStride[i] = THCTensor_(stride)(state, result, i);
     }
 
     THCStream* stream = THCState_getStream(state);
@@ -220,7 +220,7 @@ void THCTensor_(catArray)(
 #define HANDLE_CASE(DIMS)                                     \
   CatArrayBatchedCopy<scalar_t, unsigned int, DIMS>           \
       <<<catGrid, applyBlock, 0, THCStream_stream(stream)>>>( \
-          data, d_inputs, param, dimension, pad_value);
+          data, d_inputs, param, dimension, pad, pad_value);
 
     // Now we loop
     offset = 0;
@@ -240,10 +240,10 @@ void THCTensor_(catArray)(
 
           int64_t dimSize = THCTensor_(size)(state, curtensor, dimension);
 
-          InputTensorSize<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> inputParam;
+          TensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> inputParam;
           for (int k = 0; k < nDims; ++k) {
-            inputParam.inputSize[k] = THCTensor_(size)(state, curtensor, k);
-            inputParam.inputStride[k] = THCTensor_(stride)(state, curtensor, k);
+            inputParam.tensorSize[k] = THCTensor_(size)(state, curtensor, k);
+            inputParam.tensorStride[k] = THCTensor_(stride)(state, curtensor, k);
           }
 
           THCTensor* nt = THCTensor_(newWithTensor)(state, result);

--- a/aten/src/THC/generic/THCTensorMath.h
+++ b/aten/src/THC/generic/THCTensorMath.h
@@ -8,8 +8,8 @@ THC_API void THCTensor_(zero)(THCState *state, THCTensor *self);
 THC_API void THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API void THCTensor_(onesLike)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
-THC_API void THCTensor_(cat)(THCState *state, THCTensor *result, THCTensor *ta, THCTensor *tb, int dimension);
-THC_API void THCTensor_(catArray)(THCState *state, THCTensor *result, THCTensor **inputs, int numInputs, int dimension);
+THC_API void THCTensor_(cat)(THCState *state, THCTensor *result, THCTensor *ta, THCTensor *tb, int dimension, int pad, scalar_t pad_value);
+THC_API void THCTensor_(catArray)(THCState *state, THCTensor *result, THCTensor **inputs, int numInputs, int dimension, int pad, scalar_t pad_value);
 THC_API void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor, THCTensor *self);
 
 THC_API void THCTensor_(tril)(THCState *state, THCTensor *self, THCTensor *src, int64_t k);

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -783,7 +783,7 @@ void THCTensor_(btrifact)(THCState *state, THCTensor *ra_, THCudaIntTensor *rpiv
     for (int64_t i=0; i<num_batches; i++) {
       ptrs[i] = t;
     }
-    THCudaIntTensor_catArray(state, rpivots_, ptrs, num_batches, 0);
+    THCudaIntTensor_catArray(state, rpivots_, ptrs, num_batches, 0, false, 0);
     THCudaIntTensor_free(state, t);
     THFree(ptrs);
   } else {

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1989,6 +1989,16 @@ class TestAutograd(TestCase):
                               lambda a, b: torch.cat((a, b)),
                               True, f_args_variable, f_args_tensor)
 
+    def test_cat_padding(self):
+        f_args_variable = (torch.randn(1, 1, S, requires_grad=True),
+                           torch.randn(2, 2, S, requires_grad=True),
+                           torch.randn(3, 3, S, requires_grad=True),
+                           0, 0)
+        f_args_tensor = deepcopy(unpack_variables(f_args_variable))
+        run_functional_checks(self, "test_cat_padding", "cat",
+                              lambda a, b, c, dim, pad_value: torch.cat((a, b, c), dim, pad_value),
+                              True, f_args_variable, f_args_tensor)
+
     @skipIfRocm
     def test_potrf(self):
         root = Variable(torch.tril(torch.rand(S, S)), requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1990,9 +1990,9 @@ class TestAutograd(TestCase):
                               True, f_args_variable, f_args_tensor)
 
     def test_cat_padding(self):
-        f_args_variable = (torch.randn(1, 1, S, requires_grad=True),
-                           torch.randn(2, 2, S, requires_grad=True),
-                           torch.randn(3, 3, S, requires_grad=True),
+        f_args_variable = (torch.randn(1, 4, S, requires_grad=True),
+                           torch.randn(2, 3, S, requires_grad=True),
+                           torch.randn(3, 1, S, requires_grad=True),
                            0, 0)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
         run_functional_checks(self, "test_cat_padding", "cat",

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8003,8 +8003,8 @@ class TestCustomOperators(JitTestCase):
     def test_passing_and_returning_lists(self):
         # Replace with actual test once we support lists.
         a, b = torch.rand(5), torch.rand(5)
-        output = torch.ops.aten.cat([a, b])
-        output_ref = torch.cat([a, b])
+        output = torch.ops.aten.meshgrid([a, b])
+        output_ref = torch.meshgrid([a, b])
         self.assertEqual(output, output_ref)
 
     def test_script_graph_contains_custom_op(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -843,20 +843,12 @@ class TestTorch(TestCase):
             res = x.norm(p).item()
             expected = np.linalg.norm(xn, p)
             self.assertEqual(res, expected, "full reduction failed for {}-norm".format(p))
-
         # one dimension
         x = torch.randn(5, 5, device=device)
         xn = x.cpu().numpy()
         for p in [0, 1, 2, 3, 4, inf]:
             res = x.norm(p, 1).cpu().numpy()
             expected = np.linalg.norm(xn, p, 1)
-            self.assertEqual(res.shape, expected.shape)
-            self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
-
-        # matrix norm
-        for p in ['fro', 'nuc']:
-            res = x.norm(p).cpu().numpy()
-            expected = np.linalg.norm(xn, p)
             self.assertEqual(res.shape, expected.shape)
             self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
 
@@ -3743,7 +3735,7 @@ class TestTorch(TestCase):
         x = torch.rand(13, 1)
         y = torch.rand(17, 2)
         z = torch.rand(19, 3)
-torch.cat([torch.randn(1,4, requires_grad=True), torch.randn(2,3,requires_grad=True), torch.randn(2,3, requires_grad=True)], 0, 0.5).sum().backward()
+
         for pad_value in [0, 0.5, 1]:
             res1 = torch.cat((x, y, z), 0, pad_value)
             self.assertEqual(x, res1.narrow(0, 0, 13).narrow(1, 0, 1), prec=0)
@@ -7405,51 +7397,22 @@ torch.cat([torch.randn(1,4, requires_grad=True), torch.randn(2,3,requires_grad=T
         expected = torch.pow(x.pow(3).abs().sum(1), 1.0 / 3.0)
         self.assertEqual(result, expected)
 
-    @staticmethod
-    def _test_bernoulli(self, p_dtype, device):
-        for trivial_p in ([0, 1], [1, 0, 1, 1, 0, 1]):
-            x = torch.tensor(trivial_p, dtype=p_dtype, device=device)
-            self.assertEqual(x.bernoulli().tolist(), trivial_p)
+    def test_bernoulli(self):
+        t = torch.ByteTensor(10, 10)
 
         def isBinary(t):
-            return torch.ne(t, 0).mul_(torch.ne(t, 1)).sum().item() == 0
+            return torch.ne(t, 0).mul_(torch.ne(t, 1)).sum() == 0
 
-        p = torch.rand(5, 5, dtype=p_dtype, device=device)
-        self.assertTrue(isBinary(p.bernoulli()))
-
-        p = torch.rand(5, dtype=p_dtype, device=device).expand(5, 5)
-        self.assertTrue(isBinary(p.bernoulli()))
-
-        p = torch.rand(5, 5, dtype=p_dtype, device=device)
-        torch.bernoulli(torch.rand_like(p), out=p)
-        self.assertTrue(isBinary(p))
-
-        p = torch.rand(5, dtype=p_dtype, device=device).expand(5, 5)
-        torch.bernoulli(torch.rand_like(p), out=p)
-        self.assertTrue(isBinary(p))
-
-        # test that it works with integral tensors
-        t = torch.empty(10, 10, dtype=torch.uint8, device=device)
-
-        t.fill_(2)
-        t.bernoulli_(0.5)
-        self.assertTrue(isBinary(t))
-
-        p = torch.rand(10, dtype=p_dtype, device=device).expand(10, 10)
-        t.fill_(2)
+        p = 0.5
         t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 
-        t.fill_(2)
-        torch.bernoulli(torch.rand_like(t, dtype=p_dtype), out=t)
+        p = torch.rand(10, 10)
+        t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 
-        t.fill_(2)
-        t.bernoulli_(torch.rand_like(t, dtype=p_dtype))
-        self.assertTrue(isBinary(t))
-
-    def test_bernoulli(self):
-        self._test_bernoulli(self, torch.double, 'cpu')
+        q = torch.rand(5, 5)
+        self.assertTrue(isBinary(q.bernoulli()))
 
     def test_normal(self):
         q = torch.Tensor(100, 100)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3787,7 +3787,7 @@ class TestTorch(TestCase):
     def test_cat_empty_legacy(self):
         self._test_cat_empty_legacy(self)
 
-    def _test_cat_padding(self):
+    def test_cat_padding(self):
         x = torch.rand(13, 1, 3)
         y = torch.rand(17, 2, 2)
         z = torch.rand(19, 3, 1)
@@ -3803,9 +3803,6 @@ class TestTorch(TestCase):
         expect2[13:30, 0:2, 0:2] = y
         expect2[30:49, 0:3, 0:1] = z
         self.assertEqual(expect2, res1, 0)
-
-    def test_cat_padding(self):
-        self._test_cat_padding(self)
 
     @staticmethod
     def _test_cat_empty(self, use_cuda=False):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3732,23 +3732,20 @@ class TestTorch(TestCase):
         self.assertRaises(RuntimeError, lambda: torch.cat([]))
 
     def test_cat_padding(self):
-        x = torch.rand(13, 1)
-        y = torch.rand(17, 2)
-        z = torch.rand(19, 3)
+        x = torch.rand(13, 1, 3)
+        y = torch.rand(17, 2, 2)
+        z = torch.rand(19, 3, 1)
 
         for pad_value in [0, 0.5, 1]:
             res1 = torch.cat((x, y, z), 0, pad_value)
-            self.assertEqual(x, res1.narrow(0, 0, 13).narrow(1, 0, 1), 0)
-            self.assertEqual(y, res1.narrow(0, 13, 17).narrow(1, 0, 2), 0)
-            self.assertEqual(z, res1.narrow(0, 30, 19).narrow(1, 0, 3), 0)
+            self.assertEqual(x, res1.narrow(0, 0, 13).narrow(1, 0, 1).narrow(2, 0, 3), 0)
+            self.assertEqual(y, res1.narrow(0, 13, 17).narrow(1, 0, 2).narrow(2, 0, 2), 0)
+            self.assertEqual(z, res1.narrow(0, 30, 19).narrow(1, 0, 3).narrow(2, 0, 1), 0)
 
-            expect2 = torch.ones(49, 3) * pad_value
-            res1[0:13, 0:1] -= x
-            expect2[0:13, 0:1] *= 0
-            res1[13:30, 0:2] -= y
-            expect2[13:30, 0:2] *= 0
-            res1[30:49, 0:3] -= z
-            expect2[30:49, 0:3] *= 0
+            expect2 = torch.full((49, 3, 3), pad_value)
+            expect2[0:13, 0:1, 0:3] = x
+            expect2[13:30, 0:2, 0:2] = y
+            expect2[30:49, 0:3, 0:1] = z
             self.assertEqual(expect2, res1, 0)
 
     def test_cat_bad_input_sizes(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3738,15 +3738,18 @@ class TestTorch(TestCase):
 
         for pad_value in [0, 0.5, 1]:
             res1 = torch.cat((x, y, z), 0, pad_value)
-            self.assertEqual(x, res1.narrow(0, 0, 13).narrow(1, 0, 1), prec=0)
-            self.assertEqual(y, res1.narrow(0, 13, 17).narrow(1, 0, 2), prec=0)
-            self.assertEqual(z, res1.narrow(0, 30, 19).narrow(1, 0, 3), prec=0)
+            self.assertEqual(x, res1.narrow(0, 0, 13).narrow(1, 0, 1), 0)
+            self.assertEqual(y, res1.narrow(0, 13, 17).narrow(1, 0, 2), 0)
+            self.assertEqual(z, res1.narrow(0, 30, 19).narrow(1, 0, 3), 0)
 
             expect2 = torch.ones(49, 3) * pad_value
             res1[0:13, 0:1] -= x
+            expect2[0:13, 0:1] *= 0
             res1[13:30, 0:2] -= y
+            expect2[13:30, 0:2] *= 0
             res1[30:49, 0:3] -= z
-            self.assertEqual(z, res1.narrow(0, 30, 19).narrow(1, 0, 3), prec=0)
+            expect2[30:49, 0:3] *= 0
+            self.assertEqual(expect2, res1, 0)
 
     def test_cat_bad_input_sizes(self):
         x = torch.randn(2, 1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -167,7 +167,10 @@
   self: not_implemented("btrisolve")
 
 - name: cat(TensorList tensors, int64_t dim)
-  tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim)
+  tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim, false)
+
+- name: cat(TensorList tensors, int64_t dim, Scalar pad_value)
+  tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim, true)
 
 - name: cauchy_(Tensor self, double median, double sigma, Generator generator)
   self: zeros_like(grad)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -425,7 +425,11 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   return self;
 }
 
-std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
+std::vector<Tensor> cat_tensors_backward(
+    const Tensor& grad,
+    const std::vector<std::vector<int64_t>>& sizes,
+    int64_t dim,
+    bool pad) {
   dim = at::legacy_cat_wrap_dim(dim, sizes);
   std::vector<Tensor> grad_inputs(sizes.size());
   int64_t accumulate = 0;
@@ -439,6 +443,14 @@ std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<
     auto size = shape[dim];
     accumulate += size;
     grad_inputs[i] = grad.narrow(dim, accumulate - size, size);
+    if (pad) {
+      for (size_t j = 0; j < shape.size(); ++j) {
+        auto cursize = shape[j];
+        if ((int64_t)j != dim) {
+          grad_inputs[i] = grad_inputs[i].narrow(j, 0, cursize);
+        }
+      }
+    }
   }
   return grad_inputs;
 }

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -740,11 +740,17 @@ Arguments:
 
 add_docstr(torch.cat,
            r"""
-cat(seq, dim=0, out=None) -> Tensor
+cat(seq, dim=0, pad_value=None, out=None) -> Tensor
 
 Concatenates the given sequence of :attr:`seq` tensors in the given dimension.
-All tensors must either have the same shape (except in the concatenating
-dimension) or be empty.
+If pad_value is set to None, all tensors must have the same shape,
+except in the dimension corresponding to :attr:`dim`.
+If pad_value is set to a scalar, all tensors only need to have the same number
+of dimensions.The size of the resulting tensor is the size of the sum of the
+dimensions in the concatenating dimension, and the maximum of the
+dimension sizes in all other dimensions. If an input tensor needs to be
+logically expanded to fill out its place in the resulting tensor, it is
+padded with :attr:pad_value.
 
 :func:`torch.cat` can be seen as an inverse operation for :func:`torch.split`
 and :func:`torch.chunk`.
@@ -756,6 +762,9 @@ Args:
         Non-empty tensors provided must have the same shape, except in the
         cat dimension.
     dim (int, optional): the dimension over which the tensors are concatenated
+    pad_value (scalar, optional): The value is used in padding to expand
+        input tensors to same shape except in the concatenating dimension
+        (see explanation above).
     out (Tensor, optional): the output tensor
 
 Example::
@@ -776,6 +785,12 @@ Example::
              -1.0969, -0.4614],
             [-0.1034, -0.5790,  0.1497, -0.1034, -0.5790,  0.1497, -0.1034,
              -0.5790,  0.1497]])
+    >>> x = torch.ones(2, 3)
+    >>> y = torch.zeros(1, 4)
+    >>> torch.cat([x, y], dim=0, pad_value=0.5)
+    tensor([[1.0000, 1.0000, 1.0000, 0.5000],
+            [1.0000, 1.0000, 1.0000, 0.5000],
+            [0.0000, 0.0000, 0.0000, 0.0000]])
 """)
 
 add_docstr(torch.ceil,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -743,14 +743,16 @@ add_docstr(torch.cat,
 cat(seq, dim=0, pad_value=None, out=None) -> Tensor
 
 Concatenates the given sequence of :attr:`seq` tensors in the given dimension.
-If pad_value is set to None, all tensors must have the same shape,
-except in the dimension corresponding to :attr:`dim`.
-If pad_value is set to a scalar, all tensors only need to have the same number
-of dimensions.The size of the resulting tensor is the size of the sum of the
-dimensions in the concatenating dimension, and the maximum of the
+If pad_value is None, all tensors must have the same shape, except in the
+dimension corresponding to :attr:`dim`.
+If pad_value is not None (i.e. a scalar), all tensors only need to have the same
+number of dimensions. The size of the resulting tensor is the size of the sum
+of the dimensions sizes in the concatenating dimension, and the maximum of the
 dimension sizes in all other dimensions. If an input tensor needs to be
 logically expanded to fill out its place in the resulting tensor, it is
-padded with :attr:pad_value.
+padded with :attr:pad_value. For example, if we cat tensors with size
+(x0, x1, ..., xn) and (y0, y1, ..., yn) along 0 axis, the size of result tensor
+is (x0 + y0, max(x1, y1), ..., max(xn, yn)).
 
 :func:`torch.cat` can be seen as an inverse operation for :func:`torch.split`
 and :func:`torch.chunk`.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -751,8 +751,8 @@ of the dimensions sizes in the concatenating dimension, and the maximum of the
 dimension sizes in all other dimensions. If an input tensor needs to be
 logically expanded to fill out its place in the resulting tensor, it is
 padded with :attr:pad_value. For example, if we cat tensors with size
-(x0, x1, ..., xn) and (y0, y1, ..., yn) along 0 axis, the size of result tensor
-is (x0 + y0, max(x1, y1), ..., max(xn, yn)).
+(x0, x1, ..., xn) and (y0, y1, ..., yn) along dimension 0, the size of the
+result tensor is (x0 + y0, max(x1, y1), ..., max(xn, yn)).
 
 :func:`torch.cat` can be seen as an inverse operation for :func:`torch.split`
 and :func:`torch.chunk`.
@@ -765,7 +765,7 @@ Args:
         cat dimension.
     dim (int, optional): the dimension over which the tensors are concatenated
     pad_value (scalar, optional): The value is used in padding to expand
-        input tensors to same shape except in the concatenating dimension
+        input tensors to the same shape except in the concatenating dimension
         (see explanation above).
     out (Tensor, optional): the output tensor
 

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -351,7 +351,8 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       // NB: this is a specialization for the common case where all inputs are
       // of equal sizes. We can use a single split operation to handle that.
       if (std::all_of(
-              tensor_inputs.begin(), tensor_inputs.end(), has_first_sizes) && !pad) {
+              tensor_inputs.begin(), tensor_inputs.end(), has_first_sizes) &&
+          !pad) {
         auto tensor_grads = grads.at(0).chunk(tensor_inputs.size(), dim);
         tensor_grads.push_back(nullptr); // for attr::dim
         return tensor_grads;
@@ -386,7 +387,9 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
     } else if (node->kind() == prim::Constant) {
       return {};
     }
-    throw std::runtime_error(std::string("failed to differentiate `") + node->kind().toDisplayString() + "`");
+    throw std::runtime_error(
+        std::string("failed to differentiate `") +
+        node->kind().toDisplayString() + "`");
   };
   if (!isDifferentiable(node)) {
     throw std::runtime_error(std::string("differentiation of ") + node->kind().toDisplayString() + " "

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -78,8 +78,6 @@ bool isDifferentiable(Node * n) {
     "aten::sinh(Tensor self) -> Tensor",
     "aten::tan(Tensor self) -> Tensor",
     "aten::trunc(Tensor self) -> Tensor",
-    "aten::cat(Tensor[] tensors, int dim) -> Tensor",
-    "aten::cat(Tensor[] tensors, int dim, Scalar pad_value)",
   };
 
   // TODO: add support for the following fusible operators.
@@ -168,8 +166,8 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       return {nullptr, -grads.at(0) * inputs.at(0) / (inputs.at(1) * inputs.at(1))};
 
     } else if (node->matches("aten::sigmoid(Tensor self) -> Tensor")) {
-      // TODO: The order of operations matter in this case. This 
-      // works for ppc64le and x86_64. Need to look at why the 
+      // TODO: The order of operations matter in this case. This
+      // works for ppc64le and x86_64. Need to look at why the
       // order matters.
       return {(1 - outputs.at(0)) * outputs.at(0) * grads.at(0)};
 

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -334,9 +334,15 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       }
       return {sizes.at(dim) > 1 ? grads.at(0) : grads.at(0).unsqueeze(dim), nullptr};
 
-    } else if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*const=*/attr::dim)) {
+    } else if (
+        node->matches(
+            "aten::cat(Tensor[] tensors, int dim, Scalar pad_value) -> Tensor",
+            /*const=*/{attr::dim})) {
       int dim = *node->get<int64_t>(attr::dim);
-      auto tensor_inputs = inputs; tensor_inputs.pop_back();
+      at::Scalar pad_value = *node->get<at::Scalar>(attr::pad_value);
+      bool pad = std::isnan(pad_value.toFloat());
+      auto tensor_inputs = inputs;
+      tensor_inputs.pop_back();
       const auto& first_sizes = tensor_inputs.at(0).sizes();
       const auto has_first_sizes = [&first_sizes](SymbolicVariable var) {
         return var.sizes() == first_sizes;
@@ -344,7 +350,8 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
 
       // NB: this is a specialization for the common case where all inputs are
       // of equal sizes. We can use a single split operation to handle that.
-      if (std::all_of(tensor_inputs.begin(), tensor_inputs.end(), has_first_sizes)) {
+      if (std::all_of(
+              tensor_inputs.begin(), tensor_inputs.end(), has_first_sizes) && !pad) {
         auto tensor_grads = grads.at(0).chunk(tensor_inputs.size(), dim);
         tensor_grads.push_back(nullptr); // for attr::dim
         return tensor_grads;
@@ -353,7 +360,21 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         auto grad = grads.at(0);
         std::vector<SymbolicVariable> tensor_grads;
         for (auto input : tensor_inputs) {
-          tensor_grads.push_back(grad.narrow(dim, offset, input.sizes()[dim]));
+          if (pad) {
+            int64_t ndim = input.sizes().size();
+            for (int64_t i = 0; i < ndim; ++i) {
+              auto result = grad;
+              if (i == dim) {
+                result = result.narrow(dim, offset, input.sizes()[dim]);
+              } else {
+                result = result.narrow(dim, 0, input.sizes()[i]);
+              }
+              tensor_grads.push_back(result);
+            }
+          } else {
+            tensor_grads.push_back(
+                grad.narrow(dim, offset, input.sizes()[dim]));
+          }
           offset += input.sizes()[dim];
         }
         tensor_grads.push_back(nullptr); // for attr::dim


### PR DESCRIPTION
It is an updated version of PR #11252 including solving merge conflict.

This PR is let torch.cat support padding.

Example:

x = torch.ones(2, 3)
y = torch.zeros(1, 4)
torch.cat([x, y], dim=0, pad_value=0.5)

tensor([[1., 1., 1., 0.5],
[1., 1., 1., 0.5],
[0., 0., 0., 0.]])

See T33342447