### PR TITLE
implement rowwise quantization for fp16

### DIFF
--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
@@ -1,10 +1,31 @@
 #include "caffe2/operators/fused_rowwise_8bit_conversion_ops.h"
+#include <fp16.h>
 #include "c10/util/Registry.h"
 
 namespace caffe2 {
+
+namespace {
+void convertfp32fp32(float* dst, const float* src, size_t N) {
+  memcpy(dst, src, sizeof(float) * N);
+}
+
+void convertfp16fp32(float* dst, const at::Half* src, size_t N) {
+  for (size_t i = 0; i < N; i++) {
+    dst[i] = fp16_ieee_to_fp32_value(src[i].x);
+  }
+}
+
+void convertfp32fp16(at::Half* dst, const float* src, size_t N) {
+  for (size_t i = 0; i < N; i++) {
+    uint16_t out = fp16_ieee_from_fp32_value(src[i]);
+    memcpy(dst + i, &out, sizeof(uint16_t));
+  }
+}
+} // namespace
+
 REGISTER_CPU_OPERATOR(
     FloatToFused8BitRowwiseQuantized,
-    FloatToFused8BitRowwiseQuantizedOp<CPUContext>);
+    FloatToFused8BitRowwiseQuantizedOp<float, convertfp32fp32, CPUContext>);
 OPERATOR_SCHEMA(FloatToFused8BitRowwiseQuantized)
     .NumInputs(1)
     .NumOutputs(1)
@@ -32,8 +53,37 @@ bytes in the row encode single quantized values.)
 NO_GRADIENT(FloatToFused8BitRowwiseQuantized);
 
 REGISTER_CPU_OPERATOR(
+    HalfFloatToFused8BitRowwiseQuantized,
+    FloatToFused8BitRowwiseQuantizedOp<at::Half, convertfp16fp32, CPUContext>);
+OPERATOR_SCHEMA(HalfFloatToFused8BitRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 8-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 8-bit number between 0 and
+255. To later de-quantize values, the scale (range / 255) and offset
+(bias) are stored alongside the data. More precisely, the first 4 bytes
+of each row in the output matrix are a 32-bit float storing the scale,
+the next 4 bytes store the bias as a 32-bit float, and all remaining
+bytes in the row encode single quantized values.)
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfFloatToFused8BitRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
     Fused8BitRowwiseQuantizedToFloat,
-    Fused8BitRowwiseQuantizedToFloatOp<CPUContext>);
+    Fused8BitRowwiseQuantizedToFloatOp<float, convertfp32fp32, CPUContext>);
 OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToFloat)
     .NumInputs(1)
     .NumOutputs(1)
@@ -61,6 +111,40 @@ the original, un-quantized floating point values.
         0,
         "scale_bias_quantized_input",
         "Fused scale, bias and quantized data")
-    .Output(0, "float_input", "Float32 data");
+    .Output(0, "float_output", "Float32 data");
 NO_GRADIENT(Fused8BitRowwiseQuantizedToFloat);
+
+REGISTER_CPU_OPERATOR(
+    Fused8BitRowwiseQuantizedToHalfFloat,
+    Fused8BitRowwiseQuantizedToFloatOp<at::Half, convertfp32fp16, CPUContext>);
+OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToHalfFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) - 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT16);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+HalfFloatToFused8BitRowwiseQuantized operator. The input is expected to
+encode the scale as a 32-bit float in the second to the last 4 bytes of each
+row, followed by the bias as a 32-bit float in the next 4 bytes, and the
+quantized values in the preceding bytes of the row. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and bias
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float16_output", "Float16 data");
+NO_GRADIENT(Fused8BitRowwiseQuantizedToHalfFloat);
+
 } // namespace caffe2

--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
@@ -16,11 +16,16 @@ namespace caffe2 {
     return reinterpret_cast<const uint8_t*>(&kValue)[0] == 1; \
   }()
 
-template <class Context>
+template <
+    typename T,
+    void (*convert)(float* dst, const T* src, size_t N),
+    class Context>
 class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
  public:
   static constexpr float kEqualityThreshold = 1e-7f;
   static constexpr float kEpsilon = 1e-8f;
+  static constexpr float kEqualityThreshold16 = 1e-3f;
+  static constexpr float kEpsilon16 = 9e-4f;
 
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   USE_SIMPLE_CTOR_DTOR(FloatToFused8BitRowwiseQuantizedOp)
@@ -42,17 +47,28 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
     // | ... int8 data ... | scale | bias |
     // | number_of_columns |  4B   |  4B  |
     const std::vector<int64_t> output_dimensions = {input_rows,
-                                                   input_columns + 8};
+                                                    input_columns + 8};
     output->Resize(output_dimensions);
 
-    const auto* input_data = input.template data<float>();
+    const auto* input_data = input.template data<T>();
     auto* output_data = output->template mutable_data<uint8_t>();
     const auto output_columns = output->dim(1);
 
