### PR TITLE
optimize norm on ATen CPU backend

### DIFF
--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -22,14 +22,6 @@ namespace {
 
 // TODO: Maybe the foo_ variants should call th_foo_
 
-Tensor norm(const Tensor & self, Scalar p) {
-  if (_has_native(self)) {
-    return native_norm(self, p);
-  } else {
-    return th_norm(self, p);
-  }
-}
-
 Tensor clone(const Tensor& self) {
   if (_has_native(self)) {
     return native_clone(self);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -185,6 +185,10 @@ static void prod_kernel_impl(Tensor& result, const Tensor& self, at::optional<in
 
 template<typename scalar_t>
 struct NormReduction {
+  // reduction width in number of scalar elements
+  static constexpr int WIDTH = 128 / sizeof(scalar_t);
+  using Vec = Vec256<scalar_t>;
+
   static void apply(Tensor& res, const Tensor& self, Scalar p, at::optional<int64_t> dim) {
     auto out_ = res.data<scalar_t>();
     auto data_ = self.data<scalar_t>();
@@ -215,7 +219,7 @@ struct NormReduction {
         int64_t b = bi / stride;
         int64_t i = bi % stride;
         const scalar_t* data = &data_[b * n * stride + i];
-        out_[bi] = norm_calc(data, n, stride, pval);
+        out_[bi] = norm_reduce(data, n, stride, pval);
       }
     });
   }
@@ -229,45 +233,100 @@ struct NormReduction {
       [=](int64_t begin, int64_t end, scalar_t init) {
         const scalar_t* data = &data_[begin];
         int64_t n = end - begin;
-        scalar_t result = norm_calc(data, n, 1, pval);
+        scalar_t result = norm_reduce(data, n, 1, pval);
         return result;
       },
       std::plus<scalar_t>());
     return sum;
   }
 
-  static scalar_t norm_calc(const scalar_t* data, int64_t n, int64_t stride, float pval) {
-        scalar_t result = 0.0;
-        if (pval == 0) {
-          for (int64_t k = 0; k < n; k++) {
-            result += (data[k * stride] != 0.0);
-          }
-        } else if (pval == 1) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride]);
-          }
-        } else if (pval == 2) {
-          for (int64_t k = 0; k < n; k++) {
-            result += data[k * stride] * data[k * stride];
-          }
-          result = std::sqrt(result);
-        } else if (pval == 3) {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
-          }
-          result = std::pow(result, 1.0/3);
-        } else if (std::isinf(pval)) {
-          for (int64_t k = 0; k < n; k++) {
-            result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
-          }
-          result = result;
-        } else {
-          for (int64_t k = 0; k < n; k++) {
-            result += std::pow(std::abs(data[k * stride]), pval);
-          }
-          result = std::pow(result, 1.0/pval);
+  static scalar_t norm_reduce(const scalar_t* data, int64_t n, int64_t stride, float pval) {
+    scalar_t result = 0.0;
+    if (stride == 1 && (pval == 1 || pval == 2 || pval == 3) && n >= WIDTH) {
+      int64_t n_rounded = round_down(n, WIDTH);
+      scalar_t result1 = norm_reduce128(data, n_rounded, pval);
+      scalar_t result2 = norm_reduce_sequential(data + n_rounded, n - n_rounded, stride, pval);
+      result = std::pow(std::pow(result1, pval) + std::pow(result2, pval), 1.0/pval);
+    } else {
+      result = norm_reduce_sequential(data, n, stride, pval);
+    }
+    return result;
+  }
+
+  static scalar_t norm_reduce_sequential(const scalar_t* data, int64_t n, int64_t stride, float pval) {
+    scalar_t result = 0.0;
+    if (pval == 0) {
+      for (int64_t k = 0; k < n; k++) {
+        result += (data[k * stride] != 0.0);
+      }
+    } else if (pval == 1) {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::abs(data[k * stride]);
+      }
+    } else if (pval == 2) {
+      for (int64_t k = 0; k < n; k++) {
+        result += data[k * stride] * data[k * stride];
+      }
+      result = std::sqrt(result);
+    } else if (pval == 3) {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
+      }
+      result = std::pow(result, 1.0/3);
+    } else if (std::isinf(pval)) {
+      for (int64_t k = 0; k < n; k++) {
+        result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
+      }
+      result = result;
+    } else {
+      for (int64_t k = 0; k < n; k++) {
+        result += std::pow(std::abs(data[k * stride]), pval);
+      }
+      result = std::pow(result, 1.0/pval);
+    }
+    return result;
+  }
+
+  // Reduce down a column of WIDTH elements (128 bytes) with the given number n
+  // n is already rounded by 128
+  static scalar_t norm_reduce128(const scalar_t* data, int64_t n, float pval) {
+    scalar_t result = 0.0;
+    Vec acc[4] = {0.0, 0.0, 0.0, 0.0};  // 128 bytes (two cache lines)
+    static_assert(sizeof(acc) == 128, "accumulator should be 128 bytes");
+    int64_t rows = n / WIDTH;
+    if (pval == 1){
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + val.abs();
         }
-        return result;
+      }
+    }
+    else if (pval == 2) {
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + val * val;
+        }
+      }
+    }
+    else if (pval == 3) {
+      for (int row = 0; row < rows; row ++) {
+        for (int j = 0; j != 4; j++) {
+          auto val = Vec::loadu(&data[row * WIDTH + j * Vec::size]);
+          acc[j] = acc[j] + (val * val * val).abs();
+        }
+      }
+    }
+    scalar_t buf[WIDTH] = {0};
+    for (int j = 0; j != 4; j++) {
+      acc[j].store(&buf[j * Vec::size]);
+    }
+    for (int i = 0; i < WIDTH; i++) {
+      result += buf[i];
+    }
+    result = std::pow(result, 1.0/pval);
+    return result;
   }
 };
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -11,4 +11,7 @@ using reduce_fn = void(*)(Tensor &, const Tensor &, at::optional<int64_t>);
 DECLARE_DISPATCH(reduce_fn, sum_kernel);
 DECLARE_DISPATCH(reduce_fn, prod_kernel);
 
