### PR TITLE
[C++ frontend] Remove assertions in conv modules

### DIFF
--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -69,8 +69,6 @@ void ConvImpl<D, Derived>::reset() {
 }
 
 Tensor Conv1dImpl::forward(Tensor input) {
-  AT_ASSERT(input.ndimension() == 3);
-
   if (options.transposed_) {
     return torch::conv_transpose1d(
         input,
@@ -93,8 +91,6 @@ Tensor Conv1dImpl::forward(Tensor input) {
 }
 
 Tensor Conv2dImpl::forward(Tensor input) {
-  AT_ASSERT(input.ndimension() == 4);
-
   if (options.transposed_) {
     return torch::conv_transpose2d(
         input,
@@ -117,8 +113,6 @@ Tensor Conv2dImpl::forward(Tensor input) {
 }
 
 Tensor Conv3dImpl::forward(Tensor input) {
-  AT_ASSERT(input.ndimension() == 5);
-
   if (options.transposed_) {
     return torch::conv_transpose3d(
         input,


### PR DESCRIPTION
These assertions aren't necessary because these conditions are checked inside the ATen ops, and right now they're not very user-friendly because they don't have an error message or reference the dimension of the tensor being checked. Let's just remove them (the error then comes from ATen with a friendlier message).

@ezyang @ebetica 