### PR TITLE
[JIT] Get rid of emitApplyIdent

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -849,7 +849,7 @@ const auto cf_examples = R"JIT(
 void testControlFlow() {
   script::Module cu;
   script::defineMethodsInModule(
-      cu, cf_examples, torch::jit::script::nativeResolver, nullptr);
+      cu, cf_examples, std::make_shared<torch::jit::script::NativeResolver>(), nullptr);
   auto run = [&](const std::string& name, std::vector<IValue> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph);

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,7 @@ namespace jit {
 
 std::shared_ptr<script::Module> compile(const std::string& source) {
   auto module = std::make_shared<script::Module>();
-  defineMethodsInModule(*module, source, script::nativeResolver, /*self=*/nullptr);
+  defineMethodsInModule(*module, source, std::make_shared<script::NativeResolver>(), /*self=*/nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -55,7 +55,7 @@ private:
   void loadSource(const std::string& source) {
     auto module = std::make_shared<script::Module>();
     defineMethodsInModule(
-        *module, source, script::nativeResolver, /*self=*/nullptr);
+        *module, source, std::make_shared<script::NativeResolver>(), /*self=*/nullptr);
     modules.push_back(module);
     for (auto& method : module->get_methods()) {
       builtins_by_name[Symbol::fromQualString("aten::" + method.key)].push_back(

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -136,21 +136,47 @@ struct TORCH_API BuiltinModule : public SugaredValue {
   }
 };
 
-using Resolver = std::function<std::shared_ptr<
-    SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
+struct Resolver {
+  virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const = 0;
+  virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) = 0;
+  virtual void clear() = 0;
+};
 
-std::shared_ptr<SugaredValue> nativeResolver(const std::string& name, Method& m, const SourceRange& loc);
+struct NativeResolver : public Resolver {
+  virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const override {
+    if (function_table.count(name)) {
+      return function_table.at(name);
+    }
+    if (name == "torch") {
+      return std::make_shared<BuiltinModule>(name);
+    }
+    return nullptr;
+  }
+
+  virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) override {
+    function_table[name] = sv;
+  }
+
+  virtual void clear() override {
+    function_table.clear();
+  }
+
+  virtual ~NativeResolver() {}
+
+ private:
+   std::unordered_map<std::string, std::shared_ptr<SugaredValue>> function_table;
+};
 
 TORCH_API void defineMethodsInModule(
   Module & m,
   const std::vector<Def>& definitions,
-  const std::vector<Resolver>& resolvers, /* determines how we handle free variables in each definition*/
+  const std::vector<std::shared_ptr<Resolver>>& resolvers, /* determines how we handle free variables in each definition*/
   std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
 );
 
 // same as above but parse the definitions from source
-TORCH_API void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
-TORCH_API std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
+TORCH_API void defineMethodsInModule(Module & m, const std::string& source, std::shared_ptr<Resolver> resolver, std::shared_ptr<SugaredValue> self);
+TORCH_API std::shared_ptr<Graph> compileFunction(Def def, std::shared_ptr<Resolver> resolver);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -140,6 +140,7 @@ struct Resolver {
   virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const = 0;
   virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) = 0;
   virtual void clear() = 0;
+  virtual ~Resolver() {}
 };
 
 struct NativeResolver : public Resolver {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -801,7 +801,7 @@ const static auto cf_examples = R"JIT(
 )JIT";
 void testControlFlow() {
   script::Module cu;
-  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::nativeResolver, nullptr);
+  script::defineMethodsInModule(cu, cf_examples, std::make_shared<torch::jit::script::NativeResolver>(), nullptr);
   auto run = [&](const std::string & name, std::vector<IValue> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -7,6 +7,7 @@ import torch.jit.annotations
 from torch._six import raise_from, with_metaclass
 import torch.testing
 from collections import defaultdict, OrderedDict, namedtuple
+import builtins
 import sys
 import warnings
 import itertools
@@ -613,6 +614,8 @@ def createResolutionCallback(frames_up=0):
             return f_locals[key]
         elif key in f_globals:
             return f_globals[key]
+        elif hasattr(builtins, key):
+            return getattr(builtins, key)
         else:
             return None
 
@@ -1248,6 +1251,32 @@ def _register_builtin(fn, op):
 
 def _find_builtin(fn):
     return _get_builtin_table().get(id(fn))
+
+
+# Python equivalents for the empty list construction builtins. We need
+# these otherwise the tests won't execute in regular Python mode.
+def _construct_empty_int_list():
+    return []
+
+
+_register_builtin(_construct_empty_int_list, 'aten::_construct_empty_int_list')
+
+
+def _construct_empty_float_list():
+    return []
+
+
+_register_builtin(_construct_empty_float_list, 'aten::_construct_empty_float_list')
+
+
+def _construct_empty_tensor_list():
+    return []
+
+
+_register_builtin(_construct_empty_tensor_list, 'aten::_construct_empty_tensor_list')
+
+
+_register_builtin(len, 'aten::len')
 
 
 class _disable_tracing(object):


### PR DESCRIPTION
And reroute builtin/CompilationUnit function resolution through one resolution pathway