### PR TITLE
Enhance shape inference in ONNXIFI transformer

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -20,7 +20,7 @@ class OnnxExporter;
 
 class CAFFE2_API OnnxifiTransformer {
  public:
-  explicit OnnxifiTransformer(bool debug);
+  explicit OnnxifiTransformer(bool infer_shapes, bool debug);
 
   void Transform(
       Workspace* ws,
@@ -49,6 +49,9 @@ class CAFFE2_API OnnxifiTransformer {
       Workspace* ws,
       NetDef* pred_net,
       const std::unordered_map<std::string, TensorShape>& input_shape_hints);
+
+  // Run shape inference
+  bool infer_shapes_{false};
 
   // Dump onnx model for debugging
   bool debug_{false};

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -16,45 +16,32 @@ import caffe2.python._import_c_extension as C
 import numpy as np
 
 
-def _infer_shapes(pred_net, inputs):
-    workspace.RunNetOnce(pred_net)
-    hints = {}
-    for op in pred_net.op:
-        for o in op.output:
-            if o not in hints:
-                blob = workspace.FetchBlob(o)
-                if hasattr(blob, 'shape'):
-                    hints[o] = blob.shape
-        for i in op.input:
-            if i not in hints:
-                blob = workspace.FetchBlob(i)
-                if hasattr(blob, 'shape'):
-                    hints[i] = blob.shape
-
-    return hints
-
-
 def onnxifi_caffe2_net(
         pred_net,
         input_shapes,
-        populate_shapes=False,
+        infer_shapes=False,
         debug=False):
     """
     Transfrom the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
-    # Hacky way to infer shapes as not all our operators have shape inference function.
-    # Normally this is not needed
+    # Inject an fake input tensor to help popluate the shape if we
+    # do not do shape inference
     shape_hints = {}
-    if populate_shapes:
-        input_data = {}
+    if not infer_shapes:
         for k, v in input_shapes.items():
-            input_data[k] = np.random.randn(*v).astype(np.float32)
-        shape_hints = _infer_shapes(pred_net, input_data)
+            need_input_tensor = True
+            if workspace.HasBlob(k):
+                itensor = workspace.FetchBlob(k)
+                if itensor.shape == v:
+                    need_input_tensor = False
+            if need_input_tensor:
+                workspace.FeedBlob(k, np.random.randn(*v).astype(np.float32))
 
     for k, v in input_shapes.items():
         shape_hints[k] = v
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
                              shape_hints,
+                             infer_shapes,
                              debug)
     pred_net_cut = caffe2_pb2.NetDef()
     pred_net_cut.ParseFromString(pred_net_str)

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -212,7 +212,8 @@ class OnnxifiTransformTest(TestCase):
         # Cut the graph
         start = time.time()
         pred_net_cut = onnxifi_caffe2_net(pred_net,
-                                          {input_name: input_blob_dims})
+                                          {input_name: input_blob_dims},
+                                          infer_shapes=True)
         del init_net, pred_net
         #_print_net(pred_net_cut)
 

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1673,6 +1673,7 @@ void addGlobalMethods(py::module& m) {
       "onnxifi",
       [](const py::bytes& pred_net_str,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
+         bool infer_shapes,
          bool debug_builder) -> py::bytes {
         caffe2::NetDef pred_net;
         CAFFE_ENFORCE(
@@ -1684,7 +1685,7 @@ void addGlobalMethods(py::module& m) {
           tensor_shapes.emplace(
               it.first, CreateTensorShape(it.second, TensorProto::FLOAT));
         }
-        OnnxifiTransformer ts(debug_builder);
+        OnnxifiTransformer ts(infer_shapes, debug_builder);
         ts.Transform(GetCurrentWorkspace(), &pred_net, tensor_shapes);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);


### PR DESCRIPTION
Summary:
In this diff, we push the fake run of the net into the ONNXIFI transformer, because
1. We cannot do shape inference for every op
2. Since the net has been SSA rewritten, we cannot use shape info from outer workspace directly.

In addition, this diff adds input shape info when querying the `onnxBackendCompatibility` function.

Differential Revision: D10390164
