### PR TITLE
Include some JIT things in C++ docs

### DIFF
--- a/docs/cpp/Doxyfile
+++ b/docs/cpp/Doxyfile
@@ -752,6 +752,10 @@ WARN_LOGFILE           =
 
 INPUT                  =  ../../torch/csrc/api/include \
                           ../../torch/csrc/api/src \
+                          ../../torch/csrc/jit/custom_operator.h \
+                          ../../torch/csrc/jit/import.h \
+                          ../../torch/csrc/jit/ivalue.h \
+                          ../../torch/csrc/jit/script/module.h \
                           ../../aten/src/ATen/ATen.h \
                           ../../aten/src/ATen/Backend.h \
                           ../../aten/src/ATen/Device.h \

--- a/docs/cpp/check-doxygen.sh
+++ b/docs/cpp/check-doxygen.sh
@@ -21,11 +21,12 @@ ignore_warning "warning: source ../../build/aten/src/ is not a readable file"
 ignore_warning "warning: source ../../build/aten/src/ATen/Tensor.h is not a readable file"
 ignore_warning "warning: source ../../build/aten/src/ATen/Functions.h is not a readable file"
 ignore_warning "warning: documented symbol \`torch::nn::FunctionalImpl::FunctionalImpl' was not declared or defined"
+ignore_warning "functional.h:81: warning: Found ';' while parsing initializer list!"
 
 # Count the number of remaining warnings.
-warnings=$(grep 'warning:' doxygen-log.txt | wc -l)
+warnings="$(grep 'warning:' doxygen-log.txt | wc -l)"
 
-if [[ $warnings != 0 ]]; then
+if [[ "$warnings" -ne "0" ]]; then
   echo "Filtered output"
   cat doxygen-log.txt
   rm -f doxygen-log.txt original-doxygen-log.txt

--- a/test/custom_operator/op.cpp
+++ b/test/custom_operator/op.cpp
@@ -16,7 +16,7 @@ std::vector<at::Tensor> custom_op(
 }
 
 static auto registry =
-    torch::RegisterOperators()
+    torch::jit::RegisterOperators()
         // We parse the schema for the user.
         .op("custom::op", &custom_op)
         // User provided schema. Among other things, allows defaulting values,

--- a/torch/csrc/jit/import.h
+++ b/torch/csrc/jit/import.h
@@ -3,7 +3,8 @@
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/script/module.h"
 
-namespace torch { namespace jit {
+namespace torch {
+namespace jit {
 
 using ModuleLookup = std::function<std::shared_ptr<script::Module>(
     const std::vector<std::string>&)>;
@@ -12,6 +13,12 @@ TORCH_API void import_ir_module(
     ModuleLookup module_lookup,
     const std::string& filename);
 
+/// Loads a serialized `script::Module` from the given `filename`.
+///
+/// The file stored at the location given in `filename` must contain a
+/// serialized `script::Module`, exported either via `ScriptModule.save()` in
+/// Python or `torch::jit::ExportModule` in C++.
 TORCH_API std::shared_ptr<script::Module> load(const std::string& filename);
 
-}}
+} // namespace jit
+} // namespace torch

--- a/torch/script.h
+++ b/torch/script.h
@@ -6,8 +6,3 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <ATen/ATen.h>
-
-namespace torch {
-using jit::createOperator;
-using jit::RegisterOperators;
-} // namespace torch


### PR DESCRIPTION
Since we're making parts of the JIT public as part of loading script modules, they should be on the cppdocs website.

Orthogonal: We decided not to export things like `IValue` into the `torch` namespace, so `RegisterOperators` shouldn't be there either.