### PR TITLE
test_proper_exit: avoid truncation of info message

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -649,8 +649,8 @@ class TestDataLoader(TestCase):
 
     @skipIfRocm
     def test_proper_exit(self):
-        r'''There might be ConnectionResetError or leaked semaphore warning
-        (due to dirty process exit), but they are all safe to ignore'''
+        (r'''There might be ConnectionResetError or leaked semaphore warning '''
+        r'''(due to dirty process exit), but they are all safe to ignore''')
 
         # TODO: test the case where the pin_memory_thread triggers an
         #       error/fatal signal. I haven't found out how to properly do that.

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -650,7 +650,7 @@ class TestDataLoader(TestCase):
     @skipIfRocm
     def test_proper_exit(self):
         (r'''There might be ConnectionResetError or leaked semaphore warning '''
-        r'''(due to dirty process exit), but they are all safe to ignore''')
+         r'''(due to dirty process exit), but they are all safe to ignore''')
 
         # TODO: test the case where the pin_memory_thread triggers an
         #       error/fatal signal. I haven't found out how to properly do that.


### PR DESCRIPTION
test_proper_exit in the dataloader test bucket includes
(as its docstring) a reassuring message about complaints that
may appear during the test. The message is displayed
when the tests are run in verbose mode.

But the docstring includes a line break, and the unittest
framework only prints the first line of the docstring (see
shortDesription()). As a result, the 2nd (more reassuring)
half of the message is not displayed.

Catenate the docstring onto a single line so all is visible.

