### PR TITLE
Disable flaky test ObserverTest.TestMultipleNetBase

### DIFF
--- a/caffe2/core/observer_test.cc
+++ b/caffe2/core/observer_test.cc
@@ -151,6 +151,9 @@ TEST(ObserverTest, TestDAGNetBase) {
   EXPECT_EQ(1212, count_after - count_before);
 }
 
+#if 0
+// This test intermittently segfaults,
+// see https://github.com/pytorch/pytorch/issues/9137
 TEST(ObserverTest, TestMultipleNetBase) {
   Workspace ws;
   ws.CreateBlob("in");
@@ -176,4 +179,5 @@ TEST(ObserverTest, TestMultipleNetBase) {
 
   EXPECT_EQ(net.get()->NumObservers(), prev_num);
 }
+#endif
 } // namespace caffe2


### PR DESCRIPTION
Tracked in https://github.com/pytorch/pytorch/issues/9137

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

