### PR TITLE
Make TopoSort takes const graph reference

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -225,6 +225,7 @@ class Graph {
   using SubgraphType = Subgraph<T, U...>;
   using NodeRef = Node<T, U...>*;
   using EdgeRef = Edge<T, U...>*;
+  using ConstNodeRef = const Node<T, U...>*;
 
   Graph() {
     DEBUG_PRINT("Creating instance of Graph: %p\n", this);
@@ -508,6 +509,14 @@ class Graph {
     std::vector<NodeRef> result;
     for (auto& n : nodes_) {
       DEBUG_PRINT("Adding node to mutable output (%p)\n", &n);
+      result.emplace_back(&n);
+    }
+    return result;
+  }
+
+  const std::vector<ConstNodeRef> getNodes() const {
+    std::vector<ConstNodeRef> result;
+    for (auto& n : nodes_) {
       result.emplace_back(&n);
     }
     return result;

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/TopoSort.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/TopoSort.h
@@ -15,9 +15,9 @@ namespace algorithm {
 template <typename GraphT>
 class TopoSort {
  private:
-  using NodeRefT = typename GraphT::NodeRef;
+  using NodeRefT = typename GraphT::ConstNodeRef;
 
-  GraphT* graph;
+  const GraphT& graph;
 
   /// \brief performs DFS from given node.
   //  Each node and edge is visited no more than once.
@@ -26,7 +26,7 @@ class TopoSort {
   bool dfs(
       NodeRefT node,
       std::unordered_map<NodeRefT, int>& status,
-      std::vector<NodeRefT>& nodes) {
+      std::vector<NodeRefT>& nodes) const {
     // mark as visiting
     status[node] = 1;
     for (const auto& outEdge : node->getOutEdges()) {
@@ -49,17 +49,17 @@ class TopoSort {
   }
 
  public:
-  TopoSort(GraphT* graph) : graph(graph) {}
+  TopoSort(const GraphT& graph) : graph(graph) {}
 
   struct Result {
     enum { OK, CYCLE } status;
     std::vector<NodeRefT> nodes;
   };
 
-  Result run() {
+  Result run() const {
     std::vector<NodeRefT> nodes;
     std::unordered_map<NodeRefT, int> status;
-    for (auto& node : graph->getMutableNodes()) {
+    for (NodeRefT node : graph.getNodes()) {
       if (!status[node]) {
         if (dfs(node, status, nodes)) {
           return {Result::CYCLE, {}};
@@ -74,7 +74,7 @@ class TopoSort {
 //// \brief A function wrapper to infer the graph template parameters.
 /// TODO change this to const GraphT& g
 template <typename GraphT>
-typename TopoSort<GraphT>::Result topoSort(GraphT* g) {
+typename TopoSort<GraphT>::Result topoSort(const GraphT& g) {
   TopoSort<GraphT> t(g);
   return t.run();
 }

--- a/caffe2/core/nomnigraph/tests/TopoSortTest.cc
+++ b/caffe2/core/nomnigraph/tests/TopoSortTest.cc
@@ -12,7 +12,7 @@ TEST(TopoSort, Simple) {
   auto n1 = createTestNode(g);
   auto n2 = createTestNode(g);
   g.createEdge(n1, n2);
-  auto res = nom::algorithm::topoSort(&g);
+  auto res = nom::algorithm::topoSort(g);
   EXPECT_EQ(res.status, TopoSortT::Result::OK);
   EXPECT_EQ(res.nodes.size(), 2);
   EXPECT_EQ(res.nodes[0], n1);
@@ -29,7 +29,7 @@ TEST(TopoSort, DAG) {
   g.createEdge(n1, n3);
   g.createEdge(n2, n4);
   g.createEdge(n3, n4);
-  auto res = nom::algorithm::topoSort(&g);
+  auto res = nom::algorithm::topoSort(g);
   EXPECT_EQ(res.status, TopoSortT::Result::OK);
   EXPECT_EQ(res.nodes.size(), 4);
   auto i1 = std::find(res.nodes.begin(), res.nodes.end(), n1);
@@ -52,7 +52,7 @@ TEST(TopoSort, Cycle1) {
   auto n2 = createTestNode(g);
   g.createEdge(n1, n2);
   g.createEdge(n2, n1);
-  auto res = nom::algorithm::topoSort(&g);
+  auto res = nom::algorithm::topoSort(g);
   EXPECT_EQ(res.status, TopoSortT::Result::CYCLE);
   EXPECT_EQ(res.nodes.size(), 0);
 }
@@ -67,7 +67,7 @@ TEST(TopoSort, Cycle2) {
   g.createEdge(n2, n3);
   g.createEdge(n3, n4);
   g.createEdge(n4, n2);
-  auto res = nom::algorithm::topoSort(&g);
+  auto res = nom::algorithm::topoSort(g);
   EXPECT_EQ(res.status, TopoSortT::Result::CYCLE);
   EXPECT_EQ(res.nodes.size(), 0);
 }


### PR DESCRIPTION
Summary: Make TopoSort takes const graph reference and fix caller (graphmatcher.cc).

Differential Revision: D10494105
