### PR TITLE
Explicit caffe2 caffe2_gpu to fix CMake 3.12 issue

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -40,7 +40,7 @@ find_package(Caffe2 REQUIRED)
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 add_library(torch UNKNOWN IMPORTED)
-set(TORCH_LIBRARIES torch ${Caffe2_MAIN_LIBS})
+set(TORCH_LIBRARIES torch caffe2 caffe2_gpu)
 
 if (@USE_CUDA@)
   if(MSVC)


### PR DESCRIPTION
In our cmake, ${Caffe2_MAIN_LIBS} is defined as `caffe2_library;caffe2_gpu_library`. These two libraries have a lot of interface dependencies and such set up, which interestingly interfere with newer CMake (3.12 and up) versions that add native support for CUDA (see note at the top of https://cmake.org/cmake/help/v3.12/module/FindCUDA.html). Specifically, the native CUDA support from CMake seems to pass `Wl,--no-as-needed,/home/xxx/library/libtorch/lib/libcaffe2.so` to the NVCC device compiler, which then dies. By explicitly linking against the `caffe2` and `caffe2_gpu` targets, these issues are fixed.

Fixes https://github.com/pytorch/pytorch/issues/12911

@soumith @orionr 