### PR TITLE
Use byte tensor for mnist labels.

### DIFF
--- a/torch/csrc/api/src/data/datasets/mnist.cpp
+++ b/torch/csrc/api/src/data/datasets/mnist.cpp
@@ -90,7 +90,8 @@ Tensor read_targets(const std::string& root, bool train) {
   expect_int32(targets, kTargetMagicNumber);
   expect_int32(targets, count);
 
-  auto tensor = torch::empty(count);
+  at::TensorOptions options;
+  auto tensor = torch::empty(count, options.dtype(at::kByte));
   targets.read(reinterpret_cast<char*>(tensor.data_ptr()), count);
   return tensor.to(torch::kInt64);
 }

--- a/torch/csrc/api/src/data/datasets/mnist.cpp
+++ b/torch/csrc/api/src/data/datasets/mnist.cpp
@@ -90,8 +90,7 @@ Tensor read_targets(const std::string& root, bool train) {
   expect_int32(targets, kTargetMagicNumber);
   expect_int32(targets, count);
 
-  at::TensorOptions options;
-  auto tensor = torch::empty(count, options.dtype(at::kByte));
+  auto tensor = torch::empty(count, torch::kByte);
   targets.read(reinterpret_cast<char*>(tensor.data_ptr()), count);
   return tensor.to(torch::kInt64);
 }


### PR DESCRIPTION
The C++ mnist example https://github.com/goldsborough/examples/blob/cpp/cpp/mnist/mnist.cpp
 does not work because the labels are not correctly loaded.  Currently it achieves 100 % accuracy.  Specifying byte dtype fixes the issue. 