### PR TITLE
Add methods to FunctionSchema

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -939,15 +939,15 @@ void testCustomOperators() {
     ASSERT_EQ(ops.size(), 1);
 
     auto& op = ops.front();
-    ASSERT_EQ(op->schema().name, "foo::bar");
+    ASSERT_EQ(op->schema().name(), "foo::bar");
 
-    ASSERT_EQ(op->schema().arguments.size(), 2);
-    ASSERT_EQ(op->schema().arguments[0].name(), "_0");
-    ASSERT_EQ(op->schema().arguments[0].type()->kind(), TypeKind::FloatType);
-    ASSERT_EQ(op->schema().arguments[1].name(), "_1");
-    ASSERT_EQ(op->schema().arguments[1].type()->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().arguments().size(), 2);
+    ASSERT_EQ(op->schema().arguments()[0].name(), "_0");
+    ASSERT_EQ(op->schema().arguments()[0].type()->kind(), TypeKind::FloatType);
+    ASSERT_EQ(op->schema().arguments()[1].name(), "_1");
+    ASSERT_EQ(op->schema().arguments()[1].type()->kind(), TypeKind::DynamicType);
 
-    ASSERT_EQ(op->schema().returns[0].type()->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().returns()[0].type()->kind(), TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -967,16 +967,16 @@ void testCustomOperators() {
     ASSERT_EQ(ops.size(), 1);
 
     auto& op = ops.front();
-    ASSERT_EQ(op->schema().name, "foo::bar_with_schema");
+    ASSERT_EQ(op->schema().name(), "foo::bar_with_schema");
 
-    ASSERT_EQ(op->schema().arguments.size(), 2);
-    ASSERT_EQ(op->schema().arguments[0].name(), "a");
-    ASSERT_EQ(op->schema().arguments[0].type()->kind(), TypeKind::FloatType);
-    ASSERT_EQ(op->schema().arguments[1].name(), "b");
-    ASSERT_EQ(op->schema().arguments[1].type()->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().arguments().size(), 2);
+    ASSERT_EQ(op->schema().arguments()[0].name(), "a");
+    ASSERT_EQ(op->schema().arguments()[0].type()->kind(), TypeKind::FloatType);
+    ASSERT_EQ(op->schema().arguments()[1].name(), "b");
+    ASSERT_EQ(op->schema().arguments()[1].type()->kind(), TypeKind::DynamicType);
 
-    ASSERT_EQ(op->schema().returns.size(), 1);
-    ASSERT_EQ(op->schema().returns[0].type()->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().returns().size(), 1);
+    ASSERT_EQ(op->schema().returns()[0].type()->kind(), TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -998,22 +998,22 @@ void testCustomOperators() {
     ASSERT_EQ(ops.size(), 1);
 
     auto& op = ops.front();
-    ASSERT_EQ(op->schema().name, "foo::lists");
+    ASSERT_EQ(op->schema().name(), "foo::lists");
 
-    ASSERT_EQ(op->schema().arguments.size(), 3);
-    ASSERT_EQ(op->schema().arguments[0].name(), "ints");
+    ASSERT_EQ(op->schema().arguments().size(), 3);
+    ASSERT_EQ(op->schema().arguments()[0].name(), "ints");
     ASSERT_TRUE(
-        op->schema().arguments[0].type()->isSubtypeOf(ListType::ofInts()));
-    ASSERT_EQ(op->schema().arguments[1].name(), "floats");
+        op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofInts()));
+    ASSERT_EQ(op->schema().arguments()[1].name(), "floats");
     ASSERT_TRUE(
-        op->schema().arguments[1].type()->isSubtypeOf(ListType::ofFloats()));
-    ASSERT_EQ(op->schema().arguments[2].name(), "tensors");
+        op->schema().arguments()[1].type()->isSubtypeOf(ListType::ofFloats()));
+    ASSERT_EQ(op->schema().arguments()[2].name(), "tensors");
     ASSERT_TRUE(
-        op->schema().arguments[2].type()->isSubtypeOf(ListType::ofTensors()));
+        op->schema().arguments()[2].type()->isSubtypeOf(ListType::ofTensors()));
 
-    ASSERT_EQ(op->schema().returns.size(), 1);
+    ASSERT_EQ(op->schema().returns().size(), 1);
     ASSERT_TRUE(
-        op->schema().returns[0].type()->isSubtypeOf(ListType::ofFloats()));
+        op->schema().returns()[0].type()->isSubtypeOf(ListType::ofFloats()));
 
     Stack stack;
     push(stack, std::vector<int64_t>{1, 2});
@@ -1036,16 +1036,16 @@ void testCustomOperators() {
     ASSERT_EQ(ops.size(), 1);
 
     auto& op = ops.front();
-    ASSERT_EQ(op->schema().name, "foo::lists2");
+    ASSERT_EQ(op->schema().name(), "foo::lists2");
 
-    ASSERT_EQ(op->schema().arguments.size(), 1);
-    ASSERT_EQ(op->schema().arguments[0].name(), "tensors");
+    ASSERT_EQ(op->schema().arguments().size(), 1);
+    ASSERT_EQ(op->schema().arguments()[0].name(), "tensors");
     ASSERT_TRUE(
-        op->schema().arguments[0].type()->isSubtypeOf(ListType::ofTensors()));
+        op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofTensors()));
 
-    ASSERT_EQ(op->schema().returns.size(), 1);
+    ASSERT_EQ(op->schema().returns().size(), 1);
     ASSERT_TRUE(
-        op->schema().returns[0].type()->isSubtypeOf(ListType::ofTensors()));
+        op->schema().returns()[0].type()->isSubtypeOf(ListType::ofTensors()));
 
     Stack stack;
     push(stack, std::vector<at::Tensor>{autograd::make_variable(at::ones(5))});
