### PR TITLE
restore caffe2 strides

### DIFF
--- a/aten/src/ATen/core/TensorImpl.cpp
+++ b/aten/src/ATen/core/TensorImpl.cpp
@@ -46,9 +46,6 @@ IntList TensorImpl::sizes() const {
 }
 
 IntList TensorImpl::strides() const {
-  AT_ASSERTM(strides_,
-             "Caffe2 tensors don't (yet) have meaningful strides and cannot "
-             "be used in PyTorch.");
   return IntList{strides_.get(), sizes_.size()};
 }
 
@@ -56,10 +53,6 @@ bool TensorImpl::compute_contiguous() const {
   bool is_contiguous = true;
   if (is_empty())
     return is_contiguous;
-  if (!strides_) {
-    // Special case for Caffe2 tensors which don't have strides set.
-    return true;
-  }
   int64_t z = 1;
   for (int64_t d = dim() - 1; d >= 0; d--) {
     if (size(d) != 1) {
@@ -90,9 +83,6 @@ int64_t TensorImpl::size(int64_t d) const {
 }
 
 int64_t TensorImpl::stride(int64_t d) const {
-  AT_ASSERTM(strides_,
-             "Caffe2 tensors don't (yet) have meaningful strides and cannot "
-             "be used in PyTorch.");
   d = at::maybe_wrap_dim(d, dim(), false);
   return strides_[d];
 }

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -844,7 +844,14 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   inline void update_to_contiguous_strides() {
-    strides_.reset();
+    strides_ = c10::guts::make_unique<int64_t[]>(sizes_.size());
+    if (dim() > 0) {
+      int last_idx = dim() - 1;
+      strides_[last_idx] = 1;
+      for (auto i = last_idx - 1; i >= 0; --i) {
+        strides_[i] = strides_[i + 1] * std::max<int64_t>(sizes_[i + 1], 1);
+      }
+    }
     is_contiguous_ = true;
   }
 


### PR DESCRIPTION
Summary: The workflow passes after D10150834, so we can restore strides.

Differential Revision: D10220313
