### PR TITLE
Fix initialization order in MIOpen file

### DIFF
--- a/caffe2/operators/hip/conv_op_miopen.cc
+++ b/caffe2/operators/hip/conv_op_miopen.cc
@@ -31,14 +31,15 @@ class MIOPENConvOpBase : public ConvPoolOpBase<HIPContext> {
   MIOPENConvOpBase(const OperatorDef& operator_def, Workspace* ws)
       : ConvPoolOpBase<HIPContext>(operator_def, ws),
         miopen_wrapper_(&context_),
+        miopen_state_(
+            OperatorBase::GetSingleArgument<size_t>("miopen_state", 0)),
         miopen_ws_nbytes_limit_(OperatorBase::GetSingleArgument<size_t>(
             "ws_nbytes_limit",
             kCONV_MIOPEN_WORKSPACE_LIMIT_BYTES)),
-        miopen_state_(OperatorBase::GetSingleArgument<size_t>("miopen_state", 0)),
-        alpha_(OperatorBase::GetSingleArgument<float>("alpha", 1.0)),
-        beta_(OperatorBase::GetSingleArgument<float>("beta", 0.0)),
         exhaustive_search_(
-            OperatorBase::GetSingleArgument<bool>("exhaustive_search", false)) {
+            OperatorBase::GetSingleArgument<bool>("exhaustive_search", false)),
+        alpha_(OperatorBase::GetSingleArgument<float>("alpha", 1.0)),
+        beta_(OperatorBase::GetSingleArgument<float>("beta", 0.0)) {
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&bottom_desc_));
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&bias_desc_));
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&weight_desc_));
@@ -48,9 +49,9 @@ class MIOPENConvOpBase : public ConvPoolOpBase<HIPContext> {
 
     if ((operator_def.type().substr(0, 6) == "Conv") ||
         (operator_def.type().substr(0, 14) == "ConvGradient")) {
-      if(group_ > 1) {
+      if (group_ > 1) {
         mode_ = miopenGroupConv;
-      } else{
+      } else {
         mode_ = miopenConvolution;
       }
     } else if (
@@ -61,10 +62,10 @@ class MIOPENConvOpBase : public ConvPoolOpBase<HIPContext> {
       LOG(FATAL) << "Unsupported convolution method: " << operator_def.type();
     }
 
-    if(mode_ == miopenGroupConv) {
+    if (mode_ == miopenGroupConv) {
       OPERATOR_NEEDS_FEATURE(
-        dilation_h() == 1 && dilation_w() == 1,
-        "MIOpen convolution does not support dilation for groups > 1.");
+          dilation_h() == 1 && dilation_w() == 1,
+          "MIOpen convolution does not support dilation for groups > 1.");
     }
   }
 
@@ -151,12 +152,12 @@ class MIOPENConvGradientOp final : public MIOPENConvOpBase {
             OperatorBase::GetSingleArgument<bool>("bestAlgoFound", false)),
         bestWeightAlgoFound_(
             OperatorBase::GetSingleArgument<bool>("bestAlgoFound", false)),
-        bwdWeightWs_(nullptr),
-        bwdWeightWsSize_(0),
-        bwdDataWs_(nullptr),
-        bwdDataWsSize_(0),
         bwdWeiAlgo_(miopenConvolutionBwdWeightsAlgoGEMM),
-        bwdDataAlgo_(miopenConvolutionBwdDataAlgoGEMM) {
+        bwdDataAlgo_(miopenConvolutionBwdDataAlgoGEMM),
+        bwdWeightWsSize_(0),
+        bwdDataWsSize_(0),
+        bwdWeightWs_(nullptr),
+        bwdDataWs_(nullptr) {
     CAFFE_ENFORCE(
         !(no_bias_ && OutputSize() == 3),
         "If bias is not present, you should not have 3 grad output.");

--- a/caffe2/operators/hip/pool_op_miopen.cc
+++ b/caffe2/operators/hip/pool_op_miopen.cc
@@ -23,11 +23,11 @@ class MIOPENPoolOp : public ConvPoolOpBase<HIPContext> {
  public:
   MIOPENPoolOp(const OperatorDef& operator_def, Workspace* ws)
       : ConvPoolOpBase<HIPContext>(operator_def, ws),
+        poolWsSize_(0),
+        poolWs_(nullptr),
         miopen_wrapper_(&context_),
         alpha_(OperatorBase::GetSingleArgument<float>("alpha", 1.0)),
-        beta_(OperatorBase::GetSingleArgument<float>("beta", 0.0)),
-        poolWs_(nullptr),
-        poolWsSize_(0)
+        beta_(OperatorBase::GetSingleArgument<float>("beta", 0.0))
 
   {
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&bottom_desc_));
@@ -139,11 +139,11 @@ class MIOPENPoolGradientOp : public ConvPoolOpBase<HIPContext> {
  public:
   MIOPENPoolGradientOp(const OperatorDef& operator_def, Workspace* ws)
       : ConvPoolOpBase<HIPContext>(operator_def, ws),
+        poolWsSize_(0),
+        poolWs_(nullptr),
         miopen_wrapper_(&context_),
         alpha_(OperatorBase::GetSingleArgument<float>("alpha", 1.0)),
         beta_(OperatorBase::GetSingleArgument<float>("beta", 0.0)),
-        poolWs_(nullptr),
-        poolWsSize_(0),
         bwdPoolScratch_(nullptr) {
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&bottom_desc_));
     MIOPEN_ENFORCE(miopenCreateTensorDescriptor(&top_desc_));


### PR DESCRIPTION
Summary: Simply change the initialization order to make hcc happy. Otherwise will have to add -Wno-error=reorder.

Differential Revision: D12827635
