### PR TITLE
remove unused use_scratch argument from batch_matmul

### DIFF
--- a/caffe2/operators/batch_matmul_op.cc
+++ b/caffe2/operators/batch_matmul_op.cc
@@ -175,13 +175,6 @@ class GetBatchMatMulGradient : public GradientMakerBase {
     auto trans_both_arg = vector<Argument>{MakeArgument<int>("trans_a", 1),
                                            MakeArgument<int>("trans_b", 1)};
 
-    if (ArgumentHelper::HasArgument(Def(), "use_scratch")) {
-      no_trans_arg.push_back(MakeArgument<int>("use_scratch", 1));
-      trans_a_arg.push_back(MakeArgument<int>("use_scratch", 1));
-      trans_b_arg.push_back(MakeArgument<int>("use_scratch", 1));
-      trans_both_arg.push_back(MakeArgument<int>("use_scratch", 1));
-    }
-
     if (trans_a) {
       if (trans_b) {
         // A'B':

--- a/caffe2/operators/batch_matmul_op.h
+++ b/caffe2/operators/batch_matmul_op.h
@@ -17,12 +17,7 @@ class BatchMatMulOp final : public Operator<Context> {
       : Operator<Context>(operator_def, ws),
         trans_a_(this->template GetSingleArgument<int>("trans_a", 0)),
         trans_b_(this->template GetSingleArgument<int>("trans_b", 0)),
-        broadcast_(this->template GetSingleArgument<int>("broadcast", 0)),
-        use_scratch_(this->template GetSingleArgument<int>("use_scratch", 0)) {
-    if (use_scratch_) {
-      scratch_ = std::make_shared<Tensor>(Context::GetDeviceType());
-    }
-  }
+        broadcast_(this->template GetSingleArgument<int>("broadcast", 0)) {}
 
   ~BatchMatMulOp() {}
 
@@ -280,9 +275,6 @@ class BatchMatMulOp final : public Operator<Context> {
   bool trans_a_;
   bool trans_b_;
   bool broadcast_;
-
-  bool use_scratch_;
-  std::shared_ptr<Tensor> scratch_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/experimental/c10/cpu/batch_matmul_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/batch_matmul_cpu.cc
@@ -18,7 +18,6 @@ void batch_matmul_op_cpu_impl(
     int trans_a,
     int trans_b,
     int broadcast,
-    int use_scratch,
     caffe2::ops::BatchMatmul::State* state,
     BaseContext* context) {
   using Engine = caffe2::DefaultEngine;

--- a/caffe2/operators/experimental/c10/schemas/batch_matmul.cc
+++ b/caffe2/operators/experimental/c10/schemas/batch_matmul.cc
@@ -35,15 +35,6 @@ struct BroadcastParameter final {
     return 0;
   }
 };
-struct UseScratchParameter final {
-  using type = int;
-  static constexpr const char* name() {
-    return "use_scratch";
-  }
-  static constexpr int default_value() {
-    return 0;
-  }
-};
 } // namespace
 
 namespace caffe2 {
@@ -53,6 +44,5 @@ REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH_WITH_PARAMETERS(
     C10BatchMatMul_DontUseThisOpYet,
     ParameterHelper<TransAParameter>,
     ParameterHelper<TransBParameter>,
-    ParameterHelper<BroadcastParameter>,
-    ParameterHelper<UseScratchParameter>)
+    ParameterHelper<BroadcastParameter>)
 }

--- a/caffe2/operators/experimental/c10/schemas/batch_matmul.h
+++ b/caffe2/operators/experimental/c10/schemas/batch_matmul.h
@@ -20,18 +20,16 @@ struct BatchMatmul final {
       int trans_a,
       int trans_b,
       int broadcast,
-      int use_scratch,
       State* state,
       BaseContext* context);
 
-  static constexpr c10::guts::array<const char*, 9> parameter_names = {
+  static constexpr c10::guts::array<const char*, 8> parameter_names = {
       {"A",
        "B",
        "output",
        "trans_a",
        "trans_b",
        "broadcast",
-       "use_scratch",
        "state",
        "context"}};
 };


### PR DESCRIPTION
Summary: use_scratch is not used anywhere and not documented as far as I can tell

Differential Revision: D9846488
