### PR TITLE
Fix more spectral norm bugs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1726,6 +1726,7 @@ class TestNN(NNTestCase):
         m = pickle.loads(pickle.dumps(m))
         self.assertIsInstance(m, nn.Linear)
 
+    @skipIfRocm
     def test_spectral_norm(self):
         input = torch.randn(3, 5)
         m = nn.Linear(5, 7)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1801,6 +1801,7 @@ class TestNN(NNTestCase):
                 # to same value at beginning for finite difference test to pass
                 saved_u = m.weight_u.clone()
                 saved_v = m.weight_v.clone()
+
                 def fn(input):
                     m.weight_u.data.copy_(saved_u)
                     m.weight_v.data.copy_(saved_v)
@@ -1849,6 +1850,7 @@ class TestNN(NNTestCase):
                 # to same value at beginning for finite difference test to pass
                 saved_u = m.weight_u.clone()
                 saved_v = m.weight_v.clone()
+
                 def fn(input):
                     m.weight_u.data.copy_(saved_u)
                     m.weight_v.data.copy_(saved_v)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1817,10 +1817,6 @@ class TestNN(NNTestCase):
                 self.assertEqual(wrapped_m(input), pre_remove_out)
 
                 m = torch.nn.utils.spectral_norm(m)
-                m = torch.nn.utils.remove_spectral_norm(m)
-                self.assertEqual(wrapped_m(input), pre_remove_out)
-
-                m = torch.nn.utils.spectral_norm(m)
                 for i in range(3):
                     pre_remove_out = wrapped_m(input)
                 m = torch.nn.utils.remove_spectral_norm(m)
@@ -1904,13 +1900,17 @@ class TestNN(NNTestCase):
             out3_eval = snm(inp)
 
             snm.load_state_dict(version_none_state_dict)
-            snm.eval()
-            self.assertEqual(out0_eval, snm(inp))
-            snm.train()
-            self.assertEqual(out1_train, snm(inp))
-            self.assertEqual(out2_train, snm(inp))
-            snm.eval()
-            self.assertEqual(out3_eval, snm(inp))
+            if activate_times > 0:
+                # since in loading version None state dict, we assume that the
+                # values in the state dict have gone through at lease one
+                # forward, we only test for equivalence when activate_times > 0.
+                snm.eval()
+                self.assertEqual(out0_eval, snm(inp))
+                snm.train()
+                self.assertEqual(out1_train, snm(inp))
+                self.assertEqual(out2_train, snm(inp))
+                snm.eval()
+                self.assertEqual(out3_eval, snm(inp))
 
             # Test normal loading
             snm.load_state_dict(version_latest_state_dict)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1717,6 +1717,10 @@ class TestNN(NNTestCase):
         m = torch.nn.utils.weight_norm(m, dim=None)
         self.assertEqual(m(input), expected_output)
 
+        with self.assertRaisesRegex(RuntimeError, 'register two weight_norm hooks'):
+            m = torch.nn.utils.weight_norm(m)
+            m = torch.nn.utils.weight_norm(m)
+
     def test_weight_norm_pickle(self):
         m = torch.nn.utils.weight_norm(nn.Linear(5, 7))
         m = pickle.loads(pickle.dumps(m))
@@ -1734,8 +1738,9 @@ class TestNN(NNTestCase):
         # weight_u should be just a reused buffer
         self.assertTrue(hasattr(m, 'weight_u'))
         self.assertTrue('weight_u' in m._buffers)
-        self.assertTrue('weight' in m._buffers)
+        self.assertTrue('weight_v' in m._buffers)
         # weight should be a plain attribute, not counted as a buffer or a param
+        self.assertFalse('weight' in m._buffers)
         self.assertFalse('weight' in m._parameters)
         # it should also be sharing storage as `weight_orig`
         self.assertEqual(m.weight_orig.storage(), m.weight.storage())
@@ -1749,58 +1754,145 @@ class TestNN(NNTestCase):
         self.assertTrue(hasattr(m, 'weight'))
         self.assertTrue('weight' in m._parameters)
 
