### PR TITLE
reinitialize_ function for refactoring Tensor as member variable

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -482,6 +482,8 @@ class CAFFE2_API Tensor final {
   }
 };
 
+void ReinitializeTensor(Tensor* t, at::IntList dims, at::TensorOptions options);
+
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(12, Tensor)
 
 using TensorCPU = Tensor;


### PR DESCRIPTION
Summary:
We want to refactor
```
class A {

void func() {
  x_.Resize(dims);
  auto* data = x_.mutable_data<T>();
}

Tensor x(CPU);
};
```

to
```
class A {
void func() {
  reinitialize_(&x_, dims, at::dtype<T>().device(CPU));
  auto* data = x_.mutable_data<T>();
}

Tensor x_; // Undefined Tensor
};
```

This diff adds the reinitialize_ function.

Differential Revision: D10861298
