### PR TITLE
Remove implicit bool casts

### DIFF
--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -13,7 +13,7 @@ TEST_CASE("torch script") {
       def test_relu(a, b):
         return torch.relu(a + b)
       def test_while(a, i):
-        while i < 10:
+        while bool(i < 10):
           a += a
           i += 1
         return a

--- a/test/expect/TestJit.test_recursive_cse.expect
+++ b/test/expect/TestJit.test_recursive_cse.expect
@@ -2,10 +2,9 @@ graph(%z.1 : Dynamic
       %y : Dynamic) {
   %2 : int = prim::Constant[value=1]()
   %3 : Dynamic = aten::add(%z.1, %y, %2)
-  %4 : int = prim::TensorToNum(%3)
-  %5 : int = prim::TensorToNum(%z.1)
-  %6 : int = aten::gt(%4, %5)
-  %z : Dynamic = prim::If(%6)
+  %4 : Dynamic = aten::gt(%3, %z.1)
+  %5 : int = prim::TensorToNum(%4)
+  %z : Dynamic = prim::If(%5)
     block0() {
       -> (%3)
     }

--- a/test/expect/TestJit.test_recursive_cse.expect
+++ b/test/expect/TestJit.test_recursive_cse.expect
@@ -2,9 +2,10 @@ graph(%z.1 : Dynamic
       %y : Dynamic) {
   %2 : int = prim::Constant[value=1]()
   %3 : Dynamic = aten::add(%z.1, %y, %2)
-  %4 : Dynamic = aten::gt(%3, %z.1)
-  %5 : int = prim::TensorToNum(%4)
-  %z : Dynamic = prim::If(%5)
+  %4 : int = prim::TensorToNum(%3)
+  %5 : int = prim::TensorToNum(%z.1)
+  %6 : int = aten::gt(%4, %5)
+  %z : Dynamic = prim::If(%6)
     block0() {
       -> (%3)
     }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -860,7 +860,7 @@ class TestJit(JitTestCase):
 
         def fn(x, y):
             z = x
-            if x + y > x:
+            if bool(x + y > x):
                 z = x + y
             return z
 
@@ -1470,12 +1470,11 @@ class TestJit(JitTestCase):
         @torch.jit.script
         def constant_prop(a):
             b = 2 + 1
-            if a < 2:
+            if bool(a < 2):
                 c = b + 2
             else:
                 c = b - 2
             return c
-
         out_ref = constant_prop(torch.tensor(2))
         self.run_pass('constant_propagation', constant_prop.graph)
         out_test = constant_prop(torch.tensor(2))
@@ -1509,8 +1508,8 @@ class TestJit(JitTestCase):
             c0 = 1
             c1 = 1
             c2 = 1
-            if a:  # -> c0, c1
-                if b:  # -> c0
+            if bool(a):  # -> c0, c1
+                if bool(b):  # -> c0
                     if True:  # -> c0
                         c0 = c0 + 1
                         if False:
@@ -1920,7 +1919,7 @@ class TestBatched(TestCase):
 
     def test_if_else(self):
         def single_if(a, b):
-            if a > b:
+            if bool(a > b):
                 a = a + b
             else:
                 a = a - b
@@ -1940,7 +1939,7 @@ class TestBatched(TestCase):
 
     def test_if_else_with_scalar(self):
         def single_if(a, b):
-            if a > 0.1:
+            if bool(a > 0.1):
                 a = a + b
             else:
                 a = a - b
@@ -1960,7 +1959,7 @@ class TestBatched(TestCase):
 
     def test_if_noelse(self):
         def single_if(a, b):
-            if a > b:
+            if bool(a > b):
                 a = a + b
             return a
 
@@ -1978,7 +1977,7 @@ class TestBatched(TestCase):
 
     def test_if_noelse_with_scalar(self):
         def single_if(a, b):
-            if a > 0.1:
+            if bool(a > 0.1):
                 a = a + b
             return a
 
@@ -1996,7 +1995,7 @@ class TestBatched(TestCase):
 
     def test_while(self):
         def single_while(a, b):
-            while a > b:
+            while bool(a > b):
                 a = a - b
             return a
 
@@ -2084,7 +2083,7 @@ class TestBatched(TestCase):
         def greedy(x, h, c, embed, w_xi, w_xf, w_xo, w_xc, w_hi, w_hf, w_ho, w_hc,
                    b_i, b_f, b_o, b_c, w_hs, b_s, iter_num):
             iter_count = torch.zeros_like(iter_num)
-            while(iter_count < iter_num):
+            while bool(iter_count < iter_num):
                 iter_count += 1
                 # LSTM Cell
                 i_t = torch.matmul(x, w_xi) + torch.matmul(h, w_hi) + b_i
@@ -2150,7 +2149,7 @@ class TestBatched(TestCase):
             vocab_size = embed.size(1)
             iter_count = torch.zeros_like(iter_num)
             max_len = idx.size(2)
-            while(iter_count < iter_num):
+            while bool(iter_count < iter_num):
                 iter_count += 1
                 # LSTM Cell
                 i_t = torch.matmul(x, w_xi) + torch.matmul(h, w_hi) + b_i
@@ -3228,7 +3227,7 @@ a")
 
     def test_while(self):
         def func(a, b, max):
-            while a < max:
+            while bool(a < max):
                 a = a + 1
                 b = b + 1
             c = a + b
@@ -3245,7 +3244,7 @@ a")
             somenum = 5
             dontmutateme = 3
             third = 0
-            while i < lim:
+            while bool(i < lim):
                 third = first + second
                 first = second
                 second = third
@@ -3267,7 +3266,7 @@ a")
         def func(a, b):
             # type: (int, int) -> int
             d = 3
-            if a > 10:
+            if bool(a > 10):
                 a = 3 + d
             else:
                 b = 3 + d
@@ -3283,7 +3282,7 @@ a")
             # type: (int, int) -> int
             d = 3
             for _ in range(20):
-                if a > 10:
+                if bool(a > 10):
                     a = 3 + d
                 else:
                     b = 3 + d
@@ -3295,7 +3294,7 @@ a")
 
     def test_if_noelse(self):
         def func(a, b):
-            if a > 10:
+            if bool(a > 10):
                 a = 3 + b
             c = a + b
             return c
@@ -3303,11 +3302,19 @@ a")
         inputs = self._make_scalar_vars([-1, 1], torch.int64)
         self.checkScript(func, inputs, optimize=True)
 
+    def test_explicit_bool_cast(self):
+        with self.assertRaisesRegex(RuntimeError, "expected an integer"):
+            @torch.jit.script
+            def test_bool_cast(a):
+                if a:
+                    return a + 2
+                return a + 1
+
     def test_while_nonexistent_value(self):
         with self.assertRaisesRegex(RuntimeError, "undefined value x"):
             torch.jit.CompilationUnit('''
             def test_while(a, b):
-                while a < 10:
+                while bool(a < 10):
                     a = a + x
                     b = b + 1
                 return a + b
@@ -3325,7 +3332,7 @@ a")
 
     def test_while_write_outer_then_read(self):
         def func(a, b):
-            while a < 10:
+            while bool(a < 10):
                 a = a + 1
                 b = a + 1
             return a + b
@@ -3474,7 +3481,7 @@ a")
     def test_ternary(self):
         def func(a, b):
             c = 3
-            c = a + b if a > 3 else b
+            c = a + b if bool(a > 3) else b
             return c
 
         inputs_true = self._make_scalar_vars([5, 2], torch.int64)
@@ -3497,18 +3504,18 @@ a")
         @torch.jit.script
         def testNoThrows(t):
             c1 = 1
-            if (False and t[1]) or (True or t[1]):
+            if (False and bool(t[1])) or (True or bool(t[1])):
                 c1 = 0
             return c1
 
         @torch.jit.script
         def throwsOr(t):
-            c0 = False or t[1]
+            c0 = False or bool(t[1])
             print(c0)
 
         @torch.jit.script
         def throwsAnd(t):
-            c0 = True and t[1]
+            c0 = True and bool(t[1])
             print(c0)
 
         t = torch.randn(0)
@@ -3721,7 +3728,7 @@ a")
             step = 1
             while i < 10:
                 b = pyfunc(b)
-                if b > 3.0:
+                if bool(b > 3.0):
                     b = pyfunc(b)
                 i = 11
             return b
@@ -4693,7 +4700,7 @@ a")
         @torch.jit.script
         def foo(a, c):
             b = 0.0
-            if a == 0.0:
+            if bool(a == 0.0):
                 b = 1.0
             return b + c
 
@@ -4712,7 +4719,7 @@ a")
     def test_if_define(self):
         @torch.jit.script
         def foo(a):
-            if a == 0:
+            if bool(a == 0):
                 b = 1
             else:
                 b = 0
@@ -4721,14 +4728,14 @@ a")
         @torch.jit.script
         def foo2(a):
             b = 0
-            if a == 0:
+            if bool(a == 0):
                 b = 1
             return b + 1
 
         @torch.jit.script
         def foo3(a):
             b = 1
-            if a == 0:
+            if bool(a == 0):
                 c = 4
             else:
                 b = 0
@@ -5013,7 +5020,7 @@ a")
 
             @torch.jit.script_method
             def forward(self, x):
-                if torch.sum(x) > 0:
+                if bool(torch.sum(x) > 0):
                     x = torch.neg(x)
                 return x
 
@@ -5128,8 +5135,8 @@ a")
                 # we cannot use `True` as the condition. Constant prop
                 # would remove the `if` statements.
                 c = sum(x) > 4
-                if c:
-                    if c:
+                if bool(c):
+                    if bool(c):
                         y = self.m(x)
                     else:
                         y = self.m(x)
@@ -5562,7 +5569,7 @@ a")
         with self.assertRaisesRegex(RuntimeError, 'return statements can appear only at the end of the function body'):
             @torch.jit.script
             def return_stmt_wrong(x):
-                if x > 3:
+                if bool(x > 3):
                     return 3
                 else:
                     return x

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -970,11 +970,15 @@ private:
 
   Value* emitCond(Expr cond) {
     Value* v = emitExpr(cond);
-    if(v->type()->isSubtypeOf(DynamicType::get())) {
-      v = typeCast(cond.range(), v, IntType::get());
-    }
-    if(!v->type()->isSubtypeOf(IntType::get())) {
-      throw ErrorReport(cond) << "expected a tensor or integer expression for condition but found " << v->type()->str();
+    if (!v->type()->isSubtypeOf(IntType::get())) {
+      ErrorReport error(cond);
+      error << "expected an integer expression for condition but found "
+            << v->type()->str();
+      if (v->type()->isSubtypeOf(DynamicType::get())) {
+        error << ", to use a tensor in a boolean"
+              << " expression, explicitly cast it with `bool()`";
+      }
+      throw error;
     }
     return v;
   }

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -844,18 +844,18 @@ const static auto cf_examples = R"JIT(
       # FIXME: use 0 instead of a.
       # c = 0
       c = a
-      if a < b:
+      if bool(a < b):
         c = b
       else:
         c = a
       return c
   def if_one(a, b):
     c = b
-    if a < b:
+    if bool(a < b):
       c = a
     return c
   def while_test(a, i):
-    while i < 3:
+    while bool(i < 3):
       a *= a
       i += 1
     return a

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -862,7 +862,7 @@ const static auto cf_examples = R"JIT(
 )JIT";
 void testControlFlow() {
   script::Module cu;
-  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver(), nullptr);
+  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::nativeResolver, nullptr);
   auto run = [&](const std::string & name, std::vector<IValue> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph);

--- a/torch/jit/batchop.py
+++ b/torch/jit/batchop.py
@@ -140,7 +140,7 @@ def batch_select(data, mask, dims, dim_, index_):
     # if dim == 0:
     #     raise ValueError("Cannot select 0 dim in BatchTensor")
     data = data.select(dim, index)
-    if dims[dim - 1]:
+    if bool(dims[dim - 1]):
         mask = mask.select(dim, index)
     else:
         mask = mask.select(dim, 0)
@@ -171,7 +171,7 @@ def batch_index_select(data, mask, dims, dim_, index_data, index_mask, index_dim
     res_mask = torch.zeros([0])
     for i in range(batch_size):
         d = data[i].index_select(dim - 1, index_data[i]).unsqueeze(0)
-        if dims[dim - 1]:
+        if bool(dims[dim - 1]):
             m = mask[i].index_select(dim - 1, index_data[i]).unsqueeze(0)
         else:
             m = mask[i].unsqueeze(0)
@@ -310,7 +310,7 @@ def batch_argmax(data, mask, dims, dim_, keepdim_):
     batch_size = data.size(0)
     res_data = torch.zeros([0])
     for i in range(batch_size):
-        if dims[dim - 1]:
+        if bool(dims[dim - 1]):
             if dim - 1 != 0:
                 m = mask[i].transpose(0, dim - 1)
             else:
@@ -346,7 +346,7 @@ def batch_topk(data, mask, dims, k_, dim_, largest_, sorted_):
     res_data = torch.zeros([0])
     res_index = torch.zeros([0])
     for i in range(batch_size):
-        if dims[dim - 1]:
+        if bool(dims[dim - 1]):
             if dim - 1 != 0:
                 m = mask[i].transpose(0, dim - 1)
             else:
@@ -364,7 +364,7 @@ def batch_topk(data, mask, dims, k_, dim_, largest_, sorted_):
         else:
             res_data = torch.cat([res_data, d], 0)
             res_index = torch.cat([res_index, idx], 0)
-    if dims[dim - 1]:
+    if bool(dims[dim - 1]):
         mask = mask.narrow(dim, 0, k)
     return res_data, mask, dims, res_index, mask, dims
 
@@ -378,7 +378,7 @@ def batch_softmax(data, mask, dims, dim_):
     max_len = data.size(dim)
     res_data = torch.zeros([0])
     for i in range(batch_size):
-        if dims[dim - 1]:
+        if bool(dims[dim - 1]):
             if dim - 1 != 0:
                 m = mask[i].transpose(0, dim - 1)
             else:
@@ -417,7 +417,7 @@ def batch_view(data, mask, dims, sizes):
     res_dims = data_sizes_.narrow(0, 0, 1)
     for i_ in range(sizes.size(0) - 1):
         i = i_ + 1
-        if(sizes[i] == -1):
+        if bool(sizes[i] == -1):
             cur_size_ = mask.size(i)
             cur_dim = 1
         else:
@@ -434,7 +434,7 @@ def batch_view(data, mask, dims, sizes):
 def batch_cat2(data1, mask1, dims1, data2, mask2, dims2, dim_):
     dim = int(dim_)
     data = torch.cat([data1, data2], dim)
-    if(dims1[dim - 1]):
+    if bool(dims1[dim - 1]):
         mask = torch.cat([mask1, mask2], dim)
     else:
         mask = mask1
@@ -445,7 +445,7 @@ def batch_cat2(data1, mask1, dims1, data2, mask2, dims2, dim_):
 def batch_cat3(data1, mask1, dims1, data2, mask2, dims2, data3, mask3, dims3, dim_):
     dim = int(dim_)
     data = torch.cat([data1, data2, data3], dim)
-    if(dims1[dim - 1]):
+    if bool(dims1[dim - 1]):
         mask = torch.cat([mask1, mask2, mask3], dim)
     else:
         mask = mask1
@@ -460,7 +460,7 @@ def batch_narrow(data, mask, dims, dimension_, start_, length_):
     # if dimension == 0:
     #     raise ValueError("cannot do narrow along batch_dim")
     data = data.narrow(dimension, start, length)
-    if dims[dimension - 1]:
+    if bool(dims[dimension - 1]):
         mask = mask.narrow(dimension, start, length)
     else:
         mask = mask.narrow(dimension, 0, 1)


### PR DESCRIPTION
In order to comply with Python's rules on implicit casting of
non-booleans to booleans, this PR removes implicit casting in favor of
explicit casts via `bool()`

cc @zdevito 