### PR TITLE
nomnigraph - Dot string generation for a single subgraph

### DIFF
--- a/caffe2/core/nomnigraph/tests/GraphTest.cc
+++ b/caffe2/core/nomnigraph/tests/GraphTest.cc
@@ -176,3 +176,35 @@ TEST(Basic, MoveSubgraph) {
   EXPECT_EQ(g.getMutableEdges().size(), 0);
   EXPECT_EQ(g2.getMutableEdges().size(), 1);
 }
+
+TEST(Basic, DotGenerator) {
+  TestGraph g;
+  auto n1 = createTestNode(g);
+  auto n2 = createTestNode(g);
+  auto n3 = createTestNode(g);
+  auto e12 = g.createEdge(n1, n2);
+  g.createEdge(n1, n3);
+
+  std::string dot = nom::converters::convertToDotString(&g, TestNodePrinter);
+
+  // sanity check
+  std::string prefix = "digraph G";
+  EXPECT_TRUE(dot.compare(0, prefix.length(), prefix) == 0);
+
+  TestGraph::SubgraphType sg;
+  sg.addNode(n1);
+  sg.addNode(n2);
+  sg.addEdge(e12);
+
+  // Convert to dot with subgraph clusters.
+  dot = nom::converters::convertToDotString(&g, {&sg}, TestNodePrinter);
+
+  // sanity check
+  EXPECT_TRUE(dot.compare(0, prefix.length(), prefix) == 0);
+
+  // Convert a single subgraph to dot.
+  dot = nom::converters::convertToDotString<TestGraph>(&sg, TestNodePrinter);
+
+  // sanity check
+  EXPECT_TRUE(dot.compare(0, prefix.length(), prefix) == 0);
+}

--- a/caffe2/core/nomnigraph/tests/test_util.cc
+++ b/caffe2/core/nomnigraph/tests/test_util.cc
@@ -120,3 +120,10 @@ std::map<std::string, std::string> NNPrinter(typename nom::repr::NNGraph::NodeRe
 nom::Graph<TestClass>::NodeRef createTestNode(nom::Graph<TestClass>& g) {
   return g.createNode(TestClass());
 }
+
+std::map<std::string, std::string> TestNodePrinter(
+    nom::Graph<TestClass>::NodeRef /* unused */) {
+  std::map<std::string, std::string> labelMap;
+  labelMap["label"] = "Node";
+  return labelMap;
+}

--- a/caffe2/core/nomnigraph/tests/test_util.h
+++ b/caffe2/core/nomnigraph/tests/test_util.h
@@ -114,4 +114,8 @@ std::map<std::string, std::string> NNPrinter(typename nom::repr::NNGraph::NodeRe
 
 CAFFE2_API nom::Graph<TestClass>::NodeRef createTestNode(
     nom::Graph<TestClass>& g);
+
+CAFFE2_API std::map<std::string, std::string> TestNodePrinter(
+    nom::Graph<TestClass>::NodeRef node);
+
 #endif // NOM_TESTS_TEST_UTIL_H

--- a/caffe2/python/nomnigraph_test.py
+++ b/caffe2/python/nomnigraph_test.py
@@ -96,6 +96,9 @@ class TestBindings(test_util.TestCase):
         dfg.createEdge(op, w)
         dfg.createEdge(x, op)
 
+        # Dot generation
+        assert(str(dfg).startswith("digraph G"))
+
     @given(size=st.sampled_from([10, 50]))
     def test_edges_complex(self, size):
         random.seed(1337)
@@ -149,6 +152,9 @@ class TestBindings(test_util.TestCase):
         for match in nn.match(mg):
             assert len(match) == 1
             count += 1
+            # Dot generation of subgraph
+            assert(str(match).startswith("digraph G"))
+
         assert count == 1
 
     def test_match_graph_node_strict(self):
@@ -193,7 +199,7 @@ class TestBindings(test_util.TestCase):
         g = ng.Graph()
         n1 = g.createNode("hello1")
         n2 = g.createNode("hello2")
-        e = g.createEdge(n1, n2)
+        g.createEdge(n1, n2)
         ng.render(g)
 
     def test_convertToProto(self):
@@ -319,7 +325,7 @@ class TestBindings(test_util.TestCase):
         net = core.Net("name")
         net.FC(["X", "W"], ["Y"])
         d = caffe2_pb2.DeviceOption()
-        nn = ng.NNModule(net, {"X": d, "W": d})
+        ng.NNModule(net, {"X": d, "W": d})
 
         with self.assertRaises(Exception):
-            nn = ng.NNModule(net, {"X": d, "Fake": d})
+            ng.NNModule(net, {"X": d, "Fake": d})

--- a/caffe2/python/pybind_state_nomni.cc
+++ b/caffe2/python/pybind_state_nomni.cc
@@ -373,6 +373,11 @@ void addNomnigraphMethods(pybind11::module& m) {
   // Subgraph matching API
   py::class_<NNSubgraph> nnsubgraph(m, "NNSubgraph");
   nnsubgraph.def("__len__", [](NNSubgraph& s) { return s.getNodes().size(); })
+      .def(
+          "__repr__",
+          [](NNSubgraph* g) {
+            return nom::converters::convertToDotString<NNGraph>(g, NNPrinter);
+          })
       .def_property_readonly(
           "nodes",
           [](NNSubgraph& s) {


### PR DESCRIPTION
Summary:
Add ability for dot string generation for a single subgraph and python bindings (which is pretty useful for model exploration in Python)
Restructure DotGenerator class a bit to make it easy to implement this feature

Differential Revision: D10470317
