### PR TITLE
ArgumentStash for int64_t arguments

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1860,7 +1860,10 @@ class TestJit(JitTestCase):
 
             traced = torch.jit.trace(test, (torch.randn(5, 3, 10), torch.LongTensor([3, 2, 1]), torch.randn(2, 3, 20)))
             imported = self.getExportImportCopy(traced)
-            x, lengths, h0 = torch.randn(5, 3, 10), torch.LongTensor([3, 3, 2]), torch.randn(2, 3, 20)
+            # NB: We make sure to pass in a batch with a different max sequence
+            # length to ensure that the argument stashing for pad_packed works
+            # properly.
+            x, lengths, h0 = torch.randn(7, 4, 10), torch.LongTensor([7, 3, 2, 1]), torch.randn(2, 4, 20)
             self.assertEqual(traced(x, lengths, h0), imported(x, lengths, h0))
 
     def test_export_lstm(self):
@@ -1883,7 +1886,7 @@ class TestJit(JitTestCase):
                                         (torch.randn(2, 3, 20), torch.randn(2, 3, 20))))
         imported = self.getExportImportCopy(traced)
         x, lengths, h0, c0 = \
-            torch.randn(5, 3, 10), torch.LongTensor([3, 3, 2]), torch.randn(2, 3, 20), torch.randn(2, 3, 20)
+            torch.randn(7, 3, 10), torch.LongTensor([7, 5, 2]), torch.randn(2, 3, 20), torch.randn(2, 3, 20)
         self.assertEqual(traced(x, lengths, (h0, c0)), imported(x, lengths, (h0, c0)))
 
     def test_trace_variable_instantiation(self):

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -38,7 +38,15 @@ thread_local std::shared_ptr<TracingState> tracing_state;
 
 } // namespace detail
 
-void addInputs(Node *n, const char * name, int64_t value)            { detail::genericAddInput(n, value); }
+void addInputs(Node *n, const char * name, int64_t value) {
+  using ArgumentStash = jit::tracer::ArgumentStash;
+  if (ArgumentStash::hasValue(name)) {
+    Value * v = ArgumentStash::popValue(name);
+    n->addInput(v);
+  } else {
+    detail::genericAddInput(n, value);
+  }
+}
 void addInputs(Node *n, const char * name, bool value)               { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, double value)             { detail::genericAddInput(n, value); }
 void addInputs(Node *n, const char * name, const at::Scalar& value)  { detail::genericAddInput(n, value); }
@@ -175,6 +183,19 @@ void ArgumentStash::stashIntListElem(const std::string& arg_name, size_t size, s
                    ->insertAfter(ten->node())
                    ->output();
   list_trace[idx] = prim;
+}
+
+void ArgumentStash::stashValue(const std::string& arg_name, size_t idx, const Variable& var, TypePtr type) {
+  if (!isTracing()) return;
+
+  Value* ten = getValueTrace(var);
+  if (type) {
+    auto& g = *ten->owningGraph();
+    ten = g.createTensorToNum(type, ten)
+                     ->insertAfter(ten->node())
+                     ->output();
+  }
+  stash.values.emplace(arg_name, ten);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/torch/csrc/jit/tracing_state.h
+++ b/torch/csrc/jit/tracing_state.h
@@ -5,6 +5,7 @@
 #include "torch/csrc/jit/assertions.h"
 #include "torch/csrc/jit/constants.h"
 #include "torch/csrc/jit/stack.h"
+#include "torch/csrc/jit/type.h"
 #include "torch/csrc/utils/functional.h"
 #include "torch/csrc/utils/functional.h"
 #include "torch/csrc/utils/variadic.h"
@@ -81,9 +82,28 @@ struct ArgumentStash {
     return info;
   }
 
+  // Value stashing: Use these methods to stash arguments which correspond
+  // to regular Value*'s in the graph. i.e. they don't require special
+  // handling like in the case of IntLists
+  TORCH_API static void stashValue(const std::string& arg_name,
+                                   size_t idx,
+                                   const Variable& var,
+                                   TypePtr type=nullptr);
+
+  static bool hasValue(const std::string& arg_name) {
+    return stash.values.count(arg_name) > 0;
+  }
+
+  static Value* popValue(const std::string& arg_name) {
+    auto info = stash.values.at(arg_name);
+    stash.values.erase(arg_name);
+    return info;
+  }
+
 private:
   static thread_local ArgumentStash stash;
   std::unordered_map<std::string, IntListTrace> intlists;
+  std::unordered_map<std::string, Value*> values;
 };
 
 // Retrieve or set the current tracing state. Returns a nullptr if tracing is disabled.

--- a/torch/csrc/jit/tracing_state.h
+++ b/torch/csrc/jit/tracing_state.h
@@ -86,9 +86,7 @@ struct ArgumentStash {
   // to regular Value*'s in the graph. i.e. they don't require special
   // handling like in the case of IntLists
   TORCH_API static void stashValue(const std::string& arg_name,
-                                   size_t idx,
-                                   const Variable& var,
-                                   TypePtr type=nullptr);
+                                   const Variable& var);
 
   static bool hasValue(const std::string& arg_name) {
     return stash.values.count(arg_name) > 0;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -398,6 +398,11 @@ inline std::string PythonArgs::string(int i) {
 
 inline int64_t PythonArgs::toInt64(int i) {
   if (!args[i]) return signature.params[i].default_int;
+  if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
+    auto & var = THPVariable_Unpack(args[i]);
+    jit::tracer::ArgumentStash::stashValue(
+        signature.params[i].name, idx, var, jit::IntType::get());
+  }
   return THPUtils_unpackLong(args[i]);
 }
 

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -401,7 +401,7 @@ inline int64_t PythonArgs::toInt64(int i) {
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
     auto & var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
-        signature.params[i].name, idx, var, jit::IntType::get());
+        signature.params[i].name, var);
   }
   return THPUtils_unpackLong(args[i]);
 }

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1307,7 +1307,7 @@ def _pack_padded_sequence(g, input, lengths, batch_first):
     return g.op("prim::PackPadded", input, lengths, outputs=2)
 
 
-@parse_args('v', 'v', 'i', 't', 'i')
+@parse_args('v', 'v', 'i', 't', 'v')
 def _pad_packed_sequence(g, data, batch_sizes, batch_first, padding_value, total_length):
     # Ignore total_length as it is not supported in _symbolic_pad_packed_sequence
     # It is only useful/used when training using data_parallel model, so


### PR DESCRIPTION
Closes https://github.com/pytorch/pytorch/issues/12906. https://github.com/pytorch/pytorch/issues/12580 is still open because the schema is marked as `traceable=false` in the arg parser constructor, I think.