### PR TITLE
minor build fixes for incremental builds

### DIFF
--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -244,6 +244,13 @@ function build_caffe2() {
   fi
 
   ${CMAKE_INSTALL} -j"$MAX_JOBS"
+  if ls build.ninja 2>&1 >/dev/null; then
+      # workaround a cmake-ninja bug, which doesn't track the dependency
+      # between xxx-generated-xxx.cu and updating the timestamp of build.ninja,
+      # (the consequence being cmake is rerun on a next rebuild).
+      # this was surfaced after analyzing the outputs of `ninja -d explain install`
+      touch build.ninja
+  fi
 
   # Install Python proto files
   if [[ "$BUILD_PYTHON" == 'ON' ]]; then

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -142,7 +142,7 @@ install(TARGETS c10d
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
-option(BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_EXAMPLES "Build examples" OFF)
 if(BUILD_EXAMPLES)
   add_subdirectory(example)
 endif()


### PR DESCRIPTION
Workaround a cmake-ninja bug, which doesn't track the dependency between xxx-generated-xxx.cu and updating the timestamp of build.ninja, (the consequence being cmake is rerun on a next rebuild).
This was surfaced after analyzing the outputs of `ninja -d explain install`

Now, compared to https://github.com/pytorch/pytorch/pull/11487#issue-214450604 we're seeing:

```
# (with ccache)
python setup.py rebuild develop    # first time - ~1m 42s
python setup.py rebuild develop    # second time - ~12 s
```

This gets even faster if we replace the default linker with multithreaded linkers like `lld` or `gold`