### PR TITLE
Rename test/common.py to test/common_utils.py

### DIFF
--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -2,7 +2,7 @@ r"""This file is allowed to initialize CUDA context when imported."""
 
 import torch
 import torch.cuda
-from common import TEST_WITH_ROCM, TEST_NUMBA
+from common_utils import TEST_WITH_ROCM, TEST_NUMBA
 
 
 TEST_CUDA = torch.cuda.is_available()

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -7,7 +7,7 @@ from itertools import product
 import torch
 import torch.cuda
 from torch.nn.functional import _Reduction
-from common import TestCase, to_gpu, freeze_rng_state, is_iterable, TEST_WITH_ROCM
+from common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, TEST_WITH_ROCM
 from common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 import torch.backends.cudnn

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -502,9 +502,9 @@ class TestCase(unittest.TestCase):
             return text
         # NB: we take __file__ from the module that defined the test
         # class, so we place the expect directory where the test script
-        # lives, NOT where test/common.py lives.  This doesn't matter in
+        # lives, NOT where test/common_utils.py lives.  This doesn't matter in
         # PyTorch where all test scripts are in the same directory as
-        # test/common.py, but it matters in onnx-pytorch
+        # test/common_utils.py, but it matters in onnx-pytorch
         module_id = self.__class__.__module__
         munged_id = remove_prefix(self.id(), module_id + ".")
         test_file = os.path.realpath(sys.modules[module_id].__file__)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -15,7 +15,7 @@ import glob
 import os
 import shutil
 import sys
