### PR TITLE
Fixed print issue for TensorTypeId

### DIFF
--- a/aten/src/ATen/core/TensorTypeId.cpp
+++ b/aten/src/ATen/core/TensorTypeId.cpp
@@ -1,9 +1,10 @@
 #include "ATen/core/TensorTypeId.h"
+#include "caffe2/utils/string_utils.h"
 
 namespace at {
 
 std::ostream& operator<<(std::ostream& str, at::TensorTypeId rhs) {
-  return str << rhs.underlyingId();
+  return str << caffe2::to_string(rhs.underlyingId());
 }
 
 } // namespace at

--- a/aten/src/ATen/core/TensorTypeId_test.cpp
+++ b/aten/src/ATen/core/TensorTypeId_test.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+#include <sstream>
+#include "ATen/core/TensorTypeId.h"
+#include "ATen/core/TensorTypeIdRegistration.h"
+
+TEST(TensorTypeIdTest, Printing) {
+  std::ostringstream ss;
+  ss << at::UndefinedTensorId();
+  EXPECT_EQ(ss.str(), "1");
+}


### PR DESCRIPTION
Summary:
Fixed printing issue for TensorTypeID. It used to print a hex of the ID, e.g.
   /x1
Now it prints the ID as a string, e.g.
  1

Differential Revision: D10224026
