### PR TITLE
CircleCI: enable all flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,69 +941,69 @@ workflows:
   version: 2
   build:
     jobs:
-      - pytorch_linux_trusty_py2_7_9_build
-      - pytorch_linux_trusty_py2_7_9_test:
-          requires:
-            - pytorch_linux_trusty_py2_7_9_build
-      - pytorch_linux_trusty_py2_7_build
-      - pytorch_linux_trusty_py2_7_test:
-          requires:
-            - pytorch_linux_trusty_py2_7_build
-      - pytorch_linux_trusty_py3_5_build
-      - pytorch_linux_trusty_py3_5_test:
-          requires:
-            - pytorch_linux_trusty_py3_5_build
-      - pytorch_linux_trusty_py3_6_gcc4_8_build
-      - pytorch_linux_trusty_py3_6_gcc4_8_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc4_8_build
-      - pytorch_linux_trusty_py3_6_gcc5_4_build
-      - pytorch_linux_trusty_py3_6_gcc5_4_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc5_4_build
-      - pytorch_linux_trusty_py3_6_gcc7_build
-      - pytorch_linux_trusty_py3_6_gcc7_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc7_build
-      - pytorch_linux_trusty_pynightly_build
-      - pytorch_linux_trusty_pynightly_test:
-          requires:
-            - pytorch_linux_trusty_pynightly_build
-      - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_py3_clang5_asan_test:
-          requires:
-            - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_short_perf_test_gpu:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_doc_push:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
-      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      # - pytorch_linux_trusty_py2_7_9_build
+      # - pytorch_linux_trusty_py2_7_9_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py2_7_9_build
+      # - pytorch_linux_trusty_py2_7_build
+      # - pytorch_linux_trusty_py2_7_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py2_7_build
+      # - pytorch_linux_trusty_py3_5_build
+      # - pytorch_linux_trusty_py3_5_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_5_build
+      # - pytorch_linux_trusty_py3_6_gcc4_8_build
+      # - pytorch_linux_trusty_py3_6_gcc4_8_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc4_8_build
+      # - pytorch_linux_trusty_py3_6_gcc5_4_build
+      # - pytorch_linux_trusty_py3_6_gcc5_4_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc5_4_build
+      # - pytorch_linux_trusty_py3_6_gcc7_build
+      # - pytorch_linux_trusty_py3_6_gcc7_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc7_build
+      # - pytorch_linux_trusty_pynightly_build
+      # - pytorch_linux_trusty_pynightly_test:
+      #     requires:
+      #       - pytorch_linux_trusty_pynightly_build
+      # - pytorch_linux_xenial_py3_clang5_asan_build
+      # - pytorch_linux_xenial_py3_clang5_asan_test:
+      #     requires:
+      #       - pytorch_linux_xenial_py3_clang5_asan_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_short_perf_test_gpu:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_doc_push:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
 
       # - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_py3_test:
@@ -1011,35 +1011,35 @@ workflows:
       #       - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build
 
-      - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      - caffe2_py2_mkl_ubuntu16_04_build
-      - caffe2_py2_mkl_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_mkl_ubuntu16_04_build
+      # - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
+      # - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
+      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_mkl_ubuntu16_04_build
+      # - caffe2_py2_mkl_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_mkl_ubuntu16_04_build
       - caffe2_py2_gcc4_8_ubuntu14_04_build
       - caffe2_py2_gcc4_8_ubuntu14_04_test:
           requires:
             - caffe2_py2_gcc4_8_ubuntu14_04_build
-      - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
-          requires:
-            - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_clang3_8_ubuntu16_04_build
-      - caffe2_py2_clang3_9_ubuntu16_04_build
-      - caffe2_py2_android_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_centos7_build
+      # - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      # - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      # - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_clang3_8_ubuntu16_04_build
+      # - caffe2_py2_clang3_9_ubuntu16_04_build
+      # - caffe2_py2_android_ubuntu16_04_build
+      # - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
       # - caffe2_py2_ios_macos10_13_build
       # - caffe2_py2_system_macos10_13_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,69 +941,69 @@ workflows:
   version: 2
   build:
     jobs:
