### PR TITLE
Fix typo LMBD->LMDB in docs of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@
 #   USE_LEVELDB
 #     enables use of LevelDB for storage
 #
-#   USE_LMBD
+#   USE_LMDB
 #     enables use of LMDB for storage
 #
 #   BUILD_BINARY


### PR DESCRIPTION
`setup.py` reads `USE_LMDB` rather than `USE_LMBD`