### PR TITLE
Enable opencv and lmdb in ROCM CI

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -149,6 +149,11 @@ if [[ $BUILD_ENVIRONMENT == *cuda* ]]; then
   export PATH="/usr/local/cuda/bin:$PATH"
 fi
 if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
+  # This is needed to enable ImageInput operator in resnet50_trainer
+  CMAKE_ARGS+=("-USE_OPENCV=ON")
+  # This is needed to read datasets from https://download.caffe2.ai/databases/resnet_trainer.zip
+  CMAKE_ARGS+=("-USE_LMDB=ON")
+
   # TODO: This is patching the official FindHip to properly handly
   # cmake generator expression. A PR is opened in the upstream repo here:
   # https://github.com/ROCm-Developer-Tools/HIP/pull/516

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -67,7 +67,9 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
 
   python tools/amd_build/build_pytorch_amd.py
   python tools/amd_build/build_caffe2_amd.py
-  USE_ROCM=1 python setup.py install --user
+  # OPENCV is needed to enable ImageInput operator in caffe2 resnet5_trainer
+  # LMDB is needed to read datasets from https://download.caffe2.ai/databases/resnet_trainer.zip
+  USE_ROCM=1 USE_LMDB=1 USE_OPENCV=1 python setup.py install --user
   exit 0
 fi
 


### PR DESCRIPTION
They are needed to run resnet50_trainer when using datasets from https://download.caffe2.ai/databases/resnet_trainer.zip

cc @xw285cornell 
