### PR TITLE
Use CAFFE_ENFORCE instead of CHECK in caffe2 rnn executor

### DIFF
--- a/caffe2/operators/rnn/recurrent_network_executor_incl.h
+++ b/caffe2/operators/rnn/recurrent_network_executor_incl.h
@@ -57,8 +57,8 @@ struct OpTask {
   OpTask() {}
   OpTask(int _timestep, int _op_idx, int _T, int _direction)
       : timestep(_timestep), op_idx(_op_idx), T(_T), direction(_direction) {
-    CHECK(direction == 1 || direction == -1);
-    CHECK(timestep >= 0 && timestep < _T);
+    CAFFE_ENFORCE(direction == 1 || direction == -1);
+    CAFFE_ENFORCE(timestep >= 0 && timestep < _T);
   }
 
   inline bool backward() {


### PR DESCRIPTION
Use CAFFE_ENFORCE instead of CHECK when validating inputs in RNN executor