### PR TITLE
add assert statements

### DIFF
--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -69,5 +69,8 @@
           (list (variable (ident q)))
           (=)
           (variable (ident x)))))
+    (assert
+      (eq (const 1) (const 1))
+      (option (string_literal hello)))
     (return
       (list (variable (ident x))))))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3855,6 +3855,7 @@ a")
                 m = x if not z else y
             while x < y > z:
                 q = x
+            assert 1 == 1, "hello"
             return x
 
         ast = torch.jit.frontend.get_jit_ast(fn, is_method=False)
@@ -7591,6 +7592,26 @@ a")
                 else:
                     raise Exception("Hi")
                 return a
+
+    def test_assertions(self):
+        cu = torch.jit.CompilationUnit('''
+            def foo(cond):
+                assert bool(cond), "hi"
+                return 0
+        ''')
+
+        cu.foo(torch.tensor(1))
+        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+            cu.foo(torch.tensor(0))
+
+        @torch.jit.script
+        def foo(cond):
+            assert bool(cond), "hi"
+
+        foo(torch.tensor(1))
+        # we don't currently validate the name of the exception
+        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+            foo(torch.tensor(0))
 
     def test_weak_script_function(self):
         outer_var = 10

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7542,7 +7542,7 @@ a")
         ''')
 
         cu.foo(torch.tensor(0))
-        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+        with self.assertRaisesRegex(torch.jit.Error, "Exception"):
             cu.foo(torch.tensor(1))
 
         @torch.jit.script
@@ -7556,7 +7556,7 @@ a")
 
         foo(torch.tensor(0))
         # we don't currently validate the name of the exception
-        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+        with self.assertRaisesRegex(torch.jit.Error, "Exception"):
             foo(torch.tensor(1))
 
         @torch.jit.script
@@ -7565,7 +7565,7 @@ a")
             raise a
 
         # a gets DCEd because the expression following raise is ignored
-        with self.assertRaisesRegex(torch.jit._Exception, "failed in interpreter"):
+        with self.assertRaisesRegex(torch.jit.Error, "failed in interpreter"):
             foo()
 
         @torch.jit.script
@@ -7601,7 +7601,7 @@ a")
         ''')
 
         cu.foo(torch.tensor(1))
-        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+        with self.assertRaisesRegex(torch.jit.Error, "Exception"):
             cu.foo(torch.tensor(0))
 
         @torch.jit.script
@@ -7610,7 +7610,7 @@ a")
 
         foo(torch.tensor(1))
         # we don't currently validate the name of the exception
-        with self.assertRaisesRegex(torch.jit._Exception, "Exception"):
+        with self.assertRaisesRegex(torch.jit.Error, "Exception"):
             foo(torch.tensor(0))
 
     def test_weak_script_function(self):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -949,7 +949,10 @@ private:
         }
         break;
         case TK_RAISE:
-          emitRaise(Raise(stmt));
+          emitRaise(Raise(stmt).range());
+          break;
+        case TK_ASSERT:
+          emitAssert(Assert(stmt));
           break;
         case TK_RETURN:
           throw ErrorReport(stmt) << "return statements can appear only at the end "
@@ -1310,11 +1313,26 @@ private:
   // else
   //   raise Exception("Hi")
   // print(a)
