### PR TITLE
s/GetDevicetype/device_type/

### DIFF
--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -61,7 +61,7 @@ class AT_CORE_API BaseContext {
   virtual BaseStaticContext* GetStaticContext() const = 0;
 
   /* Sorry for the naming, will get rid of this in future diff */
-  virtual DeviceType GetDevicetype() const = 0;
+  virtual DeviceType device_type() const = 0;
 
   virtual void SwitchToDevice(int /*stream_id*/) = 0;
 
@@ -96,13 +96,13 @@ class AT_CORE_API BaseContext {
       DeviceType type) {
     if (type == DeviceType::CPU) {
       CopyBytesToCPU(nbytes, src, dst);
-    } else if (type == GetDevicetype()) {
+    } else if (type == device_type()) {
       CopyBytesSameDevice(nbytes, src, dst);
     } else {
       AT_ERROR(
           "CopyBytesToDevice can only copy to CPU or between same "
           "device. Can't copy from: ",
-          GetDevicetype(),
+          device_type(),
           " to",
           type);
     }

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -153,7 +153,7 @@ class CAFFE2_API CPUContext final : public BaseContext {
     return true;
   }
 
-  DeviceType GetDevicetype() const override {
+  DeviceType device_type() const override {
     return CPU;
   }
 

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -285,7 +285,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     return cudaStreamQuery(stream) == cudaSuccess;
   }
 
-  DeviceType GetDevicetype() const override {
+  DeviceType device_type() const override {
     return CUDA;
   }
 

--- a/caffe2/core/hip/context_hip.h
+++ b/caffe2/core/hip/context_hip.h
@@ -269,7 +269,7 @@ class HIPContext final : public BaseContext {
     return hipStreamQuery(stream) == hipSuccess;
   }
 
-  DeviceType GetDevicetype() const override {
+  DeviceType device_type() const override {
     return HIP;
   }
 

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -139,7 +139,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       const std::vector<TIndex>& dims,
       const std::vector<T>& values,
       at::BaseContext* context)
-      : storage_(context->GetDevicetype(), TypeMeta::Make<T>()) {
+      : storage_(context->device_type(), TypeMeta::Make<T>()) {
     Resize(dims);
     CAFFE_ENFORCE_EQ_WITH_CALLER(values.size(), numel_);
     context->CopyItemsFromCPU(
@@ -154,7 +154,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       typename T,
       typename = typename std::enable_if<std::is_scalar<T>::value>::type>
   TensorImpl(const T& value, at::BaseContext* context)
-      : storage_(context->GetDevicetype(), TypeMeta::Make<T>()) {
+      : storage_(context->device_type(), TypeMeta::Make<T>()) {
     Resize(std::vector<TIndex>{});
     context->CopyItemsFromCPU(
         storage_.dtype(), numel_, &value, mutable_data<T>());
@@ -236,7 +236,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
                 nbytes(), src.raw_data(), raw_mutable_data(), GetDeviceType());
           } else {
             CAFFE_ENFORCE(
-                context->GetDevicetype() == src.GetDeviceType(),
+                context->device_type() == src.GetDeviceType(),
                 "Type for provided context does not match the type of source");
             context->CopyBytesToDevice(
                 nbytes(), src.raw_data(), raw_mutable_data(), GetDeviceType());

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -119,7 +119,7 @@ class IDEEPContext final : public BaseContext {
     return true;
   }
 
-  DeviceType GetDevicetype() const override {
+  DeviceType device_type() const override {
     return IDEEP;
   }
 

--- a/caffe2/mkl/utils/mkl_context.h
+++ b/caffe2/mkl/utils/mkl_context.h
@@ -127,7 +127,7 @@ class MKLContext : public BaseContext {
     return true;
   }
 
-  DeviceType GetDevicetype() const override {
+  DeviceType device_type() const override {
     return MKLDNN;
   }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11637 [pytorch][PR] Merge caffe2::/at::Storage&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9806425/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11642 Split tensor.h into tensor_impl.h and tensor.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9810823/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11643 Reduce includes in tensor_impl.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9811028/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11656 s/GetDevicetype/device_type/**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9813544/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11657 Refactor Tensor/TensorImpl constructors.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9813742/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11659 Reimplement swap() using default move constructor.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9814536/)

The mis-capitalization really sticks up my craw.  I know why (we
already have a static function named GetDeviceType), but let's
name it differently.

```
codemod -d . --extensions cc,cpp,cu,cuh,h,py,hpp,TARGETS GetDevicetype device_type
```

Differential Revision: [D9813544](https://our.internmc.facebook.com/intern/diff/D9813544/)