### PR TITLE
Save and execute futures in a task queue

### DIFF
--- a/aten/src/ATen/core/thread_pool.cpp
+++ b/aten/src/ATen/core/thread_pool.cpp
@@ -1,0 +1,25 @@
+#include <ATen/core/thread_pool.h>
+#include <ATen/core/ivalue.h>
+
+namespace c10 {
+
+ThreadPool::ThreadPool() { /* intended to leave empty */ }
+
+ThreadPool::~ThreadPool() { /* intended to leave empty */ }
+
+void ThreadPool::schedule(std::function<void(void)> task) {
+  tasks.push(task);
+}
+
+void ThreadPool::workOnTasksUntilCompleted(
+    c10::intrusive_ptr<ivalue::Future> future) {
+  while (!future->completed()) {
+    auto task = tasks.front();
+    tasks.pop();
+    task();
+  }
+}
+
+ThreadPool global_work_queue;
+
+} // namespace c10

--- a/aten/src/ATen/core/thread_pool.h
+++ b/aten/src/ATen/core/thread_pool.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <functional>
+#include <queue>
+
+#include <ATen/core/intrusive_ptr.h>
+
+namespace c10 {
+
+namespace ivalue {
+struct Future;
+} // namespace ivalue
+
+struct C10_API ThreadPool final {
+  ThreadPool();
+
+  ~ThreadPool();
+
+  void schedule(std::function<void(void)> task);
+
+  void workOnTasksUntilCompleted(c10::intrusive_ptr<ivalue::Future> future);
+
+ private:
+  std::queue<std::function<void(void)>> tasks;
+};
+
+C10_API extern ThreadPool global_work_queue;
+
+} // namespace c10

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9879,6 +9879,61 @@ class TestAsync(JitTestCase):
                 fut = torch.jit._fork(x)
                 return fut
 
+    def test_async_script_multi_waits(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.neg(x).t() + x
+
+        @torch.jit.script
+        def wait_script(x):
+            fut = torch.jit._fork(foo, x)
+
+            # wait twice on the same future
+            y1 = torch.jit._wait(fut)
+            y2 = torch.jit._wait(fut)
+            return y1, y2
+
+        x = torch.rand(2, 2)
+        y1, y2 = wait_script(x)
+        self.assertEqual(y1, y2)
+
+    def test_async_script_multi_forks(self):
+        @torch.jit.script
+        def foo1(x):
+            return torch.neg(x).t() + x
+
+        @torch.jit.script
+        def foo2(x, y):
+            return torch.neg(x).t() + x + torch.neg(y).t()
+
+        @torch.jit.script
+        def foo3(x, y, z):
+            return torch.neg(z).t() + y.t() + x
+
+        x1 = torch.rand(10, 10)
+        x2 = torch.rand(10, 10)
+        x3 = torch.rand(10, 10)
+
+        @torch.jit.script
+        def wait_script(x1, x2, x3):
+            f1 = torch.jit._fork(foo1, x1)
+            f2 = torch.jit._fork(foo2, x1, x2)
+            f3 = torch.jit._fork(foo3, x1, x2, x3)
+            f4 = torch.jit._fork(foo1, x2)
+            f5 = torch.jit._fork(foo2, x2, x3)
+
+            # ignore some forks
+            y1 = torch.jit._wait(f1)
+            y2 = torch.jit._wait(f2)
+            y3 = torch.jit._wait(f3)
+
+            return y1, y2, y3
+
+        y1, y2, y3 = wait_script(x1, x2, x3)
+        self.assertEqual(y1, foo1(x1))
+        self.assertEqual(y2, foo2(x1, x2))
+        self.assertEqual(y3, foo3(x1, x2, x3))
+
 for test in autograd_method_tests:
     add_autograd_test(*test)
 

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include "c10/util/Optional.h"
 
+#include "torch/csrc/jit/ivalue.h"
 #include "torch/csrc/WindowsTorchApiMacro.h"
 
 namespace at {
@@ -28,7 +29,7 @@ using Stack = std::vector<c10::IValue>;
 struct TORCH_API Code {
   Code()
     : pImpl(nullptr) {}
-  Code(const std::shared_ptr<Graph>& graph);
+  explicit Code(const std::shared_ptr<Graph>& graph);
   ~Code();
 
   const std::vector<GraphExecutor*>& grad_executors();
@@ -45,7 +46,9 @@ private:
 
 struct InterpreterState {
   InterpreterState(const Code & code);
-  void run(Stack & stack);
+  void run(Stack& stack);
+  c10::intrusive_ptr<Future> runAsync(Stack& stack);
+  c10::intrusive_ptr<Future> getFuture();
   ~InterpreterState();
   // create a copy of InterpreterState with its current state
   // used when retain_graph=True
@@ -55,4 +58,27 @@ private:
   std::shared_ptr<InterpreterStateImpl> pImpl;
 };
 
+// Created by wait()
+struct Suspend : public std::exception {
+  virtual const char* what() const noexcept override {
+    return "Suspend";
+  }
+
+  explicit Suspend(c10::intrusive_ptr<Future> future_) : future(future_) {}
+
+  c10::intrusive_ptr<Future> future;
+};
+
+struct InterpreterContinuation {
+  InterpreterContinuation(InterpreterState state_, Stack stack_)
+      : state(std::move(state_)), stack(std::move(stack_)) {}
+
+  void operator()(void) {
+    state.runAsync(stack);
+  }
+
+ private:
+  InterpreterState state;
+  Stack stack;
+};
 }}


### PR DESCRIPTION
Upon calling wait(), save the forked thread and the current thread to a
task queue. A idling thread (which currently is single threaded) should
pick a ready task and run till there is nothing in the task queue.