### PR TITLE
Delete unnecessary include from allocator.cc/event_cpu.h

### DIFF
--- a/caffe2/core/allocator.cc
+++ b/caffe2/core/allocator.cc
@@ -1,6 +1,5 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/tensor.h"
 #include "caffe2/core/typeid.h"
 
 CAFFE2_DEFINE_bool(

--- a/caffe2/core/event_cpu.h
+++ b/caffe2/core/event_cpu.h
@@ -1,7 +1,7 @@
 #include "caffe2/core/event.h"
-#include "caffe2/core/operator.h"
 
 #include <atomic>
+#include <condition_variable>
 
 namespace caffe2 {
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11862 Delete unnecessary include from allocator.cc/event_cpu.h**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9942428/)



Differential Revision: [D9942428](https://our.internmc.facebook.com/intern/diff/D9942428/)