### PR TITLE
Differentiable and Non-differentiable Views

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -738,28 +738,36 @@ class TestAutograd(TestCase):
 
     def test_no_grad(self):
         x = torch.ones(5, 5, requires_grad=True)
-        y = Variable(torch.ones(5, 5) * 4)
-        with torch.no_grad():
-            w = x + y
+        y = torch.ones(5, 5) * 4
 
-        @torch.no_grad()
         def adder(x, y):
             return x + y
 
-        z = adder(x, y)
+        def viewer(x, y):
+            return x[1]
 
-        self.assertFalse(w.requires_grad)
-        self.assertRaises(RuntimeError, lambda: w.backward(torch.ones(5, 5)))
-        self.assertIsNone(w.grad_fn)
-        self.assertFalse(z.requires_grad)
-        self.assertRaises(RuntimeError, lambda: z.backward(torch.ones(5, 5)))
-        self.assertIsNone(z.grad_fn)
+        for binary_op in (adder, viewer):
+            with torch.no_grad():
+                w = binary_op(x, y)
 
-        # test nested decorator and with-statement on no_grad
-        with torch.no_grad():
-            self.assertFalse(torch.is_grad_enabled())
-            w = adder(x, y)
-            self.assertFalse(torch.is_grad_enabled())
+            @torch.no_grad()
+            def decorated(x, y):
+                return binary_op(x, y)
+
+            z = decorated(x, y)
+
+            self.assertFalse(w.requires_grad)
+            self.assertRaises(RuntimeError, lambda: w.backward(torch.ones(5, 5)))
+            self.assertIsNone(w.grad_fn)
+            self.assertFalse(z.requires_grad)
+            self.assertRaises(RuntimeError, lambda: z.backward(torch.ones(5, 5)))
+            self.assertIsNone(z.grad_fn)
+
+            # test nested decorator and with-statement on no_grad
+            with torch.no_grad():
+                self.assertFalse(torch.is_grad_enabled())
+                w = binary_op(x, y)
+                self.assertFalse(torch.is_grad_enabled())
 
     def test_no_grad_python_function(self):
         """Python Functions should respect grad mode."""

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -14,7 +14,7 @@ import yaml
 from collections import defaultdict
 from .utils import YamlLoader, split_name_params
 
-# See NOTE [ Autograd Variable Views ] in variable.h for details.
+# See NOTE [ Autograd View Variables ] in variable.h for details.
 VIEW_FUNCTIONS = {
     'alias', 'as_strided', 'diagonal', 'expand', 'narrow', 'permute', 'select', 'slice',
     'squeeze', 't', 'transpose', 'unfold', 'unsqueeze', 'view', 'unbind',

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -14,6 +14,7 @@ import yaml
 from collections import defaultdict
 from .utils import YamlLoader, split_name_params
 
+# See NOTE [ Autograd Variable Views ] in variable.h for details.
 VIEW_FUNCTIONS = {
     'alias', 'as_strided', 'diagonal', 'expand', 'narrow', 'permute', 'select', 'slice',
     'squeeze', 't', 'transpose', 'unfold', 'unsqueeze', 'view', 'unbind',

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -450,7 +450,8 @@ def emit_body(declaration):
         if 'Tensor' not in declaration['return_type']:
             return call
         elif is_view:
-            return 'as_view(self, {})'.format(call)
+            # See NOTE [ Autograd Variable Views ] in variable.h for details.
+            return 'as_view(self, {}, GradMode::is_enabled())'.format(call)
         else:
             return 'as_variable({})'.format(call)
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -450,6 +450,8 @@ def emit_body(declaration):
         if 'Tensor' not in declaration['return_type']:
             return call
         elif is_view:
+            # If `GradMode::is_enabled()` is False, this is a non-differentiable
+            # view. Gradients should not flow through.
             # See NOTE [ Autograd Variable Views ] in variable.h for details.
             return 'as_view(self, {}, GradMode::is_enabled())'.format(call)
         else:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -452,7 +452,7 @@ def emit_body(declaration):
         elif is_view:
             # If `GradMode::is_enabled()` is False, this is a non-differentiable
             # view. Gradients should not flow through.
-            # See NOTE [ Autograd Variable Views ] in variable.h for details.
+            # See NOTE [ Autograd View Variables ] in variable.h for details.
             return 'as_view(self, {}, GradMode::is_enabled())'.format(call)
         else:
             return 'as_variable({})'.format(call)

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -103,7 +103,7 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
   return out; // RVO
 }
 
-// See NOTE [ Autograd Variable Views ] for details.
+// See NOTE [ Autograd View Variables ] for details.
 inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
@@ -112,7 +112,7 @@ inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable
   return make_variable_view(std::move(base_var), std::move(tensor), is_differentiable);
 }
 
