### PR TITLE
Enforce invariant that storage_ is always non-null

### DIFF
--- a/aten/src/ATen/core/Storage.h
+++ b/aten/src/ATen/core/Storage.h
@@ -51,10 +51,6 @@ struct CAFFE2_API Storage {
             allocator,
             resizable)) {}
 
-  void reset() {
-    storage_impl_->reset();
-  }
-
   template <typename T>
   inline bool IsType() const {
     return storage_impl_->IsType<T>();

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -162,7 +162,8 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable);
 
   explicit TensorImpl(at::Storage storage) : storage_(std::move(storage)), storage_offset_(0) {
-    data_type_ = storage_ ? storage_.dtype() : caffe2::TypeMeta{};
+    AT_ASSERT(storage_);
+    data_type_ = storage_.dtype();
   }
 
   TensorImpl(const TensorImpl&) = default;
@@ -442,7 +443,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       numel_ = -1;
       strides_.reset();
       is_contiguous_ = true;
-      storage_.reset();
+      storage_ = at::Storage(device_type(), caffe2::TypeMeta());
       data_type_ = caffe2::TypeMeta();
       return;
     }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12328 Enforce invariant that storage_ is always non-null**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10200448/)

- Delete reset() from Storage, as it makes it easy to accidentally
  create a null storage.
- Immediately reject a storage if it is null when passed in

Differential Revision: [D10200448](https://our.internmc.facebook.com/intern/diff/D10200448/)