### PR TITLE
Add back fb logging dependency in caffe2_cpu

### DIFF
--- a/caffe2/core/operator_schema.cc
+++ b/caffe2/core/operator_schema.cc
@@ -1,5 +1,6 @@
 #include "caffe2/core/operator_schema.h"
 #include "caffe2/core/logging.h"
+#include "caffe2/utils/filler_impl.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/quantized/int8_concat_op.h
+++ b/caffe2/operators/quantized/int8_concat_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor_int8.h"
 #include "caffe2/operators/quantized/int8_utils.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -1,5 +1,6 @@
 #include "caffe2/predictor/emulator/data_filler.h"
 #include "caffe2/predictor/emulator/utils.h"
+#include "caffe2/utils/filler_impl.h"
 
 namespace caffe2 {
 namespace emulator {

--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -5,7 +5,6 @@
 
 #include "caffe2/core/logging.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
@@ -14,44 +13,10 @@ enum FillerDistribution { FD_UNIFORM, FD_FIXEDSUM, FD_SYNTHETIC };
 
 class TensorFiller {
  public:
+  // Note: to avoid including an MKL dependency, we are having the
+  // implementation of the Fill functiomn in the filler_impl.h file.
   template <class Type, class Context>
-  void Fill(Tensor* tensor, Context* context) const {
-    CAFFE_ENFORCE(context, "context is null");
-    CAFFE_ENFORCE(tensor, "tensor is null");
-    auto min = (min_ < std::numeric_limits<Type>::min())
-        ? std::numeric_limits<Type>::min()
-        : static_cast<Type>(min_);
-    auto max = (max_ > std::numeric_limits<Type>::max())
-        ? std::numeric_limits<Type>::max()
-        : static_cast<Type>(max_);
-    CAFFE_ENFORCE_LE(min, max);
-
-    Tensor temp_tensor(shape_, Context::GetDeviceType());
-    tensor->swap(temp_tensor);
-    Type* data = tensor->template mutable_data<Type>();
-
-    // select distribution
-    switch (dist_) {
-      case FD_UNIFORM: {
-        math::RandUniform<Type, Context>(
-            tensor->numel(), min, max, data, context);
-        break;
-      }
-      case FD_FIXEDSUM: {
-        auto fixed_sum = static_cast<Type>(fixed_sum_);
-        CAFFE_ENFORCE_LE(min * tensor->numel(), fixed_sum);
-        CAFFE_ENFORCE_GE(max * tensor->numel(), fixed_sum);
-        math::RandFixedSum<Type, Context>(
-            tensor->numel(), min, max, fixed_sum_, data, context);
-        break;
-      }
-      case FD_SYNTHETIC: {
-        math::RandSyntheticData<Type, Context>(
-            tensor->numel(), min, max, data, context);
-        break;
-      }
-    }
-  }
+  void Fill(Tensor* tensor, Context* context) const;
 
   TensorFiller& Dist(FillerDistribution dist) {
     dist_ = dist;

--- a/caffe2/utils/filler_impl.h
+++ b/caffe2/utils/filler_impl.h
@@ -1,0 +1,54 @@
+#ifndef CAFFE2_FILLER_IMPL_H_
+#define CAFFE2_FILLER_IMPL_H_
+
+#include <sstream>
+
+#include "caffe2/core/logging.h"
+#include "caffe2/core/tensor.h"
+#include "caffe2/utils/filler.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Type, class Context>
+void TensorFiller::Fill(Tensor* tensor, Context* context) const {
+  CAFFE_ENFORCE(context, "context is null");
+  CAFFE_ENFORCE(tensor, "tensor is null");
+  auto min = (min_ < std::numeric_limits<Type>::min())
+      ? std::numeric_limits<Type>::min()
+      : static_cast<Type>(min_);
+  auto max = (max_ > std::numeric_limits<Type>::max())
+      ? std::numeric_limits<Type>::max()
+      : static_cast<Type>(max_);
+  CAFFE_ENFORCE_LE(min, max);
+
+  Tensor temp_tensor(shape_, Context::GetDeviceType());
+  tensor->swap(temp_tensor);
+  Type* data = tensor->template mutable_data<Type>();
+
+  // select distribution
+  switch (dist_) {
+    case FD_UNIFORM: {
+      math::RandUniform<Type, Context>(
+          tensor->numel(), min, max, data, context);
+      break;
+    }
+    case FD_FIXEDSUM: {
+      auto fixed_sum = static_cast<Type>(fixed_sum_);
+      CAFFE_ENFORCE_LE(min * tensor->numel(), fixed_sum);
+      CAFFE_ENFORCE_GE(max * tensor->numel(), fixed_sum);
+      math::RandFixedSum<Type, Context>(
+          tensor->numel(), min, max, fixed_sum_, data, context);
+      break;
+    }
+    case FD_SYNTHETIC: {
+      math::RandSyntheticData<Type, Context>(
+          tensor->numel(), min, max, data, context);
+      break;
+    }
+  }
+}
+
+} // namespace caffe2
+
+#endif // CAFFE2_FILLER_IMPL_H_


### PR DESCRIPTION
Summary:
This is caught by salexspb - during the last refactor of coping with aten/core
dependency we removed caffe2_cpu_internal, but accidentally dropped support
for fb init (see D9977191). This adds the dependency back for anyone who is
using caffe2_cpu.

Differential Revision: D12853348
