### PR TITLE
Support new upsample in symbolic, caffe2 backend & caffe2 frontend

### DIFF
--- a/caffe2/onnx/helper.h
+++ b/caffe2/onnx/helper.h
@@ -71,6 +71,30 @@ inline AttributeProto MakeAttribute(
   return attr;
 }
 
+inline AttributeProto MakeAttribute(
+    const std::string& name,
+    ::ONNX_NAMESPACE::TensorProto& val) {
+  AttributeProto attr;
+  attr.set_name(name);
+  attr.mutable_t()->CopyFrom(val);
+  attr.set_type(AttributeProto::TENSOR);
+  return attr;
+}
+
+template <class T>
+::ONNX_NAMESPACE::TensorProto MakeTensor(
+    const string& name,
+    const std::vector<T>& v,
+    const ::ONNX_NAMESPACE::TensorProto_DataType& data_type_) {
+  ::ONNX_NAMESPACE::TensorProto ret;
+  ret.set_name(name);
+  ret.add_dims(v.size());
+  ret.set_data_type(data_type_);
+  ret.mutable_raw_data()->assign(
+      reinterpret_cast<const char*>(v.data()), v.size() * sizeof(T));
+  return ret;
+}
+
 CAFFE2_API NodeProto MakeNode(
     const std::string& type,
     const std::vector<std::string>& inputs,

--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -697,35 +697,53 @@ ConvertedResult OnnxExporter::CreateChannelShuffleNodes(
 ConvertedResult OnnxExporter::CreateUpsampleNodes(
     const caffe2::OperatorDef& def,
     const std::unordered_map<std::string, caffe2::TensorShape>& shapes) {
-  float width_scale = 1.0;
-  float height_scale = 1.0;
-  for (const auto& a : def.arg()) {
-    if (a.name() == "width_scale") {
-      width_scale = a.f();
-    } else if (a.name() == "height_scale") {
-      height_scale = a.f();
-    }
-  }
-  CAFFE_ENFORCE_GT(width_scale, 0);
-  CAFFE_ENFORCE_GT(height_scale, 0);
-
-  auto x = def.input(0);
-  const auto& x_shape = shapes.at(x);
-  CAFFE_ENFORCE_GE(x_shape.dims().size(), 2);
-
-  std::vector<float> scales(x_shape.dims().size(), 1.0);
-  scales[scales.size() - 2] = height_scale;
-  scales[scales.size() - 1] = width_scale;
-
   ConvertedResult result;
+  //{H, W} => {1, 1, H, W}
   auto& nodes = result.first;
-  std::vector<std::string> inputs(def.input().begin(), def.input().end());
+  auto resolved_scale = dummy_->NewDummyName();
+  if (def.input_size() == 1) {
+    float width_scale = 1.0;
+    float height_scale = 1.0;
+    for (const auto& a : def.arg()) {
+      if (a.name() == "width_scale") {
+        width_scale = a.f();
+      } else if (a.name() == "height_scale") {
+        height_scale = a.f();
+      }
+    }
+    CAFFE_ENFORCE_GT(width_scale, 0);
+    CAFFE_ENFORCE_GT(height_scale, 0);
+    std::vector<float> tmp_vector = {1, 1, height_scale, width_scale};
+    auto resolved_scale_tensor =
+        MakeTensor("resolved scale tensor", tmp_vector, TensorProto::FLOAT);
+
+    auto node = MakeNode("Constant", {}, {resolved_scale});
+    MakeAttribute("value", resolved_scale_tensor);
+    node.add_attribute()->CopyFrom(
+        MakeAttribute("value", resolved_scale_tensor));
+    nodes.emplace_back(node);
+
+  } else {
+    CAFFE_ENFORCE_EQ(def.input_size(), 2);
+    std::vector<float> tmp_vector = {1, 1};
+    auto scale_pads_tensor =
+        MakeTensor("scale pads", tmp_vector, TensorProto::FLOAT);
+    auto unresolved_scale_pads = dummy_->NewDummyName();
+
+    auto node = MakeNode("Constant", {}, {unresolved_scale_pads});
+    node.add_attribute()->CopyFrom(MakeAttribute("value", scale_pads_tensor));
+    nodes.emplace_back(node);
+
+    node = MakeNode(
+        "Concat", {unresolved_scale_pads, def.input(1)}, {resolved_scale});
+    node.add_attribute()->CopyFrom(MakeAttribute("axis", 0));
+    nodes.emplace_back(node);
+  }
+  std::vector<std::string> inputs = {def.input(0), resolved_scale};
   std::vector<std::string> outputs(def.output().begin(), def.output().end());
   auto node = MakeNode("Upsample", inputs, outputs, def.name());
-  node.add_attribute()->CopyFrom(MakeAttribute("scales", scales));
   node.add_attribute()->CopyFrom(MakeAttribute("mode", "nearest"));
   nodes.emplace_back(node);
-
   return result;
 }
 

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -383,35 +383,6 @@ class Caffe2Backend(Backend):
         return outputs
 
     @classmethod
-    def _create_upsample(cls, init_model, pred_model, n, opset_version):
-        c2_op = cls._common_onnx_node_to_caffe2_op(init_model, pred_model, n, opset_version)
-        if opset_version >= 7:
-            if len(n.attrs['scales']) != 4:
-                raise ValueError("The scales argument should have size 4")
-            elif not (np.isclose(n.attrs['scales'][0], 1) and np.isclose(n.attrs['scales'][1], 1)):
-                raise ValueError("The first two elements in the scales argument must be 1")
-            c2_op.arg.extend([caffe2.python.utils.MakeArgument('height_scale', n.attrs['scales'][2])])
-            c2_op.arg.extend([caffe2.python.utils.MakeArgument('width_scale', n.attrs['scales'][3])])
-
-        return c2_op
-
-    @classmethod
-    def _create_gaussian_fill(cls, init_model, pred_model, n, opset_version):
-        c2_op = cls._common_onnx_node_to_caffe2_op(init_model, pred_model, n,
-                                                   opset_version)
-        if "seed" in n.attrs:
-            raise ValueError("Caffe2 does not support random seed")
-
-        if "dtype" in n.attrs and n.attrs['dtype'] != onnx.TensorProtoDataType.FLOAT:
-            raise ValueError("Caffe2 does not support no-float dtype")
-
-        if "scale" in n.attrs:
-            c2_op.arg.extend([caffe2.python.utils.MakeArgument('std',
-                                                           n.attrs['scale'])])
-
-        return c2_op
-
-    @classmethod
     def _create_rnn_variant(cls, init_model, pred_model, n, opset_version):
         assert init_model is not None, "cannot convert RNNs without access to the full model"
         assert pred_model is not None, "cannot convert RNNs without access to the full model"

--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -45,7 +45,7 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
 
 # Quick patch to unbreak master CI, is working on the debugging.
 backend_test.exclude('(test_cast_.*'
-                     '|test_upsample_nearest.*'
+                     '|test_compress_.*'
                      '|test_Conv1d_.*cuda'
                      '|test_Conv3d_groups_cuda'
                      '|test_rnn_seq_length'

--- a/test/onnx/expect/TestOperators.test_upsample.expect
+++ b/test/onnx/expect/TestOperators.test_upsample.expect
@@ -3,21 +3,27 @@ producer_name: "pytorch"
 producer_version: "0.4"
 graph {
   node {
-    input: "0"
     output: "1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: FLOAT
+        raw_data: "\000\000\200?\000\000\200?\000\000\000@\000\000\000@"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "0"
+    input: "1"
+    output: "2"
     op_type: "Upsample"
     attribute {
       name: "mode"
       s: "linear"
       type: STRING
-    }
-    attribute {
-      name: "scales"
-      floats: 1
-      floats: 1
-      floats: 2
-      floats: 2
-      type: FLOATS
     }
   }
   name: "torch-jit-export"
@@ -44,7 +50,7 @@ graph {
     }
   }
   output {
-    name: "1"
+    name: "2"
     type {
       tensor_type {
         elem_type: FLOAT

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -75,7 +75,6 @@ class TestOperators(TestCase):
             import test_onnx_common
             model_def = onnx.ModelProto.FromString(onnx_model_pb)
             onnx.checker.check_model(model_def)
-
             if _onnx_test:
                 test_function = inspect.stack()[1][0].f_code.co_name
                 test_name = test_function[0:4] + "_operator" + test_function[4:]
@@ -434,7 +433,6 @@ class TestOperators(TestCase):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: x.norm(p=2, dim=2), (x))
 
-    @skipIfCI
     def test_upsample(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: nn.functional.interpolate(x, scale_factor=2., mode='bilinear'), x)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -747,6 +747,12 @@ class TestCaffe2Backend(unittest.TestCase):
         x = torch.randn(4, 3, 2, 1, requires_grad=True)
         self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_upsample(self):
+        x = torch.randn(1, 2, 3, 4, requires_grad=True)
+        model = nn.Upsample(scale_factor=2, mode='nearest')
+        self.run_model_test(model, train=False, input=(x),
+                            batch_size=BATCH_SIZE, use_gpu=False)
+
     def test_repeat_dim_overflow(self):
         class MyModel(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -642,8 +642,10 @@ replication_pad3d = replication_pad
 def upsample_nearest2d(g, input, output_size):
     height_scale = float(output_size[-2]) / input.type().sizes()[-2]
     width_scale = float(output_size[-1]) / input.type().sizes()[-1]
-    return g.op("Upsample", input,
-                scales_f=[1., 1., height_scale, width_scale],
+    scales = g.op("Constant", value_t=torch.tensor([1., 1., height_scale,
+                                                    width_scale]))
+
+    return g.op("Upsample", input, scales,
                 mode_s="nearest")
 
 
@@ -653,8 +655,9 @@ def upsample_bilinear2d(g, input, output_size, align_corners):
         return _unimplemented("upsample_bilinear2d", "align_corners == True")
     height_scale = float(output_size[-2]) / input.type().sizes()[-2]
     width_scale = float(output_size[-1]) / input.type().sizes()[-1]
-    return g.op("Upsample", input,
-                scales_f=[1., 1., height_scale, width_scale],
+    scales = g.op("Constant", value_t=torch.tensor([1., 1., height_scale,
+                                                    width_scale]))
+    return g.op("Upsample", input, scales,
                 mode_s="linear")
 
 


### PR DESCRIPTION
We updated the description of upsample_op in onnx: https://github.com/onnx/onnx/pull/1467
Therefore, we need to support the new upsample_op in caffe2-onnx backend as well.