### PR TITLE
Remove caffe2::Tensor::capacity_nbytes, at::Tensor::to##name##Data,

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -172,19 +172,11 @@ struct AT_API Tensor {
   template<typename T>
   T * data() const;
 
+  template <typename T>
+  T item() const;
+
   // Purposely not defined here to avoid inlining
   void print() const;
-
-  //toLongData(), toFloatData() etc.
-  #define TO_TYPE_DATA(T,name,_) \
-  T * to##name##Data() const;
-  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_TYPE_DATA)
-  #undef TO_TYPE_DATA
-
-  #define TO_C_TYPE(T,name,_) \
-  T toC##name () const;
-  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_C_TYPE)
-  #undef TO_C_TYPE
 
   // Return a `TensorAccessor` for CPU `Tensor`s. You have to specify scalar type and
   // dimension.

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1241,16 +1241,16 @@ inline Device Tensor::device() const {
         " but found ",                           \
         at::toString(type().scalarType()));      \
     return static_cast<T*>(this->data_ptr());    \
-  }                                              \
-  inline T* Tensor::to##name##Data() const {     \
-    return data<T>();                            \
   }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)
 #undef DEFINE_CAST
 
-#define DEFINE_TO_C_TYPE(T,name,_) \
-inline T Tensor::toC##name () const { return _local_scalar().to##name (); }
+#define DEFINE_TO_C_TYPE(T, name, _)   \
+  template <>                          \
+  inline T Tensor::item() const {      \
+    return _local_scalar().to##name(); \
+  }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO_C_TYPE)
 #undef DEFINE_TO_C_TYPE

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -168,7 +168,7 @@ Tensor & embedding_renorm_cpu_(
       continue;
     }
     auto row = self[sorted_indices[i]];
