### PR TITLE
Cleanup namespace that were moved to ATen accidentally

### DIFF
--- a/aten/src/ATen/core/interned_strings.cpp
+++ b/aten/src/ATen/core/interned_strings.cpp
@@ -11,7 +11,7 @@
 #include "ATen/core/interned_strings_class.h"
 #include "c10/util/Optional.h"
 
-namespace torch { namespace jit {
+namespace c10 {
 
 Symbol InternedStrings::symbol(const std::string& s) {
   std::lock_guard<std::mutex> guard(mutex_);
@@ -117,4 +117,4 @@ Symbol Symbol::fromDomainAndUnqualString(const std::string & d, const std::strin
   return fromQualString(qualString);
 }
 
-}}
+} // namespace c10

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -8,7 +8,7 @@
 #include <ATen/core/aten_interned_strings.h>
 #include <ATen/core/Macros.h>
 
-namespace torch { namespace jit {
+namespace c10 {
 
 #if !AT_MOBILE
 #define FORALL_NS_SYMBOLS(_)       \
@@ -157,9 +157,8 @@ namespace torch { namespace jit {
 //  1. Symbol namespace is split up into namespaces.
 //
 //  2. The intended access pattern for built-in symbols is onnx::MatMul
-//  in the torch::jit namespace (this is a Symbol).
+//  in the c10 namespace (this is a Symbol).
 //
-
 
 // Built-in constant definition strategy:
 // - Enum is the most convenient way to generate a contiguous sequence
@@ -267,16 +266,16 @@ inline bool Symbol::is_aten() const { return ns() == namespaces::aten; }
 inline bool Symbol::is_prim() const { return ns() == namespaces::prim; }
 inline bool Symbol::is_onnx() const { return ns() == namespaces::onnx; }
 
-}} // namespace torch::jit
+} // namespace c10
 
 // make symbol behave like an integer in hash tables
 namespace std {
-  template<>
-  struct hash<torch::jit::Symbol> {
-    size_t operator()(torch::jit::Symbol s) const {
-      return std::hash<uint32_t>()(static_cast<uint32_t>(s));
-    }
-  };
+template <>
+struct hash<c10::Symbol> {
+  size_t operator()(c10::Symbol s) const {
+    return std::hash<uint32_t>()(static_cast<uint32_t>(s));
+  }
+};
 }
 
 

--- a/aten/src/ATen/core/interned_strings_class.h
+++ b/aten/src/ATen/core/interned_strings_class.h
@@ -9,8 +9,7 @@
 #include "ATen/core/interned_strings.h"
 #include <cstring>
 
-namespace torch {
-namespace jit {
+namespace c10 {
 
 struct CAFFE2_API InternedStrings {
   InternedStrings();
@@ -34,5 +33,4 @@ struct CAFFE2_API InternedStrings {
   std::mutex mutex_;
 };
 
-} // namespace jit
-} // namespace torch
+} // namespace c10

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -2,22 +2,22 @@
 #include <ATen/core/Formatting.h>
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) \
-  _(Tensor) \
-  _(Double) \
-  _(Int) \
-  _(Bool) \
-  _(Tuple) \
-  _(IntList) \
-  _(DoubleList) \
-  _(BoolList) \
-  _(String) \
-  _(TensorList) \
-  _(Blob) \
-  _(GenericList) \
-  _(World) \
+  _(None)                    \
+  _(Tensor)                  \
+  _(Double)                  \
+  _(Int)                     \
+  _(Bool)                    \
+  _(Tuple)                   \
+  _(IntList)                 \
+  _(DoubleList)              \
+  _(BoolList)                \
+  _(String)                  \
+  _(TensorList)              \
+  _(Blob)                    \
+  _(GenericList)             \
+  _(World)
 
-namespace torch { namespace jit {
+namespace c10 {
 
 CAFFE2_API c10::intrusive_ptr<ConstantString> ConstantString::create(
     std::string str_) {
@@ -72,4 +72,4 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
 
 #undef TORCH_FORALL_TAGS
 
-}}
+} // namespace c10

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -9,7 +9,7 @@
 
 #include <type_traits>
 
-namespace torch { namespace jit {
+namespace c10 {
 
 template <typename T>
 using Shared = c10::intrusive_ptr<T>;
@@ -561,5 +561,4 @@ inline const std::vector<IValue>& IValue::toGenericListRef() const {
   return toGenericList()->elements();
 }
 
-
-}}
+} // namespace c10

--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -3,8 +3,7 @@
 // This file is compiled with -O0 because the fully-macro-expanded
 // function is huge and only called once at startup.
 
-namespace torch {
-namespace jit {
+namespace c10 {
 InternedStrings::InternedStrings()
     : sym_to_info_(static_cast<size_t>(_keys::num_symbols)) {
 #define REGISTER_SYMBOL(n, s)        \
@@ -14,5 +13,4 @@ InternedStrings::InternedStrings()
   FORALL_NS_SYMBOLS(REGISTER_SYMBOL)
 #undef REGISTER_SYMBOL
 }
-} // namespace jit
-} // namespace torch
+} // namespace c10

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -1,1 +1,20 @@
 #include <ATen/core/interned_strings.h>
+
+namespace torch {
+namespace jit {
+
+namespace prim {
+using namespace ::c10::prim;
+}
+namespace attr {
+using namespace ::c10::attr;
+}
+namespace aten {
+using namespace ::c10::aten;
+}
+namespace onnx {
+using namespace ::c10::onnx;
+}
+using ::c10::Symbol;
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -8,6 +8,9 @@
 namespace at {
   class Tensor;
 }
+namespace c10 {
+struct IValue;
+}
 namespace torch { namespace jit {
 
 // The interpreter run Graphs with Tensor inputs and Tensor outputs
@@ -20,8 +23,7 @@ struct CodeImpl;
 struct InterpreterStateImpl;
 struct Graph;
 struct Node;
-struct IValue;
-using Stack = std::vector<IValue>;
+using Stack = std::vector<c10::IValue>;
 
 struct TORCH_API Code {
   Code()

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1344,15 +1344,18 @@ inline void Block::destroy() {
 #define IR_IFM_CONST(x,Kind) GENERIC_IF(const,prim::Kind,x,Kind)
 #define IR_ELSEIFM_CONST(Kind) GENERIC_ELSEIF(const,prim::Kind,Kind)
 
-#define IR_IF(x, Kind) \
-  auto && __match_key = x; \
-  switch(__match_key->kind()) { \
-    case ::torch::jit::prim::Kind: { \
-      auto * value = __match_key; (void) value;
-#define IR_ELSEIF(Kind) \
-    } break; \
-    case ::torch::jit::prim::Kind: { \
-      auto * value = __match_key; (void) value;
+#define IR_IF(x, Kind)           \
+  auto&& __match_key = x;        \
+  switch (__match_key->kind()) { \
+    case ::c10::prim::Kind: {    \
+      auto* value = __match_key; \
+      (void)value;
+#define IR_ELSEIF(Kind)        \
+  }                            \
+  break;                       \
+  case ::c10::prim::Kind: {    \
+    auto* value = __match_key; \
+    (void)value;
 
 #define IR_ELSE() GENERIC_ELSE()
 #define IR_END() GENERIC_END()

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -1,1 +1,22 @@
 #include <ATen/core/ivalue.h>
+
+namespace torch {
+namespace jit {
+
+using ::c10::List;
+using ::c10::Shared;
+using ::c10::World;
+
+using ::c10::IValue;
+using ::c10::Tuple;
+
+using ::c10::BoolList;
+using ::c10::DoubleList;
+using ::c10::GenericList;
+using ::c10::IntList;
+using ::c10::TensorList;
+
+using ::c10::ConstantString;
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -33,7 +33,7 @@ public:
   }
 
   static handle cast(torch::jit::IValue src, return_value_policy /* policy */, handle /* parent */) {
-    return toPyObject(std::move(src)).release();
+    return torch::jit::toPyObject(std::move(src)).release();
   }
 };
 


### PR DESCRIPTION
Summary: torch::jit shouldn't live in aten

Differential Revision: D10389502
