### PR TITLE
Change explicit usages of at::optional to c10::optional

### DIFF
--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ATen/optional.h>
 #include <ATen/ScalarType.h>
+#include <c10/util/Optional.h>
 #include <sstream>
 #include <vector>
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -6,7 +6,7 @@
 
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 namespace at { namespace native { namespace {
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.h
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.h
@@ -2,7 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
-#include <ATen/optional.h>
+#include <c10/util/Optional.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/optional.h
+++ b/aten/src/ATen/optional.h
@@ -1,1 +1,0 @@
-#include "c10/util/Optional.h"

--- a/aten/src/ATen/test/cuda_optional_test.cu
+++ b/aten/src/ATen/test/cuda_optional_test.cu
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "ATen/ATen.h"
-#include "ATen/optional.h"
+#include "c10/util/Optional.h"
 
 #include <assert.h>
 

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1031,7 +1031,8 @@ struct hash<c10::optional<T&>> {
 };
 } // namespace std
 
-// TODO: remove at::optional when done moving files
+// Plan on record is to land 'using namespace c10' to bridge c10 into at:: and
+// caffe2:: namespaces. Until that lands, proceeding one name at a time.
 namespace at {
 template <class T>
 using optional = c10::optional<T>;

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -70,7 +70,7 @@ struct InfiniteStreamDataset
 
 struct BatchSizeSampler : samplers::Sampler {
   void reset() override {}
-  at::optional<std::vector<size_t>> next(size_t batch_size) override {
+  c10::optional<std::vector<size_t>> next(size_t batch_size) override {
     return {{batch_size}};
   }
 };

--- a/test/cpp/api/memory.cpp
+++ b/test/cpp/api/memory.cpp
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/utils/memory.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 struct TestValue {
   explicit TestValue(const int& x) : lvalue_(x) {}

--- a/torch/csrc/api/include/torch/data/samplers/random.h
+++ b/torch/csrc/api/include/torch/data/samplers/random.h
@@ -3,7 +3,7 @@
 #include <torch/data/samplers/base.h>
 #include <torch/tensor.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <algorithm>
 #include <cstddef>

--- a/torch/csrc/api/include/torch/data/samplers/sequential.h
+++ b/torch/csrc/api/include/torch/data/samplers/sequential.h
@@ -3,7 +3,7 @@
 #include <torch/data/samplers/base.h>
 #include <torch/tensor.h>
 
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <algorithm>
 #include <cstddef>

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -216,7 +216,11 @@ std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name
   return ret;
 }
 
-void VariableType::backward(Tensor & self, at::optional<Tensor> gradient, bool keep_graph, bool create_graph) const {
+void VariableType::backward(
+    Tensor& self,
+    c10::optional<Tensor> gradient,
+    bool keep_graph,
+    bool create_graph) const {
   as_variable_ref(self).backward(gradient, keep_graph, create_graph);
 }
 

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -1,3 +1,4 @@
+#include "c10/util/Optional.h"
 #include "torch/csrc/autograd/VariableTypeUtils.h"
 
 using namespace at;

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -68,8 +68,8 @@ void reduce(
     std::vector<at::Tensor>& outputs,
     int32_t root = 0,
     int32_t op = ncclSum,
-    at::optional<std::vector<at::cuda::CUDAStream>> streams = c10::nullopt,
-    at::optional<std::vector<ncclComm_t>> user_comms = c10::nullopt);
+    c10::optional<std::vector<at::cuda::CUDAStream>> streams = c10::nullopt,
+    c10::optional<std::vector<ncclComm_t>> user_comms = c10::nullopt);
 
 void reduce(
     std::vector<at::Tensor>& inputs,

--- a/torch/csrc/distributed/c10d/ddp.h
+++ b/torch/csrc/distributed/c10d/ddp.h
@@ -3,7 +3,7 @@
 #include <c10d/ProcessGroup.hpp>
 
 #include <ATen/ATen.h>
-#include <ATen/optional.h>
+#include "c10/util/Optional.h"
 
 #include <cstddef>
 #include <memory>

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -435,10 +435,10 @@ struct Module {
   void save(const std::string& filename);
 
  private:
-   void to_impl(
-       at::optional<at::Device> device,
-       at::optional<at::ScalarType> dtype,
-       bool non_blocking);
+  void to_impl(
+      c10::optional<at::Device> device,
+      c10::optional<at::ScalarType> dtype,
+      bool non_blocking);
 
   // invariant: to ensure member_inputs of Methods stay valid,
   // it is only legal to _add_ new modules and parameters.


### PR DESCRIPTION
Summary: Follow up of D10511254. For these cases we can move to preferred `optional` without namespace right away.

Differential Revision: D10844117
