### PR TITLE
Move stream to thread local

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -451,6 +451,12 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
             "In CopyFrom source and dest tensors must both be CPU for meta copy");
         data_type_.copy()(src.data(), raw_mutable_data(data_type_), numel());
       } else {
+        // The following copy uses the current (thread local) stream for copying
+        // and also takes the current GPU id previously set through CUDA API
+        // as we don't invoke SwitchToDevice anywhere
+        // TODO: this logic is overly complex and can be replaced with simple
+        // dispatch based on two device types
+        //
         // We'll need to use a non-CPU context to perform the copy if
         // one of the context is not CPU since only non-CPU context
         // knows how to copy between CPU and that context

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -55,7 +55,24 @@ class CAFFE2_CUDA_API ThreadLocalCUDAObjects {
 #ifdef CAFFE2_USE_CUDNN
       cudnn_handles_[i] = vector<cudnnHandle_t>();
 #endif // CAFFE2_USE_CUDNN
+      current_stream_id_[i] = 0;
     }
+  }
+
+  // Record current stream id for the current thread.
+  // This is the new API we're trying to migrate use cases to and get rid of
+  // explicit stream id passing. For now it's invoked in
+  // CUDAContext::SwitchToDevice
+  void SetCurrentStreamId(int gpu, int stream_id) {
+    // TODO: use current device id from thread local instead of passing gpu in
+    current_stream_id_[gpu] = stream_id;
+  }
+
+  // Uses the logical stream id from the thread local to pick the stream
+  // We're going to migrate all usages to this case API instead of passing the
+  // stream id directly
+  cudaStream_t GetStream(int gpu) {
+    return GetStream(gpu, current_stream_id_[gpu]);
   }
 
   cudaStream_t GetStream(int gpu, int stream_id) {
@@ -69,6 +86,13 @@ class CAFFE2_CUDA_API ThreadLocalCUDAObjects {
           &gpu_streams[stream_id], cudaStreamNonBlocking));
     }
     return gpu_streams[stream_id];
+  }
+
+  // Uses the logical stream id from the thread local to pick the stream
+  // We're going to migrate all usages to this case API instead of passing the
+  // stream id directly
+  cublasHandle_t GetHandle(int gpu) {
+    return GetHandle(gpu, current_stream_id_[gpu]);
   }
 
   cublasHandle_t GetHandle(int gpu, int stream_id) {
@@ -91,6 +115,13 @@ class CAFFE2_CUDA_API ThreadLocalCUDAObjects {
   }
 
 #ifdef CAFFE2_USE_CUDNN
+  // Uses the logical stream id from the thread local to pick the stream
+  // We're going to migrate all usages to this case API instead of passing the
+  // stream id directly
+  cudnnHandle_t GetCudnnHandle(int gpu) {
+    return GetCudnnHandle(gpu, current_stream_id_[gpu]);
+  }
+
   cudnnHandle_t GetCudnnHandle(int gpu, int stream_id) {
     DeviceGuard guard(gpu);
     vector<cudnnHandle_t>& gpu_handles = cudnn_handles_[gpu];
@@ -133,6 +164,7 @@ class CAFFE2_CUDA_API ThreadLocalCUDAObjects {
 #ifdef CAFFE2_USE_CUDNN
   vector<cudnnHandle_t> cudnn_handles_[CAFFE2_COMPILE_TIME_MAX_GPUS];
 #endif // CAFFE2_USE_CUDNN
+  int current_stream_id_[CAFFE2_COMPILE_TIME_MAX_GPUS];
 };
 
 class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
@@ -147,11 +179,17 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     if (curand_generator_) {
       CURAND_CHECK(curandDestroyGenerator(curand_generator_));
     }
+    // CUDAContext is used in 2 cases now:
+    // - long-lived instance inside OperatorBase in which case what happens in
+    //   destructor doesn't really matter
+    // - short-lived on-the-fly instances that are utilized as CUDAGuard - in
+    //   this case there's only one stream id (passed to SwitchToDevice) and
+    //   it's preferrable to synchronize in the destructor
     FinishDeviceComputation();
   }
 
   inline void SwitchToDevice(int stream_id) override {
-    set_stream_id(stream_id);
+    getCudaObjects().SetCurrentStreamId(gpu_id_, stream_id);
     CaffeCudaSetDevice(gpu_id_);
   }
 
@@ -166,8 +204,11 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     ev->Record(CUDA, this, err_msg);
   }
 
