### PR TITLE
remove duplicate BUILD_TEST flag in libtorch cmake file

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -10,7 +10,6 @@ else()
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
-option(BUILD_TEST "Build torch test binaries" ON)
 option(TORCH_STATIC "Build libtorch.a rather than libtorch.so" OFF)
 
 set(TORCH_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
there is already a BUILD_TEST flag in the root-level cmake file. Removing this makes sure it doesn't interfere.

