### PR TITLE
[Caffe2] MIOpen 1.5 group conv API integration

### DIFF
--- a/caffe2/operators/hip/conv_op_miopen.cc
+++ b/caffe2/operators/hip/conv_op_miopen.cc
@@ -449,6 +449,7 @@ bool MIOPENConvGradientOp::DoRunWithType() {
     }
 
     if (weight_changed) {
+      mio_weight_dims_ = Weight.dims();
       MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
           conv_desc_,
           mode_,

--- a/caffe2/operators/hip/conv_op_miopen.cc
+++ b/caffe2/operators/hip/conv_op_miopen.cc
@@ -91,6 +91,8 @@ class MIOPENConvOpBase : public ConvPoolOpBase<HIPContext> {
   }
 
  protected:
+  vector<int64_t> mio_input_dims_;
+  vector<int64_t> mio_weight_dims_;
   MIOPENWrapper miopen_wrapper_;
   miopenTensorDescriptor_t bottom_desc_;
   miopenTensorDescriptor_t bias_desc_;
@@ -257,35 +259,59 @@ bool MIOPENConvOp::DoRunWithType() {
       "If you set group, the number of output channels should be divisible "
       "by group.");
 
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
+  bool input_changed = (X.dims() != mio_input_dims_);
+  bool weight_changed = (Weight.dims() != mio_weight_dims_);
 
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      weight_desc_,
-      miopenTypeWrapper<T_W>::type,
-      M,
-      C / group_,
-      kernel_h(),
-      kernel_w()));
+  if (input_changed || weight_changed) {
+    VLOG(1) << "Changing MIOpen descriptor configurations.";
+    if (input_changed) {
+      mio_input_dims_ = X.dims();
+      MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+          bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
+    }
 
-  MIOPEN_ENFORCE(miopenGetConvolutionForwardOutputDim(
-      conv_desc_,
-      bottom_desc_,
-      weight_desc_,
-      &N_out,
-      &C_out,
-      &H_out,
-      &W_out));
+    if (weight_changed) {
+      mio_weight_dims_ = Weight.dims();
+      MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
+          conv_desc_,
+          mode_,
+          pad_t(),
+          pad_l(),
+          stride_h(),
+          stride_w(),
+          dilation_h(),
+          dilation_w()));
 
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      top_desc_, miopenTypeWrapper<T_X>::type, N_out, C_out, H_out, W_out));
+      MIOPEN_ENFORCE(miopenSetConvolutionGroupCount(
+          conv_desc_, group_));
 
-  if (InputSize() == 3) {
+      MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+          weight_desc_,
+          miopenTypeWrapper<T_W>::type,
+          M,
+          C / group_,
+          kernel_h(),
+          kernel_w()));
+    }
+
+    MIOPEN_ENFORCE(miopenGetConvolutionForwardOutputDim(
+        conv_desc_,
+        bottom_desc_,
+        weight_desc_,
+        &N_out,
+        &C_out,
+        &H_out,
+        &W_out));
+
+    MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+        top_desc_, miopenTypeWrapper<T_X>::type, N_out, C_out, H_out, W_out));
+
+    if (InputSize() == 3) {
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
           bias_desc_, miopenTypeWrapper<T_B>::type, 1, M, 1, 1));
-  }
+    }
 
-  while (!bestAlgoFound_) {
+    while (!bestAlgoFound_) {
       miopenConvAlgoPerf_t perf;
 
       MIOPEN_ENFORCE(miopenConvolutionForwardGetWorkSpaceSize(
@@ -318,8 +344,8 @@ bool MIOPENConvOp::DoRunWithType() {
       });
       bestAlgoFound_ = true;
       fwdAlgo_ = perf.fwd_algo;
+    }
   }
-
   miopen_wrapper_.with_miopen_state(miopen_state_, [&](MIOPENState* state) {
       MIOPEN_ENFORCE(miopenConvolutionForward(
         state->miopen_handle(),
@@ -424,36 +450,58 @@ bool MIOPENConvGradientOp::DoRunWithType() {
       "by group.");
 
   bool doBwdDataComputation = (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2)));
+  bool input_changed = (X.dims() != mio_input_dims_);
+  bool weight_changed = (Weight.dims() != mio_weight_dims_);
 
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
-
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      weight_desc_,
-      miopenTypeWrapper<T_X>::type,
-      M,
-      C / group_,
-      kernel_h(),
-      kernel_w()));
-
-  MIOPEN_ENFORCE(miopenGetConvolutionForwardOutputDim(
-      conv_desc_,
-      bottom_desc_,
-      weight_desc_,
-      &N_out,
-      &C_out,
-      &H_out,
-      &W_out));
-
-  MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-      top_desc_, miopenTypeWrapper<T_X>::type, N_out, C_out, H_out, W_out));
-
-  if (!no_bias_) {
+  if (input_changed || weight_changed) {
+    VLOG(1) << "Changing MIOpen descriptor configurations.";
+    if (input_changed) {
+      mio_input_dims_ = X.dims();
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
-          bias_desc_, miopenTypeWrapper<T_B>::type, 1, M, 1, 1));
-  }
+          bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
+    }
 
