### PR TITLE
[wip] Fix TensorList ambiguity

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -18,6 +18,7 @@
   _(World)
 
 namespace c10 {
+namespace ivalue {
 
 CAFFE2_API c10::intrusive_ptr<ConstantString> ConstantString::create(
     std::string str_) {
@@ -60,6 +61,8 @@ template<>
 std::ostream& operator<<(std::ostream & out, const List<IValue> & v) {
   return printList<IValue>(out, v, "(", ", ", ")");
 }
+
+} // namespace ivalue
 
 std::ostream& operator<<(std::ostream & out, const IValue & v) {
   switch(v.tag) {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -10,6 +10,9 @@
 #include <type_traits>
 
 namespace c10 {
+struct IValue;
+
+namespace ivalue {
 
 template <typename T>
 using Shared = c10::intrusive_ptr<T>;
@@ -64,7 +67,6 @@ struct World {
   int64_t world_id;
 };
 
-struct IValue;
 struct C10_EXPORT Tuple : public List<IValue> {
   using List<IValue>::List;
   static c10::intrusive_ptr<Tuple> create(std::vector<IValue> elements_) {
@@ -76,6 +78,8 @@ using TensorList = List<at::Tensor>;
 using DoubleList = List<double>;
 using BoolList = List<bool>;
 using GenericList = List<IValue>;
+
+}
 
 // IValue is the generic tagged union used by the interpreter to hold
 // all value types.
@@ -185,15 +189,15 @@ struct CAFFE2_API IValue final {
   }
 
   // Tuple
-  IValue(c10::intrusive_ptr<Tuple> v);
+  IValue(c10::intrusive_ptr<ivalue::Tuple> v);
   bool isTuple() const { return Tag::Tuple == tag; }
-  c10::intrusive_ptr<Tuple> toTuple() && {
+  c10::intrusive_ptr<ivalue::Tuple> toTuple() && {
     AT_ASSERT(isTuple());
-    return moveToIntrusivePtr<Tuple>();
+    return moveToIntrusivePtr<ivalue::Tuple>();
   }
-  c10::intrusive_ptr<Tuple> toTuple() const & {
+  c10::intrusive_ptr<ivalue::Tuple> toTuple() const & {
     AT_ASSERT(isTuple());
-    return toIntrusivePtr<Tuple>();
+    return toIntrusivePtr<ivalue::Tuple>();
   }
 
   // Double
@@ -208,12 +212,12 @@ struct CAFFE2_API IValue final {
   }
 
   // World
-  IValue(World w)
+  IValue(ivalue::World w)
   : tag(Tag::World), is_intrusive_ptr(false) {
     payload.as_world = w;
   }
   bool isWorld() const { return Tag::World == tag; }
-  World toWorld() const {
+  ivalue::World toWorld() const {
     AT_ASSERT(isWorld());
     return payload.as_world;
   }
@@ -247,18 +251,18 @@ struct CAFFE2_API IValue final {
   }
 
   // IntList
-  IValue(c10::intrusive_ptr<IntList> v);
+  IValue(c10::intrusive_ptr<ivalue::IntList> v);
   IValue(std::vector<int64_t> v);
   IValue(at::ArrayRef<int64_t> v)
   : IValue(v.vec()) {}
   bool isIntList() const { return Tag::IntList == tag; }
-  c10::intrusive_ptr<IntList> toIntList() && {
+  c10::intrusive_ptr<ivalue::IntList> toIntList() && {
     AT_ASSERT(isIntList());
-    return moveToIntrusivePtr<IntList>();
+    return moveToIntrusivePtr<ivalue::IntList>();
   }
-  c10::intrusive_ptr<IntList> toIntList() const & {
+  c10::intrusive_ptr<ivalue::IntList> toIntList() const & {
     AT_ASSERT(isIntList());
-    return toIntrusivePtr<IntList>();
+    return toIntrusivePtr<ivalue::IntList>();
   }
 
   const std::vector<int64_t>& toIntListRef() const;
@@ -269,68 +273,68 @@ struct CAFFE2_API IValue final {
   const std::string& toStringRef() const;
 
   // ConstantString
-  IValue(c10::intrusive_ptr<ConstantString> v);
+  IValue(c10::intrusive_ptr<ivalue::ConstantString> v);
   IValue(std::string v);
   bool isString() const { return Tag::String == tag; }
-  c10::intrusive_ptr<ConstantString> toString() && {
+  c10::intrusive_ptr<ivalue::ConstantString> toString() && {
     AT_ASSERT(isString());
-    return moveToIntrusivePtr<ConstantString>();
+    return moveToIntrusivePtr<ivalue::ConstantString>();
   }
-  c10::intrusive_ptr<ConstantString> toString() const & {
+  c10::intrusive_ptr<ivalue::ConstantString> toString() const & {
     AT_ASSERT(isString());
-    return toIntrusivePtr<ConstantString>();
+    return toIntrusivePtr<ivalue::ConstantString>();
   }
 
   // DoubleList
-  IValue(c10::intrusive_ptr<DoubleList> v);
+  IValue(c10::intrusive_ptr<ivalue::DoubleList> v);
   IValue(std::vector<double> v);
   bool isDoubleList() const { return Tag::DoubleList == tag; }
-  c10::intrusive_ptr<DoubleList> toDoubleList() && {
+  c10::intrusive_ptr<ivalue::DoubleList> toDoubleList() && {
     AT_ASSERT(isDoubleList());
-    return moveToIntrusivePtr<DoubleList>();
+    return moveToIntrusivePtr<ivalue::DoubleList>();
   }
-  c10::intrusive_ptr<DoubleList> toDoubleList() const & {
+  c10::intrusive_ptr<ivalue::DoubleList> toDoubleList() const & {
     AT_ASSERT(isDoubleList());
-    return toIntrusivePtr<DoubleList>();
+    return toIntrusivePtr<ivalue::DoubleList>();
   }
 
   // BoolList
-  IValue(c10::intrusive_ptr<BoolList> v);
+  IValue(c10::intrusive_ptr<ivalue::BoolList> v);
   IValue(std::vector<bool> v);
   bool isBoolList() const { return Tag::BoolList == tag; }
-  c10::intrusive_ptr<BoolList> toBoolList() && {
+  c10::intrusive_ptr<ivalue::BoolList> toBoolList() && {
     AT_ASSERT(isBoolList());
-    return moveToIntrusivePtr<BoolList>();
+    return moveToIntrusivePtr<ivalue::BoolList>();
   }
-  c10::intrusive_ptr<BoolList> toBoolList() const & {
+  c10::intrusive_ptr<ivalue::BoolList> toBoolList() const & {
     AT_ASSERT(isBoolList());
-    return toIntrusivePtr<BoolList>();
+    return toIntrusivePtr<ivalue::BoolList>();
   }
 
   //TensorList
-  IValue(c10::intrusive_ptr<TensorList> v);
+  IValue(c10::intrusive_ptr<ivalue::TensorList> v);
   IValue(std::vector<at::Tensor> v);
   bool isTensorList() const { return Tag::TensorList == tag; }
-  c10::intrusive_ptr<TensorList> toTensorList() && {
+  c10::intrusive_ptr<ivalue::TensorList> toTensorList() && {
     AT_ASSERT(isTensorList());
-    return moveToIntrusivePtr<TensorList>();
+    return moveToIntrusivePtr<ivalue::TensorList>();
   }
-  c10::intrusive_ptr<TensorList> toTensorList() const & {
+  c10::intrusive_ptr<ivalue::TensorList> toTensorList() const & {
     AT_ASSERT(isTensorList());
-    return toIntrusivePtr<TensorList>();
+    return toIntrusivePtr<ivalue::TensorList>();
   }
 
   //GenericList
-  IValue(c10::intrusive_ptr<GenericList> v);
+  IValue(c10::intrusive_ptr<ivalue::GenericList> v);
   IValue(std::vector<IValue> v);
   bool isGenericList() const { return Tag::GenericList == tag; }
-  c10::intrusive_ptr<GenericList> toGenericList() && {
+  c10::intrusive_ptr<ivalue::GenericList> toGenericList() && {
     AT_ASSERT(isGenericList());
-    return moveToIntrusivePtr<GenericList>();
+    return moveToIntrusivePtr<ivalue::GenericList>();
   }
-  c10::intrusive_ptr<GenericList> toGenericList() const & {
+  c10::intrusive_ptr<ivalue::GenericList> toGenericList() const & {
     AT_ASSERT(isGenericList());
-    return toIntrusivePtr<GenericList>();
+    return toIntrusivePtr<ivalue::GenericList>();
   }
 
   // None
@@ -426,7 +430,7 @@ struct CAFFE2_API IValue final {
     double as_double;
     bool as_bool;
     c10::intrusive_ptr_target* as_intrusive_ptr;
-    World as_world;
+    ivalue::World as_world;
   } payload;
   Tag tag;
   bool is_intrusive_ptr;
@@ -445,15 +449,15 @@ inline type IValue::to<type>() const & { \
   return this->method_name(); \
 }
 DEFINE_TO(at::Tensor, toTensor)
-DEFINE_TO(c10::intrusive_ptr<Tuple>, toTuple)
+DEFINE_TO(c10::intrusive_ptr<ivalue::Tuple>, toTuple)
 DEFINE_TO(double, toDouble)
 DEFINE_TO(int64_t, toInt)
 DEFINE_TO(bool, toBool)
-DEFINE_TO(c10::intrusive_ptr<DoubleList>, toDoubleList)
-DEFINE_TO(c10::intrusive_ptr<IntList>, toIntList)
-DEFINE_TO(c10::intrusive_ptr<TensorList>, toTensorList)
-DEFINE_TO(c10::intrusive_ptr<GenericList>, toGenericList)
-DEFINE_TO(c10::intrusive_ptr<ConstantString>, toString)
+DEFINE_TO(c10::intrusive_ptr<ivalue::DoubleList>, toDoubleList)
+DEFINE_TO(c10::intrusive_ptr<ivalue::IntList>, toIntList)
+DEFINE_TO(c10::intrusive_ptr<ivalue::TensorList>, toTensorList)
+DEFINE_TO(c10::intrusive_ptr<ivalue::GenericList>, toGenericList)
+DEFINE_TO(c10::intrusive_ptr<ivalue::ConstantString>, toString)
 DEFINE_TO(at::Scalar, toScalar)
 DEFINE_TO(std::vector<int64_t>, toIntListRef)
 DEFINE_TO(std::vector<double>, toDoubleListRef)
@@ -461,7 +465,7 @@ DEFINE_TO(std::vector<bool>, toBoolListRef)
 DEFINE_TO(std::vector<at::Tensor>, toTensorListRef)
 DEFINE_TO(std::vector<IValue>, toGenericListRef)
 DEFINE_TO(std::string, toStringRef)
-DEFINE_TO(World, toWorld)
+DEFINE_TO(ivalue::World, toWorld)
 DEFINE_TO(IValue, toIValue)
 
 #undef DEFINE_TO
@@ -495,52 +499,52 @@ DEFINE_TO_WITH_BODY(at::Device, DEVICE_BODY)
 #undef LAYOUT_BODY
 #undef DEVICE_BODY
 
-inline IValue::IValue(c10::intrusive_ptr<Tuple> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::Tuple> v)
 : tag(Tag::Tuple), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 
-inline IValue::IValue(c10::intrusive_ptr<IntList> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::IntList> v)
 : tag(Tag::IntList), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::vector<int64_t> v)
-: IValue(IntList::create(std::move(v))) {}
+: IValue(ivalue::IntList::create(std::move(v))) {}
 
-inline IValue::IValue(c10::intrusive_ptr<ConstantString> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::ConstantString> v)
 : tag(Tag::String), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::string v)
-: IValue(ConstantString::create(std::move(v))) {}
+: IValue(ivalue::ConstantString::create(std::move(v))) {}
 
-inline IValue::IValue(c10::intrusive_ptr<DoubleList> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::DoubleList> v)
 : tag(Tag::DoubleList), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::vector<double> v)
-: IValue(DoubleList::create(std::move(v))) {}
+: IValue(ivalue::DoubleList::create(std::move(v))) {}
 
-inline IValue::IValue(c10::intrusive_ptr<BoolList> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::BoolList> v)
 : tag(Tag::BoolList), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::vector<bool> v)
-: IValue(BoolList::create(std::move(v))) {}
+: IValue(ivalue::BoolList::create(std::move(v))) {}
 
-inline IValue::IValue(c10::intrusive_ptr<TensorList> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::TensorList> v)
 : tag(Tag::TensorList), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::vector<at::Tensor> v)
-: IValue(TensorList::create(std::move(v))) {}
+: IValue(ivalue::TensorList::create(std::move(v))) {}
 
-inline IValue::IValue(c10::intrusive_ptr<GenericList> v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::GenericList> v)
 : tag(Tag::GenericList), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(std::vector<IValue> v)
-: IValue(GenericList::create(std::move(v))) {}
+: IValue(ivalue::GenericList::create(std::move(v))) {}
 
 
 inline const std::vector<int64_t>& IValue::toIntListRef() const {

--- a/torch/csrc/jit/ivalue.h
+++ b/torch/csrc/jit/ivalue.h
@@ -3,20 +3,20 @@
 namespace torch {
 namespace jit {
 
-using ::c10::List;
-using ::c10::Shared;
-using ::c10::World;
+using ::c10::ivalue::List;
+using ::c10::ivalue::Shared;
+using ::c10::ivalue::World;
 
 using ::c10::IValue;
-using ::c10::Tuple;
+using ::c10::ivalue::Tuple;
 
-using ::c10::BoolList;
-using ::c10::DoubleList;
-using ::c10::GenericList;
-using ::c10::IntList;
-using ::c10::TensorList;
+using ::c10::ivalue::BoolList;
+using ::c10::ivalue::DoubleList;
+using ::c10::ivalue::GenericList;
+using ::c10::ivalue::IntList;
+using ::c10::ivalue::TensorList;
 
-using ::c10::ConstantString;
+using ::c10::ivalue::ConstantString;
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#13012 Fix TensorList ambiguity**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10518929/)

There's a TensorList type in ivalue.h and one in ScalarType.h, and they are different.
This diff deletes the one in ScalarType.h so we can merge the namespaces without conflicts.

Differential Revision: [D10518929](https://our.internmc.facebook.com/intern/diff/D10518929/)