### PR TITLE
Reimplement swap() using default move constructor.

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -188,7 +188,8 @@ class CAFFE2_API Tensor final {
   // swap method swaps the CONTENTS of the tensors, while std::swap
   // swaps the POINTERS.
   void swap(const Tensor& other) const noexcept {
-    impl_.get()->swap(*other.impl_.get());
+    // NB: use get() to get a non-const pointer!
+    std::swap(*impl_.get(), *other.impl_.get());
   }
 
   void ShareData(const Tensor& src) const {

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -91,19 +91,10 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
 
   explicit TensorImpl(at::Storage storage) : storage_(std::move(storage)) {}
 
-  /**
-   * @brief Delete the copy constructor and use Clone explicitly
-   */
-  TensorImpl(const TensorImpl& src) = delete;
-
-  TensorImpl(TensorImpl&& src) noexcept {
-    swap(src);
-  }
-
+  TensorImpl(const TensorImpl&) = default;
+  TensorImpl& operator=(const TensorImpl&) = default;
+  TensorImpl(TensorImpl&&) = default;
   TensorImpl& operator=(TensorImpl&&) = default;
-  // Note(jiayq): possibly a rule-of-three violation, but we explicitly
-  // discourage the use of = for Tensors.
-  TensorImpl& operator=(const TensorImpl& src) = delete;
 
   virtual ~TensorImpl() noexcept {}
 
@@ -395,12 +386,6 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     }
     ss << ").";
     return ss.str();
-  }
-
-  void swap(TensorImpl& other) noexcept {
-    std::swap(dims_, other.dims_);
-    std::swap(numel_, other.numel_);
-    std::swap(storage_, other.storage_);
   }
 
   /**


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11637 [pytorch][PR] Merge caffe2::/at::Storage&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9806425/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11642 Split tensor.h into tensor_impl.h and tensor.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9810823/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11643 Reduce includes in tensor_impl.h&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9811028/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11656 s/GetDevicetype/device_type/&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9813544/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11657 Refactor Tensor/TensorImpl constructors.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9813742/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11659 Reimplement swap() using default move constructor.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9814536/)

This is less error-prone and less code.

Differential Revision: [D9814536](https://our.internmc.facebook.com/intern/diff/D9814536/)