### PR TITLE
Add c10::optional to type syntax

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -443,8 +443,8 @@ public:
   Tensor ceil() const;
   Tensor & ceil_();
   std::vector<Tensor> chunk(int64_t chunks, int64_t dim=0) const;
-  Tensor clamp(Scalar min, Scalar max) const;
-  Tensor & clamp_(Scalar min, Scalar max);
+  Tensor clamp(optional<Scalar> min=nullopt, optional<Scalar> max=nullopt) const;
+  Tensor & clamp_(optional<Scalar> min=nullopt, optional<Scalar> max=nullopt);
   Tensor clamp_max(Scalar max) const;
   Tensor & clamp_max_(Scalar max);
   Tensor clamp_min(Scalar min) const;

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -443,8 +443,8 @@ public:
   Tensor ceil() const;
   Tensor & ceil_();
   std::vector<Tensor> chunk(int64_t chunks, int64_t dim=0) const;
-  Tensor clamp(optional<Scalar> min=nullopt, optional<Scalar> max=nullopt) const;
-  Tensor & clamp_(optional<Scalar> min=nullopt, optional<Scalar> max=nullopt);
+  Tensor clamp(c10::optional<Scalar> min=c10::nullopt, c10::optional<Scalar> max=c10::nullopt) const;
+  Tensor & clamp_(c10::optional<Scalar> min=c10::nullopt, c10::optional<Scalar> max=c10::nullopt);
   Tensor clamp_max(Scalar max) const;
   Tensor & clamp_max_(Scalar max);
   Tensor clamp_min(Scalar min) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -632,10 +632,10 @@ inline Tensor & Tensor::ceil_() {
 inline std::vector<Tensor> Tensor::chunk(int64_t chunks, int64_t dim) const {
     return type().chunk(*this, chunks, dim);
 }
-inline Tensor Tensor::clamp(Scalar min, Scalar max) const {
+inline Tensor Tensor::clamp(optional<Scalar> min, optional<Scalar> max) const {
     return type().clamp(*this, min, max);
 }
-inline Tensor & Tensor::clamp_(Scalar min, Scalar max) {
+inline Tensor & Tensor::clamp_(optional<Scalar> min, optional<Scalar> max) {
     return type().clamp_(*this, min, max);
 }
 inline Tensor Tensor::clamp_max(Scalar max) const {

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -632,10 +632,10 @@ inline Tensor & Tensor::ceil_() {
 inline std::vector<Tensor> Tensor::chunk(int64_t chunks, int64_t dim) const {
     return type().chunk(*this, chunks, dim);
 }
-inline Tensor Tensor::clamp(optional<Scalar> min, optional<Scalar> max) const {
+inline Tensor Tensor::clamp(c10::optional<Scalar> min, c10::optional<Scalar> max) const {
     return type().clamp(*this, min, max);
 }
-inline Tensor & Tensor::clamp_(optional<Scalar> min, optional<Scalar> max) {
+inline Tensor & Tensor::clamp_(c10::optional<Scalar> min, c10::optional<Scalar> max) {
     return type().clamp_(*this, min, max);
 }
 inline Tensor Tensor::clamp_max(Scalar max) const {

--- a/aten/src/ATen/core/TensorOptions.h
+++ b/aten/src/ATen/core/TensorOptions.h
@@ -124,10 +124,11 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Return a copy of `TensorOptions` with `device` set to the given one.
-  /// (This overload ensures that initializer lists for Device work
-  /// correctly.)
-  C10_NODISCARD TensorOptions device(Device d) const noexcept {
-    return device(c10::make_optional(d));
+  /// (This overload ensures that variadic template c10::optional constructor
+  /// for Device work correctly.)
+  template<typename ... Args>
+  C10_NODISCARD TensorOptions device(Args&&... args) const noexcept {
+    return device(optional<Device>(c10::in_place, std::forward<Args>(args)...));
   }
 
   /// Return a copy of `TensorOptions`, but with device set to CUDA, and the
@@ -136,7 +137,7 @@ struct CAFFE2_API TensorOptions {
   /// TODO: This function encourages bad behavior (assuming CUDA is
   /// the only device that matters).  Get rid of it / rename it.
   C10_NODISCARD TensorOptions device_index(int32_t device_index) const noexcept {
-    return device({Device::Type::CUDA, device_index});
+    return device(Device::Type::CUDA, device_index);
   }
 
   /// Return a copy of `TensorOptions` with `dtype` set to the given one.

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -157,7 +157,7 @@ struct CAFFE2_API Type {
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int32_t device_index = -1) const {
     return TensorOptions().dtype(scalarType())
-                          .device({backendToDeviceType(backend()), device_index})
+                          .device(backendToDeviceType(backend()), device_index)
                           .layout(layout())
                           .is_variable(is_variable());
   }

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -406,8 +406,8 @@ struct CAFFE2_API Type {
   virtual Tensor ceil(const Tensor & self) const = 0;
   virtual Tensor & ceil_(Tensor & self) const = 0;
   virtual std::vector<Tensor> chunk(const Tensor & self, int64_t chunks, int64_t dim) const = 0;
-  virtual Tensor clamp(const Tensor & self, Scalar min, Scalar max) const = 0;
-  virtual Tensor & clamp_(Tensor & self, Scalar min, Scalar max) const = 0;
+  virtual Tensor clamp(const Tensor & self, optional<Scalar> min, optional<Scalar> max) const = 0;
+  virtual Tensor & clamp_(Tensor & self, optional<Scalar> min, optional<Scalar> max) const = 0;
   virtual Tensor clamp_max(const Tensor & self, Scalar max) const = 0;
   virtual Tensor & clamp_max_(Tensor & self, Scalar max) const = 0;
   virtual Tensor clamp_min(const Tensor & self, Scalar min) const = 0;

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -406,8 +406,8 @@ struct CAFFE2_API Type {
   virtual Tensor ceil(const Tensor & self) const = 0;
   virtual Tensor & ceil_(Tensor & self) const = 0;
   virtual std::vector<Tensor> chunk(const Tensor & self, int64_t chunks, int64_t dim) const = 0;
-  virtual Tensor clamp(const Tensor & self, optional<Scalar> min, optional<Scalar> max) const = 0;
-  virtual Tensor & clamp_(Tensor & self, optional<Scalar> min, optional<Scalar> max) const = 0;
+  virtual Tensor clamp(const Tensor & self, c10::optional<Scalar> min, c10::optional<Scalar> max) const = 0;
+  virtual Tensor & clamp_(Tensor & self, c10::optional<Scalar> min, c10::optional<Scalar> max) const = 0;
   virtual Tensor clamp_max(const Tensor & self, Scalar max) const = 0;
   virtual Tensor & clamp_max_(Tensor & self, Scalar max) const = 0;
   virtual Tensor clamp_min(const Tensor & self, Scalar min) const = 0;

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -568,6 +568,7 @@ inline const std::vector<IValue>& IValue::toGenericListRef() const {
 
 inline const std::string& IValue::toStringRef() const {
   return toString()->string();
+}
 
 template<typename T>
 inline optional<T> IValue::toOptional() {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -386,6 +386,9 @@ struct CAFFE2_API IValue final {
   template<typename T>
   T to() const &;
 
+  template<typename T>
+  optional<T> toOptional();
+
   CAFFE2_API friend std::ostream& operator<<(
       std::ostream& out,
       const IValue& v);
@@ -565,6 +568,13 @@ inline const std::vector<IValue>& IValue::toGenericListRef() const {
 
 inline const std::string& IValue::toStringRef() const {
   return toString()->string();
+
+template<typename T>
+inline optional<T> IValue::toOptional() {
+  if (this->isNone()) {
+    return nullopt;
+  }
+  return this->to<T>();
 }
 
 } // namespace c10

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -973,6 +973,9 @@ def create_generic(top_env, declarations):
                     'TensorOptions': 'const TensorOptions &' if const else 'TensorOptions &',
                 }
 
+            if argument.get('is_nullable') and argument['type'] not in translate_map(False).keys():
+                argument['type'] = "optional<{}>".format(argument['type'])
+
             if (option['inplace'] and argument['name'] == 'self') or argument.get('output', False):
                 argument['type'] = translate_map(False).get(argument['type'], argument['type'])
             else:
@@ -1188,6 +1191,7 @@ def create_generic(top_env, declarations):
             except NYIError:
                 option['skip'] = True
         output_declarations.extend(output_options)
+
     return output_declarations
 
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -974,7 +974,7 @@ def create_generic(top_env, declarations):
                 }
 
             if argument.get('is_nullable') and argument['type'] not in translate_map(False).keys():
-                argument['type'] = "optional<{}>".format(argument['type'])
+                argument['type'] = "c10::optional<{}>".format(argument['type'])
 
             if (option['inplace'] and argument['name'] == 'self') or argument.get('output', False):
                 argument['type'] = translate_map(False).get(argument['type'], argument['type'])

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -30,7 +30,7 @@
 namespace at {
 namespace native {
 
-Tensor clamp(const Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
+Tensor clamp(const Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   Tensor result = at::empty({0}, self.options());
   return clamp_out(result, self, min, max);
 }
@@ -45,7 +45,7 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
   return clamp_min_out(result, self, min);
 }
 
-Tensor& _clamp__cpu(Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
+Tensor& _clamp__cpu(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   if (min && max) {
     return _th_clamp_out(self, self, *min, *max);
   } else if (max) {
@@ -60,8 +60,8 @@ Tensor& _clamp__cpu(Tensor& self, at::optional<Scalar> min, at::optional<Scalar>
 Tensor& _clamp_out_cpu(
     Tensor& result,
     const Tensor& self,
-    at::optional<Scalar> min,
-    at::optional<Scalar> max) {
+    optional<Scalar> min,
+    optional<Scalar> max) {
   if (min && max) {
     _th_clamp_out(result, self, *min, *max);
   } else if (max) {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -30,7 +30,7 @@
 namespace at {
 namespace native {
 
-Tensor clamp(const Tensor& self, Scalar min, Scalar max) {
+Tensor clamp(const Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
   Tensor result = at::empty({0}, self.options());
   return clamp_out(result, self, min, max);
 }
@@ -45,13 +45,13 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
   return clamp_min_out(result, self, min);
 }
 
-Tensor& _clamp__cpu(Tensor& self, Scalar min, Scalar max) {
-  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
-    return _th_clamp_out(self, self, min, max);
-  } else if (std::isnan(min.toDouble())) {
-    return _th_clamp_max_out(self, self, max);
-  } else if (std::isnan(max.toDouble())) {
-    return _th_clamp_min_out(self, self, min);
+Tensor& _clamp__cpu(Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
+  if (min && max) {
+    return _th_clamp_out(self, self, *min, *max);
+  } else if (max) {
+    return _th_clamp_max_out(self, self, *max);
+  } else if (min) {
+    return _th_clamp_min_out(self, self, *min);
   } else {
     return self;
   }
@@ -60,14 +60,14 @@ Tensor& _clamp__cpu(Tensor& self, Scalar min, Scalar max) {
 Tensor& _clamp_out_cpu(
     Tensor& result,
     const Tensor& self,
-    Scalar min,
-    Scalar max) {
-  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
-    _th_clamp_out(result, self, min, max);
-  } else if (std::isnan(min.toDouble())) {
-    _th_clamp_max_out(result, self, max);
-  } else if (std::isnan(max.toDouble())) {
-    _th_clamp_min_out(result, self, min);
+    at::optional<Scalar> min,
+    at::optional<Scalar> max) {
+  if (min && max) {
+    _th_clamp_out(result, self, *min, *max);
+  } else if (max) {
+    _th_clamp_max_out(result, self, *max);
+  } else if (min) {
+    _th_clamp_min_out(result, self, *min);
   }
   return result;
 }

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -2,13 +2,13 @@
 
 namespace at { namespace native {
 
-Tensor& _clamp__cuda(Tensor& self, Scalar min, Scalar max) {
-  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
-    return _th_clamp_out(self, self, min, max);
-  } else if (std::isnan(min.toDouble())) {
-    return _th_clamp_max_out(self, self, max);
-  } else if (std::isnan(max.toDouble())) {
-    return _th_clamp_min_out(self, self, min);
+Tensor& _clamp__cuda(Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
+  if (min && max) {
+    return _th_clamp_out(self, self, *min, *max);
+  } else if (max) {
+    return _th_clamp_max_out(self, self, *max);
+  } else if (min) {
+    return _th_clamp_min_out(self, self, *min);
   } else {
     return self;
   }
@@ -17,14 +17,14 @@ Tensor& _clamp__cuda(Tensor& self, Scalar min, Scalar max) {
 Tensor& _clamp_out_cuda(
     Tensor& result,
     const Tensor& self,
-    Scalar min,
-    Scalar max) {
-  if (!std::isnan(min.toDouble()) && !std::isnan(max.toDouble())) {
-    _th_clamp_out(result, self, min, max);
-  } else if (std::isnan(min.toDouble())) {
-    _th_clamp_max_out(result, self, max);
-  } else if (std::isnan(max.toDouble())) {
-    _th_clamp_min_out(result, self, min);
+    at::optional<Scalar> min,
+    at::optional<Scalar> max) {
+  if (min && max) {
+    _th_clamp_out(result, self, *min, *max);
+  } else if (max) {
+    _th_clamp_max_out(result, self, *max);
+  } else if (min) {
+    _th_clamp_min_out(result, self, *min);
   }
   return result;
 }

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -2,7 +2,7 @@
 
 namespace at { namespace native {
 
-Tensor& _clamp__cuda(Tensor& self, at::optional<Scalar> min, at::optional<Scalar> max) {
+Tensor& _clamp__cuda(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   if (min && max) {
     return _th_clamp_out(self, self, *min, *max);
   } else if (max) {
@@ -17,8 +17,8 @@ Tensor& _clamp__cuda(Tensor& self, at::optional<Scalar> min, at::optional<Scalar
 Tensor& _clamp_out_cuda(
     Tensor& result,
     const Tensor& self,
-    at::optional<Scalar> min,
-    at::optional<Scalar> max) {
+    optional<Scalar> min,
+    optional<Scalar> max) {
   if (min && max) {
     _th_clamp_out(result, self, *min, *max);
   } else if (max) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -351,28 +351,19 @@
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
   variants: function, method
 
-- func: clamp(Tensor self, Scalar min, Scalar max) -> Tensor
+- func: clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
   variants: function, method
-  python_default_init:
-    min: NAN
-    max: NAN
 
-- func: clamp_(Tensor self, Scalar min, Scalar max) -> Tensor
+- func: clamp_(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
   variants: function, method
   dispatch:
     CPU: _clamp__cpu
     CUDA: _clamp__cuda
-  python_default_init:
-    min: NAN
-    max: NAN
 
-- func: clamp_out(Tensor result, Tensor self, Scalar min, Scalar max) -> Tensor
+- func: clamp_out(Tensor result, Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
   dispatch:
     CPU: _clamp_out_cpu
     CUDA: _clamp_out_cuda
-  python_default_init:
-    min: NAN
-    max: NAN
 
 - func: clamp_max(Tensor self, Scalar max) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -22,6 +22,8 @@ def parse_default(s):
         return '{}'
     elif re.match(r'{.*}', s):
         return s
+    elif s == 'None':
+        return 'nullopt'
     try:
         return int(s)
     except Exception:

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -23,7 +23,7 @@ def parse_default(s):
     elif re.match(r'{.*}', s):
         return s
     elif s == 'None':
-        return 'nullopt'
+        return 'c10::nullopt'
     try:
         return int(s)
     except Exception:

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -235,7 +235,9 @@ def run(declarations):
             allow_kwarg=False,
             type_to_signature=TYPE_FORMAL_GENERIC,
             remove_self=True)
+
         common_with_cwrap.sort_by_number_of_options(declaration)
+
         discover_zero_dim_tensor_operations(declaration)
         discover_sparse_tensor_operations(declaration)
 
@@ -249,7 +251,6 @@ def run(declarations):
                 non_extended_methods.add(option['api_name'])
         declaration['options'] = handle_outputs_taken_as_arguments(
             declaration['options'])
-
     # We (very unfortunately) have overloaded virtual methods. Because
     # of C++'s rules, we cannot move one overload without doing some
     # extra work to make sure that overload in a superclass and an

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -9,11 +9,11 @@
 #include "ATen/core/Storage.h"
 #include "ATen/core/Generator.h"
 #include "ATen/core/Deprecated.h"
-#include "ATen/core/optional.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/DeviceGuard.h"
 #include "ATen/core/TensorOptions.h"
 #include "ATen/core/Reduction.h"
+#include "c10/util/Optional.h"
 
 namespace at {
 

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -9,6 +9,7 @@
 #include "ATen/core/Storage.h"
 #include "ATen/core/Generator.h"
 #include "ATen/core/Deprecated.h"
+#include "ATen/core/optional.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/DeviceGuard.h"
 #include "ATen/core/TensorOptions.h"

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -128,7 +128,7 @@ struct CAFFE2_API Type {
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int32_t device_index = -1) const {
     return TensorOptions().dtype(scalarType())
-                          .device({backendToDeviceType(backend()), device_index})
+                          .device(backendToDeviceType(backend()), device_index)
                           .layout(layout())
                           .is_variable(is_variable());
   }

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -477,18 +477,6 @@ class optional : private OptionalBase<T> {
     return *this;
   }
 
-  //template <class U>
-  //auto operator=(U&& v) -> typename std::enable_if<
-      //std::is_same<typename std::decay<U>::type, T>::value,
-      //optional&>::type {
-    //if (initialized()) {
-      //contained_val() = std::forward<U>(v);
-    //} else {
-      //initialize(std::forward<U>(v));
-    //}
-    //return *this;
-  //}
-
   template<class U = T>
   auto operator=(U&& v) -> typename std::enable_if<
           std::is_constructible<T, U>::value
@@ -503,7 +491,6 @@ class optional : private OptionalBase<T> {
     }
     return *this;
   }
-
 
   template <class... Args>
   void emplace(Args&&... args) {

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -655,6 +655,11 @@ class optional : private OptionalBase<T> {
 // future if it becomes a definitely necessary case.
 template <class T>
 class optional<T&> {
+  // add this assert to prevent user from using optional reference as indicated above
+  static_assert(sizeof(T) == 0, "optional references is ill-formed, \
+    consider use optional of a std::reference_wrapper of type T to \
+    hold a reference if you really need to");
+
   static_assert(!std::is_same<T, nullopt_t>::value, "bad T");
   static_assert(!std::is_same<T, in_place_t>::value, "bad T");
   T* ref;
@@ -665,14 +670,7 @@ class optional<T&> {
 
   constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
 
-  template<
-    typename U = T,
-    TR2_OPTIONAL_REQUIRES(
-        std::is_constructible<T, U&&>::value
-        && !std::is_same<typename std::decay<U>::type, in_place_t>::value
-        && !std::is_same<typename std::decay<U>::type, optional<T>>
-        )
-      >
+  template<typename U = T>
   constexpr optional(U& u) noexcept : ref(detail_::static_addressof(u)) {}
 
   template<typename U = T>

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -44,8 +44,8 @@ TEST_F(ParallelTest, DifferentiableScatter_MultiCUDA) {
 TEST_F(ParallelTest, DifferentiableGather_MultiCUDA) {
   Gather gather(torch::Device(torch::kCUDA, 1));
 
-  auto a = torch::ones(5, torch::requires_grad(true).device({torch::kCUDA, 0}));
-  auto b = torch::ones(5, torch::requires_grad(true).device({torch::kCUDA, 1}));
+  auto a = torch::ones(5, torch::requires_grad(true).device(torch::kCUDA, 0));
+  auto b = torch::ones(5, torch::requires_grad(true).device(torch::kCUDA, 1));
 
   auto outputs = gather.apply({a, b});
   ASSERT_EQ(outputs.size(), 1);

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -50,7 +50,7 @@ TEST(TensorOptionsTest, UtilityFunctionsReturnTheRightTensorOptions) {
   options = device_index(1);
   REQUIRE_OPTIONS(kCUDA, 1, kFloat, kStrided);
 
-  options = dtype(kByte).layout(kSparse).device({kCUDA, 2}).device_index(3);
+  options = dtype(kByte).layout(kSparse).device(kCUDA, 2).device_index(3);
   REQUIRE_OPTIONS(kCUDA, 3, kByte, kSparse);
 }
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4066,18 +4066,23 @@ a")
         self.checkScript(func, [torch.arange(0, 2)], optimize=True)
 
     def test_script_clamp_none(self):
-        # TODO: could not enable default/optional argument for None in JIT
-        # result from Aten native python_default_init for clamp, it is used
-        # in Aten but not in JIT, need to fix type/default arg system in ATen
         def test_script_clamp_max_none(x):
-            return torch.clamp(x, min=None, max=2)
+            return torch.clamp(x, min=2, max=None)
+
+        def test_script_clamp_max(x):
+            return torch.clamp(x, max=2)
 
         def test_script_clamp_min_none(x):
-            return torch.clamp(x, min=2, max=None)
+            return torch.clamp(x, min=None, max=2)
+
+        def test_script_clamp_min(x):
+            return torch.clamp(x, min=2)
 
         input = [torch.arange(0, 3)]
         self.checkScript(test_script_clamp_max_none, input, optimize=True)
+        self.checkScript(test_script_clamp_max, input, optimize=True)
         self.checkScript(test_script_clamp_min_none, input, optimize=True)
+        self.checkScript(test_script_clamp_min, input, optimize=True)
 
     def test_script_bool_constant(self):
         script = '''

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -186,7 +186,7 @@
 
 # For clamp, gradient is not defined at the boundaries. But empirically it's helpful
 # to be able to get gradient on min and max, so we return the subgradient 1 for these cases.
-- name: clamp(Tensor self, Scalar min, Scalar max)
+- name: clamp(Tensor self, Scalar? min, Scalar? max)
   self: clamp_backward(grad, self, min, max)
 
 - name: clamp_min(Tensor self, Scalar min)

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -62,7 +62,7 @@ def get_simple_type(arg):
     simple_type = simple_type.replace(' &', '').replace('const ', '')
     simple_type = simple_type.replace('Generator *', 'Generator')
 
-    opt_match = re.match(r'optional<(.+)>', simple_type)
+    opt_match = re.match(r'c10::optional<(.+)>', simple_type)
     if opt_match:
         simple_type = '{}?'.format(opt_match.group(1))
     return simple_type

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -11,6 +11,7 @@ import argparse
 import copy
 import os
 import yaml
+import re
 from collections import defaultdict
 from .utils import YamlLoader, split_name_params
 
@@ -60,6 +61,10 @@ def get_simple_type(arg):
     simple_type = arg['type']
     simple_type = simple_type.replace(' &', '').replace('const ', '')
     simple_type = simple_type.replace('Generator *', 'Generator')
+
+    opt_match = re.match(r'optional<(.+)>', simple_type)
+    if opt_match:
+        simple_type = '{}?'.format(opt_match.group(1))
     return simple_type
 
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -314,7 +314,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                     default_expr += '.scalarType()'
                 expr = 'r.{}({}, {})'.format(unpack_with_default, arg_index, default_expr)
             else:
-                opt_match = re.match(r'optional<(.+)>', typename)
+                opt_match = re.match(r'c10::optional<(.+)>', typename)
                 if (opt_match):
                     unpack = opt_match.group(1).lower() + 'Optional'
                 else:

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -314,7 +314,11 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                     default_expr += '.scalarType()'
                 expr = 'r.{}({}, {})'.format(unpack_with_default, arg_index, default_expr)
             else:
-                unpack = unpack_methods.get(typename, typename.lower())
+                opt_match = re.match(r'optional<(.+)>', typename)
+                if (opt_match):
+                    unpack = opt_match.group(1).lower() + 'Optional'
+                else:
+                    unpack = unpack_methods.get(typename, typename.lower())
                 expr = 'r.{}({})'.format(unpack, arg_index)
 
             if unpack_args:
@@ -745,12 +749,13 @@ def get_python_signature(declaration, include_out):
 
     def get_py_formal_arg(arg):
         typename = arg['simple_type']
-        opt_match = re.match(r'optional<(.+)>', typename)
-        if opt_match:
-            typename = opt_match.group(1)
         typename = typename if typename != 'Type' else 'ScalarType'
-        if arg.get('is_nullable') or opt_match:
+
+        # TODO: remove this and make optional types in simple_type to be consistent across
+        # tensor and other types after make Tensor? be optional instead of undefined
+        if arg.get('is_nullable') and '?' not in typename:
             typename = '{}?'.format(typename)
+
         if arg.get('size') is not None:
             typename = '{}[{}]'.format(typename, arg['size'])
         param = typename + ' ' + arg['name']

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -163,6 +163,7 @@ def process_definition(defn, declarations_by_signature):
     #     `None` means all differentiable.
     output_differentiability = defn.pop('output_differentiability', None)
     param_types, param_names = unzip([p.split(' ') for p in params if p != '*'])
+
     if 'grad_input_mask' in param_names:
         raise RuntimeError("Signature for {} has an argument named grad_input_mask, "
                            "but this name would be shadowed by our codegen. "

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -450,14 +450,16 @@ std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<
   return grad_inputs;
 }
 
-Tensor clamp_backward(const Tensor & grad, const Tensor &self, const Scalar & min, const Scalar & max) {
+Tensor clamp_backward(const Tensor & grad, const Tensor &self, optional<Scalar> & min, optional<Scalar> & max) {
   // clamp: gradients not defined on min and max, so we return the subgradient 1 for these cases.
-  if (std::isnan(min.toFloat())) {
-    return grad * (self <= max).type_as(grad);
-  } else if (std::isnan(max.toFloat())) {
-    return grad * (self >= min).type_as(grad);
+  if (max && min) {
+    return grad * ((self >= *min) * (self <= *max)).type_as(grad);
+  } else if (min) {
+    return grad * (self >= *min).type_as(grad);
+  } else if (max) {
+    return grad * (self <= *max).type_as(grad);
   } else {
-    return grad * ((self >= min) * (self <= max)).type_as(grad);
+    return grad;
   }
 }
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -450,7 +450,7 @@ std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<
   return grad_inputs;
 }
 
-Tensor clamp_backward(const Tensor & grad, const Tensor &self, optional<Scalar> & min, optional<Scalar> & max) {
+Tensor clamp_backward(const Tensor & grad, const Tensor &self, const optional<Scalar> & min, const optional<Scalar> & max) {
   // clamp: gradients not defined on min and max, so we return the subgradient 1 for these cases.
   if (max && min) {
     return grad * ((self >= *min) * (self <= *max)).type_as(grad);

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -18,6 +18,7 @@ using at::Tensor;
 using at::IntList;
 using at::Type;
 using at::TensorGeometry;
+using at::optional;
 
 inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs) {
   // NB: we must explicitly do the conversion in the lambda, otherwise template

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -18,7 +18,7 @@ using at::Tensor;
 using at::IntList;
 using at::Type;
 using at::TensorGeometry;
-using at::optional;
+using c10::optional;
 
 inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs) {
   // NB: we must explicitly do the conversion in the lambda, otherwise template

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -27,6 +27,7 @@ TYPE_MAP = {
     'std::array<bool,4>': 'bool[4]',
     'std::string': 'str',
     'Scalar': 'Scalar',
+    'Scalar?': 'Scalar?',
     'Tensor': 'Tensor',
     'TensorList': 'Tensor[]',
     # this appears in return values instead of TensorList
@@ -49,8 +50,6 @@ def jit_type_of(arg):
     if is_sized_intlist_arg(arg):
         typ = 'int[{}]'.format(arg['size'])
 
-    if arg.get('is_nullable'):
-        typ = '{}?'.format(typ)
     return typ
 
 
@@ -61,6 +60,7 @@ FROM_IVALUE = {
     'IntList': '{}.toIntList()->elements()',
     'Layout': '{}.to<at::Layout>()',
     'Scalar': '{}.toScalar()',
+    'Scalar?': '{}.toOptional<Scalar>()',
     'ScalarType': '{}.to<at::ScalarType>()',
     'Tensor': '{}.toTensor()',
     'TensorList': '{}.toTensorList()->elements()',
@@ -314,7 +314,7 @@ def gen_jit_dispatch(declarations, out, template_path):
     }
     write(out, 'aten_interned_strings.h', ATEN_INTERNED_STRINGS_H, strings_env)
 
-default_map = {'{}': 'None', 'nullptr': 'None'}
+default_map = {'{}': 'None', 'nullptr': 'None', 'nullopt': 'None'}
 
 
 def signature(decl):
@@ -329,7 +329,6 @@ def signature(decl):
                 .replace('}}', ']') \
                 .replace('true', 'True') \
                 .replace('false', 'False') \
-                .replace('nullptr', 'None') \
                 .replace('Reduction::ElementwiseMean', 'ElementwiseMean') \
                 .replace('{}', 'None' if is_tensor_arg(arg) else '[]') \
                 .replace('{', '[') \

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -314,7 +314,7 @@ def gen_jit_dispatch(declarations, out, template_path):
     }
     write(out, 'aten_interned_strings.h', ATEN_INTERNED_STRINGS_H, strings_env)
 
-default_map = {'{}': 'None', 'nullptr': 'None', 'nullopt': 'None'}
+default_map = {'{}': 'None', 'nullptr': 'None', 'c10::nullopt': 'None'}
 
 
 def signature(decl):

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -39,7 +39,7 @@ bool isDifferentiable(Node * n) {
     "aten::exp(Tensor self) -> Tensor",
     "aten::t(Tensor self) -> Tensor",
     "aten::neg(Tensor self) -> Tensor",
-    "aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor",
+    "aten::clamp(Tensor self, Scalar? min, Scalar? max) -> Tensor",
     "aten::type_as(Tensor self, Tensor other) -> Tensor",
     "aten::unsqueeze(Tensor self, int dim) -> Tensor",
     "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha) -> Tensor",
@@ -161,7 +161,7 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
     } else if (node->matches("aten::relu(Tensor self) -> Tensor")) {
       return {grads.at(0) * (outputs.at(0) > at::Scalar(0)).type_as(outputs.at(0))};
 
-    } else if (node->matches("aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor")) {
+    } else if (node->matches("aten::clamp(Tensor self, Scalar? min, Scalar? max) -> Tensor")) {
       // we do two type_as and "*" in lieu of boolean "and"
       // the "! (val > min)" is chosen such that the gradient is 0 on the
       // boundary and the factor is 1 when the boundary is NaN

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -136,6 +136,10 @@ public:
   bool isTensor() const {
     return type()->kind() == TypeKind::CompleteTensorType;
   }
+  bool isNone() const {
+    return type()->kind() == TypeKind::NoneType;
+
+  }
   size_t unique() const {
     return unique_;
   }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -118,7 +118,7 @@ struct SchemaParser {
         L.next(); // ]
         value = ListType::create(value);
       } else if(L.nextIf('?')) {
-        // pass - currently ignored but optional types would go here when implemented
+        value = OptionalType::create(value);
       } else {
         break;
       }
@@ -238,6 +238,7 @@ struct SchemaParser {
       case TypeKind::GeneratorType: {
         return parseTensorDefault(range);
       }  break;
+      case TypeKind::OptionalType:
       case TypeKind::NumberType:
       case TypeKind::IntType:
       case TypeKind::BoolType:
@@ -324,7 +325,7 @@ private:
   // Basically, every function schema is assigned a unique string you can use to match it. However,
   // parsing those strings or comparing and hashing them character by character would be very slow, so
   // we use a trick here! Every string literal in your program is guaranteed to have static storage
-  // duration and so its address won't change at runtime. This allows us to memoize answerts for every
+  // duration and so its address won't change at runtime. This allows us to memoize answers for every
   // pointer, which is done by the operators_by_sig_literal map. Still, this map is initially
   // empty, and so we still need to do the complete string matching at the first time, which is implemented
   // by performing a lookup in the operators_by_sig map.

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -26,6 +26,8 @@ static void EraseNumberTypesOnBlock(Block* block) {
       case prim::BoolToTensor:
       case prim::TensorToNum:
       case prim::ImplicitTensorToNum:
+      case prim::None:
+      // remove prim None here as ONNX does not support it
       case prim::NumToTensor: {
         it->output()->replaceAllUsesWith(it->inputs()[0]);
         // Let DCE cleanup

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -26,8 +26,6 @@ static void EraseNumberTypesOnBlock(Block* block) {
       case prim::BoolToTensor:
       case prim::TensorToNum:
       case prim::ImplicitTensorToNum:
-      case prim::None:
-      // remove prim None here as ONNX does not support it
       case prim::NumToTensor: {
         it->output()->replaceAllUsesWith(it->inputs()[0]);
         // Let DCE cleanup

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -207,7 +207,7 @@ struct GraphFuser {
           /*const_inputs=*/{attr::other, attr::alpha}) ||
         node->matches("aten::mul(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
         node->matches("aten::div(Tensor self, Scalar other) -> Tensor", /*const_inputs=*/attr::other) ||
-        node->matches("aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor", /*const_inputs=*/{attr::min, attr::max})) {
+        node->matches("aten::clamp(Tensor self, Scalar? min, Scalar? max) -> Tensor", /*const_inputs=*/{attr::min, attr::max})) {
       auto inputs = tensorInputs(node);
       return haveSupportedType(inputs);
     }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -438,7 +438,7 @@ bool PropagateTensorShapeOnNode(Node * node, bool insert_expands) {
     "aten::contiguous(Tensor self) -> Tensor",
     "aten::bernoulli(Tensor self, *, Generator generator) -> Tensor",
     "aten::celu(Tensor self, Scalar alpha) -> Tensor",
-    "aten::clamp(Tensor self, Scalar min, Scalar max) -> Tensor",
+    "aten::clamp(Tensor self, Scalar? min, Scalar? max) -> Tensor",
     "aten::clamp_max(Tensor self, Scalar max) -> Tensor",
     "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
     "aten::alpha_dropout(Tensor input, float p, bool train) -> Tensor",

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -122,6 +122,9 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
       case TypeKind::IntType:
         return py::cast<int64_t>(obj);
       case TypeKind::NoneType:
+        if(obj != Py_None)
+          throw py::cast_error();
+
         return {};
       case TypeKind::BoolType:
         return py::cast<bool>(obj);
@@ -159,6 +162,9 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
         }
       }
       case TypeKind::OptionalType:
+        // check if it's a none obj since optional accepts NoneType
+        if (obj == Py_None)
+            return {};
         return toIValue(obj, type->expect<OptionalType>()->getElementType());
       case TypeKind::WorldType:
         AT_ERROR("World arguments should not be passed in by users");

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -158,6 +158,8 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
             return createGenericList(obj, elem_type);
         }
       }
+      case TypeKind::OptionalType:
+        return toIValue(obj, type->expect<OptionalType>()->getElementType());
       case TypeKind::WorldType:
         AT_ERROR("World arguments should not be passed in by users");
       case TypeKind::NumberType:

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -429,6 +429,8 @@ void initPythonIRBindings(PyObject * module_) {
           return "DynamicType";
         case TypeKind::TensorType:
           return "TensorType";
+        case TypeKind::OptionalType:
+          return "OptionalType";
         case TypeKind::NumberType:
           return "NumberType";
         case TypeKind::NoneType:

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -223,6 +223,14 @@ RegisterOperators reg({
           };
         }),
     Operator(
+      prim::None,
+      [](Node* node) {
+        return [](Stack& stack) {
+          stack.push_back(IValue());
+          return 0;
+        };
+      }),
+    Operator(
         prim::NoneGenerator,
         [](Node* node) {
           return [](Stack& stack) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1861,7 +1861,7 @@ private:
   Value* emitTupleSlice(const SourceRange& loc,
       const NamedValue& tuple_val,
       const NamedValue& beg_val,
-      const at::optional<NamedValue&> end_val) {
+      const at::optional<NamedValue>& end_val) {
     auto tuple_type = tuple_val.value(*graph)->type()->expect<TupleType>();
     int64_t beg = getTupleIndexVal(loc, tuple_type, beg_val.value(*graph), /*allow_out_of_bounds*/true);
     int64_t end;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -467,13 +467,12 @@ Value* tryMatchArgument(
     value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
   }
 
-  if (value->node()->kind() == prim::None){
-    if (concrete_type->isSubtypeOf(NumberType::get()))
-      value = graph.insertConstant(at::Scalar(NAN), loc);
-    else if (concrete_type->isSubtypeOf(GeneratorType::get())) {
+  if (value->type()->isSubtypeOf(NoneType::get())){
+    if (concrete_type->isSubtypeOf(GeneratorType::get())) {
       value = graph.insertNode(graph.createNoneGenerator())->output();
-    } else
+    } else if (concrete_type->isSubtypeOf(DynamicType::get())) {
       value = graph.insertNode(graph.createUndefined())->output();
+    }
   }
 
   //implicit conversion of tensors to scalars
@@ -1604,7 +1603,7 @@ private:
         return graph->insertConstant(false, tree->range());
       } break;
       case TK_NONE: {
-        return emitNone(tree->range());
+        return graph->insertConstant(IValue(), tree->range());
       } break;
       case TK_SUBSCRIPT: {
         const auto subscript = Subscript(tree);
@@ -1651,13 +1650,6 @@ private:
         throw ErrorReport(tree) << "NYI: " << tree;
         break;
     }
-  }
-
-  Value* emitNone(SourceRange range) {
-    auto& g = *method.graph();
-    return g.insertNode(
-        g.create(prim::None, {}, 1)->setSourceLocation(
-          std::make_shared<SourceRange>(range)))->output();
   }
 
   Value* emitConst(const Const& c) {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -42,7 +42,7 @@ void addInputs(Node *n, const char * name, int64_t value)            { detail::g
 void addInputs(Node *n, const char * name, bool value)               { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, double value)             { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Scalar& value)  { detail::genericAddInput(n, value); }
-void addInputs(Node *n, const char * name, const at::optional<at::Scalar>& value)  {
+void addInputs(Node *n, const char * name, const c10::optional<at::Scalar>& value)  {
   if(value) {
     detail::genericAddInput(n, *value);
   } else {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -42,6 +42,13 @@ void addInputs(Node *n, const char * name, int64_t value)            { detail::g
 void addInputs(Node *n, const char * name, bool value)               { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, double value)             { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Scalar& value)  { detail::genericAddInput(n, value); }
+void addInputs(Node *n, const char * name, const at::optional<at::Scalar>& value)  {
+  if(value) {
+    detail::genericAddInput(n, *value);
+  } else {
+    detail::genericAddInput(n, IValue());
+  }
+}
 void addInputs(Node *n, const char * name, const std::string& value) { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Tensor& value)  { n->addInput(getValueTrace(value)); }
 void addInputs(Node *n, const char * name, const at::SparseTensorRef& value) { detail::badArgType(value); }

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -170,7 +170,7 @@ TORCH_API void addInputs(Node *n, const char * name, int64_t value);
 TORCH_API void addInputs(Node *n, const char * name, bool value);
 TORCH_API void addInputs(Node *n, const char * name, double value);
 TORCH_API void addInputs(Node *n, const char * name, const at::Scalar& value);
-TORCH_API void addInputs(Node *n, const char * name, const at::optional<at::Scalar>& value);
+TORCH_API void addInputs(Node *n, const char * name, const c10::optional<at::Scalar>& value);
 TORCH_API void addInputs(Node *n, const char * name, const at::Tensor& value);
 TORCH_API void addInputs(Node *n, const char * name, at::IntList value);
 TORCH_API void addInputs(Node *n, const char * name, at::TensorList value);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -170,6 +170,7 @@ TORCH_API void addInputs(Node *n, const char * name, int64_t value);
 TORCH_API void addInputs(Node *n, const char * name, bool value);
 TORCH_API void addInputs(Node *n, const char * name, double value);
 TORCH_API void addInputs(Node *n, const char * name, const at::Scalar& value);
+TORCH_API void addInputs(Node *n, const char * name, const at::optional<at::Scalar>& value);
 TORCH_API void addInputs(Node *n, const char * name, const at::Tensor& value);
 TORCH_API void addInputs(Node *n, const char * name, at::IntList value);
 TORCH_API void addInputs(Node *n, const char * name, at::TensorList value);

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -51,6 +51,9 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   } else if(t.kind() == TypeKind::ListType) {
     auto prim = t.cast<ListType>()->getElementType();
     out << *prim << "[]";
+  } else if (t.kind() == TypeKind::OptionalType) {
+    auto prim = t.cast<OptionalType>()->getElementType();
+    out << *prim << "?";
   } else if(t.kind() == TypeKind::NoneType) {
     out << "None";
   } else if(t.kind() == TypeKind::StringType) {
@@ -237,6 +240,7 @@ TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
       throw TypeMatchError(ss.str());
     }
   }
+
   AT_ERROR("unhandled free variable container: ", formal->str());
 }
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -224,11 +224,7 @@ void FunctionParameter::set_default_str(const std::string& str) {
   } else if (type_ == ParameterType::DOUBLE) {
     default_double = atof(str.c_str());
   } else if (type_ == ParameterType::SCALAR) {
-    if (str == "None") {
-      // This is a bit awkward, but convenient for clamp which takes Scalars,
-      // but allows None.
-      default_scalar = at::Scalar(NAN);
-    } else {
+    if (str != "None") {
       // we sometimes rely on integer-vs-float values, e.g. with arange.
       const auto as_integer = parse_as_integer(str);
       default_scalar = as_integer.has_value() ? at::Scalar(as_integer.value()) :

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -175,7 +175,6 @@ struct FunctionParameter {
   // anyway, and Py_Finalize can already be called when this is destructed.
   PyObject *python_name;
   at::Scalar default_scalar;
-  // at::Scalar default_scalar;
   std::vector<int64_t> default_intlist;
   union {
     bool default_bool;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -242,7 +242,7 @@ inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar
 }
 
 inline c10::optional<at::Scalar> PythonArgs::scalarOptional(int i) {
-  if (!args[i]) return at::nullopt;
+  if (!args[i]) return c10::nullopt;
   return scalar(i);
 }
 

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -125,6 +125,7 @@ struct PythonArgs {
   inline at::ScalarType scalartype(int i);
   inline at::ScalarType scalartypeWithDefault(int i, at::ScalarType default_scalartype);
   inline c10::optional<at::ScalarType> scalartypeOptional(int i);
+  inline c10::optional<at::Scalar> scalarOptional(int i);
   inline const THPLayout& layout(int i);
   inline const THPLayout& layoutWithDefault(int i, const THPLayout& default_layout);
   inline at::Device device(int i);
@@ -174,6 +175,7 @@ struct FunctionParameter {
   // anyway, and Py_Finalize can already be called when this is destructed.
   PyObject *python_name;
   at::Scalar default_scalar;
+  // at::Scalar default_scalar;
   std::vector<int64_t> default_intlist;
   union {
     bool default_bool;
@@ -237,6 +239,11 @@ inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar
     return at::Scalar(THPUtils_unpackComplexDouble(args[i]));
   }
   return at::Scalar(THPUtils_unpackDouble(args[i]));
+}
+
+inline c10::optional<at::Scalar> PythonArgs::scalarOptional(int i) {
+  if (!args[i]) return at::nullopt;
+  return scalar(i);
 }
 
 inline std::vector<at::Tensor> PythonArgs::tensorlist(int i) {

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -833,15 +833,16 @@ def pow(g, self, exponent):
     return g.op("Pow", self, _if_scalar_type_as(g, exponent, self))
 
 
-@parse_args('v', 'f', 'f')
 def clamp(g, self, min, max):
-    # check min/max is NaN or not, and dispatch the call
-    # a != a means a == NaN
-    if min != min:
+    # min or max may be prim::None that we need to dispatch to
+    # Clip separately, as ONNX does not have None syntax
+    if min.node().kind() == "prim::None":
         return clamp_max(g, self, max)
-    elif max != max:
+    elif max.node().kind() == "prim::None":
         return clamp_min(g, self, min)
     else:
+        min = _parse_arg(min, 'f')
+        max = _parse_arg(max, 'f')
         return g.op("Clip", self, min_f=min, max_f=max)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -521,9 +521,9 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 elif t == torch._C.ListType.ofInts():
                     unsqueezed = [g.op("Unsqueeze", input, axes_i=[0]) for input in inputs]
                     return g.op("Concat", *unsqueezed, axis_i=0)
-            elif op_name == "Undefined":
-                # Undefined is not an ONNX operator; keep it as prim::Undefined
-                # and let the exporter handle finally eliminating these
+            elif op_name == "Undefined" or op_name == "None":
+                # Undefined/None is not an ONNX operator; keep it as prim::Undefined/
+                # prim::None and let the exporter handle finally eliminating these
                 return None
             elif op_name == 'Loop' or op_name == 'If':
                 new_op_outputs = g.op(op_name, *inputs, outputs=n.outputsSize())


### PR DESCRIPTION
This PR adds optional type to ATen native, autograd, JIT schema and Python Arg parser, closes #9513. It allows us to use optional default values (including None) for function signature and implementations like clamp, etc., and also let us remove the python_default_init hack. 

Follow up: 

remove python_default_init completely.