### PR TITLE
Remove time prefix from rsync

### DIFF
--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -12,7 +12,7 @@ set -ex
 
 SYNC_COMMAND="cp"
 if [ -x "$(command -v rsync)" ]; then
-    SYNC_COMMAND="time rsync -lptgoD"
+    SYNC_COMMAND="rsync -lptgoD"
 fi
 
 # Options for building only a subset of the libraries


### PR DESCRIPTION
This fails with zsh saying "time: command not found".

cc @soumith

