### PR TITLE
Fix binary_cross_entropy_with_logits

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6941,6 +6941,19 @@ def bce_with_logistic_no_reduce_test():
         pickle=False,
     )
 
+def bce_with_logistic_no_reduce_legacy_test():
+    t = Variable(torch.randn(15, 10).gt(0).double())
+    sigmoid = nn.Sigmoid()
+    return dict(
+        fullname='BCEWithLogitsLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.binary_cross_entropy_with_logits(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.rand(15, 10).clamp_(2.8e-2, 1 - 2.8e-2),
+        reference_fn=lambda i, m: -(t * sigmoid(i).log() + (1 - t) * (1 - sigmoid(i)).log()),
+        check_gradgrad=False,
+        pickle=False,
+    )
+
 
 def bce_with_logistic_no_reduce_scalar_test():
     t = torch.randn(()).gt(0).double()
@@ -7417,6 +7430,7 @@ new_module_tests = [
     bceloss_no_reduce_test(),
     bceloss_weights_no_reduce_test(),
     bce_with_logistic_no_reduce_test(),
+    bce_with_logistic_no_reduce_legacy_test(),
     bceloss_no_reduce_scalar_test(),
     bceloss_weights_no_reduce_scalar_test(),
     bce_with_logistic_no_reduce_scalar_test(),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1756,7 +1756,7 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=No
          >>> loss.backward()
     """
     if size_average is not None or reduce is not None:
-        reduction = _Reduction.legacy_get_string(size_average, reduce)
+        reduction = _Reduction.legacy_get_enum(size_average, reduce)
     else:
         reduction = _Reduction.get_enum(reduction)
 


### PR DESCRIPTION
Summary: binary_cross_entropy_with_logits is broken when redcue is not None

Differential Revision: D10372032
