### PR TITLE
AsyncNet: option for time based tracing and trace path

### DIFF
--- a/caffe2/core/net_async_tracing_test.cc
+++ b/caffe2/core/net_async_tracing_test.cc
@@ -37,6 +37,78 @@ TEST(NetAsyncTracingTest, ExtractShardId) {
   testExtractShardId("FC:shard:15", 15);
 }
 
+TEST(NetAsyncTracingTest, EveryKIteration) {
+  const auto spec = R"DOC(
+      name: "example"
+      type: "async_scheduling"
+      arg {
+        name: "enable_tracing"
+        i: 1
+      }
+      arg {
+        name: "tracing_mode"
+        s: "EVERY_K_ITERATIONS"
+      }
+      arg {
+        name: "tracing_filepath"
+        s: "/tmp"
+      }
+      arg {
+        name: "trace_every_nth_batch"
+        i: 1
+      }
+      arg {
+        name: "dump_every_nth_batch"
+        i: 1
+      }
+      op {
+        output: "out"
+        type: "UniformFill"
+      }
+)DOC";
+
+  NetDef net_def;
+  CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+
+  Workspace ws;
+  std::unique_ptr<NetBase> net(CreateNet(net_def, &ws));
+  net->Run();
+}
+
+TEST(NetAsyncTracingTest, GlobalTimeSlice) {
+  const auto spec = R"DOC(
+      name: "example"
+      type: "async_scheduling"
+      arg {
+        name: "enable_tracing"
+        i: 1
+      }
+      arg {
+        name: "tracing_filepath"
+        s: "/tmp"
+      }
+      arg {
+        name: "trace_for_n_ms"
+        i: 1
+      }
+      arg {
+        name: "trace_every_n_ms"
+        i: 1
+      }
+      op {
+        output: "out"
+        type: "UniformFill"
+      }
+)DOC";
+
+  NetDef net_def;
+  CAFFE_ENFORCE(TextFormat::ParseFromString(spec, &net_def));
+
+  Workspace ws;
+  std::unique_ptr<NetBase> net(CreateNet(net_def, &ws));
+  net->Run();
+}
+
 } // namespace tracing
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Time based tracing is easier to look at when multiple nets are running asynchronously.
This diff also adds an option to change the path to dump trace files.

Differential Revision: D12479259