-  void emitRaise(const Raise& stmt) {
+  void emitRaise(const SourceRange& loc) {
     const std::string exception = "Exception";
-    auto string_input = insertConstant(*graph, exception, stmt.range());
+    auto string_input = insertConstant(*graph, exception, loc);
     graph->insertNode(graph->create(prim::RaiseException, {string_input}, 0)
-                        ->setSourceLocation(std::make_shared<SourceRange>(stmt.range())));
+                        ->setSourceLocation(std::make_shared<SourceRange>(loc)));
+  }
+
+  void emitAssert(const Assert& stmt) {
+    Value* cond_value = emitCond(stmt.test());
+    Node* n = graph->insertNode(create(prim::If, stmt.range(), 0));
+
+    n->addInput(cond_value);
+    auto* true_block = n->addBlock();
+    auto* false_block = n->addBlock();
+
+    //if assert test is false throw exception
+    pushFrame(false_block);
+    WithInsertPoint guard(false_block);
+    emitRaise(stmt.range());
+    popFrame();
   }
 
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -85,7 +85,8 @@ namespace script {
   _(TK_DECL, "decl", "")                         \
   _(TK_SLICE_EXPR, "slice expr", "")             \
   _(TK_TYPE_COMMENT, "type comment", "# type:")  \
-  _(TK_RAISE, "raise", "raise")
+  _(TK_RAISE, "raise", "raise")                  \
+  _(TK_ASSERT, "assert", "assert")
 
 
 static const char* valid_single_char_tokens = "+-*/%@()[]:,={}><.?!";

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -388,6 +388,17 @@ struct Parser {
         L.expect(TK_NEWLINE);
         return Raise::create(range, expr);
       }
+      case TK_ASSERT: {
+        auto range = L.next().range;
+        auto cond = parseExp();
+        Maybe<Expr> maybe_first = Maybe<Expr>::create(range);
+        if (L.nextIf(','))  {
+          auto msg = parseExp();
+          maybe_first = Maybe<Expr>::create(range, Expr(msg));
+        }
+        L.expect(TK_NEWLINE);
+        return Assert::create(range, cond, maybe_first);
+      }
       default: {
         List<Expr> exprs = parseList(TK_NOTHING, ',', TK_NOTHING, &Parser::parseExp);
         if (L.cur().kind != TK_NEWLINE) {

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -135,6 +135,10 @@ void initTreeViewBindings(PyObject *module) {
     .def(py::init([](const SourceRange& range, Expr *expr) {
       return Raise::create(range, wrap_maybe(range, expr));
     }));
+  py::class_<Assert, Stmt>(m, "Assert")
+    .def(py::init([](const SourceRange& range, const Expr& test, Expr *msg) {
+      return Assert::create(range, test, wrap_maybe(range, msg));
+    }));
   py::class_<If, Stmt>(m, "If")
     .def(py::init([](const SourceRange& range, const Expr& cond, std::vector<Stmt> true_branch, std::vector<Stmt> false_branch) {
       return If::create(range, cond,

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -210,6 +210,7 @@ struct Stmt : public TreeView {
       case TK_RETURN:
       case TK_EXPR_STMT:
       case TK_RAISE:
+      case TK_ASSERT:
         return;
       default:
         throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Stmt";
@@ -475,6 +476,24 @@ struct Raise : public Stmt {
   }
   static Raise create(const SourceRange& range, const Maybe<Expr>& expr) {
     return Raise(Compound::create(TK_RAISE, range, {expr}));
+  }
+};
+
+struct Assert : public Stmt {
+  explicit Assert(const TreeRef& tree) : Stmt(tree) {
+    tree_->match(TK_ASSERT);
+  }
+  Expr test() const {
+    return Expr(subtree(0));
+  }
+  Maybe<Expr> msg() const {
+    return Maybe<Expr>(subtree(1));
+  }
+  static Assert create(
+      const SourceRange& range,
+      const Expr& test,
+      const Maybe<Expr>& msg) {
+    return Assert(Compound::create(TK_ASSERT, range, {test, msg}));
   }
 };
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1374,8 +1374,8 @@ _register_builtin(len, 'aten::len')
 
 _register_builtin(_wait, 'aten::wait')
 
-# torch.jit._Exception
-_Exception = torch._C.JITException
+# torch.jit.Error
+Error = torch._C.JITException
 
 
 class _disable_tracing(object):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -279,6 +279,13 @@ class StmtBuilder(Builder):
         return Raise(r, expr)
 
     @staticmethod
+    def build_Assert(ctx, stmt):
+        r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + len("assert"))
+        test = build_expr(ctx, stmt.test)
+        msg = build_expr(ctx, stmt.msg) if stmt.msg is not None else None
+        return Assert(r, test, msg)
+
+    @staticmethod
     def build_AugAssign(ctx, stmt):
         lhs = [StmtBuilder.get_assign_lhs_expr(ctx, stmt.target)]
         rhs = build_expr(ctx, stmt.value)


### PR DESCRIPTION
Adding assert statements to unblock standard library.

The same limitations that apply to the existing implementation of Exceptions apply to this as well
(No control-flow logic, & we ignore the specific Exception thrown).