### PR TITLE
Guard against inputting or returning sparse tensors

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1580,15 +1580,15 @@ class TestJit(JitTestCase):
             output = get_sparse()
             return output, input
 
-        with self.assertRaisesRegex(RuntimeError, "Inputting sparse tensors not supported"):
+        with self.assertRaisesRegex(RuntimeError, "sparse tensors not supported"):
             sparse(get_sparse())
 
         # has a different entry point than calling sparse directly
-        with self.assertRaisesRegex(RuntimeError, "Inputting sparse tensors not supported"):
+        with self.assertRaisesRegex(RuntimeError, "sparse tensors not supported"):
             torch._C._jit_pass_shape_analysis(
                 sparse.graph, (get_sparse(),), False)
 
-        with self.assertRaisesRegex(RuntimeError, "Returning sparse tensors not supported"):
+        with self.assertRaisesRegex(RuntimeError, "sparse tensors not supported"):
             sparse(torch.tensor([1]))
 
     def test_constant_prop_simple(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1571,6 +1571,26 @@ class TestJit(JitTestCase):
         ten = torch.rand(3, 3)
         self.assertEqual(test_fn(ten, mask), traced_test_fn(ten, mask))
 
+    def test_sparse_tensors_error(self):
+        def get_sparse():
+            return torch.sparse.FloatTensor(2, 3)
+
+        @torch.jit.script
+        def sparse(input):
+            output = get_sparse()
+            return output, input
+
+        with self.assertRaisesRegex(RuntimeError, "Inputting sparse tensors not supported"):
+            sparse(get_sparse())
+
+        # has a different entry point than calling sparse directly
+        with self.assertRaisesRegex(RuntimeError, "Inputting sparse tensors not supported"):
+            torch._C._jit_pass_shape_analysis(
+                sparse.graph, (get_sparse(),), False)
+
+        with self.assertRaisesRegex(RuntimeError, "Returning sparse tensors not supported"):
+            sparse(torch.tensor([1]))
+
     def test_constant_prop_simple(self):
         @torch.jit.script
         def constant_prop(input_tensor):

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -15,9 +15,8 @@ namespace {
 std::unordered_set<Symbol> skip_list = {
   prim::If,
   prim::Loop, //TODO: handle Loop
-  //FIXME Same problem as in DCE - cpp & python PythonOp and CppOp should be
-  //FIXME treated as having side effects but ONNX depends on them being removed
   prim::Print,
+  prim::PythonOp, //may have side effects
   //all the rand functions from native_functions.yaml
   aten::rand,
   aten::rand_out,


### PR DESCRIPTION
Add guards against using sparse tensor by checking the conversion from IValue -> PyObject & PyObject -> IValue. 

This diff also changes the behavior in constant propagation to not run python ops even if all ops are constant because of possible mutation to global state. This came up in trying to run get_sparse(), and I'm including it here to make it easier to land.