### PR TITLE
fix improper calling of ShareExternalPointer from RNN op

### DIFF
--- a/caffe2/operators/rnn/recurrent_network_op.h
+++ b/caffe2/operators/rnn/recurrent_network_op.h
@@ -86,8 +86,7 @@ void applyOffsetAlias(
   dst->Resize(dims);
   CAFFE_ENFORCE(timestep == dst->size() / numDstTimesteps, "Invalid offset");
   dst->ShareExternalPointer(
-      src->template mutable_data<T>() + startDstTimestep * timestep,
-      dst->size());
+      src->template mutable_data<T>() + startDstTimestep * timestep);
 }
 
 template <typename T, class Context>


### PR DESCRIPTION
Summary: size() returns numel_, but what we really want is nbytes(), which is the capacity.

Differential Revision: D10354488
