### PR TITLE
Add optional default type annotation to support JIT None default value

### DIFF
--- a/test/expect/TestJit.test_function_default_values-none.expect
+++ b/test/expect/TestJit.test_function_default_values-none.expect
@@ -1,0 +1,3 @@
+graph(%x : int?) {
+  return (%x);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2007,6 +2007,15 @@ class TestJit(JitTestCase):
             torch.ones(1))
 
         @torch.jit.script
+        def none_fn(x=None):
+            # type: (Optional[int]) -> Optional[int]
+            return x
+
+        self.assertExpectedGraph(none_fn.graph, "none")
+        self.assertEqual(none_fn(), None)
+        self.assertEqual(none_fn(1), 1)
+
+        @torch.jit.script
         def hints(x, a=0.5, b=10):
             # type: (Tensor, float, int) -> Tensor
             return x + a + b

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2036,6 +2036,13 @@ const std::unordered_map<std::string, std::function<TypePtr(Subscript)>> &subscr
       auto elem_type = parseTypeFromExpr(*subscript.subscript_exprs().begin());
       return ListType::create(elem_type);
     }},
+    {"Optional", [](Subscript subscript) -> TypePtr {
+      if (subscript.subscript_exprs().size() != 1) {
+        throw ErrorReport(subscript) << " expected exactly one element type but found " << subscript.subscript_exprs().size();
+      }
+      auto elem_type = parseTypeFromExpr(*subscript.subscript_exprs().begin());
+      return OptionalType::create(elem_type);
+    }},
   };
   return map;
 }


### PR DESCRIPTION
As titled, this PR is a part of tasks to unblock exporting the standard library. In supporting None on function parameter, we will use Optional[T] type annotation for parameters that accepting None as default. 

It turned out to be a simple PR after we add optional type to the JIT.