### PR TITLE
Stop unnecessarily setting storage in as_strided.

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -726,17 +726,6 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     storage_offset_ = storage_offset;
   }
 
-  /* Sets the storage of this tensor to be new_storage */
-  void set_storage(const Storage& new_storage) {
-    auto* new_storage_ = new_storage.unsafeGetStorageImpl();
-    auto* old_storage_ = storage_.unsafeGetStorageImpl();
-    AT_ASSERTM(old_storage_, "Tensor: invalid null storage");
-    if (new_storage_ == old_storage_) {
-      return;
-    }
-    storage_ = new_storage;
-  }
-
   /**
    * Like set_sizes_and_strides but assumes contiguous strides.
    *

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -79,21 +79,16 @@ static inline void checkInBoundsForStorage(
 }
 
 /**
- * Set self's storage to be new_storage with sizes, strides, and storage_offset.
- * (size, stride, storage_offset) must be in bounds for the new storage.
+ * Set self's sizes, strides, and storage_offset.
+ * (size, stride, storage_offset) must be in bounds for self's storage.
  */
-inline void setStorage(
+inline void setStrided(
     const Tensor& self,
-    const Storage& new_storage,
-    int64_t storage_offset,
     IntList size,
-    IntList stride) {
-  checkInBoundsForStorage(size, stride, storage_offset, new_storage);
-
+    IntList stride,
+    int64_t storage_offset) {
   auto* self_ = self.unsafeGetTensorImpl();
-
-  /* storage */
-  self_->set_storage(new_storage);
+  checkInBoundsForStorage(size, stride, storage_offset, self_->storage());
 
   /* storage offset */
   AT_CHECK(storage_offset >= 0, "Tensor: invalid storage offset ", storage_offset);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -151,23 +151,17 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 }
 
 Tensor as_strided(const Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  auto result = at::empty({0}, self.options());
-  setStorage(
-      result,
-      self.storage(),
-      storage_offset,
-      size,
-      stride);
+  auto tid = self.type_id();
+  AT_CHECK(
+      tid == CPUTensorId() || tid == CUDATensorId(),
+      "as_strided is only implemented for strided CPU and CUDA tensors.");
+  auto result = detail::make_tensor<TensorImpl>(Storage(self.storage()), tid, false);
+  setStrided(result, size, stride, storage_offset);
   return result;
 }
 
 Tensor &as_strided_(Tensor& self, IntList size, IntList stride, int64_t storage_offset) {
-  setStorage(
-      self,
-      self.storage(),
-      storage_offset,
-      size,
-      stride);
+  setStrided(self, size, stride, storage_offset);
   return self;
 }
 


### PR DESCRIPTION
As per @ezyang's suggestion

Previously, tensor.as_strided would:
- allocate a tensor `result` and a storage
- throw away that storage in favor of the input tensor's storage.

This PR makes tensor.as_strided not allocate a storage just to throw it
away. This speeds up as_strided from 770ns to 344ns.

Test plan: wait for tests

