### PR TITLE
Move function deletion from the stack to the heap.

### DIFF
--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -137,6 +137,7 @@ def process_function(func):
         if arg['type'] == 'Tensor' or (arg['type'] == 'Scalar' and is_output):
             saved_variables.append('SavedVariable {}_;'.format(name))
             release_variables.append('{}_.reset_data();'.format(name))
+            release_variables.append('{}_.reset_grad_function();'.format(name))
             ptr = 'shared_from_this()' if is_output else ''
             unpack.append('auto {} = {}_.unpack({});'.format(name, name, ptr))
         elif arg['type'] == 'TensorList':

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -40,95 +40,53 @@ AnomalyMetadata* Function::metadata() noexcept {
   return anomaly_metadata_.get();
 }
 
-/*
- * Fix for #5534: prevent stack overflow on deletion of deep computation graph
- *
- * Sometimes one can end up with a very big computation graph of Functions
- * and Edges. Each std::shared_ptr<Function> contains a list of Edge, and
- * each Edge contains a std::shared_ptr<Function>. Deleting a
- * std::shared_ptr<Function> can trigger the recursive deletion of other
- * std::shared_ptr<Function>'s: this can stack overflow if the graph
- * is deep enough. Here is an example of such a graph:
- *
- * shared_ptr<Function> -> Edge -> shared_ptr<Function> -> Edge -> ... -> shared_ptr<Function>
- *
- * The solution here is to use a custom deleter with each
- * std::shared_ptr<Function>. The custom deleter keeps track of how many
- * nested deleters it is in. When this number exceeds the maximum allowed
- * depth, the Function* to be deleted are accumulated in a per-thread
- * delete queue and handled by one of the deleters.
- *
- * Note that these custom deleters are NOT necessary for deleting PyFunction.
- * This is because a THPFunction Python object owns a PyFunction that is in a
- * computation graph. When Python objects get recursively destroyed, they
- * are also queued into a delete list. This happens very early for them
- * (at 50 deleters): https://github.com/python/cpython/blob/f320be77ffb73e3b9e7fc98c37b8df3975d84b40/Include/object.h#L1024-L1063
- * so we don't need to worry about them.
- */
+static void gatherFunctions(Function* func,
+                            std::vector<std::shared_ptr<Function>>& stack) {
+  func->release_variables();
 
-thread_local std::deque<Function*> deleteFunctionQueue;
-thread_local size_t deleteFunctionRecursionDepth = 0;
+  for (auto& edge : func->next_edges()) {
+    if (edge.function.use_count() == 1) {
+      stack.emplace_back(std::move(edge.function));
+    } else {
+      edge.function.reset();
+    }
+  }
+}
 
 /*
- * If this number is set too high, a deep computation graph can still
- * stack overflow. The procedure for setting this number was to
- * 1) find the smallest value that would not guard against stack overflows
- *    on various machines
- * 2) Take the minimum of all such values and subtract some leeway because
- *    the memory of these stack frames will probably grow as time passes.
- * Testing on a few machines machines, the magic numbers were:
- * - Mac OSX (Macbook Pro 15) : ~60000
- * - A beefy Ubuntu 16.04 box : ~15000
- * - Windows AWS instance (g3.4xlarge): variable. My two attempts at different
- *   times have gotten the following numbers: ~8300, 3669
- */
-#ifdef _WIN32
-size_t deleteFunctionMaxRecursionDepth = 3000;
-#else
-size_t deleteFunctionMaxRecursionDepth = 10000;
-#endif
-
-struct RecursionDepthCounter {
- public:
-  explicit RecursionDepthCounter() {
-    ++deleteFunctionRecursionDepth;
-  }
-  ~RecursionDepthCounter() {
-    --deleteFunctionRecursionDepth;
-  }
-
-  size_t value() {
-    return deleteFunctionRecursionDepth;
-  }
-};
-
-/*
- * Note that the custom deleter deletes in BFS style. Without using
- * the custom deleter, the computation graph is deleted in a DFS style.
- * The BFS deletion is valid (and safe) because if a shared_ptr<Function>
- * 's reference count hits 0, nothing else will access it.
- */
+  * Fix for #5534: prevent stack overflow on deletion of deep computation graph
+  *
+  * Sometimes one can end up with a very big computation graph of Functions
+  * and Edges. Each std::shared_ptr<Function> contains a list of Edge, and
+  * each Edge contains a std::shared_ptr<Function>. Deleting a
+  * std::shared_ptr<Function> can trigger the recursive deletion of other
+  * std::shared_ptr<Function>'s: this can stack overflow if the graph
+  * is deep enough. Here is an example of such a graph:
+  *
+  * shared_ptr<Function> -> Edge -> shared_ptr<Function> -> Edge -> ... -> shared_ptr<Function>
+  *
+  * The solution here is to detect when we are decrementing away the last
+  * reference to a Function, and when doing so to buffer up the Function's
+  * that will be recursively decremented.  We can then decrement (and free)
+  * the original Function without causing a recursive cascade, before
+  * draining the buffer applying the same behavior.  This is, in effect,
+  * converting recursion to a loop, using a heap buffer in place of the
+  * recursive call stack.
+  */
 void deleteFunction(Function* function) {
-  RecursionDepthCounter recursion_depth;
-
-  if (recursion_depth.value() > deleteFunctionMaxRecursionDepth) {
-    deleteFunctionQueue.push_back(function);
-    return;
-  }
-
+  // To avoid stack overflow on large computational graphs,
+  // we need to track reference decrementing and freeing
+  // on the heap.
+  function->release_variables();
+  std::vector<std::shared_ptr<Function>> stack;
+  gatherFunctions(function, stack);
   delete function;
 
-  if (deleteFunctionQueue.empty()) {
-    return;
-  }
-  if (recursion_depth.value() != deleteFunctionMaxRecursionDepth) {
-    AT_ERROR("Only one deleter per thread should be able to process "
-             "the delete queue. Please open an issue.");
-  }
-  while (!deleteFunctionQueue.empty()) {
-    auto queued_function = deleteFunctionQueue.front();
-    deleteFunctionQueue.pop_front();
-    delete queued_function;
+  while (!stack.empty()) {
+    auto func = std::move(stack.back());
+    stack.pop_back();
+    gatherFunctions(func.get(), stack);
+    // Reference count is decremented on the loop backedge.
   }
 }
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -33,8 +33,6 @@ using edge_list = std::vector<Edge>;
 using saved_variable_list = std::vector<SavedVariable>;
 using IndexRange = std::pair<size_t, size_t>;
 
-TORCH_API extern size_t deleteFunctionMaxRecursionDepth;
-
 // Custom deleter to prevent stack overflows.
 void deleteFunction(Function* function);
 
@@ -303,16 +301,6 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
   /// NOTE: this value matters only if is_traceable() returns false.
   virtual bool passes_state_transparently() {
     return false;
-  }
-
-  /// Returns `Variable`s saved by this `Function`.
-  /// This let's the JIT find inputs to apply that are not present explicitly
-  /// in arguments. Required only for functions that are not traceable, don't
-  /// pass state to backward transparently, and are not backwards closures of
-  /// functions that don't pass the state transparently. Which means that
-  /// hopefully they will hardly ever need to be implemented :)
-  virtual std::unique_ptr<saved_variable_list> saved_variables() {
-    return nullptr;
   }
 
   static uint64_t peek_at_next_sequence_nr();

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -50,11 +50,6 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
   });
   m.def("_pop_range", []() { torch::autograd::profiler::popRange(); });
 
-  /// TODO: Replace this ASAP with a better solution for deep autograd graphs!
-  m.def("_unsafe_set_delete_function_max_recursion_depth", [](size_t value) {
-    torch::autograd::deleteFunctionMaxRecursionDepth = value;
-  });
-
   Py_RETURN_TRUE;
 }
 

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -34,6 +34,10 @@ class TORCH_API SavedVariable {
     return data_.reset();
   }
 
+  void reset_grad_function() {
+    grad_fn_.reset();
+  }
+
  private:
   at::Tensor data_;
 


### PR DESCRIPTION
This eliminates the need for any heuristics regarding stack size limits.

This is a re-do #11534 with a fix to properly handle cases where
multiple edges exist between a pair of functions.