-    for (size_t row = 0; row < input_rows; ++row) {
-      ConstEigenVectorArrayMap<float> input_row(
-          input_data + row * input_columns, input_columns);
+    float epsilon;
+    if (std::is_same<T, float>::value) {
+      epsilon = kEpsilon;
+    } else if (std::is_same<T, at::Half>::value) {
+      epsilon = kEpsilon16;
+    } else {
+      CAFFE_THROW("Unsupported data type");
+    }
 
+    vector<float> tmp;
+    tmp.resize(input_columns, 0.0);
+
+    for (size_t row = 0; row < input_rows; ++row) {
+      convert(tmp.data(), input_data + row * input_columns, input_columns);
+      ConstEigenVectorArrayMap<float> input_row(tmp.data(), input_columns);
       uint8_t* output_row = output_data + row * output_columns;
       EigenVectorArrayMap<uint8_t> output_row_values(output_row, input_columns);
       EigenVectorArrayMap<float> output_row_scale_bias(
@@ -64,7 +80,7 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
 
       output_row_scale_bias(0) = range / 255.0f;
       output_row_scale_bias(1) = minimum_element;
-      const auto inverse_scale = 255.0f / (range + kEpsilon);
+      const auto inverse_scale = 255.0f / (range + epsilon);
       output_row_values = ((input_row - minimum_element) * inverse_scale)
                               .round()
                               .cast<uint8_t>();
@@ -78,7 +94,10 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
   OUTPUT_TAGS(DATA_FUSED_SCALE_BIAS_INT8);
 };
 
-template <class Context>
+template <
+    typename T,
+    void (*convert)(T* dst, const float* src, size_t N),
+    class Context>
 class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
@@ -97,12 +116,15 @@ class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
     // The last 8 bytes per row are the scale and the bias. The rest of
     // input_columns is the number of values in the original row.
     const std::vector<int64_t> output_dimensions = {input_rows,
-                                                   input_columns - 8};
+                                                    input_columns - 8};
     output->Resize(output_dimensions);
     const auto output_columns = output->dim(1);
 
     const auto* input_data = input.template data<uint8_t>();
-    auto* output_data = output->template mutable_data<float>();
+    T* output_data = output->template mutable_data<T>();
+
+    vector<float> tmp;
+    tmp.resize(input_columns, 0.0);
 
     for (size_t row = 0; row < input_rows; ++row) {
       const uint8_t* input_row = input_data + row * input_columns;
@@ -111,11 +133,11 @@ class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
       ConstEigenVectorArrayMap<float> input_row_scale_bias(
           reinterpret_cast<const float*>(input_row + output_columns), 2);
 
-      EigenVectorArrayMap<float> output_row(
-          output_data + row * output_columns, output_columns);
-
+      EigenVectorArrayMap<float> output_row(tmp.data(), output_columns);
       output_row = input_row_values.cast<float>() * input_row_scale_bias(0) +
           input_row_scale_bias(1);
+
+      convert(output_data + row * output_columns, tmp.data(), output_columns);
     }
     return true;
   }

--- a/caffe2/python/operator_test/shape_inference_test.py
+++ b/caffe2/python/operator_test/shape_inference_test.py
@@ -518,11 +518,26 @@ class TestShapeInference(test_util.TestCase):
         self.InferTensorRunAndCompare(model)
 
     def testInt8Conversion(self):
-        model = model_helper.ModelHelper(name="int8_conversion_test")
+        model = model_helper.ModelHelper(name="fp32_int8_conversion_test")
         model.FloatToFused8BitRowwiseQuantized('x', 'x_8bit')
         model.Fused8BitRowwiseQuantizedToFloat('x_8bit', 'x_recovered')
         workspace.FeedBlob('x', np.random.rand(100, 150).astype(np.float32))
         self.InferTensorRunAndCompare(model)
+        x = workspace.FetchBlob('x')
+        x_recovered = workspace.FetchBlob('x_recovered')
+        # TODO: find a tighter bound
+        assert(np.allclose(x, x_recovered, atol=1e-2))
+
+    def testHalfInt8Conversion(self):
+        model = model_helper.ModelHelper(name="fp16_int8_conversion_test")
+        model.HalfFloatToFused8BitRowwiseQuantized('x', 'x_8bit')
+        model.Fused8BitRowwiseQuantizedToHalfFloat('x_8bit', 'x_recovered')
+        workspace.FeedBlob('x', np.random.rand(100, 150).astype(np.float16))
+        self.InferTensorRunAndCompare(model)
+        x = workspace.FetchBlob('x')
+        x_recovered = workspace.FetchBlob('x_recovered')
+        # TODO: find a tighter bound
+        assert(np.allclose(x, x_recovered, atol=1e-2))
 
     def testShapeOp(self):
         model = model_helper.ModelHelper(name="shape_op_test")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -305,6 +305,20 @@ if(USE_FFMPEG)
   endif ()
 endif()
 
+# ---[ Caffe2 depends on FP16 library for half-precision conversions
+if (NOT TARGET fp16)
+  if (NOT DEFINED FP16_SOURCE_DIR)
+    set(FP16_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../third_party/FP16" CACHE STRING "FP16 source directory")
+  endif()
+
+  set(FP16_BUILD_TESTS OFF CACHE BOOL "")
+  set(FP16_BUILD_BENCHMARKS OFF CACHE BOOL "")
+  add_subdirectory(
+    "${FP16_SOURCE_DIR}"
+    "${CONFU_DEPENDENCIES_BINARY_DIR}/FP16")
+endif()
+list(APPEND Caffe2_DEPENDENCY_LIBS fp16)
+
 # ---[ EIGEN
 # Due to license considerations, we will only use the MPL2 parts of Eigen.
 set(EIGEN_MPL2_ONLY 1)


### PR DESCRIPTION
Summary:
implement fp16-> (uint8 + scale and bias in fp32)

this is similar to fp32 rowwise quantization

we could have done scale and bias in fp16 but not too motivated since we are not saving much and those datatypes have to be converted to fp32 to process since x86 doesn't support half float operations anyways

Differential Revision: D10220463
