### PR TITLE
[clang-tidy] Enable a few hicpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,9 @@ Checks: '
   ,-cppcoreguidelines-special-member-functions
   ,-cppcoreguidelines-interfaces-global-init
   ,-cppcoreguidelines-owning-memory
+  ,hicpp-signed-bitwise
+  ,hicpp-exception-baseclass
+  ,hicpp-avoid-goto
   '
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'torch/csrc/.*'

--- a/torch/csrc/api/src/data/datasets/mnist.cpp
+++ b/torch/csrc/api/src/data/datasets/mnist.cpp
@@ -31,8 +31,8 @@ bool check_is_little_endian() {
 }
 
 constexpr uint32_t flip_endianness(uint32_t value) {
-  return ((value & 0xff) << 24) | ((value & 0xff00) << 8) |
-      ((value & 0xff0000) >> 8) | ((value & 0xff000000) >> 24);
+  return ((value & 0xffu) << 24u) | ((value & 0xff00u) << 8u) |
+      ((value & 0xff0000u) >> 8u) | ((value & 0xff000000u) >> 24u);
 }
 
 uint32_t read_int32(std::ifstream& stream) {

--- a/torch/csrc/jit/fuser/cpu/dynamic_library.h
+++ b/torch/csrc/jit/fuser/cpu/dynamic_library.h
@@ -20,7 +20,9 @@ struct DynamicLibrary {
   TH_DISALLOW_COPY_AND_ASSIGN(DynamicLibrary);
 
   DynamicLibrary(const char* name) {
-    handle = checkDL(dlopen(name, RTLD_LOCAL | RTLD_NOW));
+    handle = checkDL(dlopen(
+        name,
+        static_cast<unsigned>(RTLD_LOCAL) | static_cast<unsigned>(RTLD_NOW)));
   }
 
   void* sym(const char* name) {

--- a/torch/csrc/jit/fuser/cpu/dynamic_library.h
+++ b/torch/csrc/jit/fuser/cpu/dynamic_library.h
@@ -20,9 +20,8 @@ struct DynamicLibrary {
   TH_DISALLOW_COPY_AND_ASSIGN(DynamicLibrary);
 
   DynamicLibrary(const char* name) {
-    handle = checkDL(dlopen(
-        name,
-        static_cast<unsigned>(RTLD_LOCAL) | static_cast<unsigned>(RTLD_NOW)));
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
+    handle = checkDL(dlopen(name, RTLD_LOCAL | RTLD_NOW));
   }
 
   void* sym(const char* name) {

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -152,11 +152,13 @@ struct SharedParserData {
   }
 #ifdef _WIN32
   double strtod_c(const char * str, char** end) {
+    /// NOLINTNEXTLINE(hicpp-signed-bitwise)
     static _locale_t loc = _create_locale(LC_ALL, "C");
     return _strtod_l(str, end, loc);
   }
 #else
   double strtod_c(const char * str, char** end) {
+    /// NOLINTNEXTLINE(hicpp-signed-bitwise)
     static locale_t loc = newlocale(LC_ALL_MASK, "C", nullptr);
     return strtod_l(str, end, loc);
   }


### PR DESCRIPTION
Enabling three checks from ["High Integrity C++"](https://www.perforce.com/blog/qac/high-integrity-cpp-hicpp)

@ezyang 