### PR TITLE
requires_grad=False when no_grad()

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -307,9 +307,9 @@ static inline Tensor& bmm_out_or_baddbmm_(Tensor& self_or_result, const Tensor& 
         });
     }
   } else if (at::hasMKL() && at::native::is_floating_point(self_or_result)
-	     && batch_items_contiguous_or_transposed(batch1)
-	     && batch_items_contiguous_or_transposed(batch2)
-	     && self_or_result.is_contiguous()) {
+            && batch_items_contiguous_or_transposed(batch1)
+            && batch_items_contiguous_or_transposed(batch2)
+            && self_or_result.is_contiguous()) {
     at::native::_baddbmm_mkl_(self_or_result, batch1, batch2, beta, alpha);
   } else { // split along batch dimension
     if (is_bmm_out) {
@@ -558,7 +558,9 @@ Tensor nuclear_norm(const Tensor& self, bool keepdim) {
       "Expected a tensor with 2 dimensions, but got a ",
       self.dim(),
       " dimensions tensor instead.");
-  return at::sum(std::get<1>(at::svd(self)), 0, keepdim);
+  bool self_need_grad = self.is_variable() && self.requires_grad();
+  auto S = std::get<1>(at::svd(self, /*some=*/true, /*compute_uv=*/self_need_grad));
+  return at::sum(S, 0, keepdim);
 }
 
 Tensor &nuclear_norm_out(Tensor& result, const Tensor& self, bool keepdim) {
@@ -567,7 +569,9 @@ Tensor &nuclear_norm_out(Tensor& result, const Tensor& self, bool keepdim) {
       "Expected a tensor with 2 dimensions, but got a ",
       self.dim(),
       " dimensions tensor instead.");
-  return at::sum_out(result, std::get<1>(at::svd(self)), 0, keepdim);
+  bool self_need_grad = self.is_variable() && self.requires_grad();
+  auto S = std::get<1>(at::svd(self, /*some=*/true, /*compute_uv=*/self_need_grad));
+  return at::sum_out(result, S, 0, keepdim);
 }
 
 static inline Tensor _chain_matmul_general(TensorList matrices, std::vector<std::vector<int64_t>>& order, int64_t i, int64_t j) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1643,8 +1643,7 @@ Tensor det_backward(const Tensor & grad, const Tensor& self, const Tensor& det) 
     return grad * det * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    bool self_need_grad = self.is_variable() && self.requires_grad();
-    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
+    std::tie(u, sigma, v) = self.svd();
     auto gsigma = prod_backward(grad, sigma, det);
     return svd_backward({{}, gsigma, {}}, self, true, true, u, sigma, v);
   }
