### PR TITLE
dtype option for softmax

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -510,6 +510,7 @@ public:
   Tensor log2() const;
   Tensor & log2_();
   Tensor logdet() const;
+  Tensor log_softmax(int64_t dim, ScalarType dtype) const;
   Tensor log_softmax(int64_t dim) const;
   Tensor logsumexp(int64_t dim, bool keepdim=false) const;
   Tensor matmul(const Tensor & other) const;
@@ -564,6 +565,7 @@ public:
   Tensor slice(int64_t dim=0, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1) const;
   std::tuple<Tensor,Tensor> slogdet() const;
   Tensor smm(const Tensor & mat2) const;
+  Tensor softmax(int64_t dim, ScalarType dtype) const;
   Tensor softmax(int64_t dim) const;
   std::vector<Tensor> split(int64_t split_size, int64_t dim=0) const;
   std::vector<Tensor> split_with_sizes(IntList split_sizes, int64_t dim=0) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -833,6 +833,9 @@ inline Tensor & Tensor::log2_() {
 inline Tensor Tensor::logdet() const {
     return type().logdet(*this);
 }
+inline Tensor Tensor::log_softmax(int64_t dim, ScalarType dtype) const {
+    return type().log_softmax(*this, dim, dtype);
+}
 inline Tensor Tensor::log_softmax(int64_t dim) const {
     return type().log_softmax(*this, dim);
 }
@@ -994,6 +997,9 @@ inline std::tuple<Tensor,Tensor> Tensor::slogdet() const {
 }
 inline Tensor Tensor::smm(const Tensor & mat2) const {
     return type().smm(*this, mat2);
+}
+inline Tensor Tensor::softmax(int64_t dim, ScalarType dtype) const {
+    return type().softmax(*this, dim, dtype);
 }
 inline Tensor Tensor::softmax(int64_t dim) const {
     return type().softmax(*this, dim);

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -469,6 +469,7 @@ struct CAFFE2_API Type {
   virtual Tensor log2(const Tensor & self) const = 0;
   virtual Tensor & log2_(Tensor & self) const = 0;
   virtual Tensor logdet(const Tensor & self) const = 0;
+  virtual Tensor log_softmax(const Tensor & self, int64_t dim, ScalarType dtype) const = 0;
   virtual Tensor log_softmax(const Tensor & self, int64_t dim) const = 0;
   virtual Tensor logsumexp(const Tensor & self, int64_t dim, bool keepdim) const = 0;
   virtual Tensor matmul(const Tensor & self, const Tensor & other) const = 0;
@@ -523,6 +524,7 @@ struct CAFFE2_API Type {
   virtual Tensor slice(const Tensor & self, int64_t dim, int64_t start, int64_t end, int64_t step) const = 0;
   virtual std::tuple<Tensor,Tensor> slogdet(const Tensor & self) const = 0;
   virtual Tensor smm(const Tensor & self, const Tensor & mat2) const = 0;
+  virtual Tensor softmax(const Tensor & self, int64_t dim, ScalarType dtype) const = 0;
   virtual Tensor softmax(const Tensor & self, int64_t dim) const = 0;
   virtual std::vector<Tensor> split(const Tensor & self, int64_t split_size, int64_t dim) const = 0;
   virtual std::vector<Tensor> split_with_sizes(const Tensor & self, IntList split_sizes, int64_t dim) const = 0;

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -397,7 +397,8 @@ _(aten, log_sigmoid) \
 _(aten, log_sigmoid_backward) \
 _(aten, log_sigmoid_forward) \
 _(aten, log_softmax) \
-_(aten, log_softmax_backward_data) \
+_(aten, _log_softmax) \
+_(aten, _log_softmax_backward_data) \
 _(aten, logdet) \
 _(aten, logspace) \
 _(aten, logsumexp) \
@@ -577,7 +578,8 @@ _(aten, soft_margin_loss) \
 _(aten, soft_margin_loss_backward) \
 _(aten, soft_margin_loss_forward) \
 _(aten, softmax) \
-_(aten, softmax_backward_data) \
+_(aten, _softmax) \
+_(aten, _softmax_backward_data) \
 _(aten, softplus) \
 _(aten, softplus_backward) \
 _(aten, softplus_forward) \

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -119,8 +119,8 @@ void host_softmax_backward(
 }
 } // namespace
 
-Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool upconvert) {
-  AT_ASSERTM(!upconvert, "softmax with type upconvert not supported on CPU");
+Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_float) {
+  AT_ASSERTM(!half_to_float, "softmax with half to float conversion is not supported on CPU");
   auto input = input_.contiguous();
   Tensor output = at::native::empty_like(input);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
@@ -139,8 +139,8 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool upconver
   return output;
 }
 
-Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool upconvert) {
-  AT_ASSERTM(!upconvert, "softmax with type upconvert not supported on CPU");
+Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_float) {
+  AT_ASSERTM(!half_to_float, "softmax with half to float conversion is not supported on CPU");
   auto input = input_.contiguous();
   Tensor output = at::native::empty_like(input);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -119,7 +119,8 @@ void host_softmax_backward(
 }
 } // namespace
 
-Tensor softmax_cpu(const Tensor& input_, const int64_t dim_) {
+Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool upconvert) {
+  AT_ASSERTM(!upconvert, "softmax with type upconvert not supported on CPU");
   auto input = input_.contiguous();
   Tensor output = at::native::empty_like(input);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
@@ -138,7 +139,8 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_) {
   return output;
 }
 
-Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_) {
+Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool upconvert) {
+  AT_ASSERTM(!upconvert, "softmax with type upconvert not supported on CPU");
   auto input = input_.contiguous();
   Tensor output = at::native::empty_like(input);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
@@ -213,6 +215,30 @@ Tensor log_softmax_backward_cpu(
     });
   }
   return grad_input;
