### PR TITLE
fix forward and backward for norm with negative infinity norm 

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -286,11 +286,15 @@ struct NormReduction {
         result += std::abs(data[k * stride] * data[k * stride] * data[k * stride]);
       }
       result = std::pow(result, 1.0/3);
-    } else if (std::isinf(pval)) {
+    } else if (pval == INFINITY) {
       for (int64_t k = 0; k < n; k++) {
         result = std::abs(data[k * stride]) > result ? std::abs(data[k * stride]) : result;
       }
-      result = result;
+    } else if (pval == -INFINITY) {
+      result = INFINITY;
+      for (int64_t k = 0; k < n; k++) {
+        result = std::abs(data[k * stride]) < result ? std::abs(data[k * stride]) : result;
+      }
     } else {
       for (int64_t k = 0; k < n; k++) {
         result += std::pow(std::abs(data[k * stride]), pval);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -199,6 +199,13 @@ void THCTensor_(norm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t
                         thrust::identity<accreal>{},
                         scalar_cast<accreal>(0),
                         dimension, keepdim);
+  } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(-INFINITY))) {
+    THC_reduceDim<scalar_t>(state, self, src,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceMin<accreal>{},
+                        thrust::identity<accreal>{},
+                        scalar_cast<accreal>(INFINITY),
+                        dimension, keepdim);
   } else {
     THC_reduceDim<scalar_t>(state, self, src,
                         TensorNormOp<accreal, -1>{value},
@@ -241,6 +248,12 @@ accreal THCTensor_(normall)(THCState *state, THCTensor *self, scalar_t _value)
                         TensorNormOp<accreal, 1>{value},
                         ReduceMax<accreal>{},
                         scalar_cast<accreal>(0),
+                        &result, 0);
+  } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(-INFINITY))) {
+    THC_reduceAll<scalar_t>(state, self,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceMin<accreal>{},
+                        scalar_cast<accreal>(INFINITY),
                         &result, 0);
   } else {
     THC_reduceAll<scalar_t>(state, self,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3068,6 +3068,7 @@ method_tests = [
     ('norm', (S, S), (1,), '1'),
     ('norm', (S, S), (3,), '3'),
     ('norm', (S, S), (inf,), 'inf'),
+    ('norm', (S, S), (-inf,), '-inf'),
     ('norm', (S, S), ('fro',), 'fro_default'),
     ('norm', (S, S), ('fro', [0, 1],), 'fro'),
     ('norm', (S, S), ('nuc',), 'nuc'),

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2815,6 +2815,12 @@ a")
         s = torch.rand(1)
         self.assertTrue(foo(s))
 
+        @torch.jit.script
+        def bar(a):
+            return a > float('-inf')
+        s = torch.rand(1)
+        self.assertTrue(foo(s))
+
     def test_add(self):
         def func(a, b):
             c = a + b
@@ -8123,8 +8129,10 @@ def the_method({}):
 
 
 def get_constant(x):
-    if x == inf or x == -inf:
+    if x == inf:
         return 'float(\'inf\')' if PY2 else 'math.inf'
+    if x == -inf:
+        return 'float(\'-inf\')' if PY2 else '-math.inf'
     return x
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -839,7 +839,7 @@ class TestTorch(TestCase):
         # full reduction
         x = torch.randn(5, device=device)
         xn = x.cpu().numpy()
-        for p in [0, 1, 2, 3, 4, inf]:
+        for p in [0, 1, 2, 3, 4, inf, -inf]:
             res = x.norm(p).item()
             expected = np.linalg.norm(xn, p)
             self.assertEqual(res, expected, "full reduction failed for {}-norm".format(p))
@@ -847,7 +847,7 @@ class TestTorch(TestCase):
         # one dimension
         x = torch.randn(5, 5, device=device)
         xn = x.cpu().numpy()
-        for p in [0, 1, 2, 3, 4, inf]:
+        for p in [0, 1, 2, 3, 4, inf, -inf]:
             res = x.norm(p, 1).cpu().numpy()
             expected = np.linalg.norm(xn, p, 1)
             self.assertEqual(res.shape, expected.shape)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -87,15 +87,15 @@ Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_
     return zeros_like(self);
   } else if (p == 1.0) {
     return self.sign() * grad;
-  } else if (p < 2.0) {
-    self_scaled = self.sign() * self.abs().pow(p - 1);
-    scale_v = grad / norm.pow(p - 1);
   } else if (p == 2.0) {
     self_scaled = self;
     scale_v = grad / norm;
-  } else if (p == INFINITY) {
+  } else if (std::isinf(p)) {
     self_scaled = self.sign() * (self.abs() == norm).toType(self.type());
     scale_v = grad.clone();
+  } else if (p < 2.0) {
+    self_scaled = self.sign() * self.abs().pow(p - 1);
+    scale_v = grad / norm.pow(p - 1);
   } else {
     self_scaled = self * self.abs().pow(p - 2);
     scale_v = grad / norm.pow(p - 1);

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -171,13 +171,15 @@ RegisterOperators reg({
         [](Node* node) -> Operation {
           return [](Stack& stack) {
             auto s = pop(stack).toString();
-            if (s->string() != "inf") {
+            if (s->string() == "inf")
+              push(stack, std::numeric_limits<double>::infinity());
+            else if (s->string() == "-inf")
+              push(stack, -std::numeric_limits<double>::infinity());
+            else
               AT_ERROR(
-                  "Only 'inf' can be cast to a float, but got '",
+                  "Only 'inf' or '-inf' can be cast to a float, but got '",
                   s->string(),
                   "'");
-            }
-            push(stack, std::numeric_limits<double>::infinity());
             return 0;
           };
         }),


### PR DESCRIPTION
I found a bug in norm() and fixed it (and added tests to make sure it's fixed)
here is how to reproduce it:
```python
import torch
x = torch.FloatTensor([[10, 12, 13], [4, 0, 12]])
print(torch.norm(x, -40, dim=0, keepdim=True)) #output is tensor([[ 4.0000,  0.0000, 11.9853]])
print(torch.norm(x, float('-inf'), dim=0, keepdim=True)) #output is tensor([[1., 1., 1.]]) which is wrong!
from numpy.linalg import norm as np_norm
x = x.numpy()
print(np_norm(x, ord=-40, axis=0)) #output is array([[4., 0., 11.985261]])
print(np_norm(x, ord=float('-inf'), axis=0)) #output is array([[4., 0., 12.0]])
```
it's related to [#6817](https://github.com/pytorch/pytorch/issues/6817) and [#6969](https://github.com/pytorch/pytorch/pull/6969)