### PR TITLE
remove progress from git operations in CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ merge_pull_request_onto_master: &merge_pull_request_onto_master
 
       git config remote.origin.url https://github.com/pytorch/pytorch.git
       git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
-      git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --quiet
+      git fetch --tags https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --quiet
       if [[ "${CIRCLE_BRANCH}" == pull/* ]]; then  # if this is a forked PR
-        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/${CIRCLE_BRANCH}/head:refs/remotes/origin/${CIRCLE_BRANCH}
+        git fetch --tags https://github.com/pytorch/pytorch.git +refs/${CIRCLE_BRANCH}/head:refs/remotes/origin/${CIRCLE_BRANCH}
       else
-        git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/${CIRCLE_BRANCH}:refs/remotes/origin/${CIRCLE_BRANCH}
+        git fetch --tags https://github.com/pytorch/pytorch.git +refs/heads/${CIRCLE_BRANCH}:refs/remotes/origin/${CIRCLE_BRANCH}
       fi
 
       export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
@@ -226,7 +226,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
 
         # Need to checkout fetch PRs for onnxbot tracking PRs
         git submodule update --init third_party/onnx || true
-        cd third_party/onnx && git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/* && cd -
+        cd third_party/onnx && git fetch --tags origin +refs/pull/*:refs/remotes/origin/pr/* && cd -
 
         # Reinitialize submodules
         git submodule sync && git submodule update --init --recursive


### PR DESCRIPTION
these are pretty spammy - unless we have a reason to keep them, let's not

