### PR TITLE
Improved the caffe2 to ONNX export

### DIFF
--- a/caffe2/python/onnx/tests/ssa_test.py
+++ b/caffe2/python/onnx/tests/ssa_test.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 import onnx
 import numpy as np
 from caffe2.proto import caffe2_pb2
@@ -81,22 +82,22 @@ class TestFrontendSSAConversion(TestCase):
             init_net,
             value_info)
 
-        self.assertEqual(net.external_input, ['W_0', 'X_0', 'b_0', 's_0'])
-        self.assertEqual(net.op[0].input, ['X_0', 'W_0', 'b_0'])
+        self.assertEqual(net.external_input, ['W', 'X', 'b', 's'])
+        self.assertEqual(net.op[0].input, ['X', 'W', 'b'])
         self.assertEqual(net.op[0].output, ['Y_1'])
-        self.assertEqual(net.op[1].input, ['Y_1', 's_0'])
+        self.assertEqual(net.op[1].input, ['Y_1', 's'])
         self.assertEqual(net.op[1].output, ['Y_2'])
         self.assertEqual(net.external_output, ['Y_2'])
 
         self.assertEqual(init_net.external_input, [])
         self.assertEqual(init_net.op[0].input, [])
-        self.assertEqual(init_net.op[0].output, ['W_0'])
+        self.assertEqual(init_net.op[0].output, ['W'])
         self.assertEqual(init_net.op[1].input, [])
-        self.assertEqual(init_net.op[1].output, ['b_0'])
+        self.assertEqual(init_net.op[1].output, ['b'])
         self.assertEqual(init_net.op[2].input, [])
-        self.assertEqual(init_net.op[2].output, ['s_0'])
-        self.assertEqual(init_net.external_output, ['W_0', 'b_0', 's_0'])
-        self.assertEqual(value_info, {'X_0': (TensorProto.FLOAT, X.shape)})
+        self.assertEqual(init_net.op[2].output, ['s'])
+        self.assertEqual(init_net.external_output, ['W', 'b', 's'])
+        self.assertEqual(value_info, {'X': (TensorProto.FLOAT, X.shape)})
 
         _, ssa_output = c2_native_run_net(
             predict_net=net,
@@ -105,3 +106,30 @@ class TestFrontendSSAConversion(TestCase):
 
         self.assertSameOutputs(ssa_output, orig_output)
         self.assertSameOutputs(ssa_output, [np_result])
+
+    def test_idempotence(self):
+        net = caffe2_pb2.NetDef()
+        net.name = 'test-idempotence'
+        net.external_input[:] = ['W', 'X', 'b', 's']
+        net.op.extend([
+            core.CreateOperator(
+                'FC',
+                ['X', 'W', 'b'],
+                ['Y']
+            ),
+            core.CreateOperator(
+                'Add',
+                ['Y', 's'],
+                ['Z'],
+                broadcast=True,
+            )
+        ])
+        net.external_output[:] = ['Z']
+
+        value_info = {'X': (TensorProto.FLOAT, [4, 2])}
+        net_copy = copy.deepcopy(net)
+        c2_onnx.Caffe2Frontend._ssa_rewrite(
+            net_copy,
+            None,
+            value_info)
+        self.assertEqual(net, net_copy)


### PR DESCRIPTION
Summary:
Made the SSA transformation idempotent. This ensures that if a caffe2 graph is already in SSA form, the name of the ONNX models inputs/outputs match these of the caffe2 graph.
Avoid evaluating the model by running it if the shapes of all the blobs are present in the value_info map. This speeds up the conversion and decrease its memory usage in the case of medium to large nets.

Differential Revision: D12873354
