### PR TITLE
Rephrase unclear error message for shape mismatch

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -648,8 +648,8 @@ class Module(object):
 
                 if input_param.shape != param.shape:
                     # local shape should match the one in checkpoint
-                    error_msgs.append('size mismatch for {}: copying a param of {} from checkpoint, '
-                                      'where the shape is {} in current model.'
+                    error_msgs.append('size mismatch for {}: copying a param with shape {} from checkpoint, '
+                                      'the shape in current model is {}.'
                                       .format(key, input_param.shape, param.shape))
                     continue
 


### PR DESCRIPTION
I spent a couple of minutes trying to understand which shape corresponds to checkpoint and which one to the model