### PR TITLE
[caffe2] Remove C2GEMMContext

### DIFF
--- a/caffe2/operators/quantized/int8_conv_op.h
+++ b/caffe2/operators/quantized/int8_conv_op.h
@@ -19,7 +19,7 @@ class Int8ConvOp final : public ConvPoolOpBase<CPUContext> {
  public:
   USE_CONV_POOL_BASE_FUNCTIONS(CPUContext);
   Int8ConvOp(const OperatorDef& def, Workspace* ws)
-      : ConvPoolOpBase(def, ws), gemm_context_(ws->GetThreadPool()) {
+      : ConvPoolOpBase(def, ws) {
     OPERATOR_NEEDS_FEATURE(
         this->order_ == StorageOrder::NHWC,
         "Int8Conv only supports NHWC order");
@@ -60,7 +60,7 @@ class Int8ConvOp final : public ConvPoolOpBase<CPUContext> {
       initQNNPACK();
 
       pthreadpool_t threadpool =
-          reinterpret_cast<pthreadpool_t>(gemm_context_.threadPool());
+          reinterpret_cast<pthreadpool_t>(ws_->GetThreadPool());
 
       if (this->qnnpackObject_ == nullptr) {
         CAFFE_ENFORCE(
@@ -149,7 +149,6 @@ class Int8ConvOp final : public ConvPoolOpBase<CPUContext> {
   }
 
  private:
-  C2GEMMContext gemm_context_;
   // QNNPACK convolution object
   qnnp_operator_t qnnpackObject_{nullptr};
   // batch size in the previous call to RunOnDeviceWithOrderNHWC

--- a/caffe2/operators/quantized/int8_conv_transpose_op.h
+++ b/caffe2/operators/quantized/int8_conv_transpose_op.h
@@ -18,7 +18,7 @@ class Int8ConvTransposeOp final : public ConvTransposeUnpoolBase<CPUContext> {
  public:
   USE_CONV_TRANSPOSE_UNPOOL_BASE_FUNCTIONS(CPUContext);
   Int8ConvTransposeOp(const OperatorDef& def, Workspace* ws)
-      : ConvTransposeUnpoolBase(def, ws), gemm_context_(ws->GetThreadPool()) {
+      : ConvTransposeUnpoolBase(def, ws) {
     OPERATOR_NEEDS_FEATURE(
         this->order_ == StorageOrder::NHWC,
         "Int8ConvTransposeOp only supports NHWC order");
@@ -63,7 +63,7 @@ class Int8ConvTransposeOp final : public ConvTransposeUnpoolBase<CPUContext> {
       initQNNPACK();
 
       pthreadpool_t threadpool =
-          reinterpret_cast<pthreadpool_t>(gemm_context_.threadPool());
+          reinterpret_cast<pthreadpool_t>(ws_->GetThreadPool());
 
       if (this->qnnpackObject_ == nullptr) {
         const qnnp_status createStatus = qnnp_create_deconvolution2d_nhwc_q8(
@@ -147,7 +147,6 @@ class Int8ConvTransposeOp final : public ConvTransposeUnpoolBase<CPUContext> {
   }
 
  private:
-  C2GEMMContext gemm_context_;
   // QNNPACK convolution object
   qnnp_operator_t qnnpackObject_{nullptr};
   // batch size in the previous call to RunOnDeviceWithOrderNHWC

--- a/caffe2/operators/quantized/int8_fc_op.h
+++ b/caffe2/operators/quantized/int8_fc_op.h
@@ -17,8 +17,7 @@ class Int8FCOp final : public Operator<CPUContext> {
  public:
   Int8FCOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        ws_(ws),
-        gemm_context_(ws->GetThreadPool()) {
+        ws_(ws) {
     createSharedBuffer<CPUContext>(ws_);
   }
 
@@ -50,7 +49,7 @@ class Int8FCOp final : public Operator<CPUContext> {
       initQNNPACK();
 
       pthreadpool_t threadpool =
-          reinterpret_cast<pthreadpool_t>(gemm_context_.threadPool());
+          reinterpret_cast<pthreadpool_t>(ws_->GetThreadPool());
 
       if (this->qnnpackObject_ == nullptr) {
         const qnnp_status createStatus = qnnp_create_fully_connected_nc_q8(
@@ -115,7 +114,6 @@ class Int8FCOp final : public Operator<CPUContext> {
 
  private:
   Workspace* ws_;
-  C2GEMMContext gemm_context_;
   // QNNPACK convolution object
   qnnp_operator_t qnnpackObject_{nullptr};
   // batch size in the previous call to RunOnDeviceWithOrderNHWC


### PR DESCRIPTION
C2GEMMContext is a remnant of old times when Int8 ops used gemmlowp.
It is no longer needed: formerly gemmlowp-based ops use QNNPACK with pthreadpool interface, and other ops (Int8Add, Int8ChannelShuffle) use Caffe2 thread pool interface directly.