@@ -1134,14 +1134,14 @@ void testCustomOperators() {
 void testSchemaParser() {
   // nested arrays
   auto s = parseSchema("at::what(int[][4] foo) -> ()");
-  ASSERT_TRUE(s.arguments.at(0).N() == 4);
-  ASSERT_TRUE(IntType::get()->isSubtypeOf(s.arguments.at(0)
+  ASSERT_TRUE(s.arguments().at(0).N() == 4);
+  ASSERT_TRUE(IntType::get()->isSubtypeOf(s.arguments().at(0)
                                               .type()->expect<ListType>()
                                               ->getElementType()
                                               ->expect<ListType>()
                                               ->getElementType()));
   auto s2 = parseSchema("at::what(int[][] foo) -> ()");
-  ASSERT_TRUE(IntType::get()->isSubtypeOf(s2.arguments.at(0)
+  ASSERT_TRUE(IntType::get()->isSubtypeOf(s2.arguments().at(0)
                                             .type()->expect<ListType>()
                                             ->getElementType()
                                             ->expect<ListType>()
@@ -1158,8 +1158,8 @@ void testSchemaParser() {
   // named returns
   parseSchema("at::what(Tensor! i_will_be_written_to) -> ()");
   auto s3 = parseSchema("at::what() -> (Tensor the_return, Tensor the_return2)");
-  ASSERT_TRUE(s3.returns.at(0).name() == "the_return");
-  ASSERT_TRUE(s3.returns.at(1).name() == "the_return2");
+  ASSERT_TRUE(s3.returns().at(0).name() == "the_return");
+  ASSERT_TRUE(s3.returns().at(1).name() == "the_return2");
 
   // test tensor with annotated alias sets
   parseSchema("at::what(Tensor(t) foo) -> (Tensor(t))");

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -942,12 +942,12 @@ void testCustomOperators() {
     ASSERT_EQ(op->schema().name, "foo::bar");
 
     ASSERT_EQ(op->schema().arguments.size(), 2);
-    ASSERT_EQ(op->schema().arguments[0].name, "_0");
-    ASSERT_EQ(op->schema().arguments[0].type->kind(), TypeKind::FloatType);
-    ASSERT_EQ(op->schema().arguments[1].name, "_1");
-    ASSERT_EQ(op->schema().arguments[1].type->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().arguments[0].name(), "_0");
+    ASSERT_EQ(op->schema().arguments[0].type()->kind(), TypeKind::FloatType);
+    ASSERT_EQ(op->schema().arguments[1].name(), "_1");
+    ASSERT_EQ(op->schema().arguments[1].type()->kind(), TypeKind::DynamicType);
 
-    ASSERT_EQ(op->schema().returns[0].type->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().returns[0].type()->kind(), TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -970,13 +970,13 @@ void testCustomOperators() {
     ASSERT_EQ(op->schema().name, "foo::bar_with_schema");
 
     ASSERT_EQ(op->schema().arguments.size(), 2);
-    ASSERT_EQ(op->schema().arguments[0].name, "a");
-    ASSERT_EQ(op->schema().arguments[0].type->kind(), TypeKind::FloatType);
-    ASSERT_EQ(op->schema().arguments[1].name, "b");
-    ASSERT_EQ(op->schema().arguments[1].type->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().arguments[0].name(), "a");
+    ASSERT_EQ(op->schema().arguments[0].type()->kind(), TypeKind::FloatType);
+    ASSERT_EQ(op->schema().arguments[1].name(), "b");
+    ASSERT_EQ(op->schema().arguments[1].type()->kind(), TypeKind::DynamicType);
 
     ASSERT_EQ(op->schema().returns.size(), 1);
-    ASSERT_EQ(op->schema().returns[0].type->kind(), TypeKind::DynamicType);
+    ASSERT_EQ(op->schema().returns[0].type()->kind(), TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1001,19 +1001,19 @@ void testCustomOperators() {
     ASSERT_EQ(op->schema().name, "foo::lists");
 
     ASSERT_EQ(op->schema().arguments.size(), 3);
-    ASSERT_EQ(op->schema().arguments[0].name, "ints");
+    ASSERT_EQ(op->schema().arguments[0].name(), "ints");
     ASSERT_TRUE(
-        op->schema().arguments[0].type->isSubtypeOf(ListType::ofInts()));
-    ASSERT_EQ(op->schema().arguments[1].name, "floats");
+        op->schema().arguments[0].type()->isSubtypeOf(ListType::ofInts()));
+    ASSERT_EQ(op->schema().arguments[1].name(), "floats");
     ASSERT_TRUE(
-        op->schema().arguments[1].type->isSubtypeOf(ListType::ofFloats()));
-    ASSERT_EQ(op->schema().arguments[2].name, "tensors");
+        op->schema().arguments[1].type()->isSubtypeOf(ListType::ofFloats()));
+    ASSERT_EQ(op->schema().arguments[2].name(), "tensors");
     ASSERT_TRUE(
-        op->schema().arguments[2].type->isSubtypeOf(ListType::ofTensors()));
+        op->schema().arguments[2].type()->isSubtypeOf(ListType::ofTensors()));
 
     ASSERT_EQ(op->schema().returns.size(), 1);
     ASSERT_TRUE(
-        op->schema().returns[0].type->isSubtypeOf(ListType::ofFloats()));
+        op->schema().returns[0].type()->isSubtypeOf(ListType::ofFloats()));
 
     Stack stack;
     push(stack, std::vector<int64_t>{1, 2});
@@ -1039,13 +1039,13 @@ void testCustomOperators() {
     ASSERT_EQ(op->schema().name, "foo::lists2");
 
     ASSERT_EQ(op->schema().arguments.size(), 1);
-    ASSERT_EQ(op->schema().arguments[0].name, "tensors");
+    ASSERT_EQ(op->schema().arguments[0].name(), "tensors");
     ASSERT_TRUE(
-        op->schema().arguments[0].type->isSubtypeOf(ListType::ofTensors()));
+        op->schema().arguments[0].type()->isSubtypeOf(ListType::ofTensors()));
 
     ASSERT_EQ(op->schema().returns.size(), 1);
     ASSERT_TRUE(
-        op->schema().returns[0].type->isSubtypeOf(ListType::ofTensors()));
+        op->schema().returns[0].type()->isSubtypeOf(ListType::ofTensors()));
 
     Stack stack;
     push(stack, std::vector<at::Tensor>{autograd::make_variable(at::ones(5))});
@@ -1134,15 +1134,15 @@ void testCustomOperators() {
 void testSchemaParser() {
   // nested arrays
   auto s = parseSchema("at::what(int[][4] foo) -> ()");
-  ASSERT_TRUE(s.arguments.at(0).N == 4);
+  ASSERT_TRUE(s.arguments.at(0).N() == 4);
   ASSERT_TRUE(IntType::get()->isSubtypeOf(s.arguments.at(0)
-                                              .type->expect<ListType>()
+                                              .type()->expect<ListType>()
                                               ->getElementType()
                                               ->expect<ListType>()
                                               ->getElementType()));
   auto s2 = parseSchema("at::what(int[][] foo) -> ()");
   ASSERT_TRUE(IntType::get()->isSubtypeOf(s2.arguments.at(0)
-                                            .type->expect<ListType>()
+                                            .type()->expect<ListType>()
                                             ->getElementType()
                                             ->expect<ListType>()
                                             ->getElementType()));
@@ -1158,8 +1158,8 @@ void testSchemaParser() {
   // named returns
   parseSchema("at::what(Tensor! i_will_be_written_to) -> ()");
   auto s3 = parseSchema("at::what() -> (Tensor the_return, Tensor the_return2)");
-  ASSERT_TRUE(s3.returns.at(0).name == "the_return");
-  ASSERT_TRUE(s3.returns.at(1).name == "the_return2");
+  ASSERT_TRUE(s3.returns.at(0).name() == "the_return");
+  ASSERT_TRUE(s3.returns.at(1).name() == "the_return2");
 
   // test tensor with annotated alias sets
   parseSchema("at::what(Tensor(t) foo) -> (Tensor(t))");

--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -28,7 +28,7 @@ void get_operator_from_registry_and_execute() {
   AT_ASSERT(ops.size() == 1);
 
   auto& op = ops.front();
-  AT_ASSERT(op->schema().name == "custom::op");
+  AT_ASSERT(op->schema().name() == "custom::op");
 
   torch::jit::Stack stack;
   torch::jit::push(stack, torch::ones(5), 2.0, 3);

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -22,7 +22,7 @@ if [[ -x "$(command -v cmake3)" ]]; then
     if [[ -x "$(command -v cmake)" ]]; then
         # have both cmake and cmake3, compare versions
         CMAKE_VERSION=$(cmake --version | grep 'cmake version' | awk '{print $NF}')
-        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake version' | awk '{print $NF}')
+        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake3 version' | awk '{print $NF}')
         CMAKE3_IS_NEWER=$($PYTORCH_PYTHON -c "from distutils.version import StrictVersion; print(1 if StrictVersion(\"${CMAKE3_VERSION}\") >= StrictVersion(\"${CMAKE_VERSION}\") else 0)")
     else
         # don't have cmake

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -22,7 +22,7 @@ if [[ -x "$(command -v cmake3)" ]]; then
     if [[ -x "$(command -v cmake)" ]]; then
         # have both cmake and cmake3, compare versions
         CMAKE_VERSION=$(cmake --version | grep 'cmake version' | awk '{print $NF}')
-        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake3 version' | awk '{print $NF}')
+        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake version' | awk '{print $NF}')
         CMAKE3_IS_NEWER=$($PYTORCH_PYTHON -c "from distutils.version import StrictVersion; print(1 if StrictVersion(\"${CMAKE3_VERSION}\") >= StrictVersion(\"${CMAKE_VERSION}\") else 0)")
     else
         # don't have cmake

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -67,7 +67,7 @@ Node* getTracedNode(
 
   // Hack to call addInputs for the parameter pack in a sequenced fashion.
   // https://stackoverflow.com/questions/12030538/calling-a-function-for-each-variadic-template-argument-and-an-array
-  int _[] = {(tracer::addInputs(node, schema.arguments[Is].name.c_str(), std::get<Is>(tuple)), 0)...};
+  int _[] = {(tracer::addInputs(node, schema.arguments[Is].name().c_str(), std::get<Is>(tuple)), 0)...};
   (void)_;
 
   graph->appendNode(node);
@@ -117,10 +117,10 @@ inline void checkArgumentVector(
       inferredSchema, " | Provided schema: ", providedSchema);
   for (size_t i = 0; i < provided.size(); ++i) {
     AT_CHECK(
-        provided[i].type->isSubtypeOf(inferred[i].type),
+        provided[i].type()->isSubtypeOf(inferred[i].type()),
         "Inferred type for ", what, " #", i, " was ",
-        *inferred[i].type, ", but the provided schema specified type ",
-        *provided[i].type, " for the ", what,
+        *inferred[i].type(), ", but the provided schema specified type ",
+        *provided[i].type(), " for the ", what,
         " in that position. Inferred schema: ",
         inferredSchema, " | Provided schema: ", providedSchema);
   }

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -60,14 +60,14 @@ template <size_t... Is, typename... Types>
 Node* getTracedNode(
     const FunctionSchema& schema,
     const std::tuple<Types...>& tuple) {
-  auto symbol = Symbol::fromQualString(schema.name);
+  auto symbol = Symbol::fromQualString(schema.name());
   const auto& graph = tracer::getTracingState()->graph;
   Node* node = graph->create(std::move(symbol), /*num_outputs=*/0);
   tracer::recordSourceLocation(node);
 
   // Hack to call addInputs for the parameter pack in a sequenced fashion.
   // https://stackoverflow.com/questions/12030538/calling-a-function-for-each-variadic-template-argument-and-an-array
-  int _[] = {(tracer::addInputs(node, schema.arguments[Is].name().c_str(), std::get<Is>(tuple)), 0)...};
+  int _[] = {(tracer::addInputs(node, schema.arguments()[Is].name().c_str(), std::get<Is>(tuple)), 0)...};
   (void)_;
 
   graph->appendNode(node);
@@ -149,17 +149,17 @@ FunctionSchema inferAndCheckSchema(const std::string& schemaOrName) {
 
   const auto inferredSchema =
       torch::jit::detail::createFunctionSchemaFromTraits<Traits>(
-          providedSchema.name);
+          providedSchema.name());
   checkArgumentVector(
       "argument",
-      inferredSchema.arguments,
-      providedSchema.arguments,
+      inferredSchema.arguments(),
+      providedSchema.arguments(),
       inferredSchema,
       providedSchema);
   checkArgumentVector(
       "return value",
-      inferredSchema.returns,
-      providedSchema.returns,
+      inferredSchema.returns(),
+      providedSchema.returns(),
       inferredSchema,
       providedSchema);
   return providedSchema;

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -26,7 +26,7 @@ namespace onnx = ::ONNX_NAMESPACE;
 
 std::string getExportableSchemaStringForMethod(const script::Method& method) {
   const auto& schema = method.getSchema();
-  for (const auto& argument : schema.arguments) {
+  for (const auto& argument : schema.arguments()) {
     AT_CHECK(
         !argument.default_value(),
         "Default arguments in script graphs may currently not be exported.");

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -28,7 +28,7 @@ std::string getExportableSchemaStringForMethod(const script::Method& method) {
   const auto& schema = method.getSchema();
   for (const auto& argument : schema.arguments) {
     AT_CHECK(
-        !argument.default_value,
+        !argument.default_value(),
         "Default arguments in script graphs may currently not be exported.");
   }
   std::ostringstream stream;

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -281,9 +281,9 @@ void initJITBindings(PyObject *module) {
   }, py::arg("qualified_name"));
 
   py::class_<FunctionSchema>(m, "FunctionSchema")
-  .def_property_readonly("name", [](FunctionSchema& self) { return self.name; })
-  .def_property_readonly("arguments", [](FunctionSchema& self) { return self.arguments; })
-  .def_property_readonly("returns", [](FunctionSchema& self) { return self.returns; });
+  .def_property_readonly("name", [](FunctionSchema& self) { return self.name(); })
+  .def_property_readonly("arguments", [](FunctionSchema& self) { return self.arguments(); })
+  .def_property_readonly("returns", [](FunctionSchema& self) { return self.returns(); });
   py::class_<Argument>(m, "Argument")
   .def_property_readonly("name", [](Argument& self) { return self.name(); })
   .def_property_readonly("type", [](Argument& self) { return self.type(); })

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -285,15 +285,15 @@ void initJITBindings(PyObject *module) {
   .def_property_readonly("arguments", [](FunctionSchema& self) { return self.arguments; })
   .def_property_readonly("returns", [](FunctionSchema& self) { return self.returns; });
   py::class_<Argument>(m, "Argument")
-  .def_property_readonly("name", [](Argument& self) { return self.name; })
-  .def_property_readonly("type", [](Argument& self) { return self.type; })
+  .def_property_readonly("name", [](Argument& self) { return self.name(); })
+  .def_property_readonly("type", [](Argument& self) { return self.type(); })
   .def_property_readonly("N", [](Argument& self) -> py::object {
-    return (self.N) ? py::cast(*self.N) :  py::none();
+    return (self.N()) ? py::cast(*self.N()) :  py::none();
   })
   .def_property_readonly("default_value", [](Argument& self) -> py::object {
-    if(!self.default_value)
+    if(!self.default_value())
       return py::none();
-    IValue v = *self.default_value;
+    IValue v = *self.default_value();
     return toPyObject(std::move(v));
   });
   m.def("_jit_get_schemas_for_operator", [](const std::string& qualified_name) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -612,7 +612,7 @@ size_t findArgument(const FunctionSchema& the_schema, Symbol name) {
   auto name_str = name.toUnqualString();
   for (size_t i = 0; i < the_schema.arguments.size(); ++i) {
     const Argument* arg = &the_schema.arguments[i];
-    if (arg->name == name_str) {
+    if (arg->name() == name_str) {
       return i;
     }
   }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -610,8 +610,8 @@ void Value::replaceAllUsesWith(Value * newValue) {
 
 size_t findArgument(const FunctionSchema& the_schema, Symbol name) {
   auto name_str = name.toUnqualString();
-  for (size_t i = 0; i < the_schema.arguments.size(); ++i) {
-    const Argument* arg = &the_schema.arguments[i];
+  for (size_t i = 0; i < the_schema.arguments().size(); ++i) {
+    const Argument* arg = &the_schema.arguments()[i];
     if (arg->name() == name_str) {
       return i;
     }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -231,7 +231,7 @@ struct SchemaParser {
     L.expect(TK_NONE);
     return IValue();
   }
-  IValue parseDefaultValue(TypePtr arg_type, at::optional<int32_t> arg_N) {
+  IValue parseDefaultValue(TypePtr arg_type, c10::optional<int32_t> arg_N) {
     auto range = L.cur().range;
     switch(arg_type->kind()) {
       case TypeKind::DynamicType:

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -128,11 +128,14 @@ struct SchemaParser {
 
   Argument parseArgument(size_t idx, bool is_return, bool kwarg_only) {
     Argument result;
-    result.type = parseType();
+    auto type = parseType();
+    c10::optional<int32_t> N;
+    c10::optional<IValue> default_value;
+    std::string name;
     if(L.nextIf('[')) {
       // note: an array with a size hint can only occur at the Argument level
-      result.type = ListType::create(result.type);
-      result.N = std::stoll(L.expect(TK_NUMBER).text());
+      type = ListType::create(type);
+      N = std::stoll(L.expect(TK_NUMBER).text());
       L.expect(']');
     }
     if(L.nextIf('!')) {
@@ -142,18 +145,17 @@ struct SchemaParser {
     if(is_return) {
       // optionally named return values
       if(L.cur().kind == TK_IDENT) {
-        result.name = L.next().text();
+        name = L.next().text();
       } else {
-        result.name = "ret" + std::to_string(idx);
+        name = "ret" + std::to_string(idx);
       }
     } else {
-      result.kwarg_only = kwarg_only;
-      result.name = L.expect(TK_IDENT).text();
+      name = L.expect(TK_IDENT).text();
       if(L.nextIf('=')) {
-        parseDefaultValue(result);
+        default_value = parseDefaultValue(type, N);
       }
     }
-    return result;
+    return Argument(std::move(name), std::move(type), N, std::move(default_value), !is_return && kwarg_only);
   }
   IValue parseSingleConstant(TypeKind kind) {
     switch(L.cur().kind) {
@@ -229,29 +231,29 @@ struct SchemaParser {
     L.expect(TK_NONE);
     return IValue();
   }
-  void parseDefaultValue(Argument& arg) {
+  IValue parseDefaultValue(TypePtr arg_type, at::optional<int32_t> arg_N) {
     auto range = L.cur().range;
-    switch(arg.type->kind()) {
+    switch(arg_type->kind()) {
       case TypeKind::DynamicType:
       case TypeKind::GeneratorType: {
-        arg.default_value = parseTensorDefault(range);
+        return parseTensorDefault(range);
       }  break;
       case TypeKind::NumberType:
       case TypeKind::IntType:
       case TypeKind::BoolType:
       case TypeKind::FloatType:
-        arg.default_value = parseSingleConstant(arg.type->kind());
+        return parseSingleConstant(arg_type->kind());
         break;
       case TypeKind::ListType: {
-        auto elem_kind = arg.type->cast<ListType>()->getElementType();
+        auto elem_kind = arg_type->cast<ListType>()->getElementType();
         if(L.cur().kind == TK_IDENT) {
-          arg.default_value = parseTensorDefault(range);
-        } else if(arg.N && L.cur().kind != '[') {
+          return parseTensorDefault(range);
+        } else if(arg_N && L.cur().kind != '[') {
           IValue v = parseSingleConstant(elem_kind->kind());
-          std::vector<IValue> repeated(*arg.N, v);
-          arg.default_value = convertToList(elem_kind->kind(), range, repeated);
+          std::vector<IValue> repeated(*arg_N, v);
+          return convertToList(elem_kind->kind(), range, repeated);
         } else {
-          arg.default_value = parseConstantList(elem_kind->kind());
+          return parseConstantList(elem_kind->kind());
         }
       } break;
       default:
@@ -287,22 +289,22 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
   bool seen_kwarg_only = false;
   for(size_t i = 0; i < schema.arguments.size(); ++i) {
     if (i > 0) out << ", ";
-    if (schema.arguments[i].kwarg_only && !seen_kwarg_only) {
+    if (schema.arguments[i].kwarg_only() && !seen_kwarg_only) {
       out << "*, ";
       seen_kwarg_only = true;
     }
     const auto & arg = schema.arguments[i];
-    out << arg.type->str() << " " << arg.name;
+    out << arg.type()->str() << " " << arg.name();
   }
 
   out << ") -> ";
   if (schema.returns.size() == 1) {
-    out << schema.returns.at(0).type->str();
+    out << schema.returns.at(0).type()->str();
   } else if (schema.returns.size() > 1) {
     out << "(";
     for (size_t i = 0; i < schema.returns.size(); ++i) {
       if (i > 0) out << ", ";
-      out << schema.returns[i].type->str();
+      out << schema.returns[i].type()->str();
     }
     out << ")";
   }
@@ -415,7 +417,7 @@ bool Operator::matches(const Node* node) const {
   TypeEnv type_env;
   for(size_t i = 0; i < formals.size(); ++i) {
     try {
-      TypePtr formal = matchTypeVariables(formals[i].type, actuals[i]->type(), type_env);
+      TypePtr formal = matchTypeVariables(formals[i].type(), actuals[i]->type(), type_env);
       // mismatched input type
       if (!actuals[i]->type()->isSubtypeOf(formal)) {
         return false;

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -259,6 +259,7 @@ struct SchemaParser {
       default:
         throw ErrorReport(range) << "unexpected type, file a bug report";
     }
+    return IValue(); // silence warnings
   }
 
   void parseList(int begin, int sep, int end, std::function<void()> callback) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -71,9 +71,9 @@ c10::optional<std::vector<std::shared_ptr<T>>> gatherTensorTypes(Node* node) {
   std::vector<std::shared_ptr<T>> tensor_types;
 
   auto & schema = node->schema();
-  auto & args = schema.arguments;
+  auto & args = schema.arguments();
   // can't handle varargs primitives because we don't know what should be a Tensor
-  if (schema.is_vararg) {
+  if (schema.is_vararg()) {
     return c10::nullopt;
   }
   for (size_t i = 0; i < args.size(); ++i) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -77,9 +77,9 @@ c10::optional<std::vector<std::shared_ptr<T>>> gatherTensorTypes(Node* node) {
     return c10::nullopt;
   }
   for (size_t i = 0; i < args.size(); ++i) {
-    if (args[i].type->isSubtypeOf(ListType::ofTensors())) {
+    if (args[i].type()->isSubtypeOf(ListType::ofTensors())) {
       return c10::nullopt;
-    } else if (args[i].type->isSubtypeOf(DynamicType::get())) {
+    } else if (args[i].type()->isSubtypeOf(DynamicType::get())) {
       if (auto type = node->input(i)->type()->cast<T>()) {
         tensor_types.push_back(type);
       } else {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -44,7 +44,7 @@ inline void findErrorInKwargs(
     if(!std::count_if(
             arguments.begin(),
             arguments.end(),
-            [&key](const Argument& argument) { return argument.name == key; })) {
+            [&key](const Argument& argument) { return argument.name() == key; })) {
       throw std::runtime_error(c10::str(
           "Unknown keyword argument '",
           key,
@@ -57,11 +57,11 @@ inline void findErrorInKwargs(
   // If there are unconsumed kwargs but none of them were unknown, the first
   // positional argument present in the kwargs is duplicated.
   for (const auto& argument : arguments) {
-    if (kwargs.contains(argument.name.c_str())) {
-      AT_ASSERT(!argument.default_value);
+    if (kwargs.contains(argument.name().c_str())) {
+      AT_ASSERT(!argument.default_value());
       throw std::runtime_error(c10::str(
           "Argument '",
-          argument.name,
+          argument.name(),
           "' specified both as positional and ",
           "keyword argument. Schema: ",
           schema));
@@ -174,14 +174,14 @@ inline IValue argumentToIValue(
     py::handle object) {
   const auto& argument = schema.arguments.at(argumentPosition);
   try {
-    return toIValue(object, argument.type);
+    return toIValue(object, argument.type());
   } catch (const py::cast_error& error) {
     throw std::runtime_error(c10::str(
         schema.name,
         "() expected value of type ",
-        argument.type->str(),
+        argument.type()->str(),
         " for argument '",
-        argument.name,
+        argument.name(),
         "' in position ",
         argumentPosition,
         ", but instead got value of type ",
@@ -307,16 +307,16 @@ inline Stack createStackForSchema(
   size_t consumed_kwargs = 0;
   for (size_t i = args.size(); i < schema.arguments.size(); ++i) {
     const auto& arg = schema.arguments[i];
-    if (kwargs.contains(arg.name.c_str())) {
-      push(stack, argumentToIValue(schema, i, kwargs[arg.name.c_str()]));
+    if (kwargs.contains(arg.name().c_str())) {
+      push(stack, argumentToIValue(schema, i, kwargs[arg.name().c_str()]));
       consumed_kwargs += 1;
-    } else if (arg.default_value) {
-      push(stack, *arg.default_value);
+    } else if (arg.default_value()) {
+      push(stack, *arg.default_value());
     } else {
       throw std::runtime_error(c10::str(
           schema.name,
           "() is missing value for argument '",
-          arg.name,
+          arg.name(),
           "'. Declaration: ",
           schema));
     }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -428,7 +428,7 @@ static inline bool isIntUsedAsIntList(
     const Argument& arg) {
   // Look for int[N]
   return value->type()->kind() == TypeKind::IntType &&
-         *arg.type == *ListType::ofInts() && arg.N;
+         *arg.type() == *ListType::ofInts() && arg.N();
 }
 
 inline bool convertibleToList(TypePtr type, TypePtr list_type_) {
@@ -464,16 +464,16 @@ Value* tryMatchArgument(
   // also allow single ints to be passed in their place.
   // the single int is then repeated to the length of the list
   if (isIntUsedAsIntList(value, arg)) {
-    std::vector<Value*> repeated(*arg.N, value);
+    std::vector<Value*> repeated(*arg.N(), value);
     value = graph.insertNode(graph.createList(IntType::get(), repeated))->output();
   }
 
   TypePtr concrete_type;
   try {
-    concrete_type = matchTypeVariables(arg.type, value->type(), type_env);
+    concrete_type = matchTypeVariables(arg.type(), value->type(), type_env);
   } catch(TypeMatchError& e) {
     err() << "could not match type " << value->type()->str() << " to "
-          << arg.type->str() << " in argument '" << arg.name << "': " << e.what() << "\n"
+          << arg.type()->str() << " in argument '" << arg.name() << "': " << e.what() << "\n"
           << named_value.locOr(loc);
     return nullptr;
   }
@@ -505,7 +505,7 @@ Value* tryMatchArgument(
   }
 
   if(!value->type()->isSubtypeOf(concrete_type)) {
-    err() << "expected a value of type " << concrete_type->str() << " for argument '" << arg.name << "' but found "
+    err() << "expected a value of type " << concrete_type->str() << " for argument '" << arg.name() << "' but found "
           << value->type()->str() << "\n"
           << named_value.locOr(loc);
     return nullptr;
@@ -600,23 +600,23 @@ c10::optional<MatchedSchema> tryMatchSchema(
   for (size_t schema_i = 0; schema_i < schema.arguments.size(); ++schema_i) {
     const auto& arg = schema.arguments[schema_i];
     c10::optional<NamedValue> v;
-    if (arg.name == "self" && self) {
+    if (arg.name() == "self" && self) {
       v = self;
       self = c10::nullopt;
-    } else if (!arg.kwarg_only && used_args < modifiedArgs.size()) {
+    } else if (!arg.kwarg_only() && used_args < modifiedArgs.size()) {
       // allow zeros(IntList sizes) to work with zeros(1, 2) or zeros(1)
-      if (arg.type->kind() == TypeKind::ListType && // the formal must be a list
-          !arg.N && // it must not be a broadcasting list like int[3], otherwise
+      if (arg.type()->kind() == TypeKind::ListType && // the formal must be a list
+          !arg.N() && // it must not be a broadcasting list like int[3], otherwise
                     // a single int is a valid input
           (schema_i + 1 == schema.arguments.size() ||
            schema.arguments[schema_i + 1]
-               .kwarg_only)) { // must be the last position argument
+               .kwarg_only())) { // must be the last position argument
         auto actual_type = modifiedArgs[used_args].value(graph)->type();
         if (actual_type->kind() != TypeKind::ListType &&
             !convertibleToList(
                 actual_type,
-                arg.type)) { // and the actual should not be a list already
-          auto elem_type = arg.type->expect<ListType>()->getElementType();
+                arg.type())) { // and the actual should not be a list already
+          auto elem_type = arg.type()->expect<ListType>()->getElementType();
           Value* list = tryCreateList(
               elem_type,
               graph,
@@ -635,7 +635,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
 
       v = modifiedArgs[used_args];
       used_args++;
-    } else if (auto idx = findInputWithName(arg.name, kwargs)) {
+    } else if (auto idx = findInputWithName(arg.name(), kwargs)) {
       const NamedValue& nv = kwargs[*idx];
       if (used_kwarg[*idx]) {
         err() << "argument " << nv.name()
@@ -645,10 +645,10 @@ c10::optional<MatchedSchema> tryMatchSchema(
       }
       used_kwarg[*idx] = true;
       v = nv;
-    } else if (arg.default_value) {
-      v = NamedValue(*arg.default_value);
+    } else if (arg.default_value()) {
+      v = NamedValue(*arg.default_value());
     } else {
-      err() << "argument " << schema.arguments[schema_i].name
+      err() << "argument " << schema.arguments[schema_i].name()
             << " not provided.\n"
             << loc;
       return c10::nullopt;
@@ -684,7 +684,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
     }
   }
   auto return_types = fmap(schema.returns, [&](const Argument& r) {
-    return evalTypeVariables(r.type, type_env);
+    return evalTypeVariables(r.type(), type_env);
   });
   return MatchedSchema{std::move(positional_inputs), std::move(return_types)};
 }
@@ -859,7 +859,7 @@ struct to_ir {
 
       // Record the type for the schema and set the Type on the Value*
       arguments.push_back(schema.arguments.at(arg_annotation_idx++));
-      new_input->setType(arguments.back().type);
+      new_input->setType(arguments.back().type());
     }
     // body
     auto stmts = def.statements();
@@ -896,7 +896,7 @@ struct to_ir {
         graph->registerOutput(r);
         TypePtr type = DynamicType::get();
         if (!schema.is_varret) {
-          type = schema.returns.at(return_type_idx).type;
+          type = schema.returns.at(return_type_idx).type();
           if (!r->type()->isSubtypeOf(type)) {
             throw ErrorReport(return_stmt.range()) << "Return value at position "
               << return_type_idx << " was annotated as having type " << type->str()

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -369,7 +369,7 @@ FunctionSchema getSchemaWithDefaults(
     const FunctionSchema schema,
     const Def& def) {
   std::vector<Argument> new_args;
-  for (auto& arg : schema.arguments) {
+  for (auto& arg : schema.arguments()) {
     auto it = default_args.find(arg.name());
     if (it != default_args.end()) {
       try {
@@ -387,11 +387,11 @@ FunctionSchema getSchemaWithDefaults(
   }
 
   return FunctionSchema(
-      schema.name,
+      schema.name(),
       new_args,
-      schema.returns,
-      schema.is_vararg,
-      schema.is_varret);
+      schema.returns(),
+      schema.is_vararg(),
+      schema.is_varret());
 }
 
 void initJitScriptBindings(PyObject* module) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -370,16 +370,16 @@ FunctionSchema getSchemaWithDefaults(
     const Def& def) {
   std::vector<Argument> new_args;
   for (auto& arg : schema.arguments) {
-    auto it = default_args.find(arg.name);
+    auto it = default_args.find(arg.name());
     if (it != default_args.end()) {
       try {
-        IValue value = toIValue(it->second, arg.type);
+        IValue value = toIValue(it->second, arg.type());
         new_args.push_back(
-            Argument(arg.name, arg.type, arg.N, value, arg.kwarg_only));
+            Argument(arg.name(), arg.type(), arg.N(), value, arg.kwarg_only()));
       } catch (py::cast_error& e) {
         throw ErrorReport(def.range())
-            << "Expected a default value of type " << arg.type->str()
-            << " on parameter \"" << arg.name << "\"";
+            << "Expected a default value of type " << arg.type()->str()
+            << " on parameter \"" << arg.name() << "\"";
       }
     } else {
       new_args.push_back(arg);

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -225,17 +225,17 @@ private:
       const auto& argument = schema.arguments[pos];
       if (pos < inputs.size()) {
         const TypePtr inputType = inferTypeFrom(inputs[pos]);
-        AT_CHECK(inputType->isSubtypeOf(argument.type),
-              "Expected value of type ", *argument.type,
-              " for argument '", argument.name,
+        AT_CHECK(inputType->isSubtypeOf(argument.type()),
+              "Expected value of type ", *argument.type(),
+              " for argument '", argument.name(),
               "' in position ", pos,
               ", but instead got value of type ", *inputType,
               ". Declaration: ", schema);
-      } else if (argument.default_value) {
-        inputs.push_back(*argument.default_value);
+      } else if (argument.default_value()) {
+        inputs.push_back(*argument.default_value());
       } else {
         AT_ERROR(schema.name, "() is missing value for argument '",
-                argument.name, "'. Declaration: ", schema);
+                argument.name(), "'. Declaration: ", schema);
       }
     }
   }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -216,13 +216,13 @@ private:
     const auto& schema = getSchema();
     // Do we have more inputs than the schema accepts?
     AT_CHECK(
-        inputs.size() <= schema.arguments.size(),
-        "Expected at most ", schema.arguments.size(),
-        " argument(s) for operator '", schema.name, "', but received ",
+        inputs.size() <= schema.arguments().size(),
+        "Expected at most ", schema.arguments().size(),
+        " argument(s) for operator '", schema.name(), "', but received ",
         inputs.size(), " argument(s). Declaration: ", schema);
 
-    for (size_t pos = 0; pos < schema.arguments.size(); ++pos) {
-      const auto& argument = schema.arguments[pos];
+    for (size_t pos = 0; pos < schema.arguments().size(); ++pos) {
+      const auto& argument = schema.arguments()[pos];
       if (pos < inputs.size()) {
         const TypePtr inputType = inferTypeFrom(inputs[pos]);
         AT_CHECK(inputType->isSubtypeOf(argument.type()),
@@ -234,7 +234,7 @@ private:
       } else if (argument.default_value()) {
         inputs.push_back(*argument.default_value());
       } else {
-        AT_ERROR(schema.name, "() is missing value for argument '",
+        AT_ERROR(schema.name(), "() is missing value for argument '",
                 argument.name(), "'. Declaration: ", schema);
       }
     }

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -1087,15 +1087,15 @@ void testCustomOperators() {
     CATCH_REQUIRE(ops.size() == 1);
 
     auto& op = ops.front();
-    CATCH_REQUIRE(op->schema().name == "foo::bar");
+    CATCH_REQUIRE(op->schema().name() == "foo::bar");
 
-    CATCH_REQUIRE(op->schema().arguments.size() == 2);
-    CATCH_REQUIRE(op->schema().arguments[0].name == "_0");
-    CATCH_REQUIRE(op->schema().arguments[0].type->kind() == TypeKind::FloatType);
-    CATCH_REQUIRE(op->schema().arguments[1].name == "_1");
-    CATCH_REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
+    CATCH_REQUIRE(op->schema().arguments().size() == 2);
+    CATCH_REQUIRE(op->schema().arguments()[0].name() == "_0");
+    CATCH_REQUIRE(op->schema().arguments()[0].type()->kind() == TypeKind::FloatType);
+    CATCH_REQUIRE(op->schema().arguments()[1].name() == "_1");
+    CATCH_REQUIRE(op->schema().arguments()[1].type()->kind() == TypeKind::DynamicType);
 
-    CATCH_REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
+    CATCH_REQUIRE(op->schema().returns()[0].type()->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1115,16 +1115,16 @@ void testCustomOperators() {
     CATCH_REQUIRE(ops.size() == 1);
 
     auto& op = ops.front();
-    CATCH_REQUIRE(op->schema().name == "foo::bar_with_schema");
+    CATCH_REQUIRE(op->schema().name() == "foo::bar_with_schema");
 
-    CATCH_REQUIRE(op->schema().arguments.size() == 2);
-    CATCH_REQUIRE(op->schema().arguments[0].name == "a");
-    CATCH_REQUIRE(op->schema().arguments[0].type->kind() == TypeKind::FloatType);
-    CATCH_REQUIRE(op->schema().arguments[1].name == "b");
-    CATCH_REQUIRE(op->schema().arguments[1].type->kind() == TypeKind::DynamicType);
+    CATCH_REQUIRE(op->schema().arguments().size() == 2);
+    CATCH_REQUIRE(op->schema().arguments()[0].name() == "a");
+    CATCH_REQUIRE(op->schema().arguments()[0].type()->kind() == TypeKind::FloatType);
+    CATCH_REQUIRE(op->schema().arguments()[1].name() == "b");
+    CATCH_REQUIRE(op->schema().arguments()[1].type()->kind() == TypeKind::DynamicType);
 
-    CATCH_REQUIRE(op->schema().returns.size() == 1);
-    CATCH_REQUIRE(op->schema().returns[0].type->kind() == TypeKind::DynamicType);
+    CATCH_REQUIRE(op->schema().returns().size() == 1);
+    CATCH_REQUIRE(op->schema().returns()[0].type()->kind() == TypeKind::DynamicType);
 
     Stack stack;
     push(stack, 2.0f, autograd::make_variable(at::ones(5)));
@@ -1147,18 +1147,18 @@ void testCustomOperators() {
     CATCH_REQUIRE(ops.size() == 1);
 
     auto& op = ops.front();
-    CATCH_REQUIRE(op->schema().name == "foo::lists");
+    CATCH_REQUIRE(op->schema().name() == "foo::lists");
 
-    CATCH_REQUIRE(op->schema().arguments.size() == 3);
-    CATCH_REQUIRE(op->schema().arguments[0].name == "ints");
-    CATCH_REQUIRE(op->schema().arguments[0].type->isSubtypeOf(ListType::ofInts()));
-    CATCH_REQUIRE(op->schema().arguments[1].name == "floats");
-    CATCH_REQUIRE(op->schema().arguments[1].type->isSubtypeOf(ListType::ofFloats()));
-    CATCH_REQUIRE(op->schema().arguments[2].name == "tensors");
-    CATCH_REQUIRE(op->schema().arguments[2].type->isSubtypeOf(ListType::ofTensors()));
+    CATCH_REQUIRE(op->schema().arguments().size() == 3);
+    CATCH_REQUIRE(op->schema().arguments()[0].name() == "ints");
+    CATCH_REQUIRE(op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofInts()));
+    CATCH_REQUIRE(op->schema().arguments()[1].name() == "floats");
+    CATCH_REQUIRE(op->schema().arguments()[1].type()->isSubtypeOf(ListType::ofFloats()));
+    CATCH_REQUIRE(op->schema().arguments()[2].name() == "tensors");
+    CATCH_REQUIRE(op->schema().arguments()[2].type()->isSubtypeOf(ListType::ofTensors()));
 
-    CATCH_REQUIRE(op->schema().returns.size() == 1);
-    CATCH_REQUIRE(op->schema().returns[0].type->isSubtypeOf(ListType::ofFloats()));
+    CATCH_REQUIRE(op->schema().returns().size() == 1);
+    CATCH_REQUIRE(op->schema().returns()[0].type()->isSubtypeOf(ListType::ofFloats()));
 
     Stack stack;
     push(stack, std::vector<int64_t>{1, 2});
@@ -1182,14 +1182,14 @@ void testCustomOperators() {
     CATCH_REQUIRE(ops.size() == 1);
 
     auto& op = ops.front();
-    CATCH_REQUIRE(op->schema().name == "foo::lists2");
+    CATCH_REQUIRE(op->schema().name() == "foo::lists2");
 
-    CATCH_REQUIRE(op->schema().arguments.size() == 1);
-    CATCH_REQUIRE(op->schema().arguments[0].name == "tensors");
-    CATCH_REQUIRE(op->schema().arguments[0].type->isSubtypeOf(ListType::ofTensors()));
+    CATCH_REQUIRE(op->schema().arguments().size() == 1);
+    CATCH_REQUIRE(op->schema().arguments()[0].name() == "tensors");
+    CATCH_REQUIRE(op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofTensors()));
 
-    CATCH_REQUIRE(op->schema().returns.size() == 1);
-    CATCH_REQUIRE(op->schema().returns[0].type->isSubtypeOf(ListType::ofTensors()));
+    CATCH_REQUIRE(op->schema().returns().size() == 1);
+    CATCH_REQUIRE(op->schema().returns()[0].type()->isSubtypeOf(ListType::ofTensors()));
 
     Stack stack;
     push(stack, std::vector<at::Tensor>{autograd::make_variable(at::ones(5))});


### PR DESCRIPTION
We are beginning to use this class in a wider reaching set of use-cases. This PR refactors it so that we always access schema properties through methods. This will make adding extra information like alias information easier (i.e. we can a version of `type()` that returns the type with alias information and another version that returns a type without that information). 