### PR TITLE
don't copy weight gradients in rnn

### DIFF
--- a/docs/source/cudnn_persistent_rnn.rst
+++ b/docs/source/cudnn_persistent_rnn.rst
@@ -1,0 +1,9 @@
+.. note::
+
+    If the following conditions are satisfied:
+    1) cudnn is enabled, 
+    2) input data is on the GPU 
+    3) input data has dtype ``torch.float16`` 
+    4) V100 GPU is used,
+    5) input data is not in ``PackedSequence`` format
+    persistent algorithm can be selected to improve performance.  

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -304,6 +304,8 @@ class RNN(RNNBase):
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
 
+    .. include:: cudnn_persistent_rnn.rst
+
     Examples::
 
         >>> rnn = nn.RNN(10, 20, 2)
@@ -421,6 +423,8 @@ class LSTM(RNNBase):
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
 
+    .. include:: cudnn_persistent_rnn.rst
+
     Examples::
 
         >>> rnn = nn.LSTM(10, 20, 2)
@@ -515,6 +519,8 @@ class GRU(RNNBase):
     .. note::
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
+
+    .. include:: cudnn_persistent_rnn.rst
 
     Examples::
 


### PR DESCRIPTION
This PR gets rid of unnecessary copy of weight gradients in cudnn rnn. Also removes unnecessary check for  input size when deciding whether to use persistent rnn, and adds doc string explaining when persistent rnn can be used. cc @ezyang 