### PR TITLE
Move Device and DeviceType to c10

### DIFF
--- a/aten/src/ATen/Device.h
+++ b/aten/src/ATen/Device.h
@@ -1,2 +1,2 @@
 #pragma once
-#include <ATen/core/Device.h>
+#include <c10/Device.h>

--- a/aten/src/ATen/DeviceGuard.h
+++ b/aten/src/ATen/DeviceGuard.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/Tensor.h>
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <ATen/core/ScalarType.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/core/Allocator.h
+++ b/aten/src/ATen/core/Allocator.h
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <memory>
 
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <ATen/core/UniqueVoidPtr.h>
 #include <c10/util/Exception.h>
 

--- a/aten/src/ATen/core/Backend.h
+++ b/aten/src/ATen/core/Backend.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ATen/core/DeviceType.h>
+#include <c10/DeviceType.h>
 #include <ATen/core/TensorTypeId.h>
 #include <ATen/core/TensorTypeIdRegistration.h>
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/core/DefaultTensorOptions.h
+++ b/aten/src/ATen/core/DefaultTensorOptions.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/core/Backend.h>
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <ATen/core/Layout.h>
 #include <ATen/core/ScalarType.h>
 

--- a/aten/src/ATen/core/Macros.h
+++ b/aten/src/ATen/core/Macros.h
@@ -29,17 +29,3 @@
 #else
 #define AT_MOBILE 0
 #endif // ANDROID / IOS / MACOS
-
-namespace at {
-inline int stoi(const std::string& str) {
-#if defined(__ANDROID__)
-  std::stringstream ss;
-  int n = 0;
-  ss << str;
-  ss >> n;
-  return n;
-#else
-  return std::stoi(str);
-#endif // defined(__ANDROID__)
-}
-} // namespace at

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ATen/core/Device.h"
+#include "c10/Device.h"
 #include "ATen/core/Layout.h"
 #include "ATen/core/Scalar.h"
 #include "ATen/core/ScalarType.h"

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -9,6 +9,8 @@
 #include <ATen/core/TensorTypeId.h>
 #include <ATen/core/TensorTypeIdRegistration.h>
 #include <ATen/core/context_base.h>
+
+#include <c10/util/Exception.h>
 #include "c10/util/Optional.h"
 
 #include "c10/util/Flags.h"

--- a/aten/src/ATen/core/TensorOptions.cpp
+++ b/aten/src/ATen/core/TensorOptions.cpp
@@ -1,6 +1,6 @@
 #include <ATen/core/TensorOptions.h>
 
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <ATen/core/Layout.h>
 #include <ATen/core/OptionsGuard.h>
 #include <ATen/core/ScalarType.h>

--- a/aten/src/ATen/core/TensorOptions.h
+++ b/aten/src/ATen/core/TensorOptions.h
@@ -2,7 +2,7 @@
 
 #include <ATen/core/Backend.h>
 #include <ATen/core/DefaultTensorOptions.h>
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <ATen/core/Layout.h>
 #include <ATen/core/ScalarType.h>
 #include <ATen/core/ScalarTypeUtils.h>

