### PR TITLE
Add the OpenMP optimization for BatchPermutation.

### DIFF
--- a/modules/detectron/batch_permutation_op.cc
+++ b/modules/detectron/batch_permutation_op.cc
@@ -100,6 +100,13 @@ bool BatchPermutationOp<float, CPUContext>::RunOnDevice() {
   const float *src = X.template data<float>();
   float *dst = Y->template mutable_data<float>();
 
+#ifdef _OPENMP
+#if (_OPENMP >= 201307)
+#pragma omp parallel for simd
+#else
+#pragma omp parallel for
+#endif 
+#endif  
   for (int i = 0; i < N; i++) {
     int idx = indices.template data<int>()[i];
 


### PR DESCRIPTION
This is for Caffe2 optimization.
WIth this optimization, the following two ops can boost a lot. (Test with MaskRCNN, on SKX8180 one socket)
BatchPermutation op: reduced from 8.296387 ms to 1.4501984 ms. 