### PR TITLE
Revert "Revert D12858091: [pytorch][PR] restore USE_C10D_NCCL"

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -34,6 +34,10 @@ function(copy_header file)
   configure_file(${file} ${CMAKE_BINARY_DIR}/include/c10d/${file} COPYONLY)
 endfunction()
 
+if(USE_NCCL)
+  option(USE_C10D_NCCL "USE C10D NCCL" ON)
+endif()
+
 if(MPI_FOUND)
   option(USE_C10D_MPI "USE C10D MPI" ON)
 endif()


### PR DESCRIPTION
This reverts commit b1fe541de35381e3a31a9e71db2be4b3af59dbcc.

some CI confusion made it look like this diff needed to be reverted; however the actual issue was elsewhere
