### PR TITLE
Move function deletion from the stack to the heap.

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -33,8 +33,6 @@ using edge_list = std::vector<Edge>;
 using saved_variable_list = std::vector<SavedVariable>;
 using IndexRange = std::pair<size_t, size_t>;
 
-TORCH_API extern size_t deleteFunctionMaxRecursionDepth;
-
 // Custom deleter to prevent stack overflows.
 void deleteFunction(Function* function);
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -50,11 +50,6 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
   });
   m.def("_pop_range", []() { torch::autograd::profiler::popRange(); });
 
-  /// TODO: Replace this ASAP with a better solution for deep autograd graphs!
-  m.def("_unsafe_set_delete_function_max_recursion_depth", [](size_t value) {
-    torch::autograd::deleteFunctionMaxRecursionDepth = value;
-  });
-
   Py_RETURN_TRUE;
 }
 


### PR DESCRIPTION
This eliminates the need for any heuristics regarding stack size limits.

