### PR TITLE
Bring back warning for dtype uninitialized in serialization

### DIFF
--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -31,6 +31,15 @@
 C10_DECLARE_int(caffe2_log_level);
 C10_DECLARE_bool(caffe2_use_fatal_for_enforce);
 
+// Some versions of GLOG support less-spammy version of LOG_EVERY_MS. If it's
+// not available - just short-circuit to the always working one one.
+// We define the C10_ name to avoid confusing other files
+#ifdef LOG_EVERY_MS
+#define C10_LOG_EVERY_MS(severity, ms) LOG_EVERY_MS(severity, ms)
+#else
+#define C10_LOG_EVERY_MS(severity, ms) LOG(severity)
+#endif
+
 namespace c10 {
 
 using std::string;

--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -205,12 +205,11 @@ void TensorSerializer::Serialize(
         "created a tensor of non-zero shape but never filled its data via "
         "mutable_data() calls. This means that it makes no sense to serialize "
         "the tensor content.");
-  } else {
-    // Uncomment this when we try to remove this behavior entirely, see T35723601
-    //LOG(ERROR)
-    //    << "You're trying to serialize tensor with zero numel and no dtype. "
-    //    << "This is a legacy behavior and it WILL BREAK. Contact PyTorch team "
-    //    << "for details or see D10380678. Offending blob name: " << name;
+  } else if (!input.dtype_initialized()) {
+    C10_LOG_EVERY_MS(WARNING, 1000)
+        << "You're trying to serialize tensor with zero numel and no dtype. "
+        << "This is a legacy behavior and it WILL BREAK. Contact PyTorch team "
+        << "for details. Offending blob name: " << name;
   }
 
   TensorProto& proto = *proto_ptr;


### PR DESCRIPTION
Summary:
Previous diff missed the if (dtype_initialized) check, duh.

Also, for safety of spamming - using LOG_EVERY_MS if it's available

Differential Revision: D12818938
