### PR TITLE
Caffe 2 adoption

### DIFF
--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -596,7 +596,7 @@ int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...)
 {
   int curDev = -1;
   THCudaCheck(cudaGetDevice(&curDev));
-  va_list(args);
+  va_list args;
   va_start(args, nTensors);
   int valid = 1;
   for (unsigned int i = 0; i < nTensors; i++) {

--- a/caffe2/operators/rnn/recurrent_op_cudnn.cc
+++ b/caffe2/operators/rnn/recurrent_op_cudnn.cc
@@ -458,13 +458,13 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
     if (mode == SET_PARAM) {
       CAFFE_ENFORCE_EQ(
           biasDims[0] * biasDims[1] * biasDims[2], Input(2).size());
-      context_.template CopySameDevice<T>(
+      this->context_.template CopySameDevice<T>(
           biasDims[0] * biasDims[1] * biasDims[2],
           Input(2).template data<T>(),
           static_cast<T*>(bias));
     } else {
       Output(0)->Resize(biasDims);
-      context_.template CopySameDevice<T>(
+      this->context_.template CopySameDevice<T>(
           biasDims[0] * biasDims[1] * biasDims[2],
           static_cast<T*>(bias),
           Output(0)->template mutable_data<T>());
@@ -495,13 +495,13 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
     CAFFE_ENFORCE_EQ(numDims, 3);
     if (mode == SET_PARAM) {
       CAFFE_ENFORCE_EQ(matDims[0] * matDims[1] * matDims[2], Input(2).size());
-      context_.template CopySameDevice<T>(
+      this->context_.template CopySameDevice<T>(
           matDims[0] * matDims[1] * matDims[2],
           Input(2).template data<T>(),
           static_cast<T*>(pmatrix));
     } else {
       Output(0)->Resize(matDims);
-      context_.template CopySameDevice<T>(
+      this->context_.template CopySameDevice<T>(
           matDims[0] * matDims[1] * matDims[2],
           static_cast<T*>(pmatrix),
           Output(0)->template mutable_data<T>());


### PR DESCRIPTION
Summary:
Adapt Caffe 2 to platform007 (gcc 8):
* gcc 8 + nvcc template symbol lookup (D9319742):
context_.template CopySameDevice<T> ==> this->context_.template CopySameDevice<T>
* New gcc 8 warning (error):
  * -Werror=sizeof-pointer-div
  * Unnecessary parenthesis

Differential Revision: D10045844
