### PR TITLE
[jit] Allow int/float cast to bool

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -6,10 +6,7 @@ circular dependency problems
 
 import weakref
 import inspect
-try:
-    import builtins  # PY3
-except Exception:
-    import __builtin__ as builtins  # PY2
+from torch._six import builtins
 
 # Tracks standalone weak script functions
 _compiled_weak_fns = weakref.WeakKeyDictionary()

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -130,3 +130,8 @@ if PY2:
 elif PY3:
     def get_function_from_type(cls, name):
         return getattr(cls, name, None)
+
+if PY2:
+    import __builtin__ as builtins
+elif PY3:
+    import builtins

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -70,6 +70,7 @@ RegisterOperators reg({
             return 0;
           };
         }),
+
     Operator(
         "prim::Bool(Tensor a) -> bool",
         [](const Node* node) -> Operation {
@@ -77,6 +78,26 @@ RegisterOperators reg({
             at::Tensor a;
             pop(stack, a);
             push(stack, a.item<int64_t>() != 0);
+            return 0;
+          };
+        }),
+    Operator(
+        "prim::Bool(int a) -> bool",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            int64_t i;
+            pop(stack, i);
+            push(stack, (bool) i);
+            return 0;
+          };
+        }),
+    Operator(
+        "prim::Bool(float a) -> bool",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            double d;
+            pop(stack, d);
+            push(stack, (bool) d);
             return 0;
           };
         }),
@@ -160,6 +181,26 @@ RegisterOperators reg({
             double d;
             pop(stack, d);
             push(stack, (int64_t)d);
+            return 0;
+          };
+        }),
+    Operator(
+        "prim::Float(bool a) -> float",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            bool b;
+            pop(stack, b);
+            push(stack, (float) b);
+            return 0;
+          };
+        }),
+    Operator(
+        "prim::Int(bool a) -> int",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            bool b;
+            pop(stack, b);
+            push(stack, (int) b);
             return 0;
           };
         }),


### PR DESCRIPTION
This PR adds explicit `bool()` casts to match Python semantics

`bool(1) = True`
`bool(0) = False`
`bool(0.0) = False`
`bool(0.1) = True`