### PR TITLE
[c10d] DDP multi-GPU segfault fix

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -246,6 +246,7 @@ void broadcast(
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; i++) {
     int device = tensors[i].get_device();
     device_guard.set_index(device);
+    // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
         ? at::cuda::getCurrentCUDAStream(device).stream()
         : streams[i]->stream();
@@ -270,8 +271,8 @@ void reduce(
     std::vector<at::Tensor>& outputs,
     int32_t root,
     int32_t op,
-    const c10::optional<stream_list>& streams,
-    const c10::optional<std::vector<ncclComm_t>>& comms) {
+    const stream_list& streams,
+    const comm_list& user_comms) {
 #ifdef USE_NCCL
   using namespace torch::cuda::nccl::detail;
   AT_CHECK(
@@ -284,22 +285,19 @@ void reduce(
 
   const auto count = inputs[0].numel();
   std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  auto comms_ref =
-      comms ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(*comms);
+  auto comms_ref = user_comms.empty() ? _get_communicators(inputs)
+                                      : ArrayRef<ncclComm_t>(user_comms);
 
   at::DeviceGuard device_guard;
   AutoNcclGroup nccl_group_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();
     device_guard.set_index(device);
+    // Default to the current stream
+    const auto stream = (streams.empty() || !streams[i])
+        ? at::cuda::getCurrentCUDAStream(device).stream()
+        : streams[i]->stream();
 
-    // Default to the current  stream
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream(device).stream();
-
-    // Two levels of optional! Wow!
-    if (streams && (*streams)[i]) {
-      stream = (*streams)[i]->stream();
-    }
     NCCL_CHECK(ncclReduce(
         inputs[i].data_ptr(),
         outputs[i].data_ptr(),
@@ -319,9 +317,9 @@ void reduce(
     std::vector<at::Tensor>& inputs,
     int32_t root,
     int32_t op,
-    const c10::optional<stream_list>& streams,
-    const c10::optional<std::vector<ncclComm_t>>& comms) {
-  reduce(inputs, /*outputs=*/inputs, root, op, streams, comms);
+    const stream_list& streams,
+    const comm_list& user_comms) {
+  reduce(inputs, /*outputs=*/inputs, root, op, streams, user_comms);
 }
 } // namespace nccl
 } // namespace cuda

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -68,15 +68,15 @@ void reduce(
     std::vector<at::Tensor>& outputs,
     int32_t root = 0,
     int32_t op = ncclSum,
-    const c10::optional<stream_list>& streams = c10::nullopt,
-    const c10::optional<std::vector<ncclComm_t>>& user_comms = c10::nullopt);
+    const stream_list& streams = {},
+    const comm_list& user_comms = {});
 
 void reduce(
     std::vector<at::Tensor>& inputs,
     int32_t root = 0,
     int32_t op = ncclSum,
-    const c10::optional<stream_list>& streams = c10::nullopt,
-    const c10::optional<std::vector<ncclComm_t>>& user_comms = c10::nullopt);
+    const stream_list& streams = {},
+    const comm_list& user_comms = {});
 
 } // namespace nccl
 } // namespace cuda

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -141,7 +141,7 @@ class DistributedDataParallel(Module):
         MB = 1024 * 1024
 
         # used for intra-node param sync and inter-node sync as well
-        self.broadcast_bucket_size = 25 * MB
+        self.broadcast_bucket_size = 250 * MB
 
         # Sync params and buffers
         module_states = list(self.module.state_dict().values())


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/13200

Tested on 8 GPU machines since CI doesn't have this many GPUs, so multi-GPU test won't be triggered

```
tengli@learnfair096:~/pytorch/test$ python run_test.py -i distributed --verbose
Selected tests: distributed
Running test_distributed ... [2018-10-29 20:32:46.355858]
/public/apps/openmpi/2.1.1/gcc.5.4.0/bin/mpiexec
Running distributed tests for the gloo backend
test_DistBackend (__main__.TestDistBackend) ... ok
test_DistributedDataParallel (__main__.TestDistBackend) ... ok
test_DistributedDataParallelCPU (__main__.TestDistBackend) ... ok
```

Also I would like to bump up the bucket size of broadcast to higher for performance reasons