### PR TITLE
Check dim size preventively when doing shape inference for BatchMatMul

### DIFF
--- a/caffe2/operators/batch_matmul_op.cc
+++ b/caffe2/operators/batch_matmul_op.cc
@@ -13,6 +13,7 @@ vector<TensorShape> TensorInferenceForBatchMatMul(
   if (!broadcast) {
     const auto ndim = in[0].dims_size();
     CAFFE_ENFORCE_GE(ndim, 2);
+    CAFFE_ENFORCE_GE(in[1].dims_size(), 2);
     int a_dim0;
     int b_dim1;
     if (helper.GetSingleArgument<int>("trans_a", 0)) {


### PR DESCRIPTION
Summary: We check input(0) but not input(1) in BatchMatMul. This may result in a protobuf exception which won't be caught by upstream and causing termination of the program. Check that with `CAFFE_ENFORCE` will be caught by upstream inference function. Plus, it will print out clean stack tracing showing where went wrong.

Reviewed By: houseroad

Differential Revision: D10391130
