### PR TITLE
Fix python2 and python 3 compatibility found by lint.

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import, division, print_function, unicode_literals

--- a/torch/utils/_cpp_extension_versioner.py
+++ b/torch/utils/_cpp_extension_versioner.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import collections
 
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import warnings
 

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -1,5 +1,6 @@
 # This script outputs relevant system environment info
 # Run it with `python collect_env.py`.
+from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 import subprocess
 import sys

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import glob
 import imp

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 
 from torch._C import _from_dlpack as from_dlpack

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
+import sys
 import time
+
+if sys.version < '3.3':
+    # Note(jiayq): in Python 2, FileExistsError is not defined and the
+    # error manifests it as OSError.
+    FileExistsError = OSError
 
 
 class FileBaton:

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import time
 

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import collections
 import weakref
 import warnings

--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 
 import hashlib


### PR DESCRIPTION
Summary:
This is an example about the benefit of proper facebook linter. The old code
was not python 2.x (actually, pre-python 3.3) compatible. Note that FileExistsError
is added in Python 3.3:

https://stackoverflow.com/questions/20790580/python-specifically-handle-file-exists-exception

Differential Revision: D10858804
