### PR TITLE
[ROCm] Enable MIOpen properly

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -75,6 +75,8 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   export PYTORCH_TEST_WITH_ROCM=1
+  export LANG=C.UTF-8
+  export LC_ALL=C.UTF-8
 fi
 
 if [[ "${JOB_BASE_NAME}" == *-NO_AVX-* ]]; then

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -124,7 +124,8 @@ struct ConvolutionDescriptor
   void set(miopenDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups) {
     miopenDataType_t mathType = dataType;
     if (dataType == miopenHalf) mathType = miopenFloat;
-    MIOPEN_CHECK(miopenInitConvolutionDescriptor(mut_desc(), miopenConvolution, *pad, *pad, *stride, *stride, 1, 1));
+    MIOPEN_CHECK(miopenInitConvolutionDescriptor(mut_desc(), miopenConvolution, pad[0], pad[1], stride[0], stride[1], upscale[0], upscale[1]));
+    MIOPEN_CHECK(miopenSetConvolutionGroupCount(mut_desc(), groups));
   }
 };
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -4,7 +4,6 @@
 #include "ATen/Config.h"
 
 static const int MIOPEN_DIM_MAX = 4;
-static const bool MIOPEN_ENABLED = getenv("DISABLE_MIOPEN") == NULL;
 
 namespace at { namespace native {
 
@@ -128,7 +127,6 @@ auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
          && detail::getCUDAHooks().compiledWithMIOpen()
          && input.type().is_cuda()
          && input.dim() <= MIOPEN_DIM_MAX
-         && MIOPEN_ENABLED
          && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1
          && !transposed
          && (dilation.at(0) == dilation.at(1)) //MIOpen currently does not support assymetric dilation values.

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -3,6 +3,9 @@
 
 #include "ATen/Config.h"
 
+static const int MIOPEN_DIM_MAX = 4;
+static const bool MIOPEN_ENABLED = getenv("DISABLE_MIOPEN") == NULL;
+
 namespace at { namespace native {
 
 struct ConvParams {
@@ -120,9 +123,17 @@ auto ConvParams::use_cudnn(const at::Tensor& input) const -> bool {
 }
 
 auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
-  if (!detail::getCUDAHooks().compiledWithMIOpen() || !input.type().is_cuda() || !cudnn_enabled)
-    return false;
-  return true;
+
+  return ((input.type().scalarType() == at::kFloat) || (input.type().scalarType() == at::kHalf))
+         && detail::getCUDAHooks().compiledWithMIOpen()
+         && input.type().is_cuda()
+         && input.dim() <= MIOPEN_DIM_MAX
+         && MIOPEN_ENABLED
+         && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1
+         && !transposed
+         && (dilation.at(0) == dilation.at(1)) //MIOpen currently does not support assymetric dilation values.
+         && (stride.at(0) == stride.at(1)) //Line 549 & 635 (swapping stride and dilation values) leads to assymetric dilation values.
+         ;
 }
 
 auto ConvParams::use_mkldnn(const at::Tensor& input) const -> bool {

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 static const int MIOPEN_DIM_MAX = 4;
-static const bool MIOPEN_ENABLED = getenv("DISABLE_MIOPEN") == NULL;
 
 namespace at { namespace native {
 
@@ -77,7 +76,6 @@ Tensor batch_norm(
                && ((running_mean.defined() && running_var.defined())
                  || (!running_mean.defined() && !running_var.defined() && training))
                && detail::getCUDAHooks().compiledWithMIOpen()
-               && MIOPEN_ENABLED
                );
 
   if (use_miopen) {

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -67,9 +67,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     checkAllDefined(c, {running_mean, running_var});
   }
   checkAllSameGPU(c, {input, weight, bias, running_mean, running_var});
-  if (input->type().scalarType() == ScalarType::Half) {
-    checkScalarType(c, weight, ScalarType::Float);
-  } else {
+  if (input->type().scalarType() != ScalarType::Half) {
     checkAllSameType(c, {input, weight});
   }
   checkAllSameType(c, {weight, bias, running_mean, running_var});

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -555,9 +555,10 @@ void miopen_convolution_add_bias_(CheckedFrom c, const TensorArg& output, const 
   auto handle = getMiopenHandle();
   auto dataType = getMiopenDataType(*bias);
   Constant one(dataType, 1);
+  Constant zero(dataType, 0);
 
   MIOPEN_CHECK(miopenConvolutionForwardBias(handle, &one, bdesc.desc(), bias->data_ptr(),
-                                     &one, odesc.desc(), output->data_ptr()));
+                                     &zero, odesc.desc(), output->data_ptr()));
 }
 
 // see NOTE [ Convolution design ] in src/Aten/native/cudnn/Conv.cpp


### PR DESCRIPTION
* Disable MIOpen convolution on double tensors
* MIOpen: set group count in convolution descriptor
* MIOpen: Honor Max Dim (ROCm 222)
* MIOpen: Batchnorm - Allow half/half and half/float, disallow double
* Limit MIOpen batchnorm to same-precision
* Fix maxdim check. (ROCm 246)
* Fix reversed logic in DISABLE_MIOPEN (ROCm 253)
* Export LANG/LC_ALL also for the test step.
* Make tensors contiguous before calling MIOpen batch norm
* Actually pass dilation to MIOpen.
* Do not use MIOpen if there is dilation and the group size is > 1. - This is officially not supported currently.
* Fixes for miopenforward bias call
* Modified init conv descriptor param values and used same value for dilation
* MIOpen: disable transposed convolutions

For attention: @bddppq @ezyang 
