### PR TITLE
Fix CMake find Torch script

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -38,7 +38,7 @@ find_package(Caffe2 REQUIRED)
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 add_library(torch SHARED IMPORTED)
-set(TORCH_LIBRARIES torch ${Caffe2_MAIN_LIBS})
+set(TORCH_LIBRARIES ${TORCH_LIBRARY} ${Caffe2_MAIN_LIBS})
 
 if (@USE_CUDA@)
   if(MSVC)


### PR DESCRIPTION
On Windows, when using torch we get torch-NOTFOUND as linked library. Reusing the found library should be done with ${TORCH_LIBRARY}.

