### PR TITLE
bring caffe2::Tensor API closer to aten/pytorch

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -337,19 +337,27 @@ class CAFFE2_API Tensor final {
   /**
    * Returns the number of dimensions of the data.
    */
+  inline int dim() const {
+    return impl_->dim();
+  }
+
+  /**
+   * (To be deprecated) Returns the number of dimensions of the data.
+   */
   inline int ndim() const {
     return impl_->dim();
   }
 
   /**
-   * Returns the size (i.e. the number of items) of the tensor.
+   * (To be deprecated) Returns the size (i.e. the number of items) of the
+   * tensor.
    */
   inline int64_t size() const {
     return impl_->numel();
   }
 
   /**
-   * Returns the size (i.e. the number of items) of the tensor.
+   * Returns the number of items of the tensor.
    */
   inline int64_t numel() const {
     return impl_->numel();
@@ -375,6 +383,7 @@ class CAFFE2_API Tensor final {
     return impl_.get()->sizes();
   }
 
+  // To be deprecated
   inline at::IntList dims() const {
     return impl_.get()->sizes();
   }
@@ -429,6 +438,14 @@ class CAFFE2_API Tensor final {
   /**
    * Returns the TypeMeta object associated with the current data type.
    */
+  inline const TypeMeta& dtype() const {
+    return impl_->dtype();
+  }
+
+  /**
+   * (To be deprecated) Returns the TypeMeta object associated with the current
+   * data type.
+   */
   inline const TypeMeta& meta() const {
     return impl_->dtype();
   }
@@ -450,6 +467,11 @@ class CAFFE2_API Tensor final {
     return static_cast<int>(s);
   }
 
+  inline int64_t size(const int i) const {
+    return impl_->size(i);
+  }
+
+  // To be deprecated
   inline int64_t dim(const int i) const {
     return impl_->size(i);
   }


### PR DESCRIPTION
Summary:
For tensor, we plan to do the following renaming:
```
* t.ndim() → t.dim()
* t.size() → t.numel()
* dims() → t.sizes()
* t.meta() → t.dtype()
* t.dim(d) → t.size(d)
```
This diff adds new APIs in caffe2::Tensor so we can start codemod,
we'll remove old API after the codemod

Reviewed By: ezyang

Differential Revision: D10856028
