### PR TITLE
New chaining/partitioning algorithm for async_scheduling for inference

### DIFF
--- a/caffe2/core/net_dag_utils.cc
+++ b/caffe2/core/net_dag_utils.cc
@@ -278,6 +278,88 @@ ExecutionChains computeChains(std::vector<OperatorNode>& orig_nodes) {
   return chains;
 }
 
+// Here chains are essentially groups, we used chain/group interchangeably
+ExecutionChains computeGroups(std::vector<OperatorNode>& orig_nodes) {
+  const std::vector<OpGraphNode> nodes = pruneOpNodeGraph(orig_nodes);
+  ExecutionChains chains;
+  std::vector<int> sync_frontier;
+  std::vector<int> async_frontier;
+
+  std::vector<int> in_degrees;
+  in_degrees.reserve(nodes.size());
+  std::transform(
+      nodes.begin(),
+      nodes.end(),
+      std::back_inserter(in_degrees),
+      [](const OpGraphNode& n) { return n.parents_.size(); });
+
+  // Screen out the primary root nodes
+  for (int idx = 0; idx < (int)nodes.size(); ++idx) {
+    if (in_degrees[idx] == 0) {
+      if (orig_nodes[idx].operator_->HasAsyncPart()) {
+        async_frontier.push_back(idx);
+      } else {
+        sync_frontier.push_back(idx);
+      }
+    }
+  }
+
+  // We check sync ops on the froniter first and then async ops. This gives us a
+  // head start to execute sync ops locally while waiting for async ops to
+  // finish.
+  std::queue<int> q;
+  while (!(async_frontier.empty() && sync_frontier.empty())) {
+    // Sync ops
+    for (const auto i : sync_frontier) {
+      q.push(i);
+    }
+    sync_frontier.clear();
+    std::vector<int> chain;
+    while (!q.empty()) {
+      int idx = q.front();
+      q.pop();
+      chain.push_back(idx);
+      for (int child : nodes[idx].children_) {
+        if (--in_degrees[child] == 0) {
+          if (orig_nodes[child].operator_->HasAsyncPart()) {
+            async_frontier.push_back(child);
+          } else {
+            q.push(child);
+          }
+        }
+      }
+    }
+    // add the whole group of continuous sync ops into one chain
+    if (!chain.empty()) {
+      chains.emplace(chain.front(), chain);
+    }
+
+    // Async ops
+    for (const auto i : async_frontier) {
+      q.push(i);
+    }
+    async_frontier.clear();
+    while (!q.empty()) {
+      int idx = q.front();
+      q.pop();
+      // Put each individual node as a new chain
+      chains[idx] = {idx};
+      for (int child : nodes[idx].children_) {
+        if (--in_degrees[child] == 0) {
+          if (orig_nodes[child].operator_->HasAsyncPart()) {
+            q.push(child);
+          } else {
+            sync_frontier.push_back(child);
+          }
+        }
+      }
+    }
+  }
+
+  updateOperatorNodes(orig_nodes, chains);
+  return chains;
+}
+
 ExecutionChains singleChains(std::vector<OperatorNode>& nodes) {
   ExecutionChains chains;
   for (int i = 0; i < (int)nodes.size(); ++i) {

--- a/caffe2/core/net_dag_utils.h
+++ b/caffe2/core/net_dag_utils.h
@@ -43,11 +43,19 @@ struct OpGraphNode {
 
 using ExecutionChains = std::unordered_map<int, std::vector<int>>;
 
-ExecutionChains computeChains(std::vector<OperatorNode>& orig_nodes);
+C10_EXPORT ExecutionChains computeChains(std::vector<OperatorNode>& orig_nodes);
 
-ExecutionChains singleChains(std::vector<OperatorNode>& nodes);
+// Instead of breaking down the DAG into chains, we partition it into clusters
+// of sync ops and individual async op. This is useful for disturbuted inference
+// case where we have sync and async cpu ops. Note that we have go sync each
+// aysnc op instead of put them into the chain and sync its tail like GPU op,
+// because CPU async ops are typically rpc calls and are not guaranteed to be
+// linearized at remote site.
+C10_EXPORT ExecutionChains computeGroups(std::vector<OperatorNode>& orig_nodes);
 
-std::vector<OperatorNode> prepareOperatorNodes(
+C10_EXPORT ExecutionChains singleChains(std::vector<OperatorNode>& nodes);
+
+C10_EXPORT std::vector<OperatorNode> prepareOperatorNodes(
     const std::shared_ptr<const NetDef>& net_def,
     Workspace* ws);
 

--- a/caffe2/core/net_dag_utils_test.cc
+++ b/caffe2/core/net_dag_utils_test.cc
@@ -1,0 +1,296 @@
+#include <gtest/gtest.h>
+#include "caffe2/core/net_dag_utils.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+namespace {
+class DummySyncOp final : public Operator<CPUContext> {
+ public:
+  DummySyncOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    return true;
+  }
+};
+
+class DummyAsyncOp final : public Operator<CPUContext> {
+ public:
+  DummyAsyncOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    return true;
+  }
+
+  bool HasAsyncPart() const override {
+    return true;
+  }
+};
+
+REGISTER_CPU_OPERATOR(DagUtilTestDummySync, DummySyncOp);
+REGISTER_CPU_OPERATOR(DagUtilTestDummyAsync, DummyAsyncOp);
+
+OPERATOR_SCHEMA(DagUtilTestDummySync)
+    .NumInputs(0, INT_MAX)
+    .NumOutputs(0, INT_MAX);
+OPERATOR_SCHEMA(DagUtilTestDummyAsync)
+    .NumInputs(0, INT_MAX)
+    .NumOutputs(0, INT_MAX);
+
+class DagUtilTestContext {
+ public:
+  DagUtilTestContext(const std::string& spec, Workspace* ws) {
+    net_def_ = std::make_shared<NetDef>();
+    CAFFE_ENFORCE(TextFormat::ParseFromString(spec, net_def_.get()));
+    operator_nodes_ = dag_utils::prepareOperatorNodes(net_def_, ws);
+  }
+
+  dag_utils::ExecutionChains computeChains() {
+    return dag_utils::computeGroups(operator_nodes_);
+  }
+
+ private:
+  std::shared_ptr<NetDef> net_def_{nullptr};
+  std::vector<dag_utils::OperatorNode> operator_nodes_;
+};
+
+void PrintChains(const dag_utils::ExecutionChains& chains) {
+  for (const auto kv : chains) {
+    std::stringstream ss;
+    ss << kv.first << ": ";
+    for (const auto& v : kv.second) {
+      ss << v << ", ";
+    }
+    LOG(INFO) << ss.str();
+  }
+}
+} // namespace
+
+TEST(DagUtilTest, Empty) {
+  const auto spec = R"DOC(
+    name: "test0"
+    type: "async_scheduling"
+    )DOC";
+  Workspace ws;
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  EXPECT_TRUE(chains.empty());
+}
+
+// 4 sync ops forming a diamond
+TEST(DagUtilTest, AllSync) {
+  const auto spec = R"DOC(
+    name: "test1"
+    type: "async_scheduling"
+    external_input: "in"
+    op {
+      input: "in"
+      output: "n1"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      output: "n2"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      output: "n3"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n2"
+      input: "n3"
+      output: "out"
+      type: "DagUtilTestDummySync"
+    }
+    )DOC";
+  Workspace ws;
+  ws.CreateBlob("in");
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  dag_utils::ExecutionChains expected{{0, {0, 1, 2, 3}}};
+  EXPECT_EQ(chains, expected);
+}
+
+// 3 async ops forming an L shape
+TEST(DagUtilTest, AllAsync) {
+  const auto spec = R"DOC(
+    name: "test2"
+    type: "async_scheduling"
+    external_input: "in0"
+    external_input: "in1"
+    op {
+      input: "in0"
+      output: "n1"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "in1"
+      output: "n2"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n1"
+      output: "n3"
+      type: "DagUtilTestDummyAsync"
+    }
+    )DOC";
+  Workspace ws;
+  ws.CreateBlob("in0");
+  ws.CreateBlob("in1");
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  dag_utils::ExecutionChains expected{{0, {0}}, {1, {1}}, {2, {2}}};
+  EXPECT_EQ(chains, expected);
+}
+
+// 3 sync ops and 1 async op (#2) forming a diamond
+TEST(DagUtilTest, Mixed0) {
+  const auto spec = R"DOC(
+    name: "test3"
+    type: "async_scheduling"
+    external_input: "in"
+    op {
+      input: "in"
+      output: "n1"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      output: "n2"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      output: "n3"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n2"
+      input: "n3"
+      output: "out"
+      type: "DagUtilTestDummySync"
+    }
+    )DOC";
+  Workspace ws;
+  ws.CreateBlob("in");
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  dag_utils::ExecutionChains expected{{0, {0, 1}}, {2, {2}}, {3, {3}}};
+  EXPECT_EQ(chains, expected);
+}
+
+// 3 sync ops and 1 async op (#2) forming a Y shape
+TEST(DagUtilTest, Mixed1) {
+  const auto spec = R"DOC(
+    name: "test3"
+    type: "async_scheduling"
+    external_input: "in0"
+    external_input: "in1"
+    op {
+      input: "in0"
+      output: "n1"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "in1"
+      output: "n2"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      input: "n2"
+      output: "n3"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n3"
+      output: "out"
+      type: "DagUtilTestDummySync"
+    }
+    )DOC";
+  Workspace ws;
+  ws.CreateBlob("in0");
+  ws.CreateBlob("in1");
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  dag_utils::ExecutionChains expected{{0, {0, 1}}, {2, {2}}, {3, {3}}};
+  EXPECT_EQ(chains, expected);
+}
+// More complicated mixed case. * means async
+//  0* -> 1* -> 2
+//    |
+//  3 -> 4 -> 5
+//  |  |
+//  |    6
+//   - -> 8*
+//  7* -/
+TEST(DagUtilTest, Mixed2) {
+  const auto spec = R"DOC(
+    name: "test4"
+    type: "async_scheduling"
+    external_input: "in0"
+    external_input: "in1"
+    external_input: "in2"
+    op {
+      input: "in0"
+      output: "n1"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n1"
+      output: "n2"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n2"
+      output: "out0"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "in1"
+      output: "n3"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n1"
+      input: "n3"
+      output: "n4"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n4"
+      output: "out1"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "n3"
+      output: "out2"
+      type: "DagUtilTestDummySync"
+    }
+    op {
+      input: "in2"
+      output: "n7"
+      type: "DagUtilTestDummyAsync"
+    }
+    op {
+      input: "n3"
+      input: "n7"
+      output: "out3"
+      type: "DagUtilTestDummyAsync"
+    }
+    )DOC";
+  Workspace ws;
+  ws.CreateBlob("in0");
+  ws.CreateBlob("in1");
+  ws.CreateBlob("in2");
+  DagUtilTestContext t(spec, &ws);
+  auto chains = t.computeChains();
+  dag_utils::ExecutionChains expected{
+      {0, {0}}, {1, {1}}, {3, {3, 6}}, {4, {4, 2, 5}}, {7, {7}}, {8, {8}}};
+  EXPECT_EQ(chains, expected);
+}
+} // namespace caffe2


### PR DESCRIPTION
Summary:
For distributed inference, we want to use async_scheduling net to run the net as we need its async part. However, according to the profiling, async_net has big overhead of dispatching tasks onto worker threads. This diff improves the issue by generating a smaller number of chains/tasks by grouping the sync ops that can be run in one shot. Note that it also schedule individual async ops as a single chain because unlike gpu ops, rpc ops are not guaranteed to be linearized at the remote site. For example, if you have two rps ops `op1->op2`, op2 won't implicitly block until op1 finishes. Therefore we need to put each of the async op as one chain as async_scheduling net will only sync the tail of the chain.

For the all sync op nets, this change give us `1.5X` slower than simple_net, while without the change, it is `7X` slower.

Next step is to work on the executor to make the task scheduling faster. And add a fallback path to be able to run ops inline if it's a all-sync net.

Differential Revision: D9874140
