### PR TITLE
[JIT] Turns optimizations off when checking trace

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -317,6 +317,8 @@ class TracingCheckError(Exception):
 # Check the traced module against a set of user-provided validation inputs
 @torch.no_grad()
 def _check_trace(check_inputs, func, executor_options, module, check_tolerance):
+    # Note: tracing is independent of optimizations, which consume the trace
+    executor_options['optimize'] = False
     for inputs in check_inputs:
         if isinstance(inputs, torch.Tensor):
             inputs = (inputs,)


### PR DESCRIPTION
Currently when tracing optimizations are performed twice. This means that optimizing passes, like the fusion pass, are also called twice. This is unnecessary and this PR turns off optimizations when checking the trace (since the trace is independent of optimizations). This should improve performance and debugging. 

@apaszke who proposed this change. 