### PR TITLE
Use MPI_Isend/MPI_Irecv to back send/recv

### DIFF
--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -38,7 +38,7 @@ class ProcessGroup {
     virtual ~Work();
 
     // Checks if request has completed. Non-blocking operation.
-    virtual bool isCompleted() const = 0;
+    virtual bool isCompleted() = 0;
 
     // Returns if the work completed successfully.
     // If false, the exception function can be called to get details.

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -145,7 +145,7 @@ ProcessGroupGloo::WorkGloo::WorkGloo()
 
 ProcessGroupGloo::WorkGloo::~WorkGloo() {}
 
-bool ProcessGroupGloo::WorkGloo::isCompleted() const {
+bool ProcessGroupGloo::WorkGloo::isCompleted() {
   return completed_;
 }
 
@@ -222,7 +222,7 @@ ProcessGroupGloo::SendWork::SendWork(
     std::unique_ptr<::gloo::transport::UnboundBuffer> buffer)
     : tensor_(tensor), buffer_(std::move(buffer)) {}
 
-bool ProcessGroupGloo::SendWork::isCompleted() const {
+bool ProcessGroupGloo::SendWork::isCompleted() {
   // No way to poll for completion yet
   return true;
 }
@@ -252,7 +252,7 @@ ProcessGroupGloo::RecvWork::RecvWork(
     int* srcRank)
     : tensor_(tensor), buffer_(std::move(buffer)), srcRank_(srcRank) {}
 
-bool ProcessGroupGloo::RecvWork::isCompleted() const {
+bool ProcessGroupGloo::RecvWork::isCompleted() {
   // No way to poll for completion yet
   return true;
 }

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -177,7 +177,7 @@ class ProcessGroupGloo : public ProcessGroup {
     explicit WorkGloo();
     virtual ~WorkGloo();
 
-    bool isCompleted() const override;
+    bool isCompleted() override;
     bool isSuccess() const override;
     void synchronize() override;
     bool wait() override;
@@ -235,7 +235,7 @@ class ProcessGroupGloo : public ProcessGroup {
 
     virtual ~SendWork() = default;
 
-    bool isCompleted() const override;
+    bool isCompleted() override;
 
     bool isSuccess() const override;
 
@@ -259,7 +259,7 @@ class ProcessGroupGloo : public ProcessGroup {
 
     virtual ~RecvWork() = default;
 
-    bool isCompleted() const override;
+    bool isCompleted() override;
 
     bool isSuccess() const override;
 

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -93,7 +93,7 @@ ProcessGroupMPI::WorkMPI::WorkMPI() : completed_(false) {}
 
 ProcessGroupMPI::WorkMPI::~WorkMPI() {}
 
-bool ProcessGroupMPI::WorkMPI::isCompleted() const {
+bool ProcessGroupMPI::WorkMPI::isCompleted() {
   return completed_;
 }
 
@@ -135,6 +135,80 @@ const std::exception& ProcessGroupMPI::WorkMPI::exception() const {
   } catch (const std::exception& e) {
     return e;
   }
+}
+
+ProcessGroupMPI::AsyncWork::AsyncWork(
+    at::Tensor tensor,
+    MPI_Request request,
+    int* srcRank)
+    : tensor_(std::move(tensor)),
+      request_(request),
+      srcRank_(srcRank) {
+  memset(&status_, 0, sizeof(status_));
+}
+
+ProcessGroupMPI::AsyncWork::~AsyncWork() {
+  if (request_ != MPI_REQUEST_NULL) {
+    throw std::runtime_error(
+        "Attempted destruction of AsyncWork before work has completed");
+  }
+}
+
+bool ProcessGroupMPI::AsyncWork::isCompleted() {
+  if (request_ == MPI_REQUEST_NULL) {
+    return true;
+  }
+
+  std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+  int flag = 0;
+  MPI_CHECK(MPI_Test(&request_, &flag, &status_));
+  if (request_ != MPI_REQUEST_NULL) {
+    return false;
+  }
+
+  // request_ == MPI_REQUEST_NULL; the work has completed
+  if (srcRank_ != nullptr) {
+    *srcRank_ = status_.MPI_SOURCE;
+  }
+
+  return true;
+}
+
+bool ProcessGroupMPI::AsyncWork::isSuccess() const {
+  if (request_ != MPI_REQUEST_NULL) {
+    throw std::runtime_error(
+        "Invalid call to AsyncWork::isSuccess before work has completed");
+  }
+
+  return status_.MPI_ERROR == MPI_SUCCESS;
+}
+
+void ProcessGroupMPI::AsyncWork::synchronize() {}
+
+bool ProcessGroupMPI::AsyncWork::wait() {
+  if (request_ == MPI_REQUEST_NULL) {
+    return true;
+  }
+
+  std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+  MPI_CHECK(MPI_Wait(&request_, &status_));
+  if (srcRank_ != nullptr && status_.MPI_ERROR == MPI_SUCCESS) {
+    *srcRank_ = status_.MPI_SOURCE;
+  }
+
+  return status_.MPI_ERROR == MPI_SUCCESS;
+}
+
+const std::exception& ProcessGroupMPI::AsyncWork::exception() const {
+  if (request_ != MPI_REQUEST_NULL) {
+    throw std::runtime_error(
+        "Invalid call to AsyncWork::exception before work has completed");
+  }
+
+  std::array<char, MPI_MAX_ERROR_STRING> buf;
+  int len = buf.size();
+  MPI_CHECK(MPI_Error_string(status_.MPI_ERROR, buf.data(), &len));
+  return std::runtime_error(std::string(buf.data(), len));
 }
 
 // Static global states
@@ -581,23 +655,25 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
   if (pgComm_ == MPI_COMM_NULL) {
     return nullptr;
   }
-  checkSingleTensor(tensors);
-  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
-      [dstRank, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (entry->src)[0];
 
-        std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
-        MPI_CHECK(MPI_Send(
-            data.data_ptr(),
-            data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
-            dstRank,
-            0,
-            pgComm_));
-      };
-  auto entry = std::unique_ptr<WorkEntry>(
-      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
-  return enqueue(std::move(entry));
+  checkSingleTensor(tensors);
+
+  auto& tensor = tensors[0];
+  MPI_Request request = MPI_REQUEST_NULL;
+
+  {
+    std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+    MPI_CHECK(MPI_Isend(
+                  tensor.data_ptr(),
+                  tensor.numel(),
+                  mpiDatatype.at(tensor.type().scalarType()),
+                  dstRank,
+                  0,
+                  pgComm_,
+                  &request));
+  }
+
+  return std::make_shared<AsyncWork>(tensor, request);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
@@ -606,24 +682,25 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
   if (pgComm_ == MPI_COMM_NULL) {
     return nullptr;
   }
-  checkSingleTensor(tensors);
-  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
-      [srcRank, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (entry->src)[0];
 
-        std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
-        MPI_CHECK(MPI_Recv(
-            data.data_ptr(),
-            data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
-            srcRank,
-            0,
-            pgComm_,
-            MPI_STATUS_IGNORE));
-      };
-  auto entry = std::unique_ptr<WorkEntry>(
-      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
-  return enqueue(std::move(entry));
+  checkSingleTensor(tensors);
+
+  auto& tensor = tensors[0];
+  MPI_Request request = MPI_REQUEST_NULL;
+
+  {
+    std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+    MPI_CHECK(MPI_Irecv(
+                  tensor.data_ptr(),
+                  tensor.numel(),
+                  mpiDatatype.at(tensor.type().scalarType()),
+                  srcRank,
+                  0,
+                  pgComm_,
+                  &request));
+  }
+
+  return std::make_shared<AsyncWork>(tensor, request);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
@@ -632,27 +709,25 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
   if (pgComm_ == MPI_COMM_NULL) {
     return nullptr;
   }
-  checkSingleTensor(tensors);
-  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
-      [srcRank, this](std::unique_ptr<WorkEntry>& entry) {
-        auto data = (entry->src)[0];
-        MPI_Status status;
 
-        std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
-        MPI_CHECK(MPI_Recv(
-            data.data_ptr(),
-            data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
-            MPI_ANY_SOURCE,
-            0,
-            pgComm_,
-            &status));
-        *(entry->srcRank) = status.MPI_SOURCE;
-      };
-  auto entry = std::unique_ptr<WorkEntry>(
-      new WorkEntry(&tensors, nullptr, std::move(runFunc)));
-  entry->srcRank = srcRank;
-  return enqueue(std::move(entry));
+  checkSingleTensor(tensors);
+
+  auto& tensor = tensors[0];
+  MPI_Request request = MPI_REQUEST_NULL;
+
+  {
+    std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+    MPI_CHECK(MPI_Irecv(
+                  tensor.data_ptr(),
+                  tensor.numel(),
+                  mpiDatatype.at(tensor.type().scalarType()),
+                  MPI_ANY_SOURCE,
+                  0,
+                  pgComm_,
+                  &request));
+  }
+
+  return std::make_shared<AsyncWork>(tensor, request, srcRank);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::barrier() {

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -78,7 +78,7 @@ class ProcessGroupMPI : public ProcessGroup {
     virtual ~WorkMPI();
 
     // Checks if request has completed. Non-blocking operation.
-    bool isCompleted() const override;
+    bool isCompleted() override;
 
     // Returns if the work completed successfully
     // if false, the exception function can be called to get details.
@@ -105,6 +105,28 @@ class ProcessGroupMPI : public ProcessGroup {
     std::exception_ptr workException_;
 
     friend class ProcessGroupMPI;
+  };
+
+  class AsyncWork : public ProcessGroup::Work {
+   public:
+    AsyncWork(at::Tensor tensor, MPI_Request request, int* srcRank = nullptr);
+    virtual ~AsyncWork();
+
+    bool isCompleted() override;
+
+    bool isSuccess() const override;
+
+    void synchronize() override;
+
+    bool wait() override;
+
+    const std::exception& exception() const override;
+
+   protected:
+    at::Tensor tensor_;
+    MPI_Request request_;
+    int* const srcRank_;
+    MPI_Status status_;
   };
 
   // Constructor will spawn up the worker thread loop

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -100,7 +100,7 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<at::Device>& devices)
 ProcessGroupNCCL::WorkNCCL::~WorkNCCL() {}
 
 // Check if the NCCL kernels are queued on the GPUs
-bool ProcessGroupNCCL::WorkNCCL::isCompleted() const {
+bool ProcessGroupNCCL::WorkNCCL::isCompleted() {
   return true;
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -66,7 +66,7 @@ class ProcessGroupNCCL : public ProcessGroup {
     // Checks if request has completed. In this specific case of NCCL, it checks
     // if the NCCL operation has completed on the GPU in its own NCCL stream.
     // Non-blocking operation.
-    bool isCompleted() const override;
+    bool isCompleted() override;
 
     // Let current THC stream wait on the completing of the NCCL work
     // always return true and will throw if there are exceptions


### PR DESCRIPTION
The isCompleted function is changed to being non-const to accomodate
setting some internal status on the work object in the case of
completion. Previously, it was only checking a member field, but for the
MPI backend it calls MPI_Test to poll for completion of an asynchronous
request.