### PR TITLE
Show build output in verbose mode of C++ extensions

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -15,7 +15,7 @@ if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
 fi
 export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
 source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
-conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
+conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja future six
 if [ -z "${IN_CIRCLECI}" ]; then
   rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 fi

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -43,7 +43,7 @@ IF EXIST C:\\Jenkins\\Miniconda3 ( rd /s /q C:\\Jenkins\\Miniconda3 )
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
 .\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
 call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
-call conda install -y -q numpy mkl cffi pyyaml boto3
+call conda install -y -q numpy mkl cffi pyyaml boto3 future six
 
 pip install ninja
 

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -43,9 +43,9 @@ IF EXIST C:\\Jenkins\\Miniconda3 ( rd /s /q C:\\Jenkins\\Miniconda3 )
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
 .\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
 call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
-call conda install -y -q numpy mkl cffi pyyaml boto3 future six
+call conda install -y -q numpy mkl cffi pyyaml boto3
 
-pip install ninja
+pip install ninja future
 
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -10,6 +10,8 @@ import sysconfig
 import tempfile
 import warnings
 
+from future.utils import raise_from
+
 import torch
 from .file_baton import FileBaton
 
@@ -791,10 +793,7 @@ def _build_extension_module(name, build_directory, verbose):
         _, error, _ = sys.exc_info()
         # error.output contains the stdout and stderr of the build attempt.
         message = "Error building extension '{}': {}".format(name, error.output.decode())
-        if sys.version_info < (3, 3):
-            raise RuntimeError(message)
-        else:
-            raise RuntimeError(message) from None
+        raise_from(RuntimeError(message), None)
 
 
 def _import_module_from_library(module_name, path):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -696,7 +696,7 @@ def _jit_compile(name,
 
             if verbose:
                 print('Building extension module {}...'.format(name))
-            _build_extension_module(name, build_directory)
+            _build_extension_module(name, build_directory, verbose)
         finally:
             baton.release()
     else:
@@ -775,16 +775,26 @@ def _get_build_directory(name, verbose):
     return build_directory
 
 
-def _build_extension_module(name, build_directory):
+def _build_extension_module(name, build_directory, verbose):
     try:
-        subprocess.check_output(
-            ['ninja', '-v'], stderr=subprocess.STDOUT, cwd=build_directory)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        subprocess.run(
+            ['ninja', '-v'],
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=build_directory,
+            check=True
+        )
     except subprocess.CalledProcessError:
         # Python 2 and 3 compatible way of getting the error object.
         _, error, _ = sys.exc_info()
         # error.output contains the stdout and stderr of the build attempt.
-        raise RuntimeError("Error building extension '{}': {}".format(
-            name, error.output.decode()))
+        message = "Error building extension '{}': {}".format(name, error.output.decode())
+        if sys.version_info < (3, 3):
+            raise RuntimeError(message)
+        else:
+            raise RuntimeError(message) from None
 
 
 def _import_module_from_library(module_name, path):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -781,13 +781,18 @@ def _build_extension_module(name, build_directory, verbose):
     try:
         sys.stdout.flush()
         sys.stderr.flush()
-        subprocess.run(
-            ['ninja', '-v'],
-            stdout=None if verbose else subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            cwd=build_directory,
-            check=True
-        )
+        if sys.version_info >= (3, 5):
+            subprocess.run(
+                ['ninja', '-v'],
+                stdout=None if verbose else subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                cwd=build_directory,
+                check=True)
+        else:
+            subprocess.check_output(
+                ['ninja', '-v'],
+                stderr=subprocess.STDOUT,
+                cwd=build_directory)
     except subprocess.CalledProcessError:
         # Python 2 and 3 compatible way of getting the error object.
         _, error, _ = sys.exc_info()


### PR DESCRIPTION
Two improvements to C++ extensions:

1. In verbose mode, show the ninja build output (the exact compile commands, very useful)
2. When raising an error, don't show the `CalledProcessError` that shows ninja failing, only show the `RuntimeError` with the captured stdout

@soumith @fmassa @ezyang 