### PR TITLE
Use locale.h instead of xlocale.h

### DIFF
--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -5,11 +5,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
-#ifdef _WIN32
 #include <locale.h>
-#else
-#include <xlocale.h>
-#endif
 
 #include <vector>
 #include "torch/csrc/jit/assertions.h"


### PR DESCRIPTION
Fixes: #12809 

This is the right thing to do for Linux, it doesn't change behaviour on Windows. I would hope that locale.h is standard enough for everyone.

This updates #12739 , @zdevito I hope this is OK.