### PR TITLE
Casting for binary ops

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -98,7 +98,8 @@ void TensorIterator::compute_common_type() {
       if (op.tensor->defined() && type != op.tensor->type()) {
         if (op.tensor->dim() == 0) {
           if (type.backend() != at::Backend::CUDA) {
-            *op.tensor = op.tensor->toType(type);
+            cast_tensors_.emplace_back(op.tensor->toType(type));
+            op.tensor = &(cast_tensors_.back());
           }
         } else {
           op.needs_cast = true;

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -184,6 +184,7 @@ private:
   DimVector shape_;
   DimVector perm_;
   SmallVector<OperandInfo, 4> operands_;
+  SmallVector<Tensor, 4> cast_tensors_;
   int num_outputs_ = 0;
   bool has_coalesced_dimensions_ = false;
 };

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8861,6 +8861,20 @@ class TestTorch(TestCase):
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.cuda.FloatTensor())
         self.assertRaisesRegex(AssertionError, msg, lambda: torch.tensor([1]).to(device="cuda"))
 
+    def test_cast_binary_op(self):
+        # Scalar
+        a = torch.tensor(2)
+        b = torch.tensor(3)
+        a_copy = a.clone()
+        b_copy = b.clone()
+
+        self.assertEqual(torch.tensor(6), a.float() * b)
+
+        self.assertEqual(a.type(), a_copy.type())
+        self.assertEqual(a.data.type(), a_copy.data.type())
+        self.assertEqual(b.type(), b_copy.type())
+        self.assertEqual(b.data.type(), b_copy.type())
+
 
 # Functions to test negative dimension wrapping
 METHOD = 1


### PR DESCRIPTION
Fixes #11663

`TensorIterator` was replacing the op tensors with type casted tensors
which ended up producing side effects in binary ops like `a.float() * b`
where `a` and `b` are `LongTensor`s.

@colesbury @ezyang @apaszke 
