### PR TITLE
[caffe2] Change the mutex protection scope in AtomicFetchAddOp.

### DIFF
--- a/caffe2/operators/atomic_ops.cc
+++ b/caffe2/operators/atomic_ops.cc
@@ -27,15 +27,17 @@ class AtomicFetchAddOp final : public Operator<CPUContext> {
     auto& mutex = OperatorBase::Input<std::unique_ptr<std::mutex>>(0);
     auto& a = Input(1);
     auto& b = Input(2);
+    auto* aPtr = a.data<int32_t>();
+    auto* bPtr = b.data<int32_t>();
+    std::lock_guard<std::mutex> lg(*mutex);
+    // The Output(n) includes some memory buffer operations. It should
+    // be in the mutex protection scope.
     auto* c = Output(0);
     auto* d = Output(1);
     c->Resize(std::vector<TIndex>());
     d->Resize(std::vector<TIndex>());
-    auto* aPtr = a.data<int32_t>();
-    auto* bPtr = b.data<int32_t>();
     auto* cPtr = c->template mutable_data<int32_t>();
     auto* dPtr = d->template mutable_data<int32_t>();
-    std::lock_guard<std::mutex> lg(*mutex);
     *dPtr = *aPtr;
     *cPtr = *aPtr + *bPtr;
     return true;


### PR DESCRIPTION
There is a potential data racing in AtomicFetchAddOp. The Output(n) call includes some memory operations. If we run the AtomicFetchAddOp object simultaneously in different threads, we might hit the problem.

I saw a test failed in "[caffe2/python/operator_test/atomic_ops_test.py](https://github.com/pytorch/pytorch/blob/d4e05f4e1e276055cd3d3e1a2a1e186e6c6405ee/caffe2/python/operator_test/atomic_ops_test.py#L31)" for this problem. And I can reproduce locally.
Here is the call stack for the crash:
It calls Output(n) simultaneously in different threads. Then, cause the assertion checking in aten.
```
[I plan_executor.cc:511] Step init took 0.000375997 seconds.
libc++abi.dylib: terminating with uncaught exception of type at::Error: refcount_.load() == 0 ASSERT FAILED at ../aten/src/ATen/core/intrusive_ptr.h:83, please report a bug to PyTorch. Tried to destruct an intrusive_ptr_target that still has intrusive_ptr to it (~intrusive_ptr_target at ../aten/src/ATen/core/intrusive_ptr.h:83)
frame #0: caffe2::TensorImpl::~TensorImpl() + 134 (0x10ffa6386 in libcaffe2.dylib)
frame #1: void caffe2::Blob::Destroy<caffe2::Tensor>(void*) + 91 (0x10ffa5f1b in libcaffe2.dylib)
frame #2: caffe2::Blob::GetMutableTensor(at::DeviceType) + 378 (0x10ffa5e1a in libcaffe2.dylib)
frame #3: caffe2::fb::(anonymous namespace)::AtomicFetchAddOp::RunOnDevice() + 149 (0x1102f7c65 in libcaffe2.dylib)
frame #4: caffe2::Operator<caffe2::CPUContext>::Run(int) + 90 (0x10ff9f8ea in libcaffe2.dylib)
frame #5: caffe2::SimpleNet::Run() + 447 (0x11016215f in libcaffe2.dylib)
frame #6: caffe2::(anonymous namespace)::ExecuteStepRecursive(caffe2::(anonymous namespace)::ExecutionStepWrapper&) + 889 (0x11017efc9 in libcaffe2.dylib)
frame #7: void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, caffe2::(anonymous namespace)::ExecuteStepRecursive(caffe2::(anonymous namespace)::ExecutionStepWrapper&)::$_5> >(void*) + 156 (0x11018581c in libcaffe2.dylib)
frame #8: _pthread_body + 340 (0x7fff64bea661 in libsystem_pthread.dylib)
frame #9: _pthread_body + 0 (0x7fff64bea50d in libsystem_pthread.dylib)
frame #10: thread_start + 13 (0x7fff64be9bf9 in libsystem_pthread.dylib)

Process 16280 stopped
* thread #5, stop reason = signal SIGABRT
    frame #0: 0x00007fff64a22b66 libsystem_kernel.dylib`__pthread_kill + 10
libsystem_kernel.dylib`__pthread_kill:
->  0x7fff64a22b66 <+10>: jae    0x7fff64a22b70            ; <+20>
    0x7fff64a22b68 <+12>: movq   %rax, %rdi
    0x7fff64a22b6b <+15>: jmp    0x7fff64a19ae9            ; cerror_nocancel
    0x7fff64a22b70 <+20>: retq
Target 0: (Python) stopped.
```


