### PR TITLE
Add new NeuralNetOps for fusion

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpClasses.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Generated/OpClasses.h
@@ -639,13 +639,23 @@ class ChannelShuffle : public NeuralNetOperator {
 
 class Add : public NeuralNetOperator {
  public:
-  Add() : NeuralNetOperator(NNKind::Add) {}
+  Add(int broadcast = 0)
+      : NeuralNetOperator(NNKind::Add), broadcast_(broadcast) {}
 
   ~Add() {}
 
   NOMNIGRAPH_DEFINE_NN_RTTI(Add);
 
+  int getBroadcast() const {
+    return broadcast_;
+  }
+
+  void setBroadcast(int broadcast) {
+    broadcast_ = broadcast;
+  }
+
  private:
+  int broadcast_;
 };
 
 class Reshape : public NeuralNetOperator {

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -428,6 +428,38 @@ CAFFE2_API bool hasInputs(NNGraph::NodeRef n);
 CAFFE2_API std::vector<NNGraph::NodeRef> getInputs(NNGraph::NodeRef n);
 CAFFE2_API std::vector<NNGraph::NodeRef> getOutputs(NNGraph::NodeRef n);
 
+// Get the name of the node regardless of underlying type.
+CAFFE2_API std::string getName(NNGraph::NodeRef n);
+
+CAFFE2_API void deleteSubgraph(NNModule* nn, NNGraph::SubgraphType& sg);
+
+// Replace the producer of the first argument with the second argument
+CAFFE2_API void replaceProducer(
+    NNGraph::NodeRef tensorNode,
+    NNGraph::NodeRef newProducer);
+// Set all consumers of first argument to consume the second argument
+CAFFE2_API void replaceAllUsesWith(
+    NNGraph::NodeRef oldTensorNode,
+    NNGraph::NodeRef newTensorNode);
+// Set the second argument to consume the inputs of the first argument
+CAFFE2_API void replaceAsConsumer(
+    NNGraph::NodeRef oldConsumer,
+    NNGraph::NodeRef newConsumer);
+
+// Create an output tensor node
+CAFFE2_API NNGraph::NodeRef
+createOutput(NNModule* nn, NNGraph::NodeRef producer, std::string name);
+
+// Hack for windows compiler.
+template <typename T, typename... Args>
+CAFFE2_API NNGraph::NodeRef createOperator(NNModule* nn, Args... args);
+
+// Create an operator
+template <typename T, typename... Args>
+NNGraph::NodeRef createOperator(NNModule* nn, Args... args) {
+  return nn->dataFlow.createNode(util::make_unique<T>(args...));
+}
+
 CAFFE2_API void coalesceInsertedDataDependencies(repr::NNModule* m);
 
 template <NNGraph* G>

--- a/caffe2/core/nomnigraph/ops.def
+++ b/caffe2/core/nomnigraph/ops.def
@@ -63,6 +63,7 @@ Concat
 Softmax
 ChannelShuffle
 Add
+- Broadcast : int : 0
 Reshape
 Flatten
 

--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -84,10 +84,14 @@ OperatorDef Converter::convertToOperatorDef(
     const nom::repr::NeuralNetOperator* nnOp) {
   auto* annotation = nnOp->getAnnotation();
   // Default to using the stored operator.
-  if (isa<Caffe2Annotation>(annotation)) {
+  if (annotation && isa<Caffe2Annotation>(annotation)) {
     return dyn_cast<Caffe2Annotation>(annotation)->getOperatorDef();
   }
-  CAFFE_THROW("TODO: Cannot yet instantiate OperatorDef from nomnigraph");
+  LOG(WARNING)
+      << "Cannot instantiate this OperatorDef from nomnigraph, falling back";
+  caffe2::OperatorDef op;
+  op.set_type(nnOp->getName());
+  return op;
 }
 
 std::vector<int> getKernelShape(std::map<std::string, caffe2::Argument> argMap) {
@@ -156,11 +160,13 @@ class ClipConverter : public Converter {
     float max = std::numeric_limits<float>::max();
 
     if (argMap.count("min")) {
-      min = static_cast<float>(argMap["min"].i());
+      CAFFE_ENFORCE(argMap["min"].has_f(), "Invalid 'min' argument");
+      min = static_cast<float>(argMap["min"].f());
     }
 
     if (argMap.count("max")) {
-      max = static_cast<float>(argMap["max"].i());
+      CAFFE_ENFORCE(argMap["max"].has_f(), "Invalid 'max' argument");
+      max = static_cast<float>(argMap["max"].f());
     }
 
     return util::make_unique<repr::Clip>(min, max);
@@ -363,13 +369,14 @@ repr::NNModule convertToNNModule(
 caffe2::OperatorDef convertToOperatorDef(
     const repr::NNGraph::NodeRef& instrNode) {
   auto *nnOp = repr::nn::get<repr::NeuralNetOperator>(instrNode);
+  auto op_type = nnOp->getName();
   auto *annotation = nnOp->getAnnotation();
   caffe2::OperatorDef op;
 
-  if (ConverterRegistry()->Has(op.type())) {
-    op = ConverterRegistry()->Create(op.type())->convertToOperatorDef(nnOp);
+  if (ConverterRegistry()->Has(op_type)) {
+    op = ConverterRegistry()->Create(op_type)->convertToOperatorDef(nnOp);
   } else if (!annotation) {
-    op.set_type(nnOp->getName());
+    op.set_type(op_type);
   } else {
     if (isa<Caffe2Annotation>(annotation)) {
       auto c2_annotation = dyn_cast<Caffe2Annotation>(annotation);


### PR DESCRIPTION
Summary:
Basic ops.def update and converter.cc updates
This is the standard way to ingest networks into nomnigraph

redo of D10412639

Reviewed By: ZolotukhinM

Differential Revision: D10560324
