### PR TITLE
Add support for tracing strings

### DIFF
--- a/test/expect/TestJit.test_cpp_cuda.expect
+++ b/test/expect/TestJit.test_cpp_cuda.expect
@@ -105,19 +105,19 @@ graph(%0 : Float(2, 3, 4)
       %3 : Float(2, 3, 4)
       %4 : Float(2, 3, 4)) {
   %5 : int = prim::Constant[value=1]()
-  %6 : Float(2, 3, 4), %7 : Float(2, 3, 4) = prim::GradOf[name=aten::add](%0)
+  %6 : Float(2, 3, 4), %7 : Float(2, 3, 4) = prim::GradOf[name="aten::add"](%0)
     block0() {
       %8 : Float(2, 3, 4) = aten::mul(%0, %5)
       -> (%0, %8)
     }
-  %9 : Float(2, 3, 4), %10 : Float(2, 3, 4) = prim::GradOf[name=aten::mul](%6)
+  %9 : Float(2, 3, 4), %10 : Float(2, 3, 4) = prim::GradOf[name="aten::mul"](%6)
     block0() {
       %11 : Float(2, 3, 4) = aten::mul(%6, %2)
       %12 : Float(2, 3, 4) = aten::mul(%6, %4)
       -> (%11, %12)
     }
   %13 : Dynamic = prim::AutogradAdd(%1, %9)
-  %14 : Float(2, 3, 4), %15 : Float(2, 3, 4) = prim::GradOf[name=aten::mul](%13)
+  %14 : Float(2, 3, 4), %15 : Float(2, 3, 4) = prim::GradOf[name="aten::mul"](%13)
     block0() {
       %16 : Float(2, 3, 4) = aten::mul(%13, %3)
       %17 : Float(2, 3, 4) = aten::mul(%13, %2)
@@ -146,19 +146,19 @@ graph(%0 : Float(2, 3, 4)
       %2 : Float(2, 3, 4)
       %3 : Float(2, 3, 4)) {
   %4 : int = prim::Constant[value=1]()
-  %5 : Float(2, 3, 4), %6 : Float(2, 3, 4) = prim::GradOf[name=aten::add](%0)
+  %5 : Float(2, 3, 4), %6 : Float(2, 3, 4) = prim::GradOf[name="aten::add"](%0)
     block0() {
       %7 : Float(2, 3, 4) = aten::mul(%0, %4)
       -> (%0, %7)
     }
-  %8 : Float(2, 3, 4), %9 : Float(2, 3, 4) = prim::GradOf[name=aten::mul](%5)
+  %8 : Float(2, 3, 4), %9 : Float(2, 3, 4) = prim::GradOf[name="aten::mul"](%5)
     block0() {
       %10 : Float(2, 3, 4) = aten::mul(%5, %2)
       %11 : Float(2, 3, 4) = aten::mul(%5, %3)
       -> (%10, %11)
     }
   %12 : Dynamic = prim::AutogradAdd(%1, %8)
-  %13 : Float(2, 3, 4), %14 : Float(2, 3, 4) = prim::GradOf[name=aten::add](%12)
+  %13 : Float(2, 3, 4), %14 : Float(2, 3, 4) = prim::GradOf[name="aten::add"](%12)
     block0() {
       %15 : Float(2, 3, 4) = aten::mul(%12, %4)
       -> (%12, %15)

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,7 +1,7 @@
 graph(%a : Dynamic) {
   %2 : int = prim::Constant[value=2]()
-  %1 : string = prim::Constant[string=a\n\tb\n]()
-  %3 : string = prim::Constant[string=aa]()
+  %1 : string = prim::Constant[value="a\n\tb\n"]()
+  %3 : string = prim::Constant[value="aa"]()
    = prim::Print(%a, %1, %2, %3)
   return (%a);
 }

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -25,6 +25,7 @@ TYPE_MAP = {
     'std::array<bool,2>': 'bool[2]',
     'std::array<bool,3>': 'bool[3]',
     'std::array<bool,4>': 'bool[4]',
+    'std::string': 'str',
     'Scalar': 'Scalar',
     'Tensor': 'Tensor',
     'TensorList': 'Tensor[]',
@@ -66,6 +67,7 @@ FROM_IVALUE = {
     'bool': 'bool({}.toInt())',
     'double': '{}.toDouble()',
     'int64_t': '{}.toInt()',
+    'std::string': '{}.toString()->string()',
     'std::array<bool,2>': 'as_bool_array<2>({}.toIntList()->elements())',
     'std::array<bool,3>': 'as_bool_array<3>({}.toIntList()->elements())',
     'std::array<bool,4>': 'as_bool_array<4>({}.toIntList()->elements())',
@@ -121,7 +123,7 @@ def is_magic_method(api_name):
     return api_name.startswith('__') and api_name.endswith('__')
 
 
-blacklisted_types = {'SparseTensorRef', 'Storage', 'ScalarType', 'optional<ScalarType>', 'std::string', 'void*'}
+blacklisted_types = {'SparseTensorRef', 'Storage', 'ScalarType', 'optional<ScalarType>', 'void*'}
 default_only_types = {'Generator'}
 
 

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -33,7 +33,7 @@ Value* insertConstant(
     }));
     n->output()->setType(ListType::ofTensors());
   } else if(val.isString()) {
-    n->s_(attr::string, val.toString()->string());
+    n->s_(attr::value, val.toString()->string());
     n->output()->setType(StringType::get());
   } else {
     throw constant_not_supported_error("Unsupported value kind: " + val.tagKind());
@@ -86,7 +86,7 @@ RegisterOperators reg({
             return 0;
           };
         } else if (type == StringType::get()) {
-          auto s = node->s(attr::string);
+          auto s = node->s(attr::value);
           return [s](Stack& stack) {
             push(stack, s);
             return 0;

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -109,7 +109,6 @@ namespace torch { namespace jit {
   _(attr, transA)                  \
   _(attr, transB)                  \
   _(attr, name)                    \
-  _(attr, string)                  \
   _(attr, a)                       \
   _(attr, b)
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -125,7 +125,7 @@ void printAttributes(std::ostream & out, const Node * n, bool ignore_subgraph=fa
         printPrimList(out,n->is(name));
         break;
       case AttributeKind::s:
-        out << escapeString(n->s(name));
+        out << "\"" << escapeString(n->s(name)) << "\"";
         break;
       case AttributeKind::ss:
         printPrimList(out,n->ss(name));

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -54,6 +54,7 @@ struct SchemaParser {
       {"Layout", IntType::get() },
       {"Device", ListType::ofInts() },
       {"Scalar", NumberType::get() },
+      {"str", StringType::get() },
       {"float", FloatType::get() },
       {"int", IntType::get() },
       {"bool", IntType::get() }, // TODO: add separate bool type

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -39,8 +39,8 @@ void addInputs(Node *n, const char * name, int64_t value)            { detail::g
 void addInputs(Node *n, const char * name, bool value)               { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, double value)             { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Scalar& value)  { detail::genericAddInput(n, value); }
+void addInputs(Node *n, const char * name, const std::string& value) { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Tensor& value)  { n->addInput(getValueTrace(value)); }
-void addInputs(Node *n, const char * name, const std::string& value)         { detail::badArgType(value); }
 void addInputs(Node *n, const char * name, const at::SparseTensorRef& value) { detail::badArgType(value); }
 void addInputs(Node *n, const char * name, at::Generator * value)            { detail::badArgType(value); }
 void addInputs(Node *n, const char * name, at::ScalarType value)             { detail::badArgType(value); }


### PR DESCRIPTION
This enabled `torch.einsum` both in tracing and in script mode. It's used all over Pyro at the moment, and is needed for any use of the JIT in there.

Fixes #11157.

@zdevito @fritzo @neerajprad 