### PR TITLE
[jit] Remove tests from EXCLUDE_SCRIPT that pass

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7648,8 +7648,6 @@ EXCLUDE_SCRIPT = {
     'test_norm_fro',
     'test_norm_fro_default',
     'test_norm_nuc',
-    'test_matrix_power_n=-1',  # involves inverse
-    'test_matrix_power_n=-3',  # involves inverse
     # skipped nn functional tests
     # ops involves sampling which could not test
     'test_nn_dropout',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7645,12 +7645,9 @@ EXCLUDE_SCRIPT = {
     'test_var_dim_1d',
     'test_var_dim_1d_neg0',
     'test_var_dim_neg0',
-    'test_norm_inf',
-    'test_norm_inf_2_dim',
     'test_norm_fro',
     'test_norm_fro_default',
     'test_norm_nuc',
-    'test_renorm_norm_inf',
     'test_matrix_power_n=-1',  # involves inverse
     'test_matrix_power_n=-3',  # involves inverse
     # skipped nn functional tests


### PR DESCRIPTION
Spruriously added in #11261

I had a PR to catch these automatically (#11279), but it had some issues
passing on some CI environments but not others (e.g. for
`test_nn_group_norm`), any ideas?

