### PR TITLE
Launch bounds on ctc loss backward

### DIFF
--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -254,7 +254,9 @@ std::tuple<Tensor, Tensor> ctc_loss_gpu_template(const Tensor& log_probs, const 
 // The second (backward) half of the forward backward algorithm, (10) and (11). This is parallel to the
 // alpha kernel above. (As mentioned above, it might make sense do the calculation in the alpha kernel.)
 template<typename scalar_t, typename target_t>
-__global__ void ctc_loss_backward_log_beta_gpu_kernel(scalar_t* __restrict__ log_beta_data,
+__global__ void
+__launch_bounds__(std::is_same<scalar_t, float>::value ? 1024 : 896, 1)
+ctc_loss_backward_log_beta_gpu_kernel(scalar_t* __restrict__ log_beta_data,
                                              const scalar_t*log_probs_data, const int64_t* __restrict__ input_lengths, int64_t max_input_length,
                                              const target_t* __restrict__ targets_data, const int64_t* __restrict__ target_lengths, int64_t max_target_length,
                                              int64_t lp_input_stride, int64_t lp_batch_stride, int64_t lp_char_stride,

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -255,7 +255,9 @@ std::tuple<Tensor, Tensor> ctc_loss_gpu_template(const Tensor& log_probs, const 
 // alpha kernel above. (As mentioned above, it might make sense do the calculation in the alpha kernel.)
 template<typename scalar_t, typename target_t>
 __global__ void
+#if __CUDA_ARCH__ >= 350
 __launch_bounds__(std::is_same<scalar_t, float>::value ? 1024 : 896, 1)
+#endif
 ctc_loss_backward_log_beta_gpu_kernel(scalar_t* __restrict__ log_beta_data,
                                              const scalar_t*log_probs_data, const int64_t* __restrict__ input_lengths, int64_t max_input_length,
                                              const target_t* __restrict__ targets_data, const int64_t* __restrict__ target_lengths, int64_t max_target_length,


### PR DESCRIPTION
CTC loss backwards kernel is running out of resources on the GPU for L0. This adds launch bounds to guarantee that at least one block of max size can fit on an SM.