### PR TITLE
Speed up tensor.storage_offset

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1,13 +1,4 @@
 [[
-  name: _th_storage_offset
-  cname: storageOffset
-  cpu_half: True
-  device_guard: False
-  return: long
-  arguments:
-    - THTensor* self
-]]
-[[
   name: _th_ndimension
   cname: nDimension
   cpu_half: True

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -53,6 +53,9 @@ public:
   int64_t dim() const {
     return impl_->dim();
   }
+  int64_t storage_offset() const {
+    return impl_->storage_offset();
+  }
 
   TensorImpl * unsafeGetTensorImpl() const {
     return impl_.get();
@@ -259,7 +262,6 @@ public:
 
   //example
   //Tensor * add(Tensor & b);
-  int64_t _th_storage_offset() const;
   int64_t _th_ndimension() const;
   Tensor & _th_set_(Storage source);
   Tensor & _th_set_(Storage source, int64_t storage_offset, IntList size, IntList stride={});
@@ -655,7 +657,6 @@ public:
   Tensor to(Device device, bool non_blocking=false, bool copy=false) const;
   Tensor to(const Tensor & other, bool non_blocking=false, bool copy=false) const;
   Scalar _local_scalar() const;
-  int64_t storage_offset() const;
   Tensor & set_(Storage source);
   Tensor & set_(Storage source, int64_t storage_offset, IntList size, IntList stride={});
   Tensor & set_(const Tensor & source);

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -646,6 +646,8 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * for example, an index into a tensor will have a non-zero storage_offset().
    *
    * WARNING: This is NOT computed in bytes.
+   *
+   * XXX: The only thing stopping this function from being virtual is Variable.
    */
   virtual int64_t storage_offset() const {
     return storage_offset_;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -53,9 +53,6 @@ inline void Tensor::set_data(Tensor new_data) {
 }
 
 // all static inline to allow for inlining of the non-dynamic part of dispatch
-inline int64_t Tensor::_th_storage_offset() const {
-    return type()._th_storage_offset(*this);
-}
 inline int64_t Tensor::_th_ndimension() const {
     return type()._th_ndimension(*this);
 }
@@ -1240,9 +1237,6 @@ inline Tensor Tensor::to(const Tensor & other, bool non_blocking, bool copy) con
 }
 inline Scalar Tensor::_local_scalar() const {
     return type()._local_scalar(*this);
-}
-inline int64_t Tensor::storage_offset() const {
-    return type().storage_offset(*this);
 }
 inline Tensor & Tensor::set_(Storage source) {
     return type().set_(*this, source);

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -168,7 +168,6 @@ struct CAFFE2_API Type {
 
   // example
   // virtual Tensor * add(Tensor & a, Tensor & b) = 0;
-  virtual int64_t _th_storage_offset(const Tensor & self) const = 0;
   virtual int64_t _th_ndimension(const Tensor & self) const = 0;
   virtual Tensor & _th_set_(Tensor & self, Storage source) const = 0;
   virtual Tensor & _th_set_(Tensor & self, Storage source, int64_t storage_offset, IntList size, IntList stride) const = 0;
@@ -609,7 +608,6 @@ struct CAFFE2_API Type {
   virtual Tensor to(const Tensor & self, Device device, bool non_blocking, bool copy) const = 0;
   virtual Tensor to(const Tensor & self, const Tensor & other, bool non_blocking, bool copy) const = 0;
   virtual Scalar _local_scalar(const Tensor & self) const = 0;
-  virtual int64_t storage_offset(const Tensor & self) const = 0;
   virtual Tensor & set_(Tensor & self, Storage source) const = 0;
   virtual Tensor & set_(Tensor & self, Storage source, int64_t storage_offset, IntList size, IntList stride) const = 0;
   virtual Tensor & set_(Tensor & self, const Tensor & source) const = 0;

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -5,10 +5,6 @@ namespace at { namespace native {
 
 // Methods
 
-int64_t storage_offset(const Tensor& self) {
-  return self._th_storage_offset();
-}
-
 int64_t ndimension(const Tensor& self) {
   return self._th_ndimension();
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2294,10 +2294,6 @@
 
 # wrappers for legacy TH methods
 
-- func: storage_offset(Tensor self) -> int64_t
-  variants: method
-  device_guard: false
-
 - func: ndimension(Tensor self) -> int64_t
   variants: method
   device_guard: false

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -53,6 +53,9 @@ public:
   int64_t dim() const {
     return impl_->dim();
   }
+  int64_t storage_offset() const {
+    return impl_->storage_offset();
+  }
 
   TensorImpl * unsafeGetTensorImpl() const {
     return impl_.get();

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5058,6 +5058,17 @@ a")
         v = torch.randn(1, device='cuda')
         self.assertEqual(foo(v), 0)
 
+    def test_script_storage_offset(self):
+        @torch.jit.script
+        def foo(a):
+            return a.storage_offset()
+
+        v = torch.randn(5)
+        self.assertEqual(foo(v), 0)
+
+        v.set_(v.storage(), 3, [1], [1])
+        self.assertEquals(foo(v), 3)
+
     def test_script_chunk(self):
         @torch.jit.script
         def foo(a):

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -111,6 +111,14 @@ static PyObject * THPVariable_get_device(PyObject* self_, PyObject* args)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_storage_offset(PyObject* self_, PyObject* args)
+{
+  HANDLE_TH_ERRORS
+  auto& self = reinterpret_cast<THPVariable*>(self_)->cdata;
+  return wrap(self.storage_offset());
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
 {
    HANDLE_TH_ERRORS
@@ -648,6 +656,7 @@ PyMethodDef variable_methods[] = {
   {"short", (PyCFunction)THPVariable_short, METH_NOARGS, NULL},
   {"size", (PyCFunction)THPVariable_size, METH_VARARGS | METH_KEYWORDS, NULL},
   {"storage", (PyCFunction)THPVariable_storage, METH_NOARGS, NULL},
+  {"storage_offset", (PyCFunction)THPVariable_storage_offset, METH_NOARGS, NULL},
   {"storage_type", (PyCFunction)THPVariable_storage_type, METH_NOARGS, NULL},
   {"stride", (PyCFunction)THPVariable_stride, METH_VARARGS | METH_KEYWORDS, NULL},
   {"to", (PyCFunction)THPVariable_to, METH_VARARGS | METH_KEYWORDS, NULL},

--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -72,6 +72,16 @@ RegisterOperators reg({
       return 0;
   }
   ),
+  Operator(
+      "aten::storage_offset(Tensor self) -> int",
+      [](Stack & stack) {
+          autograd::profiler::RecordFunction record("storage_offset");
+          auto result = ((std::move(peek(stack, 0, 1))).toTensor()).storage_offset();
+          drop(stack, 1);
+          pack(stack, std::move(result));
+          return 0;
+      }
+  ),
 
   // Generated operators
   ${constructors}

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -303,7 +303,6 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
 
   int64_t dim() const override;
   const at::Storage& storage() const override;
-  int64_t storage_offset() const override;
 
   std::shared_ptr<Function> get_grad_accumulator();
   virtual std::shared_ptr<Function>& get_grad_fn() {
@@ -375,6 +374,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
   // get_grad_accumulator.
   std::mutex mutex_;
 
+  int64_t storage_offset() const override;
  private:
   int64_t get_device_slow() const override;
 };


### PR DESCRIPTION
This PR special cases tensor.storage_offset to avoid dispatches in the
common case. tensor.storage_offset is important for torch.as_strided
performance, because as_strided(sizes, strides) shares an implementation
with as_strided(sizes, strides, storage_offset) and it might not be the
best if there were two separate implementations (including backward
implementations).

This PR reduces times on a tensor.storage_offset
microbenchmark from 22ns to 2ns (these numbers are pretty stable). For
a torch.as_strided benchmark, this PR reduces numbers from 1042 to
928ns, a 100ns improvement, but this number is noisy and goes up and
down.

Test Plan: run tests. Also added new test case to make sure the JIT
accepts this special-cased tensor.storage_offset() fn.

