### PR TITLE
Convert Arguments to dictionary

### DIFF
--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -382,3 +382,28 @@ def EnumClassKeyVals(cls):
                 )
                 enum[k] = v
     return enum
+
+
+def ArgsToDict(args):
+    """
+    Convert a list of arguments to a name, value dictionary. Assumes that
+    each argument has a name. Otherwise, the argument is skipped.
+    """
+    ans = {}
+    for arg in args:
+        if not arg.HasField("name"):
+            continue
+        for d in arg.DESCRIPTOR.fields:
+            if d.name == "name":
+                continue
+            if d.label == d.LABEL_OPTIONAL and arg.HasField(d.name):
+                ans[arg.name] = getattr(arg, d.name)
+                break
+            elif d.label == d.LABEL_REPEATED:
+                list_ = getattr(arg, d.name)
+                if len(list_) > 0:
+                    ans[arg.name] = list_
+                    break
+        else:
+            ans[arg.name] = None
+    return ans

--- a/caffe2/python/utils_test.py
+++ b/caffe2/python/utils_test.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import utils, test_util
+
+import numpy as np
+
+
+class TestUtils(test_util.TestCase):
+    def testArgsToDict(self):
+        args = [utils.MakeArgument("int1", 3),
+                utils.MakeArgument("float1", 4.0),
+                utils.MakeArgument("string1", "foo"),
+                utils.MakeArgument("intlist1", np.array([3, 4])),
+                utils.MakeArgument("floatlist1", np.array([5.0, 6.0])),
+                utils.MakeArgument("stringlist1", np.array(["foo", "bar"]))]
+        dict_ = utils.ArgsToDict(args)
+        expected = {"int1" : 3,
+                    "float1" : 4.0,
+                    "string1" : b"foo",
+                    "intlist1" : [3, 4],
+                    "floatlist1" : [5.0, 6.0],
+                    "stringlist1" : [b"foo", b"bar"]}
+        self.assertEqual(dict_, expected, "dictionary version of arguments "
+                         "doesn't match original")


### PR DESCRIPTION
Summary:
revert
Add a utility function to convert a list of caffe2_pb2.Argument to a dictionary.

Differential Revision: D12871811
