### PR TITLE
[distributions] Ensure .enumerate_support() methods are jittable

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -97,8 +97,7 @@ class Bernoulli(ExponentialFamily):
         return binary_cross_entropy_with_logits(self.logits, self.probs, reduction='none')
 
     def enumerate_support(self, expand=True):
-        values = self._new((2,))
-        torch.arange(2, out=values)
+        values = torch.arange(2, dtype=self._param.dtype, device=self._param.device)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         if expand:
             values = values.expand((-1,) + self._batch_shape)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -98,7 +98,7 @@ class Binomial(Distribution):
             shape = self._extended_shape(sample_shape) + (max_count,)
             bernoullis = torch.bernoulli(self.probs.unsqueeze(-1).expand(shape))
             if self.total_count.min() != max_count:
-                arange = torch.arange(max_count, out=self.total_count.new_empty(max_count))
+                arange = torch.arange(max_count, dtype=self._param.dtype, device=self._param.device)
                 mask = arange >= self.total_count.unsqueeze(-1)
                 bernoullis.masked_fill_(mask, 0.)
             return bernoullis.sum(dim=-1)
@@ -119,8 +119,7 @@ class Binomial(Distribution):
         total_count = int(self.total_count.max())
         if not self.total_count.min() == total_count:
             raise NotImplementedError("Inhomogeneous total count not supported by `enumerate_support`.")
-        values = self._new(1 + total_count,)
-        torch.arange(1 + total_count, out=values)
+        values = torch.arange(1 + total_count, dtype=self._param.dtype, device=self._param.device)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         if expand:
             values = values.expand((-1,) + self._batch_shape)

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -120,10 +120,8 @@ class Categorical(Distribution):
 
     def enumerate_support(self, expand=True):
         num_events = self._num_events
-        values = torch.arange(num_events).long()
+        values = torch.arange(num_events, dtype=torch.long, device=self._param.device)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         if expand:
             values = values.expand((-1,) + self._batch_shape)
-        if self._param.is_cuda:
-            values = values.cuda(self._param.get_device())
         return values

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -269,7 +269,7 @@ class _LowerCholesky(Constraint):
         lower_triangular = (value_tril == value).view(value.shape[:-2] + (-1,)).min(-1)[0]
 
         n = value.size(-1)
-        diag_mask = torch.eye(n, n, out=value.new(n, n))
+        diag_mask = torch.eye(n, n, dtype=value.dtype, device=value.device)
         positive_diagonal = (value * diag_mask > (diag_mask - 1)).min(-1)[0].min(-1)[0]
         return lower_triangular & positive_diagonal
 

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -50,6 +50,10 @@ class OneHotCategorical(Distribution):
         return self._categorical._new(*args, **kwargs)
 
     @property
+    def _param(self):
+        return self._categorical._param
+
+    @property
     def probs(self):
         return self._categorical.probs
 
@@ -89,8 +93,7 @@ class OneHotCategorical(Distribution):
 
     def enumerate_support(self, expand=True):
         n = self.event_shape[0]
-        values = self._new((n, n))
-        torch.eye(n, out=values)
+        values = torch.eye(n, dtype=self._param.dtype, device=self._param.device)
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
         if expand:
             values = values.expand((n,) + self.batch_shape + (n,))


### PR DESCRIPTION
This works around #11535 by avoiding `arange(n, out=x)` and `eye(n, out=x)` in `torch.distributions`. I've confirmed that the `.enumerate_support()` methods are now jittable.