### PR TITLE
Add safety asserts for methods on TensorImpl which don't work on Variable.

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -69,9 +69,11 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   // numbers. Otherwise, they behave like their non-wrapped equivalents.
   // See [Result type computation] in TensorIterator.h.
   bool is_wrapped_number() const {
+    AT_ASSERT(!is_variable());
     return is_wrapped_number_;
   }
   void set_wrapped_number(bool value) {
+    AT_ASSERT(!is_variable());
     AT_ASSERT(dim() == 0);
     is_wrapped_number_ = value;
   }
@@ -97,10 +99,12 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
 
   template <typename T>
   inline T * data() const {
+    AT_ASSERT(!is_variable());
     return storage_.data<T>() + storage_offset_;
   }
 
   inline void* data() const {
+    AT_ASSERT(!is_variable());
     return static_cast<void*>(
         static_cast<char*>(storage_.data()) +
         data_type_.itemsize() * storage_offset_);
@@ -108,6 +112,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
 
   template <typename T>
   inline T * unsafe_data() const {
+    AT_ASSERT(!is_variable());
     return storage_.unsafe_data<T>() + storage_offset_;
   }
 
@@ -155,6 +160,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   // sizes/strides are in bounds for the storage that is allocated;
   // this is the responsibility of the caller
   void set_sizes_and_strides(at::IntList new_size, at::IntList new_stride) {
+    AT_ASSERT(!is_variable());
     AT_CHECK(
         new_size.size() == new_stride.size(),
         "dimensionality of sizes (",
@@ -192,9 +198,11 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
 
  protected:
   void refresh_numel() {
+    AT_ASSERT(!is_variable());
     numel_ = compute_numel();
   }
   void refresh_contiguous() {
+    AT_ASSERT(!is_variable());
     is_contiguous_ = compute_contiguous();
   }
   TensorTypeId type_id_;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12058 Add safety asserts for methods on TensorImpl which don't work on Variable.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10034589/)

Methods on TensorImpl have to be written very carefully, because
when you have a VariableImpl subclass of TensorImpl, usually the
local fields on the TensorImpl are not valid; instead, you have to
forward to the "wrapped" tensor.  Functions which are virtualized
are probably handled correctly by Variable, but functions which
are NOT cannot be handled correctly and shouldn't be called if you
have a Variable.  This diff add checks to determine if this is
the case or not.

Differential Revision: [D10034589](https://our.internmc.facebook.com/intern/diff/D10034589/)