### PR TITLE
Smarter differentiable subgraph slicing

### DIFF
--- a/test/expect/TestJit.test_cpp_cuda.expect
+++ b/test/expect/TestJit.test_cpp_cuda.expect
@@ -64,9 +64,9 @@ graph(%0 : Dynamic
       %2 : Dynamic
       %3 : Dynamic
       %4 : Dynamic) {
-  %23 : Dynamic, %24 : Dynamic = prim::DifferentiableGraph_0(%0, %3, %1, %4, %2)
   %7 : int = prim::Constant[value=1]()
   %19 : int = prim::Constant[value=1]()
+  %23 : Dynamic, %24 : Dynamic = prim::DifferentiableGraph_0(%0, %3, %1, %4, %2)
   return (%24, %23);
 }
 with prim::DifferentiableGraph_0 = graph(%1 : Dynamic

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8137,10 +8137,10 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             raise NotSupportedError("NYI: assertGraphHas consider_subgraphs=T")
         nodes = [node for node in graph.nodes()
                  if node.kind() == kind]
-        self.assertEquals(len(nodes), num_kind_nodes)
+        self.assertEqual(len(nodes), num_kind_nodes)
 
     def assertGraphSize(self, graph, size):
-        self.assertEquals(len(list(graph.nodes())), size)
+        self.assertEqual(len(list(graph.nodes())), size)
 
     def test_simple_merge(self):
         # o --> o

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -62,10 +62,6 @@ PY35 = sys.version_info >= (3, 5)
 WINDOWS = sys.platform == 'win32'
 
 
-def pyfn(a, b):
-    return a * b
-
-
 def LSTMCellF(input, hx, cx, *params):
     return LSTMCell(input, (hx, cx), *params)
 
@@ -2669,154 +2665,6 @@ class TestScript(JitTestCase):
             @torch.jit.script
             def foo(x):
                 return [[x]] + [[1]]
-
-    # adss == autodiff subgraph slicing
-    # TODO: It is better if we can test adss directly on graphs
-    # rather than the current end-to-end fashion.
-    def _perform_ad_subgraph_slicing(self, fn, *input_sizes):
-        ge = torch.jit.script(fn)
-        ge.debug_disable_autodiff_subgraph_inlining()
-        inputs = [torch.randn(size, requires_grad=True) for size in input_sizes]
-        ge(*inputs)
-        return ge.graph_for(*inputs)
-
-    def assertGraphContains(self, graph, kind, num_kind_nodes, consider_subgraphs=False):
-        if consider_subgraphs:
-            raise NotSupportedError("NYI: assertGraphHas consider_subgraphs=T")
-        nodes = [node for node in graph.nodes()
-                 if node.kind() == kind]
-        self.assertEquals(len(nodes), num_kind_nodes)
-
-    def assertGraphSize(self, graph, size):
-        self.assertEquals(len(list(graph.nodes())), size)
-
-    def test_adss_simple_merge(self):
-        # o --> o
-        def fn(x, y, z):
-            a = x * y
-            b = a * z
-            return b
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
-
-        self.assertGraphSize(graph, 1)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_simple_no_merge(self):
-        # o: autodiff supported. x: not autodiff supported.
-        # o --> x
-        def fn(x, y, z):
-            a = x * y
-            b = pyfn(a, z)
-            return b
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
-
-        self.assertGraphSize(graph, 2)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_does_not_merge_unrelated(self):
-        # o  o
-        def fn(w, x, y, z):
-            a = x * y
-            b = w * z
-            return a, b
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
-
-        self.assertGraphSize(graph, 2)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
-
-    def test_adss_merges_without_cycles(self):
-        # o --> o --> o
-        # |           ^
-        #  \_________/
-        def fn(w, x, y):
-            a = w * x
-            b = a * y
-            c = a * b
-            return c
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
-
-        self.assertGraphSize(graph, 1)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_merges_dense(self):
-        #   o      o
-        #   |\    /|
-        #   | \  / |
-        #   |  /\  |
-        #   vv    vv
-        #   o      o
-        def fn(x, y):
-            a, b = x.chunk(2)
-            c, d = y.chunk(2)
-            return a + c, b + d
-
-        graph = self._perform_ad_subgraph_slicing(fn, 2, 2)
-
-        self.assertGraphSize(graph, 1)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_does_not_create_cycles(self):
-        # o --> x --> o
-        # |           ^
-        #  \_________/
-        def fn(w, x, y):
-            a = w * x
-            b = pyfn(a, y)
-            c = a * b
-            return c
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
-
-        self.assertGraphSize(graph, 3)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
-
-    def test_adss_merges_up(self):
-        # o --> x     o
-        # |           ^
-        #  \_________/
-        def fn(w, x, y, z):
-            a = w * x
-            b = pyfn(a, y)
-            c = a * z
-            return b, c
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
-
-        self.assertGraphSize(graph, 2)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_merges_down(self):
-        # o     x --> o
-        # |           ^
-        #  \_________/
-        def fn(v, w, x, y):
-            a = v * w
-            b = pyfn(x, y)
-            c = b * a
-            return a, c
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
-
-        self.assertGraphSize(graph, 2)
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
-
-    def test_adss_respects_lexical_scoping(self):
-        def fn(x, k):
-            y = x * 1.1
-            if bool(k):
-                k += y
-            z = y * k
-            return z, k
-
-        graph = self._perform_ad_subgraph_slicing(fn, 1, 1)
-
-        # We should not have combined the two multiplications into
-        # the same group; they should each be a separate DiffGraph
-        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
 
     def test_script_cu(self):
         cu = torch.jit.CompilationUnit('''
@@ -8264,6 +8112,163 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
         if g2 is None and g2_ge is None:
             continue
         self.assertTrue(torch.allclose(g2, g2_test, atol=5e-4, rtol=1e-4))
+
+
+# NB: torch.jit.script, when used as a function, uses the current scope
+# to resolve variable names. This function cannot be made local to
+# TestAutodiffSubgraphSlicing because those tests call torch.jit.script on functions
+# in a different scope than they are defined in.
+def pyfn(a, b):
+    return a * b
+
+
+class TestAutodiffSubgraphSlicing(JitTestCase):
+    # TODO: It is better if we can test directly on graphs instead of the current
+    # end-to-end fashion.
+    def _perform_ad_subgraph_slicing(self, fn, *input_sizes):
+        ge = torch.jit.script(fn)
+        ge.debug_disable_autodiff_subgraph_inlining()
+        inputs = [torch.randn(size, requires_grad=True) for size in input_sizes]
+        ge(*inputs)
+        return ge.graph_for(*inputs)
+
+    def assertGraphContains(self, graph, kind, num_kind_nodes, consider_subgraphs=False):
+        if consider_subgraphs:
+            raise NotSupportedError("NYI: assertGraphHas consider_subgraphs=T")
+        nodes = [node for node in graph.nodes()
+                 if node.kind() == kind]
+        self.assertEquals(len(nodes), num_kind_nodes)
+
+    def assertGraphSize(self, graph, size):
+        self.assertEquals(len(list(graph.nodes())), size)
+
+    def test_simple_merge(self):
+        # o --> o
+        def fn(x, y, z):
+            a = x * y
+            b = a * z
+            return b
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
+
+        self.assertGraphSize(graph, 1)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_simple_no_merge(self):
+        # o: autodiff supported. x: not autodiff supported.
+        # o --> x
+        def fn(x, y, z):
+            a = x * y
+            b = pyfn(a, z)
+            return b
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
+
+        self.assertGraphSize(graph, 2)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_does_not_merge_unrelated(self):
+        # o  o
+        def fn(w, x, y, z):
+            a = x * y
+            b = w * z
+            return a, b
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
+
+        self.assertGraphSize(graph, 2)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
+
+    def test_merges_without_cycles(self):
+        # o --> o --> o
+        # |           ^
+        #  \_________/
+        def fn(w, x, y):
+            a = w * x
+            b = a * y
+            c = a * b
+            return c
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
+
+        self.assertGraphSize(graph, 1)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_merges_dense(self):
+        #   o      o
+        #   |\    /|
+        #   | \  / |
+        #   |  /\  |
+        #   vv    vv
+        #   o      o
+        def fn(x, y):
+            a, b = x.chunk(2)
+            c, d = y.chunk(2)
+            return a + c, b + d
+
+        graph = self._perform_ad_subgraph_slicing(fn, 2, 2)
+
+        self.assertGraphSize(graph, 1)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_does_not_create_cycles(self):
+        # o --> x --> o
+        # |           ^
+        #  \_________/
+        def fn(w, x, y):
+            a = w * x
+            b = pyfn(a, y)
+            c = a * b
+            return c
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1)
+
+        self.assertGraphSize(graph, 3)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
+
+    def test_merges_up(self):
+        # o --> x     o
+        # |           ^
+        #  \_________/
+        def fn(w, x, y, z):
+            a = w * x
+            b = pyfn(a, y)
+            c = a * z
+            return b, c
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
+
+        self.assertGraphSize(graph, 2)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_merges_down(self):
+        # o     x --> o
+        # |           ^
+        #  \_________/
+        def fn(v, w, x, y):
+            a = v * w
+            b = pyfn(x, y)
+            c = b * a
+            return a, c
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1, 1, 1)
+
+        self.assertGraphSize(graph, 2)
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 1)
+
+    def test_respects_lexical_scoping(self):
+        def fn(x, k):
+            y = x * 1.1
+            if bool(k):
+                k += y
+            z = y * k
+            return z, k
+
+        graph = self._perform_ad_subgraph_slicing(fn, 1, 1)
+
+        # We should not have combined the two multiplications into
+        # the same group; they should each be a separate DiffGraph
+        self.assertGraphContains(graph, 'prim::DifferentiableGraph', 2)
 
 
 class TestJitGenerated(JitTestCase):

--- a/torch/csrc/jit/dynamic_dag.h
+++ b/torch/csrc/jit/dynamic_dag.h
@@ -38,14 +38,23 @@ template <typename T> using unique_vertex = std::unique_ptr<Vertex<T>>;
 enum DFSDirection {forward, backward};
 
 // Because our graphs shouldn't fan out or in very much,
-// we use std::vector<Vertex<T>*>  to record edges.
+// we use std::vector<Vertex<T>*> to record edges.
+// In all of the complexity analysis it is assumed that
+// inserting, erasing, and finding take constant time.
 template <typename T>
 struct EdgeData {
+  // These are both sorted in topological order because iterating
+  // in topological order is useful.
   vertex_list<T> in_edges;
   vertex_list<T> out_edges;
 
   static void insert(vertex_list<T>& lst, Vertex<T>* v) {
-    lst.push_back(v);
+    // Keep the list sorted.
+    // We can do the same thing (binary search) for erase() and has()
+    // but I'm not sure if it will perform better especially since
+    // our lists should be small.
+    lst.insert(std::upper_bound(lst.begin(), lst.end(), v,
+          [](Vertex<T>* x, Vertex<T>* y) { return x->ord < y->ord; }), v);
   }
 
   static void erase(vertex_list<T>& lst, Vertex<T>* v) {

--- a/torch/csrc/jit/dynamic_dag.h
+++ b/torch/csrc/jit/dynamic_dag.h
@@ -458,11 +458,11 @@ void DynamicDAG<T>::reorder(vertex_list<T>& deltaF, vertex_list<T>& deltaB) {
     desired_vertex_ordering.push_back(std::move(vertices_.at((*it)->ord)));
   }
 
-  // Sort the ords.
-  // This is done through an O(num_affected) merge operation. For example,
-  // deltaB = { 1, 4, 7 } , deltaF = {0, 2, 5 }.
-  // These two lists already contain sorted ords; we just need to merge
-  // them to create an ordering { 0, 1, 2, 4, 5, 7 } to assign the vertices.
+  // Sort the ords by merging two already sorted lists into a large sorted list.
+  // input (example): deltaB = { 1, 4, 7 } , deltaF = {0, 2, 5 }.
+  // output: { 0, 1, 2, 5, 7 }.
+  // This merge operation is the same thing as (pseudocode)
+  // sorted_ords = std::merge(fmap(deltaB, lambda v: v->ord), fmap(deltaF, lambda v: v->ord))
   std::vector<size_t> sorted_ords;
   sorted_ords.reserve(num_affected);
   auto output = sorted_ords.begin();

--- a/torch/csrc/jit/dynamic_dag.h
+++ b/torch/csrc/jit/dynamic_dag.h
@@ -1,0 +1,388 @@
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <unordered_set>
+#include <vector>
+
+#include "torch/csrc/utils/functional.h"
+
+namespace torch { namespace jit { namespace detail {
+
+// DynamicDAG is a DAG that dynamically maintains a topological order as
+// edges/vertices are added and removed.
+//
+// The implementation is based off of the following paper:
+// "A Dynamic Topsort Algorithm for Directed Acyclic Graphs"
+// by David Pearce and Paul Kelly
+// https://www.doc.ic.ac.uk/~phjk/Publications/DynamicTopoSortAlg-JEA-07.pdf
+
+template <typename T> struct Vertex;
+
+template <typename T>
+using vertex_set = std::unordered_set<Vertex<T>*>;
+
+template <typename T>
+using vertex_list = std::vector<Vertex<T>*>;
+
+template <typename T>
+using maybe_vertex_list = std::vector<at::optional<Vertex<T>*>>;
+
+template <typename T>
+struct Vertex {
+  std::vector<T> rdata; // stored in reverse order
+  size_t ord; // index in topological ordering. Is unique.
+  bool visited; // If this vertex has been visited
+  vertex_set<T> in_edges;
+  vertex_set<T> out_edges;
+
+  std::string toString();
+};
+
+template <typename T>
+struct DynamicDAG {
+  ~DynamicDAG();
+
+  Vertex<T>* newVertex(T datum);
+  std::pair<vertex_set<T>,vertex_set<T>> removeVertex(Vertex<T>* v);
+
+  void addEdge(Vertex<T>* producer, Vertex<T>* consumer);
+  void removeEdge(Vertex<T>* producer, Vertex<T>* consumer);
+  bool contractEdge(Vertex<T>* producer, Vertex<T>* consumer);
+
+  bool contractionProducesCycle(Vertex<T>* producer, Vertex<T>* consumer);
+  bool dfsForward(Vertex<T>* producer, size_t upper_bound, vertex_list<T>& visited);
+  void dfsBackward(Vertex<T>* producer, size_t lower_bound, vertex_list<T>& visited);
+  void clearVisited(vertex_list<T>& visited);
+
+  void reorder(vertex_list<T>& deltaF, vertex_list<T>& deltaB);
+  void sort(vertex_list<T>& delta);
+
+  void checkInvariants();
+
+  Vertex<T>* at(size_t ord) const { return vertices_.at(ord).value(); };
+  const maybe_vertex_list<T>& maybe_vertices() const { return vertices_; };
+
+  // Use for debugging. Don't call this often.
+  size_t numVertices() const;
+
+  std::string toString();
+
+ private:
+
+  // Store vertices indexed by their topological order.
+  // If a vertex v has ord 5, then it can be found at vertices_[5].
+  // There may be gaps in vertices_; this is to enable fast deletion.
+  maybe_vertex_list<T> vertices_;
+
+  // temp buffers used in the PK algorithm.
+  // Their usage makes this data structure NOT thread safe.
+  vertex_list<T> deltaF_;  // all vertices visited by dfsForward
+  vertex_list<T> deltaB_;  // all vertices visited by dfsBackward
+};
+
+template <typename T>
+DynamicDAG<T>::~DynamicDAG() {
+  for (auto v : vertices_) {
+    if (v.has_value()) {
+      delete v.value();
+    }
+  }
+}
+
+// O(vertices_.size()). Used for testing, don't call this often.
+template <typename T>
+size_t DynamicDAG<T>::numVertices() const {
+  return std::count_if(vertices_.begin(), vertices_.end(), [](at::optional<Vertex<T>*> v) {
+      return v;
+  });
+}
+
+template <typename T>
+Vertex<T>* DynamicDAG<T>::newVertex(T datum) {
+  auto* vertex = new Vertex<T>();
+  vertex->rdata.push_back(datum);
+  vertex->visited = false;
+  vertex->ord = vertices_.size();
+  vertices_.push_back(vertex);
+  return vertex;
+}
+
+template <typename T>
+void DynamicDAG<T>::removeEdge(Vertex<T>* producer, Vertex<T>* consumer) {
+  JIT_ASSERT(producer != consumer);
+  JIT_ASSERT(producer->out_edges.count(consumer));
+  JIT_ASSERT(consumer->in_edges.count(producer));
+  producer->out_edges.erase(consumer);
+  consumer->in_edges.erase(producer);
+}
+
+template <typename T>
+void DynamicDAG<T>::checkInvariants() {
+  for (size_t ord = 0; ord < vertices_.size(); ++ord) {
+    const auto& maybe_vertex = vertices_.at(ord);
+    if (!maybe_vertex.has_value()) continue;
+    auto* vertex = maybe_vertex.value();
+
+    JIT_ASSERT(vertex->ord == ord);
+    for (auto* v : vertex->in_edges) {
+      JIT_ASSERT(v->ord < ord);
+    }
+    for (auto* v : vertex->out_edges) {
+      JIT_ASSERT(v->ord > ord);
+    }
+  }
+}
+
+
+template <typename T>
+std::pair<vertex_set<T>,vertex_set<T>> DynamicDAG<T>::removeVertex(Vertex<T>* v) {
+  for (auto* parent : v->in_edges) {
+    parent->out_edges.erase(v);
+  }
+  for (auto* child : v->out_edges) {
+    child->in_edges.erase(v);
+  }
+  auto in_edges = std::move(v->in_edges);
+  auto out_edges = std::move(v->out_edges);
+  vertices_[v->ord] = at::nullopt;
+  delete v;
+  return std::make_pair<vertex_set<T>,vertex_set<T>>(std::move(in_edges), std::move(out_edges));
+}
+
+// This is O(|AR|) which is the same thing as O(ord(consumer) - ord(producer))
+// AR is the "affected region": { v s.t. ord(v) in [ord(producer), ord(consumer)] }
+// consisting of the only verticies that can possibly be moved around due
+// to this edge addition.
+template <typename T>
+void DynamicDAG<T>::addEdge(Vertex<T>* producer, Vertex<T>* consumer) {
+  JIT_ASSERT(producer != consumer);
+  if (producer->out_edges.count(consumer)) return;
+  producer->out_edges.insert(consumer);
+  consumer->in_edges.insert(producer);
+
+  if (producer->ord <= consumer->ord) {
+    // topological ordering is already consistent, no need to update.
+    return;
+  }
+
+  // Search for vertices that are reachable from consumer that have a now incorrect
+  // topological ordering.
+  if (!dfsForward(consumer, producer->ord, deltaF_)) {
+    // dfsForward returns false if there is a path from consumer to producer.
+    throw std::runtime_error("Cycle detected while trying to add edge.");
+  }
+
+  // Search for vertices that can reach producer that have a now incorrect
+  // topological ordering
+  dfsBackward(producer, consumer->ord, deltaB_);
+
+  // Reorder the vertices that are reachable from consumer to occur BEFORE
+  // the vertices that can reach producer.
+  reorder(deltaF_, deltaB_);
+}
+
+// Define the affected region for contractEdge(producer, consumer) as
+// { v s.t. ord(v) in [ord(producer), ord(consumer)] }.
+// These are the only vertices that can possibly be moved around
+// during edge contraction.
+//
+// contractEdge is O(|AR| * |out_edges(producer)|)
+template <typename T>
+bool DynamicDAG<T>::contractEdge(Vertex<T>* producer, Vertex<T>* consumer) {
+  JIT_ASSERT(producer != consumer);
+  if (contractionProducesCycle(producer, consumer)) {
+    return false;
+  }
+
+  removeEdge(producer, consumer);
+
+  // We can either merge producer into consumer or the other way around.
+  // I've chosen to merge producer into consumer for now but this is arbitrary.
+  consumer->rdata.insert(consumer->rdata.end(), producer->rdata.begin(), producer->rdata.end());
+
+  vertex_set<T> in_edges;
+  vertex_set<T> out_edges;
+  std::tie(in_edges, out_edges) = removeVertex(producer);
+
+  // Each of these are constant b/c ord(consumer) > ord(producer) > ord(parent)
+  // so the edge addition still preserves the existing topological order.
+  for (auto* parent : in_edges) {
+    addEdge(parent, consumer);
+  }
+
+  // NB: each addEdge call is linear in (ord(consumer) - ord(child)).
+  // This makes contractEdges O(|out_edges(producer)| * |AR|).
+  for (auto* child : out_edges) {
+    addEdge(consumer, child);
+  }
+  return true;
+}
+
+template <typename T>
+bool DynamicDAG<T>::contractionProducesCycle(Vertex<T>* producer, Vertex<T>* consumer) {
+  // Basically a modified dfsForward
+  vertex_list<T> stack;
+  vertex_list<T> visited;
+  stack.push_back(producer);
+
+  size_t upper_bound = consumer->ord;
+
+  while (!stack.empty()) {
+    auto* vertex = stack.back();
+    stack.pop_back();
+
+    if (vertex->visited) continue;
+    vertex->visited = true;
+    visited.push_back(vertex);
+
+    for (auto* next : vertex->out_edges) {
+      if (vertex != producer && next->ord == upper_bound) {
+        clearVisited(visited);
+        return true;
+      }
+      if (next->ord < upper_bound) {
+        stack.push_back(next);
+      }
+    }
+  }
+  clearVisited(visited);
+  return false;
+}
+
+
+// Performs a forward DFS.
+// Marks vertices as 'visited' and inserts them into visited.
+// Returns false immediately if upper_bound is reached.
+// Returns true otherwise.
+template <typename T>
+bool DynamicDAG<T>::dfsForward(Vertex<T>* producer, size_t upper_bound,
+    vertex_list<T>& visited) {
+  vertex_list<T> stack;
+  stack.push_back(producer);
+
+  while (!stack.empty()) {
+    auto* vertex = stack.back();
+    stack.pop_back();
+
+    if (vertex->visited) continue;
+    vertex->visited = true;
+    visited.push_back(vertex);
+
+    for (auto* next : vertex->out_edges) {
+      if (next->ord == upper_bound) {
+        return false;
+      }
+      if (next->ord < upper_bound) {
+        stack.push_back(next);
+      }
+    }
+  }
+  return true;
+}
+
+// Performs a backward DFS.
+// Marks vertices as 'visited' and inserts them into visited.
+template <typename T>
+void DynamicDAG<T>::dfsBackward(Vertex<T>* producer, size_t lower_bound,
+    vertex_list<T>& visited) {
+  vertex_list<T> stack;
+  stack.push_back(producer);
+
+  while (!stack.empty()) {
+    auto* vertex = stack.back();
+    stack.pop_back();
+
+    if (vertex->visited) continue;
+
+    vertex->visited = true;
+    visited.push_back(vertex);
+
+    for (auto* next : vertex->in_edges) {
+      if (next->ord > lower_bound) {
+        stack.push_back(next);
+      }
+    }
+  }
+}
+
+template <typename T>
+void DynamicDAG<T>::sort(vertex_list<T>& delta) {
+  struct {
+    bool operator()(Vertex<T>* a, Vertex<T>* b) const {
+      return a->ord < b->ord;
+    }
+  } custom_less;
+  std::sort(delta.begin(), delta.end(), custom_less);
+}
+
+template <typename T>
+void DynamicDAG<T>::clearVisited(vertex_list<T>& visited) {
+  for (auto* v: visited) {
+    v->visited = false;
+  }
+  visited.clear();
+}
+
+template <typename T>
+void DynamicDAG<T>::reorder(vertex_list<T>& deltaF, vertex_list<T>& deltaB) {
+  // Reorder deltaB vertices to occur before deltaF vertices.
+  sort(deltaB);
+  sort(deltaF);
+
+  vertex_list<T> tmp;
+
+  std::vector<size_t> deltaB_ords = fmap(deltaB, [](Vertex<T>* v) { return v->ord; });
+  std::vector<size_t> deltaF_ords = fmap(deltaF, [](Vertex<T>* v) { return v->ord; });
+
+  std::vector<size_t> computed_ords;
+  computed_ords.reserve(deltaB_ords.size() + deltaF_ords.size());
+  std::merge(
+    deltaB_ords.begin(), deltaB_ords.end(),
+    deltaF_ords.begin(), deltaF_ords.end(), std::back_inserter(computed_ords));
+
+  tmp.insert(tmp.end(), deltaB.begin(), deltaB.end());
+  tmp.insert(tmp.end(), deltaF.begin(), deltaF.end());
+
+  for (size_t i = 0; i < tmp.size(); i++) {
+    auto new_ord = computed_ords[i];
+    tmp[i]->ord = new_ord;
+    vertices_[new_ord] = tmp[i];
+  }
+
+  clearVisited(deltaF);
+  clearVisited(deltaB);
+}
+
+template <typename T>
+std::string DynamicDAG<T>::toString() {
+  std::stringstream ss;
+  for (auto v : maybe_vertices()) {
+    if (v.has_value()) {
+      ss << v.value()->toString() << "\n";
+    }
+  }
+  return ss.str();
+}
+
+template <typename T>
+std::string Vertex<T>::toString() {
+  std::stringstream ss;
+  ss << "node(" << ord << ")\n";
+  ss << "[";
+  for (auto* c : in_edges) {
+    ss << c->ord << " ";
+  }
+  ss << "] -> {\n";
+  for (auto& d : rdata) {
+    ss << "  " << d;
+  }
+  ss << "} ("<< ord << ") -> [";
+  for (auto* c : out_edges) {
+    ss << c->ord << " ";
+  }
+  ss << "]\n";
+  return ss.str();
+}
+
+}}}

--- a/torch/csrc/jit/dynamic_dag.h
+++ b/torch/csrc/jit/dynamic_dag.h
@@ -49,12 +49,7 @@ struct EdgeData {
   vertex_list<T> out_edges;
 
   static void insert(vertex_list<T>& lst, Vertex<T>* v) {
-    // Keep the list sorted.
-    // We can do the same thing (binary search) for erase() and has()
-    // but I'm not sure if it will perform better especially since
-    // our lists should be small.
-    lst.insert(std::upper_bound(lst.begin(), lst.end(), v,
-          [](Vertex<T>* x, Vertex<T>* y) { return x->ord < y->ord; }), v);
+    lst.push_back(v);
   }
 
   static void erase(vertex_list<T>& lst, Vertex<T>* v) {

--- a/torch/csrc/jit/dynamic_dag.h
+++ b/torch/csrc/jit/dynamic_dag.h
@@ -103,7 +103,13 @@ struct visited_list {
     data_.push_back(elt);
   }
 
-  vertex_list<T>& vector() { return data_; }
+  void sort() {
+    std::sort(data_.begin(), data_.end(), [](Vertex<T>* a, Vertex<T>* b) {
+      return a->ord < b->ord;
+    });
+  }
+
+  const vertex_list<T>& vector() { return data_; }
 
  private:
   vertex_list<T> data_;
@@ -154,7 +160,6 @@ struct DynamicDAG {
  private:
   void mergeProducerIntoConsumer(Vertex<T>* producer, Vertex<T>* consumer);
   void mergeConsumerIntoProducer(Vertex<T>* producer, Vertex<T>* consumer);
-  void sort(vertex_list<T>& delta);
   void reorder(visited_list<T> deltaF, visited_list<T> deltaB);
   bool contractionProducesCycle(Vertex<T>* producer, Vertex<T>* consumer);
   bool dfsSearch(
@@ -184,13 +189,6 @@ template <typename T>
 Vertex<T>* DynamicDAG<T>::newVertex(T datum) {
   vertices_.emplace_back(new Vertex<T>(vertices_.size(), datum));
   return vertices_.back().get();
-}
-
-template <typename T>
-void DynamicDAG<T>::sort(vertex_list<T>& delta) {
-  std::sort(delta.begin(), delta.end(), [](Vertex<T>* a, Vertex<T>* b) {
-    return a->ord < b->ord;
-  });
 }
 
 template <typename T>
@@ -490,11 +488,11 @@ bool DynamicDAG<T>::dfsSearch(
 // Reorder deltaB vertices to occur before deltaF vertices.
 template <typename T>
 void DynamicDAG<T>::reorder(visited_list<T> deltaF, visited_list<T> deltaB) {
-  auto deltaB_ = deltaB.vector();
-  auto deltaF_ = deltaF.vector();
+  deltaB.sort();
+  deltaF.sort();
 
-  sort(deltaB_);
-  sort(deltaF_);
+  const auto& deltaB_ = deltaB.vector();
+  const auto& deltaF_ = deltaF.vector();
 
   size_t num_affected = deltaB_.size() + deltaF_.size();
 

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -219,13 +219,11 @@ static void find_differentiable_groups(
     auto* consumer = dep_graph.at(ord).value();
     if (!shouldConsiderForMerge(consumer)) continue;
 
-    // Iterate through consumer->out_edges() in reverse topological order
-    detail::vertex_list<Node*> in_edges;
-    in_edges.assign(consumer->in_edges().begin(), consumer->in_edges().end());
-    dep_graph.sort(in_edges);
+    // Iterate through consumer->in_edges() in reverse topological order
+    dep_graph.sort(consumer->in_edges());
 
     bool changed = false;
-    for (auto it = in_edges.rbegin(); it != in_edges.rend(); ++it) {
+    for (auto it = consumer->in_edges().rbegin(); it != consumer->in_edges.rend(); ++it) {
       auto * producer = *it;
       // The distance threshold makes this algorithm "not optimal": it will miss
       // some possible contraction opportunities, but it hopefully lets us:

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -3,8 +3,10 @@
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/autodiff.h"
 #include "torch/csrc/jit/assertions.h"
+#include "torch/csrc/jit/dynamic_dag.h"
 
 #include <cstddef>
+#include <limits>
 
 namespace torch { namespace jit {
 
@@ -77,7 +79,11 @@ Node* mergeNodes(Block * block, Symbol group_node_kind, ArrayRef<Node*> nodes) {
   return group_node;
 }
 
-void CreateAutodiffSubgraphs(Block * block, size_t threshold, std::vector<Node*>& diff_graphs) {
+// TODO(rzou): delete this
+void CreateAutodiffSubgraphsNaive(
+    Block * block,
+    size_t threshold,
+    std::vector<Node*>& diff_graphs) {
   // This implementation is not optimal, but it is simple.
   // It just scans through the list in order looking for runs of
   // differentiable ops, and then grouping them together when
@@ -108,7 +114,7 @@ void CreateAutodiffSubgraphs(Block * block, size_t threshold, std::vector<Node*>
       }
       groupable.clear();
       for (Block * sub_block : node->blocks()) {
-        CreateAutodiffSubgraphs(sub_block, threshold, diff_graphs);
+        CreateAutodiffSubgraphsNaive(sub_block, threshold, diff_graphs);
       }
     }
   }
@@ -117,11 +123,165 @@ void CreateAutodiffSubgraphs(Block * block, size_t threshold, std::vector<Node*>
   }
 }
 
+bool shouldConsiderForMerge(detail::Vertex<Node*>* v) {
+  if (v->rdata.size() >= 2) {
+    return true;
+  }
+  JIT_ASSERT(v->rdata.size() == 1);
+  auto * node = *v->rdata.begin();
+  if (node->kind() == prim::Constant) {
+    return false;
+  }
+  return isDifferentiable(node);
+}
+
+static detail::DynamicDAG<Node*> make_dependency_graph(Block * block) {
+  detail::DynamicDAG<Node*> dag;
+  std::unordered_map<Node*,detail::Vertex<Node*>*> node_to_vertex;
+  // NB: the block's param and return nodes are not in the dependency graph.
+  for (Node * node : block->nodes()) {
+    node_to_vertex[node] = dag.newVertex(node);
+  }
+  for (auto * node : block->nodes()) {
+    for (auto * v : node->outputs()) {
+      for (auto & use : v->uses()) {
+        // [Determine data dependencies]
+        // Consider the following code:
+        //     y = f(x)
+        //     if k:
+        //        w += y
+        //     z = g(y)
+        // This produces a dependency graph with 3 vertices:
+        // (0: f)   (1: if k ...)   (2: g)
+        // We need to peek into the if Node* to determine its data dependencies
+        // (the body depends on the output of f, so Vertex 1 depends on Vertex 0).
+        // For each Use of y, we find an owning node of y that is a part of the
+        // dependency graph (in this case, the Vertex containing the if Node*)
+        // and then record the dependency.
+        auto * owning_node = use.user;
+        while (owning_node != nullptr) {
+          auto search = node_to_vertex.find(owning_node);
+          if (search == node_to_vertex.end()) {
+            owning_node = owning_node->owningBlock()->owningNode();
+            continue;
+          }
+          dag.addEdge(node_to_vertex[node], search->second);
+          break;
+        }
+      }
+    }
+  }
+  return dag;
+}
+
+static void find_differentiable_groups(
+    detail::DynamicDAG<Node*>& dep_graph,
+    size_t distance_threshold=64,
+    size_t producer_outedge_threshold=16) {
+  // A Vertex contains a Node* or a differential group of Node*.
+  // Perform graph contraction on dep_graph: contract two vertices(x, y) if
+  // the following conditions hold:
+  // - x, y can be merged to form a differential group
+  // - the contraction would not invalidate the dag (it creates no cycles).
+
+  // Iterate in reverse topological order
+  int64_t ord = dep_graph.maybe_vertices().size() - 1;
+  while (ord >= 0) {
+    if (!dep_graph.maybe_vertices().at(ord)) {
+      --ord;
+      continue;
+    }
+
+    auto * consumer = dep_graph.at(ord);
+    if (!shouldConsiderForMerge(consumer)) {
+      --ord;
+      continue;
+    }
+
+    // Iterate through consumer->in_edges in reverse topological order
+    detail::vertex_list<Node*> in_edges;
+    in_edges.assign(consumer->in_edges.begin(), consumer->in_edges.end());
+    dep_graph.sort(in_edges);
+
+    bool changed = false;
+    for (auto it = in_edges.rbegin(); it != in_edges.rend(); ++it) {
+      auto * producer = *it;
+      // The distance threshold makes this algorithm "not optimal": it will miss
+      // some possible contraction opportunities, but it hopefully lets us:
+      // 1) preserve locality of tensors. We don't want to keep them alive for too long.
+      // 2) Bound the computation complexity for contractEdge
+      if (consumer->ord - producer->ord > distance_threshold) continue;
+      if (producer->out_edges.size() > producer_outedge_threshold) continue;
+      if (!shouldConsiderForMerge(producer)) continue;
+
+      // If the edge contraction is successful, consumer->in_edges
+      // may have changed so we break out of this loop.
+      if (dep_graph.contractEdge(producer, consumer)) {
+        changed = true;
+        break;
+      }
+    }
+    // If we successfully contracted an edge, stay at this vertex.
+    // It may have new edges that should be looked at before moving on.
+    if (!changed) {
+      --ord;
+    }
+  }
+}
+
+static void reorder_according_to_dag(Block * block, const detail::DynamicDAG<Node*>& dep_graph) {
+  auto& vertices = dep_graph.maybe_vertices();
+  for (auto it = vertices.begin(); it != vertices.end(); ++it) {
+    if (!it->has_value()) continue;
+
+    auto& rnodes = it->value()->rdata;
+    for (auto it = rnodes.rbegin(); it != rnodes.rend(); ++it) {
+      (*it)->moveBefore(block->return_node());
+    }
+  }
+}
+
+static void merge_differentiable_groups(
+    Block * block,
+    const detail::DynamicDAG<Node*>& dep_graph,
+    size_t size_threshold,
+    std::vector<Node*>& diff_graphs) {
+  auto& vertices = dep_graph.maybe_vertices();
+  for (auto it = vertices.begin(); it != vertices.end(); ++it) {
+    if (!it->has_value()) continue;
+    if (!shouldConsiderForMerge(it->value())) continue;
+
+    auto& nodes = it->value()->rdata;
+    if (nodes.size() < size_threshold) continue;
+
+    std::reverse(std::begin(nodes), std::end(nodes));
+    diff_graphs.push_back(mergeNodes(block, prim::DifferentiableGraph, nodes));
+  }
+}
+
+void CreateAutodiffSubgraphsPK(
+    Block * block,
+    size_t size_threshold,
+    std::vector<Node*>& diff_graphs) {
+  for (auto * node : block->nodes()) {
+    // Find subgraphs to run this on recursively.
+    if (isDifferentiable(node)) continue;
+    for (auto * sub_block : node->blocks()) {
+      CreateAutodiffSubgraphsPK(sub_block, size_threshold, diff_graphs);
+    }
+  }
+
+  auto dep_graph = make_dependency_graph(block);
+  find_differentiable_groups(dep_graph);
+  reorder_according_to_dag(block, dep_graph);
+  merge_differentiable_groups(block, dep_graph, size_threshold, diff_graphs);
+}
+
 } // anonymous namespace
 
 std::vector<Node*> CreateAutodiffSubgraphs(Graph & graph, size_t threshold) {
   std::vector<Node*> diff_nodes;
-  CreateAutodiffSubgraphs(graph.block(), threshold, diff_nodes);
+  CreateAutodiffSubgraphsPK(graph.block(), threshold, diff_nodes);
   return diff_nodes;
 }
 

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -212,8 +212,8 @@ static void find_differentiable_groups(
   // - the contraction would not invalidate the dag (it creates no cycles).
 
   // Iterate in reverse topological order
-  int64_t ord = dep_graph.size() - 1;
-  for (int64_t ord = dep_graph.size() - 1; ord >= 0; --ord) {
+  int64_t ord = dep_graph.max_size() - 1;
+  for (int64_t ord = dep_graph.max_size() - 1; ord >= 0; --ord) {
     if (!dep_graph.at(ord)) continue;
 
     auto* consumer = dep_graph.at(ord).value();
@@ -253,7 +253,7 @@ static void find_differentiable_groups(
 }
 
 static void reorder_according_to_dag(Block * block, const detail::DynamicDAG<Node*>& dep_graph) {
-  for (size_t ord = 0; ord < dep_graph.size(); ++ord) {
+  for (size_t ord = 0; ord < dep_graph.max_size(); ++ord) {
     const auto& vertex = dep_graph.at(ord);
     if (!vertex.has_value()) continue;
 
@@ -271,7 +271,7 @@ static void merge_differentiable_groups(
     const detail::DynamicDAG<Node*>& dep_graph,
     size_t size_threshold,
     std::vector<Node*>& diff_graphs) {
-  for (size_t ord = 0; ord < dep_graph.size(); ++ord) {
+  for (size_t ord = 0; ord < dep_graph.max_size(); ++ord) {
     const auto& vertex = dep_graph.at(ord);
     if (!vertex) continue;
     if (!shouldConsiderForMerge(vertex.value())) continue;

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -220,7 +220,7 @@ static void find_differentiable_groups(
     if (!shouldConsiderForMerge(consumer)) continue;
 
     // Iterate through consumer->in_edges() in reverse topological order
-    // Those should already be sorted by the DynamicDAG data structure.
+    dep_graph.sort(consumer->in_edges());
 
     bool changed = false;
     for (auto it = consumer->in_edges().rbegin(); it != consumer->in_edges().rend(); ++it) {

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -12,6 +12,28 @@ namespace torch { namespace jit {
 
 struct Graph;
 
+namespace detail {
+template <>
+std::string Vertex<Node*>::toString() {
+  std::stringstream ss;
+  ss << "node(" << ord << ")\n";
+  ss << "[";
+  for (auto* c : in_edges()) {
+    ss << c->ord << " ";
+  }
+  ss << "] -> {\n";
+  for (auto* d : rdata) {
+    ss << "  " << *d;
+  }
+  ss << "} ("<< ord << ") -> [";
+  for (auto* c : out_edges()) {
+    ss << c->ord << " ";
+  }
+  ss << "]\n";
+  return ss.str();
+}
+}
+
 namespace {
 
 // Move nodes that exist in graph g into a 'group_node_kind' node.

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -220,10 +220,10 @@ static void find_differentiable_groups(
     if (!shouldConsiderForMerge(consumer)) continue;
 
     // Iterate through consumer->in_edges() in reverse topological order
-    dep_graph.sort(consumer->in_edges());
+    // Those should already be sorted by the DynamicDAG data structure.
 
     bool changed = false;
-    for (auto it = consumer->in_edges().rbegin(); it != consumer->in_edges.rend(); ++it) {
+    for (auto it = consumer->in_edges().rbegin(); it != consumer->in_edges().rend(); ++it) {
       auto * producer = *it;
       // The distance threshold makes this algorithm "not optimal": it will miss
       // some possible contraction opportunities, but it hopefully lets us:

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -166,7 +166,7 @@ static void find_differentiable_groups(
     // sort is performed once per ord in dep_graph and once per contraction.
     // There can be at most dep_graph.max_size() contractions, so
     // we do at most 2 * dep_graph.max_size() sorts.
-    dep_graph.sort(consumer->in_edges());
+    consumer->in_edges().sort();
 
     for (auto it = consumer->in_edges().rbegin(); it != consumer->in_edges().rend(); ++it) {
       auto * producer = *it;

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -22,7 +22,7 @@ std::string Vertex<Node*>::toString() {
     ss << c->ord << " ";
   }
   ss << "] -> {\n";
-  for (auto* d : rdata) {
+  for (auto* d : data) {
     ss << "  " << *d;
   }
   ss << "} ("<< ord << ") -> [";
@@ -146,11 +146,11 @@ void CreateAutodiffSubgraphsNaive(
 }
 
 bool shouldConsiderForMerge(detail::Vertex<Node*>* v) {
-  if (v->rdata.size() >= 2) {
+  if (v->data.size() >= 2) {
     return true;
   }
-  JIT_ASSERT(v->rdata.size() == 1);
-  auto * node = *v->rdata.begin();
+  JIT_ASSERT(v->data.size() == 1);
+  auto * node = *v->data.begin();
   if (node->kind() == prim::Constant) {
     return false;
   }
@@ -257,8 +257,8 @@ static void reorder_according_to_dag(Block * block, const detail::DynamicDAG<Nod
     const auto& vertex = dep_graph.at(ord);
     if (!vertex.has_value()) continue;
 
-    auto& rnodes = vertex.value()->rdata;
-    for (auto it = rnodes.rbegin(); it != rnodes.rend(); ++it) {
+    auto& nodes = vertex.value()->data;
+    for (auto it = nodes.begin(); it != nodes.end(); ++it) {
       // Move all nodes according to the topological order in dep_graph. A lot
       // of the moves are unnecessary but this is a quick & easy solution.
       (*it)->moveBefore(block->return_node());
@@ -276,10 +276,9 @@ static void merge_differentiable_groups(
     if (!vertex) continue;
     if (!shouldConsiderForMerge(vertex.value())) continue;
 
-    auto& nodes = vertex.value()->rdata;
+    auto& nodes = vertex.value()->data;
     if (nodes.size() < size_threshold) continue;
 
-    std::reverse(std::begin(nodes), std::end(nodes));
     diff_graphs.push_back(mergeNodes(block, prim::DifferentiableGraph, nodes));
   }
 }

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -20,6 +20,7 @@ using Catch::StartsWith;
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/symbolic_variable.h"
 #include "torch/csrc/jit/autodiff.h"
+#include "torch/csrc/jit/dynamic_dag.h"
 #include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
 #include "torch/csrc/autograd/variable.h"
@@ -872,6 +873,213 @@ void testProto() {
   proto.set_producer_name("foo");
 }
 
+std::unique_ptr<detail::DynamicDAG<std::string>> newDynamicDAG() {
+  return std::unique_ptr<detail::DynamicDAG<std::string>>(new detail::DynamicDAG<std::string>());
+}
+
+void testNewVertex() {
+  auto graph = newDynamicDAG();
+  JIT_ASSERT(graph->numVertices() == 0);
+
+  auto a = graph->newVertex("a");
+  JIT_ASSERT(graph->numVertices() == 1);
+  JIT_ASSERT(a->ord == 0);
+  JIT_ASSERT(a->rdata.size() == 1);
+  JIT_ASSERT(a->rdata[0] == "a");
+  JIT_ASSERT(a->visited == false);
+  JIT_ASSERT(a->in_edges.size() == 0);
+  JIT_ASSERT(a->out_edges.size() == 0);
+
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  JIT_ASSERT(graph->numVertices() == 3);
+  JIT_ASSERT(b->ord == 1);
+  JIT_ASSERT(c->ord == 2);
+}
+
+void testAddEdgeBasic() {
+  // a -> b -> c
+  // \---------^
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  graph->addEdge(a, b);
+  graph->addEdge(b, c);
+  graph->addEdge(a, c);
+  JIT_ASSERT(a->in_edges.size() == 0);
+  JIT_ASSERT(a->out_edges.size() == 2);
+  JIT_ASSERT(a->out_edges.count(b));
+  JIT_ASSERT(a->out_edges.count(c));
+
+  JIT_ASSERT(b->in_edges.size() == 1);
+  JIT_ASSERT(b->out_edges.size() == 1);
+  JIT_ASSERT(b->in_edges.count(a));
+  JIT_ASSERT(b->out_edges.count(c));
+
+  JIT_ASSERT(c->in_edges.size() == 2);
+  JIT_ASSERT(c->out_edges.size() == 0);
+  JIT_ASSERT(c->in_edges.count(a));
+  JIT_ASSERT(c->in_edges.count(b));
+}
+
+void testAddEdgeCycleDetection() {
+  // a -> b -> c
+  // ^---------/
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  graph->addEdge(a, b);
+  graph->addEdge(b, c);
+
+  bool erred = false;
+  try {
+    graph->addEdge(c, a);
+  } catch (const std::runtime_error& err) {
+    erred = true;
+  }
+  JIT_ASSERT(erred);
+}
+
+void testAddEdgeReordersBasic() {
+  // a, b => b -> a
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  JIT_ASSERT(a->ord == 0);
+  JIT_ASSERT(b->ord == 1);
+
+  graph->addEdge(b, a);
+  JIT_ASSERT(a->ord == 1);
+  JIT_ASSERT(b->ord == 0);
+}
+
+void testAddEdgeReordersComplicated() {
+  // a -> b  c -> d with addEdge(d, b) ==>
+  // c -> d -> a -> b
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  auto d = graph->newVertex("d");
+  graph->addEdge(a, b);
+  graph->addEdge(c, d);
+  JIT_ASSERT(a->ord == 0);
+  JIT_ASSERT(b->ord == 1);
+  JIT_ASSERT(c->ord == 2);
+  JIT_ASSERT(d->ord == 3);
+
+  graph->addEdge(d, a);
+  JIT_ASSERT(c->ord == 0);
+  JIT_ASSERT(d->ord == 1);
+  JIT_ASSERT(a->ord == 2);
+  JIT_ASSERT(b->ord == 3);
+
+  JIT_ASSERT(c->in_edges.size() == 0);
+  JIT_ASSERT(c->out_edges.size() == 1);
+  JIT_ASSERT(c->out_edges.count(d));
+
+  JIT_ASSERT(d->in_edges.size() == 1);
+  JIT_ASSERT(d->out_edges.size() == 1);
+  JIT_ASSERT(d->in_edges.count(c));
+  JIT_ASSERT(d->out_edges.count(a));
+
+  JIT_ASSERT(a->in_edges.size() == 1);
+  JIT_ASSERT(a->out_edges.size() == 1);
+  JIT_ASSERT(a->in_edges.count(d));
+  JIT_ASSERT(a->out_edges.count(b));
+
+  JIT_ASSERT(b->in_edges.size() == 1);
+  JIT_ASSERT(b->out_edges.size() == 0);
+  JIT_ASSERT(b->in_edges.count(a));
+}
+
+void testRemoveEdgeBasic() {
+  // a -> b
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  graph->addEdge(a, b);
+  JIT_ASSERT(graph->numVertices() == 2);
+
+  graph->removeEdge(a, b);
+  JIT_ASSERT(graph->numVertices() == 2);
+  JIT_ASSERT(a->out_edges.size() == 0);
+  JIT_ASSERT(b->in_edges.size() == 0);
+}
+
+void testRemoveVertexBasic() {
+  // a -> b
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  graph->addEdge(a, b);
+  graph->addEdge(b, c);
+  JIT_ASSERT(graph->numVertices() == 3);
+
+  graph->removeVertex(b);
+  JIT_ASSERT(graph->numVertices() == 2);
+  JIT_ASSERT(a->out_edges.size() == 0);
+  JIT_ASSERT(c->in_edges.size() == 0);
+}
+
+void testContractEdgeBasic() {
+  // a -> b -> c -> d
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  auto d = graph->newVertex("d");
+  graph->addEdge(a, b);
+  graph->addEdge(b, c);
+  graph->addEdge(c, d);
+
+  graph->contractEdge(b, c);
+  JIT_ASSERT(graph->numVertices() == 3);
+  JIT_ASSERT(a->out_edges.size() == 1);
+  JIT_ASSERT(d->in_edges.size() == 1);
+  JIT_ASSERT(*a->out_edges.begin() == *d->in_edges.begin());
+
+  auto* contracted = *a->out_edges.begin();
+  JIT_ASSERT(contracted->rdata.size() == 2);
+  JIT_ASSERT(contracted->rdata[0] == "c");
+  JIT_ASSERT(contracted->rdata[1] == "b");
+
+  JIT_ASSERT(contracted->out_edges.size() == 1);
+  JIT_ASSERT(contracted->in_edges.size() == 1);
+  JIT_ASSERT(contracted->out_edges.count(d) == 1);
+  JIT_ASSERT(contracted->in_edges.count(a) == 1);
+}
+
+void testContractEdgeCycleDetection() {
+  // a -> b -> c
+  // `---------^
+  // contractEdge(a, c) will cause a cycle
+  auto graph = newDynamicDAG();
+  auto a = graph->newVertex("a");
+  auto b = graph->newVertex("b");
+  auto c = graph->newVertex("c");
+  graph->addEdge(a, b);
+  graph->addEdge(b, c);
+  graph->addEdge(a, c);
+
+  JIT_ASSERT(!graph->contractEdge(a, c));
+}
+
+void testDynamicDAG() {
+  testNewVertex();
+  testAddEdgeBasic();
+  testAddEdgeCycleDetection();
+  testAddEdgeReordersBasic();
+  testAddEdgeReordersComplicated();
+  testRemoveEdgeBasic();
+  testRemoveVertexBasic();
+  testContractEdgeBasic();
+  testContractEdgeCycleDetection();
+}
+
 void testCustomOperators() {
   {
     RegisterOperators reg({createOperator(
@@ -1071,6 +1279,7 @@ void testCustomOperators() {
 
 TORCH_API std::string runJITCPPTests() {
   std::stringstream out;
+  testDynamicDAG();
   testIValue();
   testControlFlow();
   testGraphExecutor();

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -879,20 +879,19 @@ std::unique_ptr<detail::DynamicDAG<std::string>> newDynamicDAG() {
 
 void testNewVertex() {
   auto graph = newDynamicDAG();
-  JIT_ASSERT(graph->numVertices() == 0);
+  JIT_ASSERT(graph->debugNumVertices() == 0);
 
   auto a = graph->newVertex("a");
-  JIT_ASSERT(graph->numVertices() == 1);
+  JIT_ASSERT(graph->debugNumVertices() == 1);
   JIT_ASSERT(a->ord == 0);
   JIT_ASSERT(a->rdata.size() == 1);
   JIT_ASSERT(a->rdata[0] == "a");
-  JIT_ASSERT(a->visited == false);
-  JIT_ASSERT(a->in_edges.size() == 0);
-  JIT_ASSERT(a->out_edges.size() == 0);
+  JIT_ASSERT(a->in_edges().size() == 0);
+  JIT_ASSERT(a->out_edges().size() == 0);
 
   auto b = graph->newVertex("b");
   auto c = graph->newVertex("c");
-  JIT_ASSERT(graph->numVertices() == 3);
+  JIT_ASSERT(graph->debugNumVertices() == 3);
   JIT_ASSERT(b->ord == 1);
   JIT_ASSERT(c->ord == 2);
 }
@@ -907,20 +906,20 @@ void testAddEdgeBasic() {
   graph->addEdge(a, b);
   graph->addEdge(b, c);
   graph->addEdge(a, c);
-  JIT_ASSERT(a->in_edges.size() == 0);
-  JIT_ASSERT(a->out_edges.size() == 2);
-  JIT_ASSERT(a->out_edges.count(b));
-  JIT_ASSERT(a->out_edges.count(c));
+  JIT_ASSERT(a->in_edges().size() == 0);
+  JIT_ASSERT(a->out_edges().size() == 2);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), b));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), c));
 
-  JIT_ASSERT(b->in_edges.size() == 1);
-  JIT_ASSERT(b->out_edges.size() == 1);
-  JIT_ASSERT(b->in_edges.count(a));
-  JIT_ASSERT(b->out_edges.count(c));
+  JIT_ASSERT(b->in_edges().size() == 1);
+  JIT_ASSERT(b->out_edges().size() == 1);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(b->in_edges(), a));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(b->out_edges(), c));
 
-  JIT_ASSERT(c->in_edges.size() == 2);
-  JIT_ASSERT(c->out_edges.size() == 0);
-  JIT_ASSERT(c->in_edges.count(a));
-  JIT_ASSERT(c->in_edges.count(b));
+  JIT_ASSERT(c->in_edges().size() == 2);
+  JIT_ASSERT(c->out_edges().size() == 0);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(c->in_edges(), a));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(c->in_edges(), b));
 }
 
 void testAddEdgeCycleDetection() {
@@ -936,7 +935,7 @@ void testAddEdgeCycleDetection() {
   bool erred = false;
   try {
     graph->addEdge(c, a);
-  } catch (const std::runtime_error& err) {
+  } catch (at::Error& err) {
     erred = true;
   }
   JIT_ASSERT(erred);
@@ -976,23 +975,23 @@ void testAddEdgeReordersComplicated() {
   JIT_ASSERT(a->ord == 2);
   JIT_ASSERT(b->ord == 3);
 
-  JIT_ASSERT(c->in_edges.size() == 0);
-  JIT_ASSERT(c->out_edges.size() == 1);
-  JIT_ASSERT(c->out_edges.count(d));
+  JIT_ASSERT(c->in_edges().size() == 0);
+  JIT_ASSERT(c->out_edges().size() == 1);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(c->out_edges(), d));
 
-  JIT_ASSERT(d->in_edges.size() == 1);
-  JIT_ASSERT(d->out_edges.size() == 1);
-  JIT_ASSERT(d->in_edges.count(c));
-  JIT_ASSERT(d->out_edges.count(a));
+  JIT_ASSERT(d->in_edges().size() == 1);
+  JIT_ASSERT(d->out_edges().size() == 1);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(d->in_edges(), c));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(d->out_edges(), a));
 
-  JIT_ASSERT(a->in_edges.size() == 1);
-  JIT_ASSERT(a->out_edges.size() == 1);
-  JIT_ASSERT(a->in_edges.count(d));
-  JIT_ASSERT(a->out_edges.count(b));
+  JIT_ASSERT(a->in_edges().size() == 1);
+  JIT_ASSERT(a->out_edges().size() == 1);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(a->in_edges(), d));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), b));
 
-  JIT_ASSERT(b->in_edges.size() == 1);
-  JIT_ASSERT(b->out_edges.size() == 0);
-  JIT_ASSERT(b->in_edges.count(a));
+  JIT_ASSERT(b->in_edges().size() == 1);
+  JIT_ASSERT(b->out_edges().size() == 0);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(b->in_edges(), a));
 }
 
 void testRemoveEdgeBasic() {
@@ -1001,12 +1000,12 @@ void testRemoveEdgeBasic() {
   auto a = graph->newVertex("a");
   auto b = graph->newVertex("b");
   graph->addEdge(a, b);
-  JIT_ASSERT(graph->numVertices() == 2);
+  JIT_ASSERT(graph->debugNumVertices() == 2);
 
   graph->removeEdge(a, b);
-  JIT_ASSERT(graph->numVertices() == 2);
-  JIT_ASSERT(a->out_edges.size() == 0);
-  JIT_ASSERT(b->in_edges.size() == 0);
+  JIT_ASSERT(graph->debugNumVertices() == 2);
+  JIT_ASSERT(a->out_edges().size() == 0);
+  JIT_ASSERT(b->in_edges().size() == 0);
 }
 
 void testRemoveVertexBasic() {
@@ -1017,12 +1016,12 @@ void testRemoveVertexBasic() {
   auto c = graph->newVertex("c");
   graph->addEdge(a, b);
   graph->addEdge(b, c);
-  JIT_ASSERT(graph->numVertices() == 3);
+  JIT_ASSERT(graph->debugNumVertices() == 3);
 
   graph->removeVertex(b);
-  JIT_ASSERT(graph->numVertices() == 2);
-  JIT_ASSERT(a->out_edges.size() == 0);
-  JIT_ASSERT(c->in_edges.size() == 0);
+  JIT_ASSERT(graph->debugNumVertices() == 2);
+  JIT_ASSERT(a->out_edges().size() == 0);
+  JIT_ASSERT(c->in_edges().size() == 0);
 }
 
 void testContractEdgeBasic() {
@@ -1037,20 +1036,20 @@ void testContractEdgeBasic() {
   graph->addEdge(c, d);
 
   graph->contractEdge(b, c);
-  JIT_ASSERT(graph->numVertices() == 3);
-  JIT_ASSERT(a->out_edges.size() == 1);
-  JIT_ASSERT(d->in_edges.size() == 1);
-  JIT_ASSERT(*a->out_edges.begin() == *d->in_edges.begin());
+  JIT_ASSERT(graph->debugNumVertices() == 3);
+  JIT_ASSERT(a->out_edges().size() == 1);
+  JIT_ASSERT(d->in_edges().size() == 1);
+  JIT_ASSERT(*a->out_edges().begin() == *d->in_edges().begin());
 
-  auto* contracted = *a->out_edges.begin();
+  auto* contracted = *a->out_edges().begin();
   JIT_ASSERT(contracted->rdata.size() == 2);
   JIT_ASSERT(contracted->rdata[0] == "c");
   JIT_ASSERT(contracted->rdata[1] == "b");
 
-  JIT_ASSERT(contracted->out_edges.size() == 1);
-  JIT_ASSERT(contracted->in_edges.size() == 1);
-  JIT_ASSERT(contracted->out_edges.count(d) == 1);
-  JIT_ASSERT(contracted->in_edges.count(a) == 1);
+  JIT_ASSERT(contracted->out_edges().size() == 1);
+  JIT_ASSERT(contracted->in_edges().size() == 1);
+  JIT_ASSERT(detail::EdgeData<std::string>::has(contracted->in_edges(), a));
+  JIT_ASSERT(detail::EdgeData<std::string>::has(contracted->out_edges(), d));
 }
 
 void testContractEdgeCycleDetection() {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -908,18 +908,18 @@ void testAddEdgeBasic() {
   graph->addEdge(a, c);
   JIT_ASSERT(a->in_edges().size() == 0);
   JIT_ASSERT(a->out_edges().size() == 2);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), b));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), c));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), b));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), c));
 
   JIT_ASSERT(b->in_edges().size() == 1);
   JIT_ASSERT(b->out_edges().size() == 1);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(b->in_edges(), a));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(b->out_edges(), c));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->in_edges(), a));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->out_edges(), c));
 
   JIT_ASSERT(c->in_edges().size() == 2);
   JIT_ASSERT(c->out_edges().size() == 0);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(c->in_edges(), a));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(c->in_edges(), b));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->in_edges(), a));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->in_edges(), b));
 }
 
 void testAddEdgeCycleDetection() {
@@ -977,21 +977,21 @@ void testAddEdgeReordersComplicated() {
 
   JIT_ASSERT(c->in_edges().size() == 0);
   JIT_ASSERT(c->out_edges().size() == 1);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(c->out_edges(), d));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->out_edges(), d));
 
   JIT_ASSERT(d->in_edges().size() == 1);
   JIT_ASSERT(d->out_edges().size() == 1);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(d->in_edges(), c));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(d->out_edges(), a));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(d->in_edges(), c));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(d->out_edges(), a));
 
   JIT_ASSERT(a->in_edges().size() == 1);
   JIT_ASSERT(a->out_edges().size() == 1);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(a->in_edges(), d));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(a->out_edges(), b));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->in_edges(), d));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), b));
 
   JIT_ASSERT(b->in_edges().size() == 1);
   JIT_ASSERT(b->out_edges().size() == 0);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(b->in_edges(), a));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->in_edges(), a));
 }
 
 void testRemoveEdgeBasic() {
@@ -1048,8 +1048,8 @@ void testContractEdgeBasic() {
 
   JIT_ASSERT(contracted->out_edges().size() == 1);
   JIT_ASSERT(contracted->in_edges().size() == 1);
-  JIT_ASSERT(detail::EdgeData<std::string>::has(contracted->in_edges(), a));
-  JIT_ASSERT(detail::EdgeData<std::string>::has(contracted->out_edges(), d));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(contracted->in_edges(), a));
+  JIT_ASSERT(detail::vertex_collection<std::string>::contains(contracted->out_edges(), d));
 }
 
 void testContractEdgeCycleDetection() {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -884,8 +884,8 @@ void testNewVertex() {
   auto a = graph->newVertex("a");
   JIT_ASSERT(graph->debugNumVertices() == 1);
   JIT_ASSERT(a->ord == 0);
-  JIT_ASSERT(a->rdata.size() == 1);
-  JIT_ASSERT(a->rdata[0] == "a");
+  JIT_ASSERT(a->data.size() == 1);
+  JIT_ASSERT(a->data[0] == "a");
   JIT_ASSERT(a->in_edges().size() == 0);
   JIT_ASSERT(a->out_edges().size() == 0);
 
@@ -1042,9 +1042,9 @@ void testContractEdgeBasic() {
   JIT_ASSERT(*a->out_edges().begin() == *d->in_edges().begin());
 
   auto* contracted = *a->out_edges().begin();
-  JIT_ASSERT(contracted->rdata.size() == 2);
-  JIT_ASSERT(contracted->rdata[0] == "c");
-  JIT_ASSERT(contracted->rdata[1] == "b");
+  JIT_ASSERT(contracted->data.size() == 2);
+  JIT_ASSERT(contracted->data[0] == "b");
+  JIT_ASSERT(contracted->data[1] == "c");
 
   JIT_ASSERT(contracted->out_edges().size() == 1);
   JIT_ASSERT(contracted->in_edges().size() == 1);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -908,18 +908,18 @@ void testAddEdgeBasic() {
   graph->addEdge(a, c);
   JIT_ASSERT(a->in_edges().size() == 0);
   JIT_ASSERT(a->out_edges().size() == 2);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), b));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), c));
+  JIT_ASSERT(a->out_edges().contains(b));
+  JIT_ASSERT(a->out_edges().contains(c));
 
   JIT_ASSERT(b->in_edges().size() == 1);
   JIT_ASSERT(b->out_edges().size() == 1);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->in_edges(), a));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->out_edges(), c));
+  JIT_ASSERT((b->in_edges().contains(a));
+  JIT_ASSERT(b->out_edges().contains(c));
 
   JIT_ASSERT(c->in_edges().size() == 2);
   JIT_ASSERT(c->out_edges().size() == 0);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->in_edges(), a));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->in_edges(), b));
+  JIT_ASSERT(c->in_edges().contains(a));
+  JIT_ASSERT(c->in_edges().contains(b));
 }
 
 void testAddEdgeCycleDetection() {
@@ -977,21 +977,21 @@ void testAddEdgeReordersComplicated() {
 
   JIT_ASSERT(c->in_edges().size() == 0);
   JIT_ASSERT(c->out_edges().size() == 1);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(c->out_edges(), d));
+  JIT_ASSERT(c->out_edges().contains(d));
 
   JIT_ASSERT(d->in_edges().size() == 1);
   JIT_ASSERT(d->out_edges().size() == 1);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(d->in_edges(), c));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(d->out_edges(), a));
+  JIT_ASSERT(d->in_edges().contains(c));
+  JIT_ASSERT(d->out_edges().contains(a));
 
   JIT_ASSERT(a->in_edges().size() == 1);
   JIT_ASSERT(a->out_edges().size() == 1);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->in_edges(), d));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(a->out_edges(), b));
+  JIT_ASSERT(a->in_edges().contains(d));
+  JIT_ASSERT(a->out_edges().contains(b));
 
   JIT_ASSERT(b->in_edges().size() == 1);
   JIT_ASSERT(b->out_edges().size() == 0);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(b->in_edges(), a));
+  JIT_ASSERT(b->in_edges().contains(a));
 }
 
 void testRemoveEdgeBasic() {
@@ -1048,8 +1048,8 @@ void testContractEdgeBasic() {
 
   JIT_ASSERT(contracted->out_edges().size() == 1);
   JIT_ASSERT(contracted->in_edges().size() == 1);
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(contracted->in_edges(), a));
-  JIT_ASSERT(detail::vertex_collection<std::string>::contains(contracted->out_edges(), d));
+  JIT_ASSERT(contracted->in_edges().contains(a));
+  JIT_ASSERT(contracted->out_edges().contains(d));
 }
 
 void testContractEdgeCycleDetection() {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -913,7 +913,7 @@ void testAddEdgeBasic() {
 
   JIT_ASSERT(b->in_edges().size() == 1);
   JIT_ASSERT(b->out_edges().size() == 1);
-  JIT_ASSERT((b->in_edges().contains(a));
+  JIT_ASSERT(b->in_edges().contains(a));
   JIT_ASSERT(b->out_edges().contains(c));
 
   JIT_ASSERT(c->in_edges().size() == 2);


### PR DESCRIPTION
### Motivation

If any inputs require_grad then the graph executor does differential subgraph slicing. The existing algorithm combines adjacent differentiable Node*.

There are two major motivations. The first is improving fusion opportunities: the graph fusion pass runs after differential subgraph slicing. This means that only nodes that are a part of the same differential subgraph may be considered for fusion. If something like the following happens,
```
y = f(x)
k = not_differentiable_op(m)
z = g(y)
```
and f and g are both fusible and differentiable operations, then they will be inserted into different differential subgraphs and not fused together.

The second is to enable JIT optimizations on backward passes for things like an (automatically) unrolled LSTM. Right now, in an unrolled LSTM, we see something like the following:
```
lstm_cell()
non_differentiable_list_op()
lstm_cell()
non_differentiable_list_op()
lstm_cell()
non_differentiable_list_op()
```
Each lstm_cell itself is differentiable and gets put into a separate differential subgraph. During the backwards pass, each prim::DifferentiableSubgraph has its own graph executor: these graph executors cannot talk to each other. It is better if we combined all of the lstm_cells (where applicable) into one differential subgraph so their backward passes are combined into one graph executor that can perform better optimizations than several separate graph executors.

### Problem Statement
Think about the computation graph as a DAG where edges are data dependencies and vertices are operations (the nodes). Each vertex is either black or red; a vertex is colored black if it is differentiable and red otherwise. The goal is to contract edges (merge nodes) to have the fewest black vertices remaining such that the graph is still a DAG.

### Implementation
The algorithm is the following:
- Take the Graph& and create a shadow "DynamicDAG" object to wrap Node* and edges. Each Vertex holds multiple Node* (but starts out holding one Node*) and each edge is a data dependency.
- Greedily contract vertices in the DynamicDAG if they are "differentiable". This operation is unrelated to the Graph&.
  - A Vertex is "differentiable" if all the nodes it holds is differentiable.
  - When contracting vertices, combine their Node* contents.
  - The DynamicDAG keeps its vertices in topological order and complains if the contraction is invalid so everything is good.
- Take the DynamicDAG: reorder the nodes in the Graph& to match the topological order in the DynamicDAG.
- Finally, go through each Vertex in the DynamicDAG: if it contains multiple Node* then merge all of them into a prim::DifferentiableGraph.

The DynamicDAG is based off of the dynamic top sort algorithm in [this paper](https://www.doc.ic.ac.uk/~phjk/Publications/DynamicTopoSortAlg-JEA-07.pdf) by Pearce and Kelly.

### Analysis
Each contractEdge(producer, consumer) call is `O(|AR| log |AR| * min(|out_edges(producer)|, |in_edges(consumer)|)` where `AR` is the "affected region" (defined as the set of nodes that, in topological order, are between producer and consumer). By only considering contractions such that `|ord(producer) - ord(consumer)| < threshold1` and `|out_edges(producer)| < threshold2` we can make each contractEdge(producer, consumer) call take constant time. The resulting algorithm is linear in the number of nodes.

### Test Plan
Added a lot of small test cases.

Looking for suggestions on the following:
- what big computation graphs should I run this on to test how fast or slow it is?
- what things other than correctness should I be thinking about when I test this?

cc @apaszke @zdevito 
