### PR TITLE
Unify C++ API with C++ extensions

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -24,9 +24,13 @@ endif()
 
 # Include directories.
 if (EXISTS "${TORCH_INSTALL_PREFIX}/lib/include")
-  set(TORCH_INCLUDE_DIRS "${TORCH_INSTALL_PREFIX}/lib/include")
+  set(TORCH_INCLUDE_DIRS
+    ${TORCH_INSTALL_PREFIX}/lib/include
+    ${TORCH_INSTALL_PREFIX}/lib/include/torch/csrc/api/include)
 else()
-  set(TORCH_INCLUDE_DIRS "${TORCH_INSTALL_PREFIX}/include")
+  set(TORCH_INCLUDE_DIRS
+    ${TORCH_INSTALL_PREFIX}/include
+    ${TORCH_INSTALL_PREFIX}/include/torch/csrc/api/include)
 endif()
 
 # Library dependencies.
@@ -45,7 +49,7 @@ if (@USE_CUDA@)
     set(TORCH_CUDA_LIBRARIES
       ${NVTOOLEXT_HOME}/lib/x64/nvToolsExt64_1.lib
       ${CUDA_LIBRARIES})
-    list(APPEND TORCH_INCLUDE_DIRS "${NVTOOLEXT_HOME}/include")
+    list(APPEND TORCH_INCLUDE_DIRS ${NVTOOLEXT_HOME}/include)
   elseif(APPLE)
     set(TORCH_CUDA_LIBRARIES
       ${CUDA_TOOLKIT_ROOT_DIR}/lib/libcudart.dylib
@@ -66,8 +70,8 @@ endif()
 set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=@GLIBCXX_USE_CXX11_ABI@")
 
 set_target_properties(torch PROPERTIES
-    IMPORTED_LOCATION ${TORCH_LIBRARY}
-    INTERFACE_INCLUDE_DIRECTORIES ${TORCH_INCLUDE_DIRS}
-    INTERFACE_COMPILE_OPTIONS ${TORCH_CXX_FLAGS}
+    IMPORTED_LOCATION "${TORCH_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${TORCH_INCLUDE_DIRS}"
+    INTERFACE_COMPILE_OPTIONS "${TORCH_CXX_FLAGS}"
     CXX_STANDARD 11
 )

--- a/setup.py
+++ b/setup.py
@@ -471,18 +471,9 @@ class build_deps(PytorchCommand):
             if not same:
                 shutil.copyfile(orig_file, sym_file)
 
-        # Copy headers necessary to compile C++ extensions.
-        #
-        # This is not perfect solution as build does not depend on any of
-        # the auto-generated code and auto-generated files will not be
-        # included in this copy. If we want to use auto-generated files,
-        # we need to find a better way to do this.
-        # More information can be found in conversation thread of PR #5772
-
         self.copy_tree('torch/lib/tmp_install/share', 'torch/share')
         self.copy_tree('third_party/pybind11/include/pybind11/',
                        'torch/lib/include/pybind11')
-        self.copy_file('torch/csrc/torch.h', 'torch/lib/include/torch/torch.h')
 
 
 build_dep_cmds = {}
@@ -1210,7 +1201,13 @@ if __name__ == '__main__':
                 'lib/include/caffe2/utils/*.h',
                 'lib/include/torch/*.h',
                 'lib/include/torch/csrc/*.h',
-                'lib/include/torch/csrc/api/include/torch/detail/ordered_dict.h',
+                'lib/include/torch/csrc/api/include/torch/*.h',
+                'lib/include/torch/csrc/api/include/torch/detail/*.h',
+                'lib/include/torch/csrc/api/include/torch/nn/*.h',
+                'lib/include/torch/csrc/api/include/torch/nn/modules/*.h',
+                'lib/include/torch/csrc/api/include/torch/nn/parallel/*.h',
+                'lib/include/torch/csrc/api/include/torch/optim/*.h',
+                'lib/include/torch/csrc/api/include/torch/serialize/*.h',
                 'lib/include/torch/csrc/autograd/*.h',
                 'lib/include/torch/csrc/autograd/generated/*.h',
                 'lib/include/torch/csrc/cuda/*.h',

--- a/test/cpp_extensions/complex_registration_extension.cpp
+++ b/test/cpp_extensions/complex_registration_extension.cpp
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 #include <ATen/CPUFloatType.h>
 #include <ATen/Type.h>

--- a/test/cpp_extensions/cpp_api_extension.cpp
+++ b/test/cpp_extensions/cpp_api_extension.cpp
@@ -1,0 +1,38 @@
+#include <torch/extension.h>
+#include <torch/python.h>
+#include <torch/torch.h>
+
+struct Net : torch::nn::Module {
+  Net(int64_t in, int64_t out)
+      : fc(in, out),
+        bn(torch::nn::BatchNormOptions(out).stateful(true)),
+        dropout(0.5) {
+    register_module("fc", fc);
+    register_module("bn", bn);
+    register_module("dropout", dropout);
+  }
+
+  torch::Tensor forward(torch::Tensor x) {
+    return dropout->forward(bn->forward(torch::relu(fc->forward(x))));
+  }
+
+  void set_bias(torch::Tensor bias) {
+    fc->bias = bias;
+  }
+
+  torch::Tensor get_bias() const {
+    return fc->bias;
+  }
+
+  torch::nn::Linear fc;
+  torch::nn::BatchNorm bn;
+  torch::nn::Dropout dropout;
+};
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  torch::python::bind_module<Net>(m, "Net")
+      .def(py::init<int64_t, int64_t>())
+      .def("forward", &Net::forward)
+      .def("set_bias", &Net::set_bias)
+      .def("get_bias", &Net::get_bias);
+}

