### PR TITLE
Dispatch backend-specific TensorOptions-based 'factory' functions via…

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -251,13 +251,13 @@ struct AT_CUDA_API DropoutDescriptor
   // Initialize a dropout descriptor's RNG state.
   // WARNING: This function is very expensive, avoid calling this function!
   // NB: it takes a Type so that we can generate a Variable if necessary.
-  void initialize_rng(const Type& type, cudnnHandle_t handle, float dropout, long long int seed) {
+  void initialize_rng(cudnnHandle_t handle, float dropout, long long int seed, const TensorOptions& options) {
     AT_ASSERTM(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
     size_t state_size;
     AT_CUDNN_CHECK(cudnnDropoutGetStatesSize(handle, &state_size));
-    AT_ASSERT(type.is_cuda());
-    AT_ASSERT(type.scalarType() == kByte);
-    state = at::empty({static_cast<int64_t>(state_size)}, type.options());
+    AT_ASSERT(options.device().type() == kCUDA);
+    AT_ASSERT(options.dtype() == kByte);
+    state = at::empty({static_cast<int64_t>(state_size)}, options);
     AT_CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, dropout, state.data_ptr(), state_size, seed));
   }
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -535,13 +535,16 @@ OutputDeclaration = NamedTuple('OutputDeclaration', [
 ])
 
 
-def device_guard(option, formals, is_factory_method=False):
+def device_guard(option, formals, is_factory_method, dispatch_options):
     # For factory methods the `DeviceGuard` is already in the template.
-    if option.get('device_guard', True) and not is_factory_method:
-        tensor_arguments = [f for f in formals if f['dynamic_type'] in {'Tensor', 'TensorList'}]
-        if tensor_arguments:
-            tensor_argument = tensor_arguments[0]['name']
-            return 'const DeviceGuard device_guard({});'.format(tensor_argument)
+    if option.get('device_guard', True):
+        if dispatch_options:
+            return 'const DeviceGuard device_guard({}.device());'.format(dispatch_options['name'])
+        if not is_factory_method:
+            tensor_arguments = [f for f in formals if f['dynamic_type'] in {'Tensor', 'TensorList'}]
+            if tensor_arguments:
+                tensor_argument = tensor_arguments[0]['name']
+                return 'const DeviceGuard device_guard({});'.format(tensor_argument)
     return '// DeviceGuard omitted'
 
 
@@ -826,7 +829,7 @@ def create_generic(top_env, declarations):
         broadcast_arg = get_broadcast_argument(option)
         # "s_" for "same size".
         option['method_prefix_derived'] = '' if broadcast_arg is None else 's_'
-        option['device_guard_declaration'] = device_guard(option, formals)
+        option['device_guard_declaration'] = device_guard(option, formals, False, False)
 
         env = nested_dict(option, top_env)
 
@@ -1039,10 +1042,17 @@ def create_generic(top_env, declarations):
                     return formal
             return None
 
+        type_method_dispatch = option['type_method_definition_dispatch']
         dispatch_tensor = find_dispatch_tensor(formals)
         dispatch_type = None if dispatch_tensor else find_formal('Type', formals)
         if dispatch_type:
             dispatch_type['is_type_dispatched'] = True
+        # we only dispatch via options if there is backend-specific dispatch (otherwise it's a factory function that
+        # can dispatch directly to the native function).
+        backend_dispatch = isinstance(type_method_dispatch, dict)
+        dispatch_options = (find_formal('TensorOptions', formals)
+                            if not dispatch_tensor and not dispatch_type and backend_dispatch
+                            else None)
 
         option['type_method_formals'] = [format_formal(f) for f in formals if f != dispatch_type]
         option['type_method_actuals'] = [f['name'] for f in formals if f != dispatch_type]
@@ -1052,7 +1062,7 @@ def create_generic(top_env, declarations):
 
         is_method = 'method' in option['variants']
         is_namespace_function = 'function' in option['variants']
-        is_factory_method = find_formal('TensorOptions', formals)
+        is_factory_method = find_formal('TensorOptions', formals) and not dispatch_options
         is_deprecated_factory_method = len(formals) > 0 and \
             formals[0]['dynamic_type'] == 'Type' and \
             option['return_type'] == 'Tensor' and option['deprecated']
@@ -1061,7 +1071,7 @@ def create_generic(top_env, declarations):
         check_methods_do_not_start_with_underscore(option['name'], is_method)
 
         option['method_prefix_derived'] = ''
