### PR TITLE
Make CPU fuser tests less flaky (and report better errors)

### DIFF
--- a/torch/csrc/jit/fusers/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/fusers/cpu/fused_kernel.cpp
@@ -37,15 +37,9 @@ static const std::string compile_string =
 #endif
   "-std=c++11 -fPIC ${fopenmp} -shared \"${cpp_file}\" -o \"${so_file}\" -lm";
 
-static void checkSystemFailure(const std::string& activity, int retval, int errnum) {
-  if (retval == 0) {
-    return;
-  } else if (retval == -1) {
-    AT_ERROR("Failed to ", activity, ": system() returned '", strerror(errnum), "'");
-  } else if (retval == 127) {
-    AT_ERROR("Failed to ", activity, ": shell could not be executed in child process");
-  } else {
-    AT_ERROR("Failed to ", activity, ": child process exited with return value ", retval);
+static void checkCommandFailure(const std::string& activity, int retval) {
+  if (retval != 0) {
+    AT_ERROR("Failed to ", activity, ": child exited with return value ", retval);
   }
 }
 
@@ -65,7 +59,7 @@ static void runCompiler(
     config.openmp = false; // disable for future compiles
     return runCompiler(config, cpp_file, so_file);
   }
-  checkSystemFailure("compile a fused CPU kernel", /*retval=*/r, errno);
+  checkCommandFailure("compile a fused CPU kernel", /*retval=*/r);
 }
 
 static const std::string disas_string =
@@ -75,7 +69,7 @@ static void disas(const std::string& so_file) {
   env.s("so_file", so_file);
   std::string cmd = format(disas_string, env);
   int r = runCommand(cmd.c_str());
-  checkSystemFailure("objdump", /*retval=*/r, errno);
+  checkCommandFailure("objdump", /*retval=*/r);
 }
 
 CPUFusedKernel::CPUFusedKernel(

--- a/torch/csrc/jit/fusers/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/fusers/cpu/fused_kernel.cpp
@@ -38,9 +38,7 @@ static const std::string compile_string =
   "-std=c++11 -fPIC ${fopenmp} -shared \"${cpp_file}\" -o \"${so_file}\" -lm";
 
 static void checkCommandFailure(const std::string& activity, int retval) {
-  if (retval != 0) {
-    AT_ERROR("Failed to ", activity, ": child exited with return value ", retval);
-  }
+  AT_CHECK(retval == 0, "Failed to ", activity, ": child exited with return value ", retval);
 }
 
 static void runCompiler(

--- a/torch/csrc/jit/fusers/cpu/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusers/cpu/fusion_compiler.cpp
@@ -14,7 +14,9 @@
 #include <sstream>
 #include <tuple>
 
+#ifndef __APPLE__
 #include <malloc.h> // for malloc_trim
+#endif
 
 namespace torch { namespace jit { namespace cpufuser {
 
@@ -27,7 +29,9 @@ int runCommand(const std::string& command) {
   // XXX: system() uses fork(), which can fail if the malloc allocator uses
   // too much memory. Ask the allocator nicely to free its memory for now, but
   // we should rethink using system() in the future.
+#ifndef __APPLE__
   malloc_trim(/*pad=*/0);
+#endif
   return system(command.c_str());
 }
 

--- a/torch/csrc/jit/fusers/cpu/fusion_compiler.h
+++ b/torch/csrc/jit/fusers/cpu/fusion_compiler.h
@@ -48,13 +48,9 @@ private:
 
 CPUFusionCompiler& getFusionCompiler();
 
-// XXX: A replacement for stdlib.h's `system` function.
-// `system` calls fork. Depending on the machine, even if COW is enabled,
-// fork can fail if the process uses up more than half the machine's memory.
-// We try to avoid these problems in runCommand
 int runCommand(const std::string& command);
 
-} // namespace cudafuser
+} // namespace cpufuser
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/fusers/cpu/fusion_compiler.h
+++ b/torch/csrc/jit/fusers/cpu/fusion_compiler.h
@@ -31,7 +31,7 @@ struct CPUFusionCompiler {
   ~CPUFusionCompiler() = default;
 
   std::shared_ptr<FusionHandle> getFusionHandle(Node* fusion_group);
-  
+
   std::vector<at::Tensor> debugLaunchGraph(
     Graph& graph
   , int device
@@ -48,8 +48,14 @@ private:
 
 CPUFusionCompiler& getFusionCompiler();
 
+// XXX: A replacement for stdlib.h's `system` function.
+// `system` calls fork. Depending on the machine, even if COW is enabled,
+// fork can fail if the process uses up more than half the machine's memory.
+// We try to avoid these problems in runCommand
+int runCommand(const std::string& command);
+
 } // namespace cudafuser
-} // namespace jit 
+} // namespace jit
 } // namespace torch
 
 #endif // USE_CPU_FUSER


### PR DESCRIPTION
This pr wraps the flaky system() call in a new function that does the following:
- call malloc_trim() before each system() call used by the CPU fuser.
  This is to get rid of excess memory that may prevent a fork()

I also improved the error message for when system() fails so one knows from
the logs what is wrong ("Could not allocate memory, etc")

Test Plan: code reading (I don't really have better ideas). I've verified through a debugger that the posix_spawn + vfork path is taken on two of my machines.

cc @apaszke @ezyang 