-  while ((!bestDataAlgoFound_) && doBwdDataComputation) {
+    if (weight_changed) {
+      MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
+          conv_desc_,
+          mode_,
+          pad_t(),
+          pad_l(),
+          stride_h(),
+          stride_w(),
+          dilation_h(),
+          dilation_w()));
+
+      MIOPEN_ENFORCE(miopenSetConvolutionGroupCount(
+          conv_desc_, group_));
+
+      MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+          weight_desc_,
+          miopenTypeWrapper<T_X>::type,
+          M,
+          C / group_,
+          kernel_h(),
+          kernel_w()));
+    }
+
+    MIOPEN_ENFORCE(miopenGetConvolutionForwardOutputDim(
+        conv_desc_,
+        bottom_desc_,
+        weight_desc_,
+        &N_out,
+        &C_out,
+        &H_out,
+        &W_out));
+
+    MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+        top_desc_, miopenTypeWrapper<T_X>::type, N_out, C_out, H_out, W_out));
+
+    if (!no_bias_) {
+        MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
+            bias_desc_, miopenTypeWrapper<T_B>::type, 1, M, 1, 1));
+    }
+
+    while ((!bestDataAlgoFound_) && doBwdDataComputation) {
       miopenConvAlgoPerf_t perf;
 
       MIOPEN_ENFORCE(miopenConvolutionBackwardDataGetWorkSpaceSize(
@@ -487,43 +535,43 @@ bool MIOPENConvGradientOp::DoRunWithType() {
 
       bestDataAlgoFound_ = true;
       bwdDataAlgo_ = perf.bwd_data_algo;
+    }
+
+    while (!bestWeightAlgoFound_) {
+        miopenConvAlgoPerf_t perf;
+
+        MIOPEN_ENFORCE(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+            miopen_wrapper_.inline_miopen_handle(),
+            top_desc_,
+            bottom_desc_,
+            conv_desc_,
+            weight_desc_,
+            &bwdWeightWsSize_));
+        if ((bwdWeightWsSize_ > 0) && (bwdWeightWs_ == nullptr)) {
+          HIP_CHECK(hipMalloc(&bwdWeightWs_, bwdWeightWsSize_));
+        }
+
+        miopen_wrapper_.with_miopen_state(miopen_state_, [&](MIOPENState* state) {
+          MIOPEN_ENFORCE(miopenFindConvolutionBackwardWeightsAlgorithm(
+            state->miopen_handle(),
+            top_desc_,
+            dY.template data<T_DY>(),
+            bottom_desc_,
+            X.template data<T_X>(),
+            conv_desc_,
+            weight_desc_,
+            dW->template mutable_data<T_DW>(),
+            requestAlgoCount_,
+            &returnedAlgoCount_,
+            &perf,
+            bwdWeightWs_,
+            bwdWeightWsSize_,
+            false));
+        });
+        bestWeightAlgoFound_ = true;
+        bwdWeiAlgo_ = perf.bwd_weights_algo;
+    }
   }
-
-  while (!bestWeightAlgoFound_) {
-      miopenConvAlgoPerf_t perf;
-
-      MIOPEN_ENFORCE(miopenConvolutionBackwardWeightsGetWorkSpaceSize(
-          miopen_wrapper_.inline_miopen_handle(),
-          top_desc_,
-          bottom_desc_,
-          conv_desc_,
-          weight_desc_,
-          &bwdWeightWsSize_));
-      if ((bwdWeightWsSize_ > 0) && (bwdWeightWs_ == nullptr)) {
-        HIP_CHECK(hipMalloc(&bwdWeightWs_, bwdWeightWsSize_));
-      }
-
-      miopen_wrapper_.with_miopen_state(miopen_state_, [&](MIOPENState* state) {
-        MIOPEN_ENFORCE(miopenFindConvolutionBackwardWeightsAlgorithm(
-          state->miopen_handle(),
-          top_desc_,
-          dY.template data<T_DY>(),
-          bottom_desc_,
-          X.template data<T_X>(),
-          conv_desc_,
-          weight_desc_,
-          dW->template mutable_data<T_DW>(),
-          requestAlgoCount_,
-          &returnedAlgoCount_,
-          &perf,
-          bwdWeightWs_,
-          bwdWeightWsSize_,
-          false));
-      });
-      bestWeightAlgoFound_ = true;
-      bwdWeiAlgo_ = perf.bwd_weights_algo;
-  }
-
   if (doBwdDataComputation) {
       miopen_wrapper_.with_miopen_state(miopen_state_, [&](MIOPENState* state) {
         MIOPEN_ENFORCE(miopenConvolutionBackwardData(

--- a/caffe2/operators/hip/conv_op_miopen.cc
+++ b/caffe2/operators/hip/conv_op_miopen.cc
@@ -66,19 +66,6 @@ class MIOPENConvOpBase : public ConvPoolOpBase<HIPContext> {
         dilation_h() == 1 && dilation_w() == 1,
         "MIOpen convolution does not support dilation for groups > 1.");
     }
-
-    MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
-        conv_desc_,
-        mode_,
-        pad_t(),
-        pad_l(),
-        stride_h(),
-        stride_w(),
-        dilation_h(),
-        dilation_w()));
-
-    MIOPEN_ENFORCE(miopenSetConvolutionGroupCount(
-        conv_desc_, group_));
   }
 
   ~MIOPENConvOpBase() {


### PR DESCRIPTION
This PR contains changes for:
1. Group convolutions introduced in MIOpen 1.5
2. Checks to initialize MIOpen conv operator descriptors only when needed (inputs or weights changed)

cc: @bddppq 