### PR TITLE
Revert "use TypeMeta instead of ScalarType in TensorOptions (#12768)"

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -96,13 +96,13 @@ bool Context::setFlushDenormal(bool on) {
 
 TypeExtendedInterface& getType(TensorOptions options) {
   return globalContext().getType(
-            options.backend(), typeMetaToScalarType(options.dtype()), options.is_variable());
+            options.backend(), options.dtype(), options.is_variable());
 }
 
 TypeExtendedInterface& getType(const TensorImpl* impl) {
   Backend backend = tensorTypeIdToBackend(impl->type_id());
   return globalContext().getType(
-            backend, typeMetaToScalarType(impl->dtype()), impl->is_variable());
+            backend, dataTypeToScalarType(impl->dtype().id()), impl->is_variable());
 }
 
 TypeExtendedInterface& getType(const Tensor& t) {

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -35,7 +35,7 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeM
     , sparse_dim_(1)
     , dense_dim_(0)
     , indices_(at::empty({1, 0}, at::initialTensorOptions().device(sparseTensorIdToDeviceType(type_id)).dtype(ScalarType::Long)))
-    , values_(at::empty({0}, at::initialTensorOptions().device(sparseTensorIdToDeviceType(type_id)).dtype(data_type))) {}
+    , values_(at::empty({0}, at::initialTensorOptions().device(sparseTensorIdToDeviceType(type_id)).dtype(dataTypeToScalarType(data_type.id())))) {}
 
 IntList SparseTensorImpl::sizes() const {
   return size_;

--- a/aten/src/ATen/core/DefaultTensorOptions.h
+++ b/aten/src/ATen/core/DefaultTensorOptions.h
@@ -11,25 +11,25 @@ struct TensorOptions;
 
 /// Like TensorOptions, but all fields are guaranteed to be filled.
 struct DefaultTensorOptions {
-  caffe2::TypeMeta dtype() const noexcept { return dtype_; }
-  Device device()          const noexcept { return device_; }
-  Layout layout()          const noexcept { return layout_; }
-  bool requires_grad()     const noexcept { return requires_grad_; }
-  bool is_variable()       const noexcept { return is_variable_; }
+  ScalarType dtype()    const noexcept { return dtype_; }
+  Device device()       const noexcept { return device_; }
+  Layout layout()       const noexcept { return layout_; }
+  bool requires_grad()  const noexcept { return requires_grad_; }
+  bool is_variable()    const noexcept { return is_variable_; }
 
   // Defined in TensorOptions.h
   inline DefaultTensorOptions& merge(const TensorOptions& options);
 
  private:
-  caffe2::TypeMeta dtype_ = caffe2::TypeMeta::Make<float>(); // 64-bit
-  Device device_          = at::kCPU;                        // 32-bit
-  Layout layout_          = at::kStrided;                    // 8-bit
-  bool requires_grad_     = false;                           // 8-bit
-  bool is_variable_       = false;                           // 8-bit
+  Device device_      = at::kCPU;     // 64-bit
+  ScalarType dtype_   = at::kFloat;   // 8-bit
+  Layout layout_      = at::kStrided; // 8-bit
+  bool requires_grad_ = false;        // 8-bit
+  bool is_variable_   = false;        // 8-bit
 };
 
-// TODO: Even better would be <= sizeof(int64_t)
-static_assert(sizeof(DefaultTensorOptions) <= sizeof(int64_t) * 2,
+// TODO: Even better would be < sizeof(int64_t)
+static_assert(sizeof(DefaultTensorOptions) < sizeof(int64_t) * 2,
               "DefaultTensorOptions must fit in 128 bits");
 
 } // namespace at

--- a/aten/src/ATen/core/ScalarType.h
+++ b/aten/src/ATen/core/ScalarType.h
@@ -93,25 +93,25 @@ static inline caffe2::TypeMeta scalarTypeToTypeMeta(ScalarType scalar_type) {
 #undef DEFINE_CASE
 }
 
-static inline ScalarType typeMetaToScalarType(caffe2::TypeMeta dtype) {
+static inline ScalarType dataTypeToScalarType(DataType dtype) {
 #define DEFINE_IF(ctype, name, _)                      \
-  if (dtype == caffe2::TypeMeta::Make<ctype>()) { \
+  if (dtype == caffe2::TypeIdentifier::Get<ctype>()) { \
     return ScalarType::name;                           \
   }
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_IF)
 #undef DEFINE_IF
-  if (dtype == caffe2::TypeMeta()) {
+  if (dtype == at::DataType::uninitialized()) {
     return ScalarType::Undefined;
   }
-  AT_ERROR("Unsupported TypeMeta in ATen: ", dtype, " (please report this error)");
+  AT_ERROR("Unsupported DataType in ATen: ", dtype, " (please report this error)");
 }
 
 static inline bool operator==(ScalarType t, caffe2::TypeMeta m) {
-  return typeMetaToScalarType(m) == t;
+  return dataTypeToScalarType(m.id()) == t;
 }
 
 static inline bool operator==(caffe2::TypeMeta m, ScalarType t) {
-  return typeMetaToScalarType(m) == t;
+  return dataTypeToScalarType(m.id()) == t;
 }
 
 #define DEFINE_CONSTANT(_,name,_2) \

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -143,7 +143,7 @@ public:
     return impl_->type_id();
   }
   ScalarType scalar_type() const {
-    return typeMetaToScalarType(impl_->dtype());
+    return dataTypeToScalarType(impl_->dtype().id());
   }
   const Storage& storage() const {
     return impl_->storage();

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -314,7 +314,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     // could not have been created without initializing the Type first.
     // TODO: This is not actually true via the Caffe2 codepath!  Make
     // it so.
-    return *globalLegacyTypeDispatch().getTypeRaw(tensorTypeIdToBackend(type_id()), typeMetaToScalarType(dtype()), is_variable());
+    return *globalLegacyTypeDispatch().getTypeRaw(tensorTypeIdToBackend(type_id()), dataTypeToScalarType(dtype().id()), is_variable());
   }
 
   /**

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -35,7 +35,7 @@ inline Tensor Tensor::toBackend(Backend b) const {
 }
 
 inline TensorOptions Tensor::options() const {
-  return TensorOptions().dtype(dtype())
+  return TensorOptions().dtype(scalar_type())
                         .device(device())
                         .layout(layout())
                         .is_variable(is_variable());

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -156,7 +156,7 @@ struct CAFFE2_API Type {
 
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int16_t device_index = -1) const {
-    return TensorOptions().dtype(typeMeta())
+    return TensorOptions().dtype(scalarType())
                           .device(backendToDeviceType(backend()), device_index)
                           .layout(layout())
                           .is_variable(is_variable());

--- a/aten/src/ATen/core/typeid.h
+++ b/aten/src/ATen/core/typeid.h
@@ -458,12 +458,6 @@ inline bool operator!=(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
   return !operator==(lhs, rhs);
 }
 
-inline std::ostream& operator<<(
-    std::ostream& stream,
-    caffe2::TypeMeta typeMeta) {
-  return stream << typeMeta.name();
-}
-
 /**
  * Register unique id for a type so it can be used in TypeMeta context, e.g. be
  * used as a type for Blob or for Tensor elements.

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -12,7 +12,7 @@ static void ensure_has_index(Device* device) {
 }
 
 static Tensor to_impl(const Tensor& self, const TensorOptions& options, bool non_blocking) {
-  return self.type().toBackend(options.backend()).toScalarType(typeMetaToScalarType(options.dtype()))
+  return self.type().toBackend(options.backend()).toScalarType(options.dtype())
                     .copy(self, non_blocking, options.device());
 }
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -48,7 +48,7 @@ void window_function_checks(
       " is not implemented for sparse types, got: ",
       options);
   AT_CHECK(
-      at::isFloatingType(typeMetaToScalarType(options.dtype())),
+      at::isFloatingType(options.dtype()),
       function_name,
       " expects floating point dtypes, got: ",
       options);
@@ -107,7 +107,7 @@ Tensor empty_cpu(IntList size, const TensorOptions& options) {
   AT_ASSERT(options.backend() == Backend::CPU);
   AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    options.dtype(), 0, at::getCPUAllocator(), true);
+    scalarTypeToTypeMeta(options.dtype()), 0, at::getCPUAllocator(), true);
 
   auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId(), false);
   resize_cpu_(tensor, size);  // avoid dispatch overhead

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -43,7 +43,7 @@ Tensor empty_cuda(IntList size, const TensorOptions& options) {
   AT_ASSERT(options.backend() == at::Backend::CUDA);
   AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'
   auto storage_impl = c10::make_intrusive<at::StorageImpl>(
-    options.dtype(), 0, cuda::getCUDADeviceAllocator(), true);
+    scalarTypeToTypeMeta(options.dtype()), 0, cuda::getCUDADeviceAllocator(), true);
 
   auto tensor = detail::make_tensor<TensorImpl>(storage_impl, CUDATensorId(), false);
   resize_cuda_(tensor, size); // avoid dispatch overhead

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -79,7 +79,7 @@ SparseTensor new_sparse(const TensorOptions& options) {
     type_id = SparseCPUTensorId();
   }
   return detail::make_tensor<SparseTensorImpl>(
-      type_id, options.dtype());
+      type_id, scalarTypeToTypeMeta(options.dtype()));
 }
 
 /** Actual dispatched creation methods ***/

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -143,7 +143,7 @@ public:
     return impl_->type_id();
   }
   ScalarType scalar_type() const {
-    return typeMetaToScalarType(impl_->dtype());
+    return dataTypeToScalarType(impl_->dtype().id());
   }
   const Storage& storage() const {
     return impl_->storage();

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -35,7 +35,7 @@ inline Tensor Tensor::toBackend(Backend b) const {
 }
 
 inline TensorOptions Tensor::options() const {
-  return TensorOptions().dtype(dtype())
+  return TensorOptions().dtype(scalar_type())
                         .device(device())
                         .layout(layout())
                         .is_variable(is_variable());

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -127,7 +127,7 @@ struct CAFFE2_API Type {
 
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int16_t device_index = -1) const {
-    return TensorOptions().dtype(typeMeta())
+    return TensorOptions().dtype(scalarType())
                           .device(backendToDeviceType(backend()), device_index)
                           .layout(layout())
                           .is_variable(is_variable());

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -43,7 +43,7 @@ int64_t THCTensor_strideLegacyNoScalars(THCState *state, const THCTensor *self, 
 }
 
 THCTensor *THCTensor_new(THCState *state, caffe2::TypeMeta type_meta) {
-  auto scalar_type = at::typeMetaToScalarType(type_meta);
+  auto scalar_type = at::dataTypeToScalarType(type_meta.id());
   switch (scalar_type) {
     case at::ScalarType::Byte:
       return THCudaByteTensor_new(state);

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -34,7 +34,8 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
           // Resize when the dims doesn't match
           tensor->Resize(dims);
         }
-        if (tensor->meta() == options.dtype()) {
+        auto type_meta = at::scalarTypeToTypeMeta(options.dtype());
+        if (tensor->meta() == type_meta) {
           tensor->raw_mutable_data();
         } else {
           // create a new Tensor when the data_type doesn't match

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -120,7 +120,7 @@ void TensorVectorResize(
 Tensor empty(at::IntList dims, at::TensorOptions options) {
   // TODO: merge this with at::empty after Tensor is merged
   auto tensor = Tensor(dims, options.device().type());
-  tensor.raw_mutable_data(options.dtype());
+  tensor.raw_mutable_data(scalarTypeToTypeMeta(options.dtype()));
   return tensor;
 }
 

--- a/test/cpp/api/tensor_options_cuda.cpp
+++ b/test/cpp/api/tensor_options_cuda.cpp
@@ -4,7 +4,6 @@
 #include <ATen/DeviceGuard.h>
 #include <ATen/Functions.h>
 #include <ATen/OptionsGuard.h>
-#include <ATen/core/ScalarType.h>
 #include <ATen/core/TensorOptions.h>
 
 using namespace at;
@@ -14,7 +13,7 @@ using namespace at;
   ASSERT_EQ(options.device().type(), Device((device_), (index_)).type()); \
   ASSERT_TRUE(                                                                \
       options.device().index() == Device((device_), (index_)).index());       \
-  ASSERT_EQ(typeMetaToScalarType(options.dtype()), (type_));                  \
+  ASSERT_EQ(options.dtype(), (type_));                                    \
   ASSERT_TRUE(options.layout() == (layout_))
 
 #define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)                \

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -72,7 +72,7 @@ PyTypeObject* getPyTypeObject(const at::Storage& storage)
 {
   auto attype = at::globalContext().getNonVariableTypeOpt(
       at::deviceTypeToBackend(storage.device_type()),
-      at::typeMetaToScalarType(storage.dtype()));
+      at::dataTypeToScalarType(storage.dtype().id()));
   auto it = attype_to_py_storage_type.find(attype);
   if (it != attype_to_py_storage_type.end()) {
     return it->second;

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -81,7 +81,7 @@ void addInputs(Node *n, const char * name, at::TensorList value) {
 
 void addInputs(Node* n, const char * name, const at::TensorOptions& options) {
   // [TensorOptions in script] - update this when you change how we schematize TensorOptions
-  addInputs(n, name, at::typeMetaToScalarType(options.dtype()));
+  addInputs(n, name, options.dtype());
   addInputs(n, name, options.layout());
   addInputs(n, name, options.device());
 }


### PR DESCRIPTION
This reverts commit a70573b589b12b758868b402219366fc60f22c26.

