### PR TITLE
Python <-> C++ Frontend inter-op

### DIFF
--- a/test/cpp_extensions/cpp_frontend_extension.cpp
+++ b/test/cpp_extensions/cpp_frontend_extension.cpp
@@ -4,8 +4,6 @@
 #include <string>
 
 struct Net : torch::nn::Module {
-  using torch::nn::Module::register_parameter;
-
   Net(int64_t in, int64_t out) : fc(in, out) {
     register_module("fc", fc);
     buffer = register_buffer("buf", torch::eye(5));

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -7,17 +7,17 @@ import warnings
 import common_utils as common
 import torch
 import torch.backends.cudnn
-
 import torch.utils.cpp_extension
 from torch.utils.cpp_extension import CUDA_HOME
 
-try:
-    import torch_test_cpp_extension.cpp as cpp_extension
-except ImportError:
-    warnings.warn(
-        "test_cpp_extensions.py cannot be invoked directly. Run "
-        "`python run_test.py -i cpp_extensions` instead."
-    )
+
+# try:
+#     import torch_test_cpp_extension.cpp as cpp_extension
+# except ImportError:
+#     warnings.warn(
+#         "test_cpp_extensions.py cannot be invoked directly. Run "
+#         "`python run_test.py -i cpp_extensions` instead."
+#     )
 
 
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
@@ -37,341 +37,386 @@ def dont_wipe_extensions_build_folder(func):
     return func
 
 
+class CppOrderedDict(object):
+    def __init__(self, cpp_dict):
+        self.cpp_dict = cpp_dict
+
+    def __iter__(self):
+        return self.cpp_dict.__iter__()
+
+    def __len__(self):
+        return self.cpp_dict.__len__()
+
+    def __contains__(self, key):
+        return self.cpp_dict.__contains__(key)
+
+    def __getitem__(self, key):
+        return self.cpp_dict.__getitem__(key)
+
+    def __getattr__(self, name):
+        return getattr(self.cpp_dict, name)
+
+
+class CppModule(torch.nn.Module):
+    def __init__(self, cpp_module):
+        self.cpp_module = cpp_module
+        super(CppModule, self).__init__()
+        self._parameters = CppOrderedDict(cpp_module._parameters)
+        self._buffers = CppOrderedDict(cpp_module._buffers)
+        self._modules = CppOrderedDict(cpp_module._modules)
+        for attr in dir(cpp_module):
+            if not attr.startswith('_'):
+                setattr(self, attr, getattr(self.cpp_module, attr))
+
+    @property
+    def training(self):
+        return self.cpp_module.training
+
+    @training.setter
+    def training(self, mode):
+        self.cpp_module.train(mode)
+
+    def __repr__(self):
+        return self.cpp_module.__repr__()
+
+
 class TestCppExtension(common.TestCase):
     def setUp(self):
-        test_name = self.id().split(".")[-1]
-        dont_wipe = hasattr(getattr(self, test_name), "dont_wipe")
-        if dont_wipe:
-            print(
-                "Test case {} has 'dont_wipe' attribute set, ".format(test_name)
-                + "therefore not wiping extensions build folder before running the test")
-            return
-        if sys.platform == "win32":
-            print("Not wiping extensions build folder because Windows")
-            return
-        default_build_root = torch.utils.cpp_extension.get_default_build_root()
-        if os.path.exists(default_build_root):
-            shutil.rmtree(default_build_root)
+        pass
+        # test_name = self.id().split(".")[-1]
+        # dont_wipe = hasattr(getattr(self, test_name), "dont_wipe")
+        # if dont_wipe:
+        #     print(
+        #         "Test case {} has 'dont_wipe' attribute set, ".format(test_name)
+        #         + "therefore not wiping extensions build folder before running the test"
+        #     )
+        #     return
+        # if sys.platform == "win32":
+        #     print("Not wiping extensions build folder because Windows")
+        #     return
+        # default_build_root = torch.utils.cpp_extension.get_default_build_root()
+        # if os.path.exists(default_build_root):
+        #     shutil.rmtree(default_build_root)
 
-    def test_extension_function(self):
-        x = torch.randn(4, 4)
-        y = torch.randn(4, 4)
-        z = cpp_extension.sigmoid_add(x, y)
-        self.assertEqual(z, x.sigmoid() + y.sigmoid())
-
-    def test_extension_module(self):
-        mm = cpp_extension.MatrixMultiplier(4, 8)
-        weights = torch.rand(8, 4)
-        expected = mm.get().mm(weights)
-        result = mm.forward(weights)
-        self.assertEqual(expected, result)
-
-    def test_backward(self):
-        mm = cpp_extension.MatrixMultiplier(4, 8)
-        weights = torch.rand(8, 4, requires_grad=True)
-        result = mm.forward(weights)
-        result.sum().backward()
-        tensor = mm.get()
-
-        expected_weights_grad = tensor.t().mm(torch.ones([4, 4]))
-        self.assertEqual(weights.grad, expected_weights_grad)
-
-        expected_tensor_grad = torch.ones([4, 4]).mm(weights.t())
-        self.assertEqual(tensor.grad, expected_tensor_grad)
-
-    def test_jit_compile_extension(self):
-        module = torch.utils.cpp_extension.load(
-            name="jit_extension",
-            sources=[
-                "cpp_extensions/jit_extension.cpp",
-                "cpp_extensions/jit_extension2.cpp",
-            ],
-            extra_include_paths=["cpp_extensions"],
-            extra_cflags=["-g"],
-            verbose=True,
-        )
-        x = torch.randn(4, 4)
-        y = torch.randn(4, 4)
-
-        z = module.tanh_add(x, y)
-        self.assertEqual(z, x.tanh() + y.tanh())
-
-        # Checking we can call a method defined not in the main C++ file.
-        z = module.exp_add(x, y)
-        self.assertEqual(z, x.exp() + y.exp())
-
-        # Checking we can use this JIT-compiled class.
-        doubler = module.Doubler(2, 2)
-        self.assertIsNone(doubler.get().grad)
-        self.assertEqual(doubler.get().sum(), 4)
-        self.assertEqual(doubler.forward().sum(), 8)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_cuda_extension(self):
-        import torch_test_cpp_extension.cuda as cuda_extension
-
-        x = torch.zeros(100, device="cuda", dtype=torch.float32)
-        y = torch.zeros(100, device="cuda", dtype=torch.float32)
-
-        z = cuda_extension.sigmoid_add(x, y).cpu()
-
-        # 2 * sigmoid(0) = 2 * 0.5 = 1
-        self.assertEqual(z, torch.ones_like(z))
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_jit_cuda_extension(self):
-        # NOTE: The name of the extension must equal the name of the module.
-        module = torch.utils.cpp_extension.load(
-            name="torch_test_cuda_extension",
-            sources=[
-                "cpp_extensions/cuda_extension.cpp",
-                "cpp_extensions/cuda_extension.cu",
-            ],
-            extra_cuda_cflags=["-O2"],
-            verbose=True,
-        )
-
-        x = torch.zeros(100, device="cuda", dtype=torch.float32)
-        y = torch.zeros(100, device="cuda", dtype=torch.float32)
-
-        z = module.sigmoid_add(x, y).cpu()
-
-        # 2 * sigmoid(0) = 2 * 0.5 = 1
-        self.assertEqual(z, torch.ones_like(z))
-
-    @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
-    def test_jit_cudnn_extension(self):
-        # implementation of CuDNN ReLU
-        if IS_WINDOWS:
-            extra_ldflags = ['cudnn.lib']
-        else:
-            extra_ldflags = ["-lcudnn"]
-        module = torch.utils.cpp_extension.load(
-            name="torch_test_cudnn_extension",
-            sources=["cpp_extensions/cudnn_extension.cpp"],
-            extra_ldflags=extra_ldflags,
-            verbose=True,
-            with_cuda=True,
-        )
-
-        x = torch.randn(100, device="cuda", dtype=torch.float32)
-        y = torch.zeros(100, device="cuda", dtype=torch.float32)
-        module.cudnn_relu(x, y)  # y=relu(x)
-        self.assertEqual(torch.nn.functional.relu(x), y)
-        with self.assertRaisesRegex(RuntimeError, "same size"):
-            y_incorrect = torch.zeros(20, device="cuda", dtype=torch.float32)
-            module.cudnn_relu(x, y_incorrect)
-
-    def test_optional(self):
-        has_value = cpp_extension.function_taking_optional(torch.ones(5))
-        self.assertTrue(has_value)
-        has_value = cpp_extension.function_taking_optional(None)
-        self.assertFalse(has_value)
-
-    def test_inline_jit_compile_extension_with_functions_as_list(self):
-        cpp_source = """
-        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-          return x.tanh() + y.tanh();
-        }
-        """
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="inline_jit_extension_with_functions_list",
-            cpp_sources=cpp_source,
-            functions="tanh_add",
-            verbose=True,
-        )
-
-        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "tanh_add")
-
-        x = torch.randn(4, 4)
-        y = torch.randn(4, 4)
-
-        z = module.tanh_add(x, y)
-        self.assertEqual(z, x.tanh() + y.tanh())
-
-    def test_inline_jit_compile_extension_with_functions_as_dict(self):
-        cpp_source = """
-        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-          return x.tanh() + y.tanh();
-        }
-        """
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="inline_jit_extension_with_functions_dict",
-            cpp_sources=cpp_source,
-            functions={"tanh_add": "Tanh and then sum :D"},
-            verbose=True,
-        )
-
-        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "Tanh and then sum :D")
-
-    def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
-        cpp_source1 = """
-        torch::Tensor sin_add(torch::Tensor x, torch::Tensor y) {
-          return x.sin() + y.sin();
-        }
-        """
-
-        cpp_source2 = """
-        #include <torch/extension.h>
-        torch::Tensor sin_add(torch::Tensor x, torch::Tensor y);
-        PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-          m.def("sin_add", &sin_add, "sin(x) + sin(y)");
-        }
-        """
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="inline_jit_extension",
-            cpp_sources=[cpp_source1, cpp_source2],
-            verbose=True,
-        )
-
-        x = torch.randn(4, 4)
-        y = torch.randn(4, 4)
-
-        z = module.sin_add(x, y)
-        self.assertEqual(z, x.sin() + y.sin())
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_inline_jit_compile_extension_cuda(self):
-        cuda_source = """
-        __global__ void cos_add_kernel(
-            const float* __restrict__ x,
-            const float* __restrict__ y,
-            float* __restrict__ output,
-            const int size) {
-          const auto index = blockIdx.x * blockDim.x + threadIdx.x;
-          if (index < size) {
-            output[index] = __cosf(x[index]) + __cosf(y[index]);
-          }
-        }
-
-        torch::Tensor cos_add(torch::Tensor x, torch::Tensor y) {
-          auto output = torch::zeros_like(x);
-          const int threads = 1024;
-          const int blocks = (output.numel() + threads - 1) / threads;
-          cos_add_kernel<<<blocks, threads>>>(x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
-          return output;
-        }
-        """
-
-        # Here, the C++ source need only declare the function signature.
-        cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="inline_jit_extension_cuda",
-            cpp_sources=cpp_source,
-            cuda_sources=cuda_source,
-            functions=["cos_add"],
-            verbose=True,
-        )
-
-        self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
-
-        x = torch.randn(4, 4, device="cuda", dtype=torch.float32)
-        y = torch.randn(4, 4, device="cuda", dtype=torch.float32)
-
-        z = module.cos_add(x, y)
-        self.assertEqual(z, x.cos() + y.cos())
-
-    def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
-        with self.assertRaises(ValueError):
-            torch.utils.cpp_extension.load_inline(
-                name="invalid_jit_extension", cpp_sources="", functions=5
-            )
-
-    def test_lenient_flag_handling_in_jit_extensions(self):
-        cpp_source = """
-        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-          return x.tanh() + y.tanh();
-        }
-        """
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="lenient_flag_handling_extension",
-            cpp_sources=cpp_source,
-            functions="tanh_add",
-            extra_cflags=["-g\n\n", "-O0 -Wall"],
-            extra_include_paths=["       cpp_extensions\n"],
-            verbose=True,
-        )
-
-        x = torch.zeros(100, dtype=torch.float32)
-        y = torch.zeros(100, dtype=torch.float32)
-        z = module.tanh_add(x, y).cpu()
-        self.assertEqual(z, x.tanh() + y.tanh())
-
-    def test_complex_registration(self):
-        module = torch.utils.cpp_extension.load(
-            name="complex_registration_extension",
-            sources="cpp_extensions/complex_registration_extension.cpp",
-            verbose=True,
-        )
-
-        torch.empty(2, 2, dtype=torch.complex64)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_half_support(self):
-        """
-        Checks for an issue with operator< ambiguity for half when certain
-        THC headers are included.
-
-        See https://github.com/pytorch/pytorch/pull/10301#issuecomment-416773333
-        for the corresponding issue.
-        """
-        cuda_source = """
-        #include <THC/THCNumerics.cuh>
-
-        template<typename T, typename U>
-        __global__ void half_test_kernel(const T* input, U* output) {
-            if (input[0] < input[1] || input[0] >= input[1]) {
-                output[0] = 123;
-            }
-        }
-
-        torch::Tensor half_test(torch::Tensor input) {
-            auto output = torch::empty(1, input.options().dtype(torch::kFloat));
-            AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "half_test", [&] {
-                half_test_kernel<scalar_t><<<1, 1>>>(
-                    input.data<scalar_t>(),
-                    output.data<float>());
-            });
-            return output;
-        }
-        """
-
-        module = torch.utils.cpp_extension.load_inline(
-            name="half_test_extension",
-            cpp_sources="torch::Tensor half_test(torch::Tensor input);",
-            cuda_sources=cuda_source,
-            functions=["half_test"],
-            verbose=True,
-        )
-
-        x = torch.randn(3, device="cuda", dtype=torch.half)
-        result = module.half_test(x)
-        self.assertEqual(result[0], 123)
-
-    def test_reload_jit_extension(self):
-        def compile(code):
-            return torch.utils.cpp_extension.load_inline(
-                name="reloaded_jit_extension",
-                cpp_sources=code,
-                functions="f",
-                verbose=True,
-            )
-
-        module = compile("int f() { return 123; }")
-        self.assertEqual(module.f(), 123)
-
-        module = compile("int f() { return 456; }")
-        self.assertEqual(module.f(), 456)
-        module = compile("int f() { return 456; }")
-        self.assertEqual(module.f(), 456)
-
-        module = compile("int f() { return 789; }")
-        self.assertEqual(module.f(), 789)
+    # def test_extension_function(self):
+    #     x = torch.randn(4, 4)
+    #     y = torch.randn(4, 4)
+    #     z = cpp_extension.sigmoid_add(x, y)
+    #     self.assertEqual(z, x.sigmoid() + y.sigmoid())
+    #
+    # def test_extension_module(self):
+    #     mm = cpp_extension.MatrixMultiplier(4, 8)
+    #     weights = torch.rand(8, 4)
+    #     expected = mm.get().mm(weights)
+    #     result = mm.forward(weights)
+    #     self.assertEqual(expected, result)
+    #
+    # def test_backward(self):
+    #     mm = cpp_extension.MatrixMultiplier(4, 8)
+    #     weights = torch.rand(8, 4, requires_grad=True)
+    #     result = mm.forward(weights)
+    #     result.sum().backward()
+    #     tensor = mm.get()
+    #
+    #     expected_weights_grad = tensor.t().mm(torch.ones([4, 4]))
+    #     self.assertEqual(weights.grad, expected_weights_grad)
+    #
+    #     expected_tensor_grad = torch.ones([4, 4]).mm(weights.t())
+    #     self.assertEqual(tensor.grad, expected_tensor_grad)
+    #
+    # def test_jit_compile_extension(self):
+    #     module = torch.utils.cpp_extension.load(
+    #         name="jit_extension",
+    #         sources=[
+    #             "cpp_extensions/jit_extension.cpp",
+    #             "cpp_extensions/jit_extension2.cpp",
+    #         ],
+    #         extra_include_paths=["cpp_extensions"],
+    #         extra_cflags=["-g"],
+    #         verbose=True,
+    #     )
+    #     x = torch.randn(4, 4)
+    #     y = torch.randn(4, 4)
+    #
+    #     z = module.tanh_add(x, y)
+    #     self.assertEqual(z, x.tanh() + y.tanh())
+    #
+    #     # Checking we can call a method defined not in the main C++ file.
+    #     z = module.exp_add(x, y)
+    #     self.assertEqual(z, x.exp() + y.exp())
+    #
+    #     # Checking we can use this JIT-compiled class.
+    #     doubler = module.Doubler(2, 2)
+    #     self.assertIsNone(doubler.get().grad)
+    #     self.assertEqual(doubler.get().sum(), 4)
+    #     self.assertEqual(doubler.forward().sum(), 8)
+    #
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # def test_cuda_extension(self):
+    #     import torch_test_cpp_extension.cuda as cuda_extension
+    #
+    #     x = torch.zeros(100, device="cuda", dtype=torch.float32)
+    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
+    #
+    #     z = cuda_extension.sigmoid_add(x, y).cpu()
+    #
+    #     # 2 * sigmoid(0) = 2 * 0.5 = 1
+    #     self.assertEqual(z, torch.ones_like(z))
+    #
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # def test_jit_cuda_extension(self):
+    #     # NOTE: The name of the extension must equal the name of the module.
+    #     module = torch.utils.cpp_extension.load(
+    #         name="torch_test_cuda_extension",
+    #         sources=[
+    #             "cpp_extensions/cuda_extension.cpp",
+    #             "cpp_extensions/cuda_extension.cu",
+    #         ],
+    #         extra_cuda_cflags=["-O2"],
+    #         verbose=True,
+    #     )
+    #
+    #     x = torch.zeros(100, device="cuda", dtype=torch.float32)
+    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
+    #
+    #     z = module.sigmoid_add(x, y).cpu()
+    #
+    #     # 2 * sigmoid(0) = 2 * 0.5 = 1
+    #     self.assertEqual(z, torch.ones_like(z))
+    #
+    # @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
+    # def test_jit_cudnn_extension(self):
+    #     # implementation of CuDNN ReLU
+    #     if IS_WINDOWS:
+    #         extra_ldflags = ['cudnn.lib']
+    #     else:
+    #         extra_ldflags = ["-lcudnn"]
+    #     module = torch.utils.cpp_extension.load(
+    #         name="torch_test_cudnn_extension",
+    #         sources=["cpp_extensions/cudnn_extension.cpp"],
+    #         extra_ldflags=extra_ldflags,
+    #         verbose=True,
+    #         with_cuda=True,
+    #     )
+    #
+    #     x = torch.randn(100, device="cuda", dtype=torch.float32)
+    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
+    #     module.cudnn_relu(x, y)  # y=relu(x)
+    #     self.assertEqual(torch.nn.functional.relu(x), y)
+    #     with self.assertRaisesRegex(RuntimeError, "same size"):
+    #         y_incorrect = torch.zeros(20, device="cuda", dtype=torch.float32)
+    #         module.cudnn_relu(x, y_incorrect)
+    #
+    # def test_optional(self):
+    #     has_value = cpp_extension.function_taking_optional(torch.ones(5))
+    #     self.assertTrue(has_value)
+    #     has_value = cpp_extension.function_taking_optional(None)
+    #     self.assertFalse(has_value)
+    #
+    # def test_inline_jit_compile_extension_with_functions_as_list(self):
+    #     cpp_source = """
+    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+    #       return x.tanh() + y.tanh();
+    #     }
+    #     """
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="inline_jit_extension_with_functions_list",
+    #         cpp_sources=cpp_source,
+    #         functions="tanh_add",
+    #         verbose=True,
+    #     )
+    #
+    #     self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "tanh_add")
+    #
+    #     x = torch.randn(4, 4)
+    #     y = torch.randn(4, 4)
+    #
+    #     z = module.tanh_add(x, y)
+    #     self.assertEqual(z, x.tanh() + y.tanh())
+    #
+    # def test_inline_jit_compile_extension_with_functions_as_dict(self):
+    #     cpp_source = """
+    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+    #       return x.tanh() + y.tanh();
+    #     }
+    #     """
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="inline_jit_extension_with_functions_dict",
+    #         cpp_sources=cpp_source,
+    #         functions={"tanh_add": "Tanh and then sum :D"},
+    #         verbose=True,
+    #     )
+    #
+    #     self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "Tanh and then sum :D")
+    #
+    # def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
+    #     cpp_source1 = """
+    #     torch::Tensor sin_add(torch::Tensor x, torch::Tensor y) {
+    #       return x.sin() + y.sin();
+    #     }
+    #     """
+    #
+    #     cpp_source2 = """
+    #     #include <torch/extension.h>
+    #     torch::Tensor sin_add(torch::Tensor x, torch::Tensor y);
+    #     PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    #       m.def("sin_add", &sin_add, "sin(x) + sin(y)");
+    #     }
+    #     """
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="inline_jit_extension",
+    #         cpp_sources=[cpp_source1, cpp_source2],
+    #         verbose=True,
+    #     )
+    #
+    #     x = torch.randn(4, 4)
+    #     y = torch.randn(4, 4)
+    #
+    #     z = module.sin_add(x, y)
+    #     self.assertEqual(z, x.sin() + y.sin())
+    #
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # def test_inline_jit_compile_extension_cuda(self):
+    #     cuda_source = """
+    #     __global__ void cos_add_kernel(
+    #         const float* __restrict__ x,
+    #         const float* __restrict__ y,
+    #         float* __restrict__ output,
+    #         const int size) {
+    #       const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    #       if (index < size) {
+    #         output[index] = __cosf(x[index]) + __cosf(y[index]);
+    #       }
+    #     }
+    #
+    #     torch::Tensor cos_add(torch::Tensor x, torch::Tensor y) {
+    #       auto output = torch::zeros_like(x);
+    #       const int threads = 1024;
+    #       const int blocks = (output.numel() + threads - 1) / threads;
+    #       cos_add_kernel<<<blocks, threads>>>(x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
+    #       return output;
+    #     }
+    #     """
+    #
+    #     # Here, the C++ source need only declare the function signature.
+    #     cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="inline_jit_extension_cuda",
+    #         cpp_sources=cpp_source,
+    #         cuda_sources=cuda_source,
+    #         functions=["cos_add"],
+    #         verbose=True,
+    #     )
+    #
+    #     self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
+    #
+    #     x = torch.randn(4, 4, device="cuda", dtype=torch.float32)
+    #     y = torch.randn(4, 4, device="cuda", dtype=torch.float32)
+    #
+    #     z = module.cos_add(x, y)
+    #     self.assertEqual(z, x.cos() + y.cos())
+    #
+    # def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
+    #     with self.assertRaises(ValueError):
+    #         torch.utils.cpp_extension.load_inline(
+    #             name="invalid_jit_extension", cpp_sources="", functions=5
+    #         )
+    #
+    # def test_lenient_flag_handling_in_jit_extensions(self):
+    #     cpp_source = """
+    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+    #       return x.tanh() + y.tanh();
+    #     }
+    #     """
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="lenient_flag_handling_extension",
+    #         cpp_sources=cpp_source,
+    #         functions="tanh_add",
+    #         extra_cflags=["-g\n\n", "-O0 -Wall"],
+    #         extra_include_paths=["       cpp_extensions\n"],
+    #         verbose=True,
+    #     )
+    #
+    #     x = torch.zeros(100, dtype=torch.float32)
+    #     y = torch.zeros(100, dtype=torch.float32)
+    #     z = module.tanh_add(x, y).cpu()
+    #     self.assertEqual(z, x.tanh() + y.tanh())
+    #
+    # def test_complex_registration(self):
+    #     module = torch.utils.cpp_extension.load(
+    #         name="complex_registration_extension",
+    #         sources="cpp_extensions/complex_registration_extension.cpp",
+    #         verbose=True,
+    #     )
+    #
+    #     torch.empty(2, 2, dtype=torch.complex64)
+    #
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # def test_half_support(self):
+    #     """
+    #     Checks for an issue with operator< ambiguity for half when certain
+    #     THC headers are included.
+    #
+    #     See https://github.com/pytorch/pytorch/pull/10301#issuecomment-416773333
+    #     for the corresponding issue.
+    #     """
+    #     cuda_source = """
+    #     #include <THC/THCNumerics.cuh>
+    #
+    #     template<typename T, typename U>
+    #     __global__ void half_test_kernel(const T* input, U* output) {
+    #         if (input[0] < input[1] || input[0] >= input[1]) {
+    #             output[0] = 123;
+    #         }
+    #     }
+    #
+    #     torch::Tensor half_test(torch::Tensor input) {
+    #         auto output = torch::empty(1, input.options().dtype(torch::kFloat));
+    #         AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "half_test", [&] {
+    #             half_test_kernel<scalar_t><<<1, 1>>>(
+    #                 input.data<scalar_t>(),
+    #                 output.data<float>());
+    #         });
+    #         return output;
+    #     }
+    #     """
+    #
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="half_test_extension",
+    #         cpp_sources="torch::Tensor half_test(torch::Tensor input);",
+    #         cuda_sources=cuda_source,
+    #         functions=["half_test"],
+    #         verbose=True,
+    #     )
+    #
+    #     x = torch.randn(3, device="cuda", dtype=torch.half)
+    #     result = module.half_test(x)
+    #     self.assertEqual(result[0], 123)
+    #
+    # def test_reload_jit_extension(self):
+    #     def compile(code):
+    #         return torch.utils.cpp_extension.load_inline(
+    #             name="reloaded_jit_extension",
+    #             cpp_sources=code,
+    #             functions="f",
+    #             verbose=True,
+    #         )
+    #
+    #     module = compile("int f() { return 123; }")
+    #     self.assertEqual(module.f(), 123)
+    #
+    #     module = compile("int f() { return 456; }")
+    #     self.assertEqual(module.f(), 456)
+    #     module = compile("int f() { return 456; }")
+    #     self.assertEqual(module.f(), 456)
+    #
+    #     module = compile("int f() { return 789; }")
+    #     self.assertEqual(module.f(), 789)
 
     @dont_wipe_extensions_build_folder
     @common.skipIfRocm
