### PR TITLE
CircleCI: run tests in parallel for the slowest test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         # Pull Docker image and run build
         echo "DOCKER_IMAGE: "${DOCKER_IMAGE}
         docker pull ${DOCKER_IMAGE} >/dev/null
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
         export id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
 
         git submodule sync && git submodule update -q --init
@@ -121,6 +123,8 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
         export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
         echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
         docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
         if [ -n "${CUDA_VERSION}" ]; then
           id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         else
@@ -194,6 +198,8 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
 
         echo "DOCKER_IMAGE: "${DOCKER_IMAGE}
         docker pull ${DOCKER_IMAGE} >/dev/null
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
         export id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
@@ -270,6 +276,8 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
         echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
         docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
         if [ -n "${CUDA_VERSION}" ]; then
           id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         else
@@ -603,6 +611,8 @@ jobs:
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
           id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
 
           docker cp $id:/var/lib/jenkins/workspace/env /home/circleci/project/env
@@ -635,6 +645,8 @@ jobs:
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
           id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
 
           cat >/home/circleci/project/doc_push_script.sh <<EOL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,9 +415,16 @@ jobs:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:256"
     <<: *pytorch_linux_build_defaults
 
-  pytorch_linux_trusty_py3_6_gcc5_4_test:
+  pytorch_linux_trusty_py3_6_gcc5_4_test1:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc5.4-test
+      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc5.4-test1
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:256"
+    resource_class: large
+    <<: *pytorch_linux_test_defaults
+
+  pytorch_linux_trusty_py3_6_gcc5_4_test2:
+    environment:
+      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc5.4-test2
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:256"
     resource_class: large
     <<: *pytorch_linux_test_defaults
@@ -455,9 +462,17 @@ jobs:
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
-  pytorch_linux_xenial_py3_clang5_asan_test:
+  pytorch_linux_xenial_py3_clang5_asan_test1:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-asan-test
+      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-asan-test1
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:256"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    <<: *pytorch_linux_test_defaults
+
+  pytorch_linux_xenial_py3_clang5_asan_test2:
+    environment:
+      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-asan-test2
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:256"
       PYTHON_VERSION: "3.6"
     resource_class: large
@@ -533,9 +548,18 @@ jobs:
       CUDA_VERSION: "9"
     <<: *pytorch_linux_build_defaults
 
-  pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+  pytorch_linux_xenial_cuda9_cudnn7_py3_test1:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py3-test
+      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py3-test1
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:256"
+      PYTHON_VERSION: "3.6"
+      CUDA_VERSION: "9"
+    resource_class: gpu.medium
+    <<: *pytorch_linux_test_defaults
+
+  pytorch_linux_xenial_cuda9_cudnn7_py3_test2:
+    environment:
+      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py3-test2
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:256"
       PYTHON_VERSION: "3.6"
       CUDA_VERSION: "9"
@@ -958,7 +982,10 @@ workflows:
           requires:
             - pytorch_linux_trusty_py3_6_gcc4_8_build
       - pytorch_linux_trusty_py3_6_gcc5_4_build
-      - pytorch_linux_trusty_py3_6_gcc5_4_test:
+      - pytorch_linux_trusty_py3_6_gcc5_4_test1:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc5_4_build
+      - pytorch_linux_trusty_py3_6_gcc5_4_test2:
           requires:
             - pytorch_linux_trusty_py3_6_gcc5_4_build
       - pytorch_linux_trusty_py3_6_gcc7_build
@@ -970,7 +997,10 @@ workflows:
           requires:
             - pytorch_linux_trusty_pynightly_build
       - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_py3_clang5_asan_test:
+      - pytorch_linux_xenial_py3_clang5_asan_test1:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_asan_build
+      - pytorch_linux_xenial_py3_clang5_asan_test2:
           requires:
             - pytorch_linux_xenial_py3_clang5_asan_build
       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
@@ -997,7 +1027,10 @@ workflows:
           requires:
             - pytorch_linux_xenial_cuda9_cudnn7_py2_build
       - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_test1:
+          requires:
+            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_test2:
           requires:
             - pytorch_linux_xenial_cuda9_cudnn7_py3_build
       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build


### PR DESCRIPTION
This PR tries to reduce the runtime of the slowest test jobs:
`pytorch_linux_trusty_py3_6_gcc5_4_test`  1:47:34
`pytorch_linux_xenial_py3_clang5_asan_test`  1:07:42
`pytorch_linux_xenial_cuda9_cudnn7_py3_test`  46:15

... by re-using the same parallel test logic we used in Jenkins.