### PR TITLE
[Pytorch][ONNX]Fix EraseListConstruct pass during ONNX export

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -957,7 +957,7 @@ class TestCaffe2Backend(unittest.TestCase):
             def forward(self, input):
                 return torch.cat([input, torch.zeros(input.size(0), 1).type_as(input)], dim=1)
 
-        x = torch.randn(3, 4, dtype=torch.uint8)
+        x = torch.zeros(3, 4)
         self.run_model_test(ZerosFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
 

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -952,6 +952,14 @@ class TestCaffe2Backend(unittest.TestCase):
         x = torch.randn(3, 4)
         self.run_model_test(WhereMethod(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_data_dependent_zeros_factory(self):
+        class ZerosFactory(torch.nn.Module):
+            def forward(self, input):
+                return torch.cat([input, torch.zeros(input.size(0), 1).type_as(input)], dim=1)
+
+        x = torch.randn(3, 4, dtype=torch.uint8)
+        self.run_model_test(ZerosFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
 
 # a bit of metaprogramming to set up all the rnn tests
 

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -504,10 +504,11 @@ static void eraseListConstruct(Block* block) {
             Node* unsqueezed_node = g->create(onnx::Unsqueeze, 1);
             unsqueezed_node->insertBefore(lc_node);
             unsqueezed_node->addInput(input);
-            unsqueezed_node->i_(attr::axis, 0);
+            unsqueezed_node->is_(attr::axes, {0});
             unsqueezed.emplace_back(unsqueezed_node->output());
           }
           Node* concat_node = g->create(onnx::Concat, 1);
+          concat_node->i_(attr::axis, 0);
           for(auto v: unsqueezed) {
             concat_node->addInput(v);
           }

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -488,17 +488,46 @@ static void eraseListConstruct(Block* block) {
     for (auto b : n->blocks()) {
       eraseListConstruct(b);
     }
-
     std::vector<std::tuple<size_t, std::vector<Value*>>> replacements;
 
     size_t i = 0;
     for (auto* input : n->inputs()) {
       if (input->node()->kind() == prim::ListConstruct) {
         auto* lc_node = input->node();
-        replacements.push_back(std::make_tuple(
-            i,
-            std::vector<Value*>(
-                lc_node->inputs().begin(), lc_node->inputs().end())));
+        TypePtr elem = lc_node->output()->type()->cast<ListType>()->getElementType();
+        if (elem->cast<IntType>()) {
+          // ListConstruct Int[] output case, we need to transfrom to ONNX Concat to ensure
+          // the output is a single tensor(dynamic) type in order to be consumed as inputs
+          std::vector<Value*> unsqueezed;
+          Graph *g = block->owningGraph();
+          for (auto* input: lc_node->inputs()) {
+            Node* unsqueezed_node = g->create(onnx::Unsqueeze, 1);
+            unsqueezed_node->insertBefore(lc_node);
+            unsqueezed_node->addInput(input);
+            unsqueezed_node->i_(attr::axis, 0);
+            unsqueezed.emplace_back(unsqueezed_node->output());
+          }
+          Node* concat_node = g->create(onnx::Concat, 1);
+          for(auto v: unsqueezed) {
+            concat_node->addInput(v);
+          }
+          concat_node->insertBefore(lc_node);
+
+          // make concat node output as new input, then ListConstruct should become dead
+          replacements.push_back(std::make_tuple(
+                i,
+                std::vector<Value*>({concat_node->output()})
+                ));
+
+        } else {
+          // Tensor lists are used mostly for inputs to cat/stack. They are already handled
+          // in those symbolics, and should become dead afterwards.
+          replacements.push_back(std::make_tuple(
+              i,
+              std::vector<Value*>(
+                  lc_node->inputs().begin(), lc_node->inputs().end())));
+        }
+
       }
       i++;
     }

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -873,7 +873,6 @@ inline TypePtr CompleteTensorType::fromBoolType() {
   return CompleteTensorType::create(at::kLong, -1, {});
 }
 
-
 // Attempt to find the correct supertype of t1 and t2. If none is found then
 // nullopt will be returned. If t1 == t2, or t1 is a type refinement of t2,
 // then t2 will be returned (and vice versa).

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -512,18 +512,11 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 else:
                     raise RuntimeError("Unsupported prim::Constant kind: `{}`. Send a bug report.".format(
                         n.kindOf("value")))
-            elif op_name == "ListConstruct":
-                t = n.output().type()
-                # Tensor lists are used mostly for inputs to cat/stack. They need to be handled
-                # in those symbolics, and should become dead afterwards.
-                if t == torch._C.ListType.ofTensors():
-                    return None
-                elif t == torch._C.ListType.ofInts():
-                    unsqueezed = [g.op("Unsqueeze", input, axes_i=[0]) for input in inputs]
-                    return g.op("Concat", *unsqueezed, axis_i=0)
-            elif op_name == "Undefined" or op_name == "None":
+            elif op_name == "Undefined" or op_name == "None" or op_name == "ListConstruct":
                 # Undefined/None is not an ONNX operator; keep it as prim::Undefined/
                 # prim::None and let the exporter handle finally eliminating these
+
+                # For ListConstruct, it will be erased in the ONNX peephole pass
                 return None
             elif op_name == 'Loop' or op_name == 'If':
                 new_op_outputs = g.op(op_name, *inputs, outputs=n.outputsSize())


### PR DESCRIPTION
There should really be a single place to erase or do special treatment to the prim::ListConstruct during ONNX export, this will make it consistent across different calls. e.g it will give a correct output graph in the following case: 
```python
class Test(torch.nn.Module):
    def forward(self, input):
        return torch.cat([input, torch.zeros(input.size(0), 1).type_as(input)], dim=1)
```
Before this PR, we have the onnx graph as:

```
graph(%0 : Byte(2, 3)) {
  %1 : Long() = onnx::Constant[value={0}](), scope: Test
  %2 : Dynamic = onnx::Shape(%0), scope: Test
  %3 : Long() = onnx::Gather[axis=0](%2, %1), scope: Test
  %4 : Long() = onnx::Constant[value={1}](), scope: Test
  %5 : Dynamic = onnx::Unsqueeze[axes=[0]](%3)
  %6 : Dynamic = onnx::Unsqueeze[axes=[0]](%4)
  %7 : int[] = onnx::Concat[axis=0](%5, %6)
  %8 : Float(2, 1) = onnx::ConstantFill[dtype=1, input_as_shape=1, value=0](%7), scope: Test
  %9 : Byte(2, 1) = onnx::Cast[to=2](%8), scope: Test
  %10 : Byte(2, 4) = onnx::Concat[axis=1](%0, %9), scope: Test
  return (%10);
}

```
Which is wrong since onnx does not have a concept of `int[]`, here is the onnx graph after this PR:
```
graph(%0 : Byte(2, 3)) {
  %1 : Long() = onnx::Constant[value={0}](), scope: Test
  %2 : Dynamic = onnx::Shape(%0), scope: Test
  %3 : Long() = onnx::Gather[axis=0](%2, %1), scope: Test
  %4 : Long() = onnx::Constant[value={1}](), scope: Test
  %5 : Dynamic = onnx::Unsqueeze[axes=[0]](%3)
  %6 : Dynamic = onnx::Unsqueeze[axes=[0]](%4)
  %7 : Dynamic = onnx::Concat[axis=0](%5, %6)
  %8 : Float(2, 1) = onnx::ConstantFill[dtype=1, input_as_shape=1, value=0](%7), scope: Test
  %9 : Byte(2, 1) = onnx::Cast[to=2](%8), scope: Test
  %10 : Byte(2, 4) = onnx::Concat[axis=1](%0, %9), scope: Test
  return (%10);
}
```