### PR TITLE
Fix #11430 (CPU only builds raise opaque error message when calling .…

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8850,6 +8850,7 @@ class TestTorch(TestCase):
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1], device="cuda"))
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1]).cuda())
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.FloatTensor())
+        self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1]).to(device="cuda"))
 
 
 # Functions to test negative dimension wrapping

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8843,6 +8843,14 @@ class TestTorch(TestCase):
         self.assertTrue(grid_b.equal(expected_grid_b))
         self.assertTrue(grid_c.equal(expected_grid_c))
 
+    @unittest.skipIf(torch.cuda.is_available(), "CUDA is available, can't test CUDA not built error")
+    def test_cuda_not_built(self):
+        msg = "Torch not compiled with CUDA enabled"
+        self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.current_device())
+        self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1], device="cuda"))
+        self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1]).cuda())
+        self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.FloatTensor())
+
 
 # Functions to test negative dimension wrapping
 METHOD = 1

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -427,7 +427,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         env['actuals'] = actuals
 
         if has_tensor_options:
-            env['initialize_cuda'] = 'maybe_initialize_cuda(at::getType(options));'
+            env['initialize_cuda'] = 'maybe_initialize_cuda(options);'
         else:
             env['initialize_cuda'] = 'maybe_initialize_cuda({});'.format(type_args[0]['name']) if type_args else ''
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -429,7 +429,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         if has_tensor_options:
             env['initialize_cuda'] = 'maybe_initialize_cuda(options);'
         else:
-            env['initialize_cuda'] = 'maybe_initialize_cuda({});'.format(type_args[0]['name']) if type_args else ''
+            env['initialize_cuda'] = ''
 
         if 'call_args' in declaration:
             env['dispatch_args'] = declaration['call_args']

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -65,7 +65,7 @@ inline Tensor dispatch_arange(Scalar end, Tensor result) {
 }
 
 inline Tensor dispatch_arange(Scalar end, const TensorOptions& options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::arange(end, options);
 }
@@ -76,7 +76,7 @@ inline Tensor dispatch_arange(Scalar start, Scalar end, Scalar step, Tensor resu
 }
 
 inline Tensor dispatch_arange(Scalar start, Scalar end, Scalar step, const TensorOptions& options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::arange(start, end, step, options);
 }
@@ -147,7 +147,7 @@ inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, Tensor resul
 }
 
 inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, const TensorOptions& options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   DeviceGuard device_guard(options.device());
   return torch::range(start, end, step, options);
@@ -189,7 +189,7 @@ inline Tensor dispatch_randint(int64_t high, IntList size, Generator * generator
   return at::randint_out(result, high, size, generator);
 }
 inline Tensor dispatch_randint(int64_t high, IntList size, Generator * generator, const TensorOptions & options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::randint(high, size, generator, options);
 }
@@ -198,7 +198,7 @@ inline Tensor dispatch_randint(int64_t high, IntList size, Tensor result) {
   return at::randint_out(result, high, size);
 }
 inline Tensor dispatch_randint(int64_t high, IntList size, const TensorOptions & options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::randint(high, size, options);
 }
@@ -207,7 +207,7 @@ inline Tensor dispatch_randint(int64_t low, int64_t high, IntList size, Generato
   return at::randint_out(result, low, high, size, generator);
 }
 inline Tensor dispatch_randint(int64_t low, int64_t high, IntList size, Generator * generator, const TensorOptions & options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::randint(low, high, size, generator, options);
 }
@@ -216,7 +216,7 @@ inline Tensor dispatch_randint(int64_t low, int64_t high, IntList size, Tensor r
   return at::randint_out(result, low, high, size);
 }
 inline Tensor dispatch_randint(int64_t low, int64_t high, IntList size, const TensorOptions & options) {
-  maybe_initialize_cuda(at::getType(options));
+  maybe_initialize_cuda(options);
   AutoNoGIL no_gil;
   return torch::randint(low, high, size, options);
 }

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -34,6 +34,12 @@ static void maybe_initialize_cuda(const at::Type &type) {
   }
 }
 
+static void maybe_initialize_cuda(const at::TensorOptions& options) {
+  if (options.device().is_cuda()) {
+    torch::utils::cuda_lazy_init();
+  }
+}
+
 ${py_method_dispatch}
 
 }} // namespace torch::autograd

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -28,12 +28,6 @@ static at::Type& default_type() {
   return torch::tensors::get_default_tensor_type();
 }
 
