### PR TITLE
Export and import IR graphs

### DIFF
--- a/test/expect/TestScript.test_onnx_raw_export_script_truediv.expect
+++ b/test/expect/TestScript.test_onnx_raw_export_script_truediv.expect
@@ -6,19 +6,15 @@ ModelProto {
     GraphProto {
       name: "torch-jit-export"
       inputs: [{name: "x", type:Tensor dims: 1 2 3}]
-      outputs: [{name: "10", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "6", type:Tensor dims: 1 2 3}]
       initializers: []
       nodes: [
-        Node {type: "Constant", inputs: [], outputs: [1], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Constant", inputs: [], outputs: [1], attributes: [{ name: 'value', type: int, value: 2}]},
+        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: int, value: 0}]},
         Node {type: "size", inputs: [x,2], outputs: [3], attributes: []},
-        Node {type: "Constant", inputs: [], outputs: [4], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "_cast_Float", inputs: [3,4], outputs: [5], attributes: []},
-        Node {type: "Constant", inputs: [], outputs: [6], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "_cast_Float", inputs: [1,6], outputs: [7], attributes: []},
-        Node {type: "div", inputs: [5,7], outputs: [z], attributes: []},
-        Node {type: "Constant", inputs: [], outputs: [9], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
-        Node {type: "add", inputs: [x,z,9], outputs: [10], attributes: []}
+        Node {type: "div", inputs: [3,1], outputs: [z], attributes: []},
+        Node {type: "Constant", inputs: [], outputs: [5], attributes: [{ name: 'value', type: int, value: 1}]},
+        Node {type: "add", inputs: [x,z,5], outputs: [6], attributes: []}
       ]
     }
   opset_import: [OperatorSetIdProto { domain: }],

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7134,14 +7134,14 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                DCGANGenerator(nz, ngf, nc).to(device),
-                (torch.rand(bs, nz, 1, 1, device=device),))
+            DCGANGenerator(nz, ngf, nc).to(device),
+            (torch.rand(bs, nz, 1, 1, device=device),))
         example_input = DCGANGenerator(nz, ngf, nc).to(device)(torch.rand(bs, nz, 1, 1, device=device))
         self.checkTrace(DCGANDiscriminator(nc, ndf).to(device), (example_input,),
                         export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                DCGANDiscriminator(nc, ndf).to(device), (example_input,))
+            DCGANDiscriminator(nc, ndf).to(device), (example_input,))
 
     def test_dcgan_models(self):
         self._test_dcgan_models(self, device='cpu')
@@ -7249,7 +7249,8 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                 out = self.conv2d(out)
                 return out
 
-        self.checkTrace(TransformerNet(), (torch.rand(5, 3, 64, 64),), export_import=check_export_import, ir_export_import=False)
+        self.checkTrace(TransformerNet(), (torch.rand(5, 3, 64, 64),),
+                        export_import=check_export_import, ir_export_import=False)
         self.assertExportImportModelIRGraph(TransformerNet(), (torch.rand(5, 3, 64, 64),))
 
     def test_neural_style(self):
@@ -7267,7 +7268,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                MnistNet().to(device).eval(), (torch.rand(5, 1, 28, 28, device=device),))
+            MnistNet().to(device).eval(), (torch.rand(5, 1, 28, 28, device=device),))
 
     def test_mnist(self):
         self._test_mnist(self, device='cpu')
@@ -7319,7 +7320,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         export_import=test_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                Policy().to(device), (torch.rand(1, 4, device=device),))
+            Policy().to(device), (torch.rand(1, 4, device=device),))
 
     def test_reinforcement_learning(self):
         self._test_reinforcement_learning(self, device='cpu')
@@ -7421,7 +7422,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         inputs_require_grads=False, export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                SNLIClassifier(Config()).to(device), (premise, hypothesis))
+            SNLIClassifier(Config()).to(device), (premise, hypothesis))
 
     @skipIfRocm
     def test_snli(self):
@@ -7461,7 +7462,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                Net(upscale_factor=4).to(device), (torch.rand(5, 1, 64, 64, device=device),))
+            Net(upscale_factor=4).to(device), (torch.rand(5, 1, 64, 64, device=device),))
 
     @skipIfRocm
     def test_super_resolution(self):
