### PR TITLE
CircleCI hot fix: pin awscli to 1.16.35

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ setup_ci_environment: &setup_ci_environment
   no_output_timeout: "1h"
   command: |
     set -e
-    sudo pip install awscli
+    sudo pip install awscli==1.16.35
 
     sudo apt-get update
     sudo apt-get remove linux-image-generic linux-headers-generic linux-generic


### PR DESCRIPTION
awscli==1.16.36 is broken: https://circleci.com/gh/pytorch/pytorch/77338?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link