### PR TITLE
Amend nondeterminism notes

### DIFF
--- a/docs/source/cuda_deterministic.rst
+++ b/docs/source/cuda_deterministic.rst
@@ -1,0 +1,5 @@
+.. note::
+
+    When using the CUDA backend, this operation may induce nondeterministic
+    behaviour that is not easily switched off.
+    Please see the notes on :doc:`/notes/randomness` for background.

--- a/docs/source/cuda_deterministic_backward.rst
+++ b/docs/source/cuda_deterministic_backward.rst
@@ -1,0 +1,5 @@
+.. note::
+
+    When using the CUDA backend, this operation may induce nondeterministic
+    behaviour in be backward that is not easily switched off.
+    Please see the notes on :doc:`/notes/randomness` for background.

--- a/docs/source/cudnn_deterministic.rst
+++ b/docs/source/cudnn_deterministic.rst
@@ -5,3 +5,4 @@
     undesirable, you can try to make the operation deterministic (potentially at
     a performance cost) by setting ``torch.backends.cudnn.deterministic =
     True``.
+    Please see the notes on :doc:`/notes/randomness` for background.

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -29,7 +29,7 @@ variance in the result. PyTorch functions that use :attr:`atomicAdd` in the forw
 include :meth:`torch.Tensor.index_add_`, :meth:`torch.Tensor.scatter_add_`,
 :meth:`torch.bincount`.
 A number of operations have backwards that use :attr:`atomicAdd`, in particular
-:meth:`torch.nn.functional.embedding`, :meth:`torch.nn.functional.embedding_bag`,
+:meth:`torch.nn.functional.embedding_bag`,
 :meth:`torch.nn.functional.ctc_loss` and many forms of pooling, padding, and sampling.
 There currently is no simple way of avoiding non-determinism in these functions.
 

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -1,4 +1,3 @@
-
 Reproducibility
 ===============
 
@@ -22,12 +21,25 @@ CPU and CUDA)
     import torch
     torch.manual_seed(0)
 
+There are some PyTorch functions that use CUDA functions that can be a source
+of non-determinism. One class of such CUDA functions are atomic operations,
+in particular :attr:`atomicAdd`, where the order of parallel additions to the
+same value is undetermined and, for floating-point variables, a source of
+variance in the result. PyTorch functions that use :attr:`atomicAdd` in the forward
+include :meth:`torch.Tensor.index_add_`, :meth:`torch.Tensor.scatter_add_`,
+:meth:`torch.bincount`.
+A number of operations have backwards that use :attr:`atomicAdd`, in particular
+:meth:`torch.nn.functional.embedding`, :meth:`torch.nn.functional.embedding_bag`,
+:meth:`torch.nn.functional.ctc_loss` and many forms of pooling, padding, and sampling.
+There currently is no simple way of avoiding non-determinism in these functions.
+
 
 CuDNN
 .....
-When running on the CuDNN backend, one further option must be set::
+When running on the CuDNN backend, two further options must be set::
 
     torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 .. warning::
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1036,6 +1036,8 @@ The :attr:`dim`\ th dimension of :attr:`tensor` must have the same size as the
 length of :attr:`index` (which must be a vector), and all other dimensions must
 match :attr:`self`, or an error will be raised.
 
+.. include:: cuda_deterministic.rst
+
 Args:
     dim (int): dimension along which to index
     index (LongTensor): indices of :attr:`tensor` to select from
@@ -1948,6 +1950,8 @@ dimensions ``d``, and that ``index.size(d) <= self.size(d)`` for all dimensions
 Moreover, as for :meth:`~Tensor.gather`, the values of :attr:`index` must be
 between ``0`` and ``self.size(dim) - 1`` inclusive, and all values in a row along
 the specified dimension :attr:`dim` must be unique.
