### PR TITLE
Add script::Module::to

### DIFF
--- a/test/custom_operator/model.py
+++ b/test/custom_operator/model.py
@@ -18,6 +18,7 @@ def get_custom_op_library_path():
 class Model(torch.jit.ScriptModule):
     def __init__(self):
         super(Model, self).__init__()
+        self.p = torch.nn.Parameter(torch.eye(5))
 
     @torch.jit.script_method
     def forward(self, input):

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -99,12 +99,46 @@ void Method::ensure_defined() {
   }
 }
 
+void Module::to(at::Device device, at::ScalarType dtype, bool non_blocking) {
+  to_impl(device, dtype, non_blocking);
+}
+
+void Module::to(at::ScalarType dtype, bool non_blocking) {
+  to_impl(/*device=*/at::nullopt, dtype, non_blocking);
+}
+
+void Module::to(at::Device device, bool non_blocking) {
+  to_impl(device, /*dtype=*/at::nullopt, non_blocking);
+}
+
 void Module::save(std::ostream& out) {
   ExportModule(*this, out);
 }
 
 void Module::save(const std::string& filename) {
   ExportModule(*this, filename);
+}
+
+void Module::to_impl(
+    at::optional<at::Device> device,
+    at::optional<at::ScalarType> dtype,
+    bool non_blocking) {
+  // First call `to()` on every child module.
+  for (auto& child : modules) {
+    child->module->to_impl(device, dtype, non_blocking);
+  }
+  // Then convert every of our parameters.
+  for (auto& parameter : parameters) {
+    // Need to access the `at::Tensor` as a `Variable` here.
+    autograd::Variable variable = *parameter->slot();
+    at::Tensor data = variable.data();
+    // Use the data's original device or dtype if not supplied here.
+    auto new_data = data.to(
+        device.value_or(data.device()),
+        dtype.value_or(data.dtype()),
+        non_blocking);
+    variable.set_data(new_data);
+  }
 }
 
 }}}

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -104,11 +104,11 @@ void Module::to(at::Device device, at::ScalarType dtype, bool non_blocking) {
 }
 
 void Module::to(at::ScalarType dtype, bool non_blocking) {
-  to_impl(/*device=*/at::nullopt, dtype, non_blocking);
+  to_impl(/*device=*/c10::nullopt, dtype, non_blocking);
 }
 
 void Module::to(at::Device device, bool non_blocking) {
-  to_impl(device, /*dtype=*/at::nullopt, non_blocking);
+  to_impl(device, /*dtype=*/c10::nullopt, non_blocking);
 }
 
 void Module::save(std::ostream& out) {
@@ -120,8 +120,8 @@ void Module::save(const std::string& filename) {
 }
 
 void Module::to_impl(
-    at::optional<at::Device> device,
-    at::optional<at::ScalarType> dtype,
+    c10::optional<at::Device> device,
+    c10::optional<at::ScalarType> dtype,
     bool non_blocking) {
   // First call `to()` on every child module.
   for (auto& child : modules) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -10,6 +10,7 @@
 #include "torch/csrc/jit/source_range.h"
 
 #include <torch/csrc/api/include/torch/detail/ordered_dict.h>
+#include <torch/csrc/utils/memory.h>
 
 #include <ATen/core/ArrayRef.h>
 #include "c10/util/Optional.h"
@@ -260,7 +261,7 @@ struct NamedParameter {
   NamedParameter(std::string name, at::Tensor tensor, bool is_buffer)
   : name(std::move(name))
   , is_buffer(is_buffer)
-  , parameter(new at::Tensor(std::move(tensor))) {}
+  , parameter(torch::make_unique<at::Tensor>(std::move(tensor))) {}
 
   const std::string name;
   bool is_buffer; // buffers are part of the module state but
@@ -361,6 +362,33 @@ struct Module {
     return nullptr;
   }
 
+  /// Recursively casts all parameters to the given `dtype` and `device`.
+  ///
+  /// If `non_blocking` is true and the source is in pinned memory and
+  /// destination is on the GPU or vice versa, the copy is performed
+  /// asynchronously with respect to the host. Otherwise, the argument has no
+  /// effect.
+  void to(
+      at::Device device,
+      at::ScalarType dtype,
+      bool non_blocking = false);
+
+  /// Recursively casts all parameters to the given dtype.
+  ///
+  /// If `non_blocking` is true and the source is in pinned memory and
+  /// destination is on the GPU or vice versa, the copy is performed
+  /// asynchronously with respect to the host. Otherwise, the argument has no
+  /// effect.
+  void to(at::ScalarType dtype, bool non_blocking = false);
+
+  /// Recursively moves all parameters to the given device.
+  ///
+  /// If `non_blocking` is true and the source is in pinned memory and
+  /// destination is on the GPU or vice versa, the copy is performed
+  /// asynchronously with respect to the host. Otherwise, the argument has no
+  /// effect.
+  void to(at::Device device, bool non_blocking = false);
+
   /// Run a method from this module.
   ///
   /// For example:
@@ -384,6 +412,10 @@ struct Module {
   void save(const std::string& filename);
 
  private:
+   void to_impl(
+       at::optional<at::Device> device,
+       at::optional<at::ScalarType> dtype,
+       bool non_blocking);
 
   // invariant: to ensure member_inputs of Methods stay valid,
   // it is only legal to _add_ new modules and parameters.


### PR DESCRIPTION
There is currently no obvious way for users to move their `script::Module` to GPU memory. This PR implements the `to()` functions that C++ frontend modules have.

@zdevito @apaszke 