### PR TITLE
caffe2: UpsampleBilinear support for scales

### DIFF
--- a/caffe2/python/operator_test/upsample_op_test.py
+++ b/caffe2/python/operator_test/upsample_op_test.py
@@ -40,52 +40,72 @@ class TestUpSample(serial.SerializedTestCase):
                      gc, dc):
 
         np.random.seed(seed)
-        op = core.CreateOperator(
-            "UpsampleBilinear",
-            ["X"],
-            ["Y"],
-            width_scale=width_scale,
-            height_scale=height_scale,
-        )
 
         X = np.random.rand(
             batch_size, num_channels, height, width).astype(np.float32)
+        scales = np.array([height_scale, width_scale]).astype(np.float32)
 
-        def ref(X):
-            output_height = np.int32(height * height_scale)
-            output_width = np.int32(width * width_scale)
+        ops = [
+            (
+                core.CreateOperator(
+                    "UpsampleBilinear",
+                    ["X"],
+                    ["Y"],
+                    width_scale=width_scale,
+                    height_scale=height_scale,
+                ),
+                [X],
+            ),
+            (
+                core.CreateOperator(
+                    "UpsampleBilinear",
+                    ["X", "scales"],
+                    ["Y"],
+                ),
+                [X, scales],
+            ),
+        ]
 
-            Y = np.random.rand(
-                batch_size, num_channels, output_height,
-                output_width).astype(np.float32)
+        for op, inputs in ops:
+            def ref(X, scales=None):
+                output_height = np.int32(height * height_scale)
+                output_width = np.int32(width * width_scale)
 
-            rheight = ((height - 1) / (output_height - 1)
-                    if output_height > 1
-                    else float(0))
-            rwidth = (width - 1) / (output_width - 1) if output_width > 1 else float(0)
+                Y = np.random.rand(
+                    batch_size, num_channels, output_height,
+                    output_width).astype(np.float32)
 
-            for i in range(output_height):
-                h1r = rheight * i
-                h1 = int(h1r)
-                h1p = 1 if h1 < height - 1 else 0
-                h1lambda = h1r - h1
-                h0lambda = float(1) - h1lambda
-                for j in range(output_width):
-                    w1r = rwidth * j
-                    w1 = int(w1r)
-                    w1p = 1 if w1 < width - 1 else 0
-                    w1lambda = w1r - w1
-                    w0lambda = float(1) - w1lambda
-                    Y[:, :, i, j] = (h0lambda * (w0lambda * X[:, :, h1, w1] +
-                        w1lambda * X[:, :, h1, w1 + w1p]) +
-                        h1lambda * (w0lambda * X[:, :, h1 + h1p, w1] +
-                        w1lambda * X[:, :, h1 + h1p, w1 + w1p]))
+                rheight = ((height - 1) / (output_height - 1)
+                        if output_height > 1
+                        else float(0))
+                rwidth = ((width - 1) / (output_width - 1)
+                        if output_width > 1
+                        else float(0))
 
-            return Y,
+                for i in range(output_height):
+                    h1r = rheight * i
+                    h1 = int(h1r)
+                    h1p = 1 if h1 < height - 1 else 0
+                    h1lambda = h1r - h1
+                    h0lambda = float(1) - h1lambda
+                    for j in range(output_width):
+                        w1r = rwidth * j
+                        w1 = int(w1r)
+                        w1p = 1 if w1 < width - 1 else 0
+                        w1lambda = w1r - w1
+                        w0lambda = float(1) - w1lambda
+                        Y[:, :, i, j] = (h0lambda * (
+                            w0lambda * X[:, :, h1, w1] +
+                            w1lambda * X[:, :, h1, w1 + w1p]) +
+                            h1lambda * (w0lambda * X[:, :, h1 + h1p, w1] +
+                            w1lambda * X[:, :, h1 + h1p, w1 + w1p]))
 
-        self.assertReferenceChecks(gc, op, [X], ref)
-        self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=0.1, threshold=1e-2)
+                return Y,
+
+            self.assertReferenceChecks(gc, op, inputs, ref)
+            self.assertDeviceChecks(dc, op, inputs, [0])
+            self.assertGradientChecks(gc, op, inputs, 0, [0], stepsize=0.1,
+                                      threshold=1e-2)
 
     @serial.given(height_scale=st.floats(1.0, 4.0) | st.just(2.0),
            width_scale=st.floats(1.0, 4.0) | st.just(2.0),
@@ -110,44 +130,65 @@ class TestUpSample(serial.SerializedTestCase):
                             num_channels,
                             output_height,
                             output_width).astype(np.float32)
