### PR TITLE
fix ZeroDivisionError in utils.bottleneck

### DIFF
--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -223,8 +223,8 @@ def main():
     # if their execution times are very different.
     cuda_prof_exec_time = cpu_time_total(autograd_prof_cuda)
     cpu_prof_exec_time = cpu_time_total(autograd_prof_cpu)
-    if cuda_prof_exec_time > 1e-6:
-        pct_diff = cuda_prof_exec_time - cpu_prof_exec_time / cuda_prof_exec_time
+    if cuda_prof_exec_time > 0.0:
+        pct_diff = (cuda_prof_exec_time - cpu_prof_exec_time) / cuda_prof_exec_time
         if abs(pct_diff) > 0.05:
             print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
     print_autograd_prof_summary(autograd_prof_cuda, 'CUDA', autograd_prof_sortby, autograd_prof_topk)

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -222,11 +222,12 @@ def main():
     # Print both the result of the CPU-mode and CUDA-mode autograd profilers
     # if their execution times are very different.
     cuda_prof_exec_time = cpu_time_total(autograd_prof_cuda)
-    cpu_prof_exec_time = cpu_time_total(autograd_prof_cpu)
-    if cuda_prof_exec_time > 0.0:
+    if len(autograd_prof_cpu.function_events) > 0:
+        cpu_prof_exec_time = cpu_time_total(autograd_prof_cpu)
         pct_diff = (cuda_prof_exec_time - cpu_prof_exec_time) / cuda_prof_exec_time
         if abs(pct_diff) > 0.05:
             print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
+    
     print_autograd_prof_summary(autograd_prof_cuda, 'CUDA', autograd_prof_sortby, autograd_prof_topk)
 
 if __name__ == '__main__':

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -223,9 +223,10 @@ def main():
     # if their execution times are very different.
     cuda_prof_exec_time = cpu_time_total(autograd_prof_cuda)
     cpu_prof_exec_time = cpu_time_total(autograd_prof_cpu)
-    pct_diff = cuda_prof_exec_time - cpu_prof_exec_time / cuda_prof_exec_time
-    if abs(pct_diff) > 0.05:
-        print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
+    if cuda_prof_exec_time > 1e-6:
+        pct_diff = cuda_prof_exec_time - cpu_prof_exec_time / cuda_prof_exec_time
+        if abs(pct_diff) > 0.05:
+            print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
     print_autograd_prof_summary(autograd_prof_cuda, 'CUDA', autograd_prof_sortby, autograd_prof_topk)
 
 if __name__ == '__main__':

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -227,7 +227,7 @@ def main():
         pct_diff = (cuda_prof_exec_time - cpu_prof_exec_time) / cuda_prof_exec_time
         if abs(pct_diff) > 0.05:
             print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
-    
+
     print_autograd_prof_summary(autograd_prof_cuda, 'CUDA', autograd_prof_sortby, autograd_prof_topk)
 
 if __name__ == '__main__':


### PR DESCRIPTION
**ZeroDivisionError** occurs when `cuda_prof_exec_time` is small enough.
This situation is normal for a project that has little CUDA work. 

Or someone does not make his work transferred to CUDA successfully. In this time he profiles the code, this error occurs.

