### PR TITLE
Make SparseToDense handle empty outputs properly.

### DIFF
--- a/caffe2/operators/sparse_to_dense_op.h
+++ b/caffe2/operators/sparse_to_dense_op.h
@@ -81,6 +81,9 @@ class SparseToDenseOp final : public Operator<Context> {
     output->Resize(shape);
 
     TData* output_data = output->template mutable_data<TData>();
+    if (!output_first_dim) {
+      return true;
+    }
     memset(output_data, 0, output->nbytes());
     const auto block_nitems = sparse_values.size_from_dim(1);
     const TData* sparse_values_vec = sparse_values.template data<TData>();


### PR DESCRIPTION
Summary:
memset on nullptr is undefined-behavior and as a result filament_test is failing in dev build. This diff is making operator to handle empty output properly, so we can return that test back.

I'm not sure either this is even valid to call this op with input that would require empty memset (empty batch?). Will leave this to ninghz and sunnieshang to decide.

Differential Revision: D10525605
