### PR TITLE
Replace 'struct Tensor' with 'class Tensor'.

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -22,7 +22,7 @@
 
 namespace at {
 
-struct Tensor;
+class Tensor;
 
 class CAFFE2_API Context {
  public:

--- a/aten/src/ATen/core/Scalar.h
+++ b/aten/src/ATen/core/Scalar.h
@@ -12,7 +12,7 @@
 
 namespace at {
 
-struct Tensor;
+class Tensor;
 
 class CAFFE2_API Scalar {
  public:

--- a/aten/src/ATen/core/ScalarType.h
+++ b/aten/src/ATen/core/ScalarType.h
@@ -188,7 +188,7 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
 }
 
-struct Tensor;
+class Tensor;
 typedef ArrayRef<int64_t> IntList;
 typedef ArrayRef<Tensor> TensorList;
 

--- a/aten/src/ATen/core/SparseTensorRef.h
+++ b/aten/src/ATen/core/SparseTensorRef.h
@@ -2,7 +2,7 @@
 
 namespace at {
 
-struct Tensor;
+class Tensor;
 struct SparseTensorRef {
   explicit SparseTensorRef(const Tensor& t): tref(t) {}
   const Tensor& tref;

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -37,7 +37,8 @@ namespace at {
 //
 // Note that Tensor can also be NULL, i.e. it is not associated with any underlying TensorImpl, and
 // special care must be taken to handle this.
-struct CAFFE2_API Tensor {
+class CAFFE2_API Tensor {
+public:
   Tensor(){};
   Tensor(c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl> tensor_impl)
       : tensor_impl_(std::move(tensor_impl)) {

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -15,7 +15,7 @@
 namespace at {
 struct Generator;
 struct Type;
-struct Tensor;
+class Tensor;
 struct TensorOptions;
 } // namespace at
 

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -16,7 +16,7 @@ namespace at {
 class Scalar;
 struct Type;
 struct Storage;
-struct Tensor;
+class Tensor;
 } // namespace at
 
 namespace at {

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -33,7 +33,7 @@ class Context;
 struct Allocator;
 struct Generator;
 struct Storage;
-struct Tensor;
+class Tensor;
 
 static inline void noop_deleter(void*) {}
 

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -16,7 +16,7 @@
 namespace at {
 struct Generator;
 class Scalar;
-struct Tensor;
+class Tensor;
 struct Type;
 } // namespace at
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -15,7 +15,7 @@
 namespace at {
 struct Generator;
 struct Type;
-struct Tensor;
+class Tensor;
 struct TensorOptions;
 } // namespace at
 
@@ -37,7 +37,8 @@ namespace at {
 //
 // Note that Tensor can also be NULL, i.e. it is not associated with any underlying TensorImpl, and
 // special care must be taken to handle this.
-struct CAFFE2_API Tensor {
+class CAFFE2_API Tensor {
+public:
   Tensor(){};
   Tensor(c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl> tensor_impl)
       : tensor_impl_(std::move(tensor_impl)) {

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -33,7 +33,7 @@ class Context;
 struct Allocator;
 struct Generator;
 struct Storage;
-struct Tensor;
+class Tensor;
 
 static inline void noop_deleter(void*) {}
 

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -6,7 +6,7 @@
 #include "torch/csrc/WindowsTorchApiMacro.h"
 
 namespace at {
-  struct Tensor;
+  class Tensor;
 }
 namespace torch { namespace jit {
 

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -5,7 +5,7 @@
 namespace at {
 struct Type;
 struct Device;
-struct Tensor;
+class Tensor;
 } // namespace at
 
 namespace torch { namespace tensors {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12034 Replace 'struct Tensor' with 'class Tensor'.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10024467/)

We need ATen and Caffe2 to line up, and the rule is
that if you have any private/protected members, you
should declare it as a class.  Class we go.

(There are some other obvious candidates for this treatment,
but I've kept this patch just to Tensor)

Differential Revision: [D10024467](https://our.internmc.facebook.com/intern/diff/D10024467/)