### PR TITLE
[JIT] Adds support for NaN, +inf, -inf float scalars to CPU and CUDA fusers

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2717,18 +2717,23 @@ a")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     @skipIfRocm
     def test_clamp_fusion(self):
-        def func(a, b):
+        def func2(a, b):
             return torch.clamp(a + b, min=0, max=2)
+
+        def funcInf(a, b):
+            return torch.clamp(a + b, min=0, max=float('inf'))
 
         a = torch.randn(4, 4, dtype=torch.float, device='cuda', requires_grad=True)
         b = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        s = self.checkScript(func, (a, b))
-        self.assertAllFused(s.graph_for(a, b))
+        funcs = (func2, funcInf)
+        for f in funcs:
+            s = self.checkScript(f, (a, b))
+            self.assertAllFused(s.graph_for(a, b))
 
-        c = s(a, b)
-        c.sum().backward()
-        self.assertAllFused(backward_graph(s))
+            c = s(a, b)
+            c.sum().backward()
+            self.assertAllFused(backward_graph(s))
 
     def test_mul(self):
         def func(a, b):

--- a/torch/csrc/jit/fusers/common/fused_kernel.cpp
+++ b/torch/csrc/jit/fusers/common/fused_kernel.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <cstdint>
 #include <vector>
+#include <cmath>
 
 namespace torch { namespace jit {
 
@@ -235,9 +236,22 @@ static std::string scalarValue(int64_t v) {
   return std::to_string(v);
 }
 
+// Note: The NAN, NEG_INFINITY and POS_INFINITY strings map to device-specific
+// implementations of these special values. These macros are found in the 
+// resource strings for each device.
 static std::string scalarValue(double v) {
   std::ostringstream out;
-  out << std::scientific << v << "f";
+  if (std::isnan(v)) {
+    out << "NAN";
+  } else if (std::isinf(v)) {
+    if (v < 0) {
+      out << "NEG_INFINITY";
+    } else {
+      out << "POS_INFINITY";
+    }
+  } else {
+    out << std::scientific << v << "f";
+  }
   return out.str();
 }
 

--- a/torch/csrc/jit/fusers/cpu/resource_strings.h
+++ b/torch/csrc/jit/fusers/cpu/resource_strings.h
@@ -11,6 +11,10 @@ Correct code for this case is generated, however, nvrtc does not know how to han
 so typedefs help it handle those cases*/
 
 auto type_declarations_template = CodeTemplate(R"(
+
+#define POS_INFINITY INFINITY
+#define NEG_INFINITY -INFINITY
+
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {

--- a/torch/csrc/jit/fusers/cuda/resource_strings.h
+++ b/torch/csrc/jit/fusers/cuda/resource_strings.h
@@ -18,6 +18,10 @@ typedef long long int int64_t;
 ${HalfHeader}
 ${RandHeader}
 
+#define NAN __int_as_float(0x7fffffff)
+#define POS_INFINITY __int_as_float(0x7f800000)
+#define NEG_INFINITY __int_as_float(0xff800000)
+
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {


### PR DESCRIPTION
In current upstream float scalars are always written into kernels with:

`out << std::scientific << v << "f";`

When the floats are special values like NaN, +inf, or -inf this produces nonsense that causes compilation to fail. This fix updates the conversion of float scalars to device-specific special values. The appropriate macros are added to the CPU and CUDA resource strings. Note that a NAN macro was not necessary on the CPU since math.h defines NAN. 

To verify this fix I updated the test_clamp_fusion test in test_jit.py. I wanted to test -inf, too, but -inf is not currently accepted by the interpreter. 

Edit:

Forgot to mention, this partially addresses issue #12067. 