### PR TITLE
Move some Tensor method definitions from Type.h to TensorMethods.h.

### DIFF
--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1215,6 +1215,22 @@ inline Scalar Tensor::_local_scalar() const {
     return type()._local_scalar(*this);
 }
 
+inline bool Tensor::is_variable() const noexcept {
+  return type().is_variable();
+}
+
+inline ScalarType Tensor::dtype() const noexcept {
+  return type().scalarType();
+}
+
+inline Layout Tensor::layout() const noexcept {
+  return type().layout();
+}
+
+inline Device Tensor::device() const {
+  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
+}
+
 #define DEFINE_CAST(T, name, _)                  \
   template <>                                    \
   inline T* Tensor::data() const {               \

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -629,20 +629,4 @@ protected:
 
 };
 
-inline bool Tensor::is_variable() const noexcept {
-  return type().is_variable();
-}
-
-inline ScalarType Tensor::dtype() const noexcept {
-  return type().scalarType();
-}
-
-inline Layout Tensor::layout() const noexcept {
-  return type().layout();
-}
-
-inline Device Tensor::device() const {
-  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
-}
-
 } // namespace at

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -55,6 +55,22 @@ inline void Tensor::set_data(Tensor new_data) {
 // all static inline to allow for inlining of the non-dynamic part of dispatch
 ${tensor_method_definitions}
 
+inline bool Tensor::is_variable() const noexcept {
+  return type().is_variable();
+}
+
+inline ScalarType Tensor::dtype() const noexcept {
+  return type().scalarType();
+}
+
+inline Layout Tensor::layout() const noexcept {
+  return type().layout();
+}
+
+inline Device Tensor::device() const {
+  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
+}
+
 #define DEFINE_CAST(T, name, _)                  \
   template <>                                    \
   inline T* Tensor::data() const {               \

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -143,20 +143,4 @@ protected:
 
 };
 
-inline bool Tensor::is_variable() const noexcept {
-  return type().is_variable();
-}
-
-inline ScalarType Tensor::dtype() const noexcept {
-  return type().scalarType();
-}
-
-inline Layout Tensor::layout() const noexcept {
-  return type().layout();
-}
-
-inline Device Tensor::device() const {
-  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
-}
-
 } // namespace at


### PR DESCRIPTION
There's no reason they need to be in Type.h and this moves us along the path of not having circular dependencies (so we can get rid of TensorMethods.h).