### PR TITLE
Implementation copy operator for mkl-dnn

### DIFF
--- a/caffe2/ideep/operators/utility_ops.cc
+++ b/caffe2/ideep/operators/utility_ops.cc
@@ -25,6 +25,23 @@ class CopyCPUToIDEEPOp final : public IDEEPOperator {
   }
 };
 
+class IDEEPCopyOp final : public IDEEPOperator {
+ public:
+  USE_SIMPLE_IDEEP_CTOR_DTOR(IDEEPCopyOp);
+  USE_IDEEP_DEF_ALIASES();
+
+  bool RunOnDevice() override {
+    const auto& X = OperatorBase::Input<itensor>(0);
+    auto* Y = Output(0);
+    if (X != *Y) {
+      Y->reinit_like(X);
+      ideep::direct_copy::compute(X, *Y);
+    }
+
+    return true;
+  }
+};
+
 class CopyIDEEPToCPUOp final : public IDEEPOperator {
  public:
   USE_SIMPLE_IDEEP_CTOR_DTOR(CopyIDEEPToCPUOp);
@@ -52,6 +69,7 @@ class CopyIDEEPToCPUOp final : public IDEEPOperator {
 
 REGISTER_IDEEP_OPERATOR(CopyCPUToIDEEP, CopyCPUToIDEEPOp);
 REGISTER_IDEEP_OPERATOR(CopyIDEEPToCPU, CopyIDEEPToCPUOp);
+REGISTER_IDEEP_OPERATOR(Copy, IDEEPCopyOp);
 
 OPERATOR_SCHEMA(CopyCPUToIDEEP)
     .NumInputs(1)


### PR DESCRIPTION
It is a operator to copy blob from ideep device to ideep device. 