### PR TITLE
64B align for avx512

### DIFF
--- a/caffe2/core/allocator.h
+++ b/caffe2/core/allocator.h
@@ -11,8 +11,8 @@ CAFFE2_DECLARE_bool(caffe2_cpu_allocator_do_zero_fill);
 
 namespace caffe2 {
 
-// Use 32-byte alignment should be enough for computation up to AVX512.
-constexpr size_t gCaffe2Alignment = 32;
+// Use 64-byte alignment should be enough for computation up to AVX512.
+constexpr size_t gCaffe2Alignment = 64;
 
 using MemoryDeleter = void (*)(void*);
 

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -2229,7 +2229,7 @@ class TestOperators(hu.HypothesisTestCase):
            in_place=st.booleans(),
            **hu.gcs)
     def test_unsafe_coalesce(self, sizes, in_place, gc, dc):
-        gAlignment = 32
+        gAlignment = 64
         Xs = [np.random.randn(size)
               .astype(np.random.choice([np.float32, np.float64, np.uint8]))
               for size in sizes]


### PR DESCRIPTION
Summary:
For avx512, we need to align at a multiple of 64B not 32B
Regardless of avx512, it's in general a good idea to be cache line aligned.

Differential Revision: D9845056
