### PR TITLE
guard spurious cudnn.h include

### DIFF
--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -4,8 +4,6 @@
 #include <array>
 #include <mutex>
 
-#include <cudnn.h>
-
 #include "caffe2/core/common.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
@@ -15,6 +13,8 @@
 #ifndef CAFFE2_USE_CUDNN
 #error("This Caffe2 install is not built with cudnn, so you should not include this file.");
 #endif
+
+#include <cudnn.h>
 
 static_assert(
     CUDNN_VERSION >= 5000,

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -10,7 +10,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#ifdef CAFFE2_USE_CUDNN
 #include "caffe2/core/common_cudnn.h"
+#endif // CAFFE2_USE_CUDNN
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/operator_fallback_gpu.h"
 #include "caffe2/python/pybind_state_registry.h"
@@ -39,10 +41,12 @@ namespace py = pybind11;
 void addCUDAGlobalMethods(py::module& m) {
   m.def("num_cuda_devices", &NumCudaDevices);
   m.def("get_cuda_version", &CudaVersion);
+#ifdef CAFFE2_USE_CUDNN
   m.def("get_cudnn_version", &cudnnCompiledVersion);
   m.attr("cudnn_convolution_fwd_algo_count") = py::int_((int) CUDNN_CONVOLUTION_FWD_ALGO_COUNT);
   m.attr("cudnn_convolution_bwd_data_algo_count") = py::int_((int) CUDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT);
   m.attr("cudnn_convolution_bwd_filter_algo_count") = py::int_((int) CUDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT);
+#endif
   m.def("get_cuda_peer_access_pattern", []() {
     std::vector<std::vector<bool>> pattern;
     CAFFE_ENFORCE(caffe2::GetCudaPeerAccessPattern(&pattern));


### PR DESCRIPTION
This fixes the build when CuDNN was not found on the system.

From the `git blame`, it looks like the bug has been around for 2 years :)