@@ -383,7 +428,12 @@ class TestCppExtension(common.TestCase):
         )
 
         input = torch.randn(2, 5)
-        cpp_linear = extension.Net(5, 2)
+        cpp_linear = CppModule(extension.Net(5, 2))
+        print(cpp_linear._parameters.items())
+        print(cpp_linear._buffers.items())
+        print(cpp_linear._buffers["buf"])
+        print(len(cpp_linear._buffers))
+        print(cpp_linear._modules.items())
         cpp_linear.to(torch.float64)
         python_linear = torch.nn.Linear(5, 2)
 
@@ -420,13 +470,13 @@ class TestCppExtension(common.TestCase):
             def __init__(self):
                 super(M, self).__init__()
                 self.x = torch.nn.Parameter(torch.tensor(1.0))
-                self.net = extension.Net(3, 5)
+                self.net = CppModule(extension.Net(3, 5))
                 self.net.to(torch.float64)
 
             def forward(self, input):
                 return self.net.forward(input) + self.x
 
-        net = extension.Net(5, 2)
+        net = CppModule(extension.Net(5, 2))
         self.assertEqual(str(net), "Net")
         net.double()
 
@@ -486,76 +536,77 @@ class TestCppExtension(common.TestCase):
         self.assertIn("buf", nb)
         self.assertEqual(nb[0][1], torch.eye(5))
 
-    @dont_wipe_extensions_build_folder
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    @common.skipIfRocm
-    def test_cpp_frontend_module_python_inter_op_with_cuda(self):
-        extension = torch.utils.cpp_extension.load(
-            name="cpp_frontend_extension",
-            sources="cpp_extensions/cpp_frontend_extension.cpp",
-            verbose=True,
-        )
-
-        net = extension.Net(5, 2)
-        for p in net.parameters():
-            self.assertTrue(p.device.type == "cpu")
-        cpu_parameters = [p.clone() for p in net.parameters()]
-
-        device = torch.device("cuda", 0)
-        net.to(device)
-
-        for i, p in enumerate(net.parameters()):
-            self.assertTrue(p.device.type == "cuda")
-            self.assertTrue(p.device.index == 0)
-            self.assertEqual(cpu_parameters[i], p)
-
-    def test_returns_shared_library_path_when_is_python_module_is_true(self):
-        source = '''
-        #include <torch/script.h>
-        torch::Tensor func(torch::Tensor x) { return x; }
-        static torch::jit::RegisterOperators r("test::func", &func);
-        '''
-        torch.utils.cpp_extension.load_inline(
-            name="is_python_module",
-            cpp_sources=source,
-            functions="func",
-            verbose=True,
-            is_python_module=False)
-        self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
-
-    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
-    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
-        # For this test, run_test.py will call `python setup.py install` in the
-        # cpp_extensions/no_python_abi_suffix_test folder, where the
-        # `BuildExtension` class has a `no_python_abi_suffix` option set to
-        # `True`. This *should* mean that on Python 3, the produced shared
-        # library does not have an ABI suffix like
-        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
-        # On Python 2 there is no ABI suffix anyway.
-        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
-        print(list(os.walk(os.path.join("cpp_extensions", "no_python_abi_suffix_test"))))
-        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
-        self.assertEqual(len(matches), 1, str(matches))
-        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", str(matches))
-
-    def test_set_default_type_also_changes_aten_default_type(self):
-        module = torch.utils.cpp_extension.load_inline(
-            name="test_set_default_type",
-            cpp_sources="torch::Tensor get() { return torch::empty({}); }",
-            functions="get",
-            verbose=True)
-
-        initial_default = torch.get_default_dtype()
-        try:
-            self.assertEqual(module.get().dtype, initial_default)
-            torch.set_default_dtype(torch.float64)
-            self.assertEqual(module.get().dtype, torch.float64)
-            torch.set_default_dtype(torch.float32)
-            self.assertEqual(module.get().dtype, torch.float32)
-            torch.set_default_dtype(torch.float16)
-            self.assertEqual(module.get().dtype, torch.float16)
-        finally:
-            torch.set_default_dtype(initial_default)
+    #
+    # @dont_wipe_extensions_build_folder
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # @common.skipIfRocm
+    # def test_cpp_frontend_module_python_inter_op_with_cuda(self):
+    #     extension = torch.utils.cpp_extension.load(
+    #         name="cpp_frontend_extension",
+    #         sources="cpp_extensions/cpp_frontend_extension.cpp",
+    #         verbose=True,
+    #     )
+    #
+    #     net = extension.Net(5, 2)
+    #     for p in net.parameters():
+    #         self.assertTrue(p.device.type == "cpu")
+    #     cpu_parameters = [p.clone() for p in net.parameters()]
+    #
+    #     device = torch.device("cuda", 0)
+    #     net.to(device)
+    #
+    #     for i, p in enumerate(net.parameters()):
+    #         self.assertTrue(p.device.type == "cuda")
+    #         self.assertTrue(p.device.index == 0)
+    #         self.assertEqual(cpu_parameters[i], p)
+    #
+    # def test_returns_shared_library_path_when_is_python_module_is_true(self):
+    #     source = '''
+    #     #include <torch/script.h>
+    #     torch::Tensor func(torch::Tensor x) { return x; }
+    #     static torch::jit::RegisterOperators r("test::func", &func);
+    #     '''
+    #     torch.utils.cpp_extension.load_inline(
+    #         name="is_python_module",
+    #         cpp_sources=source,
+    #         functions="func",
+    #         verbose=True,
+    #         is_python_module=False)
+    #     self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
+    #
+    # @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
+    # def test_no_python_abi_suffix_sets_the_correct_library_name(self):
+    #     # For this test, run_test.py will call `python setup.py install` in the
+    #     # cpp_extensions/no_python_abi_suffix_test folder, where the
+    #     # `BuildExtension` class has a `no_python_abi_suffix` option set to
+    #     # `True`. This *should* mean that on Python 3, the produced shared
+    #     # library does not have an ABI suffix like
+    #     # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
+    #     # On Python 2 there is no ABI suffix anyway.
+    #     root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
+    #     print(list(os.walk(os.path.join("cpp_extensions", "no_python_abi_suffix_test"))))
+    #     matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
+    #     self.assertEqual(len(matches), 1, str(matches))
+    #     self.assertEqual(matches[0], "no_python_abi_suffix_test.so", str(matches))
+    #
+    # def test_set_default_type_also_changes_aten_default_type(self):
+    #     module = torch.utils.cpp_extension.load_inline(
+    #         name="test_set_default_type",
+    #         cpp_sources="torch::Tensor get() { return torch::empty({}); }",
+    #         functions="get",
+    #         verbose=True)
+    #
+    #     initial_default = torch.get_default_dtype()
+    #     try:
+    #         self.assertEqual(module.get().dtype, initial_default)
+    #         torch.set_default_dtype(torch.float64)
+    #         self.assertEqual(module.get().dtype, torch.float64)
+    #         torch.set_default_dtype(torch.float32)
+    #         self.assertEqual(module.get().dtype, torch.float32)
+    #         torch.set_default_dtype(torch.float16)
+    #         self.assertEqual(module.get().dtype, torch.float16)
+    #     finally:
+    #         torch.set_default_dtype(initial_default)
 
 
 if __name__ == "__main__":

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -11,13 +11,13 @@ import torch.utils.cpp_extension
 from torch.utils.cpp_extension import CUDA_HOME
 
 
