### PR TITLE
Handle exceptions in at::parallel_for()

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <ATen/ATen.h>
+#include <atomic>
 #include <cstddef>
+#include <exception>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -51,14 +53,26 @@ inline void parallel_for(
     const int64_t grain_size,
     const F& f) {
 #ifdef _OPENMP
+  std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
+  std::exception_ptr eptr;
 #pragma omp parallel if (!omp_in_parallel() && ((end - begin) >= grain_size))
   {
     int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();
     int64_t chunk_size = divup((end - begin), num_threads);
     int64_t begin_tid = begin + tid * chunk_size;
-    if (begin_tid < end)
-      f(begin_tid, std::min(end, chunk_size + begin_tid));
+    if (begin_tid < end) {
+      try {
+        f(begin_tid, std::min(end, chunk_size + begin_tid));
+      } catch (...) {
+        if (!err_flag.test_and_set()) {
+          eptr = std::current_exception();
+        }
+      }
+    }
+  }
+  if (eptr) {
+    std::rethrow_exception(eptr);
   }
 #else
   if (begin < end) {

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -36,3 +36,19 @@ TEST(TestParallel, NestedParallel) {
     }
   });
 }
+
+TEST(TestParallel, Exceptions) {
+  // parallel case
+  ASSERT_THROW(
+    at::parallel_for(0, 10, 1, [&](int64_t begin, int64_t end) {
+      throw std::runtime_error("exception");
+    }),
+    std::runtime_error);
+
+  // non-parallel case
+  ASSERT_THROW(
+    at::parallel_for(0, 1, 1000, [&](int64_t begin, int64_t end) {
+      throw std::runtime_error("exception");
+    }),
+    std::runtime_error);
+}


### PR DESCRIPTION
Currently, exceptions thrown in at::parallel_for() will cause a hard crash
if the code is executed by a background thread. This catches the exception
and re-throws it in the main thread.

