### PR TITLE
fix masked_fill_ bug on non-contiguous tensor

### DIFF
--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -30,10 +30,10 @@ void THTensor_(zero)(THTensor *r_)
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
 {
 #ifdef _OPENMP
-  if (!omp_in_parallel()) {
-    int64_t tensor_size = THTensor_(nElement)(tensor);
-    int tensor_contig = THTensor_(isContiguous)(tensor);
-    int mask_contig = THTensor_(isContiguous)(mask);
+  int64_t tensor_size = THTensor_(nElement)(tensor);
+  int tensor_contig = THTensor_(isContiguous)(tensor);
+  int mask_contig = THTensor_(isContiguous)(mask);
+  if (!omp_in_parallel() && tensor_contig && mask_contig) {
     TH_TENSOR_APPLY2_OMP(tensor_size, tensor_contig, mask_contig,
       scalar_t, tensor, unsigned char, mask,
       if (*mask_data > 1) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6366,6 +6366,13 @@ class TestTorch(TestCase):
                 dst2[i] = val
         self.assertEqual(dst, dst2, 0)
 
+        # test non-contiguous case
+        dst = torch.randn(num_dest, num_dest, num_dest).permute((2, 0, 1))
+        dst2 = dst.clone()
+        dst.masked_fill_(dst > 0, val)
+        dst2.masked_fill_(dst2 > 0, val)
+        self.assertEqual(dst, dst2, 0)
+
     def test_abs(self):
         def _test_abs(tensors_dict):
             for category, tensors in tensors_dict.items():


### PR DESCRIPTION
bug fix on #12230 , the following script pass after the fix.
```python
x = torch.randn(2, 2, 2)
x = x.permute((2, 0, 1))
y = x.clone()
y.masked_fill_(y > 0, 1)
x.masked_fill_(x > 0, 1)
print((x == y).all())
```