### PR TITLE
Make TensorOptions immutable.

### DIFF
--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -150,12 +150,10 @@ struct CAFFE2_API Type {
 
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int32_t device_index = -1) const {
-    TensorOptions r;
-    r.dtype(scalarType());
-    r.device({backendToDeviceType(backend()), device_index});
-    r.layout(layout());
-    r.is_variable(is_variable());
-    return r;
+    return TensorOptions().dtype(scalarType())
+                          .device({backendToDeviceType(backend()), device_index})
+                          .layout(layout())
+                          .is_variable(is_variable());
   }
 
   operator TensorOptions() const {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -648,7 +648,7 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 
 template <typename T>
 Tensor tensor_cuda(ArrayRef<T> values, const TensorOptions& options) {
-  auto cpu_tensor = tensor_cpu(values, TensorOptions(options).device(DeviceType::CPU));
+  auto cpu_tensor = tensor_cpu(values, options.device(DeviceType::CPU));
   return cpu_tensor.to(options.device());
 }
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -121,12 +121,10 @@ struct CAFFE2_API Type {
 
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int32_t device_index = -1) const {
-    TensorOptions r;
-    r.dtype(scalarType());
-    r.device({backendToDeviceType(backend()), device_index});
-    r.layout(layout());
-    r.is_variable(is_variable());
-    return r;
+    return TensorOptions().dtype(scalarType())
+                          .device({backendToDeviceType(backend()), device_index})
+                          .layout(layout())
+                          .is_variable(is_variable());
   }
 
   operator TensorOptions() const {

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -32,4 +32,20 @@
 #define CONCAT_IMPL(x, y) x##y
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
 
+/// C10_NODISCARD - Warn if a type or return value is discarded.
+#define C10_NODISCARD
+#if __cplusplus > 201402L && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(nodiscard)
+#undef C10_NODISCARD
+#define C10_NODISCARD [[nodiscard]]
+#endif
+// Workaround for llvm.org/PR23435, since clang 3.6 and below emit a spurious
+// error when __has_cpp_attribute is given a scoped attribute in C mode.
+#elif __cplusplus && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::warn_unused_result)
+#undef C10_NODISCARD
+#define C10_NODISCARD [[clang::warn_unused_result]]
+#endif
+#endif
+
 #endif // C10_MACROS_MACROS_H_

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -35,9 +35,7 @@ class Cloneable : public virtual Module {
   /// original module.
   std::shared_ptr<Module> clone(
       at::optional<Device> device = at::nullopt) const override {
-    TensorOptions options;
-    if (device) { options.device(*device); }
-    OptionsGuard options_guard(options);
+    OptionsGuard options_guard(TensorOptions().device(device));
 
     NoGradGuard no_grad;
 


### PR DESCRIPTION
Summary:
Instead of providing mutable accessors, our "mutators" now
return new copies of TensorOptions.  Since TensorOptions is
simply two 64-bit integers, this is not a big efficiency
problem.

There may be some sites that assumed that TensorOptions was
mutable.  They need to be fixed.

Differential Revision: D10249293
