### PR TITLE
Simplify InheritOnnxSchema registration

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -163,6 +163,13 @@ class CAFFE2_API OpSchema {
   OpSchema& InheritOnnxSchema(const std::string& onnx_schema_name);
 
   /**
+   * @brief Shortcut to InheritOnnxSchema(type_)
+   */
+  OpSchema& InheritOnnxSchema() {
+    return InheritOnnxSchema(type_);
+  }
+
+  /**
    * @brief Sets the tensor inference function to produce the same output as
    * the input.
    */

--- a/caffe2/operators/abs_op.cc
+++ b/caffe2/operators/abs_op.cc
@@ -84,7 +84,7 @@ Y: [0.3005476  1.551666   1.3591481  0.39191285 0.21866608]
         0,
         "Y",
         "*(type: Tensor`<float>`)* Absolute value of input element-wise.")
-    .InheritOnnxSchema("Abs");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(AbsGradient).NumInputs(2).NumOutputs(1).IdenticalTypeAndShape();
 

--- a/caffe2/operators/batch_matmul_op.cc
+++ b/caffe2/operators/batch_matmul_op.cc
@@ -142,7 +142,7 @@ two diemnsional, it behaves like normal matrix multiplication.
     .TensorInferenceFunction(TensorInferenceForBatchMatMul)
     .CostInferenceFunction(
         OpSchema::CostInferenceFunctionType(CostInferenceForBatchMatMul))
-    .InheritOnnxSchema("BatchMatMul");
+    .InheritOnnxSchema();
 
 class GetBatchMatMulGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/cast_op.cc
+++ b/caffe2/operators/cast_op.cc
@@ -178,7 +178,7 @@ Y: [[9 5 0]
         "Y",
         "*(type: Tensor`<'to' type>`)* Output tensor with the same shape as "
         "input with type specified by the `to` argument.")
-    .InheritOnnxSchema("Cast");
+    .InheritOnnxSchema();
 
 // Some Casts are compatible with gradients, but for now we don't support it
 // GRADIENT_NOT_IMPLEMENTED_YET(Cast);

--- a/caffe2/operators/channel_shuffle_op.cc
+++ b/caffe2/operators/channel_shuffle_op.cc
@@ -142,7 +142,7 @@ OPERATOR_SCHEMA(ChannelShuffle)
     .IdenticalTypeAndShape()
     .NumInputs(1)
     .NumOutputs(1)
-    .InheritOnnxSchema("ChannelShuffle");
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(ChannelShuffleGradient)
     .IdenticalTypeAndShape()
     .NumInputs(1)

--- a/caffe2/operators/clip_op.cc
+++ b/caffe2/operators/clip_op.cc
@@ -94,10 +94,14 @@ Y: [[45. 20. 59. 60. 48.]
 </details>
 
 )DOC")
