### PR TITLE
Dedup MethodValue and FunctionValue

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -849,7 +849,7 @@ const auto cf_examples = R"JIT(
 void testControlFlow() {
   script::Module cu;
   script::defineMethodsInModule(
-      cu, cf_examples, std::make_shared<torch::jit::script::NativeResolver>(), nullptr);
+      cu, cf_examples, script::nativeResolver, nullptr);
   auto run = [&](const std::string& name, std::vector<IValue> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph);

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,7 @@ namespace jit {
 
 std::shared_ptr<script::Module> compile(const std::string& source) {
   auto module = std::make_shared<script::Module>();
-  defineMethodsInModule(*module, source, std::make_shared<script::NativeResolver>(), /*self=*/nullptr);
+  defineMethodsInModule(*module, source, script::nativeResolver, /*self=*/nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -55,7 +55,7 @@ private:
   void loadSource(const std::string& source) {
     auto module = std::make_shared<script::Module>();
     defineMethodsInModule(
-        *module, source, std::make_shared<script::NativeResolver>(), /*self=*/nullptr);
+        *module, source, script::nativeResolver, /*self=*/nullptr);
     modules.push_back(module);
     for (auto& method : module->get_methods()) {
       builtins_by_name[Symbol::fromQualString("aten::" + method.key)].push_back(

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -153,7 +153,7 @@ private:
 //      delete unnecessary ones later with replaceAllusesWith().
 struct Environment {
   Environment(Method & method, Resolver resolver, Block* b, std::shared_ptr<Environment> next = nullptr)
-      : method(method), resolver(resolver), b(b), next(next) {}
+      : method(method), resolver(std::move(resolver)), b(b), next(next) {}
 
   Method & method;
   Resolver resolver;
@@ -804,13 +804,13 @@ inline bool isSupportedListElementType(TypePtr type) {
 struct to_ir {
   to_ir(
       Def def,
-      Resolver resolver,
+      Resolver resolver_,
       SugaredValuePtr self,
       Method& method) // method being constructed
       : method(method)
       , graph(method.graph())
       , def(def)
-      , resolver(resolver)
+      , resolver(std::move(resolver_))
       , environment_stack(nullptr) {
     JIT_ASSERT(resolver);
     pushFrame(graph->block());

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -152,11 +152,11 @@ private:
 //      the IR API, but for now we choose to pessimisitically create inputs and
 //      delete unnecessary ones later with replaceAllusesWith().
 struct Environment {
-  Environment(Method & method, std::shared_ptr<Resolver> resolver, Block* b, std::shared_ptr<Environment> next = nullptr)
+  Environment(Method & method, Resolver resolver, Block* b, std::shared_ptr<Environment> next = nullptr)
       : method(method), resolver(resolver), b(b), next(next) {}
 
   Method & method;
-  std::shared_ptr<Resolver> resolver;
+  Resolver resolver;
   std::vector<std::string> captured_inputs;
   std::unordered_map<std::string, std::string> error_messages;
   Block* b;
@@ -334,7 +334,7 @@ struct Environment {
     }
 
     if(!retval) {
-      retval = (*resolver)(ident, method, range);
+      retval = resolver(ident, method, range);
     }
 
     if (!retval && required) {
@@ -804,7 +804,7 @@ inline bool isSupportedListElementType(TypePtr type) {
 struct to_ir {
   to_ir(
       Def def,
-      std::shared_ptr<Resolver> resolver,
+      Resolver resolver,
       SugaredValuePtr self,
       Method& method) // method being constructed
       : method(method)
@@ -812,6 +812,7 @@ struct to_ir {
       , def(def)
       , resolver(resolver)
       , environment_stack(nullptr) {
+    JIT_ASSERT(resolver);
     pushFrame(graph->block());
 
     auto schema = extractSchemaFromDef(def, bool(self));
@@ -909,7 +910,7 @@ private:
   Method& method;
   std::shared_ptr<Graph> graph;
   Def def;
-  std::shared_ptr<Resolver> resolver;
+  Resolver resolver;
   std::unordered_map<int64_t, Value*> integral_constants;
   std::unordered_map<double, Value*> fp_constants;
 
@@ -1888,35 +1889,40 @@ std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> input
   return outputs;
 }
 
-void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const std::vector<std::shared_ptr<Resolver>>& resolvers, SugaredValuePtr self) {
+void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const std::vector<Resolver>& resolvers, SugaredValuePtr self) {
   JIT_ASSERT(definitions.size() == resolvers.size());
   auto resolver_it = resolvers.begin();
   std::vector<Method*> methods;
+  std::unordered_map<std::string, Method*> function_table;
   for(Def def : definitions) {
     const std::string& name = def.name().name();
     auto resolver = *resolver_it++;
+    JIT_ASSERT(resolver);
+    if(!self) {
+      // if self is defined, then these are methods and do not go into the global namespace
+      // otherwise, they get defined together so we add them to the function table
+      // so the methods can see each other
+      resolver = [resolver, &function_table](
+                     const std::string& name,
+                     Method& m,
+                     const SourceRange& loc) -> std::shared_ptr<SugaredValue> {
+        auto it = function_table.find(name);
+        if (it != function_table.end()) {
+          return std::make_shared<MethodValue>(nullptr, *it->second);
+        }
+        return resolver(name, m, loc);
+      };
+    }
     auto creator = [def, resolver, self](Method& method) {
+      JIT_ASSERT(resolver);
       to_ir(def, resolver, self,  method);
     };
     Method& method = m.create_method(name, creator);
-    // if self is defined, then these are methods and do not go into the global namespace
-    // otherwise, they get defined together so we add them to the function table
-    // so the methods can see each other
-    if(!self) {
-      for (auto r : resolvers) {
-        r->addEntry(name, std::make_shared<MethodValue>(nullptr, method));
-      }
-    }
+    function_table[name] = &method;
     methods.push_back(&method);
   }
   for(Method* method : methods) {
     method->ensure_defined();
-  }
-  // Method& references stored in the Resolvers are now stale and will go out of scope.
-  // NOTE: this is actually pessimistic. Technically we can resolve functions if we
-  // call defineMethodsInModule on the same m again.
-  for (auto r : resolvers) {
-    r->clear();
   }
 }
 
@@ -2025,10 +2031,10 @@ FunctionSchema extractSchemaFromDef(const Def &def, bool is_method) {
     return FunctionSchema(name, args, returns, false, is_varret);
 }
 
-void defineMethodsInModule(Module & m, const std::string& source, const std::shared_ptr<Resolver> resolver, SugaredValuePtr self) {
+void defineMethodsInModule(Module & m, const std::string& source, Resolver resolver, SugaredValuePtr self) {
   Parser p(source);
   std::vector<Def> definitions;
-  std::vector<std::shared_ptr<Resolver>> resolvers;
+  std::vector<Resolver> resolvers;
   while (p.lexer().cur().kind != TK_EOF) {
     auto def = Def(p.parseFunction(/*is_method=*/bool(self)));
     definitions.push_back(def);
@@ -2037,7 +2043,7 @@ void defineMethodsInModule(Module & m, const std::string& source, const std::sha
   defineMethodsInModule(m, definitions, resolvers, self);
 }
 
-std::shared_ptr<Graph> compileFunction(Def def, const std::shared_ptr<Resolver> resolver) {
+std::shared_ptr<Graph> compileFunction(Def def, Resolver resolver) {
   Module m;
   defineMethodsInModule(m, {def}, {resolver}, nullptr);
   return m.get_method(def.name().name()).graph();

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -186,6 +186,23 @@ TORCH_API std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Val
 TORCH_API void ensureSizeMatches(SourceRange loc, size_t expected, size_t actual, const std::string& what);
 TORCH_API void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values);
 
+// defines how a method obtained from a module behaves in script
+struct MethodValue : public SugaredValue {
+  MethodValue(std::shared_ptr<Module> module, Method& method)
+  : module(std::move(module)) //insurance that method stays alive
+  , method(method) {}
+  std::string kind() const override {
+    return "method";
+  }
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<NamedValue> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
+    return std::make_shared<SimpleValue>(packOutputs(*caller.graph(), caller.emit_call_to(loc, method, inputs, attributes)));
+  }
+private:
+  std::shared_ptr<Module> module;
+  Method& method;
+
+};
+
 // try to match a list if inputs and keyword 'attributes' to this schema,
 // if it works return the flat list of positional inputs to the call
 // if it returns nullopt, then failure_messages contains a good error report

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -136,48 +136,25 @@ struct TORCH_API BuiltinModule : public SugaredValue {
   }
 };
 
-struct Resolver {
-  virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const = 0;
-  virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) = 0;
-  virtual void clear() = 0;
-  virtual ~Resolver() {}
-};
+using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
 
-struct NativeResolver : public Resolver {
-  virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const override {
-    if (function_table.count(name)) {
-      return function_table.at(name);
-    }
-    if (name == "torch") {
-      return std::make_shared<BuiltinModule>(name);
-    }
-    return nullptr;
+inline std::shared_ptr<SugaredValue> nativeResolver(const std::string& name, Method& m, const SourceRange& loc){
+  if (name == "torch") {
+    return std::make_shared<BuiltinModule>(name);
   }
-
-  virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) override {
-    function_table[name] = sv;
-  }
-
-  virtual void clear() override {
-    function_table.clear();
-  }
-
-  virtual ~NativeResolver() {}
-
- private:
-   std::unordered_map<std::string, std::shared_ptr<SugaredValue>> function_table;
-};
+  return nullptr;
+}
 
 TORCH_API void defineMethodsInModule(
   Module & m,
   const std::vector<Def>& definitions,
-  const std::vector<std::shared_ptr<Resolver>>& resolvers, /* determines how we handle free variables in each definition*/
+  const std::vector<Resolver>& resolvers, /* determines how we handle free variables in each definition*/
   std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
 );
 
 // same as above but parse the definitions from source
-TORCH_API void defineMethodsInModule(Module & m, const std::string& source, std::shared_ptr<Resolver> resolver, std::shared_ptr<SugaredValue> self);
-TORCH_API std::shared_ptr<Graph> compileFunction(Def def, std::shared_ptr<Resolver> resolver);
+TORCH_API void defineMethodsInModule(Module & m, const std::string& source, Resolver resolver, std::shared_ptr<SugaredValue> self);
+TORCH_API std::shared_ptr<Graph> compileFunction(Def def, Resolver resolver);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -190,23 +190,6 @@ struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
 // anticipating we will eventually need to replace Module with a py::object
 // holding the actual nn.Module class.
 
-// defines how a method obtained from a module behaves in script
-struct MethodValue : public SugaredValue {
-  MethodValue(std::shared_ptr<Module> module, Method& method)
-  : module(std::move(module)) //insurance that method stays alive
-  , method(method) {}
-  std::string kind() const override {
-    return "method";
-  }
-  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<NamedValue> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
-    return std::make_shared<SimpleValue>(packOutputs(*caller.graph(), caller.emit_call_to(loc, method, inputs, attributes)));
-  }
-private:
-  std::shared_ptr<Module> module;
-  Method& method;
-
-};
-
 
 struct ModuleValue : public SugaredValue {
   ModuleValue(std::shared_ptr<Module> module)

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -345,36 +345,20 @@ static void gatherParametersAndBuffers(std::vector<at::Tensor*> & values, const 
 }
 
 namespace {
-struct PythonResolver : public Resolver {
-  PythonResolver(ResolutionCallback rcb) : rcb(rcb) {}
-  virtual std::shared_ptr<SugaredValue> operator() (const std::string& name, Method& m, const SourceRange& loc) const override {
-    if (function_table.count(name)) {
-      return function_table.at(name);
-    }
 
+Resolver pythonResolver(ResolutionCallback rcb) {
+  return [rcb](const std::string& name, Method& m, const SourceRange& loc)
+             -> std::shared_ptr<SugaredValue> {
     AutoGIL ag;
     py::object obj = rcb(name);
     if (obj.is(py::none())) {
       return nullptr;
     }
     return toSugaredValue(obj, m, loc);
-  }
+  };
+}
 
-  virtual void addEntry(const std::string& name, std::shared_ptr<SugaredValue> sv) override {
-    function_table[name] = sv;
-  }
-
-  virtual void clear() override {
-    function_table.clear();
-  }
-
-  virtual ~PythonResolver() {}
-
- private:
-   std::unordered_map<std::string, std::shared_ptr<SugaredValue>> function_table;
-   ResolutionCallback rcb;
-};
-}  // namespace
+}
 
 FunctionSchema getSchemaWithDefaults(
     const FunctionDefaults& default_args,
@@ -429,15 +413,15 @@ void initJitScriptBindings(PyObject* module) {
              const std::string& script,
              ResolutionCallback rcb, bool has_self) {
             auto self = has_self ? std::make_shared<ModuleValue>(m) : nullptr;
-            return defineMethodsInModule(*m, script, std::make_shared<PythonResolver>(rcb), self);
+            return defineMethodsInModule(*m, script, pythonResolver(rcb), self);
           })
       .def("_create_methods", [](std::shared_ptr<Module> m,
           const std::vector<Def>& defs,
           const std::vector<ResolutionCallback>& rcbs,
           const std::vector<FunctionDefaults>& defaults) {
-        std::vector<std::shared_ptr<Resolver>> resolvers;
+        std::vector<Resolver> resolvers;
         for(auto & callback : rcbs) {
-          resolvers.push_back(std::make_shared<PythonResolver>(callback));
+          resolvers.push_back(pythonResolver(callback));
         }
         defineMethodsInModule(
           *m,
@@ -589,7 +573,7 @@ void initJitScriptBindings(PyObject* module) {
     .def("pretty_print_schema", &Method::pretty_print_schema);
 
   m.def("_jit_script_compile", [](const Def &def, ResolutionCallback rcb) {
-    return compileFunction(def, std::make_shared<PythonResolver>(rcb));
+    return compileFunction(def, pythonResolver(rcb));
   });
 
   m.def("parse_type_comment", [](const std::string& comment) {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -802,7 +802,7 @@ const static auto cf_examples = R"JIT(
 )JIT";
 void testControlFlow() {
   script::Module cu;
-  script::defineMethodsInModule(cu, cf_examples, std::make_shared<torch::jit::script::NativeResolver>(), nullptr);
+  script::defineMethodsInModule(cu, cf_examples, script::nativeResolver, nullptr);
   auto run = [&](const std::string & name, std::vector<IValue> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph);


### PR DESCRIPTION
... they are basically the same class and I didn't see it in the initial PR. I also got resolvers back onto std::functions by keeping the function_table logic local to defineMethodInModules.