### PR TITLE
Rewrite http://pytorch.org -> https://pytorch.org throughout project

### DIFF
--- a/aten/README.md
+++ b/aten/README.md
@@ -3,7 +3,7 @@
 ATen is a simple tensor library thats exposes the Tensor operations in Torch
 and PyTorch directly in C++11. The wrapper respects the semantics of operators
 in PyTorch, except minor details due to differences between C++ and Python in
-the way default arguments are handled. See the [documentation for tensors](http://pytorch.org/docs/tensors.html) in PyTorch for what these operations do.
+the way default arguments are handled. See the [documentation for tensors](https://pytorch.org/docs/tensors.html) in PyTorch for what these operations do.
 ATen's API is auto-generated from the same declarations PyTorch uses so the
 two APIs will track each other over time.
 

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -292,7 +292,7 @@ class LSTMInitializer(object):
         ]
 
 
-# based on http://pytorch.org/docs/master/nn.html#torch.nn.RNNCell
+# based on https://pytorch.org/docs/master/nn.html#torch.nn.RNNCell
 class BasicRNNCell(RNNCell):
     def __init__(
         self,

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ figures:
 	@$(PYCMD) source/scripts/build_activation_images.py
 
 docset: html
-	doc2dash --name $(SPHINXPROJ) --icon $(SOURCEDIR)/_static/img/pytorch-logo-flame.png --enable-js --online-redirect-url http://pytorch.org/docs/ --force $(BUILDDIR)/html/
+	doc2dash --name $(SPHINXPROJ) --icon $(SOURCEDIR)/_static/img/pytorch-logo-flame.png --enable-js --online-redirect-url https://pytorch.org/docs/ --force $(BUILDDIR)/html/
 
 	# Manually fix because Zeal doesn't deal well with `icon.png`-only at 2x resolution.
 	cp $(SPHINXPROJ).docset/icon.png $(SPHINXPROJ).docset/icon@2x.png

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -414,7 +414,7 @@ void fixDefaultRnnHiddenState(Block* b) {
       continue;
     }
     // Hidden state is the sixth input for RNN, LSTM, GRU.
-    // See http://pytorch.org/docs/master/nn.html#torch.nn.RNN
+    // See https://pytorch.org/docs/master/nn.html#torch.nn.RNN
     if (n->inputs().size() < 6) {
       continue;
     }
@@ -433,7 +433,7 @@ void fixDefaultLstmCellState(Block *b) {
       continue;
     }
     // Cell state is the seventh input for LSTM.
-    // See http://pytorch.org/docs/master/nn.html#torch.nn.LSTM
+    // See https://pytorch.org/docs/master/nn.html#torch.nn.LSTM
     if (n->inputs().size() < 7) {
       continue;
     }

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -86,7 +86,7 @@ http://www.nvidia.com/Download/index.aspx""")
 The NVIDIA driver on your system is too old (found version {}).
 Please update your GPU driver by downloading and installing a new
 version from the URL: http://www.nvidia.com/Download/index.aspx
-Alternatively, go to: http://pytorch.org to install
+Alternatively, go to: https://pytorch.org to install
 a PyTorch version that has been compiled with your version
 of the CUDA driver.""".format(str(torch._C._cuda_getDriverVersion())))
 
@@ -96,7 +96,7 @@ def _check_capability():
     Found GPU%d %s which requires CUDA_VERSION >= %d for
      optimal performance and fast startup time, but your PyTorch was compiled
      with CUDA_VERSION %d. Please install the correct PyTorch binary
-     using instructions from http://pytorch.org
+     using instructions from https://pytorch.org
     """
 
     old_gpu_warn = """

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -206,7 +206,7 @@ class NLLLoss2d(NLLLoss):
                  reduce=None, reduction='elementwise_mean'):
         warnings.warn("NLLLoss2d has been deprecated. "
                       "Please use NLLLoss instead as a drop-in replacement and see "
-                      "http://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.")
+                      "https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.")
         super(NLLLoss2d, self).__init__(weight, size_average, ignore_index, reduce, reduction)
 
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -141,7 +141,7 @@ class Tensor(torch._C._TensorBase):
 
         raise RuntimeError(trim(r"""reinforce() was removed.
             Use torch.distributions instead.
-            See http://pytorch.org/docs/master/distributions.html
+            See https://pytorch.org/docs/master/distributions.html
 
             Instead of:
 

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -161,7 +161,7 @@ exits in a finite amount of time.
 
 For more complicated uses of the profilers, please see
 https://docs.python.org/3/library/profile.html and
-http://pytorch.org/docs/master/autograd.html#profiler for more information.
+https://pytorch.org/docs/master/autograd.html#profiler for more information.
 """.strip()
 
 


### PR DESCRIPTION
The pytorch.org site redirects all of the http:// requests to the https:// site anyway, so the comments and error messages might as well refer directly to the https:// site. The GitHub project description should also be updated to point to https://pytorch.org