+        scales = np.array([height_scale, width_scale]).astype(np.float32)
 
-        op = core.CreateOperator(
-            "UpsampleBilinearGradient",
-            ["dY", "X"],
-            ["dX"],
-            width_scale=width_scale,
-            height_scale=height_scale,
-        )
+        ops = [
+            (
+                core.CreateOperator(
+                    "UpsampleBilinearGradient",
+                    ["dY", "X"],
+                    ["dX"],
+                    width_scale=width_scale,
+                    height_scale=height_scale,
+                ),
+                [dY, X],
+            ),
+            (
+                core.CreateOperator(
+                    "UpsampleBilinearGradient",
+                    ["dY", "X", "scales"],
+                    ["dX"],
+                ),
+                [dY, X, scales],
+            ),
+        ]
 
-        def ref(dY, X):
-            dX = np.zeros_like(X)
+        for op, inputs in ops:
+            def ref(dY, X, scales=None):
+                dX = np.zeros_like(X)
 
-            rheight = ((height - 1) / (output_height - 1)
-                    if output_height > 1
-                    else float(0))
-            rwidth = (width - 1) / (output_width - 1) if output_width > 1 else float(0)
+                rheight = ((height - 1) / (output_height - 1)
+                        if output_height > 1
+                        else float(0))
+                rwidth = ((width - 1) / (output_width - 1)
+                        if output_width > 1
+                        else float(0))
 
-            for i in range(output_height):
-                h1r = rheight * i
-                h1 = int(h1r)
-                h1p = 1 if h1 < height - 1 else 0
-                h1lambda = h1r - h1
-                h0lambda = float(1) - h1lambda
-                for j in range(output_width):
-                    w1r = rwidth * j
-                    w1 = int(w1r)
-                    w1p = 1 if w1 < width - 1 else 0
-                    w1lambda = w1r - w1
-                    w0lambda = float(1) - w1lambda
-                    dX[:, :, h1, w1] += h0lambda * w0lambda * dY[:, :, i, j]
-                    dX[:, :, h1, w1 + w1p] += h0lambda * w1lambda * dY[:, :, i, j]
-                    dX[:, :, h1 + h1p, w1] += h1lambda * w0lambda * dY[:, :, i, j]
-                    dX[:, :, h1 + h1p, w1 + w1p] += h1lambda * w1lambda * dY[:, :, i, j]
+                for i in range(output_height):
+                    h1r = rheight * i
+                    h1 = int(h1r)
+                    h1p = 1 if h1 < height - 1 else 0
+                    h1lambda = h1r - h1
+                    h0lambda = float(1) - h1lambda
+                    for j in range(output_width):
+                        w1r = rwidth * j
+                        w1 = int(w1r)
+                        w1p = 1 if w1 < width - 1 else 0
+                        w1lambda = w1r - w1
+                        w0lambda = float(1) - w1lambda
+                        dX[:, :, h1, w1] += (
+                            h0lambda * w0lambda * dY[:, :, i, j])
+                        dX[:, :, h1, w1 + w1p] += (
+                            h0lambda * w1lambda * dY[:, :, i, j])
+                        dX[:, :, h1 + h1p, w1] += (
+                            h1lambda * w0lambda * dY[:, :, i, j])
+                        dX[:, :, h1 + h1p, w1 + w1p] += (
+                            h1lambda * w1lambda * dY[:, :, i, j])
 
-            return dX,
+                return dX,
 
-        self.assertDeviceChecks(dc, op, [dY, X], [0])
-        self.assertReferenceChecks(gc, op, [dY, X], ref)
+            self.assertDeviceChecks(dc, op, inputs, [0])
+            self.assertReferenceChecks(gc, op, inputs, ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: This updates UpsampleBilinearOp and UpsampleBilinearGradientOp to support scales to bring it inline with ResizeNearestOp https://github.com/pytorch/pytorch/pull/12720.

Differential Revision: D10416228