-    .Arg("min", "*(type: float)* Minimum value, under which element is "
-    "replaced by min (default=*numeric_limits::lowest()*).")
-    .Arg("max", "*(type: float)* Maximum value, under which element is "
-    "replaced by max (default=*numeric_limits::max()*).")
+    .Arg(
+        "min",
+        "*(type: float)* Minimum value, under which element is "
+        "replaced by min (default=*numeric_limits::lowest()*).")
+    .Arg(
+        "max",
+        "*(type: float)* Maximum value, under which element is "
+        "replaced by max (default=*numeric_limits::max()*).")
     .Input(
         0,
         "X",
@@ -107,7 +111,7 @@ Y: [[45. 20. 59. 60. 48.]
         0,
         "Y",
         "*(Tensor`<float>`)* Output tensor clipped within range [`min`, `max`].")
-    .InheritOnnxSchema("Clip");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(ClipGradient).NumInputs(2).NumOutputs(1).AllowInplace({{1, 0}});
 

--- a/caffe2/operators/concat_split_op.cc
+++ b/caffe2/operators/concat_split_op.cc
@@ -24,11 +24,16 @@ OPERATOR_SCHEMA(Split)
     .NumInputs(1, 2)
     .NumOutputs(1, INT_MAX)
     .Input(0, "input", "(*Tensor*): tensor to split")
-    .Input(1, "split", "(*Tensor`<int>`*): [OPTIONAL] list of output lengths (see also arg `split`)")
+    .Input(
+        1,
+        "split",
+        "(*Tensor`<int>`*): [OPTIONAL] list of output lengths (see also arg `split`)")
     .Arg("axis", "(*int*): axis to split on")
     .Arg("split", "(*Tuple(int)*): length of each output")
-    .Arg("order", "(*string*): order of dimensions of input and output blobs; either \"NCHW\" or \"NHWC\"")
-    .Output(0,"[output_0, output_1, ...]","(*Tensor*): output tensor")
+    .Arg(
+        "order",
+        "(*string*): order of dimensions of input and output blobs; either \"NCHW\" or \"NHWC\"")
+    .Output(0, "[output_0, output_1, ...]", "(*Tensor*): output tensor")
     .DeviceInferenceFunction(splitOpDevInfer)
     .SetDoc(R"DOC(
 Split an `input` tensor into a list of tensors, along the axis specified by the `axis` dimension. The lengths of the split can be specified using argument `split` or optional second input blob to the operator. Otherwise, the tensor is split to equal sized parts.
@@ -77,7 +82,7 @@ output_2: [0 5 7 4]
 </details>
 
 )DOC")
-    .InheritOnnxSchema("Split");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(SplitByLengths)
     .NumInputs(2)
@@ -163,9 +168,11 @@ OPERATOR_SCHEMA(Concat)
     .Arg(
         "add_axis",
         "*(type: int)* Pass non-zero integer to add the axis specified in `axis` to all input tensors.")
-    .TensorInferenceFunction(OpSchema::NeedsAllInputShapes(
-      [](const OperatorDef& def,
-         const vector<TensorShape>& in) {
+    .TensorInferenceFunction(OpSchema::NeedsAllInputShapes([](const OperatorDef&
+                                                                  def,
+                                                              const vector<
+                                                                  TensorShape>&
+                                                                  in) {
       ArgumentHelper helper(def);
       const int axis = helper.HasArgument("axis")
           ? helper.GetSingleArgument<int>("axis", -1)
@@ -357,9 +364,15 @@ split_info: [1 1]
 
     )DOC")
     .Input(0, "X1, X2, ...", "*(type: Tensor`<float>`)* List of input tensors.")
-    .Output(0, "concat_result", "*(type: Tensor`<float>`)* Concatenated tensor.")
-    .Output(1, "split_info", "*(type: Tensor`<int>`)* The dimensions of the inputs.")
-    .InheritOnnxSchema("Concat");
+    .Output(
+        0,
+        "concat_result",
+        "*(type: Tensor`<float>`)* Concatenated tensor.")
+    .Output(
+        1,
+        "split_info",
+        "*(type: Tensor`<int>`)* The dimensions of the inputs.")
+    .InheritOnnxSchema();
 
 // Backward compatibility names.
 REGISTER_CPU_OPERATOR(DepthSplit, SplitOp<CPUContext>);

--- a/caffe2/operators/conv_op.cc
+++ b/caffe2/operators/conv_op.cc
@@ -173,7 +173,7 @@ OPERATOR_SCHEMA(Conv)
     .CostInferenceFunction(OpSchema::CostInferenceFunctionType(
         ConvPoolOpBase<CPUContext>::CostInferenceForConv))
     .FillUsing(ConvDocGenerator(""))
-    .InheritOnnxSchema("Conv");
+    .InheritOnnxSchema();
 
 REGISTER_CPU_OPERATOR(Conv1D, ConvOp<float, CPUContext>);
 

--- a/caffe2/operators/conv_transpose_op.cc
+++ b/caffe2/operators/conv_transpose_op.cc
@@ -115,18 +115,12 @@ Y:
     .Arg(
         "pads",
         "*(type: [int]; default: [])* Controls the amount of padding applied to the input feature map before computation.")
-    .Arg(
-        "adjs",
-        "*(type: [int]; default: [])*")
+    .Arg("adjs", "*(type: [int]; default: [])*")
     .Arg(
         "order",
         "*(type: string; default: \"NCHW\")* Specifies the order of the input data blob, where $N$ is batch size, $C$ is number of channels, $H$ is spatial height, and $W$ is spatial width. The only other valid option is \"NHWC\".")
-    .Arg(
-        "shared_buffer",
-        "*(type: int; default: 0)*")
-    .Arg(
-        "no_bias",
-        "*(type: bool; default: False)* ")
-    .InheritOnnxSchema("ConvTranspose");
+    .Arg("shared_buffer", "*(type: int; default: 0)*")
+    .Arg("no_bias", "*(type: bool; default: False)* ")
+    .InheritOnnxSchema();
 
 } // namespace caffe2

--- a/caffe2/operators/cosh_op.cc
+++ b/caffe2/operators/cosh_op.cc
@@ -88,7 +88,7 @@ Y: [1.22883528 1.05188156 1.35112322 1.43744212 1.07812598]
         "output",
         "The hyperbolic cosine values of the input tensor, computed "
         "element-wise")
-    .InheritOnnxSchema("Cosh");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(CoshGradient)
     .NumInputs(2)

--- a/caffe2/operators/ctc_beam_search_decoder_op.cc
+++ b/caffe2/operators/ctc_beam_search_decoder_op.cc
@@ -164,7 +164,7 @@ OPERATOR_SCHEMA(CTCBeamSearchDecoder)
         "VALUES",
         "Values vector, size (total_decoded_outputs). "
         "The flattened vector of final output sequences, in batch order.")
-    .InheritOnnxSchema("CTCBeamSearchDecoder");
+    .InheritOnnxSchema();
 SHOULD_NOT_DO_GRADIENT(CTCBeamSearchDecoder);
 
 } // namespace caffe2

--- a/caffe2/operators/ctc_greedy_decoder_op.cc
+++ b/caffe2/operators/ctc_greedy_decoder_op.cc
@@ -92,7 +92,7 @@ OPERATOR_SCHEMA(CTCGreedyDecoder)
         "VALUES",
         "Values vector, size (total_decoded_outputs). "
         "The vector stores the decoded classes")
-    .InheritOnnxSchema("CTCGreedyDecoder");
+    .InheritOnnxSchema();
 SHOULD_NOT_DO_GRADIENT(CTCGreedyDecoder);
 
 } // namespace caffe2

