### PR TITLE
Avoid using PyThreadState.frame as it is not a public member.

### DIFF
--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -24,17 +24,13 @@ namespace torch { namespace jit { namespace tracer {
 std::string getPythonInterpreterStackTrace() {
   std::stringstream stack_trace;
   AutoGIL gil;
-  PyThreadState *tstate = PyThreadState_GET();
-  if (nullptr != tstate && nullptr != tstate->frame) {
-    PyFrameObject *frame = tstate->frame;
-
-    while (nullptr != frame) {
-      int line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
-      std::string filename = THPUtils_unpackString(frame->f_code->co_filename);
-      std::string funcname = THPUtils_unpackString(frame->f_code->co_name);
-      stack_trace << filename << "(" << line << "): " << funcname << "\n";
-      frame = frame->f_back;
-    }
+  PyFrameObject *frame = PyEval_GetFrame();
+  while (nullptr != frame) {
+    int line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
+    std::string filename = THPUtils_unpackString(frame->f_code->co_filename);
+    std::string funcname = THPUtils_unpackString(frame->f_code->co_name);
+    stack_trace << filename << "(" << line << "): " << funcname << "\n";
+    frame = frame->f_back;
   }
   return stack_trace.str();
 }


### PR DESCRIPTION
The doc of PyThreadState [1] emphasizes that interp is its only public member. Use PyEval_GetFrame() instead.

[1] https://docs.python.org/3/c-api/init.html#c.PyThreadState

