### PR TITLE
Add a serial path to backward engine.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -76,6 +76,11 @@ def graph_desc(fn):
 
 class TestAutograd(TestCase):
 
+    def setUp(self):
+        super(TestAutograd, self).setUp()
+        force_parallel = bool(hash(self.id()) % 2)
+        Variable._execution_engine.set_force_parallel(force_parallel)
+
     def _function_test(self, cls):
         x = torch.randn(5, 5, requires_grad=True)
         y = torch.randn(5, 5, requires_grad=True)

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -50,9 +50,10 @@ struct TORCH_API Engine {
   void queue_callback(std::function<void()> callback);
 
   bool is_checkpoint_valid();
+  void set_force_parallel(bool should_force);
 
 protected:
-  void compute_dependencies(Function* root, GraphTask& task);
+  bool compute_dependencies(Function* root, GraphTask& task);
   void evaluate_function(FunctionTask& task);
   ReadyQueue& ready_queue(int device);
   void start_threads();
@@ -64,6 +65,7 @@ protected:
   std::vector<std::shared_ptr<ReadyQueue>> ready_queues;
   std::vector<std::function<void()>> final_callbacks;
   std::mutex post_callbacks_lock;
+  bool force_parallel = false;
 };
 
 // allow python_engine to override the default engine when it loads

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -211,6 +211,13 @@ PyObject* THPEngine_is_checkpoint_valid(PyObject *self) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPEngine_set_force_parallel(PyObject *self, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  engine.set_force_parallel(arg == Py_True);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject *THPEngine_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
   return type->tp_alloc(type, 0);
@@ -220,6 +227,7 @@ static struct PyMethodDef THPEngine_methods[] = {
   {(char*)"run_backward", (PyCFunction)THPEngine_run_backward, METH_VARARGS | METH_KEYWORDS, nullptr},
   {(char*)"queue_callback", (PyCFunction)THPEngine_queue_callback, METH_O, nullptr},
   {(char*)"is_checkpoint_valid", (PyCFunction)THPEngine_is_checkpoint_valid, METH_NOARGS, nullptr},
+  {(char*)"set_force_parallel", (PyCFunction)THPEngine_set_force_parallel, METH_O, nullptr},
   {nullptr}
 };
 


### PR DESCRIPTION
Many graphs execute on a single device only, and our multithreaded
solution is an overkill for them. This commit attempts to detect
that and will use the user thread to execute backward in that case.

Note that there are still many optimizations that can be applied to
the single-threaded path (e.g. it doesn't need mutexes), but I decided
to leave them for the future.

NB: This makes it impossible to trigger a parallel backward (it will be serialized) nested in a serial backward, but I don't think this will ever cause a problem, as nested graphs tend to be simple.

This patch greatly improves stability of our performance in many environments, because the forward and backward thread switching generally plays badly with CPU frequency and turbo heuristics.

Epoch times for word language model:
```
130 ms +- 23 ms (some epochs taking even longer than 150ms)
108 ms +- 4 ms  (max epoch time is 113ms)
```

@colesbury 