### PR TITLE
Align cuda multinomial without replacement to CPU behaviour

### DIFF
--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -100,13 +100,13 @@ __global__ void renormRowsL1(T* dist, long rows, long cols) {
     T sum = ScalarConvert<int, T>::to(0);
     for (int64_t col = threadIdx.x; col < cols; col += blockDim.x) {
       val = dist[row * cols + col];
-      assert(THCNumerics<T>::ge(val, zero));
+      assert(! THCNumerics<T>::lt(val, zero)); // ! < 0 for NaN handling
       sum = THCNumerics<T>::add(sum, val);
     }
 
     sum = reduceBlock(smem, blockDim.x, sum, ReduceAdd<T>(), zero);
     if (threadIdx.x == 0) {
-      assert(THCNumerics<T>::gt(sum, zero));
+      assert(! THCNumerics<T>::lt(sum, zero)); // ! < 0 for NaN handling
       smem[0] = sum;
     }
     __syncthreads();

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1552,6 +1552,17 @@ class TestCuda(TestCase):
         r = torch.multinomial(p, 1)
         self.assertNotEqual(r.min().item(), 0)
 
+        # multinomial without repeat but with less nonzero
+        # elements than draws
+        # the intention currently is to return 0 for those
+        # and match CPU behaviour, see issue #9062
+        p = torch.zeros(1, 5, device="cuda")
+        p[:, 1] = 1
+        r = torch.multinomial(p, 2, replacement=False)
+        expected = torch.zeros(1, 2, device="cuda", dtype=torch.long)
+        expected[:, 0] = 1
+        self.assertEqual(r, expected)
+
     @staticmethod
     def mute():
         os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())


### PR DESCRIPTION
We do this by being more NaN tolerant.

Fixes: #9062

