### PR TITLE
Remove ATen/Error.h and use ATen/core/Error.h instead.

### DIFF
--- a/aten/src/ATen/detail/ComplexHooksInterface.h
+++ b/aten/src/ATen/detail/ComplexHooksInterface.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ATen/Error.h>
+#include <ATen/core/Error.h>
 #include "c10/util/Registry.h"
 
 namespace at {

--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -1,7 +1,7 @@
 #include "ATen/native/TensorTransformations.h"
 
 #include <ATen/NativeFunctions.h>
-#include <ATen/Error.h>
+#include <ATen/core/Error.h>
 
 #include <algorithm>
 #include <vector>

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -6,7 +6,7 @@
 #include <torch/csrc/jit/import.h>
 #include <torch/csrc/jit/script/module.h>
 
-#include <ATen/Error.h>
+#include <ATen/core/Error.h>
 
 #include <memory>
 #include <string>

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -8,7 +8,7 @@
 
 #include <ATen/DeviceGuard.h>
 #include <ATen/ExpandUtils.h>
-#include <ATen/Error.h>
+#include <ATen/core/Error.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -9,7 +9,7 @@
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/utils/auto_gil.h"
 
-#include <ATen/Error.h>
+#include <ATen/core/Error.h>
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
Summary: TSIA. No code change involved.

Reviewed By: bwasti

Differential Revision: D10083237
