### PR TITLE
Adjust headers to handle the new Android unified header structure

### DIFF
--- a/caffe2/mobile/contrib/libopencl-stub/include/libopencl.h
+++ b/caffe2/mobile/contrib/libopencl-stub/include/libopencl.h
@@ -1,11 +1,12 @@
 #ifndef LIBOPENCL_STUB_H
 #define LIBOPENCL_STUB_H
 
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <dlfcn.h>
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Old per-API+arch headers reside in

    r*/platforms/android-*/arch-*/usr/include/

New Unified headers reside in

    r*/sysroot/usr/include/

Unified headers are not exactly drop-in replacements for the old ones. Old headers had some nested includes that are absent in the unified versions, so we need to explicitly include them.