### PR TITLE
Use DFS scheduling only within single device

### DIFF
--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -285,6 +285,16 @@ int AsyncNetBase::numOps(int task_id) const {
   return chains_[task_id].size();
 }
 
+const OperatorBase* AsyncNetBase::firstTaskOp(int task_id) const {
+  auto op_id = chains_[task_id].front();
+  return operator_nodes_[op_id].operator_.get();
+}
+
+const OperatorBase* AsyncNetBase::lastTaskOp(int task_id) const {
+  auto op_id = chains_[task_id].back();
+  return operator_nodes_[op_id].operator_.get();
+}
+
 void AsyncNetBase::asyncWait(
     int task_id,
     int stream_id,

--- a/caffe2/core/net_async_base.h
+++ b/caffe2/core/net_async_base.h
@@ -66,6 +66,8 @@ class CAFFE2_API AsyncNetBase : public NetBase {
   int getParentCount(int child_id);
   bool testAndSetScheduled(int task_id);
   int numOps(int task_id) const;
+  const OperatorBase* firstTaskOp(int task_id) const;
+  const OperatorBase* lastTaskOp(int task_id) const;
 
   void asyncWait(
       int task_id,

--- a/caffe2/core/net_async_scheduling.h
+++ b/caffe2/core/net_async_scheduling.h
@@ -22,6 +22,7 @@ class CAFFE2_API AsyncSchedulingNet : public AsyncNetBase {
   void reset() override;
   virtual void finishRun();
   void parentCallback(int parent_id);
+  bool isInlineTask(int parent_id, int child_id) const;
 
   std::mutex running_mutex_;
   std::condition_variable running_cv_;


### PR DESCRIPTION
Summary: Avoid crossing the boundary between devices when using DFS scheduling

Differential Revision: D9931091