-# try:
-#     import torch_test_cpp_extension.cpp as cpp_extension
-# except ImportError:
-#     warnings.warn(
-#         "test_cpp_extensions.py cannot be invoked directly. Run "
-#         "`python run_test.py -i cpp_extensions` instead."
-#     )
+try:
+    import torch_test_cpp_extension.cpp as cpp_extension
+except ImportError:
+    warnings.warn(
+        "test_cpp_extensions.py cannot be invoked directly. Run "
+        "`python run_test.py -i cpp_extensions` instead."
+    )
 
 
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
@@ -37,386 +37,342 @@ def dont_wipe_extensions_build_folder(func):
     return func
 
 
-class CppOrderedDict(object):
-    def __init__(self, cpp_dict):
-        self.cpp_dict = cpp_dict
-
-    def __iter__(self):
-        return self.cpp_dict.__iter__()
-
-    def __len__(self):
-        return self.cpp_dict.__len__()
-
-    def __contains__(self, key):
-        return self.cpp_dict.__contains__(key)
-
-    def __getitem__(self, key):
-        return self.cpp_dict.__getitem__(key)
-
-    def __getattr__(self, name):
-        return getattr(self.cpp_dict, name)
-
-
-class CppModule(torch.nn.Module):
-    def __init__(self, cpp_module):
-        self.cpp_module = cpp_module
-        super(CppModule, self).__init__()
-        self._parameters = CppOrderedDict(cpp_module._parameters)
-        self._buffers = CppOrderedDict(cpp_module._buffers)
-        self._modules = CppOrderedDict(cpp_module._modules)
-        for attr in dir(cpp_module):
-            if not attr.startswith('_'):
-                setattr(self, attr, getattr(self.cpp_module, attr))
-
-    @property
-    def training(self):
-        return self.cpp_module.training
-
-    @training.setter
-    def training(self, mode):
-        self.cpp_module.train(mode)
-
-    def __repr__(self):
-        return self.cpp_module.__repr__()
-
-
 class TestCppExtension(common.TestCase):
     def setUp(self):
-        pass
-        # test_name = self.id().split(".")[-1]
-        # dont_wipe = hasattr(getattr(self, test_name), "dont_wipe")
-        # if dont_wipe:
-        #     print(
-        #         "Test case {} has 'dont_wipe' attribute set, ".format(test_name)
-        #         + "therefore not wiping extensions build folder before running the test"
-        #     )
-        #     return
-        # if sys.platform == "win32":
-        #     print("Not wiping extensions build folder because Windows")
-        #     return
-        # default_build_root = torch.utils.cpp_extension.get_default_build_root()
-        # if os.path.exists(default_build_root):
-        #     shutil.rmtree(default_build_root)
+        test_name = self.id().split(".")[-1]
+        dont_wipe = hasattr(getattr(self, test_name), "dont_wipe")
+        if dont_wipe:
+            print(
+                "Test case {} has 'dont_wipe' attribute set, ".format(test_name)
+                + "therefore not wiping extensions build folder before running the test"
+            )
+            return
+        if sys.platform == "win32":
+            print("Not wiping extensions build folder because Windows")
+            return
+        default_build_root = torch.utils.cpp_extension.get_default_build_root()
+        if os.path.exists(default_build_root):
+            shutil.rmtree(default_build_root)
 
