### PR TITLE
Move torch.onnx.operators functions into ATen

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -106,9 +106,11 @@ _(aten, _pdist_forward) \
 _(aten, _prod) \
 _(aten, _prodall) \
 _(aten, _range) \
+_(aten, _reshape_from_tensor) \
 _(aten, _round) \
 _(aten, _rsqrt) \
 _(aten, _s_where) \
+_(aten, _shape_as_tensor) \
 _(aten, _sigmoid) \
 _(aten, _sigmoid_backward) \
 _(aten, _sigmoid_forward) \

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -13,6 +13,21 @@
 namespace at {
 namespace native {
 
+Tensor _reshape_from_tensor(const Tensor& self, const Tensor& shape_tensor) {
+  AT_CHECK(shape_tensor.dim() == 1);
+  std::vector<int64_t> shape;
+  auto accessor = shape_tensor.accessor<int64_t, 1>();
+  for (size_t i = 0; i < shape_tensor.numel(); ++i) {
+    shape.push_back(accessor[i]);
+  }
+  return self.reshape(IntList(shape));
+}
+
+Tensor _shape_as_tensor(const Tensor& self) {
+  auto options = self.options().dtype(at::kLong);
+  return at::tensor(self.sizes(), options);
+}
+
 std::vector<Tensor> broadcast_tensors(TensorList tensors) {
   return expand_outplace(tensors);
 }
@@ -152,16 +167,16 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_
   int64_t allDim = self.dim();
   int64_t end = start+length;
   AT_CHECK(allDim > 0, "narrow() cannot be applied to a 0-dim tensor.");
-  AT_CHECK(dim >= 0 && dim < allDim, 
+  AT_CHECK(dim >= 0 && dim < allDim,
     "Dimension ", dim, " out of range. Expecting 0 <= dim < ", allDim, ".");
   AT_CHECK(start >= 0 && length >= 0 && end <= self.size(dim),
     "Invalid range to narrow. range(start, start+length) must be a subset of range(0, ", self.size(dim), ").")
   LongTensor indices = self._indices();
   int64_t sparseDims = self._sparseDims();
-  
+
   std::vector<int64_t> newSizes = self.sizes().vec();
   newSizes[dim]=length;
-  
+
   Tensor newValues;
   LongTensor newIndices;
   if(dim < sparseDims){

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -59,6 +59,10 @@
   dispatch:
      CUDA: masked_scale_cuda
 
+- func: _reshape_from_tensor(Tensor self, Tensor shape) -> Tensor
+
+- func: _shape_as_tensor(Tensor self) -> Tensor
+
 - func: dropout(Tensor input, double p, bool train) -> Tensor
 
 - func: dropout_(Tensor self, double p, bool train) -> Tensor

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -2,6 +2,9 @@ r"""This file provides a location for operators that help exporting
 models via onnx. E.g. shape_as_tensor and reshape_from_tensor_shape
 are to make all dynamic sizes operations traceble.
 
+NOTE: at one point these functions were implemented differently.
+Since then we have implemented these directly in ATen, so this
+file is kept purely for backward-compatibility.
 """
 
 import torch
@@ -9,19 +12,9 @@ import torch.onnx
 import torch.onnx.utils
 
 
-def _shape_as_tensor(g, input):
-    return g.op('Shape', input)
-
-
-@torch.onnx.symbolic_override(_shape_as_tensor)
 def shape_as_tensor(x):
-    return torch.LongTensor(tuple(x.shape))
+    return torch._shape_as_tensor(x)
 
 
-def _reshape_from_tensor_shape(g, input, shape):
-    return g.op('Reshape', input, shape)
-
-
-@torch.onnx.symbolic_override(_reshape_from_tensor_shape)
 def reshape_from_tensor_shape(x, shape):
-    return x.reshape(shape.tolist())
+    return torch._reshape_from_tensor(x, shape)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -201,6 +201,14 @@ def unused(g):
     return g.op("prim::Undefined")
 
 
+def _shape_as_tensor(g, input):
+    return g.op('Shape', input)
+
+
+def _reshape_from_tensor(g, input, shape):
+    return g.op('Reshape', input, shape)
+
+
 def add(g, self, other, alpha=None):
     # default alpha arg is to allow no-alpha add (aten add st overload no alpha)
     if alpha and _scalar(_maybe_get_scalar(alpha)) != 1:


### PR DESCRIPTION
These were indiscriminately dumping `onnx::` instructions into traces, and making it so you couldn't run the traces in the JIT interpreter