### PR TITLE
[jit] Add default values in script

### DIFF
--- a/test/expect/TestJit.test_default_values.expect
+++ b/test/expect/TestJit.test_default_values.expect
@@ -1,0 +1,12 @@
+graph(%x : Dynamic
+      %a : Dynamic = 0.5
+      %b : Dynamic = 5
+      %c : Dynamic = 22) {
+  %4 : int = prim::Constant[value=1]()
+  %5 : Dynamic = aten::add(%x, %a, %4)
+  %6 : int = prim::Constant[value=1]()
+  %7 : Dynamic = aten::add(%5, %b, %6)
+  %8 : int = prim::Constant[value=1]()
+  %9 : Dynamic = aten::add(%7, %c, %8)
+  return (%9);
+}

--- a/test/expect/TestJit.test_default_values.expect
+++ b/test/expect/TestJit.test_default_values.expect
@@ -1,12 +1,19 @@
 graph(%x : Dynamic
       %a : Dynamic = 0.5
-      %b : Dynamic = 5
-      %c : Dynamic = 22) {
-  %4 : int = prim::Constant[value=1]()
-  %5 : Dynamic = aten::add(%x, %a, %4)
-  %6 : int = prim::Constant[value=1]()
-  %7 : Dynamic = aten::add(%5, %b, %6)
-  %8 : int = prim::Constant[value=1]()
-  %9 : Dynamic = aten::add(%7, %c, %8)
-  return (%9);
+[ Variable[CPUDoubleType]{} ]
+      %b : Dynamic = 10
+[ Variable[CPULongType]{} ]
+      %c : Dynamic = 20
+[ Variable[CPULongType]{} ]
+      %d : Dynamic = 50
+[ Variable[CPULongType]{} ]) {
+  %5 : int = prim::Constant[value=1]()
+  %6 : Dynamic = aten::add(%x, %a, %5)
+  %7 : int = prim::Constant[value=1]()
+  %8 : Dynamic = aten::add(%6, %b, %7)
+  %9 : int = prim::Constant[value=1]()
+  %10 : Dynamic = aten::add(%8, %c, %9)
+  %11 : int = prim::Constant[value=1]()
+  %12 : Dynamic = aten::add(%10, %d, %11)
+  return (%12);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1962,12 +1962,17 @@ class TestJit(JitTestCase):
         self.assertExpected(loop_use_test.graph.pretty_print(), "loop_use_test")
 
     def test_default_values(self):
+        outer_var = 20
+        outer_var2 = 30
+
         @torch.jit.script
-        def fn(x, a=0.5, b=5, c=22):
-            return x + a + b + c
+        def fn(x, a=0.5, b=10, c=outer_var, d=outer_var + outer_var2):
+            return x + a + b + c + d
 
         self.assertExpectedGraph(fn.graph)
-        self.assertEqual(fn(torch.ones(1)), torch.ones(1) + 0.5 + 5 + 22)
+        self.assertEqual(
+            fn(torch.ones(1)),
+            torch.ones(1) + 0.5 + 10 + 20 + (20 + 30))
 
 
 class TestBatched(TestCase):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1961,6 +1961,14 @@ class TestJit(JitTestCase):
         self.assertExpected(while_if_test.graph.pretty_print(), "while_if_test")
         self.assertExpected(loop_use_test.graph.pretty_print(), "loop_use_test")
 
+    def test_default_values(self):
+        @torch.jit.script
+        def fn(x, a=0.5, b=5, c=22):
+            return x + a + b + c
+
+        self.assertExpectedGraph(fn.graph)
+        self.assertEqual(fn(torch.ones(1)), torch.ones(1) + 0.5 + 5 + 22)
+
 
 class TestBatched(TestCase):
     # generate random examples and create an batchtensor with them

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -43,6 +43,19 @@ std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
   return out;
 }
 
+
+void printIValue(std::ostream& out, IValue& value) {
+  if (value.isTensor()) {
+    out << value.toTensor();
+  } else if (value.isInt()) {
+    out << value.toInt();
+  } else if (value.isDouble()) {
+    out << value.toDouble();
+  } else {
+    AT_ERROR("Unknown IValue type");
+  }
+}
+
 struct const_value_list_with_types {
   const ArrayRef<const Value*> values;
   bool use_newlines;
@@ -68,6 +81,17 @@ std::ostream& operator<<(std::ostream & out, const_value_list_with_types l) {
     printValueRef(out, n);
     out << " : ";
     out << *n->type();
+
+    // Print default value if one exists
+    const ParamValue* pv = dynamic_cast<const ParamValue*>(n);
+    if (pv != nullptr) {
+      auto value = pv->default_value();
+      if (value) {
+        out << " = ";
+        printIValue(out, *value);
+      }
+    }
+
   }
   return out;
 }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -44,18 +44,6 @@ std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
 }
 
 
