### PR TITLE
[wip] fixing too many open file error at DataLoader

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -365,7 +365,9 @@ class _DataLoaderIter(object):
         self._put_indices()
         if isinstance(batch, ExceptionWrapper):
             raise batch.exc_type(batch.exc_msg)
-        return batch
+        new_batch = self.collate_fn([batch])
+        del batch
+        return new_batch
 
     def __getstate__(self):
         # TODO: add limited pickling support for sharing an iterator


### PR DESCRIPTION
- try to fix https://github.com/pytorch/pytorch/issues/11201
- to remove returned tensor from multiprocessing.Queue share memory, this PR `del` the tensor before return the copy at DataLoader
- please note that this might not be a proper fix
- test plan:
run this script, there should not be an error
```
from torch.utils.data import Dataset
class testSet(Dataset):
    def __init__(self):
        super(testSet,self).__init__()
    def __len__(self):
        return 1000000
    def __getitem__(self,index):
        return {"index": index}

import torch

test_data = testSet()
test_data_loader = torch.utils.data.DataLoader( dataset=test_data, batch_size=1, num_workers=1)
index = []
for sample in test_data_loader:
    index.append(sample['index'])
```