### PR TITLE
Fixes for BUILD_ATEN_ONLY build flavor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if (ANDROID OR IOS)
 endif()
 
 if (BUILD_ATEN_ONLY)
+  add_compile_definitions(BUILD_ATEN_ONLY)
   set(BUILD_CAFFE2_OPS OFF)
   set(BUILD_PYTHON OFF)
   set(USE_NUMA OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if (ANDROID OR IOS)
 endif()
 
 if (BUILD_ATEN_ONLY)
-  add_compile_definitions(BUILD_ATEN_ONLY)
+  add_definitions(-DBUILD_ATEN_ONLY)
   set(BUILD_CAFFE2_OPS OFF)
   set(BUILD_PYTHON OFF)
   set(USE_NUMA OFF)

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -13,9 +13,13 @@
 
 #include "c10/util/Flags.h"
 
+#ifndef BUILD_ATEN_ONLY
 #include "caffe2/core/allocator.h"
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
+#else
+#include "caffe2/core/common.h"
+#endif
 
 // A global boolean variable to control whether we free memory when a Tensor
 // is shrinked to a smaller size. As a result, a Tensor is always going to

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -282,8 +282,10 @@ Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Ten
                   sourceSlicedSizes.begin())) {
     std::stringstream ss;
     ss << "index_copy_(): Source/destination tensor must have same slice shapes. ";
+#ifndef BUILD_ATEN_ONLY
     ss << "Destination slice shape: " << selfSlicedSizes << " at dimension " << dim;
     ss << " and source slice shape: " << sourceSlicedSizes << " at dimension 0.";
+#endif
     AT_ERROR(ss.str());
   }
   if (source.dim() > 0 && numIndices != source.size(dim)) {


### PR DESCRIPTION
Very small fixes to make BUILD_ATEN_ONLY finally link properly when used as dynamic library.

Our daily CI failed to link, looks like some stuff in `caffe2/core/allocator.cc` was missing, not sure why it didn't pick it up before. I guess that yesterday big changes triggered it finally!
