### PR TITLE
[sparse] backward for sparse.addmm(D, S, D, alpha, beta) -> D

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -117,6 +117,7 @@ _(aten, _sin) \
 _(aten, _sinh) \
 _(aten, _sparseDims) \
 _(aten, _sparse_add) \
+_(aten, _sparse_addmm) \
 _(aten, _sparse_coo_tensor_with_dims) \
 _(aten, _sparse_coo_tensor_with_dims_and_tensors) \
 _(aten, _sparse_coo_tensor_unsafe) \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1960,7 +1960,6 @@
     CUDA: s_addmm_sparse_dense_cuda_
 
 - func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-  variants: function
 
 - func: addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1959,6 +1959,9 @@
     CPU: s_addmm_sparse_dense_cpu_
     CUDA: s_addmm_sparse_dense_cuda_
 
+- func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  variants: function
+
 - func: addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -593,6 +593,7 @@ Tensor _sparse_addmm(
   Scalar beta,
   Scalar alpha
 ) {
+  AT_CHECK(sparse.is_coalesced(), "_sparse_addmm doesn't support uncoalesced SparseTensor");
   return at::s_native_addmm(t, sparse, dense, beta, alpha);
 }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -456,7 +456,9 @@ SparseTensor& mul_out_sparse_cpu(SparseTensor& r, const Tensor& t_, const Tensor
 }
 
 // --------------------------------------------------------------------
-// addmm(Tensor, SparseTensorRef, Tensor, Scalar, Scalar)  [broadcasts]
+// addmm(D1, S, D2, beta, alpha) -> D  [broadcasts]
+//
+// D = beta * D1 + alpha * mm(S, D2)
 // --------------------------------------------------------------------
 
 // NB: OMP pragmas have to get their own functions; can't put them in lambdas
@@ -584,6 +586,16 @@ Tensor& s_addmm_sparse_dense_cpu_(
   return s_addmm_out_sparse_dense_cpu(t, t, sparse, dense, beta, alpha);
 }
 
+Tensor _sparse_addmm(
+  const Tensor& t,
+  const SparseTensor& sparse,
+  const Tensor& dense,
+  Scalar beta,
+  Scalar alpha
+) {
+  return at::s_native_addmm(t, sparse, dense, beta, alpha);
+}
+
 
 // --------------------------------------------------------------------
 // hspmm(SparseTensor mat1, Tensor mat2)
@@ -665,7 +677,9 @@ SparseTensor hspmm_sparse_cpu(const SparseTensor& sparse, const Tensor& dense) {
 }
 
 // --------------------------------------------------------------------
-// sspaddmm
+// sspaddmm(S1, S2, D, beta, alpha) -> S
+//
+// S = beta * S1 + alpha * mm(S2, D)
 // --------------------------------------------------------------------
 
 SparseTensor& _sspaddmm_out_cpu(

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -101,7 +101,6 @@ An empty sparse tensor can be constructed by specifying its size:
 
     .. method:: add
     .. method:: add_
-    .. automethod:: addmm
     .. method:: clone
     .. method:: dim
     .. method:: div
@@ -130,3 +129,8 @@ An empty sparse tensor can be constructed by specifying its size:
     .. method:: _indices
     .. method:: _values
     .. method:: _nnz
+
+Functions
+=============
+
+.. autofunction:: torch.sparse.addmm

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -101,6 +101,7 @@ An empty sparse tensor can be constructed by specifying its size:
 
     .. method:: add
     .. method:: add_
+    .. automethod:: addmm
     .. method:: clone
     .. method:: dim
     .. method:: div

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -774,13 +774,21 @@ class TestSparse(TestCase):
     @skipIfRocm
     def test_sparse_addmm(self):
         def test_shape(m, n, p, nnz):
-            D1 = torch.randn(n, p).requires_grad_(True)
-            D2 = torch.randn(m, p).requires_grad_(True)
+            D1 = torch.randn(n, p, device=self.device).requires_grad_(True)
+            D2 = torch.randn(m, p, device=self.device).requires_grad_(True)
             S = self._gen_sparse(2, nnz, [n, m])[0]
+            S_dense = S.to_dense().requires_grad_(True)
             S.requires_grad_(True)
-            y = torch.sparse.addmm(D1, S, D2).sum()
+            self.assertEqual(torch.sparse.addmm(D1, S, D2), torch.addmm(D1, S_dense, D2))
+            y1 = torch.sparse.addmm(D1, S, D2).sum()
+            y2 = torch.addmm(D1, S_dense, D2).sum()
+            y1.backward()
+            y2.backward()
+            mask = (S_dense == 0)
+            self.assertEqual(S.grad.to_dense(), S_dense.grad.masked_fill_(mask, 0))
 
-        test_shape(7, 5, 3, 20)
+        if not self.is_uncoalesced:
+            test_shape(7, 8, 9, 20)
 
     @skipIfRocm
     def test_dsmm(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -772,6 +772,17 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 0, 0)
 
     @skipIfRocm
+    def test_sparse_addmm(self):
+        def test_shape(m, n, p, nnz):
+            D1 = torch.randn(n, p).requires_grad_(True)
+            D2 = torch.randn(m, p).requires_grad_(True)
+            S = self._gen_sparse(2, nnz, [n, m])[0]
+            S.requires_grad_(True)
+            y = torch.sparse.addmm(D1, S, D2).sum()
+
+        test_shape(7, 5, 3, 20)
+
+    @skipIfRocm
     def test_dsmm(self):
         def test_shape(di, dj, dk, nnz):
             x = self._gen_sparse(2, nnz, [di, dj])[0]

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -117,6 +117,11 @@
   mat1: mm_mat1_backward(grad, mat2, mat1, alpha)
   mat2: mm_mat2_backward(grad, mat1, mat2.sizes(), mat2.strides(), alpha)
 
+- name: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta, Scalar alpha)
+  self: maybe_multiply(grad, beta)
+  sparse: _sparse_addmm_sparse_backward(grad, sparse, dense, alpha)
+  dense: mm_mat2_backward(grad, sparse, dense.sizes(), dense.strides(), alpha)
+
 - name: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta, Scalar alpha)
   self: maybe_multiply(grad, beta)
   mat: grad.ger(vec) * alpha

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -21,7 +21,7 @@ SKIP_PYTHON_BINDINGS = [
     '.*_backward', '.*_backward_(out|input|weight|bias)', '.*_forward',
     '.*_forward_out', '_unsafe_view', 'tensor', '_?sparse_coo_tensor.*',
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
-    '_sparse_add.*', '_sparse_div.*', '_sparse_mul.*', '_sparse_sub.*',
+    '_sparse_add_out', '_sparse_div.*', '_sparse_mul.*', '_sparse_sub.*',
     'index',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_.*',

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -495,6 +495,12 @@ Tensor mm_mat2_backward(const Tensor & grad, const Tensor & mat1, IntList sizes,
   }
 }
 
