### PR TITLE
Fix casting logic for 0d CPU tensors in CUDA ops

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -73,8 +73,8 @@ static bool needs_cast(const Tensor& tensor, const Type& dst_type) {
   if (!tensor.defined() || dst_type == tensor.type()) {
     return false;
   }
-  if (dst_type.backend() == Backend::CUDA &&
-      tensor.type().backend() == Backend::CPU &&
+  if (dst_type.device_type() == DeviceType::CUDA &&
+      tensor.type().device_type() == DeviceType::CPU &&
       tensor.dim() == 0) {
     // zero-dim CPU tensors used in CUDA operations can be used directly without
     // casting

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -69,6 +69,20 @@ compute_result_type(at::ArrayRef<OperandInfo> operands, const F& predicate) {
   return std::make_tuple(result_type, backend);
 }
 
+static bool needs_cast(const Tensor& tensor, const Type& dst_type) {
+  if (!tensor.defined() || dst_type == tensor.type()) {
+    return false;
+  }
+  if (dst_type.backend() == Backend::CUDA &&
+      tensor.type().backend() == Backend::CPU &&
+      tensor.dim() == 0) {
+    // zero-dim CPU tensors used in CUDA operations can be used directly without
+    // casting
+    return false;
+  }
+  return true;
+}
+
 void TensorIterator::compute_common_type() {
   // See [Result type computation] in TensorIterator.h
   auto result_type = ScalarType::Undefined;
@@ -95,15 +109,11 @@ void TensorIterator::compute_common_type() {
   for (auto& op : operands_) {
     if (!op.type) {
       op.type = &type;
-      if (op.tensor->defined() && type != op.tensor->type()) {
-        if (op.tensor->dim() == 0) {
-          if (type.backend() != at::Backend::CUDA) {
-            cast_tensors_.emplace_back(op.tensor->toType(type));
-            op.tensor = &(cast_tensors_.back());
-          }
-        } else {
-          op.needs_cast = true;
-        }
+      op.needs_cast = needs_cast(*op.tensor, type);
+      if (op.needs_cast && op.tensor->dim() == 0) {
+        cast_tensors_.emplace_back(op.tensor->toType(type));
+        op.tensor = &(cast_tensors_.back());
+        op.needs_cast = false;
       }
     }
   }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -110,7 +110,7 @@ void TensorIterator::compute_common_type() {
     if (!op.type) {
       op.type = &type;
       op.needs_cast = needs_cast(*op.tensor, type);
-      if (op.needs_cast && op.tensor->dim() == 0) {
+      if (op.needs_cast && op.tensor->dim() == 0 && !op.is_output) {
         cast_tensors_.emplace_back(op.tensor->toType(type));
         op.tensor = &(cast_tensors_.back());
         op.needs_cast = false;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -161,6 +161,10 @@ def constant_tensor_add(a, b):
         return a + b
 
 
+def small_0d(t):
+    return make_tensor(t, (1,)).squeeze()
+
+
 def small_2d(t):
     return make_tensor(t, S, S)
 
@@ -258,6 +262,7 @@ tests = [
     ('mul', small_3d, lambda t: [number(3.14, 3, t)], '', types, False,
         "skipIfRocm:ByteTensor,CharTensor,HalfTensor,ShortTensor"),
     ('mul', small_3d, lambda t: [small_3d_positive(t)], 'tensor'),
+    ('mul', small_0d, lambda t: [small_0d(torch.IntTensor)], 'scalar'),
     ('div', small_3d, lambda t: [number(3.14, 3, t)], '', types, False,
         "skipIfRocm:ByteTensor,CharTensor,FloatTensor,HalfTensor,ShortTensor"),
     ('div', small_3d, lambda t: [small_3d_positive(t)], 'tensor'),

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -262,7 +262,7 @@ tests = [
     ('mul', small_3d, lambda t: [number(3.14, 3, t)], '', types, False,
         "skipIfRocm:ByteTensor,CharTensor,HalfTensor,ShortTensor"),
     ('mul', small_3d, lambda t: [small_3d_positive(t)], 'tensor'),
-    ('mul', small_0d, lambda t: [small_0d(torch.IntTensor)], 'scalar'),
+    ('mul', small_0d, lambda t: [small_0d(torch.IntTensor)], 'scalar', types, True),
     ('div', small_3d, lambda t: [number(3.14, 3, t)], '', types, False,
         "skipIfRocm:ByteTensor,CharTensor,FloatTensor,HalfTensor,ShortTensor"),
     ('div', small_3d, lambda t: [small_3d_positive(t)], 'tensor'),
@@ -907,6 +907,25 @@ class TestCuda(TestCase):
         self.assertIsInstance(y.cuda().float(), torch.cuda.FloatStorage)
         self.assertIsInstance(y.cuda().float().cpu(), torch.FloatStorage)
         self.assertIsInstance(y.cuda().float().cpu().int(), torch.IntStorage)
+
+    def test_mul_intertype_scalar(self):
+        x = torch.tensor(1.5, device='cuda')
+        y = torch.tensor(3, dtype=torch.int32, device='cuda')
+
+        self.assertEqual(x * y, 4.5)
+        self.assertEqual(y * x, 4.5)
+        with self.assertRaisesRegex(RuntimeError, 'expected type'):
+            y *= x
+        x *= y
+        self.assertEqual(x, 4.5)
+
+        x = torch.tensor(1.5, device='cuda', dtype=torch.float16)
+        self.assertEqual(x * y, 4.5)
+        # half * int currently promotes to double
+        with self.assertRaisesRegex(RuntimeError, 'expected type'):
+            x *= y
+        with self.assertRaisesRegex(RuntimeError, 'expected type'):
+            y *= x
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     @skipIfRocm


### PR DESCRIPTION
Previously, we didn't cast any 0-dim tensors used in CUDA operations. We
can only avoid the casts for 0-dim CPU tensors used in CUDA operations.

Fixes #11795

