### PR TITLE
Batch more matrix multiplies

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -67,6 +67,7 @@ namespace c10 {
   _(prim, ConstantChunk)           \
   _(prim, NoneGenerator)           \
   _(prim, MMTreeReduce)            \
+  _(prim, MMBatchSide)             \
   _(aten, floordiv)                \
   _(aten, __round_to_zero_floordiv)\
   _(prim, fork)                    \

--- a/test/expect/TestScript.test_milstm_fusion_cuda-backward.expect
+++ b/test/expect/TestScript.test_milstm_fusion_cuda-backward.expect
@@ -27,17 +27,16 @@ graph(%0 : Float(*, *)
       %outgate : Float(*, *)
       %27 : Float(*, *)) {
   %28 : Float(*, *) = prim::FusionGroup_0(%ingate, %forgetgate, %cellgate, %outgate, %12, %1, %27, %0)
-  %29 : Float(*, *) = aten::mul(%28, %Uz)
-  %30 : Float(*, *) = aten::mul(%28, %Wx)
-  %31 : Float(*, *) = prim::FusionGroup_1(%28, %22, %13)
-  %32 : Float(*, *), %33 : Float(*, *) = prim::FusionGroup_2(%Wx, %15, %28, %Uz, %14)
+  %29 : Float(*, *) = aten::mul(%28, %Wx)
+  %30 : Float(*, *) = prim::FusionGroup_1(%28, %22, %13)
+  %31 : Float(*, *), %32 : Float(*, *), %33 : Float(*, *) = prim::FusionGroup_2(%Wx, %15, %28, %14, %Uz)
   %34 : Float(*, *) = aten::t(%16)
-  %35 : Float(*, *) = aten::mm(%34, %31)
+  %35 : Float(*, *) = aten::mm(%34, %30)
   %36 : Float(*, *) = aten::t(%35)
   %37 : Float(*, *) = aten::t(%17)
-  %38 : Float(*, *) = aten::mm(%37, %33)
+  %38 : Float(*, *) = aten::mm(%37, %32)
   %39 : Float(*, *) = aten::t(%38)
-  return (%28, %29, %30, %32, %36, %39);
+  return (%28, %33, %29, %31, %36, %39);
 }
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Float(*, *)

--- a/test/expect/TestScript.test_milstm_fusion_cuda-backward.expect
+++ b/test/expect/TestScript.test_milstm_fusion_cuda-backward.expect
@@ -94,14 +94,14 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
 with prim::FusionGroup_2 = graph(%0 : Float(*, *)
       %1 : Float(*)
       %2 : Float(*, *)
-      %3 : Float(*, *)
-      %4 : Float(*)) {
+      %3 : Float(*)
+      %4 : Float(*, *)) {
   %5 : Float(*, *) = aten::mul(%2, %4)
   %6 : Float(*, *) = aten::mul(%2, %3)
-  %7 : Float(*, *) = aten::mul(%6, %1)
+  %7 : Float(*, *) = aten::mul(%5, %1)
   %8 : int = prim::Constant[value=1]()
   %9 : int = prim::Constant[value=1]()
-  %10 : Float(*, *) = aten::add(%5, %7, %9)
-  %11 : Float(*, *) = aten::mul(%6, %0)
-  return (%11, %10);
+  %10 : Float(*, *) = aten::add(%6, %7, %9)
+  %11 : Float(*, *) = aten::mul(%5, %0)
+  return (%11, %10, %5);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6653,7 +6653,7 @@ a")
                 hx, cx = lstm_cell(x[i], hx, cx, w_ih, w_hh, b_ih, b_hh)
             return hx
 
-        inputs = get_lstm_inputs('cuda', training=True, seq_length=10)
+        inputs = get_lstm_inputs('cpu', training=True, seq_length=10)
         lstm(*inputs).sum().backward()
         fw_graph = lstm.graph_for(*inputs)
         bw_graph = backward_graph(lstm, diff_graph_idx=0)

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -456,13 +456,22 @@ private:
   }
 
   void runOptimization(std::shared_ptr<Graph>& graph, const ArgumentSpec& spec) {
+    // Basic graph preprocessing to eliminate noise.
     EliminateDeadCode(graph);
     EliminateCommonSubexpression(graph);
     ConstantPooling(graph);
-    UnrollLoops(graph);
+
     PeepholeOptimize(graph);
-    CheckInplace(graph);
+
+    // Unroll small loops, and eliminate expressions that are the same at every
+    // iteration.
+    UnrollLoops(graph);
+    EliminateCommonSubexpression(graph);
+
+    // Rewrite subgraphs with many MMs into expressions that batch them.
     BatchMM(graph);
+
+    CheckInplace(graph);
   }
 
   void runNondiffOptimization(std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -917,6 +917,7 @@ Node* Node::insertAfter(Node * n) {
 
 bool Node::moveAfterTopologicallyValid(Node* n, const AliasDb& aliasDb) {
   return tryMove(n, MoveSide::AFTER, aliasDb, /*dryRun=*/false);
+}
 
 bool Node::couldMoveAfterTopologically(Node* n, const AliasDb& aliasDb) {
   return tryMove(n, MoveSide::AFTER, aliasDb, /*dryRun=*/true);

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -486,6 +486,10 @@ public:
   // violating dependencies, otherwise executes the move and returns `true`
   TORCH_API bool moveAfterTopologicallyValid(Node* n, const AliasDb& aliasDb);
 
+  // Like moveAfterTopologicallyValid, but only returns if the move is
+  // possible, without actually performing it.
+  TORCH_API bool couldMoveAfterTopologically(Node* n);
+
   // Move a node 'n' (already in the graph) before 'this' in the topological
   // order.
   //
@@ -509,6 +513,10 @@ public:
   // Returns `false` if it's impossible to move `this` after `n` without
   // violating dependencies, otherwise executes the move and returns `true`
   TORCH_API bool moveBeforeTopologicallyValid(Node* n, const AliasDb& aliasDb);
+
+  // Like moveBeforeTopologicallyValid, but only returns if the move is
+  // possible, without actually performing it.
+  TORCH_API bool couldMoveBeforeTopologically(Node* n);
 
   // Remove the input at 'i' from this node.
   //
@@ -589,7 +597,7 @@ public:
 
  private:
   enum class MoveSide { BEFORE, AFTER };
-  bool tryMove(Node* movePoint, MoveSide moveSide, const AliasDb& aliasDb);
+  bool tryMove(Node* movePoint, MoveSide moveSide, const AliasDb& aliasDb, bool dryRun);
   void move(Node* movePoint, MoveSide moveSide);
 
   std::pair<Value*, const Argument&> findInput(Symbol name);

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -488,7 +488,7 @@ public:
 
   // Like moveAfterTopologicallyValid, but only returns if the move is
   // possible, without actually performing it.
-  TORCH_API bool couldMoveAfterTopologically(Node* n);
+  TORCH_API bool couldMoveAfterTopologically(Node* n, const AliasDb& aliasdb);
 
   // Move a node 'n' (already in the graph) before 'this' in the topological
   // order.
@@ -516,7 +516,7 @@ public:
 
   // Like moveBeforeTopologicallyValid, but only returns if the move is
   // possible, without actually performing it.
-  TORCH_API bool couldMoveBeforeTopologically(Node* n);
+  TORCH_API bool couldMoveBeforeTopologically(Node* n, const AliasDb& aliasDb);
 
   // Remove the input at 'i' from this node.
   //

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -182,6 +182,8 @@ void AliasDb::analyze(Node* node) {
     case prim::TupleConstruct:
     case prim::Undefined:
     case prim::FusedConcat:
+    case prim::MMTreeReduce:
+    case prim::MMBatchSide:
       return analyzeCreator(node);
     case prim::TupleUnpack:
     case prim::TupleIndex:
@@ -354,7 +356,9 @@ void AliasDb::analyzeSubgraph(Node* node) {
 
 // For nodes that generate a fresh value from nothing
 void AliasDb::analyzeCreator(Node* node) {
-  giveFreshAlias(node->output());
+  for (Value * output : node->outputs()) {
+    giveFreshAlias(output);
+  }
 }
 
 // For nodes that extract values from a composite type. Right now, this just

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -80,7 +80,7 @@ bool have_same_shape(at::TensorList inputs) {
                      });
 }
 
-bool shape_is_fast(const at::Tensor& lhs, const at::Tensor& rhs) {
+bool shape_is_fast_for_reduce(const at::Tensor& lhs, const at::Tensor& rhs) {
   size_t l = lhs.size(0);
   size_t m = lhs.size(1);
   size_t r = rhs.size(1);
@@ -107,8 +107,7 @@ RegisterOperators mm_tree_reduction_reg({
         auto lhs_inputs = at::TensorList(inputs).slice(0, side_num_elems);
         auto rhs_inputs = at::TensorList(inputs).slice(side_num_elems);
         // TODO: checking this is not free, so we should stop if this keeps failing
-        // TODO: benchmark to find when is this really a win, and add size constraints
-        if (have_same_shape(lhs_inputs) && have_same_shape(rhs_inputs) && shape_is_fast(lhs_inputs[0], rhs_inputs[0])) {
+        if (have_same_shape(lhs_inputs) && have_same_shape(rhs_inputs) && shape_is_fast_for_reduce(lhs_inputs[0], rhs_inputs[0])) {
           auto lhs = at::cat(lhs_inputs, /*dim=*/1);
           auto rhs = at::cat(rhs_inputs, /*dim=*/0);
           push(stack, at::mm(lhs, rhs));
@@ -203,8 +202,9 @@ struct TreeToken {
   }
 };
 
-void BatchMMBlock(Block* block) {
-  enum class Side { LHS, RHS };
+enum class Side { LHS, RHS };
+
+void BatchMMTreeReduce(Block* block) {
   auto graph = block->owningGraph();
 
   // Look for trees in the block
@@ -236,7 +236,7 @@ void BatchMMBlock(Block* block) {
       }
     } else {
       for (auto block : node->blocks()) {
-        BatchMMBlock(block);
+        BatchMMTreeReduce(block);
       }
     }
   }
@@ -260,8 +260,136 @@ void BatchMMBlock(Block* block) {
   }
 }
 
+bool shape_is_fast_for_side(const at::Tensor& other_side_input) {
+  // Cutoff chosed by benchmarking on a TITAN V
+  return other_side_input.numel() <= 1024 * 2048;
+}
+
+RegisterOperators mm_batch_side_reg({
+  Operator(
+    Symbol::prim("MMBatchSide"),
+    [](Node* node) {
+      size_t num_other_side_inputs = node->inputs().size() - 1;
+      Side single_side = static_cast<Side>(node->i(Symbol::attr("side")));
+      return [num_other_side_inputs, single_side](Stack& stack) {
+        at::Tensor side_input;
+        std::vector<at::Tensor> other_side_inputs;
+        other_side_inputs.reserve(num_other_side_inputs);
+        for (auto it = stack.end() - num_other_side_inputs; it != stack.end(); ++it) {
+          other_side_inputs.push_back(std::move(*it).toTensor());
+        }
+        drop(stack, num_other_side_inputs);
+        pop(stack, side_input);
+
+        auto any_other_input = other_side_inputs[0];
+        if (have_same_shape(other_side_inputs) && shape_is_fast_for_side(other_side_inputs[0])) {
+          auto other_side_input = at::cat(other_side_inputs, single_side == Side::LHS ? 1 : 0);
+          auto mm_out = single_side == Side::LHS ? side_input.mm(other_side_input) : other_side_input.mm(side_input);
+          auto outputs = at::chunk(mm_out, num_other_side_inputs, /*dim=*/single_side == Side::LHS ? 1 : 0);
+          stack.insert(stack.end(), std::make_move_iterator(outputs.begin()),
+                                    std::make_move_iterator(outputs.end()));
+        } else {
+          if (single_side == Side::LHS) {
+            for (at::Tensor& other : other_side_inputs) {
+              stack.emplace_back(side_input.mm(other));
+            }
+          } else {
+            for (at::Tensor& other : other_side_inputs) {
+              stack.emplace_back(other.mm(side_input));
+            }
+          }
+        }
+
+        return 0;
+      };
+    })
+});
+
+std::pair<std::vector<Node*>, std::vector<Node*>>
+gatherIndependentMMUses(Value *value, const AliasDb& db) {
+  static const auto postprocess = [](std::vector<Node*> mms) {
+    if (mms.size() == 0) {
+      return mms;
+    }
+    std::sort(mms.begin(), mms.end(), [](Node* n, Node* m) { return n->isBefore(m); });
+    // Filter out dependent MMs. This algorithm might do very badly if e.g. you have
+    // a lot of independent MMs, that depend on the first one, but I doubt this will
+    // be a common scenario.
+    for (size_t i = 0; i < mms.size(); ++i) {
+      if (mms[i] == nullptr) continue;
+      for (size_t j = i + 1; j < mms.size(); ++j) {
+        if (mms[j] == nullptr) continue;
+        if (!mms[j]->couldMoveBeforeTopologically(mms[i], alias_db)) {
+          mms[j] = nullptr;
+        }
+      }
+    }
+    return filter(mms, [](Node *n) { return n != nullptr; });
+  };
+
+  Block * block = value->node()->owningBlock();
+  std::vector<Node*> lhses; // Will contain nodes where value is used as an lhs
+  std::vector<Node*> rhses; // Like above, but rhs
+  for (Use u : value->uses()) {
+    if (u.user->owningBlock() == block &&
+        u.user->matches("aten::mm(Tensor self, Tensor mat2) -> Tensor")) {
+      if (u.offset == 0 && u.user->inputs()[1] != value) {
+        lhses.push_back(u.user);
+      } else if (u.offset == 1 && u.user->inputs()[0] != value) {
+        rhses.push_back(u.user);
+      }
+    }
+  }
+  return std::make_pair(postprocess(lhses), postprocess(rhses));
+}
+
+void BatchMMSide(Block * block, const AliasDb& alias_db) {
+  // NB: 8 is the current loop unrolling factor
+  static constexpr size_t how_many_is_many = 8;
+  const auto batch_side = [&](std::vector<Node*>& mms, Side side) {
+    JIT_ASSERT(!mms.empty());
+    WithInsertPoint insert_guard { mms[0] };
+    Graph* graph = mms[0]->owningGraph();
+    Node* batch_mm = graph->create(Symbol::prim("MMBatchSide"),
+                                    /*inputs=*/{}, /*num_outputs=*/mms.size());
+    graph->insertNode(batch_mm);
+    batch_mm->i_(Symbol::attr("side"), static_cast<int>(side));
+    Value* const_side = mms[0]->inputs().at(side == Side::LHS ? 0 : 1);
+    batch_mm->addInput(const_side);
+    for (size_t i = 0; i < mms.size(); ++i) {
+      batch_mm->addInput(mms[i]->inputs().at(side == Side::LHS ? 1 : 0));
+      mms[i]->output()->replaceAllUsesWith(batch_mm->outputs().at(i));
+    }
+  };
+
+  std::unordered_set<Value*> considered_values;
+  for (Node * node : block->nodes()) {
+    if (node->matches("aten::mm(Tensor self, Tensor mat2) -> Tensor")) {
+      for (Value * input : node->inputs()) {
+        if (/*bool not_inserted = */!considered_values.emplace(input).second) {
+          continue;
+        }
+        auto uses_with_many = gatherIndependentMMUses(input);
+        if (uses_with_many.first.size() >= how_many_is_many) {
+          batch_side(uses_with_many.first, Side::LHS);
+        }
+        if (uses_with_many.second.size() >= how_many_is_many) {
+          batch_side(uses_with_many.second, Side::RHS);
+        }
+      }
+    } else {
+      for (Block* subblock : node->blocks()) {
+        BatchMMSide(subblock, alias_db);
+      }
+    }
+  }
+
+}
+
 void BatchMM(std::shared_ptr<Graph>& graph) {
-  BatchMMBlock(graph->block());
+  const auto alias_db = AliasAnalysis(graph);
+  BatchMMTreeReduce(graph->block());
+  BatchMMSide(graph->block(), alias_db);
   EliminateDeadCode(graph);
   // It's possible that transpose rearrangements have created sequences of consecutive
   // transposes that didn't exist before.

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -268,7 +268,7 @@ bool shape_is_fast_for_side(const at::Tensor& other_side_input) {
 RegisterOperators mm_batch_side_reg({
   Operator(
     Symbol::prim("MMBatchSide"),
-    [](Node* node) {
+    [](const Node* node) {
       size_t num_other_side_inputs = node->inputs().size() - 1;
       Side single_side = static_cast<Side>(node->i(Symbol::attr("side")));
       return [num_other_side_inputs, single_side](Stack& stack) {

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -837,7 +837,8 @@ TORCH_API bool printerHasSpecialCaseFor(Symbol sym) {
     prim::FusedConcat, // optimization pass adds it
     prim::FusionGroup, // optimization pass adds it
     prim::Load, // used in interpreter only
-    prim::MMTreeReduce, // used in batched execution only
+    prim::MMTreeReduce, // used as an optimization
+    prim::MMBatchSide, // used as an optimization
     prim::Store, // used in interpreter only
 
   };


### PR DESCRIPTION
This handles the input pre-multiplication in RNNs, yielding pretty significant speedups in backward times. This pass depends on loop unrolling, so we'll batch only as many elements as the unrolling factor allows.

cc @mruberry @ngimel @zou3519 @zdevito 