--- a/caffe2/operators/distance_op.cc
+++ b/caffe2/operators/distance_op.cc
@@ -598,7 +598,7 @@ Z:
     .TensorInferenceFunction(TensorInferenceForDotProduct)
     .CostInferenceFunction(
         OpSchema::CostInferenceFunctionType(CostInferenceForDotProduct))
-    .InheritOnnxSchema("DotProduct");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(DotProductGradient).NumInputs(3).NumOutputs(2);
 

--- a/caffe2/operators/dropout_op.cc
+++ b/caffe2/operators/dropout_op.cc
@@ -158,7 +158,7 @@ mask: [[False False False  True  True]
         "*(type: Tensor`<bool>`)* The output mask containing boolean values for"
         "each element, signifying which elements are dropped out. If `is_test` is"
         "nonzero, this output is not filled.")
-    .InheritOnnxSchema("Dropout");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(DropoutGrad)
     .NumInputs(1, 2)

--- a/caffe2/operators/elementwise_ops_schema.cc
+++ b/caffe2/operators/elementwise_ops_schema.cc
@@ -274,7 +274,7 @@ OPERATOR_SCHEMA(Add)
     .CostInferenceFunction(PointwiseCostInference<1>)
     .TensorInferenceFunction(ElementwiseOpShapeInference)
     .FillUsing(MathDocGenerator("addition", kAddExample))
-    .InheritOnnxSchema("Add");
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(AddGradient)
     .NumInputs(3)
     .NumOutputs(2)
@@ -287,7 +287,7 @@ OPERATOR_SCHEMA(Sub)
     .CostInferenceFunction(PointwiseCostInference<1>)
     .TensorInferenceFunction(ElementwiseOpShapeInference)
     .FillUsing(MathDocGenerator("subtraction", kSubExample))
-    .InheritOnnxSchema("Sub");
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(SubGradient)
     .NumInputs(3)
     .NumOutputs(2)
@@ -300,7 +300,7 @@ OPERATOR_SCHEMA(Mul)
     .CostInferenceFunction(PointwiseCostInference<1>)
     .TensorInferenceFunction(ElementwiseOpShapeInference)
     .FillUsing(MathDocGenerator("multiplication", kMulExample))
