### PR TITLE
Avoid undefined function call preventing build on some systems

### DIFF
--- a/caffe2/utils/fatal_signal_asan_no_sig_test.cc
+++ b/caffe2/utils/fatal_signal_asan_no_sig_test.cc
@@ -58,7 +58,7 @@ bool forkAndPipe(
     }
 
     ssize_t bytesRead;
-    while ((bytesRead = read(stderrPipe[0], buffer.data(), bufferSize)) > 0) {
+    while ((bytesRead = read(stderrPipe[0], static_cast<void*>(buffer.data()), bufferSize)) > 0) {
       const std::string tmp(buffer.data(), bytesRead);
       std::cout << tmp;
       stderrBuffer += tmp;


### PR DESCRIPTION
On some Linux systems (tested on several machines, all running Arch Linux or Arch Linux-derived distributions), at build time, a call to `unistd.h`'s function `read(int, void*, unsigned int)` is performed as `read(int, char*, unsigned int)`, leading to undefined function reference and preventing a successful build. This modification aims to fix said behaviour, while not impacting (theoretically) systems/library versions which still allowed a successful build before.