### PR TITLE
[jit] Speed up resolution callback creation

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2004,7 +2004,7 @@ class TestJit(JitTestCase):
             torch.ones(1))
 
         @torch.jit.script
-        def hints(x, a=0.5, b=10):  # noqa: E999
+        def hints(x, a=0.5, b=10):
             # type: (Tensor, float, int) -> Tensor
             return x + a + b
 
@@ -7370,11 +7370,11 @@ a")
                 x = x + 3
             return x + 4 + inner(x)
 
-        @torch.jit.weak_script
+        @torch._jit.weak_script
         def weak_script_fn_inner(x):
             return x + 6 + not_a_script_fn(x)
 
-        @torch.jit.weak_script
+        @torch._jit.weak_script
         def weak_script_fn(x):
             return x + 5 + weak_script_fn_inner(x) + weak_script_fn_inner(x)
 
@@ -8056,8 +8056,6 @@ EXCLUDE_SCRIPT = {
     'test_nn_affine_grid',
 
     # unknown builtin op
-    'test_nn_tanhshrink',
-    'test_nn_softsign',
     'test_nn_softmin',
     'test_nn_local_response_norm',
     'test_nn_poisson_nll_loss',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7370,11 +7370,11 @@ a")
                 x = x + 3
             return x + 4 + inner(x)
 
-        @torch._jit.weak_script
+        @torch._jit_internal.weak_script
         def weak_script_fn_inner(x):
             return x + 6 + not_a_script_fn(x)
 
-        @torch._jit.weak_script
+        @torch._jit_internal.weak_script
         def weak_script_fn(x):
             return x + 5 + weak_script_fn_inner(x) + weak_script_fn_inner(x)
 

--- a/torch/_jit/__init__.py
+++ b/torch/_jit/__init__.py
@@ -1,0 +1,60 @@
+import weakref
+import inspect
+import builtins
+
+compiled_weak_fns = weakref.WeakKeyDictionary()
+COMPILATION_PENDING = object()
+COMPILED = object()
+
+
+def createResolutionCallback(frames_up=0):
+    """
+    Creates a function which, given a string variable name,
+    returns the value of the variable in the scope of the caller of
+    the function which called createResolutionCallback (by default).
+
+    This is used to enable access in-scope Python variables inside
+    TorchScript fragments.
+
+    frames_up is number of additional frames to go up on the stack.
+    The default value is 0, which correspond to the frame of the caller
+    of createResolutionCallback. Also for example, if frames_up is set
+    to 1, then the frame of the caller's caller of createResolutionCallback
+    will be taken.
+
+    For example, the following program prints 2::
+
+        def bar():
+            cb = createResolutionCallback(1)
+            print(cb("foo"))
+
+        def baz():
+            foo = 2
+            bar()
+
+        baz()
+    """
+    frame = inspect.stack()[1 + frames_up][0]
+    f_locals = frame.f_locals
+    f_globals = frame.f_globals
+
+    def env(key):
+        if key in f_locals:
+            return f_locals[key]
+        elif key in f_globals:
+            return f_globals[key]
+        elif hasattr(builtins, key):
+            return getattr(builtins, key)
+        else:
+            return None
+
+    return env
+
+
+def weak_script(fn, _frames_up=0):
+    compiled_weak_fns[fn] = {
+        "status": COMPILATION_PENDING,
+        "compiled_fn": None,
+        "rcb": createResolutionCallback(_frames_up + 1)
+    }
+    return fn

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -40,7 +40,13 @@ def createResolutionCallback(frames_up=0):
 
         baz()
     """
-    frame = inspect.stack()[1 + frames_up][0]
+
+    frame = inspect.currentframe()
+    i = 0
+    while i <= frames_up:
+        frame = frame.f_back
+        i += 1
+
     f_locals = frame.f_locals
     f_globals = frame.f_globals
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -58,6 +58,12 @@ def createResolutionCallback(frames_up=0):
 
 
 def weak_script(fn, _frames_up=0):
+    """
+    Marks a function as a weak script function. When used in a script function
+    or ScriptModule, the weak script function will be lazily compiled and
+    inlined in the graph. When not used in a script function, the weak script
+    annotation has no effect.
+    """
     compiled_weak_fns[fn] = {
         "status": COMPILATION_PENDING,
         "compiled_fn": None,

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1,3 +1,9 @@
+"""
+The weak_script annotation needs to be here instead of inside torch/jit/ so it
+can be used in other places in torch/ (namely torch.nn) without running into
+circular dependency problems
+"""
+
 import weakref
 import inspect
 import builtins

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -5,7 +5,7 @@ from torch.nn import Module, ModuleList, ParameterList, Parameter, Sequential
 from torch.jit.frontend import get_jit_ast, get_default_args
 import torch.jit.annotations
 from torch._six import raise_from, with_metaclass
-from .._jit import createResolutionCallback, compiled_weak_fns, COMPILED, COMPILATION_PENDING
+from .._jit_internal import createResolutionCallback, compiled_weak_fns, COMPILED, COMPILATION_PENDING
 import torch.testing
 from collections import defaultdict, OrderedDict, namedtuple
 import sys

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1170,24 +1170,13 @@ _builtin_table = None
 
 _modules_containing_builtins = (torch, torch.nn.functional)
 
-# These functions don't have aten ops
+# These functions don't have aten ops but have been converted to weak script, so
+# don't add them as builtins
+# TODO: delete this list and remove torch.nn.functional from builtins list once
+# everything in it has been converted to weak script
 _builtin_blacklist = {
     'tanhshrink',
     'softsign',
-    'softmin',
-    'local_response_norm',
-    'poisson_nll_loss',
-    'cross_entropy',
-    'multilabel_soft_margin_loss',
-    'interpolate',
-    'pad',
-    'cosine_similarity',
-    'normalize',
-    'fold',
-    'max_unpool1d',
-    'lp_pool1d',
-    'lp_pool2d',
-    'gumbel_softmax',
 }
 
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -5,9 +5,9 @@ from torch.nn import Module, ModuleList, ParameterList, Parameter, Sequential
 from torch.jit.frontend import get_jit_ast, get_default_args
 import torch.jit.annotations
 from torch._six import raise_from, with_metaclass
+from .._jit import createResolutionCallback, compiled_weak_fns, COMPILED, COMPILATION_PENDING
 import torch.testing
 from collections import defaultdict, OrderedDict, namedtuple
-import builtins
 import sys
 import warnings
 import itertools
@@ -16,7 +16,6 @@ import types
 import contextlib
 import os
 import functools
-import inspect
 import copy
 import numbers
 import collections
@@ -47,9 +46,6 @@ _flatten = torch._C._jit_flatten
 _unflatten = torch._C._jit_unflatten
 _jit_script_compile = torch._C._jit_script_compile
 BatchTensor = torch._C._jit.BatchTensor
-compiled_weak_fns = weakref.WeakKeyDictionary()
-COMPILATION_PENDING = object()
-COMPILED = object()
 
 
 @contextlib.contextmanager
@@ -578,50 +574,6 @@ def trace(func, example_inputs, optimize=True, check_trace=True, check_inputs=No
     return module
 
 
-def createResolutionCallback(frames_up=0):
-    """
-    Creates a function which, given a string variable name,
-    returns the value of the variable in the scope of the caller of
-    the function which called createResolutionCallback (by default).
-
-    This is used to enable access in-scope Python variables inside
-    TorchScript fragments.
-
-    frames_up is number of additional frames to go up on the stack.
-    The default value is 0, which correspond to the frame of the caller
-    of createResolutionCallback. Also for example, if frames_up is set
-    to 1, then the frame of the caller's caller of createResolutionCallback
-    will be taken.
-
-    For example, the following program prints 2::
-
-        def bar():
-            cb = createResolutionCallback(1)
-            print(cb("foo"))
-
-        def baz():
-            foo = 2
-            bar()
-
-        baz()
-    """
-    frame = inspect.stack()[1 + frames_up][0]
-    f_locals = frame.f_locals
-    f_globals = frame.f_globals
-
-    def env(key):
-        if key in f_locals:
-            return f_locals[key]
-        elif key in f_globals:
-            return f_globals[key]
-        elif hasattr(builtins, key):
-            return getattr(builtins, key)
-        else:
-            return None
-
-    return env
-
-
 class CompilationUnit(object):
     def __init__(self, lang=None, optimize=True, _frames_up=0):
         self.module = torch._C.ScriptModule()
@@ -637,15 +589,6 @@ class CompilationUnit(object):
 
     def __getattr__(self, attr):
         return self.module._get_method(attr)
-
-
-def weak_script(fn, _frames_up=0):
-    compiled_weak_fns[fn] = {
-        "status": COMPILATION_PENDING,
-        "compiled_fn": None,
-        "rcb": createResolutionCallback(_frames_up + 1)
-    }
-    return fn
 
 
 def _try_compile_weak_script(fn):
@@ -1227,6 +1170,26 @@ _builtin_table = None
 
 _modules_containing_builtins = (torch, torch.nn.functional)
 
+# These functions don't have aten ops
+_builtin_blacklist = {
+    'tanhshrink',
+    'softsign',
+    'softmin',
+    'local_response_norm',
+    'poisson_nll_loss',
+    'cross_entropy',
+    'multilabel_soft_margin_loss',
+    'interpolate',
+    'pad',
+    'cosine_similarity',
+    'normalize',
+    'fold',
+    'max_unpool1d',
+    'lp_pool1d',
+    'lp_pool2d',
+    'gumbel_softmax',
+}
+
 
 # lazily built to ensure the correct initialization order
 def _get_builtin_table():
@@ -1238,7 +1201,7 @@ def _get_builtin_table():
     def register_all(mod):
         for name in dir(mod):
             v = getattr(mod, name)
-            if callable(v):
+            if callable(v) and name not in _builtin_blacklist:
                 _builtin_table[id(v)] = "aten::" + name
     for mod in _modules_containing_builtins:
         register_all(mod)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -14,6 +14,7 @@ from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
 from .modules.utils import _single, _pair, _triple, _list_with_default
 from . import grad
+from .._jit import weak_script
 
 _VF = torch._C._VariableFunctions
 
@@ -906,6 +907,7 @@ def hardshrink(input, lambd=0.5):
     return torch.hardshrink(input, lambd)
 
 
+@torch._jit.weak_script
 def tanhshrink(input):
     r"""tanhshrink(input) -> Tensor
 
@@ -916,6 +918,7 @@ def tanhshrink(input):
     return input - input.tanh()
 
 
+@torch._jit.weak_script
 def softsign(input):
     r"""softsign(input) -> Tensor
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,4 +1,5 @@
 r"""Functional interface"""
+from __future__ import division
 
 import warnings
 import math

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -20,6 +20,11 @@ from .._jit_internal import weak_script
 _VF = torch._C._VariableFunctions
 
 
+def _add_weak_docstr(fn, doc):
+    # return _add_docstr(fn, doc)
+    return torch._jit_internal.weak_script(_add_docstr(fn, doc))
+
+
 class _Reduction:
     # NB: Keep this class in sync with enums in THNN/Reduction.h
 
@@ -61,7 +66,7 @@ class _Reduction:
         return _Reduction.get_enum(_Reduction.legacy_get_string(size_average, reduce, emit_warning))
 
 
-conv1d = _add_docstr(torch.conv1d, r"""
+conv1d = _add_weak_docstr(torch.conv1d, r"""
 conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 1D convolution over an input signal composed of several input
@@ -91,7 +96,7 @@ Examples::
     >>> F.conv1d(inputs, filters)
 """)
 
-conv2d = _add_docstr(torch.conv2d, r"""
+conv2d = _add_weak_docstr(torch.conv2d, r"""
 conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 2D convolution over an input image composed of several input
@@ -122,7 +127,7 @@ Examples::
     >>> F.conv2d(inputs, filters, padding=1)
 """)  # noqa: E501
 
-conv3d = _add_docstr(torch.conv3d, r"""
+conv3d = _add_weak_docstr(torch.conv3d, r"""
 conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 3D convolution over an input image composed of several input
@@ -152,7 +157,7 @@ Examples::
     >>> F.conv3d(inputs, filters)
 """)  # noqa: E501
 
-conv_transpose1d = _add_docstr(torch.conv_transpose1d, r"""
+conv_transpose1d = _add_weak_docstr(torch.conv_transpose1d, r"""
 conv_transpose1d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 1D transposed convolution operator over an input signal
@@ -185,7 +190,7 @@ Examples::
     >>> F.conv_transpose1d(inputs, weights)
 """)
 
-conv_transpose2d = _add_docstr(torch.conv_transpose2d, r"""
+conv_transpose2d = _add_weak_docstr(torch.conv_transpose2d, r"""
 conv_transpose2d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 2D transposed convolution operator over an input image
@@ -220,7 +225,7 @@ Examples::
     >>> F.conv_transpose2d(inputs, weights, padding=1)
 """)  # noqa: E501
 
-conv_transpose3d = _add_docstr(torch.conv_transpose3d, r"""
+conv_transpose3d = _add_weak_docstr(torch.conv_transpose3d, r"""
 conv_transpose3d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 3D transposed convolution operator over an input image
@@ -254,7 +259,7 @@ Examples::
     >>> F.conv_transpose3d(inputs, weights)
 """)  # noqa: E501
 
-conv_tbc = _add_docstr(torch.conv_tbc, r"""
+conv_tbc = _add_weak_docstr(torch.conv_tbc, r"""
 Applies a 1-dimensional sequence convolution over an input sequence.
 Input and output dimensions are (Time, Batch, Channels) - hence TBC.
 
@@ -267,7 +272,7 @@ Args:
 
 
 # Pooling
-avg_pool1d = _add_docstr(torch.avg_pool1d, r"""
+avg_pool1d = _add_weak_docstr(torch.avg_pool1d, r"""
 avg_pool1d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
 Applies a 1D average pooling over an input signal composed of several
@@ -297,7 +302,7 @@ Examples::
 """)
 
 
-avg_pool2d = _add_docstr(torch._C._nn.avg_pool2d, r"""
+avg_pool2d = _add_weak_docstr(torch._C._nn.avg_pool2d, r"""
 avg_pool2d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
 Applies 2D average-pooling operation in :math:`kH \times kW` regions by step size
@@ -320,7 +325,7 @@ Args:
         averaging calculation. Default: ``True``
 """)
 
-avg_pool3d = _add_docstr(torch._C._nn.avg_pool3d, r"""
+avg_pool3d = _add_weak_docstr(torch._C._nn.avg_pool3d, r"""
 avg_pool3d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
 Applies 3D average-pooling operation in :math:`kT \times kH \times kW` regions by step
@@ -562,7 +567,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
     return ret if return_indices else ret[0]
 
 
-adaptive_avg_pool1d = _add_docstr(torch.adaptive_avg_pool1d, r"""
+adaptive_avg_pool1d = _add_weak_docstr(torch.adaptive_avg_pool1d, r"""
 adaptive_avg_pool1d(input, output_size) -> Tensor
 
 Applies a 1D adaptive average pooling over an input signal composed of
@@ -702,7 +707,7 @@ def threshold(input, threshold, value, inplace=False):
     return torch._C._nn.threshold(input, threshold, value)
 
 
-threshold_ = _add_docstr(torch._C._nn.threshold_, r"""
+threshold_ = _add_weak_docstr(torch._C._nn.threshold_, r"""
 threshold_(input, threshold, value) -> Tensor
 
 In-place version of :func:`~threshold`.
@@ -720,7 +725,7 @@ def relu(input, inplace=False):
     return torch.relu(input)
 
 
-relu_ = _add_docstr(torch.relu_, r"""
+relu_ = _add_weak_docstr(torch.relu_, r"""
 relu_(input) -> Tensor
 
 In-place version of :func:`~relu`.
@@ -762,7 +767,7 @@ def hardtanh(input, min_val=-1., max_val=1., inplace=False):
     return torch._C._nn.hardtanh(input, min_val, max_val)
 
 
-hardtanh_ = _add_docstr(torch._C._nn.hardtanh_, r"""
+hardtanh_ = _add_weak_docstr(torch._C._nn.hardtanh_, r"""
 hardtanh_(input, min_val=-1., max_val=1.) -> Tensor
 
 In-place version of :func:`~hardtanh`.
@@ -790,7 +795,7 @@ def elu(input, alpha=1., inplace=False):
     return torch._C._nn.elu(input, alpha)
 
 
-elu_ = _add_docstr(torch._C._nn.elu_, r"""
+elu_ = _add_weak_docstr(torch._C._nn.elu_, r"""
 elu_(input, alpha=1.) -> Tensor
 
 In-place version of :func:`~elu`.
@@ -811,7 +816,7 @@ def selu(input, inplace=False):
         return torch.selu_(input)
     return torch.selu(input)
 
-selu_ = _add_docstr(torch.selu_, r"""
+selu_ = _add_weak_docstr(torch.selu_, r"""
 selu_(input) -> Tensor
 
 In-place version of :func:`~selu`.
@@ -830,7 +835,7 @@ def celu(input, alpha=1., inplace=False):
         return torch.celu_(input, alpha)
     return torch.celu(input, alpha)
 
-celu_ = _add_docstr(torch.celu_, r"""
+celu_ = _add_weak_docstr(torch.celu_, r"""
 celu_(input, alpha=1.) -> Tensor
 
 In-place version of :func:`~celu`.
@@ -851,7 +856,7 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
     return torch._C._nn.leaky_relu(input, negative_slope)
 
 
-leaky_relu_ = _add_docstr(torch._C._nn.leaky_relu_, r"""
+leaky_relu_ = _add_weak_docstr(torch._C._nn.leaky_relu_, r"""
 leaky_relu_(input, negative_slope=0.01) -> Tensor
 
 In-place version of :func:`~leaky_relu`.
@@ -882,13 +887,13 @@ def rrelu(input, lower=1. / 8, upper=1. / 3, training=False, inplace=False):
     return torch.rrelu(input, lower, upper, training)
 
 
-rrelu_ = _add_docstr(torch.rrelu_, r"""
+rrelu_ = _add_weak_docstr(torch.rrelu_, r"""
 rrelu_(input, lower=1./8, upper=1./3, training=False) -> Tensor
 
 In-place version of :func:`~rrelu`.
 """)
 
-logsigmoid = _add_docstr(torch._C._nn.log_sigmoid, r"""
+logsigmoid = _add_weak_docstr(torch._C._nn.log_sigmoid, r"""
 logsigmoid(input) -> Tensor
 
 Applies element-wise :math:`\text{LogSigmoid}(x) = \log \left(\frac{1}{1 + \exp(-x_i)}\right)`
@@ -930,7 +935,7 @@ def softsign(input):
     return input / (input.abs() + 1)
 
 
-softplus = _add_docstr(torch._C._nn.softplus, r"""
+softplus = _add_weak_docstr(torch._C._nn.softplus, r"""
 softplus(input, beta=1, threshold=20) -> Tensor
 """)
 
@@ -1093,7 +1098,7 @@ def log_softmax(input, dim=None, _stacklevel=3, dtype=None):
         return input.log_softmax(dim, dtype=dtype)
 
 
-softshrink = _add_docstr(torch._C._nn.softshrink, r"""
+softshrink = _add_weak_docstr(torch._C._nn.softshrink, r"""
 softshrink(input, lambd=0.5) -> Tensor
 
 Applies the soft shrinkage function elementwise
@@ -1148,6 +1153,7 @@ def linear(input, weight, bias=None):
 
 
 def bilinear(input1, input2, weight, bias=None):
+    print("Being tested")
     return torch.bilinear(input1, input2, weight, bias)
 
 
@@ -1929,7 +1935,7 @@ def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=No
     return torch._C._nn.multi_margin_loss(input, target, p, margin, weight, reduction)
 
 
-pixel_shuffle = _add_docstr(torch.pixel_shuffle, r"""
+pixel_shuffle = _add_weak_docstr(torch.pixel_shuffle, r"""
 Rearranges elements in a tensor of shape :math:`(*, C \times r^2, H, W)` to a
 tensor of shape :math:`(C, H \times r, W \times r)`.
 
@@ -2316,7 +2322,7 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6, keepdim=False):
     return torch.pairwise_distance(x1, x2, p, eps, keepdim)
 
 
-pdist = _add_docstr(torch.pdist, r"""
+pdist = _add_weak_docstr(torch.pdist, r"""
 pdist(input, p=2) -> Tensor
 
 Computes the p-norm distance between every pair of row vectors in the input.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -14,7 +14,7 @@ from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
 from .modules.utils import _single, _pair, _triple, _list_with_default
 from . import grad
-from .._jit import weak_script
+from .._jit_internal import weak_script
 
 _VF = torch._C._VariableFunctions
 
@@ -907,7 +907,7 @@ def hardshrink(input, lambd=0.5):
     return torch.hardshrink(input, lambd)
 
 
-@torch._jit.weak_script
+@torch._jit_internal.weak_script
 def tanhshrink(input):
     r"""tanhshrink(input) -> Tensor
 
@@ -918,7 +918,7 @@ def tanhshrink(input):
     return input - input.tanh()
 
 
-@torch._jit.weak_script
+@torch._jit_internal.weak_script
 def softsign(input):
     r"""softsign(input) -> Tensor
 


### PR DESCRIPTION
Depends on: #12723 

`inspect.stack()` calls are slow since they access a bunch of extra info about the frame. This PR instead uses `inspect.currentframe()` and goes up the stack until it reaches the correct frame.

Context:
stackoverflow.com/questions/17407119/python-inspect-stack-is-slow