### PR TITLE
remove namespace aliasing

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1031,12 +1031,6 @@ struct hash<c10::optional<T&>> {
 };
 } // namespace std
 
-// TODO: remove at::optional when done moving files
-namespace at {
-template <class T>
-using optional = c10::optional<T>;
-}
-
 #undef TR2_OPTIONAL_REQUIRES
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 


### PR DESCRIPTION
Summary:
As optional.h file move is already done, this diff explicitly removes
the aliasing to enforce the use of "c10::optional" in new code, or after
we explicitly do "using namespace c10", the use of unnamespaced "optional".

Technical reason: for unification we have followed the practice of moving
namespaces along the diffs. Such as D10513246 and D10050771. The enforcement
makes future better engineering easier: all explicit use of c10:: in namespace
caffe2 and namespace at can be mechanically removed, instead of having to do
one-by-one object checks.

Counterargument about possible breakage of dependent oss code: this is not
alone for this diff, as almost all diffs for c10 folder have this side effect.
It is NOT the task for this diff to ensure possible breakage as it is already
by definition going to be in a broken stage. No complaints have been filed,
meaning that this is a moot point. Eventually with the namespace inclusion
of c10 from caffe2 and at space, this concern will be gone.

Reviewed By: teng-li

Differential Revision: D10849120
