### PR TITLE
Remove nullopt from native_parse.py

### DIFF
--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ATen/optional.h>
 #include <ATen/ScalarType.h>
+#include <c10/util/Optional.h>
 #include <sstream>
 #include <vector>
 

--- a/aten/src/ATen/core/TensorOptions.h
+++ b/aten/src/ATen/core/TensorOptions.h
@@ -117,7 +117,8 @@ struct CAFFE2_API TensorOptions {
 
   /// Return a copy of `TensorOptions` with `device` set to the given one, or
   /// cleared if `device` is `nullopt`.
-  C10_NODISCARD TensorOptions device(optional<Device> device) const noexcept {
+  C10_NODISCARD TensorOptions device(c10::optional<Device> device) const
+      noexcept {
     TensorOptions r = *this;
     r.set_device(device);
     return r;
@@ -140,7 +141,8 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Return a copy of `TensorOptions` with `dtype` set to the given one.
-  C10_NODISCARD TensorOptions dtype(optional<ScalarType> dtype) const noexcept {
+  C10_NODISCARD TensorOptions dtype(c10::optional<ScalarType> dtype) const
+      noexcept {
     TensorOptions r = *this;
     r.set_dtype(dtype);
     return r;
@@ -156,21 +158,24 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Sets the layout of the `TensorOptions`.
-  C10_NODISCARD TensorOptions layout(optional<Layout> layout) const noexcept {
+  C10_NODISCARD TensorOptions layout(c10::optional<Layout> layout) const
+      noexcept {
     TensorOptions r = *this;
     r.set_layout(layout);
     return r;
   }
 
   /// Sets the `requires_grad` property of the `TensorOptions`.
-  C10_NODISCARD TensorOptions requires_grad(optional<bool> requires_grad) const noexcept {
+  C10_NODISCARD TensorOptions
+  requires_grad(c10::optional<bool> requires_grad) const noexcept {
     TensorOptions r = *this;
     r.set_requires_grad(requires_grad);
     return r;
   }
 
   /// Sets the `is_variable` property on the `TensorOptions`.
-  C10_NODISCARD TensorOptions is_variable(optional<bool> is_variable) const noexcept {
+  C10_NODISCARD TensorOptions is_variable(c10::optional<bool> is_variable) const
+      noexcept {
     TensorOptions r = *this;
     r.set_is_variable(is_variable);
     return r;
@@ -183,7 +188,7 @@ struct CAFFE2_API TensorOptions {
 
   /// Returns the device of the `TensorOptions`, or `c10::nullopt` if
   /// device is not specified.
-  optional<Device> device_opt() const noexcept {
+  c10::optional<Device> device_opt() const noexcept {
     return has_device_ ? c10::make_optional(device_) : c10::nullopt;
   }
 
@@ -199,7 +204,7 @@ struct CAFFE2_API TensorOptions {
 
   /// Returns the dtype of the `TensorOptions`, or `c10::nullopt` if
   /// device is not specified.
-  optional<ScalarType> dtype_opt() const noexcept {
+  c10::optional<ScalarType> dtype_opt() const noexcept {
     return has_dtype_ ? c10::make_optional(dtype_) : c10::nullopt;
   }
 
@@ -210,7 +215,7 @@ struct CAFFE2_API TensorOptions {
 
   /// Returns the layout of the `TensorOptions`, or `c10::nullopt` if
   /// layout is not specified.
-  optional<Layout> layout_opt() const noexcept {
+  c10::optional<Layout> layout_opt() const noexcept {
     return has_layout_ ? c10::make_optional(layout_) : c10::nullopt;
   }
 
@@ -221,7 +226,7 @@ struct CAFFE2_API TensorOptions {
 
   /// Returns the `requires_grad` property of the `TensorOptions`, or
   /// `c10::nullopt` if `requires_grad` is not specified.
-  optional<bool> requires_grad_opt() const noexcept {
+  c10::optional<bool> requires_grad_opt() const noexcept {
     return has_requires_grad_ ? c10::make_optional(requires_grad_)
                               : c10::nullopt;
   }
@@ -233,7 +238,7 @@ struct CAFFE2_API TensorOptions {
 
   /// Returns the `is_variable` property of the `TensorOptions`, or
   /// `c10::nullopt` if `is_variable` is not specified.
-  optional<bool> is_variable_opt() const noexcept {
+  c10::optional<bool> is_variable_opt() const noexcept {
     return has_is_variable_ ? c10::make_optional(is_variable_) : c10::nullopt;
   }
 
@@ -263,7 +268,7 @@ struct CAFFE2_API TensorOptions {
   // on temporaries.)
 
   /// Mutably set the device of `TensorOptions`.
-  void set_device(optional<Device> device) & noexcept {
+  void set_device(c10::optional<Device> device) & noexcept {
     if (device) {
       device_ = *device;
       has_device_ = true;
@@ -273,7 +278,7 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Mutably set the dtype of `TensorOptions`.
-  void set_dtype(optional<ScalarType> dtype) & noexcept {
+  void set_dtype(c10::optional<ScalarType> dtype) & noexcept {
     if (dtype) {
       dtype_ = *dtype;
       has_dtype_ = true;
@@ -283,7 +288,7 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Mutably set the layout of `TensorOptions`.
-  void set_layout(optional<Layout> layout) & noexcept {
+  void set_layout(c10::optional<Layout> layout) & noexcept {
     if (layout) {
       layout_ = *layout;
       has_layout_ = true;
@@ -293,7 +298,7 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Mutably set the `requires_grad` property of `TensorOptions`.
-  void set_requires_grad(optional<bool> requires_grad) & noexcept {
+  void set_requires_grad(c10::optional<bool> requires_grad) & noexcept {
     if (requires_grad) {
       requires_grad_ = *requires_grad;
       has_requires_grad_ = true;
@@ -303,7 +308,7 @@ struct CAFFE2_API TensorOptions {
   }
 
   /// Mutably set the `is_variable` property of `TensorOptions`.
-  void set_is_variable(optional<bool> is_variable) & noexcept {
+  void set_is_variable(c10::optional<bool> is_variable) & noexcept {
     if (is_variable) {
       is_variable_ = *is_variable;
       has_is_variable_ = true;

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -129,7 +129,10 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
-  virtual Tensor copy(const Tensor & src, bool non_blocking=false, optional<Device> to_device={}) const = 0;
+  virtual Tensor copy(
+      const Tensor& src,
+      bool non_blocking = false,
+      c10::optional<Device> to_device = {}) const = 0;
   virtual Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const = 0;
   virtual Tensor & s_copy_(Tensor & self, const Tensor & src, bool non_blocking) const = 0;
   virtual Tensor & _s_copy_from(const Tensor & self, Tensor & dst, bool non_blocking) const = 0;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -21,25 +21,34 @@ DEFINE_DISPATCH(sum_kernel);
 DEFINE_DISPATCH(prod_kernel);
 DEFINE_DISPATCH(norm_kernel);
 
-static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dtype) {
+static inline Tensor integer_upcast(
+    const Tensor& self,
+    c10::optional<ScalarType> dtype) {
   ScalarType scalarType = self.type().scalarType();
   ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType) ? ScalarType::Long : scalarType);
   return self.toType(upcast_scalarType);
 }
 
-static inline Tensor cumsum(const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
+static inline Tensor cumsum(
+    const Tensor& self,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
   return at::_cumsum(integer_upcast(self, dtype), dim);
 }
 
 Tensor cumsum(const Tensor& self, int64_t dim, ScalarType dtype) {
-  return at::native::cumsum(self, dim, optional<ScalarType>(dtype));
+  return at::native::cumsum(self, dim, c10::optional<ScalarType>(dtype));
 }
 
 Tensor cumsum(const Tensor& self, int64_t dim) {
   return at::native::cumsum(self, dim, c10::nullopt);
 }
 
-static inline Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
+static inline Tensor& cumsum_out(
+    Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
       !dtype.has_value() || (result.type().scalarType() == dtype.value()),
@@ -52,26 +61,34 @@ static inline Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim
 }
 
 Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dtype) {
-  return at::native::cumsum_out(result, self, dim, optional<ScalarType>(dtype));
+  return at::native::cumsum_out(
+      result, self, dim, c10::optional<ScalarType>(dtype));
 }
 
 Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim) {
   return at::native::cumsum_out(result, self, dim, c10::nullopt);
 }
 
-static inline Tensor cumprod(const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
+static inline Tensor cumprod(
+    const Tensor& self,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
   return at::_cumprod(integer_upcast(self, dtype), dim);
 }
 
 Tensor cumprod(const Tensor& self, int64_t dim, ScalarType dtype) {
-  return at::native::cumprod(self, dim, optional<ScalarType>(dtype));
+  return at::native::cumprod(self, dim, c10::optional<ScalarType>(dtype));
 }
 
 Tensor cumprod(const Tensor& self, int64_t dim) {
   return at::native::cumprod(self, dim, c10::nullopt);
 }
 
-static inline Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
+static inline Tensor& cumprod_out(
+    Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
       !dtype.has_value() || (result.type().scalarType() == dtype.value()),
@@ -84,7 +101,8 @@ static inline Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t di
 }
 
 Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dtype) {
-  return at::native::cumprod_out(result, self, dim, optional<ScalarType>(dtype));
+  return at::native::cumprod_out(
+      result, self, dim, c10::optional<ScalarType>(dtype));
 }
 
 Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim) {
@@ -93,7 +111,7 @@ Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim) {
 
 // ALL REDUCE #################################################################
 
-static inline Tensor mean(const Tensor &self, optional<ScalarType> dtype) {
+static inline Tensor mean(const Tensor& self, c10::optional<ScalarType> dtype) {
   ScalarType scalarType = self.type().scalarType();
   AT_CHECK(
       at::isFloatingType(scalarType),
@@ -109,19 +127,19 @@ static inline Tensor mean(const Tensor &self, optional<ScalarType> dtype) {
 }
 
 Tensor mean(const Tensor &self, ScalarType dtype) {
-  return at::native::mean(self, optional<ScalarType>(dtype));
+  return at::native::mean(self, c10::optional<ScalarType>(dtype));
 }
 
 Tensor mean(const Tensor &self) {
   return at::native::mean(self, c10::nullopt);
 }
 
-static inline Tensor sum(const Tensor &self, optional<ScalarType> dtype) {
+static inline Tensor sum(const Tensor& self, c10::optional<ScalarType> dtype) {
   return at::_sum(integer_upcast(self, dtype));
 }
 
 Tensor sum(const Tensor &self, ScalarType dtype) {
-  return at::native::sum(self, optional<ScalarType>(dtype));
+  return at::native::sum(self, c10::optional<ScalarType>(dtype));
 }
 
 Tensor sum(const Tensor &self) {
@@ -137,12 +155,12 @@ Tensor _sum_cpu(const Tensor& self) {
   return at::_sumall(self);
 }
 
-static inline Tensor prod(const Tensor &self, optional<ScalarType> dtype) {
+static inline Tensor prod(const Tensor& self, c10::optional<ScalarType> dtype) {
   return at::_prod(integer_upcast(self, dtype));
 }
 
 Tensor prod(const Tensor &self, ScalarType dtype) {
-  return at::native::prod(self, optional<ScalarType>(dtype));
+  return at::native::prod(self, c10::optional<ScalarType>(dtype));
 }
 
 Tensor prod(const Tensor &self) {
@@ -162,8 +180,12 @@ Tensor _prod_cpu(const Tensor &self) {
 
 // DIM REDUCE #################################################################
 
-static inline Tensor &mean_out(Tensor &result, const Tensor &self, int64_t dim,
-                 bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor& mean_out(
+    Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   ScalarType scalarType = result.type().scalarType();
   AT_CHECK(
       at::isFloatingType(scalarType),
@@ -196,8 +218,12 @@ Tensor& mean_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dty
   return at::native::mean_out(result, self, dim, false, dtype);
 }
 
-static inline Tensor &sum_out(Tensor &result, const Tensor &self, IntList dim,
-                 bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor& sum_out(
+    Tensor& result,
+    const Tensor& self,
+    IntList dim,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
       !dtype.has_value() || (result.type().scalarType() == dtype.value()),
@@ -235,8 +261,12 @@ Tensor &_sum_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
   return at::_th_sum_out(result, self, dim, keepdim);
 }
 
-static inline Tensor &prod_out(Tensor &result, const Tensor &self, int64_t dim,
-                 bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor& prod_out(
+    Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
       !dtype.has_value() || (result.type().scalarType() == dtype.value()),
@@ -274,7 +304,11 @@ Tensor &_prod_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
   return at::_th_prod_out(result, self, dim, keepdim);
 }
 
-static inline Tensor mean(const Tensor &self, int64_t dim, bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor mean(
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   ScalarType scalarType = self.type().scalarType();
   AT_CHECK(
       at::isFloatingType(scalarType),
@@ -306,7 +340,11 @@ Tensor mean(const Tensor& self, int64_t dim, ScalarType dtype) {
   return at::native::mean(self, dim, false, dtype);
 }
 
-static inline Tensor sum(const Tensor &self, IntList dim_, bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor sum(
+    const Tensor& self,
+    IntList dim_,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   return at::_sum(integer_upcast(self, dtype), dim_, keepdim);
 }
 
@@ -328,7 +366,11 @@ Tensor _sum(const Tensor &self, int64_t dim_, bool keepdim) {
   return at::_sum_out(result, self, dim, keepdim);
 }
 
-static inline Tensor prod(const Tensor &self, int64_t dim_, bool keepdim, optional<ScalarType> dtype) {
+static inline Tensor prod(
+    const Tensor& self,
+    int64_t dim_,
+    bool keepdim,
+    c10::optional<ScalarType> dtype) {
   return at::_prod(integer_upcast(self, dtype), dim_, keepdim);
 }
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -6,7 +6,7 @@
 
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 namespace at { namespace native { namespace {
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.h
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.h
@@ -2,7 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
-#include <ATen/optional.h>
+#include <c10/util/Optional.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -546,7 +546,7 @@
   dispatch:
     CUDA: cudnn_grid_sampler_backward
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: cumsum(Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -557,7 +557,7 @@
 
 - func: cumsum_out(Tensor result, Tensor self, int64_t dim) -> Tensor
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: cumprod(Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -1025,7 +1025,7 @@
 
 - func: logspace_out(Tensor result, Scalar start, Scalar end, int64_t steps) -> Tensor
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: log_softmax(Tensor self, int64_t dim, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -1077,7 +1077,7 @@
 
 - func: max_pool3d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> Tensor
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: mean(Tensor self, *, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -1460,7 +1460,7 @@
 - func: smm(Tensor self, Tensor mat2) -> Tensor
   variants: function, method
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: softmax(Tensor self, int64_t dim, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -1558,7 +1558,7 @@
   variants: function, method
   device_guard: false
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: sum(Tensor self, *, ScalarType dtype) -> Tensor
   variants: function, method
 
@@ -1617,7 +1617,7 @@
 
 - func: std_out(Tensor result, Tensor self, int64_t dim, bool unbiased=true, bool keepdim=false) -> Tensor
 
-# FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
+# FIXME: These could be combined as c10::optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: prod(Tensor self, *, ScalarType dtype) -> Tensor
   variants: function, method
 

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -22,8 +22,6 @@ def parse_default(s):
         return '{}'
     elif re.match(r'{.*}', s):
         return s
-    elif s == 'c10::nullopt':
-        return s
     try:
         return int(s)
     except Exception:

--- a/aten/src/ATen/optional.h
+++ b/aten/src/ATen/optional.h
@@ -1,1 +1,0 @@
-#include "c10/util/Optional.h"

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -100,7 +100,10 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
-  virtual Tensor copy(const Tensor & src, bool non_blocking=false, optional<Device> to_device={}) const = 0;
+  virtual Tensor copy(
+      const Tensor& src,
+      bool non_blocking = false,
+      c10::optional<Device> to_device = {}) const = 0;
   virtual Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const = 0;
   virtual Tensor & s_copy_(Tensor & self, const Tensor & src, bool non_blocking) const = 0;
   virtual Tensor & _s_copy_from(const Tensor & self, Tensor & dst, bool non_blocking) const = 0;

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -26,7 +26,10 @@ Tensor & TypeDefault::copy_(Tensor & self, const Tensor & src, bool non_blocking
   return s_copy_(self, b_src, non_blocking);
 }
 
-Tensor TypeDefault::copy(const Tensor & src, bool non_blocking, optional<Device> to_device) const {
+Tensor TypeDefault::copy(
+    const Tensor& src,
+    bool non_blocking,
+    c10::optional<Device> to_device) const {
   DeviceGuard device_guard;
   if (to_device.has_value()) {
     device_guard.set_index(to_device.value().index());

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -25,7 +25,10 @@ struct CAFFE2_API TypeDefault : public TypeExtendedInterface {
   Type & toBackend(Backend b) const override;
   Type & toScalarType(ScalarType s) const override;
 
-  Tensor copy(const Tensor & src, bool non_blocking=false, optional<Device> to_device={}) const override;
+  Tensor copy(
+      const Tensor& src,
+      bool non_blocking = false,
+      c10::optional<Device> to_device = {}) const override;
   Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const override;
 
   void backward(

--- a/aten/src/ATen/test/cuda_optional_test.cu
+++ b/aten/src/ATen/test/cuda_optional_test.cu
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 #include <assert.h>
 

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1031,12 +1031,6 @@ struct hash<c10::optional<T&>> {
 };
 } // namespace std
 
-// TODO: remove at::optional when done moving files
-namespace at {
-template <class T>
-using optional = c10::optional<T>;
-}
-
 #undef TR2_OPTIONAL_REQUIRES
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 

--- a/test/cpp/api/memory.cpp
+++ b/test/cpp/api/memory.cpp
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/utils/memory.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 struct TestValue {
   explicit TestValue(const int& x) : lvalue_(x) {}

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -1,3 +1,4 @@
+#include "c10/util/Optional.h"
 #include "torch/csrc/autograd/VariableTypeUtils.h"
 
 using namespace at;
@@ -215,7 +216,11 @@ std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name
   return ret;
 }
 
-void VariableType::backward(Tensor & self, at::optional<Tensor> gradient, bool keep_graph, bool create_graph) const {
+void VariableType::backward(
+    Tensor& self,
+    c10::optional<Tensor> gradient,
+    bool keep_graph,
+    bool create_graph) const {
   as_variable_ref(self).backward(gradient, keep_graph, create_graph);
 }
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -412,10 +412,10 @@ struct Module {
   void save(const std::string& filename);
 
  private:
-   void to_impl(
-       at::optional<at::Device> device,
-       at::optional<at::ScalarType> dtype,
-       bool non_blocking);
+  void to_impl(
+      c10::optional<at::Device> device,
+      c10::optional<at::ScalarType> dtype,
+      bool non_blocking);
 
   // invariant: to ensure member_inputs of Methods stay valid,
   // it is only legal to _add_ new modules and parameters.


### PR DESCRIPTION
Summary:
According to zdevito - this is not used at all, so we are removing it for safety.

It is also possible that this native_parser.py will completely go away in the
near future.

Reviewed By: zdevito

Differential Revision: D10501616
