### PR TITLE
Include caffe2 proto headers in pytorch package data

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -134,4 +134,4 @@ get_filename_component(
 # Note: the current list dir is _INSTALL_PREFIX/share/cmake/Gloo.
 get_filename_component(
     _INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/include")
+set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/lib/include")

--- a/setup.py
+++ b/setup.py
@@ -1184,6 +1184,7 @@ if __name__ == '__main__':
                 'lib/include/c10/macros/*.h',
                 'lib/include/c10/util/*.h',
                 'lib/include/caffe2/core/*.h',
+                'lib/include/caffe2/proto/*.h',
                 'lib/include/torch/*.h',
                 'lib/include/torch/csrc/*.h',
                 'lib/include/torch/csrc/api/include/torch/*.h',


### PR DESCRIPTION
Summary: Caffe2 proto headers are not included in pytorch package data (https://github.com/pytorch/pytorch/blob/master/setup.py#L1180). However, they are required for building custom Caffe2 ops living outside PyTorch/Caffe2 repo (e.g. custom Detectron ops).

Differential Revision: D12815881
