### PR TITLE
Include lib subdir in caffe2 include dirs path

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -134,4 +134,4 @@ get_filename_component(
 # Note: the current list dir is _INSTALL_PREFIX/share/cmake/Gloo.
 get_filename_component(
     _INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/include")
+set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/lib/include")


### PR DESCRIPTION
Summary: Caffe2 headers are placed under `lib/include` in pytorch package data (https://github.com/pytorch/pytorch/blob/master/setup.py#L1201). However, `CAFFE2_INCLUDE_DIRS` path is set to `"${_INSTALL_PREFIX}/include"` which does not exist in package data. This results in issues when trying to build custom Caffe2 ops living outside Caffe2/PyTorch repo (e.g. custom Detectron ops).

Differential Revision: D12815878
