### PR TITLE
Enable clang-tidy in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,51 +1,11 @@
 ---
 # NOTE: there must be no spaces before the '-', so put the comma first.
 Checks: '
-  *
-  ,clang-analyzer-*
-  ,modernize-*
-  ,-cert-dcl21-cpp
-  ,-cert-err58-cpp
-  ,-cert-err60-cpp
-  ,-clang-diagnostic-*
-  ,-cppcoreguidelines-owning-memory
-  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
-  ,-cppcoreguidelines-pro-bounds-constant-array-index
-  ,-cppcoreguidelines-pro-type-member-init
-  ,-cppcoreguidelines-pro-type-static-cast-downcast
-  ,-cppcoreguidelines-pro-type-union-access
-  ,-cppcoreguidelines-pro-type-vararg
-  ,-cppcoreguidelines-special-member-functions
-  ,-fuchsia-*
-  ,-google-build-using-namespace
-  ,-google-default-arguments
-  ,-google-explicit-constructor
-  ,-google-readability-braces-around-statements
-  ,-google-readability-namespace-comments
-  ,-google-readability-todo
-  ,-google-runtime-references
-  ,-google-runtime-references
-  ,-hicpp-braces-around-statements
-  ,-hicpp-explicit-conversions
-  ,-hicpp-member-init
-  ,-hicpp-no-array-decay
-  ,-hicpp-signed-bitwise
-  ,-hicpp-special-member-functions
-  ,-hicpp-vararg
-  ,-llvm-header-guard
-  ,-llvm-include-order
-  ,-llvm-namespace-comment
-  ,-misc-unused-parameters
-  ,-modernize-make-unique
-  ,-modernize-use-default-member-init
-  ,-performance-unnecessary-value-param
-  ,-readability-braces-around-statements
-  ,-readability-else-after-return
-  ,-readability-implicit-bool-conversion
-  ,-readability-named-parameter
+  -*
+  ,modernize-deprecated-headers
   '
-WarningsAsErrors: ''
-HeaderFilterRegex: 'torch/csrc/'
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'torch/csrc/.*'
 AnalyzeTemporaryDtors: false
 CheckOptions:
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,12 @@ matrix:
       - env: CPP_DOC_CHECK
         install: sudo apt-get install -y doxygen
         script: cd docs/cpp/source && ./check-doxygen.sh
+      - env: CLANG_TIDY
+        python: "3.6"
+        addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+              - llvm-toolchain-trusty-6.0
+            packages: clang-tidy-6.0
+        script: tools/run-clang-tidy-in-ci.sh "$(which clang-tidy-6.0)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ matrix:
               - ubuntu-toolchain-r-test
               - llvm-toolchain-trusty-6.0
             packages: clang-tidy-6.0
-        script: tools/run-clang-tidy-in-ci.sh "$(which clang-tidy-6.0)"
+        script: tools/run-clang-tidy-in-ci.sh -e "$(which clang-tidy-6.0)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ if (NOT MSVC)
   set(CMAKE_C_STANDARD 11)
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # One variable that determines whether the current cmake process is being run
 # with the main Caffe2 library. This is useful for building modules - if
 # modules are built with the main Caffe2 library then one does not need to do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ have more checks than older versions. In our CI, we run clang-tidy-6.0.
    uncommitted changes). Changes are picked up based on a `git diff` with the
    given revision:
   ```sh
-  $ python tools/clang_tidy.py -d /path/to/build/ -p torch/csrc -r HEAD~1
+  $ python tools/clang_tidy.py -d build -p torch/csrc -r HEAD~1
   ```
 
 Above, it is assumed you are in the PyTorch root folder. `path/to/build` should

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,6 +354,36 @@ static_assert(std::is_same(A*, decltype(A::singelton()))::value, "hmm");
   are too large.  Splitting such files into separate files helps.
   (Example: `THTensorMath`, `THTensorMoreMath`, `THTensorEvenMoreMath`.)
 
