### PR TITLE
Topologically-safe node moves

### DIFF
--- a/test/cpp/jit/gtest.cpp
+++ b/test/cpp/jit/gtest.cpp
@@ -25,6 +25,7 @@ JIT_TEST(InternedStrings)
 JIT_TEST(IValue)
 JIT_TEST(SchemaParser)
 JIT_TEST(TopologicalIndex)
+JIT_TEST(TopologicalMove)
 
 #define JIT_TEST_CUDA(name)    \
   TEST(JitTest, name##_CUDA) { \

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -938,7 +938,6 @@ bool Node::tryMove(Node* movePoint, MoveSide moveSide) {
     curNode = curNode->next_in_graph[direction];
   }
 
-
   // 2. Decide whether we can move it all to `movePoint`.
 
   // Say we are moving directly before movePoint and `this` starts before
@@ -971,7 +970,6 @@ bool Node::tryMove(Node* movePoint, MoveSide moveSide) {
     // `this` and `movePoint`, so we can't do the move
     return false;
   }
-
 
   // 3. Execute the move
   JIT_ASSERT(curNode == movePoint);
@@ -1020,9 +1018,7 @@ bool Node::producesFor(const T& nodes) const {
         std::any_of(
                node->blocks().cbegin(),
                node->blocks().cend(),
-               [&](const Block* block) {
-                 return producesFor(block->nodes());
-               });
+               [&](const Block* block) { return producesFor(block->nodes()); });
   });
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -453,6 +453,9 @@ public:
 
   // Move 'this' (already in the graph) after 'n' in the topological order.
   //
+  // NOTE: Does not check that value dependencies are preserved, see
+  //   moveAfterTopologicallyValid
+  //
   // Given: %2 = f(%1)
   //        %3 = g(%1)
   // Execute: %2.moveAfter(%3)
@@ -461,7 +464,19 @@ public:
   //
   TORCH_API void moveAfter(Node * n);
 
+  // Move 'this' (already in the graph) after 'n' in the topological order.
+  //
+  // Tries to preserve value dependencies, so other nodes might be moved. The
+  // only guarantee is that in the new ordering, `this` is after `n`.
+  //
+  // Returns `false` if it's impossible to move `this` after `n` without
+  // violating dependencies, otherwise executes the move and returns `true`
+  TORCH_API bool moveAfterTopologicallyValid(Node * n);
+
   // Move a node 'n' (already in the graph) before 'this' in the topological order.
+  //
+  // NOTE: Does not check that value dependencies are preserved, see
+  //   moveBeforeTopologicallyValid
   //
   // Given: %2 = f(%1)
   //        %3 = g(%1)
@@ -469,6 +484,15 @@ public:
   // Result: %3 = g(%1)
   //         %2 = f(%1)
   TORCH_API void moveBefore(Node * n);
+
+  // Move 'this' (already in the graph) before 'n' in the topological order.
+  //
+  // Tries to preserve value dependencies, so other nodes might be moved. The
+  // only guarantee is that in the new ordering, `this` is before `n`
+  //
+  // Returns `false` if it's impossible to move `this` after `n` without
+  // violating dependencies, otherwise executes the move and returns `true`
+  TORCH_API bool moveBeforeTopologicallyValid(Node * n);
 
   // Remove the input at 'i' from this node.
   //
@@ -547,6 +571,19 @@ public:
 
   virtual ~Node() = default;
 private:
+  enum class MoveSide {
+    BEFORE,
+    AFTER
+  };
+  bool tryMove(Node* movePoint, MoveSide moveSide);
+  void move(Node* movePoint, MoveSide moveSide);
+
+  bool isDependent(const std::list<Node*>& nodes) const;
+
+  template<typename T>
+  bool producesFor(const T& nodes) const;
+  bool consumesFrom(const std::list<Node*>& nodes) const;
+
   std::pair<Value*, const Argument&> findInput(Symbol name);
   void findSchema() const;
   // Lookup iterator in use list of _input i_ that corresponds to its use of _this_

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -471,9 +471,10 @@ public:
   //
   // Returns `false` if it's impossible to move `this` after `n` without
   // violating dependencies, otherwise executes the move and returns `true`
-  TORCH_API bool moveAfterTopologicallyValid(Node * n);
+  TORCH_API bool moveAfterTopologicallyValid(Node* n);
 