-    .InheritOnnxSchema("Mul");
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(MulGradient)
     .NumInputs(3)
     .NumOutputs(2)
@@ -313,7 +313,7 @@ OPERATOR_SCHEMA(Div)
     .CostInferenceFunction(PointwiseCostInference<1>)
     .TensorInferenceFunction(ElementwiseOpShapeInference)
     .FillUsing(MathDocGenerator("division", kDivExample))
-    .InheritOnnxSchema("Div");
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(DivGradient)
     .NumInputs(3, 4)
     .NumOutputs(2)
@@ -927,7 +927,7 @@ Y:
     )DOC")
     .Input(0, "X", "*(Tensor`<bool>`)* Input tensor.")
     .Output(0, "Y", "*(Tensor`<bool>`)* Negated output tensor.")
-    .InheritOnnxSchema("Not");
+    .InheritOnnxSchema();
 SHOULD_NOT_DO_GRADIENT(Not);
 
 OPERATOR_SCHEMA(Sign)

--- a/caffe2/operators/elementwise_sum_op.cc
+++ b/caffe2/operators/elementwise_sum_op.cc
@@ -114,8 +114,14 @@ A after Sum: [[10.  7. 11.]
 </details>
 
 )DOC")
-    .Input(0, "A", "*(type: Tensor`<float>`)* First tensor to be added element-wise.")
-    .Input(1, "B", "*(type: Tensor`<float>`)* Second tensor to be added element-wise.")
+    .Input(
+        0,
+        "A",
+        "*(type: Tensor`<float>`)* First tensor to be added element-wise.")
+    .Input(
+        1,
+        "B",
+        "*(type: Tensor`<float>`)* Second tensor to be added element-wise.")
     .Output(0, "C", "*(type: Tensor`<float>`)* Sum of A and B.")
-    .InheritOnnxSchema("Sum");
+    .InheritOnnxSchema();
 }

--- a/caffe2/operators/elu_op.cc
+++ b/caffe2/operators/elu_op.cc
@@ -113,7 +113,7 @@ Y:
     .Arg(
         "alpha",
         "*(type: float; default: 1.0)* Defines alpha parameter used in calculation.")
-    .InheritOnnxSchema("Elu");
+    .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(EluGradient)

--- a/caffe2/operators/exp_op.cc
+++ b/caffe2/operators/exp_op.cc
@@ -69,7 +69,7 @@ X after running op:
         "Y",
         "*(type: Tensor`<float>`)* The exponential of the input tensor computed "
         "element-wise.")
-    .InheritOnnxSchema("Exp");
+    .InheritOnnxSchema();
 
 namespace {
 

--- a/caffe2/operators/expand_squeeze_dims_op.cc
+++ b/caffe2/operators/expand_squeeze_dims_op.cc
@@ -99,7 +99,7 @@ expanded.shape: (1, 1, 100, 100)
     .Arg(
         "dims",
         "*(type: [int])* List of dimensions of *data* to add single dimensional entry.")
-    .InheritOnnxSchema("ExpandDims");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(Squeeze)
     .NumInputs(1)
@@ -172,7 +172,7 @@ squeezed.shape: (100, 100)
       out[0] = CreateTensorShape(newDims, in[0].data_type());
       return out;
     })
-    .InheritOnnxSchema("Squeeze");
+    .InheritOnnxSchema();
 
 class GetSqueezeGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/flatten_op.cc