--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -178,5 +178,6 @@ inline std::unique_ptr<at::BaseContext> CreateContext(
 namespace caffe2 {
 
 using at::BaseContext;
+using at::CreateContext;
 
 } // namespace caffe2

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ATen/core/Device.h"
+#include "c10/Device.h"
 #include "ATen/core/Layout.h"
 #include "ATen/core/Scalar.h"
 #include "ATen/core/ScalarType.h"

--- a/c10/Device.cpp
+++ b/c10/Device.cpp
@@ -1,5 +1,5 @@
-#include <ATen/core/Device.h>
-#include <ATen/core/Macros.h>
+#include <c10/Device.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #include <algorithm>
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <vector>
 
-namespace at {
+namespace c10 {
 namespace {
 DeviceType parse_type(const std::string& device_string) {
   static const std::array<std::pair<std::string, DeviceType>, 7> types = {{
@@ -73,7 +73,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   }
   std::string device_index = device_string.substr(index + 1);
   try {
-    index_ = at::stoi(device_index);
+    index_ = stoi(device_index);
   } catch (const std::exception&) {
     AT_ERROR(
         "Could not parse device index '",
@@ -84,7 +84,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   }
 }
 
-std::ostream& operator<<(std::ostream& stream, const at::Device& device) {
+std::ostream& operator<<(std::ostream& stream, const Device& device) {
   stream << device.type();
   if (device.has_index()) {
     stream << ":" << device.index();
@@ -92,4 +92,4 @@ std::ostream& operator<<(std::ostream& stream, const at::Device& device) {
   return stream;
 }
 
-} // namespace at
+} // namespace c10

--- a/c10/Device.cpp
+++ b/c10/Device.cpp
@@ -73,7 +73,7 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   }
   std::string device_index = device_string.substr(index + 1);
   try {
-    index_ = stoi(device_index);
+    index_ = c10::stoi(device_index);
   } catch (const std::exception&) {
     AT_ERROR(
         "Could not parse device index '",

--- a/c10/Device.h
+++ b/c10/Device.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <ATen/core/ATenGeneral.h>
-#include <ATen/core/Backend.h>
-#include <ATen/core/DeviceType.h>
+#include <c10/DeviceType.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #include <cstddef>
@@ -10,7 +9,8 @@
 #include <iosfwd>
 #include <string>
 
-namespace at {
+namespace c10 {
+
 /// Represents a a compute device on which a tensor is located. A device is
 /// uniquely identified by a type, which specifies the type of machine it is
 /// (e.g. CPU or CUDA GPU), and a device index or ordinal, which identifies the
@@ -21,8 +21,8 @@ namespace at {
 /// 1. A negative index represents the current device, a non-negative index
 /// represents a specific, concrete device,
 /// 2. When the device type is CPU, the device index must be zero.
-struct CAFFE2_API Device {
-  using Type = at::DeviceType;
+struct C10_API Device {
+  using Type = DeviceType;
 
   /// Constructs a new `Device` from a `DeviceType` and an optional device
   /// index.
@@ -92,16 +92,16 @@ struct CAFFE2_API Device {
   int32_t index_ = -1;
 };
 
-CAFFE2_API std::ostream& operator<<(
+C10_API std::ostream& operator<<(
     std::ostream& stream,
-    const at::Device& device);
+    const Device& device);
 
-} // namespace at
+} // namespace c10
 
 namespace std {
 template <>
-struct hash<at::Device> {
-  size_t operator()(const at::Device& device) const noexcept {
+struct hash<c10::Device> {
+  size_t operator()(c10::Device device) const noexcept {
     size_t hash_val = static_cast<size_t>(device.index() + 1);
     if (device.is_cuda()) {
       hash_val += 2;
@@ -110,3 +110,8 @@ struct hash<at::Device> {
   }
 };
 } // namespace std
+
+// TODO: Remove when we add global namespace include
+namespace at {
+using c10::Device;
+}

--- a/c10/DeviceType.cpp
+++ b/c10/DeviceType.cpp
@@ -1,9 +1,9 @@
-#include <ATen/core/DeviceType.h>
+#include <c10/DeviceType.h>
 #include <c10/util/Exception.h>
 
-namespace at {
+namespace c10 {
 
-std::string DeviceTypeName(at::DeviceType d, bool lower_case) {
+std::string DeviceTypeName(DeviceType d, bool lower_case) {
   switch (d) {
     // I considered instead using ctype::tolower to lower-case the strings
     // on the fly, but this seemed a bit much.
@@ -34,9 +34,9 @@ std::string DeviceTypeName(at::DeviceType d, bool lower_case) {
   }
 }
 
-std::ostream& operator<<(std::ostream& stream, at::DeviceType type) {
-  stream << at::DeviceTypeName(type, /* lower case */ true);
+std::ostream& operator<<(std::ostream& stream, DeviceType type) {
+  stream << DeviceTypeName(type, /* lower case */ true);
   return stream;
 }
 
-} // namespace at
+} // namespace c10

--- a/c10/DeviceType.h
+++ b/c10/DeviceType.h
@@ -5,12 +5,12 @@
 // ATen/core (which would require a lot more build system hacking.)
 // If you modify me, keep me synchronized with that file.
 
-#include <ATen/core/Macros.h>
+#include <c10/macros/Macros.h>
 
 #include <ostream>
 #include <functional>
 
-namespace at {
+namespace c10 {
 
 // Underlying type declared to be int32_t for consistency with protobufs.
 enum class DeviceType : int32_t {
@@ -26,18 +26,24 @@ enum class DeviceType : int32_t {
   ONLY_FOR_TEST = 20901701, // This device type is only for test.
 };
 
-CAFFE2_API std::string DeviceTypeName(
-    at::DeviceType d,
+C10_API std::string DeviceTypeName(
+    DeviceType d,
     bool lower_case = false);
 
-CAFFE2_API std::ostream& operator<<(std::ostream& stream, at::DeviceType type);
+C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
 
 } // namespace at
 
 namespace std {
-template <> struct hash<at::DeviceType> {
-  std::size_t operator()(const at::DeviceType &k) const {
+template <> struct hash<c10::DeviceType> {
+  std::size_t operator()(c10::DeviceType k) const {
     return std::hash<int>()(static_cast<int>(k));
   }
 };
 } // namespace std
+
+// TODO: Remove me when we get a global c10 namespace using in at
+namespace at {
+using c10::DeviceType;
+using c10::DeviceTypeName;
+}

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -73,6 +73,28 @@ struct C10_API SourceLocation {
 
 std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
 
+/// Portable implementation of std::stoi, which works for Android builds.
+///
+/// TODO: You won't be able to call this unqualified, because ADL means that it
+/// will be ambiguous with std::stoi.  Maybe we should fix this by giving
+/// our version a different name.
+inline int stoi(const std::string& str) {
+#if defined(__ANDROID__)
+  std::stringstream ss;
+  int n = 0;
+  ss << str;
+  ss >> n;
+  return n;
+#else
+  return std::stoi(str);
+#endif // defined(__ANDROID__)
+}
+
 } // namespace c10
+
+// TODO: Remove me when namespace unification occurs
+namespace at {
+using c10::stoi;
+}
 
 #endif // C10_UTIL_STRINGUTIL_H_

--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -1,7 +1,7 @@
 #ifndef CAFFE2_CORE_EVENT_H_
 #define CAFFE2_CORE_EVENT_H_
 
-#include <ATen/core/DeviceType.h>
+#include <c10/DeviceType.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/proto/caffe2_pb.h"

--- a/caffe2/core/storage.h
+++ b/caffe2/core/storage.h
@@ -17,8 +17,8 @@
 #include "caffe2/core/typeid.h"
 
 #include <ATen/core/Allocator.h>
-#include <ATen/core/Device.h>
-#include <ATen/core/DeviceType.h>
+#include <c10/Device.h>
+#include <c10/DeviceType.h>
 #include <ATen/core/intrusive_ptr.h>
 #include <ATen/core/Storage.h>
 #include <ATen/core/StorageImpl.h>

--- a/caffe2/proto/caffe2_pb.h
+++ b/caffe2/proto/caffe2_pb.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ATen/core/Device.h>
+#include <c10/Device.h>
 #include <c10/util/Exception.h>
 #include <caffe2/proto/caffe2.pb.h>
 

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -1,6 +1,6 @@
 #include "caffe2/utils/proto_utils.h"
 
-#include <ATen/core/DeviceType.h>
+#include <c10/DeviceType.h>
 
 #include <fcntl.h>
 #include <cerrno>

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -37,14 +37,12 @@ INPUT                  = ../../../torch/csrc/api/include \
                          ../../../torch/csrc/jit/script/module.h \
                          ../../../aten/src/ATen/ATen.h \
                          ../../../aten/src/ATen/Backend.h \
-                         ../../../aten/src/ATen/Device.h \
                          ../../../aten/src/ATen/DeviceGuard.h \
                          ../../../aten/src/ATen/Layout.h \
                          ../../../aten/src/ATen/OptionsGuard.h \
                          ../../../aten/src/ATen/Scalar.h \
                          ../../../aten/src/ATen/TensorOptions.h \
                          ../../../aten/src/ATen/core/ArrayRef.h \
-                         ../../../aten/src/ATen/core/DeviceType.h \
                          ../../../aten/src/ATen/core/Half.h \
                          ../../../aten/src/ATen/core/ScalarType.h \
                          ../../../aten/src/ATen/core/Tensor.h \
@@ -58,6 +56,8 @@ INPUT                  = ../../../torch/csrc/api/include \
                          ../../../aten/src/ATen/mkl/Descriptors.h \
                          ../../../c10/util/Optional.h \
                          ../../../c10/util/Exception.h \
+                         ../../../c10/Device.h \
+                         ../../../c10/DeviceType.h \
                          ../../../build/aten/src/ATen/Functions.h
 # Don't include .cpp files!
 FILE_PATTERNS          = *.h

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -71,7 +71,7 @@ at::Type* get_type(const std::string& name, bool is_cuda, bool is_sparse) {
 PyTypeObject* getPyTypeObject(const at::Storage& storage)
 {
   auto attype = at::globalContext().getNonVariableTypeOpt(
-      deviceTypeToBackend(storage.device_type()),
+      at::deviceTypeToBackend(storage.device_type()),
       at::dataTypeToScalarType(storage.dtype().id()));
   auto it = attype_to_py_storage_type.find(attype);
   if (it != attype_to_py_storage_type.end()) {

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -2,9 +2,12 @@
 
 #include "torch/csrc/python_headers.h"
 
+namespace c10 {
+struct Device;
+}
+
 namespace at {
 struct Type;
-struct Device;
 class Tensor;
 } // namespace at
 
@@ -29,6 +32,6 @@ void py_set_default_dtype(PyObject* dtype_obj);
 at::Type& get_default_tensor_type();
 
 // Gets the torch::Device object of a given at::Tensor
-at::Device getDevice(const at::Tensor& tensor);
+c10::Device getDevice(const at::Tensor& tensor);
 
 }} // namespace torch::tensors


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#12995 Move Device and DeviceType to c10**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10513246/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13019 Replace direct use of int32_t with an alias DeviceIndex&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10520295/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13021 Delete default constructor from CUDAStream.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10520421/)



Differential Revision: [D10513246](https://our.internmc.facebook.com/intern/diff/D10513246/)