### PR TITLE
Enable alternative LayerNorm impl in FisherGan

### DIFF
--- a/caffe2/python/layers/layer_normalization.py
+++ b/caffe2/python/layers/layer_normalization.py
@@ -19,6 +19,7 @@ class LayerNormalization(ModelLayer):
         bias_optim=None,
         epsilon=1e-4,
         axis=1,
+        use_layer_norm_op=True,
         **kwargs
     ):
         super(LayerNormalization, self).__init__(
@@ -28,7 +29,6 @@ class LayerNormalization(ModelLayer):
             "Incorrect input type: {}".format(input_record))
 
         self.input_shape = input_record.field_type().shape
-        self.epsilon = epsilon
         self.axis = axis
 
         assert len(self.input_shape) >= 1, (
@@ -48,8 +48,20 @@ class LayerNormalization(ModelLayer):
                                        shape=[input_dims],
                                        initializer=('ConstantFill', {'value': 0.0}),
                                        optimizer=bias_optim)
+        self.use_layer_norm_op = use_layer_norm_op
 
-    def add_ops(self, net):
+        if self.use_layer_norm_op:
+            self.epsilon = epsilon
+        else:
+            assert len(self.input_shape) == 1, (
+                "When using alternative implementation, "
+                "input data can only be 2D"
+            )
+            self.epsilon = model.maybe_add_global_constant(
+                "%s_epsilon" % self.name, float(epsilon)
+            )
+
+    def add_ops_with_layer_norm_op(self, net):
         input_blob = self.input_record.field_blobs()
         ln_output = self.output_schema.field_blobs()
 
@@ -74,3 +86,35 @@ class LayerNormalization(ModelLayer):
             broadcast=1,
             axis=self.axis,
         )
+
+    def add_ops_without_layer_norm_op(self, net):
+        # two issues here:
+        #  1. use multiple ops to replace the function of LayerNorm
+        #  2. do not use legacy broadcast
+        ln_output = net.NextScopedBlob("ln_output")
+        ln_mean = net.NextScopedBlob("ln_mean")
+        ln_stdev = net.NextScopedBlob("ln_stdev")
+        ln_mean_arr = net.NextScopedBlob("ln_mean_arr")
+        net.ReduceBackMean(self.input_record.field_blobs(), [ln_mean_arr])
+        net.ExpandDims([ln_mean_arr], [ln_mean], dims=[1])
+        ln_centered = net.NextScopedBlob("ln_centered")
+        net.Sub(self.input_record.field_blobs() + [ln_mean], [ln_centered])
+        ln_sqr = net.NextScopedBlob("ln_sqr")
+        net.Sqr([ln_centered], [ln_sqr])
+        ln_sqr_mean = net.NextScopedBlob("ln_sqr_mean")
+        net.ReduceBackMean([ln_sqr], [ln_sqr_mean])
+        ln_var = net.NextScopedBlob("ln_var")
+        net.Add([ln_sqr_mean, self.epsilon], ln_var)
+        ln_std_arr = net.NextScopedBlob("ln_std_arr")
+        net.Pow([ln_var], [ln_std_arr], exponent=0.5)
+        net.ExpandDims([ln_std_arr], [ln_stdev], dims=[1])
+        net.Div([ln_centered, ln_stdev], [ln_output])
+        ln_scaled = net.NextScopedBlob("ln_scaled")
+        net.Mul([ln_output, self.scale], [ln_scaled])
+        net.Add([ln_scaled, self.bias], self.output_schema.field_blobs())
+
+    def add_ops(self, net):
+        if self.use_layer_norm_op:
+            self.add_ops_with_layer_norm_op(net)
+        else:
+            self.add_ops_without_layer_norm_op(net)

--- a/caffe2/python/normalizer.py
+++ b/caffe2/python/normalizer.py
@@ -31,11 +31,12 @@ class BatchNormalizer(Normalizer):
 
 
 class LayerNormalizer(Normalizer):
-    def __init__(self, epsilon):
+    def __init__(self, epsilon, use_layer_norm_op=True):
         super(LayerNormalizer, self).__init__()
         self._epsilon = float(epsilon)
+        self._use_layer_norm_op = use_layer_norm_op
 
     def _run(self, layer_model, param):
         return layer_model.LayerNormalization(
-            param, epsilon=self._epsilon
+            param, epsilon=self._epsilon, use_layer_norm_op=self._use_layer_norm_op
         )


### PR DESCRIPTION
Summary:
Fisher GAN calls processor_util.add_mlp, which inject the layer norm through the
normalizer. We allow to use alternative impl for LayerNorn in the normalizer.

Differential Revision: D9235528
