### PR TITLE
fix double free exposed by latest llvm

### DIFF
--- a/c10/util/Type.h
+++ b/c10/util/Type.h
@@ -16,7 +16,7 @@ C10_API std::string demangle(const char* name);
 template <typename T>
 inline const char* demangle_type() {
 #ifdef __GXX_RTTI
-  static const std::string name = demangle(typeid(T).name());
+  static const auto& name = *(new std::string(demangle(typeid(T).name())));
   return name.c_str();
 #else // __GXX_RTTI
   return "(RTTI disabled, cannot show name)";


### PR DESCRIPTION
Summary:
Latest LLVM started reporting double free related to this code. The stack trace: P60181558
Fix it by using the leaky Meyers' singleton

Reviewed By: meyering

Differential Revision: D10352976