-static void maybe_initialize_cuda(const at::Type &type) {
-  if (type.is_cuda()) {
-    torch::utils::cuda_lazy_init();
-  }
-}
-
 static void maybe_initialize_cuda(const at::TensorOptions& options) {
   if (options.device().is_cuda()) {
     torch::utils::cuda_lazy_init();

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -265,6 +265,7 @@ static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwa
   auto r = parser.parse(args, kwargs, parsed_args);
   auto device = r.isNone(0) ? at::Device(at::DeviceType::CUDA) : r.device(0);
   AT_CHECK(device.is_cuda(), "Invalid device, must be cuda device");
+  torch::utils::cuda_lazy_init();
   return THPVariable_Wrap(dispatch_to(self_, device, r.toBool(1)));
   END_HANDLE_TH_ERRORS
 }

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -265,7 +265,6 @@ static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwa
   auto r = parser.parse(args, kwargs, parsed_args);
   auto device = r.isNone(0) ? at::Device(at::DeviceType::CUDA) : r.device(0);
   AT_CHECK(device.is_cuda(), "Invalid device, must be cuda device");
-  torch::utils::cuda_lazy_init();
   return THPVariable_Wrap(dispatch_to(self_, device, r.toBool(1)));
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/autograd/generated/VariableType.h"
 #include "torch/csrc/utils/cuda_enabled.h"
+#include "torch/csrc/utils/cuda_lazy_init.h"
 
 #include <ATen/ATen.h>
 
@@ -99,6 +100,9 @@ void registerLayoutObject(THPLayout *layout, at::Backend backend) {
 
 at::Type& getVariableType(at::ScalarType scalarType, const THPLayout& layout, const at::Device& device) {
   const at::Backend backend = get_backend(device.type() == at::Device::Type::CUDA, layout.layout == at::Layout::Sparse);
+  if (device.is_cuda()) {
+    torch::utils::cuda_lazy_init();
+  }
   auto baseType = at::globalContext().getNonVariableTypeOpt(backend, scalarType);
   if (!baseType) {
     std::ostringstream oss;

--- a/torch/csrc/utils/cuda_lazy_init.cpp
+++ b/torch/csrc/utils/cuda_lazy_init.cpp
@@ -10,13 +10,19 @@ namespace torch {
 namespace utils {
 
 void cuda_lazy_init() {
-  static std::once_flag once;
-  std::call_once(once, []() {
+  AutoGIL g;
+  // Protected by the GIL.  We don't use call_once because under ASAN it
+  // has a buggy implementation that deadlocks if an instance throws an
+  // exception.  In any case, call_once isn't necessary, because we
+  // have taken a lock.
+  static bool run_yet = false;
+  if (!run_yet) {
     auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
     if (!module) throw python_error();
     auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
     if (!res) throw python_error();
-  });
+    run_yet = true;
+  }
 }
 
 }

--- a/torch/csrc/utils/cuda_lazy_init.h
+++ b/torch/csrc/utils/cuda_lazy_init.h
@@ -1,11 +1,23 @@
 #pragma once
 
-// It initially lies in torch/csrc/cuda, but to unconditionlly compile it
-// we have to put it here.
+// cuda_lazy_init() is always compiled, even for CPU-only builds.
+// Thus, it does not live in the cuda/ folder.
 
 namespace torch {
 namespace utils {
 
+// The INVARIANT is that this function MUST be called before you attempt
+// to get a CUDA Type object from ATen, in any way.  Here are some common
+// ways that a Type object may be retrieved:
+//
+//    - You call getNonVariableType or getNonVariableTypeOpt
+//    - You call toBackend() on a Type
+//
+// It's important to do this correctly, because if you forget to add it
+// you'll get an oblique error message about "Cannot initialize CUDA without
+// ATen_cuda library" if you try to use CUDA functionality from a CPU-only
+// build, which is not good UX.
+//
 void cuda_lazy_init();
 
 }


### PR DESCRIPTION
…cuda())

While I was at it, I audited all other ways I know how we might get a CUDA
type from PyTorch and fixed more constructors which don't work.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