+        with self.assertRaisesRegex(RuntimeError, 'register two spectral_norm hooks'):
+            m = torch.nn.utils.spectral_norm(m)
+            m = torch.nn.utils.spectral_norm(m)
+
+    def test_spectral_norm_load_state_dict(self):
+        inp = torch.randn(2, 3)
+        for activate_times in (0, 3):
+            # Test backward compatibility
+            # At version None -> 1: weight becomes not a buffer and v vector becomes a buffer
+            m = nn.Linear(3, 5)
+            snm = torch.nn.utils.spectral_norm(m)
+            snm.train()
+            for _ in range(activate_times):
+                snm(inp)
+
+            # craft a version None state_dict
+            version_none_state_dict = deepcopy(snm.state_dict())
+            self.assertEqual({'weight_orig', 'bias', 'weight_u', 'weight_v'}, set(version_none_state_dict.keys()))
+            self.assertIn('spectral_norm', version_none_state_dict._metadata[''])
+            del version_none_state_dict._metadata['']['spectral_norm']       # remove metadata info
+            del version_none_state_dict['weight_v']                          # remove v vector
+            version_none_state_dict['weight'] = snm.weight.detach().clone()  # set W as a buffer
+
+            # normal state_dict
+            version_latest_state_dict = deepcopy(snm.state_dict())
+
+            snm.eval()
+            out0_eval = snm(inp)
+            snm.train()
+            out1_train = snm(inp)
+            out2_train = snm(inp)
+            snm.eval()
+            out3_eval = snm(inp)
+
+            snm.load_state_dict(version_none_state_dict)
+            snm.eval()
+            self.assertEqual(out0_eval, snm(inp))
+            snm.train()
+            self.assertEqual(out1_train, snm(inp))
+            self.assertEqual(out2_train, snm(inp))
+            snm.eval()
+            self.assertEqual(out3_eval, snm(inp))
+
+            # Test normal loading
+            snm.load_state_dict(version_latest_state_dict)
+            snm.eval()
+            self.assertEqual(out0_eval, snm(inp))
+            snm.train()
+            self.assertEqual(out1_train, snm(inp))
+            self.assertEqual(out2_train, snm(inp))
+            snm.eval()
+            self.assertEqual(out3_eval, snm(inp))
+
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_spectral_norm_dp(self):
-        for requires_grad in (True, False):
-            m = nn.Linear(5, 7).to(torch.device('cuda'))
-            m.weight.requires_grad_(requires_grad)
-            m = torch.nn.utils.spectral_norm(m)
-            dpm = torch.nn.DataParallel(m, [0, 1])
-            self.assertTrue(hasattr(m, 'weight_u'))
-            u0 = m.weight_u.clone()
+        for apply_dp in (True, False):
+            if apply_dp and not TEST_MULTIGPU:
+                continue
+            if apply_dp:
+                device = torch.device('cuda:0')
 
-            # assert that u is updated
-            input = torch.randn(2, 5, device=torch.device('cuda'))
-            dpm(input)
-            self.assertNotEqual(u0, m.weight_u)
+                def maybe_wrap(m):
+                    return torch.nn.DataParallel(m, [0, 1])
+            else:
+                device = torch.device('cpu')
 
-            # test that eval works
-            dpm.eval()
-            eval_out0 = dpm(input)
-            self.assertEqual(eval_out0, dpm(input))
+                def maybe_wrap(m):
+                    return m
 
