### PR TITLE
Make chunk size configurable in SaveOp

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -224,6 +224,9 @@ workspace.RunOperatorOnce(op)
     "of the workspace.")
     .Arg("db_type", "*(type: string)* Type of db to save (options: \"lmdb\", "
     "\"leveldb\", \"minidb\").")
+    .Arg("chunk_size", "*(type: string; default: kDefaultChunkSize)* The chunk "
+    "size to split tensor data into. If not set, caffe2_tensor_chunk_size will "
+    "be used")
     .Input(0, "X", "*(type: Tensor)* Input tensor(s).");
 
 OPERATOR_SCHEMA(Checkpoint)

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -418,7 +418,10 @@ class SaveOp final : public Operator<Context> {
         db_name_(this->template GetSingleArgument<string>("db", "")),
         db_type_(this->template GetSingleArgument<string>("db_type", "")),
         blob_names_(
-            this->template GetRepeatedArgument<string>("blob_name_overrides")) {
+            this->template GetRepeatedArgument<string>("blob_name_overrides")),
+        chunk_size_(this->template GetSingleArgument<int>(
+            "chunk_size",
+            kDefaultChunkSize)) {
     CAFFE_ENFORCE_GT(db_name_.size(), 0, "Must specify a db name.");
     CAFFE_ENFORCE_GT(db_type_.size(), 0, "Must specify a db type.");
     CAFFE_ENFORCE(
@@ -471,7 +474,7 @@ class SaveOp final : public Operator<Context> {
 
     const vector<const Blob*>& inputs = OperatorBase::Inputs();
     for (int i = 0; i < inputs.size(); ++i) {
-      SerializeBlob(*inputs[i], blob_names_[i], acceptor);
+      SerializeBlob(*inputs[i], blob_names_[i], acceptor, chunk_size_);
     }
     out_db->Close();
     return true;
@@ -484,6 +487,7 @@ class SaveOp final : public Operator<Context> {
   string db_name_;
   string db_type_;
   std::vector<std::string> blob_names_;
+  int chunk_size_;
 };
 
 template <typename... Ts>


### PR DESCRIPTION
Summary: Currently the default chunk size in save operation is 1MB and I don't find a way to configure it at runtime. Add a parameter to configure chunk size in SaveOp.

Differential Revision: D10454037
