### PR TITLE
[C++ API] Document the Sequential module

### DIFF
--- a/docs/cpp/Doxyfile
+++ b/docs/cpp/Doxyfile
@@ -419,7 +419,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = YES
+EXTRACT_PRIVATE        = NO
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.

--- a/docs/cpp/Doxyfile
+++ b/docs/cpp/Doxyfile
@@ -799,7 +799,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.h *.cpp
+FILE_PATTERNS          = *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -1,11 +1,16 @@
 #include <catch.hpp>
 
 #include <torch/nn/modules.h>
+#include <torch/nn/modules/batchnorm.h>
+#include <torch/nn/modules/conv.h>
+#include <torch/nn/modules/dropout.h>
 #include <torch/nn/modules/linear.h>
+#include <torch/nn/modules/rnn.h>
 #include <torch/nn/modules/sequential.h>
 #include <torch/tensor.h>
 #include <torch/utils.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -16,298 +21,304 @@ using namespace torch::test;
 
 using Catch::StartsWith;
 
-TEST_CASE("sequential") {
-  SECTION("construction from shared pointer") {
-    struct M : torch::nn::Module {
-      explicit M(int value_) : value(value_) {}
-      int value;
-      int forward() {
-        return value;
-      }
-    };
-    Sequential sequential(
-        std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3));
-    REQUIRE(sequential->size() == 3);
-  }
-  SECTION("construction from concrete type") {
-    struct M : torch::nn::Module {
-      explicit M(int value_) : value(value_) {}
-      int value;
-      int forward() {
-        return value;
-      }
-    };
-
-    Sequential sequential(M(1), M(2), M(3));
-    REQUIRE(sequential->size() == 3);
-  }
-  SECTION("construction from module holders") {
-    struct MImpl : torch::nn::Module {
-      explicit MImpl(int value_) : value(value_) {}
-      int forward() {
-        return value;
-      }
-      int value;
-    };
-
-    struct M : torch::nn::ModuleHolder<MImpl> {
-      using torch::nn::ModuleHolder<MImpl>::ModuleHolder;
-      using torch::nn::ModuleHolder<MImpl>::get;
-    };
-
-    Sequential sequential(M(1), M(2), M(3));
-    REQUIRE(sequential->size() == 3);
-  }
-  SECTION("push_back") {
-    struct M : torch::nn::Module {
-      explicit M(int value_) : value(value_) {}
-      int forward() {
-        return value;
-      }
-      int value;
-    };
-    Sequential sequential;
-    REQUIRE(sequential->size() == 0);
-    REQUIRE(sequential->is_empty());
-    sequential->push_back(Linear(3, 4));
-    REQUIRE(sequential->size() == 1);
-    sequential->push_back(std::make_shared<M>(1));
-    REQUIRE(sequential->size() == 2);
-    sequential->push_back(M(2));
-    REQUIRE(sequential->size() == 3);
-  }
-  SECTION("access") {
-    struct M : torch::nn::Module {
-      explicit M(int value_) : value(value_) {}
-      int forward() {
-        return value;
-      }
-      int value;
-    };
-    std::vector<std::shared_ptr<M>> modules = {
-        std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3)};
-
-    Sequential sequential;
-    for (auto& module : modules) {
-      sequential->push_back(module);
+TEST_CASE("Sequential/ConstructsFromSharedPointer") {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int value;
+    int forward() {
+      return value;
     }
-    REQUIRE(sequential->size() == 3);
+  };
+  Sequential sequential(
+      std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3));
+  REQUIRE(sequential->size() == 3);
+}
 
