### PR TITLE
Make dynamic_cast_if_rtti safer

### DIFF
--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -179,7 +179,7 @@ inline Dst dynamic_cast_if_rtti(Src ptr) {
 #ifdef __GXX_RTTI
   return dynamic_cast<Dst>(ptr);
 #else
-  return reinterpret_cast<Dst>(ptr);
+  return static_cast<Dst>(ptr);
 #endif
 }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12408 Make dynamic_cast_if_rtti safer**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10227820/)

Using static_cast is better than reinterpret_cast because it will cause a compile time error in the following cases, while reinterpret_cast would run into undefined behavior and likely segfault:
- Src and Dst are not related through inheritance (say converting int* to double*)
- Src and Dst are related through virtual inheritance

Differential Revision: [D10227820](https://our.internmc.facebook.com/intern/diff/D10227820/)