### PR TITLE
split register_aten_ops.cpp into shards

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -248,7 +248,7 @@ def gen_variable_type(out, aten_declarations, template_path):
 
     gen_variable_type_shard(out, aten_declarations, template_path, None, True)
 
-    # NOTE: see the comment at the top of the VariableType.cpp
+    # NOTE: see Note [Sharded File] at the top of the VariableType.cpp
     # template regarding sharding of the generated files.
     num_shards = 5
     shards = [[] for _ in range(num_shards)]
@@ -259,7 +259,7 @@ def gen_variable_type(out, aten_declarations, template_path):
         shards[x].append(decl)
 
     for i, shard in enumerate(shards):
-        gen_variable_type_shard(out, shard, template_path, '-%d' % i, False)
+        gen_variable_type_shard(out, shard, template_path, '_%d' % i, False)
     gen_variable_type_shard(out, aten_declarations, template_path, 'Everything', False)
 
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -2,7 +2,7 @@
 
 // ${generated_comment}
 
-// NOTE on this file's split-into-shards state
+// NOTE [Sharded File]: on this file's split-into-shards state
 //
 // Back in the good old days, VariableType.cpp was generated as one
 // file with every function in it, and everything was great and
@@ -12,7 +12,7 @@
 // compiling it was very slow, and in fact was a significant
 // bottleneck for incremental rebuilds. To address this, we now
 // generate the file split across multiple shards, named
-// VariableType-0.cpp and so on, which can be compiled in parallel.
+// VariableType_0.cpp and so on, which can be compiled in parallel.
 //
 // For ease of inspection and debugging, so that it's not necessary to
 // go rooting around in multiple files, we also generate all the

--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -24,6 +24,15 @@
 
 // ${generated_comment}
 
+// NOTE [Sharded File]: This file is generated in a sharded fashion to speed up
+// incremental rebuilds. See the comment at the top of
+// templates/VariableType.cpp for an analogous, in-depth discussion.
+//
+// Note that unlike VariableType.cpp, when sharding this file we take
+// care to generate all overloads of a particular name in a single
+// file and in a particular order. See gen_jit_dispatch.py for
+// details.
+
 namespace torch { namespace jit {
 
 using autograd::Variable;
@@ -35,7 +44,7 @@ using at::DeviceGuard;
 
 namespace {
 
-int deviceForInputs(Stack & stack, size_t N) {
+inline int deviceForInputs(Stack & stack, size_t N) {
   if(N == 0)
     return -1;
   auto t = (stack.end() - N)->toTensor();

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -38,13 +38,15 @@ outputs = [
     'torch/csrc/autograd/generated/python_variable_methods.cpp',
     'torch/csrc/autograd/generated/python_variable_methods_dispatch.h',
     'torch/csrc/autograd/generated/variable_factories.h',
-    'torch/csrc/autograd/generated/VariableType-0.cpp',
-    'torch/csrc/autograd/generated/VariableType-1.cpp',
-    'torch/csrc/autograd/generated/VariableType-2.cpp',
-    'torch/csrc/autograd/generated/VariableType-3.cpp',
-    'torch/csrc/autograd/generated/VariableType-4.cpp',
+    'torch/csrc/autograd/generated/VariableType_0.cpp',
+    'torch/csrc/autograd/generated/VariableType_1.cpp',
+    'torch/csrc/autograd/generated/VariableType_2.cpp',
+    'torch/csrc/autograd/generated/VariableType_3.cpp',
+    'torch/csrc/autograd/generated/VariableType_4.cpp',
     'torch/csrc/autograd/generated/VariableType.h',
-    'torch/csrc/jit/generated/register_aten_ops.cpp',
+    'torch/csrc/jit/generated/register_aten_ops_0.cpp',
+    'torch/csrc/jit/generated/register_aten_ops_1.cpp',
+    'torch/csrc/jit/generated/register_aten_ops_2.cpp',
 ]
 
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -70,11 +70,11 @@ add_custom_command(
   "${TORCH_SRC_DIR}/csrc/nn/THNN.cpp"
   "${TORCH_SRC_DIR}/csrc/nn/THCUNN.cpp"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.h"
-  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-0.cpp"
-  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-1.cpp"
-  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-2.cpp"
-  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-3.cpp"
-  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-4.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_0.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_1.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_2.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_3.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_4.cpp"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.h"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/python_functions.h"
@@ -87,7 +87,9 @@ add_custom_command(
   "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions.h"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions_dispatch.h"
   "${TORCH_SRC_DIR}/csrc/autograd/generated/variable_factories.h"
-  "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops.cpp"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_0.cpp"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_1.cpp"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_2.cpp"
   "${TORCH_SRC_DIR}/csrc/jit/generated/aten_interned_strings.h"
   COMMAND
   ${PYCMD} tools/setup_helpers/generate_code.py
@@ -135,11 +137,11 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/autograd/functions/tensor.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/functions/utils.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp
-  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-0.cpp
-  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-1.cpp
-  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-2.cpp
-  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-3.cpp
-  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType-4.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_0.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_1.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_2.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_3.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_4.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/grad_mode.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
@@ -149,7 +151,9 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/cuda/comm.cpp
   ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp
   ${TORCH_SRC_DIR}/csrc/jit/export.cpp
-  ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_0.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_1.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_2.cpp
   ${TORCH_SRC_DIR}/csrc/jit/graph_executor.cpp
   ${TORCH_SRC_DIR}/csrc/jit/import.cpp
   ${TORCH_SRC_DIR}/csrc/jit/interpreter.cpp


### PR DESCRIPTION
after an analogous breakup of VariableType.cpp, the generated
register_aten_ops.cpp is now the slowest-to-compile file in a typical
incremental rebuild by a wide margin. Therefore, give it the same
treatment - the generated code is split across several files to allow
parallel compilation.

Note that the existing code takes some care to arrange that overloads
of the same op name are given in a particular order. This diff
preserves that behavior, by treating all overloads of the same name as
a single indivisible unit, and sharding based on these groups rather
than on individual constructors.

