### PR TITLE
Move TensorImpl::ShareExternalPointer helper overloads to caffe2::Tensor

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -653,42 +653,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     storage_offset_ = src.storage_offset();
   }
 
-  /**
-   * @brief Shares the data with an externally managed pointer.
-   *
-   * This is similar to ShareData() but the source is a pointer with an advanced
-   * deleter option. In default, no deletion takes place, and one needs to make
-   * sure that the external memory is deallocated only after the tensor finishes
-   * using it. If a Deleter object is passed in, when this tensor is reallocated
-   * or freed, the deleter function is going to be called.
-   */
-  template <typename T>
-  void
-  ShareExternalPointer(T* src, size_t capacity = 0, caffe2::MemoryDeleter d = nullptr) {
-    ShareExternalPointer((void*)src, caffe2::TypeMeta::Make<T>(), capacity, d);
-  }
-
-  template <typename T>
-  void ShareExternalPointer(at::DataPtr&& data_ptr, size_t capacity = 0) {
-    ShareExternalPointer(std::move(data_ptr), caffe2::TypeMeta::Make<T>(), capacity);
-  }
-
-  void ShareExternalPointer(
-      void* src,
-      const caffe2::TypeMeta& data_type,
-      size_t capacity = 0,
-      caffe2::MemoryDeleter d = nullptr) {
-    CAFFE_ENFORCE_WITH_CALLER(
-        is_contiguous_,
-        "Right now ShareExternalPointer is only supported for contiguos Tensor.");
-    CAFFE_ENFORCE_WITH_CALLER(
-        data_type.id() != caffe2::TypeIdentifier::uninitialized(),
-        "To share with a raw external pointer you need to pass in an "
-        "initialized data_type(TypeMeta).");
-    ShareExternalPointer(
-        at::DataPtr(src, src, d, device_type()), data_type, capacity);
-  }
-
   void ShareExternalPointer(
       at::DataPtr&& data_ptr,
       const caffe2::TypeMeta& data_type,


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11970 Make ATen-core and caffe2 mutually recursive / merge template data<T>()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9967509/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11971 Merge TensorImpl.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D9995559/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #11972 Merge UndefinedTensorImpl.&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D9995633/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12087 Rename TensorImpl::GetDeviceType to device_type, and properly test if is_variable&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10050781/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12089 Move ExtendTo to caffe2::Tensor from TensorImpl&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10050859/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12090 Move TensorImpl::ShrinkTo to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10050905/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12091 Move TensorImpl::ResizeLike to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051012/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12092 Fix bug where Reshape() trashes strides.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051005/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12094 Move TensorImpl::Reshape(vector<int>) to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051079/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12095 Move TensorImpl::DebugString() to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051078/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12096 Move TensorImpl::ShareExternalPointer helper overloads to caffe2::Tensor**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051126/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12097 Implement caffe2::Tensor::raw_data() in terms of data()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051202/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12098 Move TensorImpl ndim, size, itemsize and nbytes to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051298/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12099 Move TensorImpl size_from_dim, size_to_dim, size_between_dim, canonical_axis_index to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051365/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #12100 Move TensorImpl IsType, meta, dim32, dim, ExtractDeviceOption to caffe2::Tensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10051424/)



Differential Revision: [D10051126](https://our.internmc.facebook.com/intern/diff/D10051126/)