### PR TITLE
[FindCUDA] Workaround CUDA logging on some embedded platforms

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -88,8 +88,7 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
               RUN_OUTPUT_VARIABLE compute_capabilities)
     endif()
 
-    # Working around CUDA-level nvrm_gpu log statements to stdout on some embedded platforms (ex. Drive PX2)
-    # See https://github.com/pytorch/pytorch/issues/11518#issue-359113249 for fuller context
+    # Filter unrelated content out of the output.
     string(REGEX MATCHALL "[0-9]+\\.[0-9]+" compute_capabilities "${compute_capabilities}")
 
     if(run_result EQUAL 0)

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -88,6 +88,10 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
               RUN_OUTPUT_VARIABLE compute_capabilities)
     endif()
 
+    # Working around CUDA-level nvrm_gpu log statements to stdout on some embedded platforms (ex. Drive PX2)
+    # See https://github.com/pytorch/pytorch/issues/11518#issue-359113249 for fuller context
+    string(REGEX MATCHALL "[0-9]+\\.[0-9]+" compute_capabilities "${compute_capabilities}")
+
     if(run_result EQUAL 0)
       string(REPLACE "2.1" "2.1(2.0)" compute_capabilities "${compute_capabilities}")
       set(CUDA_GPU_DETECT_OUTPUT ${compute_capabilities}


### PR DESCRIPTION
Fixes #11518 
Upstream PR submitted at https://gitlab.kitware.com/cmake/cmake/merge_requests/2400

On some embedded platforms, the NVIDIA driver is verbose logging unexpected output to stdout.
One example is Drive PX2, where we see something like this whenever a CUDA program is run:

```
nvrm_gpu: Bug 200215060 workaround enabled.
```

This patch does a regex on the output of the architecture detection program to only capture architecture patterns.
It's more robust than before, but not fool-proof.