### PR TITLE
Delete noexcept on the move constructor of OrderedDict

### DIFF
--- a/torch/csrc/api/include/torch/detail/ordered_dict.h
+++ b/torch/csrc/api/include/torch/detail/ordered_dict.h
@@ -72,9 +72,10 @@ class OrderedDict {
 
   // Move works by default, because you can move-construct vectors of const
   // values..
-  OrderedDict(OrderedDict&& other) noexcept(
-      noexcept(std::unordered_map<Key, size_t>(std::move(other.index_))) &&
-      noexcept(std::vector<Item>(std::move(other.items_)))) = default;
+  // NB: I tried to make this noexcept (conditional on the move constructors of
+  // index_ and items_ being noexcept) but the obvious spelling didn't compile
+  // on Windows.
+  OrderedDict(OrderedDict&& other) = default;
   OrderedDict& operator=(OrderedDict&& other) = default;
 
   ~OrderedDict() = default;

--- a/torch/csrc/api/include/torch/detail/ordered_dict.h
+++ b/torch/csrc/api/include/torch/detail/ordered_dict.h
@@ -73,8 +73,8 @@ class OrderedDict {
   // Move works by default, because you can move-construct vectors of const
   // values..
   OrderedDict(OrderedDict&& other) noexcept(
-      noexcept(std::unordered_map<Key, size_t>()) &&
-      noexcept(std::vector<Item>())) = default;
+      noexcept(std::unordered_map<Key, size_t>(std::move(other.index_))) &&
+      noexcept(std::vector<Item>(std::move(other.items_)))) = default;
   OrderedDict& operator=(OrderedDict&& other) = default;
 
   ~OrderedDict() = default;


### PR DESCRIPTION
Previously we tested if default-construction was noexcept, which
doesn't really mean that the move constructor is noexcept too.

Shuts up clang-tidy.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @goldsborough 