+Tensor _sparse_addmm_sparse_backward(const Tensor& grad, const Tensor& sparse, const Tensor& dense, const Scalar& alpha) {
+  AT_ASSERT(sparse.is_sparse());
+  Tensor grad_sparse = maybe_multiply(grad.mm(dense.t()), alpha);
+  return grad_sparse.sparse_mask(at::SparseTensorRef(sparse));
+}
+
 Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64_t dim, Scalar maxnorm) {
   auto transposed_sizes = self.transpose(dim, 0).sizes().vec();
   auto flatten = [&](const Tensor & t) {

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -11,7 +11,7 @@ def addmm(mat, mat1, mat2, beta=1, alpha=1):
     .. function:: torch.sparse.addmm(mat, mat1, mat2, beta=1, alpha=1) -> Tensor
 
     This function does exact same thing as :meth:`~Torch.addmm` in the forward,
-    except that it supports backward for sparse matrix input `mat1`.
+    except that it supports backward for coalesced sparse matrix `mat1`.
 
     Args:
         mat (Tensor): a dense matrix to be added

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -9,5 +9,15 @@ __all__ = [
 def addmm(mat, mat1, mat2, beta=1, alpha=1):
     r"""
     .. function:: torch.sparse.addmm(mat, mat1, mat2, beta=1, alpha=1) -> Tensor
+
+    This function does exact same thing as :meth:`~Torch.addmm` in the forward,
+    except that it supports backward for sparse matrix input `mat1`.
+
+    Args:
+        mat (Tensor): a dense matrix to be added
+        mat1 (Tensor): a sparse matrix to be multiplied
+        mat2 (Tensor): a dense matrix be multiplied
+        beta (Number, optional): multiplier for :attr:`mat` (:math:`\beta`)
+        alpha (Number, optional): multiplier for :math:`mat1 @ mat2` (:math:`\alpha`)
     """
     return torch._sparse_addmm(mat, mat1, mat2, beta=beta, alpha=alpha)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -1,1 +1,13 @@
 # The Tensor classes are added to this module by python_tensor.cpp
+import torch
+
+__all__ = [
+    'addmm',
+]
+
+
+def addmm(mat, mat1, mat2, beta=1, alpha=1):
+    r"""
+    .. function:: torch.sparse.addmm(mat, mat1, mat2, beta=1, alpha=1) -> Tensor
+    """
+    return torch._sparse_addmm(mat, mat1, mat2, beta=beta, alpha=alpha)


### PR DESCRIPTION
- introduce `sparse.addmm()` with backward for sparse matrix input for https://github.com/pytorch/pytorch/issues/12308