### PR TITLE
Renaming dim() to size() - 1/3

### DIFF
--- a/caffe2/contrib/warpctc/ctc_op.h
+++ b/caffe2/contrib/warpctc/ctc_op.h
@@ -45,9 +45,9 @@ class CTCOp final : public Operator<Context> {
   bool RunOnDevice() override {
     // inputs
     const auto& inputs = Input(INPUTS);
-    const auto maxTimeSteps = inputs.dim(0);
-    const auto minibatchSize = inputs.dim(1);
-    const auto alphabetSize = inputs.dim(2);
+    const auto maxTimeSteps = inputs.size(0);
+    const auto minibatchSize = inputs.size(1);
+    const auto alphabetSize = inputs.size(2);
     const auto& labels = OperatorBase::template Input<Tensor>(LABELS, CPU);
     const auto& labelLengths =
         OperatorBase::template Input<Tensor>(LABEL_LENGTHS, CPU);
@@ -93,7 +93,7 @@ class CTCOp final : public Operator<Context> {
     workspace->Resize(workspaceSizeBytes);
     auto* workspaceData = workspace->template mutable_data<uint8_t>();
 
-    if (is_test_ && labels.dim(0) == 0) {
+    if (is_test_ && labels.size(0) == 0) {
       // compute_ctc_loss doesn't handle empty labels well
       T* costsData = costs->template mutable_data<T>();
       for (int i = 0; i < costs->numel(); ++i) {

--- a/caffe2/core/blob_gpu_test.cc
+++ b/caffe2/core/blob_gpu_test.cc
@@ -154,8 +154,8 @@ TYPED_TEST(TensorGPUDeathTest, CannotAccessDataWhenEmpty) {
     EXPECT_TRUE(BlobIsTensorType(new_blob, CUDA));                         \
     Tensor new_cpu_tensor(blob.Get<Tensor>(), CPU);                        \
     EXPECT_EQ(new_cpu_tensor.ndim(), 2);                                   \
-    EXPECT_EQ(new_cpu_tensor.dim(0), 2);                                   \
-    EXPECT_EQ(new_cpu_tensor.dim(1), 3);                                   \
+    EXPECT_EQ(new_cpu_tensor.size(0), 2);                                  \
+    EXPECT_EQ(new_cpu_tensor.size(1), 3);                                  \
     for (int i = 0; i < 6; ++i) {                                          \
       EXPECT_EQ(                                                           \
           cpu_tensor.data<TypeParam>()[i],                                 \

--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -217,7 +217,7 @@ void TensorSerializer::Serialize(
   proto.mutable_segment()->set_end(chunkBegin + chunkSize);
 
   for (int i = 0; i < input.ndim(); ++i) {
-    proto.add_dims(input.dim(i));
+    proto.add_dims(input.size(i));
   }
   const TensorProto::DataType data_type = TypeMetaToDataType(input.meta());
   proto.set_data_type(data_type);

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -560,7 +560,7 @@ TEST(TensorTest, Tensor64BitDimension) {
       static_cast<int64_t>(std::numeric_limits<int>::max()) + 1;
   Tensor tensor(vector<int64_t>{large_number}, CPU);
   EXPECT_EQ(tensor.ndim(), 1);
-  EXPECT_EQ(tensor.dim(0), large_number);
+  EXPECT_EQ(tensor.size(0), large_number);
   EXPECT_EQ(tensor.numel(), large_number);
   try {
     EXPECT_TRUE(tensor.mutable_data<char>() != nullptr);
@@ -582,8 +582,8 @@ TEST(TensorTest, Tensor64BitDimension) {
   // do not have a large enough memory.
   tensor.Resize(large_number, 100);
   EXPECT_EQ(tensor.ndim(), 2);
-  EXPECT_EQ(tensor.dim(0), large_number);
-  EXPECT_EQ(tensor.dim(1), 100);
+  EXPECT_EQ(tensor.size(0), large_number);
+  EXPECT_EQ(tensor.size(1), 100);
   EXPECT_EQ(tensor.numel(), large_number * 100);
 }
 
@@ -592,7 +592,7 @@ TEST(TensorDeathTest, CannotCastDownLargeDims) {
       static_cast<int64_t>(std::numeric_limits<int>::max()) + 1;
   Tensor tensor(vector<int64_t>{large_number}, CPU);
   EXPECT_EQ(tensor.ndim(), 1);
-  EXPECT_EQ(tensor.dim(0), large_number);
+  EXPECT_EQ(tensor.size(0), large_number);
   ASSERT_THROW(tensor.dim32(0), EnforceNotMet);
 }
 
@@ -623,8 +623,8 @@ TEST(TensorDeathTest, CannotCastDownLargeDims) {
     EXPECT_TRUE(BlobIsTensorType(new_blob, CPU));                         \
     const TensorCPU& new_tensor = blob.Get<TensorCPU>();                  \
     EXPECT_EQ(new_tensor.ndim(), 2);                                      \
-    EXPECT_EQ(new_tensor.dim(0), 2);                                      \
-    EXPECT_EQ(new_tensor.dim(1), 3);                                      \
+    EXPECT_EQ(new_tensor.size(0), 2);                                     \
+    EXPECT_EQ(new_tensor.size(1), 3);                                     \
     for (int i = 0; i < 6; ++i) {                                         \
       EXPECT_EQ(                                                          \
           tensor->data<TypeParam>()[i], new_tensor.data<TypeParam>()[i]); \
@@ -652,8 +652,8 @@ TEST(TensorDeathTest, CannotCastDownLargeDims) {
     EXPECT_TRUE(BlobIsTensorType(new_blob, CPU));                         \
     const TensorCPU& new_tensor = blob.Get<TensorCPU>();                  \
     EXPECT_EQ(new_tensor.ndim(), 2);                                      \
-    EXPECT_EQ(new_tensor.dim(0), 0);                                      \
-    EXPECT_EQ(new_tensor.dim(1), 3);                                      \
+    EXPECT_EQ(new_tensor.size(0), 0);                                     \
+    EXPECT_EQ(new_tensor.size(1), 3);                                     \
   }
 
 TEST_SERIALIZATION_WITH_TYPE(bool, int32_data)
@@ -683,8 +683,8 @@ TEST(TensorTest, TensorSerialization_CustomType) {
   EXPECT_TRUE(BlobIsTensorType(new_blob, CPU));
   const TensorCPU& new_tensor = blob.Get<TensorCPU>();
   EXPECT_EQ(new_tensor.ndim(), 2);
-  EXPECT_EQ(new_tensor.dim(0), 2);
-  EXPECT_EQ(new_tensor.dim(1), 3);
+  EXPECT_EQ(new_tensor.size(0), 2);
+  EXPECT_EQ(new_tensor.size(1), 3);
   for (int i = 0; i < 6; ++i) {
     EXPECT_EQ(
         new_tensor.data<BlobTestFoo>()[i].val,
@@ -726,7 +726,7 @@ TEST(TensorTest, Half) {
   EXPECT_TRUE(BlobIsTensorType(new_blob, CPU));
   const TensorCPU& new_tensor = blob.Get<TensorCPU>();
   EXPECT_EQ(new_tensor.ndim(), 1);
-  EXPECT_EQ(new_tensor.dim(0), kSize);
+  EXPECT_EQ(new_tensor.size(0), kSize);
   for (int i = 0; i < kSize; ++i) {
     EXPECT_EQ(new_tensor.data<at::Half>()[i].x, i % 10000);
   }
@@ -915,8 +915,8 @@ TYPED_TEST(TypedTensorTest, BigTensorSerialization) {
     const auto& new_tensor = new_blob->Get<TensorCPU>();
 
     EXPECT_EQ(new_tensor.ndim(), d1);
-    EXPECT_EQ(new_tensor.dim(0), d1);
-    EXPECT_EQ(new_tensor.dim(1), d2);
+    EXPECT_EQ(new_tensor.size(0), d1);
+    EXPECT_EQ(new_tensor.size(1), d2);
     for (int64_t i = 0; i < size; ++i) {
       EXPECT_EQ(static_cast<TypeParam>(i), new_tensor.data<TypeParam>()[i]);
     }

--- a/caffe2/experiments/operators/funhash_op.h
+++ b/caffe2/experiments/operators/funhash_op.h
@@ -57,13 +57,13 @@ class FunHashOp : public Operator<Context> {
     int64_t num_alpha = 1;
     if (adaptive_) {
       const auto& alpha = Input(4);
-      num_alpha = alpha.dim(0);
+      num_alpha = alpha.size(0);
     }
 
     const auto* seg_data = seg.template data<int>();
 
-    int64_t num_weight = weight.dim(0);
-    int64_t num_nz_ent = seg.dim(0);
+    int64_t num_weight = weight.size(0);
+    int64_t num_nz_ent = seg.size(0);
 
     int64_t n_segments = num_segments_;
     if (num_segments_ == -1) {
@@ -164,7 +164,7 @@ class FunHashGradientOp : public Operator<Context> {
 
     if (adaptive_) {
       const auto& alpha = Input(5);
-      num_alpha = alpha.dim(0);
+      num_alpha = alpha.size(0);
       auto* grad_alpha = Output(1);
       grad_alpha->ResizeLike(alpha);
       grad_alpha_data = grad_alpha->template mutable_data<T>();
@@ -173,8 +173,8 @@ class FunHashGradientOp : public Operator<Context> {
 
     const auto* seg_data = seg.template data<int>();
 
-    int64_t num_weight = weight.dim(0);
-    int64_t num_nz_ent = seg.dim(0);
+    int64_t num_weight = weight.size(0);
+    int64_t num_nz_ent = seg.size(0);
 
     auto* grad_weight = Output(0);
     grad_weight->ResizeLike(weight);

--- a/caffe2/experiments/operators/sparse_funhash_op.h
+++ b/caffe2/experiments/operators/sparse_funhash_op.h
@@ -56,13 +56,13 @@ class SparseFunHashOp : public Operator<Context> {
     int64_t num_alpha = 1;
     if (adaptive_) {
       const auto& alpha = Input(4);
-      num_alpha = alpha.dim(0);
+      num_alpha = alpha.size(0);
     }
 
     const auto* seg_data = seg.template data<int>();
 
-    int64_t num_weight = weight.dim(0);
-    int64_t num_nz_ent = seg.dim(0);
+    int64_t num_weight = weight.size(0);
+    int64_t num_nz_ent = seg.size(0);
 
     int64_t n_segments = num_segments_;
     if (num_segments_ == -1) {
@@ -163,7 +163,7 @@ class SparseFunHashGradientOp : public Operator<Context> {
 
     if (adaptive_) {
       const auto& alpha = Input(5);
-      num_alpha = alpha.dim(0);
+      num_alpha = alpha.size(0);
       auto* grad_alpha = Output(2);
       grad_alpha->ResizeLike(alpha);
       grad_alpha_data = grad_alpha->template mutable_data<T>();
@@ -172,8 +172,8 @@ class SparseFunHashGradientOp : public Operator<Context> {
 
     const auto* seg_data = seg.template data<int>();
 
-    int64_t num_weight = weight.dim(0);
-    int64_t num_nz_ent = seg.dim(0);
+    int64_t num_weight = weight.size(0);
+    int64_t num_nz_ent = seg.size(0);
 
     int64_t grad_weight_size = num_nz_ent * num_outputs_ * num_alpha;
     auto* grad_weight_val = Output(0);

--- a/caffe2/experiments/operators/tt_pad_op.h
+++ b/caffe2/experiments/operators/tt_pad_op.h
@@ -41,8 +41,8 @@ class TTPadOp final : public Operator<Context> {
 
     CAFFE_ENFORCE(X.ndim() == 2, X.ndim());
 
-    auto X_dim0 = X.dim(0);
-    auto X_dim1 = X.dim(1);
+    auto X_dim0 = X.size(0);
+    auto X_dim1 = X.size(1);
 
     auto* X_orig_dim0 = Output(1);
     X_orig_dim0->Resize(1);
@@ -79,8 +79,8 @@ class TTPadGradientOp final : public Operator<Context> {
     CAFFE_ENFORCE(&G == output);
 
     auto old_dim0 = *Input(1).template data<int64_t>();
-    auto new_dim0 = G.dim(0);
-    auto dim1 = G.dim(1);
+    auto new_dim0 = G.size(0);
+    auto dim1 = G.size(1);
 
     if (old_dim0 < new_dim0) {
       output->ShrinkTo(old_dim0);


### PR DESCRIPTION
Summary:
Codemod generated with clangr shard mode, 50 files per diff,
clangr code(dim->size): diffusion/FBS/browse/master/fbcode/caffe2/caffe2/fb/codemods/TensorMethodRename.cpp

Reviewed By: ezyang

Differential Revision: D12867223