-    # def test_extension_function(self):
-    #     x = torch.randn(4, 4)
-    #     y = torch.randn(4, 4)
-    #     z = cpp_extension.sigmoid_add(x, y)
-    #     self.assertEqual(z, x.sigmoid() + y.sigmoid())
-    #
-    # def test_extension_module(self):
-    #     mm = cpp_extension.MatrixMultiplier(4, 8)
-    #     weights = torch.rand(8, 4)
-    #     expected = mm.get().mm(weights)
-    #     result = mm.forward(weights)
-    #     self.assertEqual(expected, result)
-    #
-    # def test_backward(self):
-    #     mm = cpp_extension.MatrixMultiplier(4, 8)
-    #     weights = torch.rand(8, 4, requires_grad=True)
-    #     result = mm.forward(weights)
-    #     result.sum().backward()
-    #     tensor = mm.get()
-    #
-    #     expected_weights_grad = tensor.t().mm(torch.ones([4, 4]))
-    #     self.assertEqual(weights.grad, expected_weights_grad)
-    #
-    #     expected_tensor_grad = torch.ones([4, 4]).mm(weights.t())
-    #     self.assertEqual(tensor.grad, expected_tensor_grad)
-    #
-    # def test_jit_compile_extension(self):
-    #     module = torch.utils.cpp_extension.load(
-    #         name="jit_extension",
-    #         sources=[
-    #             "cpp_extensions/jit_extension.cpp",
-    #             "cpp_extensions/jit_extension2.cpp",
-    #         ],
-    #         extra_include_paths=["cpp_extensions"],
-    #         extra_cflags=["-g"],
-    #         verbose=True,
-    #     )
-    #     x = torch.randn(4, 4)
-    #     y = torch.randn(4, 4)
-    #
-    #     z = module.tanh_add(x, y)
-    #     self.assertEqual(z, x.tanh() + y.tanh())
-    #
-    #     # Checking we can call a method defined not in the main C++ file.
-    #     z = module.exp_add(x, y)
-    #     self.assertEqual(z, x.exp() + y.exp())
-    #
-    #     # Checking we can use this JIT-compiled class.
-    #     doubler = module.Doubler(2, 2)
-    #     self.assertIsNone(doubler.get().grad)
-    #     self.assertEqual(doubler.get().sum(), 4)
-    #     self.assertEqual(doubler.forward().sum(), 8)
-    #
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # def test_cuda_extension(self):
-    #     import torch_test_cpp_extension.cuda as cuda_extension
-    #
-    #     x = torch.zeros(100, device="cuda", dtype=torch.float32)
-    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
-    #
-    #     z = cuda_extension.sigmoid_add(x, y).cpu()
-    #
-    #     # 2 * sigmoid(0) = 2 * 0.5 = 1
-    #     self.assertEqual(z, torch.ones_like(z))
-    #
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # def test_jit_cuda_extension(self):
-    #     # NOTE: The name of the extension must equal the name of the module.
-    #     module = torch.utils.cpp_extension.load(
-    #         name="torch_test_cuda_extension",
-    #         sources=[
-    #             "cpp_extensions/cuda_extension.cpp",
-    #             "cpp_extensions/cuda_extension.cu",
-    #         ],
-    #         extra_cuda_cflags=["-O2"],
-    #         verbose=True,
-    #     )
-    #
-    #     x = torch.zeros(100, device="cuda", dtype=torch.float32)
-    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
-    #
-    #     z = module.sigmoid_add(x, y).cpu()
-    #
-    #     # 2 * sigmoid(0) = 2 * 0.5 = 1
-    #     self.assertEqual(z, torch.ones_like(z))
-    #
-    # @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
-    # def test_jit_cudnn_extension(self):
-    #     # implementation of CuDNN ReLU
-    #     if IS_WINDOWS:
-    #         extra_ldflags = ['cudnn.lib']
-    #     else:
-    #         extra_ldflags = ["-lcudnn"]
-    #     module = torch.utils.cpp_extension.load(
-    #         name="torch_test_cudnn_extension",
-    #         sources=["cpp_extensions/cudnn_extension.cpp"],
-    #         extra_ldflags=extra_ldflags,
-    #         verbose=True,
-    #         with_cuda=True,
-    #     )
-    #
-    #     x = torch.randn(100, device="cuda", dtype=torch.float32)
-    #     y = torch.zeros(100, device="cuda", dtype=torch.float32)
-    #     module.cudnn_relu(x, y)  # y=relu(x)
-    #     self.assertEqual(torch.nn.functional.relu(x), y)
-    #     with self.assertRaisesRegex(RuntimeError, "same size"):
-    #         y_incorrect = torch.zeros(20, device="cuda", dtype=torch.float32)
-    #         module.cudnn_relu(x, y_incorrect)
-    #
-    # def test_optional(self):
-    #     has_value = cpp_extension.function_taking_optional(torch.ones(5))
-    #     self.assertTrue(has_value)
-    #     has_value = cpp_extension.function_taking_optional(None)
-    #     self.assertFalse(has_value)
-    #
-    # def test_inline_jit_compile_extension_with_functions_as_list(self):
-    #     cpp_source = """
-    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-    #       return x.tanh() + y.tanh();
-    #     }
-    #     """
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="inline_jit_extension_with_functions_list",
-    #         cpp_sources=cpp_source,
-    #         functions="tanh_add",
-    #         verbose=True,
-    #     )
-    #
-    #     self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "tanh_add")
-    #
-    #     x = torch.randn(4, 4)
-    #     y = torch.randn(4, 4)
-    #
-    #     z = module.tanh_add(x, y)
-    #     self.assertEqual(z, x.tanh() + y.tanh())
-    #
-    # def test_inline_jit_compile_extension_with_functions_as_dict(self):
-    #     cpp_source = """
-    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-    #       return x.tanh() + y.tanh();
-    #     }
-    #     """
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="inline_jit_extension_with_functions_dict",
-    #         cpp_sources=cpp_source,
-    #         functions={"tanh_add": "Tanh and then sum :D"},
-    #         verbose=True,
-    #     )
-    #
-    #     self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "Tanh and then sum :D")
-    #
-    # def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
-    #     cpp_source1 = """
-    #     torch::Tensor sin_add(torch::Tensor x, torch::Tensor y) {
-    #       return x.sin() + y.sin();
-    #     }
-    #     """
-    #
-    #     cpp_source2 = """
-    #     #include <torch/extension.h>
-    #     torch::Tensor sin_add(torch::Tensor x, torch::Tensor y);
-    #     PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    #       m.def("sin_add", &sin_add, "sin(x) + sin(y)");
-    #     }
-    #     """
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="inline_jit_extension",
-    #         cpp_sources=[cpp_source1, cpp_source2],
-    #         verbose=True,
-    #     )
-    #
-    #     x = torch.randn(4, 4)
-    #     y = torch.randn(4, 4)
-    #
-    #     z = module.sin_add(x, y)
-    #     self.assertEqual(z, x.sin() + y.sin())
-    #
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # def test_inline_jit_compile_extension_cuda(self):
-    #     cuda_source = """
-    #     __global__ void cos_add_kernel(
-    #         const float* __restrict__ x,
-    #         const float* __restrict__ y,
-    #         float* __restrict__ output,
-    #         const int size) {
-    #       const auto index = blockIdx.x * blockDim.x + threadIdx.x;
-    #       if (index < size) {
-    #         output[index] = __cosf(x[index]) + __cosf(y[index]);
-    #       }
-    #     }
-    #
-    #     torch::Tensor cos_add(torch::Tensor x, torch::Tensor y) {
-    #       auto output = torch::zeros_like(x);
-    #       const int threads = 1024;
-    #       const int blocks = (output.numel() + threads - 1) / threads;
-    #       cos_add_kernel<<<blocks, threads>>>(x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
-    #       return output;
-    #     }
-    #     """
-    #
-    #     # Here, the C++ source need only declare the function signature.
-    #     cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="inline_jit_extension_cuda",
-    #         cpp_sources=cpp_source,
-    #         cuda_sources=cuda_source,
-    #         functions=["cos_add"],
-    #         verbose=True,
-    #     )
-    #
-    #     self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
-    #
-    #     x = torch.randn(4, 4, device="cuda", dtype=torch.float32)
-    #     y = torch.randn(4, 4, device="cuda", dtype=torch.float32)
-    #
-    #     z = module.cos_add(x, y)
-    #     self.assertEqual(z, x.cos() + y.cos())
-    #
-    # def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
-    #     with self.assertRaises(ValueError):
-    #         torch.utils.cpp_extension.load_inline(
-    #             name="invalid_jit_extension", cpp_sources="", functions=5
-    #         )
-    #
-    # def test_lenient_flag_handling_in_jit_extensions(self):
-    #     cpp_source = """
-    #     torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
-    #       return x.tanh() + y.tanh();
-    #     }
-    #     """
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="lenient_flag_handling_extension",
-    #         cpp_sources=cpp_source,
-    #         functions="tanh_add",
-    #         extra_cflags=["-g\n\n", "-O0 -Wall"],
-    #         extra_include_paths=["       cpp_extensions\n"],
-    #         verbose=True,
-    #     )
-    #
-    #     x = torch.zeros(100, dtype=torch.float32)
-    #     y = torch.zeros(100, dtype=torch.float32)
-    #     z = module.tanh_add(x, y).cpu()
-    #     self.assertEqual(z, x.tanh() + y.tanh())
-    #
-    # def test_complex_registration(self):
-    #     module = torch.utils.cpp_extension.load(
-    #         name="complex_registration_extension",
-    #         sources="cpp_extensions/complex_registration_extension.cpp",
-    #         verbose=True,
-    #     )
-    #
-    #     torch.empty(2, 2, dtype=torch.complex64)
-    #
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # def test_half_support(self):
-    #     """
-    #     Checks for an issue with operator< ambiguity for half when certain
-    #     THC headers are included.
-    #
-    #     See https://github.com/pytorch/pytorch/pull/10301#issuecomment-416773333
-    #     for the corresponding issue.
-    #     """
-    #     cuda_source = """
-    #     #include <THC/THCNumerics.cuh>
-    #
-    #     template<typename T, typename U>
-    #     __global__ void half_test_kernel(const T* input, U* output) {
-    #         if (input[0] < input[1] || input[0] >= input[1]) {
-    #             output[0] = 123;
-    #         }
-    #     }
-    #
-    #     torch::Tensor half_test(torch::Tensor input) {
-    #         auto output = torch::empty(1, input.options().dtype(torch::kFloat));
-    #         AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "half_test", [&] {
-    #             half_test_kernel<scalar_t><<<1, 1>>>(
-    #                 input.data<scalar_t>(),
-    #                 output.data<float>());
-    #         });
-    #         return output;
-    #     }
-    #     """
-    #
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="half_test_extension",
-    #         cpp_sources="torch::Tensor half_test(torch::Tensor input);",
-    #         cuda_sources=cuda_source,
-    #         functions=["half_test"],
-    #         verbose=True,
-    #     )
-    #
-    #     x = torch.randn(3, device="cuda", dtype=torch.half)
-    #     result = module.half_test(x)
-    #     self.assertEqual(result[0], 123)
-    #
-    # def test_reload_jit_extension(self):
-    #     def compile(code):
-    #         return torch.utils.cpp_extension.load_inline(
-    #             name="reloaded_jit_extension",
-    #             cpp_sources=code,
-    #             functions="f",
-    #             verbose=True,
-    #         )
-    #
-    #     module = compile("int f() { return 123; }")
-    #     self.assertEqual(module.f(), 123)
-    #
-    #     module = compile("int f() { return 456; }")
-    #     self.assertEqual(module.f(), 456)
-    #     module = compile("int f() { return 456; }")
-    #     self.assertEqual(module.f(), 456)
-    #
-    #     module = compile("int f() { return 789; }")
-    #     self.assertEqual(module.f(), 789)
+    def test_extension_function(self):
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+        z = cpp_extension.sigmoid_add(x, y)
+        self.assertEqual(z, x.sigmoid() + y.sigmoid())
+
+    def test_extension_module(self):
+        mm = cpp_extension.MatrixMultiplier(4, 8)
+        weights = torch.rand(8, 4)
+        expected = mm.get().mm(weights)
+        result = mm.forward(weights)
+        self.assertEqual(expected, result)
+
+    def test_backward(self):
+        mm = cpp_extension.MatrixMultiplier(4, 8)
+        weights = torch.rand(8, 4, requires_grad=True)
+        result = mm.forward(weights)
+        result.sum().backward()
+        tensor = mm.get()
+
+        expected_weights_grad = tensor.t().mm(torch.ones([4, 4]))
+        self.assertEqual(weights.grad, expected_weights_grad)
+
+        expected_tensor_grad = torch.ones([4, 4]).mm(weights.t())
+        self.assertEqual(tensor.grad, expected_tensor_grad)
+
+    def test_jit_compile_extension(self):
+        module = torch.utils.cpp_extension.load(
+            name="jit_extension",
+            sources=[
+                "cpp_extensions/jit_extension.cpp",
+                "cpp_extensions/jit_extension2.cpp",
+            ],
+            extra_include_paths=["cpp_extensions"],
+            extra_cflags=["-g"],
+            verbose=True,
+        )
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+
+        z = module.tanh_add(x, y)
+        self.assertEqual(z, x.tanh() + y.tanh())
+
+        # Checking we can call a method defined not in the main C++ file.
+        z = module.exp_add(x, y)
+        self.assertEqual(z, x.exp() + y.exp())
+
+        # Checking we can use this JIT-compiled class.
+        doubler = module.Doubler(2, 2)
+        self.assertIsNone(doubler.get().grad)
+        self.assertEqual(doubler.get().sum(), 4)
+        self.assertEqual(doubler.forward().sum(), 8)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_cuda_extension(self):
+        import torch_test_cpp_extension.cuda as cuda_extension
+
+        x = torch.zeros(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
+
+        z = cuda_extension.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_jit_cuda_extension(self):
+        # NOTE: The name of the extension must equal the name of the module.
+        module = torch.utils.cpp_extension.load(
+            name="torch_test_cuda_extension",
+            sources=[
+                "cpp_extensions/cuda_extension.cpp",
+                "cpp_extensions/cuda_extension.cu",
+            ],
+            extra_cuda_cflags=["-O2"],
+            verbose=True,
+        )
+
+        x = torch.zeros(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
+
+        z = module.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
+
+    @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
+    def test_jit_cudnn_extension(self):
+        # implementation of CuDNN ReLU
+        if IS_WINDOWS:
+            extra_ldflags = ["cudnn.lib"]
+        else:
+            extra_ldflags = ["-lcudnn"]
+        module = torch.utils.cpp_extension.load(
+            name="torch_test_cudnn_extension",
+            sources=["cpp_extensions/cudnn_extension.cpp"],
+            extra_ldflags=extra_ldflags,
+            verbose=True,
+            with_cuda=True,
+        )
+
+        x = torch.randn(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
+        module.cudnn_relu(x, y)  # y=relu(x)
+        self.assertEqual(torch.nn.functional.relu(x), y)
+        with self.assertRaisesRegex(RuntimeError, "same size"):
+            y_incorrect = torch.zeros(20, device="cuda", dtype=torch.float32)
+            module.cudnn_relu(x, y_incorrect)
+
+    def test_optional(self):
+        has_value = cpp_extension.function_taking_optional(torch.ones(5))
+        self.assertTrue(has_value)
+        has_value = cpp_extension.function_taking_optional(None)
+        self.assertFalse(has_value)
+
+    def test_inline_jit_compile_extension_with_functions_as_list(self):
+        cpp_source = """
+        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+          return x.tanh() + y.tanh();
+        }
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="inline_jit_extension_with_functions_list",
+            cpp_sources=cpp_source,
+            functions="tanh_add",
+            verbose=True,
+        )
+
+        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "tanh_add")
+
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+
+        z = module.tanh_add(x, y)
+        self.assertEqual(z, x.tanh() + y.tanh())
+
+    def test_inline_jit_compile_extension_with_functions_as_dict(self):
+        cpp_source = """
+        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+          return x.tanh() + y.tanh();
+        }
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="inline_jit_extension_with_functions_dict",
+            cpp_sources=cpp_source,
+            functions={"tanh_add": "Tanh and then sum :D"},
+            verbose=True,
+        )
+
+        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "Tanh and then sum :D")
+
+    def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
+        cpp_source1 = """
+        torch::Tensor sin_add(torch::Tensor x, torch::Tensor y) {
+          return x.sin() + y.sin();
+        }
+        """
+
+        cpp_source2 = """
+        #include <torch/extension.h>
+        torch::Tensor sin_add(torch::Tensor x, torch::Tensor y);
+        PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+          m.def("sin_add", &sin_add, "sin(x) + sin(y)");
+        }
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="inline_jit_extension",
+            cpp_sources=[cpp_source1, cpp_source2],
+            verbose=True,
+        )
+
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+
+        z = module.sin_add(x, y)
+        self.assertEqual(z, x.sin() + y.sin())
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_inline_jit_compile_extension_cuda(self):
+        cuda_source = """
+        __global__ void cos_add_kernel(
+            const float* __restrict__ x,
+            const float* __restrict__ y,
+            float* __restrict__ output,
+            const int size) {
+          const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+          if (index < size) {
+            output[index] = __cosf(x[index]) + __cosf(y[index]);
+          }
+        }
+
+        torch::Tensor cos_add(torch::Tensor x, torch::Tensor y) {
+          auto output = torch::zeros_like(x);
+          const int threads = 1024;
+          const int blocks = (output.numel() + threads - 1) / threads;
+          cos_add_kernel<<<blocks, threads>>>(x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
+          return output;
+        }
+        """
+
+        # Here, the C++ source need only declare the function signature.
+        cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="inline_jit_extension_cuda",
+            cpp_sources=cpp_source,
+            cuda_sources=cuda_source,
+            functions=["cos_add"],
+            verbose=True,
+        )
+
+        self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
+
+        x = torch.randn(4, 4, device="cuda", dtype=torch.float32)
+        y = torch.randn(4, 4, device="cuda", dtype=torch.float32)
+
+        z = module.cos_add(x, y)
+        self.assertEqual(z, x.cos() + y.cos())
+
+    def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
+        with self.assertRaises(ValueError):
+            torch.utils.cpp_extension.load_inline(
+                name="invalid_jit_extension", cpp_sources="", functions=5
+            )
+
+    def test_lenient_flag_handling_in_jit_extensions(self):
+        cpp_source = """
+        torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
+          return x.tanh() + y.tanh();
+        }
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="lenient_flag_handling_extension",
+            cpp_sources=cpp_source,
+            functions="tanh_add",
+            extra_cflags=["-g\n\n", "-O0 -Wall"],
+            extra_include_paths=["       cpp_extensions\n"],
+            verbose=True,
+        )
+
+        x = torch.zeros(100, dtype=torch.float32)
+        y = torch.zeros(100, dtype=torch.float32)
+        z = module.tanh_add(x, y).cpu()
+        self.assertEqual(z, x.tanh() + y.tanh())
+
+    def test_complex_registration(self):
+        module = torch.utils.cpp_extension.load(
+            name="complex_registration_extension",
+            sources="cpp_extensions/complex_registration_extension.cpp",
+            verbose=True,
+        )
+
+        torch.empty(2, 2, dtype=torch.complex64)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_half_support(self):
+        """
+        Checks for an issue with operator< ambiguity for half when certain
+        THC headers are included.
+
+        See https://github.com/pytorch/pytorch/pull/10301#issuecomment-416773333
+        for the corresponding issue.
+        """
+        cuda_source = """
+        #include <THC/THCNumerics.cuh>
+
+        template<typename T, typename U>
+        __global__ void half_test_kernel(const T* input, U* output) {
+            if (input[0] < input[1] || input[0] >= input[1]) {
+                output[0] = 123;
+            }
+        }
+
+        torch::Tensor half_test(torch::Tensor input) {
+            auto output = torch::empty(1, input.options().dtype(torch::kFloat));
+            AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "half_test", [&] {
+                half_test_kernel<scalar_t><<<1, 1>>>(
+                    input.data<scalar_t>(),
+                    output.data<float>());
+            });
+            return output;
+        }
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="half_test_extension",
+            cpp_sources="torch::Tensor half_test(torch::Tensor input);",
+            cuda_sources=cuda_source,
+            functions=["half_test"],
+            verbose=True,
+        )
+
+        x = torch.randn(3, device="cuda", dtype=torch.half)
+        result = module.half_test(x)
+        self.assertEqual(result[0], 123)
+
+    def test_reload_jit_extension(self):
+        def compile(code):
+            return torch.utils.cpp_extension.load_inline(
+                name="reloaded_jit_extension",
+                cpp_sources=code,
+                functions="f",
+                verbose=True,
+            )
+
+        module = compile("int f() { return 123; }")
+        self.assertEqual(module.f(), 123)
+
+        module = compile("int f() { return 456; }")
+        self.assertEqual(module.f(), 456)
+        module = compile("int f() { return 456; }")
+        self.assertEqual(module.f(), 456)
+
+        module = compile("int f() { return 789; }")
+        self.assertEqual(module.f(), 789)
 
     @dont_wipe_extensions_build_folder
     @common.skipIfRocm
@@ -428,12 +384,7 @@ class TestCppExtension(common.TestCase):
         )
 
         input = torch.randn(2, 5)
-        cpp_linear = CppModule(extension.Net(5, 2))
-        print(cpp_linear._parameters.items())
-        print(cpp_linear._buffers.items())
-        print(cpp_linear._buffers["buf"])
-        print(len(cpp_linear._buffers))
-        print(cpp_linear._modules.items())
+        cpp_linear = extension.Net(5, 2)
         cpp_linear.to(torch.float64)
         python_linear = torch.nn.Linear(5, 2)
 
@@ -470,13 +421,13 @@ class TestCppExtension(common.TestCase):
             def __init__(self):
                 super(M, self).__init__()
                 self.x = torch.nn.Parameter(torch.tensor(1.0))
-                self.net = CppModule(extension.Net(3, 5))
+                self.net = extension.Net(3, 5)
                 self.net.to(torch.float64)
 
             def forward(self, input):
                 return self.net.forward(input) + self.x
 
-        net = CppModule(extension.Net(5, 2))
+        net = extension.Net(5, 2)
         self.assertEqual(str(net), "Net")
         net.double()
 
@@ -536,77 +487,100 @@ class TestCppExtension(common.TestCase):
         self.assertIn("buf", nb)
         self.assertEqual(nb[0][1], torch.eye(5))
 
-    #
-    # @dont_wipe_extensions_build_folder
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # @common.skipIfRocm
-    # def test_cpp_frontend_module_python_inter_op_with_cuda(self):
-    #     extension = torch.utils.cpp_extension.load(
-    #         name="cpp_frontend_extension",
-    #         sources="cpp_extensions/cpp_frontend_extension.cpp",
-    #         verbose=True,
-    #     )
-    #
-    #     net = extension.Net(5, 2)
-    #     for p in net.parameters():
-    #         self.assertTrue(p.device.type == "cpu")
-    #     cpu_parameters = [p.clone() for p in net.parameters()]
-    #
-    #     device = torch.device("cuda", 0)
-    #     net.to(device)
-    #
-    #     for i, p in enumerate(net.parameters()):
-    #         self.assertTrue(p.device.type == "cuda")
-    #         self.assertTrue(p.device.index == 0)
-    #         self.assertEqual(cpu_parameters[i], p)
-    #
-    # def test_returns_shared_library_path_when_is_python_module_is_true(self):
-    #     source = '''
-    #     #include <torch/script.h>
-    #     torch::Tensor func(torch::Tensor x) { return x; }
-    #     static torch::jit::RegisterOperators r("test::func", &func);
-    #     '''
-    #     torch.utils.cpp_extension.load_inline(
-    #         name="is_python_module",
-    #         cpp_sources=source,
-    #         functions="func",
-    #         verbose=True,
-    #         is_python_module=False)
-    #     self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
-    #
-    # @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
-    # def test_no_python_abi_suffix_sets_the_correct_library_name(self):
-    #     # For this test, run_test.py will call `python setup.py install` in the
-    #     # cpp_extensions/no_python_abi_suffix_test folder, where the
-    #     # `BuildExtension` class has a `no_python_abi_suffix` option set to
-    #     # `True`. This *should* mean that on Python 3, the produced shared
-    #     # library does not have an ABI suffix like
-    #     # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
-    #     # On Python 2 there is no ABI suffix anyway.
-    #     root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
-    #     print(list(os.walk(os.path.join("cpp_extensions", "no_python_abi_suffix_test"))))
-    #     matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
-    #     self.assertEqual(len(matches), 1, str(matches))
-    #     self.assertEqual(matches[0], "no_python_abi_suffix_test.so", str(matches))
-    #
-    # def test_set_default_type_also_changes_aten_default_type(self):
-    #     module = torch.utils.cpp_extension.load_inline(
-    #         name="test_set_default_type",
-    #         cpp_sources="torch::Tensor get() { return torch::empty({}); }",
-    #         functions="get",
-    #         verbose=True)
-    #
-    #     initial_default = torch.get_default_dtype()
-    #     try:
-    #         self.assertEqual(module.get().dtype, initial_default)
-    #         torch.set_default_dtype(torch.float64)
-    #         self.assertEqual(module.get().dtype, torch.float64)
-    #         torch.set_default_dtype(torch.float32)
-    #         self.assertEqual(module.get().dtype, torch.float32)
-    #         torch.set_default_dtype(torch.float16)
-    #         self.assertEqual(module.get().dtype, torch.float16)
-    #     finally:
-    #         torch.set_default_dtype(initial_default)
+    @dont_wipe_extensions_build_folder
+    @common.skipIfRocm
+    def test_cpp_frontend_module_has_up_to_date_attributes(self):
+        extension = torch.utils.cpp_extension.load(
+            name="cpp_frontend_extension",
+            sources="cpp_extensions/cpp_frontend_extension.cpp",
+            verbose=True,
+        )
+
+        net = extension.Net(5, 2)
+
+        self.assertEqual(len(net._parameters), 0)
+        net.add_new_parameter("foo", torch.eye(5))
+        self.assertEqual(len(net._parameters), 1)
+
+        self.assertEqual(len(net._buffers), 1)
+        net.add_new_buffer("bar", torch.eye(5))
+        self.assertEqual(len(net._buffers), 2)
+
+        self.assertEqual(len(net._modules), 1)
+        net.add_new_submodule("fc2")
+        self.assertEqual(len(net._modules), 2)
+
+    @dont_wipe_extensions_build_folder
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @common.skipIfRocm
+    def test_cpp_frontend_module_python_inter_op_with_cuda(self):
+        extension = torch.utils.cpp_extension.load(
+            name="cpp_frontend_extension",
+            sources="cpp_extensions/cpp_frontend_extension.cpp",
+            verbose=True,
+        )
+
+        net = extension.Net(5, 2)
+        for p in net.parameters():
+            self.assertTrue(p.device.type == "cpu")
+        cpu_parameters = [p.clone() for p in net.parameters()]
+
+        device = torch.device("cuda", 0)
+        net.to(device)
+
+        for i, p in enumerate(net.parameters()):
+            self.assertTrue(p.device.type == "cuda")
+            self.assertTrue(p.device.index == 0)
+            self.assertEqual(cpu_parameters[i], p)
+
+    def test_returns_shared_library_path_when_is_python_module_is_true(self):
+        source = """
+        #include <torch/script.h>
+        torch::Tensor func(torch::Tensor x) { return x; }
+        static torch::jit::RegisterOperators r("test::func", &func);
+        """
+        torch.utils.cpp_extension.load_inline(
+            name="is_python_module",
+            cpp_sources=source,
+            functions="func",
+            verbose=True,
+            is_python_module=False,
+        )
+        self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
+
+    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
+    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
+        # For this test, run_test.py will call `python setup.py install` in the
+        # cpp_extensions/no_python_abi_suffix_test folder, where the
+        # `BuildExtension` class has a `no_python_abi_suffix` option set to
+        # `True`. This *should* mean that on Python 3, the produced shared
+        # library does not have an ABI suffix like
+        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
+        # On Python 2 there is no ABI suffix anyway.
+        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
+        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
+        self.assertEqual(len(matches), 1, str(matches))
+        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", str(matches))
+
+    def test_set_default_type_also_changes_aten_default_type(self):
+        module = torch.utils.cpp_extension.load_inline(
+            name="test_set_default_type",
+            cpp_sources="torch::Tensor get() { return torch::empty({}); }",
+            functions="get",
+            verbose=True,
+        )
+
+        initial_default = torch.get_default_dtype()
+        try:
+            self.assertEqual(module.get().dtype, initial_default)
+            torch.set_default_dtype(torch.float64)
+            self.assertEqual(module.get().dtype, torch.float64)
+            torch.set_default_dtype(torch.float32)
+            self.assertEqual(module.get().dtype, torch.float32)
+            torch.set_default_dtype(torch.float16)
+            self.assertEqual(module.get().dtype, torch.float16)
+        finally:
+            torch.set_default_dtype(initial_default)
 
 
 if __name__ == "__main__":

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -2,37 +2,56 @@ import os
 import shutil
 import sys
 import unittest
+import warnings
 
+import common_utils as common
 import torch
-import torch.utils.cpp_extension
 import torch.backends.cudnn
+
+import torch.utils.cpp_extension
+from torch.utils.cpp_extension import CUDA_HOME
 
 try:
     import torch_test_cpp_extension.cpp as cpp_extension
 except ImportError:
-    print("\'test_cpp_extensions.py\' cannot be invoked directly. " +
-          "Run \'python run_test.py -i cpp_extensions\' for the \'test_cpp_extensions.py\' tests.")
-    raise
+    warnings.warn(
+        "test_cpp_extensions.py cannot be invoked directly. Run "
+        "`python run_test.py -i cpp_extensions` instead."
+    )
 
-import common_utils as common
 
-from torch.utils.cpp_extension import CUDA_HOME
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
 TEST_CUDNN = False
 if TEST_CUDA:
-    CUDNN_HEADER_EXISTS = os.path.isfile(os.path.join(CUDA_HOME, 'include/cudnn.h'))
-    TEST_CUDNN = TEST_CUDA and CUDNN_HEADER_EXISTS and torch.backends.cudnn.is_available()
+    CUDNN_HEADER_EXISTS = os.path.isfile(os.path.join(CUDA_HOME, "include/cudnn.h"))
+    TEST_CUDNN = (
+        TEST_CUDA and CUDNN_HEADER_EXISTS and torch.backends.cudnn.is_available()
+    )
+IS_WINDOWS = sys.platform == "win32"
 
 
-IS_WINDOWS = sys.platform == 'win32'
+# This effectively allows re-using the same extension (compiled once) in
+# multiple tests, just to split up the tested properties.
+def dont_wipe_extensions_build_folder(func):
+    func.dont_wipe = True
+    return func
 
 
 class TestCppExtension(common.TestCase):
     def setUp(self):
-        if not IS_WINDOWS:
-            default_build_root = torch.utils.cpp_extension.get_default_build_root()
-            if os.path.exists(default_build_root):
-                shutil.rmtree(default_build_root)
+        test_name = self.id().split(".")[-1]
+        dont_wipe = hasattr(getattr(self, test_name), "dont_wipe")
+        if dont_wipe:
+            print(
+                "Test case {} has 'dont_wipe' attribute set, ".format(test_name)
+                + "therefore not wiping extensions build folder before running the test")
+            return
+        if sys.platform == "win32":
+            print("Not wiping extensions build folder because Windows")
+            return
+        default_build_root = torch.utils.cpp_extension.get_default_build_root()
+        if os.path.exists(default_build_root):
+            shutil.rmtree(default_build_root)
 
     def test_extension_function(self):
         x = torch.randn(4, 4)
@@ -62,14 +81,15 @@ class TestCppExtension(common.TestCase):
 
     def test_jit_compile_extension(self):
         module = torch.utils.cpp_extension.load(
-            name='jit_extension',
+            name="jit_extension",
             sources=[
-                'cpp_extensions/jit_extension.cpp',
-                'cpp_extensions/jit_extension2.cpp'
+                "cpp_extensions/jit_extension.cpp",
+                "cpp_extensions/jit_extension2.cpp",
             ],
-            extra_include_paths=['cpp_extensions'],
-            extra_cflags=['-g'],
-            verbose=True)
+            extra_include_paths=["cpp_extensions"],
+            extra_cflags=["-g"],
+            verbose=True,
+        )
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)
 
@@ -90,8 +110,8 @@ class TestCppExtension(common.TestCase):
     def test_cuda_extension(self):
         import torch_test_cpp_extension.cuda as cuda_extension
 
-        x = torch.zeros(100, device='cuda', dtype=torch.float32)
-        y = torch.zeros(100, device='cuda', dtype=torch.float32)
+        x = torch.zeros(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
 
         z = cuda_extension.sigmoid_add(x, y).cpu()
 
@@ -102,16 +122,17 @@ class TestCppExtension(common.TestCase):
     def test_jit_cuda_extension(self):
         # NOTE: The name of the extension must equal the name of the module.
         module = torch.utils.cpp_extension.load(
-            name='torch_test_cuda_extension',
+            name="torch_test_cuda_extension",
             sources=[
-                'cpp_extensions/cuda_extension.cpp',
-                'cpp_extensions/cuda_extension.cu'
+                "cpp_extensions/cuda_extension.cpp",
+                "cpp_extensions/cuda_extension.cu",
             ],
-            extra_cuda_cflags=['-O2'],
-            verbose=True)
+            extra_cuda_cflags=["-O2"],
+            verbose=True,
+        )
 
-        x = torch.zeros(100, device='cuda', dtype=torch.float32)
-        y = torch.zeros(100, device='cuda', dtype=torch.float32)
+        x = torch.zeros(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
 
         z = module.sigmoid_add(x, y).cpu()
 
@@ -124,22 +145,21 @@ class TestCppExtension(common.TestCase):
         if IS_WINDOWS:
             extra_ldflags = ['cudnn.lib']
         else:
-            extra_ldflags = ['-lcudnn']
+            extra_ldflags = ["-lcudnn"]
         module = torch.utils.cpp_extension.load(
-            name='torch_test_cudnn_extension',
-            sources=[
-                'cpp_extensions/cudnn_extension.cpp'
-            ],
+            name="torch_test_cudnn_extension",
+            sources=["cpp_extensions/cudnn_extension.cpp"],
             extra_ldflags=extra_ldflags,
             verbose=True,
-            with_cuda=True)
+            with_cuda=True,
+        )
 
-        x = torch.randn(100, device='cuda', dtype=torch.float32)
-        y = torch.zeros(100, device='cuda', dtype=torch.float32)
+        x = torch.randn(100, device="cuda", dtype=torch.float32)
+        y = torch.zeros(100, device="cuda", dtype=torch.float32)
         module.cudnn_relu(x, y)  # y=relu(x)
         self.assertEqual(torch.nn.functional.relu(x), y)
         with self.assertRaisesRegex(RuntimeError, "same size"):
-            y_incorrect = torch.zeros(20, device='cuda', dtype=torch.float32)
+            y_incorrect = torch.zeros(20, device="cuda", dtype=torch.float32)
             module.cudnn_relu(x, y_incorrect)
 
     def test_optional(self):
@@ -149,19 +169,20 @@ class TestCppExtension(common.TestCase):
         self.assertFalse(has_value)
 
     def test_inline_jit_compile_extension_with_functions_as_list(self):
-        cpp_source = '''
+        cpp_source = """
         torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
           return x.tanh() + y.tanh();
         }
