### PR TITLE
Fix "identifier following the 'template' keyword does not refer to a template"

### DIFF
--- a/caffe2/contrib/gloo/allgather_ops.h
+++ b/caffe2/contrib/gloo/allgather_ops.h
@@ -114,7 +114,7 @@ class AllgatherOp final : public Operator<Context> {
     params.size = Input(1).size();
     params.meta = Input(1).meta();
     for (auto i = 0; i < params.inputs.size(); i++) {
-      params.inputs[i] = Input(i + 1).template raw_data();
+      params.inputs[i] = Input(i + 1).raw_data();
     }
     params.outputs.resize(OutputSize());
     params.outputs[0] = Output(0)->raw_mutable_data(params.meta);

--- a/caffe2/contrib/gloo/allreduce_ops.h
+++ b/caffe2/contrib/gloo/allreduce_ops.h
@@ -117,8 +117,8 @@ class AllreduceOp final : public Operator<Context> {
     params.inputs.resize(InputSize() - 1);
     params.outputs.resize(OutputSize());
     for (auto i = 0; i < params.inputs.size(); i++) {
-      params.inputs[i] = Input(i + 1).template raw_data();
-      params.outputs[i] = Output(i)->template raw_mutable_data();
+      params.inputs[i] = Input(i + 1).raw_data();
+      params.outputs[i] = Output(i)->raw_mutable_data();
     }
     params.size = Output(0)->size();
     params.meta = Output(0)->meta();

--- a/caffe2/contrib/gloo/broadcast_ops.h
+++ b/caffe2/contrib/gloo/broadcast_ops.h
@@ -95,8 +95,8 @@ class BroadcastOp final : public Operator<Context> {
     params.inputs.resize(InputSize() - 1);
     params.outputs.resize(OutputSize());
     for (auto i = 0; i < params.inputs.size(); i++) {
-      params.inputs[i] = Input(i + 1).template raw_data();
-      params.outputs[i] = Output(i)->template raw_mutable_data();
+      params.inputs[i] = Input(i + 1).raw_data();
+      params.outputs[i] = Output(i)->raw_mutable_data();
     }
     params.size = Output(0)->size();
     params.meta = Output(0)->meta();

--- a/caffe2/contrib/gloo/reduce_scatter_ops.h
+++ b/caffe2/contrib/gloo/reduce_scatter_ops.h
@@ -108,15 +108,15 @@ class ReduceScatterOp final : public Operator<Context> {
     params.inputs.resize(InputSize() - 2);
     params.outputs.resize(OutputSize() - 1);
     for (auto i = 0; i < params.inputs.size(); i++) {
-      params.inputs[i] = Input(i + 1).template raw_data();
-      params.outputs[i] = Output(i)->template raw_mutable_data();
+      params.inputs[i] = Input(i + 1).raw_data();
+      params.outputs[i] = Output(i)->raw_mutable_data();
     }
     params.size = Output(0)->size();
     params.meta = Output(0)->meta();
 
     // Verify recvCountsSize == comm_size
     CAFFE_ENFORCE_EQ(Input(InputSize() - 1).size(), params.context->size);
-    int* recvCounts = (int*)Input(InputSize() - 1).template raw_data();
+    int* recvCounts = (int*)Input(InputSize() - 1).raw_data();
     recvCounts_.assign(recvCounts, recvCounts + Input(InputSize() - 1).size());
   }
 


### PR DESCRIPTION
Summary:
LLVM trunk emits an error diagnostic when attempting to compile caffe2. The
identifiers following the `template` keywords are not templates, so the use of
the keyword does not make sense in this context.

Differential Revision: D10024531
