### PR TITLE
Adding .expand method for TransformedDistribution

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -350,6 +350,13 @@ class TestCase(unittest.TestCase):
                     self.assertTrue(torch.equal(nan_mask, b != b), message)
                     diff = a - b
                     diff[nan_mask] = 0
+                    # inf check if allow_inf=True
+                    if allow_inf:
+                        inf_mask = (a == float("inf")) | (a == float("-inf"))
+                        self.assertTrue(torch.equal(inf_mask,
+                                                    (b == float("inf")) | (b == float("-inf"))),
+                                        message)
+                        diff[inf_mask] = 0
                     # TODO: implement abs on CharTensor
                     if diff.is_signed() and 'CharTensor' not in diff.type():
                         diff = diff.abs()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -802,13 +802,14 @@ class TestDistributions(TestCase):
                     expanded_shape = shape + d.batch_shape
                     original_shape = d.batch_shape + d.event_shape
                     expected_shape = shape + original_shape
-                    expanded = d.expand(batch_shape=expanded_shape)
+                    expanded = d.expand(batch_shape=list(expanded_shape))
                     sample = expanded.sample()
                     actual_shape = expanded.sample().shape
                     self.assertEqual(expanded.__class__, d.__class__)
                     self.assertEqual(d.sample().shape, original_shape)
                     self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
                     self.assertEqual(actual_shape, expected_shape)
