### PR TITLE
JIT Cleanups

### DIFF
--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -139,7 +139,7 @@ template <
 class C10_EXPORT intrusive_ptr final {
  private:
 //  the following static assert would be nice to have but it requires
-//  the target class T to be fully defined when intrusive_ptr<T> is instanciated
+//  the target class T to be fully defined when intrusive_ptr<T> is instantiated
 //  this is a problem for classes that contain pointers to themselves
 //  static_assert(
 //      std::is_base_of<intrusive_ptr_target, TTarget>::value,

--- a/aten/src/ATen/core/intrusive_ptr.h
+++ b/aten/src/ATen/core/intrusive_ptr.h
@@ -138,9 +138,12 @@ template <
     class NullType = detail::intrusive_target_default_null_type<TTarget>>
 class C10_EXPORT intrusive_ptr final {
  private:
-  static_assert(
-      std::is_base_of<intrusive_ptr_target, TTarget>::value,
-      "intrusive_ptr can only be used for classes that inherit from intrusive_ptr_target.");
+//  the following static assert would be nice to have but it requires
+//  the target class T to be fully defined when intrusive_ptr<T> is instanciated
+//  this is a problem for classes that contain pointers to themselves
+//  static_assert(
+//      std::is_base_of<intrusive_ptr_target, TTarget>::value,
+//      "intrusive_ptr can only be used for classes that inherit from intrusive_ptr_target.");
 #ifndef _WIN32
   // This static_assert triggers on MSVC
   //  error C2131: expression did not evaluate to a constant

--- a/test/expect/TestScript.test_addmm_fusion-jit.expect
+++ b/test/expect/TestScript.test_addmm_fusion-jit.expect
@@ -1,8 +1,8 @@
 graph(%0 : Double(*, *)
       %1 : Double(*, *)
       %2 : Double(*, *)) {
-  %3 : int = prim::Constant[value=1]()
-  %4 : Double(*, *) = aten::mm(%0, %1)
-  %5 : Double(*, *) = aten::add(%4, %2, %3)
+  %3 : int = prim::Constant[value=1](), scope: AddmmWrapper
+  %4 : Double(*, *) = aten::mm(%0, %1), scope: AddmmWrapper
+  %5 : Double(*, *) = aten::add(%4, %2, %3), scope: AddmmWrapper
   return (%5);
 }

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,13 +1,13 @@
 graph(%x : Dynamic) {
-  %6 : int[] = prim::Constant[value=[0, -1]]()
-  %5 : int = prim::Constant[value=0]()
-  %4 : int = prim::Constant[value=7]()
-  %2 : int = prim::Constant[value=3]()
-  %1 : int = prim::Constant[value=4]()
+  %6 : int[] = prim::Constant[value=[0, -1]](), scope: TracedModule
+  %5 : int = prim::Constant[value=0](), scope: TracedModule
+  %4 : int = prim::Constant[value=7](), scope: TracedModule
+  %2 : int = prim::Constant[value=3](), scope: TracedModule
+  %1 : int = prim::Constant[value=4](), scope: TracedModule
   %9 : int = prim::Constant[value=1]()
-  %3 : int[] = prim::ListConstruct(%1, %2)
-  %7 : Double(4, 3) = aten::zeros(%3, %4, %5, %6)
-  %8 : Double(3, 3) = aten::mm(%x, %7)
+  %3 : int[] = prim::ListConstruct(%1, %2), scope: TracedModule
+  %7 : Double(4, 3) = aten::zeros(%3, %4, %5, %6), scope: TracedModule
+  %8 : Double(3, 3) = aten::mm(%x, %7), scope: TracedModule
   %11 : Dynamic = aten::add(%8, %9, %9)
   return (%11);
 }

--- a/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(3, 4)) {
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: TracedModule[TracedModule]
-  %2 : Double(*, *) = aten::mm(%0, %1), scope: TracedModule[TracedModule]
+  %2 : Double(*, *) = aten::mm(%0, %1), scope: TracedModule
   %3 : Double() = prim::Constant[value={1}]()
   %4 : int = prim::Constant[value=1]()
   %5 : Double(3, 3) = aten::add(%2, %3, %4)

--- a/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
@@ -2,7 +2,7 @@ graph(%0 : Double(3, 4)
       %1 : Double(4, 5)
       %2 : Double(5, 7)) {
   %3 : Double(3, 5) = aten::mm(%0, %1), scope: TracedModule
-  %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule/TracedModule[TracedModule1][mod]
+  %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule1
   %5 : Double() = prim::Constant[value={1}](), scope: TracedModule
   %6 : int = prim::Constant[value=1](), scope: TracedModule
   %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule

--- a/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
@@ -2,6 +2,6 @@ graph(%x : Dynamic
       %1 : Dynamic
       %3 : Dynamic) {
   %2 : Dynamic = aten::mm(%x, %1)
-  %4 : Double(3, 5) = aten::mm(%2, %3)
+  %4 : Double(3, 5) = aten::mm(%2, %3), scope: TracedMod
   return (%4);
 }

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -135,7 +135,7 @@ torch::jit::Node* node = nullptr;
 std::shared_ptr<jit::tracer::TracingState> tracer_state;
 if (jit::tracer::isTracing()) {
   tracer_state = jit::tracer::getTracingState();
-  const auto op_name = jit::Symbol::fromQualString("aten::${trace_name}");
+  const static auto op_name = jit::Symbol::fromQualString("aten::${trace_name}");
   node = tracer_state->graph->create(op_name, /*num_outputs=*/0);
   jit::tracer::recordSourceLocation(node);
   ${add_trace_inputs}

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -135,7 +135,8 @@ torch::jit::Node* node = nullptr;
 std::shared_ptr<jit::tracer::TracingState> tracer_state;
 if (jit::tracer::isTracing()) {
   tracer_state = jit::tracer::getTracingState();
-  node = tracer_state->graph->create(jit::aten::${trace_name}, /*num_outputs=*/0);
+  const auto op_name = jit::Symbol::fromQualString("aten::${trace_name}");
+  node = tracer_state->graph->create(op_name, /*num_outputs=*/0);
   jit::tracer::recordSourceLocation(node);
   ${add_trace_inputs}
   tracer_state->graph->appendNode(node);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -185,26 +185,25 @@ void Graph::dumpPretty() {
   PrettyPrint(std::cout, *this);
 }
 
-Scope* Scope::push(Symbol name) {
-  children_.push_back(std::unique_ptr<Scope>(new Scope(this, name)));
-  return children_.back().get();
+ScopePtr Scope::push(Symbol name) {
+  return c10::make_intrusive<Scope>(intrusive_from_this(), name);
 }
 
-Scope* Scope::getRoot() {
-  Scope* current = this;
+ScopePtr Scope::getRoot() {
+  ScopePtr current = intrusive_from_this();
   while (current->parent_) {
     current = current->parent_;
   }
   return current;
 }
 
-std::string Scope::namesFromRoot(const std::string& separator) {
+std::string Scope::namesFromRoot(const std::string& separator) const {
   // TODO: I think the answer is we shouldn't have used Symbol here
   std::string out = this->name_.toUnqualString();
   if (this->isRoot()) {
     return out;
   }
-  Scope* parent = this->parent_;
+  ScopePtr parent = this->parent_;
   while (!parent->isRoot()) {
     // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
     out = std::string(parent->name_.toUnqualString()) + separator + out;
@@ -698,11 +697,10 @@ void Node::destroy() {
 }
 
 void Node::cloneFrom(Node * s) {
-	setSourceLocation(s->getSourceLocation());
-	if (s->owningGraph()->scope_root_ == owningGraph()->scope_root_) {
-		scope_ = s->scope_;
-	}
-	copyAttributes(*s);
+  setSourceLocation(s->getSourceLocation());
+  if(s->scope_ && !s->scope_->isBlank())
+    scope_ = s->scope_;
+  copyAttributes(*s);
 }
 
 void Node::replaceAllUsesWith(Node * n) {
@@ -888,7 +886,7 @@ Node * Graph::createNoneGenerator() {
 
 Node * Graph::createFusionGroup(int device) {
   auto n = create(prim::FusionGroup, 0);
-  n->g_(attr::Subgraph,std::make_shared<Graph>(scope_root_));
+  n->g_(attr::Subgraph,std::make_shared<Graph>(current_scope()));
   n->i_(attr::device, device);
   return n;
 }

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -113,7 +113,10 @@ private:
   ScopePtr parent_;
   Symbol name_;
   ScopePtr intrusive_from_this() {
-    c10::raw::intrusive_ptr::incref(this); // :(
+    c10::raw::intrusive_ptr::incref(this); // we are creating a new pointer
+                                           // from a raw `this` pointer
+                                           // so we need to bump the refcount
+                                           // to account for this ownership
     return c10::intrusive_ptr<Scope>::reclaim(this);
   }
 public:

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -105,39 +105,48 @@ struct Use {
 // The trie never needs to shrink, it only grows until it is disposed
 // of when Graph is deallocated. Hence, pointers to scopes held by nodes
 // will always be valid as long as Graph is alive.
-struct Scope {
+struct Scope;
+using ScopePtr = c10::intrusive_ptr<Scope>;
+
+struct TORCH_API Scope : public c10::intrusive_ptr_target {
 private:
-  Scope* parent_;
+  ScopePtr parent_;
   Symbol name_;
-  std::vector<std::unique_ptr<Scope> > children_;
+  ScopePtr intrusive_from_this() {
+    c10::raw::intrusive_ptr::incref(this); // :(
+    return c10::intrusive_ptr<Scope>::reclaim(this);
+  }
 public:
   Scope() {
     name_ = Symbol::scope("");
-    parent_ = nullptr;
   }
-  Scope(Scope* parent, Symbol name) {
+  Scope(ScopePtr parent, Symbol name) {
     name_ = name;
     parent_ = parent;
   }
-  TORCH_API Scope* push(Symbol name);
+  ScopePtr push(Symbol name);
 
-  Scope* parent() {
-    if (parent_ == nullptr) {
+  ScopePtr parent() {
+    if (!parent_) {
       throw std::runtime_error("Cannot get parent from Scope with no parent");
     }
     return parent_;
   }
-  bool isRoot() {
-    return parent_ == nullptr;
+  bool isRoot() const {
+    return !parent_;
+  }
+  bool isBlank() const {
+    static const Symbol blank = Symbol::scope("");
+    return isRoot() && name() == blank;
   }
 
-  TORCH_API Scope* getRoot();
+  ScopePtr getRoot();
 
-  Symbol name() {
+  Symbol name() const {
     return name_;
   }
 
-  TORCH_API std::string namesFromRoot(const std::string& separator="/");
+  std::string namesFromRoot(const std::string& separator="/") const;
 };
 
 // the list types are intentionally simple, but we type-def
@@ -224,6 +233,7 @@ public:
   TORCH_API Value* copyMetadata(Value * from);
 };
 
+
 struct Node : public Attributes<Node> {
   TH_DISALLOW_COPY_AND_ASSIGN(Node);
   friend struct Graph;
@@ -258,7 +268,7 @@ private:
   Graph* graph_;
   Block* owning_block_;
   std::shared_ptr<SourceLocation> source_location_;
-  Scope* scope_;
+  ScopePtr scope_;
   // Assumes FunctionSchemas are persistent, so we don't manage their lifetime.
   // This field is effective a cache that's populated on attribute lookups and
   // invalidated every time we perform an operation that could potentially change
@@ -290,14 +300,14 @@ public:
   const Block * owningBlock() const {
     return owning_block_;
   }
-  Scope* scope() {
+  ScopePtr scope() {
     return scope_;
   }
-  void setScope(Scope* scope) {
+  void setScope(ScopePtr scope) {
     scope_ = scope;
   }
   std::string scopeName() const {
-    if (scope_ == nullptr) {
+    if (!scope_) {
       return "";
     }
     return scope_->namesFromRoot();
@@ -734,8 +744,7 @@ private:
 
   std::unordered_map<std::string, Value*> unique_names_;
 
-  std::shared_ptr<Scope> scope_root_;
-  Scope * current_scope_;
+  ScopePtr current_scope_;
 
   Block* const block_;
   // when insertNode() is called, the node is inserted before this node
@@ -744,14 +753,13 @@ private:
 
 public:
 
-  Graph(std::shared_ptr<Scope> scope_root)
+  Graph(ScopePtr scope_root)
   : next_unique_(0)
-  , scope_root_(std::move(scope_root))
-  , current_scope_(scope_root_.get())
+  , current_scope_(std::move(scope_root))
   , block_(new Block(this, nullptr))
   , insert_before_(return_node()) {}
 
-  Graph() : Graph(std::make_shared<Scope>()) {}
+  Graph() : Graph(c10::make_intrusive<Scope>()) {}
 
   at::ArrayRef<Value*> inputs() {
     return block_->inputs();
@@ -786,17 +794,11 @@ public:
   void pop_scope() {
     current_scope_ = current_scope_->parent();
   }
-  Scope * current_scope() {
+  ScopePtr current_scope() {
     return current_scope_;
   }
-  void set_current_scope(Scope* scope) {
-    if (scope->getRoot() != scope_root_.get()) {
-      throw std::runtime_error("trying to set a scope as current that does not belong to the Graph's scope trie");
-    }
+  void set_current_scope(ScopePtr scope) {
     current_scope_ = scope;
-  }
-  std::shared_ptr<Scope> scope_root() {
-    return scope_root_;
   }
   Value * addInput(std::string name="") {
     return block_->addInput(std::move(name));
@@ -936,7 +938,7 @@ private:
 };
 
 struct WithCurrentScope : public ResourceGuard {
-  WithCurrentScope(Graph & g, Scope* scope)
+  WithCurrentScope(Graph & g, ScopePtr scope)
   : ResourceGuard([&g, this]() {
     g.set_current_scope(prev_scope);
   })
@@ -944,7 +946,7 @@ struct WithCurrentScope : public ResourceGuard {
     g.set_current_scope(scope);
   }
 private:
-  Scope * prev_scope;
+  ScopePtr prev_scope;
 };
 
 inline Value::Value(Node * node_, size_t offset_)

--- a/torch/csrc/jit/passes/canonicalize.cpp
+++ b/torch/csrc/jit/passes/canonicalize.cpp
@@ -5,7 +5,7 @@ namespace torch { namespace jit {
 // Canonicalize a graph, renumbering it so that all structurally equivalent
 // graphs have same numbers.
 std::shared_ptr<Graph> Canonicalize(const std::shared_ptr<Graph>& graph) {
-  auto r = std::make_shared<Graph>(graph->scope_root());
+  auto r = std::make_shared<Graph>(graph->current_scope());
   std::unordered_map<Value*, Value*> rn_env;
   auto rn_fn = [&](Value* v) { return rn_env.at(v); };
   for (auto* input : graph->inputs()) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -12,7 +12,7 @@ namespace torch { namespace jit {
 
 // Transform PythonOps into Nodes that match ONNX semantics.
 std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, ::torch::onnx::OperatorExportTypes operator_export_type) {
-  auto new_graph = std::make_shared<Graph>(graph->scope_root());
+  auto new_graph = std::make_shared<Graph>(graph->current_scope());
   std::unordered_map<Value*, Value*> env;
   BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);
   return new_graph;

--- a/torch/csrc/jit/passes/to_batch.cpp
+++ b/torch/csrc/jit/passes/to_batch.cpp
@@ -529,7 +529,7 @@ void ToBatch::toBatch(Block* block, Block* res_block) {
 }
 
 std::shared_ptr<Graph> to_batch_graph(std::shared_ptr<Graph>& graph){
-  std::shared_ptr<Graph> res_graph = std::make_shared<Graph>(graph->scope_root());
+  std::shared_ptr<Graph> res_graph = std::make_shared<Graph>();
   ToBatch to_batch;
   to_batch.toBatch(graph->block(), res_graph->block());
 


### PR DESCRIPTION
1. Change scope ownership model so they can be shared across Graphs.
   Now scopes own their parent and are intrusive pointers. Graphs
   no longer require a scope_root and cloning a node automatically
   clones its scope. This causes some changes in expect files for
   trace+script things. As far as I can tell these are not bugs but
   a different way of interpreting how scopes should propagate.
   Big traces like that of alexnet keep their scopes unchanged.
2. Remove VariableType.cpp dependency on a symbol being in the pre-
   declared symbol list.

