### PR TITLE
Fix SpectralNorm with DataParallel

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1723,6 +1723,27 @@ class TestNN(NNTestCase):
         self.assertTrue(hasattr(m, 'weight'))
         self.assertTrue('weight' in m._parameters)
 
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_spectral_norm_dp(self):
+        for requires_grad in (True, False):
+            m = nn.Linear(5, 7).to(torch.device('cuda'))
+            m.weight.requires_grad_(requires_grad)
+            m = torch.nn.utils.spectral_norm(m)
+            dpm = torch.nn.DataParallel(m, [0, 1])
+            self.assertTrue(hasattr(m, 'weight_u'))
+            u0 = m.weight_u.clone()
+
+            # assert that u is updated
+            input = torch.randn(2, 5, device=torch.device('cuda'))
+            dpm(input)
+            self.assertNotEqual(u0, m.weight_u)
+
+            # test that eval works
+            dpm.eval()
+            eval_out0 = dpm(input)
+            self.assertEqual(eval_out0, dpm(input))
+
+
     def test_spectral_norm_eval_remove(self):
         inp = torch.randn(3, 5)
         m = nn.Linear(5, 7)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1743,7 +1743,6 @@ class TestNN(NNTestCase):
             eval_out0 = dpm(input)
             self.assertEqual(eval_out0, dpm(input))
 
-
     def test_spectral_norm_eval_remove(self):
         inp = torch.randn(3, 5)
         m = nn.Linear(5, 7)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2383,10 +2383,11 @@ def normalize(input, p=2, dim=1, eps=1e-12, out=None):
         out (Tensor, optional): the output tensor. If :attr:`out` is used, this
                                 operation won't be differentiable.
     """
-    denom = input.norm(p, dim, True).clamp_(min=eps).expand_as(input)
     if out is None:
+        denom = input.norm(p, dim, True).clamp(min=eps).expand_as(input)
         return input / denom
     else:
+        denom = input.norm(p, dim, True).clamp_(min=eps).expand_as(input)
         return torch.div(input, denom, out=out)
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2360,7 +2360,7 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
                                      swap, reduction)
 
 
-def normalize(input, p=2, dim=1, eps=1e-12):
+def normalize(input, p=2, dim=1, eps=1e-12, out=None):
     r"""Performs :math:`L_p` normalization of inputs over specified dimension.
 
     Does:
@@ -2380,8 +2380,14 @@ def normalize(input, p=2, dim=1, eps=1e-12):
         p (float): the exponent value in the norm formulation. Default: 2
         dim (int): the dimension to reduce. Default: 1
         eps (float): small value to avoid division by zero. Default: 1e-12
+        out (Tensor, optional): the output tensor. If :attr:`out` is used, this
+                                operation won't be differentiable.
     """
-    return input / input.norm(p, dim, True).clamp(min=eps).expand_as(input)
+    denom = input.norm(p, dim, True).clamp_(min=eps).expand_as(input)
+    if out is None:
+      return input / denom
+    else:
+      return torch.div(input, denom, out=out)
 
 
 def assert_int_or_pair(arg, arg_name, message):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2385,9 +2385,9 @@ def normalize(input, p=2, dim=1, eps=1e-12, out=None):
     """
     denom = input.norm(p, dim, True).clamp_(min=eps).expand_as(input)
     if out is None:
-      return input / denom
+        return input / denom
     else:
-      return torch.div(input, denom, out=out)
+        return torch.div(input, denom, out=out)
 
 
 def assert_int_or_pair(arg, arg_name, message):

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -17,7 +17,7 @@ class SpectralNorm(object):
         self.n_power_iterations = n_power_iterations
         self.eps = eps
 
-    def compute_weight(self, module):
+    def compute_weight_and_update_u(self, module):
         # NB: This updates the _u vector **in-place**. This is very important
         #     because in DataParallel forward, the _u vector (being a buffer) is
         #     broadcast from the parallelized module to each module replica,
@@ -68,7 +68,7 @@ class SpectralNorm(object):
 
     def __call__(self, module, inputs):
         if module.training:
-            weight = self.compute_weight(module)
+            weight = self.compute_weight_and_update_u(module)
             setattr(module, self.name, weight)
         else:
             r_g = getattr(module, self.name + '_orig').requires_grad

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -72,13 +72,12 @@ class SpectralNorm(object):
             setattr(module, self.name, weight)
         else:
             r_g = getattr(module, self.name + '_orig').requires_grad