-        '''
+        """
 
         module = torch.utils.cpp_extension.load_inline(
-            name='inline_jit_extension_with_functions_list',
+            name="inline_jit_extension_with_functions_list",
             cpp_sources=cpp_source,
-            functions='tanh_add',
-            verbose=True)
+            functions="tanh_add",
+            verbose=True,
+        )
 
-        self.assertEqual(module.tanh_add.__doc__.split('\n')[2], 'tanh_add')
+        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "tanh_add")
 
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)
@@ -170,40 +191,41 @@ class TestCppExtension(common.TestCase):
         self.assertEqual(z, x.tanh() + y.tanh())
 
     def test_inline_jit_compile_extension_with_functions_as_dict(self):
-        cpp_source = '''
+        cpp_source = """
         torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
           return x.tanh() + y.tanh();
         }
-        '''
+        """
 
         module = torch.utils.cpp_extension.load_inline(
-            name='inline_jit_extension_with_functions_dict',
+            name="inline_jit_extension_with_functions_dict",
             cpp_sources=cpp_source,
-            functions={'tanh_add': 'Tanh and then sum :D'},
-            verbose=True)
+            functions={"tanh_add": "Tanh and then sum :D"},
+            verbose=True,
+        )
 
-        self.assertEqual(
-            module.tanh_add.__doc__.split('\n')[2], 'Tanh and then sum :D')
+        self.assertEqual(module.tanh_add.__doc__.split("\n")[2], "Tanh and then sum :D")
 
     def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
-        cpp_source1 = '''
+        cpp_source1 = """
         torch::Tensor sin_add(torch::Tensor x, torch::Tensor y) {
           return x.sin() + y.sin();
         }
-        '''
+        """
 
-        cpp_source2 = '''
+        cpp_source2 = """
         #include <torch/extension.h>
         torch::Tensor sin_add(torch::Tensor x, torch::Tensor y);
         PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           m.def("sin_add", &sin_add, "sin(x) + sin(y)");
         }
-        '''
+        """
 
         module = torch.utils.cpp_extension.load_inline(
-            name='inline_jit_extension',
+            name="inline_jit_extension",
             cpp_sources=[cpp_source1, cpp_source2],
-            verbose=True)
+            verbose=True,
+        )
 
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)
@@ -213,7 +235,7 @@ class TestCppExtension(common.TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_inline_jit_compile_extension_cuda(self):
-        cuda_source = '''
+        cuda_source = """
         __global__ void cos_add_kernel(
             const float* __restrict__ x,
             const float* __restrict__ y,
@@ -232,22 +254,23 @@ class TestCppExtension(common.TestCase):
           cos_add_kernel<<<blocks, threads>>>(x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
           return output;
         }
-        '''
+        """
 
         # Here, the C++ source need only declare the function signature.
-        cpp_source = 'torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);'
+        cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
 
         module = torch.utils.cpp_extension.load_inline(
-            name='inline_jit_extension_cuda',
+            name="inline_jit_extension_cuda",
             cpp_sources=cpp_source,
             cuda_sources=cuda_source,
-            functions=['cos_add'],
-            verbose=True)
+            functions=["cos_add"],
+            verbose=True,
+        )
 
-        self.assertEqual(module.cos_add.__doc__.split('\n')[2], 'cos_add')
+        self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
 
-        x = torch.randn(4, 4, device='cuda', dtype=torch.float32)
-        y = torch.randn(4, 4, device='cuda', dtype=torch.float32)
+        x = torch.randn(4, 4, device="cuda", dtype=torch.float32)
+        y = torch.randn(4, 4, device="cuda", dtype=torch.float32)
 
         z = module.cos_add(x, y)
         self.assertEqual(z, x.cos() + y.cos())
@@ -255,22 +278,24 @@ class TestCppExtension(common.TestCase):
     def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
         with self.assertRaises(ValueError):
             torch.utils.cpp_extension.load_inline(
-                name='invalid_jit_extension', cpp_sources='', functions=5)
+                name="invalid_jit_extension", cpp_sources="", functions=5
+            )
 
     def test_lenient_flag_handling_in_jit_extensions(self):
-        cpp_source = '''
+        cpp_source = """
         torch::Tensor tanh_add(torch::Tensor x, torch::Tensor y) {
           return x.tanh() + y.tanh();
         }
-        '''
+        """
 
         module = torch.utils.cpp_extension.load_inline(
-            name='lenient_flag_handling_extension',
+            name="lenient_flag_handling_extension",
             cpp_sources=cpp_source,
-            functions='tanh_add',
-            extra_cflags=['-g\n\n', '-O0 -Wall'],
-            extra_include_paths=['       cpp_extensions\n'],
-            verbose=True)
+            functions="tanh_add",
+            extra_cflags=["-g\n\n", "-O0 -Wall"],
+            extra_include_paths=["       cpp_extensions\n"],
+            verbose=True,
+        )
 
         x = torch.zeros(100, dtype=torch.float32)
         y = torch.zeros(100, dtype=torch.float32)
@@ -279,22 +304,23 @@ class TestCppExtension(common.TestCase):
 
     def test_complex_registration(self):
         module = torch.utils.cpp_extension.load(
-            name='complex_registration_extension',
-            sources='cpp_extensions/complex_registration_extension.cpp',
-            verbose=True)
+            name="complex_registration_extension",
+            sources="cpp_extensions/complex_registration_extension.cpp",
+            verbose=True,
+        )
 
         torch.empty(2, 2, dtype=torch.complex64)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_half_support(self):
-        '''
+        """
         Checks for an issue with operator< ambiguity for half when certain
         THC headers are included.
 
         See https://github.com/pytorch/pytorch/pull/10301#issuecomment-416773333
         for the corresponding issue.
-        '''
-        cuda_source = '''
+        """
+        cuda_source = """
         #include <THC/THCNumerics.cuh>
 
         template<typename T, typename U>
@@ -313,51 +339,120 @@ class TestCppExtension(common.TestCase):
             });
             return output;
         }