-// See NOTE [ Autograd Variable Views ] for details.
+// See NOTE [ Autograd View Variables ] for details.
 inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors,
                                    bool is_differentiable = true) {
   auto base_var = Variable(base);

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -104,23 +104,23 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
 }
 
 // See NOTE [ Autograd Variable Views ] for details.
-inline Tensor as_view(const Tensor & base, Tensor tensor, bool potential_history_tracking = true) {
+inline Tensor as_view(const Tensor & base, Tensor tensor, bool potentially_tracks_history = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
-  return make_variable_view(std::move(base_var), std::move(tensor), potential_history_tracking);
+  return make_variable_view(std::move(base_var), std::move(tensor), potentially_tracks_history);
 }
 
 // See NOTE [ Autograd Variable Views ] for details.
 inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors,
-                                   bool potential_history_tracking = true) {
+                                   bool potentially_tracks_history = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
   for(Tensor &tensor : tensors) {
-    tensor = make_variable_view(base_var, std::move(tensor), potential_history_tracking);
+    tensor = make_variable_view(base_var, std::move(tensor), potentially_tracks_history);
   }
   return tensors;
 }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -104,23 +104,23 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
 }
 
 // See NOTE [ Autograd Variable Views ] for details.
-inline Tensor as_view(const Tensor & base, Tensor tensor, bool potentially_tracks_history = true) {
+inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
-  return make_variable_view(std::move(base_var), std::move(tensor), potentially_tracks_history);
+  return make_variable_view(std::move(base_var), std::move(tensor), is_differentiable);
 }
 
 // See NOTE [ Autograd Variable Views ] for details.
 inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors,
-                                   bool potentially_tracks_history = true) {
+                                   bool is_differentiable = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
   for(Tensor &tensor : tensors) {
-    tensor = make_variable_view(base_var, std::move(tensor), potentially_tracks_history);
+    tensor = make_variable_view(base_var, std::move(tensor), is_differentiable);
   }
   return tensors;
 }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -103,21 +103,24 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
   return out; // RVO
 }
 