+++ b/caffe2/operators/flatten_op.cc
@@ -77,10 +77,7 @@ Y: [[0.53432311 0.23734561 0.56481598 0.52152617 0.33662627 0.32472711
 </details>
 
 )DOC")
-    .Input(
-        0,
-        "X",
-        "*(type: Tensor)* Input Tensor of rank >= axis.")
+    .Input(0, "X", "*(type: Tensor)* Input Tensor of rank >= axis.")
     .Output(
         0,
         "Y",
@@ -92,7 +89,7 @@ Y: [[0.53432311 0.23734561 0.56481598 0.52152617 0.33662627 0.32472711
         "axis",
         "*(type: int; default: 1)* Indicates up to which input dimensions "
         "(exclusive) should be flattened to the outer dimension of the output.")
-    .InheritOnnxSchema("Flatten");
+    .InheritOnnxSchema();
 
 class GetFlattenGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/fully_connected_op.cc
+++ b/caffe2/operators/fully_connected_op.cc
@@ -155,7 +155,7 @@ OPERATOR_SCHEMA(FCTransposed)
 Same as FC, but weight matrix is supposed to be already pretransposed.
 FCTransposed stands for calling blass with no noTrans, noTrans
 )DOC")
-    .InheritOnnxSchema("FCTransposed");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(FC)
     .NumInputs(3)

--- a/caffe2/operators/hard_sigmoid_op.cc
+++ b/caffe2/operators/hard_sigmoid_op.cc
@@ -121,7 +121,7 @@ hard_sigmoid: [ 0.81488073,  0.56326419,  0.85684538,  0.78901446,  0.06546044]
     .Arg("beta", "float: the bias value of the function. Defaults to 0.5")
     .Input(0, "X", "1D input tensor")
     .Output(0, "Y", "1D output tensor with same shape as input")
-    .InheritOnnxSchema("HardSigmoid");
+    .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(HardSigmoidGradient)

--- a/caffe2/operators/leaky_relu_op.cc
+++ b/caffe2/operators/leaky_relu_op.cc
@@ -110,7 +110,7 @@ OPERATOR_SCHEMA(LeakyReluGradient)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})
     .Arg("alpha", "Coefficient of leakage")
-    .InheritOnnxSchema("LeakyRelu");
+    .InheritOnnxSchema();
 
 class GetLeakyReluGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
@@ -33,7 +33,7 @@ stores quantized values, and then 4-byte scale and 4-byte bias).
         "LENGTHS",
         "Vector with the same sum of elements as the first dimension of DATA")
     .Output(0, "output", "output")
