### PR TITLE
Speed up tensor.options() by avoiding type dispatch

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -415,6 +415,15 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     return get_device_slow();
   }
 
+  Layout layout() const {
+    // NB: This method is not virtual and avoid dispatches for perf.
+    if (is_sparse()) {
+      return kSparse;
+    } else {
+      return kStrided;
+    }
+  }
+
   /**
    * If `condition_when_zero_dim` is true, and the tensor is a 1-dim, 1-size
    * tensor, reshape the tensor into a 0-dim tensor (scalar).

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -177,6 +177,30 @@ namespace detail {
         AT_ERROR("Unsupported layout: ", options.layout());
     }
   }
+
+  inline DeviceType computeDeviceType(TensorTypeId tid) {
+    if (tid == CPUTensorId()) {
+      return DeviceType::CPU;
+    } else if (tid == CUDATensorId()) {
+      return DeviceType::CUDA;
+    } else if (tid == MKLDNNTensorId()) {
+      return DeviceType::MKLDNN;
+    } else if (tid == OpenGLTensorId()) {
+      return DeviceType::IDEEP;
+    } else if (tid == OpenCLTensorId()) {
+      return DeviceType::OPENCL;
+    } else if (tid == IDEEPTensorId()) {
+      return DeviceType::IDEEP;
+    } else if (tid == HIPTensorId()) {
+      return DeviceType::HIP;
+    } else if (tid == SparseCPUTensorId()) {
+      return DeviceType::CPU;
+    } else if (tid == SparseCUDATensorId()) {
+      return DeviceType::CUDA;
+    } else {
+      AT_ASSERTM(false, "Unknown TensorTypeId: ", tid);
+    }
+  }
 } // namespace detail
 
 /**
@@ -413,6 +437,18 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       return storage().device().index();
     }
     return get_device_slow();
+  }
+
+  Device device() const {
+    // Special case the common case for performance reasons
+    const auto& mystorage = storage();
+    if (mystorage) {
+      return mystorage.device();
+    }
+    const auto tid = type_id();
+    const auto device_type = detail::computeDeviceType(tid);
+    bool is_cuda = device_type == DeviceType::CUDA;
+    return Device(device_type, is_cuda ? get_device() : -1);
   }
 
   Layout layout() const {

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1714,7 +1714,7 @@ inline Layout Tensor::layout() const noexcept {
 }
 
 inline Device Tensor::device() const {
-  return Device(impl_->storage().device_type(), is_cuda() ? get_device() : -1);
+  return impl_->device();
 }
 
 inline int64_t Tensor::get_device() const {

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1702,7 +1702,7 @@ inline Tensor Tensor::alias() const {
 }
 
 inline bool Tensor::is_variable() const noexcept {
-  return type().is_variable();
+  return impl_->is_variable();
 }
 
 inline caffe2::TypeMeta Tensor::dtype() const noexcept {
@@ -1710,11 +1710,11 @@ inline caffe2::TypeMeta Tensor::dtype() const noexcept {
 }
 
 inline Layout Tensor::layout() const noexcept {
-  return type().layout();
+  return impl_->layout();
 }
 
 inline Device Tensor::device() const {
-  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
+  return Device(impl_->storage().device_type(), is_cuda() ? get_device() : -1);
 }
 
 inline int64_t Tensor::get_device() const {

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -56,7 +56,7 @@ inline void Tensor::set_data(Tensor new_data) {
 ${tensor_method_definitions}
 
 inline bool Tensor::is_variable() const noexcept {
-  return type().is_variable();
+  return impl_->is_variable();
 }
 
 inline caffe2::TypeMeta Tensor::dtype() const noexcept {
@@ -64,11 +64,11 @@ inline caffe2::TypeMeta Tensor::dtype() const noexcept {
 }
 
 inline Layout Tensor::layout() const noexcept {
-  return type().layout();
+  return impl_->layout();
 }
 
 inline Device Tensor::device() const {
-  return Device(type().device_type(), type().is_cuda() ? get_device() : -1);
+  return Device(impl_->storage().device_type(), is_cuda() ? get_device() : -1);
 }
 
 inline int64_t Tensor::get_device() const {

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -68,7 +68,7 @@ inline Layout Tensor::layout() const noexcept {
 }
 
 inline Device Tensor::device() const {
-  return Device(impl_->storage().device_type(), is_cuda() ? get_device() : -1);
+  return impl_->device();
 }
 
 inline int64_t Tensor::get_device() const {


### PR DESCRIPTION
Also speeds up tensor.is_variable(), tensor.layout(), and
tensor.device(). This PR speeds up tensor.options() from 54ns to 17ns,
resulting in a comparable speedup in torch.as_strided performance:
https://gist.github.com/zou3519/7645262a4f89e237405857925bb872c3

Test Plan: run tests

