### PR TITLE
Handle an edge case of destructing dataloader iterator

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -156,6 +156,10 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
         try:
             r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
         except queue.Empty:
+            # If a dataloader iterator is destructed before all samples are drained, a worker process could terminate
+            # before the main process gets destructed, so we need a timeout check when receiving result from worker
+            if done_event.is_set():
+                return
             continue
         except Exception:
             if done_event.is_set():


### PR DESCRIPTION
If a dataloader iterator is destructed before all samples are drained, a worker process could terminate
before the main process gets destructed, so we need a timeout check when receiving result from worker.
I have encountered a few times the whole training stuck and the GDB trace back shows the main process is stuck at the `r = in_queue.get()` line in `_pin_memory_loop()`.