### PR TITLE
Fix MSVC build for Python 3.6

### DIFF
--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -190,7 +190,9 @@ inline double expm1(double x) { return THExpm1(x); }
 #define popen _popen
 #define pclose _pclose
 #include <BaseTsd.h>
+#if !defined(HAVE_SSIZE_T)
 typedef SSIZE_T ssize_t;
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
Python 3.6 headers define their own ssize_t, which clashes with our definition.
Luckily, they also define a `HAVE_SSIZE_T` macro we can use to check for this case.

Differential Revision: [D10467239](https://our.internmc.facebook.com/intern/diff/D10467239/)