### PR TITLE
[jit] Properly catch errors in PythonOps

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7158,6 +7158,17 @@ a")
 
         self.checkScript(code, (101,), name='elif_test', outputs=3028)
 
+    def test_python_op_exception(self):
+        def python_op(x):
+            raise Exception("bad!")
+
+        @torch.jit.script
+        def fn(x):
+            return python_op(x)
+
+        with self.assertRaisesRegex(RuntimeError, "operation failed in interpreter"):
+            fn(torch.tensor(4))
+
 
 class MnistNet(nn.Module):
     def __init__(self):

--- a/torch/csrc/jit/python_interpreter.cpp
+++ b/torch/csrc/jit/python_interpreter.cpp
@@ -19,6 +19,7 @@
 #include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/utils/auto_gil.h"
+#include "torch/csrc/Exceptions.h"
 
 namespace py = pybind11;
 
@@ -53,8 +54,12 @@ Operation createPythonOperation(Node* op_) {
       i++;
     }
     drop(stack, num_inputs);
-    py::object py_output(func(*py_inputs));
-    stack.push_back(returnToIValue(op->output()->type(), py_output));
+    try {
+      py::object py_output(func(*py_inputs));
+      stack.push_back(returnToIValue(op->output()->type(), py_output));
+    } catch (py::error_already_set & e) {
+      throw python_error();
+    }
     return 0;
   };
 }


### PR DESCRIPTION
If a PythonOp throws an error it raises an exception to the interpreter and also releases the GIL which causes [pybind to segfault](https://github.com/potassco/clingo/issues/42)

This fix catches pybind errors while the GIL is still held and throws a `python_error` to re-capture the GIL

Fixes #12118

@apaszke 