### PR TITLE
Fix non-ascii character in _torch_docs

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4243,7 +4243,7 @@ Example::
     #   3. SparseTensor._values().shape = (nnz, SparseTensor.shape[sparse_dim:])
     #
     # For instance, to create an empty sparse tensor with nnz = 0, dense_dim = 0 and
-    # sparse_dim = 1 (hence indices is a 2D tensor of shape = (1‚ 0))
+    # sparse_dim = 1 (hence indices is a 2D tensor of shape = (1, 0))
     >>> S = torch.sparse_coo_tensor(torch.empty([1, 0]), [], [1])
     tensor(indices=tensor([], size=(1, 0)),
            values=tensor([], size=(0,)),


### PR DESCRIPTION
```
torch/__init__.py:301: in <module>
    from . import _torch_docs, _tensor_docs, _storage_docs
E     File "torch/_torch_docs.py", line 4246
E   SyntaxError: Non-ASCII character '\xe2' in file torch/_torch_docs.py on line 4247, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

