### PR TITLE
[c10d] DDP perf improvement: move sync_reduction to C++, dedicated CUDA streams for memcpy

### DIFF
--- a/torch/csrc/distributed/c10d/ddp.cpp
+++ b/torch/csrc/distributed/c10d/ddp.cpp
@@ -8,6 +8,8 @@
 #include <c10d/ProcessGroup.hpp>
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/cuda/CUDAGuard.h>
 
 #include <cstddef>
 #include <memory>
@@ -112,8 +114,28 @@ std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
   AT_ASSERT(!gradsBatch.empty());
   AT_ASSERT(!devices.empty());
 
-  // TODO: create a copy stream to do the async memory copy and
-  // Intra node reduction with profiler perf work
+  // Events to record the current state on the default stream of each GPUs
+  std::vector<at::cuda::CUDAEvent> events;
+  events.resize(devices.size());
+
+  // Creating a separate CUDA stream to allow memory copy
+  // and intra-node reduce to be operated on this worker stream to
+  // improve performance
+  std::vector<at::cuda::CUDAStream> workerStreams;
+  for (size_t devIdx = 0; devIdx < devices.size(); ++devIdx) {
+    at::DeviceGuard guard(devices[devIdx]);
+    events[devIdx].record();
+    workerStreams.push_back(at::cuda::createCUDAStream(false, devices[devIdx]));
+    // Let the worker stream to wait for the default stream
+    events[devIdx].block(workerStreams.back());
+  }
+
+  // Stream guards, now the current stream is the worker stream
+  std::vector<at::cuda::CUDAGuard> cudaGuards;
+  for (size_t devIdx = 0; devIdx < devices.size(); ++devIdx) {
+    cudaGuards.push_back(at::cuda::CUDAGuard(workerStreams[devIdx]));
+  }
+
   std::vector<at::Tensor> gradsBatchCoalesced;
   for (size_t devIdx = 0; devIdx < devices.size(); ++devIdx) {
     at::DeviceGuard guard(devices[devIdx]);
@@ -132,4 +154,39 @@ std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
 
   return std::make_tuple(reductionWork, gradsBatchCoalesced[0]);
 }
+
+void syncReduction(
+    std::shared_ptr<ProcessGroup::Work>& reductionWork,
+    std::vector<at::Tensor>& gradsBatch,
+    at::Tensor& gradsBatchCoalesced) {
+  // Creating a separate CUDA stream to allow memory copy
+  // and intra-node reduce to be operated on this worker stream to
+  // improve performance
+  at::cuda::CUDAStream workerStream = at::cuda::createCUDAStream();
+  at::cuda::CUDAGuard cudaGuard = at::cuda::CUDAGuard(workerStream);
+
+  // Let the worker stream wait on the reduction stream
+  reductionWork->wait();
+  // Now do the copy in worker stream
+  std::vector<at::Tensor> gradsReduced =
+      torch::utils::unflatten_dense_tensors(gradsBatchCoalesced, gradsBatch);
+
+  AT_ASSERT(gradsReduced.size() == gradsBatch.size());
+
+  for (size_t i = 0; i < gradsReduced.size(); ++i) {
+    gradsBatch[i].copy_(gradsReduced[i]);
+  }
+
+  // Record the state in the worker stream
+  at::cuda::CUDAEvent event;
+  event.record(workerStream);
+
+  // Now make the BW stream wait on it
+  auto bwDevice = cudaGuard.original_device();
+  auto bwStream = cudaGuard.original_streams()[bwDevice];
+
+  // Now let the BW stream wait for the worker stream
+  event.block(bwStream);
+}
+
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ddp.cpp
+++ b/torch/csrc/distributed/c10d/ddp.cpp
@@ -125,7 +125,7 @@ std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
   for (size_t devIdx = 0; devIdx < devices.size(); ++devIdx) {
     at::DeviceGuard guard(devices[devIdx]);
     events[devIdx].record();
-    workerStreams.push_back(at::cuda::createCUDAStream(false, devices[devIdx]));
+    workerStreams.push_back(at::cuda::getStreamFromPool(false, devices[devIdx]));
     // Let the worker stream to wait for the default stream
     events[devIdx].block(workerStreams.back());
   }
@@ -162,7 +162,7 @@ void syncReduction(
   // Creating a separate CUDA stream to allow memory copy
   // and intra-node reduce to be operated on this worker stream to
   // improve performance
-  at::cuda::CUDAStream workerStream = at::cuda::createCUDAStream();
+  at::cuda::CUDAStream workerStream = at::cuda::getStreamFromPool();
   at::cuda::CUDAGuard cudaGuard = at::cuda::CUDAGuard(workerStream);
 
   // Let the worker stream wait on the reduction stream

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 namespace c10d {
+
 void distBroadcastCoalesced(
     ProcessGroup& processGroup,
     std::vector<at::Tensor>& tensors,
@@ -28,4 +29,10 @@ std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
     ProcessGroup& processGroup,
     std::vector<std::vector<at::Tensor>>& gradsBatch,
     const std::vector<int64_t>& devices);
+
+void syncReduction(
+    std::shared_ptr<ProcessGroup::Work>& reductionWork,
+    std::vector<at::Tensor>& gradsBatch,
+    at::Tensor& gradsBatchCoalesced);
+
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -404,6 +404,14 @@ PyObject* c10d_init(PyObject* _unused) {
       py::arg("grads_batch"),
       py::arg("devices"),
       py::call_guard<py::gil_scoped_release>());
+
+  module.def(
+      "_sync_reduction",
+      &::c10d::syncReduction,
+      py::arg("reduction_work"),
+      py::arg("grads_batch"),
+      py::arg("grads_batch_coalesced"),
+      py::call_guard<py::gil_scoped_release>());
 #endif
 
   Py_RETURN_TRUE;

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -355,6 +355,9 @@ class DistributedDataParallel(Module):
         return distributed_data_parallel_hook
 
     def _queue_reduction(self, bucket_idx):
+        # _queue_reduction will use a seperate CUDA stream to coalesce
+        # the small tensors to achieve more parallelisms, before passing the
+        # coalesced tensor into the c10d CUDA stream for reduction
         result = dist._queue_reduction(self.process_group,
                                        self.buckets[bucket_idx],
                                        self.device_ids)
@@ -362,17 +365,13 @@ class DistributedDataParallel(Module):
         self.buckets_coalesced[bucket_idx] = result[1]
 
     def _sync_reduction_works(self):
-        # Now only work on the first GPU of self.device_ids, uncoalesce
-        # the gradients for each bucket
+        # Now only work on the first GPU of self.device_ids
+        # _sync_reduction will use a seperate CUDA stream to uncoalesce
+        # the coalesced tensors to achieve more parallelisms
         for bucket_idx, grads_batch in enumerate(self.buckets):
-            # wait will let current stream wait on the c10d reduction stream
-            self.reduction_works[bucket_idx].wait()
-
-            grads_batch_reduced = _unflatten_dense_tensors(
-                self.buckets_coalesced[bucket_idx], grads_batch[0])
-
-            for grad, reduced in zip(grads_batch[0], grads_batch_reduced):
-                grad.copy_(reduced)
+            dist._sync_reduction(self.reduction_works[bucket_idx],
+                                 grads_batch[0],
+                                 self.buckets_coalesced[bucket_idx])
 
         # Reset the module states
         self.next_bucket = len(self.bucket_sizes) - 1


### PR DESCRIPTION
- Moved sync_reduction to C++
- Use a dedicated CUDA stream for memcpy
- Also use a dedicated CUDA stream for memcpy in queue_reduction

Added test as well.

CI should cover both DDP and unittest