### PR TITLE
[JIT] Removes debug spew in test_jit.py

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9281,7 +9281,6 @@ def add_nn_module_test(module_name, constructor_args, call_args, skipTestIf=()):
             call_args_str = ', '.join(actuals)
             call = "self.submodule({})".format(call_args_str)
             script = script_method_template.format(method_args, call)
-            print(script)
 
             # Create module to use the script method
             class TheModule(torch.jit.ScriptModule):


### PR DESCRIPTION
Looks like a print() snuck in by accident with a recent PR and it's printing a lot of spew when the tests are run. 

