### PR TITLE
 [jit] Convert functional dropouts to weak script

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8680,11 +8680,12 @@ EXCLUDE_SCRIPT = {
     'test_norm_nuc',
     # skipped nn functional tests
     # ops involves sampling which could not test
+
     # 'test_nn_dropout',
-    'test_nn_alpha_dropout',
-    'test_nn_dropout2d',
-    'test_nn_dropout3d',
-    'test_nn_feature_alpha_dropout',
+    # 'test_nn_alpha_dropout',
+    # 'test_nn_dropout2d',
+    # 'test_nn_dropout3d',
+    # 'test_nn_feature_alpha_dropout',
 
     'test_nn_adaptive_max_pool1d',
     'test_nn_adaptive_max_pool2d',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8681,12 +8681,6 @@ EXCLUDE_SCRIPT = {
     # skipped nn functional tests
     # ops involves sampling which could not test
 
-    # 'test_nn_dropout',
-    # 'test_nn_alpha_dropout',
-    # 'test_nn_dropout2d',
-    # 'test_nn_dropout3d',
-    # 'test_nn_feature_alpha_dropout',
-
     'test_nn_adaptive_max_pool1d',
     'test_nn_adaptive_max_pool2d',
     'test_nn_adaptive_max_pool3d',
@@ -8870,12 +8864,10 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
     # keep same rng state between calls
     initial_rng_state = torch.get_rng_state()
     # test no gradients case
-    torch.set_rng_state(initial_rng_state)
     outputs = reference_func(*nograd_inputs, **kwargs)
-
     torch.set_rng_state(initial_rng_state)
     outputs_test = func(*nograd_inputs, **kwargs)
-    torch.set_rng_state(initial_rng_state)
+
 
     self.assertEqual(outputs, outputs_test)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -378,7 +378,8 @@ class JitTestCase(TestCase):
         self.assertEqual(self.runAndSaveRNG(m.forward, inputs),
                          self.runAndSaveRNG(m_import.forward, inputs))
 
-    def runAndSaveRNG(self, func, inputs, kwargs={}):
+    def runAndSaveRNG(self, func, inputs, kwargs=None):
+        kwargs = kwargs if kwargs else {}
         initial_rng_state = torch.get_rng_state()
         results = func(*inputs, **kwargs)
         torch.set_rng_state(initial_rng_state)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -375,7 +375,12 @@ class JitTestCase(TestCase):
 
     def assertExportImportModule(self, m, inputs):
         m_import = self.getExportImportCopy(m)
-        self.assertEqual(m.forward(*inputs), m_import.forward(*inputs))
+        initial_rng_state = torch.get_rng_state()
+        results = m.forward(*inputs)
+        torch.set_rng_state(initial_rng_state)
+        imported_results = m_import.forward(*inputs)
+        torch.set_rng_state(initial_rng_state)
+        self.assertEqual(results, imported_results)
 
 
 class TestJit(JitTestCase):
@@ -8675,7 +8680,7 @@ EXCLUDE_SCRIPT = {
     'test_norm_nuc',
     # skipped nn functional tests
     # ops involves sampling which could not test
-    'test_nn_dropout',
+    # 'test_nn_dropout',
     'test_nn_alpha_dropout',
     'test_nn_dropout2d',
     'test_nn_dropout3d',
@@ -8861,19 +8866,28 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
     nograd_inputs, nograd_tensors = clone_inputs(False)
     recording_inputs, recording_tensors = clone_inputs(True)
 
+    # keep same rng state between calls
+    initial_rng_state = torch.get_rng_state()
     # test no gradients case
+    torch.set_rng_state(initial_rng_state)
     outputs = reference_func(*nograd_inputs, **kwargs)
+
+    torch.set_rng_state(initial_rng_state)
     outputs_test = func(*nograd_inputs, **kwargs)
+    torch.set_rng_state(initial_rng_state)
+
     self.assertEqual(outputs, outputs_test)
 
     if check_types:
         check_output_types(self, func, outputs_test, nograd_inputs, kwargs)
 
     # test single grad case
+    torch.set_rng_state(initial_rng_state)
     outputs = reference_func(*recording_inputs, **kwargs)
     grads = torch.autograd.grad(allSum(outputs), recording_tensors,
                                 allow_unused=allow_unused)
 
+    torch.set_rng_state(initial_rng_state)
     outputs_test = func(*recording_inputs, **kwargs)
     grads_test = torch.autograd.grad(allSum(outputs_test), recording_tensors,
                                      allow_unused=allow_unused)
@@ -8884,6 +8898,7 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
     if self._testMethodName in nn_functional_single_grad:
         return
 
+    torch.set_rng_state(initial_rng_state)
     outputs = reference_func(*recording_inputs, **kwargs)
     l1 = allSum(outputs)
     grads = torch.autograd.grad(l1, recording_tensors, create_graph=True,
@@ -8893,6 +8908,7 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
 
     recording_inputs, recording_tensors = clone_inputs(True)
 
+    torch.set_rng_state(initial_rng_state)
     outputs_test = func(*recording_inputs, **kwargs)
     l1_test = allSum(outputs_test)
     grads_test = torch.autograd.grad(
@@ -9429,6 +9445,7 @@ def add_nn_functional_test(name, self_size, args, skipTestIf=(), output_process_
 
     def do_test(self, name=name, args=args, test_name=test_name):
         torch.manual_seed(2)
+        initial_rng_state = torch.get_rng_state()
 
         self_variable = create_input((self_size,))[0][0]
 
@@ -9439,6 +9456,7 @@ def add_nn_functional_test(name, self_size, args, skipTestIf=(), output_process_
         args_tensor = deepcopy(unpack_variables(args_variable))
 
         output_variable = getattr(F, name)(self_variable, *args_variable, **kwargs_variable)
+        torch.set_rng_state(initial_rng_state)
 
         def fn(*inputs, **kwargs):
             output = getattr(F, name)(*inputs, **kwargs)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9431,7 +9431,6 @@ def add_nn_functional_test(name, self_size, args, skipTestIf=(), output_process_
 
     def do_test(self, name=name, args=args, test_name=test_name):
         torch.manual_seed(2)
-        initial_rng_state = torch.get_rng_state()
 
         self_variable = create_input((self_size,))[0][0]
 
@@ -9442,7 +9441,6 @@ def add_nn_functional_test(name, self_size, args, skipTestIf=(), output_process_
         args_tensor = deepcopy(unpack_variables(args_variable))
 
         output_variable = getattr(F, name)(self_variable, *args_variable, **kwargs_variable)
-        torch.set_rng_state(initial_rng_state)
 
         def fn(*inputs, **kwargs):
             output = getattr(F, name)(*inputs, **kwargs)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8867,8 +8867,6 @@ def check_against_reference(self, func, reference_func, args, kwargs=None, allow
     outputs = reference_func(*nograd_inputs, **kwargs)
     torch.set_rng_state(initial_rng_state)
     outputs_test = func(*nograd_inputs, **kwargs)
-
-
     self.assertEqual(outputs, outputs_test)
 
     if check_types:

--- a/torch/csrc/jit/fuser/config.h
+++ b/torch/csrc/jit/fuser/config.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define USE_CPU_FUSER 1
+#define USE_CUDA_FUSER 0

--- a/torch/csrc/jit/fuser/config.h
+++ b/torch/csrc/jit/fuser/config.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#define USE_CPU_FUSER 1
-#define USE_CUDA_FUSER 0

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1313,6 +1313,10 @@ _builtin_blacklist = {
     'prelu',
     'hardshrink',
     'dropout',
+    'alpha_dropout',
+    'dropout2d',
+    'dropout3d',
+    'feature_alpha_dropout',
 }
 
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1302,8 +1302,10 @@ _builtin_table = None
 
 _modules_containing_builtins = (torch, torch.nn.functional)
 
-# These functions don't have aten ops but have been converted to weak script, so
-# don't add them as builtins
+# These functions have been converted to weak script, so don't add them as
+# builtin aten ops. Instead, they will be compiled from the code in
+# torch.nn.functional when used.
+
 # TODO: delete this list, _should_skip(), and remove torch.nn.functional from
 # builtins list once everything in it has been converted to weak script
 _builtin_blacklist = {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1312,6 +1312,7 @@ _builtin_blacklist = {
     'pairwise_distance',
     'prelu',
     'hardshrink',
+    'dropout',
 }
 
 

--- a/torch/nn/_VF.py
+++ b/torch/nn/_VF.py
@@ -1,0 +1,10 @@
+import torch
+import sys
+import types
+
+
+class VFModule(types.ModuleType):
+    def __getattr__(self, attr):
+        return getattr(torch._C._VariableFunctions, attr)
+
+sys.modules[__name__] = VFModule(__name__)

--- a/torch/nn/_VF.py
+++ b/torch/nn/_VF.py
@@ -4,7 +4,11 @@ import types
 
 
 class VFModule(types.ModuleType):
+    def __init__(self, name):
+        super(VFModule, self).__init__(name)
+        self.vf = torch._C._VariableFunctions
+
     def __getattr__(self, attr):
-        return getattr(torch._C._VariableFunctions, attr)
+        return getattr(self.vf, attr)
 
 sys.modules[__name__] = VFModule(__name__)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -642,19 +642,26 @@ def dropout(input, p=0.5, training=True, inplace=False):
     return ret
 
 
+@torch._jit_internal.weak_script
 def alpha_dropout(input, p=0.5, training=False, inplace=False):
+    # type: (Tensor, float, bool, bool) -> Tensor
     r"""Applies alpha dropout to the input.
 
     See :class:`~torch.nn.AlphaDropout` for details.
     """
-    if p < 0 or p > 1:
+    if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    f = _VF.alpha_dropout_ if inplace else _VF.alpha_dropout
-    return f(input, p, training)
+    if inplace:
+        ret = _VF.alpha_dropout_(input, p, training)
+    else:
+        ret = _VF.alpha_dropout(input, p, training)
+    return ret
 
 
+@torch._jit_internal.weak_script
 def dropout2d(input, p=0.5, training=True, inplace=False):
+    # type: (Tensor, float, bool, bool) -> Tensor
     r"""
     Randomly zero out entire channels (a channel is a 2D feature map,
     e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
@@ -669,14 +676,19 @@ def dropout2d(input, p=0.5, training=True, inplace=False):
         training: apply dropout if is ``True``. Defualt: ``True``
         inplace: If set to ``True``, will do this operation in-place. Default: ``False``
     """
-    if p < 0 or p > 1:
+    if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    f = _VF.feature_dropout_ if inplace else _VF.feature_dropout
-    return f(input, p, training)
+    if inplace:
+        ret = _VF.feature_dropout_(input, p, training)
+    else:
+        ret = _VF.feature_dropout(input, p, training)
+    return ret
 
 
+@torch._jit_internal.weak_script
 def dropout3d(input, p=0.5, training=True, inplace=False):
+    # type: (Tensor, float, bool, bool) -> Tensor
     r"""
     Randomly zero out entire channels (a channel is a 3D feature map,
     e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
@@ -693,19 +705,27 @@ def dropout3d(input, p=0.5, training=True, inplace=False):
     """
     # This is 100% the same code as dropout2d. We duplicate this code so that
     # stack traces are not confusing.
-    if p < 0 or p > 1:
+    if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    f = _VF.feature_dropout_ if inplace else _VF.feature_dropout
-    return f(input, p, training)
+    if inplace:
+        ret = _VF.feature_dropout_(input, p, training)
+    else:
+        ret = _VF.feature_dropout(input, p, training)
+    return ret
 
 
+@torch._jit_internal.weak_script
 def feature_alpha_dropout(input, p=0.5, training=False, inplace=False):
-    if p < 0 or p > 1:
+    # type: (Tensor, float, bool, bool) -> Tensor
+    if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    f = _VF.feature_alpha_dropout_ if inplace else _VF.feature_alpha_dropout
-    return f(input, p, training)
+    if inplace:
+        ret = _VF.feature_alpha_dropout_(input, p, training)
+    else:
+        ret = _VF.feature_alpha_dropout(input, p, training)
+    return ret
 
 
 def threshold(input, threshold, value, inplace=False):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -626,11 +626,9 @@ def dropout(input, p=0.5, training=True, inplace=False):
     if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    if inplace:
-        ret = _VF.dropout_(input, p, training)
-    else:
-        ret = _VF.dropout(input, p, training)
-    return ret
+    return (_VF.dropout_(input, p, training)
+            if inplace
+            else _VF.dropout(input, p, training))
 
 
 @torch._jit_internal.weak_script
@@ -643,11 +641,9 @@ def alpha_dropout(input, p=0.5, training=False, inplace=False):
     if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    if inplace:
-        ret = _VF.alpha_dropout_(input, p, training)
-    else:
-        ret = _VF.alpha_dropout(input, p, training)
-    return ret
+    return (_VF.alpha_dropout_(input, p, training)
+            if inplace
+            else _VF.alpha_dropout(input, p, training))
 
 
 @torch._jit_internal.weak_script
@@ -670,11 +666,9 @@ def dropout2d(input, p=0.5, training=True, inplace=False):
     if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    if inplace:
-        ret = _VF.feature_dropout_(input, p, training)
-    else:
-        ret = _VF.feature_dropout(input, p, training)
-    return ret
+    return (_VF.feature_dropout_(input, p, training)
+            if inplace
+            else _VF.feature_dropout(input, p, training))
 
 
 @torch._jit_internal.weak_script
@@ -699,11 +693,9 @@ def dropout3d(input, p=0.5, training=True, inplace=False):
     if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    if inplace:
-        ret = _VF.feature_dropout_(input, p, training)
-    else:
-        ret = _VF.feature_dropout(input, p, training)
-    return ret
+    return (_VF.feature_dropout_(input, p, training)
+            if inplace
+            else _VF.feature_dropout(input, p, training))
 
 
 @torch._jit_internal.weak_script
@@ -712,11 +704,9 @@ def feature_alpha_dropout(input, p=0.5, training=False, inplace=False):
     if p < 0. or p > 1.:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
-    if inplace:
-        ret = _VF.feature_alpha_dropout_(input, p, training)
-    else:
-        ret = _VF.feature_alpha_dropout(input, p, training)
-    return ret
+    return (_VF.feature_alpha_dropout_(input, p, training)
+            if inplace
+            else _VF.feature_alpha_dropout(input, p, training))
 
 
 def threshold(input, threshold, value, inplace=False):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -15,17 +15,8 @@ from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
 from .modules.utils import _single, _pair, _triple, _list_with_default
 from . import grad
+from . import _VF
 from .._jit_internal import weak_script
-
-
-class _VFModule(types.ModuleType):
-    def __init__(self):
-        pass
-
-    def __getattr__(self, attr):
-        return getattr(torch._C._VariableFunctions, attr)
-
-_VF = _VFModule()
 
 
 class _Reduction:


### PR DESCRIPTION
To convert `nn.functional.dropout`
* `_VF` had to be exposed as a Python module so this PR adds a module class to forward to `torch._C._VariableFunctions`
* rng state between calls in the tests needed to be made consistent