### PR TITLE
Improve visual representation of NQL subgraphs

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
@@ -7,9 +7,12 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <queue>
 #include <sstream>
+#include <unordered_map>
 
-namespace {
+namespace nom {
+namespace converters {
 
 template <typename T, typename... U>
 class DotGenerator {
@@ -18,15 +21,24 @@ class DotGenerator {
       typename nom::Graph<T, U...>::NodeRef)>;
   using EdgePrinter = std::function<std::map<std::string, std::string>(
       typename nom::Graph<T, U...>::EdgeRef)>;
+  using NodeRef = typename nom::Graph<T, U...>::NodeRef;
 
   static std::map<std::string, std::string> defaultEdgePrinter(
-      typename nom::Graph<T, U...>::EdgeRef) {
+      typename nom::Graph<T, U...>::EdgeRef e) {
     std::map<std::string, std::string> labelMap;
     return labelMap;
   }
 
   DotGenerator(typename nom::Graph<T, U...>* g) : g_(g) {}
 
+  ~DotGenerator() {}
+
+  /**
+   * Converts given graph into DOT string
+   * @param  nodePrinter node attribute extractor
+   * @param  edgePrinter edge attribute extractor
+   * @return             DOT string representation of graph
+   */
   std::string convert(NodePrinter nodePrinter, EdgePrinter edgePrinter) {
     std::ostringstream output;
     output << "digraph G {\n\
@@ -61,6 +73,64 @@ class DotGenerator {
     return output.str();
   }
 
+  /**
+   * NOTE No subgraph support
+   * Converts given graph into DOT string w/operator input-order preserved
+   * Assumes graph is acyclic, nodes are unique_ptr
+   * (1) Get & print input nodes (nodes w/o parents)
+   *     - Node: <p0>[shape=record, label="{{Data In}|{<p0>*}}"]
+   * (2) Find operators w/BFS from input nodes
+   * (3) Print operator records & incoming edges
+   *     - Node: op_ptr[shape=record, label="{{<i0>*|<i1>*|...}|{op}|{<o0>*}"]
+   *     - Edge: <parent_node_ptr>:<ref>:s -> <this_node_ptr>:<ref>:n
+   */
+  std::string convertStruct(NodePrinter nodePrinter, EdgePrinter edgePrinter) {
+    std::ostringstream output;
+    output << "digraph G {\n";
+
+    // Get input nodes (nodes w/o parents)
+    std::unordered_map<NodeRef, int> nodeDepthMap; // Touched nodes for BFS
+    std::queue<NodeRef> workList; // Init w/parentless nodes
+    for (const auto& node : g_->getMutableNodes()) {
+      if (node->getInEdges().size() == 0 && node->getOutEdges().size() > 0) {
+        // Add input node to dot string
+        output << (uint64_t)node << "[shape=record, label=\"{{Data In}|{<"
+               << (uint64_t)node << ">";
+        for (const auto& attr : nodePrinter(node)) {
+          output << attr.second;
+        }
+        output << "}}\"]\n";
+
+        // Track input node
+        nodeDepthMap[node] = 0;
+        workList.push(node);
+      }
+    }
+
+    // BFS to get operator nodes
+    std::vector<NodeRef> ops;
+    while (workList.size() > 0) {
+      const auto& node = workList.front();
+      for (const auto& edge : node->getOutEdges()) {
+        // Enqueue child iff not touched yet
+        const auto& child = edge->head();
+        if (!nodeDepthMap.count(child)) {
+          nodeDepthMap[child] = nodeDepthMap[node] + 1;
+          workList.push(child);
+          if (nodeDepthMap[child] % 2 == 1) { // "odd" ==> operator
+            ops.emplace_back(child);
+          }
+        } else {
+        }
+      }
+      workList.pop();
+    }
+
+    // Finalize output
+    output << getOperatorSubtreeDotString(ops, nodePrinter) << "}\n";
+    return output.str();
+  }
+
   void addSubgraph(const nom::Subgraph<T, U...>* s) {
     subgraphs_.emplace_back(s);
   }
@@ -68,12 +138,80 @@ class DotGenerator {
  private:
   typename nom::Graph<T, U...>* g_;
   typename std::vector<const nom::Subgraph<T, U...>*> subgraphs_;
+
+  /**
+   * Get DOT string record of given operator and DOT string of its input edges
+   * @param  op          operator to parse
+   * @param  nodePrinter node attribute extractor
+   * @return             '\n' sep string of operator & input edges
+   */
+  std::string getOperatorDotString(NodeRef op, NodePrinter nodePrinter) {
+    std::ostringstream output;
+    std::ostringstream record; // Operator node record
+    record << (uint64_t)op << "[shape=record, label=\"{{";
+
+    // Input refs
+    std::string sep = "";
+    for (const auto& opInEdge : op->getInEdges()) {
+      // Draw edge between prev. op output to cur. op input
+      const auto& input = opInEdge->tail();
+      int inputInEdgeCt = input->getInEdges().size();
+      if (inputInEdgeCt == 0) { // Node @ top of subgraph
+        output << (uint64_t)input;
+      } else { // Node between operators
+        assert(inputInEdgeCt == 1);
+        output << (uint64_t)input->getInEdges().at(0)->tail();
+      }
+      output << ":" << (uint64_t)input << ":s -> " << (uint64_t)op << ":"
+             << (uint64_t)input << ":n\n";
+
+      // Add input to operator record
+      record << sep << "<" << (uint64_t)input << ">";
+      for (const auto& attr : nodePrinter(input)) {
+        record << attr.second;
+      }
+      sep = "|";
+    }
+
+    // Extract operator name
+    record << "}|{";
+    for (const auto& attr : nodePrinter(op)) {
+      record << attr.second;
+    }
+    record << "}|{";
+
+    // Output refs
+    sep = "";
+    for (const auto& edge : op->getOutEdges()) {
+      const auto& child = edge->head();
+      record << sep << "<" << (uint64_t)child << ">";
+      for (const auto& attr : nodePrinter(child)) {
+        record << attr.second;
+      }
+      sep = "|";
+    }
+
+    // Append record to output string
+    output << record.str() << "}}\"]\n";
+    return output.str();
+  }
+
+  /**
+   * Prints DOT string of given operator subgraph
+   * @param  ops         operators in a given subgraph
+   * @param  nodePrinter node attribute extractor
+   * @return             DOT string that renders operators subgraph
+   */
+  std::string getOperatorSubtreeDotString(
+      std::vector<NodeRef> ops,
+      NodePrinter nodePrinter) {
+    std::ostringstream output;
+    for (const auto& op : ops) {
+      output << getOperatorDotString(op, nodePrinter);
+    }
+    return output.str();
+  }
 };
-
-} // namespace
-
-namespace nom {
-namespace converters {
 
 template <typename T, typename... U>
 std::string convertToDotString(
@@ -97,6 +235,16 @@ std::string convertToDotString(
     d.addSubgraph(&subgraph);
   }
   return d.convert(nodePrinter, edgePrinter);
+}
+
+template <typename T, typename... U>
+std::string convertToDotRecordString(
+    nom::Graph<T, U...>* g,
+    typename DotGenerator<T, U...>::NodePrinter nodePrinter,
+    typename DotGenerator<T, U...>::EdgePrinter edgePrinter =
+        DotGenerator<T, U...>::defaultEdgePrinter) {
+  auto d = DotGenerator<T, U...>(g);
+  return d.convertStruct(nodePrinter, edgePrinter);
 }
 
 } // namespace converters


### PR DESCRIPTION
Summary:
For primary review (will likely delete to keep commit chain cleaner)

Retain operator input order in DOT string conversion on NQL tool.

Assumptions
* No API to discern input graph node type
* Graph is bipartite
* No generative operators; i.e. operator w/o input but creates output
* Not supporting subgraph

Mocks (from input P60154484)
Old: https://pxl.cl/j4mV (DOT string P60154515)
New: https://pxl.cl/j0wd (DOT string P60154461)

Reviewed By: bwasti

Differential Revision: D10224942
