### PR TITLE
Fix Bias Condition for Transpose Convolution

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -182,9 +182,9 @@ static void check_input_shape_forward(const at::Tensor& input,
              "Given transposed=", transposed, ", weight of size ", weight.sizes(),
              ", expected input", input.sizes(), " to have ", weight.size(0),
              " channels, but got ", input.size(1), " channels instead");
-    AT_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight.size(0)),
+    AT_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight.size(1)),
              "Given transposed=", transposed, ", weight of size ", weight.sizes(),
-             ", expected bias to be 1-dimensional with ", weight.size(0), " elements",
+             ", expected bias to be 1-dimensional with ", weight.size(1), " elements",
              ", but got bias of size ", bias.sizes(), " instead");
   }
 }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -182,9 +182,9 @@ static void check_input_shape_forward(const at::Tensor& input,
              "Given transposed=", transposed, ", weight of size ", weight.sizes(),
              ", expected input", input.sizes(), " to have ", weight.size(0),
              " channels, but got ", input.size(1), " channels instead");
-    AT_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight.size(1) * groups),
+    AT_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight.size(0)),
              "Given transposed=", transposed, ", weight of size ", weight.sizes(),
-             ", expected bias to be 1-dimensional with ", weight.size(1) * groups, " elements",
+             ", expected bias to be 1-dimensional with ", weight.size(0), " elements",
              ", but got bias of size ", bias.sizes(), " instead");
   }
 }

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                   "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(1));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -23,7 +23,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
     THNN_ARGCHECK(!weight->is_empty() && (weight->dim() == 2 || weight->dim() == 4), 5, weight,
                   "non-empty 2D or 4D weight tensor expected, but got: %s");
     if (bias != NULL) {
-      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(0));
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size(1));
     }
   } else if (!weight_nullable) {
     THError("weight tensor is expected to be non-nullable");


### PR DESCRIPTION
Bias length should be equal to output channels, regardless of if the Convolution is transposed or not. This commit corrects a runtime check that rejects when bias != inputchannels for Transpose Convolutions, Found when providing bias to F.grad.conv2d_input as part of implementing a standard convolution backward pass. Default bias is None, which is possibly why not flagged previousy.

