### PR TITLE
Remove Type.tensor, Type.native_tensor.

### DIFF
--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -134,22 +134,6 @@ Tensor& addmm_(Tensor& self, const Tensor& mat1, const Tensor& mat2, Scalar beta
   }
 }
 
-Tensor tensor(const Type& dtype) {
-  if (_type_has_native(dtype)) {
-    return at::getType(dtype.options()).native_tensor({0}, dtype.options());
-  } else {
-    return at::getType(dtype.options()).th_tensor();
-  }
-}
-
-Tensor tensor(const Type& dtype, ArrayRef<int64_t> size) {
-  if (_type_has_native(dtype)) {
-    return at::getType(dtype.options()).native_tensor(size, dtype.options());
-  } else {
-    return at::getType(dtype.options()).th_tensor(size);
-  }
-}
-
 Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values) {
   return at::getType(values.options().layout(at::kSparse)).native_sparse_coo_tensor(indices, values);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1925,16 +1925,6 @@
 - func: addmm_(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: method
 
-- func: native_tensor(IntList size, TensorOptions options) -> Tensor
-  variants: []
-  dispatch:
-    SparseCPU: new_with_size_sparse
-    SparseCUDA: new_with_size_sparse
-
-- func: tensor(IntList size, TensorOptions options) -> Tensor
-  variants: []
-
-
 # NB: I have to decompose sparse_coo_tensor into two functions, because
 # it has custom dispatch logic for which Type to dispatch on (we must
 # use the sparse equivalent of the type of the SECOND argument).

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -18,8 +18,11 @@ namespace at {
 
 Tensor & TypeDefault::copy_(Tensor & self, const Tensor & src, bool non_blocking) const {
   Tensor b_src;
-  if (is_sparse()) b_src = src;
-  else std::tie(b_src) = expand_inplace(self, src, "copy");
+  if (is_sparse()) {
+    b_src = src;
+  } else {
+    std::tie(b_src) = expand_inplace(self, src, "copy");
+  }
   return s_copy_(self, b_src, non_blocking);
 }
 
@@ -30,8 +33,11 @@ Tensor TypeDefault::copy(const Tensor & src, bool non_blocking, optional<Device>
   }
   AT_CHECK(src.defined(), "attempt to copy an undefined tensor");
   Tensor r;
-  if (is_sparse()) r = this->native_tensor({0}, this->options());
-  else r = at::empty(src.sizes(), this->options());
+  if (is_sparse()) {
+    r = at::empty({0}, this->options());
+  } else {
+    r = at::empty(src.sizes(), this->options());
+  }
   r.copy_(src, non_blocking);
   return r;
 }


### PR DESCRIPTION
They aren't needed anymore now that at::empty can handle all backends.

