### PR TITLE
Remove getTHCudaHostAllocator in favor of getPinnedMemoryAllocator

### DIFF
--- a/aten/src/THC/THCAllocator.cpp
+++ b/aten/src/THC/THCAllocator.cpp
@@ -1,27 +1,5 @@
 #include "THCAllocator.h"
 
-static void THCudaHostDeleter(void* ptr) {
-  THCudaCheck(cudaFreeHost(ptr));
-}
-
-struct THCudaHostAllocator : public at::Allocator {
-  at::DataPtr allocate(size_t size) const override {
-    void* ptr = nullptr;
-    if (size != 0) {
-      THCudaCheck(cudaMallocHost(&ptr, size));
-    }
-    return {ptr, ptr, &THCudaHostDeleter, at::DeviceType::CPU};
-  }
-  at::DeleterFnPtr raw_deleter() const override {
-    return &THCudaHostDeleter;
-  }
-};
-
-static THCudaHostAllocator th_cuda_host_allocator;
-at::Allocator* getTHCudaHostAllocator() {
-  return &th_cuda_host_allocator;
-}
-
 THCIpcDeleter::~THCIpcDeleter() {
   int prev_device;
   THCudaCheck(cudaGetDevice(&prev_device));

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -3,7 +3,6 @@
 
 #include "THCGeneral.h"
 
-THC_API THAllocator* getTHCudaHostAllocator(void);
 // IPC doesn't support (re)allocation
 
 #ifdef __cplusplus


### PR DESCRIPTION
```
Both allocate "pinned" memory on the host (CPU). The allocator returned
by at::cuda::getPinnedMemoryAllocator caches allocations, while
getTHCudaHostAllocator would synchronize on frees.
```

This is super minor, but I want to avoid people grabbing getTHCudaHostAllocator by accident. (It's not currently used anywhere).

We still need a better API for allocating pinned memory from both C++ and Python. (See https://github.com/pytorch/pytorch/issues/2206)