### PR TITLE
Caffe2: Fix for creating entries of external_input in predic_net

### DIFF
--- a/caffe2/python/predictor/mobile_exporter.py
+++ b/caffe2/python/predictor/mobile_exporter.py
@@ -92,9 +92,14 @@ def Export(workspace, net, params):
 
     # Now we make input/output_blobs line up with what Predictor expects.
     del predict_net.external_input[:]
-    predict_net.external_input.extend(input_blobs)
+
+    new_external_inputs = input_blobs
+    for external_input in proto.external_input:
+        if external_input not in new_external_inputs:
+            new_external_inputs.append(external_input)
+
     # For populating weights
-    predict_net.external_input.extend(proto.external_input)
+    predict_net.external_input.extend(new_external_inputs)
     # Ensure the output is also consistent with what we want
     del predict_net.external_output[:]
     predict_net.external_output.extend(output_blobs)


### PR DESCRIPTION
  Currently after performing export it gives two entries of externel_input
  of input data in predict_net proto because it extends the externel_input
  twice once seperately using input blob and one it is extendind all the entries
  of external_input from proto in which input blob is already included

Signed-off-by: Parth Raichura <parth.raichura@softnautics.com>

