### PR TITLE
detach returned tensors from source tensors in tensor constructors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2404,16 +2404,21 @@ class TestTorch(TestCase):
             self.assertTrue(copy.requires_grad == copy_requires_grad)
 
         source = torch.randn(5, 5, requires_grad=True)
-        # == test torch.tensor() ==
+        # test torch.tensor()
         check_copy(torch.tensor(source), True, False)
         check_copy(torch.tensor(source, requires_grad=False), True, False)
         check_copy(torch.tensor(source, requires_grad=True), True, True)
 
-        # == test tensor.new_tensor() ==
+        # test tensor.new_tensor()
         copy = torch.randn(1)
         check_copy(copy.new_tensor(source), True, False)
         check_copy(copy.new_tensor(source, requires_grad=False), True, False)
         check_copy(copy.new_tensor(source, requires_grad=True), True, True)
+
+        # test torch.as_tensor()
+        source = source.add(1)  # make source non-leaf
+        check_copy(torch.as_tensor(source), source.is_leaf, source.requires_grad)
+        check_copy(torch.as_tensor(source, dtype=torch.float), True, False)
 
     def test_tensor_factory_type_inference(self):
         def test_inference(default_dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2397,29 +2397,23 @@ class TestTorch(TestCase):
             self.assertEqual(5., res1[0].item())
 
     def test_tensor_factory_copy_var(self):
-        # default copy from var
-        source = torch.randn(5, 5, requires_grad=True)
-        copy = torch.tensor(source)
-        self.assertEqual(copy.data, source.data)
-        self.assertTrue(source.requires_grad)
-        self.assertTrue(copy.is_leaf)
-        self.assertFalse(copy.requires_grad)
 
-        # copy with requires_grad=False
-        source = torch.randn(5, 5, requires_grad=True)
-        copy = torch.tensor(source, requires_grad=False)
-        self.assertEqual(copy.data, source.data)
-        self.assertTrue(source.requires_grad)
-        self.assertTrue(copy.is_leaf)
-        self.assertFalse(copy.requires_grad)
+        def check_copy(copy, copy_is_leaf, copy_requires_grad):
+            self.assertEqual(copy.data, source.data)
+            self.assertTrue(copy.is_leaf == copy_is_leaf)
+            self.assertTrue(copy.requires_grad == copy_requires_grad)
 
-        # copy with requires_grad=True
         source = torch.randn(5, 5, requires_grad=True)
-        copy = torch.tensor(source, requires_grad=True)
-        self.assertEqual(copy.data, source.data)
-        self.assertTrue(source.requires_grad)
-        self.assertTrue(copy.is_leaf)
-        self.assertTrue(copy.requires_grad)
+        # == test torch.tensor() ==
+        check_copy(torch.tensor(source), True, False)
+        check_copy(torch.tensor(source, requires_grad=False), True, False)
+        check_copy(torch.tensor(source, requires_grad=True), True, True)
+
+        # == test tensor.new_tensor() ==
+        copy = torch.randn(1)
+        check_copy(copy.new_tensor(source), True, False)
+        check_copy(copy.new_tensor(source, requires_grad=False), True, False)
+        check_copy(copy.new_tensor(source, requires_grad=True), True, True)
 
     def test_tensor_factory_type_inference(self):
         def test_inference(default_dtype):

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -35,6 +35,13 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
     If you have a numpy array and want to avoid a copy, use
     :func:`torch.from_numpy`.
 
+.. warning::
+
+    When data is a tensor `x`, :func:`new_tensor()` reads out 'the data' from whatever it is passed,
+    and constructs a leaf variable. Therefore ``tensor.new_tensor(x)`` is equivalent to ``x.clone().detach()``
+    and ``tensor.new_tensor(x, requires_grad=True)`` is equivalent to ``x.clone().detach().requires_grad_(True)``.
+    The equivalents using ``clone()`` and ``detach()`` are recommended.
+
 Args:
     data (array_like): The returned Tensor copies :attr:`data`.
     {dtype}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -445,17 +445,10 @@ add_docstr(torch.as_tensor,
            r"""
 as_tensor(data, dtype=None, device=None) -> Tensor
 
-Convert the data into a `torch.Tensor`.  If the data is already a `Tensor` of the same `dtype` and `device`, no copy
-will be performed.  Similarly, if the data is an ``ndarray`` of the corresponding `dtype` and the `device` is the cpu,
-no copy will be performed.
-
-.. warning::
-
-    When attr:`data` is a tensor `x` with different attr:`dtype` or attr:`device`,
-    :func:`as_tensor()` reads out 'the data' from whatever it is passed,
-    and constructs a leaf variable. Therefore ``tensor.as_tensor(x, dtype=dtype, device=device)``
-    is equivalent to ``x.clone().detach().to(dtype, device)``.
-    The equivalents using ``clone()`` and ``detach()`` are recommended.
+Convert the data into a `torch.Tensor`. If the data is already a `Tensor` with the same `dtype` and `device`,
+no copy will be performed, otherwise a new `Tensor` will be returned with computational graph retained if data
+`Tensor` has ``requires_grad=True``. Similarly, if the data is an ``ndarray`` of the corresponding `dtype` and
+the `device` is the cpu, no copy will be performed.
 
 Args:
     {data}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -449,6 +449,14 @@ Convert the data into a `torch.Tensor`.  If the data is already a `Tensor` of th
 will be performed.  Similarly, if the data is an ``ndarray`` of the corresponding `dtype` and the `device` is the cpu,
 no copy will be performed.
 
+.. warning::
+
+    When attr:`data` is a tensor `x` with different attr:`dtype` or attr:`device`,
+    :func:`as_tensor()` reads out 'the data' from whatever it is passed,
+    and constructs a leaf variable. Therefore ``tensor.as_tensor(x, dtype=dtype, device=device)``
+    is equivalent to ``x.clone().detach().to(dtype, device)``.
+    The equivalents using ``clone()`` and ``detach()`` are recommended.
+
 Args:
     {data}
     {dtype}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3823,7 +3823,7 @@ Constructs a tensor with :attr:`data`.
     When data is a tensor `x`, :func:`torch.tensor` reads out 'the data' from whatever it is passed,
     and constructs a leaf variable. Therefore ``torch.tensor(x)`` is equivalent to ``x.clone().detach()``
     and ``torch.tensor(x, requires_grad=True)`` is equivalent to ``x.clone().detach().requires_grad_(True)``.
-    The equivalents use ``clone()`` and ``detach()`` are recommended.
+    The equivalents using ``clone()`` and ``detach()`` are recommended.
 
 Args:
     {data}

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -499,16 +499,19 @@ Tensor tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
   ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
-    PyErr_WarnEx(PyExc_UserWarning,
-      "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
-      "or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).", 1);
+    PyObject* data = r.pyobject(0);
+    if (THPVariable_Check(data)) {
+      PyErr_WarnEx(PyExc_UserWarning,
+        "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
+        "or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).", 1);
+    }
 
     bool type_inference = r.isNone(1);
     bool args_requires_grad = r.toBool(3);
     auto new_tensor = internal_new_from_data(
                typeWithDefault(r, 1, 2, type),
                r.deviceOptional(2),
-               r.pyobject(0),
+               data,
                true,
                true,
                type_inference);
@@ -543,15 +546,18 @@ Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
   ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
-    PyErr_WarnEx(PyExc_UserWarning,
-      "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
-      "or sourceTensor.clone().detach().requires_grad_(True), rather than tensor.new_tensor(sourceTensor).", 1);
+    PyObject* data = r.pyobject(0);
+    if (THPVariable_Check(data)) {
+      PyErr_WarnEx(PyExc_UserWarning,
+        "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
+        "or sourceTensor.clone().detach().requires_grad_(True), rather than tensor.new_tensor(sourceTensor).", 1);
+    }
 
     bool args_requires_grad = r.toBool(3);
     auto new_tensor = new_from_data_copy(
                typeWithDefault(r, 1, 2, type),
                r.deviceOptional(2),
-               r.pyobject(0));
+               data);
     new_tensor.detach_(); // making new_tensor a leaf node
     new_tensor.set_requires_grad(args_requires_grad);
     return new_tensor;


### PR DESCRIPTION
- fix PR https://github.com/pytorch/pytorch/pull/11061 by moving `detach_()` and `set_requires_grad()` to `torch.tensor_ctor()` and `tensor.new_tensor`, and also removed warnings and `args_requires_grad` from `internal_new_from_data `
- with this patch, the returned tensor from `tensor_ctor()` and `new_tensor` will be detached from source tensor, and set requires_grad based on the input args
- `torch.as_tensor` retains its behavior as documented

@gchanan @apaszke 