### PR TITLE
magma-cuda should reference updated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 conda install -c mingfeima mkldnn
 
 # Add LAPACK support for the GPU
-conda install -c pytorch magma-cuda92 # or one of [magma-cuda80 | magma-cuda91] depending on your cuda version
+conda install -c pytorch magma-cuda92 # or [magma-cuda80 | magma-cuda91] depending on your cuda version
 ```
 
 On macOS

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 conda install -c mingfeima mkldnn
 
 # Add LAPACK support for the GPU
-conda install -c pytorch magma-cuda80 # or magma-cuda90 if CUDA 9
+conda install -c pytorch magma-cuda92 # or one of [magma-cuda80 | magma-cuda91] depending on your cuda version
 ```
 
 On macOS


### PR DESCRIPTION
Source build doc section **LAPACK GPU**  only lists magma-cuda80

The magma-cuda version should reflect the installed version of cuda.  

- Verified on ubuntu with magma-cuda92 with build and test
- Verified 91 is available
