### PR TITLE
Convert some docstrings from char* to char[]

### DIFF
--- a/caffe2/operators/channel_shuffle_op.cc
+++ b/caffe2/operators/channel_shuffle_op.cc
@@ -134,7 +134,7 @@ bool ChannelShuffleGradientOp<float, CPUContext>::RunOnDeviceWithOrderNHWC() {
 }
 
 REGISTER_CPU_OPERATOR(ChannelShuffle, ChannelShuffleOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(
+REGISTER_CPU_GRADIENT_OPERATOR(
     ChannelShuffleGradient,
     ChannelShuffleGradientOp<float, CPUContext>);
 
@@ -143,7 +143,7 @@ OPERATOR_SCHEMA(ChannelShuffle)
     .NumInputs(1)
     .NumOutputs(1)
     .InheritOnnxSchema();
-OPERATOR_SCHEMA(ChannelShuffleGradient)
+GRADIENT_OPERATOR_SCHEMA(ChannelShuffleGradient)
     .IdenticalTypeAndShape()
     .NumInputs(1)
     .NumOutputs(1);

--- a/caffe2/operators/clip_op.cc
+++ b/caffe2/operators/clip_op.cc
@@ -33,7 +33,7 @@ bool ClipGradientOp<float, CPUContext>::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(Clip, ClipOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(ClipGradient, ClipGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(ClipGradient, ClipGradientOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(Clip)
     .NumInputs(1)
@@ -113,7 +113,10 @@ Y: [[45. 20. 59. 60. 48.]
         "*(Tensor`<float>`)* Output tensor clipped within range [`min`, `max`].")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(ClipGradient).NumInputs(2).NumOutputs(1).AllowInplace({{1, 0}});
+GRADIENT_OPERATOR_SCHEMA(ClipGradient)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .AllowInplace({{1, 0}});
 
 class GetClipGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/conv_op.cc
+++ b/caffe2/operators/conv_op.cc
@@ -4,7 +4,7 @@
 
 namespace caffe2 {
 
-const char* kConvDoc = R"DOC(
+const char kConvDoc[] = R"DOC(
 The Conv2D operator computes a 2D convolution operation over an input blob $(X)$, with a filter blob $(filter)$ and a bias blob $(bias)$, and outputs a single output blob $(Y)$. Although there are several options for order, the convention is that the input $(X)$ is a blob of shape $(N,C_{in},H_{in},W_{in})$ and the output $(Y)$ is a blob of shape $(N,C_{out},H_{out},W_{out})$. Here, $N$ is the batch size, $C$ is the number of channels, $H$ is the spatial height, and $W$ is the spatial width. For example, if your input data was a batch of five, 100x120pixel RGB images, $X$ would have shape $(5,3,120,100)$.
 
 The $filter$ input blob may contain multiple filters and has shape $(M, C_{in}, K_H, K_W)$. Here, $M$ is the number of individual filters contained in the blob, $C_{in}$ is the number of channels of each filter (by convention in 2D convolution it is the same as the number of channels in the input), $K_H$ is the spatial height of the kernel, and $K_W$ is the spatial width of the kernel. The $bias$ blob is a vector of length $M$, where there is one bias for each filter in the $filter$ blob.

--- a/caffe2/operators/dropout_op.cc
+++ b/caffe2/operators/dropout_op.cc
@@ -58,7 +58,9 @@ bool DropoutGradientOp<float, CPUContext>::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(Dropout, DropoutOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(DropoutGrad, DropoutGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(
+    DropoutGrad,
+    DropoutGradientOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(Dropout)
     .NumInputs(1)
@@ -160,7 +162,7 @@ mask: [[False False False  True  True]
         "nonzero, this output is not filled.")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(DropoutGrad)
+GRADIENT_OPERATOR_SCHEMA(DropoutGrad)
     .NumInputs(1, 2)
     .NumOutputs(1)
     .AllowInplace({{0, 0}});

--- a/caffe2/operators/elementwise_ops_schema.cc
+++ b/caffe2/operators/elementwise_ops_schema.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 
 namespace {
 
-const char* kBroadcastDoc = R"DOC(
+const char kBroadcastDoc[] = R"DOC(
 If necessary the right-hand-side argument will be broadcasted to match the
 shape of left-hand-side argument. When broadcasting is specified, the second
 tensor can either be of size 1 (a scalar value), or having its shape as a
@@ -31,7 +31,7 @@ Github Links:
 
 )DOC";
 
-const char* kAddExample = R"DOC(
+const char kAddExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -77,7 +77,7 @@ C:
 
 )DOC";
 
-const char* kSubExample = R"DOC(
+const char kSubExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -123,7 +123,7 @@ C:
 
 )DOC";
 
-const char* kMulExample = R"DOC(
+const char kMulExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -169,7 +169,7 @@ C:
 
 )DOC";
 
-const char* kDivExample = R"DOC(
+const char kDivExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -357,7 +357,7 @@ For example, the following tensor shapes are supported:
         "If broadcasting is disabled it should be of the same size.")
     .Output(0, "C", "Result, has same dimensions and type as B");
 
-const char* kLTExample = R"DOC(
+const char kLTExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -396,7 +396,7 @@ C: [False False  True False False  True]
 </details>
 )DOC";
 
-const char* kLEExample = R"DOC(
+const char kLEExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -435,7 +435,7 @@ C: [ True False  True  True  True  True]
 </details>
 )DOC";
 
-const char* kGTExample = R"DOC(
+const char kGTExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -474,7 +474,7 @@ C: [False  True False False False False]
 </details>
 )DOC";
 
-const char* kGEExample = R"DOC(
+const char kGEExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -513,7 +513,7 @@ C: [ True  True False  True  True False]
 </details>
 )DOC";
 
-const char* kEQExample = R"DOC(
+const char kEQExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -550,7 +550,7 @@ C: [ True False False  True  True False]
 </details>
 )DOC";
 
