### PR TITLE
Delete default constructor from Tensor (again).

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -40,7 +40,7 @@ class CAFFE2_API Tensor final {
   TensorImplPtr impl_;
 
  public:
-  Tensor() : impl_() {}
+  Tensor() = delete;
 
   operator bool() const {
     return impl_.defined();


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#11898 Delete default constructor from Tensor (again).**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9977058/)

I'm trying to flush out a bug where someone is using UndefinedTensor
as if it were a real tensor on Android.

Differential Revision: [D9977058](https://our.internmc.facebook.com/intern/diff/D9977058/)