+### Running Clang-Tidy
+
+[Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/index.html) is a C++
+linter and static analysis tool based on the clang compiler. We run clang-tidy
+in our CI to make sure that new C++ code is safe, sane and efficient. See our
+[.travis.yml](https://github.com/pytorch/pytorch/blob/master/.travis.yml) file
+for the simple commands we use for this.
+
+To run clang-tidy locally, follow these steps:
+
+1. Install clang-tidy. First, check if you already have clang-tidy by simply
+writing `clang-tidy` in your terminal. If you don't yet have clang-tidy, you
+should be able to install it easily with your package manager, e.g. by writing
+`apt-get install clang-tidy` on Ubuntu. See https://apt.llvm.org for details on
+how to install the latest version. Note that newer versions of clang-tidy will
+have more checks than older versions. In our CI, we run clang-tidy-6.0.
+
+2. Use our driver script to run clang-tidy over any changes relative to some
+   git revision (you may want to replace `HEAD~1` with `HEAD` to pick up
+   uncommitted changes). Changes are picked up based on a `git diff` with the
+   given revision:
+  ```sh
+  $ python tools/clang_tidy.py -d /path/to/build/ -p torch/csrc -r HEAD~1
+  ```
+
+Above, it is assumed you are in the PyTorch root folder. `path/to/build` should
+be the path to where you built PyTorch from source, e.g. `build` in the PyTorch
+root folder if you used `setup.py build`. You can use `-c <clang-tidy-binary>`
+to change the clang-tidy this script uses.
+
 ## Caffe2 notes
 
 In 2018, we merged Caffe2 into the PyTorch source repository.  While the

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1,3 +1,10 @@
+// NB: Must be at the top of file to avoid including the deprecated "math.h".
+// https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif
+
 #include "Functions.h"
 #include <ATen/Utils.h>
 #include <ATen/core/TensorOptions.h>
@@ -6,12 +13,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/core/Reduction.h>
 
-// define constants like M_PI and C keywords for MSVC
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
 #include <ciso646>
-#endif
-#include <math.h>
 #include <algorithm>
 #include <numeric>
 

--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -201,7 +201,6 @@ goto:eof
                   -DMKLDNN_LIBRARY="%MKLDNN_LIBRARY%" ^
                   -DATEN_NO_CONTRIB=1 ^
                   -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" ^
-                  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ^
                   -DCMAKE_C_FLAGS="%USER_CFLAGS%" ^
                   -DCMAKE_CXX_FLAGS="/EHa %USER_CFLAGS%" ^
                   -DCMAKE_EXE_LINKER_FLAGS="%USER_LDFLAGS%" ^

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -197,7 +197,7 @@ function build() {
 		       -DCMAKE_DEBUG_POSTFIX="" \
 		       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
 		       ${@:2} \
-		       -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${CMAKE_ARGS[@]}
+		       ${CMAKE_ARGS[@]}
   fi
   ${CMAKE_INSTALL} -j"$MAX_JOBS"
   popd
@@ -301,7 +301,6 @@ function build_caffe2() {
 		       -DMKLDNN_LIB_DIR=$MKLDNN_LIB_DIR \
 		       -DMKLDNN_LIBRARY=$MKLDNN_LIBRARY \
 		       -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-		       -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
 		       -DCMAKE_C_FLAGS="$USER_CFLAGS" \
 		       -DCMAKE_CXX_FLAGS="$USER_CFLAGS" \
 		       -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -28,9 +28,4 @@ if [[ ! -d build ]]; then
 fi
 
 # Run Clang-Tidy
-time python tools/clang_tidy.py     \
-  --clang-tidy-exe ${1:-clang-tidy} \
-  --verbose                         \
-  --compile-commands-dir build      \
-  --paths torch/csrc                \
-  --diff HEAD~1
+time python tools/clang_tidy.py -vp torch/csrc -d HEAD~1 "$@"

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+if [[ ! -d build ]]; then
+  git submodule update --init --recursive
+
+  mkdir build
+  pushd build
+  # We really only need compile_commands.json, so no need to build!
+  time cmake -DBUILD_TORCH=ON ..
+  popd
+
+  # Generate ATen files.
+  time python aten/src/ATen/gen.py \
+    -s aten/src/ATen \
+    -d build/aten/src/ATen \
+    aten/src/ATen/Declarations.cwrap \
+    aten/src/THNN/generic/THNN.h \
+    aten/src/THCUNN/generic/THCUNN.h \
+    aten/src/ATen/nn.yaml \
+    aten/src/ATen/native/native_functions.yaml
+
+  # Generate PyTorch files.
+  time python tools/setup_helpers/generate_code.py            \
+    --declarations-path build/aten/src/ATen/Declarations.yaml \
+    --nn-path aten/src
+fi
+
+# Run Clang-Tidy
+time python tools/clang_tidy.py     \
+  --clang-tidy-exe ${1:-clang-tidy} \
+  --verbose                         \
+  --compile-commands-dir build      \
+  --paths torch/csrc                \
+  --diff HEAD~1

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -7,6 +7,7 @@ else()
   project(torch CXX C)
   find_package(Caffe2 REQUIRED)
   option(USE_CUDA "Use CUDA" ON)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
 option(BUILD_TEST "Build torch test binaries" ON)

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -22,7 +22,7 @@
 #include <cuda_runtime.h>
 #endif
 #ifndef _WIN32
-#include <time.h>
+#include <ctime>
 #endif
 
 namespace torch { namespace autograd {

--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include "ATen/core/Error.h"
 #include "ATen/core/optional.h"
-#include "string.h"
+#include <cstring>
 #include "torch/csrc/jit/interned_strings_class.h"
 
 namespace torch { namespace jit {

--- a/torch/csrc/jit/interned_strings_class.h
+++ b/torch/csrc/jit/interned_strings_class.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include "ATen/core/Error.h"
 #include "ATen/core/optional.h"
-#include "string.h"
+#include <cstring>
 #include "torch/csrc/jit/interned_strings.h"
 
 namespace torch {


### PR DESCRIPTION
At long last, we will have clang-tidy enabled in CI. For a while I thought I could clean up the project enough to enable clang-tidy with all checks enabled, but I figure it's smarter to set up the minimal checks and at least have those in CI. We can fix more going forward.

@ezyang @apaszke 