### PR TITLE
Reimplement as_strided in ATen.

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -724,6 +724,17 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     storage_offset_ = storage_offset;
   }
 
+  /* Sets the storage of this tensor to be new_storage */
+  void set_storage(const Storage& new_storage) {
+    auto* new_storage_ = new_storage.unsafeGetStorageImpl();
+    auto* old_storage_ = storage_.unsafeGetStorageImpl();
+    AT_ASSERTM(old_storage_, "Tensor: invalid null storage");
+    if (new_storage_ == old_storage_) {
+      return;
+    }
+    storage_ = new_storage;
+  }
+
   /**
    * Like set_sizes_and_strides but assumes contiguous strides.
    *

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -8,6 +8,7 @@
 #include "ATen/WrapDimUtils.h"
 #include "c10/util/Exception.h"
 #include "c10/util/Optional.h"
+#include "ATen/native/Resize.h"
 #include <ATen/SparseTensorUtils.h>
 #include <algorithm>
 #include <vector>
@@ -150,11 +151,24 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  return at::empty({0}, self.options()).set_(self.storage(), storage_offset, size, stride);
+  auto result = at::empty({0}, self.options());
+  setStorage(
+      result.unsafeGetTensorImpl(),
+      self.storage().unsafeGetStorageImpl(),
+      storage_offset,
+      size,
+      stride);
+  return result;
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  return self.set_(self.storage(), storage_offset, size, stride);
+  setStorage(
+      self.unsafeGetTensorImpl(),
+      self.storage().unsafeGetStorageImpl(),
+      storage_offset,
+      size,
+      stride);
+  return self;
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride) {
@@ -162,7 +176,7 @@ Tensor as_strided(const Tensor& self, IntList size, IntList stride) {
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride) {
-  return at::as_strided_(self, size, stride, self.storage_offset());
+  return self.as_strided_(size, stride, self.storage_offset());
 }
 
 Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -153,8 +153,8 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
   auto result = at::empty({0}, self.options());
   setStorage(
-      result.unsafeGetTensorImpl(),
-      self.storage().unsafeGetStorageImpl(),
+      result,
+      self.storage(),
       storage_offset,
       size,
       stride);
@@ -163,8 +163,8 @@ Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t stor
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
   setStorage(
-      self.unsafeGetTensorImpl(),
-      self.storage().unsafeGetStorageImpl(),
+      self,
+      self.storage(),
       storage_offset,
       size,
       stride);

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -38,11 +38,13 @@ inline TensorImpl* resize_impl_cuda_(
     guard = DeviceGuard(self->storage().device().index());
   }
 
-  size_t storage_size = 1;
+  int64_t storage_size = 1;
   if (stride) {
     self->set_sizes_and_strides(size, *stride);
     // NB: storage size can be different from numel.
     for (size_t dim = 0; dim < size.size(); ++dim) {
+      // FIXME: Don't rely on storage_size being negative...
+      // This behavior was carried over from TH
       storage_size += (size[dim] - 1) * stride.value()[dim];
     }
   } else {

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -43,8 +43,8 @@ inline TensorImpl* resize_impl_cuda_(
     self->set_sizes_and_strides(size, *stride);
     // NB: storage size can be different from numel.
     for (size_t dim = 0; dim < size.size(); ++dim) {
-      // FIXME: Don't rely on storage_size being negative...
-      // This behavior was carried over from TH
+      // FIXME: Don't rely on storage_size being negative because this
+      // may not be true for some edge cases.
       storage_size += (size[dim] - 1) * stride.value()[dim];
     }
   } else {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -199,7 +199,6 @@
 - func: _argmin(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
   variants: function
 
-# NB: No DeviceGuard b/c it calls the other as_strided
 - func: as_strided(Tensor self, IntList size, IntList stride) -> Tensor
   variants: function, method
   device_guard: false
@@ -210,6 +209,7 @@
 
 - func: as_strided(Tensor self, IntList size, IntList stride, int64_t storage_offset) -> Tensor
   variants: function, method
+  device_guard: false
   python_default_init:
     storage_offset: self.storage_offset()
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -199,11 +199,14 @@
 - func: _argmin(Tensor self, int64_t dim, bool keepdim=false) -> Tensor
   variants: function
 
+# NB: No DeviceGuard b/c it calls the other as_strided
 - func: as_strided(Tensor self, IntList size, IntList stride) -> Tensor
   variants: function, method
+  device_guard: false
 
 - func: as_strided_(Tensor self, IntList size, IntList stride) -> Tensor
   variants: function, method
+  device_guard: false
 
 - func: as_strided(Tensor self, IntList size, IntList stride, int64_t storage_offset) -> Tensor
   variants: function, method
@@ -212,6 +215,7 @@
 
 - func: as_strided_(Tensor self, IntList size, IntList stride, int64_t storage_offset) -> Tensor
   variants: function, method
+  device_guard: false
   python_default_init:
     storage_offset: self.storage_offset()
 


### PR DESCRIPTION
This moves away from using tensor.set_(...) for as_strided, which went
through TH and was weirdly slow/complicated. The new as_strided has a
new invariant that it will never resize the storage to a larger size
(the previous as_strided allowed that behavior but it seemed weird and
none of our code relied on it.)

This offers a small speedup on as_strided: it went from 1300ns to
1100ns although the benchmarks get a little noisy here.

Also on the changelog is a quick fix to resize_ code to avoid unsigned
underflow. I'll rewrite the resize_ zero dim logic in a future diff, it
doesn't make sense the way it is written right now.

Test Plan: ran tests

