### PR TITLE
[WIP] Introduce fork/wait frontend

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -69,6 +69,8 @@ namespace c10 {
   _(prim, LoadWorld)               \
   _(prim, StoreWorld)              \
   _(prim, DummyWorld)              \
+  _(prim, Fork)                    \
+  _(prim, Wait)                    \
   _(aten, append)                  \
   _(aten, __not__)                 \
   FORALL_ATEN_BASE_SYMBOLS(_)      \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8804,6 +8804,70 @@ def post_add_test(test_name, skipTestIf, do_test):
     if not (TEST_WITH_UBSAN and test_name in UBSAN_BLACKLISTED_TESTS):
         setattr(TestJitGenerated, test_name, do_test)
 
+class TestAsync(JitTestCase):
+    def test_async_python(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.neg(x)
+
+        x = torch.rand(3, 4)
+        fut = torch.jit.fork(foo, (x,))
+        y_hat = foo(x)
+        y = torch.jit.wait(fut)
+
+        self.assertEqual(y, y_hat)
+
+    def test_async_script(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.neg(x), x
+
+        x = torch.rand(3, 4)
+
+        @torch.jit.script
+        def wait_script(x):
+            fut = torch.jit.fork(foo, (x,))
+            y_hat = foo(x)
+            y = torch.jit.wait(fut)
+            return y, y_hat
+
+        print(wait_script.graph)
+        y, y_hat = wait_script(x)
+
+        self.assertEqual(y, y_hat)
+
+    def test_async_script_nested(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.neg(x), x
+
+        x = torch.rand(3, 4)
+
+        @torch.jit.script
+        def wait_script(x):
+            fut = torch.jit.fork(foo, (x,))
+            y_hat = foo(x)
+            y = torch.jit.wait(fut)
+            return y, y_hat
+
+
+        @torch.jit.script
+        def wait_script_nest(x):
+            fut = torch.jit.fork(wait_script, (x,))
+            return torch.jit.wait(fut)
+
+        y, y_hat = wait_script_nest(x)
+
+        self.assertEqual(y, y_hat)
+
+    def test_async_script_no_script_mod(self):
+        x = torch.rand(3, 4)
+
+        with self.assertRaisesRegex(RuntimeError, 'Expected a module and a single tuple argument to fork\(\)'):
+            @torch.jit.script
+            def wait_script(x):
+                fut = torch.jit.fork((x,))
+                return fut
 
 for test in autograd_method_tests:
     add_autograd_test(*test)

--- a/torch/csrc/jit/async.h
+++ b/torch/csrc/jit/async.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "torch/csrc/jit/ivalue.h"
+#include "torch/csrc/jit/script/module.h"
+
+// TODO: remove this file
+namespace torch { namespace jit { namespace async {
+
+struct Future {
+  explicit Future(IValue result) : result(result), ready(true) {}
+  IValue result;
+  bool ready = false;
+  IValue get() const {
+    JIT_ASSERT(ready);
+    return result;
+  }
+};
+
+Future fork(script::Module &sm, std::vector<IValue> inputs) {
+  // TODO: actually fork
+  return Future(sm.forward(inputs));
+}
+
+IValue wait(Future &fut) {
+  // TODO: actually wait
+  JIT_ASSERT(fut.ready);
+  return fut.get();
+}
+
+}}}  // namespace torch::jit::async

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -47,6 +47,18 @@ TORCH_API void runRequiredPasses(const std::shared_ptr<Graph>& g);
 
 namespace detail {
 
+struct NewCoroutine : public std::exception {
+  virtual const char* what() const noexcept {
+    return "NewCoroutine";
+  }
+};
+
+struct Yield : public std::exception {
+  virtual const char* what() const noexcept {
+    return "Yield";
+  }
+};
+
 GraphExecutor* getGradExecutor(Operation& op);
 
 } // namespace detail

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -36,6 +36,7 @@
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/operator.h"
 #include "torch/csrc/jit/fusers/interface.h"
+#include "torch/csrc/jit/async.h"
 
 #include "caffe2/serialize/inline_container.h"
 
@@ -303,6 +304,13 @@ void initJITBindings(PyObject *module) {
         return op->schema();
       });
   });
+
+  py::class_<async::Future>(m, "Future")
+  .def("get", &async::Future::get);
+
+  m.def("fork", &async::fork);
+
+  m.def("wait", &async::wait);
 
 
   initPythonIRBindings(module);

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -11,6 +11,7 @@
 #include "torch/csrc/jit/ivalue.h"
 #include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/operator.h"
+#include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/variable_tensor_functions.h"
 
 #include <exception>
@@ -122,6 +123,40 @@ void desugarTripCounts(Block * b) {
     }
     for(auto sb : n->blocks()) {
       desugarTripCounts(sb);
+    }
+  }
+}
+
+// Currently inline the Fork node's block to evaluate it eagerly.
+void desugarForkJoin(Block *b) {
+  for (auto n : b->nodes()) {
+    for (auto block : n->blocks()) {
+      desugarForkJoin(block);
+    }
+    if (n->kind() == prim::Fork) {
+      auto g = n->owningGraph();
+      auto body_block = n->blocks()[0];
+      auto input_tup = n->input(0);
+      auto tup_unpack = g->createTupleUnpack(input_tup)->insertBefore(n);
+      std::unordered_map<Value*, Value*> value_remap;
+
+      for (size_t i = 0; i < body_block->inputs().size(); ++i) {
+        value_remap[body_block->inputs()[i]] = tup_unpack->outputs()[i];
+      }
+
+      {
+        WithInsertPoint guard(n);
+        for (auto sub_node : body_block->nodes()) {
+          auto inserted_node = g->insertNode(g->createClone(sub_node, [&value_remap](Value* v) { return value_remap[v];}));
+          for (size_t i = 0; i < sub_node->outputs().size(); ++i) {
+            value_remap[sub_node->outputs()[i]] = inserted_node->outputs()[i];
+          }
+        }
+        JIT_ASSERT(body_block->outputs().size() == 1);
+        n->output()->replaceAllUsesWith(value_remap[body_block->outputs()[0]]);
+      }
+    } else if (n->kind() == prim::Wait) {
+      n->output()->replaceAllUsesWith(n->input());
     }
   }
 }
