### PR TITLE
use mkldnn for 3d / dilated convolution

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -139,8 +139,7 @@ auto ConvParams::use_mkldnn(const at::Tensor& input) const -> bool {
   return input.type().backend() == at::Backend::CPU &&
          input.type().scalarType() == kFloat && // only on CPU Float Tensors
          !is_dilated() && // doesn't support dilation
-         !transposed && // or transposed tensors
-         input.ndimension() == 4; // must be in NCHW format
+         !transposed; // or transposed tensors
 #endif
   return false;
 }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -369,7 +369,6 @@ at::Tensor _convolution(
           params.padding, params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
     }
   } else if (params.use_mkldnn(input)) {
-#if AT_MKLDNN_ENABLED()
     AT_CHECK(input.type() == weight.type(),
              "Input type (", input.type().toString(), ") and weight type (", weight.type().toString(),
              ") should be the same");
@@ -378,7 +377,6 @@ at::Tensor _convolution(
              ") should be the same");
 
     output = at::mkldnn_convolution(input, weight, bias, params.padding, params.stride, params.dilation, params.groups);
-#endif
   } else {
     if (params.groups == 1) {
       output = at::_convolution_nogroup(

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -138,7 +138,6 @@ auto ConvParams::use_mkldnn(const at::Tensor& input) const -> bool {
 #if AT_MKLDNN_ENABLED()
   return input.type().backend() == at::Backend::CPU &&
          input.type().scalarType() == kFloat && // only on CPU Float Tensors
-         !is_dilated() && // doesn't support dilation
          !transposed; // or transposed tensors
 #endif
   return false;

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -106,7 +106,7 @@ at::Tensor mkldnn_convolution(
   memory::dims _stride(kdim), _dilation(kdim), _padding(kdim), _padding_r(kdim);
   for (size_t d = 0; d < kdim; ++d) {
     _stride[d] = stride[d];
-    _dilation[d] = dilation[d];
+    _dilation[d] = dilation[d] - 1;
     _padding[d] = padding[d];
 
     if (dilation[d] != 1) dilated_conv = true;


### PR DESCRIPTION
this PR enables mkldnn conv3d path in ATen and bypass `THNN` counterpart, beneficial for models like 3D-UNet.

the benchmark script reduces from `140ms` to `42ms` on xeon skylake 8180 (2*28 cores @2.5GHz):
```python
from __future__ import print_function
import torch
import torch.nn as nn
import torch.nn.functional as F
from torch.autograd  import Variable
import torch.optim as optim
import time
import random
class conv3d_net(nn.Module):
    def __init__(self):
        super(conv3d_net, self).__init__()
        self.conv3d_1 = nn.Conv3d(1, 64, kernel_size=3)
        self.conv3d_2 = nn.Conv3d(64, 64, kernel_size=3)
        self.conv3d_3 = nn.Conv3d(64, 128, kernel_size=3)
        self.conv3d_4 = nn.Conv3d(128, 128, kernel_size=3)
        self.fc1 = nn.Linear(6400, 512)
        self.fc2 = nn.Linear(512, 512)

    def forward(self, x):
        x = self.conv3d_2(self.conv3d_1(x))
        x = F.max_pool3d(x, 2)
        x = self.conv3d_4(self.conv3d_3(x))
        x = F.max_pool3d(x, 2)
        x = x.view(-1, 6400)
        x = self.fc2(self.fc1(x))
        return F.log_softmax(x, 0)


model = conv3d_net()
optimizer = optim.SGD(model.parameters(), lr = 0.1, momentum = 0.9)

warmup = 5
cycle = 10
start_t = 0
end_t = 0
def train():
    #warmup
    data = torch.randn(4, 1, 35, 35, 20)
    target = torch.LongTensor(4).zero_()
    for j in range(4):
        hot_idx = random.randint(0, 511)
        target[j]= hot_idx
    data, target = Variable(data), Variable(target)
    for i in range(warmup+cycle):
        if (i == warmup):
            start_t = time.time()
        #optimizer.zero_grad()
        output = model(data)
        loss = F.nll_loss(output, target)
        loss.backward()
        #optimizer.step()
    end_t = time.time()
    duration = (end_t - start_t)*1000.0/cycle
    print("avg time", duration, "millisecond")

train()
```