### PR TITLE
Export caffe2::Caffe2Annotation symbols

### DIFF
--- a/caffe2/opt/annotations.cc
+++ b/caffe2/opt/annotations.cc
@@ -4,22 +4,22 @@ namespace caffe2 {
 
 using namespace nom::repr;
 
-void Caffe2Annotation::setOperatorDef(const caffe2::OperatorDef& opDef) {
+CAFFE2_EXPORT void Caffe2Annotation::setOperatorDef(const caffe2::OperatorDef& opDef) {
   OpDef = opDef;
   OpDefExists = true;
 }
 
-bool Caffe2Annotation::hasOperatorDef() const {
+CAFFE2_EXPORT bool Caffe2Annotation::hasOperatorDef() const {
   return OpDefExists;
 }
 
-const caffe2::OperatorDef& Caffe2Annotation::getOperatorDef() const {
+CAFFE2_EXPORT const caffe2::OperatorDef& Caffe2Annotation::getOperatorDef() const {
   CAFFE_ENFORCE(
       OpDefExists,
       "OperatorDef was never set.  Use Caffe2Annotation::setOperatorDef.");
   return OpDef;
 }
-caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
+CAFFE2_EXPORT caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
   CAFFE_ENFORCE(
       OpDefExists,
       "OperatorDef was never set.  Use Caffe2Annotation::setOperatorDef.");
@@ -27,59 +27,59 @@ caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
 }
 
 // Distributed annotations
-void Caffe2Annotation::setDevice(std::string device) {
+CAFFE2_EXPORT void Caffe2Annotation::setDevice(std::string device) {
   Device = device;
 }
-const std::string Caffe2Annotation::getDevice() const {
+CAFFE2_EXPORT const std::string Caffe2Annotation::getDevice() const {
   return Device;
 }
 
-void Caffe2Annotation::setDeviceType(int device) {
+CAFFE2_EXPORT void Caffe2Annotation::setDeviceType(int device) {
   DeviceType = device;
 }
-int Caffe2Annotation::getDeviceType() const {
+CAFFE2_EXPORT int Caffe2Annotation::getDeviceType() const {
   return DeviceType;
 }
 
-void Caffe2Annotation::setParallelization(
+CAFFE2_EXPORT void Caffe2Annotation::setParallelization(
     Caffe2Annotation::ParallelizationScheme s,
     int num) {
   parallelization_scheme_ = s;
   parallelization_ = num;
 }
 
-Caffe2Annotation::ParallelizationScheme
+CAFFE2_EXPORT Caffe2Annotation::ParallelizationScheme
 Caffe2Annotation::getParallelizationScheme() const {
   return parallelization_scheme_;
 }
 
-int Caffe2Annotation::getParallelization() const {
+CAFFE2_EXPORT int Caffe2Annotation::getParallelization() const {
   return parallelization_;
 }
 
-void Caffe2Annotation::setKeyNode(NNGraph::NodeRef n) {
+CAFFE2_EXPORT void Caffe2Annotation::setKeyNode(NNGraph::NodeRef n) {
   key_node_ = n;
 }
-const NNGraph::NodeRef& Caffe2Annotation::getKeyNode() const {
+CAFFE2_EXPORT const NNGraph::NodeRef& Caffe2Annotation::getKeyNode() const {
   CAFFE_ENFORCE(key_node_, "No key node has been annotated");
   return key_node_;
 }
-void Caffe2Annotation::setLengthNode(NNGraph::NodeRef n) {
+CAFFE2_EXPORT void Caffe2Annotation::setLengthNode(NNGraph::NodeRef n) {
   length_node_ = n;
 }
-const NNGraph::NodeRef& Caffe2Annotation::getLengthNode() const {
+CAFFE2_EXPORT const NNGraph::NodeRef& Caffe2Annotation::getLengthNode() const {
   CAFFE_ENFORCE(length_node_, "No length node has been annotated");
   return length_node_;
 }
 
-void Caffe2Annotation::setComponentLevels(std::vector<std::string> components) {
+CAFFE2_EXPORT void Caffe2Annotation::setComponentLevels(std::vector<std::string> components) {
   component_levels_ = components;
 }
-std::vector<std::string> Caffe2Annotation::getComponentLevels() const {
+CAFFE2_EXPORT std::vector<std::string> Caffe2Annotation::getComponentLevels() const {
   return component_levels_;
 }
 
-bool Caffe2Annotation::classof(const Annotation* A) {
+CAFFE2_EXPORT bool Caffe2Annotation::classof(const Annotation* A) {
   return A->getKind() == AnnotationKind::Caffe2;
 }
 

--- a/caffe2/opt/annotations.cc
+++ b/caffe2/opt/annotations.cc
@@ -4,22 +4,22 @@ namespace caffe2 {
 
 using namespace nom::repr;
 
-CAFFE2_EXPORT void Caffe2Annotation::setOperatorDef(const caffe2::OperatorDef& opDef) {
+void Caffe2Annotation::setOperatorDef(const caffe2::OperatorDef& opDef) {
   OpDef = opDef;
   OpDefExists = true;
 }
 
-CAFFE2_EXPORT bool Caffe2Annotation::hasOperatorDef() const {
+bool Caffe2Annotation::hasOperatorDef() const {
   return OpDefExists;
 }
 
-CAFFE2_EXPORT const caffe2::OperatorDef& Caffe2Annotation::getOperatorDef() const {
+const caffe2::OperatorDef& Caffe2Annotation::getOperatorDef() const {
   CAFFE_ENFORCE(
       OpDefExists,
       "OperatorDef was never set.  Use Caffe2Annotation::setOperatorDef.");
   return OpDef;
 }
-CAFFE2_EXPORT caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
+caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
   CAFFE_ENFORCE(
       OpDefExists,
       "OperatorDef was never set.  Use Caffe2Annotation::setOperatorDef.");
@@ -27,59 +27,59 @@ CAFFE2_EXPORT caffe2::OperatorDef* Caffe2Annotation::getMutableOperatorDef() {
 }
 
 // Distributed annotations
-CAFFE2_EXPORT void Caffe2Annotation::setDevice(std::string device) {
+void Caffe2Annotation::setDevice(std::string device) {
   Device = device;
 }
-CAFFE2_EXPORT const std::string Caffe2Annotation::getDevice() const {
+const std::string Caffe2Annotation::getDevice() const {
   return Device;
 }
 
-CAFFE2_EXPORT void Caffe2Annotation::setDeviceType(int device) {
+void Caffe2Annotation::setDeviceType(int device) {
   DeviceType = device;
 }
-CAFFE2_EXPORT int Caffe2Annotation::getDeviceType() const {
+int Caffe2Annotation::getDeviceType() const {
   return DeviceType;
 }
 
-CAFFE2_EXPORT void Caffe2Annotation::setParallelization(
+void Caffe2Annotation::setParallelization(
     Caffe2Annotation::ParallelizationScheme s,
     int num) {
   parallelization_scheme_ = s;
   parallelization_ = num;
 }
 
-CAFFE2_EXPORT Caffe2Annotation::ParallelizationScheme
+Caffe2Annotation::ParallelizationScheme
 Caffe2Annotation::getParallelizationScheme() const {
   return parallelization_scheme_;
 }
 
-CAFFE2_EXPORT int Caffe2Annotation::getParallelization() const {
+int Caffe2Annotation::getParallelization() const {
   return parallelization_;
 }
 
-CAFFE2_EXPORT void Caffe2Annotation::setKeyNode(NNGraph::NodeRef n) {
+void Caffe2Annotation::setKeyNode(NNGraph::NodeRef n) {
   key_node_ = n;
 }
-CAFFE2_EXPORT const NNGraph::NodeRef& Caffe2Annotation::getKeyNode() const {
+const NNGraph::NodeRef& Caffe2Annotation::getKeyNode() const {
   CAFFE_ENFORCE(key_node_, "No key node has been annotated");
   return key_node_;
 }
-CAFFE2_EXPORT void Caffe2Annotation::setLengthNode(NNGraph::NodeRef n) {
+void Caffe2Annotation::setLengthNode(NNGraph::NodeRef n) {
   length_node_ = n;
 }
-CAFFE2_EXPORT const NNGraph::NodeRef& Caffe2Annotation::getLengthNode() const {
+const NNGraph::NodeRef& Caffe2Annotation::getLengthNode() const {
   CAFFE_ENFORCE(length_node_, "No length node has been annotated");
   return length_node_;
 }
 
-CAFFE2_EXPORT void Caffe2Annotation::setComponentLevels(std::vector<std::string> components) {
+void Caffe2Annotation::setComponentLevels(std::vector<std::string> components) {
   component_levels_ = components;
 }
-CAFFE2_EXPORT std::vector<std::string> Caffe2Annotation::getComponentLevels() const {
+std::vector<std::string> Caffe2Annotation::getComponentLevels() const {
   return component_levels_;
 }
 
-CAFFE2_EXPORT bool Caffe2Annotation::classof(const Annotation* A) {
+bool Caffe2Annotation::classof(const Annotation* A) {
   return A->getKind() == AnnotationKind::Caffe2;
 }
 

--- a/caffe2/opt/annotations.h
+++ b/caffe2/opt/annotations.h
@@ -7,7 +7,7 @@
 
 namespace caffe2 {
 
-class Caffe2Annotation : public nom::repr::Annotation {
+class CAFFE2_API Caffe2Annotation : public nom::repr::Annotation {
  public:
   Caffe2Annotation() : Annotation(AnnotationKind::Caffe2) {}
   Caffe2Annotation(std::string device)


### PR DESCRIPTION
Some of these symbols are used by device_test.cc .

https://github.com/pytorch/pytorch/commit/d0db23e95adf7ee50af0a3c109ad90fa57c21590