@@ -289,6 +324,8 @@ struct PreprocessGraph {
   PreprocessGraph(Graph & g)
   : graph(g.copy()) {
     desugarTripCounts(graph->block());
+    desugarForkJoin(graph->block());
+    EliminateDeadCode(graph->block());
     flattenIO(*graph);
     dropUnused(graph->block());
     // fill in move_flags by scanning blocks;
@@ -656,7 +693,14 @@ struct InterpreterStateImpl {
         try {
           auto & inst = instructions[pc];
           loadTensorsFromRegisters(inst.inputs, stack);
-          size_t new_pc = pc + 1 + inst.callback(stack);
+          size_t new_pc;
+          try {
+            new_pc = pc + 1 + inst.callback(stack);
+          } catch (detail::NewCoroutine nc) {
+            new_pc = pc + 1;
+          } catch (detail::Yield y) {
+            new_pc = pc + 1;
+          }
           for(int i = inst.outputs.size - 1; i >= 0; i--) {
             int reg = get(inst.outputs,i);
             registers[reg] = pop(stack);

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -163,6 +163,7 @@ inline IValue toIValue(py::handle obj, const TypePtr& type) {
       case TypeKind::NumberType:
       case TypeKind::GeneratorType:
       case TypeKind::VarType:
+      case TypeKind::FutureType:
         break;
     }
   AT_ERROR("Missing cases in toIValue for type: ", type->str(), "! File a bug report.");

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -499,6 +499,18 @@ RegisterOperators reg({
             };
           }
         }),
+    // TODO schema
+    Operator(prim::Fork, [](Node* stack) -> Operation {
+      return [=](Stack& stack) -> int {
+        throw detail::NewCoroutine();
+      };
+    }),
+    // TODO: type variable
+    Operator(prim::Wait, [](Node* stack) -> Operation {
+      return [=](Stack& stack) -> int {
+        throw detail::Yield();
+      };
+    }),
 });
 
 // define implementations for primitive number ops

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -243,6 +243,10 @@ struct ModuleValue : public SugaredValue {
     return result;
   }
 
+  FunctionSchema schema(SourceRange loc, Method &caller) override {
+    return attr(loc, caller, "forward")->schema(loc, caller);
+  }
+
  private:
   std::shared_ptr<Module> module;
 };
@@ -297,6 +301,10 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     return std::make_shared<ModuleValue>(mod);
   } else if (py::isinstance<py::module>(obj)) {
     return std::make_shared<PythonModuleValue>(obj);
+  } else if (obj.is(py::module::import("torch.jit").attr("fork"))) {
+    return std::make_shared<ForkValue>();
+  } else if (obj.is(py::module::import("torch.jit").attr("wait"))) {
+    return std::make_shared<WaitValue>();
   }
 
   py::object builtin_name = py::module::import("torch.jit").attr("_find_builtin")(obj);

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -61,6 +61,9 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << t.expect<VarType>()->name();
   } else if(t.kind() == TypeKind::WorldType) {
     out << "World";
+  } else if(t.kind() == TypeKind::FutureType) {
+    auto elem = t.cast<FutureType>()->getElementType();
+    out << "Future[" << *elem << "]";
   } else {
     AT_ERROR("unknown type kind");
   }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -47,6 +47,9 @@ _unflatten = torch._C._jit_unflatten
 _jit_script_compile = torch._C._jit_script_compile
 BatchTensor = torch._C._jit.BatchTensor
 
+Future = torch._C.Future
+fork = torch._C.fork
+wait = torch._C.wait
 
 @contextlib.contextmanager
 def scope(scope_name):


### PR DESCRIPTION
**There still has remaining comments unaddressed from #12405**

Add two new functions for jit script: fork and wait. fork takes a
function name together with a tuple of inputs and returns a future. wait
takes a future and return the value of the function result evaluated on
the tuple of inputs. This patch only introduces the syntax without a real
fork or wait.

