### PR TITLE
Do not fill in new data in every iteration if the input data only has one entry

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -203,6 +203,12 @@ void fillInputBlob(
     }
     // todo: support gpu and make this function a tempalte
     int protos_size = tensor_kv.second.protos_size();
+    if (protos_size == 1 && iteration > 0) {
+      // Do not override the input data if there is only one input data,
+      // since it will clear all caches. Rely on wipe_cache to
+      // clear caches
+      continue;
+    }
     caffe2::TensorProto* tensor_proto =
         tensor_kv.second.mutable_protos(iteration % protos_size);
     if (tensor_proto->data_type() == caffe2::TensorProto::STRING) {


### PR DESCRIPTION
Summary:
If the user has one data file to put in, the data is filled up in every iteration,
which actually flushes the caches. The retrieved latency is larger than the latency
when the caches are warm. Instead of doing that, we should only rely on wipe_cache
variable to wipe the caches.

The change is to skip filling the data if the input only has one size and it is
not the first iteration

Differential Revision: D12897946