-      # - pytorch_linux_trusty_py2_7_9_build
-      # - pytorch_linux_trusty_py2_7_9_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py2_7_9_build
-      # - pytorch_linux_trusty_py2_7_build
-      # - pytorch_linux_trusty_py2_7_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py2_7_build
-      # - pytorch_linux_trusty_py3_5_build
-      # - pytorch_linux_trusty_py3_5_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_5_build
-      # - pytorch_linux_trusty_py3_6_gcc4_8_build
-      # - pytorch_linux_trusty_py3_6_gcc4_8_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc4_8_build
-      # - pytorch_linux_trusty_py3_6_gcc5_4_build
-      # - pytorch_linux_trusty_py3_6_gcc5_4_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc5_4_build
-      # - pytorch_linux_trusty_py3_6_gcc7_build
-      # - pytorch_linux_trusty_py3_6_gcc7_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc7_build
-      # - pytorch_linux_trusty_pynightly_build
-      # - pytorch_linux_trusty_pynightly_test:
-      #     requires:
-      #       - pytorch_linux_trusty_pynightly_build
-      # - pytorch_linux_xenial_py3_clang5_asan_build
-      # - pytorch_linux_xenial_py3_clang5_asan_test:
-      #     requires:
-      #       - pytorch_linux_xenial_py3_clang5_asan_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_short_perf_test_gpu:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_doc_push:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
-      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      - pytorch_linux_trusty_py2_7_9_build
+      - pytorch_linux_trusty_py2_7_9_test:
+          requires:
+            - pytorch_linux_trusty_py2_7_9_build
+      - pytorch_linux_trusty_py2_7_build
+      - pytorch_linux_trusty_py2_7_test:
+          requires:
+            - pytorch_linux_trusty_py2_7_build
+      - pytorch_linux_trusty_py3_5_build
+      - pytorch_linux_trusty_py3_5_test:
+          requires:
+            - pytorch_linux_trusty_py3_5_build
+      - pytorch_linux_trusty_py3_6_gcc4_8_build
+      - pytorch_linux_trusty_py3_6_gcc4_8_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc4_8_build
+      - pytorch_linux_trusty_py3_6_gcc5_4_build
+      - pytorch_linux_trusty_py3_6_gcc5_4_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc5_4_build
+      - pytorch_linux_trusty_py3_6_gcc7_build
+      - pytorch_linux_trusty_py3_6_gcc7_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc7_build
+      - pytorch_linux_trusty_pynightly_build
+      - pytorch_linux_trusty_pynightly_test:
+          requires:
+            - pytorch_linux_trusty_pynightly_build
+      - pytorch_linux_xenial_py3_clang5_asan_build
+      - pytorch_linux_xenial_py3_clang5_asan_test:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_asan_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_short_perf_test_gpu:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_doc_push:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
 
       # - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_py3_test:
@@ -1011,35 +1011,35 @@ workflows:
       #       - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build
 
-      # - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      # - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_mkl_ubuntu16_04_build
-      # - caffe2_py2_mkl_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_mkl_ubuntu16_04_build
+      - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
+      - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
+      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      - caffe2_py2_mkl_ubuntu16_04_build
+      - caffe2_py2_mkl_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_mkl_ubuntu16_04_build
       - caffe2_py2_gcc4_8_ubuntu14_04_build
       - caffe2_py2_gcc4_8_ubuntu14_04_test:
           requires:
             - caffe2_py2_gcc4_8_ubuntu14_04_build
-      # - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      # - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      # - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_clang3_8_ubuntu16_04_build
-      # - caffe2_py2_clang3_9_ubuntu16_04_build
-      # - caffe2_py2_android_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_centos7_build
+      - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
+          requires:
+            - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_clang3_8_ubuntu16_04_build
+      - caffe2_py2_clang3_9_ubuntu16_04_build
+      - caffe2_py2_android_ubuntu16_04_build
+      - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
       # - caffe2_py2_ios_macos10_13_build
       # - caffe2_py2_system_macos10_13_build

--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from caffe2.python import core
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 from caffe2.python.operator_test.adagrad_test_helper import (
     ref_adagrad, adagrad_sparse_test_helper
 )
