### PR TITLE
Add move{Node,Edge,Subgraph} for Graph move-like semantics

### DIFF
--- a/caffe2/core/nomnigraph/tests/GraphTest.cc
+++ b/caffe2/core/nomnigraph/tests/GraphTest.cc
@@ -117,4 +117,65 @@ TEST(Basic, HasNode) {
   // Current graph: 3 -> 4  ,   2
   // replaceNode doesn't delete n2.
   EXPECT_TRUE(g.hasNode(n2));
+
+  // Create a second graph g2, and move the nodes from g2 to g.
+  TestClass t5;
+  nom::Graph<TestClass> g2;
+  nom::Graph<TestClass>::NodeRef n5 = g2.createNode(std::move(t5));
+  EXPECT_TRUE(g2.hasNode(n5));
+
+  EXPECT_FALSE(g.hasNode(n5));
+  g2.moveNode(n5, &g);
+  // Current graph (g1): 3 -> 4, 2, 5
+  EXPECT_TRUE(g.hasNode(n5));
+}
+
+TEST(Basic, Moves) {
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto n3 = createTestNode(g);
+  auto e1 = g.createEdge(n1, n2);
+  auto e2 = g.createEdge(n1, n3);
+  // Current graph: 1 -> 2 -> 3
+
+  TestGraph g2;
+  g.deleteEdge(e2);
+  g.moveNode(n1, &g2);
+  g.moveNode(n2, &g2);
+  g.moveEdge(e1, &g2);
+  EXPECT_TRUE(g.isValid());
+  EXPECT_TRUE(g2.isValid());
+  EXPECT_EQ(g.getMutableNodes().size(), 1);
+  EXPECT_EQ(g2.getMutableNodes().size(), 2);
+  EXPECT_EQ(g.getMutableEdges().size(), 0);
+  EXPECT_EQ(g2.getMutableEdges().size(), 1);
+}
+
+TEST(Basic, MoveSubgraph) {
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto n3 = createTestNode(g);
+  auto e1 = g.createEdge(n1, n2);
+  auto e2 = g.createEdge(n1, n3);
+  // Current graph: 1 -> 2 -> 3
+
+  TestGraph g2;
+
+  g.deleteEdge(e2);
+
+  TestGraph::SubgraphType sg;
+  sg.addNode(n1);
+  sg.addNode(n2);
+  sg.addEdge(e1);
+
+  g.moveSubgraph(sg, &g2);
+
+  EXPECT_TRUE(g.isValid());
+  EXPECT_TRUE(g2.isValid());
+  EXPECT_EQ(g.getMutableNodes().size(), 1);
+  EXPECT_EQ(g2.getMutableNodes().size(), 2);
+  EXPECT_EQ(g.getMutableEdges().size(), 0);
+  EXPECT_EQ(g2.getMutableEdges().size(), 1);
 }


### PR DESCRIPTION
Summary:
Adding back import{Node,Edge} as move{Node,Edge} and adding a new
function moveSubgraph.  Previous diff broke OSS

Differential Revision: D10182522
