### PR TITLE
3D Conv in NHWC layout

### DIFF
--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -184,84 +184,122 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
 // The implementations.
 template <typename T, class Context>
 bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
-  CAFFE_ENFORCE_EQ(
+  CAFFE_ENFORCE_LE(
       kernel_.size(),
-      2,
-      "Only 2d convolution is supported for NHWC storage type");
-
+      3,
+      "Only 1-3d convolution is supported for NHWC storage type");
   const Tensor& X = Input(INPUT);
-  auto& filter = Input(FILTER);
+  const auto& filter = Input(FILTER);
   Tensor* Y = Output(0);
-  CAFFE_ENFORCE_EQ(X.ndim(), 4);
-  const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
-
+  const int N = X.dim32(0), C = X.dim32(X.ndim() - 1);
+  const int G = group_;
   CAFFE_ENFORCE_EQ(X.ndim(), filter.ndim());
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE_EQ(filter.dim32(1), kernel_h());
-  CAFFE_ENFORCE_EQ(filter.dim32(2), kernel_w());
-  CAFFE_ENFORCE_EQ(filter.dim32(3), C / group_);
+  CAFFE_ENFORCE_EQ(
+      C,
+      filter.dim32(filter.ndim() - 1) * G,
+      "Convolution op: input channels does not match: # of input channels ",
+      C,
+      " is not equal to kernel channels * group: ",
+      filter.dim32(filter.ndim() - 1),
+      "*",
+      G);
+  CAFFE_ENFORCE_EQ(
+      M % G, 0, "The number of output channels is not divisible by group.");
 
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, filter.dim32(0));
+  int kernel_size = 1;
+  for (std::size_t i = 0; i < kernel_.size(); ++i) {
+    CAFFE_ENFORCE_EQ(filter.dim32(i + 1), kernel_[i]);
+    kernel_size *= kernel_[i];
+  }
+  ConvPoolOpBase<Context>::SetOutputSize(X, Y, M);
+  const vector<int> Y_dims = GetDims(*Y);
+  const int X_HxW = X.numel() / (N * C);
+  const int Y_HxW = Y->numel() / (N * M);
+  const vector<int> img_shape(X.sizes().cbegin() + 1, X.sizes().cend());
+  vector<int> buffer_shape(Y_dims.size() + 1);
+  std::copy(Y_dims.cbegin(), Y_dims.cend(), buffer_shape.begin());
+  buffer_shape.back() = C * kernel_size;
+
+  const int buffer_size = C * kernel_size * Y_HxW;
+
   // The dimension of each kernel
-  const int kernel_dim = kernel_h() * kernel_w() * (C / group_);
+  const int kernel_dim = C / G * kernel_size;
   // The offset corresponding to a single input image, and a single output
   // image.
-  const int input_offset = H * W * C;
+  const int input_offset = X_HxW * C;
   const int output_offset = Y->numel() / Y->dim32(0);
+
   // The output image size is the spatial size of the output.
-  const int output_image_size = Y->dim32(1) * Y->dim32(2);
-  // The col buffer is stored in HWC order as well - kernel_dim, and the height
-  // and width.
+  // The col buffer is stored in HWC order as well - the height and width, and
+  // kernel_dim.
   const T* X_data = X.template data<T>();
   const T* filter_data = filter.template data<T>();
   const T* bias_data = nullptr;
-  T* Y_data = Y->template mutable_data<T>();
   if (InputSize() == 3) {
     const auto& bias = Input(BIAS);
     CAFFE_ENFORCE_EQ(bias.ndim(), 1);
     CAFFE_ENFORCE_EQ(bias.dim32(0), M);
     bias_data = bias.template data<T>();
   }