-    .InheritOnnxSchema("SparseLengthsSumFused8BitRowwise");
+    .InheritOnnxSchema();
 NO_GRADIENT(SparseLengthsSumFused8BitRowwise);
 
 REGISTER_CPU_OPERATOR(

--- a/caffe2/operators/lengths_reducer_ops.cc
+++ b/caffe2/operators/lengths_reducer_ops.cc
@@ -80,7 +80,7 @@ OPERATOR_SCHEMA(SparseLengthsSum)
     .SetDoc(FormatDoc<SparseLengthsSumDef>())
     .Output(0, "OUTPUT", "Aggregated tensor")
     .FillUsing(SparseLengthsSumDef::PopulateSchema)
-    .InheritOnnxSchema("SparseLengthsSum");
+    .InheritOnnxSchema();
 REGISTER_CPU_OPERATOR(
     SparseLengthsSumGradient,
     SparseLengthsSumDef::BackwardOp);

--- a/caffe2/operators/local_response_normalization_op.cc
+++ b/caffe2/operators/local_response_normalization_op.cc
@@ -301,13 +301,13 @@ REGISTER_CPU_OPERATOR(LRN, LRNOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(LRNGradient, LRNGradientOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(LRN)
-  .NumInputs(1)
-  .NumOutputs(1, 2)
-  .SetDoc(R"DOC(
+    .NumInputs(1)
+    .NumOutputs(1, 2)
+    .SetDoc(R"DOC(
 
 `LRN` applies Local Response Normalization to an input blob. This operation performs
-a kind of "lateral inhibition" by normalizing over local input regions, where 
-normalization is applied across channels. This operator is typically used to 
+a kind of "lateral inhibition" by normalizing over local input regions, where
+normalization is applied across channels. This operator is typically used to
 normalize an unbounded activation (such as ReLU). The output shape is the same as
 the input shape. The `brew` module has a wrapper for this operator for use in a
 `ModelHelper` object.
@@ -393,7 +393,7 @@ X:
    [ 0.45961624]
    [-1.0201577 ]
    [ 0.62854475]
-   [-0.6395456 ]]]] 
+   [-0.6395456 ]]]]
 
 Y:
  [[[[ 0.5160766 ]
@@ -484,15 +484,19 @@ Y_scale:
 </details>
 
 )DOC")
-  .Arg("size", "*(type: int; default: 0)* Amount of neighboring channels to sum over for normalization")
-  .Arg("alpha", "*(type: float; default: 0)* Multiplicative (scaling) factor.")
-  .Arg("beta", "*(type: float; default: 0)* Exponent.")
-  .Arg("bias", "*(type: float; default: 1.0)* Additive factor.")
-  .Arg("order", "*(type: float; default: 'NCHW')* Order of blob dimensions.")
-  .Input(0, "X", "*(type: Tensor`<float>`)* Input data tensor (ReLU output).")
-  .Output(0, "Y", "*(type: Tensor`<float>`)* Output tensor.")
-  .Output(1, "Y_scale", "*(type: Tensor`<float>`)* Output scale.") 
-  .InheritOnnxSchema("LRN");
+    .Arg(
+        "size",
+        "*(type: int; default: 0)* Amount of neighboring channels to sum over for normalization")
+    .Arg(
+        "alpha",
+        "*(type: float; default: 0)* Multiplicative (scaling) factor.")
+    .Arg("beta", "*(type: float; default: 0)* Exponent.")
+    .Arg("bias", "*(type: float; default: 1.0)* Additive factor.")
+    .Arg("order", "*(type: float; default: 'NCHW')* Order of blob dimensions.")
+    .Input(0, "X", "*(type: Tensor`<float>`)* Input data tensor (ReLU output).")
+    .Output(0, "Y", "*(type: Tensor`<float>`)* Output tensor.")
+    .Output(1, "Y_scale", "*(type: Tensor`<float>`)* Output scale.")
+    .InheritOnnxSchema();
 OPERATOR_SCHEMA(LRNGradient).NumInputs(3).NumOutputs(1);
 
 class GetLRNGradient : public GradientMakerBase {

--- a/caffe2/operators/log_op.cc
+++ b/caffe2/operators/log_op.cc
@@ -68,7 +68,7 @@ X after running op:
         0,
         "Y",
         "*(type: Tensor`<float>`)* Output tensor computed as the natural log of the input tensor computed, element-wise.")
-    .InheritOnnxSchema("Log");
+    .InheritOnnxSchema();
 
 namespace {
 

--- a/caffe2/operators/minmax_ops.cc
+++ b/caffe2/operators/minmax_ops.cc
@@ -73,10 +73,16 @@ Max:
 </details>
 
 )DOC")
-    .Input(0, "X, Y, ...", "*(type: Tensor`<Ord>`)* List of input tensors with the same shape.")
-    .Output(0, "M", "*(type: Tensor`<Ord>`)* Output tensor with same dimensions as input(s)."
-    "Contains the maximum valued element at each location.")
-    .InheritOnnxSchema("Max");
+    .Input(
+        0,
+        "X, Y, ...",
+        "*(type: Tensor`<Ord>`)* List of input tensors with the same shape.")
+    .Output(
+        0,
+        "M",
+        "*(type: Tensor`<Ord>`)* Output tensor with same dimensions as input(s)."
+        "Contains the maximum valued element at each location.")
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(Min)
     .NumInputs(1, INT_MAX)
@@ -138,10 +144,16 @@ Min:
 </details>
 
 )DOC")
-    .Input(0, "X, Y, ...", "*(type: Tensor`<Ord>`)* List of input tensors with the same shape.")
-    .Output(0, "M", "*(type: Tensor`<Ord>`)* Output tensor with same dimensions as input(s)."
-"Contains the minimum valued element at each location.")
-    .InheritOnnxSchema("Min");
+    .Input(
+        0,
+        "X, Y, ...",
+        "*(type: Tensor`<Ord>`)* List of input tensors with the same shape.")
+    .Output(
+        0,
+        "M",
+        "*(type: Tensor`<Ord>`)* Output tensor with same dimensions as input(s)."
+        "Contains the minimum valued element at each location.")
+    .InheritOnnxSchema();
 
 template <typename T, class Context>
 bool MaxOp<T, Context>::Compute() {

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -922,7 +922,7 @@ OPERATOR_SCHEMA(AveragePool)
     .NumOutputs(1)
     .TensorInferenceFunction(ConvPoolOpBase<CPUContext>::TensorInferenceForPool)
     .FillUsing(AveragePoolDocGenerator(""))
-    .InheritOnnxSchema("AveragePool");
+    .InheritOnnxSchema();
 
 REGISTER_CPU_OPERATOR(
     AveragePool1D,
@@ -964,7 +964,7 @@ OPERATOR_SCHEMA(MaxPool)
     .NumOutputs(1)
     .TensorInferenceFunction(ConvPoolOpBase<CPUContext>::TensorInferenceForPool)
     .FillUsing(MaxPoolDocGenerator(""))
-    .InheritOnnxSchema("MaxPool");
+    .InheritOnnxSchema();
 
 REGISTER_CPU_OPERATOR(MaxPool1D, PoolOp<float, CPUContext, MaxPool<float>>);
 

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -332,7 +332,7 @@ Y:
         "Slope",
         "1D input slope tensor. If `Slope` is of size 1, the value is shared across different channels")
     .Output(0, "Y", "Output tensor, with same shape as $X$.")
-    .InheritOnnxSchema("PRelu");
+    .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(PReluGradient).NumInputs(4).NumOutputs(2).SetDoc(R"DOC(

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -137,7 +137,7 @@ Y:
 )DOC")
     .Input(0, "X", "1D input tensor")
     .Output(0, "Y", "1D output tensor with same shape as input")
-    .InheritOnnxSchema("Relu");
+    .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(ReluGradient)

--- a/caffe2/operators/reshape_op.cc
+++ b/caffe2/operators/reshape_op.cc
@@ -157,25 +157,21 @@ old_shape: [6]
 </details>
 
 )DOC")
-    .Arg("shape", "*(type: Tuple(int))* New shape. Do not set if using "
-    "`new_shape` input.")
-    .Input(
-        0,
-        "data",
-        "*(type: Tensor)* Input tensor.")
+    .Arg(
+        "shape",
+        "*(type: Tuple(int))* New shape. Do not set if using "
+        "`new_shape` input.")
+    .Input(0, "data", "*(type: Tensor)* Input tensor.")
     .Input(
         1,
         "new_shape",
         "*(type: Tensor`<int>`)* [OPTIONAL] Tensor containing new shape.")
-    .Output(
-        0,
-        "reshaped",
-        "*(type: Tensor)* Reshaped output tensor.")
+    .Output(0, "reshaped", "*(type: Tensor)* Reshaped output tensor.")
     .Output(
         1,
         "old_shape",
         "*(type: Tensor`<int>`)* Tensor containing old shape of `data`.")
-    .InheritOnnxSchema("Reshape");
+    .InheritOnnxSchema();
 
 class GetReshapeGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/selu_op.cc
+++ b/caffe2/operators/selu_op.cc
@@ -101,11 +101,15 @@ Y:
 </details>
 
 )DOC")
