### PR TITLE
[c10d] Fix return temporary as reference in MPI backend

### DIFF
--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -101,8 +101,7 @@ class ProcessGroupMPI : public ProcessGroup {
     std::mutex workMutex_;
     std::condition_variable workCV_;
     std::atomic<bool> completed_;
-
-    std::exception_ptr workException_;
+    std::exception_ptr exception_;
 
     friend class ProcessGroupMPI;
   };
@@ -123,10 +122,13 @@ class ProcessGroupMPI : public ProcessGroup {
     const std::exception& exception() const override;
 
    protected:
+    void populateException();
+
     at::Tensor tensor_;
     MPI_Request request_;
     int* const srcRank_;
     MPI_Status status_;
+    std::exception_ptr exception_;
   };
 
   // Constructor will spawn up the worker thread loop


### PR DESCRIPTION
The MPI async work class returned a temporary as reference, which is
invalid (hat tip to @colesbury for noticing it). This change fixes that and
uses a std::exception_ptr to hold on to the exception if applicable, and
then returns the reference by throwing it and returning it, like the
existing code path.