-inline Tensor as_view(const Tensor & base, Tensor tensor) {
+// See NOTE [ Autograd Variable Views ] for details.
+inline Tensor as_view(const Tensor & base, Tensor tensor, bool potential_history_tracking = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
-  return make_variable_view(std::move(base_var), std::move(tensor));
+  return make_variable_view(std::move(base_var), std::move(tensor), potential_history_tracking);
 }
 
-inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors) {
+// See NOTE [ Autograd Variable Views ] for details.
+inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors,
+                                   bool potential_history_tracking = true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
   for(Tensor &tensor : tensors) {
-    tensor = make_variable_view(base_var, std::move(tensor));
+    tensor = make_variable_view(base_var, std::move(tensor), potential_history_tracking);
   }
   return tensors;
 }

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -25,7 +25,7 @@ struct CopyBackwards : public Function {
 // When an in-place operation is done on a differentiable view, the base's
 // grad_fn is updated to become a `CopySlice` wrapping the backward of the
 // in-place operation.
-// See NOTE [ Autograd Variable Views ].
+// See NOTE [ Autograd View Variables ].
 struct CopySlices : public Function {
   CopySlices(
       const Variable& base_var,

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -22,6 +22,10 @@ struct CopyBackwards : public Function {
 // Performs grad[idx] = fn(grad[idx]), but out-of-place. The slicing operation
 // grad[idx] is defined by the relative sizes, strides, and offset of base and
 // view.
+// When an in-place operation is done on a differentiable view, the base's
+// grad_fn is updated to become a `CopySlice` wrapping the backward of the
+// in-place operation.
+// See NOTE [ Autograd Variable Views ].
 struct CopySlices : public Function {
   CopySlices(
       const Variable& base_var,

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -115,12 +115,6 @@ std::shared_ptr<Function> Variable::Impl::get_grad_accumulator() {
   return result;
 }
 
-Variable Variable::Impl::detach() const {
-  auto detached = make_variable(data_, /*requires_grad=*/false);
-  detached.set_version_counter(version_counter_);
-  return detached;
-}
-
 void Variable::Impl::detach_() {
   if (is_view_) {
     AT_ERROR("Can't detach views in-place. Use detach() instead");

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -64,7 +64,7 @@ struct Function;
 /// example, if you hide your code from autograd using `.no_grad()`, the
 /// `Variable`s will not be registered as having view relations, even if they
 /// share storage.
-/// See NOTE [ Autograd Variable Views ] for more details.
+/// See NOTE [ Autograd View Variables ] for more details.
 ///
 ///
 ///                               Interface
@@ -96,7 +96,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// The `gradient_edge` is an optional (gradient_function, input_number) pair.
   /// `is_differentiable` is a bool that specifies whether this view is
   /// differentiable, i.e., whether the relation should be tracked by autograd.
-  /// See NOTE [ Autograd Variable Views ] for details.
+  /// See NOTE [ Autograd View Variables ] for details.
   friend Variable make_variable_view(
       Variable base,
       at::Tensor data,
@@ -377,7 +377,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 //                     Variable::DifferentiableViewImpl
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// NOTE [ Autograd Variable Views ]
+/// NOTE [ Autograd View Variables ]
 ///
 /// Many operations return Variable that shares storage with an input Variable.
 /// The returned Varaible is called a **view** Variable on the input **base**
@@ -477,7 +477,7 @@ struct TORCH_API Variable::DifferentiableViewImpl : public Variable::Impl {
 // Factory Functions
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// See NOTE [ Autograd Variable Views ] for details.
+// See NOTE [ Autograd View Variables ] for details.
 inline Variable make_variable_view(
     Variable base,
     at::Tensor data,

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -93,13 +93,13 @@ struct TORCH_API Variable : public at::Tensor {
 
   /// Creates a `Variable` that is a *view* of another (*base*) variable.
   /// The `gradient_edge` is an optional (gradient_function, input_number) pair.
-  /// `potential_history_tracking` is a bool that specifies whether this view
+  /// `potentially_tracks_history` is a bool that specifies whether this view
   /// relation should be considered by autograd.
   /// See NOTE [ Autograd Variable Views ] for details.
   friend Variable make_variable_view(
       Variable base,
       at::Tensor data,
-      bool potential_history_tracking,
+      bool potentially_tracks_history,
       Edge gradient_edge);
 
   /// Creates a `Variable` from the given `Tensor`. `requires_grad` should be
@@ -454,10 +454,10 @@ struct TORCH_API Variable::ViewImpl : public Variable::Impl {
 inline Variable make_variable_view(
     Variable base,
     at::Tensor data,
-    bool potential_history_tracking = true,
+    bool potentially_tracks_history = true,
     Edge gradient_edge = Edge()) {
   if (data.defined()) {
-    if (potential_history_tracking) {
+    if (potentially_tracks_history) {
       return Variable(c10::make_intrusive<Variable::ViewImpl>(
               std::move(base), std::move(data), std::move(gradient_edge)));
     } else {
@@ -545,7 +545,7 @@ inline std::shared_ptr<Function> Variable::grad_accumulator() const {
 }
 
 inline Variable Variable::detach() const {
-  return make_variable_view(*this, get()->data_, /*potential_history_tracking=*/false);
+  return make_variable_view(*this, get()->data_, /*potentially_tracks_history=*/false);
 }
 
 inline void Variable::detach_() {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -433,7 +433,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 /// In certain cases, although function outputs share storage with inputs, they
 /// will **never** require gradient history tracking. Instead of registering the
 /// view relation via DifferentiableViewImpl in autograd, the views will be
-/// using usual Varaible::Impl and just share the version counters with the base
+/// using usual Variable::Impl and just share the version counters with the base
 /// Variables.
 /// Some examples are:
 ///   1. Views created from .detach(),

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -378,10 +378,12 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 
 /// NOTE [ Autograd Variable Views ]
 ///
-/// A Variable that is a view of another Variable (called base Variable), i.e.,
-/// they share storage, **and** may potentially record gradient flow between the
-/// two Variables. Even if the base currently does not require grad, it is still
-/// important to record this view relation to support operations like:
+/// Many operations return Variable that shares storage with an input Variable.
+/// The returned Varaible is called a **view** Variable on the input **base**
+/// Variable. Variable::ViewImple is created to support gradient tracking of
+/// potential **in-place** operations on either of these two Variables. Note
+/// that even if the base currently does not require grad, it is still important
+/// to record this view relation to support operations like:
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -390,31 +392,37 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 ///     torch.autograd.grad(base.sum(), var)  <- should return an all ones tensor
 ///
 /// Above example is effectively base[1].copy_(var). To support this, in the
-/// rebase_history of base[1], we need to get the update the grad_fn of the base
-/// Variable. Therefore, we still record the view relation between base and
-/// base[1] even though they don't require gradients at creation time.
+/// rebase_history of base[1], we need to update the grad_fn of base. Therefore,
+/// we still record the view relation between base and base[1] even though they
+/// don't require gradients at creation time.
 ///
-/// Another similar example is:
+/// A similar example but with in-place operation on base is:
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
 ///     #   var.requires_grad = True
+///     view = base[1]
 ///     base.copy_(var)
-///     torch.autograd.grad(base[1].sum(), var)  <- should return an all ones tensor
-///
+///     torch.autograd.grad(view.sum(), var)  <- should return a tensor with
+///                                              var[1] filled with all ones and
+///                                              zeros everywhere else
 ///
 /// In a view relation, the base and view Variables share the same
 /// version_counter. The grad_fn field of the Variable may become stale due to
 /// in-place modifications of the shared data. Accesses should go through
 /// get_grad_fn(). All other fields are always valid.
 ///
-/// NB: Some views will never require gradient history tracking, and will not be
-///     counted as views (i.e., having is_view() = true and using ViewImpl).
-///     Instead, they will be usual Variables and just sharing the version
-//      counters with the base Variables. Some examples are:
-///       1. views created from .detach(),
-///       2. views created when GradMode::enabled() = false.
-///     Relevant logic is implemented in make_variable_view.
+/// Such view Variables have is_view() = true and use ViewImpl.
+///
+/// However, some outputs, although sharing storage, will **never** require
+/// gradient history tracking, and thus will not register the above view
+/// relation in autograd using ViewImpl. Instead, they will be usual Variables
+/// and just share the version counters with the base Variables.
+/// Some examples are:
+///   1. Variables created from .detach(),
+///   2. Variables created when GradMode::enabled() = false.
+/// Relevant logic is implemented in make_variable_view below, and
+/// wrap_output of gen_variable_type.py.
 struct TORCH_API Variable::ViewImpl : public Variable::Impl {
   ViewImpl(Variable base, at::Tensor data, Edge gradient_edge);
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -380,7 +380,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 /// NOTE [ Autograd View Variables ]
 ///
 /// Many operations return Variable that shares storage with an input Variable.
-/// The returned Varaible is called a **view** Variable on the input **base**
+/// The returned Variable is called a **view** Variable on the input **base**
 /// Variable.
 ///
 /// In PyTorch, we have two types of views: differentiable views, and
@@ -398,7 +398,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 /// track the view relation because future in-place ops may require back-proping
 /// through it. For example, we need to support
 ///
-///   (1) in-place operation on view like
+///   (1) in-place operation on view, e.g.,
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -406,7 +406,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 ///     base[1] = var  # i.e., base[1].copy_(var)
 ///     torch.autograd.grad(base.sum(), var)  <- should return an all ones tensor
 ///
-///   (2) in-place operation on base after view is created like
+///   (2) in-place operation on base after view is created, e.g.,
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -437,7 +437,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 /// Variables.
 /// Some examples are:
 ///   1. Views created from .detach(),
-///   2. Views created when GradMode::enabled() = false.
+///   2. Views created when GradMode::is_enabled() = false.
 /// These are called non-differentiable views as the gradients do not flow
 /// through the view relation.
 /// Relevant logic for non-differentiable views is implemented in

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -94,13 +94,13 @@ struct TORCH_API Variable : public at::Tensor {
 
   /// Creates a `Variable` that is a *view* of another (*base*) variable.
   /// The `gradient_edge` is an optional (gradient_function, input_number) pair.
-  /// `potentially_tracks_history` is a bool that specifies whether this view
-  /// relation should be considered by autograd.
+  /// `is_differentiable` is a bool that specifies whether this view is
+  /// differentiable, i.e., whether the relation should be tracked by autograd.
   /// See NOTE [ Autograd Variable Views ] for details.
   friend Variable make_variable_view(
       Variable base,
       at::Tensor data,
-      bool potentially_tracks_history,
+      bool is_differentiable,
       Edge gradient_edge);
 
   /// Creates a `Variable` from the given `Tensor`. `requires_grad` should be
@@ -266,7 +266,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// and the `get()` method which exposes it shall forever remain private and
   /// never be exposed to the public interface of this class.
   struct Impl;
-  struct ViewImpl;
+  struct DifferentiableViewImpl;
 
   // Private Methods
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -374,30 +374,38 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//                          Variable::ViewImpl
+//                     Variable::DifferentiableViewImpl
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// NOTE [ Autograd Variable Views ]
 ///
 /// Many operations return Variable that shares storage with an input Variable.
 /// The returned Varaible is called a **view** Variable on the input **base**
-/// Variable. Variable::ViewImple is created to support gradient tracking of
-/// potential **in-place** operations on either of these two Variables. Note
-/// that even if the base currently does not require grad, it is still important
-/// to record this view relation to support operations like:
+/// Variable.
+///
+/// In PyTorch, we have two types of views: differentiable views, and
+/// non-differentiable views. In either type, to support proper version
+/// checking, the base and view Variables always share the same version_counter.
+///
+///
+/// Differentiable Views
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// Differentiable views are the view variables you still want gradients to flow
+/// back to the base variables. Out-of-place operations on views are quite
+/// straightforward, but in-place ones on views are very tricky. Even if the
+/// base variable may not require grad when we create the view, we still need to
+/// track the view relation because future in-place ops may require back-proping
+/// through it. We need to support autograd through
+///
+///   (1) in-place operation on view, e.g.,
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
 ///     #   var.requires_grad = True
-///     base[1] = var
+///     base[1] = var  # i.e., base[1].copy_(var)
 ///     torch.autograd.grad(base.sum(), var)  <- should return an all ones tensor
 ///
-/// Above example is effectively base[1].copy_(var). To support this, in the
-/// rebase_history of base[1], we need to update the grad_fn of base. Therefore,
-/// we still record the view relation between base and base[1] even though they
-/// don't require gradients at creation time.
-///
-/// A similar example but with in-place operation on base is:
+///   (2) in-place operation on base after view is created, e.g.,
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -408,26 +416,33 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 ///                                              var[1] filled with all ones and
 ///                                              zeros everywhere else
 ///
-/// In a view relation, the base and view Variables share the same
-/// version_counter. The grad_fn field of the Variable may become stale due to
-/// in-place modifications of the shared data. Accesses should go through
-/// get_grad_fn(). All other fields are always valid.
+/// Variable::DifferentiableViewImpl is created to support gradient tracking of
+/// such **in-place** operations. In particular,
+///   + if an in-place op is done on base, the grad_fn field of the view may
+///     become stale. So accesses should go through get_grad_fn(), whcih
+///     reconstruct an updated grad_fn if the version_counter had incremented.
+///     All other fields are always valid.
+///   + if an in-place op is done on view, in rebase_history() of view, which is
+///     called after every in-place op in VariableType.cpp, the grad_fn of base
+///     is updated.
 ///
-/// Such view Variables have is_view() = true and use ViewImpl.
 ///
-/// However, outputs of some functions, although sharing storage with inputs,
-/// will **never** require gradient history tracking, and thus will not register
-/// the above view relation in autograd using ViewImpl. Instead, they will be
-/// usual Variables and just share the version counters with the base Variables.
+/// Non-Differentiable Views
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// In certain cases, although function outputs share storage with inputs, they
+/// will **never** require gradient history tracking. Instead of registering the
+/// view relation via DifferentiableViewImpl in autograd, the views will be
+/// using usual Varaible::Impl and just share the version counters with the base
+/// Variables.
 /// Some examples are:
-///   1. Variables created from .detach(),
-///   2. Variables created when GradMode::enabled() = false.
-/// We call these non-differentiable views as the gradients do not flow through
-/// the view relation.
+///   1. Views created from .detach(),
+///   2. Views created when GradMode::enabled() = false.
+/// These are called non-differentiable views as the gradients do not flow
+/// through the view relation.
 /// Relevant logic for non-differentiable views is implemented in
 /// make_variable_view below, and wrap_output of gen_variable_type.py.
-struct TORCH_API Variable::ViewImpl : public Variable::Impl {
-  ViewImpl(Variable base, at::Tensor data, Edge gradient_edge);
+struct TORCH_API Variable::DifferentiableViewImpl : public Variable::Impl {
+  DifferentiableViewImpl(Variable base, at::Tensor data, Edge gradient_edge);
 
   /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
   /// re-create the grad_fn to express the up-to-date view relationship between
@@ -465,12 +480,12 @@ struct TORCH_API Variable::ViewImpl : public Variable::Impl {
 inline Variable make_variable_view(
     Variable base,
     at::Tensor data,
-    bool potentially_tracks_history = true,
+    bool is_differentiable = true,
     Edge gradient_edge = Edge()) {
   if (data.defined()) {
-    if (potentially_tracks_history) {
-      /// Differentiable view. Track history with ViewImpl.
-      return Variable(c10::make_intrusive<Variable::ViewImpl>(
+    if (is_differentiable) {
+      /// Differentiable view. Track history with DifferentiableViewImpl.
+      return Variable(c10::make_intrusive<Variable::DifferentiableViewImpl>(
               std::move(base), std::move(data), std::move(gradient_edge)));
     } else {
       /// Non-differentiable view. Just share version counter.
@@ -558,7 +573,7 @@ inline std::shared_ptr<Function> Variable::grad_accumulator() const {
 }
 
 inline Variable Variable::detach() const {
-  return make_variable_view(*this, get()->data_, /*potentially_tracks_history=*/false);
+  return make_variable_view(*this, get()->data_, /*is_differentiable=*/false);
 }
 
 inline void Variable::detach_() {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -385,19 +385,20 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 ///
 /// In PyTorch, we have two types of views: differentiable views, and
 /// non-differentiable views. In either type, to support proper version
-/// checking, the base and view Variables always share the same version_counter.
+/// checking, the base and view Variables must always share the same
+/// version_counter.
 ///
 ///
 /// Differentiable Views
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/// Differentiable views are the view variables you still want gradients to flow
+/// Differentiable views are the view variables where you want gradients to flow
 /// back to the base variables. Out-of-place operations on views are quite
-/// straightforward, but in-place ones on views are very tricky. Even if the
-/// base variable may not require grad when we create the view, we still need to
+/// straightforward, but in-place ones are very tricky. Even if the base
+/// variable may not require grad when we create the view, we still need to
 /// track the view relation because future in-place ops may require back-proping
-/// through it. We need to support autograd through
+/// through it. For example, we need to support
 ///
-///   (1) in-place operation on view, e.g.,
+///   (1) in-place operation on view like
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -405,7 +406,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 ///     base[1] = var  # i.e., base[1].copy_(var)
 ///     torch.autograd.grad(base.sum(), var)  <- should return an all ones tensor
 ///
-///   (2) in-place operation on base after view is created, e.g.,
+///   (2) in-place operation on base after view is created like
 ///
 ///     # Have:
 ///     #   base.requires_grad = False
@@ -419,8 +420,8 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 /// Variable::DifferentiableViewImpl is created to support gradient tracking of
 /// such **in-place** operations. In particular,
 ///   + if an in-place op is done on base, the grad_fn field of the view may
-///     become stale. So accesses should go through get_grad_fn(), whcih
-///     reconstruct an updated grad_fn if the version_counter had incremented.
+///     become stale. So accesses should always go through get_grad_fn(), which
+///     reconstructs an updated grad_fn if the version_counter has incremented.
 ///     All other fields are always valid.
 ///   + if an in-place op is done on view, in rebase_history() of view, which is
 ///     called after every in-place op in VariableType.cpp, the grad_fn of base

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -469,9 +469,11 @@ inline Variable make_variable_view(
     Edge gradient_edge = Edge()) {
   if (data.defined()) {
     if (potentially_tracks_history) {
+      /// Differentiable view. Track history with ViewImpl.
       return Variable(c10::make_intrusive<Variable::ViewImpl>(
               std::move(base), std::move(data), std::move(gradient_edge)));
     } else {
+      /// Non-differentiable view. Just share version counter.
       auto var = Variable(c10::make_intrusive<Variable::Impl>(
               std::move(data), false, std::move(gradient_edge)));
       var.set_version_counter(base.version_counter());


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/11390. 

This PR introduces the idea of non-differentiable views. A non-differentiable is a view that shares storage with the base variable, but gradient should never flow through the view relation. This includes:
1. .detach()
2. Views created when GradMode is disabled
3. Views that are non-differentiable by nature, e.g., `sparse_tensor.indices()` (This is being added in #11253. I base #11253 on this and update the note in that PR.)

See the note in this PR for details.


cc @colesbury @apaszke @gchanan 