### PR TITLE
Various example code fixes

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5197,8 +5197,7 @@ Args:
 
 Example::
 
-    >>> input = torch.empty((2,3), dtype=torch.int64)
-    >>> input.new(input.size())
+    >>> torch.empty((2,3), dtype=torch.int64)
     tensor([[ 9.4064e+13,  2.8000e+01,  9.3493e+13],
             [ 7.5751e+18,  7.1428e+18,  7.5955e+18]])
 """.format(**factory_like_common_args))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4211,39 +4211,36 @@ Args:
 
 Example::
 
-    >>> i = torch.tensor([[0, 1, 1],
-                          [2, 0, 2]], dtype=torch.long)
-    >>> v = torch.tensor([3, 4, 5], dtype=torch.float)
+    >>> i = torch.LongTensor([[0, 1, 1],
+                              [2, 0, 2]])
+    >>> v = torch.FloatTensor([3, 4, 5])
     >>> torch.sparse_coo_tensor(i, v, torch.Size([2,4]))
-    tensor(indices=tensor([[0, 1, 1],
-                           [2, 0, 2]]),
-           values=tensor([3., 4., 5.]),
-           size=(2, 4), nnz=3, layout=torch.sparse_coo)
-    >>> torch.sparse_coo_tensor(i, v)  # Shape inference
+    torch.sparse.FloatTensor of size (2,4) with indices:
+    tensor([[ 0,  1,  1],
+            [ 2,  0,  2]])
+    and values:
+    tensor([ 3.,  4.,  5.])
 
-    tensor(indices=tensor([[0, 1, 1],
-                           [2, 0, 2]]),
-           values=tensor([3., 4., 5.]),
-           size=(2, 3), nnz=3, layout=torch.sparse_coo)
+    >>> torch.sparse_coo_tensor(i, v)  # Shape inference
+    torch.sparse.FloatTensor of size (2,3) with indices:
+    tensor([[ 0,  1,  1],
+            [ 2,  0,  2]])
+    and values:
+    tensor([ 3.,  4.,  5.])
 
     >>> torch.sparse_coo_tensor(i, v, torch.Size([2,4]), dtype=torch.float64,
                                 device=torch.device('cuda:0'))
-    tensor(indices=tensor([[0, 1, 1],
-                           [2, 0, 2]]),
-           values=tensor([3., 4., 5.]),
-           device='cuda:0', size=(2, 4), nnz=3, dtype=torch.float64,
-           layout=torch.sparse_coo)
+    torch.cuda.sparse.DoubleTensor of size (2,4) with indices:
+    tensor([[ 0,  1,  1],
+            [ 2,  0,  2]], device='cuda:0')
+    and values:
+    tensor([ 3.,  4.,  5.], dtype=torch.float64, device='cuda:0')
 
-    >>> torch.sparse_coo_tensor(torch.empty(1,0), [], torch.Size([0]))  # Create an empty tensor (of size (0,))
-    tensor(indices=tensor([], size=(1, 0)),
-           values=tensor([], size=(0,)),
-           size=(0,), nnz=0, layout=torch.sparse_coo)
-
-    >>> torch.sparse_coo_tensor(torch.zeros(0, 1), 11.7, []))  # Create a scalar sparse Tensor
-    tensor(indices=tensor([], size=(0, 1)),
-           values=tensor([11.7000]),
-           size=(), nnz=1, layout=torch.sparse_coo)
-
+    >>> torch.sparse_coo_tensor([], [], torch.Size([])) # Create an empty tensor (of size (0,))
+    torch.sparse.FloatTensor of size () with indices:
+    tensor([], dtype=torch.int64)
+    and values:
+    tensor([])
 
 .. _torch.sparse: https://pytorch.org/docs/stable/sparse.html
 """)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1472,7 +1472,7 @@ Args:
 
 Example::
 
-    >>> torch.exp(torch.tensor([0, math.log(2)]))
+    >>> torch.exp(torch.tensor([0, math.log(2.)]))
     tensor([ 1.,  2.])
 """)
 
@@ -1496,7 +1496,7 @@ Args:
 
 Example::
 
-    >>> torch.expm1(torch.tensor([0, math.log(2)]))
+    >>> torch.expm1(torch.tensor([0, math.log(2.)]))
     tensor([ 0.,  1.])
 """)
 
@@ -4211,36 +4211,39 @@ Args:
 
 Example::
 