-void printIValue(std::ostream& out, IValue& value) {
-  if (value.isTensor()) {
-    out << value.toTensor();
-  } else if (value.isInt()) {
-    out << value.toInt();
-  } else if (value.isDouble()) {
-    out << value.toDouble();
-  } else {
-    AT_ERROR("Unknown IValue type");
-  }
-}
-
 struct const_value_list_with_types {
   const ArrayRef<const Value*> values;
   bool use_newlines;
@@ -85,10 +73,8 @@ std::ostream& operator<<(std::ostream & out, const_value_list_with_types l) {
     // Print default value if one exists
     const ParamValue* pv = dynamic_cast<const ParamValue*>(n);
     if (pv != nullptr) {
-      auto value = pv->default_value();
-      if (value) {
-        out << " = ";
-        printIValue(out, *value);
+      if (pv->default_value()) {
+        out << " = " << *pv->default_value();
       }
     }
 

--- a/torch/csrc/jit/passes/canonicalize.cpp
+++ b/torch/csrc/jit/passes/canonicalize.cpp
@@ -9,7 +9,13 @@ std::shared_ptr<Graph> Canonicalize(const std::shared_ptr<Graph>& graph) {
   std::unordered_map<Value*, Value*> rn_env;
   auto rn_fn = [&](Value* v) { return rn_env.at(v); };
   for (auto* input : graph->inputs()) {
-    auto* r_input = r->addInput();
+    auto as_param_value = dynamic_cast<const ParamValue*>(input);
+    Value* r_input = nullptr;
+    if (as_param_value != nullptr) {
+      r_input = r->addParamInput(as_param_value->default_value());
+    } else {
+      r_input = r->addInput();
+    }
     r_input->copyMetadata(input);
     r_input->setStage(input->stage());
     rn_env[input] = r_input;

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -157,7 +157,6 @@ TORCH_API std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolv
 TORCH_API Value* packOutputs(Graph& g, at::ArrayRef<Value*> values);
 TORCH_API std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
 TORCH_API void ensureSizeMatches(SourceRange loc, size_t expected, size_t actual, const std::string& what);
-TORCH_API void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values);
 
 // try to match a list if inputs and keyword 'attributes' to this schema,
 // if it works return the flat list of positional inputs to the call

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -86,6 +86,9 @@ void initTreeViewBindings(PyObject *module) {
   py::class_<Param, TreeView>(m, "Param")
     .def(py::init([](const Expr& type, const Ident& name) {
       return Param::create(name.range(), name, type);
+    }))
+    .def(py::init([](const Expr& type, const Ident& name, const Const& default_value) {
+      return Param::create(name.range(), name, type, default_value);
     }));
   py::class_<Attribute, TreeView>(m, "Attribute")
     .def(py::init([](const Ident& name, const Expr& value) {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -257,87 +257,6 @@ struct Expr : public TreeView {
   }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-// Helper nodes (mostly for function arguments)
-////////////////////////////////////////////////////////////////////////////////
-
-struct Attribute : public TreeView {
-  explicit Attribute(const TreeRef& tree) : TreeView(tree) {
-    tree_->match(TK_ATTRIBUTE);
-  }
-  Ident name() const {
-    return Ident(subtree(0));
-  }
-  Expr value() const {
-    return Expr(subtree(1));
-  }
-  static Attribute create(const SourceRange& range, const Ident& name, const TreeRef& value) {
-    return Attribute(Compound::create(TK_ATTRIBUTE, range, {name, value}));
-  }
-};
-
-
-struct Param : public TreeView {
-  explicit Param(const TreeRef& tree) : TreeView(tree) {
-    tree_->match(TK_PARAM);
-  }
-  static Param create(const SourceRange& range, const Ident& ident, const Expr& type) {
-    return Param(Compound::create(TK_PARAM, range, {ident, type}));
-  }
-  Ident ident() const {
-    return Ident(subtree(0));
-  }
-  Expr type() const {
-    return Expr(subtree(1));
-  }
-  template<typename T>
-  T typeExpect() const {
-    return T(type());
-  }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-// Top level definitions
-////////////////////////////////////////////////////////////////////////////////
-
-struct Decl : public TreeView {
-  explicit Decl(const TreeRef& tree) : TreeView(tree) {
-    tree->match(TK_DECL);
-  }
-  List<Param> params() const {
-    return List<Param>(subtree(0));
-  }
-  Maybe<Expr> return_type() const {
-    return Maybe<Expr>(subtree(1));
-  }
-  static Decl create(const SourceRange& range, const List<Param>& params, Maybe<Expr> return_type) {
-    return Decl(Compound::create(TK_DECL, range, {params, return_type}));
-  }
-};
-
-struct Def : public TreeView {
-  explicit Def(const TreeRef& tree) : TreeView(tree) {
-    tree->match(TK_DEF);
-  }
-  Ident name() const {
-    return Ident(subtree(0));
-  }
-  Decl decl() const {
-    return Decl(subtree(1));
-  }
-  List<Stmt> statements() const {
-    return List<Stmt>(subtree(2));
-  }
-  static Def create(
-      const SourceRange& range,
-      const Ident& name,
-      const Decl& decl,
-      const List<Stmt>& stmts) {
-    return Def(Compound::create(
-        TK_DEF, range, {name, decl, stmts}));
-  }
-};
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Statements
@@ -555,6 +474,105 @@ struct Const : public Expr {
   }
   static Const create(const SourceRange& range, const std::string& value) {
     return Const(Compound::create(TK_CONST, range, {String::create(value)}));
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper nodes (mostly for function arguments)
+////////////////////////////////////////////////////////////////////////////////
+
+struct Attribute : public TreeView {
+  explicit Attribute(const TreeRef& tree) : TreeView(tree) {
+    tree_->match(TK_ATTRIBUTE);
+  }
+  Ident name() const {
+    return Ident(subtree(0));
+  }
+  Expr value() const {
+    return Expr(subtree(1));
+  }
+  static Attribute create(const SourceRange& range, const Ident& name, const TreeRef& value) {
+    return Attribute(Compound::create(TK_ATTRIBUTE, range, {name, value}));
+  }
+};
+
+
+struct Param : public TreeView {
+  explicit Param(const TreeRef& tree) : TreeView(tree) {
+    tree_->match(TK_PARAM);
+  }
+  static Param create(
+      const SourceRange& range,
+      const Ident& ident,
+      const Expr& type) {
+    return Param(
+        Compound::create(TK_PARAM, range, {ident, type}));
+  }
+  static Param create(
+      const SourceRange& range,
+      const Ident& ident,
+      const Expr& type,
+      const Const& default_value) {
+    return Param(
+        Compound::create(TK_PARAM, range, {ident, type, default_value}));
+  }
+  Ident ident() const {
+    return Ident(subtree(0));
+  }
+  Expr type() const {
+    return Expr(subtree(1));
+  }
+  Const default_value() const {
+    return Const(subtree(2));
+  }
+  bool has_default() const {
+    return tree()->trees().size() == 3;
+  }
+  template<typename T>
+  T typeExpect() const {
+    return T(type());
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Top level definitions
+////////////////////////////////////////////////////////////////////////////////
+
+struct Decl : public TreeView {
+  explicit Decl(const TreeRef& tree) : TreeView(tree) {
+    tree->match(TK_DECL);
+  }
+  List<Param> params() const {
+    return List<Param>(subtree(0));
+  }
+  Maybe<Expr> return_type() const {
+    return Maybe<Expr>(subtree(1));
+  }
+  static Decl create(const SourceRange& range, const List<Param>& params, Maybe<Expr> return_type) {
+    return Decl(Compound::create(TK_DECL, range, {params, return_type}));
+  }
+};
+
+struct Def : public TreeView {
+  explicit Def(const TreeRef& tree) : TreeView(tree) {
+    tree->match(TK_DEF);
+  }
+  Ident name() const {
+    return Ident(subtree(0));
+  }
+  Decl decl() const {
+    return Decl(subtree(1));
+  }
+  List<Stmt> statements() const {
+    return List<Stmt>(subtree(2));
+  }
+  static Def create(
+      const SourceRange& range,
+      const Ident& name,
+      const Decl& decl,
+      const List<Stmt>& stmts) {
+    return Def(Compound::create(
+        TK_DEF, range, {name, decl, stmts}));
   }
 };
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -618,7 +618,7 @@ def script_method(fn):
     # createResolutionCallback internally adds 1 to get us to the scope of this
     # function (the calling function). Adding 2 gets us to the proper surrounding scope.
     rcb = createResolutionCallback(frames_up=2)
-    ast = get_jit_ast(fn, is_method=True)
+    ast = get_jit_ast(fn, is_method=True, frames_up=2)
     return ScriptMethodStub(rcb, ast, fn)
 
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -585,7 +585,7 @@ def script(fn, optimize=True, _frames_up=0):
     if not _enabled:
         return fn
     rcb = createResolutionCallback(_frames_up + 1)
-    ast = get_jit_ast(fn, is_method=False)
+    ast = get_jit_ast(fn, is_method=False, frames_up=_frames_up + 1)
     graph = _jit_script_compile(ast, rcb)
     mod = ScriptModule()
     mod._create_method_from_graph('forward', graph)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -137,7 +137,7 @@ def _uses_true_division(fn):
             '_uses_true_division: expected function or method, got {}'.format(type(fn)))
 
 
-def get_jit_ast(fn, is_method, frames_up):
+def get_jit_ast(fn, is_method, frames_up=0):
     source = dedent(inspect.getsource(fn))
     py_ast = ast.parse(source)
     if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):


### PR DESCRIPTION
PR adds support for `int` and `float` default values for script functions (values get cast to `Tensor` implicitly). Resolves expressions via `eval` (but only for types that can convert to a `Tensor`)

@apaszke @zdevito @ezyang 