### PR TITLE
Test scripts only run cases defined in the running script

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -798,7 +798,7 @@ def check_test_defined_in_running_script(test_case):
     assert test_case_class_file == running_script_path, "Class of loaded TestCase \"{}\" " \
         "is not defined in the running script \"{}\", but in \"{}\". Did you " \
         "accidentally import a unittest.TestCase from another file?".format(
-            test_case.id(), runfile, test_case_class_file)
+            test_case.id(), running_script_path, test_case_class_file)
 
 
 num_shards = os.environ.get('TEST_NUM_SHARDS', None)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -54,6 +54,14 @@ torch.manual_seed(SEED)
 
 
 def run_tests(argv=UNITTEST_ARGS):
+    runfile = os.path.realpath(__file__)
+
+    for name, obj in globals().items():
+        if isinstance(obj, unittest.TestCase):
+            assert inspect.getfile(obj) == runfile, "A unittest.TestCase class " \
+                "existing in top-level is not defined in the running script. " \
+                "Did you accidentally import a unittest.TestCase from another file?"
+
     unittest.main(argv=argv)
 
 PY3 = sys.version_info > (3, 0)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -783,10 +783,12 @@ THESE_TAKE_WAY_TOO_LONG = {
 running_script_path = None
 
 
-def set_running_file():
+def set_running_script_path():
     global running_script_path
     try:
-        running_script_path = os.path.abspath(os.path.realpath(sys.argv[0]))
+        running_file = os.path.abspath(os.path.realpath(sys.argv[0]))
+        if running_file.endswith('.py'):  # skip if the running file is not a script
+            running_script_path = running_file
     except Exception:
         pass
 
@@ -808,7 +810,7 @@ if num_shards is not None and shard is not None:
     shard = int(shard)
 
     def load_tests(loader, tests, pattern):
-        set_running_file()
+        set_running_script_path()
         test_suite = unittest.TestSuite()
         for test_group in tests:
             for test in test_group:
@@ -823,7 +825,7 @@ if num_shards is not None and shard is not None:
 else:
 
     def load_tests(loader, tests, pattern):
-        set_running_file()
+        set_running_script_path()
         test_suite = unittest.TestSuite()
         for test_group in tests:
             for test in test_group:

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 import torch.distributed as c10d
 from torch.nn.parallel import DistributedDataParallel
 
-from common_utils import TestCase, load_tests
+from common_utils import TestCase, load_tests, run_tests
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -915,4 +915,4 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 if __name__ == '__main__':
     assert not torch.cuda._initialized, "test_distributed must not have initialized CUDA context on main process"
 
-    unittest.main()
+    run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -15,6 +15,7 @@ from torch import multiprocessing as mp
 from torch._six import inf, nan
 
 from test_torch import TestTorchMixin
+
 from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_WITH_ROCM, load_tests
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -14,7 +14,7 @@ import torch.cuda.comm as comm
 from torch import multiprocessing as mp
 from torch._six import inf, nan
 
-from test_torch import TestTorch
+from test_torch import TestTorchMixin
 from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_WITH_ROCM, load_tests
 
@@ -936,7 +936,7 @@ class TestCuda(TestCase):
         self.assertEqual(x.to(torch.int).get_device(), 1)
 
     def test_neg(self):
-        TestTorch._test_neg(self, lambda t: t.cuda())
+        TestTorchMixin._test_neg(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_arithmetic_large_tensor(self):
@@ -1236,15 +1236,15 @@ class TestCuda(TestCase):
 
     @skipIfRocm
     def test_cat_empty_legacy(self):
-        TestTorch._test_cat_empty_legacy(self, use_cuda=True)
+        TestTorchMixin._test_cat_empty_legacy(self, use_cuda=True)
 
     @skipIfRocm
     def test_cat_empty(self):
-        TestTorch._test_cat_empty(self, use_cuda=True)
+        TestTorchMixin._test_cat_empty(self, use_cuda=True)
 
     def test_bernoulli(self):
-        TestTorch._test_bernoulli(self, torch.double, 'cuda')
-        TestTorch._test_bernoulli(self, torch.half, 'cuda')
+        TestTorchMixin._test_bernoulli(self, torch.double, 'cuda')
+        TestTorchMixin._test_bernoulli(self, torch.half, 'cuda')
 
     def test_cat_bad_input_sizes(self):
         x = torch.randn(2, 1).cuda()
@@ -1499,55 +1499,55 @@ class TestCuda(TestCase):
 
     @staticmethod
     def _select_broadcastable_dims(dims_full=None):
-        return TestTorch._select_broadcastable_dims(dims_full)
+        return TestTorchMixin._select_broadcastable_dims(dims_full)
 
     @skipIfRocm
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_inverse(self):
-        TestTorch._test_inverse(self, lambda t: t.cuda())
+        TestTorchMixin._test_inverse(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_pinverse(self):
-        TestTorch._test_pinverse(self, lambda t: t.cuda())
+        TestTorchMixin._test_pinverse(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_matrix_rank(self):
-        TestTorch._test_matrix_rank(self, lambda x: x.cuda())
+        TestTorchMixin._test_matrix_rank(self, lambda x: x.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_matrix_power(self):
-        TestTorch._test_matrix_power(self, conv_fn=lambda t: t.cuda())
+        TestTorchMixin._test_matrix_power(self, conv_fn=lambda t: t.cuda())
 
     def test_chain_matmul(self):
-        TestTorch._test_chain_matmul(self, cast=lambda t: t.cuda())
+        TestTorchMixin._test_chain_matmul(self, cast=lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_det_logdet_slogdet(self):
-        TestTorch._test_det_logdet_slogdet(self, lambda t: t.cuda())
+        TestTorchMixin._test_det_logdet_slogdet(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_gesv_batched(self):
-        TestTorch._test_gesv_batched(self, lambda t: t.cuda())
+        TestTorchMixin._test_gesv_batched(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_gesv_batched_dims(self):
-        TestTorch._test_gesv_batched_dims(self, lambda t: t.cuda())
+        TestTorchMixin._test_gesv_batched_dims(self, lambda t: t.cuda())
 
     def test_view(self):
-        TestTorch._test_view(self, lambda t: t.cuda())
+        TestTorchMixin._test_view(self, lambda t: t.cuda())
 
     def test_flip(self):
-        TestTorch._test_flip(self, use_cuda=True)
+        TestTorchMixin._test_flip(self, use_cuda=True)
 
     def test_rot90(self):
-        TestTorch._test_rot90(self, use_cuda=True)
+        TestTorchMixin._test_rot90(self, use_cuda=True)
 
     def test_signal_window_functions(self):
-        TestTorch._test_signal_window_functions(self, device=torch.device('cuda'))
+        TestTorchMixin._test_signal_window_functions(self, device=torch.device('cuda'))
 
     @skipIfRocm
     def test_fft_ifft_rfft_irfft(self):
-        TestTorch._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
+        TestTorchMixin._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
 
         @contextmanager
         def plan_cache_max_size(n):
@@ -1557,16 +1557,16 @@ class TestCuda(TestCase):
             torch.backends.cuda.cufft_plan_cache.max_size = original
 
         with plan_cache_max_size(max(1, torch.backends.cuda.cufft_plan_cache.size - 10)):
-            TestTorch._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
+            TestTorchMixin._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
 
         with plan_cache_max_size(0):
-            TestTorch._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
+            TestTorchMixin._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
 
         torch.backends.cuda.cufft_plan_cache.clear()
 
         # check that stll works after clearing cache
         with plan_cache_max_size(10):
-            TestTorch._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
+            TestTorchMixin._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
 
         with self.assertRaisesRegex(RuntimeError, r"must be non-negative"):
             torch.backends.cuda.cufft_plan_cache.max_size = -1
@@ -1575,11 +1575,11 @@ class TestCuda(TestCase):
             torch.backends.cuda.cufft_plan_cache.size = -1
 
     def test_stft(self):
-        TestTorch._test_stft(self, device=torch.device('cuda'))
+        TestTorchMixin._test_stft(self, device=torch.device('cuda'))
 
     @skipIfRocm
     def test_multinomial(self):
-        TestTorch._test_multinomial(self, torch.cuda.FloatTensor)
+        TestTorchMixin._test_multinomial(self, torch.cuda.FloatTensor)
 
         # Test two corner cases from older PyTorch (Issue #4858)
         freqs = torch.cuda.FloatTensor([
@@ -1646,24 +1646,24 @@ class TestCuda(TestCase):
 
     @skipIfRocm
     def test_broadcast(self):
-        TestTorch._test_broadcast(self, lambda t: t.cuda())
+        TestTorchMixin._test_broadcast(self, lambda t: t.cuda())
 
     def test_contiguous(self):
-        TestTorch._test_contiguous(self, lambda t: t.cuda())
+        TestTorchMixin._test_contiguous(self, lambda t: t.cuda())
 
     def test_broadcast_fused_matmul(self):
-        TestTorch._test_broadcast_fused_matmul(self, lambda t: t.cuda())
+        TestTorchMixin._test_broadcast_fused_matmul(self, lambda t: t.cuda())
 
     def test_broadcast_batched_matmul(self):
-        TestTorch._test_broadcast_batched_matmul(self, lambda t: t.cuda())
+        TestTorchMixin._test_broadcast_batched_matmul(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_index(self):
-        TestTorch._test_index(self, lambda t: t.cuda())
+        TestTorchMixin._test_index(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_advancedindex(self):
-        TestTorch._test_advancedindex(self, lambda t: t.cuda())
+        TestTorchMixin._test_advancedindex(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_advancedindex_mixed_cpu_cuda(self):
@@ -1716,33 +1716,33 @@ class TestCuda(TestCase):
 
     @skipIfRocm
     def test_advancedindex_big(self):
-        TestTorch._test_advancedindex_big(self, lambda t: t.cuda())
+        TestTorchMixin._test_advancedindex_big(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_btrifact(self):
-        TestTorch._test_btrifact(self, lambda t: t.cuda())
+        TestTorchMixin._test_btrifact(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_btrisolve(self):
-        TestTorch._test_btrisolve(self, lambda t: t.cuda())
+        TestTorchMixin._test_btrisolve(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_dim_reduction(self):
-        TestTorch._test_dim_reduction(self, lambda t: t.cuda())
+        TestTorchMixin._test_dim_reduction(self, lambda t: t.cuda())
 
     @skipIfRocm
     def test_tensor_gather(self):
-        TestTorch._test_gather(self, lambda t: t.cuda(), False)
+        TestTorchMixin._test_gather(self, lambda t: t.cuda(), False)
 
     def test_tensor_scatter(self):
-        TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', test_bounds=False)
+        TestTorchMixin._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', test_bounds=False)
 
     @skipIfRocm
     def test_tensor_scatterAdd(self):
-        TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_add_', test_bounds=False)
+        TestTorchMixin._test_scatter_base(self, lambda t: t.cuda(), 'scatter_add_', test_bounds=False)
 
     def test_tensor_scatterFill(self):
-        TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', True, test_bounds=False)
+        TestTorchMixin._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', True, test_bounds=False)
 
     def test_min_max_inits(self):
         # Testing if THC_reduceAll received the correct index initialization.
@@ -1758,16 +1758,16 @@ class TestCuda(TestCase):
         self.assertEqual(v, expected)
 
     def test_max_with_inf(self):
-        TestTorch._test_max_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
+        TestTorchMixin._test_max_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
 
     def test_min_with_inf(self):
-        TestTorch._test_min_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
+        TestTorchMixin._test_min_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
 
     def test_int_pow(self):
-        TestTorch._test_int_pow(self, lambda x: x.cuda())
+        TestTorchMixin._test_int_pow(self, lambda x: x.cuda())
 
     def test_remainder_overflow(self):
-        TestTorch._test_remainder_overflow(self, dtype=torch.int64, device='cuda')
+        TestTorchMixin._test_remainder_overflow(self, dtype=torch.int64, device='cuda')
 
     def test_var(self):
         cpu_tensor = torch.randn(2, 3, 3)
@@ -1868,11 +1868,11 @@ class TestCuda(TestCase):
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_symeig(self):
-        TestTorch._test_symeig(self, lambda t: t.cuda())
+        TestTorchMixin._test_symeig(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_svd_no_singularvectors(self):
-        TestTorch._test_svd_no_singularvectors(self, lambda t: t.cuda())
+        TestTorchMixin._test_svd_no_singularvectors(self, lambda t: t.cuda())
 
     def test_arange(self):
         for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:
@@ -1893,14 +1893,14 @@ class TestCuda(TestCase):
         self.assertEqual(a, b.cuda())
 
     def test_diagonal(self):
-        TestTorch._test_diagonal(self, dtype=torch.float32, device='cuda')
+        TestTorchMixin._test_diagonal(self, dtype=torch.float32, device='cuda')
 
     def test_diagflat(self):
-        TestTorch._test_diagflat(self, dtype=torch.float32, device='cuda')
+        TestTorchMixin._test_diagflat(self, dtype=torch.float32, device='cuda')
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_trtrs(self):
-        TestTorch._test_trtrs(self, lambda t: t.cuda())
+        TestTorchMixin._test_trtrs(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     @skipIfRocm
@@ -1958,11 +1958,11 @@ class TestCuda(TestCase):
         self.assertEqual(res2.numel(), 0)
 
     def test_random_neg_values(self):
-        TestTorch._test_random_neg_values(self, use_cuda=True)
+        TestTorchMixin._test_random_neg_values(self, use_cuda=True)
 
     @skipIfRocm
     def test_bincount_cuda(self):
-        TestTorch._test_bincount(self, device='cuda')
+        TestTorchMixin._test_bincount(self, device='cuda')
         # ensure CUDA code coverage
         input_size = (5000,)
         w = torch.randn(input_size, device='cuda')
@@ -2111,17 +2111,5 @@ if __name__ == '__main__':
     if TEST_CUDA:
         load_ignore_file()
         generate_tests()
-
-    # skip TestTorch tests
-    # hide in __name__ == '__main__' because we don't want this to be run when
-    # someone imports test_cuda
-    def load_tests(loader, tests, pattern):  # noqa: F811
-        test_suite = unittest.TestSuite()
-        for test_group in tests:
-            for test in test_group:
-                if test.__class__.__name__ == 'TestTorch':
-                    continue
-                test_suite.addTest(test)
-        return test_suite
 
     run_tests()

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -16,10 +16,9 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from common_utils import TestCase
+from common_utils import TestCase, run_tests
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
-from torch.autograd import Variable
 import common_utils as common
 
 BACKEND = os.environ["BACKEND"]
@@ -1409,4 +1408,4 @@ if __name__ == "__main__":
         not torch.cuda._initialized
     ), "test_distributed must not have initialized CUDA context on main process"
 
-    unittest.main()
+    run_tests()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -10,7 +10,6 @@ import torch
 import torch.cuda
 import torch.multiprocessing as mp
 import torch.utils.hooks
-from torch.autograd import Variable
 from torch.nn import Parameter
 from common_utils import (TestCase, run_tests, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, TEST_WITH_ASAN,
                           load_tests)
@@ -58,7 +57,7 @@ def send_tensor(queue, event, tp):
 
 
 def call_backward():
-    x = torch.autograd.Variable(torch.randn(3, 3), requires_grad=True)
+    x = torch.randn(3, 3, requires_grad=True)
     x.sum().backward()
 
 

--- a/test/test_thd_distributed.py
+++ b/test/test_thd_distributed.py
@@ -16,9 +16,8 @@ import torch.distributed.deprecated as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from common_utils import TestCase
+from common_utils import TestCase, run_tests
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
-from torch.autograd import Variable
 
 
 BACKEND = os.environ["BACKEND"]
@@ -1159,4 +1158,4 @@ if __name__ == "__main__":
         not torch.cuda._initialized
     ), "test_distributed must not have initialized CUDA context on main process"
 
-    unittest.main()
+    run_tests()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -94,7 +94,7 @@ class BytesIOContext(io.BytesIO):
         pass
 
 
-class TestTorch(TestCase):
+class TestTorchMixin(object):
     def _check_sum_dim(tensors, dim):
         for tensor in tensors:
             expected = tensor.numpy().sum(dim)
@@ -2811,7 +2811,7 @@ class TestTorch(TestCase):
                      "spawn start method is not supported in Python 2, \
                      but we need it for for testing failure case for CPU RNG on Windows")
     def test_multinomial_invalid_probs(self):
-        test_method = TestTorch._test_multinomial_invalid_probs
+        test_method = TestTorchMixin._test_multinomial_invalid_probs
         self._spawn_method(test_method, torch.Tensor([1, -1, 1]))
         self._spawn_method(test_method, torch.Tensor([1, inf, 1]))
         self._spawn_method(test_method, torch.Tensor([1, -inf, 1]))
@@ -6266,7 +6266,7 @@ class TestTorch(TestCase):
         idx_size = [m, n, o]
         idx_size[dim] = elems_per_row
         idx = torch.LongTensor().resize_(*idx_size)
-        TestTorch._fill_indices(self, idx, dim, src.size(dim), elems_per_row, m, n, o)
+        TestTorchMixin._fill_indices(self, idx, dim, src.size(dim), elems_per_row, m, n, o)
 
         src = cast(src)
         idx = cast(idx)
@@ -6304,7 +6304,7 @@ class TestTorch(TestCase):
         idx_size = [m, n, o]
         idx_size[dim] = elems_per_row
         idx = cast(torch.LongTensor().resize_(*idx_size))
-        TestTorch._fill_indices(self, idx, dim, ([m, n, o])[dim], elems_per_row, m, n, o)
+        TestTorchMixin._fill_indices(self, idx, dim, ([m, n, o])[dim], elems_per_row, m, n, o)
 
         if is_scalar:
             src = random.random()
@@ -6524,7 +6524,7 @@ class TestTorch(TestCase):
         self.assertEqual(tensor.view(1, 6, 2, 1), contig_tensor.view(1, 6, 2, 1))
 
     def test_view(self):
-        TestTorch._test_view(self, lambda x: x)
+        TestTorchMixin._test_view(self, lambda x: x)
 
     def test_view_empty(self):
         x = torch.randn(0, 6)
@@ -9214,10 +9214,13 @@ def add_neg_dim_tests():
 
         test_name = 'test_' + name + '_neg_dim'
 
-        assert not hasattr(TestTorch, test_name), "Duplicated test name: " + test_name
-        setattr(TestTorch, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
+        assert not hasattr(TestTorchMixin, test_name), "Duplicated test name: " + test_name
+        setattr(TestTorchMixin, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
 add_neg_dim_tests()
 
 if __name__ == '__main__':
+    class TestTorch(TestCase, TestTorchMixin):
+        pass
+
     run_tests()


### PR DESCRIPTION
1. Refactors `TestTorch` into `TestTorchMixin` (subclass of `object`) and `TestTorch` (subclass of `TestCase`, MRO `(TestCase, TestTorchMixin)`, only defined if `__name__ == '__main__'`). So other scripts won't accidentally run it.
2. Adds an assertion in `load_tests` that each script only runs cases defined in itself.

cc @yf225 @ezyang 