### PR TITLE
Use branch of exhale that fixes overloads

### DIFF
--- a/docs/cpp/requirements.txt
+++ b/docs/cpp/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=1.7.5
 sphinx_rtd_theme
 breathe
-exhale
+git+http://github.com/svenevs/exhale.git@master#egg=exhale


### PR DESCRIPTION
Docs for [`torch::jit::load`](https://pytorch.org/cppdocs/api/function_namespacetorch_1_1jit_1ace2c44fb8af5905ae17834e81086b8a3.html#exhale-function-namespacetorch-1-1jit-1ace2c44fb8af5905ae17834e81086b8a3) are currently broken. @svenevs has a fix on this branch, and we need to update to it.

Another issue that was mentioned in https://github.com/pytorch/cppdocs/issues/2 by @perone 

@soumith @ezyang 