### PR TITLE
Fix the bug when compile using nvcc compiler.

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -230,6 +230,8 @@ class BuildExtension(build_ext):
                 original_compiler = self.compiler.compiler_so
                 if _is_cuda_file(src):
                     nvcc = _join_cuda_home('bin', 'nvcc')
+                    if not isinstance(nvcc, list):
+                        nvcc = [nvcc]
                     self.compiler.set_executable('compiler_so', nvcc)
                     if isinstance(cflags, dict):
                         cflags = cflags['nvcc']


### PR DESCRIPTION
I found a bug about compiling the cuda file when I install maskrcnn-benchmark lib.

`python setup.py build develop` will throw the error:
```
  File "/usr/local/lib/python2.7/dist-packages/torch/utils/cpp_extension.py", line 214, in unix_wrap_compile
    original_compile(obj, src, ext, cc_args, cflags, pp_opts)
  File "/usr/lib/python2.7/distutils/unixccompiler.py", line 125, in _compile
    self.spawn(compiler_so + cc_args + [src, '-o', obj] +
TypeError: coercing to Unicode: need string or buffer, list found
```

For more information, please see [issue](https://github.com/facebookresearch/maskrcnn-benchmark/issues/99).

