### PR TITLE
revert \gamma to \Gamma

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2938,7 +2938,7 @@ Computes the multivariate log-gamma function with dimension :math:`p` element-wi
 .. math::
     \log(\Gamma_{p}(a)) = C + \displaystyle \sum_{i=1}^{p} \log\left(\Gamma\left(a - \frac{i - 1}{2}\right)\right)
 
-where :math:`C = \log(\pi) \times \frac{p (p - 1)}{2}` and :math:`\Gamma(.)` is the Gamma function.
+where :math:`C = \log(\pi) \times \frac{p (p - 1)}{2}` and :math:`\Gamma(\cdot)` is the Gamma function.
 
 If any of the elements are less than or equal to :math:`\frac{p - 1}{2}`, then an error
 is thrown.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1210,7 +1210,7 @@ digamma(input) -> Tensor
 Computes the logarithmic derivative of the gamma function on `input`.
 
 .. math::
-    \psi(x) = \frac{d}{dx} \ln\left(\gamma\left(x\right)\right) = \frac{\gamma'(x)}{\gamma(x)}
+    \psi(x) = \frac{d}{dx} \ln\left(\Gamma\left(x\right)\right) = \frac{\Gamma'(x)}{\Gamma(x)}
 
 Args:
     input (Tensor): the tensor to compute the digamma function on
@@ -2936,9 +2936,9 @@ mvlgamma(input, p) -> Tensor
 Computes the multivariate log-gamma function with dimension :math:`p` element-wise, given by
 
 .. math::
-    \log(\gamma_{p}(a)) = C + \displaystyle \sum_{i=1}^{p} \log\left(\gamma\left(a - \frac{i - 1}{2}\right)\right)
+    \log(\Gamma_{p}(a)) = C + \displaystyle \sum_{i=1}^{p} \log\left(\Gamma\left(a - \frac{i - 1}{2}\right)\right)
 
-where :math:`C = \log(\pi) \times \frac{p (p - 1)}{2}` and :math:`\gamma(.)` is the Gamma function.
+where :math:`C = \log(\pi) \times \frac{p (p - 1)}{2}` and :math:`\Gamma(.)` is the Gamma function.
 
 If any of the elements are less than or equal to :math:`\frac{p - 1}{2}`, then an error
 is thrown.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -648,7 +648,7 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None):
 
     Args:
         input (Tensor): the input tensor
-        p (int, float, inf, -inf, 'fro', 'nuc'): the order of norm
+        p (int, float, inf, -inf, 'fro', 'nuc', optional): the order of norm. Default: ``'fro'``
             The following norms can be calculated:
 
             =====  ============================  ==========================
@@ -667,13 +667,14 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None):
             calculated when the input tensor only has one dimension. If the input
             tensor has more than two dimensions, the vector norm will be applied to
             last dimension.
-        keepdim (bool): whether the output tensors have :attr:`dim`
+        keepdim (bool, optional): whether the output tensors have :attr:`dim`
             retained or not. Ignored if :attr:`dim` = ``None`` and
-            :attr:`out` = ``None``.
+            :attr:`out` = ``None``. Default: ``False``
         out (Tensor, optional): the output tensor. Ignored if
             :attr:`dim` = ``None`` and :attr:`out` = ``None``.
 
     Example::
+
         >>> import torch
         >>> a = torch.arange(9, dtype= torch.float) - 4
         >>> b = a.reshape((3, 3))


### PR DESCRIPTION
- revert `\gamma` changes at landed PR: https://github.com/pytorch/pytorch/pull/12126
- minor fix for docs of `torch.norm()`

@SsnL 