### PR TITLE
Consolidate c++11 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 # ---[ Project and semantic versioning.
 project(Caffe2 CXX C)
 
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_C_STANDARD 11)
+
 set(CAFFE2_VERSION_MAJOR 0)
 set(CAFFE2_VERSION_MINOR 8)
 set(CAFFE2_VERSION_PATCH 2)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -215,12 +215,6 @@ target_include_directories(caffe2 SYSTEM PRIVATE "${Caffe2_DEPENDENCY_INCLUDE}")
 # Set standard properties on the target
 aten_set_target_props(caffe2)
 
-if (MSVC)
-target_compile_options(caffe2 INTERFACE "-std=c++11")
-else()
-target_compile_options(caffe2 INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-std=c++11>")
-endif()
-
 target_compile_options(caffe2 PRIVATE "-DCAFFE2_BUILD_MAIN_LIB")
 if (MSVC AND NOT BUILD_SHARED_LIBS)
   # Note [Supporting both static and dynamic libraries on Window]

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -860,10 +860,6 @@ if (NOT BUILD_ATEN_MOBILE)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
   endif()
 
-  if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
-  endif()
-
   INCLUDE(CheckCXXSourceCompiles)
 
   # disable some verbose warnings
@@ -917,14 +913,6 @@ if (NOT BUILD_ATEN_MOBILE)
     # we want to respect the standard, and we are bored of those **** .
     ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE=1)
     LIST(APPEND CUDA_NVCC_FLAGS "-Xcompiler /wd4819 -Xcompiler /wd4503 -Xcompiler /wd4190 -Xcompiler /wd4244 -Xcompiler /wd4251 -Xcompiler /wd4275 -Xcompiler /wd4522")
-  ENDIF()
-
-  IF (NOT MSVC)
-    IF (CMAKE_VERSION VERSION_LESS "3.1")
-      SET(CMAKE_C_FLAGS "-std=c11 ${CMAKE_C_FLAGS}")
-    ELSE ()
-      SET(CMAKE_C_STANDARD 11)
-    ENDIF ()
   ENDIF()
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
Seems that we have a huge amount of places setting c++11 manually - this puts it in one place with the new cmake (post 3.1) command.