### PR TITLE
Re-sync with internal repository

### DIFF
--- a/submodules/nervanagpu-rev.txt
+++ b/submodules/nervanagpu-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit d4eefd50fbd7d34a17dddbc829888835d67b5f4a


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.