### PR TITLE
absorb THD into main cmake build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,7 @@ def build_libs(libs):
     my_env["USE_LMDB"] = "ON" if USE_LMDB else "OFF"
     my_env["USE_OPENCV"] = "ON" if USE_OPENCV else "OFF"
     my_env["USE_FFMPEG"] = "ON" if USE_FFMPEG else "OFF"
+    my_env["USE_DISTRIBUTED"] = "ON" if USE_DISTRIBUTED else "OFF"
 
     try:
         os.mkdir('build')
@@ -468,7 +469,6 @@ class build_deps(PytorchCommand):
         if USE_DISTRIBUTED:
             if IS_LINUX:
                 libs += ['c10d']
-            libs += ['THD']
         build_libs(libs)
 
         # Use copies instead of symbolic files.

--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -93,7 +93,6 @@ if "%1"=="caffe2" (
   call:build_caffe2 %~1
 ) ELSE (
   set "IS_OURS="
-  IF "%1"=="THD" set IS_OURS=1
   IF "%1"=="libshm_windows" set IS_OURS=1
   if defined IS_OURS (
     cd torch\lib
@@ -185,6 +184,7 @@ goto:eof
                   -DBUILD_CAFFE2_OPS=%BUILD_CAFFE2_OPS% ^
                   -DONNX_NAMESPACE=%ONNX_NAMESPACE% ^
                   -DUSE_CUDA=%USE_CUDA% ^
+                  -DUSE_DISTRIBUTED=%USE_DISTRIBUTED% ^
                   -DUSE_NUMPY=%USE_NUMPY% ^
                   -DUSE_NNPACK=%USE_NNPACK% ^
                   -DUSE_LEVELDB=%USE_LEVELDB% ^

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -205,7 +205,6 @@ function build() {
 		       -DTHC_SO_VERSION=1 \
 		       -DTHNN_SO_VERSION=1 \
 		       -DTHCUNN_SO_VERSION=1 \
-		       -DTHD_SO_VERSION=1 \
 		       -DUSE_CUDA=$USE_CUDA \
 		       -DBUILD_EXAMPLES=OFF \
 		       -DBUILD_TEST=$BUILD_TEST \
@@ -301,6 +300,7 @@ function build_caffe2() {
 		       -DBUILD_CAFFE2_OPS=$BUILD_CAFFE2_OPS \
 		       -DONNX_NAMESPACE=$ONNX_NAMESPACE \
 		       -DUSE_CUDA=$USE_CUDA \
+		       -DUSE_DISTRIBUTED=$USE_DISTRIBUTED \
 		       -DUSE_NUMPY=$USE_NUMPY \
 		       -DCAFFE2_STATIC_LINK_CUDA=$CAFFE2_STATIC_LINK_CUDA \
 		       -DUSE_ROCM=$USE_ROCM \
@@ -325,6 +325,8 @@ function build_caffe2() {
 		       -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
 		       -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $USER_LDFLAGS" \
 		       $GLOO_FLAGS \
+		       -DTHD_SO_VERSION=1 \
+		       $THD_FLAGS \
 		       ${EXTRA_CAFFE2_CMAKE_FLAGS[@]}
       # STOP!!! Are you trying to add a C or CXX flag?  Add it
       # to CMakeLists.txt and aten/CMakeLists.txt, not here.
@@ -373,10 +375,6 @@ for arg in "$@"; do
         popd
     elif [[ "$arg" == "caffe2" ]]; then
         build_caffe2
-    elif [[ "$arg" == "THD" ]]; then
-        pushd "$TORCH_LIB_DIR"
-        build THD $THD_FLAGS
-        popd
     elif [[ "$arg" == "libshm" ]] || [[ "$arg" == "libshm_windows" ]]; then
         pushd "$TORCH_LIB_DIR"
         build $arg

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -467,3 +467,7 @@ install(FILES
     ${PROJECT_BINARY_DIR}/TorchConfigVersion.cmake
     ${PROJECT_BINARY_DIR}/TorchConfig.cmake
     DESTINATION share/cmake/Torch)
+
+if (USE_DISTRIBUTED)
+  add_subdirectory(${TORCH_SRC_DIR}/lib/THD)
+endif()

--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -1,7 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 # TODO(jiayq): once we have unified CMake entry, remove this module path.
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules ${CMAKE_MODULE_PATH})
-SET(Gloo_USE_CUDA TRUE)
 
 ################################################################################
 # Helper functions
@@ -43,9 +42,6 @@ ENDIF(NOT HAS_THREAD_LOCAL)
 
 FIND_PACKAGE(MPI)
 
-FIND_PACKAGE(Gloo)
-
-FIND_PACKAGE(Caffe2 REQUIRED)
 INCLUDE_DIRECTORIES(${CAFFE2_INCLUDE_DIR})
 
 IF(NOT USE_CUDA)
@@ -67,9 +63,8 @@ IF(MPI_FOUND)
   MESSAGE(STATUS "MPI_LIBRARIES: ${MPI_LIBRARIES}")
 ENDIF()
 
-IF(GLOO_FOUND)
+IF(USE_GLOO AND USE_CUDA)
   ADD_DEFINITIONS(-DWITH_GLOO=1)
-  MESSAGE(STATUS "Found Gloo, will compile with Gloo distributed backend")
   IF(USE_GLOO_IBVERBS)
     MESSAGE(STATUS "Building the gloo backend with both TCP and infiniband support")
     ADD_DEFINITIONS(-DUSE_GLOO_IBVERBS=1)
@@ -95,8 +90,6 @@ ELSE()
                  "compile with NCCL distributed backend")
 ENDIF()
 
-ADD_DEFINITIONS(-D_THD_CORE=1)
-
 # Can be compiled standalone
 IF(NOT THD_INSTALL_BIN_DIR OR NOT THD_INSTALL_LIB_DIR OR NOT THD_INSTALL_INCLUDE_DIR)
   SET(THD_INSTALL_BIN_DIR "bin" CACHE PATH "THD install binary subdirectory")
@@ -115,7 +108,7 @@ IF(NOT MPI_FOUND)
   LIST(REMOVE_ITEM test_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/data_channel_mpi_smoke.cpp")
 ENDIF()
 
-IF(NOT GLOO_FOUND)
+IF(NOT USE_GLOO OR NOT USE_CUDA)
   LIST(REMOVE_ITEM base_cpp "${CMAKE_CURRENT_SOURCE_DIR}/base/data_channels/DataChannelGloo.cpp")
   LIST(REMOVE_ITEM base_cpp "${CMAKE_CURRENT_SOURCE_DIR}/base/data_channels/Store.cpp")
   LIST(REMOVE_ITEM test_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/data_channel_gloo_store.cpp")
@@ -139,6 +132,18 @@ ENDIF()
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
 ADD_LIBRARY(THD STATIC ${all_cpp})
+
+TARGET_COMPILE_DEFINITIONS(THD PRIVATE "_THD_CORE=1")
+
+ADD_DEPENDENCIES(THD caffe2)
+
+target_include_directories(THD PRIVATE
+  ${CMAKE_SOURCE_DIR}/aten/src/TH # provides "THAllocator.h" to THCGeneral.h
+  ${CMAKE_BINARY_DIR}/aten/src # provides "ATen/TypeExtendedInterface.h" to ATen.h
+  ${CMAKE_BINARY_DIR}/caffe2/aten/src # provides <TH/THGeneral.h> to THC.h
+  ${CMAKE_BINARY_DIR}/caffe2/aten/src/THC # provides "THCGeneral.h" to THC.h
+  )
+
 set_property(TARGET THD PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 IF(MPI_FOUND)
@@ -155,10 +160,9 @@ IF(MPI_FOUND)
   ENDIF()
 ENDIF()
 
-IF(GLOO_FOUND)
-  INCLUDE_DIRECTORIES(${GLOO_INCLUDE_DIR})
-  FILE(APPEND "${CMAKE_INSTALL_PREFIX}/THD_deps.txt" "${Gloo_LIBRARY};")
-  FILE(APPEND "${CMAKE_INSTALL_PREFIX}/THD_deps.txt" "${Gloo_NATIVE_LIBRARY};")
+# TODO we shouldn't need the USE_CUDA condition here. See https://github.com/pytorch/pytorch/issues/13101
+IF(USE_GLOO AND USE_CUDA)
+  ADD_DEPENDENCIES(THD gloo)
 ENDIF()
 
 # Test executables


### PR DESCRIPTION
We want to move _C into the same cmake invocation that builds
libcaffe2 and libtorch. However, _C depends on THD and c10d, which in
turn depend on libcaffe2. That means that we can't move _C into that
cmake file unless we do these two first. This change does so.