### PR TITLE
Allow train/eval, and non-Tensor arguments to python functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -532,6 +532,14 @@ class develop(setuptools.command.develop.develop):
                         for f in ninja_files + cmake_files
                         for entry in load(f)]
 
+        # cquery does not like c++ compiles that start with gcc.
+        # It forgets to include the c++ header directories.
+        # We can work around this by replacing the gcc calls that python
+        # setup.py generates with g++ calls instead
+        for command in all_commands:
+            if command['command'].startswith("gcc "):
+                command['command'] = "g++ " + command['command'][4:]
+
         new_contents = json.dumps(all_commands, indent=2)
         contents = ''
         if os.path.exists('compile_commands.json'):
@@ -540,6 +548,7 @@ class develop(setuptools.command.develop.develop):
         if contents != new_contents:
             with open('compile_commands.json', 'w') as f:
                 f.write(new_contents)
+
         if not USE_NINJA:
             print("WARNING: 'develop' is not building C++ code incrementally")
             print("because ninja is not installed. Run this to enable it:")

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -331,9 +331,9 @@ void Node::lint() const {
   IR_ELSEIFM_CONST(PythonOp)
     size_t n_scalars = 0, n_tensors = 0;
     for (auto c : value->cconv) {
-      if (c == 's') {
+      if (c == 'c') {
         n_scalars++;
-      } else if (c == 't') {
+      } else if (c == 'd') {
         n_tensors++;
       } else {
         JIT_ASSERT(0);

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1391,8 +1391,8 @@ struct PythonOp : public Node {
   // TraceInterpreterState for execution semantics.
   THPObjectPtr pyobj;
   // The calling convention for the Python function.
-  // 's' -- python scalar argument
-  // 't' -- tensor argument
+  // 'c' -- constant argument
+  // 'd' -- dynamic argument
   std::string cconv;
   // Scalar arguments to the Python function.  Not necessarily passed to
   // the function in this order; see cconv for the correct order.

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -156,10 +156,10 @@ void BlockToONNX(Block* old_block, Block* new_block, ::torch::onnx::OperatorExpo
     auto scalar_it = op->scalar_args.begin();
     for (auto arg_type : op->cconv) {
       py::object obj;
-      if (arg_type == 's') {
+      if (arg_type == 'c') {
         JIT_ASSERTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
         obj = py::reinterpret_borrow<py::object>(py::handle((scalar_it++)->get()));
-      } else if (arg_type == 't') {
+      } else if (arg_type == 'd') {
         JIT_ASSERTM(node_it != inputs.end(), "expected too many inputs");
         obj = py::cast(envFn(*node_it++));
       } else {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -167,6 +167,27 @@ inline IValue argumentToIValue(
   }
 }
 
+inline IValue returnToIValue(
+    size_t pos,
+    const TypePtr& type,
+    py::handle object) {
+  try {
+    return toIValue(object, type);
+  } catch (const py::cast_error& error) {
+    AT_ERROR(
+        " expected value of type ", type->str(),
+        " for return in position ", pos,
+        ", but instead got value of type ",
+        py::str(object.get_type().attr("__name__")));
+  } catch (const ConvertError& error) {
+    AT_ERROR(
+        " expected value of type ", type->str(),
+        " for return in position ", pos,
+        ", but instead got value of type ",
+        py::str(object.get_type().attr("__name__")));
+  }
+}
+
 inline py::object toPyObject(IValue&& ivalue) {
   if (ivalue.isNone()) {
     return py::none();

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -26,22 +26,22 @@ inline void findErrorInKwargs(
   // any argument in the schema.
   for (const auto& kwarg : kwargs) {
     const auto key = py::cast<std::string>(kwarg.first);
-    AT_CHECK(
-        std::count_if(
+    if(!std::count_if(
             arguments.begin(),
             arguments.end(),
-            [&key](const Argument& argument) { return argument.name == key; }),
-        "Unknown keyword argument '", key, "' for operator '",
-        schema.name, "'. Schema: ", schema);
+            [&key](const Argument& argument) { return argument.name == key; })) {
+        throw std::runtime_error(at::str("Unknown keyword argument '", key, "' for operator '",
+        schema.name, "'. Schema: ", schema));
+    }
   }
   // If there are unconsumed kwargs but none of them were unknown, the first
   // positional argument present in the kwargs is duplicated.
   for (const auto& argument : arguments) {
     if (kwargs.contains(argument.name.c_str())) {
       AT_ASSERT(!argument.default_value);
-      AT_ERROR(
+      throw std::runtime_error(at::str(
           "Argument '", argument.name, "' specified both as positional and ",
-          "keyword argument. Schema: ", schema);
+          "keyword argument. Schema: ", schema));
     }
   }
 }
@@ -78,19 +78,6 @@ inline IValue createGenericList(py::handle obj, const TypePtr& elem_type) {
   return ConstantList<IValue>::create(std::move(elems));
 }
 
-struct ConvertError : public std::exception {
-    ConvertError(std::string msg)
-    : msg_(std::move(msg)) {}
-    const char* what() const noexcept override  {
-        return msg_.c_str();
-    }
-private:
-    std::string msg_;
-};
-
-#define TORCH_CONVERT_ERROR(...) \
-  throw ConvertError(at::str(__VA_ARGS__))
-
 inline IValue toIValue(py::handle obj, const TypePtr& type) {
     switch (type->kind()) {
       case TypeKind::DynamicType:
@@ -104,11 +91,14 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
       case TypeKind::NoneType:
         return {};
       case TypeKind::TupleType: {
+        if(!PyTuple_Check(obj.ptr()))
+          throw py::cast_error(); // note: the py::cast does not throw cast_error
+                                  // because it attempts to iterate a non-tuple
         py::tuple tuple = py::cast<py::tuple>(obj);
         size_t tuple_size = tuple.size();
         const auto & elem_types = type->cast<TupleType>()->elements();
         if (elem_types.size() != tuple_size) {
-          TORCH_CONVERT_ERROR("Expected ", elem_types.size(), " tuple elements for argument, but got ", tuple_size);
+          throw py::cast_error();
         }
         std::vector<IValue> values;
         values.reserve(tuple_size);
@@ -134,11 +124,10 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
         }
       }
       case TypeKind::NumberType:
-        TORCH_CONVERT_ERROR("Insufficient type information to convert input");
       case TypeKind::GeneratorType:
-        TORCH_CONVERT_ERROR("Generators are not supported yet.");
+        break;
     }
-  AT_ERROR("Missing cases in toIValue! File a bug report.");
+  AT_ERROR("Missing cases in toIValue for type: ", type->str(), "! File a bug report.");
 }
 
 inline IValue argumentToIValue(
@@ -149,21 +138,14 @@ inline IValue argumentToIValue(
   try {
     return toIValue(object, argument.type);
   } catch (const py::cast_error& error) {
-    AT_ERROR(
+    throw std::runtime_error(at::str(
         schema.name, "() expected value of type ", argument.type->str(),
         " for argument '", argument.name,
         "' in position ", argumentPosition,
         ", but instead got value of type ",
-        py::str(object.get_type().attr("__name__")),
-        ".\nDeclaration: ", schema);
-  } catch (const ConvertError& error) {
-    AT_ERROR(
-        schema.name, "(): ", error.what(),
-        "\n for argument '", argument.name,
-        "' in position ", argumentPosition,
-        ", but instead got value of type ",
-        py::str(object.get_type().attr("__name__")),
-        ".\nDeclaration: ", schema);
+        py::str(object.get_type().attr("__name__")), ".",
+        "\nValue: ", py::repr(object),
+        "\nDeclaration: ", schema));
   }
 }
 
@@ -173,14 +155,11 @@ inline IValue returnToIValue(
   try {
     return toIValue(object, type);
   } catch (const py::cast_error& error) {
-    AT_ERROR(
+    throw std::runtime_error(at::str(
         " expected value of type ", type->str(),
         " for return value but instead got value of type ",
-        py::str(object.get_type().attr("__name__")));
-  } catch (const ConvertError& error) {
-    AT_ERROR(" expected value of type ", type->str(),
-    " for return value but instead got value of type ",
-    py::str(object.get_type().attr("__name__")));
+        py::str(object.get_type().attr("__name__")), ".",
+          "\nValue: ", py::repr(object)));
   }
 }
 
@@ -216,12 +195,12 @@ inline Stack createStackForSchema(
     const FunctionSchema& schema,
     py::args args,
     py::kwargs kwargs = py::kwargs()) {
-  AT_CHECK(
-      args.size() + kwargs.size() <= schema.arguments.size(),
-      schema.name, "() expected at most ", schema.arguments.size(),
-      " argument(s) but received ",
-      args.size() + kwargs.size(), " argument(s). Declaration: ", schema);
-
+  if(args.size() + kwargs.size() > schema.arguments.size()) {
+    throw std::runtime_error(at::str(
+        schema.name, "() expected at most ", schema.arguments.size(),
+        " argument(s) but received ",
+        args.size() + kwargs.size(), " argument(s). Declaration: ", schema));
+  }
   Stack stack;
   stack.reserve(schema.arguments.size());
 
@@ -243,9 +222,9 @@ inline Stack createStackForSchema(
     } else if (arg.default_value) {
       push(stack, *arg.default_value);
     } else {
-      AT_ERROR(
+      throw std::runtime_error(at::str(
           schema.name, "() is missing value for argument '", arg.name,
-          "'. Declaration: ", schema);
+          "'. Declaration: ", schema));
     }
   }
 
@@ -302,18 +281,13 @@ inline py::object invokeOperatorFromPython(
     const Operator& op,
     py::args args,
     py::kwargs kwargs) {
-  try {
-    // Create a stack full of the arguments and keyword arguments.
-    auto stack =
-        createStackForSchema(op.schema(), std::move(args), std::move(kwargs));
+  // Create a stack full of the arguments and keyword arguments.
+  auto stack =
+      createStackForSchema(op.schema(), std::move(args), std::move(kwargs));
 
-    // Invoke the operation, which puts the return values onto the stack.
-    op.getOperation()(stack);
+  // Invoke the operation, which puts the return values onto the stack.
+  op.getOperation()(stack);
 
-    return createPyObjectForStack(std::move(stack));
-  } catch (const at::Error& error) {
-    // We don't want to show the backtrace in the error message in Python.
-    throw std::runtime_error(error.what_without_backtrace());
-  }
+  return createPyObjectForStack(std::move(stack));
 }
 }}  // namespace torch::jit

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -18,6 +18,12 @@
 
 namespace torch { namespace jit {
 namespace detail {
+
+// error reporting: when reporting user-caused errors, these functions should
+// not use AT_ERROR macros, since these macros add stack trace information
+// that is confusing to display to the end user since it always reports
+// locations in libtorch code rather than user code.
+
 inline void findErrorInKwargs(
     const FunctionSchema& schema,
     py::kwargs kwargs) {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -168,7 +168,6 @@ inline IValue argumentToIValue(
 }
 
 inline IValue returnToIValue(
-    size_t pos,
     const TypePtr& type,
     py::handle object) {
   try {
@@ -176,15 +175,12 @@ inline IValue returnToIValue(
   } catch (const py::cast_error& error) {
     AT_ERROR(
         " expected value of type ", type->str(),
-        " for return in position ", pos,
-        ", but instead got value of type ",
+        " for return value but instead got value of type ",
         py::str(object.get_type().attr("__name__")));
   } catch (const ConvertError& error) {
-    AT_ERROR(
-        " expected value of type ", type->str(),
-        " for return in position ", pos,
-        ", but instead got value of type ",
-        py::str(object.get_type().attr("__name__")));
+    AT_ERROR(" expected value of type ", type->str(),
+    " for return value but instead got value of type ",
+    py::str(object.get_type().attr("__name__")));
   }
 }
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -180,29 +180,6 @@ void initPythonIRBindings(PyObject * module_) {
        py::arg("defer_weight_export")=false,
        py::arg("operator_export_type")=::torch::onnx::OperatorExportTypes::ONNX,
        py::arg("google_printer")=false)
-    .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
-      // This function should be used for situations where we have a Python function
-      // that should have different behavior when exporting for JIT interpreter
-      // execution v.s. for ONNX export. For example, nn.utils.rnn.pack_padded_sequence
-      // emits a placeholder under ONNX export, but we want to keep the ability to
-      // run this in the interpreter, thus we emit a PythonOp for that use case.
-
-      // Concretely, this function emits a PythonOp wrapping the passed-in
-      // parameter `func`, while storing the function `symbolic` for use by the
-      // ONNX export
-      std::string cconv(inputs.size(), 't');
-      func.attr("symbolic") = symbolic;
-      Node* new_node = g.insertNode(g.createPythonOp(
-        THPObjectPtr(func.release().ptr()), cconv, {}));
-      for (auto i : inputs)
-        new_node->addInput(i);
-      std::vector<Value*> outputs;
-      for (size_t i = 0; i < n_outputs; ++i)
-        new_node->addOutput();
-      auto sl = std::make_shared<StringSourceLocation>(tracer::getPythonInterpreterStackTrace());
-      new_node->setSourceLocation(sl);
-      return py::make_iterator(new_node->outputs().begin(), new_node->outputs().end());
-    }, py::return_value_policy::reference_internal)
     .def("inputs",[](Graph &g) {
       return py::make_iterator(g.inputs().begin(), g.inputs().end());
     })

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -12,7 +12,6 @@
 
 #include "ATen/core/optional.h"
 
-
 #include <climits>
 #include <set>
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -77,7 +77,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
       for (auto &arg_type : arg_types) {
         args.push_back(Argument(std::to_string(idx++), std::move(arg_type), {}, {}, false));
       }
-      rets.push_back(Argument(std::to_string(0), std::move(ret_type), {}, {}, false));
+      rets.push_back(Argument("0", std::move(ret_type), {}, {}, false));
     } else {
       // Create a default signature using what information we have
 
@@ -101,7 +101,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
         std::vector<TypePtr> tuple_values(n_binders, ret_type);
         ret_type = TupleType::create(std::move(tuple_values));
       }
-      rets.push_back(Argument(std::to_string(0), ret_type, {}, {}, false));
+      rets.push_back(Argument("0", ret_type, {}, {}, false));
     }
     return FunctionSchema("", std::move(args), std::move(rets));
   }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -998,7 +998,7 @@ _compiled_methods_whitelist = {
     '_named_members', 'parameters', 'named_parameters',
     'buffers', 'named_buffers', 'children', 'named_children', 'modules',
     'named_modules', 'zero_grad', 'share_memory', '_get_name', 'extra_repr',
-    '_slow_forward', '_tracing_name'
+    '_slow_forward', '_tracing_name', 'eval', 'train',
 }
 
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -105,16 +105,6 @@ def get_num_params(fn):
         return num_params
 
 
-def flatten_return_type(type):
-    if isinstance(type, TupleType):
-        return_types = []
-        for elem_type in type.elements():
-            return_types.append(elem_type)
-        return return_types
-    else:
-        return [type]
-
-
 def parse_type_line(type_line):
     """Parses a type annotation specified as a comment.
 
@@ -138,9 +128,7 @@ def parse_type_line(type_line):
         raise RuntimeError("Failed to parse the return type of a type annotation")
 
     arg_types = [ann_to_type(ann) for ann in arg_ann]
-    ret_types = flatten_return_type(ann_to_type(ret_ann))
-
-    return arg_types, ret_types
+    return arg_types, ann_to_type(ret_ann)
 
 
 def get_type_line(source):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -179,8 +179,8 @@ def try_real_annotations(fn):
 
     arg_types = [ann_to_type(as_ann(p.annotation))
                  for p in sig.parameters.values()]
-    return_types = flatten_return_type(ann_to_type(as_ann(sig.return_annotation)))
-    return arg_types, return_types
+    return_type = ann_to_type(as_ann(sig.return_annotation))
+    return arg_types, return_type
 
 
 def ann_to_type(ann):


### PR DESCRIPTION
This whitelists train/eval functions in script modules, and tests that nested nn.Modules still work.

This also changes the code for calling python functions from script to allow non-tensor inputs/outputs.