### PR TITLE
[merging var/std to use reduction kernel]

### DIFF
--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -26,7 +26,7 @@ __device__ __forceinline__ IndexType getReduceNoncontigDimSliceIndex() {
 template <typename T>
 struct SimpleCopyOp
 {
-  __device__ __forceinline__ T operator()(const T val) const
+  __device__ __forceinline__ T operator()(volatile const T val) const volatile
   {
     return val;
   }
@@ -124,8 +124,10 @@ __device__ __forceinline__ void reduceChunk
        *shmem = reduceOp(*shmem, *(shmem + i*blockDim.x));
   }
 
-  if(threadIdx.y == 0 && inbounds)
-    out[outOffset] = scalar_cast<T>(finalizeOp(*shmem));
+  if(threadIdx.y == 0 && inbounds) {
+    T &&o_ele = static_cast<T>(finalizeOp(*shmem));
+    out[outOffset] = o_ele;
+  }
 }
 
 // Kernel that handles an entire reduction of a slice of a tensor per each thread

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -20,6 +20,90 @@
 Reductions that (only) operate on accumulate types.
 */
 
+template <typename T, typename U>
+struct WelfordData {
+  T mean_;
+  T m_2_n_;
+  int count_; // do we need int64_t?
+
+  __host__ __device__ WelfordData() {
+    mean_ = T(0);
+    m_2_n_ = T(0);
+    count_ = 0;
+  }
+
+  __host__ __device__ WelfordData(const U data_) {
+    mean_ = static_cast<T>(data_);
+    m_2_n_ = static_cast<T>(0);
+    count_ = 1;
+  }
+
+  __host__ __device__ WelfordData(const WelfordData &t) :
+    mean_(t.mean_),
+    m_2_n_(t.m_2_n_),
+    count_(t.count_)
+  {
+  }
+
+  __host__ __device__ WelfordData(const volatile WelfordData &t) :
+    mean_(t.mean_),
+    m_2_n_(t.m_2_n_),
+    count_(t.count_)
+  {
+  }
+
+  __host__ __device__ volatile WelfordData& operator = (const volatile WelfordData &t) volatile {
+    mean_ = t.mean_;
+    m_2_n_ = t.m_2_n_;
+    count_ = t.count_;
+    return *this;
+  }
+
+  __host__ __device__ WelfordData& operator = (const WelfordData &t) {
+    mean_ = t.mean_;
+    m_2_n_ = t.m_2_n_;
+    count_ = t.count_;
+    return *this;
+  }
+
+};
+
+
+template <typename T>
+struct ModifyWelford {
+  inline __device__ T operator()(const T &a) const {
+    return a;
+  }
+};
+
+template <typename T, typename U>
+struct ReduceWelford {
+  inline __device__ WelfordData<T, U> operator()(const WelfordData<T, U> &a, const WelfordData<T, U> &b) const {
+    WelfordData<T, U> c;
+    c.count_ = THCNumerics<int>::add(a.count_, b.count_);
+    T factor = THCNumerics<T>::div(1.0, max(1, c.count_));
+    c.mean_ = THCNumerics<T>::mul(THCNumerics<T>::add(THCNumerics<T>::mul(a.mean_, a.count_), THCNumerics<T>::mul(b.mean_, b.count_)), factor);
+    c.m_2_n_ = THCNumerics<T>::add(a.m_2_n_, THCNumerics<T>::add(b.m_2_n_, THCNumerics<T>::mul(factor, THCNumerics<T>::mul(a.count_, THCNumerics<T>::mul(b.count_, THCNumerics<T>::pow(THCNumerics<T>::sub(a.mean_, b.mean_), 2) )))));
+    return c;
+  }
+};
+
+template <typename T, typename U>
+struct VarianceWelford {
+  VarianceWelford(const int _biased, const bool _apply_sqrt): biased{_biased}, apply_sqrt(_apply_sqrt) {}
+
+  inline __device__ T operator()(const WelfordData<T, U> &a) const {
+    T res = THCNumerics<T>::div(a.m_2_n_, biased!=0 ? a.count_ : a.count_-1);
+    if (apply_sqrt) {
+      return THCNumerics<T>::sqrt(res);
+    }
+    return res;
+  }
+
+  const int biased;
+  const bool apply_sqrt;
+};
+
 template <typename T>
 struct ReduceAdd {
   inline __device__ T operator()(const T a, const T b) const {
@@ -249,223 +333,6 @@ __forceinline__ __device__ T THCTensor_computeVar(
 
   return sum2;
 }
-
-/* Compute the variance (or standard deviation) along an outer dimension of a tensor.
- *
- * - num_orows is the size of the flattened outer dimensions;
- * - num_irows is the size of the flattened inner dimensions;
- * - row_size is the size of the dimension along which to compute the variance;
- * - if flag is set, normalize by `row_size` instead of `row_size - 1`
- * - if apply_sqrt is set, compute the standard deviation instead of variance
- *
- * The dimensions to the outside and inside of the specified dimension are considered as flattened.
- * Thread blocks with the same blockIdx.y process an "outer row" (i.e. an element of the flattened
- * outer dimensions, which contains several "inner rows").
- * Each thread processes a single inner row at a time.
- */
-template<typename T, typename AccT, bool flag, bool apply_sqrt>
-__global__ void THCTensor_kernel_varOuterDim(T *tgt, T *src_, unsigned num_orows, unsigned num_irows, unsigned row_size) {
-  for (unsigned orow = blockIdx.x; orow < num_orows; orow += gridDim.x) {
-    for (unsigned irow = blockIdx.y * blockDim.x + threadIdx.x; irow < num_irows; irow += gridDim.y * blockDim.x) {
-      T *src = src_ + orow * row_size * num_irows + irow;
-      AccT mean = scalar_cast<AccT>(0);
-      AccT m2 = scalar_cast<AccT>(0);
-
-      for (unsigned col = 0; col < row_size; ++col) {
-        AccT val = scalar_cast<AccT>(*src);
-        AccT delta = THCNumerics<AccT>::sub(val, mean);
-        mean = THCNumerics<AccT>::add(mean,
-            THCNumerics<AccT>::div(delta, scalar_cast<AccT>(col + 1)));
-        AccT delta2 = THCNumerics<AccT>::sub(val, mean);
-        m2 = THCNumerics<AccT>::add(m2,
-            THCNumerics<AccT>::mul(delta, delta2));
-        src += num_irows;
-      }
-
-      if (flag) {
-        m2 = THCNumerics<AccT>::div(m2, scalar_cast<AccT>(row_size));
-      } else {
-        m2 = THCNumerics<AccT>::div(m2, scalar_cast<AccT>(row_size - 1));
-      }
-
-      tgt[orow * num_irows + irow] = scalar_cast<T>(
-          apply_sqrt ? THCNumerics<AccT>::sqrt(m2) : m2);
-    }
-  }
-}
-
-template<typename TensorTypeK, typename T, typename AccT, bool apply_sqrt>
-__host__ void THCTensor_varOuterDim(THCState *state, TensorTypeK *tgt, TensorTypeK *src, int64_t dimension, int flag) {
-  unsigned ndim = THCTensor_nDimensionLegacyAll(state, src);
-  // Treat all outer dimensions (i.e. dim < dimension) as one.
-  unsigned num_orows = 1;
-  for (int64_t dim = 0; dim < dimension; dim++) {
-    num_orows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
-  }
-  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, dimension);
-  // Treat all inner dimensions (i.e. dim > dimension) as one.
-  unsigned num_irows = 1;
-  for (unsigned dim = dimension + 1; dim < ndim; dim++) {
-    num_irows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
-  }
-
-  dim3 threads(min(512, num_irows));
-  unsigned maxGridDim = 1024;
-  dim3 grid(min(maxGridDim, num_orows), min(maxGridDim, THCCeilDiv(num_irows, threads.x)));
-
-  if (flag) {
-    THCTensor_kernel_varOuterDim<T, AccT, true, apply_sqrt><<<grid, threads, 0, THCState_getCurrentStream(state)>>>(
-        tgt->template data<T>(), src->template data<T>(), num_orows, num_irows, row_size);
-  } else {
-    THCTensor_kernel_varOuterDim<T, AccT, false, apply_sqrt><<<grid, threads, 0, THCState_getCurrentStream(state)>>>(
-        tgt->template data<T>(), src->template data<T>(), num_orows, num_irows, row_size);
-  }
-
-  cudaError_t errcode = cudaGetLastError();
-  if (errcode != cudaSuccess) THError(cudaGetErrorString(errcode));
-}
-
-/* Compute the variance (or standard deviation) of the innermost dimension of a tensor.
- *
- * - num_rows is the size of the flattened outer dimensions;
- * - row_size is the size of the innermost dimension;
- * - if flag is set, normalize by `row_size` instead of `row_size - 1`
- * - if apply_sqrt is set, compute the standard deviation instead of variance
- *
- * The outer dimensions of the tensor are considered as a single dimension, i.e. the tensor is
- * considered as having 'num_rows' rows of size 'row_size'.
- * Each thread block processes one or more sets of contiguous rows (processing multiple rows
- * per thread block is quicker than processing a single row, especially for short rows).
- *
- * Uses Welford's algorithm for numeric stability. Divides the dataset into parallel groups
- * and computes the M2 and mean for each group. (M2 is \sum (x - \bar{x})^2)
- * For example, if the data is split into two groups x and y, the overall M2 can
- * be computed by:
- *
- *    overall_M2 = M2x + nx * (mean(x) - overall_mean)^2
- *               + M2y + ny * (mean(y) - overall_mean)^2
- *
- * This implementation assumes that each block has been launched with 16 x 32 threads.
- */
-template<typename T, typename AccT, bool flag, bool apply_sqrt>
-__global__ void THCTensor_kernel_varInnermostDim(T *tgt, T *src_, unsigned num_rows, unsigned row_size) {
-  /*
-   * Each block computes the var/std of blockDim.y (32) rows at once.
-   * One can visualize the computation as a 16 (x) by 32 (y) grid.
-   * - Each of the 32 rows of the block is responsible for the computation
-   *   of one input row.
-   * - Each row has 16 columns; the variance computation of one input row is
-   *   split between 16 threads.
-   * - Each of those 16 threads handles the accumulation of 1/16 of the input
-   *   row's data.
-   */
-  for (unsigned block_row = blockIdx.x * blockDim.y; block_row < num_rows; block_row += blockDim.y * gridDim.x) {
-    unsigned row = block_row + threadIdx.y;
-
-    /*
-     * Compute local mean, local M2 via Welford's algorithm for this thread.
-     */
-    AccT acc_zero = scalar_cast<AccT>(0);
-    AccT local_mean = acc_zero;
-    AccT local_M2 = acc_zero;
-    unsigned count = 0;
-
-    if (row < num_rows) {
-      T *src = src_ + row * row_size;
-
-      for (unsigned col = threadIdx.x; col < row_size; col += blockDim.x) {
-        ++count;
-        AccT val = scalar_cast<AccT>(src[col]);
-        AccT delta = THCNumerics<AccT>::sub(val, local_mean);
-        local_mean = THCNumerics<AccT>::add(
-            local_mean,
-            THCNumerics<AccT>::div(delta, scalar_cast<AccT>(count)));
-        AccT delta2 = THCNumerics<AccT>::sub(val, local_mean);
-        local_M2 = THCNumerics<AccT>::add(
-            local_M2,
-            THCNumerics<AccT>::mul(delta, delta2));
-      }
-    }
-
-    AccT local_sum =
-        THCNumerics<AccT>::mul(local_mean, scalar_cast<AccT>(count));
-
-    /*
-     * We are reducing across each row of 16 threads to find the true sum of the
-     * entire input row. The warp shfl xor loop ultimately gives each thread the
-     * true sum.
-     */
-    for (unsigned lane_mask = 8; lane_mask > 0; lane_mask >>= 1) {
-      local_sum = THCNumerics<AccT>::add(local_sum,
-          WARP_SHFL_XOR((row < num_rows) ? local_sum : acc_zero, lane_mask, 16));
-    }
-    AccT true_mean = THCNumerics<AccT>::div(local_sum,
-      scalar_cast<AccT>(row_size));
-
-    /*
-     * Adjust each local_M2 according to the following:
-     *   adjusted_M2 = local_M2 + mean_diff * mean_diff * count
-     * The sum of these adjusted M2s is equal to the overall M2.
-     */
-    AccT adjusted_M2 = acc_zero;
-    if (row < num_rows) {
-      AccT mean_diff = THCNumerics<AccT>::sub(true_mean, local_mean);
-      adjusted_M2 = THCNumerics<AccT>::add(
-          local_M2,
-          THCNumerics<AccT>::mul(
-              THCNumerics<AccT>::mul(mean_diff, mean_diff),
-              scalar_cast<AccT>(count)));
-    }
-
-    /*
-     * Sums the adjusted M2s. The thread with threadIdx.x == 0 has
-     * the total sum, which is equal to the M2 for the entire input row.
-     */
-    for (unsigned s = 8; s >= 1; s >>= 1) {
-      adjusted_M2 = THCNumerics<AccT>::add(adjusted_M2,
-          WARP_SHFL_DOWN((row < num_rows) ? adjusted_M2 : acc_zero, s, 16));
-    }
-
-    if (row < num_rows && threadIdx.x == 0) {
-      AccT M2 = adjusted_M2;
-      AccT variance;
-      if (flag) {
-        variance = THCNumerics<AccT>::div(M2, scalar_cast<AccT>(row_size));
-      } else {
-        variance = THCNumerics<AccT>::div(M2, scalar_cast<AccT>(row_size - 1));
-      }
-      tgt[row] = scalar_cast<T>(
-          apply_sqrt ? THCNumerics<AccT>::sqrt(variance) : variance);
-    }
-  }
-}
-
-template<typename TensorTypeK, typename T, typename AccT, bool apply_sqrt>
-__host__ void THCTensor_varInnermostDim(THCState *state, TensorTypeK *tgt, TensorTypeK *src, int flag) {
-  unsigned ndim = THCTensor_nDimensionLegacyAll(state, src);
-  // Treat all outer dimensions as a single dimension.
-  unsigned num_rows = 1;
-  for (unsigned dim = 0; dim < ndim - 1; dim++) {
-    num_rows *= THCTensor_sizeLegacyNoScalars(state, src, dim);
-  }
-  unsigned row_size = THCTensor_sizeLegacyNoScalars(state, src, ndim - 1);
-
-  // From limited testing, 16x32 seemed a good compromise for handling both long and short dimensions.
-  dim3 threads(16, 32);
-  dim3 grid(min(1024, THCCeilDiv(num_rows, threads.y)));
-
-  if (flag) {
-    THCTensor_kernel_varInnermostDim<T, AccT, true, apply_sqrt><<<grid, threads, 0, THCState_getCurrentStream(state)>>>(
-        tgt->template data<T>(), src->template data<T>(), num_rows, row_size);
-  } else {
-    THCTensor_kernel_varInnermostDim<T, AccT, false, apply_sqrt><<<grid, threads, 0, THCState_getCurrentStream(state)>>>(
-        tgt->template data<T>(), src->template data<T>(), num_rows, row_size);
-  }
-
-  cudaError_t errcode = cudaGetLastError();
-  if (errcode != cudaSuccess) THError(cudaGetErrorString(errcode));
-}
-
 
 /* A set of reduction kernels that take in binary ops on thrust pairs (of value, index).
    These are useful when you not only have to do a reduction, but you might have


### PR DESCRIPTION
Moved torch.var torch.std to use THC reduction kernel, this greatly improves performance for computing variance over non-contiguous dimensions.

Resolving #13192 