### PR TITLE
fix overwriting of CMAKE_EXE_LINKER_FLAGS

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -442,7 +442,7 @@ if(USE_MPI)
     message(STATUS "MPI libraries: " ${MPI_CXX_LIBRARIES})
     include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
     list(APPEND Caffe2_DEPENDENCY_LIBS ${MPI_CXX_LIBRARIES})
-    set(CMAKE_EXE_LINKER_FLAGS ${MPI_CXX_LINK_FLAGS})
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MPI_CXX_LINK_FLAGS}")
     find_program(OMPI_INFO
       NAMES ompi_info
       HINTS ${MPI_CXX_LIBRARIES}/../bin)


### PR DESCRIPTION
bug lurking since 2016

