### PR TITLE
Improved the caffe2 to ONNX conversion

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1179,7 +1179,7 @@ def get_ssa(net, blob_versions=None):
                     blob_versions[i] = 0
         inputs = [(str(i), blob_versions.get(str(i), 0)) for i in op.input]
         for o in op.output:
-            blob_versions[str(o)] = blob_versions.get(str(o), 0) + 1
+            blob_versions[str(o)] = blob_versions.get(str(o), -1) + 1
         outputs = [(str(o), blob_versions[str(o)]) for o in op.output]
         ssa.append((inputs, outputs))
     return ssa, blob_versions

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -202,6 +202,15 @@ class Caffe2Frontend(object):
         else:
             initializer = []
 
+        # Check if value_info contains the types/shapes of all the blobs, in
+        # which case we don't need to infer them by running the net.
+        run_native_net = False
+        for op in predict_net.op:
+            for name in itertools.chain(op.input, op.output):
+                if name not in value_info:
+                    run_native_net = True
+                    break
+
         # Check whether we have got type shape info of all input
         missing = (set(list(predict_net.external_input)) -
                    set(value_info.keys()))
@@ -209,22 +218,25 @@ class Caffe2Frontend(object):
             raise RuntimeError('Could not find value info of inputs: {}'.format(
                 ', '.join(missing)))
 
-        inputs = {}
-        for name in predict_net.external_input:
-            elem_type, shape = value_info[name]
-            inputs[name] = np.random.randn(*shape).astype(
-                mapping.TENSOR_TYPE_TO_NP_TYPE[elem_type])
+        ws = None
+        outputs = None
+        if run_native_net:
+            inputs = {}
+            for name in predict_net.external_input:
+                elem_type, shape = value_info[name]
+                inputs[name] = np.random.randn(*shape).astype(
+                    mapping.TENSOR_TYPE_TO_NP_TYPE[elem_type])
 
-        ws, outputs = c2_native_run_net(
-            init_net,
-            predict_net,
-            inputs)
+            ws, outputs = c2_native_run_net(
+                init_net,
+                predict_net,
+                inputs)
 
-        for name in predict_net.external_output:
-            output = outputs[name]
-            elem_type = mapping.NP_TYPE_TO_TENSOR_TYPE[output.dtype]
-            shape = output.shape
-            value_info[name] = (elem_type, shape)
+            for name in predict_net.external_output:
+                output = outputs[name]
+                elem_type = mapping.NP_TYPE_TO_TENSOR_TYPE[output.dtype]
+                shape = output.shape
+                value_info[name] = (elem_type, shape)
 
         graph_def = GraphProto()
         graph_def.name = predict_net.name
@@ -242,9 +254,12 @@ class Caffe2Frontend(object):
         for op in predict_net.op:
             shapes = {}
             for name in itertools.chain(op.input, op.output):
-                blob = ws.FetchBlob(name)
-                if hasattr(blob, 'shape'):
-                    shapes[name] = blob.shape
+                if ws:
+                    blob = ws.FetchBlob(name)
+                    if hasattr(blob, 'shape'):
+                        shapes[name] = blob.shape
+                else:
+                    shapes[name] = value_info[name][1]
             nodes, const_tensors = cls.caffe2_op_to_onnx_node(op, shapes=shapes)
             graph_def.node.extend(nodes)
             graph_def.initializer.extend(const_tensors)
@@ -295,6 +310,8 @@ class Caffe2Frontend(object):
     @classmethod
     def _ssa_rewrite(cls, net, init_net, value_info):
         def ssa_name(name, version):
+            if version == 0:
+                return name
             return '{}_{}'.format(name, version)
 
         if init_net:

--- a/caffe2/python/onnx/tests/ssa_test.py
+++ b/caffe2/python/onnx/tests/ssa_test.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 import onnx
 import numpy as np
 from caffe2.proto import caffe2_pb2
@@ -81,22 +82,22 @@ class TestFrontendSSAConversion(TestCase):
             init_net,
             value_info)
 
-        self.assertEqual(net.external_input, ['W_0', 'X_0', 'b_0', 's_0'])
-        self.assertEqual(net.op[0].input, ['X_0', 'W_0', 'b_0'])
-        self.assertEqual(net.op[0].output, ['Y_1'])
-        self.assertEqual(net.op[1].input, ['Y_1', 's_0'])
-        self.assertEqual(net.op[1].output, ['Y_2'])
-        self.assertEqual(net.external_output, ['Y_2'])
+        self.assertEqual(net.external_input, ['W', 'X', 'b', 's'])
+        self.assertEqual(net.op[0].input, ['X', 'W', 'b'])
+        self.assertEqual(net.op[0].output, ['Y'])
+        self.assertEqual(net.op[1].input, ['Y', 's'])
+        self.assertEqual(net.op[1].output, ['Y_1'])
+        self.assertEqual(net.external_output, ['Y_1'])
 
         self.assertEqual(init_net.external_input, [])
         self.assertEqual(init_net.op[0].input, [])
-        self.assertEqual(init_net.op[0].output, ['W_0'])
+        self.assertEqual(init_net.op[0].output, ['W'])
         self.assertEqual(init_net.op[1].input, [])
-        self.assertEqual(init_net.op[1].output, ['b_0'])
+        self.assertEqual(init_net.op[1].output, ['b'])
         self.assertEqual(init_net.op[2].input, [])
-        self.assertEqual(init_net.op[2].output, ['s_0'])
-        self.assertEqual(init_net.external_output, ['W_0', 'b_0', 's_0'])
-        self.assertEqual(value_info, {'X_0': (TensorProto.FLOAT, X.shape)})
+        self.assertEqual(init_net.op[2].output, ['s'])
+        self.assertEqual(init_net.external_output, ['W', 'b', 's'])
+        self.assertEqual(value_info, {'X': (TensorProto.FLOAT, X.shape)})
 
         _, ssa_output = c2_native_run_net(
             predict_net=net,
@@ -105,3 +106,30 @@ class TestFrontendSSAConversion(TestCase):
 
         self.assertSameOutputs(ssa_output, orig_output)
         self.assertSameOutputs(ssa_output, [np_result])
+
+    def test_idempotence(self):
+        net = caffe2_pb2.NetDef()
+        net.name = 'test-idempotence'
+        net.external_input[:] = ['W', 'X', 'b', 's']
+        net.op.extend([
+            core.CreateOperator(
+                'FC',
+                ['X', 'W', 'b'],
+                ['Y']
+            ),
+            core.CreateOperator(
+                'Add',
+                ['Y', 's'],
+                ['Z'],
+                broadcast=True,
+            )
+        ])
+        net.external_output[:] = ['Z']
+
+        value_info = {'X': (TensorProto.FLOAT, [4, 2])}
+        net_copy = copy.deepcopy(net)
+        c2_onnx.Caffe2Frontend._ssa_rewrite(
+            net_copy,
+            None,
+            value_info)
+        self.assertEqual(net, net_copy)


### PR DESCRIPTION
Summary:
Made the SSA transformation idempotent. This ensures that if a caffe2 graph is already in SSA form, the name of the ONNX models inputs/outputs match these of the caffe2 graph.
Avoid evaluating the model by running it if the shapes of all the blobs are given in the value_info map. This makes the conversion a lot faster in this case.wq

Differential Revision: D12871168
