### PR TITLE
nomnigraph - easy - add some python test helper methods

### DIFF
--- a/caffe2/python/test_util.py
+++ b/caffe2/python/test_util.py
@@ -16,6 +16,28 @@ def rand_array(*dims):
     return np.array(np.random.rand(*dims) - 0.5).astype(np.float32)
 
 
+def randBlob(name, type, *dims, **kwargs):
+    offset = kwargs['offset'] if 'offset' in kwargs else 0.0
+    workspace.FeedBlob(name, np.random.rand(*dims).astype(type) + offset)
+
+
+def randBlobFloat32(name, *dims, **kwargs):
+    randBlob(name, np.float32, *dims, **kwargs)
+
+
+def randBlobsFloat32(names, *dims, **kwargs):
+    for name in names:
+        randBlobFloat32(name, *dims, **kwargs)
+
+
+def str_compare(a, b, encoding="utf8"):
+    if isinstance(a, bytes):
+        a = a.decode(encoding)
+    if isinstance(b, bytes):
+        b = b.decode(encoding)
+    return a == b
+
+
 class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/caffe2/python/transformations_test.py
+++ b/caffe2/python/transformations_test.py
@@ -23,39 +23,32 @@ import hypothesis.strategies as st
 import numpy as np
 
 from caffe2.python.transformations import Transformer
-from caffe2.python import core, workspace, test_util
+from caffe2.python import core, workspace
+from caffe2.python import test_util as tu
 
 transformer = Transformer()
 
 
