### PR TITLE
Try to reduce c10d test flakiness

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -120,20 +120,37 @@ class PrefixFileStoreTest(TestCase, StoreTestBase):
         return c10d.PrefixStore(self.prefix, self.filestore)
 
 
+def create_tcp_store(addr):
+    """
+    Creates a TCP store. Retries if the chosen port is already in use.
+    """
+    while True:
+        try:
+            port = common.find_free_port()
+            return c10d.TCPStore(addr, port, True)
+        except RuntimeError as error:
+            if str(error) == "Address already in use":
+                continue
+            raise
+
+
 class TCPStoreTest(TestCase, StoreTestBase):
     def _create_store(self):
-        addr = 'localhost'
-        port = common.find_free_port()
-        store = c10d.TCPStore(addr, port, True)
+        store = create_tcp_store('localhost')
         store.set_timeout(timedelta(seconds=300))
         return store
+
+    def test_address_already_in_use(self):
+        with self.assertRaisesRegex(RuntimeError, "^Address already in use$"):
+            addr = 'localhost'
+            port = common.find_free_port()
+            store1 = c10d.TCPStore(addr, port, True)
+            store2 = c10d.TCPStore(addr, port, True)
 
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
     def setUp(self):
-        addr = 'localhost'
-        port = common.find_free_port()
-        self.tcpstore = c10d.TCPStore(addr, port, True)
+        self.tcpstore = create_tcp_store('localhost')
         self.prefix = "test_prefix"
         self.tcpstore.set_timeout(timedelta(seconds=300))
 
@@ -316,7 +333,6 @@ class MultiProcessTestCase(TestCase):
     def setUp(self):
         self.rank = self.MAIN_PROCESS_RANK
         self.file = tempfile.NamedTemporaryFile()
-        self.port = common.find_free_port()
         self.processes = [self._spawn_process(rank) for rank in range(int(self.world_size))]
 
     def tearDown(self):
@@ -687,7 +703,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     def test_gloo_backend(self):
-        store = c10d.TCPStore('localhost', self.port, self.is_master)
+        store = c10d.FileStore(self.file.name)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -698,7 +714,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @skip_if_not_multigpu
     @skip_if_not_nccl
     def test_nccl_backend(self):
-        store = c10d.TCPStore('localhost', self.port, self.is_master)
+        store = c10d.FileStore(self.file.name)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         gpus = gpus_for_rank(self.world_size)[self.rank]
         self._test_ddp_with_process_group(process_group, gpus)
@@ -706,8 +722,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     def test_dist_broadcast_coalesced(self):
-        # Set up process group.
-        store = c10d.TCPStore('localhost', self.port, self.is_master)
+        store = c10d.FileStore(self.file.name)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -734,8 +749,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     def test_sync_params_no_buffers(self):
-        # Set up process group.
-        store = c10d.TCPStore('localhost', self.port, self.is_master)
+        store = c10d.FileStore(self.file.name)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -761,8 +775,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     def test_sync_params_with_buffers(self):
-        # Set up process group.
-        store = c10d.TCPStore('localhost', self.port, self.is_master)
+        store = c10d.FileStore(self.file.name)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -800,7 +813,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @skip_if_not_multigpu
     @skip_if_not_nccl
     def test_fp16(self):
-        store = c10d.TCPStore('localhost', self.port, self.rank == 0)
+        store = c10d.FileStore(self.file.name)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         gpus = gpus_for_rank(self.world_size)[self.rank]


### PR DESCRIPTION
Summary: We have seen the "Address already in use" error popup a few times when instantiating the TCPStore. The port that it uses is dynamically generated through common.find_free_port(), which binds a new socket to a random port, closes the socket, and returns the port that the OS had assigned. If some other process grabs that port in the time between closing the socket and the TCPStore binding to it, the bind error shows up. This commit changes most tests to use the FileStore instead and includes a retry when testing the TCPStore.

Differential Revision: D10433401
