### PR TITLE
[pt1][tensor] Remove ExtractDeviceOptoin in StaticContext

### DIFF
--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -32,13 +32,6 @@ class AT_CORE_API BaseStaticContext {
 
   virtual DeviceType GetDeviceType() = 0;
 
-  /*
-   * @brief: Sets the DeviceOption for argument `device` based on the
-   * current context and the a data pointer
-   */
-  virtual void ExtractDeviceOption(
-      caffe2::DeviceOption* device,
-      const void* /*data*/) = 0;
 };
 
 /**

--- a/caffe2/core/context.cc
+++ b/caffe2/core/context.cc
@@ -33,4 +33,17 @@ BaseStaticContext* GetCPUStaticContext() {
 
 REGISTER_STATIC_CONTEXT(CPU, GetCPUStaticContext());
 
+struct ExtractDeviceOptionCPU : public ExtractDeviceOptionFn {
+  void operator()(DeviceOption* device, const void* data) override {
+    device->set_device_type(PROTO_CPU);
+  }
+};
+
+ExtractDeviceOptionFn* GetExtractDeviceOptionCPU() {
+  static ExtractDeviceOptionCPU fn;
+  return &fn;
+}
+
+REGISTER_DEVICE_OPTION_FN(CPU, GetExtractDeviceOptionCPU);
+
 } // namespace caffe2

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -196,11 +196,6 @@ class CAFFE2_API CPUStaticContext : public BaseStaticContext {
     return CPU;
   }
 
-  void ExtractDeviceOption(DeviceOption* device, const void* /*data*/)
-      override {
-    device->set_device_type(TypeToProto(GetDeviceType()));
-  }
-
  protected:
   static MemoryAllocationReporter reporter_;
 

--- a/caffe2/core/context_base.cc
+++ b/caffe2/core/context_base.cc
@@ -19,6 +19,11 @@ BaseStaticContext* get_static_context(DeviceType t) {
   return ptr;
 }
 
+CAFFE_DEFINE_POINTER_REGISTRY(
+    ExtractDeviceOptionFnRegistry,
+    DeviceType,
+    ExtractDeviceOptionFn*);
+
 CAFFE_DEFINE_TYPED_REGISTRY(
     ContextRegistry,
     DeviceType,

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -408,4 +408,11 @@ BaseStaticContext* GetCUDAStaticContext() {
 
 REGISTER_STATIC_CONTEXT(CUDA, GetCUDAStaticContext());
 
+void ExtractDeviceOptionCUDA(DeviceOption* device, const void* data) {
+  device->set_device_type(PROTO_CUDA);
+  device->set_cuda_gpu_id(GetGPUIDForPointer(data));
+}
+
+// REGISTER_DEVICE_OPTION_FN(CUDA, ExtractDeviceOptionCUDA);
+
 }  // namespace caffe2

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -389,12 +389,6 @@ class CAFFE2_CUDA_API CUDAStaticContext final : public BaseStaticContext {
     return CUDA;
   }
 
-  void ExtractDeviceOption(DeviceOption* device, const void* data) override {
-    CAFFE_ENFORCE(data, "data cannot be nullptr");
-    device->set_device_type(TypeToProto(GetDeviceType()));
-    device->set_cuda_gpu_id(GetGPUIDForPointer(data));
-  }
-
  protected:
   static void Delete(void* data);
 };

--- a/caffe2/core/hip/context_hip.cc
+++ b/caffe2/core/hip/context_hip.cc
@@ -427,4 +427,11 @@ BaseStaticContext* GetHIPStaticContext() {
 
 REGISTER_STATIC_CONTEXT(HIP, GetHIPStaticContext());
 
+void ExtractDeviceOptionHIP(DeviceOption* device, const void* data) {
+  device->set_device_type(PROTO_HIP);
+  device->set_cuda_hip_id(GetGPUIDForPointer(data));
+}
+
+// REGISTER_DEVICE_OPTION_FN(HIP, ExtractDeviceOptionHIP);
+
 } // namespace caffe2

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -75,8 +75,6 @@ void RegisterTypeCallFunction(TypeIdentifier id, TypeCall c) {
   type_call_registry_[id] = c;
 }
 
-int GetGPUIDForPointer(const void* ptr);
-
 vector<TIndex> GetTensorInfo(
     const void* c,
     size_t* capacity,

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -725,7 +725,7 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   void ExtractDeviceOption(DeviceOption* device) const {
-    GetStaticContext()->ExtractDeviceOption(device, raw_data());
+    caffe2::ExtractDeviceOption(device, raw_data(), GetDeviceType());
   }
 
   const at::Storage& storage() {

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -182,10 +182,6 @@ class IDEEPStaticContext : public BaseStaticContext {
     return IDEEP;
   }
 
-  void ExtractDeviceOption(DeviceOption* device, const void* /*data*/)
-      override {
-    device->set_device_type(TypeToProto(GetDeviceType()));
-  }
 };
 
 } // namespace caffe2

--- a/caffe2/ideep/utils/ideep_register.cc
+++ b/caffe2/ideep/utils/ideep_register.cc
@@ -36,4 +36,10 @@ BaseStaticContext* GetIDEEPStaticContext() {
 
 REGISTER_STATIC_CONTEXT(IDEEP, GetIDEEPStaticContext());
 
+void ExtractDeviceOptionIDEEP(DeviceOption* device, const void* data) {
+  device->set_device_type(PROTO_IDEEP);
+}
+
+// REGISTER_DEVICE_OPTION_FN(IDEEP, ExtractDeviceOptionIDEEP);
+
 } // namespace caffe2

--- a/caffe2/mkl/utils/mkl_context.cc
+++ b/caffe2/mkl/utils/mkl_context.cc
@@ -28,4 +28,10 @@ BaseStaticContext* GetMKLStaticContext() {
 
 REGISTER_STATIC_CONTEXT(MKLDNN, GetMKLStaticContext());
 
+void ExtractDeviceOptionMKLDNN(DeviceOption* device, const void* data) {
+  device->set_device_type(PROTO_MKLDNN);
+}
+
+// REGISTER_DEVICE_OPTION_FN(MKLDNN, ExtractDeviceOptionMKLDNN);
+
 } // namespace caffe2

--- a/caffe2/mkl/utils/mkl_context.h
+++ b/caffe2/mkl/utils/mkl_context.h
@@ -159,10 +159,6 @@ class MKLStaticContext : public BaseStaticContext {
     return MKLDNN;
   }
 
-  void ExtractDeviceOption(DeviceOption* device, const void* /*data*/)
-      override {
-    device->set_device_type(TypeToProto(GetDeviceType()));
-  }
 };
 
 } // namespace caffe2


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11688 [pt1][tensor] Move CreateContext to global registry&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9779821/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11689 [pt1][tensor] Remove ExtractDeviceOptoin in StaticContext**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9826209/)

Move the ExtractDeviceOption function to a global registry

Differential Revision: [D9826209](https://our.internmc.facebook.com/intern/diff/D9826209/)