-    SECTION("at()") {
-      SECTION("returns the correct module for a given index") {
-        for (size_t i = 0; i < modules.size(); ++i) {
-          REQUIRE(&sequential->at<M>(i) == modules[i].get());
-        }
-      }
-      SECTION("throws for a bad index") {
-        REQUIRE_THROWS_WITH(
-            sequential->at<M>(modules.size() + 1),
-            StartsWith("Index out of range"));
-        REQUIRE_THROWS_WITH(
-            sequential->at<M>(modules.size() + 1000000),
-            StartsWith("Index out of range"));
-      }
+TEST_CASE("Sequential/ConstructsFromConcreteType") {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int value;
+    int forward() {
+      return value;
     }
+  };
 
-    SECTION("ptr()") {
-      SECTION("returns the correct module for a given index") {
-        for (size_t i = 0; i < modules.size(); ++i) {
-          REQUIRE(sequential->ptr(i).get() == modules[i].get());
-          REQUIRE(sequential[i].get() == modules[i].get());
-          REQUIRE(sequential->ptr<M>(i).get() == modules[i].get());
-        }
-      }
-      SECTION("throws for a bad index") {
-        REQUIRE_THROWS_WITH(
-            sequential->ptr(modules.size() + 1),
-            StartsWith("Index out of range"));
-        REQUIRE_THROWS_WITH(
-            sequential->ptr(modules.size() + 1000000),
-            StartsWith("Index out of range"));
-      }
+  Sequential sequential(M(1), M(2), M(3));
+  REQUIRE(sequential->size() == 3);
+}
+TEST_CASE("Sequential/ConstructsFromModuleHolder") {
+  struct MImpl : torch::nn::Module {
+    explicit MImpl(int value_) : value(value_) {}
+    int forward() {
+      return value;
     }
+    int value;
+  };
+
+  struct M : torch::nn::ModuleHolder<MImpl> {
+    using torch::nn::ModuleHolder<MImpl>::ModuleHolder;
+    using torch::nn::ModuleHolder<MImpl>::get;
+  };
+
+  Sequential sequential(M(1), M(2), M(3));
+  REQUIRE(sequential->size() == 3);
+}
+
+TEST_CASE("Sequential/PushBackAddsAnElement") {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int forward() {
+      return value;
+    }
+    int value;
+  };
+  Sequential sequential;
+  REQUIRE(sequential->size() == 0);
+  REQUIRE(sequential->is_empty());
+  sequential->push_back(Linear(3, 4));
+  REQUIRE(sequential->size() == 1);
+  sequential->push_back(std::make_shared<M>(1));
+  REQUIRE(sequential->size() == 2);
+  sequential->push_back(M(2));
+  REQUIRE(sequential->size() == 3);
+}
+
+TEST_CASE("Sequential/AccessWithAt") {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int forward() {
+      return value;
+    }
+    int value;
+  };
+  std::vector<std::shared_ptr<M>> modules = {
+      std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3)};
+
+  Sequential sequential;
+  for (auto& module : modules) {
+    sequential->push_back(module);
   }
