### PR TITLE
[ROCm] Enable test_nn embedding tests and use correct warp size in Embedding.cu

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -17,8 +17,13 @@ namespace at { namespace native {
 
 namespace {
 
+#ifdef __HIP_PLATFORM_HCC__
+static const int WARP_SIZE = 64;
+static const int BLOCKDIMY = 16;
+#else
 static const int WARP_SIZE = 32;
 static const int BLOCKDIMY = 32;
+#endif
 
 template
   <typename scalar_t,
@@ -80,7 +85,11 @@ __global__ void embedding_backward_feature_kernel
           (dst_row == indices_batch[chunk_start - batch_start + threadIdx.x]);
         if(threadIdx.x >= n_this_chunk)
           match_found_this_thread = 0;
+#ifdef __HIP_PLATFORM_HCC__
+        unsigned long long int matchmask = WARP_BALLOT(match_found_this_thread);
+#else
         unsigned int matchmask = WARP_BALLOT(match_found_this_thread);
+#endif
 
         int first_remaining_peer = __ffs(matchmask) - 1;
 
@@ -243,9 +252,9 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
            (indices_contig.data<int64_t>(),
             grad.data<scalar_t>(),
             grad_weight.data<scalar_t>(),
-            num_indices,
-            stride,
-            padding_idx);
+            static_cast<int>(num_indices),
+            static_cast<int64_t>(stride),
+            static_cast<int>(padding_idx));
        });
 
     THCudaCheck(cudaGetLastError());

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -606,7 +606,6 @@ criterion_tests = [
         reference_fn=lambda i, t, m:
             hingeembeddingloss_reference(i, t, reduction=get_reduction(m)),
         check_sum_reduction=True,
-        test_cuda=(not TEST_WITH_ROCM)
     ),
     dict(
         module_name='HingeEmbeddingLoss',
@@ -617,7 +616,6 @@ criterion_tests = [
             hingeembeddingloss_reference(i, t, margin=0.5, reduction=get_reduction(m)),
         desc='margin',
         check_sum_reduction=True,
-        test_cuda=(not TEST_WITH_ROCM)
     ),
     dict(
         module_name='MultiLabelMarginLoss',
@@ -722,7 +720,6 @@ criterion_tests = [
         reference_fn=lambda i, t, m:
             cosineembeddingloss_reference(i[0], i[1], t, reduction=get_reduction(m)),
         check_sum_reduction=True,
-        test_cuda=(not TEST_WITH_ROCM)
     ),
     dict(
         module_name='CosineEmbeddingLoss',
@@ -733,7 +730,6 @@ criterion_tests = [
             cosineembeddingloss_reference(i[0], i[1], t, margin=0.7, reduction=get_reduction(m)),
         desc='margin',
         check_sum_reduction=True,
-        test_cuda=(not TEST_WITH_ROCM)
     ),
     dict(
         module_name='MarginRankingLoss',


### PR DESCRIPTION
* Enable test_nn embedding tests and use correct warp size in Embedding.cu
* Fix embedding_backward_feature_kernel kernel for HIP

For attention: @bddppq @ezyang 