### PR TITLE
Copy caffe2 layer_norm kernel to c10

### DIFF
--- a/caffe2/operators/experimental/c10/cpu/layer_norm_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/layer_norm_cpu.cc
@@ -1,0 +1,93 @@
+#include "caffe2/core/dispatch/KernelRegistration.h"
+#include "caffe2/operators/experimental/c10/schemas/layer_norm.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+using caffe2::Tensor;
+
+namespace caffe2 {
+namespace {
+
+template <typename T>
+void ComputeStdDevAndFusedParams(
+    const int N,
+    const T* mean,
+    const T* var,
+    T* stddev,
+    T* scale,
+    T* bias,
+    float epsilon) {
+  ConstEigenVectorArrayMap<T> var_arr(var, N);
+  EigenVectorArrayMap<T> stddev_arr(stddev, N);
+  EigenVectorArrayMap<T> scale_arr(scale, N);
+  scale_arr = (var_arr + static_cast<T>(epsilon)).rsqrt();
+  stddev_arr = scale_arr * (var_arr + static_cast<T>(epsilon));
+  EigenVectorArrayMap<T>(bias, N) =
+      -scale_arr * ConstEigenVectorArrayMap<T>(mean, N);
+}
+
+template <typename T>
+void LayerNormForward(
+    const int M,
+    const int N,
+    const T* X,
+    const T* scale,
+    const T* bias,
+    T* Y) {
+  EigenArrayMap<T>(Y, N, M) =
+      (ConstEigenArrayMap<T>(X, N, M).rowwise() *
+       ConstEigenVectorArrayMap<T>(scale, M).transpose())
+          .rowwise() +
+      ConstEigenVectorArrayMap<T>(bias, M).transpose();
+}
+
+template <class DataType>
+void layer_norm_impl(
+    const Tensor& X,
+    Tensor* Y,
+    Tensor* mean,
+    Tensor* sig,
+    int axis,
+    float epsilon,
+    ops::LayerNorm::Cache* cache,
+    BaseContext* context) {
+
+  CAFFE_ENFORCE_GE(X.ndim(), 2, "LayerNorm requires input dim >= 2.");
+  const int canonical_axis = X.canonical_axis_index(axis);
+  const int M = X.size_to_dim(canonical_axis);
+  const int N = X.size_from_dim(canonical_axis);
+  Y->ResizeLike(X);
+  std::vector<int> moments_dims(
+      X.dims().cbegin(), X.dims().cbegin() + canonical_axis);
+  moments_dims.push_back(1);
+  mean->Resize(moments_dims);
+  sig->Resize(moments_dims);
+  cache->scale.Resize(M);
+  cache->bias.Resize(M);
+
+  const DataType* X_data = X.template data<DataType>();
+  DataType* Y_data = Y->template mutable_data<DataType>();
+  DataType* mean_data = mean->template mutable_data<DataType>();
+  DataType* sig_data = sig->template mutable_data<DataType>();
+  DataType* scale_data = cache->scale.template mutable_data<DataType>();
+  DataType* bias_data = cache->bias.template mutable_data<DataType>();
+
+  const std::array<int, 2> dims = {M, N};
+  const int axis_ = 1;
+  math::Moments<DataType, CPUContext>(
+      2, dims.data(), 1, &axis_, X_data, mean_data, sig_data, static_cast<CPUContext*>(context));
+  ComputeStdDevAndFusedParams<DataType>(
+      M, mean_data, sig_data, sig_data, scale_data, bias_data, epsilon);
+  LayerNormForward<DataType>(M, N, X_data, scale_data, bias_data, Y_data);
+}
+} // namespace
+} // namespace caffe2
+
+namespace c10 {
+C10_REGISTER_KERNEL(caffe2::ops::LayerNorm)
+    .kernel(&caffe2::layer_norm_impl<float>)
+    .dispatchKey(c10::DispatchKey<1>{
+        c10::details::TensorParameterDispatchKey{DeviceTypeId::CPU,
+                                                 LayoutId(0),
+                                                 caffe2::TypeMeta::Id<float>()}});
+} // namespace c10

--- a/caffe2/operators/experimental/c10/schemas/layer_norm.cc
+++ b/caffe2/operators/experimental/c10/schemas/layer_norm.cc
@@ -1,0 +1,39 @@
+#include "caffe2/operators/experimental/c10/schemas/layer_norm.h"
+#include "caffe2/core/dispatch/OpSchemaRegistration.h"
+#include "caffe2/core/operator_c10wrapper.h"
+
+using caffe2::CPUContext;
+using caffe2::Tensor;
+
+C10_DEFINE_OP_SCHEMA(caffe2::ops::LayerNorm);
+
+namespace {
+
+struct AxisParameter final {
+  using type = int;
+  static constexpr const char* name() {
+    return "axis";
+  }
+  static constexpr int default_value() {
+    return 1;
+  }
+};
+struct EpsilonParameter final {
+  using type = float;
+  static constexpr const char* name() {
+    return "epsilon";
+  }
+  static constexpr float default_value() {
+    return 0.001f;
+  }
+};
+} // namespace
+
+namespace caffe2 {
+REGISTER_C10_OPERATOR_FOR_CAFFE2_DISPATCH_WITH_PARAMETERS(
+    ops::LayerNorm,
+    ops::LayerNorm::Cache,
+    C10LayerNorm_DontUseThisOpYet,
+    ParameterHelper<AxisParameter>,
+    ParameterHelper<EpsilonParameter>)
+}

--- a/caffe2/operators/experimental/c10/schemas/layer_norm.h
+++ b/caffe2/operators/experimental/c10/schemas/layer_norm.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "caffe2/core/tensor.h"
+#include <c10/util/Array.h>
+
+namespace caffe2 {
+namespace ops {
+
+struct LayerNorm final {
+  static constexpr const char* name = "LayerNorm";
+
+  struct Cache final {
+    Tensor scale = Tensor{CPU};
+    Tensor bias = Tensor{CPU};
+  };
+
+  using Signature = void(
+      const Tensor& input,
+      Tensor* output,
+      Tensor* output_mean,
+      Tensor* output_stddev,
+      int axis,
+      float epsilon,
+      Cache* cache,
+      BaseContext* context);
+
+  static constexpr c10::guts::array<const char*, 8> parameter_names = {
+      {"input", "output", "output_mean", "output_stddev", "axis", "epsilon", "cache", "context"}};
+};
+
+} // namespace ops
+} // namespace caffe2


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#13487 Copy caffe2 layer_norm kernel to c10**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12894386/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13488 Call c10 layer_norm from PyTorch&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12894385/)

This is step 1 of the plan to call the caffe2 layer_norm from PyTorch.
Step 2 (stacked on top) will call this c10 kernel from ATen.

Differential Revision: [D12894386](https://our.internmc.facebook.com/intern/diff/D12894386/)