-    .Arg("alpha", "*(type: float; default: 1.673263~)* Alpha constant in equation.")
-    .Arg("scale", "*(type: float; default: 1.050700~; must be > 1.0)* Scale constant in equation.")
+    .Arg(
+        "alpha",
+        "*(type: float; default: 1.673263~)* Alpha constant in equation.")
+    .Arg(
+        "scale",
+        "*(type: float; default: 1.050700~; must be > 1.0)* Scale constant in equation.")
     .Input(0, "X", "Input tensor of data to be operated on.")
     .Output(0, "Y", "Output tensor with same shape as input.")
-    .InheritOnnxSchema("Selu");
+    .InheritOnnxSchema();
 
 // Input: Y, dY; output: dX
 OPERATOR_SCHEMA(SeluGradient)

--- a/caffe2/operators/sigmoid_op.cc
+++ b/caffe2/operators/sigmoid_op.cc
@@ -76,7 +76,7 @@ sigmoid: [0.8284105  0.57842743 0.85621804 0.80923885 0.10222916]
 )DOC")
     .Input(0, "X", "*(type: Tensor`<float>`)* Input tensor.")
     .Output(0, "Y", "*(type: Tensor`<float>`)* Output tensor.")
-    .InheritOnnxSchema("Sigmoid");
+    .InheritOnnxSchema();
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(SigmoidGradient)
     .NumInputs(2)

--- a/caffe2/operators/sinh_op.cc
+++ b/caffe2/operators/sinh_op.cc
@@ -88,7 +88,7 @@ Y: [1.15841695 0.5541099  0.03216984 1.09924557 0.49732079]
         "output",
         "The hyperbolic sine values of the input tensor, computed "
         "element-wise")
