### PR TITLE
Introduce type variables to implement generic list operators

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -12,7 +12,7 @@
   _(String) \
   _(TensorList) \
   _(Blob) \
-  _(GenericList) \
+  _(GenericList)
 
 namespace torch { namespace jit {
 

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -1,10 +1,18 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/Formatting.h>
 
-#define TORCH_FORALL_TAGS(_)                                             \
-  _(None)                                                                \
-  _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) \
-      _(TensorList) _(Blob)
+#define TORCH_FORALL_TAGS(_) \
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
+  _(Blob) \
+  _(GenericList) \
 
 namespace torch { namespace jit {
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -35,10 +35,11 @@ struct CAFFE2_API ConstantString final : c10::intrusive_ptr_target {
 
 // non-mutable list
 template <typename Elem>
-struct C10_EXPORT ConstantList final : c10::intrusive_ptr_target {
+struct C10_EXPORT ConstantList : c10::intrusive_ptr_target {
  private:
   const std::vector<Elem> elements_;
  public:
+  typedef Elem ElemType;
   ConstantList(std::vector<Elem> elements_)
   : elements_(std::move(elements_)) {}
   static c10::intrusive_ptr<ConstantList<Elem>> create(std::vector<Elem> elements_) {
@@ -53,10 +54,16 @@ struct C10_EXPORT ConstantList final : c10::intrusive_ptr_target {
 };
 
 struct IValue;
-using Tuple = ConstantList<IValue>;
+struct C10_EXPORT Tuple : public ConstantList<IValue> {
+  using ConstantList<IValue>::ConstantList;
+  static c10::intrusive_ptr<Tuple> create(std::vector<IValue> elements_) {
+    return c10::make_intrusive<Tuple>(std::move(elements_));
+  }
+};
 using IntList = ConstantList<int64_t>;
 using TensorList = ConstantList<at::Tensor>;
 using DoubleList = ConstantList<double>;
+using GenericList = ConstantList<IValue>;
 
 // IValue is the generic tagged union used by the interpreter to hold
 // all value types.
@@ -65,10 +72,18 @@ using DoubleList = ConstantList<double>;
 // to mark whether that type is a subtype of c10::intrusive_ptr_target and needs
 // retain/release calls.
 
-#define TORCH_FORALL_TAGS(_)                                             \
-  _(None)                                                                \
-  _(Tensor) _(Double) _(Int) _(Tuple) _(IntList) _(DoubleList) _(String) \
-      _(TensorList) _(Blob)
+#define TORCH_FORALL_TAGS(_) \
+  _(None) \
+  _(Tensor) \
+  _(Double) \
+  _(Int) \
+  _(Tuple) \
+  _(IntList) \
+  _(DoubleList) \
+  _(String) \
+  _(TensorList) \
+  _(Blob) \
+  _(GenericList) \
 
 struct CAFFE2_API IValue final {
   IValue()
@@ -207,6 +222,7 @@ struct CAFFE2_API IValue final {
   const std::vector<int64_t>& toIntListRef() const;
   const std::vector<double>& toDoubleListRef() const;
   const std::vector<at::Tensor>& toTensorListRef() const;
+  const std::vector<IValue>& toGenericListRef() const;
 
   // ConstantString
   IValue(c10::intrusive_ptr<ConstantString> v);
@@ -245,6 +261,19 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<TensorList> toTensorList() const & {
     AT_ASSERT(isTensorList());
     return toIntrusivePtr<TensorList>();
+  }
+
+  //GenericList
+  IValue(c10::intrusive_ptr<GenericList> v);
+  IValue(std::vector<IValue> v);
+  bool isGenericList() const { return Tag::GenericList == tag; }
+  c10::intrusive_ptr<GenericList> toGenericList() && {
+    AT_ASSERT(isGenericList());
+    return moveToIntrusivePtr<GenericList>();
+  }
+  c10::intrusive_ptr<GenericList> toGenericList() const & {
+    AT_ASSERT(isGenericList());
+    return toIntrusivePtr<GenericList>();
   }
 
   // None
@@ -362,12 +391,14 @@ DEFINE_TO(int64_t, toInt)
 DEFINE_TO(c10::intrusive_ptr<DoubleList>, toDoubleList)
 DEFINE_TO(c10::intrusive_ptr<IntList>, toIntList)
 DEFINE_TO(c10::intrusive_ptr<TensorList>, toTensorList)
+DEFINE_TO(c10::intrusive_ptr<GenericList>, toGenericList)
 DEFINE_TO(c10::intrusive_ptr<ConstantString>, toString)
 DEFINE_TO(at::Scalar, toScalar)
 DEFINE_TO(bool, toInt)
 DEFINE_TO(std::vector<int64_t>, toIntListRef)
 DEFINE_TO(std::vector<double>, toDoubleListRef)
 DEFINE_TO(std::vector<at::Tensor>, toTensorListRef)
+DEFINE_TO(std::vector<IValue>, toGenericListRef)
 
 #undef DEFINE_TO
 
@@ -433,6 +464,14 @@ inline IValue::IValue(c10::intrusive_ptr<TensorList> v)
 inline IValue::IValue(std::vector<at::Tensor> v)
 : IValue(TensorList::create(std::move(v))) {}
 
+inline IValue::IValue(c10::intrusive_ptr<GenericList> v)
+: tag(Tag::GenericList), is_intrusive_ptr(true) {
+  payload.as_intrusive_ptr = v.release();
+}
+inline IValue::IValue(std::vector<IValue> v)
+: IValue(GenericList::create(std::move(v))) {}
+
+
 inline const std::vector<int64_t>& IValue::toIntListRef() const {
   return toIntList()->elements();
 }
@@ -443,6 +482,10 @@ inline const std::vector<double>& IValue::toDoubleListRef() const {
 
 inline const std::vector<at::Tensor>& IValue::toTensorListRef() const {
   return toTensorList()->elements();
+}
+
+inline const std::vector<IValue>& IValue::toGenericListRef() const {
+  return toGenericList()->elements();
 }
 
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -83,7 +83,7 @@ using GenericList = ConstantList<IValue>;
   _(String) \
   _(TensorList) \
   _(Blob) \
-  _(GenericList) \
+  _(GenericList)
 
 struct CAFFE2_API IValue final {
   IValue()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2657,6 +2657,12 @@ class TestScript(JitTestCase):
             return [[4]] + [[4, 5]]
         self.checkScript(foo, ())
 
+    def test_generic_list_errors(self):
+        with self.assertRaisesRegex(RuntimeError, "previously matched to type"):
+            @torch.jit.script
+            def foo(x):
+                return [[x]] + [[1]]
+
     def test_script_cu(self):
         cu = torch.jit.CompilationUnit('''
             def foo(a):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2645,18 +2645,17 @@ class TestScript(JitTestCase):
             return torch.ones(x), x
         self.checkScript(stuff3, ([3, 2],))
 
-    def test_nested_list_error(self):
-        with self.assertRaisesRegex(RuntimeError, "Lists can only contain"):
-            @torch.jit.script
-            def foo(x):
-                # type: (Tuple[List[List[int]]]) -> int
-                return 4
+    def test_nested_list(self):
+        def foo(z):
+            # type: (Tuple[int, List[List[int]]]) -> int
+            x, y = z
+            return y[0][1]
+        self.checkScript(foo, ((1, [[1, 2], [3, 4]]),))
 
-    def test_nested_list_construct_error(self):
-        with self.assertRaisesRegex(RuntimeError, "Lists can only contain"):
-            @torch.jit.script
-            def foo(x):
-                return [[4]]
+    def test_nested_list_construct(self):
+        def foo():
+            return [[4]] + [[4, 5]]
+        self.checkScript(foo, ())
 
     def test_script_cu(self):
         cu = torch.jit.CompilationUnit('''

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -61,7 +61,6 @@ static_assert(sizeof(ArgumentInfo) == sizeof(ArgumentInfo::plain_data_type),
 struct ArgumentSpec {
   ArgumentSpec(bool with_grad, at::ArrayRef<IValue> inputs, size_t num_flat_inputs) {
     hash_code = num_flat_inputs;
-
     args.resize(num_flat_inputs);
     size_t offset = 0;
     for (size_t i = 0; i < inputs.size(); ++i) {

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -564,6 +564,8 @@ void ModuleEncoder::EncodeTypeInfo(
     type_proto->set_denotation("GeneratorType");
   } else if (kind == TypeKind::StringType) {
     type_proto->set_denotation("StringType");
+  } else if (kind == TypeKind::VarType) {
+    type_proto->set_denotation("TypeVar:" + type->expect<VarType>()->name());
   } else {
     throw std::runtime_error("unexpected type kind");
   }

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -260,8 +260,10 @@ TypePtr ModuleDecoder::buildType(const onnx::TypeProto& type_proto) {
     return NoneType::get();
   } else if (kind == "GeneratorType") {
     return GeneratorType::get();
-  }else if (kind == "StringType") {
+  } else if (kind == "StringType") {
     return StringType::get();
+  } else if (kind.find("TypeVar:") == 0) {
+    return VarType::create(kind.substr(strlen("TypeVar:")));
   } else {
     throw std::runtime_error("unexpected string for type kind");
   }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -62,8 +62,14 @@ struct SchemaParser {
     auto tok = L.expect(TK_IDENT);
     auto text = tok.text();
     auto it = type_map.find(text);
-    if(it == type_map.end())
+    if(it == type_map.end()) {
+      if(text.size() > 0 && islower(text[0])) {
+        // lower case identifiers that are not otherwise valid types
+        // are treated as type variables
+        return VarType::create(text);
+      }
       throw ErrorReport(tok.range) << "unknown type specifier";
+    }
     return it->second;
   }
   void parseArgumentType(std::vector<Argument>& arguments) {
@@ -358,9 +364,16 @@ bool Operator::matches(const Node* node) const {
   if(actuals.size() < formals.size())
     return false;
 
+
+  std::unordered_map<std::string, TypePtr> type_env;
   for(size_t i = 0; i < formals.size(); ++i) {
-    // mismatched input type
-    if (!actuals[i]->type()->isSubtypeOf(formals[i].type)) {
+    try {
+      TypePtr formal = matchTypeVariables(formals[i].type, actuals[i]->type(), type_env);
+      // mismatched input type
+      if (!actuals[i]->type()->isSubtypeOf(formal)) {
+        return false;
+      }
+    } catch(TypeMatchError& err) {
       return false;
     }
   }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -365,7 +365,7 @@ bool Operator::matches(const Node* node) const {
     return false;
 
 
-  std::unordered_map<std::string, TypePtr> type_env;
+  TypeEnv type_env;
   for(size_t i = 0; i < formals.size(); ++i) {
     try {
       TypePtr formal = matchTypeVariables(formals[i].type, actuals[i]->type(), type_env);

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -199,6 +199,14 @@ inline py::object toPyObject(IValue&& ivalue) {
     return py::cast(ivalue.toDoubleListRef());
   } else if (ivalue.isTensorList()) {
     return py::cast(ivalue.toTensorListRef());
+  } else if (ivalue.isGenericList()) {
+    auto list = ivalue.toGenericList();
+    const auto & elements = list->elements();
+    py::list t { elements.size() };
+    for (size_t i = 0; i < elements.size(); ++i) {
+      t[i] = toPyObject(IValue{elements[i]});
+    }
+    return t;
   } else if (ivalue.isTuple()) {
     auto tuple = ivalue.toTuple();
     const auto & elements = tuple->elements();

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -142,6 +142,7 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
       }
       case TypeKind::NumberType:
       case TypeKind::GeneratorType:
+      case TypeKind::VarType:
         break;
     }
   AT_ERROR("Missing cases in toIValue for type: ", type->str(), "! File a bug report.");

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -455,6 +455,8 @@ void initPythonIRBindings(PyObject * module_) {
           return "StringType";
         case TypeKind::GeneratorType:
           return "GeneratorType";
+        case TypeKind::VarType:
+          return "VarType";
         }
         // not reachable, but some compilers complain
         AT_ERROR("Unknown Type Kind");

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -519,17 +519,6 @@ Operation listEq(Node* node) {
   };
 }
 
-template<>
-Operation listEq<Shared<GenericList>>(Node* node) {
-  return [=](Stack& stack) {
-    Shared<GenericList> a;
-    Shared<GenericList> b;
-    pop(stack, a, b);
-    AT_ERROR("NYI: compare generic lists");
-    return 0;
-  };
-}
-
 // Specialization for at::Tensor, since it doesn't define operator==
 template <>
 Operation listEq<Shared<TensorList>>(Node* node) {
@@ -623,7 +612,6 @@ RegisterOperators reg2({
 #define CREATE_LIST_OPS(decl_type, c_type) \
     Operator("aten::select(" decl_type "[] a, int b) -> " decl_type, listSelect<Shared<c_type>>), \
     Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
-    Operator("aten::eq(" decl_type "[] a, " decl_type "[] b) -> int", listEq<Shared<c_type>>), \
     Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
     Operator( \
         "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \
@@ -634,6 +622,11 @@ RegisterOperators reg2({
     CREATE_LIST_OPS("float", DoubleList)
     CREATE_LIST_OPS("Tensor", TensorList)
     CREATE_LIST_OPS("t", GenericList)
+
+    Operator("aten::eq(int[] a, int[] b) -> int", listEq<Shared<IntList>>),
+    Operator("aten::eq(float[] a, float[] b) -> int", listEq<Shared<DoubleList>>),
+    Operator("aten::eq(Tensor[] a, Tensor[] b) -> int", listEq<Shared<TensorList>>),
+
 
     DEFINE_BINARY_OP(aten::add, a + b)
     DEFINE_BINARY_OP(aten::sub, a - b)

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -399,9 +399,17 @@ RegisterOperators reg({
               return 0;
             };
           } else {
-            std::stringstream ss;
-            ss << "unsupported list type: " << *lt->getElementType();
-            throw std::runtime_error(ss.str());
+            return [=](Stack& stack) {
+              const size_t stack_size = stack.size();
+              std::vector<IValue> vals;
+              vals.reserve(num_inputs);
+              for (size_t i = stack_size - num_inputs; i < stack_size; ++i) {
+                vals.push_back(std::move(stack[i]));
+              }
+              drop(stack, num_inputs);
+              push(stack, std::move(vals));
+              return 0;
+            };
           }
         }),
 });
@@ -506,11 +514,18 @@ Operation listEq(Node* node) {
     T a;
     T b;
     pop(stack, a, b);
-    if (a->elements() == b->elements()) {
-      push(stack, 1);
-    } else {
-      push(stack, 0);
-    }
+    push(stack, a->elements() == b->elements() ? 1 : 0);
+    return 0;
+  };
+}
+
+template<>
+Operation listEq<Shared<GenericList>>(Node* node) {
+  return [=](Stack& stack) {
+    Shared<GenericList> a;
+    Shared<GenericList> b;
+    pop(stack, a, b);
+    AT_ERROR("NYI: compare generic lists");
     return 0;
   };
 }
@@ -604,31 +619,21 @@ Operation listSlice(Node* node) {
 }
 
 RegisterOperators reg2({
-    Operator("aten::select(int[] a, int b) -> int", listSelect<Shared<IntList>>),
-    Operator("aten::select(float[] a, int b) -> float", listSelect<Shared<DoubleList>>),
-    Operator("aten::select(Tensor[] a, int b) -> Tensor", listSelect<Shared<TensorList>>),
 
-    Operator("aten::len(int[] a) -> int", listLen<Shared<IntList>>),
-    Operator("aten::len(float[] a) -> int", listLen<Shared<DoubleList>>),
-    Operator("aten::len(Tensor[] a) -> int", listLen<Shared<TensorList>>),
+#define CREATE_LIST_OPS(decl_type, c_type) \
+    Operator("aten::select(" decl_type "[] a, int b) -> " decl_type, listSelect<Shared<c_type>>), \
+    Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
+    Operator("aten::eq(" decl_type "[] a, " decl_type "[] b) -> int", listEq<Shared<c_type>>), \
+    Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
+    Operator( \
+        "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \
+        listSlice<Shared<c_type>, c_type::ElemType>),
 
-    Operator("aten::eq(int[] a, int[] b) -> int", listEq<Shared<IntList>>),
-    Operator("aten::eq(float[] a, float[] b) -> int", listEq<Shared<DoubleList>>),
-    Operator("aten::eq(Tensor[] a, Tensor[] b) -> int", listEq<Shared<TensorList>>),
 
-    Operator("aten::add(int[] a, int[] b) -> int[]", listAdd<Shared<IntList>, int64_t>),
-    Operator("aten::add(float[] a, float[] b) -> float[]", listAdd<Shared<DoubleList>, double>),
-    Operator("aten::add(Tensor[] a, Tensor[] b) -> Tensor[]", listAdd<Shared<TensorList>, at::Tensor>),
-
-    Operator(
-        "aten::slice(int[] l, int start, int end=9223372036854775807, int step=1) -> int[]",
-        listSlice<Shared<IntList>, int64_t>),
-    Operator(
-        "aten::slice(float[] l, int start, int end=9223372036854775807, int step=1) -> float[]",
-        listSlice<Shared<DoubleList>, double>),
-    Operator(
-        "aten::slice(Tensor[] l, int start, int end=9223372036854775807, int step=1) -> Tensor[]",
-        listSlice<Shared<TensorList>, at::Tensor>),
+    CREATE_LIST_OPS("int", IntList)
+    CREATE_LIST_OPS("float", DoubleList)
+    CREATE_LIST_OPS("Tensor", TensorList)
+    CREATE_LIST_OPS("t", GenericList)
 
     DEFINE_BINARY_OP(aten::add, a + b)
     DEFINE_BINARY_OP(aten::sub, a - b)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -449,7 +449,8 @@ Value* tryMatchArgument(
     const SourceRange& loc,
     const NamedValue& named_value,
     std::function<std::ostream&()> err,
-    bool convert_tensors_to_nums) {
+    bool convert_tensors_to_nums,
+    std::unordered_map<std::string, TypePtr>& type_env) {
   Value* value = named_value.value(graph);
 
   // some functions that take lists of integers for fixed size arrays
@@ -460,35 +461,44 @@ Value* tryMatchArgument(
     value = graph.insertNode(graph.createList(IntType::get(), repeated))->output();
   }
 
+  TypePtr concrete_type;
+  try {
+    concrete_type = matchTypeVariables(arg.type, value->type(), type_env);
+  } catch(TypeMatchError& e) {
+    err() << "could not match type " << value->type()->str() << " to "
+          << arg.type->str() << " in argument '" << arg.name << "':" << e.what() << "\n"
+          << named_value.locOr(loc);
+    return nullptr;
+  }
+
   // Allow homogeneous tuples to be casted implicitly to lists of appropriate types
-  if (convertibleToList(value->type(), arg.type) &&
+  if (convertibleToList(value->type(), concrete_type) &&
       value->type()->kind() == TypeKind::TupleType) {
     auto unpacked = createTupleUnpack(value);
-    auto elem_type = arg.type->expect<ListType>()->getElementType();
+    auto elem_type = concrete_type->expect<ListType>()->getElementType();
     value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
   }
 
   if (value->node()->kind() == prim::None){
-    if (arg.type->isSubtypeOf(NumberType::get()))
+    if (concrete_type->isSubtypeOf(NumberType::get()))
       value = graph.insertConstant(at::Scalar(NAN), loc);
-    else if (arg.type->isSubtypeOf(GeneratorType::get())) {
-      value = graph.insertNode(graph.createNoneGenerator())
-        ->output()->setType(GeneratorType::get());
+    else if (concrete_type->isSubtypeOf(GeneratorType::get())) {
+      value = graph.insertNode(graph.createNoneGenerator())->output();
     } else
       value = graph.insertNode(graph.createUndefined())->output();
   }
 
   //implicit conversion of tensors to scalars
-  if(convert_tensors_to_nums && arg.type->isSubtypeOf(NumberType::get())
+  if(convert_tensors_to_nums && concrete_type->isSubtypeOf(NumberType::get())
       && value->type()->isSubtypeOf(DynamicType::get())) {
-      auto n = graph.createImplicitTensorToNum(arg.type, value);
+      auto n = graph.createImplicitTensorToNum(concrete_type, value);
       value = graph.insertNode(n)
         ->setSourceLocation(std::make_shared<SourceRange>(loc))
         ->output();
   }
 
-  if(!value->type()->isSubtypeOf(arg.type)) {
-    err() << "expected a value of type " << arg.type->str() << " for argument '" << arg.name << "' but found "
+  if(!value->type()->isSubtypeOf(concrete_type)) {
+    err() << "expected a value of type " << concrete_type->str() << " for argument '" << arg.name << "' but found "
           << value->type()->str() << "\n"
           << named_value.locOr(loc);
     return nullptr;
@@ -510,11 +520,12 @@ Value* tryCreateList(
     const SourceRange& loc,
     at::ArrayRef<NamedValue> varargs,
     std::function<std::ostream&()> err,
-    bool convert_tensor_to_num) {
-  Argument elem_arg("", elem_type);
+    bool convert_tensor_to_num,
+    std::unordered_map<std::string, TypePtr>& type_env) {
+  Argument elem_arg("<varargs>", elem_type);
   std::vector<Value*> list_ctor;
   for(const auto& a : varargs) {
-    Value* av = tryMatchArgument(elem_arg, graph, loc, a, err, convert_tensor_to_num);
+    Value* av = tryMatchArgument(elem_arg, graph, loc, a, err, convert_tensor_to_num, type_env);
     if(!av)
       return nullptr;
     list_ctor.push_back(av);
@@ -537,7 +548,7 @@ static Value* materializeConstant(T val, Graph& graph,
   return new_constant;
 }
 
-at::optional<std::vector<Value*>> tryMatchSchema(
+at::optional<MatchedSchema> tryMatchSchema(
   const FunctionSchema& schema,
   const SourceRange& loc,
   Graph& graph,
@@ -550,6 +561,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
       return failure_messages;
     };
 
+    std::unordered_map<std::string, TypePtr> type_env;
     std::vector<Value*> positional_inputs;
     std::vector<bool> used_kwarg(kwargs.size(), false);
 
@@ -564,16 +576,18 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         // allow zeros(IntList sizes) to work with zeros(1, 2) or zeros(1)
         if (arg.type->kind() == TypeKind::ListType && // the formal must be a list
             !arg.N && // it must not be a broadcasting list like int[3], otherwise a single int is a valid input
-            (schema_i + 1 == schema.arguments.size() || schema.arguments[schema_i + 1].kwarg_only) &&  // must be the last position argument
-            !convertibleToList(args[schema_i].value(graph)->type(), arg.type)) { // and the actual should not be a list already
-          auto elem_type = arg.type->expect<ListType>()->getElementType();
-          Value* list = tryCreateList(elem_type, graph, loc, args.slice(schema_i),
-            err, convert_tensors_to_nums);
-          if(!list)
-            return at::nullopt;
-          used_args = args.size();
-          positional_inputs.push_back(list);
-          continue;
+            (schema_i + 1 == schema.arguments.size() || schema.arguments[schema_i + 1].kwarg_only)) {  // must be the last position argument
+          auto actual_type = args[schema_i].value(graph)->type();
+          if (actual_type->kind() != TypeKind::ListType && !convertibleToList(actual_type, arg.type)) { // and the actual should not be a list already
+            auto elem_type = arg.type->expect<ListType>()->getElementType();
+            Value* list = tryCreateList(elem_type, graph, loc, args.slice(schema_i),
+              err, convert_tensors_to_nums, type_env);
+            if(!list)
+              return at::nullopt;
+            used_args = args.size();
+            positional_inputs.push_back(list);
+            continue;
+          }
         }
 
         v = args[schema_i];
@@ -592,7 +606,7 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         err() << "argument " << schema.arguments[schema_i].name << " not provided.\n" << loc;
         return at::nullopt;
       }
-      Value * positional = tryMatchArgument(arg, graph, loc, *v, err, convert_tensors_to_nums);
+      Value * positional = tryMatchArgument(arg, graph, loc, *v, err, convert_tensors_to_nums, type_env);
       if(!positional)
         return at::nullopt;
       positional_inputs.push_back(positional);
@@ -616,7 +630,10 @@ at::optional<std::vector<Value*>> tryMatchSchema(
         return at::nullopt;
       }
     }
-    return positional_inputs;
+    auto return_type = fmap(schema.returns, [&](const Argument& r) {
+      return evalTypeVariables(r.type, type_env);
+    });
+    return MatchedSchema {std::move(positional_inputs), std::move(return_type) };
 }
 
 
@@ -630,17 +647,17 @@ static Value* tryEmitBuiltin(
   at::ArrayRef<NamedValue> attributes,
   bool convert_tensors_to_nums) {
 
-  auto matched_inputs = tryMatchSchema(op->schema(), loc, graph, inputs, attributes,
+  auto matched_schema = tryMatchSchema(op->schema(), loc, graph, inputs, attributes,
     failure_messages, convert_tensors_to_nums);
-  if(!matched_inputs)
+  if(!matched_schema)
     return nullptr;
   // we successfully matched this schema, construct the node
 
-  auto n = graph.insertNode(graph.create(name, *matched_inputs, 0))
+  auto n = graph.insertNode(graph.create(name, matched_schema->inputs, 0))
                 ->setSourceLocation(std::make_shared<SourceRange>(loc));
 
-  for(auto & ret : op->schema().returns) {
-    n->addOutput()->setType(ret.type);
+  for(auto & ret : matched_schema->return_types) {
+    n->addOutput()->setType(ret);
   }
 
   // assert that we did indeed create an op that has implementation
@@ -791,7 +808,7 @@ struct to_ir {
       // Record the type for the schema and set the Type on the Value*
       arguments.push_back(schema.arguments.at(arg_annotation_idx++));
       new_input->setType(arguments.back().type);
-      ensureLegalType((*it).ident().range(), arguments.back().type);
+      // ensureLegalType((*it).ident().range(), arguments.back().type);
     }
     // body
     auto stmts = def.statements();
@@ -1577,7 +1594,7 @@ private:
         }
         Value* result = graph->insertNode(graph->createList(elem_type, values))
             ->output();
-        ensureLegalType(tree->range(), result->type());
+        // ensureLegalType(tree->range(), result->type());
         return result;
       } break;
       case TK_TUPLE_LITERAL: {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -466,7 +466,7 @@ Value* tryMatchArgument(
     concrete_type = matchTypeVariables(arg.type, value->type(), type_env);
   } catch(TypeMatchError& e) {
     err() << "could not match type " << value->type()->str() << " to "
-          << arg.type->str() << " in argument '" << arg.name << "':" << e.what() << "\n"
+          << arg.type->str() << " in argument '" << arg.name << "': " << e.what() << "\n"
           << named_value.locOr(loc);
     return nullptr;
   }

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -164,7 +164,13 @@ TORCH_API void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> valu
 // if it returns nullopt, then failure_messages contains a good error report
 // set convert_tensor_to_num to true if ImplicitTensorToNums should be inserted to
 // match the schema
-TORCH_API at::optional<std::vector<Value*>> tryMatchSchema(
+
+struct MatchedSchema {
+  std::vector<Value*> inputs;
+  std::vector<TypePtr> return_types;
+};
+
+TORCH_API at::optional<MatchedSchema> tryMatchSchema(
   const FunctionSchema& schema,
   const SourceRange& loc,
   Graph& graph,

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -114,9 +114,9 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     auto schema = getSchema(inputs.size(), n_binders);
 
     std::stringstream failure_messages;
-    at::optional<std::vector<Value*>> all_inputs =
+    at::optional<MatchedSchema> matched_schema =
       tryMatchSchema(schema, loc, *m.graph(), inputs_, attributes, failure_messages, /*conv_tensor_to_num*/true);
-    if (!all_inputs)
+    if (!matched_schema)
       throw ErrorReport(loc) << failure_messages.str();
 
     // Release the function object so we can wrap it in a PythonOp
@@ -125,12 +125,12 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     Node* new_node = m.graph()->insertNode(m.graph()->createPythonOp(
       THPObjectPtr(func.release().ptr()), cconv, {}));
     new_node->setSourceLocation(std::make_shared<SourceRange>(loc));
-    for(auto &i : *all_inputs)
+    for(auto &i : matched_schema->inputs)
       new_node->addInput(i);
 
     std::vector<Value*> outputs;
-    for(auto & ret_arg : schema.returns) {
-      outputs.push_back(new_node->addOutput()->setType(ret_arg.type));
+    for(auto & ret_arg : matched_schema->return_types) {
+      outputs.push_back(new_node->addOutput()->setType(ret_arg));
     }
     return std::make_shared<SimpleValue>(packOutputs(*m.graph(), outputs));
   }

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -48,18 +48,18 @@ std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, Array
   auto fn = callee.graph();
 
   std::stringstream failure_messages;
-  auto all_inputs = tryMatchSchema(
+  auto matched_schema = tryMatchSchema(
     callee.getSchema(),
     loc, *graph(), args, kwargs, failure_messages, /*conv_tensors_to_nums*/true);
-  if(!all_inputs)
+  if(!matched_schema)
     throw ErrorReport(loc) << failure_messages.str();
 
   // parameters to callee method (which become parameters to _this_ method
   // if they were not already)
   for(at::Tensor* member : callee.member_inputs) {
-    all_inputs->push_back(get_or_add_parameter(member));
+    matched_schema->inputs.push_back(get_or_add_parameter(member));
   }
-  return inlineCallTo(*graph(), *callee.graph(), *all_inputs);
+  return inlineCallTo(*graph(), *callee.graph(), matched_schema->inputs);
 }
 
 void Method::ensure_defined() {

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -172,7 +172,7 @@ at::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
   return at::nullopt;
 }
 
-TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, std::unordered_map<std::string, TypePtr>& type_env) {
+TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
   if(!formal->hasFreeVariables())
     return formal;
   if(auto vt = formal->cast<VarType>()) {
@@ -220,7 +220,7 @@ TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, std::unordered_map<st
   AT_ERROR("unhandled free variable container: ", formal->str());
 }
 
-// change return types like List[List[int]] into List[List[int]]
+// change return types like List[List[t]] into List[List[int]]
 TORCH_API TypePtr evalTypeVariables(TypePtr type, std::unordered_map<std::string, TypePtr>& type_env) {
   if(!type->hasFreeVariables())
     return type;

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -55,6 +55,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "string";
   } else if(t.kind() == TypeKind::GeneratorType) {
     out << "Generator";
+  } else if(t.kind() == TypeKind::VarType) {
+    out << t.expect<VarType>()->name();
   } else {
     AT_ERROR("unknown type kind");
   }

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -170,4 +170,71 @@ at::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
   return at::nullopt;
 }
 
+TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, std::unordered_map<std::string, TypePtr>& type_env) {
+  if(!formal->hasFreeVariables())
+    return formal;
+  if(auto vt = formal->cast<VarType>()) {
+    auto it = type_env.find(vt->name());
+    if(it == type_env.end()) {
+      type_env[vt->name()] = actual;
+      return actual;
+    } else if(auto unified = unifyTypes(it->second, actual)) {
+      type_env[vt->name()] = *unified;
+      return *unified;
+    }
+    std::stringstream ss;
+    ss << "type variable '" << vt->name() <<"' previously matched to type " <<
+      it->second->str() << " is matched to type " << actual->str();
+    throw TypeMatchError(ss.str());
+  } else if(auto lt_formal = formal->cast<ListType>()) {
+    if(auto lt_actual = actual->cast<ListType>()) {
+      return ListType::create(matchTypeVariables(lt_formal->getElementType(), lt_actual->getElementType(), type_env));
+    } else {
+      std::stringstream ss;
+      ss << "cannot match a list to " << actual->str();
+      throw TypeMatchError(ss.str());
+    }
+  } else if(auto tp_formal = formal->cast<TupleType>()) {
+    if(auto tp_actual = actual->cast<TupleType>()) {
+      if(tp_formal->elements().size() != tp_actual->elements().size()) {
+        std::stringstream ss;
+        throw TypeMatchError("cannot match tuples of mismatched size");
+      }
+      std::vector<TypePtr> elements;
+      for(size_t i = 0; i < tp_formal->elements().size(); ++i) {
+        TypePtr result = matchTypeVariables(
+            tp_formal->elements()[i],
+            tp_actual->elements()[i],
+            type_env);
+        elements.push_back(result);
+      }
+      return TupleType::create(std::move(elements));
+    } else {
+      std::stringstream ss;
+      ss << "cannot match a tuple to " << actual->str();
+      throw TypeMatchError(ss.str());
+    }
+  }
+  AT_ERROR("unhandled free variable container: ", formal->str());
+}
+
+// change return types like List[List[int]] into List[List[int]]
+TORCH_API TypePtr evalTypeVariables(TypePtr type, std::unordered_map<std::string, TypePtr>& type_env) {
+  if(!type->hasFreeVariables())
+    return type;
+
+  if(auto vt = type->cast<VarType>()) {
+    auto it = type_env.find(vt->name());
+    AT_ASSERTM(it != type_env.end(), "schema has unbound type variable '", vt->name(), "' in its return type");
+    return it->second;
+  } else if(auto lt = type->cast<ListType>()) {
+    return ListType::create(evalTypeVariables(lt->getElementType(), type_env));
+  } else if(auto tp = type->cast<TupleType>()) {
+    return TupleType::create(fmap(tp->elements(), [&](const TypePtr& typ) {
+      return evalTypeVariables(typ, type_env);
+    }));
+  }
+  return type;
+}
+
 }} // namespace torch::jit

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -745,8 +745,8 @@ struct TORCH_API TypeMatchError : public std::exception {
 private:
   std::string msg_;
 };
-
-TORCH_API TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, std::unordered_map<std::string, TypePtr>& type_env);
-TORCH_API TypePtr evalTypeVariables(TypePtr type, std::unordered_map<std::string, TypePtr>& type_env);
+using TypeEnv = std::unordered_map<std::string, TypePtr>;
+TORCH_API TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv & type_env);
+TORCH_API TypePtr evalTypeVariables(TypePtr type, TypeEnv & type_env);
 
 }} // namespace torch::jit

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -27,6 +27,7 @@ _(IntType) \
 _(NoneType) \
 _(StringType) \
 _(GeneratorType) \
+_(VarType)
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -133,6 +134,9 @@ public:
     return r;
   }
   virtual ~Type() = default;
+  virtual bool hasFreeVariables() const {
+    return false;
+  }
 };
 
 inline bool operator!=(const Type & lhs, const Type & rhs) {
@@ -400,6 +404,9 @@ struct TORCH_API ListType : public Type {
   TypePtr getElementType() const {
     return elem;
   }
+  bool hasFreeVariables() const override {
+    return has_free_variables_;
+  }
   // common cast List[Tensor]
   static ListTypePtr ofTensors();
   static ListTypePtr ofInts();
@@ -408,8 +415,11 @@ struct TORCH_API ListType : public Type {
   static const TypeKind Kind = TypeKind::ListType;
 private:
   ListType(TypePtr elem)
-  : Type(TypeKind::ListType), elem(std::move(elem)) {}
+  : Type(TypeKind::ListType)
+  , elem(std::move(elem))
+  , has_free_variables_(getElementType()->hasFreeVariables()) {}
   TypePtr elem;
+  bool has_free_variables_;
 };
 
 struct TupleType;
@@ -461,12 +471,20 @@ struct TORCH_API TupleType : public Type {
     ss << "]";
     return ss.str();
   }
+  bool hasFreeVariables() const override {
+    return has_free_variables_;
+  }
 
   static const TypeKind Kind = TypeKind::TupleType;
 private:
   TupleType(std::vector<TypePtr> elements_)
   : Type(TypeKind::TupleType)
-  , elements_(std::move(elements_)) {}
+  , elements_(std::move(elements_)) {
+    has_free_variables_ =
+        std::any_of(elements_.begin(), elements_.end(), [](TypePtr v) {
+          return v->hasFreeVariables();
+        });
+  }
 
   bool compare(const Type& rhs, std::function<bool(const TypePtr, const TypePtr)> fn) const {
     if(rhs.kind() != kind())
@@ -482,6 +500,7 @@ private:
     return true;
   }
   std::vector<TypePtr> elements_;
+  bool has_free_variables_;
 };
 
 struct NumberType;
@@ -631,6 +650,34 @@ private:
 };
 
 
+// a type variable, used in FunctionSchema
+struct VarType;
+using VarTypePtr = std::shared_ptr<VarType>;
+struct VarType : public Type {
+  static constexpr bool is_singleton = false;
+  template<typename ... T>
+  static VarTypePtr create(std::string name_) {
+    return VarTypePtr(new VarType(std::move(name_)));
+  }
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return name();
+  }
+  static const TypeKind Kind = TypeKind::VarType;
+  const std::string& name() const {
+    return name_;
+  }
+  bool hasFreeVariables() const override {
+    return true;
+  }
+private:
+  VarType(std::string name_)
+  : Type(TypeKind::VarType), name_(name_) {}
+  std::string name_;
+};
+
 TORCH_API std::ostream& operator<<(std::ostream & out, const Type & t);
 // what is the type, ignoring extra size/shape information?
 // e.g. Tensor(2x3) -> Dynamic, and Tuple(Tensor(2x3),...) -> Tuple(Dynamic,...)
@@ -688,5 +735,18 @@ template<> inline TypePtr getTypePtr<std::vector<double>>() { return ListType::o
 template<> inline TypePtr getTypePtr<std::vector<int64_t>>() { return ListType::ofInts(); }
 
 TORCH_API TypePtr inferTypeFrom(const IValue& value);
+
+struct TORCH_API TypeMatchError : public std::exception {
+  TypeMatchError(std::string msg_)
+  : msg_(std::move(msg_)) {}
+  const char * what() const noexcept override {
+    return msg_.c_str();
+  }
+private:
+  std::string msg_;
+};
+
+TORCH_API TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, std::unordered_map<std::string, TypePtr>& type_env);
+TORCH_API TypePtr evalTypeVariables(TypePtr type, std::unordered_map<std::string, TypePtr>& type_env);
 
 }} // namespace torch::jit


### PR DESCRIPTION
We generate specialized list operations for int, float, and Tensor lists so that small lists of integers like the arguments to conv do not involve tons of boxing code.

This PR adds a fallback GenericList for List types that contain any other type. It does so by adding type variables to `jit::Type`, and machinery for matching/replacing the type variables during `tryMatchSchema` and operator lookup.

It also modifies the builtin list ops to include a fallback that works on a GenericList object that simply holds IValues. This is distinguished from IValue's tuple type so that conversion to/from Python still happens losslessly.
