### PR TITLE
Prevent hanging in data loader altogether

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -92,7 +92,7 @@ TEST_MKL = torch.backends.mkl.is_available()
 TEST_LIBROSA = _check_module_exists('librosa') and PY3
 
 # Python 2.7 doesn't have spawn
-NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1' and sys.version_info[0] == 3
+NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1' or sys.version_info[0] == 2
 TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 TEST_WITH_ROCM = os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1'

--- a/test/common.py
+++ b/test/common.py
@@ -91,7 +91,8 @@ TEST_MKL = torch.backends.mkl.is_available()
 # TODO: allow Py2 when librosa 0.6.2 releases
 TEST_LIBROSA = _check_module_exists('librosa') and PY3
 
-NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1'
+# Python 2.7 doesn't have spawn
+NO_MULTIPROCESSING_SPAWN = os.environ.get('NO_MULTIPROCESSING_SPAWN', '0') == '1' and sys.version_info[0] == 3
 TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 TEST_WITH_ROCM = os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1'

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -336,10 +336,12 @@ def _test_proper_exit(use_workers, pin_memory, exit_method, hold_iter_reference,
             elif exit_method == 'worker_kill':
                 kill_pid(worker_pids[0])
 
-    # Tries to trigger the __del__ clean-up rather than the automatic exiting of
-    # daemonic children. Technically it should be automatically triggered, but
-    # I don't want to rely on the implementation detail of Python gc.
-    gc.collect()
+    if not hold_iter_reference:
+        # Tries to trigger the __del__ clean-up rather than the automatic
+        # exiting of daemonic children. Technically it should be automatically
+        # triggered, but I don't want to rely on the implementation detail of
+        # Python gc.
+        gc.collect()
 
 
 # test custom init function

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -266,9 +266,11 @@ def disable_stderr(worker_id):
     r"""
     Avoids printing "ERROR: Unexpected segmentation fault encountered in worker."
     from workers. Since worker signal handler prints with low-level write(),
-    this has to be done on OS level.
+    this has to be done on OS level via dup.
     """
-    os.close(sys.stderr.fileno())
+    sys.stderr.flush()  # flush library buffers that dup2 knows nothing about
+    devnull = open(os.devnull, 'w')
+    os.dup2(devnull.fileno(), sys.stderr.fileno())
 
 
 def _test_segfault():

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -261,7 +261,6 @@ def _test_timeout_pin_memory():
     dataset = SleepDataset(10, 3)
     dataloader = DataLoader(dataset, batch_size=2, num_workers=2, timeout=1, pin_memory=True)
     _ = next(iter(dataloader))
-    time.sleep(100)
 
 
 def disable_stderr(_):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -439,7 +439,11 @@ class TestDataLoader(TestCase):
 
     @skipIfRocm
     def test_timeout(self):
-        for target in (_test_timeout, _test_timeout_pin_memory):
+        if TEST_CUDA and not NO_MULTIPROCESSING_SPAWN:
+            targets = (_test_timeout, _test_timeout_pin_memory)
+        else:
+            targets = (_test_timeout,)
+        for target in targets:
             p = ErrorTrackingProcess(target=target)
             p.start()
             p.join(JOIN_TIMEOUT)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -9,21 +9,21 @@ import time
 import traceback
 import unittest
 import subprocess
+import itertools
+import threading
 from torch import multiprocessing as mp
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
-from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
+from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MP_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm
 
-# We cannot import TEST_CUDA from common_nn here, because if we do that,
-# the TEST_CUDNN line from common_nn will be executed multiple times
+# We cannot import TEST_CUDA from common_cuda here, because if we do that,
+# the TEST_CUDNN line from common_cuda will be executed multiple times
 # as well during the execution of this test suite, and it will cause
 # CUDA OOM error on Windows.
 TEST_CUDA = torch.cuda.is_available()
 
-# We need spawn start method for test_manager_unclean_exit, but
-# Python 2.7 doesn't allow it.
-if sys.version_info[0] == 3:
+if not NO_MULTIPROCESSING_SPAWN:
     # Get a multiprocessing context because some test / third party library will
     # set start_method when imported, and setting again triggers RuntimeError.
     mp = mp.get_context(method='spawn')
@@ -149,15 +149,12 @@ class ErrorTrackingProcess(mp.Process):
         self._exception = None
 
     def run(self):
-        # Disable stderr printing from os level, and make workers not printing
-        # to stderr.
-        # Can't use sys.stderr.close, otherwise Python `raise` will error with
-        # ValueError: I/O operation on closed file.
-        os.close(sys.stderr.fileno())
+        # Disable polluting stderr with errors that are supposed to happen.
+        sys.stderr = open(os.devnull, "w")
         try:
             super(ErrorTrackingProcess, self).run()
             self._cconn.send(None)
-        except Exception as e:
+        except Exception:
             self._cconn.send(ExceptionWrapper(sys.exc_info()))
             raise
 
@@ -259,10 +256,79 @@ def _test_timeout():
     _ = next(iter(dataloader))
 
 
+def _test_timeout_pin_memory():
+    dataset = SleepDataset(10, 3)
+    dataloader = DataLoader(dataset, batch_size=2, num_workers=2, timeout=1, pin_memory=True)
+    _ = next(iter(dataloader))
+    time.sleep(100)
+
+
+def disable_stderr(_):
+    r"""
+    Avoids printing "ERROR: Unexpected segmentation fault encountered in worker."
+    from workers.
+    """
+    os.close(sys.stderr.fileno())
+
+
 def _test_segfault():
     dataset = SegfaultDataset(10)
-    dataloader = DataLoader(dataset, batch_size=2, num_workers=2)
+
+    dataloader = DataLoader(dataset, batch_size=2, num_workers=2, worker_init_fn=disable_stderr)
     _ = next(iter(dataloader))
+
+
+class TestProperExitDataset(object):
+    def __init__(self, size, error_event):
+        self.size = size
+        self.error_event = error_event
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        if self.error_event is not None and self.error_event.is_set():
+            raise RuntimeError('Worker error')
+        return torch.tensor([idx])
+
+
+# See TestDataLoader.test_proper_exit for usage
+def _test_proper_exit(use_workers, pin_memory, exit_method, hold_iter_reference,
+                      worker_pids, setup_event):
+    num_workers = 2 if use_workers else 0
+
+    if exit_method == 'worker_error' or exit_method == 'worker_kill':
+        assert use_workers is True
+
+    ds = TestProperExitDataset(10, setup_event if exit_method == 'worker_error' else None)
+
+    loader = DataLoader(ds, batch_size=2, shuffle=False,
+                        num_workers=num_workers, pin_memory=pin_memory)
+    it = iter(loader)
+    if use_workers:
+        for i, w in enumerate(it.workers):
+            worker_pids[i] = w.pid
+
+    assert len(loader) > 2
+
+    def kill_pid(pid):
+        if IS_WINDOWS:
+            os.system('taskkill /PID ' + str(os.getpid()) + ' /F')
+        else:
+            os.kill(os.getpid(), signal.SIGKILL)
+
+    for i, _ in enumerate(it):
+        if i == 0:
+            if not hold_iter_reference:
+                del it
+            setup_event.set()
+        elif i == 2:
+            if exit_method == 'main_error':
+                raise RuntimeError('Error')
+            elif exit_method == 'main_kill':
+                kill_pid(os.getpid())
+            elif exit_method == 'worker_kill':
+                kill_pid(worker_pids[0])
 
 
 # test custom init function
@@ -373,16 +439,17 @@ class TestDataLoader(TestCase):
 
     @skipIfRocm
     def test_timeout(self):
-        p = ErrorTrackingProcess(target=_test_timeout)
-        p.start()
-        p.join(JOIN_TIMEOUT)
-        try:
-            self.assertFalse(p.is_alive())
-            self.assertNotEqual(p.exitcode, 0)
-            self.assertIsInstance(p.exception, RuntimeError)
-            self.assertRegex(str(p.exception), r'DataLoader timed out after \d+ seconds')
-        finally:
-            p.terminate()
+        for target in (_test_timeout, _test_timeout_pin_memory):
+            p = ErrorTrackingProcess(target=target)
+            p.start()
+            p.join(JOIN_TIMEOUT)
+            try:
+                self.assertFalse(p.is_alive())
+                self.assertNotEqual(p.exitcode, 0)
+                self.assertIsInstance(p.exception, RuntimeError)
+                self.assertRegex(str(p.exception), r'DataLoader timed out after \d+ seconds')
+            finally:
+                p.terminate()
 
     def test_worker_seed(self):
         num_workers = 6
@@ -526,24 +593,6 @@ class TestDataLoader(TestCase):
                 self.assertFalse(pin_memory_thread.is_alive())
 
     @staticmethod
-    def _main_process(dataset, worker_pids, main_exit_event, raise_error):
-        loader = iter(DataLoader(dataset, batch_size=2, num_workers=4, pin_memory=True))
-        workers = loader.workers
-        for i in range(len(workers)):
-            worker_pids[i] = int(workers[i].pid)
-        for i, sample in enumerate(loader):
-            if i == 3:
-                # Simulate an exit of the manager process
-                main_exit_event.set()
-                if raise_error:
-                    raise RuntimeError('Error')
-                else:
-                    if IS_WINDOWS:
-                        os.system('taskkill /PID ' + str(os.getpid()) + ' /F')
-                    else:
-                        os.kill(os.getpid(), signal.SIGKILL)
-
-    @staticmethod
     def _is_process_alive(pid, pname):
         # There is a chance of a terminated child process's pid being reused by a new unrelated process,
         # but since we are looping this check very frequently, we will know that the child process dies
@@ -558,51 +607,89 @@ class TestDataLoader(TestCase):
         output = output.decode('utf-8')
         return pname in output
 
-    @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
-                     don't support multiprocessing with spawn start method")
-    @unittest.skipIf(sys.version_info[0] == 2,
-                     "spawn start method is not supported in Python 2, \
-                     but we need it for creating another process with CUDA")
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @skipIfRocm
-    def test_main_process_unclean_exit(self):
-        r'''There might be ConnectionResetError or leaked semaphore warning (due to dirty process exit), \
-but they are all safe to ignore'''
+    def test_proper_exit(self):
+        r'''There might be ConnectionResetError or leaked semaphore warning
+        (due to dirty process exit), but they are all safe to ignore'''
 
-        # `raise_error` controls if the main process is KILL-ed by OS or just
-        # simply raises an error. Both cases are interesting because
-        # 1. In case of it is KILL-ed by OS, the workers need to automatically
-        #    discover that their parent is dead and exit gracefully.
-        # 2. In case of it raises an error itself, the parent process needs to
-        #    take care of exiting the worker and then exits itself gracefully.
-        for raise_error in (True, False):
-            worker_pids = mp.Array('i', [0] * 4)
+        # Array to store the worker pids.
+        worker_pids = mp.Array('i', [-1 for _ in range(10)])
 
-            main_exit_event = mp.Event()
-            p = mp.Process(target=TestDataLoader._main_process,
-                           args=(self.dataset, worker_pids, main_exit_event, raise_error))
-            p.start()
-            worker_pids[-1] = p.pid
-
-            main_exit_event.wait()
-
-            exit_status = [False] * len(worker_pids)
+        def wait_pids(pids, timeout):
+            r"""Wait for all process specified in pids to exit in given timeout."""
+            exit_status = [False for _ in pids]
             start_time = time.time()
             pname = 'python'
             while True:
-                for i in range(len(worker_pids)):
-                    pid = worker_pids[i]
+                for i in range(len(pids)):
+                    pid = pids[i]
                     if not exit_status[i]:
                         if not TestDataLoader._is_process_alive(pid, pname):
                             exit_status[i] = True
                 if all(exit_status):
                     break
                 else:
-                    if time.time() - start_time > MANAGER_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT:
-                        self.fail('subprocess not terminated')
-                    time.sleep(1)
-            p.join(MANAGER_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT - (time.time() - start_time))
-            self.assertFalse(p.is_alive(), 'main process not terminated')
+                    if time.time() - start_time > timeout:
+                        break
+                    time.sleep(0.5)
+            return exit_status
+
+        for use_workers, pin_memory, hold_iter_reference in itertools.product([True, False], repeat=3):
+            # `hold_iter_reference` specifies whether we hold a reference to the
+            # iterator. This is interesting because Python3 error traces holds a
+            # reference to the frames, which hold references to all the local
+            # variables. It is important to see that the processes still exit.
+
+            if pin_memory and (not TEST_CUDA or NO_MULTIPROCESSING_SPAWN):
+                # Can't use CUDA without spawn
+                continue
+
+            # `exit_method` controls the way the loader process ends.
+            #   - `*_kill` means that `*` is killed by OS.
+            #   - `*_error` means that `*` raises an error.
+            #   - `None` means that no error happens.
+            # In all cases, all processes should end properly.
+            if use_workers:
+                exit_methods = [None, 'main_error', 'main_kill', 'worker_kill', 'worker_error']
+            else:
+                exit_methods = [None, 'main_error', 'main_kill']
+
+            for exit_method in exit_methods:
+
+                # clear pids array first
+                for i in range(len(worker_pids)):
+                    worker_pids[i] = -1
+
+                # Event that the loader process uses to signal testing process
+                # that various things are setup, including that the worker pids
+                # are specified in `worker_pids` array.
+                setup_event = mp.Event()
+
+                p = ErrorTrackingProcess(target=_test_proper_exit,
+                                         args=(use_workers, pin_memory, exit_method,
+                                               hold_iter_reference, worker_pids, setup_event))
+                p.start()
+
+                # Wait for loader process to set everything up, i.e., filling
+                # worker pids in `worker_pids`.
+                setup_event.wait(timeout=JOIN_TIMEOUT)
+                self.assertTrue(setup_event.is_set(), 'loader process setup timed out')
+
+                pids = [pid for pid in worker_pids if pid > 0]
+
+                try:
+                    exit_status = wait_pids(pids, timeout=(MP_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT))
+                    if not all(exit_status):
+                        self.fail('subprocess (pid(s) {}) not terminated'.format(
+                            ', '.join(p for p, exited in zip(pids, exit_status) if not exited)))
+                    p.join(JOIN_TIMEOUT)
+                    self.assertFalse(p.is_alive(), 'loader process not terminated')
+                    if exit_method is None:
+                        self.assertEqual(p.exitcode, 0)
+                    else:
+                        self.assertNotEqual(p.exitcode, 0)
+                finally:
+                    p.terminate()
 
     def test_len(self):
         def check_len(dl, expected):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -686,7 +686,7 @@ class TestDataLoader(TestCase):
                     if not all(exit_status):
                         self.fail('subprocess (pid(s) {}) not terminated'.format(
                             ', '.join(p for p, exited in zip(pids, exit_status) if not exited)))
-                    p.join(JOIN_TIMEOUT)
+                    p.join(JOIN_TIMEOUT + MP_STATUS_CHECK_INTERVAL)
                     self.assertFalse(p.is_alive(), 'loader process not terminated')
                     if exit_method is None:
                         self.assertEqual(p.exitcode, 0)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -329,8 +329,8 @@ def _test_proper_exit(use_workers, pin_memory, exit_method, hold_iter_reference,
             elif exit_method == 'worker_kill':
                 kill_pid(worker_pids[0])
 
-    # tries to trigger the __del__ clean-up rather than the exit of daemonic
-    # children.
+    # Tries to trigger the __del__ clean-up rather than the automatic exiting of
+    # daemonic children.
     gc.collect()
 
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -619,6 +619,9 @@ class TestDataLoader(TestCase):
         r'''There might be ConnectionResetError or leaked semaphore warning
         (due to dirty process exit), but they are all safe to ignore'''
 
+        # TODO: test the case where the pin_memory_thread triggers an
+        #       error/fatal signal. I haven't found out how to properly do that.
+
         # Array to store the worker pids.
         worker_pids = mp.Array('i', [-1 for _ in range(10)])
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -262,7 +262,7 @@ def _test_timeout_pin_memory():
     _ = next(iter(dataloader))
 
 
-def disable_stderr(_):
+def disable_stderr(worker_id):
     r"""
     Avoids printing "ERROR: Unexpected segmentation fault encountered in worker."
     from workers. Since worker signal handler prints with low-level write(),

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -317,18 +317,22 @@ def _test_proper_exit(use_workers, pin_memory, exit_method, hold_iter_reference,
         else:
             os.kill(os.getpid(), signal.SIGKILL)
 
-    for i, _ in enumerate(it):
-        if i == 0:
-            if not hold_iter_reference:
-                del it
-            setup_event.set()
-        elif i == 2:
-            if exit_method == 'main_error':
-                raise RuntimeError('Error')
-            elif exit_method == 'main_kill':
-                kill_pid(os.getpid())
-            elif exit_method == 'worker_kill':
-                kill_pid(worker_pids[0])
+    # Use more than 1 epoch because it is interesting to test the natural
+    # exiting case where the iterator depletes.
+    for epoch in range(2):
+        for i, _ in enumerate(it):
+            if epoch == 0:
+                if i == 0:
+                    if not hold_iter_reference:
+                        del it
+                    setup_event.set()
+                elif i == 2:
+                    if exit_method == 'main_error':
+                        raise RuntimeError('Error')
+                    elif exit_method == 'main_kill':
+                        kill_pid(os.getpid())
+                    elif exit_method == 'worker_kill':
+                        kill_pid(worker_pids[0])
 
 
 # test custom init function

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -11,7 +11,6 @@ import traceback
 import unittest
 import subprocess
 import itertools
-import threading
 from torch import multiprocessing as mp
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
@@ -266,14 +265,14 @@ def _test_timeout_pin_memory():
 def disable_stderr(_):
     r"""
     Avoids printing "ERROR: Unexpected segmentation fault encountered in worker."
-    from workers.
+    from workers. Since worker signal handler prints with low-level write(),
+    this has to be done on OS level.
     """
     os.close(sys.stderr.fileno())
 
 
 def _test_segfault():
     dataset = SegfaultDataset(10)
-
     dataloader = DataLoader(dataset, batch_size=2, num_workers=2, worker_init_fn=disable_stderr)
     _ = next(iter(dataloader))
 

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -1,15 +1,14 @@
 #include "DataLoader.h"
 
 // In cases like DataLoader, if a worker process die due to bus error/segfault
-// or just hang, the main process, if implemented with
-// multiprocessing.queue.SimpleQueue, will hang waiting for data. This is
-// difficult to avoid on PyTorch side as it can be caused by limited shm, or
-// other libraries users call in the workers. The following methods is an effort
-// to do our best provide some error message to users when such unfortunate
-// events happen.
+// or just hang, the main process, will hang waiting for data. This is difficult
+// to avoid on PyTorch side as it can be caused by limited shm, or other
+// libraries users call in the workers. The following methods is an effort to do
+// our best provide some error message to users when such unfortunate events
+// happen.
 
 // TODO: The following don't work on Windows. Specifically, sigaction, waitid
-// calls ,and SIGCHLD handler. Currently, dummy implementations are provided
+// calls, and SIGCHLD handler. Currently, dummy implementations are provided
 // for Windows.
 
 #ifndef _WIN32
@@ -130,9 +129,7 @@ static PyObject *THPModule_errorIfAnyWorkerFails(PyObject *module) {
       }  else if (infop.si_code == CLD_KILLED || infop.si_code == CLD_DUMPED) {  // killed by signal
         std::ostringstream oss;
         oss << "DataLoader worker (pid " << worker_pid << ") is killed "
-            << "by signal: " << strsignal(infop.si_status) << ". "
-            << "Details are lost due to multiprocessing. Rerunning with "
-            << "num_workers=0 may give better error trace.";
+            << "by signal: " << strsignal(infop.si_status) << ". ";
         // This is necessary. Otherwise, the runtime error will kill the other
         // workers, and trigger this again.
         pid_set->clear();

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -1,10 +1,10 @@
 #include "DataLoader.h"
 
-// In cases like DataLoader, if a worker process die due to bus error/segfault
-// or just hang, the main process, will hang waiting for data. This is difficult
+// In cases like DataLoader, if a worker process dies due to bus error/segfault
+// or just hang, the main process will hang waiting for data. This is difficult
 // to avoid on PyTorch side as it can be caused by limited shm, or other
 // libraries users call in the workers. The following methods is an effort to do
-// our best provide some error message to users when such unfortunate events
+// our best to provide some error message to users when such unfortunate events
 // happen.
 
 // TODO: The following don't work on Windows. Specifically, sigaction, waitid
@@ -62,6 +62,7 @@ static inline void setSignalHandler(int signal, void(*handler)(int, siginfo_t *,
 SIGNAL_HANDLER(SIGBUS, handler_SIGBUS, "ERROR: Unexpected bus error encountered in worker. "
   "This might be caused by insufficient shared memory (shm).\n");
 SIGNAL_HANDLER(SIGSEGV, handler_SIGSEGV, "ERROR: Unexpected segmentation fault encountered in worker.\n");
+SIGNAL_HANDLER(SIGFPE, handler_SIGFPE, "ERROR: Unexpected floating-point exception encountered in worker.\n");
 
 // When an error happend in DataLoader methods and Python starts to exit, the
 // error trace will keep the loader alive, and Python may kill the children

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -92,6 +92,7 @@ static PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *a
   setSignalHandler(SIGBUS, &handler_SIGBUS, nullptr);
   setSignalHandler(SIGSEGV, &handler_SIGSEGV, nullptr);
   setSignalHandler(SIGTERM, &handler_SIGTERM, nullptr);
+  setSignalHandler(SIGFPE, &handler_SIGFPE, nullptr);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -11,7 +11,6 @@ import re
 import sys
 import threading
 import traceback
-import atexit
 import os
 import time
 from torch._six import string_classes, int_classes, FileNotFoundError

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -401,7 +401,7 @@ class _DataLoaderIter(object):
     #                 are stopping the workers.
     #             ii. for main process that sends indices to workers, if workers
     #                 exit unexpectedly, the SIGCHLD handler registered in (a)
-    #                 above will interrupt the main process, and should cause
+    #                 above will interrupt the main process, and should trigger
     #                 cleaning-up. The putting thread of `index_queue` will then
     #                 fail with SIGPIPE when closed (`.close()` is alawys called
     #                 before joining).
@@ -482,11 +482,6 @@ class _DataLoaderIter(object):
                           self.worker_result_queue, self.done_event,
                           self.collate_fn, base_seed + i,
                           self.worker_init_fn, i))
-                # NB: Do **not** set w.daemon=True. Otherwise during cleaning up
-                #     Python may terminate the workers before they send the last
-                #     `None`s over and signaling termination to either
-                #     pin_memory_thread or main process.
-                #
                 w.daemon = True
                 # NB: Process.start() actually take some time as it needs to
                 #     start a process and pass the arguments over via a pipe.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -530,6 +530,8 @@ class _DataLoaderIter(object):
         else:
             batch = self.data_queue.get()
         if self.pin_memory:
+            # In this case, `self.data_queue` is a `queue.Queue`, which needs us
+            # calling `.task_done()`.
             self.data_queue.task_done()
         return batch
 
@@ -628,6 +630,8 @@ class _DataLoaderIter(object):
                 # `pin_memory_thread`)
                 while not self.data_queue.empty():
                     self.data_queue.get()
+                    # In this case, `self.data_queue` is a `queue.Queue`, which
+                    # needs us calling `.task_done()`.
                     self.data_queue.task_done()
                 self.data_queue.join()
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -146,7 +146,6 @@ def _worker_loop(dataset, index_queue, data_queue, done_event, collate_fn, seed,
         pass
 
 
-
 def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
     torch.cuda.set_device(device_id)
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -369,9 +369,10 @@ class _DataLoaderIter(object):
     #
     #      As shown above, the workers are set as daemonic children of the main
     #      process. However, automatic cleaning-up of such child processes only
-    #      happen if the parent process exits gracefully (e.g., SIGTERM). So we
-    #      must ensure that each process will exit even the process that should
-    #      send/receive data to/from it were killed, i.e.,
+    #      happens if the parent process exits gracefully (e.g., not via fatal
+    #      signals like SIGKILL). So we must ensure that each process will exit
+    #      even the process that should send/receive data to/from it were
+    #      killed, i.e.,
     #
     #        a. A process won't hang when getting from a queue.
     #

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -154,7 +154,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
     # logic of this function.
     while True:
         try:
-            r = in_queue.get(False)
+            r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
         except queue.Empty:
             continue
         except Exception:


### PR DESCRIPTION
Test plan:

Trained 16000 LeNets (total) on MNIST on 160 processes. Previously some of them will either hang during training or during program exiting. Now every process finishes successfully.

```
    # NOTE [ Data Loader Multiprocessing Shutdown Logic ]
    #
    # Preliminary:
    #
    # Our data model looks like this (queues are indicated with curly brackets):
    #
    #                main process                              ||
    #                     |                                    ||
    #               {index_queue}                              ||
    #                     |                                    ||
    #              worker processes                            ||     DATA
    #                     |                                    ||
    #            {worker_result_queue}                         ||     FLOW
    #                     |                                    ||
    #      pin_memory_thread of main process                   ||   DIRECTION
    #                     |                                    ||
    #               {data_queue}                               ||
    #                     |                                    ||
    #                data output                               \/
    #
    # P.S. `worker_result_queue` and `pin_memory_thread` part may be omitted if
    #      `pin_memory=False`.
    #
    #
    # Terminating multiprocessing logic requires very careful design. In
    # particular, we need to make sure that
    #
    #   1. The iterator gracefully exits the workers when its last reference is
    #      gone.
    #
    #      In this case, the workers should be gracefully exited because the
    #      main process may still need to continue to run, and we want cleaning
    #      up code in the workers to be executed (e.g., releasing GPU memory).
    #      Naturally, we implement the shutdown logic in `__del__` of
    #      DataLoaderIterator.
    #
    #      We delay the discussion on the logic in this case until later.
    #
    #   2. The iterator exits the workers when the problem ends
    #
    #      We set all workers and `pin_memory_thread` to have `daemon=True`.
    #      Doing so means that when the program ends, it shuts the workers down
    #      with a SIGTERM. `pin_memory_thread` will exit too, but by a different
    #      mechanism.
    #
    #      You may ask, why don't we just not set the workers as daemonic, and
    #      gracefully exit using the same logic as we have in `__del__` when the
    #      iterator gets deleted (see 1 above)? The answer requires a bit
    #      understanding of Python multiprocessing design. As of Python 3.7, for
    #      reasons I have yet to understand, in a subprocess, Python runs the
    #      given function (e.g., the `target` argument passed to a `mp.Process`)
    #      using this pattern (unrelated code removed for clarity):
    #
    #          # These are run the sub-process
    #          try:
    #              user_provided_function()
    #          finally:
    #              multiprocessing.util._exit_function()
    #
    #      In `_exit_function`, Python joins all non-daemonic subprocesses of
    #      this process (which is a subprocess of a Python process itself), and
    #      sends SIGTERM to the daemonic ones. Therefore, if a DataLoader is
    #      used in a subprocess (i.e., used in `user_provided_function` above),
    #      and an error is raised containing frames that references the
    #      DataLoaderIter (Python exception traces keeps local objects in
    #      relevant frames alive), workers will be joined in `_exit_function`
    #      before the `__del__` is called (which starts the shutdown logic). And
    #      unfortunately the DataLoaderIter process will hang. E.g., such errors
    #      can be timeout, or arbitrary error if users hold a reference to an
    #      iterator.
    #
    #      For context, `_exit_function` is also registered as an `atexit` call.
    #      So I really don't understand the need to do this in a finally block
    #      The code dates back to 2008 and there is no comment on the original
    #      PEP 371 or patch https://bugs.python.org/issue3050 (containing both
    #      the finally block and the `atexit` registration) that explains this.
    #
    #      Another choice is to just shutdown workers with logic in 1 above
    #      whenever we see an error in `next`. This isn't ideal because
    #        a. It prevents users from using try-catch to resume data loading.
    #        b. It doesn't prevent hanging if users have references to the
    #           iterator.
    #
    #   3. All processes exit if any of them die unexpectedly (e.g., error,
    #      SIGKILL).
    #
    #      As shown above, the workers are set as daemonic children of the main
    #      process. However, automatic cleaning-up of such child processes only
    #      happen if the parent process exits gracefully (e.g., SIGTERM). So we
    #      must ensure that each process will exit even the process that should
    #      send/receive data to/from it were killed, i.e.,
    #
    #        a. A process won't hang when getting from a queue.
    #
    #           Even with carefully designed data dependencies (i.e., a `put()`
    #           always corresponding to a `get()`), hanging on `get()` can still
    #           happen when data in queue is corrupted (e.g., due to
    #           `cancel_join_thread` or unexpected exit).
    #
    #           For child exit, we register SIGCHLD handler on main process,
    #           which checks if any of the workers fail in the (Python) handler.
    #           See DataLoader.cpp.
    #
    #           For `.get()` calls where the sender(s) is not the workers, we
    #           guard them with timeouts, and check the status of the sender
    #           when timeout happens:
    #             + in the workers, the `ManagerWatchdog` class checks the main
    #               process status.
    #             + if `pin_memory=True`, when getting from `pin_memory_thread`,
    #               check `pin_memory_thread` status periodically until `.get()`
    #               returns or see that `pin_memory_thread` died.
    #
    #        b. A process won't hang when putting into a queue;
    #
    #           We use `mp.Queue` which has a separate background thread to put
    #           objects. The background thread is usually automatically joined
    #           when the process exits.
    #
    #           However, in case that the receiver has ended abruptly while
    #           reading from the pipe, the join will hang forever. Therefore,
    #           for both `worker_result_queue` (worker -> main process/pin_memory_thread)
    #           and each `index_queue` (main process -> worker), we use
    #           `q.cancel_join_thread()` in sender process before any `q.put` to
    #           prevent this automatic join.
    #
    #           Moreover, having all queues called `cancel_join_thread` makes
    #           implementing graceful shutdown logic in `__del__` much easier.
    #           It won't need to get from any queue, which would also need to be
    #           guarded by periodic status checks.
    #
    #           Note that this may leave corrupted data in the queue, but we
    #           don't care about the data anyways once we are shutting down.
    #
    #
    # Now let's get back to 1:
    #   how we gracefully exit the workers when the last reference to the
    #   iteartor is gone.
    #
    # To achieve this, we implement the following logic along with the design
    # choices mentioned above:
    #
    # [pin_memory_thread] and [worker processes]
    #   When getting from queues,
    #     if get a `None`, exit.
    #     if get anything else or time out, check `done_event`,
    #        if set, keep getting until see the `None`, then exit.
    #        otherwise, process the data.
    #
    # [main process]
    #   In the DataLoader Iter's `__del__`
    #     a. Set `done_event` (shared with `pin_memory_thread` and workers).
    #
    #        Note: from here on, the workers & `pin_memory_thread` may exit at
    #              any time after they receive `None`.
    #
    #     b. Exit `pin_memory_thread`
    #          i.   Put `None` in `worker_result_queue`.
    #          ii.  Join the `pin_memory_thread`.
    #
    #     c. Exit the workers.
    #          i.   Put `None` in each worker's `index_queue`.
    #          ii.  Join the workers.
    #
    #        Note: This has to be after (b) because it may leave corrupted data
    #              in `worker_result_queue`, which `pin_memory_thread` reads
    #              from.
    #
    #   Note: If `pin_memory=False`, there is no `pin_memory_thread` and (b)
    #         can be omitted
    #
    # NB: `done_event`s isn't strictly needed. E.g., we can just check for
    #     `None` from `index_queue`, but it allows us to skip wasting resources
    #     processing indices already in `index_queue` if we are already shutting
    #     down.
```

Original desc:

In `DataLoaderIter` `__del__`, ensure that `None` is sent to `pin_memory_thread` before joining workers.


Trace when interrupted at such a hang:
```
 Exception ignored in: <function _DataLoaderIter.__del__ at 0x7facf66760d0>
 Traceback (most recent call last):
   File "/private/home/ssnl/miniconda3/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 412, in __del__
     self._shutdown_workers()
   File "/private/home/ssnl/miniconda3/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 408, in _shutdown_worke

     self.pin_memory_thread.join()
   File "/private/home/ssnl/miniconda3/lib/python3.7/threading.py", line 1032, in join
     self._wait_for_tstate_lock()
   File "/private/home/ssnl/miniconda3/lib/python3.7/threading.py", line 1048, in _wait_for_tstate_lock
     elif lock.acquire(block, timeout):
 KeyboardInterrupt

```

The 1st commit solves majority of the hang, but uncovers another problem:
```
36: Exception ignored in: <function _DataLoaderIter.__del__ at 0x7f214fa412f0>
36: Traceback (most recent call last):
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 416, in __
del__
36:     self._shutdown_workers()
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 401, in _s
hutdown_workers
36:     self.worker_result_queue.join_thread()
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/multiprocessing/queues.py", line 145, in join_thread
36:     self._jointhread()
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/multiprocessing/util.py", line 189, in __call__
36:     res = self._callback(*self._args, **self._kwargs)
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/multiprocessing/queues.py", line 192, in _finalize_join
36:     thread.join()
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/threading.py", line 1032, in join
36:     self._wait_for_tstate_lock()
36:   File "/private/home/ssnl/miniconda3/lib/python3.7/threading.py", line 1048, in _wait_for_tstate_lock
36:     elif lock.acquire(block, timeout):
36: KeyboardInterrupt
```