### PR TITLE
Fix bug in some reductions that use global memory

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cu
+++ b/aten/src/ATen/native/cuda/Reduce.cu
@@ -41,7 +41,8 @@ std::ostream& operator<<(std::ostream& out, const ReduceConfig& config) {
   out << "], ";
   out << "values_per_thread=" << config.values_per_thread() << ", ";
   out << "block=" << config.block() << ", ";
-  out << "grid=" << config.grid();
+  out << "grid=" << config.grid() << ", ";
+  out << "global_memory_size=" << config.global_memory_size();
   out << ")";
   return out;
 }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1494,6 +1494,13 @@ class TestCuda(TestCase):
         self.assertEqual(gpu_tensor1[0], 1)
         self.assertEqual(gpu_tensor0[0], 2)
 
+    def test_sum_noncontig(self):
+        x = torch.randn(1, 75, 57, 20, device='cuda').permute(0, 3, 1, 2)
+        y = x.cpu()
+        self.assertEqual(x.sum().cpu(), y.sum())
+        self.assertEqual(x.sum(dim=(-1, -2)).cpu(), y.sum(dim=(-1, -2)))
+        self.assertEqual(x.sum(dim=(1, 3)).cpu(), y.sum(dim=(1, 3)))
+
     @staticmethod
     def _select_broadcastable_dims(dims_full=None):
         return TestTorch._select_broadcastable_dims(dims_full)


### PR DESCRIPTION
Reductions that used global memory, but didn't reduce
across threads in a warp did not have enough global memory
allocated for their intermediate results. These reductions
that were non-contiguous in their reduced dimension and
large enough to benefit from reducing across blocks in a
grid.

Fixes #13209
