### PR TITLE
[JIT] Allow gathering tuple

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2823,6 +2823,21 @@ a")
 
         self.checkScript(func, [x], optimize=True)
 
+        with self.assertRaises(RuntimeError):
+            @torch.jit.script
+            def func(x):
+                return (x, 1)[2]
+
+        with self.assertRaises(RuntimeError):
+            @torch.jit.script
+            def func(x):
+                return (x, 1)[-3]
+
+        with self.assertRaises(RuntimeError):
+            @torch.jit.script
+            def func(x):
+                return (x, 1)[1.0]
+
     def test_random(self):
         @torch.jit.script
         def f(mean, std):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2808,12 +2808,14 @@ a")
 
         self.checkScript(func, [x], optimize=True)
 
-        def func(x, i:int):
+        def func(x, i):
+            # type: (Tensor, int) -> Tensor
             return [x, x + 1, x + 2, x + 3][i]
 
         self.checkScript(func, [x, 1], optimize=True)
 
-        def func(x, i:int):
+        def func(x, i):
+            # type: (Tensor, int) -> Tensor
             return (x, x + 1, x + 2, x + 3)[i]
 
         self.checkScript(func, [x, 1], optimize=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2801,10 +2801,26 @@ a")
         self.checkScript(func2, [x], optimize=True)
 
     def test_gather(self):
+        x = torch.rand(10, dtype=torch.float, requires_grad=True)
+
         def func(x):
             return x[0]
 
-        x = torch.rand(10, dtype=torch.float, requires_grad=True)
+        self.checkScript(func, [x], optimize=True)
+
+        def func(x, i:int):
+            return [x, x + 1, x + 2, x + 3][i]
+
+        self.checkScript(func, [x, 1], optimize=True)
+
+        def func(x, i:int):
+            return (x, x + 1, x + 2, x + 3)[i]
+
+        self.checkScript(func, [x, 1], optimize=True)
+
+        def func(x):
+            return (x, 1)[0]
+
         self.checkScript(func, [x], optimize=True)
 
     def test_random(self):

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -99,6 +99,7 @@ struct TreeView {
   int kind() const {
     return tree_->kind();
   }
+  virtual ~TreeView() {}
 
 protected:
   const TreeRef& subtree(size_t i) const {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -99,7 +99,6 @@ struct TreeView {
   int kind() const {
     return tree_->kind();
   }
-  virtual ~TreeView() {}
 
 protected:
   const TreeRef& subtree(size_t i) const {


### PR DESCRIPTION
Closes: https://github.com/pytorch/pytorch/issues/12365

Current, the following code gives an error:
```python
@torch.jit.script
def f(x):
    return torch.sort(x)[0]
```
With error message:
```
Traceback (most recent call last):
  File "quicktest.py", line 3, in <module>
    @torch.jit.script
  File "/Users/gaoxiang/anaconda3/lib/python3.6/site-packages/torch/jit/__init__.py", line 589, in script
    graph = _jit_script_compile(ast, rcb)
RuntimeError: gatherable->type()->isSubtypeOf(DynamicType::get()) ASSERT FAILED at /Users/administrator/nightlies/2018_09_28/wheel_build_dirs/conda_3.6/conda/conda-bld/pytorch-nightly_1538131714608/work/torch/csrc/jit/script/compiler.cpp:1819, please report a bug to PyTorch. (emitBasicGather at /Users/administrator/nightlies/2018_09_28/wheel_build_dirs/conda_3.6/conda/conda-bld/pytorch-nightly_1538131714608/work/torch/csrc/jit/script/compiler.cpp:1819)
frame #0: torch::jit::script::to_ir::emitSimpleExpr(std::__1::shared_ptr<torch::jit::script::Tree> const&) + 2371 (0x10c3e5e53 in libtorch.dylib)
frame #1: torch::jit::script::to_ir::emitSugaredExpr(torch::jit::script::Expr, unsigned long) + 1446 (0x10c3dd326 in libtorch.dylib)
frame #2: torch::jit::script::to_ir::emitExpr(torch::jit::script::Expr) + 69 (0x10c3dddd5 in libtorch.dylib)
frame #3: torch::jit::script::to_ir::getNamedValues(std::__1::vector<std::__1::shared_ptr<torch::jit::script::Tree>, std::__1::allocator<std::__1::shared_ptr<torch::jit::script::Tree> > >, bool) + 1216 (0x10c3e6a40 in libtorch.dylib)
frame #4: torch::jit::script::to_ir::getValues(std::__1::vector<std::__1::shared_ptr<torch::jit::script::Tree>, std::__1::allocator<std::__1::shared_ptr<torch::jit::script::Tree> > >, bool) + 64 (0x10c3eec30 in libtorch.dylib)
frame #5: torch::jit::script::to_ir::getValues(torch::jit::script::List<torch::jit::script::Expr>, bool) + 86 (0x10c3d8156 in libtorch.dylib)
frame #6: torch::jit::script::to_ir::to_ir(torch::jit::script::Def, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, torch::jit::script::Method&, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, torch::jit::script::Method&> > >&, std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)> const&, std::__1::shared_ptr<torch::jit::script::SugaredValue>, torch::jit::script::Method&) + 2754 (0x10c3d5082 in libtorch.dylib)
frame #7: std::__1::__function::__func<torch::jit::script::defineMethodsInModule(torch::jit::script::Module&, std::__1::vector<torch::jit::script::Def, std::__1::allocator<torch::jit::script::Def> > const&, std::__1::vector<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)>, std::__1::allocator<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)> > > const&, std::__1::shared_ptr<torch::jit::script::SugaredValue>)::$_5, std::__1::allocator<torch::jit::script::defineMethodsInModule(torch::jit::script::Module&, std::__1::vector<torch::jit::script::Def, std::__1::allocator<torch::jit::script::Def> > const&, std::__1::vector<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)>, std::__1::allocator<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)> > > const&, std::__1::shared_ptr<torch::jit::script::SugaredValue>)::$_5>, void (torch::jit::script::Method&)>::operator()(torch::jit::script::Method&) + 111 (0x10c3d452f in libtorch.dylib)
frame #8: torch::jit::script::Method::ensure_defined() + 175 (0x10c3f7fbf in libtorch.dylib)
frame #9: torch::jit::script::defineMethodsInModule(torch::jit::script::Module&, std::__1::vector<torch::jit::script::Def, std::__1::allocator<torch::jit::script::Def> > const&, std::__1::vector<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)>, std::__1::allocator<std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)> > > const&, std::__1::shared_ptr<torch::jit::script::SugaredValue>) + 2520 (0x10c3bfa28 in libtorch.dylib)
frame #10: torch::jit::script::compileFunction(torch::jit::script::Def, std::__1::function<std::__1::shared_ptr<torch::jit::script::SugaredValue> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, torch::jit::script::Method&, torch::jit::SourceRange const&)> const&) + 620 (0x10c3c405c in libtorch.dylib)
frame #11: void pybind11::cpp_function::initialize<torch::jit::script::initJitScriptBindings(_object*)::$_21, std::__1::shared_ptr<torch::jit::Graph>, torch::jit::script::Def const&, std::__1::function<pybind11::function (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)>, pybind11::name, pybind11::scope, pybind11::sibling>(torch::jit::script::initJitScriptBindings(_object*)::$_21&&, std::__1::shared_ptr<torch::jit::Graph> (*)(torch::jit::script::Def const&, std::__1::function<pybind11::function (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)>), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&)::'lambda'(pybind11::detail::function_call&)::__invoke(pybind11::detail::function_call&) + 408 (0x10937fe58 in _C.cpython-36m-darwin.so)
frame #12: pybind11::cpp_function::dispatcher(_object*, _object*, _object*) + 3308 (0x108fc570c in _C.cpython-36m-darwin.so)
<omitting python frames>
frame #25: start + 1 (0x7fff67c8f085 in libdyld.dylib)
```
This PR fix this issue by allowing JIT to emit code for gathering tuples.