### PR TITLE
Make sure to update success_ at the end of the run

### DIFF
--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -449,6 +449,9 @@ void AsyncNetBase::finalizeEvents() {
     } else if (status == EventStatus::EVENT_INITIALIZED) {
       event(task_id).SetFinished();
     }
+    if (event(task_id).Query() != EventStatus::EVENT_SUCCESS) {
+      success_ = false;
+    }
   }
 }
 

--- a/caffe2/core/net_test.cc
+++ b/caffe2/core/net_test.cc
@@ -815,4 +815,42 @@ TEST(NetTest, PendingOpsAndNetFailure) {
   ASSERT_FALSE(net->Run());
 }
 
+class SetFinishErrorOp final : public Operator<CPUContext> {
+ public:
+  SetFinishErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    event().SetFinished("error");
+    return true;
+  }
+
+  bool HasAsyncPart() const override {
+    return true;
+  }
+};
+
+REGISTER_CPU_OPERATOR(SetFinishErrorOp, SetFinishErrorOp);
+
+OPERATOR_SCHEMA(SetFinishErrorOp);
+
+TEST(NetTest, SetFinishErrorOpTest) {
+  const auto spec = R"DOC(
+        name: "example"
+        type: "async_scheduling"
+        op {
+          type: "SetFinishErrorOp"
+        }
+)DOC";
+
+  NetDef net_def;
+  CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+
+  Workspace ws;
+  std::unique_ptr<NetBase> net(CreateNet(net_def, &ws));
+
+  // net run returns false
+  ASSERT_FALSE(net->Run());
+}
+
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Make sure to update success_ status at the end of the run when going through
task statuses

Differential Revision: D10443704
