### PR TITLE
Fix a few bugs in format and vararg handling

### DIFF
--- a/test/expect/TestScript.test_format-stdout.expect
+++ b/test/expect/TestScript.test_format-stdout.expect
@@ -1,1 +1,4 @@
 Hello, I'm a test
+format blank
+stuff before hi
+hi stuff after

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4175,6 +4175,9 @@ a")
     def test_format(self):
         def func(x):
             print("{}, I'm a {}".format("Hello", "test"))
+            print("format blank".format())
+            print("stuff before {}".format("hi"))
+            print("{} stuff after".format("hi"))
             return x + 1
 
         x = torch.arange(4., requires_grad=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9514,7 +9514,6 @@ def add_nn_module_test(module_name, constructor_args, call_args, skipTestIf=()):
             call_args_str = ', '.join(actuals)
             call = "self.submodule({})".format(call_args_str)
             script = script_method_template.format(method_args, call)
-            print(script)
 
             # Create module to use the script method
             class TheModule(torch.jit.ScriptModule):

--- a/torch/csrc/jit/function_schema.h
+++ b/torch/csrc/jit/function_schema.h
@@ -157,10 +157,13 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
       out << "*, ";
       seen_kwarg_only = true;
     }
-    if (schema.is_vararg() && i == schema.arguments().size() - 1) {
-      out << "*";
-    }
     out << schema.arguments()[i];
+  }
+
+  if(schema.is_vararg()) {
+    if(schema.arguments().size() > 0)
+      out << ", ";
+    out << "...";
   }
 
   out << ") -> ";

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -25,19 +25,13 @@ struct SchemaParser {
     bool is_vararg = false;
     size_t idx = 0;
     parseList('(', ',', ')', [&] {
+      if(is_vararg)
+        throw ErrorReport(L.cur()) << "... must be the last element of the argument list";
       if (L.nextIf('*')) {
-        auto tok = L.cur();
-        if (tok.kind == TK_IDENT) {
-          is_vararg = true;
-          arguments.push_back(parseArgument(
-              idx++, /*is_return=*/false, /*kwarg_only=*/kwarg_only, writes));
-        } else {
-          kwarg_only = true;
-        }
+        kwarg_only = true;
+      } else if(L.nextIf(TK_DOTS)) {
+        is_vararg = true;
       } else {
-        if (is_vararg) {
-          AT_ERROR("Found argument after varargs declaration");
-        }
         arguments.push_back(parseArgument(
             idx++, /*is_return=*/false, /*kwarg_only=*/kwarg_only, writes));
       }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -620,18 +620,16 @@ c10::optional<MatchedSchema> tryMatchSchema(
     if (!positional)
       return c10::nullopt;
     positional_inputs.push_back(positional);
-
-    if (schema.is_vararg() && schema_i == schema.arguments().size() - 1) {
-      // Freeze iteration to the last argument in the schema and keep going for
-      // all of the provided arguments
-      if (used_args < args.size()) {
-        schema_i--;
-      }
-    }
   }
   // check for unused self argument
   if(self != c10::nullopt) {
     err() << "provided self argument not used in schema\n";
+  }
+
+  if (schema.is_vararg()) {
+    for(;used_args < args.size(); ++used_args) {
+      positional_inputs.push_back(args[used_args].value(graph));
+    }
   }
 
   // check for unused positional arguments

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -88,7 +88,8 @@ namespace script {
   _(TK_SLICE_EXPR, "slice expr", "")             \
   _(TK_TYPE_COMMENT, "type comment", "# type:")  \
   _(TK_RAISE, "raise", "raise")                  \
-  _(TK_ASSERT, "assert", "assert")
+  _(TK_ASSERT, "assert", "assert")               \
+  _(TK_DOTS, "dots", "...")
 
 
 static const char* valid_single_char_tokens = "+-*/%@()[]:,={}><.?!";


### PR DESCRIPTION
There are a couple subtle bugs in the way varargs is implemented:

1. it fails if you pass 0 arguments, because it doesn't handle the case when there are 0 varargs, and because Operator::matches was not updated.
2. it breaks all the named-based lookups on nodes. For instance node->get<int>(attr::value)
   will return a single entry of the varargs if you look it up by name.

Furthermore it complicates some assumptions about the positional arguments (e.g. they use to be
1-to-1 with node inputs but with varargs they are not).

Because varargs are only being used for format, this diff instead
just allows format to take any value as input, regardless of type. It just provides a way to set is_vararg
from the schema but does not restrict the type of the varargs things. This is inline with
the pre-existing behavior for is_vararg so it doesn't require Operator::matches changes.

This also keeps format inline with how print works, and is closer to the python implementation of format. Note that the implementation
of format already worked with arbitrary IValues so restricting to strings was just making it more conservative than needed.

This also fixes the implementation of format to work when there are 0 arguments or text before and after a format string, where it would not print things.