### PR TITLE
Update README.md of ATen Documentation

### DIFF
--- a/aten/README.md
+++ b/aten/README.md
@@ -232,9 +232,12 @@ entry point for the script which does all this work is
 [`src/ATen/gen.py`](src/ATen/gen.py), which ingests
 [`src/ATen/Declarations.cwrap`](src/ATen/Declarations.cwrap),
 [`src/ATen/nn.yaml`](src/ATen/nn.yaml),
-[`src/ATen/native/native_functions.yaml`](src/ATen/native/native_functions.yaml) and the THNN/THCUNN headers and
+[`src/ATen/native/native_functions.yaml`](src/ATen/native/native_functions.yaml) and the THNN/THCUNN headers ([`src/THCUNN/generic/THCUNN.h`](src/THCUNN/generic/THCUNN.h), [`src/THNN/generic/THNN.h`](src/THCUNN/generic/THCUNN.h)) and
 produces all of the headers and wrapping code necessary to generate
-the ATen interface.
+the ATen interface. Be aware that the naming of function parameters in THNN/THCUNN header files (camelCase convention) must match those in the respective yaml files (snake_case convention), such that the parsing ([`src/ATen/nn_parse.py`](src/ATen/native_parse.py), [`src/ATen/native_parse.py`](src/ATen/nn_parse.py)) works.
+      
+      
+       
 
 If you need to understand how ATen understands a declaration after all
 of this processing occurs, it's helpful to look at the generated file


### PR DESCRIPTION
The changes are made to clarify how the parsing between the yaml files and header files of THNN and THCUNN works. As issue #12320 shows it is not that easy to understand the existing code without a hint to the important files.

