### PR TITLE
Allow check_compiler_abi_compatibility to check c++ version

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -125,7 +125,7 @@ def check_compiler_abi_compatibility(compiler):
         warnings.warn('Error checking compiler version: {}'.format(error))
     else:
         info = info.decode().lower()
-        if 'gcc' in info or 'g++' in info:
+        if 'gcc' in info or 'g++' in info or 'c++' in info:
             # Sometimes the version is given as "major.x" instead of semver.
             version = re.search(r'(\d+)\.(\d+|x)', info)
             if version is not None:


### PR DESCRIPTION
In `torch.utils.cpp_extension`, the default compiler binary on unix is `"c++"`: 

https://github.com/pytorch/pytorch/blob/master/torch/utils/cpp_extension.py#L746

However `check_compiler_abi_compatibility` only checks version info for `"gcc"` and `"g++"`; if the compiler is "`c++`" then it doesn't even try to check for compatible versions and a warning is always issued.

On many systems `c++` is symlinked to `g++`, so the version checking logic should also apply when the default compiler `"c++"` is selected.