### PR TITLE
Add the missing header

### DIFF
--- a/caffe2/proto/torch_pb.h
+++ b/caffe2/proto/torch_pb.h
@@ -1,7 +1,8 @@
 #ifndef CAFFE2_PROTO_TORCH_PB_H_
 #define CAFFE2_PROTO_TORCH_PB_H_
 
-#include <caffe2/proto/caffe2.pb.h>
+#include <caffe2/core/common.h>
+#include <caffe2/proto/caffe2_pb.h>
 #include <caffe2/proto/torch.pb.h>
 
 #endif // CAFFE2_PROTO_TORCH_PB_H_


### PR DESCRIPTION
Otherwise, some macro doesn't have the definition.