### PR TITLE
Diff against master and enable bugprone-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,8 @@
 Checks: '
   -*
   ,modernize-deprecated-headers
+  ,bugprone-*
+  ,-bugprone-macro-parentheses
   '
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'torch/csrc/.*'

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -131,7 +131,7 @@ torch::jit::Node* node = nullptr;
 std::shared_ptr<jit::tracer::TracingState> tracer_state;
 if (jit::tracer::isTracing()) {
   tracer_state = jit::tracer::getTracingState();
-  node = tracer_state->graph->create(jit::aten::${trace_name}, /*outputs=*/0);
+  node = tracer_state->graph->create(jit::aten::${trace_name}, /*num_outputs=*/0);
   jit::tracer::recordSourceLocation(node);
   ${add_trace_inputs}
   tracer_state->graph->appendNode(node);

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -13,6 +13,7 @@ glob or regular expressions.
 """
 
 import argparse
+import collections
 import fnmatch
 import json
 import os.path
@@ -20,6 +21,9 @@ import re
 import shlex
 import subprocess
 import sys
+
+
+Patterns = collections.namedtuple("Patterns", "positive, negative")
 
 
 # NOTE: Clang-tidy cannot lint headers directly, because headers are not
@@ -46,25 +50,47 @@ def run_shell_command(arguments):
     return output
 
 
+def split_negative_from_positive_patterns(patterns):
+    """Separates negative patterns (that start with a dash) from positive patterns"""
+    positive, negative = [], []
+    for pattern in patterns:
+        if pattern.startswith("-"):
+            negative.append(pattern[1:])
+        else:
+            positive.append(pattern)
+
+    return Patterns(positive, negative)
+
+
 def get_file_patterns(globs, regexes):
     """Returns a list of compiled regex objects from globs and regex pattern strings."""
     # fnmatch.translate converts a glob into a regular expression.
     # https://docs.python.org/2/library/fnmatch.html#fnmatch.translate
-    regexes += [fnmatch.translate(glob) for glob in globs]
-    return [re.compile(regex) for regex in regexes] or [DEFAULT_FILE_PATTERN]
+    glob = split_negative_from_positive_patterns(globs)
+    regexes = split_negative_from_positive_patterns(regexes)
+
+    positive_regexes = regexes.positive + [fnmatch.translate(g) for g in glob.positive]
+    negative_regexes = regexes.negative + [fnmatch.translate(g) for g in glob.negative]
+
+    positive_patterns = [re.compile(regex) for regex in positive_regexes] or [
+        DEFAULT_FILE_PATTERN
+    ]
+    negative_patterns = [re.compile(regex) for regex in negative_regexes]
+
+    return Patterns(positive_patterns, negative_patterns)
 
 
 def filter_files(files, file_patterns):
     """Returns all files that match any of the patterns."""
+    if VERBOSE:
+        print("Filtering with these file patterns: {}".format(file_patterns))
     for file in files:
-        has_match = False
-        for pattern in file_patterns:
-            if pattern.match(file):
+        if not any(n.match(file) for n in file_patterns.negative):
+            if any(p.match(file) for p in file_patterns.positive):
                 yield file
-                has_match = True
-        if not has_match and VERBOSE:
-            message = "{} does not match any file pattern in {{{}}}"
-            print(message.format(file, ", ".join(map(str, file_patterns))))
+                continue
+        if VERBOSE:
+            print("{} ommitted due to file filters".format(file))
 
 
 def get_changed_files(revision, paths):
@@ -135,17 +161,19 @@ def parse_options():
     parser.add_argument(
         "-g",
         "--glob",
-        nargs="+",
+        action="append",
         default=[],
         help="Only lint files that match these glob patterns "
-        "(see documentation for `fnmatch` for supported syntax)",
+        "(see documentation for `fnmatch` for supported syntax)."
+        "If a pattern starts with a - the search is negated for that pattern.",
     )
     parser.add_argument(
         "-x",
         "--regex",
-        nargs="+",
+        action="append",
         default=[],
-        help="Only lint files that match these regular expressions (from the start of the filename)",
+        help="Only lint files that match these regular expressions (from the start of the filename). "
+        "If a pattern starts with a - the search is negated for that pattern.",
     )
     parser.add_argument(
         "-c",

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -28,4 +28,4 @@ if [[ ! -d build ]]; then
 fi
 
 # Run Clang-Tidy
-time python tools/clang_tidy.py -vp torch/csrc -d HEAD~1 "$@"
+time python tools/clang_tidy.py -vp torch/csrc -d master "$@"

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -28,6 +28,8 @@ if [[ ! -d build ]]; then
 fi
 
 # Run Clang-Tidy
+# The negative filters below are to exclude files that include onnx_pb.h,
+# otherwise we'd have to build ONNX protos as part of this CI job.
 time python tools/clang_tidy.py    \
   --verbose                        \
   --paths torch/csrc               \
@@ -37,5 +39,3 @@ time python tools/clang_tidy.py    \
   -g"-torch/csrc/jit/import.cpp"   \
   -g"-torch/csrc/jit/test_jit.cpp" \
   "$@"
-
-# The negative filters above are to exclude files that include onnx_pb.h

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -28,4 +28,14 @@ if [[ ! -d build ]]; then
 fi
 
 # Run Clang-Tidy
-time python tools/clang_tidy.py -vp torch/csrc -d master "$@"
+time python tools/clang_tidy.py    \
+  --verbose                        \
+  --paths torch/csrc               \
+  --diff master                    \
+  -g"-torch/csrc/jit/init.cpp"     \
+  -g"-torch/csrc/jit/export.cpp"   \
+  -g"-torch/csrc/jit/import.cpp"   \
+  -g"-torch/csrc/jit/test_jit.cpp" \
+  "$@"
+
+# The negative filters above are to exclude files that include onnx_pb.h

--- a/torch/csrc/api/include/torch/detail/ordered_dict.h
+++ b/torch/csrc/api/include/torch/detail/ordered_dict.h
@@ -71,7 +71,7 @@ class OrderedDict {
   }
 
   // Move works by default, because you can move-construct vectors of const
-  // values..
+  // values.
   // NB: I tried to make this noexcept (conditional on the move constructors of
   // index_ and items_ being noexcept) but the obvious spelling didn't compile
   // on Windows.

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -103,14 +103,14 @@ void RNNImplBase<Derived>::flatten_parameters() {
   // Cache the flattened weight and bias vector.
   flat_weights_ = flat_weights();
 
-  if (!cudnn_mode_ || !torch::cudnn_is_acceptable(/*sample=*/w_ih.at(0))) {
+  if (!cudnn_mode_ || !torch::cudnn_is_acceptable(w_ih.at(0))) {
     return;
   }
 
   NoGradGuard no_grad;
   torch::_cudnn_rnn_flatten_weight(
       flat_weights_,
-      /*weight_stride=*/options.with_bias_ ? 4 : 2,
+      /*weight_stride0=*/options.with_bias_ ? 4 : 2,
       options.input_size_,
       static_cast<int64_t>(*cudnn_mode_),
       options.hidden_size_,

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -77,7 +77,7 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
       AT_ASSERT(res[i].defined());
       if (i == 0) {
         grad_slice.copy_(res[i]);
-        grad_inputs[i] = std::move(result);
+        grad_inputs[i] = std::move(result); // NOLINT(bugprone-use-after-move)
       } else {
         grad_inputs[i] = std::move(res[i]);
       }

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -129,7 +129,7 @@ std::vector<at::Tensor> scatter(
   std::vector<at::Tensor> chunks;
   if (chunk_sizes) {
     const int64_t chunk_size_sum =
-        std::accumulate(chunk_sizes->begin(), chunk_sizes->end(), 0);
+        std::accumulate(chunk_sizes->begin(), chunk_sizes->end(), int64_t{0});
     AT_CHECK(
       chunk_size_sum == tensor.size(dim),
       "given chunk sizes don't sum up to the tensor's size ",

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -309,7 +309,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
         returned_grad = returned_grad.unsqueeze(*it);
       return {returned_grad};
 
-    } else if (node->matches("aten::squeeze(Tensor self, int dim) -> Tensor", /*const=*/attr::dim)) {
+    } else if (node->matches("aten::squeeze(Tensor self, int dim) -> Tensor", /*const_inputs=*/attr::dim)) {
       int64_t dim = *node->get<int64_t>(attr::dim);
       const auto& sizes = inputs.at(0).sizes();
       wrapDim(dim, sizes);
@@ -318,7 +318,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       }
       return {sizes.at(dim) > 1 ? grads.at(0) : grads.at(0).unsqueeze(dim), nullptr};
 
-    } else if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*const=*/attr::dim)) {
+    } else if (node->matches("aten::cat(Tensor[] tensors, int dim) -> Tensor", /*const_inputs=*/attr::dim)) {
       int dim = *node->get<int64_t>(attr::dim);
       auto tensor_inputs = inputs; tensor_inputs.pop_back();
       const auto& first_sizes = tensor_inputs.at(0).sizes();

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -62,7 +62,7 @@ Node* getTracedNode(
     const std::tuple<Types...>& tuple) {
   auto symbol = Symbol::fromQualString(schema.name);
   const auto& graph = tracer::getTracingState()->graph;
-  Node* node = graph->create(std::move(symbol), /*outputs=*/0);
+  Node* node = graph->create(std::move(symbol), /*num_outputs=*/0);
   tracer::recordSourceLocation(node);
 
   // Hack to call addInputs for the parameter pack in a sequenced fashion.
@@ -207,7 +207,7 @@ Operator createOperator(
     ArgumentTuple tuple;
     torch::jit::detail::callOperatorWithTuple(
         schema,
-        std::move(implementation),
+        std::move(implementation), // NOLINT(bugprone-move-forwarding-reference)
         stack,
         tuple,
         typename MakeIndices<std::tuple_size<ArgumentTuple>::value>::indices{});

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -692,7 +692,7 @@ void ModuleEncoder::EncodeTensor(
           tensor.storage(),
           /* storageOffset = */ 0,
           /* size = */ { static_cast<int64_t>(tensor.storage().size()) },
-          /* strides = */ { 1 })
+          /* stride = */ { 1 })
         .cpu();
     }
 

--- a/torch/csrc/jit/fusers/cuda/fused_kernel.h
+++ b/torch/csrc/jit/fusers/cuda/fused_kernel.h
@@ -35,7 +35,7 @@ protected:
 
   virtual uint64_t get_rand_offset(uint32_t numel) override {
      int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
-     return 4 * (ceil(numel/(4 * blockSize * numBlocks)) + 1);
+     return 4 * (ceil(numel / (4.0 * blockSize * numBlocks)) + 1);
   }
 
   virtual void launch_raw(uint32_t numel, void ** arguments) override;
@@ -53,7 +53,7 @@ protected:
 };
 
 } // namespace cudafuser
-} // namespace jit 
+} // namespace jit
 } // namespace torch
 
 #endif // USE_CUDA_FUSER

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -372,7 +372,7 @@ ModuleDecoder::ModuleDecoder(
 void import_ir_module(
     ModuleLookup module_lookup,
     std::istream& in) {
-  ModuleDecoder(module_lookup, in);
+  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
 }
 
 void import_ir_module(
@@ -380,7 +380,7 @@ void import_ir_module(
     const std::string& filename) {
   std::ifstream in(filename, std::ios_base::binary);
 
-  ModuleDecoder(module_lookup, in);
+  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
 }
 
 std::shared_ptr<script::Module> load(std::istream& in) {
@@ -397,7 +397,7 @@ std::shared_ptr<script::Module> load(std::istream& in) {
     return curr;
   };
 
-  ModuleDecoder(module_lookup, in);
+  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
 
   return module;
 }

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -372,7 +372,8 @@ ModuleDecoder::ModuleDecoder(
 void import_ir_module(
     ModuleLookup module_lookup,
     std::istream& in) {
-  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
+  ModuleDecoder decoder(module_lookup, in);
+  (void)decoder;
 }
 
 void import_ir_module(
@@ -380,7 +381,8 @@ void import_ir_module(
     const std::string& filename) {
   std::ifstream in(filename, std::ios_base::binary);
 
-  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
+  ModuleDecoder decoder(module_lookup, in);
+  (void)decoder;
 }
 
 std::shared_ptr<script::Module> load(std::istream& in) {
@@ -397,7 +399,8 @@ std::shared_ptr<script::Module> load(std::istream& in) {
     return curr;
   };
 
-  ModuleDecoder(module_lookup, in); // NOLINT(bugprone-unused-raii)
+  ModuleDecoder decoder(module_lookup, in);
+  (void)decoder;
 
   return module;
 }

--- a/torch/csrc/jit/passes/annotate_effects.cpp
+++ b/torch/csrc/jit/passes/annotate_effects.cpp
@@ -259,7 +259,7 @@ class AnnotateEffectsImpl {
   Value* addFenceForNode(Node* node, Value* curToken) {
     // Add a start fence
     auto startFence =
-        node->owningGraph()->create(prim::MemoryFence, /*outputs=*/0);
+        node->owningGraph()->create(prim::MemoryFence, /*num_outputs=*/0);
 
     // Add world tokens as the first input and output
     startFence->addInput(curToken);
@@ -282,7 +282,7 @@ class AnnotateEffectsImpl {
 
     // Add an end fence
     auto endFence =
-        node->owningGraph()->create(prim::MemoryFence, /*outputs=*/0);
+        node->owningGraph()->create(prim::MemoryFence, /*num_outputs=*/0);
 
     // Add world tokens as the first input and output
     endFence->addInput(curToken);

--- a/torch/csrc/jit/passes/canonicalize_ops.cpp
+++ b/torch/csrc/jit/passes/canonicalize_ops.cpp
@@ -45,7 +45,7 @@ static void CanonicalizeOps(Block* block) {
     // shape analysis and differentiation passes for those two individual ops.
     // Later, we will fuse together those two ops into a single addmm.
     if (it->matches("aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha) -> Tensor",
-                    /*with_const=*/{attr::beta, attr::alpha})) {
+                    /*const_inputs=*/{attr::beta, attr::alpha})) {
       if (it->get<at::Scalar>(attr::alpha)->toDouble() != 1.0 ||
           it->get<at::Scalar>(attr::beta)->toDouble() != 1.0) {
         continue;
@@ -63,7 +63,7 @@ static void CanonicalizeOps(Block* block) {
       it->output()->replaceAllUsesWith(result);
       it.destroyCurrent();
     } else if (it->matches("aten::chunk(Tensor self, int chunks, int dim) -> Tensor[]",
-                           /*with_const=*/{attr::chunks, attr::dim})) {
+                           /*const_inputs=*/{attr::chunks, attr::dim})) {
       if (auto orig_outputs = getChunkOutputs(*it)) {
         WithInsertPoint guard(*it);
         SymbolicVariable self {it->namedInput(attr::self)};

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -205,32 +205,32 @@ struct GraphFuser {
     if (!isSimpleMap(node)) return false;
 
     if (node->matches("aten::add(Tensor self, Tensor other, *, Scalar alpha) -> Tensor",
-          /*const=*/attr::alpha) ||
+          /*const_inputs=*/attr::alpha) ||
         node->matches("aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor",
-          /*const=*/{attr::other, attr::alpha}) ||
+          /*const_inputs=*/{attr::other, attr::alpha}) ||
         node->matches("aten::sub(Tensor self, Tensor other, *, Scalar alpha) -> Tensor",
-          /*const=*/attr::alpha) ||
+          /*const_inputs=*/attr::alpha) ||
         node->matches("aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor",
-          /*const=*/{attr::other, attr::alpha}) ||
-        node->matches("aten::mul(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::div(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
-        node->matches("aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor", /*const=*/{attr::min, attr::max})) {
+          /*const_inputs=*/{attr::other, attr::alpha}) ||
+        node->matches("aten::mul(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
+        node->matches("aten::div(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
+        node->matches("aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor", /*const_inputs=*/{attr::min, attr::max})) {
       auto inputs = tensorInputs(node);
       return haveSupportedType(inputs);
     }
     else if (
         node->matches("aten::lt(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::lt(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
+        node->matches("aten::lt(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::le(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::le(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
+        node->matches("aten::le(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::gt(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::gt(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
+        node->matches("aten::gt(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::ge(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::ge(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
+        node->matches("aten::ge(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::eq(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::eq(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other) ||
+        node->matches("aten::eq(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::ne(Tensor self, Tensor other) -> Tensor") ||
-        node->matches("aten::ne(Tensor self, Scalar other) -> Tensor", /*const=*/attr::other)) {
+        node->matches("aten::ne(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other)) {
       // comparison operators produce Byte type, and it's ok, check only inputs
       auto inputs = tensorInputs(node);
       return haveSupportedType(inputs);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1177,7 +1177,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     node->output()->setType(tp->withSizesStrides(sizes, strides));
     return true;
   } else if (node->matches("aten::narrow(Tensor self, int dim, int start, int length) -> Tensor",
-                           /*with_const=*/{attr::dim, attr::length})) {
+                           /*const_inputs=*/{attr::dim, attr::length})) {
     auto tp = tensor_types.at(0);
     auto sizes = tp->sizes();
     int64_t dim = node->get<int64_t>(attr::dim).value();
@@ -1190,7 +1190,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     node->output()->setType(tensor_types.at(0)->withSizes({}));
     return true;
   } else if (node->matches("aten::sum(Tensor self, int[] dim, bool keepdim) -> Tensor",
-             /*with_const=*/{attr::dim, attr::keepdim})) {
+             /*const_inputs=*/{attr::dim, attr::keepdim})) {
     auto & tp = tensor_types.at(0);
     auto sizes = tp->sizes();
     auto dims = node->get<std::vector<int64_t>>(attr::dim).value();
@@ -1206,7 +1206,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     }
     node->output()->setType(tp->withSizes(sizes));
     return true;
-  } else if (node->matches("aten::squeeze(Tensor self, int dim) -> Tensor", /*with_const=*/attr::dim)) {
+  } else if (node->matches("aten::squeeze(Tensor self, int dim) -> Tensor", /*const_inputs=*/attr::dim)) {
     auto & tp = tensor_types.at(0);
     auto sizes = tp->sizes();
     auto strides = tp->strides();
@@ -1218,7 +1218,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     }
     node->output()->setType(tp->withSizesStrides(sizes, strides));
     return true;
-  } else if (node->matches("aten::unsqueeze(Tensor self, int dim) -> Tensor", /*with_const=*/attr::dim)) {
+  } else if (node->matches("aten::unsqueeze(Tensor self, int dim) -> Tensor", /*const_inputs=*/attr::dim)) {
     auto & tp = tensor_types.at(0);
     auto sizes = tp->sizes();
     auto strides = tp->strides();
@@ -1229,7 +1229,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     strides.insert(strides.begin() + dim, new_stride);
     node->output()->setType(tp->withSizesStrides(sizes, strides));
     return true;
-  } else if (node->matches("aten::view(Tensor self, int[] size) -> Tensor", /*with_const=*/attr::size)) {
+  } else if (node->matches("aten::view(Tensor self, int[] size) -> Tensor", /*const_inputs=*/attr::size)) {
     auto sizes = node->get<std::vector<int64_t>>(attr::size).value();
     bool inferred = false;
     size_t inferred_idx;
@@ -1263,7 +1263,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     }
     return true;
   } else if (node->matches("aten::expand(Tensor self, int[] size, *, bool implicit) -> Tensor",
-             /*with_const=*/attr::size)) {
+             /*const_inputs=*/attr::size)) {
     auto tp = tensor_types.at(0);
     std::vector<int64_t> sizes, strides;
     std::tie(sizes, strides) = at::inferExpandGeometry(
@@ -1271,7 +1271,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     node->output()->setType(tp->withSizesStrides(sizes, strides));
     return true;
   } else if (node->matches("aten::index_select(Tensor self, int dim, Tensor index) -> Tensor",
-             /*with_const=*/attr::dim)) {
+             /*const_inputs=*/attr::dim)) {
     auto ten = tensor_types.at(0);
     auto index = tensor_types.at(1);
     int64_t dim = node->get<int64_t>(attr::dim).value();
@@ -1282,7 +1282,7 @@ bool PropagateCompleteShapeOnNode(Node * node, bool insert_expands,
     node->output()->setType(ten->withSizes(sizes));
     return true;
   } else if (node->matches("aten::chunk(Tensor self, int chunks, int dim) -> Tensor[]",
-                           /*with_const=*/{attr::chunks, attr::dim})) {
+                           /*const_inputs=*/{attr::chunks, attr::dim})) {
     auto input_type = tensor_types.at(0);
     auto sizes = input_type->sizes();
     const auto & strides = input_type->strides();

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -140,8 +140,8 @@ struct SharedParserData {
     }
 
 #define ADD_CASE(tok, _, tokstring) \
-  if (*tokstring != '\0') {         \
-    head->insert(tokstring, tok);   \
+  if (*(tokstring) != '\0') {         \
+    head->insert((tokstring), (tok));   \
   }
     TC_FORALL_TOKEN_KINDS(ADD_CASE)
 #undef ADD_CASE

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -114,7 +114,8 @@ struct Method {
     for (at::Tensor* inp : member_inputs) {
       stack.push_back(*inp);
     }
-    setInputTypes(*retval, ArgumentSpec(with_grad, std::move(stack), stack.size()));
+    const auto size = stack.size();
+    setInputTypes(*retval, ArgumentSpec(with_grad, std::move(stack), size));
     PropagateInputShapes(*retval);
     return retval;
   }

--- a/torch/csrc/jit/stack.h
+++ b/torch/csrc/jit/stack.h
@@ -73,7 +73,7 @@ static inline void push(Stack& stack, Types&&... args) {
 // pack takes the return values of aten functions pushes them onto the stack
 template<typename T>
 inline void pack(Stack & stack, T&& v) {
-  stack.emplace_back(std::move(v));
+  stack.emplace_back(std::forward<T>(v));
 }
 
 template<std::size_t remaining, typename... Args>

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -706,7 +706,7 @@ void argumentSpecTest() {
   CATCH_REQUIRE(no_grad != a);
 
   std::unordered_set<CompleteArgumentSpec> spec;
-  spec.insert(std::move(a));
+  spec.insert(a);
   CATCH_REQUIRE(spec.count(b) > 0);
   CATCH_REQUIRE(spec.count(no_grad) == 0);
   spec.insert(std::move(no_grad));
@@ -832,7 +832,7 @@ void testIValue() {
   auto foo2 = std::move(bar);
   JIT_ASSERT(foo.use_count() == 3);
   JIT_ASSERT(foo2.isIntList());
-  JIT_ASSERT(bar.isNone());
+  JIT_ASSERT(bar.isNone()); // NOLINT(bugprone-use-after-move)
   foo2 = IValue(4.0);
   JIT_ASSERT(foo2.isDouble());
   JIT_ASSERT(foo2.toDouble() == 4.0);
@@ -841,7 +841,7 @@ void testIValue() {
 
   auto move_it = std::move(baz).toIntList();
   JIT_ASSERT(foo.use_count() == 2);
-  JIT_ASSERT(baz.isNone());
+  JIT_ASSERT(baz.isNone()); // NOLINT(bugprone-use-after-move)
   IValue i(4);
   JIT_ASSERT(i.isInt() && i.toInt() == 4);
   IValue dlist(DoubleList::create({3.5}));
@@ -849,7 +849,7 @@ void testIValue() {
       dlist.isDoubleList() &&
       ArrayRef<double>(std::move(dlist).toDoubleList()->elements())
           .equals({3.5}));
-  JIT_ASSERT(dlist.isNone());
+  JIT_ASSERT(dlist.isNone()); // NOLINT(bugprone-use-after-move)
   dlist = IValue(DoubleList::create({3.4}));
   JIT_ASSERT(ArrayRef<double>(dlist.toDoubleList()->elements()).equals({3.4}));
   IValue the_list(Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));


### PR DESCRIPTION
This PR:

1. Makes clang-tidy diff against `master` instead of `HEAD~1` in CI, which makes much more sense
2. Enables all checks in the `bugprone-*` category (see https://clang.llvm.org/extra/clang-tidy/checks/list.html) except one about parantheses in macros, because it doesn't always apply too well for us.

Fixed some nice code smells.

@ezyang 