### PR TITLE
[jit] Speed up resolution callback creation

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -43,7 +43,12 @@ def createResolutionCallback(frames_up=0):
 
         baz()
     """
-    frame = inspect.stack()[1 + frames_up][0]
+    frame = inspect.currentframe()
+    i = 0
+    while i < frames_up + 1:
+        frame = frame.f_back
+        i += 1
+
     f_locals = frame.f_locals
     f_globals = frame.f_globals
 


### PR DESCRIPTION
`inspect.stack()` calls are slow since they access a bunch of extra info about the frame. This PR instead uses `inspect.currentframe()` and goes up the stack until it reaches the correct frame. [Context](stackoverflow.com/questions/17407119/python-inspect-stack-is-slow)
