### PR TITLE
add explicit fpga context

### DIFF
--- a/c10/DeviceType.h
+++ b/c10/DeviceType.h
@@ -20,8 +20,9 @@ enum class DeviceType : int16_t {
   OPENCL = 4, // OpenCL
   IDEEP = 5, // IDEEP.
   HIP = 6, // AMD HIP
+  FPGA = 7, // FPGA
   // Change the following number if you add more devices in the code.
-  COMPILE_TIME_MAX_DEVICE_TYPES = 7,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 8,
   ONLY_FOR_TEST = 20901, // This device type is only for test.
 };
 

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -166,7 +166,7 @@ message Argument {
 // DeviceType that Caffe2 currently supports.
 // Note: if you add a device type, make sure you add the corresponding device
 // line in the DeviceTypeName() function in caffe2/utils/proto_utils.cc
-// and update ATen/core/DeviceType.h
+// and update c10/DeviceType.h
 enum DeviceTypeProto {
   PROTO_CPU = 0;                    // In default, we will use CPU.
   PROTO_CUDA = 1;                   // CUDA.
@@ -175,8 +175,9 @@ enum DeviceTypeProto {
   PROTO_OPENCL = 4;                 // OpenCL
   PROTO_IDEEP = 5;                  // IDEEP.
   PROTO_HIP = 6;                    // AMD HIP
+  PROTO_FPGA = 7;                   // FPGA
   // Change the following number if you add more devices in the code.
-  PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = 7;
+  PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = 8;
   PROTO_ONLY_FOR_TEST = 20901;   // This device type is only for test.
 }
 


### PR DESCRIPTION
Summary:
add a context to describe fpga

this will remove the need of having opencl with fpga engine

the next step is to change the opencl implementation to explicitly use the fpga context

Differential Revision: D12828795
