### PR TITLE
Expunge (transitive) caffe2_pb2 dependency from tensor_impl.h from context_base.h

### DIFF
--- a/aten/src/ATen/core/DeviceType.h
+++ b/aten/src/ATen/core/DeviceType.h
@@ -8,6 +8,7 @@
 #include <ATen/core/Macros.h>
 
 #include <ostream>
+#include <functional>
 
 namespace at {
 
@@ -32,3 +33,11 @@ AT_CORE_API std::string DeviceTypeName(
 AT_CORE_API std::ostream& operator<<(std::ostream& stream, at::DeviceType type);
 
 } // namespace at
+
+namespace std {
+template <> struct hash<at::DeviceType> {
+  std::size_t operator()(const at::DeviceType &k) const {
+    return std::hash<int>()(static_cast<int>(k));
+  }
+};
+} // namespace std

--- a/aten/src/ATen/core/context_base.cpp
+++ b/aten/src/ATen/core/context_base.cpp
@@ -1,0 +1,22 @@
+#include <ATen/core/context_base.h>
+
+namespace caffe2 {
+
+// TODO: rename context.h -> context_cpu.h & context_base.h -> context.h
+StaticContextMap& GetStaticContexts() {
+  static StaticContextMap static_contexts;
+  return static_contexts;
+}
+
+void set_static_context(at::DeviceType t, BaseStaticContext* ptr) {
+  auto& static_contexts = GetStaticContexts();
+  static_contexts[t] = ptr;
+}
+
+BaseStaticContext* get_static_context(at::DeviceType t) {
+  auto* ptr = GetStaticContexts()[t];
+  AT_ASSERTM(ptr, "StaticContext for ", t, " is not registered yet.");
+  return ptr;
+}
+
+} // namespace caffe2

--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -10,6 +10,7 @@
 #include <ATen/core/Error.h>
 #include <ATen/core/UniqueVoidPtr.h>
 #include <ATen/core/typeid.h>
+#include <ATen/core/ATenGeneral.h>
 
 namespace caffe2 {
 class Event;
@@ -184,3 +185,27 @@ class AT_CORE_API BaseContext {
 };
 
 } // namespace at
+
+namespace caffe2 {
+
+using at::BaseContext;
+using at::BaseStaticContext;
+
+using StaticContextMap = std::unordered_map<at::DeviceType, BaseStaticContext*>;
+AT_API StaticContextMap& GetStaticContexts();
+AT_API void set_static_context(at::DeviceType t, BaseStaticContext* ptr);
+AT_API BaseStaticContext* get_static_context(at::DeviceType t);
+
+template <at::DeviceType t>
+struct StaticContextFunctionRegisterer {
+  explicit StaticContextFunctionRegisterer(BaseStaticContext* ptr) {
+    set_static_context(t, ptr);
+  }
+};
+
+#define REGISTER_STATIC_CONTEXT(t, f)                                \
+  namespace {                                                        \
+  static StaticContextFunctionRegisterer<t> g_static_context_##d(f); \
+  }
+
+} // namespace caffe2

--- a/caffe2/core/context_base.cc
+++ b/caffe2/core/context_base.cc
@@ -1,22 +1,4 @@
 #include "context_base.h"
 
 namespace caffe2 {
-
-// TODO: rename context.h -> context_cpu.h & context_base.h -> context.h
-StaticContextMap& GetStaticContexts() {
-  static StaticContextMap static_contexts;
-  return static_contexts;
-}
-
-void set_static_context(DeviceType t, BaseStaticContext* ptr) {
-  auto& static_contexts = GetStaticContexts();
-  static_contexts[t] = ptr;
-}
-
-BaseStaticContext* get_static_context(DeviceType t) {
-  auto* ptr = GetStaticContexts()[t];
-  CAFFE_ENFORCE(ptr, "StaticContext is not registered yet.");
-  return ptr;
-}
-
 } // namespace caffe2

--- a/caffe2/core/context_base.h
+++ b/caffe2/core/context_base.h
@@ -5,26 +5,3 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/proto/caffe2_pb.h"
-
-namespace caffe2 {
-using at::BaseContext;
-using at::BaseStaticContext;
-
-using StaticContextMap = CaffeMap<DeviceType, BaseStaticContext*>;
-CAFFE2_API StaticContextMap& GetStaticContexts();
-CAFFE2_API void set_static_context(DeviceType t, BaseStaticContext* ptr);
-CAFFE2_API BaseStaticContext* get_static_context(DeviceType t);
-
-template <DeviceType t>
-struct StaticContextFunctionRegisterer {
-  explicit StaticContextFunctionRegisterer(BaseStaticContext* ptr) {
-    set_static_context(t, ptr);
-  }
-};
-
-#define REGISTER_STATIC_CONTEXT(t, f)                                \
-  namespace {                                                        \
-  static StaticContextFunctionRegisterer<t> g_static_context_##d(f); \
-  }
-
-} // namespace caffe2

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -3,12 +3,12 @@
 #include <ATen/core/DimVector.h>
 #include <ATen/core/TensorImpl.h>
 #include <ATen/core/context_base.h>
+#include <ATen/core/context_base.h>
 
 #include "caffe2/core/allocator.h"
 #include "caffe2/core/common.h"
 #include "caffe2/core/flags.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/context_base.h"
 
 // A global boolean variable to control whether we free memory when a Tensor
 // is shrinked to a smaller size. As a result, a Tensor is always going to
@@ -21,6 +21,9 @@ CAFFE2_DECLARE_bool(caffe2_keep_on_shrink);
 CAFFE2_DECLARE_int64(caffe2_max_keep_on_shrink_memory);
 
 namespace caffe2 {
+
+// Defined by protobuf
+class DeviceOption;
 
 /**
  * A utility function to convert vector<int> to vector<TIndex>.


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11818 Expunge (transitive) caffe2_pb2 dependency from tensor_impl.h from context_base.h**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9924348/)

To do this, I have to move the static context registry into ATen/core.
I take the opportunity to convert it into an unordered_map.

Differential Revision: [D9924348](https://our.internmc.facebook.com/intern/diff/D9924348/)