### PR TITLE
Turn some th_ prefixes into _th_ prefixes for conformity.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -147,7 +147,7 @@
     - THTensor* self
 ]]
 [[
-  name: th_clone
+  name: _th_clone
   cname: newClone
   return: THTensor*
   variants:
@@ -167,7 +167,7 @@
       long_args: True
 ]]
 [[
-  name: th_resize_as_
+  name: _th_resize_as_
   cname: resizeAs
   variants:
     - function
@@ -1639,7 +1639,7 @@
           default: "false"
 ]]
 [[
-  name: th_norm
+  name: _th_norm
   cname: norm
   types:
     - floating_point
@@ -1831,7 +1831,7 @@
     - THTensor* other
 ]]
 [[
-  name: th_pow
+  name: _th_pow
   cname: pow
   variants:
     - function
@@ -1986,7 +1986,7 @@
       default: 0
 ]]
 [[
-  name: th_zero_
+  name: _th_zero_
   cname: zero
   return: self
   variants:
@@ -3226,19 +3226,6 @@
         - THTensor* x
         - THTensor* alpha
         - THTensor* total
-]]
-[[
-  name: th_tensor
-  return: THTensor*
-  cpu_half: True
-  variants: [function]
-  options:
-    - cname: new
-      arguments: []
-    - cname: newWithSize
-      arguments:
-        - IntListSize size
-        - CONSTANT {}
 ]]
 [[
   name: tensor

--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -26,7 +26,7 @@ Tensor clone(const Tensor& self) {
   if (_has_native(self)) {
     return native_clone(self);
   } else {
-    return th_clone(self);
+    return _th_clone(self);
   }
 }
 
@@ -34,7 +34,7 @@ Tensor& resize_as_(Tensor& self, const Tensor& the_template) {
   if (_has_native(self)) {
     return native_resize_as_(self, the_template);
   } else {
-    return th_resize_as_(self, the_template);
+    return _th_resize_as_(self, the_template);
   }
 }
 
@@ -42,7 +42,7 @@ Tensor& pow_out(Tensor& result, const Tensor& self, Scalar exponent) {
   if (_has_native(self)) {
     return native_pow_out(result, self, exponent);
   } else {
-    return th_pow_out(result, self, exponent);
+    return _th_pow_out(result, self, exponent);
   }
 }
 
@@ -50,7 +50,7 @@ Tensor pow(const Tensor& self, Scalar exponent) {
   if (_has_native(self)) {
     return native_pow(self, exponent);
   } else {
-    return th_pow(self, exponent);
+    return _th_pow(self, exponent);
   }
 }
 
@@ -58,7 +58,7 @@ Tensor& zero_(Tensor& self) {
   if (_has_native(self)) {
     return native_zero_(self);
   } else {
-    return th_zero_(self);
+    return _th_zero_(self);
   }
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -628,14 +628,14 @@ Tensor _norm(const Tensor &self, Scalar p) {
              "norm only supports CPU AND CUDA backend, got: ", at::toString(self.type().backend()));
     AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
     if (self.is_cuda()) {
-      return at::th_norm(self, p);
+      return at::_th_norm(self, p);
     } else {
       if (self.is_contiguous()) {
         Tensor result = CPU(kFloat).scalarTensor(0).toType(self.type());
         norm_kernel(kCPU, result, self, p, c10::nullopt);
         return result;
       } else {
-        return at::th_norm(self, p);
+        return at::_th_norm(self, p);
       }
     }
   }


### PR DESCRIPTION
This is the same as https://github.com/pytorch/pytorch/pull/12889 with the addmm changes stripped out, since that appears to cause onnx broadcasting issues I don't understand.