### PR TITLE
Replace tmpnam usage

### DIFF
--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <torch/csrc/utils/tempfile.h>
 #include <torch/nn/init.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/tensor.h>
@@ -50,4 +51,9 @@ TEST(NNInitTest, CanInitializeTensorThatRequiresGrad) {
       "a leaf Variable that requires grad "
       "has been used in an in-place operation");
   ASSERT_EQ(torch::nn::init::ones_(tensor).sum().item<int32_t>(), 12);
+}
+
+TEST(TempFileTest, MatchesExpectedPattern) {
+  torch::utils::TempFile pattern = torch::utils::make_tempfile("test-pattern-");
+  ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);
 }

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -54,7 +54,7 @@ TEST(SerializeTest, BasicToFile) {
 
   auto x = torch::randn({5, 5});
 
-  torch::test::TempFile tempfile;
+  auto tempfile = torch::make_tempfile();
   torch::save(x, tempfile.name);
 
   torch::Tensor y;
@@ -135,7 +135,7 @@ TEST(SerializeTest, XOR) {
     epoch++;
   }
 
-  torch::test::TempFile tempfile;
+  auto tempfile = torch::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -149,7 +149,7 @@ TEST(SerializeTest, Optim) {
   auto model3 = Linear(5, 2);
 
   // Models 1, 2, 3 will have the same parameters.
-  torch::test::TempFile model_tempfile;
+  auto model_tempfile = torch::make_tempfile();
   torch::save(model1, model_tempfile.name);
   torch::load(model2, model_tempfile.name);
   torch::load(model3, model_tempfile.name);
@@ -194,7 +194,7 @@ TEST(SerializeTest, Optim) {
   // Do 2 steps of model 3 while saving the optimizer
   step(optim3, model3);
 
-  torch::test::TempFile optim_tempfile;
+  auto optim_tempfile = torch::make_tempfile();
   torch::save(optim3, optim_tempfile.name);
   torch::load(optim3_2, optim_tempfile.name);
   step(optim3_2, model3);
@@ -247,7 +247,7 @@ TEST(SerializeTest, XOR_CUDA) {
     epoch++;
   }
 
-  torch::test::TempFile tempfile;
+  auto tempfile = torch::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -255,7 +255,7 @@ TEST(SerializeTest, XOR_CUDA) {
   ASSERT_LT(loss.item<float>(), 0.1);
 
   model2->to(torch::kCUDA);
-  torch::test::TempFile tempfile2;
+  auto tempfile2 = torch::make_tempfile();
   torch::save(model2, tempfile2.name);
   torch::load(model3, tempfile2.name);
 

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -54,7 +54,7 @@ TEST(SerializeTest, BasicToFile) {
 
   auto x = torch::randn({5, 5});
 
-  auto tempfile = torch::make_tempfile();
+  auto tempfile = torch::utils::make_tempfile();
   torch::save(x, tempfile.name);
 
   torch::Tensor y;
@@ -135,7 +135,7 @@ TEST(SerializeTest, XOR) {
     epoch++;
   }
 
-  auto tempfile = torch::make_tempfile();
+  auto tempfile = torch::utils::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -149,7 +149,7 @@ TEST(SerializeTest, Optim) {
   auto model3 = Linear(5, 2);
 
   // Models 1, 2, 3 will have the same parameters.
-  auto model_tempfile = torch::make_tempfile();
+  auto model_tempfile = torch::utils::make_tempfile();
   torch::save(model1, model_tempfile.name);
   torch::load(model2, model_tempfile.name);
   torch::load(model3, model_tempfile.name);
@@ -194,7 +194,7 @@ TEST(SerializeTest, Optim) {
   // Do 2 steps of model 3 while saving the optimizer
   step(optim3, model3);
 
-  auto optim_tempfile = torch::make_tempfile();
+  auto optim_tempfile = torch::utils::make_tempfile();
   torch::save(optim3, optim_tempfile.name);
   torch::load(optim3_2, optim_tempfile.name);
   step(optim3_2, model3);
@@ -247,7 +247,7 @@ TEST(SerializeTest, XOR_CUDA) {
     epoch++;
   }
 
-  auto tempfile = torch::make_tempfile();
+  auto tempfile = torch::utils::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -255,7 +255,7 @@ TEST(SerializeTest, XOR_CUDA) {
   ASSERT_LT(loss.item<float>(), 0.1);
 
   model2->to(torch::kCUDA);
-  auto tempfile2 = torch::make_tempfile();
+  auto tempfile2 = torch::utils::make_tempfile();
   torch::save(model2, tempfile2.name);
   torch::load(model3, tempfile2.name);
 

--- a/test/cpp/common/support.h
+++ b/test/cpp/common/support.h
@@ -1,44 +1,16 @@
 #pragma once
 
-#include "c10/util/Exception.h"
+#include <torch/csrc/utils/tempfile.h>
+
+#include <c10/util/Exception.h>
 
 #include <gtest/gtest.h>
 
-#include <cstdio>
-#include <cstdlib>
 #include <stdexcept>
 #include <string>
-#include <utility>
-
-#ifndef WIN32
-#include <unistd.h>
-#endif
 
 namespace torch {
 namespace test {
-
-#ifdef WIN32
-struct TempFile {
-  std::string name{std::tmpnam(nullptr)};
-};
-#else
-struct TempFile {
-  TempFile() {
-    // http://pubs.opengroup.org/onlinepubs/009695399/functions/mkstemp.html
-    char filename[] = "/tmp/fileXXXXXX";
-    fd_ = mkstemp(filename);
-    AT_CHECK(fd_ != -1, "Error creating tempfile");
-    name.assign(filename);
-  }
-
-  ~TempFile() {
-    close(fd_);
-  }
-
-  std::string name;
-  int fd_;
-};
-#endif
 
 #define ASSERT_THROWS_WITH(statement, substring)                        \
   {                                                                     \

--- a/torch/csrc/utils/tempfile.h
+++ b/torch/csrc/utils/tempfile.h
@@ -4,23 +4,32 @@
 #include <c10/util/Optional.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
+#include <utility>
+#include <vector>
 
 #if !defined(_WIN32)
 #include <unistd.h>
 #endif
 
 namespace torch {
+namespace utils {
 namespace detail {
 // Creates the filename pattern passed to and completed by `mkstemp`.
-// Returns std::vector<char> because `mkstemp` needs a (non-const) `char*`.
+// Returns std::vector<char> because `mkstemp` needs a (non-const) `char*` and
+// `std::string` only provides `const char*` before C++17.
 #if !defined(_WIN32)
 inline std::vector<char> make_filename(std::string name_prefix) {
   // The filename argument to `mkstemp` needs "XXXXXX" at the end according to
   // http://pubs.opengroup.org/onlinepubs/009695399/functions/mkstemp.html
   static const std::string kRandomPattern = "XXXXXX";
+
+  // We see if any of these environment variables is set and use their value, or
+  // else default the temporary directory to `/tmp`.
   static const char* env_variables[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
 
   std::string tmp_directory = "/tmp";
@@ -33,12 +42,13 @@ inline std::vector<char> make_filename(std::string name_prefix) {
 
   std::vector<char> filename;
   filename.reserve(
-      tmp_directory.size() + 1 + name_prefix.size() + kRandomPattern.size());
+      tmp_directory.size() + name_prefix.size() + kRandomPattern.size() + 2);
 
   filename.insert(filename.end(), tmp_directory.begin(), tmp_directory.end());
   filename.push_back('/');
   filename.insert(filename.end(), name_prefix.begin(), name_prefix.end());
   filename.insert(filename.end(), kRandomPattern.begin(), kRandomPattern.end());
+  filename.push_back('\0');
 
   return filename;
 }
@@ -60,14 +70,16 @@ struct TORCH_API TempFile {
   const std::string name;
 };
 
-/// Attempts to return a temporary file or returns nullopt if an error ocurred.
+/// Attempts to return a temporary file or returns `nullopt` if an error
+/// ocurred.
+///
 /// The file returned follows the pattern
 /// `<tmp-dir>/<name-prefix><random-pattern>`, where `<tmp-dir>` is the value of
 /// the `"TMPDIR"`, `"TMP"`, `"TEMP"` or
 /// `"TEMPDIR"` environment variable if any is set, or otherwise `/tmp`;
 /// `<name-prefix>` is the value supplied to this function, and
 /// `<random-pattern>` is a random sequence of numbers.
-/// On Windows, `name_prefix` is ignored.
+/// On Windows, `name_prefix` is ignored and `tmpnam` is used.
 inline c10::optional<TempFile> try_make_tempfile(
     std::string name_prefix = "torch-file-") {
 #if defined(_WIN32)
@@ -88,6 +100,7 @@ inline TempFile make_tempfile(std::string name_prefix = "torch-file-") {
   if (auto tempfile = try_make_tempfile(std::move(name_prefix))) {
     return *tempfile;
   }
-  AT_ERROR("Error generating temporary filename");
+  AT_ERROR("Error generating temporary file: ", std::strerror(errno));
 }
+} // namespace utils
 } // namespace torch

--- a/torch/csrc/utils/tempfile.h
+++ b/torch/csrc/utils/tempfile.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
+namespace torch {
+namespace detail {
+// Creates the filename pattern passed to and completed by `mkstemp`.
+// Returns std::vector<char> because `mkstemp` needs a (non-const) `char*`.
+#if !defined(_WIN32)
+inline std::vector<char> make_filename(std::string name_prefix) {
+  // The filename argument to `mkstemp` needs "XXXXXX" at the end according to
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/mkstemp.html
+  static const std::string kRandomPattern = "XXXXXX";
+  static const char* env_variables[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
+
+  std::string tmp_directory = "/tmp";
+  for (const char* variable : env_variables) {
+    if (const char* path = getenv(variable)) {
+      tmp_directory = path;
+      break;
+    }
+  }
+
+  std::vector<char> filename;
+  filename.reserve(
+      tmp_directory.size() + 1 + name_prefix.size() + kRandomPattern.size());
+
+  filename.insert(filename.end(), tmp_directory.begin(), tmp_directory.end());
+  filename.push_back('/');
+  filename.insert(filename.end(), name_prefix.begin(), name_prefix.end());
+  filename.insert(filename.end(), kRandomPattern.begin(), kRandomPattern.end());
+
+  return filename;
+}
+#endif // !defined(_WIN32)
+} // namespace detail
+
+struct TORCH_API TempFile {
+#if !defined(_WIN32)
+  TempFile(std::string name, int fd) : fd(fd), name(std::move(name)) {}
+
+  ~TempFile() {
+    unlink(name.c_str());
+    close(fd);
+  }
+
+  const int fd;
+#endif // !defined(_WIN32)
+
+  const std::string name;
+};
+
+/// Attempts to return a temporary file or returns nullopt if an error ocurred.
+/// The file returned follows the pattern
+/// `<tmp-dir>/<name-prefix><random-pattern>`, where `<tmp-dir>` is the value of
+/// the `"TMPDIR"`, `"TMP"`, `"TEMP"` or
+/// `"TEMPDIR"` environment variable if any is set, or otherwise `/tmp`;
+/// `<name-prefix>` is the value supplied to this function, and
+/// `<random-pattern>` is a random sequence of numbers.
+/// On Windows, `name_prefix` is ignored.
+inline c10::optional<TempFile> try_make_tempfile(
+    std::string name_prefix = "torch-file-") {
+#if defined(_WIN32)
+  return TempFile{std::tmpnam(nullptr)};
+#else
+  std::vector<char> filename = detail::make_filename(std::move(name_prefix));
+  const int fd = mkstemp(filename.data());
+  if (fd == -1) {
+    return c10::nullopt;
+  }
+  return TempFile(std::string(filename.begin(), filename.end()), fd);
+#endif // defined(_WIN32)
+}
+
+/// Like `try_make_tempfile`, but throws an exception if a temporary file could
+/// not be returned.
+inline TempFile make_tempfile(std::string name_prefix = "torch-file-") {
+  if (auto tempfile = try_make_tempfile(std::move(name_prefix))) {
+    return *tempfile;
+  }
+  AT_ERROR("Error generating temporary filename");
+}
+} // namespace torch

--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -2,7 +2,8 @@ project(libshm C CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
 CMAKE_POLICY(VERSION 2.6)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/public/threads.cmake)
+set(TORCH_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../)
+include(${TORCH_ROOT}/cmake/public/threads.cmake)
 
 IF(NOT LIBSHM_INSTALL_LIB_SUBDIR)
   SET(LIBSHM_INSTALL_LIB_SUBDIR "lib" CACHE PATH "libshm install library directory")
@@ -24,6 +25,7 @@ ENDIF ()
 ADD_LIBRARY(shm SHARED core.cpp)
 
 target_include_directories(shm PRIVATE
+  ${TORCH_ROOT}
   ${CMAKE_SOURCE_DIR}/aten/src/TH # provides "THAllocator.h" to THCGeneral.h
   ${CMAKE_BINARY_DIR}/aten/src # provides "ATen/TypeExtendedInterface.h" to ATen.h
   ${CMAKE_BINARY_DIR}/caffe2/aten/src # provides <TH/THGeneral.h> to THC.h

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
 
   std::unique_ptr<ManagerServerSocket> srv_socket;
   const auto tempfile =
-      torch::try_make_tempfile(/*name_prefix=*/"torch-shm-file-");
+      torch::utils::try_make_tempfile(/*name_prefix=*/"torch-shm-file-");
   try {
     if (!tempfile.has_value()) {
       throw std::runtime_error(


### PR DESCRIPTION
Fix 
```
/torch_shm_manager#compile-manager.cpp.oc089dac2,gcc-5-glibc-2.23-clang/manager.cpp.o:manager.cpp:function main: 
warning: the use of `tmpnam' is dangerous, better use `mkstemp`
```

@apaszke 