-        '''
+        """
 
         module = torch.utils.cpp_extension.load_inline(
-            name='half_test_extension',
-            cpp_sources='torch::Tensor half_test(torch::Tensor input);',
+            name="half_test_extension",
+            cpp_sources="torch::Tensor half_test(torch::Tensor input);",
             cuda_sources=cuda_source,
-            functions=['half_test'],
-            verbose=True)
+            functions=["half_test"],
+            verbose=True,
+        )
 
-        x = torch.randn(3, device='cuda', dtype=torch.half)
+        x = torch.randn(3, device="cuda", dtype=torch.half)
         result = module.half_test(x)
         self.assertEqual(result[0], 123)
 
     def test_reload_jit_extension(self):
         def compile(code):
             return torch.utils.cpp_extension.load_inline(
-                name='reloaded_jit_extension',
+                name="reloaded_jit_extension",
                 cpp_sources=code,
-                functions='f',
-                verbose=True)
+                functions="f",
+                verbose=True,
+            )
 
-        module = compile('int f() { return 123; }')
+        module = compile("int f() { return 123; }")
         self.assertEqual(module.f(), 123)
 
-        module = compile('int f() { return 456; }')
+        module = compile("int f() { return 456; }")
         self.assertEqual(module.f(), 456)
-        module = compile('int f() { return 456; }')
+        module = compile("int f() { return 456; }")
         self.assertEqual(module.f(), 456)
 
-        module = compile('int f() { return 789; }')
+        module = compile("int f() { return 789; }")
         self.assertEqual(module.f(), 789)
 
-    @unittest.skipIf(IS_WINDOWS, "C++ API not yet supported on Windows")
-    def test_cpp_api_extension(self):
-        here = os.path.abspath(__file__)
-        pytorch_root = os.path.dirname(os.path.dirname(here))
-        api_include = os.path.join(pytorch_root, 'torch', 'csrc', 'api', 'include')
-        module = torch.utils.cpp_extension.load(
-            name='cpp_api_extension',
-            sources='cpp_extensions/cpp_api_extension.cpp',
-            extra_include_paths=api_include,
-            verbose=True)
+    @dont_wipe_extensions_build_folder
+    def test_cpp_frontend_module_has_same_output_as_python(self):
+        extension = torch.utils.cpp_extension.load(
+            name="cpp_frontend_extension",
+            sources="cpp_extensions/cpp_frontend_extension.cpp",
+            verbose=True,
+        )
 
-        net = module.Net(3, 5)
+        input = torch.randn(2, 5)
+        cpp_linear = extension.Net(5, 2)
+        cpp_linear.to(torch.float64)
+        python_linear = torch.nn.Linear(5, 2)
 
+        # First make sure they have the same parameters
+        cpp_parameters = dict(cpp_linear.named_parameters())
+        with torch.no_grad():
+            python_linear.weight.copy_(cpp_parameters["fc.weight"])
+            python_linear.bias.copy_(cpp_parameters["fc.bias"])
+
+        cpp_output = cpp_linear.forward(input)
+        python_output = python_linear(input)
+        self.assertEqual(cpp_output, python_output)
+
+        cpp_output.sum().backward()
+        python_output.sum().backward()
+
+        for p in cpp_linear.parameters():
+            self.assertFalse(p.grad is None)
+
+        self.assertEqual(cpp_parameters["fc.weight"].grad, python_linear.weight.grad)
+        self.assertEqual(cpp_parameters["fc.bias"].grad, python_linear.bias.grad)
+
+    @dont_wipe_extensions_build_folder
+    def test_cpp_frontend_module_python_inter_op(self):
+        extension = torch.utils.cpp_extension.load(
+            name="cpp_frontend_extension",
+            sources="cpp_extensions/cpp_frontend_extension.cpp",
+            verbose=True,
+        )
+
+        # Create a torch.nn.Module which uses the C++ module as a submodule.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.x = torch.nn.Parameter(torch.tensor(1.0))
+                self.net = extension.Net(3, 5)
+                self.net.to(torch.float64)
+
+            def forward(self, input):
+                return self.net.forward(input) + self.x
+
+        net = extension.Net(5, 2)
+        self.assertEqual(str(net), "Net")
+        net.double()
+
+        # Further embed the torch.nn.Module into a Sequential, and also add the
+        # C++ module as an element of the Sequential.
+        sequential = torch.nn.Sequential(M(), torch.nn.Tanh(), net, torch.nn.Sigmoid())
+
+        input = torch.randn(2, 3)
+        # Try calling the module!
+        output = sequential.forward(input)
+        # The call operator is bound to forward too.
+        self.assertEqual(output, sequential(input))
+        self.assertEqual(list(output.shape), [2, 2])
+
+        # Try differentiating through the whole module.
+        for parameter in net.parameters():
+            self.assertIsNone(parameter.grad)
+        output.sum().backward()
+        for parameter in net.parameters():
+            self.assertFalse(parameter.grad is None)
+            self.assertGreater(parameter.grad.sum(), 0)
+
+        # Try calling zero_grad()
+        net.zero_grad()
+        for p in net.parameters():
+            self.assertEqual(p.grad, torch.zeros_like(p))
+
+        # Test train(), eval(), training (a property)
         self.assertTrue(net.training)
         net.eval()
         self.assertFalse(net.training)
@@ -365,27 +460,51 @@ class TestCppExtension(common.TestCase):
         self.assertTrue(net.training)
         net.eval()
 
-        input = torch.randn(2, 3)
-        output = net.forward(input)
-        self.assertEqual(output, net.forward(input))
-        self.assertEqual(list(output.shape), [2, 5])
-
-        bias = net.get_bias()
-        self.assertEqual(list(bias.shape), [5])
+        # Try calling the additional methods we registered.
+        biased_input = torch.randn(4, 5)
+        output_before = net.forward(biased_input)
+        bias = net.get_bias().clone()
+        self.assertEqual(list(bias.shape), [2])
         net.set_bias(bias + 1)
         self.assertEqual(net.get_bias(), bias + 1)
-        output2 = net.forward(input)
+        output_after = net.forward(biased_input)
 
-        self.assertNotEqual(output + 1, output2)
+        self.assertNotEqual(output_before, output_after)
 
-        self.assertEqual(len(net.parameters()), 4)
+        # Try accessing parameters
+        self.assertEqual(len(net.parameters()), 2)
+        np = net.named_parameters()
+        self.assertEqual(len(np), 2)
+        self.assertIn("fc.weight", np)
+        self.assertIn("fc.bias", np)
 
-        p = net.named_parameters()
-        self.assertEqual(len(p), 4)
-        self.assertIn('fc.weight', p)
-        self.assertIn('fc.bias', p)
-        self.assertIn('bn.weight', p)
-        self.assertIn('bn.bias', p)
+        self.assertEqual(len(net.buffers()), 1)
+        nb = net.named_buffers()
+        self.assertEqual(len(nb), 1)
+        self.assertIn("buf", nb)
+        self.assertEqual(nb[0][1], torch.eye(5))
+
+    @dont_wipe_extensions_build_folder
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_cpp_frontend_module_python_inter_op_with_cuda(self):
+        extension = torch.utils.cpp_extension.load(
+            name="cpp_frontend_extension",
+            sources="cpp_extensions/cpp_frontend_extension.cpp",
+            verbose=True,
+        )
+
+        net = extension.Net(5, 2)
+        for p in net.parameters():
+            self.assertTrue(p.device.type == "cpu")
+        cpu_parameters = [p.clone() for p in net.parameters()]
+
+        device = torch.device("cuda", 0)
+        net.to(device)
+
+        for i, p in enumerate(net.parameters()):
+            self.assertTrue(p.device.type == "cuda")
+            self.assertTrue(p.device.index == 0)
+            self.assertEqual(cpu_parameters[i], p)
 
     def test_returns_shared_library_path_when_is_python_module_is_true(self):
         source = '''
@@ -436,5 +555,5 @@ class TestCppExtension(common.TestCase):
             torch.set_default_dtype(initial_default)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     common.run_tests()

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -374,6 +374,7 @@ class TestCppExtension(common.TestCase):
         self.assertEqual(module.f(), 789)
 
     @dont_wipe_extensions_build_folder