-    def test_spectral_norm_eval_remove(self):
-        inp = torch.randn(3, 5)
-        m = nn.Linear(5, 7)
-        m = torch.nn.utils.spectral_norm(m)
-        x0 = m(inp)
-        m.eval()
-        # test that eval mode and removing / adding+removing doesn't change weight and output
-        x1 = m(inp)
-        x2 = m(inp)
-        self.assertEqual(x0, x1)
-        self.assertEqual(x0, x2)
-        # test that we can backward several times without running into problems
-        x1 = m(inp)
-        x1.sum().backward()
-        x1 = m(inp)
-        x1.sum().backward()
-        # test removing
-        m = torch.nn.utils.remove_spectral_norm(m)
-        x3 = m(inp)
-        self.assertEqual(x0, x3)
-        m = torch.nn.utils.spectral_norm(m)
-        m = torch.nn.utils.remove_spectral_norm(m)
-        x4 = m(inp)
-        self.assertEqual(x0, x4)
-        # check that removing after train doesn't change output
-        m.train()
-        m = torch.nn.utils.spectral_norm(m)
-        for i in range(5):
-            x0 = m(inp)
-        m = torch.nn.utils.remove_spectral_norm(m)
-        x1 = m(inp)
-        self.assertEqual(x0, x1)
+            for requires_grad in (True, False):
+                m = nn.Linear(3, 4).to(device)
+                m.weight.requires_grad_(requires_grad)
+                m = torch.nn.utils.spectral_norm(m)
+                wrapped_m = maybe_wrap(m)
+                self.assertTrue(hasattr(m, 'weight_u'))
+                u0 = m.weight_u.clone()
+                v0 = m.weight_v.clone()
+
+                # TEST TRAINING BEHAVIOR
+
+                # assert that u and v are updated
+                input = torch.randn(2, 3, device=device)
+                out = wrapped_m(input)
+                self.assertNotEqual(u0, m.weight_u)
+                self.assertNotEqual(v0, m.weight_v)
+
+                # assert that backprop reaches weight_orig
+                # can't use gradcheck because the function changes as we
+                # activate through it in training mode
+                if requires_grad:
+                    torch.autograd.grad(out.sum(), m.weight_orig)
+
+                # test backward works
+                wrapped_m(input).sum().backward()
+                wrapped_m(input).sum().backward()
+
+                # test removing
+                pre_remove_out = wrapped_m(input)
+                m = torch.nn.utils.remove_spectral_norm(m)
+                self.assertEqual(wrapped_m(input), pre_remove_out)
+
+                m = torch.nn.utils.spectral_norm(m)
+                m = torch.nn.utils.remove_spectral_norm(m)
+                self.assertEqual(wrapped_m(input), pre_remove_out)
+
+                m = torch.nn.utils.spectral_norm(m)
+                for i in range(3):
+                    pre_remove_out = wrapped_m(input)
+                m = torch.nn.utils.remove_spectral_norm(m)
+                self.assertEqual(wrapped_m(input), pre_remove_out)
+
+                # TEST EVAL BEHAVIOR
+
+                m = torch.nn.utils.spectral_norm(m)
+                wrapped_m(input)
+                last_train_out = wrapped_m(input)
+                last_train_u = m.weight_u.clone()
+                last_train_v = m.weight_v.clone()
+                wrapped_m.zero_grad()
+                wrapped_m.eval()
+
+                eval_out0 = wrapped_m(input)
+                # assert eval gives same result as last training iteration
+                self.assertEqual(eval_out0, last_train_out)
+                # assert doing more iteartion in eval don't change things
+                self.assertEqual(eval_out0, wrapped_m(input))
+                self.assertEqual(last_train_u, m.weight_u)
+                self.assertEqual(last_train_v, m.weight_v)
+
+                # test backward works
+                wrapped_m(input).sum().backward()
+                wrapped_m(input).sum().backward()
+
+                # assert that backprop reaches weight_orig in eval
+                if requires_grad:
+                    def fn(weight):
+                        return wrapped_m(input)
+
+                    torch.autograd.gradcheck(fn, (m.weight_orig,))
 
     def test_spectral_norm_dim(self):
         inp = torch.randn(2, 3, 10, 12)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -70,9 +70,9 @@ class _BatchNorm(Module):
         return '{num_features}, eps={eps}, momentum={momentum}, affine={affine}, ' \
                'track_running_stats={track_running_stats}'.format(**self.__dict__)
 
