### PR TITLE
Fix tensor doc

### DIFF
--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -48,6 +48,7 @@ INPUT                  = ../../../torch/csrc/api/include \
                          ../../../aten/src/ATen/core/Error.h \
                          ../../../aten/src/ATen/core/Half.h \
                          ../../../aten/src/ATen/core/ScalarType.h \
+                         ../../../aten/src/ATen/core/Tensor.h \
                          ../../../aten/src/ATen/cuda/CUDAGuard.h \
                          ../../../aten/src/ATen/cuda/CUDAStream.h \
                          ../../../aten/src/ATen/cuda/CUDAContext.h \
@@ -56,7 +57,6 @@ INPUT                  = ../../../torch/csrc/api/include \
                          ../../../aten/src/ATen/cudnn/Types.h \
                          ../../../aten/src/ATen/cudnn/Utils.h \
                          ../../../aten/src/ATen/mkl/Descriptors.h \
-                         ../../../build/aten/src/ATen/Tensor.h \
                          ../../../build/aten/src/ATen/Functions.h
 # Don't include .cpp files!
 FILE_PATTERNS          = *.h
@@ -104,7 +104,7 @@ EXTRACT_ALL            = YES
 EXTRACT_PACKAGE        = YES
 EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = NO
-EXCLUDE_SYMBOLS        = c10::* caffe2::* cereal* DL* TH* cudnn* std::*
+EXCLUDE_SYMBOLS        = c10::* caffe2::* cereal* DL* TH* cudnn* std::* *::detail::*
 ################################################################################
 # Docstring control / customization.                                           #
 ################################################################################


### PR DESCRIPTION
The C++ docs for `at::Tensor` are currently broken because we moved the place `Tensor.h` gets generated to without updating our docs. I use `GEN_TO_SOURCE=1` when generating ATen files, so the `Tensor.h` file should end up in `aten/src/ATen/core/Tensor.h` if i understand correctly.

@dzhulgakov @ezyang @gchanan 