### PR TITLE
Aten: catch2gtest

### DIFF
--- a/aten/src/ATen/test/apply_test.cpp
+++ b/aten/src/ATen/test/apply_test.cpp
@@ -1,121 +1,135 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "cuda.h"
 #include "cuda_runtime.h"
 
 #include "ATen/cuda/detail/TensorInfo.cuh"
-
+#define ASSERT_EQ_CUDA(X, Y) \
+  {                          \
+    bool _isEQ = X == Y;     \
+    ASSERT_TRUE(_isEQ);      \
+  }
 /*
-Tests related to tensor indexing and applying operations. 
+   Tests related to tensor indexing and applying operations.
 */
 #ifndef _WIN32
 
-CATCH_TEST_CASE("2D Contiguous", "Collapses a 2D contiguous tensor to 1D contiguous") {
-    int sizes[] = {4, 4};
-    int strides[] = {4, 1};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 2, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 1);
-    CATCH_REQUIRE(ti.sizes[0] == (4 * 4));
+// CATCH_TEST_CASE("2D Contiguous", "Collapses a 2D contiguous tensor to 1D
+// contiguous") {
+TEST(ApplyTest, Contiguous2D) {
+  int sizes[] = {4, 4};
+  int strides[] = {4, 1};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 2, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 1);
+  ASSERT_EQ_CUDA(ti.sizes[0], (4 * 4));
 }
 
-CATCH_TEST_CASE("3D Contiguous", "Collapses a 3D contiguous tensor to a 1D contiguous") {
-    int sizes[] = {6, 3, 7};
-    int strides[] = {3 * 7, 7, 1};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 1);
-    CATCH_REQUIRE(ti.sizes[0] == (6 * 3 * 7));
+// CATCH_TEST_CASE("3D Contiguous", "Collapses a 3D contiguous tensor to a 1D
+// contiguous") {
+TEST(ApplyTest, Contiguous3D) {
+  int sizes[] = {6, 3, 7};
+  int strides[] = {3 * 7, 7, 1};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 1);
+  ASSERT_EQ_CUDA(ti.sizes[0], (6 * 3 * 7));
+}
+// CATCH_TEST_CASE("3D Partial Collapse", "Collapses a 3D noncontiguous tensor
+// to a 2D tensor") {
+TEST(ApplyTest, PartialCollapse3D) {
+  int sizes[] = {4, 3, 2};
+  int strides[] = {3 * 3, 3, 1};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 2);
+  ASSERT_EQ_CUDA(ti.sizes[0], (4 * 3));
+  ASSERT_EQ_CUDA(ti.sizes[1], 2);
 }
 
-CATCH_TEST_CASE("3D Partial Collapse", "Collapses a 3D noncontiguous tensor to a 2D tensor") {
-    int sizes[] = {4, 3, 2};
-    int strides[] = {3 * 3, 3, 1};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 2);
-    CATCH_REQUIRE(ti.sizes[0] == (4 * 3));
-    CATCH_REQUIRE(ti.sizes[1] == 2);
+// Collapses a 2D skip contiguous tensor to a 1D skip contiguous tensor
+TEST(ApplyTest, StridedCollapse2D) {
+  int sizes[] = {3, 2};
+  int strides[] = {2 * 2, 2};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 2, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 1);
+  ASSERT_EQ_CUDA(ti.sizes[0], (3 * 2));
+  ASSERT_EQ_CUDA(ti.strides[0], 2);
 }
 
-CATCH_TEST_CASE("2D Strided Collapse", "Collapses a 2D skip contiguous tensor to a 1D skip contiguous tensor") {
-    int sizes[] = {3, 2};
-    int strides[] = {2 * 2, 2};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 2, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 1);
-    CATCH_REQUIRE(ti.sizes[0] == (3 * 2));
-    CATCH_REQUIRE(ti.strides[0] == 2);
+// Collapses a 4D tensor to a 2D tensor
+TEST(ApplyTest, PartialStridedCollapse4D) {
+  int sizes[] = {3, 6, 5, 2};
+  int strides[] = {6 * 22, 22, 2 * 2, 2};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 2);
+  ASSERT_EQ_CUDA(ti.sizes[0], (3 * 6));
+  ASSERT_EQ_CUDA(ti.strides[0], 22);
+  ASSERT_EQ_CUDA(ti.sizes[1], (5 * 2));
+  ASSERT_EQ_CUDA(ti.strides[1], 2);
 }
 
-CATCH_TEST_CASE("4D Partial Strided Collapse", "Collapses a 4D tensor to a 2D tensor"){
-    int sizes[] = {3, 6, 5, 2};
-    int strides[] = {6 * 22, 22, 2 * 2, 2};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 2);
-    CATCH_REQUIRE(ti.sizes[0] == (3 * 6));
-    CATCH_REQUIRE(ti.strides[0] == 22);
-    CATCH_REQUIRE(ti.sizes[1] == (5 * 2));
-    CATCH_REQUIRE(ti.strides[1] == 2);
+// Collapses a 5D tensor to a 1D tensor
+TEST(ApplyTest, CollapsesZerosAndOnes) {
+  int sizes[] = {1, 10, 1, 5, 4};
+  int strides[] = {4, 0, 16, 0, 1};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 5, sizes, strides};
+  ti.collapseDims();
+  ASSERT_EQ_CUDA(ti.dims, 2);
+  ASSERT_EQ_CUDA(ti.sizes[0], (10 * 5));
+  ASSERT_EQ_CUDA(ti.strides[0], 0);
+  ASSERT_EQ_CUDA(ti.sizes[1], 4);
+  ASSERT_EQ_CUDA(ti.strides[1], 1);
 }
 
-CATCH_TEST_CASE("Collapsing Zeros and Ones", "Collapses a 5D tensor to a 1D tensor") {
-    int sizes[] = {1, 10, 1, 5, 4};
-    int strides[] = {4, 0, 16, 0, 1};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 5, sizes, strides};
-    ti.collapseDims();
-    CATCH_REQUIRE(ti.dims == 2);
-    CATCH_REQUIRE(ti.sizes[0] == (10 * 5));
-    CATCH_REQUIRE(ti.strides[0] == 0);
-    CATCH_REQUIRE(ti.sizes[1] == 4);
-    CATCH_REQUIRE(ti.strides[1] == 1);
+// Collapses a 3D tensor to a point tensor
+TEST(ApplyTest, CollapseToPointTensor) {
+  int sizes[] = {1, 1, 1};
+  int strides[] = {17, 12, 3};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
+  ASSERT_EQ_CUDA(ti.collapseDims(), 0);
+  ASSERT_EQ_CUDA(ti.dims, 1);
+  ASSERT_EQ_CUDA(ti.sizes[0], 1);
+  ASSERT_EQ_CUDA(ti.strides[0], 1);
 }
 
-CATCH_TEST_CASE("Collapsing to a Point Tensor", "Collapses a 3D tensor to a point tensor") {
-    int sizes[] = {1, 1, 1};
-    int strides[] = {17, 12, 3};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
-    CATCH_REQUIRE(ti.collapseDims() == 0);
-    CATCH_REQUIRE(ti.dims == 1);
-    CATCH_REQUIRE(ti.sizes[0] == 1);
-    CATCH_REQUIRE(ti.strides[0] == 1);
+// Collapses a 4D tensor to a 3D tensor
+TEST(ApplyTest, ExcludingInContiguous4D) {
+  int sizes[] = {3, 6, 5, 2};
+  int strides[] = {6 * 22, 22, 2 * 2, 2};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
+  ASSERT_EQ_CUDA(ti.collapseDims(1), 1);
+  ASSERT_EQ_CUDA(ti.dims, 3);
+  ASSERT_EQ_CUDA(ti.sizes[0], 3);
+  ASSERT_EQ_CUDA(ti.strides[0], (6 * 22));
+  ASSERT_EQ_CUDA(ti.sizes[1], 6);
+  ASSERT_EQ_CUDA(ti.strides[1], 22);
+  ASSERT_EQ_CUDA(ti.sizes[2], (5 * 2));
+  ASSERT_EQ_CUDA(ti.strides[2], 2);
 }
 
-CATCH_TEST_CASE("Excluding in a 4D Contiguous", "Collapses a 4D tensor to a 3D tensor") {
-    int sizes[] = {3, 6, 5, 2};
-    int strides[] = {6 * 22, 22, 2 * 2, 2};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
-    CATCH_REQUIRE(ti.collapseDims(1) == 1);
-    CATCH_REQUIRE(ti.dims == 3);
-    CATCH_REQUIRE(ti.sizes[0] == 3);
-    CATCH_REQUIRE(ti.strides[0] == (6 * 22));
-    CATCH_REQUIRE(ti.sizes[1] == 6);
-    CATCH_REQUIRE(ti.strides[1] == 22);
-    CATCH_REQUIRE(ti.sizes[2] == (5 * 2));
-    CATCH_REQUIRE(ti.strides[2] == 2);
+// Collapses a 4D tensor to a 3D tensor
+TEST(ApplyTest, RovingExclusion) {
+  int sizes[] = {3, 6, 5, 2};
+  int strides[] = {6 * 22, 22, 2 * 2, 2};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
+  ASSERT_EQ_CUDA(ti.collapseDims(2), 1);
+  ASSERT_EQ_CUDA(ti.dims, 3);
+  ASSERT_EQ_CUDA(ti.sizes[0], (3 * 6));
+  ASSERT_EQ_CUDA(ti.strides[0], 22);
+  ASSERT_EQ_CUDA(ti.sizes[1], 5);
+  ASSERT_EQ_CUDA(ti.strides[1], 4);
+  ASSERT_EQ_CUDA(ti.sizes[2], 2);
+  ASSERT_EQ_CUDA(ti.strides[2], 2);
 }
 
-CATCH_TEST_CASE("Roving Exclusion", "Collapses a 4D tensor to a 3D tensor") {
-    int sizes[] = {3, 6, 5, 2};
-    int strides[] = {6 * 22, 22, 2 * 2, 2};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 4, sizes, strides};
-    CATCH_REQUIRE(ti.collapseDims(2) == 1);
-    CATCH_REQUIRE(ti.dims == 3);
-    CATCH_REQUIRE(ti.sizes[0] == (3 * 6));
-    CATCH_REQUIRE(ti.strides[0] == 22);
-    CATCH_REQUIRE(ti.sizes[1] == 5);
-    CATCH_REQUIRE(ti.strides[1] == 4);
-    CATCH_REQUIRE(ti.sizes[2] == 2);
-    CATCH_REQUIRE(ti.strides[2] == 2);
+// Attempts to exclude a nonexisting dimension
+TEST(ApplyTest, InvalidExclusion) {
+  int sizes[] = {1, 1, 1};
+  int strides[] = {17, 12, 3};
+  ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
+  ASSERT_ANY_THROW(ti.collapseDims(5));
 }
-
-CATCH_TEST_CASE("Invalid Exclusion", "Attempts to exclude a nonexisting dimension") {
-    int sizes[] = {1, 1, 1};
-    int strides[] = {17, 12, 3};
-    ::at::cuda::detail::TensorInfo<void, int> ti{nullptr, 3, sizes, strides};
-    _CATCH_REQUIRE_THROWS(ti.collapseDims(5));
-} 
-
 #endif

--- a/aten/src/ATen/test/apply_utils_test.cpp
+++ b/aten/src/ATen/test/apply_utils_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/CPUApplyUtils.h"
@@ -108,32 +107,38 @@ void test(Type& type, IntList shape, int64_t a = 0, int64_t b = 1) {
   });
 }
 
-CATCH_TEST_CASE("apply utils test 2-dim small contiguous", "[cpu]") {
+// apply utils test 2-dim small contiguous
+TEST(ApplyUtilsTest, Contiguous2D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {2, 1}, -1, -1);
 }
 
-CATCH_TEST_CASE("apply utils test 2-dim small", "[cpu]") {
+// apply utils test 2-dim small
+TEST(ApplyUtilsTest, Small2D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {2, 1});
 }
 
-CATCH_TEST_CASE("apply utils test 2-dim", "[cpu]") {
+// apply utils test 2-dim
+TEST(ApplyUtilsTest, _2D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {20, 10});
 }
 
-CATCH_TEST_CASE("apply utils test 3-dim", "[cpu]") {
+// apply utils test 3-dim
+TEST(ApplyUtilsTest, _3D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 4, 2});
 }
 
-CATCH_TEST_CASE("apply utils test 3-dim medium", "[cpu]") {
+// apply utils test 3-dim medium
+TEST(ApplyUtilsTest, Medium3D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 40, 2});
 }
 
