### PR TITLE
Remove unnecessary check on device option pointer

### DIFF
--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -403,7 +403,6 @@ class CAFFE2_CUDA_API CUDAStaticContext final : public BaseStaticContext {
   }
 
   void ExtractDeviceOption(DeviceOption* device, const void* data) override {
-    CAFFE_ENFORCE(data, "data cannot be nullptr");
     device->set_device_type(TypeToProto(GetDeviceType()));
     device->set_cuda_gpu_id(GetGPUIDForPointer(data));
   }


### PR DESCRIPTION
Summary:
The device pointer will be used by cudaPointerGetAttributes, which handles nullptr already. So this check is not necessary.

https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__UNIFIED.html#group__CUDART__UNIFIED_1gd89830e17d399c064a2f3c3fa8bb4390

Differential Revision: D9929828