-            weight = getattr(module, self.name)
-            if weight.requires_grad != r_g:
-                # NB: Cannot detach weight in-place here because if this is used
-                #     DataParallel, the buffesr are broadcast using
-                #     broadacast_coalesced and `weight` here is actually a view
-                #     and you can't detach views in-place.
-                setattr(module, self.name, weight.detach().requires_grad_(r_g))
+            weight = getattr(module, self.name).detach()
+            # NB: Cannot detach weight in-place here because if this is used
+            #     DataParallel, the bufferr are broadcast using
+            #     `broadacast_coalesced` and `weight` here is actually a view,
+            #     and you can't detach views in-place.
+            setattr(module, self.name, weight.requires_grad_(r_g))
 
     @staticmethod
     def apply(module, name, n_power_iterations, dim, eps):

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -74,7 +74,7 @@ class SpectralNorm(object):
             r_g = getattr(module, self.name + '_orig').requires_grad
             weight = getattr(module, self.name).detach()
             # NB: Cannot detach weight in-place here because if this is used
-            #     DataParallel, the bufferr are broadcast using
+            #     DataParallel, the buffers are broadcast using
             #     `broadacast_coalesced` and `weight` here is actually a view,
             #     and you can't detach views in-place.
             setattr(module, self.name, weight.requires_grad_(r_g))

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -18,6 +18,26 @@ class SpectralNorm(object):
         self.eps = eps
 
     def compute_weight(self, module):
+        # NB: This updates the _u vector **in-place**. This is very important
+        #     because in DataParallel forward, the _u vector (being a buffer) is
+        #     broadcast from the parallelized module to each module replica,
+        #     which is a new module object on the fly. And each replica runs its
+        #     own spectral norm power iteration. So simply assigning the updated
+        #     _u vector to module this runs on will cause the update to be lost
+        #     forever. And the next time the parallelized module is replicated,
+        #     the same randomly initialized _u vector is broadcast!
+        #
+        #     Therefore, to make the change propagate back, we rely on two
+        #     important bahaviors (also enforced via tests):
+        #       1. DataParallel doesn't clone storage if the broadcast tensor is
+        #          alreay on correct device; and it makes sure that the
+        #          parallelized module is already on device[0].
+        #       2. If the out tensor in out= kwarg has correct shape, it will
+        #          just fill in the values.
+        #     Therefore, since the same power iteration is performed on all
+        #     devices, simply updating the _u tensor in-place will make sure
+        #     that the module replica on device[0] will update the _u vector on
+        #     the parallized module (by shared storage).
         weight = getattr(module, self.name + '_orig')
         u = getattr(module, self.name + '_u')
         weight_mat = weight
@@ -33,11 +53,11 @@ class SpectralNorm(object):
                 # are the first left and right singular vectors.
                 # This power iteration produces approximations of `u` and `v`.
                 v = normalize(torch.matmul(weight_mat.t(), u), dim=0, eps=self.eps)
-                u = normalize(torch.matmul(weight_mat, v), dim=0, eps=self.eps)
+                u = normalize(torch.matmul(weight_mat, v), dim=0, eps=self.eps, out=u)
 
         sigma = torch.dot(u, torch.matmul(weight_mat, v))
         weight = weight / sigma
-        return weight, u
+        return weight
 
     def remove(self, module):
         weight = getattr(module, self.name)
@@ -48,12 +68,17 @@ class SpectralNorm(object):
 
     def __call__(self, module, inputs):
         if module.training:
-            weight, u = self.compute_weight(module)
+            weight = self.compute_weight(module)
             setattr(module, self.name, weight)
-            setattr(module, self.name + '_u', u)
         else:
             r_g = getattr(module, self.name + '_orig').requires_grad
-            getattr(module, self.name).detach_().requires_grad_(r_g)
+            weight = getattr(module, self.name)
+            if weight.requires_grad != r_g:
+                # NB: Cannot detach weight in-place here because if this is used
+                #     DataParallel, the buffesr are broadcast using
+                #     broadacast_coalesced and `weight` here is actually a view
+                #     and you can't detach views in-place.
+                setattr(module, self.name, weight.detach().requires_grad_(r_g))
 
     @staticmethod
     def apply(module, name, n_power_iterations, dim, eps):


### PR DESCRIPTION
There were two problems with SN + DP:

1. In SN, the updated _u vector is saved back to module via a `setattr`. However, in DP, everything is run on a replica, so those updates are lost.
2. In DP, the buffers are broadcast via a `broadcast_coalesced`, so on replicas they are all views. Therefore, the `detach_` call won't work.

Fixes are:
1. Update _u vector in-place so, by the shared storage between 1st replica and the parallelized module, the update is retained
2. Do not call `detach_`.
3. Added comments in SN about the subtlety.
4. Added a note to the DP doc on this particular behavior of DP.

cc @crcrpar @taesung89 @t-vi @yaoshengfu

Fixes https://github.com/pytorch/pytorch/issues/11476