-  SECTION("forward") {
-    SECTION("calling forward() on an empty sequential is disallowed") {
-      Sequential empty;
-      REQUIRE_THROWS_WITH(
-          empty->forward<int>(),
-          StartsWith("Cannot call forward() on an empty Sequential"));
-    }
+  REQUIRE(sequential->size() == 3);
 
-    SECTION("calling forward() on a non-empty sequential chains correctly") {
-      struct MockModule : torch::nn::Module {
-        explicit MockModule(int value) : expected(value) {}
-        int expected;
-        int forward(int value) {
-          REQUIRE(value == expected);
-          return value + 1;
-        }
-      };
-
-      Sequential sequential(MockModule{1}, MockModule{2}, MockModule{3});
-
-      REQUIRE(sequential->forward<int>(1) == 4);
-    }
-
-    SECTION("calling forward() with the wrong return type throws") {
-      struct M : public torch::nn::Module {
-        int forward() {
-          return 5;
-        }
-      };
-
-      Sequential sequential(M{});
-      REQUIRE(sequential->forward<int>() == 5);
-      REQUIRE_THROWS_WITH(
-          sequential->forward<float>(),
-          StartsWith("The type of the return value "
-                     "is int, but you asked for type float"));
-    }
-
-    SECTION("The return type of forward() defaults to Tensor") {
-      struct M : public torch::nn::Module {
-        torch::Tensor forward(torch::Tensor v) {
-          return v;
-        }
-      };
-
-      Sequential sequential(M{});
-      auto variable = torch::ones({3, 3}, torch::requires_grad());
-      REQUIRE(sequential->forward(variable).equal(variable));
-    }
+  // returns the correct module for a given index
+  for (size_t i = 0; i < modules.size(); ++i) {
+    REQUIRE(&sequential->at<M>(i) == modules[i].get());
   }
 
-  SECTION("returns the last value") {
-    torch::manual_seed(0);
-    Sequential sequential(Linear(10, 3), Linear(3, 5), Linear(5, 100));
+  // throws for a bad index
+  REQUIRE_THROWS_WITH(
+      sequential->at<M>(modules.size() + 1), StartsWith("Index out of range"));
+  REQUIRE_THROWS_WITH(
+      sequential->at<M>(modules.size() + 1000000),
+      StartsWith("Index out of range"));
+}
 
-    auto x = torch::randn({1000, 10}, torch::requires_grad());
-    auto y = sequential->forward(x);
-    REQUIRE(y.ndimension() == 2);
-    REQUIRE(y.size(0) == 1000);
-    REQUIRE(y.size(1) == 100);
-  }
-
-  SECTION("can hold other important modules") {
-    Sequential sequential(
-        Linear(10, 3),
-        Conv2d(1, 2, 3),
-        Dropout(0.5),
-        BatchNorm(5),
-        Embedding(4, 10),
-        LSTM(4, 5));
-  }
-
-  SECTION("converts at::Tensor to torch::Tensor correctly") {
-    struct M : torch::nn::Module {
-      torch::Tensor forward(torch::Tensor input) {
-        return input;
-      }
-    };
-
-    Sequential sequential(M{});
-    torch::Tensor variable = torch::ones(5);
-    REQUIRE(sequential->forward(variable).sum().toCFloat() == 5);
-
-    at::Tensor tensor_that_is_actually_a_variable = variable * 2;
-    REQUIRE(
-        sequential->forward(tensor_that_is_actually_a_variable)
-            .sum()
-            .toCFloat() == 10);
-  }
-  SECTION("extend() pushes modules from other Sequential") {
-    struct A : torch::nn::Module {
-      int forward(int x) {
-        return x;
-      }
-    };
-    struct B : torch::nn::Module {
-      int forward(int x) {
-        return x;
-      }
-    };
-    struct C : torch::nn::Module {
-      int forward(int x) {
-        return x;
-      }
-    };
-    struct D : torch::nn::Module {
-      int forward(int x) {
-        return x;
-      }
-    };
-    Sequential a(A{}, B{});
-    Sequential b(C{}, D{});
-    a->extend(*b);
-
-    REQUIRE(a->size() == 4);
-    REQUIRE(a[0]->as<A>());
-    REQUIRE(a[1]->as<B>());
-    REQUIRE(a[2]->as<C>());
-    REQUIRE(a[3]->as<D>());
-
-    REQUIRE(b->size() == 2);
-    REQUIRE(b[0]->as<C>());
-    REQUIRE(b[1]->as<D>());
-
-    std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
-                                         std::make_shared<A>()};
-    b->extend(c);
-
-    REQUIRE(b->size() == 4);
-    REQUIRE(b[0]->as<C>());
-    REQUIRE(b[1]->as<D>());
-    REQUIRE(b[2]->as<A>());
-    REQUIRE(b[3]->as<A>());
-  }
-  SECTION("has reference semantics") {
-    Sequential first(Linear(2, 3), Linear(4, 4), Linear(4, 5));
-    Sequential second(first);
-
-    REQUIRE(first.get() == second.get());
-    REQUIRE(first->size() == second->size());
-    REQUIRE(std::equal(
-        first->begin(),
-        first->end(),
-        second->begin(),
-        [](const AnyModule& first, const AnyModule& second) {
-          return &first == &second;
-        }));
-  }
-  SECTION("Is cloneable") {
-    Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
-    Sequential clone =
-        std::dynamic_pointer_cast<SequentialImpl>(sequential->clone());
-    REQUIRE(sequential->size() == clone->size());
-
-    for (size_t i = 0; i < sequential->size(); ++i) {
-      // The modules should be the same kind (type).
-      REQUIRE(sequential[i]->name() == clone[i]->name());
-      // But not pointer-equal (distinct objects).
-      REQUIRE(sequential[i] != clone[i]);
+TEST_CASE("Sequential/AccessWithPtr") {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int forward() {
+      return value;
     }
+    int value;
+  };
+  std::vector<std::shared_ptr<M>> modules = {
+      std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3)};
 
-    // Verify that the clone is deep, i.e. parameters of modules are cloned too.
+  Sequential sequential;
+  for (auto& module : modules) {
+    sequential->push_back(module);
+  }
+  REQUIRE(sequential->size() == 3);
 
-    torch::NoGradGuard no_grad;
+  // returns the correct module for a given index
+  for (size_t i = 0; i < modules.size(); ++i) {
+    REQUIRE(sequential->ptr(i).get() == modules[i].get());
+    REQUIRE(sequential[i].get() == modules[i].get());
+    REQUIRE(sequential->ptr<M>(i).get() == modules[i].get());
+  }
 
-    auto params1 = sequential->parameters();
-    auto params2 = clone->parameters();
-    REQUIRE(params1.size() == params2.size());
-    for (auto& param : params1) {
-      REQUIRE(!pointer_equal(param.value, params2[param.key]));
-      REQUIRE(param->device() == params2[param.key].device());
-      REQUIRE(param->allclose(params2[param.key]));
-      param->add_(2);
+  // throws for a bad index
+  REQUIRE_THROWS_WITH(
+      sequential->ptr(modules.size() + 1), StartsWith("Index out of range"));
+  REQUIRE_THROWS_WITH(
+      sequential->ptr(modules.size() + 1000000),
+      StartsWith("Index out of range"));
+}
+
+TEST_CASE("Sequential/CallingForwardOnEmptySequentialIsDisallowed") {
+  Sequential empty;
+  REQUIRE_THROWS_WITH(
+      empty->forward<int>(),
+      StartsWith("Cannot call forward() on an empty Sequential"));
+}
+
+TEST_CASE("Sequential/CallingForwardChainsCorrectly") {
+  struct MockModule : torch::nn::Module {
+    explicit MockModule(int value) : expected(value) {}
+    int expected;
+    int forward(int value) {
+      REQUIRE(value == expected);
+      return value + 1;
     }
-    for (auto& param : params1) {
-      REQUIRE(!param->allclose(params2[param.key]));
+  };
+
+  Sequential sequential(MockModule{1}, MockModule{2}, MockModule{3});
+
+  REQUIRE(sequential->forward<int>(1) == 4);
+}
+
+TEST_CASE("Sequential/CallingForwardWithTheWrongReturnTypeThrows") {
+  struct M : public torch::nn::Module {
+    int forward() {
+      return 5;
     }
+  };
+
+  Sequential sequential(M{});
+  REQUIRE(sequential->forward<int>() == 5);
+  REQUIRE_THROWS_WITH(
+      sequential->forward<float>(),
+      StartsWith("The type of the return value "
+                 "is int, but you asked for type float"));
+}
+
+TEST_CASE("Sequential/TheReturnTypeOfForwardDefaultsToTensor") {
+  struct M : public torch::nn::Module {
+    torch::Tensor forward(torch::Tensor v) {
+      return v;
+    }
+  };
+
+  Sequential sequential(M{});
+  auto variable = torch::ones({3, 3}, torch::requires_grad());
+  REQUIRE(sequential->forward(variable).equal(variable));
+}
+
+TEST_CASE("Sequential/ForwardReturnsTheLastValue") {
+  torch::manual_seed(0);
+  Sequential sequential(Linear(10, 3), Linear(3, 5), Linear(5, 100));
+
+  auto x = torch::randn({1000, 10}, torch::requires_grad());
+  auto y = sequential->forward(x);
+  REQUIRE(y.ndimension() == 2);
+  REQUIRE(y.size(0) == 1000);
+  REQUIRE(y.size(1) == 100);
+}
+
+TEST_CASE("Sequential/SanityCheckForHoldingStandardModules") {
+  Sequential sequential(
+      Linear(10, 3),
+      Conv2d(1, 2, 3),
+      Dropout(0.5),
+      BatchNorm(5),
+      Embedding(4, 10),
+      LSTM(4, 5));
+}
+
+TEST_CASE("Sequential/ExtendPushesModulesFromOtherSequential") {
+  struct A : torch::nn::Module {
+    int forward(int x) {
+      return x;
+    }
+  };
+  struct B : torch::nn::Module {
+    int forward(int x) {
+      return x;
+    }
+  };
+  struct C : torch::nn::Module {
+    int forward(int x) {
+      return x;
+    }
+  };
+  struct D : torch::nn::Module {
+    int forward(int x) {
+      return x;
+    }
+  };
+  Sequential a(A{}, B{});
+  Sequential b(C{}, D{});
+  a->extend(*b);
+
+  REQUIRE(a->size() == 4);
+  REQUIRE(a[0]->as<A>());
+  REQUIRE(a[1]->as<B>());
+  REQUIRE(a[2]->as<C>());
+  REQUIRE(a[3]->as<D>());
+
+  REQUIRE(b->size() == 2);
+  REQUIRE(b[0]->as<C>());
+  REQUIRE(b[1]->as<D>());
+
+  std::vector<std::shared_ptr<A>> c = {std::make_shared<A>(),
+                                       std::make_shared<A>()};
+  b->extend(c);
+
+  REQUIRE(b->size() == 4);
+  REQUIRE(b[0]->as<C>());
+  REQUIRE(b[1]->as<D>());
+  REQUIRE(b[2]->as<A>());
+  REQUIRE(b[3]->as<A>());
+}
+
+TEST_CASE("Sequential/HasReferenceSemantics") {
+  Sequential first(Linear(2, 3), Linear(4, 4), Linear(4, 5));
+  Sequential second(first);
+
+  REQUIRE(first.get() == second.get());
+  REQUIRE(first->size() == second->size());
+  REQUIRE(std::equal(
+      first->begin(),
+      first->end(),
+      second->begin(),
+      [](const AnyModule& first, const AnyModule& second) {
+        return &first == &second;
+      }));
+}
+
+TEST_CASE("Sequential/IsCloneable") {
+  Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
+  Sequential clone =
+      std::dynamic_pointer_cast<SequentialImpl>(sequential->clone());
+  REQUIRE(sequential->size() == clone->size());
+
+  for (size_t i = 0; i < sequential->size(); ++i) {
+    // The modules should be the same kind (type).
+    REQUIRE(sequential[i]->name() == clone[i]->name());
+    // But not pointer-equal (distinct objects).
+    REQUIRE(sequential[i] != clone[i]);
+  }
+
+  // Verify that the clone is deep, i.e. parameters of modules are cloned too.
+
+  torch::NoGradGuard no_grad;
+
+  auto params1 = sequential->parameters();
+  auto params2 = clone->parameters();
+  REQUIRE(params1.size() == params2.size());
+  for (auto& param : params1) {
+    REQUIRE(!pointer_equal(param.value, params2[param.key]));
+    REQUIRE(param->device() == params2[param.key].device());
+    REQUIRE(param->allclose(params2[param.key]));
+    param->add_(2);
+  }
+  for (auto& param : params1) {
+    REQUIRE(!param->allclose(params2[param.key]));
   }
 }
 
-TEST_CASE("sequential/clone-to-device", "[cuda]") {
+TEST_CASE("Sequential/RegistersElementsAsSubmodules") {
+  Sequential sequential(Linear(10, 3), Conv2d(1, 2, 3), FeatureDropout(0.5));
+
+  auto modules = sequential->modules();
+  REQUIRE(modules.size() == sequential->children().size());
+
+  REQUIRE(modules[0]->as<Linear>());
+  REQUIRE(modules[1]->as<Conv2d>());
+  REQUIRE(modules[2]->as<FeatureDropout>());
+}
+
+TEST_CASE("Sequential/CloneToDevice", "[cuda]") {
   Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
   torch::Device device(torch::kCUDA, 0);
   Sequential clone =

--- a/torch/csrc/api/include/torch/jit.h
+++ b/torch/csrc/api/include/torch/jit.h
@@ -17,7 +17,7 @@ namespace jit {
 ///
 /// For example:
 /// \rst
-/// .. code-block::
+/// .. code-block:: cpp
 ///   auto module = torch::jit::compile(R"JIT(
 ///     def relu_script(a, b):
 ///       return torch.relu(a + b)

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -225,8 +225,8 @@ class Module {
   ///     }
   ///   }
   ///
-  /// MyModule module;
-  /// module->modules().apply(initialize_weights);
+  ///   MyModule module;
+  ///   module->modules().apply(initialize_weights);
   /// \endrst
   template <typename ModuleType>
   typename ModuleType::ContainedType* as() noexcept;
@@ -244,8 +244,8 @@ class Module {
   ///     }
   ///   }
   ///
-  /// MyModule module;
-  /// module->modules().apply(initialize_weights);
+  ///   MyModule module;
+  ///   module->modules().apply(initialize_weights);
   /// \endrst
   template <
       typename ModuleType,

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -38,7 +38,7 @@ namespace nn {
 /// Example:
 ///
 /// \rst
-/// .. code-block::
+/// .. code-block:: cpp
 ///   struct GenericTrainer {
 ///     torch::nn::AnyModule module;
 ///
@@ -57,7 +57,7 @@ namespace nn {
 /// `AnyModule` will compile, but throw an exception at runtime:
 ///
 /// \rst
-/// .. code-block::
+/// .. code-block:: cpp
 ///   torch::nn::AnyModule module(torch::nn::Linear(3, 4));
 ///   // Linear takes a tensor as input, but we are passing an integer.
 ///   // This will compile, but throw a `torch::Error` exception at runtime.
@@ -79,7 +79,7 @@ namespace nn {
 /// for example.
 ///
 /// \rst
-/// .. code-block::
+/// .. code-block:: cpp
 ///   torch::nn::AnyModule module(torch::nn::Linear(3, 4));
 ///   auto output = module.forward(torch::ones({2, 3}));
 ///
@@ -97,7 +97,7 @@ namespace nn {
 /// using `.get<T>()` where `T` is the concrete module type.
 ///
 /// \rst
-/// .. code-block::
+/// .. code-block:: cpp
 ///   torch::nn::AnyModule module(torch::nn::Linear(3, 4));
 ///   std::shared_ptr<nn::Module> ptr = module.ptr();
 ///   torch::nn::Linear linear(module.get<torch::nn::Linear>());

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -18,18 +18,81 @@
 
 namespace torch {
 namespace nn {
-/// A `Sequential` module is a container for any number of other modules. Its
-/// `forward()` method chains outputs to inputs and returns the final output.
-/// The `Sequential` class reference semantics.
+
+/// A list of `Module`s that acts as a `Module` itself.
+///
+/// A `Sequential` is fundamentally a list of objects that are subclasses of
+/// module and each have a `forward()` method. `Sequential` provides a
+/// `forward()` method of its own, which accepts any input and forwards it to
+/// the first module it stores. It then "chains" outputs to inputs sequentially
+/// for each subsequent module, finally returning the output of the last module.
+/// For example:
+///
+/// \rst
+/// .. code-block:: cpp
+///
+///   torch::nn::Sequential seq(
+///     torch::nn::Linear(3, 4),
+///     torch::nn::BatchNorm(4),
+///     torch::nn::Dropout(0.5)
+///   );
+///
+///   auto output = seq->forward(torch::ones(3));
+///
+/// \endrst
+///
+/// This can conceptually be thought of as the following loop (using Python as
+/// pseudocode):
+///
+/// \rst
+/// .. code-block:: python
+///
+///   def forward(sequential, input):
+///     for module in sequential:
+///       input = module(input)
+///     return input
+///
+/// \endrst
+///
+/// The value a `Sequential` further provides is that it allows treating a whole
+/// list of modules as a single module, such that performing a
+/// transformation on the `Sequential` applies to each of the modules it stores
+/// (which are each a registered submodule of the `Sequential`). For example,
+/// calling `.to(torch::kCUDA)` on a `Sequential` will move each module in the
+/// list to CUDA memory. For example:
+///
+/// \rst
+/// .. code-block:: cpp
+///
+///   torch::nn::Sequential seq(
+///     torch::nn::Linear(3, 4),
+///     torch::nn::BatchNorm(4),
+///     torch::nn::Dropout(0.5)
+///   );
+///
+///   // Convert all modules to CUDA.
+///   seq->to(torch::kCUDA);
+///
+/// \endrst
+///
+/// Finally, `Sequential` provides a lightweight container API, such as allowing
+/// iteration over submodules, positional access, adding a new module after
+/// construction via `push_back`, as well as joining two `Sequential`s via
+/// `extend`.
+///
+/// \rst
+/// .. attention::
+///   One current limitation of `Sequential` is that all except the first module
+///   must accept a single argument. You may define your modules to take tuples
+///   to satisfy this constraints, but `Sequential` will currently not unpack
+///   this tuple into an argument list for you.
+/// \endrst
 class SequentialImpl : public Cloneable<SequentialImpl> {
  public:
   using Iterator = std::vector<AnyModule>::iterator;
   using ConstIterator = std::vector<AnyModule>::const_iterator;
 
-  /// Constructs the `Sequential` from a pack of modules. Each module can either
-  /// be a plain value (e.g. `Linear`) or a boxed value (e.g.
-  /// `shared_ptr<Linear>`). Unboxed modules will be moved into `shared_ptr`s
-  /// internally.
+  /// Constructs the `Sequential` from a variadic list of modules.
   template <typename... Modules>
   explicit SequentialImpl(Modules&&... modules) {
     modules_.reserve(sizeof...(Modules));
@@ -47,19 +110,34 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     return clone;
   }
 
-  /// `reset()` is empty for `Sequential`, since it does not have parameter of
+  /// `reset()` is empty for `Sequential`, since it does not have parameters of
   /// its own.
   void reset() override {}
 
-  /// Feeds the `inputs` to the first module, then chains the output of each
-  /// module with the input of the next, in order of construction.
-  template <typename ReturnType = Tensor, typename... ArgumentTypes>
-  ReturnType forward(ArgumentTypes&&... arguments) {
+  /// Feeds `inputs` to the first module and then chains outputs to inputs,
+  /// returning the last output.
+  ///
+  /// Conceptually the following loop in Python:
+  ///
+  /// \rst
+  /// .. code-block:: python
+  ///
+  ///   def forward(sequential, input):
+  ///     for module in sequential:
+  ///       input = module(input)
+  ///     return input
+  ///
+  /// \endrst
+  ///
+  /// The return type is taken as the first template parameter. It defaults to
+  /// `Tensor`. If the last module in the `Sequential` returns another type `T`,
+  /// you should call `forward<T>(inputs)` instead of just `forward(inputs)`.
+  template <typename ReturnType = Tensor, typename... InputTypes>
+  ReturnType forward(InputTypes&&... inputs) {
     AT_CHECK(!is_empty(), "Cannot call forward() on an empty Sequential");
 
     auto iterator = modules_.begin();
-    auto input =
-        iterator->any_forward(std::forward<ArgumentTypes>(arguments)...);
+    auto input = iterator->any_forward(std::forward<InputTypes>(inputs)...);
 
     for (++iterator; iterator != modules_.end(); ++iterator) {
       input = iterator->any_forward(std::move(input));
@@ -126,6 +204,8 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   Iterator begin() {
     return modules_.begin();
   }
+
+  /// Returns a const iterator to the start of the `Sequential`.
   ConstIterator begin() const {
     return modules_.begin();
   }
@@ -134,6 +214,8 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   Iterator end() {
     return modules_.end();
   }
+
+  /// Returns a const iterator to the end of the `Sequential`.
   ConstIterator end() const {
     return modules_.end();
   }
@@ -227,6 +309,10 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   std::vector<AnyModule> modules_;
 };
 
+/// A `ModuleHolder` subclass for `SequentialImpl`.
+/// See the documentation for `SequentialImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Sequential);
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
1. Document the Sequential module in the C++ API at a high, why-does-this-exist, and low, how-to-use, level
2. Change the Sequential tests to be in a style that makes them easier to convert to gtest. No code changes.

@ebetica @ezyang @apaszke 