### PR TITLE
remove redundant generate_code call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -630,8 +630,6 @@ class build_ext(build_ext_parent):
         else:
             print('-- Building without distributed package')
 
-        generate_code(ninja_global)
-
         if USE_NINJA:
             # before we start the normal build make sure all generated code
             # gets built


### PR DESCRIPTION
I believe that the CMakeLists already invokes this, and it is getting erroneously called in no-op builds.

This reduces my no-op `rebuild develop` from ~10 seconds to ~2 seconds.