### PR TITLE
speed up torch.sparse_mask() cpu kernel

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -69,6 +69,7 @@ inline Tensor new_values_with_size_of(const Tensor& values, int64_t nnz) {
   return at::empty(size, values.options());
 }
 
+// NOTE [ Flatten Sparse Indices ]
 // This helper function flattens a sparse indices tensor (a LongTensor) into a 1D
 // indices tensor. E.g.,
 //   input = [[2, 4, 0],

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -400,6 +400,36 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
   return dst;
 }
 
+
+// --------------------------------------------------------------------
+// sparse_mask(D, S) -> S
+//
+// Filter Tensor D by S.indices() and output a SparseTensor.
+// --------------------------------------------------------------------
+
+template <typename scalar_t>
+void inline sparse_mask_out_cpu_kernel(
+  Tensor& r_values,
+  const Tensor& t,
+  const int64_t r_nnz,
+  const int64_t sparse_dim,
+  const LongTensor& mask_indices
+) {
+  auto r_values_accessor = r_values.accessor<scalar_t, 1>();
+  auto mask_indices_accessor = mask_indices.accessor<int64_t, 2>();
+  scalar_t* t_ptr = t.data<scalar_t>();
+  int64_t i;
+
+  #pragma omp parallel for private(i) if (r_nnz > 1000)
+  for (i = 0; i < r_nnz; i++) {
+    int64_t idx = 0;
+    for (int64_t d = 0; d < sparse_dim; d++) {
+      idx += mask_indices_accessor[d][i] * t.stride(d);
+    }
+    r_values_accessor[i] = t_ptr[idx];
+  }
+}
+
 SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const SparseTensor& mask) {
   AT_CHECK(mask.is_coalesced(), "sparse_mask: mask is uncoalesced");
   AT_CHECK(mask.sizes().equals(t.sizes()), "sparse_mask: operands have incompatible sizes; self has size ",
@@ -409,8 +439,7 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
   AT_CHECK(!mask.is_cuda(), "sparse_mask: expected 'mask' to be CPU, but got CUDA");
   resize_as_sparse_(r, mask);
   if (mask._nnz() == 0) {
-    r.zero_();
-    return r;
+    return r.zero_();
   }
   int64_t dim = t.dim();
   int64_t sparse_dim = mask.sparse_dim();
@@ -426,35 +455,32 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
     return r;
   }
 
-  // NB: Relies on mask._nnz() == 0 test above
-  auto mask_indices_accessor = mask_indices.accessor<int64_t, 2>();
-
   if (dim > sparse_dim) {
-    // NB: This used to reuse buffers, but I deoptimized it
-    for (int64_t i = 0; i < r_nnz; i++) {
-      Tensor srcBuffer = t;
-      for (int64_t d = 0; d < sparse_dim; d++) {
-        srcBuffer = srcBuffer.select(0, mask_indices_accessor[d][i]);
-      }
-      Tensor dstBuffer = r_values.select(0, i);
-      dstBuffer.copy_(srcBuffer);
+    LongTensor indices = at::zeros({mask._nnz()}, mask_indices.options());
+
+    for (int64_t d = 0; d < mask.sparse_dim(); d++) {
+      indices.mul_(mask.size(d));
+      // This used to use a buffer but I deoptimized it
+      indices.add_(mask_indices.select(0, d));
     }
+
+    std::vector<int64_t> view_size(1 + mask.dense_dim());
+    view_size[0] = -1;
+    for (int64_t d = 0; d < mask.dense_dim(); d++) {
+      view_size[d + 1] = mask.size(mask.sparse_dim() + d);
+    }
+
+    Tensor t_view = t.view(view_size);
+    // TODO: Re-audit this; it used to be an indexSelect directly into r_values
+    at::index_select_out(r_values, t_view, 0, indices);
   } else {
-    AT_DISPATCH_ALL_TYPES(
-        r_values.type(), "sparse_mask", [&] {
-          auto r_values_accessor = r_values.accessor<scalar_t, 1>();
-          // NB: The old code did this pointer access in a weird way (going straight
-          // to storage + storageOffset.)  Was there perhaps a method to the
-          // madness?
-          scalar_t* t_ptr = t.data<scalar_t>();
-          for (int64_t i = 0; i < r_nnz; i++) {
-            int64_t idx = 0;
-            for (int64_t d = 0; d < sparse_dim; d++) {
-              idx += mask_indices_accessor[d][i] * t.stride(d);
-            }
-            scalar_t val = t_ptr[idx];
-            r_values_accessor[i] = val;
-          }
+    AT_DISPATCH_ALL_TYPES(r_values.type(), "sparse_mask", [&] {
+      sparse_mask_out_cpu_kernel<scalar_t>(
+        r_values,
+        t,
+        r_nnz,
+        sparse_dim,
+        mask_indices);
     });
   }
   return r;

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -463,7 +463,6 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
     LongTensor indices = at::zeros({mask._nnz()}, mask_indices.options());
     for (int64_t d = 0; d < mask.sparse_dim(); d++) {
       indices.mul_(mask.size(d));
-      // This used to use a buffer but I deoptimized it
       indices.add_(mask_indices.select(0, d));
     }
 

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -405,6 +405,7 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
 // sparse_mask(D, S) -> S
 //
 // Filter Tensor D by S.indices() and output a SparseTensor.
+// D and S must share the same shape.
 // --------------------------------------------------------------------
 
 template <typename scalar_t>
@@ -456,8 +457,10 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
   }
 
   if (dim > sparse_dim) {
-    LongTensor indices = at::zeros({mask._nnz()}, mask_indices.options());
 
+    // Get a flattened sparse indices, similar to NOTE [ Flatten Sparse Indices ].
+    // Keeping this implementation because it is faster than flatten_indices()
+    LongTensor indices = at::zeros({mask._nnz()}, mask_indices.options());
     for (int64_t d = 0; d < mask.sparse_dim(); d++) {
       indices.mul_(mask.size(d));
       // This used to use a buffer but I deoptimized it

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
@@ -30,8 +30,9 @@ SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const Spars
     return r;
   }
 
+  // Get a flattened sparse indices, similar to NOTE [ Flatten Sparse Indices ].
+  // Keeping this implementation because it is faster than flatten_indices()
   LongTensor indices = at::zeros({mask._nnz()}, mask_indices.options());
-
   for (int64_t d = 0; d < mask.sparse_dim(); d++) {
     indices.mul_(mask.size(d));
     // This used to use a buffer but I deoptimized it

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -361,6 +361,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: slogdet
    .. automethod:: sort
    .. automethod:: split
+   .. automethod:: sparse_mask
    .. automethod:: sqrt
    .. automethod:: sqrt_
    .. automethod:: squeeze

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -225,7 +225,6 @@ class _TestTorchMixin(object):
                        'to_dense',
                        'sparse_resize_',
                        'sparse_resize_and_clear_',
-                       'sparse_mask',
                        )
         test_namespace(torch.nn)
         test_namespace(torch.nn.functional, 'assert_int_or_pair', 'bilinear', 'feature_alpha_dropout')

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1191,6 +1191,45 @@ index_select(dim, index) -> Tensor
 See :func:`torch.index_select`
 """)
 
+add_docstr_all('sparse_mask',
+               r"""
+sparse_mask(input, mask) -> Tensor
+
+Returns a new SparseTensor with values from Tensor :attr:`input` filtered
+by indices of SparseTensor :attr:`mask`. :attr:`input` and :attr:`mask`
+must have the same shape.
+
+Args:
+    input (Tensor): an input Tensor
+    mask (SparseTensor): a SparseTensor which we filter :attr:`input` based on its indices
+
+Example::
+
+    >>> nnz = 5
+    >>> dims = [5, 5, 2, 2]
+    >>> I = torch.cat([torch.randint(0, dims[0], size=(nnz,)),
+                       torch.randint(0, dims[1], size=(nnz,))], 0).reshape(2, nnz)
+    >>> V = torch.randn(nnz, dims[2], dims[3])
+    >>> size = torch.Size(dims)
+    >>> S = torch.sparse_coo_tensor(I, V, size).coalesce()
+    >>> D = torch.randn(dims)
+    >>> D.sparse_mask(S)
+    tensor(indices=tensor([[0, 0, 0, 2],
+                           [0, 1, 4, 3]]),
+           values=tensor([[[ 1.6550,  0.2397],
+                           [-0.1611, -0.0779]],
+
+                          [[ 0.2326, -1.0558],
+                           [ 1.4711,  1.9678]],
+
+                          [[-0.5138, -0.0411],
+                           [ 1.9417,  0.5158]],
+
+                          [[ 0.0793,  0.0036],
+                           [-0.2569, -0.1055]]]),
+           size=(5, 5, 2, 2), nnz=4, layout=torch.sparse_coo)
+""")
+
 add_docstr_all('inverse',
                r"""
 inverse() -> Tensor

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1196,7 +1196,7 @@ add_docstr_all('sparse_mask',
 sparse_mask(input, mask) -> Tensor
 
 Returns a new SparseTensor with values from Tensor :attr:`input` filtered
-by indices of SparseTensor :attr:`mask`. :attr:`input` and :attr:`mask`
+by indices of :attr:`mask` and values are ignored. :attr:`input` and :attr:`mask`
 must have the same shape.
 
 Args:


### PR DESCRIPTION
- `sparse_mask(D, S)` is useful to implement backward for `sparse_addmm()`
- previous `sparse_mask(D, S)` cpu kernel is not parallelized
- this PR speed up the cpu kernel for two separated cases:
  - `D.dim == S.sparse_dim`: simply parallelize the kernel
  - `D.dim > S.sparse_dim`: simply use CUDA kernel implementation
- performance:

`D.dim == S.sparse_dim`
```
>>> nnz = 100000
>>> dims = [1000, 1000]
>>> I = torch.cat([torch.randint(0, dims[0], size=(nnz,)), 
               torch.randint(0, dims[1], size=(nnz,))], 0).reshape(2, nnz)
>>> V = torch.randn(nnz)
>>> size = torch.Size(dims)

>>> S = torch.sparse_coo_tensor(I, V, size).coalesce()
>>> D = torch.randn(dims)

>>> %timeit D.sparse_mask(S)

======= before change =======
6.4 ms ± 684 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

======= after change =======
333 µs ± 89.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

`D.dim > S.sparse_dim`
```
>>> nnz = 100000
>>> dims = [1000, 1000, 2, 2]
>>> I = torch.cat([torch.randint(0, dims[0], size=(nnz,)), 
               torch.randint(0, dims[1], size=(nnz,))], 0).reshape(2, nnz)
>>> V = torch.randn(nnz, dims[2], dims[3])
>>> size = torch.Size(dims)

>>> S = torch.sparse_coo_tensor(I, V, size).coalesce()
>>> D = torch.randn(dims)
%timeit D.sparse_mask(S)

======= before change =======
495 ms ± 41.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

======= after change =======
594 µs ± 68.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```