### PR TITLE
Introduce builtin script functions

### DIFF
--- a/test/expect/TestJit.test_constant_prop_print.expect
+++ b/test/expect/TestJit.test_constant_prop_print.expect
@@ -2,6 +2,7 @@ graph(%input_tensor : Dynamic) {
   %1 : int = prim::Constant[value=6]()
    = prim::Print(%1)
   %2 : int = prim::Constant[value=8]()
-  %3 : Dynamic = aten::add(%2, %input_tensor)
-  return (%3);
+  %3 : int = prim::Constant[value=1]()
+  %4 : Dynamic = aten::add(%input_tensor, %2, %3)
+  return (%4);
 }

--- a/test/expect/TestJit.test_constant_prop_simple.expect
+++ b/test/expect/TestJit.test_constant_prop_simple.expect
@@ -1,5 +1,6 @@
 graph(%input_tensor : Dynamic) {
   %1 : int = prim::Constant[value=8]()
-  %2 : Dynamic = aten::add(%1, %input_tensor)
-  return (%2);
+  %2 : int = prim::Constant[value=1]()
+  %3 : Dynamic = aten::add(%input_tensor, %1, %2)
+  return (%3);
 }

--- a/test/expect/TestScript.test_scalar_fusion.expect
+++ b/test/expect/TestScript.test_scalar_fusion.expect
@@ -6,7 +6,7 @@ graph(%x : Float()
 with prim::FusionGroup_0 = graph(%0 : Float()
       %1 : Float()) {
   %2 : int = prim::Constant[value=2]()
-  %3 : Float() = aten::mul(%2, %1)
+  %3 : Float() = aten::mul(%1, %2)
   %4 : int = prim::Constant[value=1]()
   %5 : Float() = aten::add(%3, %0, %4)
   return (%5);

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -174,6 +174,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/register_special_ops.cpp
   ${TORCH_SRC_DIR}/csrc/jit/register_symbols.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/compiler.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/builtin_functions.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
   ${TORCH_SRC_DIR}/csrc/jit/test_jit.cpp

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -27,14 +27,10 @@ bool isDifferentiable(Node * n) {
   static OperatorSet differentiable_ops = {
     "aten::add(Tensor self, Tensor other, *, Scalar alpha) -> Tensor",
     "aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor",
-    "aten::add(Scalar other, Tensor self) -> Tensor",
     "aten::sub(Tensor self, Tensor other, *, Scalar alpha) -> Tensor",
     "aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor",
-    "aten::sub(Scalar other, Tensor self) -> Tensor",
     "aten::mul(Tensor self, Tensor other) -> Tensor",
     "aten::mul(Tensor self, Scalar other) -> Tensor",
-    "aten::mul(Scalar other, Tensor self) -> Tensor",
-    "aten::div(Scalar other, Tensor self) -> Tensor",
     "aten::div(Tensor self, Tensor other) -> Tensor",
     "aten::div(Tensor self, Scalar other) -> Tensor",
     "aten::sigmoid(Tensor self) -> Tensor",
@@ -132,9 +128,6 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
     } else if (node->matches("aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor")) {
       return {grads.at(0), nullptr, nullptr};
 
-    } else if (node->matches("aten::add(Scalar other, Tensor self) -> Tensor")) {
-      return {nullptr, grads.at(0)};
-
     } else if (node->kind() == prim::AutogradAdd) {
       return {grads.at(0), grads.at(0)};
 
@@ -144,26 +137,17 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
     } else if (node->matches("aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor")) {
       return {grads.at(0), nullptr, nullptr};
 
-    } else if (node->matches("aten::sub(Scalar other, Tensor self) -> Tensor")) {
-      return {nullptr, -grads.at(0)};
-
     } else if (node->matches("aten::mul(Tensor self, Tensor other) -> Tensor")) {
       return {grads.at(0) * inputs.at(1), grads.at(0) * inputs.at(0)};
 
     } else if (node->matches("aten::mul(Tensor self, Scalar other) -> Tensor")) {
       return {grads.at(0) * inputs.at(1), nullptr};
 
-    } else if (node->matches("aten::mul(Scalar other, Tensor self) -> Tensor")) {
-      return {nullptr, grads.at(0) * inputs.at(0)};
-
     } else if (node->matches("aten::div(Tensor self, Tensor other) -> Tensor")) {
       return {grads.at(0) / inputs.at(1), -grads.at(0) * inputs.at(0) / (inputs.at(1) * inputs.at(1))};
 
     } else if (node->matches("aten::div(Tensor self, Scalar other) -> Tensor")) {
       return {grads.at(0) / inputs.at(1), nullptr};
-
-    } else if (node->matches("aten::div(Scalar other, Tensor self) -> Tensor")) {
-      return {nullptr, -grads.at(0) * inputs.at(0) / (inputs.at(1) * inputs.at(1))};
 
     } else if (node->matches("aten::sigmoid(Tensor self) -> Tensor")) {
       // TODO: The order of operations matter in this case. This 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -208,16 +208,12 @@ struct GraphFuser {
           /*const=*/attr::alpha) ||
         node->matches("aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor",
           /*const=*/{attr::other, attr::alpha}) ||
-        node->matches("aten::add(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::sub(Tensor self, Tensor other, *, Scalar alpha) -> Tensor",
           /*const=*/attr::alpha) ||
         node->matches("aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor",
           /*const=*/{attr::other, attr::alpha}) ||
-        node->matches("aten::sub(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::mul(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::mul(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::div(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::div(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor", /*const=*/{attr::min, attr::max})) {
       auto inputs = tensorInputs(node);
       return haveSupportedType(inputs);
@@ -225,22 +221,16 @@ struct GraphFuser {
     else if (
         node->matches("aten::lt(Tensor self, Tensor other) -> Tensor") ||
         node->matches("aten::lt(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::lt(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::le(Tensor self, Tensor other) -> Tensor") ||
         node->matches("aten::le(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::le(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::gt(Tensor self, Tensor other) -> Tensor") ||
         node->matches("aten::gt(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::gt(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::ge(Tensor self, Tensor other) -> Tensor") ||
         node->matches("aten::ge(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::ge(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::eq(Tensor self, Tensor other) -> Tensor") ||
         node->matches("aten::eq(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::eq(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other) ||
         node->matches("aten::ne(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::ne(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::ne(Scalar other, Tensor self) -> Tensor", /*const=*/attr::other)) {
+        node->matches("aten::ne(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other)) {
       // comparison operators produce Byte type, and it's ok, check only inputs
       auto inputs = tensorInputs(node);
       return haveSupportedType(inputs);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -557,10 +557,6 @@ bool PropagateTensorShapeOnNode(Node * node, bool insert_expands) {
     "aten::pow(Tensor self, Scalar exponent) -> Tensor",
     "aten::fmod(Tensor self, Scalar other) -> Tensor",
     "aten::remainder(Tensor self, Scalar other) -> Tensor",
-    "aten::add(Scalar other, Tensor self) -> Tensor",
-    "aten::sub(Scalar other, Tensor self) -> Tensor",
-    "aten::mul(Scalar other, Tensor self) -> Tensor",
-    "aten::div(Scalar other, Tensor self) -> Tensor",
     "aten::pow(Scalar base, Tensor self) -> Tensor",
     "aten::__and__(Tensor self, Scalar other) -> Tensor",
     "aten::__or__(Tensor self, Scalar other) -> Tensor",
@@ -1139,10 +1135,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
   } else if (node->matches("aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor") ||
              node->matches("aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor") ||
              node->matches("aten::mul(Tensor self, Scalar other) -> Tensor") ||
-             node->matches("aten::pow(Tensor self, Scalar exponent) -> Tensor") ||
-             node->matches("aten::add(Scalar other, Tensor self) -> Tensor") ||
-             node->matches("aten::sub(Scalar other, Tensor self) -> Tensor") ||
-             node->matches("aten::mul(Scalar other, Tensor self) -> Tensor")) {
+             node->matches("aten::pow(Tensor self, Scalar exponent) -> Tensor")) {
     node->output()->setType(tensor_types.at(0));
     return true;
   } else if (insert_expands && (

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -449,26 +449,6 @@ RegisterOperators reg({
 #define DEFINE_BINARY_OP(aten_op, op) DEFINE_GENERIC_OP(aten_op, op, op, float)
 #define DEFINE_COMPARISON_OP(aten_op, op) DEFINE_GENERIC_OP(aten_op, op, op, int)
 
-// define helpers for where aten is missing scalar overloads
-// note: it would be better to define these in a standard library as
-// script functions and have the compiler substitute them in
-// however, we need to add type annotations to the parser in order for us
-// to move them there.
-// e.g. s + t ==> t + s
-// e.g. s - d == -d + s
-
-#define DEFINE_ST_OP(aten_op, reverse_exp)                             \
-  Operator("aten::" #aten_op "(Scalar other, Tensor self) -> Tensor", [](Node* node) { \
-    return [=](Stack& stack) {                                         \
-      at::Scalar a;                                                    \
-      at::Tensor b;                                                    \
-      pop(stack, a, b);                                                \
-      at::DeviceGuard guard(b);                                        \
-      push(stack, reverse_exp);                                        \
-      return 0;                                                        \
-    };                                                                 \
-  }),
-
 // Convert an python index (which may be negative) into an index usable for a
 // C++ container
 int64_t normalizeIndex(int64_t idx, int64_t list_size) {
@@ -746,21 +726,5 @@ RegisterOperators reg2({
             return 0;
           };
         }),
-    // commutative
-    DEFINE_ST_OP(mul, at::mul(b, a))
-    DEFINE_ST_OP(add, at::add(b, a))
-    DEFINE_ST_OP(ne, at::ne(b, a))
-    DEFINE_ST_OP(eq, at::eq(b, a))
-
-    // comparisons, reverse the condition
-    DEFINE_ST_OP(lt, b > a)
-    DEFINE_ST_OP(le, b >= a)
-    DEFINE_ST_OP(gt, b < a)
-    DEFINE_ST_OP(ge, b <= a)
-
-    // rsub
-    DEFINE_ST_OP(sub, at::add(b.neg(), a))
-    // rdiv
-    DEFINE_ST_OP(div, at::mul(at::reciprocal(b), a))
 });
 }}} // torch::jit::anon

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -1,0 +1,83 @@
+#include "torch/csrc/jit/script/builtin_functions.h"
+#include "torch/csrc/api/include/torch/jit.h"
+#include "torch/csrc/jit/code_template.h"
+
+namespace torch { namespace jit { namespace script {
+
+auto scalar_operators_source = CodeTemplate(
+R"SCRIPT(
+def mul(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b * a
+def add(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b + a
+def ne(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b != a
+def eq(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b == a
+def lt(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b > a
+def le(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b >= a
+def gt(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b < a
+def ge(a : ${Scalar}, b : Tensor) -> Tensor:
+  return b <= a
+def sub(a : ${Scalar}, b : Tensor) -> Tensor:
+  return torch.neg(b) + a
+def div(a : ${Scalar}, b : Tensor) -> Tensor:
+  return torch.reciprocal(b) * a
+)SCRIPT");
+
+struct BuiltinFunctionRegistry {
+
+  const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name) {
+    const static std::vector<Method*> empty;
+    // when initializing the builtin function library, we will re-enter
+    // getAllBuiltinFunctionsFor since it is called in the compiler to
+    // lookup builtins and initializing the builtin functions calls the compiler.
+    // To avoid deadlocking, we use a recursive mutex (same thread can re-lock,
+    // the mutex without waiting), and report no loaded builtins during init.
+    std::lock_guard<std::recursive_mutex> guard(mutex);
+    if(state == INTIIALIZING) {
+      return empty;
+    } else if (state == UNINITIALIZED) {
+      state = INTIIALIZING;
+      loadBuiltinFunctions();
+      state = INITIALIZED;
+    }
+    JIT_ASSERT(state == INITIALIZED);
+    auto it = builtins_by_name.find(name);
+    if(it == builtins_by_name.end())
+      return empty;
+    return it->second;
+  }
+private:
+  void loadSource(const std::string& source) {
+    auto module = std::make_shared<script::Module>();
+    defineMethodsInModule(
+        *module, source, script::nativeResolver, /*self=*/nullptr);
+    modules.push_back(module);
+    for (auto& method : module->get_methods()) {
+      builtins_by_name[Symbol::fromQualString("aten::" + method.key)].push_back(
+          method.value.get());
+    }
+  }
+  void loadBuiltinFunctions() {
+    for(auto scalar : {"float", "int"}) {
+      TemplateEnv env;
+      env.s("Scalar", scalar);
+      loadSource(scalar_operators_source.format(env));
+    }
+  }
+  enum {UNINITIALIZED, INTIIALIZING, INITIALIZED} state = UNINITIALIZED;
+  std::recursive_mutex mutex;
+  std::vector<std::shared_ptr<Module>> modules;
+  std::unordered_map<Symbol, std::vector<Method*>> builtins_by_name;
+};
+
+TORCH_API const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name) {
+  static BuiltinFunctionRegistry registry;
+  return registry.getAllBuiltinFunctionsFor(name);
+}
+
+}}}

--- a/torch/csrc/jit/script/builtin_functions.h
+++ b/torch/csrc/jit/script/builtin_functions.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "torch/csrc/WindowsTorchApiMacro.h"
+#include "torch/csrc/jit/script/module.h"
+
+namespace torch { namespace jit { namespace script {
+
+
+TORCH_API const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name);
+
+
+
+}}}

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -37,8 +37,15 @@ const FunctionSchema& Method::getSchema() const {
   return *schema;
 }
 
-std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs) {
-  JIT_ASSERT(!executor);
+at::optional<std::vector<Value*>> try_emit_call_to(
+    Graph& graph,
+    SourceRange loc,
+    Method& callee,
+    ArrayRef<NamedValue> args,
+    ArrayRef<NamedValue> kwargs,
+    std::stringstream& failure_messages,
+    Method* caller,
+    bool conv_tensors_to_nums) {
   try {
     callee.ensure_defined();
   } catch (RecursiveMethodCallError&) {
@@ -47,19 +54,38 @@ std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, Array
   }
   auto fn = callee.graph();
 
-  std::stringstream failure_messages;
   auto matched_schema = tryMatchSchema(
     callee.getSchema(),
-    loc, *graph(), args, kwargs, failure_messages, /*conv_tensors_to_nums*/true);
+    loc, graph, args, kwargs, failure_messages, conv_tensors_to_nums);
   if(!matched_schema)
-    throw ErrorReport(loc) << failure_messages.str();
+    return at::nullopt;
 
   // parameters to callee method (which become parameters to _this_ method
   // if they were not already)
-  for(at::Tensor* member : callee.member_inputs) {
-    matched_schema->inputs.push_back(get_or_add_parameter(member));
+  for(at::Tensor* member : callee.params()) {
+    if(!caller) {
+      throw ErrorReport(loc) << " attempting to call a method with parameters from a raw graph. File a bug report";
+    }
+    matched_schema->inputs.push_back(caller->get_or_add_parameter(member));
   }
-  return inlineCallTo(*graph(), *callee.graph(), matched_schema->inputs);
+  return inlineCallTo(graph, *callee.graph(), matched_schema->inputs);
+}
+
+std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs) {
+  JIT_ASSERT(!executor);
+  std::stringstream failure_messages;
+  if (auto result = try_emit_call_to(
+          *graph(),
+          loc,
+          callee,
+          args,
+          kwargs,
+          failure_messages,
+          this,
+          /*conv_tensors_to_nums=*/true)) {
+    return *result;
+  }
+  throw ErrorReport(loc) << failure_messages.str();
 }
 
 void Method::ensure_defined() {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -84,6 +84,7 @@ struct Method {
 
   // defined here to keep details of member_input handling confined to this class
   std::vector<Value*> emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs);
+
   // if this isn't yet defined, run its method_creator function
   void ensure_defined();
 
@@ -389,5 +390,19 @@ struct Module {
   torch::detail::OrderedDict<std::string, std::unique_ptr<Method>> methods;
   bool optimize;
 };
+
+// returns at::nullopt and fills in failure_messages if the callee does not
+// match the functions schema
+at::optional<std::vector<Value*>> try_emit_call_to(
+    Graph& graph,
+    SourceRange loc,
+    Method& callee,
+    ArrayRef<NamedValue> args,
+    ArrayRef<NamedValue> kwargs,
+    std::stringstream& failure_messages,
+    // when callee uses no parameters (e.g. it is a function in a compilation unit,
+    // and not a method), then nullptr can be passed as caller.
+    Method* caller,
+    bool conv_tensors_to_nums);
 
 }}}


### PR DESCRIPTION
This functionality replaces the Scalar-Tensor builtin operators,
with builtin functions.

Builtin functions are used in place of operators where one operator
can be defined using a composition of another. This simplifies later
optimization passes by allowing us to have fewer operator.

In the future, builtin functions can be used for other purposes.
For example, we can define derivative functions as code rather than
building graphs.

