### PR TITLE
First cut at simplifying model exporting

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -449,7 +449,6 @@ class Module(object):
         return None
 
     def _slow_forward(self, *input, **kwargs):
-        input_vars = tuple(torch.autograd.function._iter_tensors(input))
         tracing_state = torch._C._get_tracing_state()
         if not tracing_state:
             return self.forward(*input, **kwargs)


### PR DESCRIPTION
Summary: Defining an interface to generalize model exporting through ONNX. The key point here is that the model would expose methods to provide necessary arguments for ONNX tracing.

Differential Revision: D9805096
