### PR TITLE
[C++ frontend] Code-reorg to have TORCH_ARG in its own header

### DIFF
--- a/torch/csrc/api/include/torch/arg.h
+++ b/torch/csrc/api/include/torch/arg.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <utility>
+
+#define TORCH_ARG(T, name)                                       \
+  auto name(const T& new_##name)->decltype(*this) { /* NOLINT */ \
+    this->name##_ = new_##name;                                  \
+    return *this;                                                \
+  }                                                              \
+  auto name(T&& new_##name)->decltype(*this) { /* NOLINT */      \
+    this->name##_ = std::move(new_##name);                       \
+    return *this;                                                \
+  }                                                              \
+  const T& name() const noexcept { /* NOLINT */                  \
+    return this->name##_;                                        \
+  }                                                              \
+  T name##_ /* NOLINT */

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/arg.h>
 #include <torch/csrc/utils/variadic.h>
 #include <torch/tensor.h>
 
@@ -154,20 +155,6 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
 };
 } // namespace nn
 } // namespace torch
-
-#define TORCH_ARG(T, name)                                       \
-  auto name(const T& new_##name)->decltype(*this) { /* NOLINT */ \
-    this->name##_ = new_##name;                                  \
-    return *this;                                                \
-  }                                                              \
-  auto name(T&& new_##name)->decltype(*this) { /* NOLINT */      \
-    this->name##_ = std::move(new_##name);                       \
-    return *this;                                                \
-  }                                                              \
-  const T& name() const noexcept { /* NOLINT */                  \
-    return this->name##_;                                        \
-  }                                                              \
-  T name##_ /* NOLINT */
 
 /// Defines a class `Name` which inherits from `nn::ModuleHolder` to provide a
 /// wrapper over a `std::shared_ptr<Impl>`.

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <torch/arg.h>
 #include <torch/nn/module.h>
-#include <torch/nn/pimpl.h>
 #include <torch/optim/optimizer.h>
 #include <torch/serialization.h>
 

--- a/torch/csrc/api/include/torch/optim/lbfgs.h
+++ b/torch/csrc/api/include/torch/optim/lbfgs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/serialization.h>

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/serialization.h>

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <torch/arg.h>
 #include <torch/nn/module.h>
-#include <torch/nn/pimpl.h>
 #include <torch/optim/optimizer.h>
 #include <torch/serialization.h>
 #include <torch/tensor.h>


### PR DESCRIPTION
I noticed I was including `torch/nn/pimpl.h` in the optimizer library just to access `TORCH_ARG`, even though that file includes a lot of irrelevant code. Let's save some re-compilation time by refactoring this macro into a separate logical file. #small-wins

@ebetica @ezyang @apaszke 