### PR TITLE
Generate base seed for DataLoaderIter only if num workers larger than 0

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -525,8 +525,6 @@ class _DataLoaderIter(object):
 
         self.sample_iter = iter(self.batch_sampler)
 
-        base_seed = torch.LongTensor(1).random_().item()
-
         if self.num_workers > 0:
             self.worker_init_fn = loader.worker_init_fn
             self.worker_queue_idx = 0
@@ -541,6 +539,9 @@ class _DataLoaderIter(object):
 
             self.index_queues = []
             self.workers = []
+
+            base_seed = torch.LongTensor(1).random_().item()
+
             for i in range(self.num_workers):
                 index_queue = multiprocessing.Queue()
                 index_queue.cancel_join_thread()


### PR DESCRIPTION
This PR moves the generation of the workers `base_seed` such that it is only generated if data is fetched with workers, i.e, `num_workers > 0`. This allows to run for example a validation set without changing the random state und ensuring determinism in between to different experiments in which the number of validation times differs.