### PR TITLE
Throw error on indexing a 0 dim tensor

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -274,12 +274,14 @@ class TestIndexing(TestCase):
         self.assertRaisesRegex(TypeError, 'slice indices', lambda: x["0":"1"])
 
     def test_zero_dim_index(self):
-        # We temporarily support indexing a zero-dim tensor as if it were
-        # a one-dim tensor to better maintain backwards compatibility.
         x = torch.tensor(10)
-        with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(x, x[0])
-            self.assertEqual(len(w), 1)
+        self.assertEqual(x, x.item())
+
+        def runner():
+            print(x[0])
+            return x[0]
+
+        self.assertRaisesRegex(IndexError, 'invalid index', runner)
 
 
 # The tests below are from NumPy test_indexing.py with some modifications to

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -91,11 +91,9 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
 
 static Variable applySelect(const Variable& self, int64_t dim, int64_t index) {
   if (index == 0 && dim == 0 && self.dim() == 0) {
-    // Deprecated support for indexing 0-dim tensors as if they were 1-dim.
-    PyErr_WarnEx(PyExc_UserWarning,
-        "invalid index of a 0-dim tensor. This will be an error in PyTorch 0.5. "
-        "Use tensor.item() to convert a 0-dim tensor to a Python number", 1);
-    return at::alias(self);
+    throw IndexError(
+        "invalid index of a 0-dim tensor. "
+        "Use tensor.item() to convert a 0-dim tensor to a Python number");
   }
   int64_t size = self.size(dim);
   if (index < -size || index >= size) {


### PR DESCRIPTION
Following through on warning that indexing 0-dim tensor would be an
error in PyTorch 0.5 and to use `item()` instead