@@ -165,7 +164,6 @@ class TestAdagrad(serial.SerializedTestCase):
 
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(inputs=hu.tensors(n=2),
            lr=st.floats(min_value=0.01, max_value=0.99,

--- a/caffe2/python/operator_test/crf_test.py
+++ b/caffe2/python/operator_test/crf_test.py
@@ -7,7 +7,6 @@ from caffe2.python.model_helper import ModelHelper
 import numpy as np
 from scipy.misc import logsumexp
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import hypothesis.strategies as st
 from hypothesis import given
 import unittest
@@ -58,7 +57,6 @@ class TestCRFOp(hu.HypothesisTestCase):
             err_msg='CRF LOSS is not matching the reference'
         )
 
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @given(num_tags=st.integers(1, 4),
            num_words=st.integers(2, 4))
     def test_crf_gradient(self, num_tags, num_words):

--- a/caffe2/python/operator_test/fc_operator_test.py
+++ b/caffe2/python/operator_test/fc_operator_test.py
@@ -7,7 +7,6 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from hypothesis import assume, given, settings, HealthCheck
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import caffe2.python.serialized_test.serialized_test_util as serial
 import hypothesis.strategies as st
 import numpy as np
@@ -78,7 +77,6 @@ class TestFcOperator(serial.SerializedTestCase):
             self.assertGradientChecks(gc, op, [X, W, b], i, [0],
                                       threshold=threshold, stepsize=stepsize)
 
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @settings(max_examples=50, suppress_health_check=[HealthCheck.filter_too_much])
     @serial.given(n=st.integers(1, 5),
            m=st.integers(0, 5),

--- a/caffe2/python/operator_test/im2col_col2im_test.py
+++ b/caffe2/python/operator_test/im2col_col2im_test.py
@@ -7,7 +7,6 @@ from caffe2.python import core
 from hypothesis import assume, given
 
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import hypothesis.strategies as st
 import numpy as np
 
@@ -115,7 +114,6 @@ class TestReduceFrontSum(hu.HypothesisTestCase):
             atol=1e-4,
             rtol=1e-4)
 
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @given(batch_size=st.integers(1, 3),
            stride=st.integers(1, 3),
            pad=st.integers(0, 3),

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -7,7 +7,6 @@ from caffe2.python import brew, core
 from caffe2.python.model_helper import ModelHelper
 from hypothesis import given
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import caffe2.python.serialized_test.serialized_test_util as serial
 import numpy as np
 import os
@@ -15,7 +14,6 @@ import unittest
 
 
 class TestLayerNormOp(serial.SerializedTestCase):
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @serial.given(X=hu.tensors(n=1), **hu.gcs)
     def test_layer_norm_grad_op(self, X, gc, dc):
         X = X[0]
@@ -87,7 +85,6 @@ class TestLayerNormOp(serial.SerializedTestCase):
             outputs_to_check=[0],
         )
 
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @given(X=hu.tensors(n=1), **hu.gcs)
     def test_layer_norm_op(self, X, gc, dc):
         X = X[0]

--- a/caffe2/python/operator_test/recurrent_network_test.py
+++ b/caffe2/python/operator_test/recurrent_network_test.py
@@ -7,7 +7,6 @@ from caffe2.python import recurrent, workspace
 from caffe2.python.model_helper import ModelHelper
 from hypothesis import given
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import caffe2.python.serialized_test.serialized_test_util as serial
 import hypothesis.strategies as st
 import numpy as np
@@ -16,7 +15,6 @@ import os
 import unittest
 
 class RecurrentNetworkTest(serial.SerializedTestCase):
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @given(T=st.integers(1, 4),
            n=st.integers(1, 5),
            d=st.integers(1, 5))

--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -7,7 +7,6 @@ from caffe2.python import core, workspace
 from hypothesis import given
 
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.test_util import IN_CIRCLECI_FLAKY_ENV
 import caffe2.python.serialized_test.serialized_test_util as serial
 import hypothesis.strategies as st
 import numpy as np
@@ -57,7 +56,6 @@ class TestReduceOps(serial.SerializedTestCase):
                 self.run_reduce_op_test_impl(
                     op_name, X, axes, keepdims, ref_func, gc, dc)
 
-    @unittest.skipIf(IN_CIRCLECI_FLAKY_ENV, "FIXME: flaky test in CircleCI")
     @serial.given(
         X=hu.tensor(max_dim=3, dtype=np.float32), keepdims=st.booleans(),
         num_axes=st.integers(1, 3), **hu.gcs)

--- a/caffe2/python/test_util.py
+++ b/caffe2/python/test_util.py
@@ -10,8 +10,6 @@ from caffe2.python import core, workspace
 import unittest
 import os
 
-IN_CIRCLECI_FLAKY_ENV = "IN_CIRCLECI" in os.environ and "py2-gcc4.8-ubuntu14.04" in os.environ.get("BUILD_ENVIRONMENT", "")
-
 def rand_array(*dims):
     # np.random.rand() returns float instead of 0-dim array, that's why need to
     # do some tricks


### PR DESCRIPTION
A few Caffe2 tests are currently disabled in `py2-gcc4.8-ubuntu14.04` test job because they are known to be flaky. https://github.com/pytorch/pytorch/pull/13055 likely had fixed the flakiness, and this PR tests it.

Fixes https://github.com/pytorch/pytorch/issues/12395.