### PR TITLE
[CUDA/NCCL] Eliminate CUDAStream nullptr in NCCL

### DIFF
--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -1,12 +1,12 @@
 #include "python_nccl.h"
 
 #include "nccl.h"
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/Exceptions.h"
 #include "torch/csrc/THP.h"
 #include "torch/csrc/Types.h"
-#include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/cuda/THCP.h"
 #include "torch/csrc/cuda/nccl.h"
-#include "torch/csrc/Exceptions.h"
 #include "torch/csrc/utils/functional.h"
 
 #include <nccl.h>
@@ -21,11 +21,11 @@ using namespace torch::cuda::nccl::detail;
 
 static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
 
-PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_version(PyObject* self, PyObject* args) {
   return PyInt_FromLong(version());
 }
 
-PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_unique_id(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   ncclUniqueId id;
   NCCL_CHECK(ncclGetUniqueId(&id));
@@ -34,8 +34,10 @@ PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args) {
 }
 
 static ncclComm_t unpack_nccl_comm(PyObject* capsule) {
-  ncclComm_t comm = (ncclComm_t)PyCapsule_GetPointer(capsule, COMM_CAPSULE_NAME);
-  if (!comm) throw python_error();
+  ncclComm_t comm =
+      (ncclComm_t)PyCapsule_GetPointer(capsule, COMM_CAPSULE_NAME);
+  if (!comm)
+    throw python_error();
   return comm;
 }
 
@@ -52,9 +54,7 @@ static void destroy_nccl_comm(PyObject* capsule) {
 
   HANDLE_TH_ERRORS
   ncclComm_t comm = unpack_nccl_comm(capsule);
-  with_no_gil([&]{
-    ncclCommDestroy(comm);
-  });
+  with_no_gil([&] { ncclCommDestroy(comm); });
   END_HANDLE_TH_ERRORS_RET()
 }
 
@@ -64,7 +64,8 @@ static std::vector<THCStream*> unpack_streams(PyObject* obj, size_t size) {
   }
   auto streams = THPUtils_PySequence_to_THCStreamList(obj);
   if (streams.size() != size) {
-    throw std::runtime_error("number of streams is not equal to number of inputs");
+    throw std::runtime_error(
+        "number of streams is not equal to number of inputs");
   }
   return streams;
 }
@@ -77,10 +78,11 @@ static std::vector<ncclComm_t> unpack_comms(PyObject* obj, size_t size) {
   }
   std::vector<ncclComm_t> comms;
   if (PyCapsule_CheckExact(obj)) {
-    comms = { unpack_nccl_comm(obj) };
+    comms = {unpack_nccl_comm(obj)};
   } else {
     auto seq = THPObjectPtr(PySequence_Fast(obj, "comm is not a sequence"));
-    if (!seq) throw python_error();
+    if (!seq)
+      throw python_error();
     auto size = PySequence_Fast_GET_SIZE(seq.get());
     comms = std::vector<ncclComm_t>(size);
     for (int64_t i = 0; i < size; i++) {
@@ -88,54 +90,70 @@ static std::vector<ncclComm_t> unpack_comms(PyObject* obj, size_t size) {
     }
   }
   if (comms.size() != size) {
-    throw std::runtime_error("number of communicators is not equal to number of inputs");
+    throw std::runtime_error(
+        "number of communicators is not equal to number of inputs");
   }
   return comms;
 }
 
-PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_init_rank(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   int nranks;
   const char* id;
   Py_ssize_t id_len;
   int rank;
 
-  if (!PyArg_ParseTuple(args, "is#i:nccl_init_rank", &nranks, &id, &id_len, &rank)) {
+  if (!PyArg_ParseTuple(
+          args, "is#i:nccl_init_rank", &nranks, &id, &id_len, &rank)) {
     return nullptr;
   }
-  THPUtils_assert(id_len == NCCL_UNIQUE_ID_BYTES,
+  THPUtils_assert(
+      id_len == NCCL_UNIQUE_ID_BYTES,
       "invalid unqiue_id (expected %d bytes, got %zd)",
-      NCCL_UNIQUE_ID_BYTES, id_len);
+      NCCL_UNIQUE_ID_BYTES,
+      id_len);
 
   ncclUniqueId commId;
   memcpy(&commId, id, NCCL_UNIQUE_ID_BYTES);
   ncclComm_t comm;
-  with_no_gil([&]{
-    NCCL_CHECK(ncclCommInitRank(&comm, nranks, commId, rank));
-  });
+  with_no_gil(
+      [&] { NCCL_CHECK(ncclCommInitRank(&comm, nranks, commId, rank)); });
   return PyCapsule_New(comm, COMM_CAPSULE_NAME, &destroy_nccl_comm);
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_reduce(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject *_inputs, *_outputs, *_streams, *_comms;
   int root, op;
 
-  if (!PyArg_ParseTuple(args, "OOiiOO", &_inputs, &_outputs, &root, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, nullptr, "nccl_reduce", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int root,"
-            " int op, sequence[torch.cuda.Stream or None]");
+  if (!PyArg_ParseTuple(
+          args,
+          "OOiiOO",
+          &_inputs,
+          &_outputs,
+          &root,
+          &op,
+          &_streams,
+          &_comms)) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "nccl_reduce",
+        1,
+        "(sequence[Tensor] inputs, sequence[Tensor] outputs, int root,"
+        " int op, sequence[torch.cuda.Stream or None]");
     return nullptr;
   }
 
   std::vector<at::Tensor> inputs = extract_tensors(_inputs);
   std::vector<at::Tensor> outputs = extract_tensors(_outputs);
   std::vector<THCStream*> thc_streams = unpack_streams(_streams, inputs.size());
-  std::vector<at::cuda::CUDAStream> streams = fmap<at::cuda::CUDAStream>(thc_streams);
+  std::vector<at::cuda::CUDAStream> streams =
+      fmap<at::cuda::CUDAStream>(thc_streams);
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  with_no_gil([&]{
+  with_no_gil([&] {
     torch::cuda::nccl::reduce(inputs, outputs, root, op, streams, user_comms);
   });
 
@@ -143,13 +161,18 @@ PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_all_reduce(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject *_inputs, *_outputs, *_streams, *_comms;
   int op;
 
-  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, nullptr, "nccl_all_reduce", 1,
+  if (!PyArg_ParseTuple(
+          args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "nccl_all_reduce",
+        1,
         "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op,"
         " sequence[torch.cuda.Stream] streams,"
         " sequence[torch.cuda.nccl.Communicator] comms)");
@@ -161,7 +184,7 @@ PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
   auto streams = unpack_streams(_streams, inputs.size());
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  with_no_gil([&]{
+  with_no_gil([&] {
     _check_inputs(inputs, outputs, 1, 1);
     size_t len = inputs.size();
 
@@ -169,15 +192,24 @@ PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
 
     int64_t count = inputs[0].numel();
     std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    auto comms = user_comms.empty() ? _get_communicators(inputs)
+                                    : ArrayRef<ncclComm_t>(user_comms);
     at::DeviceGuard device_guard;
     AutoNcclGroup nccl_group_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();
       device_guard.set_index(device);
-      auto stream = (streams[i] == nullptr) ? nullptr : THCStream_stream(streams[i]);
-      NCCL_CHECK(ncclAllReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+      auto stream = (streams[i] == nullptr)
+          ? at::cuda::getCurrentCUDAStream(device).stream()
+          : THCStream_stream(streams[i]);
+      NCCL_CHECK(ncclAllReduce(
+          inputs[i].data_ptr(),
+          outputs[i].data_ptr(),
+          count,
+          data_type,
+          (ncclRedOp_t)op,
+          comms[i],
+          stream));
     }
   });
 
@@ -185,14 +217,18 @@ PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_broadcast(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject *_inputs, *_streams, *_comms;
   int root;
 
   if (!PyArg_ParseTuple(args, "OiOO", &_inputs, &root, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, nullptr, "nccl_broadcast", 1,
-			      "(sequence[Tensor] inputs, int root)");
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "nccl_broadcast",
+        1,
+        "(sequence[Tensor] inputs, int root)");
     return nullptr;
   }
 
@@ -201,21 +237,25 @@ PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
   auto streams = unpack_streams(_streams, inputs.size());
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  with_no_gil([&]{
-    torch::cuda::nccl::broadcast(inputs, streams, user_comms);
-  });
+  with_no_gil(
+      [&] { torch::cuda::nccl::broadcast(inputs, streams, user_comms); });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_all_gather(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject *_inputs, *_outputs, *_streams, *_comms;
 
-  if (!PyArg_ParseTuple(args, "OOOO", &_inputs, &_outputs, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, nullptr, "nccl_all_gather", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs");
+  if (!PyArg_ParseTuple(
+          args, "OOOO", &_inputs, &_outputs, &_streams, &_comms)) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "nccl_all_gather",
+        1,
+        "(sequence[Tensor] inputs, sequence[Tensor] outputs");
     return nullptr;
   }
 
@@ -224,7 +264,7 @@ PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
   auto streams = unpack_streams(_streams, inputs.size());
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  with_no_gil([&]{
+  with_no_gil([&] {
     size_t len = inputs.size();
     _check_inputs(inputs, outputs, len, 1);
 
@@ -232,20 +272,33 @@ PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
 
     int64_t count = inputs[0].numel();
     std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    auto comms = user_comms.empty() ? _get_communicators(inputs)
+                                    : ArrayRef<ncclComm_t>(user_comms);
     at::DeviceGuard device_guard;
     AutoNcclGroup nccl_group_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();
       device_guard.set_index(device);
-      auto stream = (streams[i] == nullptr) ? nullptr : THCStream_stream(streams[i]);
-    #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-      NCCL_CHECK(ncclAllGather(inputs[i].data_ptr(), outputs[i].data_ptr(),
-        count, data_type, comms[i], stream));
-    #else
-      NCCL_CHECK(ncclAllGather(inputs[i].data_ptr(), count, data_type,
-        outputs[i].data_ptr(), comms[i], stream));
-    #endif
+      auto stream = (streams[i] == nullptr)
+          ? at::cuda::getCurrentCUDAStream(device).stream()
+          : THCStream_stream(streams[i]);
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+      NCCL_CHECK(ncclAllGather(
+          inputs[i].data_ptr(),
+          outputs[i].data_ptr(),
+          count,
+          data_type,
+          comms[i],
+          stream));
+#else
+      NCCL_CHECK(ncclAllGather(
+          inputs[i].data_ptr(),
+          count,
+          data_type,
+          outputs[i].data_ptr(),
+          comms[i],
+          stream));
+#endif
     }
   });
 
@@ -253,14 +306,19 @@ PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
+PyObject* THCPModule_nccl_reduce_scatter(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject *_inputs, *_outputs, *_streams, *_comms;
   int op;
 
-  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, nullptr, "nccl_reduce_scatter", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op");
+  if (!PyArg_ParseTuple(
+          args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "nccl_reduce_scatter",
+        1,
+        "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op");
     return nullptr;
   }
 
@@ -269,7 +327,7 @@ PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
   auto streams = unpack_streams(_streams, inputs.size());
   auto user_comms = unpack_comms(_comms, inputs.size());
 
-  with_no_gil([&]{
+  with_no_gil([&] {
     size_t len = inputs.size();
     _check_inputs(inputs, outputs, 1, len);
 
@@ -277,15 +335,24 @@ PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
 
     int64_t count = inputs[0].numel() / len;
     std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    auto comms = user_comms.empty() ? _get_communicators(inputs)
+                                    : ArrayRef<ncclComm_t>(user_comms);
     at::DeviceGuard device_guard;
     AutoNcclGroup nccl_group_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();
       device_guard.set_index(device);
-      auto stream = (streams[i] == nullptr) ? nullptr : THCStream_stream(streams[i]);
-      NCCL_CHECK(ncclReduceScatter(inputs[i].data_ptr(), outputs[i].data_ptr(),
-          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+      auto stream = (streams[i] == nullptr)
+          ? at::cuda::getCurrentCUDAStream(device).stream()
+          : THCStream_stream(streams[i]);
+      NCCL_CHECK(ncclReduceScatter(
+          inputs[i].data_ptr(),
+          outputs[i].data_ptr(),
+          count,
+          data_type,
+          (ncclRedOp_t)op,
+          comms[i],
+          stream));
     }
   });
 
@@ -295,16 +362,18 @@ PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
 
 static std::vector<at::Tensor> extract_tensors(PyObject* obj) {
   auto seq = THPObjectPtr(PySequence_Fast(obj, "expected a sequence"));
-  if (!seq) throw python_error();
+  if (!seq)
+    throw python_error();
 
   std::vector<at::Tensor> list;
   Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
   for (Py_ssize_t i = 0; i < length; i++) {
     PyObject* item = PySequence_Fast_GET_ITEM(seq.get(), i);
     if (!THPVariable_Check(item)) {
-      throw TypeError("expected Tensor at %d (got %s)", (int)i, Py_TYPE(item)->tp_name);
+      throw TypeError(
+          "expected Tensor at %d (got %s)", (int)i, Py_TYPE(item)->tp_name);
     }
-    auto var = (THPVariable*) item;
+    auto var = (THPVariable*)item;
     list.emplace_back(var->cdata.data());
   }
   return list;


### PR DESCRIPTION
As the title says, we should always use the current stream on device in NCCL.

This can unblock @ezyang on his further work