### PR TITLE
Enable unused-private-field warning

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -153,7 +153,6 @@ class CAFFE2_API NeuralNetData : public Data {
 
  private:
   NNDataKind kind_;
-  size_t version_ = 0;
 };
 
 class CAFFE2_API Tensor : public NeuralNetData {


### PR DESCRIPTION
Summary: This diff enables -Wunused-private-field clang warning for Android builds and fixes all broken targets.

Differential Revision: D12881793
