### PR TITLE
Back out "Revert D10494123: [c10] Remove at::Optional"

### DIFF
--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ATen/optional.h>
 #include <ATen/ScalarType.h>
+#include <c10/util/Optional.h>
 #include <sstream>
 #include <vector>
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -6,7 +6,7 @@
 
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 namespace at { namespace native { namespace {
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.h
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.h
@@ -2,7 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
-#include <ATen/optional.h>
+#include <c10/util/Optional.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/optional.h
+++ b/aten/src/ATen/optional.h
@@ -1,1 +1,0 @@
-#include "c10/util/Optional.h"

--- a/aten/src/ATen/test/cuda_optional_test.cu
+++ b/aten/src/ATen/test/cuda_optional_test.cu
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 #include <assert.h>
 

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1031,7 +1031,8 @@ struct hash<c10::optional<T&>> {
 };
 } // namespace std
 
-// TODO: remove at::optional when done moving files
+// Plan on record is to land 'using namespace c10' to bridge c10 into at:: and
+// caffe2:: namespaces. Until that lands, proceeding one name at a time.
 namespace at {
 template <class T>
 using optional = c10::optional<T>;

--- a/test/cpp/api/memory.cpp
+++ b/test/cpp/api/memory.cpp
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/utils/memory.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 struct TestValue {
   explicit TestValue(const int& x) : lvalue_(x) {}

--- a/torch/csrc/api/include/torch/data/samplers/random.h
+++ b/torch/csrc/api/include/torch/data/samplers/random.h
@@ -3,7 +3,7 @@
 #include <torch/data/samplers/base.h>
 #include <torch/tensor.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <algorithm>
 #include <cstddef>

--- a/torch/csrc/api/include/torch/data/samplers/sequential.h
+++ b/torch/csrc/api/include/torch/data/samplers/sequential.h
@@ -3,7 +3,7 @@
 #include <torch/data/samplers/base.h>
 #include <torch/tensor.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <algorithm>
 #include <cstddef>

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -1,3 +1,4 @@
+#include "c10/util/Optional.h"
 #include "torch/csrc/autograd/VariableTypeUtils.h"
 
 using namespace at;

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -3,7 +3,7 @@
 #include <c10d/ProcessGroup.hpp>
 
 #include <ATen/ATen.h>
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <cstddef>
 #include <memory>


### PR DESCRIPTION
Summary:
Previous commit missed a file in test/cpp, which did not have a fbcode internal
target and slipped off contbuild. Will export to oss and ensure that things
build this time.

Differential Revision: D10511254
