### PR TITLE
Back out "[aibench] Use caffe2::int8::Int8TensorCPU when input type is uint8_t" (#12270)

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -28,7 +28,6 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/core/tensor_int8.h"
 #include "caffe2/utils/bench_utils.h"
 #include "caffe2/utils/string_utils.h"
 #include "observers/net_observer_reporter_print.h"
@@ -164,16 +163,12 @@ void loadInput(
           CAFFE_THROW("Not support GPU on mobile.");
 #endif
         } else {
+          caffe2::TensorCPU* tensor = BlobGetMutableTensor(blob, caffe2::CPU);
+          CHECK_NOTNULL(tensor);
+          tensor->Resize(input_dims);
           if (input_type_list[i] == "uint8_t") {
-            caffe2::int8::Int8TensorCPU* tensor =
-                blob->GetMutable<caffe2::int8::Int8TensorCPU>();
-            CHECK_NOTNULL(tensor);
-            tensor->t.Resize(input_dims);
-            tensor->t.mutable_data<uint8_t>();
+            tensor->mutable_data<uint8_t>();
           } else if (input_type_list[i] == "float") {
-            caffe2::TensorCPU* tensor = BlobGetMutableTensor(blob, caffe2::CPU);
-            CHECK_NOTNULL(tensor);
-            tensor->Resize(input_dims);
             tensor->mutable_data<float>();
           } else {
             CAFFE_THROW("Unsupported input type: ", input_type_list[i]);

--- a/binaries/speed_benchmark.cc
+++ b/binaries/speed_benchmark.cc
@@ -20,7 +20,6 @@
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/core/tensor_int8.h"
 #ifdef CAFFE2_OPTIMIZER
 #include "caffe2/opt/optimizer.h"
 #endif
@@ -138,18 +137,14 @@ int main(int argc, char** argv) {
         if (blob == nullptr) {
           blob = workspace->CreateBlob(input_names[i]);
         }
+        caffe2::TensorCPU* tensor = BlobGetMutableTensor(blob, caffe2::CPU);
+        CHECK_NOTNULL(tensor);
+        tensor->Resize(input_dims);
         if (input_type_list[i] == "uint8_t") {
-          caffe2::int8::Int8TensorCPU* tensor =
-              blob->GetMutable<caffe2::int8::Int8TensorCPU>();
-          CHECK_NOTNULL(tensor);
-          tensor->t.Resize(input_dims);
-          tensor->t.mutable_data<uint8_t>();
+          tensor->mutable_data<uint8_t>();
         } else if (input_type_list[i] == "float") {
-          caffe2::TensorCPU* tensor = BlobGetMutableTensor(blob, caffe2::CPU);
-          CHECK_NOTNULL(tensor);
-          tensor->Resize(input_dims);
           tensor->mutable_data<float>();
-        } else {
+        }  else {
           CAFFE_THROW("Unsupported input type: ", input_type_list[i]);
         }
       }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/12270

Original commit changeset: b63cd3a75f87

Reviewed By: bddppq

Differential Revision: D10154512