-    >>> i = torch.LongTensor([[0, 1, 1],
-                              [2, 0, 2]])
-    >>> v = torch.FloatTensor([3, 4, 5])
+    >>> i = torch.tensor([[0, 1, 1],
+                          [2, 0, 2]], dtype=torch.long)
+    >>> v = torch.tensor([3, 4, 5], dtype=torch.float)
     >>> torch.sparse_coo_tensor(i, v, torch.Size([2,4]))
-    torch.sparse.FloatTensor of size (2,4) with indices:
-    tensor([[ 0,  1,  1],
-            [ 2,  0,  2]])
-    and values:
-    tensor([ 3.,  4.,  5.])
-
+    tensor(indices=tensor([[0, 1, 1],
+                           [2, 0, 2]]),
+           values=tensor([3., 4., 5.]),
+           size=(2, 4), nnz=3, layout=torch.sparse_coo)
     >>> torch.sparse_coo_tensor(i, v)  # Shape inference
-    torch.sparse.FloatTensor of size (2,3) with indices:
-    tensor([[ 0,  1,  1],
-            [ 2,  0,  2]])
-    and values:
-    tensor([ 3.,  4.,  5.])
+
+    tensor(indices=tensor([[0, 1, 1],
+                           [2, 0, 2]]),
+           values=tensor([3., 4., 5.]),
+           size=(2, 3), nnz=3, layout=torch.sparse_coo)
 
     >>> torch.sparse_coo_tensor(i, v, torch.Size([2,4]), dtype=torch.float64,
                                 device=torch.device('cuda:0'))
-    torch.cuda.sparse.DoubleTensor of size (2,4) with indices:
-    tensor([[ 0,  1,  1],
-            [ 2,  0,  2]], device='cuda:0')
-    and values:
-    tensor([ 3.,  4.,  5.], dtype=torch.float64, device='cuda:0')
+    tensor(indices=tensor([[0, 1, 1],
+                           [2, 0, 2]]),
+           values=tensor([3., 4., 5.]),
+           device='cuda:0', size=(2, 4), nnz=3, dtype=torch.float64,
+           layout=torch.sparse_coo)
 
-    >>> torch.sparse_coo_tensor([], [], torch.Size([])) # Create an empty tensor (of size (0,))
-    torch.sparse.FloatTensor of size () with indices:
-    tensor([], dtype=torch.int64)
-    and values:
-    tensor([])
+    >>> torch.sparse_coo_tensor(torch.empty(1,0), [], torch.Size([0]))  # Create an empty tensor (of size (0,))
+    tensor(indices=tensor([], size=(1, 0)),
+           values=tensor([], size=(0,)),
+           size=(0,), nnz=0, layout=torch.sparse_coo)
+
+    >>> torch.sparse_coo_tensor(torch.zeros(0, 1), 11.7, []))  # Create a scalar sparse Tensor
+    tensor(indices=tensor([], size=(0, 1)),
+           values=tensor([11.7000]),
+           size=(), nnz=1, layout=torch.sparse_coo)
+
 
 .. _torch.sparse: https://pytorch.org/docs/stable/sparse.html
 """)

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -66,7 +66,7 @@ class enable_grad(object):
         >>> @torch.enable_grad()
         ... def doubler(x):
         ...     return x * 2
-        >>> with torch.no_grad:
+        >>> with torch.no_grad():
         ...     z = doubler(x)
         >>> z.requires_grad
         True

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -254,7 +254,7 @@ def isfinite(tensor):
 
     Example::
 
-        >>> torch.isfinite(torch.Tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
+        >>> torch.isfinite(torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
         tensor([ 1,  0,  1,  0,  0], dtype=torch.uint8)
     """
     if not isinstance(tensor, torch.Tensor):
@@ -273,7 +273,7 @@ def isinf(tensor):
 
     Example::
 
-        >>> torch.isinf(torch.Tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
+        >>> torch.isinf(torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
         tensor([ 0,  1,  0,  1,  0], dtype=torch.uint8)
     """
     if not isinstance(tensor, torch.Tensor):


### PR DESCRIPTION
- Fix broken sparse_coo_examples, update output
- Tensor(...) to tensor(...)
- Fix arguments to math.log to be floats

While the last might be debateable, mypy currently complains when passing an int to math.log. As it is not essential for our examples, let's be clean w.r.t. other people's expectations.

These popped up while checking examples in the context of  #12500 .