### PR TITLE
Make promoteType(half, integer) -> half

### DIFF
--- a/aten/src/ATen/core/ScalarType.h
+++ b/aten/src/ATen/core/ScalarType.h
@@ -178,10 +178,10 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
             /* u1  i1  i2  i4  i8  f2  f4  f8 */
     /* u1 */ { u1, i2, i2, i4, i8, f2, f4, f8 },
     /* i1 */ { i2, i1, i2, i4, i8, f2, f4, f8 },
-    /* i2 */ { i2, i2, i2, i4, i8, f4, f4, f8 },
-    /* i4 */ { i4, i4, i4, i4, i8, f8, f4, f8 },
-    /* i8 */ { i8, i8, i8, i8, i8, f8, f4, f8 },
-    /* f2 */ { f2, f2, f4, f8, f8, f2, f4, f8 },
+    /* i2 */ { i2, i2, i2, i4, i8, f2, f4, f8 },
+    /* i4 */ { i4, i4, i4, i4, i8, f2, f4, f8 },
+    /* i8 */ { i8, i8, i8, i8, i8, f2, f4, f8 },
+    /* f2 */ { f2, f2, f2, f2, f2, f2, f4, f8 },
     /* f4 */ { f4, f4, f4, f4, f4, f4, f4, f8 },
     /* f8 */ { f8, f8, f8, f8, f8, f8, f8, f8 },
   };

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -909,23 +909,20 @@ class TestCuda(TestCase):
         self.assertIsInstance(y.cuda().float().cpu().int(), torch.IntStorage)
 
     def test_mul_intertype_scalar(self):
-        x = torch.tensor(1.5, device='cuda')
-        y = torch.tensor(3, dtype=torch.int32, device='cuda')
+        def test_mul(dtype):
+            x = torch.tensor(1.5, dtype=dtype, device='cuda')
+            y = torch.tensor(3, dtype=torch.int32, device='cuda')
 
-        self.assertEqual(x * y, 4.5)
-        self.assertEqual(y * x, 4.5)
-        with self.assertRaisesRegex(RuntimeError, 'expected type'):
-            y *= x
-        x *= y
-        self.assertEqual(x, 4.5)
-
-        x = torch.tensor(1.5, device='cuda', dtype=torch.float16)
-        self.assertEqual(x * y, 4.5)
-        # half * int currently promotes to double
-        with self.assertRaisesRegex(RuntimeError, 'expected type'):
+            self.assertEqual(x * y, 4.5)
+            self.assertEqual(y * x, 4.5)
+            with self.assertRaisesRegex(RuntimeError, 'expected type'):
+                y *= x
             x *= y
-        with self.assertRaisesRegex(RuntimeError, 'expected type'):
-            y *= x
+            self.assertEqual(x, 4.5)
+
+        test_mul(torch.float16)
+        test_mul(torch.float32)
+        test_mul(torch.float64)
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     @skipIfRocm


### PR DESCRIPTION
Changes the result type of half type and any integer type to return half
type (instead of float or double).