### PR TITLE
[jit] add augmented assignment ops

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -188,6 +188,7 @@ _(aten, adaptive_max_pool3d) \
 _(aten, adaptive_max_pool3d_backward) \
 _(aten, adaptive_max_pool3d_forward) \
 _(aten, add) \
+_(aten, add_) \
 _(aten, addbmm) \
 _(aten, addcdiv) \
 _(aten, addcmul) \
@@ -289,6 +290,7 @@ _(aten, digamma) \
 _(aten, dim) \
 _(aten, dist) \
 _(aten, div) \
+_(aten, div_) \
 _(aten, dot) \
 _(aten, dropout) \
 _(aten, eig) \
@@ -467,6 +469,7 @@ _(aten, mse_loss) \
 _(aten, mse_loss_backward) \
 _(aten, mse_loss_forward) \
 _(aten, mul) \
+_(aten, mul_) \
 _(aten, multi_margin_loss) \
 _(aten, multi_margin_loss_backward) \
 _(aten, multi_margin_loss_forward) \
@@ -612,6 +615,7 @@ _(aten, storage_offset) \
 _(aten, stride) \
 _(aten, strides) \
 _(aten, sub) \
+_(aten, sub_) \
 _(aten, rsub) \
 _(aten, sum) \
 _(aten, svd) \

--- a/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
@@ -7,7 +7,7 @@ def script(y1):
   z = z1
   t11 = t10
   while t11:
-    y2 = aten::add(y, 1, 1)
+    y2 = aten::add_(y, 1, 1)
     t17 = aten::lt(y2, 8)
     t11 = prim::TensorToBool(t17)
     y = y2

--- a/test/expect/TestJit.test_pretty_printer-while_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-while_test.expect
@@ -5,9 +5,9 @@ def script(a1, i1):
   i = i1
   t6 = t5
   while t6:
-    i2 = aten::add(i, 1, 1)
+    i2 = aten::add_(i, 1, 1)
     t13 = aten::lt(i2, 3)
     t6 = prim::TensorToBool(t13)
-    a = aten::mul(a, a)
+    a = aten::mul_(a, a)
     i = i2
   return a

