### PR TITLE
CUDA 10 warnings fixed

### DIFF
--- a/caffe2/core/common_gpu.cc
+++ b/caffe2/core/common_gpu.cc
@@ -147,7 +147,7 @@ int GetGPUIDForPointer(const void* ptr) {
   // Otherwise, there must be no error
   CUDA_ENFORCE(err);
 
-  if (attr.memoryType == cudaMemoryTypeHost) {
+  if (attr.CAFFE2_CUDA_PTRATTR_MEMTYPE == cudaMemoryTypeHost) {
     return -1;
   }
 

--- a/caffe2/core/common_gpu.h
+++ b/caffe2/core/common_gpu.h
@@ -108,6 +108,12 @@ namespace caffe2 {
 class TensorCoreEngine {};
 #endif
 
+#if CUDA_VERSION >= 10000
+  #define CAFFE2_CUDA_PTRATTR_MEMTYPE type
+#else
+  #define CAFFE2_CUDA_PTRATTR_MEMTYPE memoryType
+#endif
+
 /**
  * A runtime function to report the cuda version that Caffe2 is built with.
  */

--- a/caffe2/core/context_gpu_test.cc
+++ b/caffe2/core/context_gpu_test.cc
@@ -70,7 +70,7 @@ TEST(CUDAContextTest, MemoryPoolAllocateDealloc) {
     EXPECT_NE(allocated, nullptr);
     cudaPointerAttributes attr;
     CUDA_ENFORCE(cudaPointerGetAttributes(&attr, allocated.get()));
-    EXPECT_EQ(attr.memoryType, cudaMemoryTypeDevice);
+    EXPECT_EQ(attr.CAFFE2_CUDA_PTRATTR_MEMTYPE, cudaMemoryTypeDevice);
     EXPECT_EQ(attr.device, i);
     void* prev_allocated = allocated.get();
     allocated.reset();

--- a/caffe2/core/hip/common_hip.cc
+++ b/caffe2/core/hip/common_hip.cc
@@ -158,7 +158,7 @@ int GetGPUIDForPointer(const void* ptr)
     // Otherwise, there must be no error
     HIP_ENFORCE(err);
 
-    if(attr.memoryType == hipMemoryTypeHost)
+    if(attr.CAFFE2_HIP_PTRATTR_MEMTYPE == hipMemoryTypeHost)
     {
         return -1;
     }

--- a/caffe2/core/hip/common_hip.h
+++ b/caffe2/core/hip/common_hip.h
@@ -25,6 +25,12 @@
  */
 #define CAFFE2_HIP_MAX_PEER_SIZE 8
 
+#if CUDA_VERSION >= 10000
+  #define CAFFE2_HIP_PTRATTR_MEMTYPE type
+#else
+  #define CAFFE2_HIP_PTRATTR_MEMTYPE memoryType
+#endif
+
 namespace caffe2 {
 
 /**


### PR DESCRIPTION
Deprecation warning against `cudaPointerAttributes`, where `memoryType` field has been deprecated in favor of `type`, see https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__UNIFIED.html#contents-end
for details