### PR TITLE
Show demangled names on nvtx ranges

### DIFF
--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -98,6 +98,12 @@ void popRange() {
 }
 
 RecordFunction::RecordFunction(Function* fn) {
+  // typeid(*fn).name() would avoid an additional string allocation.
+  // However, typeid(*fn).name() would cause nvtx annotations for all user-defined 
+  // (Python-side) custom autograd function backward() methods to have the same name,
+  // because they route through the same C++ side class.
+  // fn->name() ensures that nvtx annotations for custom function backward() methods
+  // receive a relevant, demangled name.
   pushRangeImpl(fn->name(), ", stashed seq=", fn->sequence_nr());
 }
 

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -98,10 +98,7 @@ void popRange() {
 }
 
 RecordFunction::RecordFunction(Function* fn) {
-  // NB: we don't use fn->name() here, because it will unnecessarily allocate
-  // a string. We will run a demangler on all the names anyway, so it's ok to
-  // avoid doing it now.
-  pushRangeImpl(typeid(*fn).name(), ", stashed seq=", fn->sequence_nr());
+  pushRangeImpl(fn->name(), ", stashed seq=", fn->sequence_nr());
 }
 
 RecordFunction::RecordFunction(std::string name) {


### PR DESCRIPTION
@apaszke As we discussed, this changes the backward pass profiler annotations such that 1. they're demangled and 2. if they came from a custom Python-side autograd function, they show a unique name based on the name of that Python-side function.