### PR TITLE
size_from_dim(0) is like numel() but worse. Don't do it.

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -327,6 +327,13 @@ class CAFFE2_API Tensor final {
   }
 
   /**
+   * Returns the size (i.e. the number of items) of the tensor.
+   */
+  inline int64_t numel() const {
+    return impl_->numel();
+  }
+
+  /**
    * Return the number of bytes each item takes in the tensor.
    */
   inline size_t itemsize() const {

--- a/caffe2/experiments/operators/tt_contraction_op.h
+++ b/caffe2/experiments/operators/tt_contraction_op.h
@@ -44,8 +44,8 @@ class TTContractionOp final : public Operator<Context> {
 
     CAFFE_ENFORCE(A.ndim() == 2, A.ndim());
 
-    int64_t A_size = A.size_from_dim(0);
-    int64_t B_size = B.size_from_dim(0);
+    int64_t A_size = A.numel();
+    int64_t B_size = B.numel();
 
     CAFFE_ENFORCE(
         K_ * M_ == A_size,
@@ -106,7 +106,7 @@ class TTContractionGradientOp final : public Operator<Context> {
     auto* dA = Output(0);
     auto* dB = Output(1);
 
-    int64_t G_size = G.size_from_dim(0);
+    int64_t G_size = G.numel();
     int64_t D_ = G_size / (M_ * N_);
 
     int64_t dB_size = D_ * K_ * N_;

--- a/caffe2/ideep/operators/concat_split_op.cc
+++ b/caffe2/ideep/operators/concat_split_op.cc
@@ -38,7 +38,7 @@ class IDEEPConcatOp final : public IDEEPOperator {
             "Expect cpu tensor if not itensor");
         auto& tensor_cpu = OperatorBase::Input<Tensor>(i, CPU);
         CAFFE_ENFORCE(tensor_cpu.dims().size() == 0 ||
-                      tensor_cpu.size_from_dim(0) == 0,
+                      tensor_cpu.numel() == 0,
                       "Expect zero dim tensor");
       }
     }

--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -127,7 +127,7 @@ class C10_EXPORT IDEEPFallbackOp final : public IDEEPOperator {
       const auto& src = local_output_blobs_[i]->template Get<TensorCPU>();
       auto src_dims = src.dims().vec();
       if (src.template IsType<float>() &&
-          src.dims().size() != 0 && src.size_from_dim(0) != 0 &&
+          src.dims().size() != 0 && src.numel() != 0 &&
           base_op_->type() != "Python") {
         Blob* dst = OperatorBase::OutputBlob(i);
         // The output tensor must be ideep tensor with public format.

--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -64,7 +64,7 @@ class ReshapeOp : public Operator<Context> {
     // Checks if the new shape is valid and fills in the missing dimension
     // specified by -1.
     // NOTE: At most one dimension can be -1.
-    auto total_size = input.size_from_dim(0);
+    auto total_size = input.numel();
     T size = 1;
     int unknown_idx = -1;
     for (int i = 0; i < actual_new_shape.size(); ++i) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12729 size_from_dim(0) is like numel() but worse. Don't do it.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10415069/)

This may have a dependency on D10380678 if size_from_dim(0)
was required because numel() used to return -1 in some cases.
This is no longer true.

Differential Revision: [D10415069](https://our.internmc.facebook.com/intern/diff/D10415069/)