### PR TITLE
Fix issues with ATenOp handling methods where `self` is not the first arg

### DIFF
--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -237,13 +237,7 @@ if __name__ == '__main__':
         }
         defined_inferred_type = False
 
-        if 'Tensor' in o['method_of']:
-            # make sure 'self' is the first argument. currently Declarations.yaml
-            # does not always do this. Instead it keeps the argument list the same order
-            # as the Type method.
-            # o['arguments'] = self_as_first_argument(o['arguments'])
-            pass
-        elif 'namespace' not in o['method_of']:
+        if 'namespace' not in o['method_of'] and 'Tensor' not in o['method_of']:
             # methods on type like 'ones' or 'zeros' always take a
             # string attribute that is translated into the at::Type object
             # e.g. "Float" is at::kFloat

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -241,7 +241,8 @@ if __name__ == '__main__':
             # make sure 'self' is the first argument. currently Declarations.yaml
             # does not always do this. Instead it keeps the argument list the same order
             # as the Type method.
-            o['arguments'] = self_as_first_argument(o['arguments'])
+            # o['arguments'] = self_as_first_argument(o['arguments'])
+            pass
         elif 'namespace' not in o['method_of']:
             # methods on type like 'ones' or 'zeros' always take a
             # string attribute that is translated into the at::Type object
@@ -289,11 +290,11 @@ if __name__ == '__main__':
             assignment = CT(t).substitute(env, offset=i, output=get_output(o, i))
             env['assignments'].append(assignment)
 
-        if 'Tensor' in o['method_of']:
+        if 'namespace' in o['method_of']:
+            env['invocation'] = CT("at::${name}(${arguments})").substitute(env)
+        elif 'Tensor' in o['method_of']:
             env['invocation'] = "self.{}({})".format(
                 o['name'], ', '.join(env['arguments'][1:]))
-        elif 'namespace' in o['method_of']:
-            env['invocation'] = CT("at::${name}(${arguments})").substitute(env)
         else:
             assert('Type' in o['method_of'])
             env['invocation'] = CT(

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -927,6 +927,22 @@ class TestCaffe2Backend(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_where_functional(self):
+        class WhereFunctional(torch.nn.Module):
+            def forward(self, x):
+                return torch.where(x > 2.0, x, torch.neg(x))
+
+        x = torch.randn(3, 4)
+        self.run_model_test(WhereFunctional(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
+    def test_where_method(self):
+        class WhereMethod(torch.nn.Module):
+            def forward(self, x):
+                return x.where(x > 2.0, torch.neg(x))
+
+        x = torch.randn(3, 4)
+        self.run_model_test(WhereMethod(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
 
 # a bit of metaprogramming to set up all the rnn tests
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -641,6 +641,10 @@ def le(g, input, other):
     return g.op("Not", gt(g, input, _if_scalar_type_as(g, other, input)))
 
 
+def where(g, condition, self, other):
+    return g.op("ATen", condition, self, other, operator_s="where")
+
+
 @parse_args('v', 'i')
 def log_softmax(g, input, dim=None):
     # PyTorch dim and ONNX axis have different meanings.


### PR DESCRIPTION
ATenOp was handling `torch.where` incorrectly. Whereas the `torch.where` overload (and `aten::` function) had arguments in the order `Tensor condition, Tensor self, Tensor other`, ATenOp was emitting code that assumed that `self` was the 0th argument, and thus was trying to interpret the wrong value as the condition.