### PR TITLE
Add back proto opt disable feature that was lost during refactor

### DIFF
--- a/caffe2/predictor/predictor_config.cc
+++ b/caffe2/predictor/predictor_config.cc
@@ -1,8 +1,10 @@
 #include "predictor_config.h"
 #include "caffe2/core/init.h"
+#include "caffe2/utils/proto_utils.h"
 #ifdef CAFFE2_OPTIMIZER
 #include "caffe2/opt/optimizer.h"
 #endif
+
 namespace caffe2 {
 
 namespace {
@@ -69,7 +71,8 @@ PredictorConfig makePredictorConfig(
 #if CAFFE2_MOBILE
   GlobalInit();
 #endif
-  if (optimization) {
+  if (optimization &&
+      !ArgumentHelper::HasArgument(*config.predict_net, "disable_nomnigraph")) {
 #ifdef CAFFE2_OPTIMIZER
     try {
       *config.predict_net =


### PR DESCRIPTION
Summary:
Seems like the refactor to predictor_config dropped some functionality that is now blocking aloha

rFBS2b30208263c14ce7039f27c618a3b232bf11ee33 is the change that was missed

hoping to land this quickly :)

Differential Revision: D9948324