+    @common.skipIfRocm
     def test_cpp_frontend_module_has_same_output_as_python(self):
         extension = torch.utils.cpp_extension.load(
             name="cpp_frontend_extension",
@@ -406,6 +407,7 @@ class TestCppExtension(common.TestCase):
         self.assertEqual(cpp_parameters["fc.bias"].grad, python_linear.bias.grad)
 
     @dont_wipe_extensions_build_folder
+    @common.skipIfRocm
     def test_cpp_frontend_module_python_inter_op(self):
         extension = torch.utils.cpp_extension.load(
             name="cpp_frontend_extension",
@@ -486,6 +488,7 @@ class TestCppExtension(common.TestCase):
 
     @dont_wipe_extensions_build_folder
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    @common.skipIfRocm
     def test_cpp_frontend_module_python_inter_op_with_cuda(self):
         extension = torch.utils.cpp_extension.load(
             name="cpp_frontend_extension",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -502,6 +502,7 @@ if (BUILD_PYTHON)
     ${TORCH_SRC_DIR}/csrc/PtrWrapper.cpp
     ${TORCH_SRC_DIR}/csrc/Size.cpp
     ${TORCH_SRC_DIR}/csrc/Storage.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/python/init.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/functions/init.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/generated/python_functions.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions.cpp
@@ -572,6 +573,7 @@ if (BUILD_PYTHON)
     ${TORCH_ROOT}/third_party/pybind11/include
 
     ${TORCH_SRC_DIR}/csrc
+    ${TORCH_SRC_DIR}/csrc/api/include
     ${TORCH_SRC_DIR}/lib
     )
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -227,7 +227,7 @@ CONFIGURE_FILE(
     ${TORCH_SRC_DIR}/csrc/jit/fuser/config.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/jit/fuser/config.h)
 
-if (NOT NO_API AND NOT USE_ROCM)
+if (NOT NO_API)
   list(APPEND TORCH_SRCS
     ${TORCH_SRC_DIR}/csrc/api/src/cuda.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/data/datasets/mnist.cpp
@@ -342,7 +342,7 @@ if(OPENMP_FOUND)
   endif()
 endif()
 
-if (NOT NO_API AND NOT USE_ROCM)
+if (NOT NO_API)
   target_include_directories(torch PUBLIC
     ${TORCH_SRC_DIR}/csrc/api
     ${TORCH_SRC_DIR}/csrc/api/include)
@@ -435,7 +435,7 @@ if (BUILD_TEST AND NOT MSVC AND NOT USE_ROCM)
   add_subdirectory(${TORCH_ROOT}/test/cpp/jit ${CMAKE_BINARY_DIR}/test_jit)
 endif()
 
-if (BUILD_TEST AND NOT NO_API AND NOT USE_ROCM)
+if (BUILD_TEST AND NOT NO_API)
   add_subdirectory(${TORCH_ROOT}/test/cpp/api ${CMAKE_BINARY_DIR}/test_api)
 endif()
 

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <torch/csrc/python_headers.h>
-#include <torch/csrc/WindowsApiMacro.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <ATen/Device.h>
 

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <torch/csrc/python_headers.h>
+#include <torch/csrc/WindowsApiMacro.h>
 
 #include <ATen/Device.h>
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct THPDevice {
+struct TORCH_API THPDevice {
   PyObject_HEAD
   at::Device device;
 };
 
-extern PyTypeObject THPDeviceType;
+TORCH_API extern PyTypeObject THPDeviceType;
 
 inline bool THPDevice_Check(PyObject *obj) {
   return Py_TYPE(obj) == &THPDeviceType;

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -2,7 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <torch/csrc/python_headers.h>
-#include <torch/csrc/WindowsApiMacro.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 
 const int DTYPE_NAME_LEN = 64;
 

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -1,17 +1,18 @@
 #pragma once
 
-#include <torch/csrc/python_headers.h>
 #include <ATen/ATen.h>
+#include <torch/csrc/python_headers.h>
+#include <torch/csrc/WindowsApiMacro.h>
 
 const int DTYPE_NAME_LEN = 64;
 
-struct THPDtype {
+struct TORCH_API THPDtype {
   PyObject_HEAD
   at::ScalarType scalar_type;
   char name[DTYPE_NAME_LEN + 1];
 };
 
-extern PyTypeObject THPDtypeType;
+TORCH_API extern PyTypeObject THPDtypeType;
 
 inline bool THPDtype_Check(PyObject *obj) {
   return Py_TYPE(obj) == &THPDtypeType;

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -8,6 +8,7 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/utils/auto_gil.h>
 #include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/WindowsApiMacro.h>
 
 #define HANDLE_TH_ERRORS                                                       \
   try {
@@ -121,7 +122,7 @@ struct IndexError : public PyTorchError {
 
 // Translates to Python TypeError
 struct TypeError : public PyTorchError {
-  TypeError(const char *format, ...);
+  TORCH_API TypeError(const char *format, ...);
   PyObject* python_type() override {
     return PyExc_TypeError;
   }

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -8,7 +8,7 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/utils/auto_gil.h>
 #include <torch/csrc/utils/object_ptr.h>
-#include <torch/csrc/WindowsApiMacro.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 
 #define HANDLE_TH_ERRORS                                                       \
   try {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -38,6 +38,7 @@
 #include <torch/csrc/jit/init.h>
 #include <torch/csrc/jit/python_ir.h>
 #include <torch/csrc/onnx/init.h>
+#include <torch/csrc/api/include/torch/python/init.h>
 
 #ifdef USE_CUDNN
 #include <cudnn.h>
@@ -579,6 +580,7 @@ PyObject* initModule() {
   torch::jit::initJITBindings(module);
   torch::autograd::initNNFunctions(module);
   torch::autograd::init_legacy_variable(module);
+  torch::python::init_bindings(module);
 #ifdef USE_CUDA
   torch::cuda::initModule(module);
 #endif

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -253,11 +253,12 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// their keys.
   OrderedDict<std::string, std::shared_ptr<Module>> named_children() const;
 
-  /// Enables training mode.
-  virtual void train();
+  /// Enables "training" mode.
+  virtual void train(bool on = true);
 
-  /// Disables training mode.
-  virtual void eval();
+  /// Calls train(false) to enable "eval" mode.
+  /// Do not override this method, override `train()` instead.
+  void eval();
 
   /// True if the module is in training mode.
   ///

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -5,90 +5,38 @@
 
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
-#include <torch/types.h>
-#include <torch/ordered_dict.h>
 
-#include <iterator>
-#include <string>
-#include <unordered_map>
-#include <utility>
-#include <vector>
+#include <memory>
 
 namespace torch {
 namespace python {
 namespace detail {
-inline std::unordered_map<std::string, Tensor> ordered_dict_to_map(
-    const OrderedDict<std::string, torch::Tensor>& dict) {
-  auto pairs = dict.pairs();
-  return {pairs.begin(), pairs.end()};
-}
+// The first template argument is the ModuleType we are binding, the second is
+// the base class and the last is the holder type for the created object when
+// going between C++ and Python.
+template <typename ModuleType>
+using ModulePybindClass =
+    py::class_<ModuleType, torch::nn::Module, std::shared_ptr<ModuleType>>;
 } // namespace detail
 
-/// Adds method bindings for a pybind11 `class_` that binds an `nn::Module`
-/// subclass.
-///
-/// Say you have a pybind11 class object created with `py::class_<Net>(m,
-/// "Net")`. This function will add all the necessary `.def()` calls to bind the
-/// `nn::Module` base class' methods, such as `train()`, `eval()` etc. into
-/// Python. The exact list of supported methods and their Python signatures are:
-/// - `train()`
-/// - `eval()`
-/// - `is_training() -> bool`
-/// - `zero_grad()`
-/// - `cuda()`
-/// - `cpu()`
-/// - `parameters() -> List<Tensor>`
-/// - `named_parameters() -> Dict<String, Tensor>`
-/// - `buffers() -> List<Tensor>`
-/// - `named_buffers() -> Dict<String, Tensor>`
-template <typename M, typename... Extra>
-py::class_<M, Extra...> add_module_bindings(py::class_<M, Extra...> module) {
-  return module.def("train", [](M& module) { module.train(); })
-      .def("eval", [](M& module) { module.eval(); })
-      .def("clone", [](M& module) { return module.clone(); })
-      .def_property_readonly(
-          "training", [](M& module) { return module.is_training(); })
-      .def("zero_grad", [](M& module) { module.zero_grad(); })
-      .def("cuda", [](M& module) { module.to(torch::kCUDA); })
-      .def("cpu", [](M& module) { module.to(torch::kCPU); })
-      .def("parameters", [](M& module) { return module.parameters(); })
-      .def(
-          "named_parameters",
-          [](M& module) {
-            return detail::ordered_dict_to_map(module.named_parameters());
-          })
-      .def("buffers", [](M& module) { return module.buffers(); })
-      .def("named_buffers", [](M& module) {
-        return detail::ordered_dict_to_map(module.named_buffers());
-      });
+template <typename ModuleType>
+torch::disable_if_t<
+    torch::detail::has_forward<ModuleType>::value,
+    detail::ModulePybindClass<ModuleType>>
+bind_module(py::module module, const char* name) {
+  return {module, name};
 }
 
-/// Creates a pybind11 class object for an `nn::Module` subclass type and adds
-/// default bindings.
-///
-/// After adding the default bindings, the class object is returned, such that
-/// you can add more bindings.
-///
-/// Example usage:
-/// \rst
-/// .. code-block:: cpp
-///
-///   struct Net : torch::nn::Module {
-///     Net(int in, int out) { }
-///     torch::Tensor forward(torch::Tensor x) { return x; }
-///   };
-///
-///   PYBIND11_MODULE(my_module, m) {
-///     torch::python::bind_module<Net>(m, "Net")
-///       .def(py::init<int, int>())
-///       .def("forward", &Net::forward);
-///  }
-/// \endrst
-template <typename M>
-py::class_<M, std::shared_ptr<M>> bind_module(
+template <
+    typename ModuleType,
+    typename =
+        torch::enable_if_t<torch::detail::has_forward<ModuleType>::value>>
+detail::ModulePybindClass<ModuleType> bind_module(
     py::module module,
     const char* name) {
-  return add_module_bindings(py::class_<M, std::shared_ptr<M>>(module, name));
+  return detail::ModulePybindClass<ModuleType>(module, name)
+      .def("forward", &ModuleType::forward)
+      .def("__call__", &ModuleType::forward);
 }
 } // namespace python
 } // namespace torch

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -1,40 +1,199 @@
 #pragma once
 
 #include <torch/detail/static.h>
+#include <torch/nn/module.h>
+#include <torch/ordered_dict.h>
 #include <torch/types.h>
 
+#include <torch/csrc/Device.h>
+#include <torch/csrc/Dtype.h>
+#include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 
-#include <memory>
+#include <iterator>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace torch {
 namespace python {
 namespace detail {
-// The first template argument is the ModuleType we are binding, the second is
-// the base class and the last is the holder type for the created object when
-// going between C++ and Python.
-template <typename ModuleType>
-using ModulePybindClass =
-    py::class_<ModuleType, torch::nn::Module, std::shared_ptr<ModuleType>>;
+inline Device py_object_to_device(py::object object) {
+  PyObject* obj = object.ptr();
+  if (THPDevice_Check(obj)) {
+    return reinterpret_cast<THPDevice*>(obj)->device;
+  }
+  throw TypeError("Expected device");
+}
+
+inline Dtype py_object_to_dtype(py::object object) {
+  PyObject* obj = object.ptr();
+  if (THPDtype_Check(obj)) {
+    return reinterpret_cast<THPDtype*>(obj)->scalar_type;
+  }
+  throw TypeError("Expected dtype");
+}
+
 } // namespace detail
 
+/// Adds method bindings for a pybind11 `class_` that binds an `nn::Module`
+/// subclass.
+///
+/// Say you have a pybind11 class object created with `py::class_<Net>(m,
+/// "Net")`. This function will add all the necessary `.def()` calls to bind the
+/// `nn::Module` base class' methods, such as `train()`, `eval()` etc. into
+/// Python.
+///
+/// Users should prefer to use `bind_module` if possible.
+template <typename ModuleType, typename... Extra>
+py::class_<ModuleType, Extra...> add_module_bindings(
+    py::class_<ModuleType, Extra...> module) {
+  // clang-format off
+  return module
+      .def("train",
+          [](ModuleType& module, bool mode) { module.train(mode); },
+          py::arg("mode") = true)
+      .def("eval", [](ModuleType& module) { module.eval(); })
+      .def("clone", [](ModuleType& module) { return module.clone(); })
+      .def_property_readonly(
+          "training", [](ModuleType& module) { return module.is_training(); })
+      .def("zero_grad", [](ModuleType& module) { module.zero_grad(); })
+      .def("cuda", [](ModuleType& module) { module.to(torch::kCUDA); })
+      .def("cpu", [](ModuleType& module) { module.to(torch::kCPU); })
+      .def_property_readonly( "_parameters", [](ModuleType& module) {
+            return module.named_parameters(/*recurse=*/false);
+          })
+      .def("parameters", [](ModuleType& module, bool recurse) {
+            return module.parameters(recurse);
+          },
+          py::arg("recurse") = true)
+      .def("named_parameters", [](ModuleType& module, bool recurse) {
+            return module.named_parameters(recurse);
+          },
+          py::arg("recurse") = true)
+      .def_property_readonly("_buffers", [](ModuleType& module) {
+            return module.named_buffers(/*recurse=*/false);
+          })
+      .def("buffers", [](ModuleType& module, bool recurse) {
+            return module.buffers(recurse); },
+          py::arg("recurse") = true)
+      .def("named_buffers", [](ModuleType& module, bool recurse) {
+            return module.named_buffers(recurse);
+          },
+          py::arg("recurse") = true)
+      .def_property_readonly(
+          "_modules", [](ModuleType& module) { return module.children(); })
+      .def("modules", [](ModuleType& module) { return module.modules(); })
+      .def("named_modules",
+          [](ModuleType& module, py::object /* unused */, std::string prefix) {
+            return module.named_modules(std::move(prefix));
+          },
+          py::arg("memo") = py::none(),
+          py::arg("prefix") = std::string())
+      .def("children", [](ModuleType& module) { return module.children(); })
+      .def("named_children",
+          [](ModuleType& module) { return module.named_children(); })
+      .def("to", [](ModuleType& module, py::object object, bool non_blocking) {
+            if (THPDevice_Check(object.ptr())) {
+              module.to(
+                  reinterpret_cast<THPDevice*>(object.ptr())->device,
+                  non_blocking);
+            } else {
+              module.to(detail::py_object_to_dtype(object), non_blocking);
+            }
+          },
+          py::arg("dtype_or_device"),
+          py::arg("non_blocking") = false)
+      .def("to",
+          [](ModuleType& module,
+             py::object device,
+             py::object dtype,
+             bool non_blocking) {
+            module.to(
+                detail::py_object_to_device(device),
+                detail::py_object_to_dtype(dtype),
+                non_blocking);
+          },
+          py::arg("device"),
+          py::arg("dtype"),
+          py::arg("non_blocking") = false)
+      .def("cuda", [](ModuleType& module) { module.to(kCUDA); })
+      .def("cpu", [](ModuleType& module) { module.to(kCPU); })
+      .def("float", [](ModuleType& module) { module.to(kFloat32); })
+      .def("double", [](ModuleType& module) { module.to(kFloat64); })
+      .def("half", [](ModuleType& module) { module.to(kFloat16); })
+      .def("__str__", [](ModuleType& module) { return module.name(); })
+      .def("__repr__", [](ModuleType& module) { return module.name(); });
+  // clang-format on
+}
+
+/// Creates a pybind11 class object for an `nn::Module` subclass type and adds
+/// default bindings.
+///
+/// After adding the default bindings, the class object is returned, such that
+/// you can add more bindings.
+///
+/// Example usage:
+/// \rst
+/// .. code-block:: cpp
+///
+///   struct Net : torch::nn::Module {
+///     Net(int in, int out) { }
+///     torch::Tensor forward(torch::Tensor x) { return x; }
+///   };
+///
+///   PYBIND11_MODULE(my_module, m) {
+///     torch::python::bind_module<Net>(m, "Net")
+///       .def(py::init<int, int>())
+///       .def("forward", &Net::forward);
+///  }
+/// \endrst
 template <typename ModuleType>
 torch::disable_if_t<
     torch::detail::has_forward<ModuleType>::value,
-    detail::ModulePybindClass<ModuleType>>
+    py::class_<ModuleType, std::shared_ptr<ModuleType>>>
 bind_module(py::module module, const char* name) {
-  return {module, name};
+  return add_module_bindings(
+      py::class_<ModuleType, std::shared_ptr<ModuleType>>(
+          module, name, py::base<torch::nn::Module>()));
 }
 
+/// Creates a pybind11 class object for an `nn::Module` subclass type and adds
+/// default bindings.
+///
+/// After adding the default bindings, the class object is returned, such that
+/// you can add more bindings.
+///
+/// If the class has a `forward()` method, it is automatically exposed as
+/// `forward()` and `__call__` in Python.
+///
+/// Example usage:
+/// \rst
+/// .. code-block:: cpp
+///
+///   struct Net : torch::nn::Module {
+///     Net(int in, int out) { }
+///     torch::Tensor forward(torch::Tensor x) { return x; }
+///   };
+///
+///   PYBIND11_MODULE(my_module, m) {
+///     torch::python::bind_module<Net>(m, "Net")
+///       .def(py::init<int, int>())
+///       .def("forward", &Net::forward);
+///  }
+/// \endrst
 template <
     typename ModuleType,
     typename =
         torch::enable_if_t<torch::detail::has_forward<ModuleType>::value>>
-detail::ModulePybindClass<ModuleType> bind_module(
+py::class_<ModuleType, std::shared_ptr<ModuleType>> bind_module(
     py::module module,
     const char* name) {
-  return detail::ModulePybindClass<ModuleType>(module, name)
+  return add_module_bindings(
+             py::class_<ModuleType, std::shared_ptr<ModuleType>>(
+                 module, name, py::base<torch::nn::Module>()))
       .def("forward", &ModuleType::forward)
       .def("__call__", &ModuleType::forward);
 }

--- a/torch/csrc/api/include/torch/python/init.h
+++ b/torch/csrc/api/include/torch/python/init.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <torch/csrc/utils/python_stub.h>
+
+namespace torch {
+namespace python {
+/// Initializes Python bindings for the C++ frontend.
+void init_bindings(PyObject* module);
+} // namespace python
+} // namespace torch

--- a/torch/csrc/api/include/torch/types.h
+++ b/torch/csrc/api/include/torch/types.h
@@ -21,6 +21,7 @@ constexpr auto kInt8 = at::kChar;
 constexpr auto kInt16 = at::kShort;
 constexpr auto kInt32 = at::kInt;
 constexpr auto kInt64 = at::kLong;
+constexpr auto kFloat16 = at::kHalf;
 constexpr auto kFloat32 = at::kFloat;
 constexpr auto kFloat64 = at::kDouble;
 
@@ -30,6 +31,7 @@ constexpr auto kI8 = kInt8;
 constexpr auto kI16 = kInt16;
 constexpr auto kI32 = kInt32;
 constexpr auto kI64 = kInt64;
+constexpr auto kF16 = kFloat16;
 constexpr auto kF32 = kFloat32;
 constexpr auto kF64 = kFloat64;
 } // namespace torch

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -227,18 +227,15 @@ OrderedDict<std::string, std::shared_ptr<Module>> Module::named_children()
   return children_;
 }
 
-void Module::train() {
+void Module::train(bool on) {
   for (auto& child : children_) {
-    child.value()->train();
+    child.value()->train(on);
   }
-  is_training_ = true;
+  is_training_ = on;
 }
 
 void Module::eval() {
-  for (auto& child : children_) {
-    child.value()->eval();
-  }
-  is_training_ = false;
+  train(/*on=*/false);
 }
 
 void Module::to(torch::Device device, torch::Dtype dtype, bool non_blocking) {

--- a/torch/csrc/api/src/python/init.cpp
+++ b/torch/csrc/api/src/python/init.cpp
@@ -5,10 +5,6 @@
 
 #include <torch/csrc/utils/pybind.h>
 
-#include <torch/csrc/Device.h>
-#include <torch/csrc/Dtype.h>
-#include <torch/csrc/DynamicTypes.h>
-
 #include <string>
 #include <vector>
 
@@ -39,28 +35,8 @@ ITEM_TYPE_CASTER(std::shared_ptr<torch::nn::Module>, Module);
 
 namespace torch {
 namespace python {
-namespace {
-Device py_object_to_device(py::object object) {
-  PyObject* obj = object.ptr();
-  if (THPDevice_Check(obj)) {
-    return reinterpret_cast<THPDevice*>(obj)->device;
-  }
-  throw TypeError("Expected device");
-}
-Dtype py_object_to_dtype(py::object object) {
-  PyObject* obj = object.ptr();
-  if (THPDtype_Check(obj)) {
-    return reinterpret_cast<THPDtype*>(obj)->scalar_type;
-  }
-  throw TypeError("Expected dtype");
-}
-} // namespace
-
 template <typename T>
-void bind_ordered_dict(
-    py::module module,
-    const char* dict_name,
-    const char* item_name) {
+void bind_ordered_dict(py::module module, const char* dict_name) {
   using ODict = OrderedDict<std::string, T>;
   // clang-format off
   py::class_<ODict>(module, dict_name)
@@ -85,66 +61,11 @@ void init_bindings(PyObject* module) {
   py::module m = py::handle(module).cast<py::module>();
   py::module cpp = m.def_submodule("cpp");
 
-  bind_ordered_dict<Tensor>(cpp, "OrderedTensorDict", "OrderedTensorDictItem");
-  bind_ordered_dict<std::shared_ptr<nn::Module>>(
-      cpp, "OrderedModuleDict", "OrderedModuleDictItem");
+  bind_ordered_dict<Tensor>(cpp, "OrderedTensorDict");
+  bind_ordered_dict<std::shared_ptr<nn::Module>>(cpp, "OrderedModuleDict");
 
-  // clang-format off
   py::module nn = cpp.def_submodule("nn");
-  py::class_<nn::Module, std::shared_ptr<nn::Module>>(nn, "Module")
-      .def("train", &nn::Module::train, py::arg("mode") = true)
-      .def("eval", &nn::Module::eval)
-      .def("clone", &nn::Module::clone)
-      .def_property_readonly("training", &nn::Module::is_training)
-      .def("zero_grad", &nn::Module::zero_grad)
-      .def_property_readonly("_parameters", [](nn::Module& module) {
-          return module.named_parameters(/*recurse=*/false);
-        })
-      .def("parameters", &nn::Module::parameters, py::arg("recurse") = true)
-      .def("named_parameters", &nn::Module::named_parameters, py::arg("recurse") = true)
-      .def_property_readonly("_buffers", [](nn::Module& module) {
-            return module.named_buffers(/*recurse=*/false);
-          })
-      .def("buffers", &nn::Module::buffers, py::arg("recurse") = true)
-      .def("named_buffers", &nn::Module::named_buffers, py::arg("recurse") = true)
-      .def("modules", &nn::Module::modules)
-      .def("named_modules", [](nn::Module& module, py::object memo, std::string prefix) {
-            return module.named_modules(std::move(prefix));
-          },
-          py::arg("memo") = py::none(),
-          py::arg("prefix") = std::string())
-      .def_property_readonly("_modules", &nn::Module::children)
-      .def("children", &nn::Module::children)
-      .def("named_children", &nn::Module::named_children)
-      .def("to", [](nn::Module& module, py::object object, bool non_blocking) {
-            if (THPDevice_Check(object.ptr())) {
-              module.to(reinterpret_cast<THPDevice*>(object.ptr())->device, non_blocking);
-            } else {
-              module.to(py_object_to_dtype(object), non_blocking);
-            }
-          },
-          py::arg("dtype_or_device"),
-          py::arg("non_blocking") = false)
-      .def("to", [](nn::Module& module,
-                    py::object device,
-                    py::object dtype,
-                    bool non_blocking) {
-            module.to(
-                py_object_to_device(device),
-                py_object_to_dtype(dtype),
-                non_blocking);
-          },
-          py::arg("device"),
-          py::arg("dtype"),
-          py::arg("non_blocking") = false)
-      .def("cuda", [](nn::Module& module) { module.to(kCUDA); })
-      .def("cpu", [](nn::Module& module) { module.to(kCPU); })
-      .def("float", [](nn::Module& module) { module.to(kFloat32); })
-      .def("double", [](nn::Module& module) { module.to(kFloat64); })
-      .def("half", [](nn::Module& module) { module.to(kFloat16); })
-      .def("__str__", &nn::Module::name)
-      .def("__repr__", &nn::Module::name);
-  // clang-format on
+  py::class_<nn::Module, std::shared_ptr<nn::Module>>(nn, "Module");
 }
 } // namespace python
 } // namespace torch

--- a/torch/csrc/api/src/python/init.cpp
+++ b/torch/csrc/api/src/python/init.cpp
@@ -1,0 +1,150 @@
+#include <torch/python/init.h>
+
+#include <torch/nn/module.h>
+#include <torch/ordered_dict.h>
+
+#include <torch/csrc/utils/pybind.h>
+
+#include <torch/csrc/Device.h>
+#include <torch/csrc/Dtype.h>
+#include <torch/csrc/DynamicTypes.h>
+
+#include <string>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace pybind11 {
+namespace detail {
+#define ITEM_TYPE_CASTER(T, Name)                                             \
+  template <>                                                                 \
+  struct type_caster<typename torch::OrderedDict<std::string, T>::Item> {     \
+   public:                                                                    \
+    using Item = typename torch::OrderedDict<std::string, T>::Item;           \
+    using PairCaster = make_caster<std::pair<std::string, T>>;                \
+    PYBIND11_TYPE_CASTER(Item, _("Ordered" #Name "DictItem"));                \
+    bool load(handle src, bool convert) {                                     \
+      return PairCaster().load(src, convert);                                 \
+    }                                                                         \
+    static handle cast(Item src, return_value_policy policy, handle parent) { \
+      return PairCaster::cast(                                                \
+          src.pair(), std::move(policy), std::move(parent));                  \
+    }                                                                         \
+  }
+
+ITEM_TYPE_CASTER(torch::Tensor, Tensor);
+ITEM_TYPE_CASTER(std::shared_ptr<torch::nn::Module>, Module);
+} // namespace detail
+} // namespace pybind11
+
+namespace torch {
+namespace python {
+namespace {
+Device py_object_to_device(py::object object) {
+  PyObject* obj = object.ptr();
+  if (THPDevice_Check(obj)) {
+    return reinterpret_cast<THPDevice*>(obj)->device;
+  }
+  throw TypeError("Expected device");
+}
+Dtype py_object_to_dtype(py::object object) {
+  PyObject* obj = object.ptr();
+  if (THPDtype_Check(obj)) {
+    return reinterpret_cast<THPDtype*>(obj)->scalar_type;
+  }
+  throw TypeError("Expected dtype");
+}
+} // namespace
+
+template <typename T>
+void bind_ordered_dict(
+    py::module module,
+    const char* dict_name,
+    const char* item_name) {
+  using ODict = OrderedDict<std::string, T>;
+  // clang-format off
+  py::class_<ODict>(module, dict_name)
+      .def("items", &ODict::items)
+      .def("keys", &ODict::keys)
+      .def("values", &ODict::values)
+      .def("__iter__", [](const ODict& dict) {
+            return py::make_iterator(dict.begin(), dict.end());
+          }, py::keep_alive<0, 1>())
+      .def("__len__", &ODict::size)
+      .def("__contains__", &ODict::contains)
+      .def("__getitem__", [](const ODict& dict, const std::string& key) {
+        return dict[key];
+      })
+      .def("__getitem__", [](const ODict& dict, size_t index) {
+        return dict[index];
+      });
+  // clang-format on
+}
+
+void init_bindings(PyObject* module) {
+  py::module m = py::handle(module).cast<py::module>();
+  py::module cpp = m.def_submodule("cpp");
+
+  bind_ordered_dict<Tensor>(cpp, "OrderedTensorDict", "OrderedTensorDictItem");
+  bind_ordered_dict<std::shared_ptr<nn::Module>>(
+      cpp, "OrderedModuleDict", "OrderedModuleDictItem");
+
+  // clang-format off
+  py::module nn = cpp.def_submodule("nn");
+  py::class_<nn::Module, std::shared_ptr<nn::Module>>(nn, "Module")
+      .def("train", &nn::Module::train, py::arg("mode") = true)
+      .def("eval", &nn::Module::eval)
+      .def("clone", &nn::Module::clone)
+      .def_property_readonly("training", &nn::Module::is_training)
+      .def("zero_grad", &nn::Module::zero_grad)
+      .def_property_readonly("_parameters", [](nn::Module& module) {
+          return module.named_parameters(/*recurse=*/false);
+        })
+      .def("parameters", &nn::Module::parameters, py::arg("recurse") = true)
+      .def("named_parameters", &nn::Module::named_parameters, py::arg("recurse") = true)
+      .def_property_readonly("_buffers", [](nn::Module& module) {
+            return module.named_buffers(/*recurse=*/false);
+          })
+      .def("buffers", &nn::Module::buffers, py::arg("recurse") = true)
+      .def("named_buffers", &nn::Module::named_buffers, py::arg("recurse") = true)
+      .def("modules", &nn::Module::modules)
+      .def("named_modules", [](nn::Module& module, py::object memo, std::string prefix) {
+            return module.named_modules(std::move(prefix));
+          },
+          py::arg("memo") = py::none(),
+          py::arg("prefix") = std::string())
+      .def_property_readonly("_modules", &nn::Module::children)
+      .def("children", &nn::Module::children)
+      .def("named_children", &nn::Module::named_children)
+      .def("to", [](nn::Module& module, py::object object, bool non_blocking) {
+            if (THPDevice_Check(object.ptr())) {
+              module.to(reinterpret_cast<THPDevice*>(object.ptr())->device, non_blocking);
+            } else {
+              module.to(py_object_to_dtype(object), non_blocking);
+            }
+          },
+          py::arg("dtype_or_device"),
+          py::arg("non_blocking") = false)
+      .def("to", [](nn::Module& module,
+                    py::object device,
+                    py::object dtype,
+                    bool non_blocking) {
+            module.to(
+                py_object_to_device(device),
+                py_object_to_dtype(dtype),
+                non_blocking);
+          },
+          py::arg("device"),
+          py::arg("dtype"),
+          py::arg("non_blocking") = false)
+      .def("cuda", [](nn::Module& module) { module.to(kCUDA); })
+      .def("cpu", [](nn::Module& module) { module.to(kCPU); })
+      .def("float", [](nn::Module& module) { module.to(kFloat32); })
+      .def("double", [](nn::Module& module) { module.to(kFloat64); })
+      .def("half", [](nn::Module& module) { module.to(kFloat16); })
+      .def("__str__", &nn::Module::name)
+      .def("__repr__", &nn::Module::name);
+  // clang-format on
+}
+} // namespace python
+} // namespace torch

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -92,6 +92,7 @@ private:
   std::vector<int64_t> v_value;
 };
 
+// Pybind11 bindings for our optional type.
 // http://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
 template <typename T>
 struct type_caster<c10::optional<T>> : optional_caster<c10::optional<T>> {};

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -14,7 +14,6 @@ from .._jit_internal import createResolutionCallback, _compiled_weak_fns, \
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, \
     _list_with_default
 import torch.testing
-from torch.nn.modules.module import ModuleMeta
 
 import math
 from collections import defaultdict, OrderedDict, namedtuple
@@ -957,16 +956,7 @@ class ScriptMeta(type(torch._C.ScriptModule)):
 
 
 if _enabled:
-    class IntermediateMeta(ScriptMeta, ModuleMeta):
-        '''
-        An intermediate metaclass to combine the ScriptMeta and ModuleMeta metaclasses.
-        Required because ModuleMeta is the metaclass of torch.nn.Module, and ScriptMeta
-        the metaclass we want to give ScriptModule, but they need to resolve to a common,
-        intermediate metaclass first.
-        '''
-        pass
-
-    class ScriptModule(with_metaclass(IntermediateMeta, torch._C.ScriptModule, Module)):
+    class ScriptModule(with_metaclass(ScriptMeta, torch._C.ScriptModule, Module)):
         r"""
         The core data structure in TorchScript is the ``ScriptModule``. It is an
         analogue of torch's nn.Module and represents an entire model as a tree of

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -14,6 +14,8 @@ from .._jit_internal import createResolutionCallback, _compiled_weak_fns, \
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, \
     _list_with_default
 import torch.testing
+from torch.nn.modules.module import ModuleMeta
+
 import math
 from collections import defaultdict, OrderedDict, namedtuple
 import sys
@@ -955,7 +957,16 @@ class ScriptMeta(type(torch._C.ScriptModule)):
 
 
 if _enabled:
-    class ScriptModule(with_metaclass(ScriptMeta, torch._C.ScriptModule, Module)):
+    class IntermediateMeta(ScriptMeta, ModuleMeta):
+        '''
+        An intermediate metaclass to combine the ScriptMeta and ModuleMeta metaclasses.
+        Required because ModuleMeta is the metaclass of torch.nn.Module, and ScriptMeta
+        the metaclass we want to give ScriptModule, but they need to resolve to a common,
+        intermediate metaclass first.
+        '''
+        pass
+
+    class ScriptModule(with_metaclass(IntermediateMeta, torch._C.ScriptModule, Module)):
         r"""
         The core data structure in TorchScript is the ``ScriptModule``. It is an
         analogue of torch's nn.Module and represents an entire model as a tree of

--- a/torch/nn/cpp.py
+++ b/torch/nn/cpp.py
@@ -1,16 +1,18 @@
-'''Functionality for Python <-> C++ frontend inter-op.'''
+"""Functionality for Python <-> C++ frontend inter-op."""
 
 from torch import nn
 
+
 class OrderedDictWrapper(object):
-    '''
+    """
     A wrapper around a C++ OrderedDict that dynamically evaluates the
     OrderedDict getter on a bound C++ module, such that new changes on the C++
     side are picked up. Otherwise accessing e.g. ``cpp_module._parameters`` just
     once would get a frozen copy of the parameters at the time of access.
     ``torch.nn.Module`` accesses ``_parameters`` et al. via ``self.__dict__`` so
     using properties does not work.
-    '''
+    """
+
     def __init__(self, cpp_dict_getter):
         self.cpp_dict_getter = cpp_dict_getter
 
@@ -38,10 +40,11 @@ class OrderedDictWrapper(object):
 
 
 class ModuleWrapper(nn.Module):
-    '''
+    """
     A subclass of ``torch.nn.Module`` that wraps a C++ frontend module and
     delegates all access.
-    '''
+    """
+
     def __init__(self, cpp_module):
         # Assign before the super class constructor so ``self.training`` can be
         # assigned to in the super class constructor.

--- a/torch/nn/cpp.py
+++ b/torch/nn/cpp.py
@@ -1,0 +1,67 @@
+'''Functionality for Python <-> C++ frontend inter-op.'''
+
+from torch import nn
+
+class OrderedDictWrapper(object):
+    '''
+    A wrapper around a C++ OrderedDict that dynamically evaluates the
+    OrderedDict getter on a bound C++ module, such that new changes on the C++
+    side are picked up. Otherwise accessing e.g. ``cpp_module._parameters`` just
+    once would get a frozen copy of the parameters at the time of access.
+    ``torch.nn.Module`` accesses ``_parameters`` et al. via ``self.__dict__`` so
+    using properties does not work.
+    '''
+    def __init__(self, cpp_dict_getter):
+        self.cpp_dict_getter = cpp_dict_getter
+
+    @property
+    def cpp_dict(self):
+        return self.cpp_dict_getter()
+
+    # Magic methods cannot be assigned dynamically and bypass ``getattr``, so we
+    # must manually override them.
+
+    def __iter__(self):
+        return self.cpp_dict.__iter__()
+
+    def __len__(self):
+        return self.cpp_dict.__len__()
+
+    def __contains__(self, key):
+        return self.cpp_dict.__contains__(key)
+
+    def __getitem__(self, key):
+        return self.cpp_dict.__getitem__(key)
+
+    def __getattr__(self, name):
+        return getattr(self.cpp_dict, name)
+
+
+class ModuleWrapper(nn.Module):
+    '''
+    A subclass of ``torch.nn.Module`` that wraps a C++ frontend module and
+    delegates all access.
+    '''
+    def __init__(self, cpp_module):
+        # Assign before the super class constructor so ``self.training`` can be
+        # assigned to in the super class constructor.
+        self.cpp_module = cpp_module
+        super(ModuleWrapper, self).__init__()
+        self._parameters = OrderedDictWrapper(lambda: cpp_module._parameters)
+        self._buffers = OrderedDictWrapper(lambda: cpp_module._buffers)
+        self._modules = OrderedDictWrapper(lambda: cpp_module._modules)
+        for attr in dir(cpp_module):
+            # Skip magic methods and the three attributes above.
+            if not attr.startswith("_"):
+                setattr(self, attr, getattr(self.cpp_module, attr))
+
+    @property
+    def training(self):
+        return self.cpp_module.training
+
+    @training.setter
+    def training(self, mode):
+        self.cpp_module.train(mode)
+
+    def __repr__(self):
+        return self.cpp_module.__repr__()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -304,6 +304,7 @@ class Module(torch._six.with_metaclass(ModuleMeta)):
             Module: self
         """
         return self._apply(lambda t: t.cpu())
+
     def type(self, dst_type):
         r"""Casts all parameters and buffers to :attr:`dst_type`.
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -3,7 +3,6 @@ import functools
 import itertools
 
 import torch
-import torch._six
 from ..backends.thnn import backend as thnn_backend
 from ..parameter import Parameter
 import torch.utils.hooks as hooks
@@ -21,31 +20,6 @@ def _addindent(s_, numSpaces):
     return s
 
 
-class ModuleMeta(type):
-    '''
-    A metaclass for torch.nn.Module to enable isinstance(m, torch.nn.Module) to
-    return true when ``m`` is a C++ module bound into Python.
-    '''
-    def __instancecheck__(cls, instance):
-        # See https://docs.python.org/3/reference/
-        # datamodel.html#customizing-instance-and-subclass-checks
-        if isinstance(instance, torch.cpp.nn.Module):
-            return True
-        return super(ModuleMeta, cls).__instancecheck__(instance)
-
-
-def with_metaclass(metaclass, *bases):
-    '''
-    Creates a base class with a metaclass, but first creates an intermediary
-    metaclass derived from both the given ``metaclass``, and ``ModuleMeta``.
-    This is required anytime you subclass ``torch.nn.Module`` and give it a
-    different metaclass.
-    '''
-    class IntermediateMeta(ModuleMeta, metaclass):
-        pass
-    return torch._six.with_metaclass(IntermediateMeta, *bases)
-
-
 def _if_float_tensor(fn):
     '''
     Calls `fn` on a value `t` only if `t` is a float tensor, or not a tensor (in
@@ -58,7 +32,7 @@ def _if_float_tensor(fn):
     return apply
 
 
-class Module(torch._six.with_metaclass(ModuleMeta)):
+class Module(object):
     r"""Base class for all neural network modules.
 
     Your models should also subclass this class.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 
 import torch
+import torch._six
 from ..backends.thnn import backend as thnn_backend
 from ..parameter import Parameter
 import torch.utils.hooks as hooks
@@ -20,7 +21,19 @@ def _addindent(s_, numSpaces):
     return s
 
 
-class Module(object):
+class ModuleMeta(type):
+    '''
+    A metaclass for torch.nn.Module to enable isinstance(m, torch.nn.Module) to
+    return true when ``m`` is a C++ module bound into Python.
+    '''
+    def __instancecheck__(self, instance):
+        # See https://docs.python.org/3/reference/datamodel.html#customizing-instance-and-subclass-checks
+        if isinstance(instance, torch.cpp.nn.Module):
+            return True
+        return super(ModuleMeta, self).__instancecheck__(instance)
+
+
+class Module(torch._six.with_metaclass(ModuleMeta)):
     r"""Base class for all neural network modules.
 
     Your models should also subclass this class.

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -955,7 +955,7 @@ def _build_extension_module(name, build_directory, verbose):
         # error.output contains the stdout and stderr of the build attempt.
         message = "Error building extension '{}'".format(name)
         if hasattr(error, 'output') and error.output:
-            message += ": {}".format(error.output.decode())
+            message += ": {}".format(str(error.output))
         raise RuntimeError(message)
 
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -967,7 +967,7 @@ def _import_module_from_library(module_name, path, is_python_module):
         if is_python_module:
             return imp.load_module(module_name, file, path, description)
         else:
-            return torch.ops.load_library(path)
+            torch.ops.load_library(path)
 
 
 def _write_ninja_file(path,


### PR DESCRIPTION
This PR enables C++ frontend modules to be bound into Python and added as submodules of Python modules. For this, I added lots of pybind11 bindings for the `torch::nn::Module` class, and modified the `torch.nn.Module` class in Python to have a new Metaclass that makes `isinstance(m, torch.nn.Module)` return true when `m` is a C++ frontend module. The methods and fields of C++ modules are bound in such a way that they work seamlessly as submodules of Python modules for most operations (one exception I know of: calling `.to()` ends up calling `.apply()` on each submodule with a Python lambda, which cannot be used in C++ -- this may require small changes on Python side).

I've added quite a bunch of tests to verify the bindings and equality with Python. I think I should also try out adding a C++ module as part of some large PyTorch module, like a WLM or something, and see if everything works smoothly.

The next step for inter-op across our system is ScriptModule <-> C++ Frontend Module inter-op. I think this will then also allow using C++ frontend modules from TorchScript.

@apaszke @zdevito 

CC @dzhulgakov