-import common
+import common_utils as common
 
 
 '''Usage: python test/onnx/test_operators.py [--no-onnx] [--produce-onnx-test-data]

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -13,7 +13,7 @@ import torch.autograd.function as function
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(-1, pytorch_test_dir)
 
-from common import *
+from common_utils import *
 
 torch.set_default_tensor_type('torch.FloatTensor')
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -13,7 +13,7 @@ import tempfile
 
 import torch
 from torch.utils import cpp_extension
-from common import TEST_WITH_ROCM
+from common_utils import TEST_WITH_ROCM
 import torch.distributed as dist
 
 TESTS = [

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -14,12 +14,12 @@ from torch._six import inf, nan
 from torch.autograd.gradcheck import gradgradcheck, gradcheck
 from torch.autograd.function import once_differentiable
 from torch.autograd.profiler import profile
-from common import (TEST_MKL, TestCase, run_tests, skipIfNoLapack,
-                    suppress_warnings, skipIfRocm,
-                    prod_single_zero, random_square_matrix_of_rank,
-                    random_symmetric_matrix, random_symmetric_psd_matrix,
-                    random_symmetric_pd_matrix, make_nonzero_det,
-                    random_fullrank_matrix_distinct_singular_value)
+from common_utils import (TEST_MKL, TestCase, run_tests, skipIfNoLapack,
+                          suppress_warnings, skipIfRocm,
+                          prod_single_zero, random_square_matrix_of_rank,
+                          random_symmetric_matrix, random_symmetric_psd_matrix,
+                          random_symmetric_pd_matrix, make_nonzero_det,
+                          random_fullrank_matrix_distinct_singular_value)
 from torch.autograd import Variable, Function, detect_anomaly
 from torch.autograd.function import InplaceFunction
 from torch.testing import make_non_contiguous, randn_like

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -12,13 +12,13 @@ from functools import wraps
 from collections import namedtuple
 
 import torch
-import common
+import common_utils as common
 from torch import nn
 import torch.nn.functional as F
 import torch.distributed as c10d
 from torch.nn.parallel import DistributedDataParallel
 
-from common import TestCase
+from common_utils import TestCase
 
 
 if not c10d.is_available():

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -13,7 +13,7 @@ except ImportError:
           "Run \'python run_test.py -i cpp_extensions\' for the \'test_cpp_extensions.py\' tests.")
     raise
 
-import common
+import common_utils as common
 
 from torch.utils.cpp_extension import CUDA_HOME
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -15,7 +15,7 @@ from torch import multiprocessing as mp
 from torch._six import inf, nan
 
 from test_torch import TestTorch
-from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
+from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_WITH_ROCM
 
 # We cannot import TEST_CUDA and TEST_MULTIGPU from common_cuda here,

--- a/test/test_cuda_primary_ctx.py
+++ b/test/test_cuda_primary_ctx.py
@@ -1,6 +1,6 @@
 import ctypes
 import torch
-from common import TestCase, run_tests, skipIfRocm
+from common_utils import TestCase, run_tests, skipIfRocm
 import unittest
 
 # NOTE: this needs to be run in a brand new process

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -15,7 +15,7 @@ from torch import multiprocessing as mp
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MP_STATUS_CHECK_INTERVAL
-from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm
+from common_utils import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm
 
 # We cannot import TEST_CUDA from common_cuda here, because if we do that,
 # the TEST_CUDNN line from common_cuda will be executed multiple times

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -16,10 +16,10 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from common import TestCase
+from common_utils import TestCase
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch.autograd import Variable
-import common
+import common_utils as common
 
 BACKEND = os.environ["BACKEND"]
 TEMP_DIR = os.environ["TEMP_DIR"]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -31,7 +31,7 @@ from random import shuffle
 
 import torch
 from torch._six import inf
-from common import TestCase, run_tests, set_rng_seed, TEST_WITH_UBSAN
+from common_utils import TestCase, run_tests, set_rng_seed, TEST_WITH_UBSAN
 from common_cuda import TEST_CUDA
 from torch.autograd import grad, gradcheck
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,4 +1,4 @@
-from common import TestCase, run_tests
+from common_utils import TestCase, run_tests
 import torch
 import warnings
 from torch import tensor

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11,7 +11,7 @@ from torch.autograd.function import traceable
 from torch.testing import assert_allclose
 from torch.onnx import OperatorExportTypes
 from torch._six import inf, PY2
-from common import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, skipIfRocm, suppress_warnings
+from common_utils import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, skipIfRocm, suppress_warnings
 from textwrap import dedent
 import os
 import io

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -12,7 +12,7 @@ import torch.multiprocessing as mp
 import torch.utils.hooks
 from torch.autograd import Variable
 from torch.nn import Parameter
-from common import TestCase, run_tests, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, TEST_WITH_ASAN
+from common_utils import TestCase, run_tests, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, TEST_WITH_ASAN
 from multiprocessing.reduction import ForkingPickler
 
 

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -4,7 +4,7 @@ import torch
 import torch.cuda.nccl as nccl
 import torch.cuda
 
-from common import TestCase, run_tests, IS_WINDOWS
+from common_utils import TestCase, run_tests, IS_WINDOWS
 from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -28,7 +28,7 @@ from torch.autograd import Variable, gradcheck
 from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
-from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, TEST_WITH_ROCM, \
+from common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, TEST_WITH_ROCM, \
     TEST_NUMPY, TEST_SCIPY, IS_WINDOWS, download_file, PY3, PY34, to_gpu, \
     get_function_arglist, skipCUDAMemoryLeakCheckIf
 from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -1,8 +1,8 @@
 import unittest
 import sys
 
-import common
-from common import TEST_NUMBA, TEST_NUMPY
+import common_utils as common
+from common_utils import TEST_NUMBA, TEST_NUMPY
 from common_cuda import TEST_NUMBA_CUDA, TEST_CUDA, TEST_MULTIGPU
 
 import torch

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -10,7 +10,7 @@ from torch.optim import SGD
 from torch.autograd import Variable
 from torch import sparse
 from torch.optim.lr_scheduler import LambdaLR, StepLR, MultiStepLR, ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau
-from common import TestCase, run_tests, TEST_WITH_UBSAN, skipIfRocm
+from common_utils import TestCase, run_tests, TEST_WITH_UBSAN, skipIfRocm
 
 
 def rosenbrock(tensor):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5,7 +5,7 @@ import itertools
 import functools
 import random
 import unittest
-from common import TestCase, run_tests, skipIfRocm
+from common_utils import TestCase, run_tests, skipIfRocm
 from common_cuda import TEST_CUDA
 from test_torch import TestTorch
 from numbers import Number

--- a/test/test_thd_distributed.py
+++ b/test/test_thd_distributed.py
@@ -16,7 +16,7 @@ import torch.distributed.deprecated as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from common import TestCase
+from common_utils import TestCase
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch.autograd import Variable
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -22,7 +22,7 @@ from torch._six import inf, nan, string_classes
 from itertools import product, combinations
 from functools import reduce
 from torch import multiprocessing as mp
-from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
+from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     TEST_LIBROSA, run_tests, download_file, skipIfNoLapack, suppress_warnings, \
     IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, skipIfRocm
 from multiprocessing.reduction import ForkingPickler
@@ -4043,7 +4043,7 @@ class TestTorch(TestCase):
 
     @staticmethod
     def _test_gesv_batched(self, cast):
-        from common import random_fullrank_matrix_distinct_singular_value as fullrank
+        from common_utils import random_fullrank_matrix_distinct_singular_value as fullrank
         # test against gesv: one batch
         A = cast(fullrank(5, 1))
         b = cast(torch.randn(1, 5, 10))
@@ -4096,7 +4096,7 @@ class TestTorch(TestCase):
             return
 
         from numpy.linalg import solve
-        from common import random_fullrank_matrix_distinct_singular_value as fullrank
+        from common_utils import random_fullrank_matrix_distinct_singular_value as fullrank
 
         # test against numpy.linalg.solve
         A = cast(fullrank(4, 2, 1, 3))
@@ -4725,7 +4725,7 @@ class TestTorch(TestCase):
 
         # Single matrix, but full rank
         # This is for negative powers
-        from common import random_fullrank_matrix_distinct_singular_value
+        from common_utils import random_fullrank_matrix_distinct_singular_value
         M = conv_fn(random_fullrank_matrix_distinct_singular_value(5))
         run_test(M)
         run_test(M, sign=-1)

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -1,4 +1,4 @@
-from common import TestCase, run_tests, TEST_NUMPY
+from common_utils import TestCase, run_tests, TEST_NUMPY
 
 import torch
 import unittest

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,11 +16,11 @@ import warnings
 from torch.utils.checkpoint import checkpoint, checkpoint_sequential
 from torch.autograd._functions.utils import prepare_onnx_paddings
 from torch.autograd._functions.utils import check_onnx_broadcast
-from common import IS_WINDOWS, IS_PPC, skipIfRocm
+from common_utils import IS_WINDOWS, IS_PPC, skipIfRocm
 
 HAS_CUDA = torch.cuda.is_available()
 
-from common import TestCase, run_tests, download_file
+from common_utils import TestCase, run_tests, download_file
 
 
 class RandomDatasetMock(object):
@@ -211,7 +211,7 @@ class TestBottleneck(TestCase):
     def _run(self, command):
         """Returns (return-code, stdout, stderr)"""
         import subprocess
-        from common import PY3
+        from common_utils import PY3
 
         p = subprocess.Popen(command, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, shell=True)


### PR DESCRIPTION
Summary:
common.py is used in base_module for almost all tests in test/. The
name of this file is so common that can easily conflict with other dependencies
if they happen to have another common.py in the base module. Rename the file to
avoid conflict.

(for more context, it can conflict with `fbcode/common`)

Differential Revision: D10438204
