### PR TITLE
When looking for pybind11, do not attempt to get properties from pybind11:pybind11.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -489,7 +489,7 @@ endif()
 
 if(pybind11_FOUND)
     message(STATUS "System pybind11 found")
-    message(STATUS "pybind11l include dirs: " ${pybind11_INCLUDE_DIRS})
+    message(STATUS "pybind11 include dirs: " ${pybind11_INCLUDE_DIRS})
     include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
 else()
     message(STATUS "Using third_party/pybind11.")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -483,9 +483,7 @@ endif()
 
 # ---[ pybind11
 find_package(pybind11 CONFIG)
-if((DEFINED pybind11_DIR) AND pybind11_DIR)
-  get_target_property(pybind11_INCLUDE_DIRS pybind11::pybind11 INTERFACE_INCLUDE_DIRECTORIES)
-else()
+if(NOT pybind11_FOUND)
   find_package(pybind11)
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -489,7 +489,7 @@ endif()
 
 if(pybind11_FOUND)
     message(STATUS "System pybind11 found")
-    message(STATUS "pybind11 include dirs: " ${pybind11_INCLUDE_DIRS})
+    message(STATUS "pybind11 include dirs: " "${pybind11_INCLUDE_DIRS}")
     include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
 else()
     message(STATUS "Using third_party/pybind11.")


### PR DESCRIPTION
There is no property name "INTERFACE_INCLUDE_DIRECTORIES" for pybind11::pybind11. This will cause cmake error if there exists a system installation of pybind11. In addition, pybind11_INCLUDE_DIRS is already set once "find_package(pybind11 CONFIG)" finds pybind11.

