### PR TITLE
add npair builtins

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5316,6 +5316,18 @@ a")
                 # type: (int, Tuple[int, int[2]]) -> List[int]
                 return x
 
+    def test_ntuple_builtins(self):
+        from torch.nn.modules.utils import _single, _pair, _triple, _quadruple
+
+        def test_ints():
+            return _single(1), _pair(2), _triple(3), _quadruple(4)
+
+        def test_floats():
+            return _single(1), _pair(2.1), _triple(3.1), _quadruple(4.1)
+
+        self.checkScript(test_ints, ())
+        self.checkScript(test_floats, ())
+
     def test_type_annotations(self):
         def fn(x, y):
             # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor, Tensor]

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -33,6 +33,12 @@ def warn(string: str):
   print(string)
 )SCRIPT";
 
+auto _ntuple_ops = CodeTemplate(
+R"SCRIPT(
+def _${name}(x: BroadcastingList[${Scalar}, ${Length}]) -> List[${Scalar}]:
+  return x
+)SCRIPT");
+
 struct BuiltinFunctionRegistry {
 
   const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name) {
@@ -74,6 +80,23 @@ private:
       loadSource(scalar_operators_source.format(env));
     }
     loadSource(python_builtins_source);
+
+    using str_pair = std::pair<std::string, std::string>;
+    const std::vector<str_pair> name_len = {
+      str_pair("single", "1"),
+      str_pair("pair", "2"),
+      str_pair("triple", "3"),
+      str_pair("quadruple", "4"),
+    };
+    for(auto scalar: {"float", "int"}) {
+      for (auto pair: name_len) {
+        TemplateEnv env;
+        env.s("Scalar", scalar);
+        env.s("name", pair.first);
+        env.s("Length", pair.second);
+        loadSource(_ntuple_ops.format(env));
+      }
+    }
   }
   enum {UNINITIALIZED, INTIIALIZING, INITIALIZED} state = UNINITIALIZED;
   std::recursive_mutex mutex;

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -8,6 +8,7 @@ from torch._six import raise_from, with_metaclass, get_function_from_type
 from .._jit_internal import createResolutionCallback, _compiled_weak_fns, \
     _weak_script_methods, _weak_modules, _weak_types, COMPILED, \
     COMPILATION_PENDING
+from ..nn.modules.utils import _single, _pair, _triple, _quadruple
 import torch.testing
 from collections import defaultdict, OrderedDict, namedtuple
 import sys
@@ -1333,7 +1334,12 @@ def _get_builtin_table():
                 _builtin_table[id(v)] = "aten::" + name
     for mod in _modules_containing_builtins:
         register_all(mod)
+
     _builtin_table[id(warnings.warn)] = "aten::warn"
+    _builtin_table[id(_single)] = "aten::_single"
+    _builtin_table[id(_pair)] = "aten::_pair"
+    _builtin_table[id(_triple)] = "aten::_triple"
+    _builtin_table[id(_quadruple)] = "aten::_quadruple"
 
     return _builtin_table
 


### PR DESCRIPTION
Add npair builtins to unblock standard library. As with broadcasting list, the only occurrences are with int/floats. 