--- a/test/cpp_extensions/cuda_extension.cpp
+++ b/test/cpp_extensions/cuda_extension.cpp
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 // Declare the function from cuda_extension.cu. It will be compiled
 // separately with nvcc and linked with the object file of cuda_extension.cpp

--- a/test/cpp_extensions/cudnn_extension.cpp
+++ b/test/cpp_extensions/cudnn_extension.cpp
@@ -10,7 +10,7 @@
  * 5) Return something (optional).
  */
 
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 #include <ATen/cudnn/Descriptors.h> // for TensorDescriptor
 #include <ATen/cuda/Exceptions.h> // for CUDNN_CHECK

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 struct Doubler {
   Doubler(int A, int B) {

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
   return x.sigmoid() + y.sigmoid();

--- a/test/cpp_extensions/half_support.cu
+++ b/test/cpp_extensions/half_support.cu
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 #include <THC/THCNumerics.cuh>
 

--- a/test/cpp_extensions/jit_extension.cpp
+++ b/test/cpp_extensions/jit_extension.cpp
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 #include "doubler.h"
 

--- a/test/cpp_extensions/jit_extension2.cpp
+++ b/test/cpp_extensions/jit_extension2.cpp
@@ -1,4 +1,4 @@
-#include <torch/torch.h>
+#include <torch/extension.h>
 
 using namespace at;
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -411,7 +411,7 @@ endif()
 install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
         DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
         FILES_MATCHING PATTERN "*.h")
-install(FILES "${TORCH_SRC_DIR}/script.h"
+install(FILES "${TORCH_SRC_DIR}/script.h" "${TORCH_SRC_DIR}/extension.h"
         DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch)
 
 install(TARGETS torch

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -12,20 +12,18 @@ namespace nn {
 
 /// Options for `Dropout` and `FeatureDropout`.
 struct DropoutOptions {
-  DropoutOptions(double rate);
+  /* implicit */ DropoutOptions(double rate = 0.5);
   /// The probability with which a particular component of the input is set to
   /// zero.
   /// Changes to this parameter at runtime are effective.
-  TORCH_ARG(double, rate) = 0.5;
+  TORCH_ARG(double, rate);
 };
 
 namespace detail {
 template <typename Derived>
 class DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  explicit DropoutImplBase(double rate)
-      : DropoutImplBase(DropoutOptions(rate)) {}
-  explicit DropoutImplBase(DropoutOptions options_);
+  explicit DropoutImplBase(DropoutOptions options_ = DropoutOptions());
 
   void reset() override;
 

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -92,6 +92,8 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   using Iterator = std::vector<AnyModule>::iterator;
   using ConstIterator = std::vector<AnyModule>::const_iterator;
 
+  SequentialImpl() = default;
+
   /// Constructs the `Sequential` from a variadic list of modules.
   template <typename... Modules>
   explicit SequentialImpl(Modules&&... modules) {

--- a/torch/csrc/api/include/torch/nn/pimpl-inl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl-inl.h
@@ -1,0 +1,47 @@
+// This class exists  only to do SFINAE on abstract types `T` that are really
+// `ModuleHolder<ModuleType>`, because there's no good way to say that `T` is a
+// `ModuleHolder` over some unknown type `ModuleType`. With this, you can do
+// `enable_if_t<is_base_of_v<ModuleHolderIndicator, T>>`.
+struct ModuleHolderIndicator {};
+
+// A type trait that is true for types that are `ModuleHolder`s.
+template <typename T>
+using is_module_holder = std::is_base_of<ModuleHolderIndicator, decay_t<T>>;
+
+template <typename T>
+using disable_if_module_holder_t = disable_if_t<is_module_holder<T>::value>;
+
+// A collection of templates that answer the question whether a type `T` is a
+// `ModuleHolder`, and if so whether its contained type is of type `C`. This is
+// tricky because it is hard to short circuit in template metaprogramming. A
+// naive and incorrect solution to this problem would be something like
+// `disable_if<is_module_holder<T>::value && typename T::ContainedType == C>`.
+// This would disable all types that are not `ModuleHolder`s, because even
+// though the `is_module_holder<T>::value` may be `false` for such types the
+// `T::ContainedType` access would be ill-formed and thus fail the whole
+// expression by the rules of SFINAE. Instead we have to use template
+// specialization to statically branch on the first condition
+// (`is_module_holder<T>`) and are only then allowed to query
+// `T::ContainedType` in the branch for which the condition was true.
+
+// Base template.
+template <bool is_module_holder_value, typename T, typename C>
+struct is_module_holder_of_impl;
+
+// False branch. `T` is not a `ModuleHolder` and thus not a `ModuleHolder` with
+// contained type `C`.
+template <typename T, typename C>
+struct is_module_holder_of_impl<false, T, C> : std::false_type {};
+
+// True branch. `T` is a `ModuleHolder` and thus we can legit access its
+// `ContainedType` and compare it against `C`.
+template <typename T, typename C>
+struct is_module_holder_of_impl<true, T, C>
+    : std::is_same<typename T::ContainedType, C> {};
+
+// Helper template.
+template <typename T, typename C>
+struct is_module_holder_of : is_module_holder_of_impl<
+                                 detail::is_module_holder<T>::value,
+                                 torch::decay_t<T>,
+                                 torch::decay_t<C>> {};

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -10,17 +10,8 @@
 
 namespace torch {
 namespace detail {
-/// This class exists  only to do SFINAE on abstract types `T` that are really
-/// `ModuleHolder<ModuleType>`, because there's no good way to say that `T` is a
-/// `ModuleHolder` over some unknown type `ModuleType`. With this, you can do
-/// `enable_if_t<is_base_of_v<ModuleHolderIndicator, T>>`.
-struct ModuleHolderIndicator {};
-
-template <typename T>
-using is_module_holder = std::is_base_of<ModuleHolderIndicator, decay_t<T>>;
-
-template <typename T>
-using disable_if_module_holder_t = disable_if_t<is_module_holder<T>::value>;
+// Dump all the template metaprogramming in this file.
+#include "pimpl-inl.h"
 } // namespace detail
 
 namespace nn {
@@ -40,7 +31,9 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   using ContainedType = Contained;
 
   /// Default constructs the contained module if if has a default constructor,
-  /// else produces a static error. NOTE: This uses the behavior of template
+  /// else produces a static error.
+  ///
+  /// NOTE: This uses the behavior of template
   /// classes in C++ that constructors (or any methods) are only compiled when
   /// actually used.
   ModuleHolder() : impl_(default_construct()) {
@@ -58,9 +51,16 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 
   /// Constructs the `ModuleHolder` with a contained module, forwarding all
   /// arguments to its constructor.
-  template <typename... Ts>
-  explicit ModuleHolder(Ts&&... ts)
-      : impl_(new Contained(std::forward<Ts>(ts)...)) {}
+  template <
+      typename Head,
+      typename... Tail,
+      typename = torch::disable_if_t<
+          detail::is_module_holder_of<Head, ContainedType>::value &&
+          (sizeof...(Tail) == 0)>>
+  explicit ModuleHolder(Head&& head, Tail&&... tail)
+      : impl_(new Contained(
+            std::forward<Head>(head),
+            std::forward<Tail>(tail)...)) {}
 
   /// Constructs the `ModuleHolder` from a pointer to the contained type.
   /// Example: `Linear(std::make_shared<LinearImpl>(...))`.
@@ -158,15 +158,10 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 
 /// Defines a class `Name` which inherits from `nn::ModuleHolder` to provide a
 /// wrapper over a `std::shared_ptr<Impl>`.
-#define TORCH_MODULE_IMPL(Name, Impl)                                         \
-  class Name : public torch::nn::ModuleHolder<Impl> { /* NOLINT */            \
-   public:                                                                    \
-    using torch::nn::ModuleHolder<Impl>::ModuleHolder;                        \
-    Name(const Name&) = default; /* NOLINT */                                 \
-    Name(Name&&) = default; /* NOLINT */                                      \
-    Name(Name& other) : Name(static_cast<const Name&>(other)) {} /* NOLINT */ \
-    Name& operator=(const Name&) = default; /* NOLINT */                      \
-    Name& operator=(Name&&) = default; /* NOLINT */                           \
+#define TORCH_MODULE_IMPL(Name, Impl)                              \
+  class Name : public torch::nn::ModuleHolder<Impl> { /* NOLINT */ \
+   public:                                                         \
+    using torch::nn::ModuleHolder<Impl>::ModuleHolder;             \
   }
 
 /// Like `TORCH_MODULE_IMPL`, but defaults the `Impl` name to `<Name>Impl`.

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <torch/csrc/utils/pybind.h>
+#include <torch/tensor.h>
+
+#include <iterator>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace torch {
+namespace python {
+namespace detail {
+template <typename Cursor>
+std::vector<Tensor> cursor_to_vector(const Cursor& cursor) {
+  std::vector<Tensor> vector;
+  vector.reserve(cursor.size());
+  cursor.map(
+      std::back_inserter(vector), [](const Tensor& tensor) { return tensor; });
+  return vector;
+}
+
+template <typename Cursor>
+std::unordered_map<std::string, Tensor> cursor_to_map(const Cursor& cursor) {
+  std::unordered_map<std::string, Tensor> map;
+  map.reserve(cursor.size());
+  cursor.map_items(
+      std::inserter(map, map.end()),
+      [](const std::string& key, const Tensor& tensor) {
+        return std::make_pair(key, tensor);
+      });
+  return map;
+}
+} // namespace detail
+
+/// Adds method bindings for a pybind11 `class_` that binds an `nn::Module`
+/// subclass.
+///
+/// Say you have a pybind11 class object created with `py::class_<Net>(m,
+/// "Net")`. This function will add all the necessary `.def()` calls to bind the
+/// `nn::Module` base class' methods, such as `train()`, `eval()` etc. into
+/// Python. The exact list of supported methods and their Python signatures are:
+/// - `train()`
+/// - `eval()`
+/// - `is_training() -> bool`
+/// - `zero_grad()`
+/// - `cuda()`
+/// - `cpu()`
+/// - `parameters() -> List<Tensor>`
+/// - `named_parameters() -> Dict<String, Tensor>`
+/// - `buffers() -> List<Tensor>`
+/// - `named_buffers() -> Dict<String, Tensor>`
+template <typename M, typename... Extra>
+py::class_<M, Extra...> add_module_bindings(py::class_<M, Extra...> module) {
+  return module.def("train", [](M& module) { module.train(); })
+      .def("eval", [](M& module) { module.eval(); })
+      .def("clone", [](M& module) { return module.clone(); })
+      .def_property_readonly(
+          "training", [](M& module) { return module.is_training(); })
+      .def("zero_grad", [](M& module) { module.zero_grad(); })
+      .def("cuda", [](M& module) { module.to(torch::kCUDA); })
+      .def("cpu", [](M& module) { module.to(torch::kCPU); })
+      .def(
+          "parameters",
+          [](M& module) {
+            return detail::cursor_to_vector(module.parameters());
+          })
+      .def(
+          "named_parameters",
+          [](M& module) { return detail::cursor_to_map(module.parameters()); })
+      .def(
+          "buffers",
+          [](M& module) { return detail::cursor_to_vector(module.buffers()); })
+      .def("named_buffers", [](M& module) {
+        return detail::cursor_to_map(module.buffers());
+      });
+}
+
+/// Creates a pybind11 class object for an `nn::Module` subclass type and adds
+/// default bindings.
+///
+/// After adding the default bindings, the class object is returned, such that
+/// you can add more bindings.
+///
+/// Example usage:
+/// \rst
+/// .. code-block::
+///   struct Net : torch::nn::Module {
+///     Net(int in, int out) { }
+///     torch::Tensor forward(torch::Tensor x) { return x; }
+///   };
+///
+///   PYBIND11_MODULE(my_module, m) {
+///     torch::python::bind_module<Net>(m, "Net")
+///       .def(py::init<int, int>())
+///       .def("forward", &Net::forward);
+///  }
+/// \endrst
+template <typename M, typename... Extra>
+py::class_<M, Extra...> bind_module(py::module module, const char* name) {
+  return add_module_bindings(py::class_<M, Extra...>(module, name));
+}
+} // namespace python
+} // namespace torch

--- a/torch/csrc/api/include/torch/torch.h
+++ b/torch/csrc/api/include/torch/torch.h
@@ -1,8 +1,14 @@
 #pragma once
 
 #include <torch/cuda.h>
+#include <torch/jit.h>
 #include <torch/nn.h>
 #include <torch/optim.h>
 #include <torch/serialize.h>
 #include <torch/tensor.h>
 #include <torch/utils.h>
+
+#ifdef TORCH_API_INCLUDE_EXTENSION_H
+#include <torch/extension.h>
+#warning "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h"
+#endif // defined(TORCH_API_INCLUDE_EXTENSION_H)

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -3,7 +3,6 @@
 #include <structmember.h>
 #include <pybind11/pybind11.h>
 
-#include "torch/csrc/torch.h"
 #include "torch/csrc/Dtype.h"
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/Exceptions.h"
@@ -17,6 +16,7 @@
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/utils/tensor_new.h"
 #include "torch/csrc/utils/tensor_types.h"
+#include "torch/csrc/variable_tensor_functions.h"
 
 #include <ATen/ATen.h>
 

--- a/torch/extension.h
+++ b/torch/extension.h
@@ -2,6 +2,5 @@
 
 #include <Python.h>
 
-#include <pybind11/pybind11.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/variable_tensor_functions.h>


### PR DESCRIPTION
Currently the C++ API and C++ extensions are effectively two different, entirely orthogonal code paths. This PR unifies the C++ API with the C++ extension API by adding an element of Python binding support to the C++ API. This means the `torch/torch.h` included by C++ extensions, which currently routes to `torch/csrc/torch.h`, can now be rerouted to `torch/csrc/api/include/torch/torch.h` -- i.e. the main C++ API header. This header then includes Python binding support conditioned on a define (`TORCH_WITH_PYTHON_BINDINGS`), *which is only passed when building a C++ extension*.

Currently stacked on top of https://github.com/pytorch/pytorch/pull/11498

Why is this useful?

1. One less codepath. In particular, there has been trouble again and again due to the two `torch/torch.h` header files and ambiguity when both ended up in the include path. This is now fixed.
2. I have found that it is quite common to want to bind a C++ API module back into Python. This could be for simple experimentation, or to have your training loop in Python but your models in C++. This PR makes this easier by adding pybind11 support to the C++ API.
3. The C++ extension API simply becomes richer by gaining access to the C++ API headers.

@soumith @ezyang @apaszke 