-    .InheritOnnxSchema("Sinh");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(SinhGradient)
     .NumInputs(2)

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -110,7 +110,7 @@ Y:
           CreateTensorShape(dst_sizes, data.data_type())};
     })
     .Output(0, "Y", "(*Tensor*): sliced output tensor")
-    .InheritOnnxSchema("Slice");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(SliceGradient);
 

--- a/caffe2/operators/softmax_op.cc
+++ b/caffe2/operators/softmax_op.cc
@@ -160,7 +160,7 @@ softmax: [[0.24422921 0.43525138 0.18582782 0.12303016 0.01166145]]
         0,
         "Y",
         "*(type: Tensor`<float>`)* The softmax normalized output tensor with the same shape as input tensor.")
-    .InheritOnnxSchema("Softmax");
+    .InheritOnnxSchema();
 
 // Input: Y, dY. Output: dX
 OPERATOR_SCHEMA(SoftmaxGradient).NumInputs(2).NumOutputs(1);

--- a/caffe2/operators/softplus_op.cc
+++ b/caffe2/operators/softplus_op.cc
@@ -99,7 +99,7 @@ Y:
 )DOC")
     .Input(0, "X", "Input data blob to be operated on.")
     .Output(0, "Y", "Output data blob with same shape as input.")
-    .InheritOnnxSchema("Softplus");
+    .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
 OPERATOR_SCHEMA(SoftplusGradient)

--- a/caffe2/operators/softsign_op.cc
+++ b/caffe2/operators/softsign_op.cc
@@ -106,7 +106,7 @@ Y:
 )DOC")
     .Input(0, "input", "Input data blob to be operated on.")
     .Output(0, "output", "Output data blob with same shape as input")
-    .InheritOnnxSchema("Softsign");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(SoftsignGradient)
     .NumInputs(2)

--- a/caffe2/operators/tanh_op.cc
+++ b/caffe2/operators/tanh_op.cc
@@ -88,7 +88,7 @@ X:
         "output",
         "The hyperbolic tangent values of the input tensor, computed "
         "element-wise")
-    .InheritOnnxSchema("Tanh");
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(TanhGradient).NumInputs(2).NumOutputs(1).AllowInplace({{1, 0}});
 

--- a/caffe2/operators/tile_op.cc
+++ b/caffe2/operators/tile_op.cc
@@ -84,13 +84,16 @@ Y:
     .Arg("tiles", "(*int*): number of replicas")
     .Arg("axis", "(*int*): axis to replicate along")
     .Input(0, "X", "(*Tensor*): input tensor")
-    .Input(1, "tiles", "(*Tensor`<int>`*): [OPTIONAL] number of replicas (overrides `tiles` argument)")
-    .Input(2, "axis", "(*Tensor`<int>`*): [OPTIONAL] axis to replicate along (overrides `axis` argument)")
-    .Output(
-        0,
-        "Y",
-        "(*Tensor*): output tensor")
-    .InheritOnnxSchema("Tile");
+    .Input(
+        1,
+        "tiles",
+        "(*Tensor`<int>`*): [OPTIONAL] number of replicas (overrides `tiles` argument)")
+    .Input(
+        2,
+        "axis",
+        "(*Tensor`<int>`*): [OPTIONAL] axis to replicate along (overrides `axis` argument)")
+    .Output(0, "Y", "(*Tensor*): output tensor")
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(TileGradient).NumInputs(1, 3).NumOutputs(1);
 

--- a/caffe2/operators/transpose_op.cc
+++ b/caffe2/operators/transpose_op.cc
@@ -90,7 +90,7 @@ Y.shape (NCHW order): (1, 3, 32, 32)
         "the dimensions by default.")
     .Input(0, "X", "*(type: Tensor)* Input tensor.")
     .Output(0, "Y", "*(type: Tensor)* Transposed output.")
-    .InheritOnnxSchema("Transpose");
+    .InheritOnnxSchema();
 
 class GetTransposeGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;


### PR DESCRIPTION
Summary: In majority of the case, we use `InheritOnnxSchema(type_)`. This diff makes declaration of such case easier.

Differential Revision: D10395109