+}
+
+Tensor softmax(const Tensor& input_, const int64_t dim_) {
+  return at::_softmax(input_, dim_, false);
+}
+
+Tensor softmax(const Tensor& input_, const int64_t dim_, ScalarType dtype) {
+  if (input_.is_cuda() && input_.type().scalarType() == ScalarType::Half && dtype == ScalarType::Float){
+      return at::_softmax(input_, dim_, true);
+  } else {
+      return at::_softmax(input_.toType(dtype), dim_, false);
+  }
+}
+
+Tensor log_softmax(const Tensor& input_, const int64_t dim_) {
+  return at::_log_softmax(input_, dim_, false);
+}
+
+Tensor log_softmax(const Tensor& input_, const int64_t dim_, ScalarType dtype) {
+  if (input_.is_cuda() && input_.type().scalarType() == ScalarType::Half && dtype == ScalarType::Float){
+      return at::_log_softmax(input_, dim_, true);
+  } else {
+      return at::_log_softmax(input_.toType(dtype), dim_, false);
+  }
 }
 
 DEFINE_DISPATCH(softmax_lastdim_kernel);

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -9,59 +9,59 @@
 
 #include "ATen/AccumulateType.h"
 #include "ATen/cuda/NumericLimits.cuh"
-
+#include <type_traits>
 
 namespace at {
 namespace native {
 
 namespace {
 
-template<typename T, typename AccumT>
+template<typename T, typename AccumT, typename OutT>
 struct LogSoftMaxForwardEpilogue {
   __device__ __forceinline__ LogSoftMaxForwardEpilogue(AccumT max_input, AccumT sum)
     : logsum(max_input + std::log(sum)) {}
 
-  __device__ __forceinline__ T operator()(T input) const {
-    return static_cast<T>(input - logsum);
+  __device__ __forceinline__ OutT operator()(T input) const {
+    return static_cast<OutT>(input - logsum);
 }
 
   const AccumT logsum;
 };
 
-template<typename T, typename AccumT>
+template<typename T, typename AccumT, typename OutT>
 struct LogSoftMaxBackwardEpilogue {
   __device__ __forceinline__ LogSoftMaxBackwardEpilogue(AccumT sum)
     : sum(sum) {}
 
-  __device__ __forceinline__ T operator()(T gradOutput, T output) const {
+  __device__ __forceinline__ T operator()(OutT gradOutput, OutT output) const {
     return static_cast<T>(gradOutput - std::exp(static_cast<AccumT>(output)) * sum);
   }
 
   const AccumT sum;
 };
 
-template<typename T, typename AccumT>
+template<typename T, typename AccumT, typename OutT>
 struct SoftMaxForwardEpilogue {
   __device__ __forceinline__ SoftMaxForwardEpilogue(AccumT max_input, AccumT sum)
     : max_input(max_input)
     , sum(sum) {}
 
-  __device__ __forceinline__ T operator()(T input) const {
-    return static_cast<T>(std::exp(input - max_input) / sum);
+  __device__ __forceinline__ OutT operator()(T input) const {
+    return static_cast<OutT>(std::exp(input - max_input) / sum);
   }
 
   const AccumT max_input;
   const AccumT sum;
 };
 
-template<typename T, typename AccumT>
+template<typename T, typename AccumT, typename OutT>
 struct SoftMaxBackwardEpilogue {
   __device__ __forceinline__ SoftMaxBackwardEpilogue(AccumT sum)
     : sum(sum) {}
 
   // XXX: gradOutput that we get here is really gradOutput * output
   // Look for cmul in SoftMax_updateGradInput
-  __device__ __forceinline__ T operator()(T gradOutput, T output) const {
+  __device__ __forceinline__ T operator()(OutT gradOutput, OutT output) const {
     return static_cast<T>(gradOutput - output * sum);
   }
 
@@ -178,9 +178,9 @@ T spatialBlockReduceX(T *shared, T val) {
   return shared[0];
 }
 
-template <typename scalar_t, typename accscalar_t, template<typename, typename> class Epilogue>
+template <typename scalar_t, typename accscalar_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
 __global__ void cunn_SpatialSoftMaxForward(
-    scalar_t *output, scalar_t *input,
+    outscalar_t *output, scalar_t *input,
     uint32_t outer_size, uint32_t dim_size, uint32_t inner_size)
 {
   extern __shared__ unsigned char smem[];
@@ -213,7 +213,7 @@ __global__ void cunn_SpatialSoftMaxForward(
                  - max_input);
         sum = spatialBlockReduceX<accscalar_t, Add>(sdata, sum);
 
-        Epilogue<scalar_t, accscalar_t> epilogue(max_input, sum);
+        Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(max_input, sum);
         for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
           output[data_offset + d * dim_stride] = epilogue(input[data_offset + d * dim_stride]);
       } else {
@@ -226,7 +226,7 @@ __global__ void cunn_SpatialSoftMaxForward(
         for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
           sum += std::exp(static_cast<accscalar_t>(input[data_offset + d * dim_stride])
                  - max_input);
-        Epilogue<scalar_t, accscalar_t> epilogue(max_input, sum);
+        Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(max_input, sum);
         for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
           output[data_offset + d * dim_stride] = epilogue(input[data_offset + d * dim_stride]);
       }
@@ -236,9 +236,9 @@ __global__ void cunn_SpatialSoftMaxForward(
 
 
 
-template <typename scalar_t, typename accscalar_t, template<typename, typename> class Epilogue>
+template <typename scalar_t, typename accscalar_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
 __global__ void cunn_SpatialSoftMaxBackward(
-    scalar_t *gradInput, scalar_t *output, scalar_t *gradOutput,
+    scalar_t *gradInput, outscalar_t *output, outscalar_t *gradOutput,
     uint32_t outer_size, uint32_t dim_size, uint32_t inner_size)
 {
   extern __shared__ unsigned char smem[];
@@ -257,7 +257,7 @@ __global__ void cunn_SpatialSoftMaxBackward(
           sum += gradOutput[data_offset + d * dim_stride];
         sum = spatialBlockReduceX<accscalar_t, Add>(sdata, sum);
 
-        Epilogue<scalar_t, accscalar_t> epilogue(sum);
+        Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(sum);
         for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x) {
           gradInput[data_offset + d * dim_stride] =
             epilogue(gradOutput[data_offset + d * dim_stride],
@@ -268,7 +268,7 @@ __global__ void cunn_SpatialSoftMaxBackward(
         for (uint32_t d = 0; d < dim_size; d++)
           sum += gradOutput[data_offset + d * dim_stride];
 
-        Epilogue<scalar_t, accscalar_t> epilogue(sum);
+        Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(sum);
         for (uint32_t d = 0; d < dim_size; d++) {
           gradInput[data_offset + d * dim_stride] =
             epilogue(gradOutput[data_offset + d * dim_stride],
@@ -390,9 +390,9 @@ ilpReduce(T* data,
   return threadVal;
 }
 
-template <int ILP, typename scalar_t, typename accscalar_t, template <typename, typename> class Epilogue>
+template <int ILP, typename scalar_t, typename accscalar_t, typename outscalar_t, template <typename, typename, typename> class Epilogue>
 __global__ void
-cunn_SoftMaxForward(scalar_t *output, scalar_t *input, int classes)
+cunn_SoftMaxForward(outscalar_t *output, scalar_t *input, int classes)
 {
   extern __shared__ unsigned char smem[];
   auto sdata = reinterpret_cast<accscalar_t*>(smem);
@@ -413,7 +413,7 @@ cunn_SoftMaxForward(scalar_t *output, scalar_t *input, int classes)
   accscalar_t sumAll = blockReduce<Add, accscalar_t>(
       sdata, threadExp, Add<accscalar_t>(), static_cast<accscalar_t>(0));
 
-  Epilogue<scalar_t, accscalar_t> epilogue(max_k, sumAll);
+  Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(max_k, sumAll);
   int offset = threadIdx.x;
   int last = classes % (ILP * blockDim.x);
   for (; offset < classes - last; offset += blockDim.x * ILP) {
@@ -432,9 +432,9 @@ cunn_SoftMaxForward(scalar_t *output, scalar_t *input, int classes)
     output[offset] = epilogue(input[offset]);
 }
 
-template <int ILP, typename scalar_t, typename accscalar_t, template<typename, typename> class Epilogue>
+template <int ILP, typename scalar_t, typename accscalar_t, typename outscalar_t, template<typename, typename, typename> class Epilogue>
 __global__ void
-cunn_SoftMaxBackward(scalar_t *gradInput, scalar_t *output, scalar_t *gradOutput, int classes)
+cunn_SoftMaxBackward(scalar_t *gradInput, outscalar_t *output, outscalar_t *gradOutput, int classes)
 {
   extern __shared__ unsigned char smem[];
   auto sdata = reinterpret_cast<accscalar_t*>(smem);
@@ -442,17 +442,17 @@ cunn_SoftMaxBackward(scalar_t *gradInput, scalar_t *output, scalar_t *gradOutput
   output += blockIdx.x * classes;
   gradOutput += blockIdx.x * classes;
 
-  accscalar_t threadSum = ilpReduce<AddFloat, 4, scalar_t, accscalar_t>(
-      gradOutput, classes, AddFloat<scalar_t, accscalar_t>(), accscalar_t(0));
+  accscalar_t threadSum = ilpReduce<AddFloat, 4, outscalar_t, accscalar_t>(
+      gradOutput, classes, AddFloat<outscalar_t, accscalar_t>(), accscalar_t(0));
   accscalar_t sum_k = blockReduce<Add, accscalar_t>(
         sdata, threadSum, Add<accscalar_t>(), accscalar_t(0));
 
-  Epilogue<scalar_t, accscalar_t> epilogue(sum_k);
+  Epilogue<scalar_t, accscalar_t, outscalar_t> epilogue(sum_k);
   int offset = threadIdx.x;
   int last = classes % (ILP * blockDim.x);
   for (; offset < classes - last; offset += blockDim.x * ILP) {
-    scalar_t tmpGradOutput[ILP];
-    scalar_t tmpOutput[ILP];
+    outscalar_t tmpGradOutput[ILP];
+    outscalar_t tmpOutput[ILP];
 
 #pragma unroll
     for (int j = 0; j < ILP; ++j) {
@@ -474,10 +474,11 @@ cunn_SoftMaxBackward(scalar_t *gradInput, scalar_t *output, scalar_t *gradOutput
 
 
 
-template<template<typename, typename> class Epilogue>
-Tensor host_softmax(const Tensor & input_, const int64_t dim_){
+template<template<typename, typename, typename> class Epilogue>
+Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool upconvert){
+  if (upconvert) AT_ASSERTM(input_.type().scalarType() == ScalarType::Half,"upconvert is supported for Half type only");
   auto input = input_.contiguous();
-  Tensor output = at::empty_like(input);
+  Tensor output = upconvert ? at::empty_like(input, input.options().dtype(ScalarType::Float)) : at::empty_like(input);
   if (input.dim() == 0) input = input.view(1);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
   AT_CHECK(dim >=0 && dim < input.dim(), "dim must be non-negative and less than input dimensions");
@@ -499,10 +500,19 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_){
       dim3 block = SoftMax_getBlockSize(ILP, dim_size);
       AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "host_softmax", [&] {
       using accscalar_t = acc_type<scalar_t, true>;
-      cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, Epilogue>
-        <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
-          output.data<scalar_t>(), input.data<scalar_t>(), dim_size
-      );
+      if (!upconvert) {
+          cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, scalar_t, Epilogue>
+            <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
+              output.data<scalar_t>(), input.data<scalar_t>(), dim_size
+          );
+      } else {
+          bool accscalar_assert = std::is_same<accscalar_t, float>::value; 
+          AT_ASSERTM(accscalar_assert, "accscalar_t for mixed precision softmax should be float"); 
+          cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
+            <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
+              output.data<accscalar_t>(), input.data<scalar_t>(), dim_size
+          );
+      }
       });
     // This kernel runs in a 2D grid, where each application along y dimension has a fixed
     // outer_size, and runs in parallel over inner_size. Dimension x is parallel over outer_size.
@@ -512,14 +522,27 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_){
       dim3 grid, block;
       AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "host_softmax", [&] {
       using accscalar_t = acc_type<scalar_t, true>;
-      SpatialSoftMax_getLaunchSizes<accscalar_t>(
-          &cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, Epilogue>,
-          outer_size, dim_size, inner_size,
-          grid, block, smem_size);
-      cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, Epilogue>
-        <<<grid, block, smem_size, stream>>>(
-          output.data<scalar_t>(), input.data<scalar_t>(), outer_size, dim_size, inner_size
+      if (!upconvert) {
+          SpatialSoftMax_getLaunchSizes<accscalar_t>(
+              &cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, scalar_t, Epilogue>,
+              outer_size, dim_size, inner_size,
+              grid, block, smem_size);
+          cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, scalar_t, Epilogue>
+            <<<grid, block, smem_size, stream>>>(
+             output.data<scalar_t>(), input.data<scalar_t>(), outer_size, dim_size, inner_size
       );
+      } else {
+          bool accscalar_assert = std::is_same<accscalar_t, float>::value; 
+          AT_ASSERTM(accscalar_assert, "accscalar_t for mixed precision softmax should be float"); 
+          SpatialSoftMax_getLaunchSizes<accscalar_t>(
+              &cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, accscalar_t, Epilogue>,
+              outer_size, dim_size, inner_size,
+              grid, block, smem_size);
+          cunn_SpatialSoftMaxForward<scalar_t, accscalar_t, accscalar_t, Epilogue>
+            <<<grid, block, smem_size, stream>>>(
+             output.data<accscalar_t>(), input.data<scalar_t>(), outer_size, dim_size, inner_size
+      );
+      }
       });
     }
     THCudaCheck(cudaGetLastError());
@@ -527,11 +550,11 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_){
   return output;
 }
 
-template<template<typename, typename> class Epilogue>
-Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t dim_){
+template<template<typename, typename, typename> class Epilogue>
+Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t dim_, bool upconvert){
   int64_t dim = maybe_wrap_dim(dim_, grad_.dim());
   auto grad = grad_.contiguous();
-  Tensor gI = at::empty_like(grad);
+  Tensor gI = upconvert? at::empty_like(grad, grad.options().dtype(ScalarType::Half)) : at::empty_like(grad);
   if (grad.dim() == 0) grad = grad.view(1);
   AT_CHECK(dim >=0 && dim < grad.dim(), "dim must be non-negative and less than input dimensions");
   auto output = output_.contiguous();
@@ -549,28 +572,52 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
     const int ILP = 2;
     dim3 grid(outer_size);
     dim3 block = SoftMax_getBlockSize(ILP, dim_size);
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "host_softmax_backward", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(gI.type(), "host_softmax_backward", [&] {
     using accscalar_t = acc_type<scalar_t, true>;
-    cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, Epilogue>
-      <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
-        gI.data<scalar_t>(), output.data<scalar_t>(), grad.data<scalar_t>(), dim_size
+    if (!upconvert) {
+        cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, scalar_t, Epilogue>
+         <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
+            gI.data<scalar_t>(), output.data<scalar_t>(), grad.data<scalar_t>(), dim_size
     );
+    } else {
+       bool accscalar_assert = std::is_same<accscalar_t, float>::value;
+       AT_ASSERTM(accscalar_assert, "accscalar_t for mixed precision softmax should be float"); 
+        cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
+         <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
+            gI.data<scalar_t>(), output.data<accscalar_t>(), grad.data<accscalar_t>(), dim_size
+    );
+    }
     });
   } else {
     uint32_t smem_size;
     dim3 grid, block;
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "host_softmax_backward", [&] {
     using accscalar_t = acc_type<scalar_t, true>;
-    SpatialSoftMax_getLaunchSizes<accscalar_t>(
-        &cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, Epilogue>,
-        outer_size, dim_size, inner_size,
-        grid, block, smem_size);
-
-    cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, Epilogue>
-      <<<grid, block, smem_size, stream>>>(
-        gI.data<scalar_t>(), output.data<scalar_t>(), grad.data<scalar_t>(),
-        outer_size, dim_size, inner_size
-    );
+    if (!upconvert) {
+        SpatialSoftMax_getLaunchSizes<accscalar_t>(
+            &cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, scalar_t, Epilogue>,
+            outer_size, dim_size, inner_size,
+            grid, block, smem_size);
+    
+        cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, scalar_t, Epilogue>
+          <<<grid, block, smem_size, stream>>>(
+            gI.data<scalar_t>(), output.data<scalar_t>(), grad.data<scalar_t>(),
+            outer_size, dim_size, inner_size
+        );
+    } else {
+        bool accscalar_assert = std::is_same<accscalar_t, float>::value;
+        AT_ASSERTM(accscalar_assert, "accscalar_t for mixed precision softmax should be float"); 
+        SpatialSoftMax_getLaunchSizes<accscalar_t>(
+            &cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, accscalar_t, Epilogue>,
+            outer_size, dim_size, inner_size,
+            grid, block, smem_size);
+    
+        cunn_SpatialSoftMaxBackward<scalar_t, accscalar_t, accscalar_t, Epilogue>
+          <<<grid, block, smem_size, stream>>>(
+            gI.data<scalar_t>(), output.data<accscalar_t>(), grad.data<accscalar_t>(),
+            outer_size, dim_size, inner_size
+        );
+    }
     });
   }
   THCudaCheck(cudaGetLastError());
@@ -578,22 +625,29 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
 }
 }
 
-Tensor log_softmax_cuda(const Tensor &input, const int64_t dim){
-  return host_softmax<LogSoftMaxForwardEpilogue>(input, dim);
+Tensor log_softmax_cuda(const Tensor &input, const int64_t dim, const bool upconvert){
+  return host_softmax<LogSoftMaxForwardEpilogue>(input, dim, upconvert);
 }
 
 Tensor log_softmax_backward_cuda(const Tensor &grad, const Tensor &output, int64_t dim, const Tensor &input){
-  return host_softmax_backward<LogSoftMaxBackwardEpilogue>(grad, output, dim);
+  bool upconvert = grad.type().scalarType() != input.type().scalarType();
+  if (upconvert) {
+     AT_ASSERTM((grad.type().scalarType() == ScalarType::Float && input.type().scalarType() == ScalarType::Half), "expected input and grad types to match, or input to be at::Half and grad to be at::Float");
+  }
+  return host_softmax_backward<LogSoftMaxBackwardEpilogue>(grad, output, dim, upconvert);
 }
 
-Tensor softmax_cuda(const Tensor &input, const int64_t dim){
-  return host_softmax<SoftMaxForwardEpilogue>(input, dim);
+Tensor softmax_cuda(const Tensor &input, const int64_t dim, const bool upconvert){
+  return host_softmax<SoftMaxForwardEpilogue>(input, dim, upconvert);
 }
 
 Tensor softmax_backward_cuda(const Tensor &grad, const Tensor &output, int64_t dim, const Tensor &input){
-
+  bool upconvert = grad.type().scalarType() != input.type().scalarType();
+  if (upconvert) {
+     AT_ASSERTM((grad.type().scalarType() == ScalarType::Float && input.type().scalarType() == ScalarType::Half), "expected input and grad types to match, or input to be at::Half and grad to be at::Float");
+  }
   Tensor tmp = grad * output;
-  return host_softmax_backward<SoftMaxBackwardEpilogue>(tmp, output, dim);
+  return host_softmax_backward<SoftMaxBackwardEpilogue>(tmp, output, dim, upconvert);
 }
 
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1007,7 +1007,6 @@
 - func: log_softmax(Tensor self, int64_t dim, ScalarType dtype) -> Tensor
   variants: function, method
 
->>>>>>> add mixed precision softmax
 - func: log_softmax(Tensor self, int64_t dim) -> Tensor
   variants: function, method
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1003,13 +1003,20 @@
 
 - func: logspace_out(Tensor result, Scalar start, Scalar end, int64_t steps) -> Tensor
 
+# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+- func: log_softmax(Tensor self, int64_t dim, ScalarType dtype) -> Tensor
+  variants: function, method
+
+>>>>>>> add mixed precision softmax
 - func: log_softmax(Tensor self, int64_t dim) -> Tensor
   variants: function, method
+
+- func: _log_softmax(Tensor self, int64_t dim, bool upconvert) -> Tensor
   dispatch:
     CPU: log_softmax_cpu
     CUDA: log_softmax_cuda
 
-- func: log_softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self) -> Tensor
+- func: _log_softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self) -> Tensor
   dispatch:
     CPU: log_softmax_backward_cpu
     CUDA: log_softmax_backward_cuda
@@ -1432,13 +1439,19 @@
 - func: smm(Tensor self, Tensor mat2) -> Tensor
   variants: function, method
 
+# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+- func: softmax(Tensor self, int64_t dim, ScalarType dtype) -> Tensor
+  variants: function, method
+
 - func: softmax(Tensor self, int64_t dim) -> Tensor
   variants: function, method
+
+- func: _softmax(Tensor self, int64_t dim, bool upconvert) -> Tensor
   dispatch:
     CPU: softmax_cpu
     CUDA: softmax_cuda
 
-- func: softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self) -> Tensor
+- func: _softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self) -> Tensor
   dispatch:
     CPU: softmax_backward_cpu
     CUDA: softmax_backward_cuda

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1010,7 +1010,7 @@
 - func: log_softmax(Tensor self, int64_t dim) -> Tensor
   variants: function, method
 
-- func: _log_softmax(Tensor self, int64_t dim, bool upconvert) -> Tensor
+- func: _log_softmax(Tensor self, int64_t dim, bool half_to_float) -> Tensor
   dispatch:
     CPU: log_softmax_cpu
     CUDA: log_softmax_cuda
@@ -1445,7 +1445,7 @@
 - func: softmax(Tensor self, int64_t dim) -> Tensor
   variants: function, method
 
-- func: _softmax(Tensor self, int64_t dim, bool upconvert) -> Tensor
+- func: _softmax(Tensor self, int64_t dim, bool half_to_float) -> Tensor
   dispatch:
     CPU: softmax_cpu
     CUDA: softmax_cuda

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8152,13 +8152,12 @@ class TestCustomOperators(JitTestCase):
         ):
             torch.ops.aten.relu()
 
-    @unittest.skipIf(True, "temporarily disabled")
     def test_passing_one_positional_but_not_the_second(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "aten::log_softmax\(\) is missing value for argument 'dim'."
+            "aten::transpose\(\) is missing value for argument 'dim0'."
         ):
-            torch.ops.aten.log_softmax(torch.ones(5))
+            torch.ops.aten.transpose(torch.ones(5, 5))
 
     def test_passing_an_argument_both_as_positional_and_kwarg(self):
         with self.assertRaisesRegex(

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8152,6 +8152,7 @@ class TestCustomOperators(JitTestCase):
         ):
             torch.ops.aten.relu()
 
+    @unittest.skipIf(True, "temporarily disabled")
     def test_passing_one_positional_but_not_the_second(self):
         with self.assertRaisesRegex(
             RuntimeError,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1893,10 +1893,8 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types([torch.float, torch.half])
     def test_softmax_dtype(self, dtype=torch.float):
-        input = torch.tensor([32, 100], device="cuda", dtype=dtype).uniform_()
-        input.requires_grad = True
-        inputf = input.to(torch.float).detach()
-        inputf.requires_grad = True
+        input = torch.rand(32, 100, device="cuda", dtype=dtype, requires_grad=True)
+        inputf = input.to(torch.float).detach().requires_grad_(True)
         out = F.softmax(input, dim=-1, dtype=torch.float)
         outf = F.softmax(inputf, dim=-1)
         # should be bitwise equal

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1890,6 +1890,23 @@ class TestNN(NNTestCase):
         res_F = F.embedding(a, embeddings)
         self.assertEqual(res_old, res_F)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types([torch.float, torch.half])
+    def test_softmax_dtype(self, dtype=torch.float):
+        input = torch.tensor([32, 100], device="cuda", dtype=dtype).uniform_()
+        input.requires_grad = True
+        inputf = input.to(torch.float).detach()
+        inputf.requires_grad = True
+        out = F.softmax(input, dim=-1, dtype=torch.float)
+        outf = F.softmax(inputf, dim=-1)
+        # should be bitwise equal
+        self.assertEqual(out, outf, prec=0)
+        gO = torch.empty_like(outf).uniform_()
+        out.backward(gO)
+        outf.backward(gO)
+        # should be bitwise equal
+        self.assertEqual(input.grad, inputf.grad.to(dtype), prec=0)
+
     def _test_gumbel_softmax_st(self, cuda, dtype=torch.float):
         th = torch.cuda if cuda else torch
         """
@@ -8562,6 +8579,13 @@ new_module_tests = [
         pickle=False,
     ),
     dict(
+        constructor=wrap_functional(F.softmax, dim=1, dtype=torch.float64),
+        input_size=(2, 128),
+        fullname='softmax_lastdim_dtype',
+        pickle=False,
+        test_cuda=False
+    ),
+    dict(
         constructor=wrap_functional(F.softmax, dim=1),
         input_size=(2, 128, 2, 2),  # trigger special case of spatial CUDA algo
         fullname='softmax_spatial_special',
@@ -8573,6 +8597,13 @@ new_module_tests = [
         input_size=(2, 2, 4, 4),  # regular spatial algorithm
         fullname='softmax_spatial',
         pickle=False,
+    ),
+    dict(
+        constructor=wrap_functional(F.softmax, dim=1, dtype=torch.float64),
+        input_size=(2, 2, 4, 4),  # regular spatial algorithm
+        fullname='softmax_spatial_dtype',
+        pickle=False,
+        test_cuda=False
     ),
     dict(
         constructor=wrap_functional(F.softmax, dim=0),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -866,8 +866,8 @@
 - name: log_sigmoid_forward(Tensor self)
   self: log_sigmoid_backward(grad, self, buffer)
 
-- name: log_softmax(Tensor self, int64_t dim)
-  self: log_softmax_backward_data(grad, result, dim, self)
+- name: _log_softmax(Tensor self, int64_t dim, bool upconvert)
+  self: _log_softmax_backward_data(grad, result, dim, self)
 
 - name: prelu(Tensor self, Tensor weight)
   self, weight: prelu_backward(grad, self, weight)
@@ -881,8 +881,8 @@
 - name: rrelu_with_noise_forward_(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_with_noise_backward(grad, output, noise, lower, upper, training)
 
-- name: softmax(Tensor self, int64_t dim)
-  self: softmax_backward_data(grad, result, dim, self)
+- name: _softmax(Tensor self, int64_t dim, bool upconvert)
+  self: _softmax_backward_data(grad, result, dim, self)
 
 - name: softplus_forward(Tensor self, Scalar beta, Scalar threshold)
   self: softplus_backward(grad, self, beta, threshold, output)
@@ -1068,9 +1068,9 @@
   grad_output: log_sigmoid_backward(grad, self, buffer)
   self: log_sigmoid_double_backward(grad * grad_output, self)
 
-- name: log_softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self)
+- name: _log_softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self)
   grad_output: grad - (grad * output.exp()).sum(dim, true)
-  self: log_softmax_double_backward(grad, grad_output, dim, output)
+  self: log_softmax_double_backward(grad, grad_output, dim, output).type_as(self)
 
 - name: leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope)
   grad_output: leaky_relu_backward(grad, self, negative_slope)
@@ -1132,9 +1132,9 @@
   grad_output: softplus_backward(grad, self, beta, threshold, output)
   self: softplus_double_backward(grad * grad_output, self, beta, threshold)
 
-- name: softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self)
-  grad_output: softmax_backward_data(grad, output, dim, self)
-  self: softmax_double_backward(grad, grad_output, dim, output)
+- name: _softmax_backward_data(Tensor grad_output, Tensor output, int64_t dim, Tensor self)
+  grad_output: _softmax_backward_data(grad, output, dim, self)
+  self: softmax_double_backward(grad, grad_output, dim, output).type_as(self)
 
 - name: soft_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int64_t reduction)
   grad_output: soft_margin_loss_double_backward_grad_output(grad, grad_output, self, target, reduction)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -866,7 +866,7 @@
 - name: log_sigmoid_forward(Tensor self)
   self: log_sigmoid_backward(grad, self, buffer)
 
-- name: _log_softmax(Tensor self, int64_t dim, bool upconvert)
+- name: _log_softmax(Tensor self, int64_t dim, bool half_to_float)
   self: _log_softmax_backward_data(grad, result, dim, self)
 
 - name: prelu(Tensor self, Tensor weight)
@@ -881,7 +881,7 @@
 - name: rrelu_with_noise_forward_(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_with_noise_backward(grad, output, noise, lower, upper, training)
 
-- name: _softmax(Tensor self, int64_t dim, bool upconvert)
+- name: _softmax(Tensor self, int64_t dim, bool half_to_float)
   self: _softmax_backward_data(grad, result, dim, self)
 
 - name: softplus_forward(Tensor self, Scalar beta, Scalar threshold)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1022,7 +1022,7 @@ Example::
 
 add_docstr(torch.cumsum,
            r"""
-cumsum(input, dim, out=None) -> Tensor
+cumsum(input, dim, out=None, dtype=None) -> Tensor
 
 Returns the cumulative sum of elements of :attr:`input` in the dimension
 :attr:`dim`.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1081,7 +1081,6 @@ def log_softmax(input, dim=None, _stacklevel=3, dtype=None):
         If specified, the input tensor is casted to :attr:`dtype` before the operation
         is performed. This is useful for preventing data type overflows. Default: None.
     """
-    print(torch.typename(input), input.size(), dtype)
     if dim is None:
         dim = _get_softmax_dim('log_softmax', input.dim(), _stacklevel)
     if dtype is None:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -940,7 +940,7 @@ def _get_softmax_dim(name, ndim, stacklevel):
         return 1
 
 
-def softmin(input, dim=None, _stacklevel=3):
+def softmin(input, dim=None, _stacklevel=3, dtype=None):
     r"""Applies a softmin function.
 
     Note that :math:`\text{Softmin}(x) = \text{Softmax}(-x)`. See softmax definition for mathematical formula.
@@ -951,13 +951,19 @@ def softmin(input, dim=None, _stacklevel=3):
         input (Tensor): input
         dim (int): A dimension along which softmin will be computed (so every slice
             along dim will sum to 1).
+        dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+        If specified, the input tensor is casted to :attr:`dtype` before the operation
+        is performed. This is useful for preventing data type overflows. Default: None.
     """
     if dim is None:
         dim = _get_softmax_dim('softmin', input.dim(), _stacklevel)
-    return (-input).softmax(dim)
+    if dtype is None:
+        return (-input).softmax(dim)
+    else:
+        return (-input).softmax(dim, dtype=dtype)
 
 
-def softmax(input, dim=None, _stacklevel=3):
+def softmax(input, dim=None, _stacklevel=3, dtype=None):
     r"""Applies a softmax function.
 
     Softmax is defined as:
@@ -972,6 +978,10 @@ def softmax(input, dim=None, _stacklevel=3):
     Arguments:
         input (Tensor): input
         dim (int): A dimension along which softmax will be computed.
+        dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+        If specified, the input tensor is casted to :attr:`dtype` before the operation
+        is performed. This is useful for preventing data type overflows. Default: None.
+
 
     .. note::
         This function doesn't work directly with NLLLoss,
@@ -981,7 +991,10 @@ def softmax(input, dim=None, _stacklevel=3):
     """
     if dim is None:
         dim = _get_softmax_dim('softmax', input.dim(), _stacklevel)
-    return input.softmax(dim)
+    if dtype is None:
+        return input.softmax(dim)
+    else:
+        return input.softmax(dim, dtype=dtype)
 
 
 def _sample_gumbel(shape, eps=1e-10, out=None):
@@ -1052,7 +1065,7 @@ def gumbel_softmax(logits, tau=1, hard=False, eps=1e-10):
     return y
 
 
-def log_softmax(input, dim=None, _stacklevel=3):
+def log_softmax(input, dim=None, _stacklevel=3, dtype=None):
     r"""Applies a softmax followed by a logarithm.
 
     While mathematically equivalent to log(softmax(x)), doing these two
@@ -1064,10 +1077,17 @@ def log_softmax(input, dim=None, _stacklevel=3):
     Arguments:
         input (Tensor): input
         dim (int): A dimension along which log_softmax will be computed.
+        dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+        If specified, the input tensor is casted to :attr:`dtype` before the operation
+        is performed. This is useful for preventing data type overflows. Default: None.
     """
+    print(torch.typename(input), input.size(), dtype)
     if dim is None:
         dim = _get_softmax_dim('log_softmax', input.dim(), _stacklevel)
-    return input.log_softmax(dim)
+    if dtype is None:
+        return input.log_softmax(dim)
+    else:
+        return input.log_softmax(dim, dtype=dtype)
 
 
 softshrink = _add_docstr(torch._C._nn.softshrink, r"""


### PR DESCRIPTION
Add dtype argument to softmax/log_softmax functions. 
Computing softmax in fp32 precision is necessary for mixed precision training, and converting output of the previous layer into fp32 and then reading it as fp32 in softmax is expensive, memory and perf-wise, this PR allows one to avoid it. 
For most input data/dtype combinations, input data is converted to dtype and then softmax is computed. If input data is half type and dtype is fp32, kernels with the corresponding template arguments are called. 