-        option['device_guard_declaration'] = device_guard(option, formals, is_factory_method)
+        option['device_guard_declaration'] = device_guard(option, formals, is_factory_method, dispatch_options)
 
         env = nested_dict(option, top_env)
 
@@ -1079,8 +1089,7 @@ def create_generic(top_env, declarations):
                 top_env['pure_virtual_type_method_declarations'].append(
                     PURE_VIRTUAL_TYPE_METHOD_DECLARATION.substitute(env))
             top_env['type_method_declarations'].append(TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
-        dispatch = option['type_method_definition_dispatch']
-        option['native_type_method_dispatch'] = dispatch
+        option['native_type_method_dispatch'] = type_method_dispatch
 
         # Note [Abstract ATen methods]
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1091,7 +1100,7 @@ def create_generic(top_env, declarations):
         # we just implement it in the base Type.  This is exposed
         # in Declarations.yaml via a field named 'abstract'.
         abstract = False
-        if isinstance(dispatch, dict):
+        if isinstance(type_method_dispatch, dict):
             abstract = True
             top_env['type_method_definitions'].append(
                 TYPE_METHOD_DEFINITION_ABSTRACT.substitute(env))
@@ -1106,10 +1115,10 @@ def create_generic(top_env, declarations):
 
         # generate the at::native function declarations (i.e. what the user will implement)
         if needs_native_definition:
-            if isinstance(dispatch, dict):
+            if isinstance(type_method_dispatch, dict):
                 generated_native_functions = []  # type: List[str]
-                for key in sorted(dispatch.keys()):
-                    value = dispatch[key]
+                for key in sorted(type_method_dispatch.keys()):
+                    value = type_method_dispatch[key]
                     if value not in generated_native_functions:
                         option['native_type_method_dispatch'] = value
                         top_env['native_function_declarations'].append(
@@ -1132,6 +1141,8 @@ def create_generic(top_env, declarations):
                 option['inferred_type'] = 'static_cast<const TypeExtendedInterface&>({})'.format(dispatch_type['name'])
             elif dispatch_tensor:
                 option['inferred_type'] = 'detail::infer_type({})'.format(dispatch_tensor)
+            elif dispatch_options:
+                option['inferred_type'] = 'at::getType({})'.format(dispatch_options['name'])
             else:
                 # doesn't depend on a specific type, use undefined float
                 option['inferred_type'] = 'at::getNonVariableType(at::Backend::Undefined, at::ScalarType::Float)'

--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -136,7 +136,7 @@ Tensor& addmm_(Tensor& self, const Tensor& mat1, const Tensor& mat2, Scalar beta
 
 Tensor tensor(const Type& dtype) {
   if (_type_has_native(dtype)) {
-    return at::getType(dtype.options()).native_tensor({0});
+    return at::getType(dtype.options()).native_tensor({0}, dtype.options());
   } else {
     return at::getType(dtype.options()).th_tensor();
   }
@@ -144,7 +144,7 @@ Tensor tensor(const Type& dtype) {
 
 Tensor tensor(const Type& dtype, ArrayRef<int64_t> size) {
   if (_type_has_native(dtype)) {
-    return at::getType(dtype.options()).native_tensor(size);
+    return at::getType(dtype.options()).native_tensor(size, dtype.options());
   } else {
     return at::getType(dtype.options()).th_tensor(size);
   }
@@ -159,8 +159,8 @@ Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values, ArrayRef<i
 }
 
 Tensor sparse_coo_tensor(ArrayRef<int64_t> size, const TensorOptions& options) {
-  TensorOptions toptions = options;
-  return at::getType(toptions.layout(at::kSparse)).native_sparse_coo_tensor(size);
+  TensorOptions toptions = TensorOptions(options).layout(at::kSparse);
+  return at::getType(toptions).native_sparse_coo_tensor(size, toptions);
 }
 
 Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values, const TensorOptions& options) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -103,10 +103,15 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor empty(IntList size, const TensorOptions& options) {
-  // Note [Native bindings for legacy TH factory functions]
-  // Can't call a factory function, because the buck stops with us!
-  return getFactoryType(options).tensor(size);
+Tensor empty_cpu(IntList size, const TensorOptions& options) {
+  AT_ASSERT(options.backend() == Backend::CPU);
+  AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'
+  auto storage_impl = c10::make_intrusive<StorageImpl>(
+    scalarTypeToTypeMeta(options.dtype()), 0, at::getCPUAllocator(), true);
+
+  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId(), false);
+  tensor.resize_(size);
+  return tensor;
 }
 
 Tensor& empty_out(Tensor& result, IntList size) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/CUDAEvent.h>
 #include <ATen/native/RNN.h>
+#include <ATen/InitialTensorOptions.h>
 #include <ATen/TensorUtils.h>
 
 #if !AT_CUDNN_ENABLED()
@@ -51,7 +52,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
   AT_ERROR("_cudnn_rnn_backward: ATen not compiled with cuDNN support");
 }
 
-Tensor _cudnn_init_dropout_state(const Type& ty, double dropout, bool train, int64_t dropout_seed) {
+Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, const TensorOptions& options) {
   AT_ERROR("_cudnn_init_dropout_state: ATen not compiled with cuDNN support");
 }
 
@@ -436,7 +437,7 @@ namespace {
           // TODO: The use of CPU tensor here is a bit goofy in C++,
           // some sort of alloca would be good enough except that it is
           // kind of convenient to be able to prod() on it.
-          Tensor filter_dim_a = at::CPU(kInt).tensor(min_dim);
+          Tensor filter_dim_a = at::empty(min_dim, at::initialTensorOptions().dtype(kInt));
           AT_CUDNN_CHECK(cudnnGetFilterNdDescriptor(
                 lin_layer_mat_desc.desc(),
                 min_dim,
@@ -1060,11 +1061,11 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
 
 // TODO: I am not sure if we actually need the 'dropout' and 'train' parameters
 // to initialize just the state tensor
-Tensor _cudnn_init_dropout_state(const Type& ty, double dropout, bool train, int64_t dropout_seed) {
+Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, const TensorOptions& options) {
   auto handle = getCudnnHandle();
   DropoutDescriptor dropout_desc;
   auto dropout_p = train ? dropout : 0;
-  dropout_desc.initialize_rng(ty, handle, dropout_p, dropout_seed);
+  dropout_desc.initialize_rng(handle, dropout_p, dropout_seed, options);
   return dropout_desc.state;
 }
 
@@ -1131,7 +1132,7 @@ struct DropoutState {
   }
 };
 
-DropoutState& get_dropout_state(const Type& tp, double dropout_p, bool train) {
+DropoutState& get_dropout_state(double dropout_p, bool train, TensorOptions options) {
   // Each state is slightly over 2MB and initialized lazily, so it's fine to cache them.
   static std::vector<DropoutState> ten_dropout_state_cache { static_cast<size_t>(cuda::getNumGPUs()) };
   static std::vector<DropoutState> var_dropout_state_cache { static_cast<size_t>(cuda::getNumGPUs()) };
@@ -1139,13 +1140,13 @@ DropoutState& get_dropout_state(const Type& tp, double dropout_p, bool train) {
 
   int device = cuda::current_device();
   std::unique_lock<std::mutex> lock {state_cache_mut};
-  auto& state = tp.is_variable() ? var_dropout_state_cache.at(device)
-                                 : ten_dropout_state_cache.at(device);
+  auto& state = options.is_variable() ? var_dropout_state_cache.at(device)
+                                      : ten_dropout_state_cache.at(device);
   if (train && dropout_p > 0 && !state.buffer.defined()) {
     std::unique_lock<std::mutex> lock {state.mutex};
     int64_t seed = at::empty({}, at::kLong).random_().item<int64_t>();
     state.buffer = at::_cudnn_init_dropout_state(
-      tp.toScalarType(at::kByte), dropout_p, train, seed);
+      dropout_p, train, seed, options.dtype(at::kByte));
     // NB: CUDA binds the event to a device at creation time, so we can initialize it
     // only now, when we know we're on the correct device.
     state.event.emplace();
@@ -1221,7 +1222,7 @@ std::pair<Tensor, hidden_type> _cudnn_impl(
   AT_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
   IntList batch_sizes { _batch_sizes.data<int64_t>(), static_cast<size_t>(_batch_sizes.size(0)) };
 
-  auto & dropout_state = get_dropout_state(input.type(), dropout_p, train);
+  auto & dropout_state = get_dropout_state(dropout_p, train, input.options());
   std::unique_lock<DropoutState> lock { dropout_state };
   // cudnn_output = std::tuple<output, hy, cy, reserve, new_weight_buf>
   auto cudnn_output = at::_cudnn_rnn(
@@ -1248,7 +1249,7 @@ std::pair<Tensor, hidden_type> _cudnn_impl(
     AT_WARN(WEIGHT_FORMAT_WARN);
   }
 
-  auto & dropout_state = get_dropout_state(input.type(), dropout_p, train);
+  auto & dropout_state = get_dropout_state(dropout_p, train, input.options());
   std::unique_lock<DropoutState> lock { dropout_state };
   // cudnn_output = std::tuple<output, hy, cy, reserve, new_weight_buf>
   auto cudnn_output = at::_cudnn_rnn(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -45,7 +45,7 @@
   dispatch:
     CUDA: _cudnn_rnn_backward
 
-- func: _cudnn_init_dropout_state(Type self_ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
+- func: _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, TensorOptions options) -> Tensor
   dispatch:
     CUDA: _cudnn_init_dropout_state
 
@@ -652,6 +652,12 @@
     CUDA: _embedding_bag_dense_backward_cuda
 
 - func: empty(IntList size, TensorOptions options={}) -> Tensor
+  cpu_half: True
+  dispatch:
+    CPU: empty_cpu
+    CUDA: empty_cuda
+    SparseCPU: empty_sparse
+    SparseCUDA: empty_sparse
 
 - func: empty_out(Tensor result, IntList size) -> Tensor
 
@@ -1919,13 +1925,13 @@
 - func: addmm_(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: method
 
-- func: native_tensor(Type self_ty, IntList size) -> Tensor
+- func: native_tensor(IntList size, TensorOptions options) -> Tensor
   variants: []
   dispatch:
     SparseCPU: new_with_size_sparse
     SparseCUDA: new_with_size_sparse
 
-- func: tensor(Type dtype, IntList size) -> Tensor
+- func: tensor(IntList size, TensorOptions options) -> Tensor
   variants: []
 
 
@@ -1940,7 +1946,7 @@
 # just only ever dispatch to CPULongTensor or CUDALongTensor, but that
 # seems a bit too finely balanced.)
 
-- func: native_sparse_coo_tensor(Type self_ty, IntList size) -> Tensor
+- func: native_sparse_coo_tensor(IntList size, TensorOptions options) -> Tensor
   variants: []
   dispatch:
     SparseCPU: new_with_size_sparse

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -59,18 +59,17 @@ Tensor _values_sparse(const SparseTensor& self) {
  ******************************************************************************/
 
 /* Empty init */
-SparseTensor new_sparse(const SparseType& dtype) {
-  AT_ASSERT(!dtype.is_undefined());
-  AT_ASSERT(!dtype.is_variable());
-  AT_ASSERT(dtype.is_sparse());
+SparseTensor new_sparse(const TensorOptions& options) {
+  AT_ASSERT(!options.is_variable());
+  AT_ASSERT(options.layout() == kSparse);
   TensorTypeId type_id;
-  if (dtype.is_cuda()) {
+  if (options.device().is_cuda()) {
     type_id = SparseCUDATensorId();
   } else {
     type_id = SparseCPUTensorId();
   }
   return detail::make_tensor<SparseTensorImpl>(
-      type_id, scalarTypeToTypeMeta(dtype.scalarType()));
+      type_id, scalarTypeToTypeMeta(options.dtype()));
 }
 
 /*** Helper methods ***/
@@ -123,8 +122,8 @@ SparseTensor new_with_tensor_sparse(const LongTensor& indices, const Tensor& val
   return _new_with_dims_and_tensor_sparse(dtype, sparseDims, denseDims, computed_sizes, indices, values);
 }
 
-SparseTensor new_with_dims_and_size_sparse(const SparseType& dtype, int64_t sparseDims, int64_t denseDims, ArrayRef<int64_t> size) {
-  SparseTensor self = new_sparse(dtype);
+SparseTensor new_with_dims_and_size_sparse(int64_t sparseDims, int64_t denseDims, ArrayRef<int64_t> size, const TensorOptions& options) {
+  SparseTensor self = new_sparse(options);
   AT_CHECK(size.size() != 0,
     "cannot construct sparse tensor with 0 dimensions and no values; you must specify at least 1 dimension if you want to create a sparse tensor with no elements, \
 or you must provide a single-element `values` tensor (e.g. x = torch.sparse_coo_tensor(torch.zeros(0, 1), 12.3, [])) if you want to create a scalar sparse tensor");
@@ -132,8 +131,25 @@ or you must provide a single-element `values` tensor (e.g. x = torch.sparse_coo_
   return self;
 }
 
-SparseTensor new_with_size_sparse(const SparseType& dtype, ArrayRef<int64_t> size) {
-  return new_with_dims_and_size_sparse(dtype, size.size(), 0, size);
+Tensor empty_sparse(IntList size, const TensorOptions& options) {
+  AT_CHECK(size.size() != 0,
+    "cannot construct sparse tensor with 0 dimensions and no values; you must specify at least 1 dimension if you want to create a sparse tensor with no elements, \
+     or you must provide a single-element `values` tensor (e.g. x = torch.sparse_coo_tensor(torch.zeros(0, 1), 12.3, [])) if you want to create a scalar sparse tensor");
+  AT_ASSERT(!options.is_variable());
+  AT_ASSERT(options.layout() == kSparse);
+  TensorTypeId type_id;
+  if (options.device().type() == kCUDA) {
+    type_id = SparseCUDATensorId();
+  } else {
+    type_id = SparseCPUTensorId();
+  }
+  auto tensor = Tensor(c10::make_intrusive<SparseTensorImpl>(type_id, scalarTypeToTypeMeta(options.dtype())));
+  _get_sparse_impl(tensor)->resize_and_clear_(size.size(), 0, size);
+  return tensor;
+}
+
+SparseTensor new_with_size_sparse(IntList size, const TensorOptions& options) {
+  return new_with_dims_and_size_sparse(size.size(), 0, size, options);
 }
 
 // NOTE: new_with_tensor_and_size_unsafe_sparse() differs from new_with_tensor_and_size_sparse()
@@ -205,7 +221,7 @@ SparseTensor new_with_tensor_and_size_sparse(const LongTensor& indices, const Te
 // NB: Deleted newWithSizeNd variants
 
 SparseTensor clone_sparse(const SparseTensor& self) {
-  SparseTensor other = new_with_dims_and_size_sparse(self.type(), self._sparseDims(), self._denseDims(), self.sizes());
+  SparseTensor other = new_with_dims_and_size_sparse(self._sparseDims(), self._denseDims(), self.sizes(), self.options());
   _copy_into_sparse(other, _get_sparse_impl(self)->indices(), _get_sparse_impl(self)->values(), true);
   _get_sparse_impl(other)->set_coalesced(self.is_coalesced());
   return other;
@@ -285,7 +301,7 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
     factor *= self.size(d);
   }
 
-  SparseTensor dst = new_sparse(self.type());
+  SparseTensor dst = new_sparse(self.options());
   _get_sparse_impl(dst)->resize_(sparseDims, denseDims, self.sizes());
   // TODO: is there a more idiomatic way to do this?
   LongTensor newIndices = at::empty(indices.sizes(), indices.options());

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -30,7 +30,7 @@ Tensor TypeDefault::copy(const Tensor & src, bool non_blocking, optional<Device>
   }
   AT_CHECK(src.defined(), "attempt to copy an undefined tensor");
   Tensor r;
-  if (is_sparse()) r = this->native_tensor({0});
+  if (is_sparse()) r = this->native_tensor({0}, this->options());
   else r = at::empty(src.sizes(), this->options());
   r.copy_(src, non_blocking);
   return r;

--- a/aten/src/ATen/test/cudnn_test.cpp
+++ b/aten/src/ATen/test/cudnn_test.cpp
@@ -14,7 +14,7 @@ TEST(CUDNNTest, CUDNNTestCUDA) {
 #if CUDNN_VERSION < 7000
   auto handle = getCudnnHandle();
   DropoutDescriptor desc1, desc2;
-  desc1.initialize_rng(at::CUDA(kByte), handle, 0.5, 42);
+  desc1.initialize_rng(handle, 0.5, 42, TensorOptions().device(DeviceType::CUDA).dtype(kByte));
   desc2.set(handle, 0.5, desc1.state);
   bool isEQ;
   isEQ = (desc1.desc()->dropout == desc2.desc()->dropout);

--- a/test/cpp_extensions/complex_registration_extension.cpp
+++ b/test/cpp_extensions/complex_registration_extension.cpp
@@ -43,7 +43,7 @@ struct CPUComplexFloatType : public at::CPUTypeDefault {
   Tensor& _s_copy_from(const Tensor& self, Tensor& dst, bool non_blocking)
       const override;
 
-  Tensor tensor(IntList size) const override {
+  Tensor empty(IntList size, const TensorOptions & options) const override {
     // TODO: Upstream this
     int64_t numel = 1;
     for (auto s : size) {

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -34,7 +34,8 @@ def gen_variable_factories(out, declarations, template_path):
     function_definitions = []
     for decl in declarations:
         has_tensor_options = any(a["simple_type"] == "TensorOptions" for a in decl["arguments"])
-        if has_tensor_options or decl["name"].endswith("_like"):
+        is_namespace_fn = 'namespace' in decl['method_of']
+        if (has_tensor_options or decl["name"].endswith("_like")) and is_namespace_fn:
             function_definitions.append(process_function(decl, has_tensor_options))
     write(out,
           "variable_factories.h",

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -93,6 +93,9 @@ ${return_type} VariableType::${method_prefix_derived}${api_name}(${type_method_f
 UNPACK_TENSOR = CodeTemplate("""\
 auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
 
+UNPACK_OPTIONS = CodeTemplate("""\
+auto ${arg_name}_ = TensorOptions(${arg_name}).is_variable(false);""")
+
 DECLARE_GRAD_FN = CodeTemplate("""\
 std::shared_ptr<${op}> grad_fn;
 """)
@@ -271,9 +274,11 @@ def gen_variable_type_shard(out, aten_declarations, template_path, suffix, heade
     type_definitions = []
 
     for declaration in aten_declarations:
-        # Factory methods shall not appear in `VariableType` at all, since they
-        # don't dispatch via `Type`.
-        if any(arg['simple_type'] == 'TensorOptions' for arg in declaration['arguments']):
+        # Factory methods usually do not appear in `VariableType` at all, since they
+        # don't dispatch via `Type`; except in the case where the implementation is 'abstract'
+        # in which case they do!
+        if (not declaration['abstract'] and
+                any(arg['simple_type'] == 'TensorOptions' for arg in declaration['arguments'])):
             continue
         type_declarations.append(METHOD_DECLARATION.substitute(declaration))
         if declaration['name'] not in MANUAL_IMPLEMENTATIONS:
@@ -311,6 +316,8 @@ def emit_body(declaration):
 
     # These exclude things like BoolTensor, int64_t, and Scalar
     def is_differentiable(arg):
+        if 'TensorOptions' in arg['type']:
+            return False
         if 'Tensor' not in arg['type']:
             return False
         if arg['dynamic_type'] in {'IndexTensor', 'BoolTensor'}:
@@ -564,16 +571,23 @@ def unpack_args(env, declaration):
             continue
 
         dynamic_type = arg['dynamic_type']
-        is_nullable = arg.get('is_nullable', False)
-        ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensorRef']
-        suffix = '_opt' if is_nullable else ''
+        if 'TensorOptions' not in dynamic_type:
+            is_nullable = arg.get('is_nullable', False)
+            ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensorRef']
+            suffix = '_opt' if is_nullable else ''
 
-        body.append(UNPACK_TENSOR.substitute(
-            arg_name=arg['name'],
-            arg_pos=i,
-            suffix=suffix,
-            ref='&' if ref else '',
-        ))
+            body.append(UNPACK_TENSOR.substitute(
+                arg_name=arg['name'],
+                arg_pos=i,
+                suffix=suffix,
+                ref='&' if ref else '',
+            ))
+        else:
+            # Okay, we are abusing the definition of 'unpack' here a bit,
+            # although it's stll getting the non-variable from the variable
+            # (in this case via TensorOptions rather than Variable/Tensor).
+            body.append(UNPACK_OPTIONS.substitute(arg_name=arg['name']))
+
         unpacked_args.append(arg['name'] + '_')
 
     env['unpacked_args'] = unpacked_args

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -26,6 +26,7 @@ using at::ScalarType;
 using at::Storage;
 using at::Tensor;
 using at::TensorList;
+using at::TensorOptions;
 using at::Type;
 using at::ScalarType;
 using at::optional;


### PR DESCRIPTION
… Type.

This allows one to write a cpu/cuda split 'factory' function that uses TensorOptions.
Also move all remaining native_functions with either function or method variants that use Type to use TensorOptions.
Thus, there are no more Types in the public function / method API.

I believe there is a _lot_ of opportunity for cleanup here, as the old tensor, th_tensor, native_tensor and sparse variants can probably be removed, but let's do that in a follow-on patch.