-def str_compare(a, b, encoding="utf8"):
-    if isinstance(a, bytes):
-        a = a.decode(encoding)
-    if isinstance(b, bytes):
-        b = b.decode(encoding)
-    return a == b
-
-
-class TestTransformations(test_util.TestCase):
+class TestTransformations(tu.TestCase):
     def test_transformer_AddNNPACK(self):
         net = core.Net("net")
         net.Conv(["X", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y"], ["Y2"])
         transformer.AddNNPACK(net)
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
 
     def test_transformer_FuseNNPACKConvRelu(self):
         net = core.Net("net")
         net.Conv(["X", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y"], ["Y2"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 1
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
 
@@ -65,12 +58,12 @@ class TestTransformations(test_util.TestCase):
         net.Relu(["Y"], ["Y2"])
         net.Relu(["Y"], ["Y3"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 3
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation") and str_compare(arg.s, "Relu"):
+            if tu.str_compare(arg.name, "activation") and tu.str_compare(arg.s, "Relu"):
                 has_activation_arg = True
         assert not has_activation_arg
 
@@ -79,13 +72,13 @@ class TestTransformations(test_util.TestCase):
         net.Conv(["X", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y"], ["X"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 1
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
         assert net.Proto().op[0].output[0] != net.Proto().op[0].input[0]
@@ -95,13 +88,13 @@ class TestTransformations(test_util.TestCase):
         net.Conv(["X", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y"], ["Y"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 1
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
         assert net.Proto().op[0].output[0] != net.Proto().op[0].input[0]
@@ -112,13 +105,13 @@ class TestTransformations(test_util.TestCase):
         net.Relu(["Y"], ["X"])
         net.Conv(["X", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 2
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
         assert net.Proto().op[0].output[0] != net.Proto().op[0].input[0]
@@ -131,13 +124,13 @@ class TestTransformations(test_util.TestCase):
         net.Conv(["Y2", "w", "b"], ["Y"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y"], ["Y2"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 2
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
         assert net.Proto().op[0].output[0] != net.Proto().op[0].input[0]
@@ -150,13 +143,13 @@ class TestTransformations(test_util.TestCase):
         net.Conv(["Y", "w", "b"], ["Y2"], stride=1, pad=0, kernel=3, order="NCHW")
         net.Relu(["Y2"], ["Y2"])
         transformer.AddNNPACK(net)  # get the NNPACK engine
-        assert str_compare(net.Proto().op[0].engine, "NNPACK")
+        assert tu.str_compare(net.Proto().op[0].engine, "NNPACK")
         transformer.FuseNNPACKConvRelu(net)
         assert len(net.Proto().op) == 2
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
-            if str_compare(arg.name, "activation"):
-                assert str_compare(arg.s, "Relu")
+            if tu.str_compare(arg.name, "activation"):
+                assert tu.str_compare(arg.s, "Relu")
                 has_activation_arg = True
         assert has_activation_arg
         assert net.Proto().op[0].output[0] != net.Proto().op[0].input[0]
@@ -168,8 +161,8 @@ class TestTransformations(test_util.TestCase):
         net.MaxPool(["Y"], ["Y1"], kernel=3)
         net.Relu(["Y1"], ["Y1"])
         transformer.SinkMaxPool(net)
-        assert str_compare(net.Proto().op[1].type, "Relu")
-        assert str_compare(net.Proto().op[2].type, "MaxPool")
+        assert tu.str_compare(net.Proto().op[1].type, "Relu")
+        assert tu.str_compare(net.Proto().op[2].type, "MaxPool")
 
     @given(
         size=st.integers(7, 10),
@@ -196,18 +189,16 @@ class TestTransformations(test_util.TestCase):
 
         np.random.seed(seed)
         if order == "NCHW":
-            workspace.FeedBlob("X", np.random.rand(1, c, h, w).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, c, k, k).astype(np.float32))
+            tu.randBlobFloat32("X", 1, c, h, w)
+            tu.randBlobFloat32("w", c, c, k, k)
         else:
-            workspace.FeedBlob("X", np.random.rand(1, h, w, c).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, k, k, c).astype(np.float32))
-        workspace.FeedBlob("b", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("scale", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("bias", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("mean", np.random.rand(c).astype(np.float32))
+            tu.randBlobFloat32("X", 1, h, w, c)
+            tu.randBlobFloat32("w", c, k, k, c)
+        tu.randBlobsFloat32(["b", "scale", "bias", "mean"], c)
+
         # This is necessary because 1/sqrt(var) is used and if var is too small
         # we get floating point artifacts that cause test failures
-        workspace.FeedBlob("var", np.random.rand(c).astype(np.float32) + 0.5)
+        tu.randBlobFloat32("var", c, offset=0.5)
         workspace.RunNetOnce(net)
         preTransformOutput = workspace.FetchBlob("Y2").flatten()
         workspace.FeedBlob("Y2", np.zeros((1, 1)))
@@ -250,17 +241,15 @@ class TestTransformations(test_util.TestCase):
 
         np.random.seed(seed)
         if order == "NCHW":
-            workspace.FeedBlob("X", np.random.rand(1, c, h, w).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, c, k, k).astype(np.float32))
+            tu.randBlobFloat32("X", 1, c, h, w)
+            tu.randBlobFloat32("w", c, c, k, k)
         else:
-            workspace.FeedBlob("X", np.random.rand(1, h, w, c).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, k, k, c).astype(np.float32))
-        workspace.FeedBlob("scale", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("bias", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("mean", np.random.rand(c).astype(np.float32))
+            tu.randBlobFloat32("X", 1, h, w, c)
+            tu.randBlobFloat32("w", c, k, k, c)
+        tu.randBlobsFloat32(["scale", "bias", "mean"], c)
         # This is necessary because 1/sqrt(var) is used and if var is too small
         # we get floating point artifacts that cause test failures
-        workspace.FeedBlob("var", np.random.rand(c).astype(np.float32) + 0.5)
+        tu.randBlobFloat32("var", c, offset=0.5)
         workspace.RunNetOnce(net)
         preTransformOutput = workspace.FetchBlob("Y2").flatten()
         workspace.FeedBlob("Y2", np.zeros((1, 1)))
@@ -303,17 +292,15 @@ class TestTransformations(test_util.TestCase):
 
         np.random.seed(seed)
         if order == "NCHW":
-            workspace.FeedBlob("X", np.random.rand(1, c, h, w).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, c, k, k).astype(np.float32))
+            tu.randBlobFloat32("X", 1, c, h, w)
+            tu.randBlobFloat32("w", c, c, k, k)
         else:
-            workspace.FeedBlob("X", np.random.rand(1, h, w, c).astype(np.float32))
-            workspace.FeedBlob("w", np.random.rand(c, k, k, c).astype(np.float32))
-        workspace.FeedBlob("scale", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("_bias0", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("mean", np.random.rand(c).astype(np.float32))
+            tu.randBlobFloat32("X", 1, h, w, c)
+            tu.randBlobFloat32("w", c, k, k, c)
+        tu.randBlobsFloat32(["scale", "_bias0", "mean"], c)
         # This is necessary because 1/sqrt(var) is used and if var is too small
         # we get floating point artifacts that cause test failures
-        workspace.FeedBlob("var", np.random.rand(c).astype(np.float32) + 0.5)
+        tu.randBlobFloat32("var", c, offset=0.5)
         workspace.RunNetOnce(net)
         preTransformOutput = workspace.FetchBlob("Y2").flatten()
         workspace.FeedBlob("Y2", np.zeros((1, 1)))
@@ -366,15 +353,12 @@ class TestTransformations(test_util.TestCase):
         )
 
         np.random.seed(seed)
-        workspace.FeedBlob("X", np.random.rand(1, c, t, h, w).astype(np.float32))
-        workspace.FeedBlob("w", np.random.rand(c, c, kt, kh, kw).astype(np.float32))
-        workspace.FeedBlob("b", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("scale", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("bias", np.random.rand(c).astype(np.float32))
-        workspace.FeedBlob("mean", np.random.rand(c).astype(np.float32))
+        tu.randBlobFloat32("X", 1, c, t, h, w)
+        tu.randBlobFloat32("w", c, c, kt, kh, kw)
+        tu.randBlobsFloat32(["b", "scale", "bias", "mean"], c)
         # This is necessary because 1/sqrt(var) is used and if var is too small
         # we get floating point artifacts that cause test failures
-        workspace.FeedBlob("var", np.random.rand(c).astype(np.float32) + 0.5)
+        tu.randBlobFloat32("var", c, offset=0.5)
         workspace.RunNetOnce(net)
         preTransformOutput = workspace.FetchBlob("Y2").flatten()
         workspace.FeedBlob("Y2", np.zeros((1, 1)))


### PR DESCRIPTION
Summary:
- make it less verbose to create random blobs in python unit test by adding some test helper methods
- move str_compare test helper method to test_util.py

Differential Revision: D10003637
