### PR TITLE
add string as supported input / output of script functions

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -266,6 +266,7 @@ struct CAFFE2_API IValue final {
   const std::vector<bool>& toBoolListRef() const;
   const std::vector<at::Tensor>& toTensorListRef() const;
   const std::vector<IValue>& toGenericListRef() const;
+  const std::string& toStringRef() const;
 
   // ConstantString
   IValue(c10::intrusive_ptr<ConstantString> v);
@@ -459,6 +460,7 @@ DEFINE_TO(std::vector<double>, toDoubleListRef)
 DEFINE_TO(std::vector<bool>, toBoolListRef)
 DEFINE_TO(std::vector<at::Tensor>, toTensorListRef)
 DEFINE_TO(std::vector<IValue>, toGenericListRef)
+DEFINE_TO(std::string, toStringRef)
 DEFINE_TO(World, toWorld)
 DEFINE_TO(IValue, toIValue)
 
@@ -559,6 +561,10 @@ inline const std::vector<bool>& IValue::toBoolListRef() const {
 
 inline const std::vector<IValue>& IValue::toGenericListRef() const {
   return toGenericList()->elements();
+}
+
+inline const std::string& IValue::toStringRef() const {
+  return toString()->string();
 }
 
 } // namespace c10

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5198,9 +5198,15 @@ a")
             q = fn(x, x)
             return x
 
+        def fn_string(str, strpair):
+            # type: (str, Tuple[str, str]) -> Tuple[str, int, str, str]
+            str1, str2 = strpair
+            return str, 2, str1, str2
+
         x = torch.ones(2, 2)
         self.checkScript(fn_unpack, (x,), optimize=True)
         self.checkScript(fn_index, (x,), optimize=True)
+        self.checkScript(fn_string, ("1", ("3", "4")), optimize=True)
 
     def test_type_annotations_varargs(self):
         def fn_varargs(x, *args):

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -216,8 +216,10 @@ inline py::object toPyObject(IValue&& ivalue) {
     return py::cast(ivalue.toDouble());
   } else if (ivalue.isInt()) {
     return py::cast(ivalue.toInt());
-  }else if (ivalue.isBool()) {
+  } else if (ivalue.isBool()) {
     return py::cast(ivalue.toBool());
+  } else if (ivalue.isString()) {
+    return py::cast(ivalue.toStringRef());
   } else if (ivalue.isIntList()) {
     return py::cast(ivalue.toIntListRef());
   } else if (ivalue.isDoubleList()) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1937,6 +1937,7 @@ const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
     {"int", IntType::get()},
     {"float", FloatType::get()},
     {"bool", BoolType::get()},
+    {"str", StringType::get()},
   };
   return map;
 }


### PR DESCRIPTION
Add strings to our set of built-in types for annotations. This is used in the the functional library.