### PR TITLE
Delete "default" codeowners from root directories.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,9 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-/aten/ @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/aten/src/ATen/core/
-/torch/ @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/docs/source @apaszke @soumith @colesbury @gchanan @zdevito @ezyang @ssnl @zou3519
-/docs/cpp @goldsborough @ebetica @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/test @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/tools @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/README.md @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/setup.py @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/requirements.txt @apaszke @soumith @colesbury @gchanan @zdevito @ezyang
-/torch/csrc/api/ @apaszke @soumith @colesbury @gchanan @zdevito @ezyang @ebetica @goldsborough
-/test/cpp/api/ @apaszke @soumith @colesbury @gchanan @zdevito @ezyang @ebetica @goldsborough
+/docs/cpp @goldsborough @ebetica
+/torch/csrc/api/ @ebetica @goldsborough
+/test/cpp/api/ @ebetica @goldsborough
 /torch/onnx/ @anderspapitto @bddppq @dzhulgakov @ezyang @houseroad @jamesr66a @smessmer @Yangqing
 /torch/csrc/onnx/ @anderspapitto @bddppq @dzhulgakov @ezyang @houseroad @jamesr66a @smessmer @Yangqing
 /torch/csrc/jit/passes/onnx/ @anderspapitto @bddppq @dzhulgakov @ezyang @houseroad @jamesr66a @smessmer @Yangqing


### PR DESCRIPTION
We will still have an informal notion of codeowner, but it
is not necessary to get a review from these people in particular
for these directories.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

