### PR TITLE
Fix allocator handling in raw_mutable_data

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -1206,12 +1206,9 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       }
       const at::Allocator* allocator = storage_.allocator();
       // TODO: Get rid of StaticContext
-      AT_ASSERTM(
-          allocator == nullptr,
-          "Allocator in storage_ is not used within Caffe2 functions. \
-           we are using global function to get the allocator based on device \
-           type.");
-      allocator = caffe2::GetAllocator(storage_.device_type());
+      if (allocator == nullptr) {
+        allocator = caffe2::GetAllocator(storage_.device_type());
+      }
       if (meta.placementNew()) {
         // For types that need placement new, we will call it, as well as
         // making sure that when the data is freed, it calls the right


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#13349 Fix allocator handling in raw_mutable_data**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12850833/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13104 [wip] Copy caffe2 layer_norm kernel to c10&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10849864/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13105 [wip] Call c10 layer_norm from PyTorch&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D10849862/)

When we get a Tensor that was created in ATen, it will have an allocator set.
Such tensors, before, crashed when you called raw_mutable_data on them.
This diff fixes that.

Differential Revision: [D12850833](https://our.internmc.facebook.com/intern/diff/D12850833/)