-  // Move a node 'n' (already in the graph) before 'this' in the topological order.
+  // Move a node 'n' (already in the graph) before 'this' in the topological
+  // order.
   //
   // NOTE: Does not check that value dependencies are preserved, see
   //   moveBeforeTopologicallyValid
@@ -492,7 +493,7 @@ public:
   //
   // Returns `false` if it's impossible to move `this` after `n` without
   // violating dependencies, otherwise executes the move and returns `true`
-  TORCH_API bool moveBeforeTopologicallyValid(Node * n);
+  TORCH_API bool moveBeforeTopologicallyValid(Node* n);
 
   // Remove the input at 'i' from this node.
   //
@@ -570,17 +571,15 @@ public:
   void dump() const;
 
   virtual ~Node() = default;
-private:
-  enum class MoveSide {
-    BEFORE,
-    AFTER
-  };
+
+ private:
+  enum class MoveSide { BEFORE, AFTER };
   bool tryMove(Node* movePoint, MoveSide moveSide);
   void move(Node* movePoint, MoveSide moveSide);
 
   bool isDependent(const std::list<Node*>& nodes) const;
 
-  template<typename T>
+  template <typename T>
   bool producesFor(const T& nodes) const;
   bool consumesFrom(const std::list<Node*>& nodes) const;
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -209,10 +209,6 @@ private:
   // This list represents a topological sort
 
   Node* next_in_graph[2] = { nullptr, nullptr };
-  Node* & next() { return next_in_graph[kNextDirection]; }
-  Node* & prev() { return next_in_graph[kPrevDirection]; }
-  Node* const & next() const { return next_in_graph[kNextDirection]; }
-  Node* const & prev() const { return next_in_graph[kPrevDirection]; }
 
   const NodeKind kind_;
   std::vector<Value*> inputs_;
@@ -233,6 +229,11 @@ private:
 protected:
   TORCH_API Node(Graph * graph_, NodeKind kind_); //defined after graph
 public:
+  Node* & next() { return next_in_graph[kNextDirection]; }
+  Node* & prev() { return next_in_graph[kPrevDirection]; }
+  Node* const & next() const { return next_in_graph[kNextDirection]; }
+  Node* const & prev() const { return next_in_graph[kPrevDirection]; }
+
   NodeKind kind() const {
     return kind_;
   }
@@ -466,8 +467,10 @@ public:
 
   // Move 'this' (already in the graph) after 'n' in the topological order.
   //
-  // Tries to preserve value dependencies, so other nodes might be moved. The
-  // only guarantee is that in the new ordering, `this` is after `n`.
+  // Tries to preserve value dependencies, so other nodes might be moved. We
+  // make two gurantees about the postcondition of the node list:
+  //   - `this` is directly after `n`.
+  //   - only nodes between `this` and `n` have been moved
   //
   // Returns `false` if it's impossible to move `this` after `n` without
   // violating dependencies, otherwise executes the move and returns `true`
@@ -488,8 +491,10 @@ public:
 
   // Move 'this' (already in the graph) before 'n' in the topological order.
   //
-  // Tries to preserve value dependencies, so other nodes might be moved. The
-  // only guarantee is that in the new ordering, `this` is before `n`
+  // Tries to preserve value dependencies, so other nodes might be moved. We
+  // make two gurantees about the postcondition of the node list:
+  //   - `this` is directly before `n`.
+  //   - only nodes between `this` and `n` have been moved
   //
   // Returns `false` if it's impossible to move `this` after `n` without
   // violating dependencies, otherwise executes the move and returns `true`

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -577,12 +577,6 @@ public:
   bool tryMove(Node* movePoint, MoveSide moveSide);
   void move(Node* movePoint, MoveSide moveSide);
 
-  bool isDependent(const std::list<Node*>& nodes) const;
-
-  template <typename T>
-  bool producesFor(const T& nodes) const;
-  bool consumesFrom(const std::list<Node*>& nodes) const;
-
   std::pair<Value*, const Argument&> findInput(Symbol name);
   void findSchema() const;
   // Lookup iterator in use list of _input i_ that corresponds to its use of _this_


### PR DESCRIPTION
Add new methods to move a node before/after another node while preserving data data dependencies.

Any suggestions for a pithier name for the methods would be appreciated 😃 