### PR TITLE
Add Caffe2 cost observer

### DIFF
--- a/caffe2/observers/cost_observer.cc
+++ b/caffe2/observers/cost_observer.cc
@@ -1,0 +1,107 @@
+#include "cost_observer.h"
+#include "caffe2/core/common.h"
+
+namespace caffe2 {
+
+CostObserver::CostObserver(NetBase* subject_)
+    : ObserverBase<NetBase>(subject_),
+      detailedOpStats_(subject_->GetOperators().size()),
+      net_name_(subject_->Name()) {
+  const auto& ops = subject_->GetOperators();
+  for (int i = 0; i < ops.size(); i++) {
+    ops[i]->AttachObserver(
+        caffe2::make_unique<CostOpObserver>(ops[i], &detailedOpStats_[i]));
+  }
+}
+
+CostObserver::~CostObserver() {
+  // put logging under the lock so that logs from different nets don't overlap
+  // perf is not of concern since it's debug mode and we're talking only about
+  // destruction
+  static std::mutex loggingMutex;
+  std::lock_guard<std::mutex> lock(loggingMutex);
+
+  CaffeMap<string, OpSchema::Cost> cost_per_op_type = getCostPerOpType();
+  // sort by decreasing flops.
+  std::vector<std::pair<std::string, OpSchema::Cost>> cost_per_op_type_vec(
+      cost_per_op_type.begin(), cost_per_op_type.end());
+  std::sort(
+      cost_per_op_type_vec.begin(),
+      cost_per_op_type_vec.end(),
+      [](const std::pair<std::string, OpSchema::Cost>& left,
+         const std::pair<std::string, OpSchema::Cost>& right) {
+        return left.second.flops > right.second.flops;
+      });
+  LOG(INFO) << "================ Detailed stats for net " << net_name_
+            << " ================";
+  LOG(INFO) << "Cost (flops, bytes_read, bytes_written) per operator type:";
+  for (const auto& item : cost_per_op_type_vec) {
+    LOG(INFO) << std::setw(15) << std::setfill(' ') << item.second.flops << " "
+              << item.second.bytes_read << " " << item.second.bytes_written
+              << " " << item.first;
+  }
+}
+
+CostOpObserver::CostOpObserver(OperatorBase* op, DetailedStat* stat)
+    : ObserverBase<OperatorBase>(op), stat_(stat) {
+  stat->opType = op->debug_def().type();
+  stat->displayName =
+      (op->debug_def().name().size()
+           ? op->debug_def().name()
+           : (op->debug_def().output_size() ? op->debug_def().output(0)
+                                            : "NO_OUTPUT"));
+}
+
+void CostObserver::Start() {}
+
+void CostObserver::Stop() {}
+
+void CostOpObserver::Start() {
+  if (subject_->HasAsyncPart()) {
+    LOG(INFO) << "Not printing shape info for an async operator";
+  } else {
+    if (subject_->debug_def().type() != "FC" && subject_->InputSize() > 1) {
+      return;
+    }
+    if (subject_->debug_def().type() == "FC") {
+      const vector<TensorShape>& in = subject_->InputTensorShapes();
+      const OperatorDef& def = subject_->debug_def();
+      ArgumentHelper helper(def);
+
+      auto axis = helper.GetSingleArgument<int32_t>("axis", 1);
+      const auto canonical_axis =
+          canonical_axis_index_(axis, in[0].dims().size());
+      const uint64_t M = size_to_dim_(canonical_axis, GetDimsVector(in[0]));
+      const uint64_t K = size_from_dim_(canonical_axis, GetDimsVector(in[0]));
+      auto axis_w = helper.GetSingleArgument<int32_t>("axis_w", 1);
+      const int canonical_axis_w =
+          canonical_axis_index_(axis_w, in[1].dims().size());
+      const uint64_t N = size_to_dim_(canonical_axis_w, GetDimsVector(in[1]));
+
+      stat_->c.flops += M * N * (2 * K + 1);
+      stat_->c.bytes_read += (K * (M + N) + N);
+      stat_->c.bytes_written += M * N;
+      stat_->c.params_bytes = (K * N + N);
+    } else if (subject_->debug_def().type() == "Log") {
+      const auto& blob = subject_->InputBlob(0);
+      auto tensor_info_fun = GetTensorInfoFunction(blob.meta().id());
+      if (tensor_info_fun) {
+        size_t capacity;
+        DeviceOption device;
+        vector<int64_t> shape =
+            tensor_info_fun(blob.GetRaw(), &capacity, &device);
+        uint64_t input_size = 1;
+        for (int i = 0; i < shape.size(); i++) {
+          input_size *= shape[i];
+        }
+        stat_->c.flops += input_size;
+        stat_->c.bytes_read += input_size;
+        stat_->c.bytes_written += input_size;
+      }
+    }
+  }
+}
+
+void CostOpObserver::Stop() {}
+
+} // namespace caffe2