-const char* kNEExample = R"DOC(
+const char kNEExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -650,7 +650,7 @@ CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(LE, "<=", "less or equal than", kLEExampl
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(GT, ">", "greater than", kGTExample);
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(GE, ">=", "greater or equal than", kGEExample);
 
-const char* kAndExample = R"DOC(
+const char kAndExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -698,7 +698,7 @@ C:
 </details>
 )DOC";
 
-const char* kOrExample = R"DOC(
+const char kOrExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>
@@ -746,7 +746,7 @@ C:
 </details>
 )DOC";
 
-const char* kXorExample = R"DOC(
+const char kXorExample[] = R"DOC(
 <details>
 
 <summary> <b>Example</b> </summary>

--- a/caffe2/operators/elu_op.cc
+++ b/caffe2/operators/elu_op.cc
@@ -42,7 +42,7 @@ REGISTER_CPU_OPERATOR(
         TensorTypes<float>,
         CPUContext,
         EluFunctor<CPUContext>>);
-REGISTER_CPU_OPERATOR(
+REGISTER_CPU_GRADIENT_OPERATOR(
     EluGradient,
     BinaryElementwiseWithArgsOp<
         TensorTypes<float>,
@@ -116,7 +116,7 @@ Y:
     .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
-OPERATOR_SCHEMA(EluGradient)
+GRADIENT_OPERATOR_SCHEMA(EluGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})

--- a/caffe2/operators/normalize_op.cc
+++ b/caffe2/operators/normalize_op.cc
@@ -66,10 +66,10 @@ Given a matrix, apply L2-normalization along the specified dimension.
 )DOC")
     .IdenticalTypeAndShape();
 
