### PR TITLE
Support for saving exceptions in async CPU ops

### DIFF
--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -1,6 +1,8 @@
 #ifndef CAFFE2_CORE_EVENT_H_
 #define CAFFE2_CORE_EVENT_H_
 
+#include <chrono>
+
 #include <c10/DeviceType.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
@@ -103,6 +105,10 @@ class CAFFE2_API Event {
   void Reset() {
     CAFFE_ENFORCE(event_resetter_[type_]);
     event_resetter_[type_](this);
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    caught_exception_ = nullptr;
+    exception_timestamp_ = 0;
+#endif // CAFFE2_USE_EXCEPTION_PTR
   }
 
   const DeviceOption& GetDeviceOption() const {
@@ -165,6 +171,53 @@ class CAFFE2_API Event {
     return type_;
   }
 
+  void SetFinishedWithException(const char* err_msg = nullptr) {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    if (!caught_exception_) {
+      caught_exception_ = std::current_exception();
+      typedef std::chrono::high_resolution_clock clock;
+      exception_timestamp_ =
+          clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    }
+    CAFFE_ENFORCE(caught_exception_, "No exception found");
+#else
+    VLOG(1) << "No support for exceptions in Event";
+#endif // CAFFE2_USE_EXCEPTION_PTR
+    if (err_msg) {
+      SetFinished(err_msg);
+    } else {
+      SetFinished("Error happened during an operator run");
+    }
+  }
+
+  bool HasException() const {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    return (bool)caught_exception_;
+#else
+    VLOG(1) << "No support for exceptions in Event";
+    return false;
+#endif // CAFFE2_USE_EXCEPTION_PTR
+  }
+
+  int64_t ExceptionTimestamp() const {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    return exception_timestamp_;
+#else
+    VLOG(1) << "No support for exceptions in Event";
+    return 0;
+#endif // CAFFE2_USE_EXCEPTION_PTR
+  }
+
+  void RethrowException() const {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    if (caught_exception_) {
+      std::rethrow_exception(caught_exception_);
+    }
+#else
+    VLOG(1) << "No support for exceptions in Event";
+#endif // CAFFE2_USE_EXCEPTION_PTR
+  }
+
   // event_ is going to be accessed by the EventCreate/Record/Wait/Finish
   // functions, but one should not use it outside the own Event functionalities.
   // In the future we may move it to a private member.
@@ -173,6 +226,11 @@ class CAFFE2_API Event {
  private:
   int type_;
   DeviceOption option_;
+
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+  std::exception_ptr caught_exception_;
+  int64_t exception_timestamp_;
+#endif // CAFFE2_USE_EXCEPTION_PTR
 
   static EventCreateFunction event_creator_[MaxDeviceTypes];
   static EventRecordFunction event_recorder_[MaxDeviceTypes];

--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -117,11 +117,28 @@ AsyncNetBase::AsyncNetBase(
 
 bool AsyncNetBase::handleRunError() {
 #ifdef CAFFE2_USE_EXCEPTION_PTR
-  std::unique_lock<std::mutex> exception_lock(exception_mutex_);
-  if (caught_exception_) {
-    std::rethrow_exception(caught_exception_);
+  // Check net's events for exceptions and rethrow chronologically the first one
+  int first_exc_task_id = -1;
+  int64_t first_exc_ts = 0;
+  for (int task_id = 0; task_id < tasksNum(); ++task_id) {
+    if (event(task_id).HasException()) {
+      if (first_exc_task_id >= 0) {
+        auto exc_ts = event(task_id).ExceptionTimestamp();
+        if (exc_ts < first_exc_ts) {
+          first_exc_task_id = task_id;
+          first_exc_ts = exc_ts;
+        }
+      } else {
+        first_exc_task_id = task_id;
+        first_exc_ts = event(task_id).ExceptionTimestamp();
+      }
+    }
+  }
+  if (first_exc_task_id >= 0) {
+    event(first_exc_task_id).RethrowException();
   }
 #endif // CAFFE2_USE_EXCEPTION_PTR
+
   return success_;
 }
 
@@ -341,26 +358,25 @@ void AsyncNetBase::reset() {
   }
 
   success_ = true;
-#ifdef CAFFE2_USE_EXCEPTION_PTR
-  std::unique_lock<std::mutex> exception_lock(exception_mutex_);
-  caught_exception_ = nullptr;
-#endif // CAFFE2_USE_EXCEPTION_PTR
 }
 
-void AsyncNetBase::storeExceptionPtr() {
-#ifdef CAFFE2_USE_EXCEPTION_PTR
-  std::unique_lock<std::mutex> exception_lock(exception_mutex_);
-  if (!caught_exception_) {
-    caught_exception_ = std::current_exception();
-  }
-#endif // CAFFE2_USE_EXCEPTION_PTR
-}
-
-void AsyncNetBase::setTaskErrorMessage(
+void AsyncNetBase::handleChainError(
     int task_id,
-    const std::string& err_msg) {
+    OperatorBase* op,
+    const char* err_str,
+    bool save_exception) {
+  std::string err_msg = err_str;
+  if (op) {
+    err_msg += ",  op " + (op->has_debug_def() ? op->type() : " unknown");
+  }
+  LOG(ERROR) << err_msg;
+  // mark end of chain with an error
   if (query(task_id) == EventStatus::EVENT_INITIALIZED) {
-    event(task_id).SetFinished(err_msg.c_str());
+    if (save_exception) {
+      event(task_id).SetFinishedWithException(err_msg.c_str());
+    } else {
+      event(task_id).SetFinished(err_msg.c_str());
+    }
   }
 }
 
@@ -393,11 +409,9 @@ bool AsyncNetBase::run(int task_id, int stream_id) {
         }
         counters_.AddPerOpEndTime(op_id);
       }
+
       if (!success) {
-        auto err_msg = "Failed to execute an op: " +
-            (op->has_debug_def() ? op->type() : " unknown");
-        setTaskErrorMessage(task_id, err_msg);
-        LOG(ERROR) << err_msg;
+        handleChainError(task_id, op, "Failed to execute an op");
         return false;
       }
     }
@@ -407,22 +421,14 @@ bool AsyncNetBase::run(int task_id, int stream_id) {
       operators_[chains_[task_id].back()]->event().Finish();
     }
   } catch (const std::exception& e) {
-    storeExceptionPtr();
-    std::string err_msg = e.what();
-    if (op) {
-      err_msg += ",  op " + (op->has_debug_def() ? op->type() : " unknown");
-    }
-    setTaskErrorMessage(task_id, err_msg);
-    LOG(ERROR) << err_msg;
+    handleChainError(task_id, op, e.what(), /* save_exception */ true);
     return false;
   } catch (...) {
-    storeExceptionPtr();
-    std::string err_msg = "Failed to execute task: unknown error";
-    if (op) {
-      err_msg += ",  op " + (op->has_debug_def() ? op->type() : " unknown");
-    }
-    setTaskErrorMessage(task_id, err_msg);
-    LOG(ERROR) << err_msg;
+    handleChainError(
+        task_id,
+        op,
+        "Failed to execute task: unknown error",
+        /* save_exception */ true);
     return false;
   }
 

--- a/caffe2/core/net_async_base.h
+++ b/caffe2/core/net_async_base.h
@@ -116,13 +116,12 @@ class CAFFE2_API AsyncNetBase : public NetBase {
   int num_workers_;
 
   // Exception/error handling
-  void setTaskErrorMessage(int task_id, const std::string& err_msg);
+  void handleChainError(
+      int task_id,
+      OperatorBase* op,
+      const char* err_msg,
+      bool save_exception = false);
   std::atomic<bool> success_;
-#ifdef CAFFE2_USE_EXCEPTION_PTR
-  // Mutex that protects caught_exception_
-  std::mutex exception_mutex_;
-  std::exception_ptr caught_exception_;
-#endif // CAFFE2_USE_EXCEPTION_PTR
 
   // Tracing
   std::shared_ptr<tracing::Tracer> tracer_;
@@ -143,8 +142,6 @@ class CAFFE2_API AsyncNetBase : public NetBase {
   C10_DISABLE_COPY_AND_ASSIGN(AsyncNetBase);
 
  private:
-  void storeExceptionPtr();
-
   TaskThreadPoolBase*
   poolGetter(PoolsMap& pools, int device_type, int device_id, int pool_size);
 

--- a/caffe2/core/net_test.cc
+++ b/caffe2/core/net_test.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "c10/util/StringUtil.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/net_async_scheduling.h"
 #include "caffe2/core/net_dag.h"
@@ -815,41 +816,245 @@ TEST(NetTest, PendingOpsAndNetFailure) {
   ASSERT_FALSE(net->Run());
 }
 
-class SetFinishErrorOp final : public Operator<CPUContext> {
+class AsyncErrorOp final : public Operator<CPUContext> {
  public:
-  SetFinishErrorOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<CPUContext>(operator_def, ws) {}
+  AsyncErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        throw_(OperatorBase::GetSingleArgument<bool>("throw", false)),
+        fail_in_sync_(
+            OperatorBase::GetSingleArgument<bool>("fail_in_sync", false)),
+        sleep_time_s_(OperatorBase::GetSingleArgument<int>("sleep_time", 1)),
+        error_msg_(OperatorBase::GetSingleArgument<std::string>(
+            "error_msg",
+            "Error")) {}
 
   bool RunOnDevice() override {
-    event().SetFinished("error");
-    return true;
+    if (fail_in_sync_) {
+      if (throw_) {
+        throw std::logic_error(error_msg_);
+      } else {
+        return false;
+      }
+    } else {
+      if (thread_) {
+        thread_->join();
+      }
+      thread_ = caffe2::make_unique<std::thread>([this]() {
+        try {
+          std::this_thread::sleep_for(std::chrono::seconds(sleep_time_s_));
+          if (throw_) {
+            throw std::logic_error(error_msg_);
+          } else {
+            event().SetFinished(error_msg_.c_str());
+          }
+        } catch (...) {
+          event().SetFinishedWithException(error_msg_.c_str());
+        }
+      });
+      return true;
+    }
   }
 
   bool HasAsyncPart() const override {
     return true;
   }
+
+  ~AsyncErrorOp() {
+    if (thread_) {
+      thread_->join();
+    }
+  }
+
+ private:
+  std::unique_ptr<std::thread> thread_;
+  bool throw_;
+  bool fail_in_sync_;
+  int sleep_time_s_;
+  std::string error_msg_;
 };
 
-REGISTER_CPU_OPERATOR(SetFinishErrorOp, SetFinishErrorOp);
+REGISTER_CPU_OPERATOR(AsyncErrorOp, AsyncErrorOp);
+OPERATOR_SCHEMA(AsyncErrorOp);
 
-OPERATOR_SCHEMA(SetFinishErrorOp);
-
-TEST(NetTest, SetFinishErrorOpTest) {
-  const auto spec = R"DOC(
-        name: "example"
+std::unique_ptr<NetBase> AsyncErrorNet(
+    Workspace* ws,
+    const std::string& net_name,
+    bool throw_,
+    bool fail_in_sync) {
+  std::string spec_template = R"DOC(
+        name: "<NET_NAME>"
         type: "async_scheduling"
         op {
-          type: "SetFinishErrorOp"
+          type: "AsyncErrorOp"
+          arg {
+            name: "throw"
+            i: <THROW>
+          }
+          arg {
+            name: "fail_in_sync"
+            i: <FAIL_IN_SYNC>
+          }
         }
-)DOC";
+  )DOC";
+
+  std::string spec = spec_template;
+  ReplaceAll(spec, "<NET_NAME>", net_name.c_str());
+  ReplaceAll(spec, "<THROW>", throw_ ? "1" : "0");
+  ReplaceAll(spec, "<FAIL_IN_SYNC>", fail_in_sync ? "1" : "0");
 
   NetDef net_def;
   CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+  return CreateNet(net_def, ws);
+}
 
+TEST(NetTest, AsyncErrorOpTest) {
   Workspace ws;
-  std::unique_ptr<NetBase> net(CreateNet(net_def, &ws));
 
-  // net run returns false
+  // Throw in sync part
+  auto net = AsyncErrorNet(&ws, "net1", /*throw_*/ true, /*fail_in_sync*/ true);
+  ASSERT_THROW(net->Run(), std::logic_error);
+
+  // Return false in sync part
+  net = AsyncErrorNet(&ws, "net2", /*throw_*/ false, /*fail_in_sync*/ true);
+  ASSERT_FALSE(net->Run());
+
+  // SetFinishedWithException in async part
+  net = AsyncErrorNet(&ws, "net3", /*throw_*/ true, /*fail_in_sync*/ false);
+  ASSERT_THROW(net->Run(), std::logic_error);
+
+  // SetFinished(err) in async part
+  net = AsyncErrorNet(&ws, "net4", /*throw_*/ false, /*fail_in_sync*/ false);
+  ASSERT_FALSE(net->Run());
+}
+
+TEST(NetTest, AsyncErrorTimingsTest) {
+  Workspace ws;
+  std::string spec = R"DOC(
+        name: "net"
+        type: "async_scheduling"
+        op {
+          type: "AsyncErrorOp"
+          arg {
+            name: "throw"
+            i: 1
+          }
+          arg {
+            name: "fail_in_sync"
+            i: 0
+          }
+          arg {
+            name: "sleep_time"
+            i: 2
+          }
+          arg {
+            name: "error_msg"
+            s: "Error1"
+          }
+        }
+        op {
+          type: "AsyncErrorOp"
+          arg {
+            name: "throw"
+            i: 1
+          }
+          arg {
+            name: "fail_in_sync"
+            i: 0
+          }
+          arg {
+            name: "sleep_time"
+            i: 1
+          }
+          arg {
+            name: "error_msg"
+            s: "Error2"
+          }
+        }
+  )DOC";
+
+  NetDef net_def;
+  CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+  auto net = CreateNet(net_def, &ws);
+
+  try {
+    net->Run();
+  } catch (const std::logic_error& e) {
+    ASSERT_TRUE(std::string(e.what()) == "Error2");
+  } catch (...) {
+    FAIL() << "Expected std::logic_error thrown";
+  }
+}
+
+class SyncErrorOp final : public Operator<CPUContext> {
+ public:
+  SyncErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        fail_(OperatorBase::GetSingleArgument<bool>("fail", true)),
+        throw_(OperatorBase::GetSingleArgument<bool>("throw", false)) {}
+
+  bool RunOnDevice() override {
+    if (fail_) {
+      if (throw_) {
+        throw std::logic_error("Error");
+      } else {
+        return false;
+      }
+    } else {
+      return true;
+    }
+  }
+
+  ~SyncErrorOp() {}
+
+ private:
+  bool fail_;
+  bool throw_;
+};
+
+REGISTER_CPU_OPERATOR(SyncErrorOp, SyncErrorOp);
+OPERATOR_SCHEMA(SyncErrorOp);
+
+std::unique_ptr<NetBase>
+ChainErrorNet(Workspace* ws, const std::string& net_name, bool throw_) {
+  std::string spec_template = R"DOC(
+        name: "<NET_NAME>"
+        type: "async_scheduling"
+        op {
+          type: "SyncErrorOp"
+          arg {
+            name: "fail"
+            i: 1
+          }
+          arg {
+            name: "throw"
+            i: <THROW>
+          }
+        }
+        op {
+          type: "SyncErrorOp"
+          arg {
+            name: "fail"
+            i: 0
+          }
+        }
+  )DOC";
+
+  std::string spec = spec_template;
+  ReplaceAll(spec, "<NET_NAME>", net_name.c_str());
+  ReplaceAll(spec, "<THROW>", throw_ ? "1" : "0");
+
+  NetDef net_def;
+  CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+  return CreateNet(net_def, ws);
+}
+
+TEST(NetTest, ChainErrorTest) {
+  Workspace ws;
+
+  auto net = ChainErrorNet(&ws, "net1", /*throw_*/ true);
+  ASSERT_THROW(net->Run(), std::logic_error);
+
+  net = ChainErrorNet(&ws, "net2", /*throw_*/ false);
   ASSERT_FALSE(net->Run());
 }
 


### PR DESCRIPTION
Summary:
Enabling support for saving exceptions in async parts of CPU ops via
event().SaveException(). The error contract for CPU ops becomes:
 - return false in sync part -> net->Run() returns false
 - throw in sync part -> net->Run() rethrows the same exception
 - SetFinished("error msg") in async part -> net->Run() returns false
 - event().SetFinishedWithException("error msg") in async part -> net->Run() rethrows the same
   exception

Differential Revision: D10479130
