### PR TITLE
[c10] Unify all *_EXPORT and *_IMPORT macros across c++ backend

### DIFF
--- a/aten/src/ATen/core/ATenCoreTest.h
+++ b/aten/src/ATen/core/ATenCoreTest.h
@@ -4,5 +4,5 @@
 
 namespace at {
 
-AT_CORE_API int CoreTest();
+CAFFE2_API int CoreTest();
 }

--- a/aten/src/ATen/core/ATenGeneral.h
+++ b/aten/src/ATen/core/ATenGeneral.h
@@ -1,7 +1,3 @@
 #pragma once
 
 #include "ATen/core/Macros.h"
-
-// TODO: Merge the *_API macros.
-#define AT_EXPORT AT_CORE_EXPORT
-#define AT_IMPORT AT_CORE_IMPORT

--- a/aten/src/ATen/core/Allocator.h
+++ b/aten/src/ATen/core/Allocator.h
@@ -115,7 +115,7 @@ struct Allocator {
   }
 };
 
-struct AT_CORE_API InefficientStdFunctionContext {
+struct CAFFE2_API InefficientStdFunctionContext {
   std::unique_ptr<void, std::function<void(void*)>> ptr_;
   InefficientStdFunctionContext(
       std::unique_ptr<void, std::function<void(void*)>>&& ptr)

--- a/aten/src/ATen/core/Backtrace.h
+++ b/aten/src/ATen/core/Backtrace.h
@@ -8,7 +8,7 @@
 
 namespace at {
 /// Utility to demangle a C++ symbol name.
-AT_CORE_API std::string demangle(const char* name);
+CAFFE2_API std::string demangle(const char* name);
 
 /// Returns the printable name of the type.
 template <typename T>
@@ -21,7 +21,7 @@ inline const char* demangle_type() {
 #endif // __GXX_RTTI
 }
 
-AT_CORE_API std::string get_backtrace(
+CAFFE2_API std::string get_backtrace(
     size_t frames_to_skip = 0,
     size_t maximum_number_of_frames = 64,
     bool skip_python_frames = true);

--- a/aten/src/ATen/core/Device.h
+++ b/aten/src/ATen/core/Device.h
@@ -21,7 +21,7 @@ namespace at {
 /// 1. A negative index represents the current device, a non-negative index
 /// represents a specific, concrete device,
 /// 2. When the device type is CPU, the device index must be zero.
-struct AT_CORE_API Device {
+struct CAFFE2_API Device {
   using Type = at::DeviceType;
 
   /// Constructs a new `Device` from a `DeviceType` and an optional device
@@ -92,7 +92,7 @@ struct AT_CORE_API Device {
   int32_t index_ = -1;
 };
 
-AT_CORE_API std::ostream& operator<<(
+CAFFE2_API std::ostream& operator<<(
     std::ostream& stream,
     const at::Device& device);
 

--- a/aten/src/ATen/core/DeviceType.h
+++ b/aten/src/ATen/core/DeviceType.h
@@ -26,11 +26,11 @@ enum class DeviceType : int32_t {
   ONLY_FOR_TEST = 20901701, // This device type is only for test.
 };
 
-AT_CORE_API std::string DeviceTypeName(
+CAFFE2_API std::string DeviceTypeName(
     at::DeviceType d,
     bool lower_case = false);
 
-AT_CORE_API std::ostream& operator<<(std::ostream& stream, at::DeviceType type);
+CAFFE2_API std::ostream& operator<<(std::ostream& stream, at::DeviceType type);
 
 } // namespace at
 

--- a/aten/src/ATen/core/Error.h
+++ b/aten/src/ATen/core/Error.h
@@ -19,7 +19,7 @@ namespace at {
 namespace detail {
 
 // Obtains the base name from a full path.
-AT_CORE_API std::string StripBasename(const std::string& full_path);
+CAFFE2_API std::string StripBasename(const std::string& full_path);
 
 inline std::ostream& _str(std::ostream& ss) {
   return ss;
@@ -56,7 +56,7 @@ inline std::string str(const char* c_str) {
 }
 
 /// Represents a location in source code (for debugging).
-struct AT_CORE_API SourceLocation {
+struct CAFFE2_API SourceLocation {
   const char* function;
   const char* file;
   uint32_t line;
@@ -71,7 +71,7 @@ std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
 ///
 /// NB: at::Error is handled specially by the default torch to suppress the
 /// backtrace, see torch/csrc/Exceptions.h
-class AT_CORE_API Error : public std::exception {
+class CAFFE2_API Error : public std::exception {
   std::vector<std::string> msg_stack_;
   std::string backtrace_;
 
@@ -128,7 +128,7 @@ class AT_CORE_API Error : public std::exception {
   }
 };
 
-class AT_CORE_API Warning {
+class CAFFE2_API Warning {
   using handler_t =
       void (*)(const SourceLocation& source_location, const char* msg);
 
@@ -152,7 +152,7 @@ class AT_CORE_API Warning {
 
 // A utility function to return an exception std::string by prepending its
 // exception type before its what() content
-AT_CORE_API std::string GetExceptionString(const std::exception& e);
+CAFFE2_API std::string GetExceptionString(const std::exception& e);
 
 } // namespace at
 

--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -34,8 +34,8 @@ namespace at {
 
 namespace detail {
 
-AT_CORE_API float halfbits2float(unsigned short bits);
-AT_CORE_API unsigned short float2halfbits(float value);
+CAFFE2_API float halfbits2float(unsigned short bits);
+CAFFE2_API unsigned short float2halfbits(float value);
 
 } // namespace detail
 
@@ -178,7 +178,7 @@ To checked_convert(From f, const char* name) {
   return convert<To, From>(f);
 }
 
-AT_CORE_API std::ostream& operator<<(std::ostream& out, const Half& value);
+CAFFE2_API std::ostream& operator<<(std::ostream& out, const Half& value);
 
 } // namespace at
 

--- a/aten/src/ATen/core/IdWrapper.h
+++ b/aten/src/ATen/core/IdWrapper.h
@@ -22,7 +22,7 @@ namespace at {
  * for you, given the underlying type supports it.
  */
 template <class ConcreteType, class UnderlyingType>
-class AT_CORE_API IdWrapper {
+class CAFFE2_API IdWrapper {
  public:
   using underlying_type = UnderlyingType;
   using concrete_type = ConcreteType;

--- a/aten/src/ATen/core/LegacyTypeDispatch.h
+++ b/aten/src/ATen/core/LegacyTypeDispatch.h
@@ -30,7 +30,7 @@
 
 namespace at {
 
-struct AT_CORE_API LegacyTypeInitInterface {
+struct CAFFE2_API LegacyTypeInitInterface {
   virtual ~LegacyTypeInitInterface() {}
   virtual void initCPU() const {
     AT_ERROR("cannot use CPU without ATen library");
@@ -42,15 +42,15 @@ struct AT_CORE_API LegacyTypeInitInterface {
     AT_ERROR("cannot use complex without ATen Complex library");
   }
 };
-struct AT_CORE_API LegacyTypeInitArgs {};
+struct CAFFE2_API LegacyTypeInitArgs {};
 AT_DECLARE_REGISTRY(LegacyTypeInitRegistry, LegacyTypeInitInterface, LegacyTypeInitArgs);
 #define REGISTER_LEGACY_TYPE_INIT(clsname) AT_REGISTER_CLASS(LegacyTypeInitRegistry, clsname, clsname)
 
-AT_CORE_API const LegacyTypeInitInterface& getLegacyTypeInit();
+CAFFE2_API const LegacyTypeInitInterface& getLegacyTypeInit();
 
 struct Type;
 
-struct AT_CORE_API LegacyTypeDeleter {
+struct CAFFE2_API LegacyTypeDeleter {
   using TypeDeleterFun = void(Type*);
   TypeDeleterFun *fn_ = nullptr;
   LegacyTypeDeleter() {}
@@ -62,7 +62,7 @@ struct AT_CORE_API LegacyTypeDeleter {
   }
 };
 
-class AT_CORE_API LegacyTypeDispatch {
+class CAFFE2_API LegacyTypeDispatch {
 public:
   using TypeUniquePtr = std::unique_ptr<Type, LegacyTypeDeleter>;
   // WARNING: This function has the precondition that you have
@@ -150,6 +150,6 @@ private:
     [static_cast<int>(ScalarType::NumOptions)];
 };
 
-AT_CORE_API LegacyTypeDispatch & globalLegacyTypeDispatch();
+CAFFE2_API LegacyTypeDispatch & globalLegacyTypeDispatch();
 
 } // namespace at

--- a/aten/src/ATen/core/SmallVector.h
+++ b/aten/src/ATen/core/SmallVector.h
@@ -59,7 +59,7 @@ static inline uint64_t NextPowerOf2(uint64_t A) {
 } // namespace detail
 
 /// This is all the non-templated stuff common to all SmallVectors.
-class AT_CORE_API SmallVectorBase {
+class CAFFE2_API SmallVectorBase {
  protected:
   void *BeginX, *EndX, *CapacityX;
 

--- a/aten/src/ATen/core/TensorTypeId.h
+++ b/aten/src/ATen/core/TensorTypeId.h
@@ -17,7 +17,7 @@ using _tensorTypeId_underlyingType = uint8_t;
  * Dynamic type ID of a Tensor argument.  It represents something like
  * CPUTensor, etc.
  */
-class AT_CORE_API TensorTypeId final
+class CAFFE2_API TensorTypeId final
     : public at::
           IdWrapper<TensorTypeId, details::_tensorTypeId_underlyingType> {
  public:
@@ -32,10 +32,10 @@ class AT_CORE_API TensorTypeId final
       : IdWrapper(id) {}
 
   friend class TensorTypeIdCreator;
-  friend AT_CORE_API std::ostream& operator<<(std::ostream&, TensorTypeId);
+  friend CAFFE2_API std::ostream& operator<<(std::ostream&, TensorTypeId);
 };
 
-AT_CORE_API std::ostream& operator<<(std::ostream&, at::TensorTypeId);
+CAFFE2_API std::ostream& operator<<(std::ostream&, at::TensorTypeId);
 
 } // namespace at
 

--- a/aten/src/ATen/core/TensorTypeIdRegistration.h
+++ b/aten/src/ATen/core/TensorTypeIdRegistration.h
@@ -29,7 +29,7 @@ class CAFFE2_API TensorTypeIdCreator final {
  private:
   std::atomic<details::_tensorTypeId_underlyingType> last_id_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdCreator);
+  C10_DISABLE_COPY_AND_ASSIGN(TensorTypeIdCreator);
 };
 
 class CAFFE2_API TensorTypeIdRegistry final {
@@ -43,7 +43,7 @@ class CAFFE2_API TensorTypeIdRegistry final {
   std::unordered_set<at::TensorTypeId> registeredTypeIds_;
   std::mutex mutex_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistry);
+  C10_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistry);
 };
 
 class CAFFE2_API TensorTypeIds final {
@@ -61,7 +61,7 @@ class CAFFE2_API TensorTypeIds final {
   TensorTypeIdCreator creator_;
   TensorTypeIdRegistry registry_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIds);
+  C10_DISABLE_COPY_AND_ASSIGN(TensorTypeIds);
 };
 
 inline constexpr at::TensorTypeId TensorTypeIds::undefined() noexcept {
@@ -78,7 +78,7 @@ class CAFFE2_API TensorTypeIdRegistrar final {
  private:
   at::TensorTypeId id_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistrar);
+  C10_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistrar);
 };
 
 inline at::TensorTypeId TensorTypeIdRegistrar::id() const noexcept {

--- a/aten/src/ATen/core/TensorTypeIdRegistration.h
+++ b/aten/src/ATen/core/TensorTypeIdRegistration.h
@@ -16,7 +16,7 @@
 
 namespace at {
 
-class AT_CORE_API TensorTypeIdCreator final {
+class CAFFE2_API TensorTypeIdCreator final {
  public:
   TensorTypeIdCreator();
 
@@ -32,7 +32,7 @@ class AT_CORE_API TensorTypeIdCreator final {
   AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdCreator);
 };
 
-class AT_CORE_API TensorTypeIdRegistry final {
+class CAFFE2_API TensorTypeIdRegistry final {
  public:
   TensorTypeIdRegistry();
 
@@ -46,7 +46,7 @@ class AT_CORE_API TensorTypeIdRegistry final {
   AT_DISABLE_COPY_AND_ASSIGN(TensorTypeIdRegistry);
 };
 
-class AT_CORE_API TensorTypeIds final {
+class CAFFE2_API TensorTypeIds final {
  public:
   static TensorTypeIds& singleton();
 
@@ -68,7 +68,7 @@ inline constexpr at::TensorTypeId TensorTypeIds::undefined() noexcept {
   return TensorTypeIdCreator::undefined();
 }
 
-class AT_CORE_API TensorTypeIdRegistrar final {
+class CAFFE2_API TensorTypeIdRegistrar final {
  public:
   TensorTypeIdRegistrar();
   ~TensorTypeIdRegistrar();
@@ -85,7 +85,7 @@ inline at::TensorTypeId TensorTypeIdRegistrar::id() const noexcept {
   return id_;
 }
 
-#define AT_DECLARE_TENSOR_TYPE(TensorName) AT_CORE_API at::TensorTypeId TensorName();
+#define AT_DECLARE_TENSOR_TYPE(TensorName) CAFFE2_API at::TensorTypeId TensorName();
 
 #define AT_DEFINE_TENSOR_TYPE(TensorName)           \
   at::TensorTypeId TensorName() {                   \

--- a/aten/src/ATen/core/UniqueVoidPtr.h
+++ b/aten/src/ATen/core/UniqueVoidPtr.h
@@ -10,7 +10,7 @@ using DeleterFnPtr = void (*)(void*);
 namespace detail {
 
 // Does not delete anything
-AT_CORE_API void deleteNothing(void*);
+CAFFE2_API void deleteNothing(void*);
 
 // A detail::UniqueVoidPtr is an owning smart pointer like unique_ptr, but
 // with three major differences:

--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -25,7 +25,7 @@ class BaseContext;
    functions that are invoked statically before in Tensor class, e.g. New,
    We will merge this with Allocator later.
  */
-class AT_CORE_API BaseStaticContext {
+class CAFFE2_API BaseStaticContext {
  public:
   virtual ~BaseStaticContext() noexcept {}
 
@@ -55,7 +55,7 @@ class AT_CORE_API BaseStaticContext {
  * functions in the BaseContext class.
  * TODO: add docs after this is finalized.
  */
-class AT_CORE_API BaseContext {
+class CAFFE2_API BaseContext {
  public:
   virtual ~BaseContext() noexcept {}
 

--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -114,7 +114,7 @@ class AT_CORE_API intrusive_ptr_target {
 
 namespace detail {
 template <class TTarget>
-struct AT_CORE_EXPORT intrusive_target_default_null_type final {
+struct C10_EXPORT intrusive_target_default_null_type final {
   static constexpr TTarget* singleton() noexcept {
     return nullptr;
   }
@@ -136,7 +136,7 @@ class weak_intrusive_ptr;
 template <
     class TTarget,
     class NullType = detail::intrusive_target_default_null_type<TTarget>>
-class AT_CORE_EXPORT intrusive_ptr final {
+class C10_EXPORT intrusive_ptr final {
  private:
   static_assert(
       std::is_base_of<intrusive_ptr_target, TTarget>::value,
@@ -391,7 +391,7 @@ inline bool operator!=(
 template <
     typename TTarget,
     class NullType = detail::intrusive_target_default_null_type<TTarget>>
-class AT_CORE_EXPORT weak_intrusive_ptr final {
+class C10_EXPORT weak_intrusive_ptr final {
  private:
   static_assert(
       std::is_base_of<intrusive_ptr_target, TTarget>::value,
@@ -739,13 +739,13 @@ namespace std {
 // To allow intrusive_ptr and weak_intrusive_ptr inside std::unordered_map or
 // std::unordered_set, we need std::hash
 template <class TTarget, class NullType>
-struct AT_CORE_EXPORT hash<c10::intrusive_ptr<TTarget, NullType>> {
+struct C10_EXPORT hash<c10::intrusive_ptr<TTarget, NullType>> {
   size_t operator()(const c10::intrusive_ptr<TTarget, NullType>& x) const {
     return std::hash<TTarget*>()(x.get());
   }
 };
 template <class TTarget, class NullType>
-struct AT_CORE_EXPORT hash<c10::weak_intrusive_ptr<TTarget, NullType>> {
+struct C10_EXPORT hash<c10::weak_intrusive_ptr<TTarget, NullType>> {
   size_t operator()(const c10::weak_intrusive_ptr<TTarget, NullType>& x) const {
     return std::hash<TTarget*>()(x._unsafe_get_target());
   }

--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -33,7 +33,7 @@ namespace c10 {
 // tells us if the object was allocated by us.  If it wasn't, no
 // intrusive_ptr for you!
 
-class AT_CORE_API intrusive_ptr_target {
+class CAFFE2_API intrusive_ptr_target {
   // Note [Weak references for intrusive refcounting]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Here's the scheme:

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -34,7 +34,7 @@ struct CAFFE2_API ConstantString final : c10::intrusive_ptr_target {
 
 // non-mutable list
 template <typename Elem>
-struct AT_CORE_EXPORT ConstantList final : c10::intrusive_ptr_target {
+struct C10_EXPORT ConstantList final : c10::intrusive_ptr_target {
  private:
   const std::vector<Elem> elements_;
  public:

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -409,7 +409,7 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
 #ifdef _MSC_VER
 #define CAFFE_KNOWN_TYPE(T)                                               \
   template <>                                                             \
-  AT_CORE_EXPORT TypeIdentifier TypeMeta::Id<T>() {                       \
+  C10_EXPORT TypeIdentifier TypeMeta::Id<T>() {                       \
     static const TypeIdentifier type_id = TypeIdentifier::createTypeId(); \
     static TypeNameRegisterer<T> registerer(type_id, #T);                 \
     return type_id;                                                       \

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -47,7 +47,7 @@ class TypeMeta;
  * use TypeIdentifier with custom types. This is for example used to store the
  * dtype of tensors.
  */
-class AT_CORE_API TypeIdentifier final : public at::IdWrapper<TypeIdentifier, uint16_t> {
+class CAFFE2_API TypeIdentifier final : public at::IdWrapper<TypeIdentifier, uint16_t> {
  public:
   static TypeIdentifier createTypeId();
 
@@ -88,11 +88,11 @@ AT_DEFINE_HASH_FOR_IDWRAPPER(caffe2::TypeIdentifier)
 
 namespace caffe2 {
 
-AT_CORE_API std::unordered_map<TypeIdentifier, std::string>& gTypeNames();
-AT_CORE_API std::unordered_set<std::string>& gRegisteredTypeNames();
+CAFFE2_API std::unordered_map<TypeIdentifier, std::string>& gTypeNames();
+CAFFE2_API std::unordered_set<std::string>& gRegisteredTypeNames();
 
 
-AT_CORE_API std::mutex& gTypeRegistrationMutex();
+CAFFE2_API std::mutex& gTypeRegistrationMutex();
 
 template <typename T>
 struct TypeNameRegisterer {
@@ -139,7 +139,7 @@ struct TypeNameRegisterer {
  * stores some additional data such as the item size and the name of the type
  * for run-time inspection.
  */
-class AT_CORE_API TypeMeta {
+class CAFFE2_API TypeMeta {
  public:
   using PlacementNew = void(void*, size_t);
   using TypedCopy = void(const void*, void*, size_t);
@@ -240,7 +240,7 @@ class AT_CORE_API TypeMeta {
    * is generated during run-time. Do NOT serialize the id for storage.
    */
   template <typename T>
-  AT_CORE_API static TypeIdentifier Id();
+  CAFFE2_API static TypeIdentifier Id();
 
   /**
    * Returns the item size of the type. This is equivalent to sizeof(T).
@@ -396,20 +396,16 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
  *
  * NOTE: the macro needs to be invoked in ::caffe2 namespace
  */
-// Implementation note: in MSVC, we will need to prepend the AT_CORE_API
+// Implementation note: in MSVC, we will need to prepend the CAFFE2_API
 // keyword in order to get things compiled properly. in Linux, gcc seems to
 // create attribute ignored error for explicit template instantiations, see
 //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0537r0.html
 //   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51930
 // and as a result, we define these two macros slightly differently.
-// TODO(jiayq): AT_CORE_API below is not correct, because we may use the
-// definition in third party dependent libraries. The proper way is to use
-// C10_EXPORT (which explicitly requires dllexport). Marking this as a
-// todo item when the unified build is finished.
 #ifdef _MSC_VER
 #define CAFFE_KNOWN_TYPE(T)                                               \
   template <>                                                             \
-  C10_EXPORT TypeIdentifier TypeMeta::Id<T>() {                       \
+  C10_EXPORT TypeIdentifier TypeMeta::Id<T>() {                           \
     static const TypeIdentifier type_id = TypeIdentifier::createTypeId(); \
     static TypeNameRegisterer<T> registerer(type_id, #T);                 \
     return type_id;                                                       \
@@ -433,7 +429,7 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
 #ifdef _MSC_VER
 #define CAFFE_DECLARE_KNOWN_TYPE(PreallocatedId, T)       \
   template <>                                             \
-  inline AT_CORE_API TypeIdentifier TypeMeta::Id<T>() {   \
+  inline CAFFE2_API TypeIdentifier TypeMeta::Id<T>() {    \
     return TypeIdentifier(PreallocatedId);                \
   }
 #else // _MSC_VER

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -404,7 +404,7 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
 // and as a result, we define these two macros slightly differently.
 // TODO(jiayq): AT_CORE_API below is not correct, because we may use the
 // definition in third party dependent libraries. The proper way is to use
-// CAFFE2_EXPORT (which explicitly requires dllexport). Marking this as a
+// C10_EXPORT (which explicitly requires dllexport). Marking this as a
 // todo item when the unified build is finished.
 #ifdef _MSC_VER
 #define CAFFE_KNOWN_TYPE(T)                                               \

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -20,6 +20,11 @@ file(GLOB_RECURSE C10_HEADERS *.h)
 add_library(c10 ${C10_SRCS} ${C10_HEADERS})
 # If building shared library, set dllimport/dllexport proper.
 target_compile_options(c10 PRIVATE "-DC10_BUILD_MAIN_LIB")
+# Enable hidden visibility if compiler supports it.
+if (${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
+  target_compile_options(c10 PRIVATE "-fvisibility=hidden")
+endif()
+
 target_include_directories(
     c10 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>

--- a/c10/macros/Legacy.h
+++ b/c10/macros/Legacy.h
@@ -5,7 +5,3 @@
  */
 
 #pragma once
-
-// Note: this is for both aten and c2, due to cross reference between c2 and
-// aten that we try to unentangle. Will need to codemod.
-#define AT_DISABLE_COPY_AND_ASSIGN C10_DISABLE_COPY_AND_ASSIGN

--- a/c10/macros/Legacy.h
+++ b/c10/macros/Legacy.h
@@ -8,8 +8,6 @@
 
 // Note: this is for aten/src/*. Will need to codemod.
 #define AT_CORE_API CAFFE2_API
-#define AT_CORE_EXPORT C10_EXPORT
-#define AT_CORE_IMPORT C10_IMPORT
 
 // Note: this is for both aten and c2, due to cross reference between c2 and
 // aten that we try to unentangle. Will need to codemod.

--- a/c10/macros/Legacy.h
+++ b/c10/macros/Legacy.h
@@ -6,10 +6,6 @@
 
 #pragma once
 
-// Note: this is for caffe2/*. Will need to codemod to use direct C10.
-#define CAFFE2_EXPORT C10_EXPORT
-#define CAFFE2_IMPORT C10_IMPORT
-
 // Note: this is for aten/src/*. Will need to codemod.
 #define AT_CORE_API CAFFE2_API
 #define AT_CORE_EXPORT C10_EXPORT

--- a/c10/macros/Legacy.h
+++ b/c10/macros/Legacy.h
@@ -6,9 +6,6 @@
 
 #pragma once
 
-// Note: this is for aten/src/*. Will need to codemod.
-#define AT_CORE_API CAFFE2_API
-
 // Note: this is for both aten and c2, due to cross reference between c2 and
 // aten that we try to unentangle. Will need to codemod.
 #define AT_DISABLE_COPY_AND_ASSIGN C10_DISABLE_COPY_AND_ASSIGN

--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -72,7 +72,7 @@ class NCCLContext {
   cudaEvent_t master_event_;
   std::vector<cudaEvent_t> events_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(NCCLContext);
+  C10_DISABLE_COPY_AND_ASSIGN(NCCLContext);
 };
 
 // We share the contexts across multiple operators, hence the

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -241,7 +241,7 @@ class CAFFE2_API Blob final {
   void* pointer_ = nullptr;
   DestroyCall* destroy_ = nullptr;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Blob);
+  C10_DISABLE_COPY_AND_ASSIGN(Blob);
 };
 
 inline void swap(Blob& lhs, Blob& rhs) {

--- a/caffe2/core/common_cudnn.h
+++ b/caffe2/core/common_cudnn.h
@@ -258,7 +258,7 @@ class cudnnTensorDescWrapper {
   cudnnTensorFormat_t format_;
   cudnnDataType_t type_;
   vector<int> dims_;
-  AT_DISABLE_COPY_AND_ASSIGN(cudnnTensorDescWrapper);
+  C10_DISABLE_COPY_AND_ASSIGN(cudnnTensorDescWrapper);
 };
 
 class cudnnFilterDescWrapper {
@@ -312,7 +312,7 @@ class cudnnFilterDescWrapper {
   StorageOrder order_;
   cudnnDataType_t type_;
   vector<int> dims_;
-  AT_DISABLE_COPY_AND_ASSIGN(cudnnFilterDescWrapper);
+  C10_DISABLE_COPY_AND_ASSIGN(cudnnFilterDescWrapper);
 };
 
 

--- a/caffe2/core/cudnn_wrappers.h
+++ b/caffe2/core/cudnn_wrappers.h
@@ -89,7 +89,7 @@ class CuDNNState {
   cudaStream_t stream_{nullptr};
   CuDNNWorkspace workspace_;
   size_t gpu_id_{0};
-  AT_DISABLE_COPY_AND_ASSIGN(CuDNNState);
+  C10_DISABLE_COPY_AND_ASSIGN(CuDNNState);
 };
 
 /**
@@ -153,7 +153,7 @@ class CuDNNWrapper {
       CAFFE2_COMPILE_TIME_MAX_GPUS>;
   static PerGPUCuDNNStates& cudnn_states();
 
-  AT_DISABLE_COPY_AND_ASSIGN(CuDNNWrapper);
+  C10_DISABLE_COPY_AND_ASSIGN(CuDNNWrapper);
 };
 
 }; // namespace caffe2

--- a/caffe2/core/db.cc
+++ b/caffe2/core/db.cc
@@ -119,7 +119,7 @@ class MiniDBTransaction : public Transaction {
   FILE* file_;
   std::lock_guard<std::mutex> lock_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(MiniDBTransaction);
+  C10_DISABLE_COPY_AND_ASSIGN(MiniDBTransaction);
 };
 
 class MiniDB : public DB {

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -52,7 +52,7 @@ class CAFFE2_API Cursor {
    */
   virtual bool Valid() = 0;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Cursor);
+  C10_DISABLE_COPY_AND_ASSIGN(Cursor);
 };
 
 /**
@@ -71,7 +71,7 @@ class CAFFE2_API Transaction {
    */
   virtual void Commit() = 0;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Transaction);
+  C10_DISABLE_COPY_AND_ASSIGN(Transaction);
 };
 
 /**
@@ -99,7 +99,7 @@ class CAFFE2_API DB {
  protected:
   Mode mode_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(DB);
+  C10_DISABLE_COPY_AND_ASSIGN(DB);
 };
 
 // Database classes are registered by their names so we can do optional
@@ -285,7 +285,7 @@ class CAFFE2_API DBReader {
   uint32_t num_shards_;
   uint32_t shard_id_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(DBReader);
+  C10_DISABLE_COPY_AND_ASSIGN(DBReader);
 };
 
 class CAFFE2_API DBReaderSerializer : public BlobSerializerBase {

--- a/caffe2/core/dispatch/KernelRegistration.h
+++ b/caffe2/core/dispatch/KernelRegistration.h
@@ -57,7 +57,7 @@ private:
   const typename Schema::dispatch::dispatch_key_type dispatch_key_;
   bool owns_registration_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(KernelRegistrar);
+  C10_DISABLE_COPY_AND_ASSIGN(KernelRegistrar);
 };
 
 /**

--- a/caffe2/core/flags.cc
+++ b/caffe2/core/flags.cc
@@ -9,7 +9,7 @@ namespace caffe2 {
 
 #ifdef CAFFE2_USE_GFLAGS
 
-CAFFE2_EXPORT void SetUsageMessage(const string& str) {
+C10_EXPORT void SetUsageMessage(const string& str) {
   if (UsageMessage() != nullptr) {
     // Usage message has already been set, so we will simply return.
     return;
@@ -17,16 +17,16 @@ CAFFE2_EXPORT void SetUsageMessage(const string& str) {
   gflags::SetUsageMessage(str);
 }
 
-CAFFE2_EXPORT const char* UsageMessage() {
+C10_EXPORT const char* UsageMessage() {
   return gflags::ProgramUsage();
 }
 
-CAFFE2_EXPORT bool ParseCaffeCommandLineFlags(int* pargc, char*** pargv) {
+C10_EXPORT bool ParseCaffeCommandLineFlags(int* pargc, char*** pargv) {
   if (*pargc == 0) return true;
   return gflags::ParseCommandLineFlags(pargc, pargv, true);
 }
 
-CAFFE2_EXPORT bool CommandLineFlagsHasBeenParsed() {
+C10_EXPORT bool CommandLineFlagsHasBeenParsed() {
   // There is no way we query gflags right now, so we will simply return true.
   return true;
 }
@@ -49,10 +49,10 @@ static string gUsageMessage = "(Usage message not set.)";
 }
 
 
-CAFFE2_EXPORT void SetUsageMessage(const string& str) { gUsageMessage = str; }
-CAFFE2_EXPORT const char* UsageMessage() { return gUsageMessage.c_str(); }
+C10_EXPORT void SetUsageMessage(const string& str) { gUsageMessage = str; }
+C10_EXPORT const char* UsageMessage() { return gUsageMessage.c_str(); }
 
-CAFFE2_EXPORT bool ParseCaffeCommandLineFlags(int* pargc, char*** pargv) {
+C10_EXPORT bool ParseCaffeCommandLineFlags(int* pargc, char*** pargv) {
   if (*pargc == 0) return true;
   char** argv = *pargv;
   bool success = true;
@@ -136,18 +136,18 @@ CAFFE2_EXPORT bool ParseCaffeCommandLineFlags(int* pargc, char*** pargv) {
   return success;
 }
 
-CAFFE2_EXPORT bool CommandLineFlagsHasBeenParsed() {
+C10_EXPORT bool CommandLineFlagsHasBeenParsed() {
   return gCommandLineFlagsParsed;
 }
 
 template <>
-CAFFE2_EXPORT bool Caffe2FlagParser::Parse<string>(const string& content, string* value) {
+C10_EXPORT bool Caffe2FlagParser::Parse<string>(const string& content, string* value) {
   *value = content;
   return true;
 }
 
 template <>
-CAFFE2_EXPORT bool Caffe2FlagParser::Parse<int>(const string& content, int* value) {
+C10_EXPORT bool Caffe2FlagParser::Parse<int>(const string& content, int* value) {
   try {
     *value = std::atoi(content.c_str());
     return true;
@@ -159,7 +159,7 @@ CAFFE2_EXPORT bool Caffe2FlagParser::Parse<int>(const string& content, int* valu
 }
 
 template <>
-CAFFE2_EXPORT bool Caffe2FlagParser::Parse<int64_t>(const string& content, int64_t* value) {
+C10_EXPORT bool Caffe2FlagParser::Parse<int64_t>(const string& content, int64_t* value) {
   try {
     static_assert(sizeof(long long) == sizeof(int64_t), "");
 #ifdef __ANDROID__
@@ -177,7 +177,7 @@ CAFFE2_EXPORT bool Caffe2FlagParser::Parse<int64_t>(const string& content, int64
 }
 
 template <>
-CAFFE2_EXPORT bool Caffe2FlagParser::Parse<double>(const string& content, double* value) {
+C10_EXPORT bool Caffe2FlagParser::Parse<double>(const string& content, double* value) {
   try {
     *value = std::atof(content.c_str());
     return true;
@@ -190,7 +190,7 @@ CAFFE2_EXPORT bool Caffe2FlagParser::Parse<double>(const string& content, double
 }
 
 template <>
-CAFFE2_EXPORT bool Caffe2FlagParser::Parse<bool>(const string& content, bool* value) {
+C10_EXPORT bool Caffe2FlagParser::Parse<bool>(const string& content, bool* value) {
   if (content == "false" || content == "False" || content == "FALSE" ||
       content == "0") {
     *value = false;

--- a/caffe2/core/flags.h
+++ b/caffe2/core/flags.h
@@ -79,14 +79,14 @@ namespace gflags = google;
 // (3) Gflags has a design issue that does not properly expose the global flags,
 // if one builds the library with -fvisibility=hidden. The current gflags (as of
 // Aug 2018) only deals with the Windows case using dllexport, and not the Linux
-// counterparts. As a result, we will explciitly use CAFFE2_EXPORT to export the
+// counterparts. As a result, we will explciitly use C10_EXPORT to export the
 // flags defined in Caffe2. This is done via a global reference, so the flag
 // itself is not duplicated - under the hood it is the same global gflags flag.
 #define CAFFE2_GFLAGS_DEF_WRAPPER(                                             \
     type, real_type, name, default_value, help_str)                            \
   DEFINE_##type(name, default_value, help_str);                                \
   namespace caffe2 {                                                           \
-    CAFFE2_EXPORT real_type& FLAGS_##name = ::FLAGS_##name;                    \
+    C10_EXPORT real_type& FLAGS_##name = ::FLAGS_##name;                    \
   }
 
 #define CAFFE2_DEFINE_int(name, default_value, help_str)                       \
@@ -105,7 +105,7 @@ namespace gflags = google;
 #define CAFFE2_GFLAGS_DECLARE_WRAPPER(type, real_type, name)                   \
   DECLARE_##type(name);                                                        \
   namespace caffe2 {                                                           \
-    CAFFE2_IMPORT extern real_type& FLAGS_##name;                              \
+    C10_IMPORT extern real_type& FLAGS_##name;                              \
   }  // namespace caffe2
 
 #define CAFFE2_DECLARE_int(name)                                               \
@@ -152,7 +152,7 @@ CAFFE_DECLARE_REGISTRY(Caffe2FlagsRegistry, Caffe2FlagParser, const string&);
 
 #define CAFFE2_DEFINE_typed_var(type, name, default_value, help_str)           \
   namespace caffe2 {                                                           \
-  CAFFE2_EXPORT type FLAGS_##name = default_value;                             \
+  C10_EXPORT type FLAGS_##name = default_value;                             \
   namespace {                                                                  \
   class Caffe2FlagParser_##name : public Caffe2FlagParser {                    \
    public:                                                                     \
@@ -182,7 +182,7 @@ CAFFE_DECLARE_REGISTRY(Caffe2FlagsRegistry, Caffe2FlagParser, const string&);
 // DECLARE_typed_var should be used in header files and in the global namespace.
 #define CAFFE2_DECLARE_typed_var(type, name)                                   \
   namespace caffe2 {                                                           \
-    CAFFE2_IMPORT extern type FLAGS_##name;                                    \
+    C10_IMPORT extern type FLAGS_##name;                                    \
   } // namespace caffe2
 
 #define CAFFE2_DECLARE_int(name) CAFFE2_DECLARE_typed_var(int, name)

--- a/caffe2/core/hip/common_miopen.h
+++ b/caffe2/core/hip/common_miopen.h
@@ -164,7 +164,7 @@ class miopenTensorDescWrapper
     miopenTensorDescriptor_t desc_;
     miopenDataType_t type_;
     vector<int> dims_;
-    AT_DISABLE_COPY_AND_ASSIGN(miopenTensorDescWrapper);
+    C10_DISABLE_COPY_AND_ASSIGN(miopenTensorDescWrapper);
 };
 
 } // namespace caffe2

--- a/caffe2/core/hip/miopen_wrapper.h
+++ b/caffe2/core/hip/miopen_wrapper.h
@@ -92,7 +92,7 @@ class MIOPENState
     hipStream_t stream_{nullptr};
     MIOPENWorkspace workspace_;
     size_t gpu_id_{0};
-    AT_DISABLE_COPY_AND_ASSIGN(MIOPENState);
+    C10_DISABLE_COPY_AND_ASSIGN(MIOPENState);
 };
 
 /**
@@ -157,7 +157,7 @@ class MIOPENWrapper
                    CAFFE2_COMPILE_TIME_MAX_HIP_GPUS>;
     static PerGPUMIOPENStates& miopen_states();
 
-    AT_DISABLE_COPY_AND_ASSIGN(MIOPENWrapper);
+    C10_DISABLE_COPY_AND_ASSIGN(MIOPENWrapper);
 };
 
 }; // namespace caffe2

--- a/caffe2/core/hip/net_async_dag_hip.cc
+++ b/caffe2/core/hip/net_async_dag_hip.cc
@@ -58,7 +58,7 @@ class ProfiledRange
     ProfiledRange(const OperatorDef& def, Color color) {}
 
     private:
-    AT_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
+    C10_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
 };
 
 } // namespace

--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -124,7 +124,7 @@ class CAFFE2_API NetBase : public Observable<NetBase> {
   string name_;
   vector<const Event*> events_;
   std::shared_ptr<const NetDef> net_def_;
-  AT_DISABLE_COPY_AND_ASSIGN(NetBase);
+  C10_DISABLE_COPY_AND_ASSIGN(NetBase);
 };
 
 class CAFFE2_API ExecutorHelper {

--- a/caffe2/core/net_async_base.h
+++ b/caffe2/core/net_async_base.h
@@ -125,7 +125,7 @@ class CAFFE2_API AsyncNetBase : public NetBase {
   bool use_per_net_pools_;
   bool is_blocking_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(AsyncNetBase);
+  C10_DISABLE_COPY_AND_ASSIGN(AsyncNetBase);
 
  private:
   void storeExceptionPtr();

--- a/caffe2/core/net_async_dag_gpu.cc
+++ b/caffe2/core/net_async_dag_gpu.cc
@@ -71,7 +71,7 @@ class ProfiledRange {
 
  private:
   nvtxRangeId_t range_ = 0;
-  AT_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
+  C10_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
 };
 
 #else
@@ -81,7 +81,7 @@ class ProfiledRange {
   ProfiledRange(const OperatorDef& def, Color color) {}
 
  private:
-  AT_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
+  C10_DISABLE_COPY_AND_ASSIGN(ProfiledRange);
 };
 
 #endif // ifdef CAFFE2_USE_NVTX

--- a/caffe2/core/net_async_dag_gpu.h
+++ b/caffe2/core/net_async_dag_gpu.h
@@ -32,7 +32,7 @@ class AsyncDAGNet : public DAGNetBase {
   int stream(const DeviceOption& device_option);
   static thread_local std::vector<int> stream_counters_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(AsyncDAGNet);
+  C10_DISABLE_COPY_AND_ASSIGN(AsyncDAGNet);
 };
 
 } // namespace caffe2

--- a/caffe2/core/net_async_polling.h
+++ b/caffe2/core/net_async_polling.h
@@ -40,7 +40,7 @@ class AsyncPollingNet : public AsyncNetBase {
   void reset() override;
   std::atomic<bool> has_chain_failed_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(AsyncPollingNet);
+  C10_DISABLE_COPY_AND_ASSIGN(AsyncPollingNet);
 };
 
 } // namespace caffe2

--- a/caffe2/core/net_async_scheduling.h
+++ b/caffe2/core/net_async_scheduling.h
@@ -30,7 +30,7 @@ class CAFFE2_API AsyncSchedulingNet : public AsyncNetBase {
 
   std::atomic<int> processed_tasks_num_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(AsyncSchedulingNet);
+  C10_DISABLE_COPY_AND_ASSIGN(AsyncSchedulingNet);
 };
 
 } // namespace caffe2

--- a/caffe2/core/net_dag.h
+++ b/caffe2/core/net_dag.h
@@ -84,7 +84,7 @@ class CAFFE2_API DAGNetBase : public NetBase {
   mutable std::vector<DAGNetStats> stats_;
   std::unordered_map<int, std::unique_ptr<Timer>> task_timers_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(DAGNetBase);
+  C10_DISABLE_COPY_AND_ASSIGN(DAGNetBase);
 };
 
 class CAFFE2_API DAGNet : public DAGNetBase {

--- a/caffe2/core/net_simple.h
+++ b/caffe2/core/net_simple.h
@@ -48,7 +48,7 @@ class CAFFE2_API SimpleNet : public NetBase {
 
   vector<unique_ptr<OperatorBase>> operators_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(SimpleNet);
+  C10_DISABLE_COPY_AND_ASSIGN(SimpleNet);
 };
 
 } // namespace caffe2

--- a/caffe2/core/net_simple_async.h
+++ b/caffe2/core/net_simple_async.h
@@ -43,7 +43,7 @@ class AsyncSimpleNet : public NetBase {
 
   vector<unique_ptr<OperatorBase>> operators_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(AsyncSimpleNet);
+  C10_DISABLE_COPY_AND_ASSIGN(AsyncSimpleNet);
 };
 
 } // namespace caffe2

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -259,7 +259,7 @@ template <bool B, class T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
 template <typename T, typename U>
-struct CAFFE2_EXPORT inheritedFrom {
+struct C10_EXPORT inheritedFrom {
   static constexpr bool value =
       std::is_base_of<U, T>::value && !std::is_same<U, T>::value;
 };
@@ -267,14 +267,14 @@ struct CAFFE2_EXPORT inheritedFrom {
 // This is just a way to fix issues when the isa<> implementation
 // can't automatically downcast.
 template <typename T, typename N, typename = void>
-struct CAFFE2_EXPORT is_impl {
+struct C10_EXPORT is_impl {
   inline static bool impl(N n) {
     return isa<T>(n->data());
   }
 };
 
 template <typename T, typename N>
-struct CAFFE2_EXPORT is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
+struct C10_EXPORT is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
   inline static bool impl(N n) {
     if (!isa<NeuralNetOperator>(n->data().get())) {
       return false;
@@ -285,7 +285,7 @@ struct CAFFE2_EXPORT is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperato
 };
 
 template <typename T, typename N>
-struct CAFFE2_EXPORT is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
+struct C10_EXPORT is_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
   inline static bool impl(N n) {
     if (!isa<NeuralNetData>(n->data().get())) {
       return false;
@@ -303,14 +303,14 @@ inline bool is(N n) {
 // This is just a way to fix issues when the dyn_cast<> implementation
 // can't automatically downcast.
 template <typename T, typename N, typename = void>
-struct CAFFE2_EXPORT get_impl {
+struct C10_EXPORT get_impl {
   inline static T* impl(N n) {
     return dyn_cast<T>(n->data().get());
   }
 };
 
 template <typename T, typename N>
-struct CAFFE2_EXPORT get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
+struct C10_EXPORT get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperator>::value>> {
   inline static T* impl(N n) {
     if (!is<T>(n)) {
       assert(0 && "Cannot get type from node");
@@ -322,7 +322,7 @@ struct CAFFE2_EXPORT get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetOperat
 };
 
 template <typename T, typename N>
-struct CAFFE2_EXPORT get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
+struct C10_EXPORT get_impl<T, N, enable_if_t<inheritedFrom<T, NeuralNetData>::value>> {
   inline static T* impl(N n) {
     if (!is<T>(n)) {
       assert(0 && "Cannot get type from node");
@@ -422,7 +422,7 @@ CAFFE2_API std::vector<NNGraph::NodeRef> getOutputs(NNGraph::NodeRef n);
 CAFFE2_API void coalesceInsertedDataDependencies(repr::NNModule* m);
 
 template <NNGraph* G>
-struct CAFFE2_EXPORT NodeHelper {};
+struct C10_EXPORT NodeHelper {};
 
 struct NNNodeMatchCriteria {
   std::function<bool(NNGraph::NodeRef)> predicate;

--- a/caffe2/core/observer.h
+++ b/caffe2/core/observer.h
@@ -51,7 +51,7 @@ class Observable {
 
   virtual ~Observable() = default;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Observable);
+  C10_DISABLE_COPY_AND_ASSIGN(Observable);
 
   using Observer = ObserverBase<T>;
 

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -825,7 +825,7 @@ CAFFE_DECLARE_REGISTRY(
 #define REGISTER_CPU_OPERATOR_CREATOR(key, ...) \
   CAFFE_REGISTER_CREATOR(CPUOperatorRegistry, key, __VA_ARGS__)
 #define REGISTER_CPU_OPERATOR(name, ...)                           \
-  CAFFE2_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();\
+  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();\
   static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CPU##name() { \
     CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                \
   }                                                                \
@@ -844,7 +844,7 @@ CAFFE_DECLARE_REGISTRY(
 #define REGISTER_CUDA_OPERATOR_CREATOR(key, ...) \
   CAFFE_REGISTER_CREATOR(CUDAOperatorRegistry, key, __VA_ARGS__)
 #define REGISTER_CUDA_OPERATOR(name, ...)                           \
-  CAFFE2_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();       \
+  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();       \
   static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CUDA##name() { \
     CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                 \
   }                                                                 \
@@ -869,7 +869,7 @@ CAFFE_DECLARE_REGISTRY(
 #define REGISTER_HIP_OPERATOR_CREATOR(key, ...) \
   CAFFE_REGISTER_CREATOR(HIPOperatorRegistry, key, __VA_ARGS__)
 #define REGISTER_HIP_OPERATOR(name, ...)                           \
-  CAFFE2_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();       \
+  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();       \
   static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_HIP##name() { \
     CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                 \
   }                                                                 \

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -397,7 +397,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   // An event used by asynchronous execution.
   std::unique_ptr<Event> event_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(OperatorBase);
+  C10_DISABLE_COPY_AND_ASSIGN(OperatorBase);
 };
 
 // If your operator does not need any specialized contructor or destructor,

--- a/caffe2/core/operator_schema.cc
+++ b/caffe2/core/operator_schema.cc
@@ -415,7 +415,7 @@ std::vector<TensorFiller> OpSchema::SupplyDenseFillers(
   return fillers;
 }
 
-CAFFE2_EXPORT std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
+C10_EXPORT std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
   if (!schema.args().empty()) {
     out << "Arguments:" << std::endl;
     for (const auto& arg : schema.args()) {

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -577,14 +577,14 @@ OpSchema::Cost PointwiseCostInference(
 #ifndef CAFFE2_NO_OPERATOR_SCHEMA
 
 #define OPERATOR_SCHEMA(name)                                     \
-  CAFFE2_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};          \
+  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};          \
   static OpSchema* CAFFE_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED = \
       &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else // CAFFE2_NO_OPERATOR_SCHEMA
 
 #define OPERATOR_SCHEMA(name)                                     \
-  CAFFE2_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};          \
+  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};          \
   static OpSchema* CAFFE_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED = \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 

--- a/caffe2/core/qtensor.h
+++ b/caffe2/core/qtensor.h
@@ -14,7 +14,7 @@
 namespace caffe2 {
 
 template <class Context>
-class CAFFE2_EXPORT QTensor {
+class C10_EXPORT QTensor {
  public:
   QTensor() {}
   virtual ~QTensor() {}

--- a/caffe2/core/registry.h
+++ b/caffe2/core/registry.h
@@ -100,7 +100,7 @@ class Registry {
   CaffeMap<SrcType, string> help_message_;
   std::mutex register_mutex_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Registry);
+  C10_DISABLE_COPY_AND_ASSIGN(Registry);
 };
 
 template <class SrcType, class ObjectPtrType, class... Args>

--- a/caffe2/core/registry.h
+++ b/caffe2/core/registry.h
@@ -144,14 +144,14 @@ class Registerer {
  */
 #define CAFFE_DECLARE_TYPED_REGISTRY(                                    \
     RegistryName, SrcType, ObjectType, PtrType, ...)                     \
-  CAFFE2_EXPORT Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*   \
+  C10_EXPORT Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*   \
   RegistryName();                                                        \
   typedef Registerer<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>        \
       Registerer##RegistryName;
 
 #define CAFFE_DEFINE_TYPED_REGISTRY(                                         \
     RegistryName, SrcType, ObjectType, PtrType, ...)                         \
-  CAFFE2_EXPORT Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*       \
+  C10_EXPORT Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*       \
   RegistryName() {                                                           \
     static Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>* registry = \
         new Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>();         \

--- a/caffe2/core/timer.h
+++ b/caffe2/core/timer.h
@@ -41,7 +41,7 @@ class Timer {
 
  protected:
   std::chrono::time_point<clock> start_time_;
-  AT_DISABLE_COPY_AND_ASSIGN(Timer);
+  C10_DISABLE_COPY_AND_ASSIGN(Timer);
 };
 }
 

--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -328,7 +328,7 @@ class CAFFE2_API Workspace {
   std::mutex thread_pool_creation_mutex_;
   std::shared_ptr<Bookkeeper> bookkeeper_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(Workspace);
+  C10_DISABLE_COPY_AND_ASSIGN(Workspace);
 };
 
 }  // namespace caffe2

--- a/caffe2/db/create_db_op.h
+++ b/caffe2/db/create_db_op.h
@@ -34,7 +34,7 @@ class CreateDBOp final : public Operator<Context> {
   string db_name_;
   uint32_t num_shards_;
   uint32_t shard_id_;
-  AT_DISABLE_COPY_AND_ASSIGN(CreateDBOp);
+  C10_DISABLE_COPY_AND_ASSIGN(CreateDBOp);
 };
 
 } // namespace caffe2

--- a/caffe2/db/leveldb.cc
+++ b/caffe2/db/leveldb.cc
@@ -51,7 +51,7 @@ class LevelDBTransaction : public Transaction {
   leveldb::DB* db_;
   std::unique_ptr<leveldb::WriteBatch> batch_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(LevelDBTransaction);
+  C10_DISABLE_COPY_AND_ASSIGN(LevelDBTransaction);
 };
 
 class LevelDB : public DB {

--- a/caffe2/db/lmdb.cc
+++ b/caffe2/db/lmdb.cc
@@ -114,7 +114,7 @@ class LMDBTransaction final : public Transaction {
   MDB_dbi mdb_dbi_;
   MDB_txn* mdb_txn_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(LMDBTransaction);
+  C10_DISABLE_COPY_AND_ASSIGN(LMDBTransaction);
 };
 
 class LMDB : public DB {

--- a/caffe2/db/protodb.cc
+++ b/caffe2/db/protodb.cc
@@ -60,7 +60,7 @@ class ProtoDBTransaction : public Transaction {
   TensorProtos* proto_;
   std::unordered_set<string> existing_names_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(ProtoDBTransaction);
+  C10_DISABLE_COPY_AND_ASSIGN(ProtoDBTransaction);
 };
 
 class ProtoDB : public DB {

--- a/caffe2/mkl/utils/mkl_memory.h
+++ b/caffe2/mkl/utils/mkl_memory.h
@@ -58,7 +58,7 @@ class PrimitiveWrapper {
 
  private:
   dnnPrimitive_t primitive_ = 0;
-  AT_DISABLE_COPY_AND_ASSIGN(PrimitiveWrapper);
+  C10_DISABLE_COPY_AND_ASSIGN(PrimitiveWrapper);
 };
 
 template <typename T>
@@ -138,7 +138,7 @@ class LayoutWrapper {
 
  private:
   dnnLayout_t layout_ = 0;
-  AT_DISABLE_COPY_AND_ASSIGN(LayoutWrapper);
+  C10_DISABLE_COPY_AND_ASSIGN(LayoutWrapper);
 };
 
 /**
@@ -557,7 +557,7 @@ class MKLMemory {
   // The primitive to use to convert from internal layout to user layout
   PrimitiveWrapper<T> convert_out_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(MKLMemory);
+  C10_DISABLE_COPY_AND_ASSIGN(MKLMemory);
 };
 
 template <typename T>
@@ -575,7 +575,7 @@ class MKLWorkspace {
 
  private:
   void* buffer_;
-  AT_DISABLE_COPY_AND_ASSIGN(MKLWorkspace);
+  C10_DISABLE_COPY_AND_ASSIGN(MKLWorkspace);
 };
 
 } // namespace mkl

--- a/caffe2/mobile/contrib/arm-compute/core/net_gl.h
+++ b/caffe2/mobile/contrib/arm-compute/core/net_gl.h
@@ -57,7 +57,7 @@ class GLNet : public NetBase {
 
   vector<unique_ptr<OperatorBase>> operators_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(GLNet);
+  C10_DISABLE_COPY_AND_ASSIGN(GLNet);
 };
 
 } // namespace caffe2

--- a/caffe2/operators/expand_squeeze_dims_op.h
+++ b/caffe2/operators/expand_squeeze_dims_op.h
@@ -112,7 +112,7 @@ class SqueezeOp : public Operator<Context> {
   vector<int> dims_;
 
  public:
-  AT_DISABLE_COPY_AND_ASSIGN(SqueezeOp);
+  C10_DISABLE_COPY_AND_ASSIGN(SqueezeOp);
 };
 } // namespace caffe2
 #endif // CAFFE2_OPERATORS_EXPAND_SQUEEZE_DIMS_OP_H_

--- a/caffe2/operators/partition_ops.h
+++ b/caffe2/operators/partition_ops.h
@@ -221,7 +221,7 @@ class PartitionOp : public PartitionOpBase {
     return true;
   }
 
-  AT_DISABLE_COPY_AND_ASSIGN(PartitionOp);
+  C10_DISABLE_COPY_AND_ASSIGN(PartitionOp);
 };
 
 class LengthsPartitionOp : public PartitionOpBase {
@@ -302,7 +302,7 @@ class LengthsPartitionOp : public PartitionOpBase {
     return true;
   }
 
-  AT_DISABLE_COPY_AND_ASSIGN(LengthsPartitionOp);
+  C10_DISABLE_COPY_AND_ASSIGN(LengthsPartitionOp);
 
   vector<int32_t*> out_length_;
 };

--- a/caffe2/operators/slice_op.cu
+++ b/caffe2/operators/slice_op.cu
@@ -302,7 +302,7 @@ class SliceGradientOp<CUDAContext> : public Operator<CUDAContext> {
         ends_(this->template GetRepeatedArgument<int64_t>("ends")),
         statically_inited_(false) {}
 
-  AT_DISABLE_COPY_AND_ASSIGN(SliceGradientOp);
+  C10_DISABLE_COPY_AND_ASSIGN(SliceGradientOp);
 
   bool RunOnDevice() override {
     if (InputSize() == 4) {

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -249,7 +249,7 @@ class SliceOp : public Operator<Context> {
         output, data, starts_host_, ends_host_, &context_);
   }
 
-  AT_DISABLE_COPY_AND_ASSIGN(SliceOp);
+  C10_DISABLE_COPY_AND_ASSIGN(SliceOp);
 
  protected:
   std::vector<int64_t> starts_;
@@ -269,7 +269,7 @@ class SliceGradientOp : public Operator<Context> {
         ends_(this->template GetRepeatedArgument<int64_t>("ends")),
         statically_inited_(false) {}
 
-        AT_DISABLE_COPY_AND_ASSIGN(SliceGradientOp);
+        C10_DISABLE_COPY_AND_ASSIGN(SliceGradientOp);
 
   bool RunOnDevice() override {
     if (InputSize() == 4) {

--- a/caffe2/opt/fusion.h
+++ b/caffe2/opt/fusion.h
@@ -37,7 +37,7 @@ CAFFE2_API void fuseConvBN(repr::NNModule* nn, caffe2::Workspace* ws);
 // \param postprocess Functor to postprocess the conv node,
 // attaching additional attributes if necessary
 template <typename OperationT, typename ActivationT>
-CAFFE2_EXPORT void fuseActivation(
+C10_EXPORT void fuseActivation(
     repr::NNModule* nn,
     std::function<bool(const OperationT& conv)> should_fuse,
     std::function<void(repr::NNGraph::NodeRef conv_node)> postprocess) {

--- a/caffe2/opt/sink.cc
+++ b/caffe2/opt/sink.cc
@@ -8,7 +8,7 @@ namespace opt {
 
 using namespace nom;
 
-CAFFE2_EXPORT void sinkMaxPool(nom::repr::NNModule* nn) {
+C10_EXPORT void sinkMaxPool(nom::repr::NNModule* nn) {
   for (auto max_pool_node :
        repr::nn::nodeIterator<repr::MaxPool>(nn->dataFlow)) {
     if (repr::nn::getInputs(max_pool_node).size() != 1) {

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -43,7 +43,7 @@ void addObjectMethods(pybind11::module& m);
 // Get current workspace
 Workspace* GetCurrentWorkspace();
 
-class CAFFE2_EXPORT BlobFetcherBase {
+class C10_EXPORT BlobFetcherBase {
  public:
   struct FetchedBlob {
     pybind11::object obj;
@@ -60,7 +60,7 @@ class BlobFeederBase {
   Feed(const DeviceOption& option, PyArrayObject* array, Blob* blob) = 0;
 };
 
-CAFFE2_EXPORT CAFFE_DECLARE_TYPED_REGISTRY(
+C10_EXPORT CAFFE_DECLARE_TYPED_REGISTRY(
     BlobFetcherRegistry,
     TypeIdentifier,
     BlobFetcherBase,

--- a/caffe2/queue/blobs_queue_db.cc
+++ b/caffe2/queue/blobs_queue_db.cc
@@ -32,7 +32,7 @@ class CreateBlobsQueueDBOp : public Operator<CPUContext> {
   }
 
  private:
-  AT_DISABLE_COPY_AND_ASSIGN(CreateBlobsQueueDBOp);
+  C10_DISABLE_COPY_AND_ASSIGN(CreateBlobsQueueDBOp);
 };
 
 REGISTER_CPU_OPERATOR(CreateBlobsQueueDB, CreateBlobsQueueDBOp<CPUContext>);

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -76,7 +76,7 @@ namespace math {
 // (transpose) if the argument TransA or TransB is set to CblasNoTrans or
 // CblasTrans, respectively, for each of A and B.
 template <>
-CAFFE2_EXPORT void Gemm<float, CPUContext>(
+C10_EXPORT void Gemm<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int M,
@@ -134,7 +134,7 @@ CAFFE2_EXPORT void Gemm<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void GemmEx<float, CPUContext>(
+C10_EXPORT void GemmEx<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int M,
@@ -206,7 +206,7 @@ CAFFE2_EXPORT void GemmEx<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void Gemv<float, CPUContext>(
+C10_EXPORT void Gemv<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const int M,
     const int N,
@@ -245,7 +245,7 @@ CAFFE2_EXPORT void Gemv<float, CPUContext>(
 
 #define CAFFE2_SPECIALIZED_DOT(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Dot<T, CPUContext>(                                               \
+  C10_EXPORT void Dot<T, CPUContext>(                                               \
       const int N, const T* a, const T* b, T* y, CPUContext* context) {  \
     *y = ConstEigenVectorMap<T>(a, N).dot(ConstEigenVectorMap<T>(b, N)); \
   }
@@ -254,12 +254,12 @@ CAFFE2_SPECIALIZED_DOT(float)
 
 #define CAFFE2_SPECIALIZED_AXPY(T)                                          \
   template <>                                                               \
-  CAFFE2_EXPORT void Axpy<T, CPUContext>(                                                 \
+  C10_EXPORT void Axpy<T, CPUContext>(                                                 \
       const int N, const T alpha, const T* x, T* Y, CPUContext* context) {  \
     EigenVectorMap<T>(Y, N) += ConstEigenVectorMap<T>(x, N) * alpha;        \
   }                                                                         \
   template <>                                                               \
-  CAFFE2_EXPORT void Axpy<T, CPUContext>(                                                 \
+  C10_EXPORT void Axpy<T, CPUContext>(                                                 \
       const int N, const T* alpha, const T* x, T* Y, CPUContext* context) { \
     EigenVectorMap<T>(Y, N) += ConstEigenVectorMap<T>(x, N) * (*alpha);     \
   }
@@ -268,7 +268,7 @@ CAFFE2_SPECIALIZED_AXPY(float)
 
 #define CAFFE2_SPECIALIZED_AXPBY(T)                                     \
   template <>                                                           \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                                         \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                                         \
       const int N,                                                      \
       const T alpha,                                                    \
       const T* x,                                                       \
@@ -279,7 +279,7 @@ CAFFE2_SPECIALIZED_AXPY(float)
     y_arr = y_arr * beta + ConstEigenVectorArrayMap<T>(x, N) * alpha;   \
   }                                                                     \
   template <>                                                           \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                                         \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                                         \
       const int N,                                                      \
       const T* alpha,                                                   \
       const T* x,                                                       \
@@ -295,7 +295,7 @@ CAFFE2_SPECIALIZED_AXPBY(float)
 #else // CAFFE2_USE_EIGEN_FOR_BLAS
 
 template <>
-CAFFE2_EXPORT void Gemm<float, CPUContext>(
+C10_EXPORT void Gemm<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int M,
@@ -328,7 +328,7 @@ CAFFE2_EXPORT void Gemm<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void GemmEx<float, CPUContext>(
+C10_EXPORT void GemmEx<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int M,
@@ -361,7 +361,7 @@ CAFFE2_EXPORT void GemmEx<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void Gemv<float, CPUContext>(
+C10_EXPORT void Gemv<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const int M,
     const int N,
@@ -377,7 +377,7 @@ CAFFE2_EXPORT void Gemv<float, CPUContext>(
 
 #define CAFFE2_SPECIALIZED_SCALE(TAlpha, TData, prefix)          \
   template <>                                                    \
-  CAFFE2_EXPORT void Scale<TAlpha, TData, CPUContext>(                         \
+  C10_EXPORT void Scale<TAlpha, TData, CPUContext>(                         \
       const int n,                                               \
       const TAlpha alpha,                                        \
       const TData* x,                                            \
@@ -391,7 +391,7 @@ CAFFE2_EXPORT void Gemv<float, CPUContext>(
     }                                                            \
   }                                                              \
   template <>                                                    \
-  CAFFE2_EXPORT void Scale<TAlpha, TData, CPUContext>(                         \
+  C10_EXPORT void Scale<TAlpha, TData, CPUContext>(                         \
       const int n,                                               \
       const TAlpha* alpha,                                       \
       const TData* x,                                            \
@@ -411,7 +411,7 @@ CAFFE2_SPECIALIZED_SCALE(float, double, d)
 
 #define CAFFE2_SPECIALIZED_DOT(T, prefix)                       \
   template <>                                                   \
-  CAFFE2_EXPORT void Dot<T, CPUContext>(                                      \
+  C10_EXPORT void Dot<T, CPUContext>(                                      \
       const int N, const T* a, const T* b, T* y, CPUContext*) { \
     *y = cblas_##prefix##dot(N, a, 1, b, 1);                    \
   }
@@ -420,12 +420,12 @@ CAFFE2_SPECIALIZED_DOT(float, s)
 
 #define CAFFE2_SPECIALIZED_AXPY(T, prefix)                          \
   template <>                                                       \
-  CAFFE2_EXPORT void Axpy<T, CPUContext>(                                         \
+  C10_EXPORT void Axpy<T, CPUContext>(                                         \
       const int N, const T alpha, const T* x, T* y, CPUContext*) {  \
     cblas_##prefix##axpy(N, alpha, x, 1, y, 1);                     \
   }                                                                 \
   template <>                                                       \
-  CAFFE2_EXPORT void Axpy<T, CPUContext>(                                         \
+  C10_EXPORT void Axpy<T, CPUContext>(                                         \
       const int N, const T* alpha, const T* x, T* y, CPUContext*) { \
     cblas_##prefix##axpy(N, *alpha, x, 1, y, 1);                    \
   }
@@ -437,7 +437,7 @@ CAFFE2_SPECIALIZED_AXPY(float, s)
 #ifdef CAFFE2_USE_MKL
 #define CAFFE2_SPECIALIZED_AXPBY(T, prefix)              \
   template <>                                            \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                          \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                          \
       const int N,                                       \
       const T alpha,                                     \
       const T* x,                                        \
@@ -447,7 +447,7 @@ CAFFE2_SPECIALIZED_AXPY(float, s)
     cblas_##prefix##axpby(N, alpha, x, 1, beta, y, 1);   \
   }                                                      \
   template <>                                            \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                          \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                          \
       const int N,                                       \
       const T* alpha,                                    \
       const T* x,                                        \
@@ -459,7 +459,7 @@ CAFFE2_SPECIALIZED_AXPY(float, s)
 #else // CAFFE2_USE_MKL
 #define CAFFE2_SPECIALIZED_AXPBY(T, prefix)      \
   template <>                                    \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                  \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                  \
       const int N,                               \
       const T alpha,                             \
       const T* x,                                \
@@ -470,7 +470,7 @@ CAFFE2_SPECIALIZED_AXPY(float, s)
     cblas_##prefix##axpy(N, alpha, x, 1, y, 1);  \
   }                                              \
   template <>                                    \
-  CAFFE2_EXPORT void Axpby<T, T, CPUContext>(                  \
+  C10_EXPORT void Axpby<T, T, CPUContext>(                  \
       const int N,                               \
       const T* alpha,                            \
       const T* x,                                \
@@ -488,7 +488,7 @@ CAFFE2_SPECIALIZED_AXPBY(float, s)
 
 #define CAFFE2_SPECIALIZED_SCALE(TAlpha, TData)                        \
   template <>                                                          \
-  CAFFE2_EXPORT void Scale<TAlpha, TData, CPUContext>(                               \
+  C10_EXPORT void Scale<TAlpha, TData, CPUContext>(                               \
       const int n,                                                     \
       const TAlpha alpha,                                              \
       const TData* x,                                                  \
@@ -498,7 +498,7 @@ CAFFE2_SPECIALIZED_AXPBY(float, s)
         ConstEigenVectorMap<TData>(x, n) * static_cast<TData>(alpha);  \
   }                                                                    \
   template <>                                                          \
-  CAFFE2_EXPORT void Scale<TAlpha, TData, CPUContext>(                               \
+  C10_EXPORT void Scale<TAlpha, TData, CPUContext>(                               \
       const int n,                                                     \
       const TAlpha* alpha,                                             \
       const TData* x,                                                  \
@@ -517,7 +517,7 @@ CAFFE2_SPECIALIZED_SCALE(std::int64_t, std::int64_t)
 #undef CAFFE2_SPECIALIZED_SCALE
 
 template <>
-CAFFE2_EXPORT void GemmBatched<float, CPUContext>(
+C10_EXPORT void GemmBatched<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int batch_size,
@@ -563,7 +563,7 @@ CAFFE2_EXPORT void GemmBatched<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void GemmStridedBatched<float, CPUContext>(
+C10_EXPORT void GemmStridedBatched<float, CPUContext>(
     const CBLAS_TRANSPOSE trans_A,
     const CBLAS_TRANSPOSE trans_B,
     const int batch_size,
@@ -634,7 +634,7 @@ CAFFE2_EXPORT void GemmStridedBatched<float, CPUContext>(
 
 #define DELEGATE_SIMPLE_UNARY_FUNCTION(T, Funcname, OriginalFunc, ...)       \
   template <>                                                                \
-  CAFFE2_EXPORT void Funcname<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
+  C10_EXPORT void Funcname<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
     OriginalFunc(N, x, y, ##__VA_ARGS__);                                    \
   }
 DELEGATE_SIMPLE_UNARY_FUNCTION(
@@ -683,7 +683,7 @@ DELEGATE_SIMPLE_UNARY_FUNCTION(double, Inv, vdInv)
 
 #define DELEGATE_SINCOS_FUNCTION(T, OriginalFunc)           \
   template <>                                               \
-  CAFFE2_EXPORT void SinCos<T, CPUContext>(                               \
+  C10_EXPORT void SinCos<T, CPUContext>(                               \
       const int N, const T* a, T* ys, T* yc, CPUContext*) { \
     OriginalFunc(N, a, ys, yc);                             \
   }
@@ -693,7 +693,7 @@ DELEGATE_SINCOS_FUNCTION(double, vdSinCos)
 
 #define DELEGATE_POWX_FUNCTION(T, OriginalFunc)                               \
   template <>                                                                 \
-  CAFFE2_EXPORT void Powx<T, CPUContext>(const int N, const T* a, T b, T* y, CPUContext*) { \
+  C10_EXPORT void Powx<T, CPUContext>(const int N, const T* a, T b, T* y, CPUContext*) { \
     OriginalFunc(N, a, b, y);                                                 \
   }
 DELEGATE_POWX_FUNCTION(float, vsPowx)
@@ -702,7 +702,7 @@ DELEGATE_POWX_FUNCTION(double, vdPowx)
 
 #define DELEGATE_SIMPLE_BINARY_FUNCTION(T, Func, FuncImpl)      \
   template <>                                                   \
-  CAFFE2_EXPORT void Func<T, CPUContext>(                                     \
+  C10_EXPORT void Func<T, CPUContext>(                                     \
       const int N, const T* A, const T* B, T* C, CPUContext*) { \
     FuncImpl(N, A, B, C);                                       \
   }
@@ -720,7 +720,7 @@ DELEGATE_SIMPLE_BINARY_FUNCTION(double, Div, vdDiv)
 
 #define DELEGATE_SIMPLE_UNARY_FUNCTION(T, Funcname, expr)                    \
   template <>                                                                \
-  CAFFE2_EXPORT void Funcname<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
+  C10_EXPORT void Funcname<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, N) = ConstEigenVectorArrayMap<T>(x, N).expr();      \
   }
 DELEGATE_SIMPLE_UNARY_FUNCTION(float, Exp, exp)
@@ -750,7 +750,7 @@ DELEGATE_SIMPLE_UNARY_FUNCTION(double, Rsqrt, rsqrt)
 
 #define DELEGATE_SINCOS_FUNCTION(T)                                     \
   template <>                                                           \
-  CAFFE2_EXPORT void SinCos<T, CPUContext>(                                           \
+  C10_EXPORT void SinCos<T, CPUContext>(                                           \
       const int N, const T* x, T* ys, T* yc, CPUContext*) {             \
     EigenVectorMap<T>(ys, N) = ConstEigenVectorArrayMap<T>(x, N).sin(); \
     EigenVectorMap<T>(yc, N) = ConstEigenVectorArrayMap<T>(x, N).cos(); \
@@ -761,7 +761,7 @@ DELEGATE_SINCOS_FUNCTION(double)
 
 #define DELEGATE_TANH_FUNCTION(T)                                             \
   template <>                                                                 \
-  CAFFE2_EXPORT void Tanh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) {      \
+  C10_EXPORT void Tanh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) {      \
     EigenVectorMap<T>(Y, N) = T(1) -                                          \
         ((ConstEigenVectorArrayMap<T>(X, N) * T(2)).exp() + T(1)).inverse() * \
             T(2);                                                             \
@@ -772,7 +772,7 @@ DELEGATE_TANH_FUNCTION(double)
 
 #define DELEGATE_CBRT_FUNCTION(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Cbrt<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
+  C10_EXPORT void Cbrt<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
     std::transform(X, X + N, Y, [](const T x) { return cbrt(x); });      \
   }
 DELEGATE_CBRT_FUNCTION(float)
@@ -781,7 +781,7 @@ DELEGATE_CBRT_FUNCTION(double)
 
 #define DELEGATE_POWX_FUNCTION(T)                                       \
   template <>                                                           \
-  CAFFE2_EXPORT void Powx<T, CPUContext>(                                             \
+  C10_EXPORT void Powx<T, CPUContext>(                                             \
       const int N, const T* a, const T b, T* y, CPUContext*) {          \
     EigenVectorMap<T>(y, N) = ConstEigenVectorArrayMap<T>(a, N).pow(b); \
   }
@@ -790,7 +790,7 @@ DELEGATE_POWX_FUNCTION(float)
 
 #define DELEGATE_SINH_FUNCTION(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Sinh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
+  C10_EXPORT void Sinh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
     ConstEigenVectorArrayMap<T> X_arr(X, N);                             \
     EigenVectorMap<T>(Y, N) = (X_arr.exp() - (-X_arr).exp()) / 2;        \
   }
@@ -800,7 +800,7 @@ DELEGATE_SINH_FUNCTION(double)
 
 #define DELEGATE_COSH_FUNCTION(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Cosh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
+  C10_EXPORT void Cosh<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
     ConstEigenVectorArrayMap<T> X_arr(X, N);                             \
     EigenVectorMap<T>(Y, N) = (X_arr.exp() + (-X_arr).exp()) / 2;        \
   }
@@ -810,7 +810,7 @@ DELEGATE_COSH_FUNCTION(double)
 
 #define DELEGATE_INV_FUNCTION(T)                                           \
   template <>                                                              \
-  CAFFE2_EXPORT void Inv<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) {    \
+  C10_EXPORT void Inv<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) {    \
     EigenVectorMap<T>(y, N) = ConstEigenVectorArrayMap<T>(x, N).inverse(); \
   }
 DELEGATE_INV_FUNCTION(float)
@@ -821,7 +821,7 @@ DELEGATE_INV_FUNCTION(double)
 
 #define DELEGATE_NEG_FUNCTION(T)                                        \
   template <>                                                           \
-  CAFFE2_EXPORT void Neg<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
+  C10_EXPORT void Neg<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, N) = -ConstEigenVectorMap<T>(x, N);            \
   }
 DELEGATE_NEG_FUNCTION(float)
@@ -832,7 +832,7 @@ DELEGATE_NEG_FUNCTION(std::int64_t)
 
 #define DELEGATE_SIGN_FUNCTION(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Sign<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
+  C10_EXPORT void Sign<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, N) = ConstEigenVectorArrayMap<T>(x, N).sign();  \
   }
 DELEGATE_SIGN_FUNCTION(float)
@@ -843,7 +843,7 @@ DELEGATE_SIGN_FUNCTION(std::int64_t)
 
 #define DELEGATE_ABS_FUNCTION(T)                                        \
   template <>                                                           \
-  CAFFE2_EXPORT void Abs<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
+  C10_EXPORT void Abs<T, CPUContext>(const int N, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, N) = ConstEigenVectorArrayMap<T>(x, N).abs();  \
   }
 #ifndef CAFFE2_USE_MKL
@@ -856,7 +856,7 @@ DELEGATE_ABS_FUNCTION(std::int64_t)
 
 #define DELEGATE_CUBE_FUNCTION(T)                                        \
   template <>                                                            \
-  CAFFE2_EXPORT void Cube<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
+  C10_EXPORT void Cube<T, CPUContext>(const int N, const T* X, T* Y, CPUContext*) { \
     EigenVectorMap<T>(Y, N) = ConstEigenVectorArrayMap<T>(X, N).cube();  \
   }
 DELEGATE_CUBE_FUNCTION(float)
@@ -867,7 +867,7 @@ DELEGATE_CUBE_FUNCTION(std::int64_t)
 
 #define EIGEN_SIMPLE_BINARY_FUNCTION(T, Func, expr)             \
   template <>                                                   \
-  CAFFE2_EXPORT void Func<T, CPUContext>(                                     \
+  C10_EXPORT void Func<T, CPUContext>(                                     \
       const int N, const T* A, const T* B, T* C, CPUContext*) { \
     EigenVectorMap<T>(C, N) = ConstEigenVectorArrayMap<T>(A, N) \
         expr ConstEigenVectorArrayMap<T>(B, N);                 \
@@ -905,7 +905,7 @@ DEFINE_SIMPLE_BINARY_FUNCTION(Div, /)
 
 #define CAFFE2_SPECIALIZED_SET(T)                                             \
   template <>                                                                 \
-  CAFFE2_EXPORT void Set<T, CPUContext>(const size_t N, const T alpha, T* Y, CPUContext*) { \
+  C10_EXPORT void Set<T, CPUContext>(const size_t N, const T alpha, T* Y, CPUContext*) { \
     if (N == 0) {                                                             \
       return;                                                                 \
     }                                                                         \
@@ -932,7 +932,7 @@ CAFFE2_SPECIALIZED_SET(uint16_t);
 
 #define CAFFE2_SPECIALIZED_REDUCEMIN(T)                \
   template <>                                          \
-  CAFFE2_EXPORT void ReduceMin<T, CPUContext>(                       \
+  C10_EXPORT void ReduceMin<T, CPUContext>(                       \
       const int N,                                     \
       const T* x,                                      \
       T* y,                                            \
@@ -945,7 +945,7 @@ CAFFE2_SPECIALIZED_REDUCEMIN(float)
 
 #define CAFFE2_SPECIALIZED_REDUCEMAX(T)                \
   template <>                                          \
-  CAFFE2_EXPORT void ReduceMax<T, CPUContext>(                       \
+  C10_EXPORT void ReduceMax<T, CPUContext>(                       \
       const int N,                                     \
       const T* x,                                      \
       T* y,                                            \
@@ -991,7 +991,7 @@ struct SquaredL2NormFunctor {
 
 #define DELEGATE_ROWWISE_REDUCE_FUNCTION(Func, EigenOp)                    \
   template <typename T>                                                    \
-  CAFFE2_EXPORT void Rowwise##Func(                                                      \
+  C10_EXPORT void Rowwise##Func(                                                      \
       const int rows, const int cols, const T alpha, const T* X, T* Y) {   \
     EigenVectorMap<T>(Y, rows) =                                           \
         ConstEigenMatrixMap<T>(X, cols, rows).colwise().EigenOp() * alpha; \
@@ -1006,7 +1006,7 @@ DELEGATE_ROWWISE_REDUCE_FUNCTION(ReduceL2, norm)
 
 #define DELEGATE_COLWISE_REDUCE_FUNCTION(Func, EigenOp)                    \
   template <typename T>                                                    \
-  CAFFE2_EXPORT void Colwise##Func(                                                      \
+  C10_EXPORT void Colwise##Func(                                                      \
       const int rows, const int cols, const T alpha, const T* X, T* Y) {   \
     EigenVectorMap<T>(Y, cols) =                                           \
         ConstEigenMatrixMap<T>(X, cols, rows).rowwise().EigenOp() * alpha; \
@@ -1020,7 +1020,7 @@ DELEGATE_COLWISE_REDUCE_FUNCTION(ReduceL2, norm)
 #undef DELEGATE_COLWISE_REDUCE_FUNCTION
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceMin(
+C10_EXPORT void BothEndsReduceMin(
     const int pre,
     const int mid,
     const int nxt,
@@ -1044,7 +1044,7 @@ CAFFE2_EXPORT void BothEndsReduceMin(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceMax(
+C10_EXPORT void BothEndsReduceMax(
     const int pre,
     const int mid,
     const int nxt,
@@ -1066,7 +1066,7 @@ CAFFE2_EXPORT void BothEndsReduceMax(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceSum(
+C10_EXPORT void BothEndsReduceSum(
     const int pre,
     const int mid,
     const int nxt,
@@ -1087,7 +1087,7 @@ CAFFE2_EXPORT void BothEndsReduceSum(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceMean(
+C10_EXPORT void BothEndsReduceMean(
     const int pre,
     const int mid,
     const int nxt,
@@ -1108,7 +1108,7 @@ CAFFE2_EXPORT void BothEndsReduceMean(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceL1(
+C10_EXPORT void BothEndsReduceL1(
     const int pre,
     const int mid,
     const int nxt,
@@ -1135,7 +1135,7 @@ CAFFE2_EXPORT void BothEndsReduceL1(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsReduceL2(
+C10_EXPORT void BothEndsReduceL2(
     const int pre,
     const int mid,
     const int nxt,
@@ -1155,7 +1155,7 @@ CAFFE2_EXPORT void BothEndsReduceL2(
 }
 
 template <typename T, class Reducer>
-CAFFE2_EXPORT void ReduceTensor(
+C10_EXPORT void ReduceTensor(
     const int ndim,
     const int* X_dims,
     const int* Y_dims,
@@ -1183,7 +1183,7 @@ CAFFE2_EXPORT void ReduceTensor(
 
 #define DELEGATE_REDUCE_FUNCTION(T, Func, reducer, init, is_norm)              \
   template <>                                                                  \
-  CAFFE2_EXPORT void Func<T, CPUContext>(                                                    \
+  C10_EXPORT void Func<T, CPUContext>(                                                    \
       const int num_dims,                                                      \
       const int* dims,                                                         \
       const int num_axes,                                                      \
@@ -1325,7 +1325,7 @@ DELEGATE_REDUCE_FUNCTION(
 
 #define CAFFE2_SPECIALIZED_REDUCE_MEAN(T)                                      \
   template <>                                                                  \
-  CAFFE2_EXPORT void ReduceMean<T, CPUContext>(                                              \
+  C10_EXPORT void ReduceMean<T, CPUContext>(                                              \
       const int num_dims,                                                      \
       const int* dims,                                                         \
       const int num_axes,                                                      \
@@ -1392,7 +1392,7 @@ CAFFE2_SPECIALIZED_REDUCE_MEAN(double)
 
 #define CAFFE2_SPECIALIZED_REDUCE_L2(T)                                        \
   template <>                                                                  \
-  CAFFE2_EXPORT void ReduceL2<T, CPUContext>(                                                \
+  C10_EXPORT void ReduceL2<T, CPUContext>(                                                \
       const int num_dims,                                                      \
       const int* dims,                                                         \
       const int num_axes,                                                      \
@@ -1462,7 +1462,7 @@ CAFFE2_SPECIALIZED_REDUCE_L2(double)
 namespace {
 
 template <typename T>
-CAFFE2_EXPORT void BroadcastImpl(
+C10_EXPORT void BroadcastImpl(
     const int X_ndim,
     const int* X_dims,
     const int Y_ndim,
@@ -1495,7 +1495,7 @@ CAFFE2_EXPORT void BroadcastImpl(
 
 #define CAFFE2_SPECIALIZED_BROADCAST(T)                                     \
   template <>                                                               \
-  CAFFE2_EXPORT void Broadcast<T, CPUContext>(                                            \
+  C10_EXPORT void Broadcast<T, CPUContext>(                                            \
       const int X_ndim,                                                     \
       const int* X_dims,                                                    \
       const int Y_ndim,                                                     \
@@ -1515,7 +1515,7 @@ CAFFE2_SPECIALIZED_BROADCAST(double)
 namespace {
 
 template <typename T>
-CAFFE2_EXPORT void RowwiseMoments(
+C10_EXPORT void RowwiseMoments(
     const int rows,
     const int cols,
     const T* X,
@@ -1529,7 +1529,7 @@ CAFFE2_EXPORT void RowwiseMoments(
 }
 
 template <typename T>
-CAFFE2_EXPORT void ColwiseMoments(
+C10_EXPORT void ColwiseMoments(
     const int rows,
     const int cols,
     const T* X,
@@ -1551,7 +1551,7 @@ CAFFE2_EXPORT void ColwiseMoments(
 }
 
 template <typename T>
-CAFFE2_EXPORT void BothEndsMoments(
+C10_EXPORT void BothEndsMoments(
     const int pre,
     const int mid,
     const int nxt,
@@ -1576,7 +1576,7 @@ CAFFE2_EXPORT void BothEndsMoments(
 }
 
 template <typename T>
-CAFFE2_EXPORT void MomentsImpl(
+C10_EXPORT void MomentsImpl(
     const int num_dims,
     const int* dims,
     const int num_axes,
@@ -1643,7 +1643,7 @@ CAFFE2_EXPORT void MomentsImpl(
 
 #define CAFFE2_SPECIALIZED_MOMENTS(T)                                \
   template <>                                                        \
-  CAFFE2_EXPORT void Moments<T, CPUContext>(                                       \
+  C10_EXPORT void Moments<T, CPUContext>(                                       \
       const int num_dims,                                            \
       const int* dims,                                               \
       const int num_axes,                                            \
@@ -1674,7 +1674,7 @@ CAFFE2_SPECIALIZED_INV_STD(float)
 
 #define CAFFE2_SPECIALIZED_ROWWISEMAX(T)                         \
   template <>                                                    \
-  CAFFE2_EXPORT void RowwiseMax<T, CPUContext>(                                \
+  C10_EXPORT void RowwiseMax<T, CPUContext>(                                \
       const int N, const int D, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, N) =                                    \
         ConstEigenMatrixMap<T>(x, D, N).colwise().maxCoeff();    \
@@ -1684,7 +1684,7 @@ CAFFE2_SPECIALIZED_ROWWISEMAX(float)
 
 #define CAFFE2_SPECIALIZED_COLWISEMAX(T)                         \
   template <>                                                    \
-  CAFFE2_EXPORT void ColwiseMax<T, CPUContext>(                                \
+  C10_EXPORT void ColwiseMax<T, CPUContext>(                                \
       const int N, const int D, const T* x, T* y, CPUContext*) { \
     EigenVectorMap<T>(y, D) =                                    \
         ConstEigenMatrixMap<T>(x, D, N).rowwise().maxCoeff();    \
@@ -1694,7 +1694,7 @@ CAFFE2_SPECIALIZED_COLWISEMAX(float)
 
 #define CAFFE2_SPECIALIZED_ELEMWISEMAX(T)                                   \
   template <>                                                               \
-  CAFFE2_EXPORT void ElemwiseMax<T, CPUContext>(                                          \
+  C10_EXPORT void ElemwiseMax<T, CPUContext>(                                          \
       const int N, const T* x, const T* y, T* z, CPUContext* /*context*/) { \
     std::transform(x, x + N, y, z, [](const T& x_i, const T& y_i) {         \
       return std::max(x_i, y_i);                                            \
@@ -1705,7 +1705,7 @@ CAFFE2_SPECIALIZED_ELEMWISEMAX(float)
 
 #define CAFFE2_SPECIALIZED_MAXIMUM(T)                                          \
   template <>                                                                  \
-  CAFFE2_EXPORT void Maximum<T, CPUContext>(                                                 \
+  C10_EXPORT void Maximum<T, CPUContext>(                                                 \
       const int N, const float alpha, const T* x, T* y, CPUContext* context) { \
     std::transform(                                                            \
         x, x + N, y, [&alpha](const T& x_i) { return std::max(x_i, alpha); }); \
@@ -1718,7 +1718,7 @@ CAFFE2_SPECIALIZED_MAXIMUM(float)
 
 #define DELEGATE_EIGEN_2D_BROADCAST_1ST_BINARY_FUNCTION(T, Func, expr) \
   template <>                                                          \
-  CAFFE2_EXPORT void Rowwise##Func<T, CPUContext, true>(                             \
+  C10_EXPORT void Rowwise##Func<T, CPUContext, true>(                             \
       const int rows,                                                  \
       const int cols,                                                  \
       const T* A,                                                      \
@@ -1735,7 +1735,7 @@ CAFFE2_SPECIALIZED_MAXIMUM(float)
     }                                                                  \
   }                                                                    \
   template <>                                                          \
-  CAFFE2_EXPORT void Colwise##Func<T, CPUContext, true>(                             \
+  C10_EXPORT void Colwise##Func<T, CPUContext, true>(                             \
       const int rows,                                                  \
       const int cols,                                                  \
       const T* A,                                                      \
@@ -1755,7 +1755,7 @@ CAFFE2_SPECIALIZED_MAXIMUM(float)
 
 #define DELEGATE_EIGEN_2D_BROADCAST_2ND_BINARY_FUNCTION(T, Func, expr) \
   template <>                                                          \
-  CAFFE2_EXPORT void Rowwise##Func<T, CPUContext, false>(                            \
+  C10_EXPORT void Rowwise##Func<T, CPUContext, false>(                            \
       const int rows,                                                  \
       const int cols,                                                  \
       const T* A,                                                      \
@@ -1772,7 +1772,7 @@ CAFFE2_SPECIALIZED_MAXIMUM(float)
     }                                                                  \
   }                                                                    \
   template <>                                                          \
-  CAFFE2_EXPORT void Colwise##Func<T, CPUContext, false>(                            \
+  C10_EXPORT void Colwise##Func<T, CPUContext, false>(                            \
       const int rows,                                                  \
       const int cols,                                                  \
       const T* A,                                                      \
@@ -1808,7 +1808,7 @@ DEFINE_EIGEN_2D_BROADCAST_BINARY_FUNCTION(Mul, *)
 
 #define DEFINE_EIGEN_2D_BROADCAST_SUB_FUNCTION(T)           \
   template <>                                               \
-  CAFFE2_EXPORT void RowwiseSub<T, CPUContext, true>(                     \
+  C10_EXPORT void RowwiseSub<T, CPUContext, true>(                     \
       const int rows,                                       \
       const int cols,                                       \
       const T* A,                                           \
@@ -1820,7 +1820,7 @@ DEFINE_EIGEN_2D_BROADCAST_BINARY_FUNCTION(Mul, *)
         ConstEigenVectorArrayMap<T>(A, cols);               \
   }                                                         \
   template <>                                               \
-  CAFFE2_EXPORT void ColwiseSub<T, CPUContext, true>(                     \
+  C10_EXPORT void ColwiseSub<T, CPUContext, true>(                     \
       const int rows,                                       \
       const int cols,                                       \
       const T* A,                                           \
@@ -1842,7 +1842,7 @@ DEFINE_EIGEN_2D_BROADCAST_SUB_FUNCTION(std::int64_t)
 
 #define DEFINE_EIGEN_2D_BROADCAST_DIV_FUNCTION(T)                  \
   template <>                                                      \
-  CAFFE2_EXPORT void RowwiseDiv<T, CPUContext, true>(                            \
+  C10_EXPORT void RowwiseDiv<T, CPUContext, true>(                            \
       const int rows,                                              \
       const int cols,                                              \
       const T* A,                                                  \
@@ -1854,7 +1854,7 @@ DEFINE_EIGEN_2D_BROADCAST_SUB_FUNCTION(std::int64_t)
         ConstEigenVectorArrayMap<T>(A, cols);                      \
   }                                                                \
   template <>                                                      \
-  CAFFE2_EXPORT void ColwiseDiv<T, CPUContext, true>(                            \
+  C10_EXPORT void ColwiseDiv<T, CPUContext, true>(                            \
       const int rows,                                              \
       const int cols,                                              \
       const T* A,                                                  \
@@ -1878,7 +1878,7 @@ DELEGATE_EIGEN_2D_BROADCAST_2ND_BINARY_FUNCTION(std::int64_t, Div, /)
 #undef DELEGATE_EIGEN_2D_BROADCAST_2ND_BINARY_FUNCTION
 
 template <>
-CAFFE2_EXPORT void Not<bool, CPUContext>(
+C10_EXPORT void Not<bool, CPUContext>(
     const int N,
     const bool* x,
     bool* y,
@@ -1893,7 +1893,7 @@ CAFFE2_EXPORT void Not<bool, CPUContext>(
 
 #define CAFFE2_SPECIALIZED_CPU_ADD_STRIPED_BATCH(T)             \
   template <>                                                   \
-  CAFFE2_EXPORT void AddStripedBatch(                                         \
+  C10_EXPORT void AddStripedBatch(                                         \
       const int N,                                              \
       const T* first,                                           \
       T* y,                                                     \
@@ -1911,7 +1911,7 @@ CAFFE2_SPECIALIZED_CPU_ADD_STRIPED_BATCH(float);
 namespace {
 
 template <typename TIn, typename TOut, class BinaryOperator, bool kBroadcast1st>
-CAFFE2_EXPORT void RowwiseBinaryOp(
+C10_EXPORT void RowwiseBinaryOp(
     const int rows,
     const int cols,
     const BinaryOperator& op,
@@ -1929,7 +1929,7 @@ CAFFE2_EXPORT void RowwiseBinaryOp(
 }
 
 template <typename TIn, typename TOut, class BinaryOperator, bool kBroadcast1st>
-CAFFE2_EXPORT void ColwiseBinaryOp(
+C10_EXPORT void ColwiseBinaryOp(
     const int rows,
     const int cols,
     const BinaryOperator& op,
@@ -1947,7 +1947,7 @@ CAFFE2_EXPORT void ColwiseBinaryOp(
 }
 
 template <typename TIn, typename TOut, class BinaryOperator>
-CAFFE2_EXPORT void BroadcastBinaryOpImpl(
+C10_EXPORT void BroadcastBinaryOpImpl(
     const int ndim,
     const int* A_dims,
     const int* B_dims,
@@ -1971,7 +1971,7 @@ CAFFE2_EXPORT void BroadcastBinaryOpImpl(
 
 #define DELEGATE_1D_BINARY_FUNCTION(TIn, TOut, Func, Op)               \
   template <>                                                          \
-  CAFFE2_EXPORT void Func<TIn, CPUContext>(                                          \
+  C10_EXPORT void Func<TIn, CPUContext>(                                          \
       const int N, const TIn* A, const TIn* B, TOut* C, CPUContext*) { \
     std::transform(A, A + N, B, C, Op<TIn>());                         \
   }
@@ -2011,7 +2011,7 @@ DEFINE_1D_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
 
 #define DELEGATE_2D_BROADCAST_BINARY_FUNCTION(TIn, TOut, Func, Op)             \
   template <>                                                                  \
-  CAFFE2_EXPORT void Rowwise##Func<TIn, CPUContext, true>(                                   \
+  C10_EXPORT void Rowwise##Func<TIn, CPUContext, true>(                                   \
       const int rows,                                                          \
       const int cols,                                                          \
       const TIn* A,                                                            \
@@ -2021,7 +2021,7 @@ DEFINE_1D_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
     RowwiseBinaryOp<TIn, TOut, Op<TIn>, true>(rows, cols, Op<TIn>(), A, B, C); \
   }                                                                            \
   template <>                                                                  \
-  CAFFE2_EXPORT void Rowwise##Func<TIn, CPUContext, false>(                                  \
+  C10_EXPORT void Rowwise##Func<TIn, CPUContext, false>(                                  \
       const int rows,                                                          \
       const int cols,                                                          \
       const TIn* A,                                                            \
@@ -2032,7 +2032,7 @@ DEFINE_1D_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
         rows, cols, Op<TIn>(), A, B, C);                                       \
   }                                                                            \
   template <>                                                                  \
-  CAFFE2_EXPORT void Colwise##Func<TIn, CPUContext, true>(                                   \
+  C10_EXPORT void Colwise##Func<TIn, CPUContext, true>(                                   \
       const int rows,                                                          \
       const int cols,                                                          \
       const TIn* A,                                                            \
@@ -2042,7 +2042,7 @@ DEFINE_1D_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
     ColwiseBinaryOp<TIn, TOut, Op<TIn>, true>(rows, cols, Op<TIn>(), A, B, C); \
   }                                                                            \
   template <>                                                                  \
-  CAFFE2_EXPORT void Colwise##Func<TIn, CPUContext, false>(                                  \
+  C10_EXPORT void Colwise##Func<TIn, CPUContext, false>(                                  \
       const int rows,                                                          \
       const int cols,                                                          \
       const TIn* A,                                                            \
@@ -2088,7 +2088,7 @@ DEFINE_2D_BROADCAST_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
 
 #define DEFINE_2D_BROADCAST_1ST_DIV_FUNCTION(T)   \
   template <>                                     \
-  CAFFE2_EXPORT void RowwiseDiv<T, CPUContext, true>(           \
+  C10_EXPORT void RowwiseDiv<T, CPUContext, true>(           \
       const int rows,                             \
       const int cols,                             \
       const T* A,                                 \
@@ -2099,7 +2099,7 @@ DEFINE_2D_BROADCAST_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
         rows, cols, std::divides<T>(), A, B, C);  \
   }                                               \
   template <>                                     \
-  CAFFE2_EXPORT void ColwiseDiv<T, CPUContext, true>(           \
+  C10_EXPORT void ColwiseDiv<T, CPUContext, true>(           \
       const int rows,                             \
       const int cols,                             \
       const T* A,                                 \
@@ -2115,7 +2115,7 @@ DEFINE_2D_BROADCAST_1ST_DIV_FUNCTION(std::int64_t)
 
 #define DELEGATE_BROADCAST_BINARY_FUNCTION(TIn, TOut, Func, Op)              \
   template <>                                                                \
-  CAFFE2_EXPORT void Func<TIn, CPUContext>(                                                \
+  C10_EXPORT void Func<TIn, CPUContext>(                                                \
       const int A_ndim,                                                      \
       const int* A_dims,                                                     \
       const int B_ndim,                                                      \
@@ -2258,7 +2258,7 @@ DEFINE_BROADCAST_BITWISE_BINARY_FUNCTION(BitwiseXor, std::bit_xor)
 
 #define CAFFE2_RAND_UNIFORM_REAL(T)                                      \
   template <>                                                            \
-  CAFFE2_EXPORT void RandUniform<T, CPUContext>(                                       \
+  C10_EXPORT void RandUniform<T, CPUContext>(                                       \
       const size_t n, const T a, const T b, T* r, CPUContext* context) { \
     std::uniform_real_distribution<T> distribution(a, b);                \
     for (size_t i = 0; i < n; ++i) {                                     \
@@ -2271,7 +2271,7 @@ CAFFE2_RAND_UNIFORM_REAL(double);
 
 #define CAFFE2_RAND_UNIFORM_CHAR(T)                                        \
   template <>                                                              \
-  CAFFE2_EXPORT void RandUniform<T, CPUContext>(                                         \
+  C10_EXPORT void RandUniform<T, CPUContext>(                                         \
       const size_t n, const T a, const T b, T* r, CPUContext* context) {   \
     std::uniform_int_distribution<short> distribution((short)a, (short)b); \
     for (size_t i = 0; i < n; ++i) {                                       \
@@ -2284,7 +2284,7 @@ CAFFE2_RAND_UNIFORM_CHAR(uint8_t);
 
 #define CAFFE2_RAND_UNIFORM_INT(T)                                       \
   template <>                                                            \
-  CAFFE2_EXPORT void RandUniform<T, CPUContext>(                                       \
+  C10_EXPORT void RandUniform<T, CPUContext>(                                       \
       const size_t n, const T a, const T b, T* r, CPUContext* context) { \
     std::uniform_int_distribution<T> distribution(a, b);                 \
     for (size_t i = 0; i < n; ++i) {                                     \
@@ -2310,7 +2310,7 @@ CAFFE2_RAND_UNIFORM_INT(uint64_t);
 // each value.
 #define CAFFE2_RAND_FIXED_SUM(T)                                        \
   template <>                                                           \
-  CAFFE2_EXPORT void RandFixedSum<T, CPUContext>(                                     \
+  C10_EXPORT void RandFixedSum<T, CPUContext>(                                     \
       const size_t n,                                                   \
       const T a,                                                        \
       const T b,                                                        \
@@ -2404,7 +2404,7 @@ Ind_t generate_stack_distance(
 }
 
 template <class Type, class Val_t, class Ind_t, class Context_t, bool cdf_app>
-CAFFE2_EXPORT void generate_trace_lru(
+C10_EXPORT void generate_trace_lru(
     std::vector<Ind_t>& uni_ref,
     std::vector<Ind_t>& cum_val,
     std::vector<Val_t>& cum_dis,
@@ -2481,7 +2481,7 @@ CAFFE2_EXPORT void generate_trace_lru(
 // case we need to know the table id, to sample from the right distribution
 #define CAFFE2_RAND_SYNTHETIC_DATA(T)                                         \
   template <>                                                                 \
-  CAFFE2_EXPORT void RandSyntheticData<T, CPUContext>(                                      \
+  C10_EXPORT void RandSyntheticData<T, CPUContext>(                                      \
       const size_t n, const T a, const T b, T* r, CPUContext* context) {      \
     /* unique memory references */                                            \
     std::vector<int> mem_ref = {1, 2, 3, 4, 5, 6};                            \
@@ -2520,7 +2520,7 @@ CAFFE2_RAND_SYNTHETIC_DATA(uint64_t);
 
 #define CAFFE2_SPECIALIZED_RAND_UNIFORM_UNIQUE(T)                      \
   template <>                                                          \
-  CAFFE2_EXPORT void RandUniformUnique<T, CPUContext>(                               \
+  C10_EXPORT void RandUniformUnique<T, CPUContext>(                               \
       const size_t n,                                                  \
       const T a,                                                       \
       const T b,                                                       \
@@ -2533,7 +2533,7 @@ CAFFE2_RAND_SYNTHETIC_DATA(uint64_t);
     std::unordered_set<T> avoid_set(n);                                \
     if (m) {                                                           \
       avoid_set.insert(avoid, avoid + m);                              \
-      CAFFE_ENFORCE_EQ(m, avoid_set.size(), "ACAFFE2_EXPORT void should be unique"); \
+      CAFFE_ENFORCE_EQ(m, avoid_set.size(), "AC10_EXPORT void should be unique"); \
     }                                                                  \
     std::uniform_int_distribution<T> distribution(a, b);               \
     T v = 0;                                                           \
@@ -2551,7 +2551,7 @@ CAFFE2_SPECIALIZED_RAND_UNIFORM_UNIQUE(int64_t);
 #undef CAFFE2_SPECIALIZED_RAND_UNIFORM_UNIQUE
 
 template <>
-CAFFE2_EXPORT void RandGaussian<float, CPUContext>(
+C10_EXPORT void RandGaussian<float, CPUContext>(
     const size_t n,
     const float mean,
     const float std,
@@ -2565,7 +2565,7 @@ CAFFE2_EXPORT void RandGaussian<float, CPUContext>(
 
 #define CAFFE2_SPECIALIZED_SUM(T)            \
   template <>                                \
-  CAFFE2_EXPORT void Sum<T, CPUContext>(                   \
+  C10_EXPORT void Sum<T, CPUContext>(                   \
       const int N,                           \
       const T* x,                            \
       T* y,                                  \
@@ -2581,7 +2581,7 @@ CAFFE2_SPECIALIZED_SUM(int64_t);
 #undef CAFFE2_SPECIALIZED_SUM
 
 template <>
-CAFFE2_EXPORT void SumSqr<float, CPUContext>(
+C10_EXPORT void SumSqr<float, CPUContext>(
     const int N,
     const float* x,
     float* y,
@@ -2591,7 +2591,7 @@ CAFFE2_EXPORT void SumSqr<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void Select<float, CPUContext>(
+C10_EXPORT void Select<float, CPUContext>(
     const int N,
     const int D,
     const float* x,
@@ -2605,7 +2605,7 @@ CAFFE2_EXPORT void Select<float, CPUContext>(
 }
 
 template <>
-CAFFE2_EXPORT void CopyMatrix<CPUContext>(
+C10_EXPORT void CopyMatrix<CPUContext>(
     const size_t itemsize,
     const int M,
     const int N,
@@ -2648,7 +2648,7 @@ CAFFE2_EXPORT void CopyMatrix<CPUContext>(
 
 #define DELEGATE_COPY_MATRIX_FUNCTION(T, Func)  \
   template <>                                   \
-  CAFFE2_EXPORT void CopyMatrix<T, CPUContext>(               \
+  C10_EXPORT void CopyMatrix<T, CPUContext>(               \
       const int M,                              \
       const int N,                              \
       const T* A,                               \
@@ -2659,7 +2659,7 @@ CAFFE2_EXPORT void CopyMatrix<CPUContext>(
     Func('R', 'N', M, N, T(1), A, lda, B, ldb); \
   }                                             \
   template <>                                   \
-  CAFFE2_EXPORT void CopyMatrix<T, CPUContext>(               \
+  C10_EXPORT void CopyMatrix<T, CPUContext>(               \
       const int M,                              \
       const int N,                              \
       const T* A,                               \
@@ -2690,7 +2690,7 @@ DELEGATE_COPY_MATRIX_FUNCTION(double, mkl_domatcopy)
 
 #define CAFFE2_SPECIALIZED_COPY_MATRIX(T)                                \
   template <>                                                            \
-  CAFFE2_EXPORT void CopyMatrix<T, CPUContext>(                                        \
+  C10_EXPORT void CopyMatrix<T, CPUContext>(                                        \
       const int M,                                                       \
       const int N,                                                       \
       const T* A,                                                        \
@@ -2720,7 +2720,7 @@ DELEGATE_COPY_MATRIX_FUNCTION(double, mkl_domatcopy)
     }                                                                    \
   }                                                                      \
   template <>                                                            \
-  CAFFE2_EXPORT void CopyMatrix<T, CPUContext>(                                        \
+  C10_EXPORT void CopyMatrix<T, CPUContext>(                                        \
       const int M,                                                       \
       const int N,                                                       \
       const T* A,                                                        \
@@ -2759,7 +2759,7 @@ CAFFE2_SPECIALIZED_COPY_MATRIX(std::uint16_t)
 namespace {
 
 template <typename T>
-CAFFE2_EXPORT void Im2ColZeroPaddingAndNoDilationNCHW(
+C10_EXPORT void Im2ColZeroPaddingAndNoDilationNCHW(
     const int C,
     const int H,
     const int W,
@@ -2806,7 +2806,7 @@ CAFFE2_EXPORT void Im2ColZeroPaddingAndNoDilationNCHW(
 }
 
 template <typename T>
-CAFFE2_EXPORT void Col2ImZeroPaddingAndNoDilationNCHW(
+C10_EXPORT void Col2ImZeroPaddingAndNoDilationNCHW(
     const int C,
     const int H,
     const int W,
@@ -2842,7 +2842,7 @@ CAFFE2_EXPORT void Col2ImZeroPaddingAndNoDilationNCHW(
 }
 
 template <typename T>
-CAFFE2_EXPORT void Im2ColZeroPaddingAndNoDilationNHWC(
+C10_EXPORT void Im2ColZeroPaddingAndNoDilationNHWC(
     const int C,
     const int H,
     const int W,
@@ -2867,7 +2867,7 @@ CAFFE2_EXPORT void Im2ColZeroPaddingAndNoDilationNHWC(
 }
 
 template <typename T>
-CAFFE2_EXPORT void Col2ImZeroPaddingAndNoDilationNHWC(
+C10_EXPORT void Col2ImZeroPaddingAndNoDilationNHWC(
     const int C,
     const int H,
     const int W,
@@ -2894,7 +2894,7 @@ CAFFE2_EXPORT void Col2ImZeroPaddingAndNoDilationNHWC(
 }
 
 template <typename T, bool kCol2Im>
-CAFFE2_EXPORT void Im2ColNdNCHWImpl(
+C10_EXPORT void Im2ColNdNCHWImpl(
     const int N,
     const int img_size,
     const int col_size,
@@ -2950,7 +2950,7 @@ CAFFE2_EXPORT void Im2ColNdNCHWImpl(
 } // namespace
 
 template <>
-CAFFE2_EXPORT void Im2ColNd<float, CPUContext, StorageOrder::NCHW>(
+C10_EXPORT void Im2ColNd<float, CPUContext, StorageOrder::NCHW>(
     const int N,
     const int img_size,
     const int col_size,
@@ -2978,7 +2978,7 @@ CAFFE2_EXPORT void Im2ColNd<float, CPUContext, StorageOrder::NCHW>(
 }
 
 template <>
-CAFFE2_EXPORT void Col2ImNd<float, CPUContext, StorageOrder::NCHW>(
+C10_EXPORT void Col2ImNd<float, CPUContext, StorageOrder::NCHW>(
     const int N,
     const int img_size,
     const int col_size,
@@ -3006,7 +3006,7 @@ CAFFE2_EXPORT void Col2ImNd<float, CPUContext, StorageOrder::NCHW>(
 }
 
 template <>
-CAFFE2_EXPORT void Im2Col<float, CPUContext, StorageOrder::NCHW>(
+C10_EXPORT void Im2Col<float, CPUContext, StorageOrder::NCHW>(
     const int C,
     const int H,
     const int W,
@@ -3072,7 +3072,7 @@ CAFFE2_EXPORT void Im2Col<float, CPUContext, StorageOrder::NCHW>(
 }
 
 template <>
-CAFFE2_EXPORT void Im2Col<float, CPUContext, StorageOrder::NHWC>(
+C10_EXPORT void Im2Col<float, CPUContext, StorageOrder::NHWC>(
     const int C,
     const int H,
     const int W,
@@ -3172,7 +3172,7 @@ CAFFE2_EXPORT void Im2Col<float, CPUContext, StorageOrder::NHWC>(
 }
 
 template <>
-CAFFE2_EXPORT void Col2Im<float, CPUContext, StorageOrder::NCHW>(
+C10_EXPORT void Col2Im<float, CPUContext, StorageOrder::NCHW>(
     const int C,
     const int H,
     const int W,
@@ -3239,7 +3239,7 @@ CAFFE2_EXPORT void Col2Im<float, CPUContext, StorageOrder::NCHW>(
 }
 
 template <>
-CAFFE2_EXPORT void Col2Im<float, CPUContext, StorageOrder::NHWC>(
+C10_EXPORT void Col2Im<float, CPUContext, StorageOrder::NHWC>(
     const int C,
     const int H,
     const int W,
@@ -3335,7 +3335,7 @@ CAFFE2_EXPORT void Col2Im<float, CPUContext, StorageOrder::NHWC>(
 }
 
 template <>
-CAFFE2_EXPORT void BiasCHW<float, CPUContext>(
+C10_EXPORT void BiasCHW<float, CPUContext>(
     const float* bias,
     const float* /*bias_multiplier*/,
     const int bias_channels,
@@ -3420,7 +3420,7 @@ CAFFE2_EXPORT void BiasCHW<float, CPUContext>(
 
 #define CAFFE2_SPECIALIZED_COPYVECTOR(T)                            \
   template <>                                                       \
-  CAFFE2_EXPORT void CopyVector<T, CPUContext>(                                   \
+  C10_EXPORT void CopyVector<T, CPUContext>(                                   \
       const int N, const T* src, T* dst, CPUContext* /*context*/) { \
     if (src != dst && N > 0) {                                      \
       memcpy(dst, src, sizeof(T) * N);                              \
@@ -3633,7 +3633,7 @@ void TransposeCPUImpl(
 
 #define CAFFE2_SPECIALIZED_TRANSPOSE(T)       \
   template <>                                 \
-  CAFFE2_EXPORT void Transpose<T, CPUContext>(              \
+  C10_EXPORT void Transpose<T, CPUContext>(              \
       const int ndim,                         \
       const int* dims,                        \
       const int* axes,                        \

--- a/caffe2/utils/proto_convert.cc
+++ b/caffe2/utils/proto_convert.cc
@@ -3,7 +3,7 @@
 
 namespace caffe2 {
 
-CAFFE2_EXPORT void ArgumentToAttributeProto(
+C10_EXPORT void ArgumentToAttributeProto(
     const Argument& arg,
     ::torch::AttributeProto* attr) {
   CAFFE_ENFORCE(arg.has_name());
@@ -29,7 +29,7 @@ CAFFE2_EXPORT void ArgumentToAttributeProto(
   }
 }
 
-CAFFE2_EXPORT void AttributeProtoToArgument(
+C10_EXPORT void AttributeProtoToArgument(
     const ::torch::AttributeProto& attr,
     Argument* arg) {
   CAFFE_ENFORCE(attr.has_name());
@@ -94,7 +94,7 @@ CAFFE2_EXPORT void AttributeProtoToArgument(
   }
 }
 
-CAFFE2_EXPORT void OperatorDefToNodeProto(
+C10_EXPORT void OperatorDefToNodeProto(
     const OperatorDef& def,
     ::torch::NodeProto* node) {
   node->mutable_input()->CopyFrom(def.input());
@@ -141,7 +141,7 @@ CAFFE2_EXPORT void OperatorDefToNodeProto(
   }
 }
 
-CAFFE2_EXPORT void NodeProtoToOperatorDef(
+C10_EXPORT void NodeProtoToOperatorDef(
     const ::torch::NodeProto& node,
     OperatorDef* def) {
   def->mutable_input()->CopyFrom(node.input());

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -21,11 +21,11 @@ using ::google::protobuf::MessageLite;
 
 namespace caffe2 {
 
-CAFFE2_EXPORT std::string DeviceTypeName(const int32_t& d) {
+C10_EXPORT std::string DeviceTypeName(const int32_t& d) {
   return at::DeviceTypeName(static_cast<at::DeviceType>(d));
 }
 
-CAFFE2_EXPORT int DeviceId(const DeviceOption& option) {
+C10_EXPORT int DeviceId(const DeviceOption& option) {
   switch (option.device_type()) {
     case PROTO_CPU:
       return option.numa_node_id();
@@ -40,7 +40,7 @@ CAFFE2_EXPORT int DeviceId(const DeviceOption& option) {
   }
 }
 
-CAFFE2_EXPORT bool IsSameDevice(const DeviceOption& lhs, const DeviceOption& rhs) {
+C10_EXPORT bool IsSameDevice(const DeviceOption& lhs, const DeviceOption& rhs) {
   return (
       lhs.device_type() == rhs.device_type() &&
       lhs.cuda_gpu_id() == rhs.cuda_gpu_id() &&
@@ -49,7 +49,7 @@ CAFFE2_EXPORT bool IsSameDevice(const DeviceOption& lhs, const DeviceOption& rhs
       lhs.numa_node_id() == rhs.numa_node_id());
 }
 
-CAFFE2_EXPORT bool ReadStringFromFile(const char* filename, string* str) {
+C10_EXPORT bool ReadStringFromFile(const char* filename, string* str) {
   std::ifstream ifs(filename, std::ios::in);
   if (!ifs) {
     VLOG(1) << "File cannot be opened: " << filename
@@ -64,7 +64,7 @@ CAFFE2_EXPORT bool ReadStringFromFile(const char* filename, string* str) {
   return true;
 }
 
-CAFFE2_EXPORT bool WriteStringToFile(const string& str, const char* filename) {
+C10_EXPORT bool WriteStringToFile(const string& str, const char* filename) {
   std::ofstream ofs(filename, std::ios::out | std::ios::trunc);
   if (!ofs.is_open()) {
     VLOG(1) << "File cannot be created: " << filename
@@ -102,11 +102,11 @@ class IfstreamInputStream : public ::google::protobuf::io::CopyingInputStream {
 };
 }  // namespace
 
-CAFFE2_EXPORT string ProtoDebugString(const MessageLite& proto) {
+C10_EXPORT string ProtoDebugString(const MessageLite& proto) {
   return proto.SerializeAsString();
 }
 
-CAFFE2_EXPORT bool ParseProtoFromLargeString(const string& str, MessageLite* proto) {
+C10_EXPORT bool ParseProtoFromLargeString(const string& str, MessageLite* proto) {
   ::google::protobuf::io::ArrayInputStream input_stream(str.data(), str.size());
   ::google::protobuf::io::CodedInputStream coded_stream(&input_stream);
   // Set PlanDef message size limit to 2G.
@@ -114,7 +114,7 @@ CAFFE2_EXPORT bool ParseProtoFromLargeString(const string& str, MessageLite* pro
   return proto->ParseFromCodedStream(&coded_stream);
 }
 
-CAFFE2_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* proto) {
+C10_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* proto) {
   ::google::protobuf::io::CopyingInputStreamAdaptor stream(
       new IfstreamInputStream(filename));
   stream.SetOwnsCopyingStream(true);
@@ -125,7 +125,7 @@ CAFFE2_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* pr
   return proto->ParseFromCodedStream(&coded_stream);
 }
 
-CAFFE2_EXPORT void WriteProtoToBinaryFile(
+C10_EXPORT void WriteProtoToBinaryFile(
     const MessageLite& /*proto*/,
     const char* /*filename*/) {
   LOG(FATAL) << "Not implemented yet.";
@@ -144,16 +144,16 @@ using ::google::protobuf::io::CodedOutputStream;
 using ::google::protobuf::Message;
 
 namespace TextFormat {
-CAFFE2_EXPORT bool ParseFromString(const string& spec, Message* proto) {
+C10_EXPORT bool ParseFromString(const string& spec, Message* proto) {
   return ::google::protobuf::TextFormat::ParseFromString(spec, proto);
 }
 } // namespace TextFormat
 
-CAFFE2_EXPORT string ProtoDebugString(const Message& proto) {
+C10_EXPORT string ProtoDebugString(const Message& proto) {
   return proto.ShortDebugString();
 }
 
-CAFFE2_EXPORT bool ParseProtoFromLargeString(const string& str, Message* proto) {
+C10_EXPORT bool ParseProtoFromLargeString(const string& str, Message* proto) {
   ::google::protobuf::io::ArrayInputStream input_stream(str.data(), str.size());
   ::google::protobuf::io::CodedInputStream coded_stream(&input_stream);
   // Set PlanDef message size limit to 2G.
@@ -161,7 +161,7 @@ CAFFE2_EXPORT bool ParseProtoFromLargeString(const string& str, Message* proto) 
   return proto->ParseFromCodedStream(&coded_stream);
 }
 
-CAFFE2_EXPORT bool ReadProtoFromTextFile(const char* filename, Message* proto) {
+C10_EXPORT bool ReadProtoFromTextFile(const char* filename, Message* proto) {
   int fd = open(filename, O_RDONLY);
   CAFFE_ENFORCE_NE(fd, -1, "File not found: ", filename);
   FileInputStream* input = new FileInputStream(fd);
@@ -171,7 +171,7 @@ CAFFE2_EXPORT bool ReadProtoFromTextFile(const char* filename, Message* proto) {
   return success;
 }
 
-CAFFE2_EXPORT void WriteProtoToTextFile(const Message& proto, const char* filename) {
+C10_EXPORT void WriteProtoToTextFile(const Message& proto, const char* filename) {
   int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   FileOutputStream* output = new FileOutputStream(fd);
   CAFFE_ENFORCE(google::protobuf::TextFormat::Print(proto, output));
@@ -179,7 +179,7 @@ CAFFE2_EXPORT void WriteProtoToTextFile(const Message& proto, const char* filena
   close(fd);
 }
 
-CAFFE2_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* proto) {
+C10_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* proto) {
 #if defined (_MSC_VER)  // for MSC compiler binary flag needs to be specified
   int fd = open(filename, O_RDONLY | O_BINARY);
 #else
@@ -198,7 +198,7 @@ CAFFE2_EXPORT bool ReadProtoFromBinaryFile(const char* filename, MessageLite* pr
   return success;
 }
 
-CAFFE2_EXPORT void WriteProtoToBinaryFile(const MessageLite& proto, const char* filename) {
+C10_EXPORT void WriteProtoToBinaryFile(const MessageLite& proto, const char* filename) {
   int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   CAFFE_ENFORCE_NE(
       fd, -1, "File cannot be created: ", filename, " error number: ", errno);
@@ -214,7 +214,7 @@ CAFFE2_EXPORT void WriteProtoToBinaryFile(const MessageLite& proto, const char* 
 #endif  // CAFFE2_USE_LITE_PROTO
 
 
-CAFFE2_EXPORT ArgumentHelper::ArgumentHelper(const OperatorDef& def) {
+C10_EXPORT ArgumentHelper::ArgumentHelper(const OperatorDef& def) {
   for (auto& arg : def.arg()) {
     if (arg_map_.count(arg.name())) {
       if (arg.SerializeAsString() != arg_map_[arg.name()].SerializeAsString()) {
@@ -235,7 +235,7 @@ CAFFE2_EXPORT ArgumentHelper::ArgumentHelper(const OperatorDef& def) {
   }
 }
 
-CAFFE2_EXPORT ArgumentHelper::ArgumentHelper(const NetDef& netdef) {
+C10_EXPORT ArgumentHelper::ArgumentHelper(const NetDef& netdef) {
   for (auto& arg : netdef.arg()) {
     CAFFE_ENFORCE(
         arg_map_.count(arg.name()) == 0,
@@ -245,7 +245,7 @@ CAFFE2_EXPORT ArgumentHelper::ArgumentHelper(const NetDef& netdef) {
   }
 }
 
-CAFFE2_EXPORT bool ArgumentHelper::HasArgument(const string& name) const {
+C10_EXPORT bool ArgumentHelper::HasArgument(const string& name) const {
   return arg_map_.count(name);
 }
 
@@ -270,7 +270,7 @@ std::ostream& operator<<(std::ostream& output, const NetDef& n) {
 #define INSTANTIATE_GET_SINGLE_ARGUMENT(                                      \
     T, fieldname, enforce_lossless_conversion)                                \
   template <>                                                                 \
-  CAFFE2_EXPORT T ArgumentHelper::GetSingleArgument<T>(                       \
+  C10_EXPORT T ArgumentHelper::GetSingleArgument<T>(                       \
       const string& name, const T& default_value) const {                     \
     if (arg_map_.count(name) == 0) {                                          \
       VLOG(1) << "Using default parameter value " << default_value            \
@@ -297,7 +297,7 @@ std::ostream& operator<<(std::ostream& output, const NetDef& n) {
     return static_cast<T>(value);                                             \
   }                                                                           \
   template <>                                                                 \
-  CAFFE2_EXPORT bool ArgumentHelper::HasSingleArgumentOfType<T>(const string& name) const { \
+  C10_EXPORT bool ArgumentHelper::HasSingleArgumentOfType<T>(const string& name) const { \
     if (arg_map_.count(name) == 0) {                                          \
       return false;                                                           \
     }                                                                         \
@@ -321,7 +321,7 @@ INSTANTIATE_GET_SINGLE_ARGUMENT(NetDef, n, false)
 #define INSTANTIATE_GET_REPEATED_ARGUMENT(                             \
     T, fieldname, enforce_lossless_conversion)                         \
   template <>                                                          \
-  CAFFE2_EXPORT vector<T> ArgumentHelper::GetRepeatedArgument<T>(      \
+  C10_EXPORT vector<T> ArgumentHelper::GetRepeatedArgument<T>(      \
       const string& name, const std::vector<T>& default_value) const { \
     if (arg_map_.count(name) == 0) {                                   \
       return default_value;                                            \
@@ -360,7 +360,7 @@ INSTANTIATE_GET_REPEATED_ARGUMENT(NetDef, nets, false)
 
 #define CAFFE2_MAKE_SINGULAR_ARGUMENT(T, fieldname)                            \
 template <>                                                                    \
-CAFFE2_EXPORT Argument MakeArgument(const string& name, const T& value) {      \
+C10_EXPORT Argument MakeArgument(const string& name, const T& value) {      \
   Argument arg;                                                                \
   arg.set_name(name);                                                          \
   arg.set_##fieldname(value);                                                  \
@@ -375,12 +375,12 @@ CAFFE2_MAKE_SINGULAR_ARGUMENT(string, s)
 #undef CAFFE2_MAKE_SINGULAR_ARGUMENT
 
 template <>
-CAFFE2_EXPORT bool ArgumentHelper::RemoveArgument(OperatorDef& def, int index);
+C10_EXPORT bool ArgumentHelper::RemoveArgument(OperatorDef& def, int index);
 template <>
 bool ArgumentHelper::RemoveArgument(NetDef& def, int index);
 
 template <>
-CAFFE2_EXPORT Argument MakeArgument(const string& name, const MessageLite& value) {
+C10_EXPORT Argument MakeArgument(const string& name, const MessageLite& value) {
   Argument arg;
   arg.set_name(name);
   arg.set_s(value.SerializeAsString());
@@ -389,7 +389,7 @@ CAFFE2_EXPORT Argument MakeArgument(const string& name, const MessageLite& value
 
 #define CAFFE2_MAKE_REPEATED_ARGUMENT(T, fieldname)                            \
 template <>                                                                    \
-CAFFE2_EXPORT Argument MakeArgument(const string& name, const vector<T>& value) {\
+C10_EXPORT Argument MakeArgument(const string& name, const vector<T>& value) {\
   Argument arg;                                                                \
   arg.set_name(name);                                                          \
   for (const auto& v : value) {                                                \
@@ -404,7 +404,7 @@ CAFFE2_MAKE_REPEATED_ARGUMENT(int64_t, ints)
 CAFFE2_MAKE_REPEATED_ARGUMENT(string, strings)
 #undef CAFFE2_MAKE_REPEATED_ARGUMENT
 
-CAFFE2_EXPORT bool HasOutput(const OperatorDef& op, const std::string& output) {
+C10_EXPORT bool HasOutput(const OperatorDef& op, const std::string& output) {
   for (const auto& outp : op.output()) {
     if (outp == output) {
       return true;
@@ -413,7 +413,7 @@ CAFFE2_EXPORT bool HasOutput(const OperatorDef& op, const std::string& output) {
   return false;
 }
 
-CAFFE2_EXPORT bool HasInput(const OperatorDef& op, const std::string& input) {
+C10_EXPORT bool HasInput(const OperatorDef& op, const std::string& input) {
   for (const auto& inp : op.input()) {
     if (inp == input) {
       return true;
@@ -423,7 +423,7 @@ CAFFE2_EXPORT bool HasInput(const OperatorDef& op, const std::string& input) {
 }
 
 // Return the argument index or -1 if it does not exist.
-CAFFE2_EXPORT int GetArgumentIndex(
+C10_EXPORT int GetArgumentIndex(
     const google::protobuf::RepeatedPtrField<Argument>& args,
     const string& name) {
   int index = 0;
@@ -436,7 +436,7 @@ CAFFE2_EXPORT int GetArgumentIndex(
   return -1;
 }
 
-CAFFE2_EXPORT const Argument& GetArgument(const OperatorDef& def, const string& name) {
+C10_EXPORT const Argument& GetArgument(const OperatorDef& def, const string& name) {
   int index = GetArgumentIndex(def.arg(), name);
   if (index != -1) {
     return def.arg(index);
@@ -449,7 +449,7 @@ CAFFE2_EXPORT const Argument& GetArgument(const OperatorDef& def, const string& 
   }
 }
 
-CAFFE2_EXPORT const Argument& GetArgument(const NetDef& def, const string& name) {
+C10_EXPORT const Argument& GetArgument(const NetDef& def, const string& name) {
   int index = GetArgumentIndex(def.arg(), name);
   if (index != -1) {
     return def.arg(index);
@@ -462,7 +462,7 @@ CAFFE2_EXPORT const Argument& GetArgument(const NetDef& def, const string& name)
   }
 }
 
-CAFFE2_EXPORT bool GetFlagArgument(
+C10_EXPORT bool GetFlagArgument(
     const google::protobuf::RepeatedPtrField<Argument>& args,
     const string& name,
     bool default_value) {
@@ -476,21 +476,21 @@ CAFFE2_EXPORT bool GetFlagArgument(
   return default_value;
 }
 
-CAFFE2_EXPORT bool GetFlagArgument(
+C10_EXPORT bool GetFlagArgument(
     const OperatorDef& def,
     const string& name,
     bool default_value) {
   return GetFlagArgument(def.arg(), name, default_value);
 }
 
-CAFFE2_EXPORT bool GetFlagArgument(
+C10_EXPORT bool GetFlagArgument(
     const NetDef& def,
     const string& name,
     bool default_value) {
   return GetFlagArgument(def.arg(), name, default_value);
 }
 
-CAFFE2_EXPORT Argument* GetMutableArgument(
+C10_EXPORT Argument* GetMutableArgument(
     const string& name,
     const bool create_if_missing,
     OperatorDef* def) {

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -194,7 +194,7 @@ CAFFE2_API bool HasInput(const OperatorDef& op, const std::string& input);
  * does not copy the operator def, so one would need to make sure that the
  * lifetime of the OperatorDef object outlives that of the ArgumentHelper.
  */
-class CAFFE2_EXPORT ArgumentHelper {
+class C10_EXPORT ArgumentHelper {
  public:
   template <typename Def>
   static bool HasArgument(const Def& def, const string& name) {

--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -360,7 +360,7 @@ class WorkersPool {
     counter_to_decrement_when_ready_.Wait();
   }
 
-  AT_DISABLE_COPY_AND_ASSIGN(WorkersPool);
+  C10_DISABLE_COPY_AND_ASSIGN(WorkersPool);
   std::vector<std::unique_ptr<Worker, AlignedDeleter<Worker>>> workers_;
   // The BlockingCounter used to wait for the workers.
   BlockingCounter counter_to_decrement_when_ready_;

--- a/caffe2/utils/zmq_helper.h
+++ b/caffe2/utils/zmq_helper.h
@@ -26,7 +26,7 @@ class ZmqContext {
  private:
   void* ptr_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(ZmqContext);
+  C10_DISABLE_COPY_AND_ASSIGN(ZmqContext);
 };
 
 class ZmqMessage {
@@ -48,7 +48,7 @@ class ZmqMessage {
 
  private:
   zmq_msg_t msg_;
-  AT_DISABLE_COPY_AND_ASSIGN(ZmqMessage);
+  C10_DISABLE_COPY_AND_ASSIGN(ZmqMessage);
 };
 
 class ZmqSocket {

--- a/modules/rocksdb/rocksdb.cc
+++ b/modules/rocksdb/rocksdb.cc
@@ -67,7 +67,7 @@ class RocksDBTransaction : public Transaction {
   rocksdb::DB* db_;
   std::unique_ptr<rocksdb::WriteBatch> batch_;
 
-  AT_DISABLE_COPY_AND_ASSIGN(RocksDBTransaction);
+  C10_DISABLE_COPY_AND_ASSIGN(RocksDBTransaction);
 };
 
 class RocksDB : public DB {


### PR DESCRIPTION
TSIA. Right now we should basically use C10_EXPORT and C10_IMPORT for explicitly marking dllexport and dllimport, as a continued effort of the C10 unification.

This is a codemod by mechanically doing the following change:

CAFFE2_{EXPORT,IMPORT} -> C10_{EXPORT,IMPORT}
AT_CORE_{EXPORT,IMPORT} -> C10_{EXPORT,IMPORT}
AT_DISABLE_COPY_AND_ASSIGN -> C10_DISABLE_COPY_AND_ASSIGN

