### PR TITLE
Add utility function make_tensor

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -677,6 +677,17 @@ struct CAFFE2_API WeakTensor {
 private:
   c10::weak_intrusive_ptr<TensorImpl, UndefinedTensorImpl> weak_impl_;
 };
+
+namespace detail {
+// Helper creator for Tensor clas which doesn't requires the users to pass
+// in an intrusive_ptr instead it just converts the argument passed to
+// requested intrusive_ptr type.
+template <typename T, typename... Args>
+Tensor make_tensor(Args&&... args) {
+  return Tensor(c10::make_intrusive<T>(std::forward<Args>(args)...));
+}
+} // namespace detail
+
 } // namespace at
 
 #include "ATen/core/TensorMethods.h"

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -68,7 +68,8 @@ SparseTensor new_sparse(const SparseType& dtype) {
   } else {
     type_id = SparseCPUTensorId();
   }
-  return SparseTensor(c10::make_intrusive<SparseTensorImpl>(type_id, scalarTypeToTypeMeta(dtype.scalarType())));
+  return detail::make_tensor<SparseTensorImpl>(
+      type_id, scalarTypeToTypeMeta(dtype.scalarType()));
 }
 
 /*** Helper methods ***/

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -290,6 +290,17 @@ struct CAFFE2_API WeakTensor {
 private:
   c10::weak_intrusive_ptr<TensorImpl, UndefinedTensorImpl> weak_impl_;
 };
+
+namespace detail {
+// Helper creator for Tensor clas which doesn't requires the users to pass
+// in an intrusive_ptr instead it just converts the argument passed to
+// requested intrusive_ptr type.
+template <typename T, typename... Args>
+Tensor make_tensor(Args&&... args) {
+  return Tensor(c10::make_intrusive<T>(std::forward<Args>(args)...));
+}
+} // namespace detail
+
 } // namespace at
 
 #include "ATen/core/TensorMethods.h"


### PR DESCRIPTION
Summary: Current implementation of Tensor takes an intrusive_ptr as an argument for storing data. But instead of requiring users to explicitly pass an intrusive_ptr we want them to pass args for intrusive ptr directly which are forwarded internally through new helper function called make_tensor

Differential Revision: D10152661
