### PR TITLE
Accept external input hint when doing ONNXIFI transform

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -25,15 +25,24 @@ class CAFFE2_API OnnxifiTransformer {
   void Transform(
       Workspace* ws,
       NetDef* pred_net,
+      const std::vector<std::string>& external_inputs,
       const std::unordered_map<std::string, TensorShape>& shape_hints);
 
+  const std::unordered_map<std::string, std::string>& input_mapping() const {
+    return input_mapping_;
+  }
+
+  const std::unordered_map<std::string, std::string>& reverse_input_mapping()
+      const {
+    return reverse_input_mapping_;
+  }
+
  private:
-  // Note that we have two workspaces here as inputs. The first mapped_ws is
-  // used to mapped SSA names back to c2 original names. The second one is
-  // actually used to inject more weights into the original workspace
+  // Since we create new tensors during the conversion process, we actually need
+  // into inject them into the original workspace
   caffe2::NetDef SubnetToOnnxifiOp(
       const caffe2::NetDef& net,
-      const Workspace& mapped_ws,
+      const std::unordered_set<std::string>& weights_in_ws,
       Workspace* ws,
       onnx::OnnxExporter* exporter,
       std::unordered_map<std::string, TensorShape>* shape_hints);
@@ -64,7 +73,11 @@ class CAFFE2_API OnnxifiTransformer {
 
   // Backned IDs
   std::vector<onnxBackendID> backend_ids_;
-  // Input mapping
+
+  // Input mapping of input name -> original input name
   std::unordered_map<std::string, std::string> input_mapping_;
+
+  // Input mapping of orignal input name -> input name
+  std::unordered_map<std::string, std::string> reverse_input_mapping_;
 };
 } // namespace caffe2

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -27,6 +27,7 @@ def onnxifi_caffe2_net(
     # Inject an fake input tensor to help popluate the shape if we
     # do not do shape inference
     shape_hints = {}
+    external_inputs = []
     if not infer_shapes:
         for k, v in input_shapes.items():
             need_input_tensor = True
@@ -36,10 +37,12 @@ def onnxifi_caffe2_net(
                     need_input_tensor = False
             if need_input_tensor:
                 workspace.FeedBlob(k, np.random.randn(*v).astype(np.float32))
+                external_inputs.append(k)
 
     for k, v in input_shapes.items():
         shape_hints[k] = v
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
+                             external_inputs,
                              shape_hints,
                              infer_shapes,
                              debug)

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1633,6 +1633,7 @@ void addGlobalMethods(py::module& m) {
   m.def(
       "onnxifi",
       [](const py::bytes& pred_net_str,
+         const std::vector<std::string>& external_inputs,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
          bool infer_shapes,
          bool debug_builder) -> py::bytes {
@@ -1647,7 +1648,8 @@ void addGlobalMethods(py::module& m) {
               it.first, CreateTensorShape(it.second, TensorProto::FLOAT));
         }
         OnnxifiTransformer ts(infer_shapes, debug_builder);
-        ts.Transform(GetCurrentWorkspace(), &pred_net, tensor_shapes);
+        ts.Transform(
+            GetCurrentWorkspace(), &pred_net, external_inputs, tensor_shapes);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary: Workspace sometimes will be populated with input tensors for shape inference but net.external_input() is not a reliable way to tell weights from input in the workspace. We say in some usecases where net.external_input() is empty. In this case, we need to give user an option to provide input hint.

Differential Revision: D10476822
