### PR TITLE
Add C10_LIKELY/C10_UNLIKELY macros

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -59,4 +59,14 @@ namespace c10 {} // namespace c10
 #define C10_NORETURN __attribute__((noreturn))
 #endif
 
+// C10_LIKELY/C10_UNLIKELY
+// TODO: Define this to use the C++20 syntax... if we ever move to C++20 (haha)
+#if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
+#define C10_LIKELY(expr)    __builtin_expect(!(expr), 0)
+#define C10_UNLIKELY(expr)  __builtin_expect((expr),  0)
+#else
+#define C10_LIKELY
+#define C10_UNLIKELY
+#endif
+
 #endif // C10_MACROS_MACROS_H_

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -60,13 +60,23 @@ namespace c10 {} // namespace c10
 #endif
 
 // C10_LIKELY/C10_UNLIKELY
-// TODO: Define this to use the C++20 syntax... if we ever move to C++20 (haha)
+//
+// These macros provide parentheses, so you can use these macros as:
+//
+//    if C10_LIKELY(some_expr) {
+//      ...
+//    }
+//
+// NB: static_cast to boolean is mandatory in C++, because __builtin_expect
+// takes a long argument, which means you may trigger the wrong conversion
+// without it.
+//
 #if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
-#define C10_LIKELY(expr)    __builtin_expect(!(expr), 0)
-#define C10_UNLIKELY(expr)  __builtin_expect((expr),  0)
+#define C10_LIKELY(expr)    (__builtin_expect(static_cast<bool>(expr), 1))
+#define C10_UNLIKELY(expr)  (__builtin_expect(static_cast<bool>(expr), 0))
 #else
-#define C10_LIKELY
-#define C10_UNLIKELY
+#define C10_LIKELY(expr)    (expr)
+#define C10_UNLIKELY(expr)  (expr)
 #endif
 
 #endif // C10_MACROS_MACROS_H_

--- a/caffe2/share/contrib/depthwise/depthwise3x3_conv_op.cc
+++ b/caffe2/share/contrib/depthwise/depthwise3x3_conv_op.cc
@@ -3,6 +3,8 @@
 #include "caffe2/operators/conv_op.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 
+#include "c10/macros/Macros.h"
+
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
 #endif
@@ -163,11 +165,11 @@ void runDepthwise3x3Conv(
       int ih = oth * 2 - args.pad_rows;
       int iw = otw * 2 - args.pad_cols;
       // fast-path, all accesses in-bounds
-      if (__builtin_expect(
+      if (C10_LIKELY(
               ih >= 0 && iw >= 0 && ih + 3 < args.in_rows &&
                   iw + 3 < args.in_cols && 2 * oth + 1 < args.out_rows &&
-                  2 * otw + 1 < args.out_cols,
-              1)) {
+                  2 * otw + 1 < args.out_cols
+              )) {
         float32x4x4_t input_tile;
         for (int row = 0; row < 4; ++row) {
           input_tile.val[row] =


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12932 Add C10_LIKELY/C10_UNLIKELY macros**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10488399/)

I was looking at some assembly for some code I was working on,
and felt a desire to have likely()/unlikely() macros.  I checked
if we already had them, and we didn't.  This commit adds them,
and fixes up all known use sites to make use of it.

Differential Revision: [D10488399](https://our.internmc.facebook.com/intern/diff/D10488399/)