--- a/caffe2/observers/cost_observer.h
+++ b/caffe2/observers/cost_observer.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "caffe2/core/observer.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+class CostObserver;
+
+class CostOpObserver : public ObserverBase<OperatorBase> {
+ public:
+  struct DetailedStat {
+    int64_t invocations = 0;
+    double timeSpentSum = 0;
+    string opType;
+    string displayName;
+    struct OpSchema::Cost c;
+  };
+
+  CostOpObserver(OperatorBase* op, DetailedStat* stat);
+
+ private:
+  void Start() override;
+  void Stop() override;
+
+ private:
+  DetailedStat* stat_;
+};
+
+class CostObserver : public ObserverBase<NetBase> {
+ public:
+  explicit CostObserver(NetBase* subject_);
+  ~CostObserver();
+  CaffeMap<string, OpSchema::Cost> getCostPerOpType() const {
+    CaffeMap<string, OpSchema::Cost> cost_per_op_type;
+    for (int idx = 0; idx < detailedOpStats_.size(); ++idx) {
+      const auto& stat = detailedOpStats_[idx];
+      uint64_t flops = stat.c.flops;
+      uint64_t bytes_read = stat.c.bytes_read;
+      uint64_t bytes_written = stat.c.bytes_written;
+
+      cost_per_op_type[stat.opType].flops += flops;
+      cost_per_op_type[stat.opType].bytes_read += bytes_read;
+      cost_per_op_type[stat.opType].bytes_written += bytes_written;
+    }
+    return cost_per_op_type;
+  }
+
+ private:
+  void Start() override;
+  void Stop() override;
+
+  std::vector<CostOpObserver::DetailedStat> detailedOpStats_;
+  std::string net_name_;
+};
+
+} // namespace caffe2

--- a/caffe2/observers/cost_observer_test.cc
+++ b/caffe2/observers/cost_observer_test.cc
@@ -1,0 +1,105 @@
+#include "caffe2/core/common.h"
+#include "caffe2/core/net.h"
+#include "caffe2/core/observer.h"
+#include "caffe2/core/operator.h"
+#include "cost_observer.h"
+
+#include <gtest/gtest.h>
+#include "caffe2/utils/proto_utils.h"
+
+namespace caffe2 {
+
+namespace {
+
+OperatorDef* add_op(
+    const vector<string>& input,
+    const vector<string>& output,
+    const string& type,
+    NetDef* net) {
+  CHECK(net);
+  auto& op = *net->add_op();
+  op.set_type(type);
+  for (const auto& in : input) {
+    op.add_input(in);
+  }
+  for (const auto& out : output) {
+    op.add_output(out);
+  }
+
+  return net->mutable_op(net->op_size() - 1);
+}
+
+void fill_tensor(
+    const vector<int64_t>& shape,
+    const vector<float>& data,
+    TensorCPU* tensor) {
+  tensor->Resize(shape);
+  CAFFE_ENFORCE_EQ(data.size(), tensor->size());
+  auto ptr = tensor->mutable_data<float>();
+  for (int i = 0; i < tensor->size(); ++i) {
+    ptr[i] = data[i];
+  }
+}
+
+void add_blob(
+    const string& name,
+    const vector<int64_t>& shape,
+    const vector<float>& data,
+    Workspace* ws) {
+  auto* blob = ws->CreateBlob(name);
+  fill_tensor(shape, data, BlobGetMutableTensor(blob, CPU));
+}
+
+} // namespace
+
+TEST(CostObserverTest, TestFC) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N, int K) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X", "W", "b"}, {"Y"}, "FC", net_def.get());
+    add_blob("W", {N, K}, vector<float>(N * K), &ws);
+    add_blob("b", {N}, vector<float>(N), &ws);
+    add_blob("X", {M, K}, vector<float>(M * K), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3, K = 4;
+  NetBase* net = ws.CreateNet(create_net_def(M, N, K), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<CostObserver>(net);
+  const auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getCostPerOpType();
+  CAFFE_ENFORCE(cost_per_op_type["FC"].flops == M * N * (2 * K + 1));
+  CAFFE_ENFORCE(cost_per_op_type["FC"].bytes_read == (K * (M + N) + N));
+  CAFFE_ENFORCE(cost_per_op_type["FC"].bytes_written == M * N);
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestLog) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X"}, {"Y"}, "Log", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<CostObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getCostPerOpType();
+  CAFFE_ENFORCE(cost_per_op_type["Log"].flops == M * N);
+  CAFFE_ENFORCE(cost_per_op_type["Log"].bytes_read == M * N);
+  CAFFE_ENFORCE(cost_per_op_type["Log"].bytes_written == M * N);
+  net->DetachObserver(ref);
+}
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Add Caffe2 cost observer to report the analytical cost for operators. This will be used to do the throughput study for non-linear operators in NMT models. Since this study needs to compare the analytical cost of non-linear operators with FC operator, this cost observer supports FC and Log operators at first.

Next:
- Add support for more non-linear operators used in NMT models: Sigmoid, LSTMUnit, Softmax, Div, Pow

Differential Revision: D10219981
