### PR TITLE
Fix move constructor on c10d::CUDAEvent

### DIFF
--- a/torch/lib/c10d/CUDAUtils.hpp
+++ b/torch/lib/c10d/CUDAUtils.hpp
@@ -12,7 +12,7 @@ class CUDAEvent {
  public:
   CUDAEvent(cudaEvent_t event, int device) : device_(device), event_(event) {}
 
-  CUDAEvent() : CUDAEvent(nullptr, 0) {}
+  CUDAEvent() {}
 
   ~CUDAEvent() noexcept(false);
 
@@ -44,8 +44,8 @@ class CUDAEvent {
   }
 
  protected:
-  int device_;
-  cudaEvent_t event_;
+  int device_ = 0;
+  cudaEvent_t event_ = nullptr;
 };
 
 } // namespace c10d


### PR DESCRIPTION
Previously, the move constructor performed a swap
between the item being moved in, and the uninitialized
garbage from the object itself.

I didn't bother adding a test because I shortly intend
to kill this class entirely.  But the fix is so easy that
I wanted to put it in in case I don't get around to doing
this.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

