### PR TITLE
Remove deprecate warning for Upsampling

### DIFF
--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -50,6 +50,9 @@ class Upsample(Module):
         0.3.1. Since then, the default behavior is ``align_corners = False``.
         See below for concrete examples on how this affects the outputs.
 
+    .. note::
+        If you want down sampling, you should use :func:`~nn.functional.interpolate`.
+
     Examples::
 
         >>> input = torch.arange(1, 5).view(1, 1, 2, 2).float()
@@ -142,6 +145,9 @@ class UpsamplingNearest2d(Upsample):
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
 
+    .. warning::
+        This class is deprecated in favor of :func:`~nn.functional.interpolate`.
+
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
         - Output: :math:`(N, C, H_{out}, W_{out})` where
@@ -170,6 +176,7 @@ class UpsamplingNearest2d(Upsample):
         super(UpsamplingNearest2d, self).__init__(size, scale_factor, mode='nearest')
 
     def forward(self, input):
+        warnings.warn("nn.UpsamplingNearest2d is deprecated. Use nn.functional.interpolate instead.")
         return super(UpsamplingNearest2d, self).forward(input)
 
 
@@ -185,6 +192,10 @@ class UpsamplingBilinear2d(Upsample):
     Args:
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
+
+    .. warning::
+        This class is deprecated in favor of :func:`~nn.functional.interpolate`. It is
+        equivalent to ``nn.functional.interpolate(..., mode='bilinear', align_corners=True)``.
 
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
@@ -214,4 +225,5 @@ class UpsamplingBilinear2d(Upsample):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor, mode='bilinear', align_corners=True)
 
     def forward(self, input):
+        warnings.warn("nn.UpsamplingBilinear2d is deprecated. Use nn.functional.interpolate instead.")
         return super(UpsamplingBilinear2d, self).forward(input)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -50,9 +50,6 @@ class Upsample(Module):
         0.3.1. Since then, the default behavior is ``align_corners = False``.
         See below for concrete examples on how this affects the outputs.
 
-    .. warning::
-        This class is deprecated in favor of :func:`~nn.functional.interpolate`.
-
     Examples::
 
         >>> input = torch.arange(1, 5).view(1, 1, 2, 2).float()
@@ -121,7 +118,6 @@ class Upsample(Module):
         self.align_corners = align_corners
 
     def forward(self, input):
-        warnings.warn("nn.Upsampling is deprecated. Use nn.functional.interpolate instead.")
         return F.interpolate(input, self.size, self.scale_factor, self.mode, self.align_corners)
 
     def extra_repr(self):
@@ -145,9 +141,6 @@ class UpsamplingNearest2d(Upsample):
     Args:
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
-
-    .. warning::
-        This class is deprecated in favor of :func:`~nn.functional.interpolate`.
 
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
@@ -177,7 +170,6 @@ class UpsamplingNearest2d(Upsample):
         super(UpsamplingNearest2d, self).__init__(size, scale_factor, mode='nearest')
 
     def forward(self, input):
-        warnings.warn("nn.UpsamplingNearest2d is deprecated. Use nn.functional.interpolate instead.")
         return super(UpsamplingNearest2d, self).forward(input)
 
 
@@ -193,10 +185,6 @@ class UpsamplingBilinear2d(Upsample):
     Args:
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
-
-    .. warning::
-        This class is deprecated in favor of :func:`~nn.functional.interpolate`. It is
-        equivalent to ``nn.functional.interpolate(..., mode='bilinear', align_corners=True)``.
 
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
@@ -226,5 +214,4 @@ class UpsamplingBilinear2d(Upsample):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor, mode='bilinear', align_corners=True)
 
     def forward(self, input):
-        warnings.warn("nn.UpsamplingBilinear2d is deprecated. Use nn.functional.interpolate instead.")
         return super(UpsamplingBilinear2d, self).forward(input)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -51,7 +51,7 @@ class Upsample(Module):
         See below for concrete examples on how this affects the outputs.
 
     .. note::
-        If you want down sampling, you should use :func:`~nn.functional.interpolate`.
+        If you want downsampling/general resizing, you should use :func:`~nn.functional.interpolate`.
 
     Examples::
 


### PR DESCRIPTION
Fixes #11452 .

Based on the discussion with @SsnL  and @soumith , we want to bring back Upsample as a module instead of introducing a new nn.interpolate module for now. If anyone want to do downsample, they should use `nn.functional.interpolate ` instead.