### PR TITLE
Refactor Tensor/TensorImpl constructors.

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -50,45 +50,75 @@ class CAFFE2_API Tensor final {
     return impl_.get();
   }
 
-  explicit Tensor(DeviceType type)
-      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(type)) {}
+  explicit Tensor(Storage storage)
+      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(std::move(storage))) {}
 
+  /**
+   * @brief Creates a tensor of the given dimension.
+   *
+   * Note that the actual data allocation is not going to be carried out until
+   * the first time mutable_data() is called.
+   */
   explicit Tensor(const vector<TIndex>& dims, DeviceType type)
-      : impl_(
-            c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(dims, type)) {}
+      : Tensor(Storage(type)) {
+    // TODO: here, we create a Storage
+    // and immediately discard it in Resize() since
+    // reset_tensor will be true and FreeMemory will be called,
+    // we might want to avoid creating Storage twice?
+    Resize(dims);
+  }
 
   explicit Tensor(const vector<int>& dims, DeviceType type)
-      : impl_(
-            c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(dims, type)) {}
+      : Tensor(Storage(type)) {
+    Resize(dims);
+  }
 
+  /**
+   * context_for_copy is required to have the same DeviceType as src
+   */
   Tensor(const Tensor& src, BaseContext* context_for_copy, DeviceType type)
-      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
-            *src.impl_,
-            context_for_copy,
-            type)) {}
+      : Tensor(Storage(type)) {
+    CopyFrom(src, context_for_copy);
+  }
 
+  /**
+   * @brief: Create a Tensor of at::DeviceType `type` and initialize it with
+   * src Tensor
+   */
   Tensor(const Tensor& src, DeviceType type)
-      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
-            *src.impl_,
-            type)) {}
+      : Tensor(Storage(type)) {
+    CopyFrom(src);
+  }
 
+  /**
+   * @brief Creates a tensor, and fills its contents with the given values.
+   * The type of tensor will be decided by the context parameter
+   */
   template <typename T>
   Tensor(
       const vector<TIndex>& dims,
       const vector<T>& values,
       BaseContext* context)
-      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
-            dims,
-            values,
-            context)) {}
+      : Tensor(Storage(context->device_type(), TypeMeta::Make<T>())) {
+    Resize(dims);
+    CAFFE_ENFORCE_EQ_WITH_CALLER(values.size(), size());
+    context->CopyItemsFromCPU(
+        storage().dtype(), size(), values.data(), mutable_data<T>());
+  }
 
+  /**
+   * @brief Creates a scalar tensor, and fills its content with the given value.
+   * The type of tensor will be decided by the context parameter
+   */
   template <
       typename T,
       typename = typename std::enable_if<std::is_scalar<T>::value>::type>
   Tensor(const T& value, BaseContext* context)
-      : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
-            value,
-            context)) {}
+      : Tensor(Storage(context->device_type(), TypeMeta::Make<T>())) {
+    Resize(std::vector<TIndex>{});
+    context->CopyItemsFromCPU(
+        storage().dtype(), size(), &value, mutable_data<T>());
+  }
 
   Tensor Clone() const {
     Tensor x(GetDeviceType());
@@ -274,6 +304,10 @@ class CAFFE2_API Tensor final {
 
   inline void ExtractDeviceOption(DeviceOption* device) const {
     return impl_.get()->ExtractDeviceOption(device);
+  }
+
+  const Storage& storage() {
+    return impl_->storage();
   }
 };
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11637 [pytorch][PR] Merge caffe2::/at::Storage&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9806425/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11642 Split tensor.h into tensor_impl.h and tensor.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9810823/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11643 Reduce includes in tensor_impl.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9811028/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11656 s/GetDevicetype/device_type/&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9813544/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11657 Refactor Tensor/TensorImpl constructors.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9813742/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11659 Reimplement swap() using default move constructor.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9814536/)

Previously, we had a constructor in TensorImpl for every constructor in Tensor.
This was unnecessary and wordy: Tensor is the user-visible class, so it deserves
the constructors, but TensorImpl is internal and doesn't need it.  So
I replaced TensorImpl with a single, Storage accepting constructor, and then
rewrote Tensor to use that constructor.

Differential Revision: [D9813742](https://our.internmc.facebook.com/intern/diff/D9813742/)