### PR TITLE
Fix accesses to uninitialized memory when running sum() within an OMP…

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -36,6 +36,14 @@ inline int get_thread_num() {
 #endif
 }
 
+inline bool in_parallel_region() {
+#ifdef _OPENMP
+  return omp_in_parallel();
+#else
+  return false;
+#endif
+}
+
 template <class F>
 inline void parallel_for(
     const int64_t begin,

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -1,7 +1,8 @@
 #include "gtest/gtest.h"
 
-#include "ATen/ATen.h"
-#include "ATen/DLConvertor.h"
+#include <ATen/ATen.h>
+#include <ATen/DLConvertor.h>
+#include <ATen/Parallel.h>
 
 #include <iostream>
 #include <string.h>
@@ -23,4 +24,15 @@ TEST(TestParallel, TestParallel) {
   as[1] = 0;
   as[2] = 0;
   ASSERT_TRUE(a.sum(0).equal(as));
+}
+
+TEST(TestParallel, NestedParallel) {
+  Tensor a = ones({1024, 1024});
+  auto expected = a.sum();
+  // check that calling sum() from within a parallel block computes the same result
+  at::parallel_for(0, 10, 1, [&](int64_t begin, int64_t end) {
+    if (begin == 0) {
+      ASSERT_TRUE(a.sum().equal(expected));
+    }
+  });
 }


### PR DESCRIPTION
```
… parallel region.

The two_pass_reduction code allocates a buffer of size at::max_threads().
When called within a parallel region, at::parallel_for only uses 1 thread
so some of this buffer is not written.

This makes two changes:

1) two_pass_reduction is not called when already in a parallel region
2) two_pass_reduction fills unwritten buffer elements with the identity
   (the value in dst)
```

cc @t-vi @SsnL: I think this should fix the NaNs in BatchNorm when calling sum() within a parallel region.