### PR TITLE
Use default timeout of 30 minutes for gloo backend

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -332,8 +332,11 @@ PyObject* c10d_init(PyObject* _unused) {
            int,
            int,
            ::c10d::ProcessGroupGloo::Options>())
-      .def(py::init(
-          [](const std::shared_ptr<::c10d::Store>& store, int rank, int size) {
+      .def(
+          py::init([](const std::shared_ptr<::c10d::Store>& store,
+                      int rank,
+                      int size,
+                      std::chrono::milliseconds timeout) {
             ::c10d::ProcessGroupGloo::Options options;
 
             // By default, use the hostname to resolve the network address to
@@ -349,9 +352,14 @@ PyObject* c10d_init(PyObject* _unused) {
             attr.hostname = hostname.data();
             options.devices.push_back(
                 ::gloo::transport::tcp::CreateDevice(attr));
+            options.timeout = timeout;
             return std::make_shared<::c10d::ProcessGroupGloo>(
                 store, rank, size, options);
-          }));
+          }),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("timeout") = std::chrono::milliseconds(10 * 1000));
 
 #ifdef USE_C10D_NCCL
   shared_ptr_class_<::c10d::ProcessGroupNCCL>(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1,5 +1,6 @@
 import torch
 from torch._six import string_classes
+from datetime import timedelta
 
 from .rendezvous import rendezvous, register_rendezvous_handler
 from . import BroadcastOptions, AllreduceOptions, ReduceOptions, \
@@ -83,6 +84,12 @@ _pg_group_ranks = {}
 # Default process group state
 _default_pg = None
 _default_pg_init_method = None
+
+# Default process group wide timeout, if applicable.
+# This currently only applies to the gloo backend. To make an attempt at
+# backwards compatibility with THD, we use an extraordinarily high default
+# timeout, given that THD did not have timeouts.
+_default_pg_timeout = timedelta(minutes=30)
 
 # Process group count for default naming
 _group_count = 0
@@ -280,7 +287,11 @@ def init_process_group(backend,
             store, rank, world_size = next(rendezvous(init_method))
 
         if backend == DistBackend.GLOO:
-            _default_pg = ProcessGroupGloo(store, rank, world_size)
+            _default_pg = ProcessGroupGloo(
+                store,
+                rank,
+                world_size,
+                timeout=_default_pg_timeout)
             _pg_map[_default_pg] = (DistBackend.GLOO, store)
             _pg_names[_default_pg] = group_name
         elif backend == DistBackend.NCCL:
@@ -330,7 +341,11 @@ def _new_process_group_helper(world_size,
         store = PrefixStore(group_name, default_store)
 
         if default_backend == DistBackend.GLOO:
-            pg = ProcessGroupGloo(store, rank, world_size)
+            pg = ProcessGroupGloo(
+                store,
+                rank,
+                world_size,
+                timeout=_default_pg_timeout)
             _pg_map[pg] = (DistBackend.GLOO, store)
             _pg_names[pg] = group_name
         elif default_backend == DistBackend.NCCL:


### PR DESCRIPTION
Summary:
The existing default timeout was set at 10 seconds, which is too low
for asynchronous tasks that depend on a barrier to resynchronize.
Having a single timeout for all operations is not ideal and this will
be addressed in future commits.

Differential Revision: D10558746
