### PR TITLE
Add CHECKs into GetTensorInfo and ExtractDeviceOption

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -207,6 +207,7 @@ class CAFFE2_API CPUStaticContext : public BaseStaticContext {
 
   void ExtractDeviceOption(DeviceOption* device, const void* /*data*/)
       override {
+    CHECK(device);
     device->set_device_type(TypeToProto(GetDeviceType()));
   }
 

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -81,6 +81,7 @@ vector<TIndex> GetTensorInfo(
     const void* c,
     size_t* capacity,
     DeviceOption* device) {
+  CHECK(capacity);
   const Tensor* tc = static_cast<const Tensor*>(c);
   CHECK(tc);
   CHECK(tc->unsafeGetTensorImpl());

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -103,7 +103,8 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * context pointer in tensor, which indicates the type of the tensor.
    */
   at::BaseStaticContext* GetStaticContext() const {
-    return get_static_context(GetDeviceType());
+    auto device_type = GetDeviceType();
+    return get_static_context(device_type);
   }
 
   /* @brief
@@ -732,7 +733,9 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   void ExtractDeviceOption(DeviceOption* device) const {
-    GetStaticContext()->ExtractDeviceOption(device, raw_data());
+    auto* context = GetStaticContext();
+    CHECK(context);
+    context->ExtractDeviceOption(device, raw_data());
   }
 
   const at::Storage& storage() {


### PR DESCRIPTION
Summary:
We should always CHECK pointers which we plan to dereference
if they are inputs to the function. Nobody knows how the function will
be called in the future.

Differential Revision: D9800002
