### PR TITLE
add __deepcopy__ back to Parameter

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7409,7 +7409,7 @@ class TestTorchMixin(object):
         self.assertEqual(torch.nn.Parameter, type(s['weight']))
         self.assertEqual(torch.nn.Parameter, type(s['bias']))
 
-        s2 = copy.deepcopy(s)
+        s2 = deepcopy(s)
         self.assertEqual(torch.nn.Parameter, type(s2['weight']))
         self.assertEqual(torch.nn.Parameter, type(s2['bias']))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7402,6 +7402,17 @@ class TestTorchMixin(object):
         self.assertEqual(a.size(), deepcopy(a).size())
         self.assertEqual(a, deepcopy(a))
 
+    def test_deepcopy_parameter(self):
+        from copy import deepcopy
+        l = torch.nn.Linear(10, 1)
+        s = l.state_dict(keep_vars=True)
+        self.assertEqual(torch.nn.Parameter, type(s['weight']))
+        self.assertEqual(torch.nn.Parameter, type(s['bias']))
+
+        s2 = copy.deepcopy(s)
+        self.assertEqual(torch.nn.Parameter, type(s2['weight']))
+        self.assertEqual(torch.nn.Parameter, type(s2['bias']))
+
     def test_copy(self):
         from copy import copy
         a = torch.randn(5, 5)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -25,6 +25,11 @@ class Parameter(torch.Tensor):
             data = torch.Tensor()
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 
+    def __deepcopy__(self, memo):
+        result = type(self)(self.data.clone(), self.requires_grad)
+        memo[id(self)] = result
+        return result
+
     def __repr__(self):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -26,9 +26,12 @@ class Parameter(torch.Tensor):
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 
     def __deepcopy__(self, memo):
-        result = type(self)(self.data.clone(), self.requires_grad)
-        memo[id(self)] = result
-        return result
+        if id(self) in memo:
+            return memo[id(self)]
+        else:
+            result = type(self)(self.data.clone(), self.requires_grad)
+            memo[id(self)] = result
+            return result
 
     def __repr__(self):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()


### PR DESCRIPTION
- fix https://github.com/pytorch/pytorch/issues/315
- add `__deepcopy__` back to Parameter class