### PR TITLE
Fix incorrect sampling in Dirichlet and Beta

### DIFF
--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -9,7 +9,7 @@ from torch.distributions.utils import _finfo, broadcast_all, clamp_probs
 
 
 def _dirichlet_sample_nograd(concentration):
-    probs = torch._standard_gamma(concentration)
+    probs = torch._standard_gamma(concentration.clone())
     probs /= probs.sum(-1, True)
     return clamp_probs(probs)
 


### PR DESCRIPTION
#12373 Solves sampling with single concentration0, concentration1 in Beta distribution or single row of concentration in Dirichlet results that before resulted in incorrect behaviour by cloning concentration before sending to `torch._standard_gamma`

This would solve the issue but there might be a better solution for someone to find. Some debugging info can be found in the issue

