### PR TITLE
Improve mm / addmm error message with sparse tensors and write deriva…

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -583,6 +583,20 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad, sparse_grad1 + sparse_grad2)
 
     @skipIfRocm
+    def test_sparse_mm_backward(self):
+        size = (3, 3)
+        sparse = torch.sparse_coo_tensor(size, requires_grad=True)
+        dense = torch.randn(size, requires_grad=True)
+
+        z = sparse.mm(dense)
+        with self.assertRaisesRegex(RuntimeError, "calculating the gradient of a sparse Tensor argument to mm is not supported."):
+            z.sum().backward()
+
+        z = dense.addmm(sparse, dense)
+        with self.assertRaisesRegex(RuntimeError, "calculating the gradient of a sparse Tensor argument to mm is not supported."):
+            z.sum().backward()
+
+    @skipIfRocm
     def test_sparse_ctor_getter_backward(self):
         # See NOTE [ Sparse: autograd and API ] on the expected behavior of this test
         def test(size, sparse_dim, nnz, device):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -589,11 +589,13 @@ class TestAutograd(TestCase):
         dense = torch.randn(size, requires_grad=True)
 
         z = sparse.mm(dense)
-        with self.assertRaisesRegex(RuntimeError, "calculating the gradient of a sparse Tensor argument to mm is not supported."):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "calculating the gradient of a sparse Tensor argument to mm is not supported."):
             z.sum().backward()
 
         z = dense.addmm(sparse, dense)
-        with self.assertRaisesRegex(RuntimeError, "calculating the gradient of a sparse Tensor argument to mm is not supported."):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "calculating the gradient of a sparse Tensor argument to mm is not supported."):
             z.sum().backward()
 
     @skipIfRocm

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -112,14 +112,9 @@
   tensor1: grad * tensor2 * value
   tensor2: grad * tensor1 * value
 
-- name: _th_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha)
+- name: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha)
   self: maybe_multiply(grad, beta)
-  mat1: mm_mat1_backward(grad, mat2, mat1.sizes(), mat1.strides(), alpha)
-  mat2: mm_mat2_backward(grad, mat1, mat2.sizes(), mat2.strides(), alpha)
-
-- name: s_native_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha)
-  self: maybe_multiply(grad, beta)
-  mat1: mm_mat1_backward(grad, mat2, mat1.sizes(), mat1.strides(), alpha)
+  mat1: mm_mat1_backward(grad, mat2, mat1, alpha)
   mat2: mm_mat2_backward(grad, mat1, mat2.sizes(), mat2.strides(), alpha)
 
 - name: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta, Scalar alpha)
@@ -490,8 +485,8 @@
   self: grad.clone().masked_fill_(self >= other, 0)
   other: grad.clone().masked_fill_(self < other, 0)
 
-- name: _th_mm(Tensor self, Tensor mat2)
-  self: mm_mat1_backward(grad, mat2, self.sizes(), self.strides(), 1)
+- name: mm(Tensor self, Tensor mat2)
+  self: mm_mat1_backward(grad, mat2, self, 1)
   mat2: mm_mat2_backward(grad, self, mat2.sizes(), mat2.strides(), 1)
 
 - name: mode(Tensor self, int64_t dim, bool keepdim)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -50,8 +50,6 @@ DONT_RECORD_TRACE = {
 
 # These functions have their names recorded under trace renamed,
 RENAME_TRACE = {
-    '_th_addmm': 'addmm',
-    's_native_addmm': 'addmm',
     'zero': 'zeros_like',
     'fill': 'full_like',
 }
@@ -183,13 +181,6 @@ def should_trace(declaration):
     name = declaration['name']
     base_name = name[:-1] if declaration['inplace'] else name[:-4] if name.endswith('_out') else name
     if base_name in DONT_RECORD_TRACE or name in DONT_RECORD_TRACE:
-        return False
-    # We need to disable these because their inner implementations implement
-    # broadcasting, and if we trace them top level we will lose the expand nodes.
-    # However, we can't use DONT_RECORD_TRACE, because we must only disable
-    # these for overloads that come from native (the TH overloads still "work")
-    overload = [arg['simple_type'] for arg in declaration['arguments'] if not arg.get('output', False)]
-    if base_name == 'addmm' and overload == ['Tensor', 'Tensor', 'Tensor', 'Scalar', 'Scalar']:
         return False
     return True
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -466,9 +466,8 @@ Tensor clamp_backward(const Tensor & grad, const Tensor &self, const optional<Sc
 
 Tensor mm_mat1_backward(const Tensor & grad, const Tensor & mat2, const Tensor & mat1, const Scalar & alpha) {
   // if input was column-major, return grad as column-order for efficiency
-  if (mat1.is_sparse()) {
-    throw std::runtime_error("calculating the gradient of a sparse Tensor argument to mm is not supported.");
-  }
+  AT_CHECK(!mat1.is_sparse(),
+           "calculating the gradient of a sparse Tensor argument to mm is not supported.");
   at::IntList sizes = mat1.sizes();
   at::IntList strides = mat1.strides();
   if (strides[0] == 1 && strides[1] == sizes[0]) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -464,8 +464,13 @@ Tensor clamp_backward(const Tensor & grad, const Tensor &self, const optional<Sc
   }
 }
 
-Tensor mm_mat1_backward(const Tensor & grad, const Tensor & mat2, IntList sizes, IntList strides, const Scalar & alpha) {
+Tensor mm_mat1_backward(const Tensor & grad, const Tensor & mat2, const Tensor & mat1, const Scalar & alpha) {
   // if input was column-major, return grad as column-order for efficiency
+  if (mat1.is_sparse()) {
+    throw std::runtime_error("calculating the gradient of a sparse Tensor argument to mm is not supported.");
+  }
+  at::IntList sizes = mat1.sizes();
+  at::IntList strides = mat1.strides();
   if (strides[0] == 1 && strides[1] == sizes[0]) {
     return maybe_multiply(mat2.mm(grad.t()).t(), alpha);
   } else {


### PR DESCRIPTION
…tives in terms of native functions.

Previously the backwards would try to access strides which would give a non-descript error message.