-REGISTER_CPU_OPERATOR(
+REGISTER_CPU_GRADIENT_OPERATOR(
     NormalizeGradient,
     NormalizeGradientOp<float, CPUContext>);
-OPERATOR_SCHEMA(NormalizeGradient)
+GRADIENT_OPERATOR_SCHEMA(NormalizeGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .Arg("axis", "axis to normalize");

--- a/caffe2/operators/pad_op.cc
+++ b/caffe2/operators/pad_op.cc
@@ -418,7 +418,9 @@ std::vector<TensorShape> PadImageOp<float, CPUContext>::PadTensorInference(
 }
 
 REGISTER_CPU_OPERATOR(PadImage, PadImageOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(PadImageGradient, PadImageGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(
+    PadImageGradient,
+    PadImageGradientOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(PadImage)
     .NumInputs(1)
@@ -444,7 +446,7 @@ values and stride sizes defined by the ConvPoolOpBase operator.
         "the tensor. Dimensions will vary based on various pad and stride "
         "sizes.");
 
-OPERATOR_SCHEMA(PadImageGradient).NumInputs(1).NumOutputs(1);
+GRADIENT_OPERATOR_SCHEMA(PadImageGradient).NumInputs(1).NumOutputs(1);
 
 class GetPadImageGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -728,7 +728,7 @@ bool PoolOp<T, Context, PoolType>::RunOnDeviceWithOrderNHWC() {
   }
   return true;
 }
-const char* kAveragePoolDoc = R"DOC(
+const char kAveragePoolDoc[] = R"DOC(
 consumes an input blob and applies average pooling across the the blob according
 to kernel sizes, stride sizes, pad lengths and dilation. Average pooling consists
 of taking the average value of a subset of the input tensor according to the kernel
@@ -797,7 +797,7 @@ Y:
 
 )DOC";
 
-const char* kMaxPoolDoc = R"DOC(
+const char kMaxPoolDoc[] = R"DOC(
 consumes an input blob and applies max pooling across the the blob according to
 kernel sizes, stride sizes, pad lengths and dilation. Max pooling consists of
 taking the maximum value of a subset of the input tensor according to the kernel

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -254,7 +254,9 @@ bool PReluGradientOp<float, CPUContext>::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(PRelu, PReluOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(PReluGradient, PReluGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(
+    PReluGradient,
+    PReluGradientOp<float, CPUContext>);
 
 // Input: X, Slope, output: Y
 OPERATOR_SCHEMA(PRelu)
@@ -335,7 +337,7 @@ Y:
     .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
-OPERATOR_SCHEMA(PReluGradient).NumInputs(4).NumOutputs(2).SetDoc(R"DOC(
+GRADIENT_OPERATOR_SCHEMA(PReluGradient).NumInputs(4).NumOutputs(2).SetDoc(R"DOC(
 
 PReluGradient takes both Y and dY and uses this to update dX and dW according
 to the chain rule and derivatives of the rectified linear function.

--- a/caffe2/operators/quant_decode_op.cc
+++ b/caffe2/operators/quant_decode_op.cc
@@ -6,7 +6,7 @@
 namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(QuantDecode, QuantDecodeOp<QuantDecodeRunTy::RUN_ALWAYS>);
-REGISTER_CPU_OPERATOR(QuantDecodeGradient, QuantDecodeGradientOp);
+REGISTER_CPU_GRADIENT_OPERATOR(QuantDecodeGradient, QuantDecodeGradientOp);
 #ifdef CAFFE2_USE_MPSCNN
 REGISTER_CPU_OPERATOR(
     MPSCNNQuantDecode,
@@ -42,7 +42,7 @@ Output:
     .Output(1, "decoded_1", "Decoded tensor for codes_1 (float)")
     .Output(2, "decoded_n", "Decoded tensor for codes_n (float)");
 
-OPERATOR_SCHEMA(QuantDecodeGradient)
+GRADIENT_OPERATOR_SCHEMA(QuantDecodeGradient)
     .NumInputs([](int in) { return in >= 3 && in % 2 == 1; })
     .NumOutputs(1);
 

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -67,7 +67,7 @@ REGISTER_CPU_OPERATOR(
         TensorTypes<float>,
         CPUContext,
         ReluFunctor<CPUContext>>);
-REGISTER_CPU_OPERATOR(
+REGISTER_CPU_GRADIENT_OPERATOR(
     ReluGradient,
     BinaryElementwiseOp<
         TensorTypes<float>,
@@ -140,7 +140,7 @@ Y:
     .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
-OPERATOR_SCHEMA(ReluGradient)
+GRADIENT_OPERATOR_SCHEMA(ReluGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})

--- a/caffe2/operators/resize_op.cc
+++ b/caffe2/operators/resize_op.cc
@@ -151,8 +151,9 @@ bool ResizeNearestGradientOp<float, CPUContext>::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(ResizeNearest, ResizeNearestOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(ResizeNearestGradient,
-                      ResizeNearestGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(
+    ResizeNearestGradient,
+    ResizeNearestGradientOp<float, CPUContext>);
 
 // Input: X, output: Y
 OPERATOR_SCHEMA(ResizeNearest)
@@ -176,7 +177,7 @@ output_height = floor(output_height * height_scale)
     .InheritOnnxSchema("Upsample");
 
 // Input: dY, output: dX
-OPERATOR_SCHEMA(ResizeNearestGradient)
+GRADIENT_OPERATOR_SCHEMA(ResizeNearestGradient)
     .NumInputs(2, 3)
     .NumOutputs(1)
     .Arg("width_scale", "Scale along width dimension")

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -4,7 +4,7 @@
 namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(Slice, SliceOp<CPUContext>);
-REGISTER_CPU_OPERATOR(SliceGradient, SliceGradientOp<CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(SliceGradient, SliceGradientOp<CPUContext>);
 
 OPERATOR_SCHEMA(Slice)
     .NumInputs(1, 3)
@@ -112,7 +112,7 @@ Y:
     .Output(0, "Y", "(*Tensor*): sliced output tensor")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(SliceGradient);
+GRADIENT_OPERATOR_SCHEMA(SliceGradient);
 
 namespace {
 struct GetSliceGradient : public GradientMakerBase {

--- a/caffe2/operators/softmax_op.cc
+++ b/caffe2/operators/softmax_op.cc
@@ -79,7 +79,9 @@ bool SoftmaxGradientOp<float, CPUContext>::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(Softmax, SoftmaxOp<float, CPUContext>);
-REGISTER_CPU_OPERATOR(SoftmaxGradient, SoftmaxGradientOp<float, CPUContext>);
+REGISTER_CPU_GRADIENT_OPERATOR(
+    SoftmaxGradient,
+    SoftmaxGradientOp<float, CPUContext>);
 
 OPERATOR_SCHEMA(Softmax)
     .NumInputs(1)
@@ -163,7 +165,7 @@ softmax: [[0.24422921 0.43525138 0.18582782 0.12303016 0.01166145]]
     .InheritOnnxSchema();
 
 // Input: Y, dY. Output: dX
-OPERATOR_SCHEMA(SoftmaxGradient).NumInputs(2).NumOutputs(1);
+GRADIENT_OPERATOR_SCHEMA(SoftmaxGradient).NumInputs(2).NumOutputs(1);
 
 class GetSoftmaxGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/softsign_op.cc
+++ b/caffe2/operators/softsign_op.cc
@@ -40,7 +40,7 @@ REGISTER_CPU_OPERATOR(
         TensorTypes<float>,
         CPUContext,
         SoftsignFunctor<CPUContext>>);
-REGISTER_CPU_OPERATOR(
+REGISTER_CPU_GRADIENT_OPERATOR(
     SoftsignGradient,
     BinaryElementwiseOp<
         TensorTypes<float>,
@@ -108,7 +108,7 @@ Y:
     .Output(0, "output", "Output data blob with same shape as input")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(SoftsignGradient)
+GRADIENT_OPERATOR_SCHEMA(SoftsignGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})


### PR DESCRIPTION
Summary:
Gold (the linker) isn't able to gc unreferenced string constants, but
converting these to arrays puts them in their own data sections and reduces
(Android) binary size as a result.

I'm told even in server builds, this reduces binary size by a few dozen bytes
and speeds up startup by a few hundred ns. :-P

Reviewed By: Yangqing

Differential Revision: D10510808
