### PR TITLE
Fix saving loaded module

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -239,6 +239,13 @@ class JitTestCase(TestCase):
             imported = torch.jit.load(f.name)
         finally:
             os.unlink(f.name)
+        f = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            f.close()
+            imported.save(f.name)
+            imported = torch.jit.load(f.name)
+        finally:
+            os.unlink(f.name)
         return imported
 
     def assertGraphContains(self, graph, kind):

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -319,7 +319,7 @@ at::Tensor ModuleDecoder::buildTensorCommon(
     auto storage = std::make_shared<at::Storage>(
       at::CPU(type).typeMeta(),
       std::move(storage_ptr),
-      size,
+      size / at::CPU(type).typeMeta().itemsize(),
       nullptr);
     storage_map_.insert(std::make_pair(record_number, storage));
     return at::CPU(type).tensor(*storage, storage_offset, dims, strides);


### PR DESCRIPTION
This PR fixes #11913.

In order to test for this, the model is serialized twice in `getExportImportCopy`.