### PR TITLE
Temporary fix for LibTorch download link

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -4,7 +4,7 @@ Installing C++ Distributions of PyTorch
 We provide binary distributions of all headers, libraries and CMake
 configuration files required to depend on PyTorch. We call this distribution
 *LibTorch*, and you can download ZIP archives containing the latest LibTorch
-distribution on `our website <https://pytorch.org/get-started/locally/>`_. Below
+distribution on `our website <https://gist.github.com/goldsborough/fc3d94917f0405a9da7ec2899710eb9f>`_. Below
 is a small example of writing a minimal application that depends on LibTorch
 and uses the `at::Tensor` class which comes with the PyTorch C++ API.
 
@@ -16,9 +16,8 @@ example:
 
 .. code-block:: sh
 
-  wget http://pytorch.org/libtorch/libtorch-latest.zip
-  unzip libtorch-latest.zip
-  ls -1R libtorch-latest
+  wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
+  unzip libtorch-shared-with-deps-latest.zip
 
 
 Next, we can write a minimal CMake build configuration to develop a small


### PR DESCRIPTION
We're waiting for the libtorch links to show up on the website. I had a fake link in the docs so far which is misleading. This PR changes it to a temporary markdown file until the web people fix the site tomorrow.