### PR TITLE
Reduce size of TensorImpl from 160 bytes to 128 bytes

### DIFF
--- a/aten/src/ATen/core/TensorImpl.cpp
+++ b/aten/src/ATen/core/TensorImpl.cpp
@@ -46,7 +46,7 @@ IntList TensorImpl::sizes() const {
 }
 
 IntList TensorImpl::strides() const {
-  AT_ASSERTM(!strides_,
+  AT_ASSERTM(strides_,
              "Caffe2 tensors don't (yet) have meaningful strides and cannot "
              "be used in PyTorch.");
   return IntList{strides_.get(), sizes_.size()};
@@ -90,7 +90,7 @@ int64_t TensorImpl::size(int64_t d) const {
 }
 
 int64_t TensorImpl::stride(int64_t d) const {
-  AT_ASSERTM(!strides_,
+  AT_ASSERTM(strides_,
              "Caffe2 tensors don't (yet) have meaningful strides and cannot "
              "be used in PyTorch.");
   d = at::maybe_wrap_dim(d, dim(), false);

--- a/aten/src/ATen/core/TensorImpl.cpp
+++ b/aten/src/ATen/core/TensorImpl.cpp
@@ -31,31 +31,32 @@ TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable
 
 TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::TypeMeta& data_type, bool is_variable)
     : storage_(std::move(storage)),
-      storage_offset_(0),
       sizes_{0},
-      strides_{1},
-      is_contiguous_(true),
+      storage_offset_(0),
       numel_(0),
-      type_id_(type_id),
       data_type_(data_type),
-      is_variable_(is_variable) {}
+      type_id_(type_id),
+      is_variable_(is_variable) {
+  strides_.reset(new int64_t[1]);
+  strides_[0] = 1;
+}
 
 IntList TensorImpl::sizes() const {
   return sizes_;
 }
 
 IntList TensorImpl::strides() const {
-  AT_ASSERTM(strides_.size() == sizes_.size(),
+  AT_ASSERTM(!strides_,
              "Caffe2 tensors don't (yet) have meaningful strides and cannot "
              "be used in PyTorch.");
-  return strides_;
+  return IntList{strides_.get(), sizes_.size()};
 }
 
 bool TensorImpl::compute_contiguous() const {
   bool is_contiguous = true;
   if (is_empty())
     return is_contiguous;
-  if (strides_.empty()) {
+  if (!strides_) {
     // Special case for Caffe2 tensors which don't have strides set.
     return true;
   }
@@ -89,7 +90,7 @@ int64_t TensorImpl::size(int64_t d) const {
 }
 
 int64_t TensorImpl::stride(int64_t d) const {
-  AT_ASSERTM(strides_.size() == sizes_.size(),
+  AT_ASSERTM(!strides_,
              "Caffe2 tensors don't (yet) have meaningful strides and cannot "
              "be used in PyTorch.");
   d = at::maybe_wrap_dim(d, dim(), false);

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -218,11 +218,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   virtual Tensor& grad();
   virtual const Tensor& grad() const;
 
-  // TODO: make these protected
-  // Note: storage->size() may be greater than the recorded size
-  // of a tensor
-  at::Storage storage_;
-
   template <typename T>
   inline T * data() const {
     AT_ASSERT(!is_variable());
@@ -276,7 +271,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     // NB: This is *truly* a resize; calling code (e.g., squeeze)
     // assumes that old values are preserved
     sizes_.resize(ndim);
-    strides_.resize(ndim);
+    strides_.reset(new int64_t[ndim]);
     refresh_numel();
     refresh_contiguous();
   }
@@ -288,7 +283,9 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   virtual void set_stride(int64_t dim, int64_t new_stride) {
-    strides_.at(dim) = new_stride;
+    AT_ASSERTM(strides_, "Caffe2 tensors don't have meaningful strides and "
+                         "cannot be used in PyTorch");
+    strides_[dim] = new_stride;
     refresh_numel();
     refresh_contiguous();
   }
@@ -311,8 +308,14 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
         ") must match dimensionality of strides (",
         new_stride.size(),
         ")");
+    auto old_dim = sizes_.size();
     sizes_ = new_size.vec();
-    strides_ = new_stride.vec();
+    if (old_dim != sizes_.size()) {
+      strides_.reset(new int64_t[sizes_.size()]);
+    }
+    for (int64_t i = 0; i < sizes_.size(); i++) {
+      strides_[i] = new_stride[i];
+    }
     refresh_numel();
     refresh_contiguous();
   }
@@ -323,13 +326,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   bool is_variable() const { return is_variable_; };
 
  private:
-  int64_t storage_offset_ = 0;
-  std::vector<int64_t> sizes_;
-  std::vector<int64_t> strides_;
-
-  bool is_contiguous_ = true;
-  int64_t numel_ = -1;
-
   int64_t compute_numel() const {
     int64_t n = 1;
     for (auto s : sizes()) {
@@ -348,12 +344,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     AT_ASSERT(!is_variable());
     is_contiguous_ = compute_contiguous();
   }
-  TensorTypeId type_id_;
-  // INVARIANT: When storage is non-null, this type meta must
-  // agree with the type meta in storage
-  caffe2::TypeMeta data_type_;
-  bool is_variable_ = false;
-  bool is_wrapped_number_ = false;
 
  private:
   TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::TypeMeta& data_type, bool is_variable);
@@ -399,7 +389,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if (src.numel() == -1) {
       sizes_.clear();
       numel_ = -1;
-      strides_.clear();
+      strides_.reset();
       is_contiguous_ = true;
       storage_.reset();
       data_type_ = caffe2::TypeMeta();
@@ -785,13 +775,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     return sizes_;
   }
 
- protected:
-  // we decide to keep reserved_ and it will
-  // live in Tensor after the split
-  // The logic is that if Extend() or ReserveSpace() were ever called,
-  // then subsequent Resize()s will not free up Storage.
-  bool reserved_ = false;
-
  private:
   template <
       typename T,
@@ -864,9 +847,34 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   inline void update_to_contiguous_strides() {
-    strides_.resize(0);
+    strides_.reset();
     is_contiguous_ = true;
   }
+
+protected:
+  at::Storage storage_;
+
+  std::vector<int64_t> sizes_;
+  std::unique_ptr<int64_t[]> strides_; // this saves two words
+
+  int64_t storage_offset_ = 0;
+  int64_t numel_ = -1;
+
+  // INVARIANT: When storage is non-null, this type meta must
+  // agree with the type meta in storage
+  caffe2::TypeMeta data_type_;
+
+  // You get to have eight byte-size fields here, before you
+  // should pack this into a bitfield.
+  TensorTypeId type_id_;
+  bool is_contiguous_ = true;
+  bool is_variable_ = false;
+  bool is_wrapped_number_ = false;
+  // we decide to keep reserved_ and it will
+  // live in Tensor after the split
+  // The logic is that if Extend() or ReserveSpace() were ever called,
+  // then subsequent Resize()s will not free up Storage.
+  bool reserved_ = false;
 
 };
 } // namespace at

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -851,9 +851,10 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     is_contiguous_ = true;
   }
 
-protected:
-  at::Storage storage_;
+public:
+  at::Storage storage_; // TODO: Fix visibility on me
 
+protected:
   std::vector<int64_t> sizes_;
   std::unique_ptr<int64_t[]> strides_; // this saves two words
 

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -313,7 +313,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     if (old_dim != sizes_.size()) {
       strides_.reset(new int64_t[sizes_.size()]);
     }
-    for (int64_t i = 0; i < sizes_.size(); i++) {
+    for (size_t i = 0; i < sizes_.size(); i++) {
       strides_[i] = new_stride[i];
     }
     refresh_numel();


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12266 Reduce size of TensorImpl from 160 bytes to 128 bytes**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10150834/)

- Put all byte-size fields together (booleans and TensorTypeId),
  so they can be coalesced into a single word.
- Replace std::vector<int64_t> strides with
  std::unique_ptr<int64_t[]>, saving two words.

Differential Revision: [D10150834](https://our.internmc.facebook.com/intern/diff/D10150834/)