+  T* Y_data = Y->template mutable_data<T>();
+
   // Specialized path for 1 by 1 convolution with stride 1, pad 0 - we
   // can skip im2col.
   if (kernel_dim == (C / group_) && !HasPad() && !HasStride()) {
-    const int HxW = X.numel() / (N * C);
     if (bias_data != nullptr) {
+      // For this specialized path, we need a bigger bias_multiplier_ because
+      // we're doing just 1 big GEMM.
       ConvPoolOpBase<Context>::template SetBiasMultiplier<T>(
-          N * HxW, &bias_multiplier_);
+          N * X_HxW, &bias_multiplier_);
     }
     return Run1x1ConvOnDeviceWithOrderNHWC(
-        N, C, HxW, M, X_data, filter_data, bias_data, Y_data);
+        N, C, X_HxW, M, X_data, filter_data, bias_data, Y_data);
   }
 
   if (bias_data != nullptr) {
     ConvPoolOpBase<Context>::template SetBiasMultiplier<T>(
-        output_image_size, &bias_multiplier_);
+        Y_HxW, &bias_multiplier_);
   }
   auto f = [&](Tensor* col_buffer) {
-    col_buffer->Resize(
-        vector<int64_t>{Y->dim32(1), Y->dim32(2), kernel_h(), kernel_w(), C});
+    col_buffer->Resize(buffer_shape);
     T* col_buffer_data = col_buffer->template mutable_data<T>();
     // Im2Col, followed by gemm.
     for (int image_id = 0; image_id < N; ++image_id) {
-      math::Im2Col<T, Context, StorageOrder::NHWC>(
-          C,
-          H,
-          W,
-          kernel_h(),
-          kernel_w(),
-          dilation_h(),
-          dilation_w(),
-          pad_t(),
-          pad_l(),
-          pad_b(),
-          pad_r(),
-          stride_h(),
-          stride_w(),
-          X_data,
-          col_buffer_data,
-          &context_,
-          group_);
+      if (kernel_.size() <= 2) {
+        math::Im2Col<T, Context, StorageOrder::NHWC>(
+            C,
+            X.dim32(1),
+            kernel_.size() == 2 ? X.dim32(2) : 1,
+            kernel_h(),
+            kernel_.size() == 2 ? kernel_w() : 1,
+            dilation_h(),
+            kernel_.size() == 2 ? dilation_w() : 1,
+            pad_t(),
+            kernel_.size() == 2 ? pad_l() : 0,
+            kernel_.size() == 2 ? pad_b() : pad_l(),
+            kernel_.size() == 2 ? pad_r() : 0,
+            stride_h(),
+            kernel_.size() == 2 ? stride_w() : 1,
+            X_data,
+            col_buffer_data,
+            &context_,
+            group_);
+      } else {
+        math::Im2ColNd<T, Context, StorageOrder::NHWC>(
+            kernel_.size(),
+            C * X_HxW,
+            buffer_size,
+            img_shape.data(),
+            buffer_shape.data(),
+            kernel_.data(),
+            stride_.data(),
+            dilation_.data(),
+            pads_.data(),
+            X_data,
+            col_buffer_data,
+            &context_);
+      }
       // Weight term
       for (int group_id = 0; group_id < group_; ++group_id) {
         // col_buffer_data in G (H W) (R S C/G) layout
@@ -269,7 +307,7 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
         math::GemmEx<T, Context>(
             CblasNoTrans,
             CblasTrans,
-            output_image_size,
+            Y_HxW,
             M / group_,
             kernel_dim,
             1,
@@ -287,7 +325,7 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
         math::Gemm<T, Context>(
             CblasNoTrans,
             CblasNoTrans,
-            output_image_size,
+            Y_HxW,
             M,
             1,
             1,
@@ -456,15 +494,15 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   ConvPoolOpBase<Context>::ComputePads(input_dims);
   CAFFE_ENFORCE_EQ(X.ndim(), filter.ndim());
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE(filter.dim32(1) * group_ == C);
+  CAFFE_ENFORCE_EQ(C, filter.dim32(1) * group_);
 
   int kernel_dims_size = 1;
   for (int i = 0; i < kernel_.size(); ++i) {
-    CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
+    CAFFE_ENFORCE_EQ(filter.dim32(i + 2), kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
 
-  CAFFE_ENFORCE(M % group_ == 0);
+  CAFFE_ENFORCE_EQ(M % group_, 0);
   dfilter->ResizeLike(filter);
   // The dimension of each kernel
   const int kernel_dim = C / group_ * kernel_dims_size;
@@ -652,28 +690,49 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   auto& filter = Input(FILTER);
   auto& dY = Input(OUTPUT_GRAD);
   auto* dfilter = Output(FILTER_GRAD);
+  const int N = X.dim32(0), C = X.dim32(X.ndim() - 1);
 
-  const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
-  ConvPoolOpBase<Context>::ComputePads({H, W});
-  CAFFE_ENFORCE_EQ(filter.ndim(), 4);
+  const vector<int> input_dims = this->GetDims(X);
+  const int input_image_size = this->GetDimsSize(X);
+
+  const vector<int> output_dims = this->GetDims(dY);
+  // The output image size is the spatial size of the output.
+  const int output_image_size = this->GetDimsSize(dY);
+
+  ConvPoolOpBase<Context>::ComputePads(input_dims);
+  CAFFE_ENFORCE_EQ(X.ndim(), filter.ndim());
   const int M = filter.dim32(0);
-  CAFFE_ENFORCE_EQ(filter.dim32(1), kernel_h());
-  CAFFE_ENFORCE_EQ(filter.dim32(2), kernel_w());
-  CAFFE_ENFORCE_EQ(filter.dim32(3), C / group_);
-  dfilter->ResizeLike(filter);
+  CAFFE_ENFORCE_EQ(C, filter.dim32(filter.ndim() - 1) * group_);
 
+  int kernel_dims_size = 1;
+  for (int i = 0; i < kernel_.size(); ++i) {
+    CAFFE_ENFORCE_EQ(filter.dim32(i + 1), kernel_[i]);
+    kernel_dims_size *= kernel_[i];
+  }
+
+  CAFFE_ENFORCE_EQ(M % group_, 0);
+  dfilter->ResizeLike(filter);
   // The dimension of each kernel
-  const int kernel_dim = kernel_h() * kernel_w() * (C / group_);
+  const int kernel_dim = C / group_ * kernel_dims_size;
   // The offset corresponding to a single input image, and a single output
   // image.
-  const int input_offset = H * W * C;
+  const int input_offset = C * input_image_size;
   const int output_offset = dY.numel() / dY.dim32(0);
-  // The output image size is the spatial size of the output.
-  const int output_image_size = dY.dim32(1) * dY.dim32(2);
-  // The col buffer is stored in CHW order as well - kernel_dim, and the height
-  // and width.
-  col_buffer_.Resize(output_image_size, group_ * kernel_dim);
 
+  // The col buffer is stored in HWC order as well - the height and width, and
+  // kernel_dim.
+  vector<int> img_shape(X.sizes().cbegin() + 1, X.sizes().cend());
+  vector<int> col_buffer_shape(output_dims.size() + 1);
+  std::copy(output_dims.cbegin(), output_dims.cend(), col_buffer_shape.begin());
+  col_buffer_shape.back() = C * kernel_dims_size;
+  col_buffer_.Resize(col_buffer_shape);
+
+  if (kernel_.size() != 2) {
+    SetDeviceTensor(img_shape, &img_shape_device_);
+    SetDeviceTensor(col_buffer_shape, &col_buffer_shape_device_);
+  }
+
+  const int col_buffer_size = C * kernel_dims_size * output_image_size;
   const T* Xdata = X.template data<T>();
   const T* const filter_data = filter.template data<T>();
   const T* const dYdata = dY.template data<T>();
@@ -703,24 +762,40 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   for (int image_id = 0; image_id < N; ++image_id) {
     // When we compute the gradient with respect to the filters, we need to do
     // im2col to allow gemm-type computation.
-    math::Im2Col<T, Context, StorageOrder::NHWC>(
-        C,
-        H,
-        W,
-        kernel_h(),
-        kernel_w(),
-        dilation_h(),
-        dilation_w(),
-        pad_t(),
-        pad_l(),
-        pad_b(),
-        pad_r(),
-        stride_h(),
-        stride_w(),
-        Xdata,
-        col_buffer_data,
-        &context_,
-        group_);
+    if (kernel_.size() <= 2) {
+      math::Im2Col<T, Context, StorageOrder::NHWC>(
+          C,
+          X.dim(1),
+          kernel_.size() == 2 ? X.dim32(2) : 1,
+          kernel_h(),
+          kernel_.size() == 2 ? kernel_w() : 1,
+          dilation_h(),
+          kernel_.size() == 2 ? dilation_w() : 1,
+          pad_t(),
+          kernel_.size() == 2 ? pad_l() : 0,
+          kernel_.size() == 2 ? pad_b() : pad_l(),
+          kernel_.size() == 2 ? pad_r() : 0,
+          stride_h(),
+          kernel_.size() == 2 ? stride_w() : 1,
+          Xdata,
+          col_buffer_data,
+          &context_,
+          group_);
+    } else {
+      math::Im2ColNd<T, Context, StorageOrder::NHWC>(
+          kernel_.size(),
+          C * input_image_size,
+          col_buffer_size,
+          img_shape.data(),
+          col_buffer_shape.data(),
+          kernel_.data(),
+          stride_.data(),
+          dilation_.data(),
+          pads_.data(),
+          Xdata,
+          col_buffer_data,
+          &context_);
+    }
     // Gradient with respect to filter.
     for (int group_id = 0; group_id < group_; ++group_id) {
       math::GemmEx<T, Context>(
@@ -753,7 +828,7 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
           &context_);
     }
     Xdata += input_offset;
-  }
+  } // for each image
 
   if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
     // Compute the gradient w.r.t. the input.
@@ -779,26 +854,42 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
             group_ * kernel_dim,
             &context_);
       }
-      math::Col2Im<T, Context, StorageOrder::NHWC>(
-          C,
-          H,
-          W,
-          kernel_h(),
-          kernel_w(),
-          dilation_h(),
-          dilation_w(),
-          pad_t(),
-          pad_l(),
-          pad_b(),
-          pad_r(),
-          stride_h(),
-          stride_w(),
-          col_buffer_data,
-          dXdata,
-          &context_,
-          group_);
+      if (kernel_.size() <= 2) {
+        math::Col2Im<T, Context, StorageOrder::NHWC>(
+            C,
+            X.dim(1),
+            kernel_.size() == 2 ? X.dim32(2) : 1,
+            kernel_h(),
+            kernel_.size() == 2 ? kernel_w() : 1,
+            dilation_h(),
+            kernel_.size() == 2 ? dilation_w() : 1,
+            pad_t(),
+            kernel_.size() == 2 ? pad_l() : 0,
+            kernel_.size() == 2 ? pad_b() : pad_l(),
+            kernel_.size() == 2 ? pad_r() : 0,
+            stride_h(),
+            kernel_.size() == 2 ? stride_w() : 1,
+            col_buffer_data,
+            dXdata,
+            &context_,
+            group_);
+      } else {
+        math::Col2ImNd<T, Context, StorageOrder::NHWC>(
+            kernel_.size(),
+            C * input_image_size,
+            col_buffer_size,
+            img_shape.data(),
+            col_buffer_shape.data(),
+            kernel_.data(),
+            stride_.data(),
+            dilation_.data(),
+            pads_.data(),
+            col_buffer_data,
+            dXdata,
+            &context_);
+      }
       dXdata += input_offset;
-    }
+    } // for each image
   }
   return true;
 }

