### PR TITLE
raise warnings when  cudnn.flags has both benchmark=True and deterministic=True

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3459,6 +3459,21 @@ class TestNN(NNTestCase):
             self.assertEqual(conv1.bias.grad.data, conv2.bias.grad.data, prec=0.0)
             self.assertEqual(conv1.weight.grad.data, conv2.weight.grad.data, prec=0.0)
 
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_errorMsg_on_determinstic_and_benchmark_flag(self):
+        def fn():
+            with cudnn.flags(benchmark=True, deterministic=True):
+                pass
+
+        import warnings
+        import re
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            fn()
+            msg = str(ws[-1].message)
+            self.assertTrue(re.search(r'torch.backends.cudnn.deterministic=True will be ignored', msg))
+
     def test_Conv2d_missing_argument(self):
         c = nn.Conv2d(3, 3, 3)
         self.assertRaises(TypeError, lambda: c(None))

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -353,6 +353,13 @@ PyObject *THPModule_setDeterministicCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_deterministic_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
+  if (arg == Py_True && at::globalContext().benchmarkCuDNN() == true) {
+    std::ostringstream ss;
+    ss << "torch.backends.cudnn.deterministic=True will be ignored when "
+       << "torch.backends.cudnn.benchmark=True.",
+    PyErr_WarnEx(PyExc_UserWarning, ss.str().c_str(), 1);
+  }
+
   at::globalContext().setDeterministicCuDNN(arg == Py_True);
   Py_RETURN_NONE;
 }
@@ -367,6 +374,13 @@ PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
+  if (arg == Py_True && at::globalContext().deterministicCuDNN() == true) {
+    std::ostringstream ss;
+    ss << "torch.backends.cudnn.deterministic=True will be ignored when "
+       << "torch.backends.cudnn.benchmark=True.",
+    PyErr_WarnEx(PyExc_UserWarning, ss.str().c_str(), 1);
+  }
+
   at::globalContext().setBenchmarkCuDNN(arg == Py_True);
   Py_RETURN_NONE;
 }


### PR DESCRIPTION
- fixes https://github.com/pytorch/pytorch/issues/6351
- give warnings when:
```
torch.backends.cudnn.flags(benchmark=True, deterministic=True)
```
or 
```
torch.backends.cudnn.benchmark = True
torch.backends.cudnn.deterministic = True
```

