### PR TITLE
[build] Use cmake3 if it exists and cmake isn't sufficient

### DIFF
--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -21,8 +21,15 @@ CMAKE_COMMAND="cmake"
 if [[ -x "$(command -v cmake3)" ]]; then
     if [[ -x "$(command -v cmake)" ]]; then
         # have both cmake and cmake3, compare versions
-        CMAKE_VERSION=$(cmake --version | grep 'cmake\d* version' | awk '{print $NF}')
-        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake\d* version' | awk '{print $NF}')
+        # Usually cmake --version returns two lines,
+        #   cmake version #.##.##
+        #   <an empty line>
+        # On the nightly machines it returns one line
+        #   cmake3 version 3.11.0 CMake suite maintained and supported by Kitware (kitware.com/cmake).
+        # Thus we extract the line that has 'version' in it and hope the actual
+        # version number is gonna be the 3rd element
+        CMAKE_VERSION=$(cmake --version | grep 'version' | awk '{print $3}')
+        CMAKE3_VERSION=$(cmake3 --version | grep 'version' | awk '{print $3}')
         CMAKE3_NEEDED=$($PYTORCH_PYTHON -c "from distutils.version import StrictVersion; print(1 if StrictVersion(\"${CMAKE_VERSION}\") < StrictVersion(\"3.5.0\") and StrictVersion(\"${CMAKE3_VERSION}\") > StrictVersion(\"${CMAKE_VERSION}\") else 0)")
     else
         # don't have cmake

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -21,17 +21,17 @@ CMAKE_COMMAND="cmake"
 if [[ -x "$(command -v cmake3)" ]]; then
     if [[ -x "$(command -v cmake)" ]]; then
         # have both cmake and cmake3, compare versions
-        CMAKE_VERSION=$(cmake --version | grep 'cmake version' | awk '{print $NF}')
-        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake3 version' | awk '{print $NF}')
-        CMAKE3_IS_NEWER=$($PYTORCH_PYTHON -c "from distutils.version import StrictVersion; print(1 if StrictVersion(\"${CMAKE3_VERSION}\") >= StrictVersion(\"${CMAKE_VERSION}\") else 0)")
+        CMAKE_VERSION=$(cmake --version | grep 'cmake\d* version' | awk '{print $NF}')
+        CMAKE3_VERSION=$(cmake3 --version | grep 'cmake\d* version' | awk '{print $NF}')
+        CMAKE3_NEEDED=$($PYTORCH_PYTHON -c "from distutils.version import StrictVersion; print(1 if StrictVersion(\"${CMAKE_VERSION}\") < StrictVersion(\"3.5.0\") and StrictVersion(\"${CMAKE3_VERSION}\") > StrictVersion(\"${CMAKE_VERSION}\") else 0)")
     else
         # don't have cmake
-        CMAKE3_IS_NEWER=1
+        CMAKE3_NEEDED=1
     fi
-    if [[ $CMAKE3_IS_NEWER == "1" ]]; then
+    if [[ $CMAKE3_NEEDED == "1" ]]; then
         CMAKE_COMMAND="cmake3"
     fi
-    unset CMAKE_VERSION CMAKE3_VERSION CMAKE3_IS_NEWER
+    unset CMAKE_VERSION CMAKE3_VERSION CMAKE3_NEEDED
 fi
 
 # Options for building only a subset of the libraries


### PR DESCRIPTION
A tweak to https://github.com/pytorch/pytorch/pull/12916 that only uses cmake3 when cmake isn't good enough. Hopefully fixes the issue @zdevito saw.

cc @zdevito @SsnL  