### PR TITLE
Fix clang tidy master comparison

### DIFF
--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -2,6 +2,14 @@
 
 set -ex
 
+BASE_BRANCH=master
+# From https://docs.travis-ci.com/user/environment-variables
+if [[ $TRAVIS ]]; then
+  git remote add upstream https://github.com/pytorch/pytorch
+  git fetch upstream "$TRAVIS_BRANCH"
+  BASE_BRANCH="upstream/$TRAVIS_BRANCH"
+fi
+
 if [[ ! -d build ]]; then
   git submodule update --init --recursive
 
@@ -33,7 +41,7 @@ fi
 time python tools/clang_tidy.py    \
   --verbose                        \
   --paths torch/csrc               \
-  --diff master                    \
+  --diff "$BASE_BRANCH"            \
   -g"-torch/csrc/jit/init.cpp"     \
   -g"-torch/csrc/jit/export.cpp"   \
   -g"-torch/csrc/jit/import.cpp"   \


### PR DESCRIPTION
This PR makes the clang-tidy CI get its diff by comparing the current commit against the base branch that the PR is targeting.

@ezyang 