### PR TITLE
Stop moving constants into DifferentiableSubgraphs

### DIFF
--- a/test/expect/TestJit.test_cpp_cuda.expect
+++ b/test/expect/TestJit.test_cpp_cuda.expect
@@ -65,6 +65,8 @@ graph(%0 : Dynamic
       %3 : Dynamic
       %4 : Dynamic) {
   %23 : Dynamic, %24 : Dynamic = prim::DifferentiableGraph_0(%0, %3, %1, %4, %2)
+  %7 : int = prim::Constant[value=1]()
+  %19 : int = prim::Constant[value=1]()
   return (%24, %23);
 }
 with prim::DifferentiableGraph_0 = graph(%1 : Dynamic
@@ -74,20 +76,20 @@ with prim::DifferentiableGraph_0 = graph(%1 : Dynamic
       %17 : Dynamic) {
   %0 : Dynamic = aten::mm(%1, %2)
   %3 : Dynamic = aten::mm(%4, %5)
-  %6 : int = prim::Constant[value=1]()
-  %7 : Dynamic = aten::add(%0, %3, %6)
-  %8 : Dynamic, %9 : Dynamic, %10 : Dynamic, %11 : Dynamic = prim::ConstantChunk[chunks=4, dim=1](%7)
+  %7 : int = prim::Constant[value=1]()
+  %6 : Dynamic = aten::add(%0, %3, %7)
+  %8 : Dynamic, %9 : Dynamic, %10 : Dynamic, %11 : Dynamic = prim::ConstantChunk[chunks=4, dim=1](%6)
   %12 : Dynamic = aten::sigmoid(%8)
   %13 : Dynamic = aten::sigmoid(%11)
   %14 : Dynamic = aten::tanh(%10)
   %15 : Dynamic = aten::sigmoid(%9)
   %16 : Dynamic = aten::mul(%15, %17)
   %18 : Dynamic = aten::mul(%12, %14)
-  %19 : int = prim::Constant[value=1]()
-  %20 : Dynamic = aten::add(%16, %18, %19)
-  %21 : Dynamic = aten::tanh(%20)
+  %20 : int = prim::Constant[value=1]()
+  %19 : Dynamic = aten::add(%16, %18, %20)
+  %21 : Dynamic = aten::tanh(%19)
   %22 : Dynamic = aten::mul(%13, %21)
-  return (%20, %22);
+  return (%19, %22);
 }
 
 testDifferentiate

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -521,6 +521,21 @@ class TestJit(JitTestCase):
         input = torch.rand(3, 4)
         self.assertEqual(2 * input + 1, m(input))
 
+    def test_diff_subgraph_clones_constants(self):
+        @torch.jit.script
+        def f(x, y):
+            return x + x + y + x + y + x + y + x + y + x
+
+        def count_constants(graph):
+            return sum(node.kind() == 'prim::Constant' for node in graph.nodes())
+
+        graph = f.graph.copy()
+        self.run_pass('cse', graph)
+        self.run_pass('create_autodiff_subgraphs', graph)
+        nodes = list(graph.nodes())
+        self.assertEqual(count_constants(graph), 1)
+        self.assertEqual(count_constants(nodes[1].g('Subgraph')), 1)
+
     # Backwards tracing was broken for indexing by a constant,
     # because it's internally implemented using as_strided,
     # and we attempted to trace its derivative (which is not

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -16,6 +16,9 @@ Value* insertConstant(
     if(!ref.defined()) {
       throw constant_not_supported_error("undefined tensors cannot become constants");
     }
+    if (ref.is_variable()) {
+      ref = autograd::Variable(ref).data();
+    }
     n->output()->inferTypeFrom(ref); // note: before t_ because of std::move(ref)
     n->t_(attr::value, std::move(ref));
   } else if(val.isInt()) {

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -14,6 +14,7 @@
 #include "torch/csrc/jit/passes/erase_number_types.h"
 #include "torch/csrc/jit/passes/onnx/prepare_division_for_onnx.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
+#include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
 #include "torch/csrc/jit/passes/peephole.h"
 #include "torch/csrc/jit/passes/canonicalize.h"
 #include "torch/csrc/jit/passes/onnx/peephole.h"
@@ -99,6 +100,9 @@ void initJITBindings(PyObject *module) {
      return ConstantPropagation(g);
    })
    .def("_jit_pass_erase_shape_information", EraseShapeInformation)
+   .def("_jit_pass_create_autodiff_subgraphs", [](Graph& graph) {
+     CreateAutodiffSubgraphs(graph);
+   })
    .def("_jit_run_cpp_tests", [] {
      // We have to release the GIL inside this method, because if we happen to
      // initialize the autograd engine in these tests, the newly spawned worker threads will

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -74,8 +74,6 @@ Node* mergeNodes(Block * block, Symbol group_node_kind, ArrayRef<Node*> nodes) {
   return group_node;
 }
 
-}
-
 void CreateAutodiffSubgraphs(Block * block, size_t threshold, std::vector<Node*>& diff_graphs) {
   // This implementation is not optimal, but it is simple.
   // It just scans through the list in order looking for runs of
@@ -116,11 +114,12 @@ void CreateAutodiffSubgraphs(Block * block, size_t threshold, std::vector<Node*>
   }
 }
 
+} // anonymous namespace
+
 std::vector<Node*> CreateAutodiffSubgraphs(Graph & graph, size_t threshold) {
   std::vector<Node*> diff_nodes;
   CreateAutodiffSubgraphs(graph.block(), threshold, diff_nodes);
   return diff_nodes;
 }
-
 
 }}

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -1,7 +1,10 @@
-#include <cstddef>
+#include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
+
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/autodiff.h"
 #include "torch/csrc/jit/assertions.h"
+
+#include <cstddef>
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.h
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.h
@@ -1,8 +1,12 @@
 #pragma once
+
+#include "torch/csrc/WindowsTorchApiMacro.h"
+
 #include <cstddef>
 
 namespace torch { namespace jit {
 
+struct Node;
 struct Graph;
 
 // insert GraphExecutor nodes that group together

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.h
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.h
@@ -1,13 +1,11 @@
 #pragma once
 
+#include "torch/csrc/jit/ir.h"
 #include "torch/csrc/WindowsTorchApiMacro.h"
 
 #include <cstddef>
 
 namespace torch { namespace jit {
-
-struct Node;
-struct Graph;
 
 // insert GraphExecutor nodes that group together
 // subgraphs that are differentiable by the jit's autodiff passes


### PR DESCRIPTION
Or even taking them as inputs. This prevents optimizations to happen
either inside the differentiable subgraphs, or in the surrounding graph.

