### PR TITLE
fix _AllReduce not applying the DeviceScope guard to model.Copy operations.

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1037,19 +1037,19 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
         """
         devices = [model._devices[idx] for idx in dev_indices]
         blobs = [blobs_group[idx] for idx in dev_indices]
-        for i, peer in enumerate(devices):
-            if i == 0:
-                continue  # Skip the first device
-            if p2p_access_pattern is not None and not p2p_access_pattern[
-                devices[0], peer
-            ]:
-                # Copy from peer to d0
-                blobs[i] = model.Copy(
-                    blobs[i],
-                    'gpu_{}/{}_gpu{}_copy'.format(devices[0], param, peer)
-                )
         device_opt = core.DeviceOption(model._device_type, devices[0])
         with core.DeviceScope(device_opt):
+            for i, peer in enumerate(devices):
+                if i == 0:
+                    continue  # Skip the first device
+                if p2p_access_pattern is not None and not p2p_access_pattern[
+                    devices[0], peer
+                ]:
+                    # Copy from peer to d0
+                    blobs[i] = model.Copy(
+                        blobs[i],
+                        'gpu_{}/{}_gpu{}_copy'.format(devices[0], param, peer)
+                    )
             net.Sum(blobs, [blobs[0]], name='dpm')
 
     if len(devices) == 16:


### PR DESCRIPTION
This resolves an issue where the `model.Copy` operation would
copy to the wrong GPU, such that the below `net.Sum` operation
would use an input argument for which p2p access was not enabled.