--- a/test/expect/TestScript.test_augmented_assign.expect
+++ b/test/expect/TestScript.test_augmented_assign.expect
@@ -1,0 +1,9 @@
+graph(%a.1 : Dynamic
+      %b : Dynamic) {
+  %2 : int = prim::Constant[value=1]()
+  %a.2 : Dynamic = aten::add_(%a.1, %b, %2)
+  %a.3 : Dynamic = aten::sub_(%a.2, %b, %2)
+  %a.4 : Dynamic = aten::div_(%a.3, %b)
+  %a : Dynamic = aten::mul_(%a.4, %b)
+  return (%a, %b);
+}

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -15,11 +15,9 @@
   (list
     (assign
       (list (variable (ident q)))
-      (=)
       (None))
     (assign
       (list (variable (ident q)))
-      (=)
       (-
         (+
           (variable (ident x))
@@ -38,7 +36,6 @@
           (list))))
     (assign
       (list (variable (ident w)))
-      (=)
       (unary minus
         (variable (ident z))))
     (if
@@ -50,7 +47,6 @@
       (list
         (assign
           (list (variable (ident m)))
-          (=)
           (if
             (not (variable (ident z)))
             (variable (ident x))
@@ -67,7 +63,6 @@
       (list
         (assign
           (list (variable (ident q)))
-          (=)
           (variable (ident x)))))
     (assert
       (eq (const 1) (const 1))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2473,7 +2473,7 @@ class TestBatched(TestCase):
                    b_i, b_f, b_o, b_c, w_hs, b_s, iter_num):
             iter_count = torch.zeros_like(iter_num)
             while bool(iter_count < iter_num):
-                iter_count += 1
+                iter_count = iter_count + 1
                 # LSTM Cell
                 i_t = torch.matmul(x, w_xi) + torch.matmul(h, w_hi) + b_i
                 f_t = torch.matmul(x, w_xf) + torch.matmul(h, w_hf) + b_f
@@ -2539,7 +2539,7 @@ class TestBatched(TestCase):
             iter_count = torch.zeros_like(iter_num)
             max_len = idx.size(2)
             while bool(iter_count < iter_num):
-                iter_count += 1
+                iter_count = iter_count + 1
                 # LSTM Cell
                 i_t = torch.matmul(x, w_xi) + torch.matmul(h, w_hi) + b_i
                 f_t = torch.matmul(x, w_xf) + torch.matmul(h, w_hf) + b_f
@@ -2681,7 +2681,15 @@ class TestScript(JitTestCase):
             ge = torch.jit.script(script, optimize)
             ge(*inputs)
 
-    def checkScript(self, script, inputs, optimize=True, outputs=None, name='func', capture_output=False, frames_up=1):
+    def checkScript(self,
+                    script,
+                    inputs,
+                    optimize=True,
+                    outputs=None,
+                    name='func',
+                    capture_output=False,
+                    frames_up=1,
+                    check_expected=False):
         if isinstance(script, str):
             cu = torch.jit.CompilationUnit(script, optimize, _frames_up=frames_up)
             ge = getattr(cu, name)
@@ -2693,7 +2701,15 @@ class TestScript(JitTestCase):
                 outputs = script(*inputs)
             # Check the string frontend first
             source = textwrap.dedent(inspect.getsource(script))
-            self.checkScript(source, inputs, optimize, outputs, script.__name__, capture_output, frames_up=2)
+            self.checkScript(
+                source,
+                inputs,
+                optimize,
+                outputs,
+                script.__name__,
+                capture_output,
+                frames_up=2,
+                check_expected=check_expected)
             # Continue checking the Python frontend
             ge = torch.jit.script(script, optimize, _frames_up=1)
 
@@ -2705,6 +2721,9 @@ class TestScript(JitTestCase):
         else:
             outputs_ge = ge(*inputs)
         self.assertEqual(outputs, outputs_ge)
+
+        if check_expected:
+            self.assertExpectedGraph(ge.graph)
 
         return ge
 
@@ -6334,6 +6353,7 @@ a")
             return c
 
         graph = torch.jit.script(func).graph
+        self.run_pass('remove_inplace_ops', graph)
         self.run_pass('erase_number_types', graph)
         self.assertExpectedGraph(graph)
 
@@ -6514,8 +6534,9 @@ a")
             ''')
 
     def test_multi_reduction(self):
-        with self.assertRaisesRegex(RuntimeError, 'reductions are only allowed when there is a single variable on'
-                                                  ' the left-hand side'):
+        with self.assertRaisesRegex(
+                RuntimeError,
+                'augmented assignment can only have one LHS expression'):
             cu = torch.jit.CompilationUnit('''
             def multi_reduction(x):
                 a, b += x
@@ -8117,6 +8138,15 @@ a")
             return e
         self.checkScript(foo, (torch.rand(3), torch.rand(3)))
 
+    def test_augmented_assign(self):
+        def foo(a, b):
+            a += b
+            a -= b
+            a /= b
+            a *= b
+            return a, b
+        self.checkScript(foo, (torch.rand(3), torch.rand(3)), check_expected=True)
+
 
 class MnistNet(nn.Module):
     def __init__(self):
@@ -9100,7 +9130,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
         def fn(x, k):
             y = x * 1.1
             if bool(k):
-                k += y
+                k = k + y
             z = y * k
             return z, k
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -179,6 +179,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/passes/lower_tuples.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/peephole.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/remove_expands.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/remove_inplace_ops.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/shape_analysis.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/requires_grad_analysis.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/specialize_undef.cpp

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -12,7 +12,6 @@
 #include "torch/csrc/jit/passes/constant_pooling.h"
 #include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
-#include "torch/csrc/jit/passes/erase_number_types.h"
 #include "torch/csrc/jit/passes/graph_fuser.h"
 #include "torch/csrc/jit/passes/inplace_check.h"
 #include "torch/csrc/jit/passes/peephole.h"

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -23,6 +23,7 @@
 #include "torch/csrc/jit/passes/onnx/fixup_onnx_loop.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/canonicalize_ops.h"
+#include "torch/csrc/jit/passes/remove_inplace_ops.h"
 #include "torch/csrc/jit/passes/constant_propagation.h"
 #include "torch/csrc/jit/passes/loop_unrolling.h"
 #include "torch/csrc/jit/passes/to_batch.h"
@@ -99,6 +100,9 @@ void initJITBindings(PyObject *module) {
    })
    .def("_jit_pass_cse", [](std::shared_ptr<Graph>& g) {
      return EliminateCommonSubexpression(g); // overload resolution
+   })
+   .def("_jit_pass_remove_inplace_ops", [](std::shared_ptr<Graph> g) {
+      return RemoveInplaceOps(g);
    })
    .def("_jit_pass_constant_pooling", ConstantPooling)
    .def("_jit_pass_peephole", [](const std::shared_ptr<Graph>& g, bool addmm_fusion_enabled) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -727,7 +727,8 @@ Node::Node(Graph * graph_, NodeKind kind_) :
   graph_(graph_),
   owning_block_(nullptr),
   scope_(graph_->current_scope_),
-  schema_(nullptr) {
+  schema_(nullptr),
+  topo_position_(0) {
   graph_->all_nodes.emplace(this);
 }
 

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -1,0 +1,59 @@
+#include "remove_inplace_ops.h"
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+
+namespace torch {
+namespace jit {
+namespace {
+static const std::unordered_map<NodeKind, NodeKind> inPlaceToOutOfPlace = {
+    {aten::add_, aten::add},
+    {aten::sub_, aten::sub},
+    {aten::div_, aten::div},
+    {aten::mul_, aten::mul}};
+
+bool isInplaceOp(const Node* node) {
+  return inPlaceToOutOfPlace.count(node->kind()) != 0;
+}
+
+// Remove all in-place ops and replace them with out-of-place equivalents.
+// e.g.
+//   %foo = aten::add_(%foo, %n)
+// becomes
+//   %foo.2 = aten::add(%foo, %n)
+//
+// NOTE: this is NOT SAFE, since it assumes that the LHS is not aliased by
+// another value. This is only to avoid breaking ONNX export; when alias
+// analysis is done we can emit a warning if someone tries to export.
+void RemoveInplaceOps(Block* block) {
+  auto graph = block->owningGraph();
+  auto it = block->nodes().begin();
+  while (it != block->nodes().end()) {
+    auto node = *it;
+    ++it;
+    for (auto block : node->blocks()) {
+      RemoveInplaceOps(block);
+    }
+
+    if (isInplaceOp(node)) {
+      // create a replacement out of place op
+      auto newNode = graph->create(inPlaceToOutOfPlace.at(node->kind()));
+      newNode->insertBefore(node);
+
+      // copy inputs
+      for (auto input : node->inputs()) {
+        newNode->addInput(input);
+      }
+
+      // Create a new output node and replace all uses of self with it
+      newNode->output()->copyMetadata(node->output());
+      node->replaceAllUsesWith(newNode);
+      node->destroy();
+    }
+  }
+}
+}
+
+void RemoveInplaceOps(std::shared_ptr<Graph> graph) {
+  RemoveInplaceOps(graph->block());
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/remove_inplace_ops.h
+++ b/torch/csrc/jit/passes/remove_inplace_ops.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+// see .cpp for docs
+TORCH_API void RemoveInplaceOps(std::shared_ptr<Graph> graph);
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -46,6 +46,7 @@ namespace script {
   _(TK_INFERRED, "inferred", "")                 \
   _(TK_ACCESS, "access", "")                     \
   _(TK_ASSIGN, "assign", "")                     \
+  _(TK_AUG_ASSIGN, "aug_assign", "")             \
   _(TK_ATTRIBUTE, "attribute", "")               \
   _(TK_IF, "if", "if")                           \
   _(TK_ELSE, "else", "else")                     \

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -127,7 +127,7 @@ struct Parser {
     }
     return prefix;
   }
-  TreeRef parseOptionalReduction() {
+  TreeRef parseAssignmentOp() {
     auto r = L.cur().range;
     switch (L.cur().kind) {
       case TK_PLUS_EQ:
@@ -356,12 +356,23 @@ struct Parser {
   // 'first' has already been parsed since expressions can exist
   // alone on a line:
   // first[,other,lhs] = rhs
-  Assign parseAssign(List<Expr> list) {
-    auto red = parseOptionalReduction();
+  TreeRef parseAssign(List<Expr> lhs) {
+    auto op = parseAssignmentOp();
     auto rhs = parseExpOrExpTuple(TK_NEWLINE);
     L.expect(TK_NEWLINE);
-    return Assign::create(list.range(), list, AssignKind(red), Expr(rhs));
+    if (op->kind() == '=') {
+      return Assign::create(lhs.range(), lhs, Expr(rhs));
+    } else {
+      // this is an augmented assignment
+      if (lhs.size() != 1) {
+        throw ErrorReport(lhs.range())
+            << " augmented assignment can only have one LHS expression";
+      }
+      return AugAssign::create(
+          lhs.range(), lhs[0], AugAssignKind(op), Expr(rhs));
+    }
   }
+
   TreeRef parseStmt() {
     switch (L.cur().kind) {
       case TK_IF:

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -122,10 +122,15 @@ void initTreeViewBindings(PyObject *module) {
 
 
   py::class_<Assign, Stmt>(m, "Assign")
-    .def(py::init([](std::vector<Expr> lhs, std::string kind_str, const Expr& rhs) {
+    .def(py::init([](std::vector<Expr> lhs, const Expr& rhs) {
       auto r = lhs.at(0).range();
-      auto kind = AssignKind(Compound::create(stringToKind(kind_str), r, {}));
-      return Assign::create(r, List<Expr>::create(r, std::move(lhs)), kind, rhs);
+      return Assign::create(r, List<Expr>::create(r, std::move(lhs)), rhs);
+    }));
+  py::class_<AugAssign, Stmt>(m, "AugAssign")
+    .def(py::init([](const Expr& lhs, std::string kind_str, const Expr& rhs) {
+      auto r = lhs.range();
+      auto kind = AugAssignKind(Compound::create(stringToKind(kind_str), r, {}));
+      return AugAssign::create(r, lhs, kind, rhs);
     }));
   py::class_<Return, Stmt>(m, "Return")
     .def(py::init([](const SourceRange& range, std::vector<Expr> values) {

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -76,7 +76,7 @@ struct Tree : std::enable_shared_from_this<Tree> {
     if (kind() != k) {
       std::stringstream ss;
       ss << filename << ":" << lineno << ": expecting kind '" << kindToString(k)
-         << "' but found '" << kind() << "'\n";
+         << "' but found '" << kindToString(kind()) << "'\n";
       range().highlight(ss);
       throw std::runtime_error(ss.str());
     }

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -27,7 +27,8 @@ namespace script {
 //       | While(Expr cond, List<Stmt> body)                            TK_WHILE
 //       | Global(List<Ident> idents)                                   TK_GLOBAL
 //       -- NB: the only type of Expr's allowed on lhs are Starred and Var
-//       | Assign(List<Expr> lhs, AssignType maybe_reduce, Expr rhs)    TK_ASSIGN
+//       | Assign(List<Expr> lhs, Expr rhs)                             TK_ASSIGN
+//       | AugAssign(Expr lhs, AugAssignKind aug_op, Expr rhs)          TK_AUG_ASSIGN
 //       | Return(List<Expr> values)                                    TK_RETURN
 //       | ExprStmt(List<Expr> expr)                                    TK_EXPR_STMT
 //       | Raise(Expr expr)                                             TK_RAISE
@@ -69,7 +70,7 @@ namespace script {
 //        (List as a value, not type constructor)
 // Attribute = Attribute(Ident name, Expr value)                        TK_ATTRIBUTE
 //
-// AssignKind = Regular()                                               '='
+// AugAssignKind =
 //            | Add()                                                   TK_PLUS_EQ
 //            | Sub()                                                   TK_MINUS_EQ
 //            | Mul()                                                   TK_TIMES_EQ
@@ -210,6 +211,7 @@ struct Stmt : public TreeView {
       case TK_WHILE:
       case TK_GLOBAL:
       case TK_ASSIGN:
+      case TK_AUG_ASSIGN:
       case TK_RETURN:
       case TK_EXPR_STMT:
       case TK_RAISE:
@@ -422,21 +424,44 @@ struct Global : public Stmt {
   }
 };
 
-struct AssignKind : public TreeView {
-  explicit AssignKind(const TreeRef& tree) : TreeView(tree) {
+struct AugAssignKind : public TreeView {
+  explicit AugAssignKind(const TreeRef& tree) : TreeView(tree) {
     switch (tree->kind()) {
-      case '=':
       case '+':
       case '-':
       case '*':
       case '/':
-      case '%':
         return;
       default:
-        throw ErrorReport(tree) << "is not a valid AssignKind";
+        throw ErrorReport(tree) << "is not a valid AugAssignKind";
     }
   }
 };
+
+// Augmented assignment, like "foo += bar"
+struct AugAssign : public Stmt {
+  explicit AugAssign(const TreeRef& tree) : Stmt(tree) {
+    tree_->match(TK_AUG_ASSIGN);
+  }
+  static AugAssign create(
+      const SourceRange& range,
+      const Expr& lhs,
+      const AugAssignKind& aug_op,
+      const Expr& rhs) {
+    return AugAssign(
+        Compound::create(TK_AUG_ASSIGN, range, {lhs, aug_op, rhs}));
+  }
+  Expr lhs() const {
+    return Expr(subtree(0));
+  }
+  int aug_op() const {
+    return subtree(1)->kind();
+  }
+  Expr rhs() const {
+    return Expr(subtree(2));
+  }
+};
+
 
 struct Assign : public Stmt {
   explicit Assign(const TreeRef& tree) : Stmt(tree) {
@@ -445,18 +470,14 @@ struct Assign : public Stmt {
   static Assign create(
       const SourceRange& range,
       const List<Expr>& lhs,
-      const AssignKind& reduction,
       const Expr& rhs) {
-    return Assign(Compound::create(TK_ASSIGN, range, {lhs, reduction, rhs}));
+    return Assign(Compound::create(TK_ASSIGN, range, {lhs, rhs}));
   }
   List<Expr> lhs() const {
     return List<Expr>(subtree(0));
   }
-  int reduction() const {
-    return subtree(1)->kind();
-  }
   Expr rhs() const {
-    return Expr(subtree(2));
+    return Expr(subtree(1));
   }
 };
 

--- a/torch/jit/batchop.py
+++ b/torch/jit/batchop.py
@@ -278,7 +278,7 @@ def batch_dim(data, mask, dims):
 @torch.jit.script
 def batch_squeeze(data, mask, dims, dim_):
     if int(dim_) < 0:
-        dim_ += data.dim()
+        dim_ = dim_ + data.dim()
     dim = int(dim_)
     # if dim == 0:
     #     raise ValueError("cannot do squeeze along batch_dim")
@@ -291,7 +291,7 @@ def batch_squeeze(data, mask, dims, dim_):
 @torch.jit.script
 def batch_unsqueeze(data, mask, dims, dim_):
     if int(dim_) < 0:
-        dim_ += data.dim() + 1
+        dim_ = dim_ + data.dim() + 1
     dim = int(dim_)
     # if dim == 0:
     #     raise ValueError("cannot do unsqueeze along batch_dim")

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -258,7 +258,7 @@ class StmtBuilder(Builder):
                                     "Performing multiple assignments in a single line isn't supported")
         py_lhs = stmt.targets[0]
         py_lhs_exprs = py_lhs.elts if isinstance(py_lhs, ast.Tuple) else [py_lhs]
-        return Assign([StmtBuilder.get_assign_lhs_expr(ctx, e) for e in py_lhs_exprs], '=', rhs)
+        return Assign([StmtBuilder.get_assign_lhs_expr(ctx, e) for e in py_lhs_exprs], rhs)
 
     @staticmethod
     def build_Return(ctx, stmt):
@@ -287,7 +287,7 @@ class StmtBuilder(Builder):
 
     @staticmethod
     def build_AugAssign(ctx, stmt):
-        lhs = [StmtBuilder.get_assign_lhs_expr(ctx, stmt.target)]
+        lhs = StmtBuilder.get_assign_lhs_expr(ctx, stmt.target)
         rhs = build_expr(ctx, stmt.value)
         op = type(stmt.op)
         if op in StmtBuilder.augassign_map:
@@ -296,7 +296,7 @@ class StmtBuilder(Builder):
             raise NotSupportedError(
                 find_before(ctx, rhs.range().start, '=', offsets=(-1, 0)),
                 "unsupported kind of augumented assignment: " + op.__name__)
-        return Assign(lhs, op_token, rhs)
+        return AugAssign(lhs, op_token, rhs)
 
     @staticmethod
     def build_While(ctx, stmt):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -124,6 +124,7 @@ def _split_tensor_list_constants(g, block):
 
 
 def _optimize_graph(graph, operator_export_type):
+    torch._C._jit_pass_remove_inplace_ops(graph)
     # we record now record some ops like ones/zeros
     # into a trace where we previously recorded constants
     # use constant prop to maintain our current level of onnx support


### PR DESCRIPTION
This PR changes the compiler to correctly emit in-place operators for augmented assignments (`+=` and friends).
- To better match the Python AST structure, add an `AugAssign` tree view and make `Assign` apply only to `=` assignments.
- Emit those `AugAssign` exprs in the compiler, dispatching to in-place aten ops for tensors and lowering to simple assignments for scalar types.
- In order to preserve (suspect) ONNX export semantics, add a pass to lower the in-place operators to out-of-place operators.