-    auto norm = row.norm(norm_type).toCDouble();
+    auto norm = row.norm(norm_type).item<double>();
     if (norm > max_norm) {
       auto scale = max_norm / (norm + 1e-7);
       row *= scale;

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -143,8 +143,8 @@ static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
 
 static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size) {
   if (index.numel() != 0) {
-    auto max_idx = index.max().toCLong();
-    auto min_idx = index.min().toCLong();
+    auto max_idx = index.max().item<int64_t>();
+    auto min_idx = index.min().item<int64_t>();
     AT_CHECK(max_idx < dim_size,
              "index ", max_idx, " is out of bounds for dimension ", dim, " with size ", dim_size);
     AT_CHECK(min_idx >= -dim_size,

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -22,7 +22,7 @@ static inline std::tuple<double, Tensor, int> _lu_det_P_diag_U_info(const Tensor
   std::tie(lu, p, info) = self.unsqueeze(0).btrifact_with_info();
   p.squeeze_(0);
   lu.squeeze_(0);
-  int int_info = info.squeeze_().toCInt();
+  int int_info = info.squeeze_().item<int32_t>();
   AT_CHECK(int_info >= 0, "LU factorization (getrf) failed with info = ", int_info);
   auto n = self.size(0);
   auto num_exchanges = (at::arange(1, n + 1, p.type()) != p).nonzero().size(0);
@@ -63,7 +63,7 @@ Tensor logdet(const Tensor& self) {
   } else {
     det = diag_U.prod().mul_(det_P);
   }
-  if (det.sign().toCDouble() <= 0) {
+  if (det.sign().item<double>() <= 0) {
     return det.log_();  // in order to get proper -inf (det=0) or nan (det<0)
   } else {
     return diag_U.abs().log().sum();

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -34,7 +34,7 @@ DEFINE_DISPATCH(max_kernel);
 DEFINE_DISPATCH(min_kernel);
 
 bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {
-  return at::isclose(self, other, rtol, atol, equal_nan).all().toCByte();
+  return at::isclose(self, other, rtol, atol, equal_nan).all().item<uint8_t>();
 }
 
 Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -99,7 +99,7 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
 Tensor mvlgamma(const Tensor& self, int64_t p) {
   AT_CHECK(at::isFloatingType(self.type().scalarType()),
            "mvlgamma is not implemented for ", self.type());
-  AT_CHECK((self > 0.5 * (p - 1.)).all().toCByte(),
+  AT_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   AT_CHECK(p >= 1, "p has to be greater than or equal to 1");
   Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
@@ -110,7 +110,7 @@ Tensor mvlgamma(const Tensor& self, int64_t p) {
 Tensor& mvlgamma_(Tensor& self, int64_t p) {
   AT_CHECK(at::isFloatingType(self.type().scalarType()),
            "mvlgamma is not implemented for ", self.type());
-  AT_CHECK((self > 0.5 * (p - 1.)).all().toCByte(),
+  AT_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   AT_CHECK(p >= 1, "p has to be greater than or equal to 1");
   Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -258,7 +258,7 @@ Tensor _bincount_cuda_template(
     AT_ERROR("input and weights should have the same length");
   }
 
-  auto nbins = self.max().toCLong() + 1L;
+  auto nbins = self.max().item<int64_t>() + 1L;
   nbins = std::max(nbins, minlength);
   // alloc output counter on GPU
   Tensor output;

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1125,7 +1125,7 @@ DropoutState& get_dropout_state(const Type& tp, double dropout_p, bool train) {
                                  : ten_dropout_state_cache.at(device);
   if (train && dropout_p > 0 && !state.buffer.defined()) {
     std::unique_lock<std::mutex> lock {state.mutex};
-    int64_t seed = at::empty({}, at::kLong).random_().toCLong();
+    int64_t seed = at::empty({}, at::kLong).random_().item<int64_t>();
     state.buffer = at::_cudnn_init_dropout_state(
       tp.toScalarType(at::kByte), dropout_p, train, seed);
     // NB: CUDA binds the event to a device at creation time, so we can initialize it

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -172,19 +172,11 @@ struct AT_API Tensor {
   template<typename T>
   T * data() const;
 
+  template <typename T>
+  T item() const;
+
   // Purposely not defined here to avoid inlining
   void print() const;
-
-  //toLongData(), toFloatData() etc.
-  #define TO_TYPE_DATA(T,name,_) \
-  T * to##name##Data() const;
-  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_TYPE_DATA)
-  #undef TO_TYPE_DATA
-
-  #define TO_C_TYPE(T,name,_) \
-  T toC##name () const;
-  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(TO_C_TYPE)
-  #undef TO_C_TYPE
 
   // Return a `TensorAccessor` for CPU `Tensor`s. You have to specify scalar type and
   // dimension.

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -81,16 +81,16 @@ inline Device Tensor::device() const {
         " but found ",                           \
         at::toString(type().scalarType()));      \
     return static_cast<T*>(this->data_ptr());    \
-  }                                              \
-  inline T* Tensor::to##name##Data() const {     \
-    return data<T>();                            \
   }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)
 #undef DEFINE_CAST
 
-#define DEFINE_TO_C_TYPE(T,name,_) \
-inline T Tensor::toC##name () const { return _local_scalar().to##name (); }
+#define DEFINE_TO_C_TYPE(T, name, _)   \
+  template <>                          \
+  inline T Tensor::item() const {      \
+    return _local_scalar().to##name(); \
+  }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO_C_TYPE)
 #undef DEFINE_TO_C_TYPE

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -18,7 +18,7 @@ void trace() {
     trace += foo_a[i][i];
   }
 
-  EXPECT_FLOAT_EQ(foo.trace().toCFloat(), trace);
+  EXPECT_FLOAT_EQ(foo.trace().item<float>(), trace);
 }
 
 // TEST_CASE( "atest", "[]" ) {
@@ -27,7 +27,6 @@ TEST(atest, atest) {
   manual_seed(123, at::kCUDA);
 
   auto foo = rand({12,6});
-  EXPECT_EQ(foo.data<float>(), foo.toFloatData());
 
   EXPECT_EQ(foo.size(0), 12);
   EXPECT_EQ(foo.size(1), 6);

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -31,15 +31,15 @@ static void test(Type & type) {
 
   CATCH_SECTION( "ones and dot" ) {
     Tensor b0 = ones({1, 1}, type);
-    CATCH_REQUIRE(2 == (b0+b0).sum().toCDouble());
+    CATCH_REQUIRE(2 == (b0+b0).sum().item<double>());
 
     Tensor b1 = ones({1, 2}, type);
-    CATCH_REQUIRE(4 == (b1+b1).sum().toCDouble());
+    CATCH_REQUIRE(4 == (b1+b1).sum().item<double>());
 
     Tensor b = ones({3, 4}, type);
-    CATCH_REQUIRE(24 == (b+b).sum().toCDouble());
+    CATCH_REQUIRE(24 == (b+b).sum().item<double>());
     CATCH_REQUIRE(12 == b.numel());
-    CATCH_REQUIRE(b.view(-1).dot(b.view(-1)).toCDouble() == 12);
+    CATCH_REQUIRE(b.view(-1).dot(b.view(-1)).item<double>() == 12);
   }
 
   CATCH_SECTION( "rand" ) {
@@ -54,7 +54,7 @@ static void test(Type & type) {
     auto z = b.sort(1);
     auto z_sorted = std::get<0>(z);
 
-    CATCH_REQUIRE(z_sorted[0][0].toCFloat() < z_sorted[0][1].toCFloat());
+    CATCH_REQUIRE(z_sorted[0][0].item<float>() < z_sorted[0][1].item<float>());
   }
 
   if(type.backend() != Backend::CUDA)
@@ -62,7 +62,7 @@ static void test(Type & type) {
     Tensor b = randperm(15, type);
     Tensor rv, ri;
     std::tie(rv, ri) = sort(b, 0);
-    CATCH_REQUIRE(rv[0].toCFloat() <= rv[1].toCFloat());
+    CATCH_REQUIRE(rv[0].item<float>() <= rv[1].item<float>());
   }
 
   CATCH_SECTION( "context" ) {
@@ -89,7 +89,7 @@ static void test(Type & type) {
     auto end = std::chrono::high_resolution_clock::now();
     //TODO TEST PERF?
     std::cout << std::dec << "   " << std::chrono::duration_cast<std::chrono::milliseconds>(end-begin).count() << " ms" << std::endl;
-    CATCH_REQUIRE(norm(100000*d).toCDouble() == norm(r).toCDouble());
+    CATCH_REQUIRE(norm(100000*d).item<double>() == norm(r).item<double>());
   }
 
   CATCH_SECTION( "loads of adds (with copy)" ) {
@@ -102,7 +102,7 @@ static void test(Type & type) {
     auto end = std::chrono::high_resolution_clock::now();
     //TODO TEST PERF?
     std::cout << std::dec << "   " << std::chrono::duration_cast<std::chrono::milliseconds>(end-begin).count() << " ms" << std::endl;
-    CATCH_REQUIRE(norm(100000*d).toCDouble() == norm(r).toCDouble());
+    CATCH_REQUIRE(norm(100000*d).item<double>() == norm(r).item<double>());
   }
 
   CATCH_SECTION( "isContiguous" ) {
@@ -154,7 +154,7 @@ static void test(Type & type) {
 
   CATCH_SECTION( "abs(value)" ) {
     Tensor r = at::abs(type.scalarTensor(-3));
-    CATCH_REQUIRE(r.toCInt() == 3);
+    CATCH_REQUIRE(r.item<int32_t>() == 3);
   }
 
 //TODO(zach): operator overloads
@@ -195,7 +195,7 @@ static void test(Type & type) {
     auto f = rand({3,4}, type);
     f[2] = zeros({4}, type);
     f[1][0] = -1;
-    CATCH_REQUIRE(f[2][0].toCDouble() == 0);
+    CATCH_REQUIRE(f[2][0].item<double>() == 0);
   }
 
   CATCH_SECTION( "tensor from TH" ) {
@@ -206,14 +206,14 @@ static void test(Type & type) {
     CATCH_REQUIRE_NOTHROW(tt);
   }
 
-  CATCH_SECTION( "toCFloat" ) {
+  CATCH_SECTION( "item<float>" ) {
     Tensor a = zeros({3,4});
     Tensor b = ones({3,7});
     Tensor c = cat({a,b},1);
     CATCH_REQUIRE(c.size(1) == 11);
 
     Tensor e = rand({});
-    CATCH_REQUIRE(*e.data<float>() == e.sum().toCFloat());
+    CATCH_REQUIRE(*e.data<float>() == e.sum().item<float>());
   }
 
   CATCH_SECTION( "to string" ) {

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -71,7 +71,7 @@ CATCH_TEST_CASE( "scalar test", "[]" ) {
   auto t = ones({4,4});
 
   auto wha2 = zeros({4,4}).add(t).sum();
-  CATCH_REQUIRE( wha2.toCDouble() == 16.0 );
+  CATCH_REQUIRE( wha2.item<double>() == 16.0 );
 
   CATCH_REQUIRE( t.sizes()[0] == 4 );
   CATCH_REQUIRE( t.sizes()[1] == 4 );
@@ -116,10 +116,10 @@ CATCH_TEST_CASE( "scalar test", "[]" ) {
   // test direct C-scalar type conversions
   {
     auto x = ones({1,2}, T);
-    _CATCH_REQUIRE_THROWS(x.toCFloat());
+    _CATCH_REQUIRE_THROWS(x.item<float>());
   }
   auto float_one = ones({}, T);
-  CATCH_REQUIRE(float_one.toCFloat() == 1);
-  CATCH_REQUIRE(float_one.toCInt() == 1);
-  CATCH_REQUIRE((float_one.toCHalf() == 1));
+  CATCH_REQUIRE(float_one.item<float>() == 1);
+  CATCH_REQUIRE(float_one.item<int32_t>() == 1);
+  CATCH_REQUIRE((float_one.item<at::Half>() == 1));
 }

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -86,7 +86,7 @@ vector<int64_t> GetTensorInfo(
   CHECK(tc);
   CHECK(tc->unsafeGetTensorImpl());
   CHECK(tc->unsafeGetTensorImpl()->storage().unsafeGetStorageImpl());
-  *capacity = tc->capacity_nbytes();
+  *capacity = tc->storage().capacity();
   tc->ExtractDeviceOption(device);
   return tc->dims();
 }

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -262,10 +262,6 @@ class CAFFE2_API Tensor final {
     return impl_.get()->nbytes();
   }
 
-  inline size_t capacity_nbytes() const {
-    return impl_.get()->capacity_nbytes();
-  }
-
   inline const vector<int64_t>& dims() const {
     return impl_.get()->dims();
   }
@@ -320,6 +316,10 @@ class CAFFE2_API Tensor final {
   }
 
   const Storage& storage() {
+    return impl_->storage();
+  }
+
+  const Storage& storage() const {
     return impl_->storage();
   }
 };

--- a/caffe2/core/tensor_impl.h
+++ b/caffe2/core/tensor_impl.h
@@ -693,11 +693,6 @@ class CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     ;
   }
 
-  // NB: This capacity may also include available space
-  // in the storage BEFORE the tensor data, if storage_offset != 0
-  inline size_t capacity_nbytes() const {
-    return storage_.capacity();
-  }
   /**
    * Returns the dimensions of the tensor as a vector.
    */

--- a/caffe2/mobile/contrib/opengl/test/opengl_test.cc
+++ b/caffe2/mobile/contrib/opengl/test/opengl_test.cc
@@ -2039,19 +2039,19 @@ void compareModelsForOpenGL(std::string name,
       CAFFE_ENFORCE_EQ(input_type, "uint8_t");
       t_gl->Resize(1, height, width, channel);
       uint8_t* input = t_gl->mutable_data<uint8_t>();
-      memcpy(input, t_cpu->mutable_data<uint8_t>(), t_cpu->capacity_nbytes());
+      memcpy(input, t_cpu->mutable_data<uint8_t>(), t_cpu->storage().capacity());
     } else if (name == "segmentation") {
       CAFFE_ENFORCE_EQ(input_order, "NCHW");
       CAFFE_ENFORCE_EQ(input_type, "float");
       t_gl->Resize(1, channel, height, width);
       float* input = t_gl->mutable_data<float>();
-      memcpy(input, t_cpu->mutable_data<float>(), t_cpu->capacity_nbytes());
+      memcpy(input, t_cpu->mutable_data<float>(), t_cpu->storage().capacity());
     } else if (name == "denoiser") {
       CAFFE_ENFORCE_EQ(input_order, "NCHW");
       CAFFE_ENFORCE_EQ(input_type, "float");
       t_gl->Resize(1, channel, height, width);
       float* input = t_gl->mutable_data<float>();
-      memcpy(input, t_cpu->mutable_data<float>(), t_cpu->capacity_nbytes());
+      memcpy(input, t_cpu->mutable_data<float>(), t_cpu->storage().capacity());
     }
 
     cws.RunNetOnce(truncatedPredictNet);
@@ -2149,14 +2149,14 @@ void compareBatchedToTiledModels(std::string name,
       CAFFE_ENFORCE_EQ(input_type, "uint8_t");
       t_tiling->Resize(1, height, width, channel);
       uint8_t* input = t_tiling->mutable_data<uint8_t>();
-      memcpy(input, t_batch->mutable_data<uint8_t>(), t_batch->capacity_nbytes());
+      memcpy(input, t_batch->mutable_data<uint8_t>(), t_batch->storage().capacity());
 
     } else if (name == "segmentation") {
       CAFFE_ENFORCE_EQ(input_order, "NCHW");
       CAFFE_ENFORCE_EQ(input_type, "float");
       t_tiling->Resize(1, channel, height, width);
       float* input = t_tiling->mutable_data<float>();
-      memcpy(input, t_batch->mutable_data<float>(), t_batch->capacity_nbytes());
+      memcpy(input, t_batch->mutable_data<float>(), t_batch->storage().capacity());
     }
 
     bws.RunNetOnce(bachedNet);

--- a/test/cpp/api/any.cpp
+++ b/test/cpp/api/any.cpp
@@ -71,7 +71,7 @@ TEST_F(
   ASSERT_TRUE(
       any.forward(std::string("a"), std::string("ab"), std::string("abc"))
           .sum()
-          .toCInt() == 6);
+          .item<int32_t>() == 6);
 }
 
 TEST_F(AnyModuleTest, WrongArgumentType) {
@@ -232,10 +232,10 @@ TEST_F(AnyModuleTest, ConvertsVariableToTensorCorrectly) {
   // mismatch).
   AnyModule any(M{});
   ASSERT_TRUE(
-      any.forward(torch::autograd::Variable(torch::ones(5))).sum().toCFloat() ==
+      any.forward(torch::autograd::Variable(torch::ones(5))).sum().item<float>() ==
       5);
   // at::Tensors that are not variables work too.
-  ASSERT_EQ(any.forward(at::ones(5)).sum().toCFloat(), 5);
+  ASSERT_EQ(any.forward(at::ones(5)).sum().item<float>(), 5);
 }
 
 namespace torch {

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -63,10 +63,10 @@ class CartPole {
   }
 
   void step(int action) {
-    auto x = state[0].toCFloat();
-    auto x_dot = state[1].toCFloat();
-    auto theta = state[2].toCFloat();
-    auto theta_dot = state[3].toCFloat();
+    auto x = state[0].item<float>();
+    auto x_dot = state[1].item<float>();
+    auto theta = state[2].item<float>();
+    auto theta_dot = state[3].item<float>();
 
     auto force = (action == 1) ? force_mag : -force_mag;
     auto costheta = std::cos(theta);
@@ -222,7 +222,7 @@ bool test_mnist(
   torch::NoGradGuard guard;
   auto result = std::get<1>(forward_op(tedata).max(1));
   torch::Tensor correct = (result == telabel).toType(torch::kFloat32);
-  return correct.sum().toCFloat() > telabel.size(0) * 0.8;
+  return correct.sum().item<float>() > telabel.size(0) * 0.8;
 }
 
 struct IntegrationTest : torch::test::SeedingFixture {};
@@ -251,7 +251,7 @@ TEST_F(IntegrationTest, CartPole) {
     auto out = forward(state);
     auto probs = torch::Tensor(std::get<0>(out));
     auto value = torch::Tensor(std::get<1>(out));
-    auto action = probs.multinomial(1)[0].toCInt();
+    auto action = probs.multinomial(1)[0].item<int32_t>();
     // Compute the log prob of a multinomial distribution.
     // This should probably be actually implemented in autogradpp...
     auto p = probs / probs.sum(-1, true);
@@ -274,7 +274,7 @@ TEST_F(IntegrationTest, CartPole) {
     std::vector<torch::Tensor> policy_loss;
     std::vector<torch::Tensor> value_loss;
     for (auto i = 0U; i < saved_log_probs.size(); i++) {
-      auto r = rewards[i] - saved_values[i].toCFloat();
+      auto r = rewards[i] - saved_values[i].item<float>();
       policy_loss.push_back(-r * saved_log_probs[i]);
       value_loss.push_back(
           torch::smooth_l1_loss(saved_values[i], torch::ones(1) * rewards[i]));

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -20,10 +20,10 @@ TEST(TorchScriptTest, CanCompileMultipleFunctions) {
   auto a = torch::ones(1);
   auto b = torch::ones(1);
 
-  ASSERT_EQ(1, module->run_method("test_mul", a, b).toTensor().toCLong());
+  ASSERT_EQ(1, module->run_method("test_mul", a, b).toTensor().item<int64_t>());
 
-  ASSERT_EQ(2, module->run_method("test_relu", a, b).toTensor().toCLong());
+  ASSERT_EQ(2, module->run_method("test_relu", a, b).toTensor().item<int64_t>());
 
   ASSERT_TRUE(
-      0x200 == module->run_method("test_while", a, b).toTensor().toCLong());
+      0x200 == module->run_method("test_while", a, b).toTensor().item<int64_t>());
 }

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -49,5 +49,5 @@ TEST(NNInitTest, CanInitializeTensorThatRequiresGrad) {
       tensor.fill_(1),
       "a leaf Variable that requires grad "
       "has been used in an in-place operation");
-  ASSERT_EQ(torch::nn::init::ones_(tensor).sum().toCInt(), 12);
+  ASSERT_EQ(torch::nn::init::ones_(tensor).sum().item<int32_t>(), 12);
 }

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -41,13 +41,13 @@ TEST_F(ModuleTest, ZeroGrad) {
   for (auto& parameter : module->parameters()) {
     auto grad = parameter->grad();
     ASSERT_TRUE(grad.defined());
-    ASSERT_NE(grad.sum().toCFloat(), 0);
+    ASSERT_NE(grad.sum().item<float>(), 0);
   }
   module->zero_grad();
   for (auto& parameter : module->parameters()) {
     auto grad = parameter->grad();
     ASSERT_TRUE(grad.defined());
-    ASSERT_EQ(grad.sum().toCFloat(), 0);
+    ASSERT_EQ(grad.sum().item<float>(), 0);
   }
 }
 
@@ -72,7 +72,7 @@ TEST_F(ModuleTest, ZeroGradWithUndefined) {
   ASSERT_TRUE(module.x.grad().defined());
   ASSERT_FALSE(module.y.grad().defined());
 
-  ASSERT_EQ(module.x.grad().sum().toCFloat(), 0);
+  ASSERT_EQ(module.x.grad().sum().item<float>(), 0);
 }
 
 TEST_F(ModuleTest, CanGetName) {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -134,7 +134,7 @@ TEST_F(ModulesTest, SimpleContainer) {
   ASSERT_EQ(x.ndimension(), 2);
   ASSERT_EQ(x.size(0), 1000);
   ASSERT_EQ(x.size(1), 100);
-  ASSERT_EQ(x.min().toCFloat(), 0);
+  ASSERT_EQ(x.min().item<float>(), 0);
 }
 
 TEST_F(ModulesTest, EmbeddingBasic) {
@@ -181,12 +181,12 @@ TEST_F(ModulesTest, Dropout) {
   y.backward();
   ASSERT_EQ(y.ndimension(), 1);
   ASSERT_EQ(y.size(0), 100);
-  ASSERT_LT(y.sum().toCFloat(), 130); // Probably
-  ASSERT_GT(y.sum().toCFloat(), 70); // Probably
+  ASSERT_LT(y.sum().item<float>(), 130); // Probably
+  ASSERT_GT(y.sum().item<float>(), 70); // Probably
 
   dropout->eval();
   y = dropout->forward(x);
-  ASSERT_EQ(y.sum().toCFloat(), 100);
+  ASSERT_EQ(y.sum().item<float>(), 100);
 }
 
 TEST_F(ModulesTest, Parameters) {
@@ -228,15 +228,15 @@ TEST_F(ModulesTest, FunctionalCallsSuppliedFunction) {
 
 TEST_F(ModulesTest, FunctionalWithTorchFunction) {
   auto functional = Functional(torch::relu);
-  ASSERT_EQ(functional(torch::ones({})).toCFloat(), 1);
-  ASSERT_EQ(functional(torch::ones({})).toCFloat(), 1);
-  ASSERT_EQ(functional(torch::ones({}) * -1).toCFloat(), 0);
+  ASSERT_EQ(functional(torch::ones({})).item<float>(), 1);
+  ASSERT_EQ(functional(torch::ones({})).item<float>(), 1);
+  ASSERT_EQ(functional(torch::ones({}) * -1).item<float>(), 0);
 }
 
 TEST_F(ModulesTest, FunctionalArgumentBinding) {
   auto functional =
       Functional(torch::elu, /*alpha=*/1, /*scale=*/0, /*input_scale=*/1);
-  ASSERT_EQ(functional(torch::ones({})).toCFloat(), 0);
+  ASSERT_EQ(functional(torch::ones({})).item<float>(), 0);
 }
 
 TEST_F(ModulesTest, BatchNormStateful) {

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -44,7 +44,7 @@ bool test_optimizer_xor(Options options) {
     auto labels = torch::empty({kBatchSize});
     for (size_t i = 0; i < kBatchSize; i++) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
-      labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
+      labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
     inputs.set_requires_grad(true);
     optimizer.zero_grad();
@@ -54,7 +54,7 @@ bool test_optimizer_xor(Options options) {
 
     optimizer.step();
 
-    running_loss = running_loss * 0.99 + loss.toCFloat() * 0.01;
+    running_loss = running_loss * 0.99 + loss.item<float>() * 0.01;
     if (epoch > kMaximumNumberOfEpochs) {
       std::cout << "Loss is too high after epoch " << epoch << ": "
                 << running_loss << std::endl;
@@ -286,14 +286,14 @@ TEST(OptimTest, ZeroGrad) {
 
   for (const auto& parameter : model->parameters()) {
     ASSERT_TRUE(parameter->grad().defined());
-    ASSERT_GT(parameter->grad().sum().toCFloat(), 0);
+    ASSERT_GT(parameter->grad().sum().item<float>(), 0);
   }
 
   optimizer.zero_grad();
 
   for (const auto& parameter : model->parameters()) {
     ASSERT_TRUE(parameter->grad().defined());
-    ASSERT_EQ(parameter->grad().sum().toCFloat(), 0);
+    ASSERT_EQ(parameter->grad().sum().item<float>(), 0);
   }
 }
 

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -38,7 +38,7 @@ TEST_F(ParallelTest, DifferentiableScatter_MultiCUDA) {
 
   ASSERT_TRUE(input.grad().defined());
   ASSERT_TRUE(input.grad().device().is_cpu());
-  ASSERT_EQ(input.grad().sum().toCInt(), 10);
+  ASSERT_EQ(input.grad().sum().item<int32_t>(), 10);
 }
 
 TEST_F(ParallelTest, DifferentiableGather_MultiCUDA) {
@@ -62,11 +62,11 @@ TEST_F(ParallelTest, DifferentiableGather_MultiCUDA) {
 
   ASSERT_TRUE(a.grad().defined());
   ASSERT_EQ(a.grad().device(), torch::Device(torch::kCUDA, 0));
-  ASSERT_EQ(a.grad().sum().toCInt(), 5);
+  ASSERT_EQ(a.grad().sum().item<int32_t>(), 5);
 
   ASSERT_TRUE(b.grad().defined());
   ASSERT_EQ(b.grad().device(), torch::Device(torch::kCUDA, 1));
-  ASSERT_EQ(b.grad().sum().toCInt(), 5);
+  ASSERT_EQ(b.grad().sum().item<int32_t>(), 5);
 }
 
 TEST_F(ParallelTest, Replicate_MultiCUDA) {
@@ -226,6 +226,6 @@ TEST_F(ParallelTest, DataParallelUsesAllAvailableCUDADevices_CUDA) {
   const auto device_count = torch::cuda::device_count();
   ASSERT_EQ(output.numel(), device_count);
   for (size_t i = 0; i < device_count; ++i) {
-    ASSERT_EQ(output[i].toCInt(), i);
+    ASSERT_EQ(output[i].item<int32_t>(), i);
   }
 }

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -56,7 +56,7 @@ bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
     loss.backward();
     optimizer.step();
 
-    running_loss = running_loss * 0.99 + loss.toCFloat() * 0.01;
+    running_loss = running_loss * 0.99 + loss.item<float>() * 0.01;
     if (epoch > max_epoch) {
       return false;
     }
@@ -81,7 +81,7 @@ void check_lstm_sizes(RNNOutput output) {
   ASSERT_EQ(output.state.size(3), 64); // 64 hidden dims
 
   // Something is in the hiddens
-  ASSERT_GT(output.state.norm().toCFloat(), 0);
+  ASSERT_GT(output.state.norm().item<float>(), 0);
 }
 
 struct RNNTest : torch::test::SeedingFixture {};
@@ -103,7 +103,7 @@ TEST_F(RNNTest, CheckOutputSizes) {
   torch::Tensor diff = next.state - output.state;
 
   // Hiddens changed
-  ASSERT_GT(diff.abs().sum().toCFloat(), 1e-3);
+  ASSERT_GT(diff.abs().sum().item<float>(), 1e-3);
 }
 
 TEST_F(RNNTest, CheckOutputValuesMatchPyTorch) {
@@ -137,7 +137,7 @@ TEST_F(RNNTest, CheckOutputValuesMatchPyTorch) {
                    0.6620, 0.7860, 0.6501, 0.7741, 0.7889, 0.9003,
                    0.7769, 0.8905, 0.7635, 0.8794, 0.7484, 0.8666};
   for (size_t i = 0; i < 3 * 4 * 2; i++) {
-    ASSERT_LT(std::abs(flat[i].toCFloat() - c_out[i]), 1e-3);
+    ASSERT_LT(std::abs(flat[i].item<float>() - c_out[i]), 1e-3);
   }
 
   ASSERT_EQ(out.state.ndimension(), 4); // (hx, cx) x layers x B x 2
@@ -163,7 +163,7 @@ TEST_F(RNNTest, CheckOutputValuesMatchPyTorch) {
                    1.0931,
                    1.4911};
   for (size_t i = 0; i < 16; i++) {
-    ASSERT_LT(std::abs(flat[i].toCFloat() - h_out[i]), 1e-3);
+    ASSERT_LT(std::abs(flat[i].item<float>() - h_out[i]), 1e-3);
   }
 }
 
@@ -206,7 +206,7 @@ TEST_F(RNNTest, Sizes_CUDA) {
   torch::Tensor diff = next.state - output.state;
 
   // Hiddens changed
-  ASSERT_GT(diff.abs().sum().toCFloat(), 1e-3);
+  ASSERT_GT(diff.abs().sum().item<float>(), 1e-3);
 }
 
 TEST_F(RNNTest, EndToEndLSTM_CUDA) {

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -90,7 +90,7 @@ TEST(Serialize, XOR) {
     auto labels = torch::empty({batch_size});
     for (size_t i = 0; i < batch_size; i++) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
-      labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
+      labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
     auto x = model->forward<torch::Tensor>(inputs);
     return torch::binary_cross_entropy(x, labels);
@@ -112,7 +112,7 @@ TEST(Serialize, XOR) {
     loss.backward();
     optimizer.step();
 
-    running_loss = running_loss * 0.99 + loss.sum().toCFloat() * 0.01;
+    running_loss = running_loss * 0.99 + loss.sum().item<float>() * 0.01;
     ASSERT_LT(epoch, 3000);
     epoch++;
   }
@@ -122,7 +122,7 @@ TEST(Serialize, XOR) {
   torch::load(model2, tempfile.str());
 
   auto loss = getLoss(model2, 100);
-  ASSERT_LT(loss.toCFloat(), 0.1);
+  ASSERT_LT(loss.item<float>(), 0.1);
 }
 
 TEST(Serialize, Optim) {
@@ -188,9 +188,9 @@ TEST(Serialize, Optim) {
     const auto& name = p.key;
     // Model 1 and 3 should be the same
     ASSERT_TRUE(
-        param1[name].norm().toCFloat() == param3[name].norm().toCFloat());
+        param1[name].norm().item<float>() == param3[name].norm().item<float>());
     ASSERT_TRUE(
-        param1[name].norm().toCFloat() != param2[name].norm().toCFloat());
+        param1[name].norm().item<float>() != param2[name].norm().item<float>());
   }
 }
 
@@ -202,7 +202,7 @@ TEST(Serialize, Optim) {
 //     auto labels = torch::empty({batch_size});
 //     for (size_t i = 0; i < batch_size; i++) {
 //       inputs[i] = torch::randint(2, {2}, torch::kInt64);
-//       labels[i] = inputs[i][0].toCLong() ^ inputs[i][1].toCLong();
+//       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
 //     }
 //     auto x = model->forward<torch::Tensor>(inputs);
 //     return torch::binary_cross_entropy(x, labels);
@@ -224,7 +224,7 @@ TEST(Serialize, Optim) {
 //     loss.backward();
 //     optimizer.step();
 //
-//     running_loss = running_loss * 0.99 + loss.sum().toCFloat() * 0.01;
+//     running_loss = running_loss * 0.99 + loss.sum().item<float>() * 0.01;
 //     ASSERT_LT(epoch, 3000);
 //     epoch++;
 //   }
@@ -234,7 +234,7 @@ TEST(Serialize, Optim) {
 //   torch::load(model2, tempfile.str());
 //
 //   auto loss = getLoss(model2, 100);
-//   ASSERT_LT(loss.toCFloat(), 0.1);
+//   ASSERT_LT(loss.item<float>(), 0.1);
 //
 //   model2->to(torch::kCUDA);
 //   torch::test::TempFile tempfile2;
@@ -242,5 +242,5 @@ TEST(Serialize, Optim) {
 //   torch::load(model3, tempfile2.str());
 //
 //   loss = getLoss(model3, 100);
-//   ASSERT_LT(loss.toCFloat(), 0.1);
+//   ASSERT_LT(loss.item<float>(), 0.1);
 // }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -104,7 +104,7 @@ TEST(TensorTest, ContainsCorrectValueForSingleValue) {
   auto tensor = at::tensor(123);
   ASSERT_EQ(tensor.numel(), 1);
   ASSERT_EQ(tensor.dtype(), at::kInt);
-  ASSERT_EQ(tensor[0].toCInt(), 123);
+  ASSERT_EQ(tensor[0].item<int32_t>(), 123);
 
   tensor = at::tensor(123.456f);
   ASSERT_EQ(tensor.numel(), 1);
@@ -189,7 +189,7 @@ TEST(TensorTest, FromBlob) {
   auto tensor = torch::from_blob(v.data(), v.size(), torch::kInt32);
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
-  ASSERT_EQ(tensor[0].toCInt(), 1);
-  ASSERT_EQ(tensor[1].toCInt(), 2);
-  ASSERT_EQ(tensor[2].toCInt(), 3);
+  ASSERT_EQ(tensor[0].item<int32_t>(), 1);
+  ASSERT_EQ(tensor[1].item<int32_t>(), 2);
+  ASSERT_EQ(tensor[2].item<int32_t>(), 3);
 }

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -219,7 +219,7 @@ Tensor prod_backward(Tensor grad, const Tensor& input, Tensor result, int64_t di
 
   Tensor zero_mask = (input == 0);
   Tensor slice_zero_count = zero_mask.sum(dim, true);
-  int64_t total_zeros = slice_zero_count.sum().toCLong();
+  int64_t total_zeros = slice_zero_count.sum().item<int64_t>();
   if (total_zeros == 0) {
     return (grad * result) / input;
   } else {
@@ -321,7 +321,7 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
   }
 
   // Simple case with nonzero elements in the input
-  if ((input != 0).all().toCByte()) {
+  if ((input != 0).all().item<uint8_t>()) {
     Tensor result = at::cumprod(input, dim);
     return sum_scan_exclusive(result * grad, dim) / input;
   }
@@ -1600,7 +1600,7 @@ Tensor symeig_backward(const std::vector<torch::autograd::Variable> &grads, cons
 // Invertible case is derived from Jacobi's formula, and also can be found at:
 // http://eprints.maths.ox.ac.uk/1079/1/NA-08-01.pdf
 Tensor det_backward(const Tensor & grad, const Tensor& self, const Tensor& det) {
-  auto det_val = det.toCDouble();
+  auto det_val = det.item<double>();
   if (det_val != 0 /* invertible */) {
     return grad * det * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
@@ -1612,7 +1612,7 @@ Tensor det_backward(const Tensor & grad, const Tensor& self, const Tensor& det) 
 }
 
 Tensor logdet_backward(const Tensor & grad, const Tensor& self, const Tensor& logdet) {
-  auto logdet_val = logdet.toCDouble();
+  auto logdet_val = logdet.item<double>();
   if (logdet_val != -INFINITY /* det != 0, invertible */) {
     return grad * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
@@ -1628,7 +1628,7 @@ Tensor slogdet_backward(const std::vector<torch::autograd::Variable> &grads,
                         const Tensor& self,
                         const Tensor& signdet, const Tensor& logabsdet) {
   AT_ASSERTM(!grads[0].defined(), "slogdet's sign output should never have gradient");
-  auto signdet_val = signdet.toCDouble();
+  auto signdet_val = signdet.item<double>();
   if (signdet_val != 0 /* det != 0, invertible */) {
     return grads[1] * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -156,7 +156,7 @@ static double dispatch_to_CDouble(const Tensor & self) {
   if (self.numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
-  return self.toCDouble();
+  return self.item<double>();
 }
 
 static std::complex<double> dispatch_to_CComplexDouble(const Tensor & self) {
@@ -165,7 +165,7 @@ static std::complex<double> dispatch_to_CComplexDouble(const Tensor & self) {
   if (self.numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
-  return self.toCComplexDouble();
+  return self.item<std::complex<double>>();
 }
 
 static int64_t dispatch_to_CLong(const Tensor & self) {
@@ -174,7 +174,7 @@ static int64_t dispatch_to_CLong(const Tensor & self) {
   if (self.numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
-  return self.toCLong();
+  return self.item<int64_t>();
 }
 
 static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
@@ -190,7 +190,7 @@ static PyObject * THPVariable_integral_scalar(PyObject* self, PyObject* args) {
   jit::tracer::warn("Converting a tensor to a Python integer", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   if (isFloatingType(self_.type().scalarType())) {
-    // we can't dispatch to toCLong here because we want to avoid ATen overflow checks;
+    // we can't dispatch to item<int64_t> here because we want to avoid ATen overflow checks;
     // the python integral type (long in python2) can't overflow.
     return THPUtils_packDoubleAsInt(dispatch_to_CDouble(self_));
   } else {

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -51,7 +51,7 @@ void serialize(
     BufferContainer& buffers) {
   torch::Tensor size_tensor;
   archive.read(key + "/size", size_tensor);
-  const size_t size = size_tensor.toCLong();
+  const size_t size = size_tensor.item<int64_t>();
   for (size_t index = 0; index < size; ++index) {
     buffers.emplace_back();
     archive.read(

--- a/torch/csrc/api/src/optim/serialize.cpp
+++ b/torch/csrc/api/src/optim/serialize.cpp
@@ -31,7 +31,7 @@ void serialize(
   serialize(archive, key, tensors);
   steps.clear();
   for (const auto& step : tensors) {
-    steps.push_back(step.toCLong());
+    steps.push_back(step.item<int64_t>());
   }
 }
 } // namespace detail

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -407,7 +407,7 @@ auto Engine::evaluate_function(FunctionTask& task) -> void {
     for (int i = 0; i < num_outputs; ++i) {
       auto& output = outputs[i];
       at::DeviceGuard guard(output);
-      if (output.defined() && output.ne(output).any().toCByte()) {
+      if (output.defined() && output.ne(output).any().item<uint8_t>()) {
         std::stringstream ss;
         ss << "Function '" << fn.name() << "' returned nan values in its " << i << "th output.";
         throw std::runtime_error(ss.str());

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -173,7 +173,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
           result = applySelect(result, dim, THPUtils_unpackLong(obj));
         } else {
           result = result.unsqueeze(dim);
-          handle_var(boolToIndexingTensor(result, var.toCByte() != 0));
+          handle_var(boolToIndexingTensor(result, var.item<uint8_t>() != 0));
         }
       } else {
         handle_var(var);

--- a/torch/csrc/jit/batched/BatchTensor.cpp
+++ b/torch/csrc/jit/batched/BatchTensor.cpp
@@ -34,7 +34,7 @@ BatchTensor::BatchTensor(const std::vector<at::Tensor> datalist, at::Tensor dims
     for(auto x : datalist){
       sizes[i] = std::max(sizes[i], x.size(i));
     }
-    mask_sizes[i] = *dims[i - 1].toByteData() ? sizes[i] : 1;
+    mask_sizes[i] = *dims[i - 1].data<uint8_t>() ? sizes[i] : 1;
   }
   data = datalist[0].type().tensor(sizes);
   data.fill_(0);
@@ -44,7 +44,7 @@ BatchTensor::BatchTensor(const std::vector<at::Tensor> datalist, at::Tensor dims
     auto data_item = data.narrow(0, i, 1);
     auto mask_item = mask.narrow(0, i, 1);
     for(int64_t j = 0; j < dims.size(0); j++){
-      if(*dims[j].toByteData()){
+      if(*dims[j].data<uint8_t>()){
         data_item = data_item.narrow(j + 1, 0, datalist[i].size(j + 1));
         mask_item = mask_item.narrow(j + 1, 0, datalist[i].size(j + 1));
       }
@@ -62,12 +62,12 @@ std::vector<at::Tensor> BatchTensor::examples() {
     data = data.sum(d, /*keepdim=*/true);
     while(data.dim() >= 1)
       data = data[0];
-    return *data.toLongData();
+    return *data.data<int64_t>();
   };
   for(int64_t i = 0; i < data.size(0); i++){
     auto data_tmp = data.narrow(0, i, 1);
     for(int64_t d = 0; d < dims.size(0); d++){
-      if(*dims[d].toByteData()){
+      if(*dims[d].data<uint8_t>()){
         data_tmp = data_tmp.narrow(d + 1, 0, mask_sum(mask[i], d));
       }
     }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -70,7 +70,7 @@ RegisterOperators reg({
               at::Tensor a;
               pop(stack, a);
               at::DeviceGuard guard(a);
-              push(stack, a.toCLong());
+              push(stack, a.item<int64_t>());
               return 0;
             };
           } else {
@@ -78,7 +78,7 @@ RegisterOperators reg({
               at::Tensor a;
               pop(stack, a);
               at::DeviceGuard guard(a);
-              push(stack, a.toCDouble());
+              push(stack, a.item<double>());
               return 0;
             };
           }
@@ -92,7 +92,7 @@ RegisterOperators reg({
               pop(stack, a);
               checkImplicitTensorToNum(a, /*to int*/true);
               at::DeviceGuard guard(a);
-              push(stack, a.toCLong());
+              push(stack, a.item<int64_t>());
               return 0;
             };
           } else {
@@ -101,7 +101,7 @@ RegisterOperators reg({
               pop(stack, a);
               checkImplicitTensorToNum(a, /*to int*/false);
               at::DeviceGuard guard(a);
-              push(stack, a.toCDouble());
+              push(stack, a.item<double>());
               return 0;
             };
           }
@@ -727,7 +727,7 @@ RegisterOperators reg2({
             pop(stack, t);
             std::vector<int64_t> elems;
             for(int i = 0; i < t.size(0); i++){
-              elems.push_back(*t[i].toIntData());
+              elems.push_back(*t[i].data<int32_t>());
             }
             push(stack, jit::IntList::create(elems));
             return 0;

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -148,7 +148,7 @@ static void fusionTests() {
     auto outputs = debugLaunchGraph(graph, 0, {a,b});
     CATCH_REQUIRE(outputs.size() == 1);
     auto o2 = a*b;
-    float max_diff = (o2 - outputs[0]).abs().max().toCDouble();
+    float max_diff = (o2 - outputs[0]).abs().max().item<double>();
     //std::cout << "max diff: " << max_diff << "\n";
     CATCH_REQUIRE(max_diff == 0);
   };
@@ -202,7 +202,7 @@ static void fusionTests() {
     auto outputs = debugLaunchGraph(graph, 0, inputs);
     CATCH_REQUIRE(outputs.size() == graph.outputs().size());
     CATCH_REQUIRE(out0.is_same_size(outputs.front()));
-    float max_diff = (outputs.front() - out0).abs().max().toCDouble();
+    float max_diff = (outputs.front() - out0).abs().max().item<double>();
     CATCH_REQUIRE(max_diff < 1e-6);
 
   };
@@ -236,9 +236,9 @@ static void fusionTests() {
     auto outputs = debugLaunchGraph(graph, 0, {a,b});
     CATCH_REQUIRE(outputs.size() == 2);
 
-    float max_diff = (o_r - outputs[0]).abs().max().toCDouble();
+    float max_diff = (o_r - outputs[0]).abs().max().item<double>();
     CATCH_REQUIRE(max_diff == 0);
-    float max_diff2 = (o2_r - outputs[1]).abs().max().toCDouble();
+    float max_diff2 = (o2_r - outputs[1]).abs().max().item<double>();
     CATCH_REQUIRE(max_diff2 == 0);
   };
   testConcat(0);
@@ -325,16 +325,16 @@ at::Tensor t_def(at::Tensor x) {
 bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
   double maxValue = 0.0;
   for (auto& tensor : inputs) {
-    maxValue = fmax(tensor.abs().max().toCFloat(), maxValue);
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
   }
-  return diff.abs().max().toCFloat() < 2e-6 * maxValue;
+  return diff.abs().max().item<float>() < 2e-6 * maxValue;
 }
 bool almostEqual(const at::Tensor & a, const at::Tensor & b) {
   return checkRtol(a - b,{a, b});
 }
 
 bool exactlyEqual(const at::Tensor & a, const at::Tensor & b) {
-  return (a - b).abs().max().toCFloat() == 0.f;
+  return (a - b).abs().max().item<float>() == 0.f;
 }
 
 std::pair<at::Tensor, at::Tensor>
@@ -873,7 +873,7 @@ void testControlFlow() {
   };
 
   auto L = [](int64_t l) { return IValue(autograd::make_variable(scalar_to_tensor(at::Scalar(l)))); };
-  auto V = [](IValue t) { return std::move(t).toTensor().toCLong(); };
+  auto V = [](IValue t) { return std::move(t).toTensor().item<int64_t>(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
     return V(run(name, {L(a), L(b)})[0]);
   };

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -72,7 +72,7 @@ public:
       for (int idx = 0; idx < size; idx++) {
 	PyObject* obj = tuple ? PyTuple_GET_ITEM(source, idx) : PyList_GET_ITEM(source, idx);
 	if (THPVariable_Check(obj)) {
-	  v_value[idx] = THPVariable_Unpack(obj).toCLong();
+	  v_value[idx] = THPVariable_Unpack(obj).item<int64_t>();
 	} else if (PyLong_Check(obj)) {
 	  // use THPUtils_unpackLong after it is safe to include python_numbers.h
 	  v_value[idx] = THPUtils_unpackLong(obj);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -300,7 +300,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(int i, std::vector<in
         auto & var = THPVariable_Unpack(obj);
         jit::tracer::ArgumentStash::stashIntListElem(
             signature.params[i].name, size, idx, var);
-        res[idx] = var.toCLong();
+        res[idx] = var.item<int64_t>();
         continue;
       } else {
         res[idx] = THPUtils_unpackIndex(obj);


### PR DESCRIPTION
Summary: Modern C++ api instead of macros, item() is aligned with Python frontend. caffe2::Tensor::capacity_nbytes is effecitvely unused and confusing w.r.t. caffe2::Tensor::nbytes().

Differential Revision: D9948572
