### PR TITLE
Fix convtranspose3d output_size calculation

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3584,6 +3584,12 @@ class TestNN(NNTestCase):
                 else:
                     self.assertRaises(ValueError, lambda: m(i, (h, w)))
 
+    def test_ConvTranspose3d_correct_output_size(self):
+        # Check that ConvTranspose3d can take a 5d output_size.
+        m = nn.ConvTranspose3d(2, 2, 2)
+        i = torch.rand(1, 2, 1, 1, 1)
+        out = m(i, output_size=(1, 2, 2, 2, 2))
+
     def _test_Conv2d_naive_groups(self, device="cpu", dtype=torch.float):
         # Check that grouped convolutions matches two half convolutions
         m = nn.Conv2d(4, 4, kernel_size=3, groups=2).to(device, dtype)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -459,7 +459,7 @@ class _ConvTransposeMixin(object):
         output_size = list(output_size)
         k = input.dim() - 2
         if len(output_size) == k + 2:
-            output_size = output_size[-2:]
+            output_size = output_size[2:]
         if len(output_size) != k:
             raise ValueError(
                 "output_size must have {} or {} elements (got {})"


### PR DESCRIPTION
Closes #2119.

There was a small bug where the output_size got sliced with `[-2:]`
where we really meant to slice it as `[2:]` (to remove the batch and
channel dimensions).

Added a new test for this.

