### PR TITLE
disable LN with dim=1

### DIFF
--- a/caffe2/python/layers/layer_normalization.py
+++ b/caffe2/python/layers/layer_normalization.py
@@ -34,6 +34,7 @@ class LayerNormalization(ModelLayer):
         assert len(self.input_shape) >= 1, (
             "This layer supports only >= 2D tesnors")
         input_dims = self.input_shape[0]
+        assert input_dims > 1, "input dim ({}) too small, trivial layer norm"
 
         self.output_schema = schema.Scalar(
             (np.float32, self.input_shape),

--- a/caffe2/python/normalizer.py
+++ b/caffe2/python/normalizer.py
@@ -37,6 +37,10 @@ class LayerNormalizer(Normalizer):
         self._use_layer_norm_op = use_layer_norm_op
 
     def _run(self, layer_model, param):
-        return layer_model.LayerNormalization(
-            param, epsilon=self._epsilon, use_layer_norm_op=self._use_layer_norm_op
-        )
+        # LayerNorm with dim = 1 is trivial and output constant 0
+        if param.dtype.shape[0] > 1:
+            return layer_model.LayerNormalization(
+                param, epsilon=self._epsilon, use_layer_norm_op=self._use_layer_norm_op
+            )
+        else:
+            return param


### PR DESCRIPTION
Summary:
as found in experiments, LN with dim=1 is producing zero constant gradient. This is
becasue of LN performs layerwise normalization and therefore it outputs zero

Differential Revision: D10502670
