### PR TITLE
[easy] Fix warning about copy when not copying

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -207,9 +207,11 @@ Tensor internal_new_from_data(const Type & type, at::optional<Device> device_opt
   }
 
   if (THPVariable_Check(data)) {
-      PyErr_WarnEx(PyExc_UserWarning,
-        "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
-        "or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).", 1);
+      if (copy_variables) {
+        PyErr_WarnEx(PyExc_UserWarning,
+          "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
+          "or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).", 1);
+      }
 
       auto var = reinterpret_cast<THPVariable*>(data)->cdata;
       auto type_inference_device_type = device_opt.has_value() ? device_opt->type()


### PR DESCRIPTION
Fixes a warning about copying a tensor was being printed even when there is no
copy taking place for `as_tensor`

See `test/test_jit.py TestJit.test_export_lstm` for before and after
