### PR TITLE
Add the OpenMP optimization for UpsampleNearest and BatchPermutation.

### DIFF
--- a/modules/detectron/batch_permutation_op.cc
+++ b/modules/detectron/batch_permutation_op.cc
@@ -100,6 +100,13 @@ bool BatchPermutationOp<float, CPUContext>::RunOnDevice() {
   const float *src = X.template data<float>();
   float *dst = Y->template mutable_data<float>();
 
+#ifdef _OPENMP
+#if (_OPENMP >= 201307)
+#pragma omp parallel for simd
+#else
+#pragma omp parallel for
+#endif 
+#endif  
   for (int i = 0; i < N; i++) {
     int idx = indices.template data<int>()[i];
 

--- a/modules/detectron/upsample_nearest_op.h
+++ b/modules/detectron/upsample_nearest_op.h
@@ -74,6 +74,13 @@ class UpsampleNearestOp final : public Operator<Context> {
     const T *input_data = X.template data<T>();
     T *output_data = Y->template mutable_data<T>();
 
+#ifdef _OPENMP
+#if (_OPENMP >= 201307)
+#pragma omp parallel for simd
+#else
+#pragma omp parallel for
+#endif 
+#endif  
     for (int ii = 0; ii < Y->size(); ii++) {
       int ipidx = translate_idx(ii, d1, d2, d3, scale_);
       output_data[ii] = input_data[ipidx];


### PR DESCRIPTION
WIth this optimization, the following two ops can boost a lot. (Test with MaskRCNN, on SKX8180 one socket)
UpsampleNearest op: reduced from 240.7196 ms to 9.225 ms
BatchPermutation op: reduced from 8.296387 ms to 1.4501984 ms.