+using reduce_norm_fn = void(*)(Tensor &, const Tensor &, Scalar, at::optional<int64_t>);
+DECLARE_DISPATCH(reduce_norm_fn, norm_kernel);
+
 }} // namespace at::native


### PR DESCRIPTION
current torch.norm() runs sequentially on CPU. This PR did parallelization and vectorization of torch.norm() on ATen CPU path, roughly provide 2 order of magnitude performance boost.

Performance is benchmarks on Xeon skylake 8180, 2*28 cores @2.5GHz, using the following script:
```python
import torch
from time import time

count = 1000
size = 1000*1000

def test_norm(p=2):
    a = torch.randn(size)
    tstart = time()
    for i in range(count):
        torch.norm(a, p)
    tend = time()
    print("norm on size %d tensor p = %d: %f s" % (size, p, (tend-tstart)))

for p in range(4):
    test_norm(p)
```

without this optimization,
```
(intel-pytorch) [mingfeim@mlt-skx065 unit_tests]$ python test_norm.py
norm on size 1000000 tensor p = 0: 1.071235 s
norm on size 1000000 tensor p = 1: 1.069149 s
norm on size 1000000 tensor p = 2: 1.068212 s
norm on size 1000000 tensor p = 3: 69.735312 s
```

and with this optimization,
```
(pytorch-tf) [mingfeim@mlt-skx053 unit_tests]$ python test_norm.py
norm on size 1000000 tensor p = 0: 0.127507 s
norm on size 1000000 tensor p = 1: 0.011867 s
norm on size 1000000 tensor p = 2: 0.011907 s
norm on size 1000000 tensor p = 3: 0.014470 s
```