### PR TITLE
Give default values to members of TensorImpl.

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -174,12 +174,12 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   bool is_variable() const { return is_variable_; };
 
  private:
-  int64_t storage_offset_;
+  int64_t storage_offset_ = 0;
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
 
-  bool is_contiguous_;
-  int64_t numel_;
+  bool is_contiguous_ = true;
+  int64_t numel_ = -1;
 
   int64_t compute_numel() const {
     int64_t n = 1;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12033 Give default values to members of TensorImpl.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10024439/)

These are reasonable sensible default values.  One key
pick is -1 for numel: this is because in Caffe2, a tensor
may be in "un-allocated" with no storage state; this is
historically represented in Caffe2 with numel_ == -1

Differential Revision: [D10024439](https://our.internmc.facebook.com/intern/diff/D10024439/)