### PR TITLE
Pin Sphinx to 1.7.9

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -117,9 +117,8 @@ fi
 if [[ "$BUILD_ENVIRONMENT" == *xenial-cuda8-cudnn6-py3* ]]; then
   pushd docs
   # TODO: Don't run this here
-  # TODO: Reenable doc build
-  #pip install -r requirements.txt || true
-  #LC_ALL=C make html
+  pip install -r requirements.txt || true
+  LC_ALL=C make html
   popd
 fi
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx==1.7.9
 -e git://github.com/snide/sphinx_rtd_theme.git#egg=sphinx_rtd_theme
 sphinxcontrib.katex


### PR DESCRIPTION
Sphinx 1.8.0 breaks us.  Upgrading is tracked in #11618.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

