### PR TITLE
enable group conv test in NHWC layout in CPU

### DIFF
--- a/caffe2/python/operator_test/conv_test.py
+++ b/caffe2/python/operator_test/conv_test.py
@@ -80,8 +80,8 @@ class TestConvolution(serial.SerializedTestCase):
             self, op_type, stride_h, stride_w, pad_t, pad_l, pad_b, pad_r,
             kernel, size, input_channels, output_channels, batch_size, group,
             order, engine, shared_buffer, use_bias, gc, dc):
-        if order == "NHWC":
-            group = 1
+        # TODO: Group conv in NHWC not implemented for GPU yet.
+        assume(group == 1 or order == "NCHW" or gc.device_type != caffe2_pb2.CUDA)
 
         input_channels *= group
         output_channels *= group
@@ -205,8 +205,12 @@ class TestConvolution(serial.SerializedTestCase):
             self, op_type, stride, pad, kernel, dilation, size, input_channels,
             output_channels, batch_size, group, order, engine, use_bias,
             force_algo_fwd, force_algo_dgrad, force_algo_wgrad, gc, dc):
-        if order == "NHWC" or engine == "MKLDNN":
-            group = 1
+        # TODO: Group conv in NHWC not implemented for GPU yet.
+        assume(
+            group == 1
+            or (order == "NCHW" or gc.device_type != caffe2_pb2.CUDA)
+            and engine != "MKLDNN"
+        )
 
         input_channels *= group
         output_channels *= group
@@ -740,5 +744,4 @@ class TestConvolution(serial.SerializedTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     unittest.main()


### PR DESCRIPTION
Summary:
Group conv in NHWC layout was enabled in CPU after D7547497.
In D7547497, unit test of group conv in NHWC layout in CPU was enabled in group_conv_test.py but not in conv_test.py . This diff also enables it in conv_test.py .

Differential Revision: D10233252
