### PR TITLE
Add checking of nullptrs in GetTensorInfo

### DIFF
--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -403,6 +403,7 @@ class CAFFE2_CUDA_API CUDAStaticContext final : public BaseStaticContext {
   }
 
   void ExtractDeviceOption(DeviceOption* device, const void* data) override {
+    CAFFE_ENFORCE(data, "data cannot be nullptr");
     device->set_device_type(TypeToProto(GetDeviceType()));
     device->set_cuda_gpu_id(GetGPUIDForPointer(data));
   }

--- a/caffe2/core/storage.h
+++ b/caffe2/core/storage.h
@@ -214,6 +214,11 @@ class CAFFE2_API Storage {
     storage_impl_->reset();
   }
 
+  // For debugging purpose only, please don't call it
+  StorageImpl* unsafeGetStorageImp() const {
+    return storage_impl_.get();
+  }
+
   template <typename T>
   inline bool IsType() const {
     return storage_impl_->IsType<T>();

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -94,6 +94,9 @@ vector<TIndex> GetTensorInfo(
     size_t* capacity,
     DeviceOption* device) {
   const Tensor* tc = static_cast<const Tensor*>(c);
+  CHECK(tc);
+  CHECK(tc->unsafeGetTensorImpl());
+  CHECK(tc->unsafeGetTensorImpl()->storage().unsafeGetStorageImp());
   *capacity = tc->capacity_nbytes();
   tc->ExtractDeviceOption(device);
   return tc->dims();


### PR DESCRIPTION
Summary:
To help debug the issue in T33295362, we add some checks in the function.

Possible crashing site in `GetTensorInfo`
1. tc is nullptr, which is checked.
2. tc->capacity_nbytes() hits nullptr, this is unlikely because storage is not a pointer and compute of capacity_nbytes doesn't involve pointers. It's numel * itermsize().
3. tc->ExtractDeviceOption hits nullpt. One possibility raw_data() is nullptr because tc->ExtractDeviceOption will use that. This is checked.
4. Tensor itself which is not a reference. This is also checked.

Differential Revision: D9793484
