### PR TITLE
Fix missing final activation in NLLLoss second example

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -185,10 +185,11 @@ class NLLLoss(_WeightedLoss):
         >>> loss = nn.NLLLoss()
         >>> # input is of size N x C x height x width
         >>> data = torch.randn(N, 16, 10, 10)
-        >>> m = nn.Conv2d(16, C, (3, 3))
+        >>> conv = nn.Conv2d(16, C, (3, 3))
+        >>> m = nn.LogSoftmax()
         >>> # each element in target has to have 0 <= value < C
         >>> target = torch.empty(N, 8, 8, dtype=torch.long).random_(0, C)
-        >>> output = loss(m(data), target)
+        >>> output = loss(m(conv(data)), target)
         >>> output.backward()
     """
 


### PR DESCRIPTION
Fixed the second example in NLLLoss.
The LogSoftmax activation was missing after the convolution layer. Without this activation, the second example loss was sometimes negative.