@@ -1656,8 +1655,7 @@ Tensor logdet_backward(const Tensor & grad, const Tensor& self, const Tensor& lo
     return grad * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    bool self_need_grad = self.is_variable() && self.requires_grad();
-    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
+    std::tie(u, sigma, v) = self.svd();
     // backward det = \sum log(sigma)
     auto gsigma = grad.div(sigma);
     return svd_backward({{}, gsigma, {}}, self, true, true, u, sigma, v);
@@ -1673,8 +1671,7 @@ Tensor slogdet_backward(const std::vector<torch::autograd::Variable> &grads,
     return grads[1] * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    bool self_need_grad = self.is_variable() && self.requires_grad();
-    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
+    std::tie(u, sigma, v) = self.svd();
     // sigma has all non-negative entries (also with at least one zero entry)
     // so logabsdet = \sum log(abs(sigma))
     // but det = 0, so backward logabsdet = \sum log(sigma)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1643,7 +1643,8 @@ Tensor det_backward(const Tensor & grad, const Tensor& self, const Tensor& det) 
     return grad * det * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    std::tie(u, sigma, v) = self.svd();
+    bool self_need_grad = self.is_variable() && self.requires_grad();
+    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
     auto gsigma = prod_backward(grad, sigma, det);
     return svd_backward({{}, gsigma, {}}, self, true, true, u, sigma, v);
   }
@@ -1655,7 +1656,8 @@ Tensor logdet_backward(const Tensor & grad, const Tensor& self, const Tensor& lo
     return grad * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    std::tie(u, sigma, v) = self.svd();
+    bool self_need_grad = self.is_variable() && self.requires_grad();
+    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
     // backward det = \sum log(sigma)
     auto gsigma = grad.div(sigma);
     return svd_backward({{}, gsigma, {}}, self, true, true, u, sigma, v);
@@ -1671,7 +1673,8 @@ Tensor slogdet_backward(const std::vector<torch::autograd::Variable> &grads,
     return grads[1] * self.inverse().t();
   } else /* otherwise det = \prod(sigma) = 0, use svd */ {
     Tensor u, sigma, v;
-    std::tie(u, sigma, v) = self.svd();
+    bool self_need_grad = self.is_variable() && self.requires_grad();
+    std::tie(u, sigma, v) = self.svd(/*some=*/true, /*compute_uv=*/self_need_grad);
     // sigma has all non-negative entries (also with at least one zero entry)
     // so logabsdet = \sum log(abs(sigma))
     // but det = 0, so backward logabsdet = \sum log(sigma)

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -30,7 +30,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     return {};
   if (variable.grad_fn())
     throw std::logic_error("leaf variable has been moved into the graph interior");
-  if (!variable.requires_grad())
+  if (!variable.accumulates_grad())
     return {};
 
   auto new_grad = std::move(grads[0]);

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -42,9 +42,6 @@ struct ComputeRequiresGrad : IterArgs<ComputeRequiresGrad> {
 
 template <typename... Args>
 inline bool compute_requires_grad(Args&&... args) {
-  if (!GradMode::is_enabled()) {
-    return false;
-  }
   return ComputeRequiresGrad().apply(std::forward<Args>(args)...).out;
 }
 

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -22,7 +22,7 @@ using function_constructor = std::function<std::shared_ptr<Function>(edge_list&&
 TORCH_API variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
                                      function_constructor ctr);
 
-///  Checks that inputs contains exactly `args` items and that the first `required_args`
+/// Checks that inputs contains exactly `args` items and that the first `required_args`
 /// items are not nullptr. If not specified, `required_args` defaults to `args`.
 TORCH_API void check_input_variables(const char* name, const variable_list& inputs, int args, int required_args=-1);
 

--- a/torch/csrc/autograd/grad_mode.cpp
+++ b/torch/csrc/autograd/grad_mode.cpp
@@ -4,11 +4,11 @@ namespace torch { namespace autograd {
 
 thread_local bool GradMode_enabled = true;
 
-bool GradMode::is_enabled() {
+bool GradMode::is_enabled() noexcept {
   return GradMode_enabled;
 }
 
-void GradMode::set_enabled(bool enabled) {
+void GradMode::set_enabled(bool enabled) noexcept {
   GradMode_enabled = enabled;
 }
 }}

--- a/torch/csrc/autograd/grad_mode.h
+++ b/torch/csrc/autograd/grad_mode.h
@@ -5,8 +5,8 @@
 namespace torch { namespace autograd {
 
 struct TORCH_API GradMode {
-  static bool is_enabled();
-  static void set_enabled(bool enabled);
+  static bool is_enabled() noexcept;
+  static void set_enabled(bool enabled) noexcept;
 };
 
 // A RAII, thread local (!) guard that enables or disables grad mode upon

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -6,6 +6,7 @@
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable_version.h"
+#include "torch/csrc/autograd/grad_mode.h"
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
@@ -325,6 +326,9 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
   }
 
   bool requires_grad() const override {
+    if (!GradMode::is_enabled()) {
+      return false;
+    }
     return requires_grad_ || grad_fn_ || (is_view_ && base().requires_grad());
   }
 
@@ -332,6 +336,7 @@ struct TORCH_API Variable::Impl : public at::TensorImpl {
   Variable& grad() override {
     return grad_;
   }
+
   const Variable& grad() const override {
     return grad_;
   }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -149,8 +149,8 @@ struct TORCH_API Variable : public at::Tensor {
   /// Gets the raw gradient function pointer, whatever it currently is.
   Function* grad_fn_unsafe() const;
 
-  /// Returns whether this `Variable` should accumulate gradient. Only
-  /// meaningful if this is a leaf.
+  /// Returns whether this `Variable` should accumulate gradient. This can be
+  /// true only if this is a leaf.
   bool accumulates_grad() const noexcept;
 
   /// Set the gradient accumulator of the `Variable`. This is only applicable to


### PR DESCRIPTION
This allows native functions to do computation conditioning on whether gradient is needed. 

For example, SVD backward needs U and V tensors, but if we just need the singular values and the decomposed tensor doesn't require grad, we can safely skip computing U and V. Empirically, this speeds up nuclear norm calculation for tenors with `requires_grad=False` a lot.

```py
# CUDA_LAUNCH_BLOCKING=1

x = (torch.randn(1000, 1000) + torch.eye(1000).div_(20)).cuda()

%timeit -r 100 x.norm('nuc')

# pre patch: 21.3 ms ± 1.99 ms per loop (mean ± std. dev. of 100 runs, 1 loop each)
# post patch: 9.77 ms ± 295 µs per loop (mean ± std. dev. of 100 runs, 1 loop each)

x.requires_grad_()

%timeit -r 100 x.norm('nuc')

# pre patch: 25.4 ms ± 2.24 ms per loop (mean ± std. dev. of 100 runs, 1 loop each)
# post patch: 24.9 ms ± 1.46 ms per loop (mean ± std. dev. of 100 runs, 1 loop each)

x = (torch.randn(1000, 1000) + torch.eye(1000).div_(20)).cpu()

%timeit -r 100 x.norm('nuc')

# pre patch: 3.73 ms ± 396 µs per loop (mean ± std. dev. of 100 runs, 1 loop each)
# post patch: 1.86 ms ± 52.7 µs per loop (mean ± std. dev. of 100 runs, 1 loop each)

x.requires_grad_()

%timeit -r 100 x.norm('nuc')

# pre patch: 3.3 ms ± 478 µs per loop (mean ± std. dev. of 100 runs, 1 loop each)
# post patch: 3.55 ms ± 434 µs per loop (mean ± std. dev. of 100 runs, 1 loop each)
```

