### PR TITLE
fix flip() shape bug in CPU

### DIFF
--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -12,7 +12,7 @@ namespace at {
 
 constexpr size_t dim_bitset_size = 64;
 
-static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntList dims, int64_t ndims, bool wrap_scalar=true) {
+static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntList dims, int64_t ndims) {
   AT_CHECK(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
   std::bitset<dim_bitset_size> seen;
   for (size_t i = 0; i < dims.size(); i++) {

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -10,50 +10,92 @@ namespace at {
 namespace native {
 
 Tensor flip_cpu(const Tensor& self, IntList dims) {
-  const int64_t total_dims = self.dim(), flip_dims_size = dims.size();
-  flip_check_errors(total_dims, flip_dims_size, dims);
-
+  auto in_tensor = self;
+  const int64_t total_dims = self.dim();
+  const int64_t numel = self.numel();
+  auto strides = self.strides();
+  auto sizes = self.sizes();
+  const int64_t flip_dims_size = dims.size();
   auto flip_dims_v = dims.vec();
+
+  flip_check_errors(total_dims, flip_dims_size, dims);
   wrap_all_dims(flip_dims_v, total_dims);
-  std::sort(flip_dims_v.begin(), flip_dims_v.end());
-  auto final_indices = std::vector<at::Tensor>(total_dims);
+  // std::sort(flip_dims_v.begin(), flip_dims_v.end());
+  // auto final_indices = std::vector<at::Tensor>(total_dims);
+  //
+  // auto indices = std::vector<at::Tensor>(flip_dims_size);
+  // for (int64_t i = 0; i < flip_dims_size; i++) {
+  //   indices[i] = at::arange(self.size(flip_dims_v[i]) - 1, -1, -1, self.type().toScalarType(at::kLong));
+  //   // creates a meshgrid
+  //   auto temp = std::vector<int64_t>(flip_dims_size, 1);
+  //   temp[i] = indices[i].size(0);
+  //   indices[i] = indices[i].view(IntList(temp));
+  //   final_indices[flip_dims_v[i]] = indices[i];
+  // }
+  //
+  // // check if distance between two flip dims >= 2, where permute of output tensor is needed,
+  // // because the advanced indexing puts all non-consecutive indices in the beginning of the tensor
+  // bool to_permute = false;
+  // int64_t first = flip_dims_v[0], second = flip_dims_v[0];
+  // for (int64_t i = 1; i < flip_dims_size; i++) {
+  //   second = flip_dims_v[i];
+  //   if (second - first >= 2) {
+  //     to_permute = true;
+  //     break;
+  //   }
+  //   first = second;
+  // }
+  //
+  // if (to_permute) {
+  //   // permute output tensor
+  //   auto permute_order = std::vector<int64_t>(flip_dims_v);
+  //   for (int64_t i = 0; i < total_dims; i++) {
+  //     if (std::find(flip_dims_v.begin(), flip_dims_v.end(), i) == flip_dims_v.end()) {
+  //       permute_order.emplace_back(i);
+  //     }
+  //   }
+  //   auto out_tensor = self.index(TensorList(final_indices));
+  //   return out_tensor.permute(IntList(permute_order));
+  // }
+  //
+  // auto out_tensor = self.index(TensorList(final_indices));
 
-  auto indices = std::vector<at::Tensor>(flip_dims_size);
-  for (int64_t i = 0; i < flip_dims_size; i++) {
-    indices[i] = at::arange(self.size(flip_dims_v[i]) - 1, -1, -1, self.type().toScalarType(at::kLong));
-    // creates a meshgrid
-    auto temp = std::vector<int64_t>(flip_dims_size, 1);
-    temp[i] = indices[i].size(0);
-    indices[i] = indices[i].view(IntList(temp));
-    final_indices[flip_dims_v[i]] = indices[i];
-  }
-
-  // check if distance between two flip dims >= 2, where permute of output tensor is needed,
-  // because the advanced indexing puts all non-consecutive indices in the beginning of the tensor
-  bool to_permute = false;
-  int64_t first = flip_dims_v[0], second = flip_dims_v[0];
-  for (int64_t i = 1; i < flip_dims_size; i++) {
-    second = flip_dims_v[i];
-    if (second - first >= 2) {
-      to_permute = true;
-      break;
+  Tensor out_tensor = at::empty_like(in_tensor);
+  Tensor stride_contiguous = at::zeros({total_dims}, kLong);
+  int64_t* stride_contiguous_d = stride_contiguous.data<int64_t>();
+  for (int64_t i = total_dims - 1; i >= 0; i--) {
+    if (i == total_dims - 1) {
+      stride_contiguous_d[i] = 1;
+    } else {
+      stride_contiguous_d[i] = std::max<int64_t>(sizes[i+1], 1) * stride_contiguous_d[i + 1];
     }
-    first = second;
   }
 
-  if (to_permute) {
-    // permute output tensor
-    auto permute_order = std::vector<int64_t>(flip_dims_v);
-    for (int64_t i = 0; i < total_dims; i++) {
-      if (std::find(flip_dims_v.begin(), flip_dims_v.end(), i) == flip_dims_v.end()) {
-        permute_order.emplace_back(i);
+  AT_DISPATCH_ALL_TYPES(in_tensor.type(), "flip_cpu", [&] {
+
+    auto out_tensor_d = out_tensor.data<scalar_t>();
+    auto in_tensor_d = in_tensor.data<scalar_t>();
+
+    for (int64_t i = 0; i < numel; i++) {
+      int64_t cur_indices = i;
+      int64_t rem = 0;
+      int64_t dst_offset = 0;
+
+      for (int64_t d = 0; d < total_dims; d++) {
+        int64_t temp = cur_indices;
+        cur_indices = cur_indices / stride_contiguous_d[d];
+        rem = temp - cur_indices * stride_contiguous_d[d];
+        // flip the indices if it is in flip_dims
+        for (auto fd : flip_dims_v) {
+          if (d == fd) cur_indices = sizes[d] - 1 - cur_indices;
+        }
+        dst_offset += cur_indices * strides[d];
+        cur_indices = rem;
       }
+      out_tensor_d[i] = out_tensor_d[dst_offset];
     }
-    auto out_tensor = self.index(TensorList(final_indices));
-    return out_tensor.permute(IntList(permute_order));
-  }
+  });
 
-  auto out_tensor = self.index(TensorList(final_indices));
   return out_tensor;
 }
 

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -92,7 +92,7 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
         dst_offset += cur_indices * strides[d];
         cur_indices = rem;
       }
-      out_tensor_d[i] = out_tensor_d[dst_offset];
+      out_tensor_d[i] = in_tensor_d[dst_offset];
     }
   });
 

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -9,56 +9,60 @@
 namespace at {
 namespace native {
 
+template <typename scalar_t>
+void inline flip_cpu_kernel(
+  const int64_t numel,
+  const int64_t total_dims,
+  const int64_t flip_dims_size,
+  const int64_t* stride_contiguous_d,
+  const int64_t* flip_dims_d,
+  const int64_t* strides_d,
+  const int64_t* sizes_d,
+  const scalar_t* in_tensor_d,
+  scalar_t* out_tensor_d
+){
+  int64_t i;
+
+  #pragma omp parallel for private(i) if (numel > 1000)
+  for (i = 0; i < numel; i++) {
+    int64_t cur_indices = i;
+    int64_t rem = 0;
+    int64_t dst_offset = 0;
+
+    for (int64_t d = 0; d < total_dims; d++) {
+      int64_t temp = cur_indices;
+      cur_indices = cur_indices / stride_contiguous_d[d];
+      rem = temp - cur_indices * stride_contiguous_d[d];
+      // flip the indices if it is in flip_dims
+      for (int64_t j = 0; j < flip_dims_size; j++) {
+        if (d == flip_dims_d[j]) cur_indices = sizes_d[d] - 1 - cur_indices;
+      }
+      dst_offset += cur_indices * strides_d[d];
+      cur_indices = rem;
+    }
+    out_tensor_d[i] = in_tensor_d[dst_offset];
+  }
+}
+
 Tensor flip_cpu(const Tensor& self, IntList dims) {
   auto in_tensor = self;
   const int64_t total_dims = self.dim();
   const int64_t numel = self.numel();
+
   auto strides = self.strides();
+  auto strides_v = strides.vec();
+  auto strides_t = at::CPU(kLong).tensorFromBlob(strides_v.data(), {static_cast<int64_t>(strides_v.size())});
+
   auto sizes = self.sizes();
+  auto sizes_v = sizes.vec();
+  auto sizes_t = at::CPU(kLong).tensorFromBlob(sizes_v.data(), {static_cast<int64_t>(sizes_v.size())});
+
   const int64_t flip_dims_size = dims.size();
   auto flip_dims_v = dims.vec();
+  auto flip_dims_t = at::CPU(kLong).tensorFromBlob(flip_dims_v.data(), {static_cast<int64_t>(flip_dims_v.size())});
 
   flip_check_errors(total_dims, flip_dims_size, dims);
   wrap_all_dims(flip_dims_v, total_dims);
-  // std::sort(flip_dims_v.begin(), flip_dims_v.end());
-  // auto final_indices = std::vector<at::Tensor>(total_dims);
-  //
-  // auto indices = std::vector<at::Tensor>(flip_dims_size);
-  // for (int64_t i = 0; i < flip_dims_size; i++) {
-  //   indices[i] = at::arange(self.size(flip_dims_v[i]) - 1, -1, -1, self.type().toScalarType(at::kLong));
-  //   // creates a meshgrid
-  //   auto temp = std::vector<int64_t>(flip_dims_size, 1);
-  //   temp[i] = indices[i].size(0);
-  //   indices[i] = indices[i].view(IntList(temp));
-  //   final_indices[flip_dims_v[i]] = indices[i];
-  // }
-  //
-  // // check if distance between two flip dims >= 2, where permute of output tensor is needed,
-  // // because the advanced indexing puts all non-consecutive indices in the beginning of the tensor
-  // bool to_permute = false;
-  // int64_t first = flip_dims_v[0], second = flip_dims_v[0];
-  // for (int64_t i = 1; i < flip_dims_size; i++) {
-  //   second = flip_dims_v[i];
-  //   if (second - first >= 2) {
-  //     to_permute = true;
-  //     break;
-  //   }
-  //   first = second;
-  // }
-  //
-  // if (to_permute) {
-  //   // permute output tensor
-  //   auto permute_order = std::vector<int64_t>(flip_dims_v);
-  //   for (int64_t i = 0; i < total_dims; i++) {
-  //     if (std::find(flip_dims_v.begin(), flip_dims_v.end(), i) == flip_dims_v.end()) {
-  //       permute_order.emplace_back(i);
-  //     }
-  //   }
-  //   auto out_tensor = self.index(TensorList(final_indices));
-  //   return out_tensor.permute(IntList(permute_order));
-  // }
-  //
-  // auto out_tensor = self.index(TensorList(final_indices));
 
   Tensor out_tensor = at::empty_like(in_tensor);
   Tensor stride_contiguous = at::zeros({total_dims}, kLong);
@@ -72,28 +76,20 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
   }
 
   AT_DISPATCH_ALL_TYPES(in_tensor.type(), "flip_cpu", [&] {
-
     auto out_tensor_d = out_tensor.data<scalar_t>();
     auto in_tensor_d = in_tensor.data<scalar_t>();
 
-    for (int64_t i = 0; i < numel; i++) {
-      int64_t cur_indices = i;
-      int64_t rem = 0;
-      int64_t dst_offset = 0;
-
-      for (int64_t d = 0; d < total_dims; d++) {
-        int64_t temp = cur_indices;
-        cur_indices = cur_indices / stride_contiguous_d[d];
-        rem = temp - cur_indices * stride_contiguous_d[d];
-        // flip the indices if it is in flip_dims
-        for (auto fd : flip_dims_v) {
-          if (d == fd) cur_indices = sizes[d] - 1 - cur_indices;
-        }
-        dst_offset += cur_indices * strides[d];
-        cur_indices = rem;
-      }
-      out_tensor_d[i] = in_tensor_d[dst_offset];
-    }
+    flip_cpu_kernel<scalar_t>(
+      numel,
+      total_dims,
+      flip_dims_size,
+      stride_contiguous_d,
+      flip_dims_t.data<int64_t>(),
+      strides_t.data<int64_t>(),
+      sizes_t.data<int64_t>(),
+      in_tensor_d,
+      out_tensor_d
+    );
   });
 
   return out_tensor;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7215,6 +7215,19 @@ class _TestTorchMixin(object):
         self.assertEqual(torch.tensor([7, 8, 5, 6, 3, 4, 1, 2]).view(2, 2, 2), data.flip(0, 1))
         self.assertEqual(torch.tensor([8, 7, 6, 5, 4, 3, 2, 1]).view(2, 2, 2), data.flip(0, 1, 2))
 
+        # test for shape
+        size = [2, 2, 2]
+        test_dims = []
+        for i in range(0, 3):
+            test_dims += combinations(range(len(size)), i)
+
+        for ds in test_dims:
+            data_flipped = data.clone()
+            for d in ds:
+                data_flipped = data_flipped.flip(d)
+            self.assesrtEqual(data_flipped, data.flip(ds))
+            self.assesrtEqual(data_flipped.size(), data.flip(ds).size())
+
         # check for wrap dim
         self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(-1))
         # check for permute

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7215,16 +7215,6 @@ class _TestTorchMixin(object):
         self.assertEqual(torch.tensor([7, 8, 5, 6, 3, 4, 1, 2]).view(2, 2, 2), data.flip(0, 1))
         self.assertEqual(torch.tensor([8, 7, 6, 5, 4, 3, 2, 1]).view(2, 2, 2), data.flip(0, 1, 2))
 
-        # test for shape
-        data = torch.randn(2, 3, 4, device=device)
-        size = [2, 3, 4]
-        test_dims = []
-        for i in range(1, 3):
-            test_dims += combinations(range(len(size)), i)
-
-        for ds in test_dims:
-            self.assertEqual(size, list(data.flip(ds).size()))
-
         # check for wrap dim
         self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(-1))
         # check for permute
@@ -7249,6 +7239,16 @@ class _TestTorchMixin(object):
             tranposed_data = torch.arange(1, 9).view(2, 2, 2).transpose(0, 1)
         self.assertEqual(torch.tensor([3, 3, 2, 2, 1, 1]).view(3, 2), expanded_data.flip(0))
         self.assertEqual(torch.tensor([8, 7, 4, 3, 6, 5, 2, 1]).view(2, 2, 2), tranposed_data.flip(0, 1, 2))
+
+        # test for shape
+        data = torch.randn(2, 3, 4, device=device)
+        size = [2, 3, 4]
+        test_dims = []
+        for i in range(1, 3):
+            test_dims += combinations(range(len(size)), i)
+
+        for ds in test_dims:
+            self.assertEqual(size, list(data.flip(ds).size()))
 
         # test rectangular case
         data = torch.tensor([1, 2, 3, 4, 5, 6]).view(2, 3)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7231,12 +7231,8 @@ class _TestTorchMixin(object):
         self.assertRaises(RuntimeError, lambda: data.flip(3))
 
         # test for non-contiguous case
-        if use_cuda:
-            expanded_data = torch.arange(1, 4, device=cuda).view(3, 1).expand(3, 2)
-            tranposed_data = torch.arange(1, 9, device=cuda).view(2, 2, 2).transpose(0, 1)
-        else:
-            expanded_data = torch.arange(1, 4).view(3, 1).expand(3, 2)
-            tranposed_data = torch.arange(1, 9).view(2, 2, 2).transpose(0, 1)
+        expanded_data = torch.arange(1, 4, device=device).view(3, 1).expand(3, 2)
+        tranposed_data = torch.arange(1, 9, device=device).view(2, 2, 2).transpose(0, 1)
         self.assertEqual(torch.tensor([3, 3, 2, 2, 1, 1]).view(3, 2), expanded_data.flip(0))
         self.assertEqual(torch.tensor([8, 7, 4, 3, 6, 5, 2, 1]).view(2, 2, 2), tranposed_data.flip(0, 1, 2))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7206,14 +7206,8 @@ class _TestTorchMixin(object):
 
     @staticmethod
     def _test_flip(self, use_cuda=False):
-        if use_cuda:
-            cuda = torch.device("cuda")
-            data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device=cuda).view(2, 2, 2)
-            # large data testing
-            large_data = torch.arange(0, 100000000, device=cuda).view(10000, 10000)
-            large_data.flip([0, 1])
-        else:
-            data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8]).view(2, 2, 2)
+        device = torch.device('cuda') if use_cuda else torch.device('cpu')
+        data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device=device).view(2, 2, 2)
 
         self.assertEqual(torch.tensor([5, 6, 7, 8, 1, 2, 3, 4]).view(2, 2, 2), data.flip(0))
         self.assertEqual(torch.tensor([3, 4, 1, 2, 7, 8, 5, 6]).view(2, 2, 2), data.flip(1))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7216,17 +7216,14 @@ class _TestTorchMixin(object):
         self.assertEqual(torch.tensor([8, 7, 6, 5, 4, 3, 2, 1]).view(2, 2, 2), data.flip(0, 1, 2))
 
         # test for shape
-        size = [2, 2, 2]
+        data = torch.randn(2, 3, 4, device=device)
+        size = [2, 3, 4]
         test_dims = []
-        for i in range(0, 3):
+        for i in range(1, 3):
             test_dims += combinations(range(len(size)), i)
 
         for ds in test_dims:
-            data_flipped = data.clone()
-            for d in ds:
-                data_flipped = data_flipped.flip(d)
-            self.assesrtEqual(data_flipped, data.flip(ds))
-            self.assesrtEqual(data_flipped.size(), data.flip(ds).size())
+            self.assertEqual(size, list(data.flip(ds).size()))
 
         # check for wrap dim
         self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(-1))


### PR DESCRIPTION
- fix #13292, root cause please see https://github.com/pytorch/pytorch/pull/13682
- this PR brings in `filp()` CUDA implementation for CPU kernel
- with this change:
```
>>> t = torch.randn(1, 3, 4, 5)
>> t.flip(1, 3).shape
torch.Size([1, 3, 4, 5])
```
- performance:
```
====== with this PR ======
>>> a = torch.randn(1000, 1000)
>>> %timeit -r 100 a.flip(0, 1)
1.98 ms ± 579 µs per loop (mean ± std. dev. of 100 runs, 1000 loops each)

====== Perf at previous PR #7873 ======   
100 loops, best of 3: 11 ms per loop
```