### PR TITLE
Don't segfault on Tensor.__delitem__

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5495,6 +5495,11 @@ class TestTorch(TestCase):
         self.assertRaises(IndexError, lambda: reference[0.0, ..., 0.0:2.0])
         self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0])
 
+        def delitem():
+            del reference[0]
+
+        self.assertRaises(TypeError, delitem)
+
     def test_index(self):
         self._test_index(self, lambda x: x)
 

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -331,6 +331,10 @@ static void copy_to(Variable dst, const Variable& src) {
 
 int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   HANDLE_TH_ERRORS
+  if (py_value == nullptr) {
+    throw TypeError("Tensor does not support deleting items");
+  }
+
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   DeviceGuard device_guard(self_);
   auto value = valueToTensor(self_.type(), py_value);


### PR DESCRIPTION
The mapping protocol stipulates that when `__delitem__` is called, this is passed to `__setitem__` [(well, the same function in the C extension interface)](https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript) with NULL data. 

PyTorch master crashes in this situation, with this patch, it does not anymore.

Test code (careful, sefaults your interpreter):
```python
import torch
a = torch.randn(5)
del a[2]
```