--- a/caffe2/utils/hip/math_hip.cc
+++ b/caffe2/utils/hip/math_hip.cc
@@ -2521,6 +2521,7 @@ void Col2Im<float, HIPContext, StorageOrder::NCHW>(
     float* img_data,
     HIPContext* context,
     const int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Im2Col.
   const int dkernel_h = dilation_h * (kernel_h - 1) + 1;
   const int dkernel_w = dilation_w * (kernel_w - 1) + 1;
   const int output_h = (height + pad_t + pad_b - dkernel_h) / stride_h + 1;
@@ -2611,7 +2612,9 @@ void Im2ColNd<float, HIPContext, StorageOrder::NCHW>(
     const int* pad,
     const float* img_data,
     float* col_data,
-    HIPContext* context) {
+    HIPContext* context,
+    const int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Im2Col.
   DISPATCH_FUNCTION_BY_VALUE_WITH_TYPE_1(
       N,
       Im2ColNdNCHWHIPImpl,
@@ -2630,6 +2633,24 @@ void Im2ColNd<float, HIPContext, StorageOrder::NCHW>(
 }
 
 template <>
+void Im2ColNd<float, HIPContext, StorageOrder::NHWC>(
+    const int N,
+    const int img_size,
+    const int col_size,
+    const int* img_shape,
+    const int* col_shape,
+    const int* kernel_shape,
+    const int* stride,
+    const int* dilation,
+    const int* pad,
+    const float* img_data,
+    float* col_data,
+    HIPContext* context,
+    const int groups) {
+  CAFFE_NOT_IMPLEMENTED;
+}
+
+template <>
 void Col2ImNd<float, HIPContext, StorageOrder::NCHW>(
     const int N,
     const int img_size,
@@ -2642,7 +2663,9 @@ void Col2ImNd<float, HIPContext, StorageOrder::NCHW>(
     const int* pad,
     const float* col_data,
     float* img_data,
-    HIPContext* context) {
+    HIPContext* context,
+    const int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Col2Im.
   DISPATCH_FUNCTION_BY_VALUE_WITH_TYPE_1(
       N,
       Col2ImNdNCHWHIPImpl,
@@ -2658,6 +2681,24 @@ void Col2ImNd<float, HIPContext, StorageOrder::NCHW>(
       col_data,
       img_data,
       context);
+}
+
+template <>
+void Col2ImNd<float, HIPContext, StorageOrder::NHWC>(
+    const int N,
+    const int img_size,
+    const int col_size,
+    const int* img_shape,
+    const int* col_shape,
+    const int* kernel_shape,
+    const int* stride,
+    const int* dilation,
+    const int* pad,
+    const float* col_data,
+    float* img_data,
+    HIPContext* context,
+    const int groups) {
+  CAFFE_NOT_IMPLEMENTED;
 }
 
 template <>

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -548,6 +548,7 @@ CAFFE2_API void Im2Col(
     Context* context,
     const int groups = 1);
 
+// groups must be 1 for GPU
 template <typename T, class Context, StorageOrder kOrder>
 CAFFE2_API void Im2ColNd(
     const int N,
@@ -561,7 +562,8 @@ CAFFE2_API void Im2ColNd(
     const int* pad,
     const T* img_data,
     T* col_data,
-    Context* context);
+    Context* context,
+    const int groups = 1);
 
 // groups must be 1 for GPU
 // For NHWC order with groups > 1, the result will be layout in
@@ -588,6 +590,11 @@ CAFFE2_API void Col2Im(
     Context* context,
     const int groups = 1);
 
+// groups must be 1 for GPU
+// For NHWC order with groups > 1, the result will be layout in
+// NHW G RS C/G order to make data within the same group to be contiguous.
+// For NCHW order, groups doesn't make any difference because we're doing Im2Col
+// for each N and C is the slowest moving dimension among CHW.
 template <typename T, class Context, StorageOrder kOrder>
 CAFFE2_API void Col2ImNd(
     const int N,
@@ -601,7 +608,8 @@ CAFFE2_API void Col2ImNd(
     const int* pad,
     const T* col_data,
     T* img_data,
-    Context* context);
+    Context* context,
+    const int groups = 1);
 
 // Applies a per-channel bias value to each channel of the input
 // image. image_size is H * W

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -2895,6 +2895,7 @@ CAFFE2_CUDA_EXPORT void Col2Im<float, CUDAContext, StorageOrder::NCHW>(
     float* img_data,
     CUDAContext* context,
     const int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Col2Im.
   const int dkernel_h = dilation_h * (kernel_h - 1) + 1;
   const int dkernel_w = dilation_w * (kernel_w - 1) + 1;
   const int output_h = (height + pad_t + pad_b - dkernel_h) / stride_h + 1;
@@ -2983,7 +2984,9 @@ CAFFE2_CUDA_EXPORT void Im2ColNd<float, CUDAContext, StorageOrder::NCHW>(
     const int* pad,
     const float* img_data,
     float* col_data,
-    CUDAContext* context) {
+    CUDAContext* context,
+    const int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Im2Col.
   DISPATCH_FUNCTION_BY_VALUE_WITH_TYPE_1(
       N,
       Im2ColNdNCHWCUDAImpl,
@@ -3002,6 +3005,24 @@ CAFFE2_CUDA_EXPORT void Im2ColNd<float, CUDAContext, StorageOrder::NCHW>(
 }
 
 template <>
+CAFFE2_CUDA_EXPORT void Im2ColNd<float, CUDAContext, StorageOrder::NHWC>(
+    const int N,
+    const int img_size,
+    const int col_size,
+    const int* img_shape,
+    const int* col_shape,
+    const int* kernel_shape,
+    const int* stride,
+    const int* dilation,
+    const int* pad,
+    const float* img_data,
+    float* col_data,
+    CUDAContext* context,
+    const int groups) {
+  CAFFE_NOT_IMPLEMENTED;
+}
+
+template <>
 CAFFE2_CUDA_EXPORT void Col2ImNd<float, CUDAContext, StorageOrder::NCHW>(
     const int N,
     const int img_size,
@@ -3014,7 +3035,9 @@ CAFFE2_CUDA_EXPORT void Col2ImNd<float, CUDAContext, StorageOrder::NCHW>(
     const int* pad,
     const float* col_data,
     float* img_data,
-    CUDAContext* context) {
+    CUDAContext* context,
+    int /* groups */) {
+  // In NCHW, the number of groups doesn't affect Col2Im.
   DISPATCH_FUNCTION_BY_VALUE_WITH_TYPE_1(
       N,
       Col2ImNdNCHWCUDAImpl,
@@ -3030,6 +3053,24 @@ CAFFE2_CUDA_EXPORT void Col2ImNd<float, CUDAContext, StorageOrder::NCHW>(
       col_data,
       img_data,
       context);
+}
+
+template <>
+CAFFE2_CUDA_EXPORT void Col2ImNd<float, CUDAContext, StorageOrder::NHWC>(
+    const int N,
+    const int img_size,
+    const int col_size,
+    const int* img_shape,
+    const int* col_shape,
+    const int* kernel_shape,
+    const int* stride,
+    const int* dilation,
+    const int* pad,
+    const float* col_data,
+    float* img_data,
+    CUDAContext* context,
+    int groups) {
+  CAFFE_NOT_IMPLEMENTED;
 }
 
 template <>


### PR DESCRIPTION
Summary: Conv in NHWC layout only works for 2D images. This has been a pain point when implementing quantized 3D convolution because we need NHWC layout for best performance (note that NHWC layout in general gives better performance in CPU not just for quantized operators). For example, our quantized ops have a functionality to measure quantized error operator by operator but this needs running a shadow fp32 operator, but this is not easy when there's no 3D conv in NHWC layout is available (currently we're doing layout conversion on the fly for the shadow fp32 operator which is error prone). Some of Caffe2 frameworks like brew generates error when we try to create a 3D conv op in NHWC layout. This was also a blocker for using aibench because aibench is using brew.

Differential Revision: D10333829