@@ -7573,7 +7574,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
                         export_import=check_export_import,
                         ir_export_import=False)
         self.assertExportImportModelIRGraph(
-                VAE().to(device).eval(), (torch.rand(128, 1, 28, 28, device=device), ))
+            VAE().to(device).eval(), (torch.rand(128, 1, 28, 28, device=device), ))
 
     def test_vae(self):
         self._test_vae(self, device='cpu')

--- a/torch/csrc/jit/import.h
+++ b/torch/csrc/jit/import.h
@@ -6,6 +6,9 @@
 namespace torch {
 namespace jit {
 
+TORCH_API std::tuple<std::shared_ptr<Graph>, std::vector<at::Tensor>>
+    import_ir_graph(const std::string &proto_str);
+
 using ModuleLookup = std::function<std::shared_ptr<script::Module>(
     const std::vector<std::string>&)>;
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -5,6 +5,7 @@
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/jit/export.h"
+#include "torch/csrc/jit/import.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/argument_spec.h"
 #include "torch/csrc/utils/auto_gil.h"
@@ -502,5 +503,10 @@ void initPythonIRBindings(PyObject * module_) {
   py::class_<Use>(m,"Use")
   .def_readonly("user",&Use::user)
   .def_readonly("offset",&Use::offset);
+
+  m.def("import_ir_graph", [](const std::string &proto_str) {
+    return import_ir_graph(proto_str);
+  });
+
 }
 }}

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -356,6 +356,11 @@ struct TORCH_API ListType : public Type {
     }
     return false;
   }
+  // bool isSubtypeOf(const TypePtr rhs) const override {
+  //   if (rhs->kind() == TypeKind::DynamicType)
+  //     return true;
+  //   return *this == *rhs;
+  // }
   std::string str() const override {
     std::stringstream ss;
     ss << getElementType()->str() << "[]";

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -15,6 +15,7 @@ class ExportTypes:
     ZIP_ARCHIVE = 2
     COMPRESSED_ZIP_ARCHIVE = 3
     DIRECTORY = 4
+    PROTOBUF_STRING = 5
 
 
 def _export(*args, **kwargs):
@@ -25,6 +26,18 @@ def _export(*args, **kwargs):
 def export(*args, **kwargs):
     from torch.onnx import utils
     return utils.export(*args, **kwargs)
+
+
+def export_ir_graph(*args, **kwargs):
+    from torch.onnx import utils
+    kwargs['operator_export_type'] = OperatorExportTypes.RAW
+    kwargs['export_type'] = ExportTypes.PROTOBUF_STRING
+    return utils.export(*args, **kwargs)
+
+
+def import_ir_graph(*args, **kwargs):
+    from torch.onnx import utils
+    return utils.import_ir_graph(*args, **kwargs)
 
 
 def export_to_pretty_string(*args, **kwargs):


### PR DESCRIPTION
This PR adds the possibility to export and import PyTorch IR graphs, in a very similar way as done by ModuleEncoder, but using the ONNX protobuf without additional components.

[Addition]
The current situation in master is that it is possible to export an ONNX proto with JIT ops (without type information), but it is not possible to import it back into a graph. The only way to do the roundtrip is through ScriptModule serialization. This PR adds the possibility to export and import the JIT IR (with type information, just like in Module serialization), but independently from modules.
In the process of exposing the functionality for importing graphs, I encountered an error trying to do the roundtrip with `resnet18`: https://gist.github.com/lantiga/0a7578dffbc044ca8fd62ce03808887b
I then chose to make sure the graph was exported and imported back using the exact same methods used in ScriptModule serialization.

This opens up the possibility to:
- export the IR (the same IR that would be saved in a module, without converting to ONNX) and inspect it using an ONNX file visualizer like Netron
- export the IR, manipulate it using a standard ONNX library and load it back up for execution in the JIT
- (eventually, down the road) take a proper ONNX model, transform it using an ONNX library to a into JIT IR opset and load it in the JIT

Example of usage:

```
import torch
import torch.onnx as onnx
from torchvision import models

resnet18 = models.resnet18()

x = torch.zeros(1, 3, 224, 224)

proto = onnx.export_ir_graph(resnet18, (x, ))

with open('bar.onnx', 'wb') as f:
    f.write(proto)
    # 'bar.onnx' can be opened in e.g. Netron

graph, initializers = onnx.import_ir_graph(proto_str)

m = torch.jit.ScriptModule()
m._create_method_from_graph("forward", graph)
m.forward(*([x]+ initializers))

# this also works
import onnx
onnx_model = onnx.load_from_string(proto)
```

/cc @apaszke 