+  // Note on current use cases:
+  // FinishDeviceComputation must be called on the same cpu thread as
+  // SwitchToDevice()
   void FinishDeviceComputation() override {
-    cudaStreamSynchronize(getCudaObjects().GetStream(gpu_id_, stream_id_));
+    cudaStreamSynchronize(getCudaObjects().GetStream(gpu_id_));
     cudaError_t error = cudaGetLastError();
     if (error != cudaSuccess) {
       CAFFE_THROW("Encountered CUDA error: ", cudaGetErrorString(error));
@@ -178,12 +219,8 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     return gpu_id_;
   }
 
-  inline cudaStream_t cuda_stream() {
-    return cuda_stream(gpu_id_, stream_id_);
-  }
-
   inline cudaStream_t cuda_stream() const {
-    return cuda_stream(gpu_id_, stream_id_);
+    return getCudaObjects().GetStream(gpu_id_);
   }
 
   static cudaStream_t cuda_stream(int gpu_id, int stream_id) {
@@ -191,12 +228,12 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   }
 
   cublasHandle_t cublas_handle() {
-    return getCudaObjects().GetHandle(gpu_id_, stream_id_);
+    return getCudaObjects().GetHandle(gpu_id_);
   }
 
 #ifdef CAFFE2_USE_CUDNN
   cudnnHandle_t cudnn_handle() {
-    return getCudaObjects().GetCudnnHandle(gpu_id_, stream_id_);
+    return getCudaObjects().GetCudnnHandle(gpu_id_);
   }
 #endif // CAFFE2_USE_CUDNN
 
@@ -234,7 +271,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
         src,
         nbytes,
         cudaMemcpyDefault,
-        getCudaObjects().GetStream(gpu_id_, stream_id_)));
+        getCudaObjects().GetStream(gpu_id_)));
   }
 
   void CopyBytesSameDevice(size_t nbytes, const void* src, void* dst) override {
@@ -290,12 +327,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   }
 
  protected:
-  void set_stream_id(int stream_id) {
-    stream_id_ = stream_id;
-  }
-
   int gpu_id_;
-  int stream_id_ = 0;
   int random_seed_;
   curandGenerator_t curand_generator_{nullptr};
   static ThreadLocalCUDAObjects& getCudaObjects();

--- a/caffe2/core/context_gpu_test.cc
+++ b/caffe2/core/context_gpu_test.cc
@@ -97,6 +97,36 @@ TEST(CUDAContextTest, TestSameThreadSameObject) {
   EXPECT_NE(context_a.curand_generator(), context_b.curand_generator());
 }
 
+TEST(CUDAContextTest, TestSameThreadTempObject) {
+  if (!HasCudaGPU())
+    return;
+  CUDAContext context_outer(0); // gpu id
+  context_outer.SwitchToDevice(0); // logical stream id
+
+  auto before_stream = context_outer.cuda_stream();
+
+  // try to mess up current device
+  CUDAContext context_different_device(1);
+  context_different_device.SwitchToDevice(10);
+
+  // go back
+  context_outer.SwitchToDevice(0); // logical stream id
+  EXPECT_EQ(context_outer.cuda_stream(), before_stream);
+
+  // do nothing - infers the current device and stream
+  CUDAContext context_noop;
+  EXPECT_EQ(context_outer.cuda_stream(), before_stream);
+  EXPECT_EQ(context_noop.cuda_stream(), before_stream);
+
+  // override stream - the previous context is not valid any more until
+  // SwitchToDevice is called again (needs to be refactored into proper guard)
+  CUDAContext context_override;
+  context_override.SwitchToDevice(1); // logical stream id
+  EXPECT_NE(context_override.cuda_stream(), before_stream);
+  // note, that accessing streams from context_outer and context_noop is not
+  // semantically valid any more
+}
+
 TEST(CUDAContextTest, TestSameThreadDifferntObjectIfDifferentDevices) {
   if (NumCudaDevices() > 1) {
     CUDAContext context_a(0);

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -345,7 +345,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     return !event_;
   }
 
-  virtual void FinishDeviceComputation() {
+  // Internal API invoked by observers. Normal callers shouldn't invoke it.
+  virtual void SyncDeviceBarrierForObservers() {
     CAFFE_NOT_IMPLEMENTED;
   }
 
@@ -613,7 +614,7 @@ class Operator : public OperatorBase {
     return HasAsyncPart() && context_.SupportsAsyncScheduling();
   }
 
-  void FinishDeviceComputation() override {
+  void SyncDeviceBarrierForObservers() override {
     context_.FinishDeviceComputation();
   }
 


### PR DESCRIPTION
Summary:
This is the first step to untangle this logic:
- moves stream id to thread local mechanically
- relies on the fact that the value of thread local is valid in conjunction with CUDAContext only until the next SwitchToDevice is called - we should move to proper RAII in the following diffs

Follow up diffs are going to move more stuff outside of CUDAContext (by making gpu_id thread local too) and simplify the CopyFrom.

The only expected change in behavior is that before CopyFrom would do copy on stream logical id 0 if the context was created on the fly and now it'd do so on the current stream. Since it'd block explicitly, I don't think it matters much.

Also, observers were semi-broken by waiting on the potentially wrong stream. It can be fixed later - I renamed the method to avoid abuse.

Differential Revision: D10525134
