### PR TITLE
remove protobuf inclusion in core/logging.h

### DIFF
--- a/caffe2/core/logging.cc
+++ b/caffe2/core/logging.cc
@@ -52,17 +52,6 @@ void ThrowEnforceNotMet(
   throw e;
 }
 
-static std::function<void(const OperatorDef&)> OperatorLogger =
-    [](const OperatorDef&) { return; };
-
-void SetOperatorLogger(std::function<void(const OperatorDef&)> tracer) {
-  OperatorLogger = tracer;
-}
-
-std::function<void(const OperatorDef&)> GetOperatorLogger() {
-  return OperatorLogger;
-}
-
 }  // namespace caffe2
 
 

--- a/caffe2/core/logging.h
+++ b/caffe2/core/logging.h
@@ -9,7 +9,6 @@
 
 #include <ATen/core/Error.h>
 #include "caffe2/core/flags.h"
-#include "caffe2/proto/caffe2_pb.h"
 
 // CAFFE2_LOG_THRESHOLD is a compile time flag that would allow us to turn off
 // logging at compile time so no logging message below that level is produced

--- a/caffe2/core/logging.h
+++ b/caffe2/core/logging.h
@@ -105,9 +105,6 @@ size_t ReplaceAll(string& s, const char* from, const char* to);
 
 CAFFE2_API void SetStackTraceFetcher(std::function<string(void)> fetcher);
 
-CAFFE2_API void SetOperatorLogger(std::function<void(const OperatorDef&)> tracer);
-std::function<void(const OperatorDef&)> GetOperatorLogger();
-
 using EnforceNotMet = at::Error;
 
 #define CAFFE_ENFORCE(condition, ...)                                         \

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -693,4 +693,15 @@ std::set<std::string> GetRegisteredOperators() {
   return all_keys;
 }
 
+static std::function<void(const OperatorDef&)> OperatorLogger =
+    [](const OperatorDef&) { return; };
+
+void SetOperatorLogger(std::function<void(const OperatorDef&)> tracer) {
+  OperatorLogger = tracer;
+}
+
+std::function<void(const OperatorDef&)> GetOperatorLogger() {
+  return OperatorLogger;
+}
+
 }  // namespace caffe2

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -988,6 +988,10 @@ CAFFE2_API std::map<string, std::pair<DeviceOption, DeviceOption>> ValidateTenso
 // Get a set of registered operator names
 CAFFE2_API std::set<std::string> GetRegisteredOperators();
 
+// Operator logging capabilities
+CAFFE2_API void SetOperatorLogger(std::function<void(const OperatorDef&)> tracer);
+std::function<void(const OperatorDef&)> GetOperatorLogger();
+
 }  // namespace caffe2
 
 #endif  // CAFFE2_CORE_OPERATOR_H_


### PR DESCRIPTION
This should not be there since logging does not depend on protobuf.