-CATCH_TEST_CASE("apply utils test 10-dim", "[cpu]") {
+// apply utils test 10-dim
+TEST(ApplyUtilsTest, _10D) {
   manual_seed(123, at::kCPU);
   test(CPU(kDouble), {3, 4, 2, 5, 2, 1, 3, 4, 2, 3});
 }

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -8,17 +8,17 @@ using namespace std;
 using namespace at;
 
 void trace() {
-  Tensor foo = rand({12,12});
+  Tensor foo = rand({12, 12});
 
   // ASSERT foo is 2-dimensional and holds floats.
-  auto foo_a = foo.accessor<float,2>();
+  auto foo_a = foo.accessor<float, 2>();
   float trace = 0;
 
-  for(int i = 0; i < foo_a.size(0); i++) {
+  for (int i = 0; i < foo_a.size(0); i++) {
     trace += foo_a[i][i];
   }
 
-  EXPECT_FLOAT_EQ(foo.trace().item<float>(), trace);
+  ASSERT_FLOAT_EQ(foo.trace().item<float>(), trace);
 }
 
 // TEST_CASE( "atest", "[]" ) {
@@ -26,82 +26,78 @@ TEST(atest, atest) {
   manual_seed(123, at::kCPU);
   manual_seed(123, at::kCUDA);
 
-  auto foo = rand({12,6});
+  auto foo = rand({12, 6});
 
-  EXPECT_EQ(foo.size(0), 12);
-  EXPECT_EQ(foo.size(1), 6);
+  ASSERT_EQ(foo.size(0), 12);
+  ASSERT_EQ(foo.size(1), 6);
 
-  foo = foo+foo*3;
+  foo = foo + foo * 3;
   foo -= 4;
 
   Scalar a = 4;
   float b = a.to<float>();
-  EXPECT_EQ(b, 4);
+  ASSERT_EQ(b, 4);
 
-  foo = (foo*foo) == (foo.pow(3));
-  foo =  2 + (foo+1);
-  //foo = foo[3];
-  auto foo_v = foo.accessor<uint8_t,2>();
+  foo = (foo * foo) == (foo.pow(3));
+  foo = 2 + (foo + 1);
+  // foo = foo[3];
+  auto foo_v = foo.accessor<uint8_t, 2>();
 
-  for(int i = 0; i < foo_v.size(0); i++) {
-    for(int j = 0; j < foo_v.size(1); j++) {
+  for (int i = 0; i < foo_v.size(0); i++) {
+    for (int j = 0; j < foo_v.size(1); j++) {
       foo_v[i][j]++;
     }
   }
 
-  EXPECT_TRUE(foo.equal(4 * ones({12, 6}, kByte)));
+  ASSERT_TRUE(foo.equal(4 * ones({12, 6}, kByte)));
 
   trace();
 
-  float data[] = { 1, 2, 3,
-                   4, 5, 6};
+  float data[] = {1, 2, 3, 4, 5, 6};
 
-  auto f = CPU(kFloat).tensorFromBlob(data, {1,2,3});
-  auto f_a = f.accessor<float,3>();
+  auto f = CPU(kFloat).tensorFromBlob(data, {1, 2, 3});
+  auto f_a = f.accessor<float, 3>();
 
-  EXPECT_EQ(f_a[0][0][0], 1.0);
-  EXPECT_EQ(f_a[0][1][1], 5.0);
+  ASSERT_EQ(f_a[0][0][0], 1.0);
+  ASSERT_EQ(f_a[0][1][1], 5.0);
 
-  EXPECT_EQ(f.strides()[0], 6);
-  EXPECT_EQ(f.strides()[1], 3);
-  EXPECT_EQ(f.strides()[2], 1);
-  EXPECT_EQ(f.sizes()[0], 1);
-  EXPECT_EQ(f.sizes()[1], 2);
-  EXPECT_EQ(f.sizes()[2], 3);
+  ASSERT_EQ(f.strides()[0], 6);
+  ASSERT_EQ(f.strides()[1], 3);
+  ASSERT_EQ(f.strides()[2], 1);
+  ASSERT_EQ(f.sizes()[0], 1);
+  ASSERT_EQ(f.sizes()[1], 2);
+  ASSERT_EQ(f.sizes()[2], 3);
 
   // TODO(ezyang): maybe do a more precise exception type.
-  ASSERT_THROW(f.resize_({3,4,5}), std::exception);
+  ASSERT_THROW(f.resize_({3, 4, 5}), std::exception);
   {
     int isgone = 0;
     {
-      auto f2 = CPU(kFloat).tensorFromBlob(data, {1,2,3}, [&](void*) {
-        isgone++;
-      });
+      auto f2 =
+          CPU(kFloat).tensorFromBlob(data, {1, 2, 3}, [&](void*) { isgone++; });
     }
-    EXPECT_EQ(isgone, 1);
+    ASSERT_EQ(isgone, 1);
   }
   {
     int isgone = 0;
     Tensor a_view;
     {
-      auto f2 = CPU(kFloat).tensorFromBlob(data, {1,2,3}, [&](void*) {
-        isgone++;
-      });
-      a_view = f2.view({3,2,1});
+      auto f2 =
+          CPU(kFloat).tensorFromBlob(data, {1, 2, 3}, [&](void*) { isgone++; });
+      a_view = f2.view({3, 2, 1});
     }
-    EXPECT_EQ(isgone, 0);
+    ASSERT_EQ(isgone, 0);
     a_view.reset();
-    EXPECT_EQ(isgone, 1);
+    ASSERT_EQ(isgone, 1);
   }
 
-  if(at::hasCUDA()) {
+  if (at::hasCUDA()) {
     int isgone = 0;
     {
-      auto base = CUDA(kFloat).tensor({1,2,3});
-      auto f2 = CUDA(kFloat).tensorFromBlob(base.data_ptr(), {1,2,3}, [&](void*) {
-        isgone++;
-      });
+      auto base = CUDA(kFloat).tensor({1, 2, 3});
+      auto f2 = CUDA(kFloat).tensorFromBlob(
+          base.data_ptr(), {1, 2, 3}, [&](void*) { isgone++; });
     }
-    EXPECT_EQ(isgone, 1);
+    ASSERT_EQ(isgone, 1);
   }
 }

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -19,36 +19,35 @@ using namespace at;
 
 using Catch::Matchers::StartsWith;
 
-static void test(Type & type) {
-  CATCH_SECTION( "resize" ) {
+static void test(Type& type) {
+  CATCH_SECTION("resize") {
     auto a = at::empty({0}, type.options());
-    a.resize_({3,4});
+    a.resize_({3, 4});
     CATCH_REQUIRE(a.numel() == 12);
     a.resize_({5, 7});
     CATCH_REQUIRE(a.numel() == 35);
-
   }
 
-  CATCH_SECTION( "ones and dot" ) {
+  CATCH_SECTION("ones and dot") {
     Tensor b0 = ones({1, 1}, type);
-    CATCH_REQUIRE(2 == (b0+b0).sum().item<double>());
+    CATCH_REQUIRE(2 == (b0 + b0).sum().item<double>());
 
     Tensor b1 = ones({1, 2}, type);
-    CATCH_REQUIRE(4 == (b1+b1).sum().item<double>());
+    CATCH_REQUIRE(4 == (b1 + b1).sum().item<double>());
 
     Tensor b = ones({3, 4}, type);
-    CATCH_REQUIRE(24 == (b+b).sum().item<double>());
+    CATCH_REQUIRE(24 == (b + b).sum().item<double>());
     CATCH_REQUIRE(12 == b.numel());
     CATCH_REQUIRE(b.view(-1).dot(b.view(-1)).item<double>() == 12);
   }
 
-  CATCH_SECTION( "rand" ) {
-    for(auto i = 0; i < 10; i++) {
-      Tensor a = rand({3,4}, type.toScalarType(i % 2 == 0 ? kFloat : kDouble));
+  CATCH_SECTION("rand") {
+    for (auto i = 0; i < 10; i++) {
+      Tensor a = rand({3, 4}, type.toScalarType(i % 2 == 0 ? kFloat : kDouble));
     }
   }
 
-  CATCH_SECTION( "sort" ) {
+  CATCH_SECTION("sort") {
     Tensor b = rand({3, 4}, type);
 
     auto z = b.sort(1);
@@ -57,93 +56,101 @@ static void test(Type & type) {
     CATCH_REQUIRE(z_sorted[0][0].item<float>() < z_sorted[0][1].item<float>());
   }
 
-  if(type.backend() != Backend::CUDA)
-  CATCH_SECTION( "randperm" ) {
-    Tensor b = randperm(15, type);
-    Tensor rv, ri;
-    std::tie(rv, ri) = sort(b, 0);
-    CATCH_REQUIRE(rv[0].item<float>() <= rv[1].item<float>());
-  }
+  if (type.backend() != Backend::CUDA)
+    CATCH_SECTION("randperm") {
+      Tensor b = randperm(15, type);
+      Tensor rv, ri;
+      std::tie(rv, ri) = sort(b, 0);
+      CATCH_REQUIRE(rv[0].item<float>() <= rv[1].item<float>());
+    }
 
-  CATCH_SECTION( "context" ) {
+  CATCH_SECTION("context") {
     std::stringstream ss;
     ss << "context: " << std::hex << (int64_t)&globalContext() << std::endl;
   }
 
-  CATCH_SECTION( "add" ) {
+  CATCH_SECTION("add") {
     Tensor a = rand({3, 4}, type);
     Tensor b = rand({3, 4}, type);
     Tensor c = add(a, add(a, b));
-    //TODO:0-dim Tensor d(3.f);
+    // TODO:0-dim Tensor d(3.f);
     Scalar d = 3.f;
-    CATCH_REQUIRE( add(c, d).allclose(a + a + b + d) );
+    CATCH_REQUIRE(add(c, d).allclose(a + a + b + d));
   }
 
-  CATCH_SECTION( "loads of adds" ) {
+  CATCH_SECTION("loads of adds") {
     auto begin = std::chrono::high_resolution_clock::now();
     Tensor d = ones({3, 4}, type);
     Tensor r = zeros({3, 4}, type);
-    for(auto i = 0; i < 100000; i++) {
+    for (auto i = 0; i < 100000; i++) {
       add_out(r, r, d);
     }
     auto end = std::chrono::high_resolution_clock::now();
-    //TODO TEST PERF?
-    std::cout << std::dec << "   " << std::chrono::duration_cast<std::chrono::milliseconds>(end-begin).count() << " ms" << std::endl;
-    CATCH_REQUIRE(norm(100000*d).item<double>() == norm(r).item<double>());
+    // TODO TEST PERF?
+    std::cout << std::dec << "   "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                     end - begin)
+                     .count()
+              << " ms" << std::endl;
+    CATCH_REQUIRE(norm(100000 * d).item<double>() == norm(r).item<double>());
   }
 
-  CATCH_SECTION( "loads of adds (with copy)" ) {
+  CATCH_SECTION("loads of adds (with copy)") {
     auto begin = std::chrono::high_resolution_clock::now();
     Tensor d = ones({3, 4}, type);
     Tensor r = zeros({3, 4}, type);
-    for(auto i = 0; i < 100000; i++) {
+    for (auto i = 0; i < 100000; i++) {
       r = add(r, d);
     }
     auto end = std::chrono::high_resolution_clock::now();
-    //TODO TEST PERF?
-    std::cout << std::dec << "   " << std::chrono::duration_cast<std::chrono::milliseconds>(end-begin).count() << " ms" << std::endl;
-    CATCH_REQUIRE(norm(100000*d).item<double>() == norm(r).item<double>());
+    // TODO TEST PERF?
+    std::cout << std::dec << "   "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                     end - begin)
+                     .count()
+              << " ms" << std::endl;
+    CATCH_REQUIRE(norm(100000 * d).item<double>() == norm(r).item<double>());
   }
 
-  CATCH_SECTION( "isContiguous" ) {
+  CATCH_SECTION("isContiguous") {
     Tensor a = rand({3, 4}, type);
     CATCH_REQUIRE(a.is_contiguous());
     a = a.transpose(0, 1);
     CATCH_REQUIRE(!a.is_contiguous());
   }
 
-  CATCH_SECTION( "permute" ) {
+  CATCH_SECTION("permute") {
     Tensor a = rand({3, 4, 5}, type);
     Tensor b = a.permute({1, 2, 0});
     CATCH_REQUIRE(b.sizes().equals({4, 5, 3}));
     CATCH_REQUIRE(b.strides().equals({5, 1, 20}));
   }
 
-  CATCH_SECTION( "mm" ) {
+  CATCH_SECTION("mm") {
     Tensor a = rand({3, 4}, type);
     Tensor b = rand({4}, type);
     Tensor c = mv(a, b);
     CATCH_REQUIRE(c.equal(addmv(zeros({3}, type), a, b, 0, 1)));
   }
 
-  CATCH_SECTION( "squeeze" ) {
+  CATCH_SECTION("squeeze") {
     Tensor a = rand({2, 1}, type);
     Tensor b = squeeze(a);
     CATCH_REQUIRE(b.dim() == 1);
     a = rand({1}, type);
     b = squeeze(a);
-    //TODO 0-dim squeeze
+    // TODO 0-dim squeeze
     CATCH_REQUIRE(a[0].equal(b));
   }
 
-  CATCH_SECTION( "copy" ) {
+  CATCH_SECTION("copy") {
     Tensor a = zeros({4, 3}, type);
     Tensor e = rand({4, 3}, type);
     a.copy_(e);
     CATCH_REQUIRE(a.equal(e));
   }
 
-  CATCH_SECTION( "copy (broadcasting)" ) {
+  CATCH_SECTION("copy (broadcasting)") {
     Tensor a = zeros({4, 3}, type);
     Tensor e = rand({3}, type);
     a.copy_(e);
@@ -152,12 +159,12 @@ static void test(Type & type) {
     }
   }
 
-  CATCH_SECTION( "abs(value)" ) {
+  CATCH_SECTION("abs(value)") {
     Tensor r = at::abs(type.scalarTensor(-3));
     CATCH_REQUIRE(r.item<int32_t>() == 3);
   }
 
-//TODO(zach): operator overloads
+// TODO(zach): operator overloads
 #if 0
   {
     std::cout << "eq (value):" << std::endl;
@@ -168,60 +175,60 @@ static void test(Type & type) {
   }
 #endif
 
-  CATCH_SECTION( "adding a value with a scalar" ) {
+  CATCH_SECTION("adding a value with a scalar") {
     Tensor a = rand({4, 3}, type);
-    CATCH_REQUIRE((ones({4,3}, type) + a).equal(add(a,1)));
+    CATCH_REQUIRE((ones({4, 3}, type) + a).equal(add(a, 1)));
   }
 
-  CATCH_SECTION( "select" ) {
+  CATCH_SECTION("select") {
     Tensor a = rand({3, 7}, type);
     auto a_13 = select(a, 1, 3);
     auto a_13_02 = select(select(a, 1, 3), 0, 2);
-    CATCH_REQUIRE( a[0][3].equal(a_13[0]) );
-    CATCH_REQUIRE( a[2][3].equal(a_13_02) );
+    CATCH_REQUIRE(a[0][3].equal(a_13[0]));
+    CATCH_REQUIRE(a[2][3].equal(a_13_02));
   }
 
-  CATCH_SECTION( "zero-dim" ) {
-    Tensor a =  type.scalarTensor(4); //rand(type, {1});
+  CATCH_SECTION("zero-dim") {
+    Tensor a = type.scalarTensor(4); // rand(type, {1});
 
-    Tensor b = rand({3,4}, type);
+    Tensor b = rand({3, 4}, type);
     CATCH_REQUIRE((a + a).dim() == 0);
     CATCH_REQUIRE((1 + a).dim() == 0);
     CATCH_REQUIRE((b + a).dim() == 2);
     CATCH_REQUIRE((a + b).dim() == 2);
-    auto c = rand({3,4}, type);
+    auto c = rand({3, 4}, type);
     CATCH_REQUIRE(c[1][2].dim() == 0);
 
-    auto f = rand({3,4}, type);
+    auto f = rand({3, 4}, type);
     f[2] = zeros({4}, type);
     f[1][0] = -1;
     CATCH_REQUIRE(f[2][0].item<double>() == 0);
   }
 
-  CATCH_SECTION( "tensor from TH" ) {
+  CATCH_SECTION("tensor from TH") {
     int a = 4;
-    THFloatTensor *t = THFloatTensor_newWithSize2d(a, a);
+    THFloatTensor* t = THFloatTensor_newWithSize2d(a, a);
     THFloatTensor_fill(t, a);
-    Tensor tt = CPU(kFloat).unsafeTensorFromTH(t,false);
+    Tensor tt = CPU(kFloat).unsafeTensorFromTH(t, false);
     CATCH_REQUIRE_NOTHROW(tt);
   }
 
-  CATCH_SECTION( "item<float>" ) {
-    Tensor a = zeros({3,4});
-    Tensor b = ones({3,7});
-    Tensor c = cat({a,b},1);
+  CATCH_SECTION("item<float>") {
+    Tensor a = zeros({3, 4});
+    Tensor b = ones({3, 7});
+    Tensor c = cat({a, b}, 1);
     CATCH_REQUIRE(c.size(1) == 11);
 
     Tensor e = rand({});
     CATCH_REQUIRE(*e.data<float>() == e.sum().item<float>());
   }
 
-  CATCH_SECTION( "to string" ) {
-    Tensor b = ones({3,7})*.0000001f;
+  CATCH_SECTION("to string") {
+    Tensor b = ones({3, 7}) * .0000001f;
     std::stringstream s;
     s << b << "\n";
     std::string expect = "1e-07 *";
-    CATCH_REQUIRE(s.str().substr(0,expect.size()) == expect);
+    CATCH_REQUIRE(s.str().substr(0, expect.size()) == expect);
   }
   CATCH_SECTION("indexing by Scalar") {
     Tensor tensor = arange(0, 10, kInt);
@@ -243,8 +250,7 @@ static void test(Type & type) {
     }
     CATCH_REQUIRE_THROWS_WITH(
         tensor[Scalar(3.14)].equal(one),
-        StartsWith(
-            "Can only index tensors with integral scalars"));
+        StartsWith("Can only index tensors with integral scalars"));
   }
   CATCH_SECTION("indexing by zero-dim tensor") {
     Tensor tensor = arange(0, 10, kInt);
@@ -254,8 +260,7 @@ static void test(Type & type) {
     }
     CATCH_REQUIRE_THROWS_WITH(
         tensor[ones({}) * 3.14].equal(one),
-        StartsWith(
-            "Can only index tensors with integral scalars"));
+        StartsWith("Can only index tensors with integral scalars"));
     CATCH_REQUIRE_THROWS_WITH(
         tensor[Tensor()].equal(one),
         StartsWith("Can only index with tensors that are defined"));
@@ -275,16 +280,16 @@ static void test(Type & type) {
   }
 }
 
-CATCH_TEST_CASE( "basic tests CPU", "[cpu]" ) {
+CATCH_TEST_CASE("basic tests CPU", "[cpu]") {
   manual_seed(123, at::kCPU);
 
   test(CPU(kFloat));
 }
 
-CATCH_TEST_CASE( "basic tests GPU", "[cuda]" ) {
+CATCH_TEST_CASE("basic tests GPU", "[cuda]") {
   manual_seed(123, at::kCUDA);
 
-  if(at::hasCUDA()) {
+  if (at::hasCUDA()) {
     test(CUDA(kFloat));
   }
 }

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -164,6 +164,7 @@ static void test(Type& type) {
     CATCH_REQUIRE(r.item<int32_t>() == 3);
   }
 
+
 // TODO(zach): operator overloads
 #if 0
   {

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -1,154 +1,192 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "test_seed.h"
 
 using namespace at;
 
-CATCH_TEST_CASE( "broadcast", "[]" ) {
+// can't expand empty tensor
+void TestEmptyTensor(Type& T) {
+  auto empty = randn({0}, T);
+  ASSERT_ANY_THROW(empty.expand({3}));
+}
 
+// out-place function with 2 args
+void TestOut2Basic(Type& T) {
+  auto a = randn({3, 1}, T);
+  auto b = randn({5}, T);
+  std::vector<int64_t> expanded_sizes = {3, 5};
+  ASSERT_TRUE(
+      (a + b).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes)));
+}
+
+// with scalar
+void TestOut2WithScalar(Type& T) {
+  auto aScalar = ones({1}, T);
+  aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto b = randn({3, 5}, T);
+  ASSERT_TRUE(
+      (aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
+}
+
+// old fallback behavior yields error
+void TestOut2OldFallback(Type& T) {
+  auto a = randn({3, 5}, T);
+  auto b = randn({5, 3}, T);
+  ASSERT_ANY_THROW(a + b);
+}
+
+// with mismatched sizes
+void TestOut2MismatchedSizes(Type& T) {
+  auto a = randn({3, 5}, T);
+  auto b = randn({7, 5}, T);
+  ASSERT_ANY_THROW(a + b);
+}
+
+// out-place function with 3 args
+void TestOut3Basic(Type& T) {
+  auto a = randn({3, 1, 1}, T);
+  auto b = randn({1, 2, 1}, T);
+  auto c = randn({1, 1, 5}, T);
+  std::vector<int64_t> expanded_sizes = {3, 2, 5};
+  ASSERT_TRUE((a + b + c).equal(
+      a.expand(expanded_sizes) + b.expand(expanded_sizes) +
+      c.expand(expanded_sizes)));
+}
+
+// with scalar
+void TestOut3WithScalar(Type& T) {
+  auto aTensorScalar = ones({1}, T);
+  aTensorScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto b = randn({3, 2, 1}, T);
+  auto c = randn({1, 2, 5}, T);
+  std::vector<int64_t> expanded_sizes = {3, 2, 5};
+  ASSERT_TRUE(aTensorScalar.addcmul(b, c).equal(
+      aTensorScalar.expand(expanded_sizes)
+          .addcmul(b.expand(expanded_sizes), c.expand(expanded_sizes))));
+}
+
+// old fallback behavior yields error
+void TestOut3OldFallback(Type& T) {
+  auto a = randn({3, 2, 5}, T);
+  auto b = randn({2, 3, 5}, T);
+  auto c = randn({5, 3, 2}, T);
+  ASSERT_ANY_THROW(a.addcmul(b, c));
+}
+
+// with mismatched sizes
+void TestOut3MismatchedSizes(Type& T) {
+  auto a = randn({3, 2, 5}, T);
+  auto b = randn({2, 3, 5}, T);
+  auto c = randn({5, 5, 5}, T);
+  ASSERT_ANY_THROW(a.addcmul(b, c));
+}
+
+// in-place function with 2 args
+void TestIn2Basic(Type& T) {
+  auto a = randn({3, 5}, T);
+  auto b = randn({3, 1}, T);
+  ASSERT_TRUE((a + b).equal(a + b.expand({3, 5})));
+}
+
+// with scalar
+void TestIn2WithScalar(Type& T) {
+  auto a = randn({3, 5}, T);
+  auto bScalar = ones({1}, T);
+  bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  ASSERT_TRUE((a + bScalar).equal(a + bScalar.expand(a.sizes())));
+}
+
+// error: would have to expand inplace arg
+void TestIn2ExpandError(Type& T) {
+  auto a = randn({1, 5}, T);
+  auto b = randn({3, 1}, T);
+  ASSERT_ANY_THROW(a.add_(b));
+}
+
+// in-place function with 3 args
+void TestIn3Basic(Type& T) {
+  auto a = randn({3, 5, 2}, T);
+  auto b = randn({3, 1, 2}, T);
+  auto c = randn({1, 5, 1}, T);
+  auto aClone = a.clone();
+  ASSERT_TRUE(a.addcmul_(b, c).equal(
+      aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
+}
+
+// with scalar
+void TestIn3WithScalar(Type& T) {
+  auto a = randn({3, 5, 2}, T);
+  auto b = randn({3, 1, 2}, T);
+  auto c = randn({1, 5, 1}, T);
+  auto aClone = a.clone();
+  auto bScalar = ones({1}, T);
+  bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  ASSERT_TRUE(a.addcmul_(bScalar, c)
+                  .equal(aClone.addcmul_(
+                      bScalar.expand(a.sizes()), c.expand(a.sizes()))));
+}
+
+// error: would have to expand inplace arg
+void TestIn3ExpandError(Type& T) {
+  auto a = randn({1, 3, 5}, T);
+  auto b = randn({4, 1, 1}, T);
+  auto c = randn({1, 3, 1}, T);
+  ASSERT_ANY_THROW(a.addcmul_(b, c));
+}
+
+// explicit dim specification
+void TestExplicitDimBasic(Type& T) {
+  auto a = randn({1}, T);
+  auto b = randn({5, 3}, T);
+  auto c = randn({3, 7}, T);
+  ASSERT_TRUE(a.addmm(b, c).equal(a.expand({5, 7}).addmm(b, c)));
+}
+
+// with scalar
+void TestExplicitDimWithScalar(Type& T) {
+  auto a = randn({1}, T);
+  auto b = randn({5, 3}, T);
+  auto c = randn({3, 7}, T);
+  Tensor aScalar = ones({1}, T);
+  aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  ASSERT_TRUE(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
+}
+
+// with mismatched sizes
+void TestExplicitDimWithMismatchedSizes(Type& T) {
+  auto b = randn({5, 3}, T);
+  auto c = randn({3, 7}, T);
+  auto a = randn({3, 3}, T);
+  ASSERT_ANY_THROW(a.addmm(b, c));
+}
+
+TEST(BroadcastTest, Broadcast) {
   manual_seed(123, at::kCPU);
+  Type& T = CPU(kFloat);
 
-  Type & T = CPU(kFloat);
+  TestEmptyTensor(T);
 
-  // 0) pre-req tests:
-  CATCH_SECTION( "can't expand empty tensor" ) {
-    auto empty = randn({0}, T);
-    _CATCH_REQUIRE_THROWS(empty.expand({3}));
-  }
+  TestOut2Basic(T);
+  TestOut2WithScalar(T);
+  TestOut2OldFallback(T);
+  TestOut2MismatchedSizes(T);
 
-  // 1) out-place function with 2 args
-  CATCH_SECTION( "out-place function with 2 args" ) {
+  TestOut3Basic(T);
+  TestOut3WithScalar(T);
+  TestOut3OldFallback(T);
+  TestOut3MismatchedSizes(T);
 
-    CATCH_SECTION( "basic" ) {
-      auto a = randn({3, 1}, T);
-      auto b = randn({5}, T);
-      std::vector<int64_t> expanded_sizes = {3, 5};
-      CATCH_REQUIRE((a + b).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes)));
-    }
+  TestIn2Basic(T);
+  TestIn2WithScalar(T);
+  TestIn2ExpandError(T);
 
-    CATCH_SECTION( "with scalar" ) {
-      auto aScalar = ones({1}, T);
-      aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
-      auto b = randn({3, 5}, T);
-      CATCH_REQUIRE((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
-    }
+  TestIn3Basic(T);
+  TestIn3WithScalar(T);
+  TestIn3ExpandError(T);
 
-    CATCH_SECTION( "old fallback behavior yields error" ) {
-      auto a = randn({3, 5}, T);
-      auto b = randn({5, 3}, T);
-      _CATCH_REQUIRE_THROWS(a + b);
-    }
-
-    CATCH_SECTION( "with mismatched sizes" ) {
-      auto a = randn({3, 5}, T);
-      auto b = randn({7, 5}, T);
-      _CATCH_REQUIRE_THROWS(a + b);
-    }
-  }
-
-  CATCH_SECTION( "out-place function with 3 args" ) {
-
-    CATCH_SECTION( "basic" ) {
-      auto a = randn({3, 1, 1}, T);
-      auto b = randn({1, 2, 1}, T);
-      auto c = randn({1, 1, 5}, T);
-      std::vector<int64_t> expanded_sizes = {3, 2, 5};
-      CATCH_REQUIRE((a + b + c).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes) + c.expand(expanded_sizes)));
-    }
-
-    CATCH_SECTION( "with scalar" ) {
-      auto aTensorScalar = ones({1}, T);
-      aTensorScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
-      auto b = randn({3, 2, 1}, T);
-      auto c = randn({1, 2, 5}, T);
-      std::vector<int64_t> expanded_sizes = {3, 2, 5};
-      CATCH_REQUIRE(aTensorScalar.addcmul(b, c).equal(
-                aTensorScalar.expand(expanded_sizes).addcmul(b.expand(expanded_sizes), c.expand(expanded_sizes))));
-    }
-
-    CATCH_SECTION( "old fallback behavior yields error" ) {
-      auto a = randn({3, 2, 5}, T);
-      auto b = randn({2, 3, 5}, T);
-      auto c = randn({5, 3, 2}, T);
-      _CATCH_REQUIRE_THROWS(a.addcmul(b, c));
-    }
-
-    CATCH_SECTION( "with mismatched sizes" ){
-      auto a = randn({3, 2, 5}, T);
-      auto b = randn({2, 3, 5}, T);
-      auto c = randn({5, 5, 5}, T);
-      _CATCH_REQUIRE_THROWS(a.addcmul(b, c));
-    }
-  }
-
-  CATCH_SECTION( "in-place function with 2 args" ) {
-    CATCH_SECTION( "basic" ) {
-      auto a = randn({3, 5}, T);
-      auto b = randn({3, 1}, T);
-      CATCH_REQUIRE((a + b).equal(a + b.expand({3, 5})));
-    }
-
-    CATCH_SECTION( "with scalar" ) {
-      auto a = randn({3, 5}, T);
-      auto bScalar = ones({1}, T);
-      bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
-      CATCH_REQUIRE((a + bScalar).equal(a + bScalar.expand(a.sizes())));
-    }
-
-    CATCH_SECTION( "error: would have to expand inplace arg" ) {
-      auto a = randn({1, 5}, T);
-      auto b = randn({3, 1}, T);
-      _CATCH_REQUIRE_THROWS(a.add_(b));
-    }
-  }
-
-  CATCH_SECTION( "in-place function with 3 args" ) {
-
-    auto a = randn({3, 5, 2}, T);
-    auto b = randn({3, 1, 2}, T);
-    auto c = randn({1, 5, 1}, T);
-
-    CATCH_SECTION( "basic" ) {
-      auto aClone = a.clone();
-      CATCH_REQUIRE(a.addcmul_(b, c).equal(aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
-    }
-
-    CATCH_SECTION( "with scalar" ) {
-      auto aClone = a.clone();
-      auto bScalar = ones({1}, T);
-      bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
-      CATCH_REQUIRE(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
-    }
-
-    CATCH_SECTION( "error: would have to expand inplace arg" ) {
-      auto a = randn({1, 3, 5}, T);
-      auto b = randn({4, 1, 1}, T);
-      auto c = randn({1, 3, 1}, T);
-      _CATCH_REQUIRE_THROWS(a.addcmul_(b, c));
-    }
-  }
-
-  CATCH_SECTION( "explicit dim specification" ) {
-
-    auto a = randn({1}, T);
-    auto b = randn({5, 3}, T);
-    auto c = randn({3, 7}, T);
-
-    CATCH_SECTION( "basic" ) {
-      CATCH_REQUIRE(a.addmm(b, c).equal(a.expand({5,7}).addmm(b, c)));
-    }
-
-    CATCH_SECTION( "with scalar" ) {
-      Tensor aScalar = ones({1}, T);
-      aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
-      CATCH_REQUIRE(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
-    }
-
-    CATCH_SECTION( "with mismatched sizes" ) {
-      auto a = randn({3, 3}, T);
-      _CATCH_REQUIRE_THROWS(a.addmm(b, c));
-    }
-  }
+  TestExplicitDimBasic(T);
+  TestExplicitDimWithScalar(T);
+  TestExplicitDimWithMismatchedSizes(T);
 }

--- a/aten/src/ATen/test/catch_utils.hpp
+++ b/aten/src/ATen/test/catch_utils.hpp
@@ -3,6 +3,8 @@
 #define CATCH_CONFIG_PREFIX_ALL
 #include <catch.hpp>
 
-// CATCH_REQUIRE_THROWS is not defined identically to REQUIRE_THROWS and causes warning;
-// define our own version that doesn't warn.
-#define _CATCH_REQUIRE_THROWS( ... ) INTERNAL_CATCH_THROWS( "CATCH_REQUIRE_THROWS", Catch::ResultDisposition::Normal, __VA_ARGS__ )
+// CATCH_REQUIRE_THROWS is not defined identically to REQUIRE_THROWS and causes
+// warning; define our own version that doesn't warn.
+#define _CATCH_REQUIRE_THROWS(...) \
+  INTERNAL_CATCH_THROWS(           \
+      "CATCH_REQUIRE_THROWS", Catch::ResultDisposition::Normal, __VA_ARGS__)

--- a/aten/src/ATen/test/cuda_half_test.cu
+++ b/aten/src/ATen/test/cuda_half_test.cu
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/cuda/NumericLimits.cuh"
@@ -12,7 +11,6 @@
 using namespace at;
 
 __device__ void test(){
-  
   // test half construction and implicit conversions in device
   assert(Half(3) == Half(3.0f));
   assert(static_cast<Half>(3.0f) == Half(3.0f));
@@ -24,7 +22,7 @@ __device__ void test(){
   __half c = a - Half(b);
   assert(static_cast<Half>(c) == Half(1.0));
 
-  // asserting if the  functions used on 
+  // asserting if the  functions used on
   // half types give almost equivalent results when using
   //  functions on double.
   // The purpose of these asserts are to test the device side
@@ -61,17 +59,18 @@ __device__ void test(){
   assert(::abs(::abs(Half(-3.0)) - ::abs(-3.0f)) <= threshold);
   assert(::abs(::round(Half(2.3)) - ::round(2.3f)) <= threshold);
   assert(::abs(::pow(Half(2.0), Half(10.0)) - ::pow(2.0f, 10.0f)) <= threshold);
-  assert(::abs(::atan2(Half(7.0), Half(0.0)) - ::atan2(7.0f, 0.0f)) <= threshold);
+  assert(
+      ::abs(::atan2(Half(7.0), Half(0.0)) - ::atan2(7.0f, 0.0f)) <= threshold);
   // note: can't use  namespace on isnan and isinf in device code
-  #ifdef _MSC_VER
-    // Windows requires this explicit conversion. The reason is unclear
-    // related issue with clang: https://reviews.llvm.org/D37906
-    assert(::abs(::isnan((float)Half(0.0)) - ::isnan(0.0f)) <= threshold);
-    assert(::abs(::isinf((float)Half(0.0)) - ::isinf(0.0f)) <= threshold);
-  #else
-    assert(::abs(::isnan(Half(0.0)) - ::isnan(0.0f)) <= threshold);
-    assert(::abs(::isinf(Half(0.0)) - ::isinf(0.0f)) <= threshold);
-  #endif
+#ifdef _MSC_VER
+  // Windows requires this explicit conversion. The reason is unclear
+  // related issue with clang: https://reviews.llvm.org/D37906
+  assert(::abs(::isnan((float)Half(0.0)) - ::isnan(0.0f)) <= threshold);
+  assert(::abs(::isinf((float)Half(0.0)) - ::isinf(0.0f)) <= threshold);
+#else
+  assert(::abs(::isnan(Half(0.0)) - ::isnan(0.0f)) <= threshold);
+  assert(::abs(::isinf(Half(0.0)) - ::isinf(0.0f)) <= threshold);
+#endif
 }
 
 __global__ void kernel(){
@@ -79,12 +78,13 @@ __global__ void kernel(){
 }
 
 void launch_function(){
-  kernel<<<1,1>>>();
+  kernel<<<1, 1>>>();
 }
 
-CATCH_TEST_CASE( "half common math functions tests in device", "[cuda]" ) {
+// half common math functions tests in device
+TEST(HalfCuda, HalfCuda) {
   launch_function();
   cudaError_t err = cudaDeviceSynchronize();
-  CATCH_REQUIRE(err == cudaSuccess);
+  bool isEQ = err == cudaSuccess;
+  ASSERT_TRUE(isEQ);
 }
-

--- a/aten/src/ATen/test/cuda_optional_test.cu
+++ b/aten/src/ATen/test/cuda_optional_test.cu
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/optional.h"
@@ -8,15 +7,15 @@
 
 using namespace at;
 
-CATCH_TEST_CASE( "optional in cuda files", "[cuda]" ) {
+// optional in cuda files
+TEST(OptionalTest, OptionalTestCUDA) {
   at::optional<int64_t> trivially_destructible;
   at::optional<std::vector<int64_t>> non_trivially_destructible;
-  CATCH_REQUIRE(!trivially_destructible.has_value());
-  CATCH_REQUIRE(!non_trivially_destructible.has_value());
+  ASSERT_FALSE(trivially_destructible.has_value());
+  ASSERT_FALSE(non_trivially_destructible.has_value());
 
   trivially_destructible = {5};
   non_trivially_destructible = std::vector<int64_t>{5, 10};
-  CATCH_REQUIRE(trivially_destructible.has_value());
-  CATCH_REQUIRE(non_trivially_destructible.has_value());
+  ASSERT_TRUE(trivially_destructible.has_value());
+  ASSERT_TRUE(non_trivially_destructible.has_value());
 }
-

--- a/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
+++ b/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "test_seed.h"
@@ -10,9 +9,10 @@
 
 using namespace at;
 
-__global__ void test_tensor_packed_accessor_kernel(PackedTensorAccessor<float,1,RestrictPtrTraits> resa,
-						   PackedTensorAccessor<float,2,RestrictPtrTraits> t1a,
-						   PackedTensorAccessor<float,1,RestrictPtrTraits> t2a){
+__global__ void test_tensor_packed_accessor_kernel(
+    PackedTensorAccessor<float, 1, RestrictPtrTraits> resa,
+    PackedTensorAccessor<float, 2, RestrictPtrTraits> t1a,
+    PackedTensorAccessor<float, 1, RestrictPtrTraits> t2a) {
   for (int64_t i = 0; i < resa.size(0); i++) {
     float val = 0.0f;
     for (int64_t j = 0; j < t1a.size(1); j++) {
@@ -22,7 +22,8 @@ __global__ void test_tensor_packed_accessor_kernel(PackedTensorAccessor<float,1,
   }
 }
 
-CATCH_TEST_CASE( "test PackedTensorAccessor and Tensor.packed_accessor", "[cuda]" ) {
+// test PackedTensorAccessor and Tensor.packed_accessor
+TEST(PackedtensoraccessorTest, PackedtensoraccessorTestCUDA) {
   manual_seed(123, at::kCPU);
   manual_seed(123, at::kCUDA);
 
@@ -35,12 +36,13 @@ CATCH_TEST_CASE( "test PackedTensorAccessor and Tensor.packed_accessor", "[cuda]
   auto resa = res.packed_accessor<float, 1, RestrictPtrTraits>();
 
   auto stream = at::cuda::getCurrentCUDAStream();
-  
+
   test_tensor_packed_accessor_kernel<<<1, 1, 0, stream>>>(resa, t1a, t2a);
   cudaError_t err = cudaDeviceSynchronize();
-  CATCH_REQUIRE(err == cudaSuccess);
+  bool isEQ = err == cudaSuccess;
+  ASSERT_TRUE(isEQ);
 
   auto expected = mv(t1, t2);
 
-  CATCH_REQUIRE(res.allclose(expected));
+  ASSERT_TRUE(res.allclose(expected));
 }

--- a/aten/src/ATen/test/cuda_rng_test.cpp
+++ b/aten/src/ATen/test/cuda_rng_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "cuda.h"
@@ -21,7 +20,6 @@ void testCudaRNGMultithread() {
   }
 };
 
-CATCH_TEST_CASE( "CUDA RNG test", "[cuda]" ) {
-  CATCH_SECTION( "multithread" )
-    testCudaRNGMultithread();
+TEST(Cuda_RNGTest, MultithreadRNGTest) {
+  testCudaRNGMultithread();
 }

--- a/aten/src/ATen/test/cudnn_test.cpp
+++ b/aten/src/ATen/test/cudnn_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/cudnn/Descriptors.h"
@@ -9,7 +8,7 @@
 using namespace at;
 using namespace at::native;
 
-CATCH_TEST_CASE( "cudnn", "[cuda]" ) {
+TEST(CUDNNTest, CUDNNTestCUDA) {
   manual_seed(123, at::kCUDA);
 
 #if CUDNN_VERSION < 7000
@@ -17,9 +16,12 @@ CATCH_TEST_CASE( "cudnn", "[cuda]" ) {
   DropoutDescriptor desc1, desc2;
   desc1.initialize_rng(at::CUDA(kByte), handle, 0.5, 42);
   desc2.set(handle, 0.5, desc1.state);
-
-  CATCH_REQUIRE(desc1.desc()->dropout == desc2.desc()->dropout);
-  CATCH_REQUIRE(desc1.desc()->nstates == desc2.desc()->nstates);
-  CATCH_REQUIRE(desc1.desc()->states == desc2.desc()->states);
+  bool isEQ;
+  isEQ = (desc1.desc()->dropout == desc2.desc()->dropout);
+  ASSERT_TRUE(isEQ);
+  isEQ = (desc1.desc()->nstates == desc2.desc()->nstates);
+  ASSERT_TRUE(isEQ);
+  isEQ = (desc1.desc()->states == desc2.desc()->states);
+  ASSERT_TRUE(isEQ);
 #endif
 }

--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/DLConvertor.h"
@@ -10,18 +9,13 @@
 #include "test_seed.h"
 
 using namespace at;
-
-CATCH_TEST_CASE( "dlconvertor", "[cpu]" ) {
-
+TEST(TestDlconvertor, TestDlconvertor) {
   manual_seed(123, at::kCPU);
 
-  CATCH_INFO( "convert ATen to DLTensor" );
-
-  Tensor a = rand({3,4});
+  Tensor a = rand({3, 4});
   DLManagedTensor* dlMTensor = toDLPack(a);
 
-  CATCH_INFO( "convert DLTensor to ATen" );
   Tensor b = fromDLPack(dlMTensor);
 
-  CATCH_REQUIRE(a.equal(b));
+  ASSERT_TRUE(a.equal(b));
 }

--- a/aten/src/ATen/test/half_test.cpp
+++ b/aten/src/ATen/test/half_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include <ATen/ATen.h>
 #include <iostream>
@@ -12,53 +11,53 @@
 
 using namespace at;
 
-CATCH_TEST_CASE( "half arithmetic", "[]" ) {
+TEST(TestHalf, Arithmetic) {
   Half zero = 0;
   Half one = 1;
-  CATCH_REQUIRE(zero + one == one);
-  CATCH_REQUIRE(zero + zero == zero);
-  CATCH_REQUIRE(zero * one == zero);
-  CATCH_REQUIRE(one * one == one);
-  CATCH_REQUIRE(one / one == one);
-  CATCH_REQUIRE(one - one == zero);
-  CATCH_REQUIRE(one - zero == one);
-  CATCH_REQUIRE(zero - one == -one);
-  CATCH_REQUIRE(one + one == Half(2));
-  CATCH_REQUIRE(one + one == 2);
+  ASSERT_EQ(zero + one, one);
+  ASSERT_EQ(zero + zero, zero);
+  ASSERT_EQ(zero * one, zero);
+  ASSERT_EQ(one * one, one);
+  ASSERT_EQ(one / one, one);
+  ASSERT_EQ(one - one, zero);
+  ASSERT_EQ(one - zero, one);
+  ASSERT_EQ(zero - one, -one);
+  ASSERT_EQ(one + one, Half(2));
+  ASSERT_EQ(one + one, 2);
 }
 
-CATCH_TEST_CASE( "half comparisons", "[]" ) {
+TEST(TestHalf, Comparisions) {
   Half zero = 0;
   Half one = 1;
-  CATCH_REQUIRE(zero < one);
-  CATCH_REQUIRE(zero < 1);
-  CATCH_REQUIRE(1 > zero);
-  CATCH_REQUIRE(0 >= zero);
-  CATCH_REQUIRE(0 != one);
-  CATCH_REQUIRE(zero == 0);
-  CATCH_REQUIRE(zero == zero);
-  CATCH_REQUIRE(zero == -zero);
+  ASSERT_LT(zero, one);
+  ASSERT_LT(zero, 1);
+  ASSERT_GT(1, zero);
+  ASSERT_GE(0, zero);
+  ASSERT_NE(0, one);
+  ASSERT_EQ(zero, 0);
+  ASSERT_EQ(zero, zero);
+  ASSERT_EQ(zero, -zero);
 }
 
-CATCH_TEST_CASE( "half cast", "[]" ) {
+TEST(TestHalf, Cast) {
   Half value = 1.5f;
-  CATCH_REQUIRE((int)value == 1);
-  CATCH_REQUIRE((short)value == 1);
-  CATCH_REQUIRE((long long)value == 1LL);
-  CATCH_REQUIRE((float)value == 1.5f);
-  CATCH_REQUIRE((double)value == 1.5);
-  CATCH_REQUIRE((bool)value == true);
-  CATCH_REQUIRE((bool)Half(0.0f) == false);
+  ASSERT_EQ((int)value, 1);
+  ASSERT_EQ((short)value, 1);
+  ASSERT_EQ((long long)value, 1LL);
+  ASSERT_EQ((float)value, 1.5f);
+  ASSERT_EQ((double)value, 1.5);
+  ASSERT_EQ((bool)value, true);
+  ASSERT_EQ((bool)Half(0.0f), false);
 }
 
-CATCH_TEST_CASE( "half construction", "[]" ) {
-  CATCH_REQUIRE(Half((short)3) == Half(3.0f));
-  CATCH_REQUIRE(Half((unsigned short)3) == Half(3.0f));
-  CATCH_REQUIRE(Half(3) == Half(3.0f));
-  CATCH_REQUIRE(Half(3U) == Half(3.0f));
-  CATCH_REQUIRE(Half(3LL) == Half(3.0f));
-  CATCH_REQUIRE(Half(3ULL) == Half(3.0f));
-  CATCH_REQUIRE(Half(3.5) == Half(3.5f));
+TEST(TestHalf, Construction) {
+  ASSERT_EQ(Half((short)3), Half(3.0f));
+  ASSERT_EQ(Half((unsigned short)3), Half(3.0f));
+  ASSERT_EQ(Half(3), Half(3.0f));
+  ASSERT_EQ(Half(3U), Half(3.0f));
+  ASSERT_EQ(Half(3LL), Half(3.0f));
+  ASSERT_EQ(Half(3ULL), Half(3.0f));
+  ASSERT_EQ(Half(3.5), Half(3.5f));
 }
 
 static std::string to_string(const Half& h) {
@@ -67,31 +66,31 @@ static std::string to_string(const Half& h) {
   return ss.str();
 }
 
-CATCH_TEST_CASE( "half to string", "[]" ) {
-  CATCH_REQUIRE(to_string(Half(3.5f)) == "3.5");
-  CATCH_REQUIRE(to_string(Half(-100.0f)) == "-100");
+TEST(TestHalf, Half2String) {
+  ASSERT_EQ(to_string(Half(3.5f)), "3.5");
+  ASSERT_EQ(to_string(Half(-100.0f)), "-100");
 }
 
-CATCH_TEST_CASE( "half numeric limits", "[]" ) {
+TEST(TestHalf, HalfNumericLimits) {
   using limits = std::numeric_limits<Half>;
-  CATCH_REQUIRE(limits::lowest() == -65504.0f);
-  CATCH_REQUIRE(limits::max() == 65504.0f);
-  CATCH_REQUIRE(limits::min() > 0);
-  CATCH_REQUIRE(limits::min() < 1);
-  CATCH_REQUIRE(limits::denorm_min() > 0);
-  CATCH_REQUIRE(limits::denorm_min() / 2  == 0);
-  CATCH_REQUIRE(limits::infinity() == std::numeric_limits<float>::infinity());
-  CATCH_REQUIRE(limits::quiet_NaN() != limits::quiet_NaN());
-  CATCH_REQUIRE(limits::signaling_NaN() != limits::signaling_NaN());
+  ASSERT_EQ(limits::lowest(), -65504.0f);
+  ASSERT_EQ(limits::max(), 65504.0f);
+  ASSERT_GT(limits::min(), 0);
+  ASSERT_LT(limits::min(), 1);
+  ASSERT_GT(limits::denorm_min(), 0);
+  ASSERT_EQ(limits::denorm_min() / 2, 0);
+  ASSERT_EQ(limits::infinity(), std::numeric_limits<float>::infinity());
+  ASSERT_NE(limits::quiet_NaN(), limits::quiet_NaN());
+  ASSERT_NE(limits::signaling_NaN(), limits::signaling_NaN());
 }
 
 // Check the declared type of members of numeric_limits<Half> matches
 // the declared type of that member on numeric_limits<float>
 
-#define ASSERT_SAME_TYPE(name) \
-  static_assert( \
-      std::is_same< \
-          decltype(std::numeric_limits<Half>::name), \
+#define ASSERT_SAME_TYPE(name)                                \
+  static_assert(                                              \
+      std::is_same<                                           \
+          decltype(std::numeric_limits<Half>::name),          \
           decltype(std::numeric_limits<float>::name)>::value, \
       "decltype(" #name ") differs")
 
@@ -119,7 +118,7 @@ ASSERT_SAME_TYPE(max_exponent10);
 ASSERT_SAME_TYPE(traps);
 ASSERT_SAME_TYPE(tinyness_before);
 
-CATCH_TEST_CASE( "half common math functions test", "[]" ) {
+TEST(TestHalf, CommonMath) {
   float threshold = 0.00001;
   assert(std::abs(std::lgamma(Half(10.0)) - std::lgamma(10.0f)) <= threshold);
   assert(std::abs(std::exp(Half(1.0)) - std::exp(1.0f)) <= threshold);
@@ -147,14 +146,22 @@ CATCH_TEST_CASE( "half common math functions test", "[]" ) {
   assert(std::abs(std::erfc(Half(10.0)) - std::erfc(10.0f)) <= threshold);
   assert(std::abs(std::abs(Half(-3.0)) - std::abs(-3.0f)) <= threshold);
   assert(std::abs(std::round(Half(2.3)) - std::round(2.3f)) <= threshold);
-  assert(std::abs(std::pow(Half(2.0), Half(10.0)) - std::pow(2.0f, 10.0f)) <= threshold);
-  assert(std::abs(std::atan2(Half(7.0), Half(0.0)) - std::atan2(7.0f, 0.0f)) <= threshold);
-  #ifdef __APPLE__
-    // @TODO: can macos do implicit conversion of Half?
-    assert(std::abs(std::isnan(static_cast<float>(Half(0.0))) - std::isnan(0.0f)) <= threshold);
-    assert(std::abs(std::isinf(static_cast<float>(Half(0.0))) - std::isinf(0.0f)) <= threshold);
-  #else
-    assert(std::abs(std::isnan(Half(0.0)) - std::isnan(0.0f)) <= threshold);
-    assert(std::abs(std::isinf(Half(0.0)) - std::isinf(0.0f)) <= threshold);
-  #endif
+  assert(
+      std::abs(std::pow(Half(2.0), Half(10.0)) - std::pow(2.0f, 10.0f)) <=
+      threshold);
+  assert(
+      std::abs(std::atan2(Half(7.0), Half(0.0)) - std::atan2(7.0f, 0.0f)) <=
+      threshold);
+#ifdef __APPLE__
+  // @TODO: can macos do implicit conversion of Half?
+  assert(
+      std::abs(std::isnan(static_cast<float>(Half(0.0))) - std::isnan(0.0f)) <=
+      threshold);
+  assert(
+      std::abs(std::isinf(static_cast<float>(Half(0.0))) - std::isinf(0.0f)) <=
+      threshold);
+#else
+  assert(std::abs(std::isnan(Half(0.0)) - std::isnan(0.0f)) <= threshold);
+  assert(std::abs(std::isinf(Half(0.0)) - std::isinf(0.0f)) <= threshold);
+#endif
 }

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -1,192 +1,222 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "test_seed.h"
 
 using namespace at;
 
-using Catch::Matchers::StartsWith;
+#define ASSERT_EQUAL(t1, t2) ASSERT_TRUE(t1.equal(t2));
 
-#define REQUIRE_EQUAL(t1, t2) \
-  CATCH_REQUIRE(t1.equal(t2));
+#define ASSERT_ALLCLOSE(t1, t2)     \
+  ASSERT_TRUE(t1.is_same_size(t2)); \
+  ASSERT_TRUE(t1.allclose(t2));
 
-#define REQUIRE_ALLCLOSE(t1, t2)   \
-  CATCH_REQUIRE(t1.is_same_size(t2));    \
-  CATCH_REQUIRE(t1.allclose(t2));
-
-#define REQUIRE_ALLCLOSE_TOLERANCES(t1, t2, atol, rtol)   \
-  CATCH_REQUIRE(t1.is_same_size(t2));    \
-  CATCH_REQUIRE(t1.allclose(t2, atol, rtol));
+#define ASSERT_ALLCLOSE_TOLERANCES(t1, t2, atol, rtol) \
+  ASSERT_TRUE(t1.is_same_size(t2));                    \
+  ASSERT_TRUE(t1.allclose(t2, atol, rtol));
 
 void requireEqualTensorList(TensorList t1, TensorList t2) {
-  CATCH_REQUIRE(t1.size() == t2.size());
+  ASSERT_EQ(t1.size(), t2.size());
   for (size_t i = 0; i < t1.size(); ++i) {
-    REQUIRE_EQUAL(t1[ i ], t2[ i ]);
+    ASSERT_EQUAL(t1[i], t2[i]);
   }
 }
 
-void test(Type & T, Type & AccT) {
+// split: test method, type, namespace give same result
+void TestSplit(Type& T, Tensor& t) {
+  auto splitMethod = t.split(1, 0);
+  auto splitType = T.split(t, 1, 0);
+  auto splitNs = at::split(t, 1, 0);
+  requireEqualTensorList(splitMethod, splitType);
+  requireEqualTensorList(splitMethod, splitNs);
+
+  // test rebuilding with cat
+  ASSERT_EQUAL(at::cat(splitMethod, 0), t);
+}
+
+// chunk: test method, type, namespace give same result
+void TestChunk(Type& T, Tensor& t) {
+  // test method, type, namespace give same result
+  auto chunkMethod = t.chunk(3, 0);
+  auto chunkType = T.chunk(t, 3, 0);
+  auto chunkNs = at::chunk(t, 3, 0);
+  requireEqualTensorList(chunkMethod, chunkType);
+  requireEqualTensorList(chunkMethod, chunkNs);
+
+  // test rebuilding with cat
+  ASSERT_EQUAL(at::cat(chunkMethod, 0), t);
+}
+
+void TestStack(Type& T, Tensor& t) {
+  auto x = rand({2, 3, 4});
+  auto y = rand({2, 3, 4});
+  auto z = rand({2, 3, 4});
+  for (int64_t dim = 0; dim < 4; ++dim) {
+    auto res = at::stack({x, y, z}, dim);
+    auto res_neg = at::stack({x, y, z}, dim - 4);
+    std::vector<int64_t> expected_size;
+    expected_size.insert(
+        expected_size.end(), x.sizes().begin(), x.sizes().begin() + dim);
+    expected_size.insert(expected_size.end(), 3);
+    expected_size.insert(
+        expected_size.end(), x.sizes().begin() + dim, x.sizes().end());
+
+    ASSERT_EQUAL(res, res_neg);
+    ASSERT_TRUE(res.sizes().equals(expected_size));
+    ASSERT_EQUAL(res.select(dim, 0), x);
+    ASSERT_EQUAL(res.select(dim, 1), y);
+    ASSERT_EQUAL(res.select(dim, 2), z);
+  }
+}
+
+// size / stride
+void TestSize(Type& T, Tensor& t) {
+  auto scalar = randn({}, T);
+  // Throw StartsWith("dimension specified as 0 but tensor has no dimensions")
+  ASSERT_ANY_THROW(scalar.size(0));
+  // Throw StartsWith("dimension specified as -1 but tensor has no dimensions")
+  ASSERT_ANY_THROW(scalar.size(-1));
+  // Throw StartsWith("dimension specified as 0 but tensor has no dimensions")
+  ASSERT_ANY_THROW(scalar.stride(0));
+  // Throw StartsWith("dimension specified as -1 but tensor has no dimensions")
+  ASSERT_ANY_THROW(scalar.stride(-1));
+
+  auto empty = randn({0}, T);
+  ASSERT_EQ(empty.size(0), 0);
+  ASSERT_EQ(empty.size(-1), 0);
+  ASSERT_EQ(empty.stride(0), 1);
+  ASSERT_EQ(empty.stride(-1), 1);
+}
+
+void TestMatmul(Type& T, Tensor& t, Type& AccT) {
+  auto scalar = randn({}, T);
+  auto d1 = randn({3}, T);
+  auto d2 = randn({2, 3}, T);
+
+  // 0-d
+  // Throw StartsWith("both arguments to matmul need to be at least 1D")
+  ASSERT_ANY_THROW(scalar.matmul(d2));
+  // Throw StartsWith("both arguments to matmul need to be at least 1D")
+  ASSERT_ANY_THROW(d2.matmul(scalar));
+
+  // 1-d
+  ASSERT_ALLCLOSE(d1.matmul(d1), d1.dot(d1));
+  ASSERT_ALLCLOSE(d2.matmul(d1), d2.mv(d1));
+  auto d1o = randn({2}, T);
+  ASSERT_ALLCLOSE(d1o.matmul(d2), d1o.unsqueeze(0).mm(d2).squeeze(0));
+
+  // 2-d
+  auto d2o = randn({3, 5}, T);
+  ASSERT_ALLCLOSE(d2.matmul(d2o), d2.mm(d2o));
+
+  // > 2-d, 1-d
+  auto d3 = randn({5, 2, 3}, T);
+  ASSERT_ALLCLOSE(
+      d3.matmul(d1), d3.bmm(d1.view({1, 3, 1}).expand({5, 3, 1})).view({5, 2}));
+  ASSERT_ALLCLOSE(d1o.matmul(d3), d1o.expand({5, 1, 2}).bmm(d3).view({5, 3}));
+
+  auto d5 = randn({3, 2, 4, 2, 3}, T);
+  ASSERT_ALLCLOSE(
+      d5.matmul(d1),
+      d5.view({24, 2, 3})
+          .bmm(d1.view({1, 3, 1}).expand({24, 3, 1}))
+          .view({3, 2, 4, 2}));
+  ASSERT_ALLCLOSE(
+      d1o.matmul(d5),
+      d1o.expand({24, 1, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 3}));
+
+  // > 2-d, 2-d
+  // we use a "folding" algorithm in this case of matmul, so the direct
+  // comparison to bmm doesn't work; instead, compare to the higher precision
+  // computation (technically, we should always do this). Tolerances are
+  // selected empirically.
+  double atol = 1e-04;
+  double rtol = 1e-06;
+  d2 = randn({3, 4}, T);
+  d2o = randn({4, 2}, T);
+  auto result = d5.matmul(d2).toType(AccT);
+
+  auto d5Acc = d5.toType(AccT);
+  auto d2Acc = d2.toType(AccT);
+  auto acc_result = d5Acc.view({24, 2, 3})
+                        .bmm(d2Acc.expand({24, 3, 4}))
+                        .view({3, 2, 4, 2, 4});
+  ASSERT_ALLCLOSE_TOLERANCES(result, acc_result, atol, rtol);
+  ASSERT_ALLCLOSE(
+      d2o.matmul(d5),
+      d2o.expand({24, 4, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 4, 3}));
+
+  // > 2-d, > 2-d
+  auto d5o = randn({2, 1, 2, 4, 3, 2}, T);
+  auto d5_bmm_view =
+      d5.expand({2, 3, 2, 4, 2, 3}).contiguous().view({48, 2, 3});
+  auto d5o_bmm_view =
+      d5o.expand({2, 3, 2, 4, 3, 2}).contiguous().view({48, 3, 2});
+  ASSERT_ALLCLOSE(
+      d5.matmul(d5o), d5_bmm_view.bmm(d5o_bmm_view).view({2, 3, 2, 4, 2, 2}));
+
+  // non-expandable case
+  auto d5wrong = randn({2, 4, 2, 4, 3, 2}, T);
+  // Throw Contains("must match the size")
+  ASSERT_ANY_THROW(d5.matmul(d5wrong));
+}
+
+void TestStandardGammaGrad(Type& T, Tensor& t) {
+  // check empty
+  auto empty = ones({0}, T);
+  ASSERT_EQUAL(empty, at::_standard_gamma_grad(empty, empty));
+
+  // check scalar equals one element
+  auto one_scalar = ones({}, T).mul(5);
+  auto one_with_dim = ones({1}, T).mul(5);
+  ASSERT_ALLCLOSE(
+      at::_standard_gamma_grad(one_scalar, one_scalar),
+      at::_standard_gamma_grad(one_with_dim, one_with_dim).sum());
+
+  // check mixing types
+  auto t1 = randn({3, 4}, T);
+  auto t2 = randn({3, 4}, T).toType(kDouble);
+  // Throw StartsWith("expected scalar type")
+  ASSERT_ANY_THROW(at::_standard_gamma_grad(t1, t2));
+}
+
+void TestWhere(Type& T, Tensor& t) {
+  // empty
+  auto empty = ones({0}, T);
+  auto& bT = T.toScalarType(ScalarType::Byte);
+  auto empty_byte = ones({0}, bT);
+  ASSERT_EQUAL(empty, at::where(empty_byte, empty, empty));
+
+  // check scalar equals one element
+  auto x_scalar = ones({}, T).mul(5);
+  auto y_scalar = ones({}, T).mul(7);
+  auto cond_scalar = zeros({}, bT);
+  auto x_1d = x_scalar.unsqueeze(0);
+  auto y_1d = y_scalar.unsqueeze(0);
+  auto cond_1d = cond_scalar.unsqueeze(0);
+  ASSERT_ALLCLOSE(
+      at::where(cond_scalar, x_scalar, y_scalar).unsqueeze(0),
+      at::where(cond_1d, x_1d, y_1d));
+}
+
+void test(Type& T, Type& AccT) {
   auto t = randn({3, 3}, T);
-
-  CATCH_SECTION( "split: test method, type, namespace give same result" ) {
-    auto splitMethod = t.split(1, 0);
-    auto splitType = T.split(t, 1, 0);
-    auto splitNs = at::split(t, 1, 0);
-    requireEqualTensorList(splitMethod, splitType);
-    requireEqualTensorList(splitMethod, splitNs);
-
-    // test rebuilding with cat
-    REQUIRE_EQUAL(at::cat(splitMethod, 0), t);
-  }
-
-  CATCH_SECTION( "chunk: test method, type, namespace give same result" ) {
-    // test method, type, namespace give same result
-    auto chunkMethod = t.chunk(3, 0);
-    auto chunkType = T.chunk(t, 3, 0);
-    auto chunkNs = at::chunk(t, 3, 0);
-    requireEqualTensorList(chunkMethod, chunkType);
-    requireEqualTensorList(chunkMethod, chunkNs);
-
-    // test rebuilding with cat
-    REQUIRE_EQUAL(at::cat(chunkMethod, 0), t);
-  }
-
-  // stack
-  CATCH_SECTION( "stack" ) {
-    auto x = rand({2, 3, 4});
-    auto y = rand({2, 3, 4});
-    auto z = rand({2, 3, 4});
-    for (int64_t dim = 0; dim < 4; ++dim) {
-      auto res = at::stack({x, y, z}, dim);
-      auto res_neg = at::stack({x, y, z}, dim - 4);
-      std::vector<int64_t> expected_size;
-      expected_size.insert(expected_size.end(), x.sizes().begin(), x.sizes().begin() + dim);
-      expected_size.insert(expected_size.end(), 3);
-      expected_size.insert(expected_size.end(), x.sizes().begin() + dim, x.sizes().end());
-
-      REQUIRE_EQUAL(res, res_neg);
-      CATCH_REQUIRE(res.sizes().equals(expected_size));
-      REQUIRE_EQUAL(res.select(dim, 0), x);
-      REQUIRE_EQUAL(res.select(dim, 1), y);
-      REQUIRE_EQUAL(res.select(dim, 2), z);
-    }
-  }
-
-  CATCH_SECTION( "size / stride" ) {
-    auto scalar = randn({}, T);
-    CATCH_REQUIRE_THROWS_WITH(scalar.size(0), StartsWith("dimension specified as 0 but tensor has no dimensions"));
-    CATCH_REQUIRE_THROWS_WITH(scalar.size(-1), StartsWith("dimension specified as -1 but tensor has no dimensions"));
-    CATCH_REQUIRE_THROWS_WITH(scalar.stride(0), StartsWith("dimension specified as 0 but tensor has no dimensions"));
-    CATCH_REQUIRE_THROWS_WITH(scalar.stride(-1), StartsWith("dimension specified as -1 but tensor has no dimensions"));
-
-    auto empty = randn({0}, T);
-    CATCH_REQUIRE(empty.size(0) == 0);
-    CATCH_REQUIRE(empty.size(-1) == 0);
-    CATCH_REQUIRE(empty.stride(0) == 1);
-    CATCH_REQUIRE(empty.stride(-1) == 1);
-  }
-
-  // matmul
-  CATCH_SECTION( "matmul" ) {
-    auto scalar = randn({}, T);
-    auto d1 = randn({3}, T);
-    auto d2 = randn({2, 3}, T);
-
-    // 0-d
-    CATCH_REQUIRE_THROWS_WITH(scalar.matmul(d2), Catch::StartsWith("both arguments to matmul need to be at least 1D"));
-    CATCH_REQUIRE_THROWS_WITH(d2.matmul(scalar), Catch::StartsWith("both arguments to matmul need to be at least 1D"));
-
-    // 1-d
-    REQUIRE_ALLCLOSE(d1.matmul(d1), d1.dot(d1));
-    REQUIRE_ALLCLOSE(d2.matmul(d1), d2.mv(d1));
-    auto d1o = randn({2}, T);
-    REQUIRE_ALLCLOSE(d1o.matmul(d2), d1o.unsqueeze(0).mm(d2).squeeze(0));
-
-    // 2-d
-    auto d2o = randn({3, 5}, T);
-    REQUIRE_ALLCLOSE(d2.matmul(d2o), d2.mm(d2o));
-
-    // > 2-d, 1-d
-    auto d3 = randn({5, 2, 3}, T);
-    REQUIRE_ALLCLOSE(d3.matmul(d1), d3.bmm(d1.view({1, 3, 1}).expand({5, 3, 1})).view({5, 2}));
-    REQUIRE_ALLCLOSE(d1o.matmul(d3), d1o.expand({5, 1, 2}).bmm(d3).view({5, 3}));
-
-    auto d5 = randn({3, 2, 4, 2, 3}, T);
-    REQUIRE_ALLCLOSE(d5.matmul(d1), d5.view({24, 2, 3}).bmm(d1.view({1, 3, 1}).expand({24, 3, 1})).view({3, 2, 4, 2}));
-    REQUIRE_ALLCLOSE(d1o.matmul(d5), d1o.expand({24, 1, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 3}));
-
-    // > 2-d, 2-d
-    // we use a "folding" algorithm in this case of matmul, so the direct comparison to bmm doesn't work;
-    // instead, compare to the higher precision computation (technically, we should always do this).
-    // Tolerances are selected empirically.
-    double atol = 1e-04;
-    double rtol = 1e-06;
-    d2 = randn({3, 4}, T);
-    d2o = randn({4, 2}, T);
-    auto result = d5.matmul(d2).toType(AccT);
-
-    auto d5Acc = d5.toType(AccT);
-    auto d2Acc = d2.toType(AccT);
-    auto acc_result = d5Acc.view({24, 2, 3}).bmm(d2Acc.expand({24, 3, 4})).view({3, 2, 4, 2, 4});
-    REQUIRE_ALLCLOSE_TOLERANCES(result, acc_result, atol, rtol);
-    REQUIRE_ALLCLOSE(d2o.matmul(d5), d2o.expand({24, 4, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 4, 3}));
-
-    // > 2-d, > 2-d
-    auto d5o = randn({2, 1, 2, 4, 3, 2}, T);
-    auto d5_bmm_view = d5.expand({2, 3, 2, 4, 2, 3}).contiguous().view({48, 2, 3});
-    auto d5o_bmm_view = d5o.expand({2, 3, 2, 4, 3, 2}).contiguous().view({48, 3, 2});
-    REQUIRE_ALLCLOSE(d5.matmul(d5o), d5_bmm_view.bmm(d5o_bmm_view).view({2, 3, 2, 4, 2, 2}));
-
-    // non-expandable case
-    auto d5wrong = randn({2, 4, 2, 4, 3, 2}, T);
-    CATCH_REQUIRE_THROWS_WITH(d5.matmul(d5wrong), Catch::Contains("must match the size"));
-  }
-
-  // _standard_gamma_grad
-  CATCH_SECTION( "_standard_gamma_grad" ) {
-    // check empty
-    auto empty = ones({0}, T);
-    REQUIRE_EQUAL(empty, at::_standard_gamma_grad(empty, empty));
-
-    // check scalar equals one element
-    auto one_scalar = ones({}, T).mul(5);
-    auto one_with_dim = ones({1}, T).mul(5);
-    REQUIRE_ALLCLOSE(at::_standard_gamma_grad(one_scalar, one_scalar),
-		     at::_standard_gamma_grad(one_with_dim, one_with_dim).sum());
-
-    // check mixing types
-    auto t1 = randn({3, 4}, T);
-    auto t2 = randn({3, 4}, T).toType(kDouble);
-    CATCH_REQUIRE_THROWS_WITH(at::_standard_gamma_grad(t1, t2), Catch::StartsWith("expected scalar type"));
-  }
-
-  CATCH_SECTION( "where" ) {
-    // empty
-    auto empty = ones({0}, T);
-    auto &bT = T.toScalarType(ScalarType::Byte);
-    auto empty_byte = ones({0}, bT);
-    REQUIRE_EQUAL(empty, at::where(empty_byte, empty, empty));
-
-    // check scalar equals one element
-    auto x_scalar = ones({}, T).mul(5);
-    auto y_scalar = ones({}, T).mul(7);
-    auto cond_scalar = zeros({}, bT);
-    auto x_1d = x_scalar.unsqueeze(0);
-    auto y_1d = y_scalar.unsqueeze(0);
-    auto cond_1d = cond_scalar.unsqueeze(0);
-    REQUIRE_ALLCLOSE(at::where(cond_scalar, x_scalar, y_scalar).unsqueeze(0),
-                     at::where(cond_1d, x_1d, y_1d));
-  }
+  TestSplit(T, t);
+  TestChunk(T, t);
+  TestStack(T, t);
+  TestSize(T, t);
+  TestMatmul(T, t, AccT);
+  TestStandardGammaGrad(T, t);
+  TestWhere(T, t);
 }
 
-CATCH_TEST_CASE( "native test CPU", "[cpu]" ) {
+TEST(TestNative, NativeTestCPU) {
   manual_seed(123, at::kCPU);
 
   test(CPU(kFloat), CPU(kDouble));
 }
 
-CATCH_TEST_CASE( "native test CUDA", "[cuda]" ) {
+TEST(TestNative, NativeTestGPU) {
   manual_seed(123, at::kCUDA);
 
   if (at::hasCUDA()) {

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "test_seed.h"
@@ -9,31 +8,33 @@
 
 using namespace at;
 
-#define TRY_CATCH_ELSE(fn, catc, els)                           \
-  {                                                             \
-    /* avoid mistakenly passing if els code throws exception*/  \
-    bool _passed = false;                                       \
-    try {                                                       \
-      fn;                                                       \
-      _passed = true;                                           \
-      els;                                                      \
-    } catch (std::exception &e) {                               \
-      CATCH_REQUIRE(!_passed);                                        \
-      catc;                                                     \
-    }                                                           \
+#define TRY_CATCH_ELSE(fn, catc, els)                          \
+  {                                                            \
+    /* avoid mistakenly passing if els code throws exception*/ \
+    bool _passed = false;                                      \
+    try {                                                      \
+      fn;                                                      \
+      _passed = true;                                          \
+      els;                                                     \
+    } catch (std::exception & e) {                             \
+      ASSERT_FALSE(_passed);                                   \
+      catc;                                                    \
+    }                                                          \
   }
 
 void require_equal_size_dim(const Tensor &lhs, const Tensor &rhs) {
-  CATCH_REQUIRE(lhs.dim() == rhs.dim());
-  CATCH_REQUIRE(lhs.sizes().equals(rhs.sizes()));
+  ASSERT_EQ(lhs.dim(), rhs.dim());
+  ASSERT_TRUE(lhs.sizes().equals(rhs.sizes()));
 }
 
 bool should_expand(const IntList &from_size, const IntList &to_size) {
-  if(from_size.size() > to_size.size()) {
+  if (from_size.size() > to_size.size()) {
     return false;
   }
-  for (auto from_dim_it = from_size.rbegin(); from_dim_it != from_size.rend(); ++from_dim_it) {
-    for (auto to_dim_it = to_size.rbegin(); to_dim_it != to_size.rend(); ++to_dim_it) {
+  for (auto from_dim_it = from_size.rbegin(); from_dim_it != from_size.rend();
+       ++from_dim_it) {
+    for (auto to_dim_it = to_size.rbegin(); to_dim_it != to_size.rend();
+         ++to_dim_it) {
       if (*from_dim_it != 1 && *from_dim_it != *to_dim_it) {
         return false;
       }
@@ -43,21 +44,22 @@ bool should_expand(const IntList &from_size, const IntList &to_size) {
 }
 
 void test(Type &T) {
-  std::vector<std::vector<int64_t> > sizes = { {}, {0}, {1}, {1, 1}, {2}};
+  std::vector<std::vector<int64_t>> sizes = {{}, {0}, {1}, {1, 1}, {2}};
 
   // single-tensor/size tests
   for (auto s = sizes.begin(); s != sizes.end(); ++s) {
     // verify that the dim, sizes, strides, etc match what was requested.
     auto t = ones(*s, T);
-    CATCH_REQUIRE((size_t)t.dim() == s->size());
-    CATCH_REQUIRE((size_t)t.ndimension() == s->size());
-    CATCH_REQUIRE(t.sizes().equals(*s));
-    CATCH_REQUIRE(t.strides().size() == s->size());
-    auto numel = std::accumulate(s->begin(), s->end(), 1, std::multiplies<int64_t>());
-    CATCH_REQUIRE(t.numel() == numel);
+    ASSERT_EQ((size_t)t.dim(), s->size());
+    ASSERT_EQ((size_t)t.ndimension(), s->size());
+    ASSERT_TRUE(t.sizes().equals(*s));
+    ASSERT_EQ(t.strides().size(), s->size());
+    auto numel =
+        std::accumulate(s->begin(), s->end(), 1, std::multiplies<int64_t>());
+    ASSERT_EQ(t.numel(), numel);
     // verify we can output
     std::stringstream ss;
-    CATCH_REQUIRE_NOTHROW(ss << t << std::endl);
+    ASSERT_NO_THROW(ss << t << std::endl);
 
     // set_
     auto t2 = ones(*s, T);
@@ -65,22 +67,22 @@ void test(Type &T) {
     require_equal_size_dim(t2, ones({0}, T));
 
     // unsqueeze
-    CATCH_REQUIRE(t.unsqueeze(0).dim() == t.dim() + 1);
+    ASSERT_EQ(t.unsqueeze(0).dim(), t.dim() + 1);
 
     // unsqueeze_
     {
       auto t2 = ones(*s, T);
       auto r = t2.unsqueeze_(0);
-      CATCH_REQUIRE(r.dim() == t.dim() + 1);
+      ASSERT_EQ(r.dim(), t.dim() + 1);
     }
 
     // squeeze (with dimension argument)
     if (t.dim() == 0 || t.sizes()[0] == 1) {
-      CATCH_REQUIRE(t.squeeze(0).dim() == std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT_EQ(t.squeeze(0).dim(), std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
-      // in NumPy this is an error.
-      CATCH_REQUIRE(t.squeeze(0).dim() == t.dim());
+      // In PyTorch, it is a no-op to try to squeeze a dimension that has size
+      // != 1; in NumPy this is an error.
+      ASSERT_EQ(t.squeeze(0).dim(), t.dim());
     }
 
     // squeeze (with no dimension argument)
@@ -98,12 +100,12 @@ void test(Type &T) {
     {
       // squeeze_ (with dimension argument)
       auto t2 = ones(*s, T);
-      if (t2.dim() == 0 ||  t2.sizes()[0] == 1) {
-        CATCH_REQUIRE(t2.squeeze_(0).dim() == std::max<int64_t>(t.dim() - 1, 0));
+      if (t2.dim() == 0 || t2.sizes()[0] == 1) {
+        ASSERT_EQ(t2.squeeze_(0).dim(), std::max<int64_t>(t.dim() - 1, 0));
       } else {
-        // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
-        // in NumPy this is an error.
-        CATCH_REQUIRE(t2.squeeze_(0).dim() == t.dim());
+        // In PyTorch, it is a no-op to try to squeeze a dimension that has size
+        // != 1; in NumPy this is an error.
+        ASSERT_EQ(t2.squeeze_(0).dim(), t.dim());
       }
     }
 
@@ -122,154 +124,156 @@ void test(Type &T) {
 
     // reduce (with dimension argument and with 1 return argument)
     if (t.numel() != 0) {
-      CATCH_REQUIRE(t.sum(0).dim() == std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT_EQ(t.sum(0).dim(), std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      CATCH_REQUIRE(t.sum(0).equal(at::zeros({}, T)));
+      ASSERT_TRUE(t.sum(0).equal(at::zeros({}, T)));
     }
 
     // reduce (with dimension argument and with 2 return arguments)
     if (t.numel() != 0) {
       auto ret = t.min(0);
-      CATCH_REQUIRE(std::get<0>(ret).dim() == std::max<int64_t>(t.dim() - 1, 0));
-      CATCH_REQUIRE(std::get<1>(ret).dim() == std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT_EQ(std::get<0>(ret).dim(), std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT_EQ(std::get<1>(ret).dim(), std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      _CATCH_REQUIRE_THROWS(t.min(0));
+      ASSERT_ANY_THROW(t.min(0));
     }
 
     // simple indexing
     if (t.dim() > 0 && t.numel() != 0) {
-      CATCH_REQUIRE(t[0].dim() == std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT_EQ(t[0].dim(), std::max<int64_t>(t.dim() - 1, 0));
     } else {
-      _CATCH_REQUIRE_THROWS(t[0]);
+      ASSERT_ANY_THROW(t[0]);
     }
 
     // fill_ (argument to fill_ can only be a 0-dim tensor)
-    TRY_CATCH_ELSE(t.fill_(t.sum(0)),
-                   CATCH_REQUIRE(t.dim() > 1),
-                   CATCH_REQUIRE(t.dim() <= 1));
+    TRY_CATCH_ELSE(
+        t.fill_(t.sum(0)), ASSERT_GT(t.dim(), 1), ASSERT_LE(t.dim(), 1));
   }
 
   for (auto lhs_it = sizes.begin(); lhs_it != sizes.end(); ++lhs_it) {
     for (auto rhs_it = sizes.begin(); rhs_it != sizes.end(); ++rhs_it) {
       // is_same_size should only match if they are the same shape
       {
-          auto lhs = ones(*lhs_it, T);
-          auto rhs = ones(*rhs_it, T);
-          if(*lhs_it != *rhs_it) {
-            CATCH_REQUIRE(!lhs.is_same_size(rhs));
-            CATCH_REQUIRE(!rhs.is_same_size(lhs));
-          }
+        auto lhs = ones(*lhs_it, T);
+        auto rhs = ones(*rhs_it, T);
+        if (*lhs_it != *rhs_it) {
+          ASSERT_FALSE(lhs.is_same_size(rhs));
+          ASSERT_FALSE(rhs.is_same_size(lhs));
+        }
       }
       // forced size functions (resize_, resize_as, set_)
+      {// resize_
+       {auto lhs = ones(*lhs_it, T);
+      auto rhs = ones(*rhs_it, T);
+      lhs.resize_(*rhs_it);
+      require_equal_size_dim(lhs, rhs);
+    }
+    // resize_as_
+    {
+      auto lhs = ones(*lhs_it, T);
+      auto rhs = ones(*rhs_it, T);
+      lhs.resize_as_(rhs);
+      require_equal_size_dim(lhs, rhs);
+    }
+    // set_
+    {
       {
-        // resize_
-        {
-          auto lhs = ones(*lhs_it, T);
-          auto rhs = ones(*rhs_it, T);
-          lhs.resize_(*rhs_it);
-          require_equal_size_dim(lhs, rhs);
-        }
-        // resize_as_
-        {
-          auto lhs = ones(*lhs_it, T);
-          auto rhs = ones(*rhs_it, T);
-          lhs.resize_as_(rhs);
-          require_equal_size_dim(lhs, rhs);
-        }
-        // set_
-        {
-          {
-            // with tensor
-            auto lhs = ones(*lhs_it, T);
-            auto rhs = ones(*rhs_it, T);
-            lhs.set_(rhs);
-            require_equal_size_dim(lhs, rhs);
-          }
-          {
-            // with storage
-            auto lhs = ones(*lhs_it, T);
-            auto rhs = ones(*rhs_it, T);
-            auto storage = T.storage(rhs.numel(), false);
-            lhs.set_(storage);
-            // should not be dim 0 because an empty storage is dim 1; all other storages aren't scalars
-            CATCH_REQUIRE(lhs.dim() != 0);
-          }
-          {
-            // with storage, offset, sizes, strides
-            auto lhs = ones(*lhs_it, T);
-            auto rhs = ones(*rhs_it, T);
-            auto storage = T.storage(rhs.numel(), false);
-            lhs.set_(storage, rhs.storage_offset(), rhs.sizes(), rhs.strides());
-            require_equal_size_dim(lhs, rhs);
-          }
-        }
-      }
-
-      // view
-      {
+        // with tensor
         auto lhs = ones(*lhs_it, T);
         auto rhs = ones(*rhs_it, T);
-        auto rhs_size = *rhs_it;
-        TRY_CATCH_ELSE(auto result = lhs.view(rhs_size),
-                       CATCH_REQUIRE(lhs.numel() != rhs.numel()),
-                       CATCH_REQUIRE(lhs.numel() == rhs.numel()); require_equal_size_dim(result, rhs););
+        lhs.set_(rhs);
+        require_equal_size_dim(lhs, rhs);
       }
-
-      // take
       {
-        auto lhs = ones(*lhs_it, T);
-        auto rhs = zeros(*rhs_it, T).toType(ScalarType::Long);
-        TRY_CATCH_ELSE(auto result = lhs.take(rhs),
-                       CATCH_REQUIRE(lhs.numel() == 0); CATCH_REQUIRE(rhs.numel() != 0),
-                       require_equal_size_dim(result, rhs));
-      }
-
-
-      // ger
-      {
+        // with storage
         auto lhs = ones(*lhs_it, T);
         auto rhs = ones(*rhs_it, T);
-        TRY_CATCH_ELSE(auto result = lhs.ger(rhs),
-                       CATCH_REQUIRE((lhs.numel() == 0 || rhs.numel() == 0 || lhs.dim() != 1 || rhs.dim() != 1)),
-                       [&]() {
-                         int64_t dim0 = lhs.dim() == 0 ? 1 : lhs.size(0);
-                         int64_t dim1 = rhs.dim() == 0 ? 1 : rhs.size(0);
-                         require_equal_size_dim(result, at::empty({dim0, dim1}, result.options()));
-                       }(););
+        auto storage = T.storage(rhs.numel(), false);
+        lhs.set_(storage);
+        // should not be dim 0 because an empty storage is dim 1; all other
+        // storages aren't scalars
+        ASSERT_NE(lhs.dim(), 0);
       }
-
-      // expand
       {
+        // with storage, offset, sizes, strides
         auto lhs = ones(*lhs_it, T);
-        auto lhs_size = *lhs_it;
         auto rhs = ones(*rhs_it, T);
-        auto rhs_size = *rhs_it;
-        bool should_pass = should_expand(lhs_size, rhs_size);
-        TRY_CATCH_ELSE(auto result = lhs.expand(rhs_size),
-                       CATCH_REQUIRE(!should_pass),
-                       CATCH_REQUIRE(should_pass); require_equal_size_dim(result, rhs););
-
-        // in-place functions (would be good if we can also do a non-broadcasting one, b/c
-        // broadcasting functions will always end up operating on tensors of same size;
-        // is there an example of this outside of assign_ ?)
-        {
-          bool should_pass_inplace = should_expand(rhs_size, lhs_size);
-          TRY_CATCH_ELSE(lhs.add_(rhs),
-                         CATCH_REQUIRE(!should_pass_inplace),
-                         CATCH_REQUIRE(should_pass_inplace); require_equal_size_dim(lhs, ones(*lhs_it, T)););
-        }
+        auto storage = T.storage(rhs.numel(), false);
+        lhs.set_(storage, rhs.storage_offset(), rhs.sizes(), rhs.strides());
+        require_equal_size_dim(lhs, rhs);
       }
     }
   }
+
+  // view
+  {
+    auto lhs = ones(*lhs_it, T);
+    auto rhs = ones(*rhs_it, T);
+    auto rhs_size = *rhs_it;
+    TRY_CATCH_ELSE(auto result = lhs.view(rhs_size),
+                   ASSERT_NE(lhs.numel(), rhs.numel()),
+                   ASSERT_EQ(lhs.numel(), rhs.numel());
+                   require_equal_size_dim(result, rhs););
+  }
+
+  // take
+  {
+    auto lhs = ones(*lhs_it, T);
+    auto rhs = zeros(*rhs_it, T).toType(ScalarType::Long);
+    TRY_CATCH_ELSE(auto result = lhs.take(rhs), ASSERT_EQ(lhs.numel(), 0);
+                   ASSERT_NE(rhs.numel(), 0),
+                   require_equal_size_dim(result, rhs));
+  }
+
+  // ger
+  {
+    auto lhs = ones(*lhs_it, T);
+    auto rhs = ones(*rhs_it, T);
+    TRY_CATCH_ELSE(auto result = lhs.ger(rhs),
+                   ASSERT_TRUE(
+                       (lhs.numel() == 0 || rhs.numel() == 0 ||
+                        lhs.dim() != 1 || rhs.dim() != 1)),
+                   [&]() {
+                     int64_t dim0 = lhs.dim() == 0 ? 1 : lhs.size(0);
+                     int64_t dim1 = rhs.dim() == 0 ? 1 : rhs.size(0);
+                     require_equal_size_dim(
+                         result, at::empty({dim0, dim1}, result.options()));
+                   }(););
+  }
+
+  // expand
+  {
+    auto lhs = ones(*lhs_it, T);
+    auto lhs_size = *lhs_it;
+    auto rhs = ones(*rhs_it, T);
+    auto rhs_size = *rhs_it;
+    bool should_pass = should_expand(lhs_size, rhs_size);
+    TRY_CATCH_ELSE(auto result = lhs.expand(rhs_size),
+                   ASSERT_FALSE(should_pass),
+                   ASSERT_TRUE(should_pass);
+                   require_equal_size_dim(result, rhs););
+
+    // in-place functions (would be good if we can also do a non-broadcasting
+    // one, b/c broadcasting functions will always end up operating on tensors
+    // of same size; is there an example of this outside of assign_ ?)
+    {
+      bool should_pass_inplace = should_expand(rhs_size, lhs_size);
+      TRY_CATCH_ELSE(lhs.add_(rhs),
+                     ASSERT_FALSE(should_pass_inplace),
+                     ASSERT_TRUE(should_pass_inplace);
+                     require_equal_size_dim(lhs, ones(*lhs_it, T)););
+    }
+  }
+}
+}
 }
 
-CATCH_TEST_CASE( "scalar tensor test CPU", "[cpu]" ) {
+TEST(TestScalarTensor, TestScalarTensorCPU) {
   manual_seed(123, at::kCPU);
-
   test(CPU(kFloat));
 }
 
-CATCH_TEST_CASE( "scalar tensor test CUDA", "[cuda]" ) {
+TEST(TestScalarTensor, TestScalarTensorCUDA) {
   manual_seed(123, at::kCUDA);
 
   if (at::hasCUDA()) {

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include <iostream>
 // define constants like M_PI and C keywords for MSVC
@@ -33,26 +32,25 @@ struct Foo<Half> {
 
 void test_overflow() {
   auto s1 = Scalar(M_PI);
-  CATCH_REQUIRE(s1.toFloat() == static_cast<float>(M_PI));
+  ASSERT_EQ(s1.toFloat(), static_cast<float>(M_PI));
   s1.toHalf();
 
   s1 = Scalar(100000);
-  CATCH_REQUIRE(s1.toFloat() == 100000.0);
-  CATCH_REQUIRE(s1.toInt() == 100000);
+  ASSERT_EQ(s1.toFloat(), 100000.0);
+  ASSERT_EQ(s1.toInt(), 100000);
 
-  CATCH_REQUIRE_THROWS_AS(s1.toHalf(), std::domain_error);
+  ASSERT_THROW(s1.toHalf(), std::domain_error);
 
   s1 = Scalar(NAN);
-  CATCH_REQUIRE(std::isnan(s1.toFloat()));
-  CATCH_REQUIRE_THROWS_AS(s1.toInt(), std::domain_error);
+  ASSERT_TRUE(std::isnan(s1.toFloat()));
+  ASSERT_THROW(s1.toInt(), std::domain_error);
 
   s1 = Scalar(INFINITY);
-  CATCH_REQUIRE(std::isinf(s1.toFloat()));
-  CATCH_REQUIRE_THROWS_AS(s1.toInt(), std::domain_error);
+  ASSERT_TRUE(std::isinf(s1.toFloat()));
+  ASSERT_THROW(s1.toInt(), std::domain_error);
 }
 
-CATCH_TEST_CASE( "scalar test", "[]" ) {
-
+TEST(TestScalar, TestScalar) {
   manual_seed(123, at::kCPU);
   manual_seed(123, at::kCUDA);
 
@@ -60,54 +58,57 @@ CATCH_TEST_CASE( "scalar test", "[]" ) {
   Scalar bar = 3.0;
   Half h = bar.toHalf();
   Scalar h2 = h;
-  cout << "H2: " << h2.toDouble() << " " << what.toFloat() << " " << bar.toDouble() << " " << what.isIntegral() <<  "\n";
-  Generator & gen = at::globalContext().defaultGenerator(at::kCPU);
-  CATCH_REQUIRE_NOTHROW(gen.seed());
-  auto && C = at::globalContext();
-  if(at::hasCUDA()) {
-    auto t2 = zeros({4,4}, at::kCUDA);
+  cout << "H2: " << h2.toDouble() << " " << what.toFloat() << " "
+       << bar.toDouble() << " " << what.isIntegral() << "\n";
+  Generator& gen = at::globalContext().defaultGenerator(at::kCPU);
+  ASSERT_NO_THROW(gen.seed());
+  auto&& C = at::globalContext();
+  if (at::hasCUDA()) {
+    auto t2 = zeros({4, 4}, at::kCUDA);
     cout << &t2 << "\n";
   }
-  auto t = ones({4,4});
+  auto t = ones({4, 4});
 
-  auto wha2 = zeros({4,4}).add(t).sum();
-  CATCH_REQUIRE( wha2.item<double>() == 16.0 );
+  auto wha2 = zeros({4, 4}).add(t).sum();
+  ASSERT_EQ(wha2.item<double>(), 16.0);
 
-  CATCH_REQUIRE( t.sizes()[0] == 4 );
-  CATCH_REQUIRE( t.sizes()[1] == 4 );
-  CATCH_REQUIRE( t.strides()[0] == 4 );
-  CATCH_REQUIRE( t.strides()[1] == 1 );
+  ASSERT_EQ(t.sizes()[0], 4);
+  ASSERT_EQ(t.sizes()[1], 4);
+  ASSERT_EQ(t.strides()[0], 4);
+  ASSERT_EQ(t.strides()[1], 1);
 
-  Type & T = CPU(Float);
-  Tensor x = randn({1,10}, T);
-  Tensor prev_h = randn({1,20}, T);
-  Tensor W_h = randn({20,20}, T);
-  Tensor W_x = randn({20,10}, T);
+  Type& T = CPU(Float);
+  Tensor x = randn({1, 10}, T);
+  Tensor prev_h = randn({1, 20}, T);
+  Tensor W_h = randn({20, 20}, T);
+  Tensor W_x = randn({20, 10}, T);
   Tensor i2h = at::mm(W_x, x.t());
   Tensor h2h = at::mm(W_h, prev_h.t());
   Tensor next_h = i2h.add(h2h);
   next_h = next_h.tanh();
 
-  _CATCH_REQUIRE_THROWS(at::_local_scalar(Tensor{}));
+  ASSERT_ANY_THROW(at::_local_scalar(Tensor{}));
 
   test_overflow();
 
-  if(at::hasCUDA()) {
+  if (at::hasCUDA()) {
     auto r = CUDA(Float).copy(next_h);
-    CATCH_REQUIRE(CPU(Float).copy(r).equal(next_h));
+    ASSERT_TRUE(CPU(Float).copy(r).equal(next_h));
   }
-  CATCH_REQUIRE_NOTHROW(randn({10,10,2}, T));
+  ASSERT_NO_THROW(randn({10, 10, 2}, T));
 
   // check Scalar.toTensor on Scalars backed by different data types
-  CATCH_REQUIRE(scalar_to_tensor(bar).type().scalarType() == kDouble);
-  CATCH_REQUIRE(scalar_to_tensor(what).type().scalarType() == kLong);
-  CATCH_REQUIRE(scalar_to_tensor(ones({})._local_scalar()).type().scalarType() == kDouble);
+  ASSERT_EQ(scalar_to_tensor(bar).type().scalarType(), kDouble);
+  ASSERT_EQ(scalar_to_tensor(what).type().scalarType(), kLong);
+  ASSERT_EQ(
+      scalar_to_tensor(ones({})._local_scalar()).type().scalarType(), kDouble);
 
   if (x.type().scalarType() != ScalarType::Half) {
     AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {
       scalar_t s = 1;
       std::stringstream ss;
-      CATCH_REQUIRE_NOTHROW(ss << "hello, dispatch" << x.type().toString() << s << "\n");
+      ASSERT_NO_THROW(
+          ss << "hello, dispatch" << x.type().toString() << s << "\n");
       auto data = (scalar_t*)x.data_ptr();
       (void)data;
     });
@@ -115,11 +116,11 @@ CATCH_TEST_CASE( "scalar test", "[]" ) {
 
   // test direct C-scalar type conversions
   {
-    auto x = ones({1,2}, T);
-    _CATCH_REQUIRE_THROWS(x.item<float>());
+    auto x = ones({1, 2}, T);
+    ASSERT_ANY_THROW(x.item<float>());
   }
   auto float_one = ones({}, T);
-  CATCH_REQUIRE(float_one.item<float>() == 1);
-  CATCH_REQUIRE(float_one.item<int32_t>() == 1);
-  CATCH_REQUIRE((float_one.item<at::Half>() == 1));
+  ASSERT_EQ(float_one.item<float>(), 1);
+  ASSERT_EQ(float_one.item<int32_t>(), 1);
+  ASSERT_EQ(float_one.item<at::Half>(), 1);
 }

--- a/aten/src/ATen/test/stream_test.cpp
+++ b/aten/src/ATen/test/stream_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/cuda/CUDAContext.h"
 #include "ATen/cuda/CUDAGuard.h"
@@ -11,12 +10,23 @@
 #include <thread>
 #include <unordered_set>
 
+#define ASSERT_EQ_CUDA(X, Y) \
+  {                          \
+    bool isTRUE = X == Y;    \
+    ASSERT_TRUE(isTRUE);     \
+  }
+
+#define ASSERT_NE_CUDA(X, Y) \
+  {                          \
+    bool isFALSE = X == Y;   \
+    ASSERT_FALSE(isFALSE);   \
+  }
+
 /*
-Tests related to ATen streams.
-*/
-CATCH_TEST_CASE(
-    "Copying and Moving Streams",
-    "Verifies streams are live through copying and moving") {
+   Tests related to ATen streams.
+   */
+// Verifies streams are live through copying and moving
+TEST(TestStream, CopyAndMoveTest) {
   int32_t device = -1;
   cudaStream_t cuda_stream;
 
@@ -29,14 +39,14 @@ CATCH_TEST_CASE(
 
     copyStream = s;
 
-    CATCH_REQUIRE(copyStream.internals() == s.internals());
-    CATCH_REQUIRE(copyStream.device() == device);
-    CATCH_REQUIRE(copyStream.stream() == cuda_stream);
+    ASSERT_EQ_CUDA(copyStream.internals(), s.internals());
+    ASSERT_EQ_CUDA(copyStream.device(), device);
+    ASSERT_EQ_CUDA(copyStream.stream(), cuda_stream);
   }
 
-  CATCH_REQUIRE(copyStream.internals());
-  CATCH_REQUIRE(copyStream.device() == device);
-  CATCH_REQUIRE(copyStream.stream() == cuda_stream);
+  ASSERT_TRUE(copyStream.internals());
+  ASSERT_EQ_CUDA(copyStream.device(), device);
+  ASSERT_EQ_CUDA(copyStream.stream(), cuda_stream);
 
   // Tests that moving works as expected and preserves the stream
   at::cuda::CUDAStream moveStream;
@@ -47,43 +57,43 @@ CATCH_TEST_CASE(
 
     moveStream = std::move(s);
 
-    CATCH_REQUIRE(moveStream.device() == device);
-    CATCH_REQUIRE(moveStream.stream() == cuda_stream);
+    ASSERT_EQ_CUDA(moveStream.device(), device);
+    ASSERT_EQ_CUDA(moveStream.stream(), cuda_stream);
   }
 
-  CATCH_REQUIRE(moveStream.internals());
-  CATCH_REQUIRE(moveStream.device() == device);
-  CATCH_REQUIRE(moveStream.stream() == cuda_stream);
+  ASSERT_TRUE(moveStream.internals());
+  ASSERT_EQ_CUDA(moveStream.device(), device);
+  ASSERT_EQ_CUDA(moveStream.stream(), cuda_stream);
 }
 
-CATCH_TEST_CASE("Getting and Setting Streams", "Verifies streams are set properly") {
+// Verifies streams are set properly
+TEST(TestStream, GetAndSetTest) {
   at::cuda::CUDAStream myStream = at::cuda::createCUDAStream();
 
   // Sets and gets
   at::cuda::setCurrentCUDAStream(myStream);
   at::cuda::CUDAStream curStream = at::cuda::getCurrentCUDAStream();
 
-  CATCH_REQUIRE(myStream == curStream);
+  ASSERT_EQ_CUDA(myStream, curStream);
 
   // Gets, sets, and gets default stream
   at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
   at::cuda::setCurrentCUDAStream(defaultStream);
   curStream = at::cuda::getCurrentCUDAStream();
 
-  CATCH_REQUIRE(defaultStream != myStream);
-  CATCH_REQUIRE(curStream == defaultStream);
+  ASSERT_NE_CUDA(defaultStream, myStream);
+  ASSERT_EQ_CUDA(curStream, defaultStream);
 }
 
 void thread_fun(at::cuda::CUDAStream& cur_thread_stream) {
   auto new_stream = at::cuda::createCUDAStream();
   at::cuda::setCurrentCUDAStream(new_stream);
   cur_thread_stream = at::cuda::getCurrentCUDAStream();
-  CATCH_REQUIRE(cur_thread_stream == new_stream);
+  ASSERT_EQ_CUDA(cur_thread_stream, new_stream);
 }
 
-CATCH_TEST_CASE(
-    "Multithread Getting and Setting",
-    "Ensures streams are thread local") {
+// Ensures streams are thread local
+TEST(TestStream, MultithreadGetAndSetTest) {
   at::cuda::CUDAStream s0, s1;
 
   std::thread t0{thread_fun, std::ref(s0)};
@@ -94,25 +104,25 @@ CATCH_TEST_CASE(
   at::cuda::CUDAStream cur_stream = at::cuda::getCurrentCUDAStream();
   at::cuda::CUDAStream default_stream = at::cuda::getDefaultCUDAStream();
 
-  CATCH_REQUIRE(cur_stream == default_stream);
-  CATCH_REQUIRE(cur_stream != s0);
-  CATCH_REQUIRE(cur_stream != s1);
-  CATCH_REQUIRE(s0 != s1);
+  ASSERT_EQ_CUDA(cur_stream, default_stream);
+  ASSERT_NE_CUDA(cur_stream, s0);
+  ASSERT_NE_CUDA(cur_stream, s1);
+  ASSERT_NE_CUDA(s0, s1);
 }
 
-CATCH_TEST_CASE("CUDAGuard") {
+// CUDA Guard
+TEST(TestStream, CUDAGuardTest) {
   if (at::cuda::getNumGPUs() < 2) {
     return;
   }
 
   // -- begin setup
 
-  CATCH_REQUIRE(at::cuda::current_device() == 0);
+  ASSERT_EQ_CUDA(at::cuda::current_device(), 0);
   std::vector<at::cuda::CUDAStream> streams0 = {
-      at::cuda::getDefaultCUDAStream(),
-      at::cuda::createCUDAStream()};
-  CATCH_REQUIRE(streams0[0].device() == 0);
-  CATCH_REQUIRE(streams0[1].device() == 0);
+      at::cuda::getDefaultCUDAStream(), at::cuda::createCUDAStream()};
+  ASSERT_EQ_CUDA(streams0[0].device(), 0);
+  ASSERT_EQ_CUDA(streams0[1].device(), 0);
   at::cuda::setCurrentCUDAStream(streams0[0]);
 
   std::vector<at::cuda::CUDAStream> streams1;
@@ -121,47 +131,46 @@ CATCH_TEST_CASE("CUDAGuard") {
     streams1.push_back(at::cuda::getDefaultCUDAStream());
     streams1.push_back(at::cuda::createCUDAStream());
   }
-  CATCH_REQUIRE(streams1[0].device() == 1);
-  CATCH_REQUIRE(streams1[1].device() == 1);
+  ASSERT_EQ_CUDA(streams1[0].device(), 1);
+  ASSERT_EQ_CUDA(streams1[1].device(), 1);
   at::cuda::setCurrentCUDAStream(streams1[0]);
 
-  CATCH_REQUIRE(at::cuda::current_device() == 0);
+  ASSERT_EQ_CUDA(at::cuda::current_device(), 0);
 
   // -- end setup
 
   // Test that all original streams are recorded.
   {
     at::cuda::CUDAGuard guard;
-    CATCH_REQUIRE(guard.original_streams().empty());
+    ASSERT_TRUE(guard.original_streams().empty());
     guard.set_stream(streams0[0]);
-    CATCH_REQUIRE(
-        guard.original_streams().size() == at::cuda::getNumGPUs());
-    CATCH_REQUIRE(guard.original_streams()[0] == streams0[0]);
-    CATCH_REQUIRE(guard.original_streams()[1] == streams1[0]);
+    ASSERT_EQ_CUDA(guard.original_streams().size(), at::cuda::getNumGPUs());
+    ASSERT_EQ_CUDA(guard.original_streams()[0], streams0[0]);
+    ASSERT_EQ_CUDA(guard.original_streams()[1], streams1[0]);
   }
 
   // Setting a stream changes the current device and the stream on that device
   {
     at::cuda::CUDAGuard guard(streams1[1]);
-    CATCH_REQUIRE(guard.last_device() == 1);
-    CATCH_REQUIRE(at::cuda::current_device() == 1);
-    CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(1) == streams1[1]);
+    ASSERT_EQ_CUDA(guard.last_device(), 1);
+    ASSERT_EQ_CUDA(at::cuda::current_device(), 1);
+    ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(1), streams1[1]);
   }
 
   // Device and stream are now reset
-  CATCH_REQUIRE(at::cuda::current_device() == 0);
-  CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(1) == streams1[0]);
+  ASSERT_EQ_CUDA(at::cuda::current_device(), 0);
+  ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(1), streams1[0]);
 
   // Setting only the device changes only the current device and not the stream
   {
     at::cuda::CUDAGuard guard(/*device=*/1);
-    CATCH_REQUIRE(guard.last_device() == 1);
-    CATCH_REQUIRE(at::cuda::current_device() == 1);
-    CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(1) == streams1[0]);
+    ASSERT_EQ_CUDA(guard.last_device(), 1);
+    ASSERT_EQ_CUDA(at::cuda::current_device(), 1);
+    ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(1), streams1[0]);
   }
 
-  CATCH_REQUIRE(at::cuda::current_device() == 0);
-  CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(0) == streams0[0]);
+  ASSERT_EQ_CUDA(at::cuda::current_device(), 0);
+  ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(0), streams0[0]);
 
   // Setting the stream first, and then the device, first changes the devices
   // back, and then resets the stream on the initial device.
@@ -171,12 +180,13 @@ CATCH_TEST_CASE("CUDAGuard") {
     guard.set_device(1);
   }
 
-  CATCH_REQUIRE(at::cuda::current_device() == 0);
-  CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(0) == streams0[0]);
-  CATCH_REQUIRE(at::cuda::getCurrentCUDAStream(1) == streams1[0]);
+  ASSERT_EQ_CUDA(at::cuda::current_device(), 0);
+  ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(0), streams0[0]);
+  ASSERT_EQ_CUDA(at::cuda::getCurrentCUDAStream(1), streams1[0]);
 }
 
-CATCH_TEST_CASE("CUDAGuardIsMovable") {
+// CUDAGuardIsMovable
+TEST(TestStream, CUDAGuardMovableTest) {
   if (at::cuda::getNumGPUs() < 2) {
     return;
   }
@@ -185,17 +195,18 @@ CATCH_TEST_CASE("CUDAGuardIsMovable") {
   at::cuda::CUDAGuard first(stream);
   first.set_device(1);
   at::cuda::CUDAGuard second(std::move(first));
-  CATCH_REQUIRE(second.original_streams().size() == device_count);
-  CATCH_REQUIRE(second.original_device() == 0);
-  CATCH_REQUIRE(second.last_device() == 1);
+  ASSERT_EQ_CUDA(second.original_streams().size(), device_count);
+  ASSERT_EQ_CUDA(second.original_device(), 0);
+  ASSERT_EQ_CUDA(second.last_device(), 1);
   at::cuda::CUDAGuard third;
   third = std::move(second);
-  CATCH_REQUIRE(third.original_streams().size() == device_count);
-  CATCH_REQUIRE(third.original_device() == 0);
-  CATCH_REQUIRE(third.last_device() == 1);
+  ASSERT_EQ_CUDA(third.original_streams().size(), device_count);
+  ASSERT_EQ_CUDA(third.original_device(), 0);
+  ASSERT_EQ_CUDA(third.last_device(), 1);
 }
 
-CATCH_TEST_CASE("Streampool Round Robin") {
+// Streampool Round Robin
+TEST(TestStream, StreamPoolTest) {
   std::vector<at::cuda::CUDAStream> streams{};
   for (int i = 0; i < 200; ++i) {
     streams.emplace_back(at::cuda::detail::CUDAStream_createStream());
@@ -206,14 +217,17 @@ CATCH_TEST_CASE("Streampool Round Robin") {
   for (auto i = decltype(streams.size()){0}; i < streams.size(); ++i) {
     cudaStream_t cuda_stream = streams[i];
     auto result_pair = stream_set.insert(cuda_stream);
-    if (!result_pair.second) hasDuplicates = true;
+    if (!result_pair.second)
+      hasDuplicates = true;
   }
 
-  CATCH_REQUIRE(hasDuplicates);
+  ASSERT_TRUE(hasDuplicates);
 }
 
-CATCH_TEST_CASE("Multi-GPU") {
-  if (at::cuda::getNumGPUs() < 2) return;
+// Multi-GPU
+TEST(TestStream, MultiGPUTest) {
+  if (at::cuda::getNumGPUs() < 2)
+    return;
 
   at::cuda::CUDAStream s0 = at::cuda::createCUDAStream(true, 0);
   at::cuda::CUDAStream s1 = at::cuda::createCUDAStream(false, 1);
@@ -221,17 +235,18 @@ CATCH_TEST_CASE("Multi-GPU") {
   at::cuda::setCurrentCUDAStream(s0);
   at::cuda::setCurrentCUDAStream(s1);
 
-  CATCH_REQUIRE(s0 == at::cuda::getCurrentCUDAStream());
+  ASSERT_EQ_CUDA(s0, at::cuda::getCurrentCUDAStream());
 
   at::DeviceGuard device_guard{1};
-  CATCH_REQUIRE(s1 == at::cuda::getCurrentCUDAStream());
+  ASSERT_EQ_CUDA(s1, at::cuda::getCurrentCUDAStream());
 }
 
-CATCH_TEST_CASE("CUDAEvent Syncs") {
+// CUDAEvent Syncs
+TEST(TestStream, CUDAEventSyncTest) {
   const auto stream = at::cuda::createCUDAStream();
   at::cuda::CUDAEvent event;
 
-  CATCH_REQUIRE(!event.happened());
+  ASSERT_FALSE(event.happened());
 
   event.recordOnce(stream);
 
@@ -242,11 +257,13 @@ CATCH_TEST_CASE("CUDAEvent Syncs") {
   wait_stream1.synchronize_with(event);
 
   cudaStreamSynchronize(wait_stream0);
-  CATCH_REQUIRE(event.happened());
+  ASSERT_TRUE(event.happened());
 }
 
-CATCH_TEST_CASE("Cross-Device Events") {
-  if (at::cuda::getNumGPUs() < 2) return;
+// Cross-Device Events
+TEST(TestStream, CrossDeviceTest) {
+  if (at::cuda::getNumGPUs() < 2)
+    return;
 
   const auto stream0 = at::cuda::createCUDAStream();
   at::cuda::CUDAEvent event0;
@@ -257,13 +274,13 @@ CATCH_TEST_CASE("Cross-Device Events") {
 
   event0.record(stream0);
   event1.record(stream1);
-  
+
   event0 = std::move(event1);
-  
-  CATCH_REQUIRE(event0.device() == 1);
+
+  ASSERT_EQ_CUDA(event0.device(), 1);
 
   stream0.synchronize_with(event0);
-  
+
   cudaStreamSynchronize(stream0);
-  CATCH_REQUIRE(event0.happened());
+  ASSERT_TRUE(event0.happened());
 }

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/DLConvertor.h"
@@ -11,12 +10,11 @@
 
 using namespace at;
 
-CATCH_TEST_CASE( "parallel", "[cpu]" ) {
-
+TEST(TestParallel, TestParallel) {
   manual_seed(123, at::kCPU);
   set_num_threads(1);
 
-  Tensor a = rand({1,3});
+  Tensor a = rand({1, 3});
   a[0][0] = 1;
   a[0][1] = 0;
   a[0][2] = 0;
@@ -24,5 +22,5 @@ CATCH_TEST_CASE( "parallel", "[cpu]" ) {
   as[0] = 1;
   as[1] = 0;
   as[2] = 0;
-  CATCH_REQUIRE(a.sum(0).equal(as));
+  ASSERT_TRUE(a.sum(0).equal(as));
 }

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "ATen/core/UndefinedTensorImpl.h"
@@ -8,7 +7,7 @@
 
 using namespace at;
 
-CATCH_TEST_CASE( "undefined tensor test", "[]" ) {
+TEST(TestUndefined, UndefinedTest) {
   manual_seed(123, at::kCPU);
 
   // mainly test ops on undefined tensors don't segfault and give a reasonable errror message.
@@ -17,36 +16,36 @@ CATCH_TEST_CASE( "undefined tensor test", "[]" ) {
 
   std::stringstream ss;
   ss << und << std::endl;
-  CATCH_REQUIRE(!und.defined());
-  CATCH_REQUIRE(std::string("UndefinedType") == und.toString());
+  ASSERT_FALSE(und.defined());
+  ASSERT_EQ(std::string("UndefinedType"), und.toString());
 
-  _CATCH_REQUIRE_THROWS(und.strides());
-  _CATCH_REQUIRE_THROWS(und.dim());
-  _CATCH_REQUIRE_THROWS([]() {return Tensor();}() = Scalar(5));
-  _CATCH_REQUIRE_THROWS(und.add(und));
-  _CATCH_REQUIRE_THROWS(und.add(ft));
-  _CATCH_REQUIRE_THROWS(ft.add(und));
-  _CATCH_REQUIRE_THROWS(und.add(5));
-  _CATCH_REQUIRE_THROWS(und.mm(und));
+  ASSERT_ANY_THROW(und.strides());
+  ASSERT_ANY_THROW(und.dim());
+  ASSERT_ANY_THROW([]() { return Tensor(); }() = Scalar(5));
+  ASSERT_ANY_THROW(und.add(und));
+  ASSERT_ANY_THROW(und.add(ft));
+  ASSERT_ANY_THROW(ft.add(und));
+  ASSERT_ANY_THROW(und.add(5));
+  ASSERT_ANY_THROW(und.mm(und));
 
   und.toType(und.type());
-  _CATCH_REQUIRE_THROWS(und.toType(ft.type()));
-  _CATCH_REQUIRE_THROWS(ft.toType(und.type()));
+  ASSERT_ANY_THROW(und.toType(ft.type()));
+  ASSERT_ANY_THROW(ft.toType(und.type()));
   und.toType(ScalarType::Undefined);
-  _CATCH_REQUIRE_THROWS(und.toType(ScalarType::Float));
-  _CATCH_REQUIRE_THROWS(ft.toType(ScalarType::Undefined));
+  ASSERT_ANY_THROW(und.toType(ScalarType::Float));
+  ASSERT_ANY_THROW(ft.toType(ScalarType::Undefined));
 
   // copy_
-  _CATCH_REQUIRE_THROWS(und.copy_(und));
-  _CATCH_REQUIRE_THROWS(und.copy_(ft));
-  _CATCH_REQUIRE_THROWS(ft.copy_(und));
+  ASSERT_ANY_THROW(und.copy_(und));
+  ASSERT_ANY_THROW(und.copy_(ft));
+  ASSERT_ANY_THROW(ft.copy_(und));
 
   und.toBackend(Backend::Undefined);
-  _CATCH_REQUIRE_THROWS(und.toBackend(Backend::CPU));
-  _CATCH_REQUIRE_THROWS(ft.toBackend(Backend::Undefined));
+  ASSERT_ANY_THROW(und.toBackend(Backend::CPU));
+  ASSERT_ANY_THROW(ft.toBackend(Backend::Undefined));
 
   Tensor to_move = ones({1}, CPU(kFloat));
   Tensor m(std::move(to_move));
-  CATCH_REQUIRE(!to_move.defined());
-  CATCH_REQUIRE(to_move.unsafeGetTensorImpl() == UndefinedTensorImpl::singleton());
+  ASSERT_FALSE(to_move.defined());
+  ASSERT_EQ(to_move.unsafeGetTensorImpl(), UndefinedTensorImpl::singleton());
 }

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -1,43 +1,45 @@
-#define CATCH_CONFIG_MAIN
-#include "catch_utils.hpp"
+#include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
 #include "test_seed.h"
 
 using namespace at;
+void TestSimpleCase(Type& T) {
+  auto a = randn({2, 3, 4, 5}, T);
+  ASSERT_TRUE(a.prod(-4).equal(a.prod(0)));
+  ASSERT_TRUE(a.prod(3).equal(a.prod(-1)));
+}
 
-CATCH_TEST_CASE( "wrapdim test", "[]" ) {
+void TestExpressionSpecification(Type& T) {
+  auto a = randn({2, 3, 4, 5}, T);
+  ASSERT_TRUE(a.unsqueeze(-5).equal(a.unsqueeze(0)));
+  ASSERT_TRUE(a.unsqueeze(4).equal(a.unsqueeze(-1)));
+
+  // can unsqueeze scalar
+  auto b = randn(1, T);
+  b.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  ASSERT_TRUE(b.unsqueeze(0).equal(b.unsqueeze(-1)));
+}
+
+void TestEmptyTensor(Type& T) {
+  auto a = randn(0, T);
+  ASSERT_TRUE(a.prod(0).equal(at::ones({}, T)));
+}
+
+void TestScalarVs1Dim1Size(Type& T) {
+  auto a = randn(1, T);
+  ASSERT_TRUE(a.prod(0).equal(a.prod(-1)));
+  a.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  ASSERT_EQ(a.dim(), 0);
+  ASSERT_TRUE(a.prod(0).equal(a.prod(-1)));
+}
+
+TEST(TestWrapdim, TestWrapdim) {
   manual_seed(123, at::kCPU);
+  Type& T = CPU(kFloat);
 
-  Type & T = CPU(kFloat);
-
-  CATCH_SECTION( "simple case" ) {
-    auto a = randn({2, 3, 4, 5}, T);
-    CATCH_REQUIRE(a.prod(-4).equal(a.prod(0)));
-    CATCH_REQUIRE(a.prod(3).equal(a.prod(-1)));
-  }
-
-  CATCH_SECTION( "expression specification" ) {
-    auto a = randn({2, 3, 4, 5}, T);
-    CATCH_REQUIRE(a.unsqueeze(-5).equal(a.unsqueeze(0)));
-    CATCH_REQUIRE(a.unsqueeze(4).equal(a.unsqueeze(-1)));
-
-    // can unsqueeze scalar
-    auto b = randn(1, T);
-    b.unsafeGetTensorImpl()->maybe_zero_dim(true);
-    CATCH_REQUIRE(b.unsqueeze(0).equal(b.unsqueeze(-1)));
-  }
-
-  CATCH_SECTION( "empty tensor" ) {
-    auto a = randn(0, T);
-    CATCH_REQUIRE(a.prod(0).equal(at::ones({}, T)));
-  }
-
-  CATCH_SECTION( "scalar vs 1-dim, 1-size" ) {
-    auto a = randn(1, T);
-    CATCH_REQUIRE(a.prod(0).equal(a.prod(-1)));
-    a.unsafeGetTensorImpl()->maybe_zero_dim(true);
-    CATCH_REQUIRE(a.dim() == 0);
-    CATCH_REQUIRE(a.prod(0).equal(a.prod(-1)));
-  }
+  TestSimpleCase(T);
+  TestEmptyTensor(T);
+  TestScalarVs1Dim1Size(T);
+  TestExpressionSpecification(T);
 }


### PR DESCRIPTION
migrant all tests in aten to use gtest except of basic.cpp
Sinc features of gtest are different from catch test, some of the tests has been re-writted with similar meaning.

Basic test has some version conflict with valgrind according to CI, therefore this testcase is still implementing catch.
It will be resolved by a different pr.