### PR TITLE
[C++ Frontend] Do a better job of checking registered names

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -75,6 +75,74 @@ TEST_F(ModuleTest, ZeroGradWithUndefined) {
   ASSERT_EQ(module.x.grad().sum().item<float>(), 0);
 }
 
+TEST_F(ModuleTest, RegisterModuleThrowsForEmptyOrDottedName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_module;
+  };
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_module("name.with.dot", torch::nn::Linear(3, 4)),
+      "Submodule name must not contain a dot (got 'name.with.dot')");
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_module("", torch::nn::Linear(3, 4)),
+      "Submodule name must not be empty");
+}
+
+TEST_F(ModuleTest, RegisterModuleThrowsForDuplicateModuleName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_module;
+  };
+  TestModel model;
+  model.register_module("linear", torch::nn::Linear(3, 4));
+  ASSERT_THROWS_WITH(
+      model.register_module("linear", torch::nn::Linear(3, 4)),
+      "Submodule 'linear' already defined");
+}
+
+TEST_F(ModuleTest, RegisterParameterThrowsForEmptyOrDottedName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_parameter;
+  };
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_parameter("name.with.dot", torch::ones(5)),
+      "Parameter name must not contain a dot (got 'name.with.dot')");
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_parameter("", torch::ones(5)),
+      "Parameter name must not be empty");
+}
+
+TEST_F(ModuleTest, RegisterParameterThrowsForDuplicateModuleName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_parameter;
+  };
+  TestModel model;
+  model.register_parameter("p", torch::ones(5));
+  ASSERT_THROWS_WITH(
+      model.register_parameter("p", torch::ones(5)),
+      "Parameter 'p' already defined");
+}
+
+TEST_F(ModuleTest, RegisterBufferThrowsForEmptyOrDottedName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_buffer;
+  };
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_buffer("name.with.dot", torch::ones(5)),
+      "Buffer name must not contain a dot (got 'name.with.dot')");
+  ASSERT_THROWS_WITH(
+      TestModel{}.register_buffer("", torch::ones(5)),
+      "Buffer name must not be empty");
+}
+
+TEST_F(ModuleTest, RegisterBufferThrowsForDuplicateModuleName) {
+  struct TestModel : public torch::nn::Module {
+    using torch::nn::Module::register_buffer;
+  };
+  TestModel model;
+  model.register_buffer("p", torch::ones(5));
+  ASSERT_THROWS_WITH(
+      model.register_buffer("p", torch::ones(5)), "Buffer 'p' already defined");
+}
+
 TEST_F(ModuleTest, CanGetName) {
   // CHECK instead of REQUIRE because demangling may fail.
   AGIUnit agi;

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -72,12 +72,11 @@ namespace nn {
 class Module {
  public:
   /// Tells the base `Module` about the name of the submodule.
-  explicit Module(std::string name);
-
-  /// Constructs the base module without immediate knowledge of the submodule's
-  /// name. The name of the submodule is inferred via RTTI the first time
+  /// If the `name` is empty, constructs the module without immediate knowledge
+  /// of the submodule's name. The name of the submodule is inferred via RTTI
+  /// (if possible) the first time
   /// `.name()` is invoked.
-  Module() = default;
+  explicit Module(std::string name = std::string());
 
   virtual ~Module() = default;
 
@@ -340,13 +339,13 @@ class Module {
   void to_impl(Ts&&... ts);
 
   /// The registered parameters of this `Module`.
-  OrderedDict<Tensor> parameters_{"Parameter"};
+  OrderedDict<Tensor> parameters_;
 
   /// The registered buffers of this `Module`.
-  OrderedDict<Tensor> buffers_{"Buffer"};
+  OrderedDict<Tensor> buffers_;
 
   /// The registered (direct) submodules of this `Module`.
-  OrderedDict<std::shared_ptr<Module>> children_{"Submodule"};
+  OrderedDict<std::shared_ptr<Module>> children_;
 
   /// The module's name (e.g. "LSTM").
   mutable c10::optional<std::string> name_;

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -72,11 +72,12 @@ namespace nn {
 class Module {
  public:
   /// Tells the base `Module` about the name of the submodule.
-  /// If the `name` is empty, constructs the module without immediate knowledge
-  /// of the submodule's name. The name of the submodule is inferred via RTTI
-  /// (if possible) the first time
-  /// `.name()` is invoked.
-  explicit Module(std::string name = std::string());
+  explicit Module(std::string name);
+
+  /// Constructs the module without immediate knowledge of the submodule's name.
+  /// The name of the submodule is inferred via RTTI (if possible) the first
+  /// time `.name()` is invoked.
+  Module();
 
   virtual ~Module() = default;
 

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -16,11 +16,12 @@
 namespace torch {
 namespace nn {
 
-Module::Module(std::string name)
-    : parameters_("Parameter"),
-      buffers_("Buffer"),
-      children_("Submodule"),
-      name_(std::move(name)) {}
+Module::Module()
+    : parameters_("Parameter"), buffers_("Buffer"), children_("Submodule") {}
+
+Module::Module(std::string name) : Module() {
+  name_ = std::move(name);
+}
 
 const std::string& Module::name() const noexcept {
   // If the name optional is empty at this point, we grab the name of the

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -156,11 +156,23 @@ Tensor& Module::register_parameter(
     std::string name,
     Tensor tensor,
     bool requires_grad) {
+  AT_CHECK(!name.empty(), "Parameter name must not be empty");
+  AT_CHECK(
+      name.find('.') == std::string::npos,
+      "Parameter name must not contain a dot (got '",
+      name,
+      "')");
   tensor.set_requires_grad(requires_grad);
   return parameters_.insert(std::move(name), std::move(tensor));
 }
 
 Tensor& Module::register_buffer(std::string name, Tensor tensor) {
+  AT_CHECK(!name.empty(), "Buffer name must not be empty");
+  AT_CHECK(
+      name.find('.') == std::string::npos,
+      "Buffer name must not contain a dot (got '",
+      name,
+      "')");
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -16,7 +16,11 @@
 namespace torch {
 namespace nn {
 
-Module::Module(std::string name) : name_(std::move(name)) {}
+Module::Module(std::string name)
+    : parameters_("Parameter"),
+      buffers_("Buffer"),
+      children_("Submodule"),
+      name_(std::move(name)) {}
 
 const std::string& Module::name() const noexcept {
   // If the name optional is empty at this point, we grab the name of the


### PR DESCRIPTION
We currently don't check names in `register_module` and `register_parameter` as thoroughly as we do in Python. This PR fixes this.

Python checks are e.g. in https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L108

@ezyang @ebetica @apaszke 