+
+.. include:: cuda_deterministic.rst
 
 Args:
     dim (int): the axis along which to index

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -649,6 +649,8 @@ tensor of size 0. If :attr:`minlength` is specified, the number of bins is at le
 ``out[n] += weights[i]`` if :attr:`weights` is specified else
 ``out[n] += 1``.
 
+.. include:: cuda_deterministic.rst
+
 Arguments:
     input (Tensor): 1-d int tensor
     weights (Tensor): optional, weight for each value in the input tensor.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1138,6 +1138,8 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
 
     See :class:`torch.nn.Embedding` for more details.
 
+    .. include:: cuda_deterministic_backward.rst
+
     Args:
         input (LongTensor): Tensor containing indices into the embedding matrix
         weight (Tensor): The embedding matrix
@@ -1211,6 +1213,7 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
     intermediate embeddings.
 
     See :class:`torch.nn.EmbeddingBag` for more details.
+    .. include:: cuda_deterministic_backward.rst
 
     Args:
         input (LongTensor): Tensor containing bags of indices into the embedding matrix
@@ -1416,6 +1419,7 @@ def ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0,
     See :class:`~torch.nn.CTCLoss` for details.
 
     .. include:: cudnn_deterministic.rst
+    .. include:: cuda_deterministic_backward.rst
 
     Args:
         log_probs: :math:`(T, N, C)` where `C = number of characters in alphabet including blank`,
@@ -1946,6 +1950,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
         This function is deprecated in favor of :func:`torch.nn.functional.interpolate`.
         This is equivalent with ``nn.functional.interpolate(...)``.
 
+    .. include:: cuda_deterministic_backward.rst
 
     The algorithm used for upsampling is determined by :attr:`mode`.
 
@@ -2020,6 +2025,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         See :class:`~torch.nn.Upsample` for concrete examples on how this
         affects the outputs.
 
+    .. include:: cuda_deterministic_backward.rst
     """
     from numbers import Integral
     from .modules.utils import _ntuple
@@ -2105,6 +2111,8 @@ def upsample_nearest(input, size=None, scale_factor=None):
         size (int or Tuple[int, int] or Tuple[int, int, int]): output spatia
             size.
         scale_factor (int): multiplier for spatial size. Has to be an integer.
+
+    .. include:: cuda_deterministic_backward.rst
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_nearest is deprecated. Use nn.functional.interpolate instead.")
@@ -2126,6 +2134,8 @@ def upsample_bilinear(input, size=None, scale_factor=None):
         input (Tensor): input
         size (int or Tuple[int, int]): output spatial size.
         scale_factor (int or Tuple[int, int]): multiplier for spatial size
+
+    .. include:: cuda_deterministic_backward.rst
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_bilinear is deprecated. Use nn.functional.interpolate instead.")
@@ -2183,6 +2193,7 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
           ``x'' = -0.5``.
 
     .. Note:: This function is often used in building Spatial Transformer Networks.
+    .. include:: cuda_deterministic_backward.rst
 
     Args:
         input (Tensor): input of shape :math:`(N, C, H_\text{in}, W_\text{in})` (4-D case)
@@ -2244,6 +2255,8 @@ def pad(input, pad, mode='constant', value=0):
         tensor, or the last 2 dimensions of 4D input tensor, or the last dimension of
         3D input tensor. Reflect padding is only implemented for padding the last 2
         dimensions of 4D input tensor, or the last dimension of 3D input tensor.
+
+    .. include:: cuda_deterministic_backward.rst
 
     Args:
         input (Tensor): `Nd` tensor

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1138,8 +1138,6 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
 
     See :class:`torch.nn.Embedding` for more details.
 
-    .. include:: cuda_deterministic_backward.rst
-
     Args:
         input (LongTensor): Tensor containing indices into the embedding matrix
         weight (Tensor): The embedding matrix


### PR DESCRIPTION
include atomicAdd commentary as this is less well known

There is some discussion in #12207

Unfortunately, I cannot seem to get the ..include working in `_tensor_docs.py` and `_torch_docs.py`. I could use a hint for that.
