### PR TITLE
Stop warnings on AT_DECLARE_TENSOR_TYPE(.);

### DIFF
--- a/aten/src/ATen/core/TensorTypeIdRegistration.h
+++ b/aten/src/ATen/core/TensorTypeIdRegistration.h
@@ -86,7 +86,7 @@ inline at::TensorTypeId TensorTypeIdRegistrar::id() const noexcept {
 }
 
 #define AT_DECLARE_TENSOR_TYPE(TensorName) \
-  CAFFE2_API at::TensorTypeId TensorName();
+  CAFFE2_API at::TensorTypeId TensorName()
 
 #define AT_DEFINE_TENSOR_TYPE(TensorName)           \
   at::TensorTypeId TensorName() {                   \


### PR DESCRIPTION
e.g.,
```
│../aten/src/ATen/core/TensorTypeIdRegistration.h:101:43: warning: extra ‘;’ [-Wpedantic]
│ AT_DECLARE_TENSOR_TYPE(SparseCUDATensorId);
```