### PR TITLE
[WIP] Strawman/Tracker for fixing grad copy elision + post hooks (e.g. DDP) interaction

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -358,6 +358,18 @@ static variable_list call_function(FunctionTask& task) {
   variable_list outputs;
 
   if(has_post_hooks){
+    // In functions/accumulate_grad.cpp, there is some logic to check the conditions under which
+    // the incoming gradient can be stolen directly (which elides a deep copy) instead of cloned.
+    // One of these conditions is that the incoming gradient's refcount must be 1 (nothing else
+    // is referencing the same data).  Stashing inputs_copy here bumps the refcount, so if post hooks 
+    // are employed, it's actually still ok for accumulate_grad.cpp to steal the gradient if the 
+    // refcount is 2.
+    //
+    // "new_grad.use_count() <= 1 + !post_hooks().empty()" in accumulate_grad.cpp accounts for this,
+    // but also creates a silent dependency between engine.cpp (ie, this particular engine 
+    // implementation) and accumulate_grad.cpp.
+    //
+    // If you change the logic here, make sure it's compatible with accumulate_grad.cpp.
     auto inputs_copy = inputs;
     outputs = fn(std::move(inputs_copy));
   }else{

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -44,11 +44,14 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     if (!GradMode::is_enabled()
         && !new_grad.type().is_sparse()
         && new_grad.is_contiguous()
-        && new_grad.use_count() == 1) {
+        && new_grad.use_count() <= 1 + !post_hooks().empty()) {
       // first check it is in first-order grad only mode
       // then check not sparse before is_contiguous
       // then check contiguous, otherwise later in place accumulation may fail
-      // and lastly, check it is the last reference before we grab it
+      // and lastly, check it is the last reference before we grab it.
+      // If the function has post hooks (for example, a DDP allreduce hook),
+      // call_function in Engine.cpp will temporarily bump the refcount by one, hence the
+      // addition of !post_hooks().empty().
       variable.grad() = new_grad.detach();
     } else {
       variable.grad() = new_grad.clone();


### PR DESCRIPTION
@FDecaYed wrote some nice logic into [accumulate_grad.cpp](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/functions/accumulate_grad.cpp#L44-L47) to elide unnecessary cloning or accumulation of incoming gradients.  Under certain conditions, the incoming gradient can be stolen and used directly.

One of these conditions is that the incoming gradient's [refcount must be 1](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/functions/accumulate_grad.cpp#L47).  Nothing else can be referencing the data (which might happen, for instance, for c = b + a:  the + operator's backward can simply pass c's incoming gradient tensor directly to both a and b's `AccumulateGrad` functions).

However, if a given param's `AccumulateGrad` function has post hooks (like, for example, the allreduce hooks employed by both apex and c10d DDP), the autograd engine [stashes a copy](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/engine.cpp#L361) of the incoming gradients, which increments the refcount, causing `AccumulateGrad`'s hard check that the refcount is 1 to fail, and triggering an (in this case) unnecessary deep copy.  

This PR updates the logic to account for the possible presence of post hooks on the `AccumulateGrad` function.  I discussed it with @apaszke and we both agree it introduces a worrisome silent dependency between `engine.cpp` and `accumulate_grad.cpp`.  I've commented the relevant pieces, but I'm open to suggestions as to how this check could be made more agnostic to the implementation of `engine.cpp`.
