### PR TITLE
[distributed sampler update]

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -478,7 +478,7 @@ class TestDataLoader(TestCase):
         scanned_data = torch.IntTensor([])
         for i in range(num_processes):
             s = DistributedSampler(data_set, num_processes, i)
-            d_loader = DataLoader(data_set, batch_size = int(num_batches/num_processes), drop_last=True, sampler=s)
+            d_loader = DataLoader(data_set, batch_size=int(num_batches / num_processes), drop_last=True, sampler=s)
             for k, data in enumerate(d_loader):
                 scanned_data = torch.cat((scanned_data, data), 0)
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -468,6 +468,22 @@ class TestDataLoader(TestCase):
 
         self.assertRaises(ValueError, lambda: RandomSampler(self.dataset, num_samples=0))
 
+    def test_duplicating_data_with_drop_last(self):
+
+        from torch.utils.data.distributed import DistributedSampler
+
+        num_processes = 4
+        num_batches = 9
+        data_set = torch.IntTensor(range(num_batches))
+        scanned_data = torch.IntTensor([])
+        for i in range(num_processes):
+            s = DistributedSampler(data_set, num_processes, i)
+            d_loader = DataLoader(data_set, batch_size = int(num_batches/num_processes), drop_last=True, sampler=s)
+            for k, data in enumerate(d_loader):
+                scanned_data = torch.cat((scanned_data, data), 0)
+
+        self.assertEqual(scanned_data.size(), scanned_data.unique().size())
+
     @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
                      don't support multiprocessing with spawn start method")
     def test_batch_sampler(self):

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -49,8 +49,7 @@ class DistributedSampler(Sampler):
         assert len(indices) == self.total_size
 
         # subsample
-        offset = self.num_samples * self.rank
-        indices = indices[offset:offset + self.num_samples]
+        indices = indices[self.rank:self.total_size:self.num_replicas]
         assert len(indices) == self.num_samples
 
         return iter(indices)


### PR DESCRIPTION
  Modifies the DistributedSampler logic. Now each process samples elements with
a given interval, instead of a consecutive section.

  This eliminates the possibility where the DataLoader uses padded data while
dropping the real data. It happens when:
  1. DistributedSampler padded data; and
  2. DataLoader drops_last is effectively true, and drops less then the number
of padded data.
  from the example down, we see that data (10, 11, 12) are padded through
duplicating data sample (1, 2, 3)
  The old sampler drops legit original data (3, 6, 9) and introduces duplication
(10, 11) into the training set; while the new sampler logic samples correct data
points from the data set.
  This example has been added to dataloader unit test

example:
```
  data after shuffle: 1, 2, 3, 4, 5, 6, 7, 8, 9
  padded data : 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12

  old sampler:       ->  DataLoader with (batch_size=2 and drop_last=True)
   p 1: 1, 2, 3          1, 2
   p 2: 4, 5, 6          4, 5
   p 3: 7, 8, 9          7, 8
   p 4:10,11,12         10,11

  new sampler:       ->
   p 1: 1, 5, 9          1, 5
   p 2: 2, 6,10          2, 6
   p 3: 3, 7,11          3, 7
   p 4: 4, 8,12          4, 8
```

