### PR TITLE
Hide c10::optional and nullopt in torch namespace

### DIFF
--- a/test/cpp/api/memory.cpp
+++ b/test/cpp/api/memory.cpp
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/utils/memory.h>
 
-#include "c10/util/Optional.h"
+#include <c10/util/Optional.h>
 
 struct TestValue {
   explicit TestValue(const int& x) : lvalue_(x) {}

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -239,7 +239,7 @@ TEST_F(ModuleTest, CallingCloneOnModuleThatDoesNotOverrideCloneThrows) {
 TEST_F(ModuleTest, CallingCloneOnModuleThatDoesOverrideCloneDoesNotThrow) {
   struct Cloneable : Module {
     std::shared_ptr<Module> clone(
-        c10::optional<torch::Device> device = c10::nullopt) const override {
+        torch::optional<torch::Device> device = torch::nullopt) const override {
       return nullptr;
     }
   };

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -189,7 +189,7 @@ TEST_F(
     auto output = parallel::data_parallel(
         m,
         input,
-        /*devices=*/nullopt,
+        /*devices=*/torch::nullopt,
         /*output_device=*/torch::Device(torch::kCUDA, 1));
     ASSERT_TRUE(output.defined());
     ASSERT_TRUE(output.device().is_cuda());

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -189,7 +189,7 @@ TEST_F(
     auto output = parallel::data_parallel(
         m,
         input,
-        /*devices=*/c10::nullopt,
+        /*devices=*/nullopt,
         /*output_device=*/torch::Device(torch::kCUDA, 1));
     ASSERT_TRUE(output.defined());
     ASSERT_TRUE(output.device().is_cuda());

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -7,7 +7,6 @@
 #include <ATen/OptionsGuard.h>
 #include <ATen/core/TensorOptions.h>
 #include <c10/util/Exception.h>
-#include <c10/util/Optional.h>
 
 #include <memory>
 #include <utility>
@@ -34,7 +33,7 @@ class Cloneable : public virtual Module {
   /// and submodules in the cloned module are different from those in the
   /// original module.
   std::shared_ptr<Module> clone(
-      c10::optional<Device> device = c10::nullopt) const override {
+      optional<Device> device = nullopt) const override {
     OptionsGuard options_guard(TensorOptions().device(device));
 
     NoGradGuard no_grad;

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -109,7 +109,7 @@ class Module {
   ///   easier-to-use polymorphic interface.
   /// \endrst
   virtual std::shared_ptr<Module> clone(
-      c10::optional<Device> device = c10::nullopt) const;
+      optional<Device> device = nullopt) const;
 
   /// Provides a means to traverse the `Module` tree.
   ///
@@ -333,7 +333,7 @@ class Module {
   // Private methods.
 
   /// Used in the implementation of `Cloneable`.
-  virtual void clone_(Module& other, c10::optional<Device> device);
+  virtual void clone_(Module& other, optional<Device> device);
 
   /// The implementation of the various `to()` methods.
   template <typename... Ts>
@@ -349,7 +349,7 @@ class Module {
   OrderedDict<std::shared_ptr<Module>> children_;
 
   /// The module's name (e.g. "LSTM").
-  mutable c10::optional<std::string> name_;
+  mutable optional<std::string> name_;
 
   /// Whether the module is in training mode.
   bool is_training_{true};

--- a/torch/csrc/api/include/torch/nn/modules/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/any.h
@@ -10,7 +10,6 @@
 #include <torch/csrc/utils/variadic.h>
 
 #include <ATen/Device.h>
-#include "c10/util/Optional.h"
 
 #include <memory>
 #include <type_traits>
@@ -135,7 +134,7 @@ class AnyModule {
 
   /// Creates a deep copy of an `AnyModule` if it contains a module, else an
   /// empty `AnyModule` if it is empty.
-  AnyModule clone(c10::optional<Device> device = c10::nullopt) const;
+  AnyModule clone(optional<Device> device = nullopt) const;
 
   /// Assigns a module to the `AnyModule` (to circumvent the explicit
   /// constructor).
@@ -334,7 +333,7 @@ struct AnyModule::Placeholder : public AnyModule::Value::Placeholder {
 
   /// Returns a `Placeholder` with a deep copy of this `AnyModule`.
   virtual std::unique_ptr<Placeholder> clone(
-      c10::optional<Device> device) const = 0;
+      optional<Device> device) const = 0;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AnyModule::Holder ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -399,7 +398,7 @@ struct AnyModule::Holder : public AnyModule::Placeholder {
   }
 
   std::unique_ptr<Placeholder> clone(
-      c10::optional<Device> device) const override {
+      optional<Device> device) const override {
     return torch::make_unique<Holder>(
         std::dynamic_pointer_cast<ModuleType>(module->clone(device)));
   }
@@ -435,7 +434,7 @@ inline AnyModule& AnyModule::operator=(const AnyModule& other) {
   return *this;
 }
 
-inline AnyModule AnyModule::clone(c10::optional<Device> device) const {
+inline AnyModule AnyModule::clone(optional<Device> device) const {
   AnyModule clone;
   clone.content_ = content_ ? content_->clone(device) : nullptr;
   return clone;

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -7,7 +7,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
-#include "c10/util/Optional.h"
 
 #include <cstddef>
 #include <functional>
@@ -62,7 +61,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
 
   explicit RNNImplBase(
       RNNOptionsBase options_,
-      c10::optional<CuDNNMode> cudnn_mode = c10::nullopt,
+      optional<CuDNNMode> cudnn_mode = nullopt,
       int64_t number_of_gates = 1);
 
   /// Initializes the parameters of the RNN module.
@@ -128,7 +127,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   int64_t number_of_gates_;
 
   /// The cuDNN RNN mode, if this RNN subclass has any.
-  c10::optional<CuDNNMode> cudnn_mode_;
+  optional<CuDNNMode> cudnn_mode_;
 
   /// The cached result of the latest `flat_weights()` call.
   std::vector<Tensor> flat_weights_;

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -104,7 +104,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   /// Special cloning function for `Sequential` because it does not use
   /// `reset()`.
   std::shared_ptr<Module> clone(
-      c10::optional<Device> device = c10::nullopt) const override {
+      optional<Device> device = nullopt) const override {
     auto clone = std::make_shared<SequentialImpl>();
     for (const auto& module : modules_) {
       clone->push_back(module.clone(device));

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -14,7 +14,6 @@
 #include <ATen/Parallel.h>
 #include <ATen/core/TensorOptions.h>
 #include <c10/util/Exception.h>
-#include "c10/util/Optional.h"
 
 #include <cstddef>
 #include <exception>
@@ -72,7 +71,7 @@ template <typename ModuleType>
 std::vector<Tensor> parallel_apply(
     std::vector<ModuleType>& modules,
     const std::vector<Tensor>& inputs,
-    const c10::optional<std::vector<Device>>& devices = c10::nullopt) {
+    const optional<std::vector<Device>>& devices = nullopt) {
   AT_CHECK(
       modules.size() == inputs.size(), "Must have as many inputs as modules");
   if (devices) {
@@ -135,8 +134,8 @@ template <typename ModuleType>
 Tensor data_parallel(
     ModuleType module,
     Tensor input,
-    c10::optional<std::vector<Device>> devices = c10::nullopt,
-    c10::optional<Device> output_device = c10::nullopt,
+    optional<std::vector<Device>> devices = nullopt,
+    optional<Device> output_device = nullopt,
     int64_t dim = 0) {
   if (!devices) {
     const auto device_count = torch::cuda::device_count();
@@ -157,7 +156,7 @@ Tensor data_parallel(
   }
 
 #ifdef USE_CUDA
-  autograd::Scatter scatter(*devices, /*chunk_sizes=*/c10::nullopt, dim);
+  autograd::Scatter scatter(*devices, /*chunk_sizes=*/nullopt, dim);
   auto scattered_inputs = fmap<Tensor>(scatter.apply({std::move(input)}));
 
   auto replicas = replicate(module, *devices);

--- a/torch/csrc/api/include/torch/tensor.h
+++ b/torch/csrc/api/include/torch/tensor.h
@@ -13,6 +13,9 @@ using namespace at; // NOLINT
 using c10::optional;
 using c10::nullopt;
 
+using c10::optional;
+using c10::nullopt;
+
 using Dtype = at::ScalarType;
 
 /// Fixed width dtypes.

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -5,7 +5,6 @@
 #include <torch/csrc/autograd/generated/VariableType.h>
 
 #include <c10/util/Exception.h>
-#include "c10/util/Optional.h"
 
 #include <algorithm>
 #include <map>
@@ -40,7 +39,7 @@ const std::string& Module::name() const noexcept {
   return *name_;
 }
 
-std::shared_ptr<Module> Module::clone(c10::optional<Device> device) const {
+std::shared_ptr<Module> Module::clone(optional<Device> device) const {
   AT_ERROR(
       "clone() has not been implemented for ",
       name(),
@@ -181,6 +180,6 @@ Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 
-void Module::clone_(Module& other, c10::optional<Device> device) {}
+void Module::clone_(Module& other, optional<Device> device) {}
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -5,7 +5,6 @@
 #include <torch/utils.h>
 
 #include <c10/util/Exception.h>
-#include "c10/util/Optional.h"
 
 #include <array>
 #include <cmath>
@@ -31,7 +30,7 @@ RNNOptionsBase::RNNOptionsBase(int64_t input_size, int64_t hidden_size)
 template <typename Derived>
 RNNImplBase<Derived>::RNNImplBase(
     RNNOptionsBase options_,
-    c10::optional<CuDNNMode> cudnn_mode,
+    optional<CuDNNMode> cudnn_mode,
     int64_t number_of_gates)
     : options(options_),
       number_of_gates_(number_of_gates),


### PR DESCRIPTION
Does

```cpp
namespace torch {
using c10::optional;
using c10::nullopt;
}
```

So that users can be oblivious of our changes with ATen/c10 happening in the background, and also don't have to deal with multiple namespaces (which is very confusing).

@ezyang 