+                    self.assertEqual(expanded.batch_shape, expanded_shape)
                     try:
                         self.assertEqual(expanded.mean,
                                          d.mean.expand(expanded_shape + d.event_shape),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -809,7 +809,6 @@ class TestDistributions(TestCase):
                     self.assertEqual(d.sample().shape, original_shape)
                     self.assertEqual(expanded.log_prob(sample), d.log_prob(sample))
                     self.assertEqual(actual_shape, expected_shape)
-                    print(d.__class__)
                     try:
                         self.assertEqual(expanded.mean,
                                          d.mean.expand(expanded_shape + d.event_shape),

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -24,7 +24,6 @@ class Chi2(Gamma):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Chi2, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(Chi2, self).expand(batch_shape, new)
 
     @property

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -40,7 +40,6 @@ class Gumbel(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Gumbel, _instance)
-        batch_shape = torch.Size(batch_shape)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         return super(Gumbel, self).expand(batch_shape, _instance=new)

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -41,11 +41,9 @@ class Gumbel(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Gumbel, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist = self.base_dist.expand(batch_shape)
-        transforms = self.transforms
-        super(Gumbel, new).__init__(base_dist, transforms, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        return super(Gumbel, self).expand(batch_shape, _instance=new)
 
     @property
     def mean(self):

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -36,10 +36,7 @@ class HalfCauchy(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfCauchy, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(HalfCauchy, new).__init__(base_dist, AbsTransform(), validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        return super(HalfCauchy, self).expand(batch_shape, _instance=new)
 
     @property
     def scale(self):

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -35,7 +35,6 @@ class HalfCauchy(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfCauchy, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(HalfCauchy, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -35,7 +35,6 @@ class HalfNormal(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfNormal, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(HalfNormal, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -36,10 +36,7 @@ class HalfNormal(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfNormal, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(HalfNormal, new).__init__(base_dist, AbsTransform(), validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        return super(HalfNormal, self).expand(batch_shape, _instance=new)
 
     @property
     def scale(self):

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -33,7 +33,6 @@ class LogNormal(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogNormal, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(LogNormal, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -34,10 +34,7 @@ class LogNormal(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogNormal, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(LogNormal, new).__init__(base_dist, ExpTransform(), validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        return super(LogNormal, self).expand(batch_shape, _instance=new)
 
     @property
     def loc(self):

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -41,7 +41,6 @@ class LogisticNormal(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogisticNormal, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(LogisticNormal, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -42,13 +42,7 @@ class LogisticNormal(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogisticNormal, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist = self.base_dist.expand(batch_shape + self.base_dist.batch_shape[-1:])
-        super(LogisticNormal, new).__init__(base_dist,
-                                            StickBreakingTransform(),
-                                            validate_args=False)
-        new._event_shape = self._event_shape
-        new._validate_args = self._validate_args
-        return new
+        return super(LogisticNormal, self).expand(batch_shape, _instance=new)
 
     @property
     def loc(self):

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -30,7 +30,6 @@ class Pareto(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Pareto, _instance)
-        batch_shape = torch.Size(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         new.alpha = self.alpha.expand(batch_shape)
         return super(Pareto, self).expand(batch_shape, _instance=new)

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -30,10 +30,10 @@ class Pareto(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Pareto, _instance)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(Pareto, new).__init__(base_dist, self.transforms, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        batch_shape = torch.Size(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        new.alpha = self.alpha.expand(batch_shape)
+        return super(Pareto, self).expand(batch_shape, _instance=new)
 
     @property
     def mean(self):

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -120,7 +120,6 @@ class RelaxedBernoulli(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedBernoulli, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(RelaxedBernoulli, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -120,10 +120,8 @@ class RelaxedBernoulli(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedBernoulli, _instance)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(RelaxedBernoulli, new).__init__(base_dist, SigmoidTransform(), validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        batch_shape = torch.Size(batch_shape)
+        return super(RelaxedBernoulli, self).expand(batch_shape, _instance=new)
 
     @property
     def temperature(self):

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -116,12 +116,8 @@ class RelaxedOneHotCategorical(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedOneHotCategorical, _instance)
-        base_dist = self.base_dist.expand(batch_shape)
-        super(RelaxedOneHotCategorical, new).__init__(base_dist,
-                                                      ExpTransform(),
-                                                      validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+        batch_shape = torch.Size(batch_shape)
+        return super(RelaxedOneHotCategorical, self).expand(batch_shape, _instance=new)
 
     @property
     def temperature(self):

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -116,7 +116,6 @@ class RelaxedOneHotCategorical(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedOneHotCategorical, _instance)
-        batch_shape = torch.Size(batch_shape)
         return super(RelaxedOneHotCategorical, self).expand(batch_shape, _instance=new)
 
     @property

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -56,6 +56,16 @@ class TransformedDistribution(Distribution):
         event_shape = shape[len(shape) - event_dim:]
         super(TransformedDistribution, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(TransformedDistribution, _instance)
+        batch_shape = torch.Size(batch_shape)
+        base_dist_batch_shape = batch_shape + self.base_dist.batch_shape[len(batch_shape):]
+        new.base_dist = self.base_dist.expand(base_dist_batch_shape)
+        new.transforms = self.transforms
+        super(TransformedDistribution, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
     @constraints.dependent_property
     def support(self):
         return self.transforms[-1].codomain if self.transforms else self.base_dist.support

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -59,7 +59,7 @@ class TransformedDistribution(Distribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(TransformedDistribution, _instance)
         batch_shape = torch.Size(batch_shape)
-        base_dist_batch_shape = batch_shape + self.base_dist.batch_shape[len(batch_shape):]
+        base_dist_batch_shape = batch_shape + self.base_dist.batch_shape[len(self.batch_shape):]
         new.base_dist = self.base_dist.expand(base_dist_batch_shape)
         new.transforms = self.transforms
         super(TransformedDistribution, new).__init__(batch_shape, self.event_shape, validate_args=False)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -39,9 +39,12 @@ class Weibull(TransformedDistribution):
         batch_shape = torch.Size(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
+        new.concentration_reciprocal = new.concentration.reciprocal()
         base_dist = self.base_dist.expand(batch_shape)
+        transforms = [PowerTransform(exponent=new.concentration_reciprocal),
+                      AffineTransform(loc=0, scale=new.scale)]
         super(Weibull, new).__init__(base_dist,
-                                     self.transforms,
+                                     transforms,
                                      validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -36,7 +36,6 @@ class Weibull(TransformedDistribution):
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Weibull, _instance)
-        batch_shape = torch.Size(batch_shape)
         new.scale = self.scale.expand(batch_shape)
         new.concentration = self.concentration.expand(batch_shape)
         new.concentration_reciprocal = new.concentration.reciprocal()


### PR DESCRIPTION
 This PR:
 - adds a `.expand` method for `TransformedDistribution` along the lines of #11341.
 - uses this method to simplify `.expand` in distribution classes that subclass off of `TransformedDistribution`.
 - restores testing of `TransformedDistribution` fixtures.
 - fixes some bugs wherein we were not setting certain attributes in the expanded instances, and adds tests for `.mean` and `.variance` which use these attributes.

### Motivation:

There are many cases where users directly use `TransformedDistribution` rather than subclassing off it. In such cases, it seems rather inconvenient to have to write a separate class just to define a `.expand` method. The default implementation should suffice in these cases.

cc. @fritzo, @vishwakftw, @alicanb