-    def _load_from_state_dict(self, state_dict, prefix, metadata, strict,
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        version = metadata.get('version', None)
+        version = local_metadata.get('version', None)
 
         if (version is None or version < 2) and self.track_running_stats:
             # at version 2: added num_batches_tracked buffer
@@ -82,7 +82,7 @@ class _BatchNorm(Module):
                 state_dict[num_batches_tracked_key] = torch.tensor(0, dtype=torch.long)
 
         super(_BatchNorm, self)._load_from_state_dict(
-            state_dict, prefix, metadata, strict,
+            state_dict, prefix, local_metadata, strict,
             missing_keys, unexpected_keys, error_msgs)
 
 

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -11,9 +11,9 @@ class _InstanceNorm(_BatchNorm):
     def _check_input_dim(self, input):
         raise NotImplementedError
 
-    def _load_from_state_dict(self, state_dict, prefix, metadata, strict,
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        version = metadata.get('version', None)
+        version = local_metadata.get('version', None)
         # at version 1: removed running_mean and running_var when
         # track_running_stats=False (default)
         if version is None and not self.track_running_stats:
@@ -38,7 +38,7 @@ class _InstanceNorm(_BatchNorm):
                     state_dict.pop(key)
 
         super(_InstanceNorm, self)._load_from_state_dict(
-            state_dict, prefix, metadata, strict,
+            state_dict, prefix, local_metadata, strict,
             missing_keys, unexpected_keys, error_msgs)
 
     def forward(self, input):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -66,6 +66,8 @@ class Module(object):
         self._backward_hooks = OrderedDict()
         self._forward_hooks = OrderedDict()
         self._forward_pre_hooks = OrderedDict()
+        self._state_dict_hooks = OrderedDict()
+        self._load_state_dict_pre_hooks = OrderedDict()
         self._modules = OrderedDict()
         self.training = True
 
@@ -571,6 +573,11 @@ class Module(object):
         else:
             object.__delattr__(self, name)
 
+    def _register_state_dict_hook(self, hook):
+        handle = hooks.RemovableHandle(self._state_dict_hooks)
+        self._state_dict_hooks[handle.id] = hook
+        return handle
+
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         r"""Returns a dictionary containing a whole state of the module.
 
@@ -590,7 +597,7 @@ class Module(object):
         if destination is None:
             destination = OrderedDict()
             destination._metadata = OrderedDict()
-        destination._metadata[prefix[:-1]] = dict(version=self._version)
+        destination._metadata[prefix[:-1]] = local_metadata = dict(version=self._version)
         for name, param in self._parameters.items():
             if param is not None:
                 destination[prefix + name] = param if keep_vars else param.data
@@ -600,16 +607,26 @@ class Module(object):
         for name, module in self._modules.items():
             if module is not None:
                 module.state_dict(destination, prefix + name + '.', keep_vars=keep_vars)
+        for hook in self._state_dict_hooks.values():
+            hook_result = hook(self, destination, prefix, local_metadata)
+            if hook_result is not None:
+                destination = hook_result
         return destination
 
-    def _load_from_state_dict(self, state_dict, prefix, metadata, strict, missing_keys, unexpected_keys, error_msgs):
+    def _register_load_state_dict_pre_hook(self, hook):
+        handle = hooks.RemovableHandle(self._load_state_dict_pre_hooks)
+        self._load_state_dict_pre_hooks[handle.id] = hook
+        return handle
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
         r"""Copies parameters and buffers from :attr:`state_dict` into only
         this module, but not its descendants. This is called on every submodule
         in :meth:`~torch.nn.Module.load_state_dict`. Metadata saved for this
-        module in input :attr:`state_dict` is provided as :attr`metadata`.
-        For state dicts without meta data, :attr`metadata` is empty.
+        module in input :attr:`state_dict` is provided as :attr`local_metadata`.
+        For state dicts without metadata, :attr`local_metadata` is empty.
         Subclasses can achieve class-specific backward compatible loading using
-        the version number at `metadata.get("version", None)`.
+        the version number at `local_metadata.get("version", None)`.
 
         .. note::
             :attr:`state_dict` is not the same object as the input
@@ -621,7 +638,7 @@ class Module(object):
                 persistent buffers.
             prefix (str): the prefix for parameters and buffers used in this
                 module
-            metadata (dict): a dict containing the metadata for this moodule.
+            local_metadata (dict): a dict containing the metadata for this moodule.
                 See
             strict (bool): whether to strictly enforce that the keys in
                 :attr:`state_dict` with :attr:`prefix` match the names of
@@ -634,6 +651,9 @@ class Module(object):
                 list, and will be reported together in
                 :meth:`~torch.nn.Module.load_state_dict`
         """
+        for hook in self._load_state_dict_pre_hooks.values():
+            hook(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
+
         local_name_params = itertools.chain(self._parameters.items(), self._buffers.items())
         local_state = {k: v.data for k, v in local_name_params if v is not None}
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -500,8 +500,13 @@ class Module(object):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        # Support loading old checkpoints that don't have the following attrs:
         if '_forward_pre_hooks' not in self.__dict__:
             self._forward_pre_hooks = OrderedDict()
+        if '_state_dict_hooks' not in self.__dict__:
+            self._state_dict_hooks = OrderedDict()
+        if '_load_state_dict_pre_hooks' not in self.__dict__:
+            self._load_state_dict_pre_hooks = OrderedDict()
 
     def __getattr__(self, name):
         if '_parameters' in self.__dict__:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -574,6 +574,12 @@ class Module(object):
             object.__delattr__(self, name)
 
     def _register_state_dict_hook(self, hook):
+        r"""These hooks will be called with arguments: `self`, `state_dict`,
+        `prefix`, `local_metadata`, after the `state_dict` of `self` is set.
+        Note that only parameters and buffers of `self` or its children are
+        guaranteed to exist in `state_dict`. The hooks may modify `state_dict`
+        inplace or return a new one.
+        """
         handle = hooks.RemovableHandle(self._state_dict_hooks)
         self._state_dict_hooks[handle.id] = hook
         return handle
@@ -614,6 +620,11 @@ class Module(object):
         return destination
 
     def _register_load_state_dict_pre_hook(self, hook):
+        r"""These hooks will be called with arguments: `state_dict`, `prefix`,
+        `local_metadata`, `strict`, `missing_keys`, `unexpected_keys`,
+        `error_msgs`, before loading `state_dict` into `self`. These arguments
+        are exactly the same as those of `_load_from_state_dict`.
+        """
         handle = hooks.RemovableHandle(self._load_state_dict_pre_hooks)
         self._load_state_dict_pre_hooks[handle.id] = hook
         return handle

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -7,6 +7,10 @@ from torch.nn.parameter import Parameter
 
 
 class SpectralNorm(object):
+    # Invariant before and after each function call:
+    #   u = normalize(W @ v)
+
+    _version = 1
 
     def __init__(self, name='weight', n_power_iterations=1, dim=0, eps=1e-12):
         self.name = name
@@ -17,87 +21,142 @@ class SpectralNorm(object):
         self.n_power_iterations = n_power_iterations
         self.eps = eps
 
-    def compute_weight_and_update_u(self, module):
-        # NB: This updates the _u vector **in-place**. This is very important
-        #     because in DataParallel forward, the _u vector (being a buffer) is
-        #     broadcast from the parallelized module to each module replica,
-        #     which is a new module object on the fly. And each replica runs its
-        #     own spectral norm power iteration. So simply assigning the updated
-        #     _u vector to module this runs on will cause the update to be lost
-        #     forever. And the next time the parallelized module is replicated,
-        #     the same randomly initialized _u vector is broadcast!
-        #
-        #     Therefore, to make the change propagate back, we rely on two
-        #     important bahaviors (also enforced via tests):
-        #       1. DataParallel doesn't clone storage if the broadcast tensor is
-        #          alreay on correct device; and it makes sure that the
-        #          parallelized module is already on device[0].
-        #       2. If the out tensor in out= kwarg has correct shape, it will
-        #          just fill in the values.
-        #     Therefore, since the same power iteration is performed on all
-        #     devices, simply updating the _u tensor in-place will make sure
-        #     that the module replica on device[0] will update the _u vector on
-        #     the parallized module (by shared storage).
-        weight = getattr(module, self.name + '_orig')
-        u = getattr(module, self.name + '_u')
+    def reshape_weight_to_matrix(self, weight):
         weight_mat = weight
         if self.dim != 0:
             # permute dim to front
             weight_mat = weight_mat.permute(self.dim,
                                             *[d for d in range(weight_mat.dim()) if d != self.dim])
         height = weight_mat.size(0)
-        weight_mat = weight_mat.reshape(height, -1)
-        with torch.no_grad():
-            for _ in range(self.n_power_iterations):
-                # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
-                # are the first left and right singular vectors.
-                # This power iteration produces approximations of `u` and `v`.
-                v = normalize(torch.matmul(weight_mat.t(), u), dim=0, eps=self.eps)
-                u = normalize(torch.matmul(weight_mat, v), dim=0, eps=self.eps, out=u)
+        return weight_mat.reshape(height, -1)
 
-        sigma = torch.dot(u, torch.matmul(weight_mat, v))
+    def compute_weight(self, module, do_power_iteration):
+        # NB: If `do_power_iteration` is set, the `_u` and `_v` vectors are
+        #     updated in power iteration **in-place**. This is very important
+        #     because in `DataParallel` forward, the vectors (being buffers) are
+        #     broadcast from the parallelized module to each module replica,
+        #     which is a new module object created on the fly. And each replica
+        #     runs its own spectral norm power iteration. So simply assigning
+        #     the updated vectors to the module this function runs on will cause
+        #     the update to be lost forever. And the next time the parallelized
+        #     module is replicated, the same randomly initialized vectors are
+        #     broadcast and used!
+        #
+        #     Therefore, to make the change propagate back, we rely on two
+        #     important bahaviors (also enforced via tests):
+        #       1. `DataParallel` doesn't clone storage if the broadcast tensor
+        #          is alreay on correct device; and it makes sure that the
+        #          parallelized module is already on `device[0]`.
+        #       2. If the out tensor in `out=` kwarg has correct shape, it will
+        #          just fill in the values.
+        #     Therefore, since the same power iteration is performed on all
+        #     devices, simply updating the tensors in-place will make sure that
+        #     the module replica on `device[0]` will update the _u vector on the
+        #     parallized module (by shared storage).
+        weight = getattr(module, self.name + '_orig')
+        u = getattr(module, self.name + '_u')
+        v = getattr(module, self.name + '_v')
+        weight_mat = self.reshape_weight_to_matrix(weight)
+
+        if do_power_iteration:
+            with torch.no_grad():
+                for _ in range(self.n_power_iterations):
+                    # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
+                    # are the first left and right singular vectors.
+                    # This power iteration produces approximations of `u` and `v`.
+                    v = normalize(torch.mv(weight_mat.t(), u), dim=0, eps=self.eps, out=v)
+                    u = normalize(torch.mv(weight_mat, v), dim=0, eps=self.eps, out=u)
+
+        sigma = torch.dot(u, torch.mv(weight_mat, v))
         weight = weight / sigma
         return weight
 
     def remove(self, module):
-        weight = getattr(module, self.name)
+        weight = self.compute_weight(module, do_power_iteration=False)
         delattr(module, self.name)
         delattr(module, self.name + '_u')
+        delattr(module, self.name + '_v')
         delattr(module, self.name + '_orig')
         module.register_parameter(self.name, torch.nn.Parameter(weight))
 
     def __call__(self, module, inputs):
-        if module.training:
-            weight = self.compute_weight_and_update_u(module)
-            setattr(module, self.name, weight)
-        else:
-            r_g = getattr(module, self.name + '_orig').requires_grad
-            weight = getattr(module, self.name).detach()
-            # NB: Cannot detach weight in-place here because if this is used
-            #     DataParallel, the buffers are broadcast using
-            #     `broadacast_coalesced` and `weight` here is actually a view,
-            #     and you can't detach views in-place.
-            setattr(module, self.name, weight.requires_grad_(r_g))
+        setattr(module, self.name, self.compute_weight(module, do_power_iteration=module.training))
+
+    def _state_dict_hook(self, module, state_dict, prefix, local_metadata):
+        if 'spectral_norm' not in local_metadata:
+            local_metadata['spectral_norm'] = {}
+        key = self.name + '.version'
+        if key in local_metadata['spectral_norm']:
+            raise RuntimeError("Unexpected key in metadata['spectral_norm']: {}".format(key))
+        local_metadata['spectral_norm'][key] = self._version
+
+    def _solve_v_and_rescale(self, weight_mat, u, target_sigma):
+        # Tries to returns a vector `v` s.t. `u = normalize(W @ v)`
+        # (the invariant at top of this class) and `u @ W @ v = sigma`.
+        # This uses pinverse in case W^T W is not invertible.
+        v = torch.chain_matmul(weight_mat.t().mm(weight_mat).pinverse(), weight_mat.t(), u.unsqueeze(1)).squeeze(1)
+        return v.mul_(target_sigma / torch.dot(u, torch.mv(weight_mat, v)))
+
+    def _load_state_dict_pre_hook(self, state_dict, prefix, local_metadata,
+                                  strict, missing_keys, unexpected_keys,
+                                  error_msgs):
+        version = local_metadata.get('spectral_norm', {}).get(self.name + '.version', None)
+        if version is None or version < 1:
+            # At version 1:
+            #   made  `W` not a buffer,
+            #   added `v` as a buffer, and
+            #   made eval mode use `W = u @ W_orig @ v` rather than the stored `W`.
+            #
+            # For the old state_dict, we have
+            #
+            #    u = normalize(W_orig @ v)
+            #    W = W_orig / sigma, where sigma = u @ W_orig @ v
+            #
+            # To compute `v`, we solve `W_orig @ x = u`, and let
+            #    v = x / (u @ W_orig @ x) * (W / W_orig).
+            with torch.no_grad():
+                weight_orig = state_dict[prefix + self.name + '_orig']
+                weight = state_dict.pop(prefix + self.name)
+                sigma = (weight_orig / weight).mean()
+                weight_mat = self.reshape_weight_to_matrix(weight_orig)
+                u = state_dict[prefix + self.name + '_u']
+                v = self._solve_v_and_rescale(weight_mat, u, sigma)
+                state_dict[prefix + self.name + '_v'] = v
 
     @staticmethod
     def apply(module, name, n_power_iterations, dim, eps):
+        for k, hook in module._forward_pre_hooks.items():
+            if isinstance(hook, SpectralNorm) and hook.name == name:
+                raise RuntimeError("Cannot register two spectral_norm hooks on "
+                                   "the same parameter {}".format(name))
+
         fn = SpectralNorm(name, n_power_iterations, dim, eps)
         weight = module._parameters[name]
-        height = weight.size(dim)
 
-        u = normalize(weight.new_empty(height).normal_(0, 1), dim=0, eps=fn.eps)
+        with torch.no_grad():
+            weight_mat = fn.reshape_weight_to_matrix(weight)
+
+            h, w = weight_mat.size()
+            u = normalize(weight.new_empty(h).normal_(0, 1), dim=0, eps=fn.eps)
+            # compute `v` to satisfy the invariant (see top of this class)
+            # make `u @ W @ v` equal to 1 so at beginning this gives same result
+            v = fn._solve_v_and_rescale(weight_mat, u, target_sigma=1)
+
         delattr(module, fn.name)
         module.register_parameter(fn.name + "_orig", weight)
         # We still need to assign weight back as fn.name because all sorts of
         # things may assume that it exists, e.g., when initializing weights.
         # However, we can't directly assign as it could be an nn.Parameter and
-        # gets added as a parameter. Instead, we register weight.data as a
-        # buffer, which will cause weight to be included in the state dict
-        # and also supports nn.init due to shared storage.
-        module.register_buffer(fn.name, weight.data)
+        # gets added as a parameter. Instead, we register weight.data as a plain
+        # attribute.
+        setattr(module, fn.name, weight.data)
         module.register_buffer(fn.name + "_u", u)
+        module.register_buffer(fn.name + "_v", v)
 
         module.register_forward_pre_hook(fn)
+
+        module._register_state_dict_hook(fn._state_dict_hook)
+        module._register_load_state_dict_pre_hook(fn._load_state_dict_pre_hook)
         return fn
 
 

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -19,6 +19,11 @@ class WeightNorm(object):
 
     @staticmethod
     def apply(module, name, dim):
+        for k, hook in module._forward_pre_hooks.items():
+            if isinstance(hook, WeightNorm) and hook.name == name:
+                raise RuntimeError("Cannot register two weight_norm hooks on "
+                                   "the same parameter {}".format(name))
+
         if dim is None:
             dim = -1
 


### PR DESCRIPTION
Problems with SN and DP after #12671 : 
1. in eval mode, `weight_orig` is not getting correct gradient #12737 .

    Fix: keep `v` vector around as a buffer and always calculate `W = W_orig / (u @ W_orig @ v)` even in eval.

2. in training mode, the `weight` buffer of the parallelized module is never updated, if someone touches `weight_orig` and/or `weight` and makes them not sharing storage. So in `eval` the weight used is wrong.

    Fix: Make `weight` not a buffer anymore and always calculate it as above.

3. #12671 changed SN to update `u` in-place to make DP work correctly, but then it breaks backward through two forwards (e.g., the common GAN loss `D(real) - D(fake)`) because the vectors needed to backprop the 1st forward is changed in the 2nd forward. 

    Fix: This PR clones `u` and `v` before using them.

To maintain BC, I added a hook interface for producing and loading state_dict. This is ugly and we should really have better interface for spectral_norm. But for the purpose to fix this issue, I make this patch. Even if we have a better interface, BC mechanism for legacy loading legacy state_dict still needs to be done.

cc @t-vi @crcrpar 