### PR TITLE
nn.Module hook fix and improvements

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -667,6 +667,7 @@ class TestNN(NNTestCase):
 
     def test_hook_fail(self):
         module = nn.Sigmoid()
+
         class ModuleMoreArgs(nn.Module):
             def forward(self, arg1, arg2):
                 return arg1.clone(), arg2.clone()
@@ -743,10 +744,10 @@ class TestNN(NNTestCase):
             return tuple(gi * 2 for gi in grad_input)
 
         def fw_pre_hook(module, input):
-            return (3*input[0],)
+            return (3 * input[0],)
 
         def fw_hook(module, input, output):
-            return 2*output
+            return 2 * output
 
         with module.register_backward_hook(bw_hook):
             module(input).backward(torch.ones(5, 5))
@@ -758,11 +759,10 @@ class TestNN(NNTestCase):
             out = module(input)
             self.assertEqual(out, expected_out * 2)
 
-        expected_out = module(3*input)
+        expected_out = module(3 * input)
         with module.register_forward_pre_hook(fw_pre_hook):
             out = module(input)
             self.assertEqual(out, expected_out)
-
 
     def test_to(self):
         m = nn.Linear(3, 5)
@@ -940,6 +940,7 @@ class TestNN(NNTestCase):
         def pre_fw_hook(mod, inp):
             mod.pre_fw_hook = True
             return inp
+
         def fw_hook(mod, inp, ouput):
             mod.fw_hook = True
             return ouput

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -21,6 +21,15 @@ class Type(Function):
                 return grad_output.type(ctx.input_type), None
 
 
+class Noop(Function):
+    @staticmethod
+    def forward(ctx, *inputs):
+        return inputs
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        return Noop.apply(*grad_outputs)
+
 # TODO: deprecate this
 class Resize(Function):
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -30,6 +30,7 @@ class Noop(Function):
     def backward(ctx, *grad_outputs):
         return Noop.apply(*grad_outputs)
 
+
 # TODO: deprecate this
 class Resize(Function):
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -8,6 +8,7 @@ from ..parameter import Parameter
 import torch.utils.hooks as hooks
 from torch.autograd._functions import Noop
 
+
 def _addindent(s_, numSpaces):
     s = s_.split('\n')
     # don't do anything for single-line stuff
@@ -19,24 +20,27 @@ def _addindent(s_, numSpaces):
     s = first + '\n' + s
     return s
 
+
 def _check_same_shape(base, new, caller_name):
     if not isinstance(base, tuple):
         base = (base,)
         new = (new,)
     if type(base) != type(new):
         raise RuntimeError("{} returned invalid type {} "
-            "expected {}".format(caller_name, type(new).__name__, type(base).__name__))
+                           "expected {}".format(caller_name, type(new).__name__, type(base).__name__))
     if not len(base) == len(new):
         raise RuntimeError("{} return an incorrect number of "
-            "results {}, expected {}".format(caller_name, len(new), len(base)))
+                           "results {}, expected {}".format(caller_name, len(new), len(base)))
     for arg_index, (base_el, new_el) in enumerate(zip(base, new)):
         if type(base_el) != type(new_el):
             raise RuntimeError("{} returned invalid type for element {}: {}"
-                ", expected {}".format(caller_name, arg_index, type(new_el).__name__, type(base_el).__name__))
+                               ", expected {}".format(caller_name, arg_index, type(new_el).__name__,
+                                                      type(base_el).__name__))
         if torch.is_tensor(base_el) and not base_el.size() == new_el.size():
             raise RuntimeError("{} returned invalid size for element {}:"
-                " expected {} got {}".format(caller_name,
-                    arg_index, base_el.size(), new_el.size()))
+                               " expected {} got {}".format(caller_name, arg_index, base_el.size(),
+                                                            new_el.size()))
+
 
 def _get_prev_function(var):
     while not isinstance(var, torch.Tensor):
@@ -45,6 +49,7 @@ def _get_prev_function(var):
         else:
             var = var[0]
     return var.grad_fn
+
 
 def _ensure_tuple(obj):
     if isinstance(obj, tuple):
@@ -508,8 +513,8 @@ class Module(object):
         for i, element in enumerate(args):
             if not torch.is_tensor(element):
                 raise RuntimeError("Backward hooks on nn.Module only works for Modules"
-                " that only use Tensors and the {}th {} of {} is of type {}"
-                "".format(i, position, self.__class__.__name__, type(element).__name__))
+                                   " that only use Tensors and the {}th {} of {} is of type {}"
+                                   "".format(i, position, self.__class__.__name__, type(element).__name__))
 
     def _get_backward_hooks(self):
         backward_hooks = []

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import functools
 import itertools
 
 import torch

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import collections
 import weakref
 import warnings
+import functools
 
 
 class RemovableHandle(object):
@@ -45,10 +46,9 @@ class BackwardHook():
         self.module = module
 
     def get_input_hook(self):
+        @functools.wraps(self.user_hook)
         def hook(grad_input, _):
             return self.user_hook(self.module, grad_input, self.grad_output)
-        # Make error message more user-friendly
-        hook.__name__ = self.user_hook.__name__
         return hook
 
     def get_output_hook(self):

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -39,7 +39,7 @@ class RemovableHandle(object):
         self.remove()
 
 
-class BackwardHook():
+class BackwardHook(object):
     def __init__(self, module, user_hook):
         self.grad_outputs = None
         self.user_hook = user_hook

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -38,6 +38,25 @@ class RemovableHandle(object):
         self.remove()
 
 
+class BackwardHook():
+    def __init__(self, module, user_hook):
+        self.grad_outputs = None
+        self.user_hook = user_hook
+        self.module = module
+
+    def get_input_hook(self):
+        def hook(grad_input, _):
+            return self.user_hook(self.module, grad_input, self.grad_output)
+        # Make error message more user-friendly
+        hook.__name__ = self.user_hook.__name__
+        return hook
+
+    def get_output_hook(self):
+        def hook(_, grad_output):
+            self.grad_output = grad_output
+        return hook
+
+
 def unserializable_hook(f):
     """
     Decorator which marks a function as an unserializable hook.


### PR DESCRIPTION
This PR adds the following:
- Allow forward pre hooks and foward hooks to modify the input by returning a not-None value. Some checks are done here to make sure the returned value is similar to the input.
- Fix the backward hooks for the case where all inputs and outputs are Tensors. Raise an error if any input or output is not a Tensor.

 Do we actually want to check the returned values from the forward hooks?

Adding support for Module taking other things than Tensors (and giving `None` gradient for these) is left to be done later.
This is a breaking change with the current nn.Module backward hooks. But no one should be using them as they are heavily broken atm anyway.