### PR TITLE
CircleCI: disable output buffering to better locate test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ setup_ci_environment: &setup_ci_environment
       linux-headers-$(uname -r) \
       linux-image-generic \
       moreutils \
-      nvidia-docker2
+      nvidia-docker2 \
+      expect-dev
 
     sudo pkill -SIGHUP dockerd
 
@@ -99,7 +100,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
         export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -q -c "${COMMAND}" /dev/null | ts
+        echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -132,7 +133,7 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
         else
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         fi
-        script -q -c "${COMMAND}" /dev/null | ts
+        echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
 caffe2_linux_build_defaults: &caffe2_linux_build_defaults
   resource_class: large
@@ -200,7 +201,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
         export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -q -c "${COMMAND}" /dev/null | ts
+        echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -281,7 +282,7 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
 
         export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_test_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -q -c "${COMMAND}" /dev/null | ts
+        echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
 caffe2_macos_build_defaults: &caffe2_macos_build_defaults
   macos:
@@ -299,6 +300,8 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
           # moreutils installs a `parallel` executable by default, which conflicts with the executable from the `parallel` formulae
           brew install moreutils --without-parallel
           brew install cmake
+
+          brew install expect
 
           # Reinitialize submodules
           git submodule sync && git submodule update -q --init --recursive
@@ -346,12 +349,12 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
 
           # Build
           if [ "${BUILD_IOS:-0}" -eq 1 ]; then
-            script -q /dev/null scripts/build_ios.sh 2>&1 | ts
+            unbuffer scripts/build_ios.sh 2>&1 | ts
           elif [ -n "${CAFFE2_USE_ANACONDA}" ]; then
             # All conda build logic should be in scripts/build_anaconda.sh
-            script -q /dev/null scripts/build_anaconda.sh 2>&1 | ts
+            unbuffer scripts/build_anaconda.sh 2>&1 | ts
           else
-            script -q /dev/null scripts/build_local.sh 2>&1 | ts
+            unbuffer scripts/build_local.sh 2>&1 | ts
           fi
 
           # Show sccache stats if it is running
@@ -592,7 +595,7 @@ jobs:
           docker cp /home/circleci/project/env $id:/var/lib/jenkins/workspace/env
 
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          script -q -c "${COMMAND}" /dev/null | ts
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
   pytorch_doc_push:
     environment:
@@ -669,7 +672,7 @@ jobs:
           docker cp /home/circleci/project/doc_push_script.sh $id:/var/lib/jenkins/workspace/doc_push_script.sh
 
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          script -q -c "${COMMAND}" /dev/null | ts
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
   pytorch_macos_10_13_py3_build:
     macos:
@@ -700,7 +703,7 @@ jobs:
 
             git submodule sync && git submodule update -q --init
             chmod a+x .jenkins/pytorch/macos-build.sh
-            script -q /dev/null .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
 
             mkdir -p /Users/distiller/pytorch-ci-env/workspace
             cp -r /Users/distiller/project/. /Users/distiller/pytorch-ci-env/workspace
@@ -735,7 +738,7 @@ jobs:
             cp -r /Users/distiller/pytorch-ci-env/workspace/. /Users/distiller/project
 
             chmod a+x .jenkins/pytorch/macos-test.sh
-            script -q /dev/null .jenkins/pytorch/macos-test.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
 
   pytorch_macos_10_13_cuda9_2_cudnn7_py3_build:
     macos:
@@ -782,7 +785,7 @@ jobs:
 
             git submodule sync && git submodule update -q --init
             chmod a+x .jenkins/pytorch/macos-build.sh
-            script -q /dev/null .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
 
   caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
         export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -c "${COMMAND}" /dev/null | ts
+        script -q -c "${COMMAND}" /dev/null | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -123,16 +123,16 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
         echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
         docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
         if [ -n "${CUDA_VERSION}" ]; then
-          id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         else
-          id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         fi
         if [ -n "${MULTI_GPU}" ]; then
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/multigpu-test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         else
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         fi
-        script -c "${COMMAND}" /dev/null | ts
+        script -q -c "${COMMAND}" /dev/null | ts
 
 caffe2_linux_build_defaults: &caffe2_linux_build_defaults
   resource_class: large
@@ -200,7 +200,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
         export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -c "${COMMAND}" /dev/null | ts
+        script -q -c "${COMMAND}" /dev/null | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -274,14 +274,14 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
         docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
         if [ -n "${CUDA_VERSION}" ]; then
-          id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         else
-          id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         fi
         docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
 
         export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_test_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-        script -c "${COMMAND}" /dev/null | ts
+        script -q -c "${COMMAND}" /dev/null | ts
 
 caffe2_macos_build_defaults: &caffe2_macos_build_defaults
   macos:
@@ -583,7 +583,7 @@ jobs:
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
-          id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run --runtime=nvidia -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
 
           docker cp $id:/var/lib/jenkins/workspace/env /home/circleci/project/env
           # This IAM user allows write access to S3 bucket for perf test numbers
@@ -592,7 +592,7 @@ jobs:
           docker cp /home/circleci/project/env $id:/var/lib/jenkins/workspace/env
 
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          script -c "${COMMAND}" /dev/null | ts
+          script -q -c "${COMMAND}" /dev/null | ts
 
   pytorch_doc_push:
     environment:
@@ -616,7 +616,7 @@ jobs:
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
-          id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          export id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
 
           cat >/home/circleci/project/doc_push_script.sh <<EOL
           # =================== The following code will be executed inside Docker container ===================
@@ -669,7 +669,7 @@ jobs:
           docker cp /home/circleci/project/doc_push_script.sh $id:/var/lib/jenkins/workspace/doc_push_script.sh
 
           export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          script -c "${COMMAND}" /dev/null | ts
+          script -q -c "${COMMAND}" /dev/null | ts
 
   pytorch_macos_10_13_py3_build:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        ((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        script -c "${COMMAND}" /dev/null | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -127,10 +128,11 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
           id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         fi
         if [ -n "${MULTI_GPU}" ]; then
-          ((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/multigpu-test.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/multigpu-test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         else
-          ((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         fi
+        script -c "${COMMAND}" /dev/null | ts
 
 caffe2_linux_build_defaults: &caffe2_linux_build_defaults
   resource_class: large
@@ -197,7 +199,8 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         export id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        ((echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        script -c "${COMMAND}" /dev/null | ts
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
@@ -277,7 +280,8 @@ caffe2_linux_test_defaults: &caffe2_linux_test_defaults
         fi
         docker cp /home/circleci/project/. "$id:/var/lib/jenkins/workspace"
 
-        ((echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && ./ci_test_script.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_test_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        script -c "${COMMAND}" /dev/null | ts
 
 caffe2_macos_build_defaults: &caffe2_macos_build_defaults
   macos:
@@ -342,12 +346,12 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
 
           # Build
           if [ "${BUILD_IOS:-0}" -eq 1 ]; then
-            scripts/build_ios.sh 2>&1 | ts
+            script -q /dev/null scripts/build_ios.sh 2>&1 | ts
           elif [ -n "${CAFFE2_USE_ANACONDA}" ]; then
             # All conda build logic should be in scripts/build_anaconda.sh
-            scripts/build_anaconda.sh 2>&1 | ts
+            script -q /dev/null scripts/build_anaconda.sh 2>&1 | ts
           else
-            scripts/build_local.sh 2>&1 | ts
+            script -q /dev/null scripts/build_local.sh 2>&1 | ts
           fi
 
           # Show sccache stats if it is running
@@ -587,7 +591,8 @@ jobs:
           echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_PERF_TEST_S3_BUCKET_V2}" >> /home/circleci/project/env
           docker cp /home/circleci/project/env $id:/var/lib/jenkins/workspace/env
 
-          ((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          script -c "${COMMAND}" /dev/null | ts
 
   pytorch_doc_push:
     environment:
@@ -663,7 +668,8 @@ jobs:
           chmod +x /home/circleci/project/doc_push_script.sh
           docker cp /home/circleci/project/doc_push_script.sh $id:/var/lib/jenkins/workspace/doc_push_script.sh
 
-          ((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo 'sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh') | docker exec -u jenkins -i "$id" bash) 2>&1 | ts
+          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          script -c "${COMMAND}" /dev/null | ts
 
   pytorch_macos_10_13_py3_build:
     macos:
@@ -694,7 +700,7 @@ jobs:
 
             git submodule sync && git submodule update -q --init
             chmod a+x .jenkins/pytorch/macos-build.sh
-            .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            script -q /dev/null .jenkins/pytorch/macos-build.sh 2>&1 | ts
 
             mkdir -p /Users/distiller/pytorch-ci-env/workspace
             cp -r /Users/distiller/project/. /Users/distiller/pytorch-ci-env/workspace
@@ -729,7 +735,7 @@ jobs:
             cp -r /Users/distiller/pytorch-ci-env/workspace/. /Users/distiller/project
 
             chmod a+x .jenkins/pytorch/macos-test.sh
-            .jenkins/pytorch/macos-test.sh 2>&1 | ts
+            script -q /dev/null .jenkins/pytorch/macos-test.sh 2>&1 | ts
 
   pytorch_macos_10_13_cuda9_2_cudnn7_py3_build:
     macos:
@@ -776,7 +782,7 @@ jobs:
 
             git submodule sync && git submodule update -q --init
             chmod a+x .jenkins/pytorch/macos-build.sh
-            .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            script -q /dev/null .jenkins/pytorch/macos-build.sh 2>&1 | ts
 
   caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && cat /fdafjdajfoadpfja") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
@@ -200,7 +200,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         export id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && cat /fdafjdajfoadpfja") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
@@ -954,65 +954,65 @@ workflows:
       - pytorch_linux_trusty_py2_7_9_test:
           requires:
             - pytorch_linux_trusty_py2_7_9_build
-      - pytorch_linux_trusty_py2_7_build
-      - pytorch_linux_trusty_py2_7_test:
-          requires:
-            - pytorch_linux_trusty_py2_7_build
-      - pytorch_linux_trusty_py3_5_build
-      - pytorch_linux_trusty_py3_5_test:
-          requires:
-            - pytorch_linux_trusty_py3_5_build
-      - pytorch_linux_trusty_py3_6_gcc4_8_build
-      - pytorch_linux_trusty_py3_6_gcc4_8_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc4_8_build
-      - pytorch_linux_trusty_py3_6_gcc5_4_build
-      - pytorch_linux_trusty_py3_6_gcc5_4_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc5_4_build
-      - pytorch_linux_trusty_py3_6_gcc7_build
-      - pytorch_linux_trusty_py3_6_gcc7_test:
-          requires:
-            - pytorch_linux_trusty_py3_6_gcc7_build
-      - pytorch_linux_trusty_pynightly_build
-      - pytorch_linux_trusty_pynightly_test:
-          requires:
-            - pytorch_linux_trusty_pynightly_build
-      - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_py3_clang5_asan_test:
-          requires:
-            - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_short_perf_test_gpu:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_doc_push:
-          requires:
-            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
-      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
-          requires:
-            - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      # - pytorch_linux_trusty_py2_7_build
+      # - pytorch_linux_trusty_py2_7_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py2_7_build
+      # - pytorch_linux_trusty_py3_5_build
+      # - pytorch_linux_trusty_py3_5_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_5_build
+      # - pytorch_linux_trusty_py3_6_gcc4_8_build
+      # - pytorch_linux_trusty_py3_6_gcc4_8_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc4_8_build
+      # - pytorch_linux_trusty_py3_6_gcc5_4_build
+      # - pytorch_linux_trusty_py3_6_gcc5_4_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc5_4_build
+      # - pytorch_linux_trusty_py3_6_gcc7_build
+      # - pytorch_linux_trusty_py3_6_gcc7_test:
+      #     requires:
+      #       - pytorch_linux_trusty_py3_6_gcc7_build
+      # - pytorch_linux_trusty_pynightly_build
+      # - pytorch_linux_trusty_pynightly_test:
+      #     requires:
+      #       - pytorch_linux_trusty_pynightly_build
+      # - pytorch_linux_xenial_py3_clang5_asan_build
+      # - pytorch_linux_xenial_py3_clang5_asan_test:
+      #     requires:
+      #       - pytorch_linux_xenial_py3_clang5_asan_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_short_perf_test_gpu:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_doc_push:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      # - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
+      #     requires:
+      #       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
 
       # - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_py3_test:
@@ -1024,31 +1024,31 @@ workflows:
       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
           requires:
             - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      - caffe2_py2_mkl_ubuntu16_04_build
-      - caffe2_py2_mkl_ubuntu16_04_test:
-          requires:
-            - caffe2_py2_mkl_ubuntu16_04_build
-      - caffe2_py2_gcc4_8_ubuntu14_04_build
-      - caffe2_py2_gcc4_8_ubuntu14_04_test:
-          requires:
-            - caffe2_py2_gcc4_8_ubuntu14_04_build
-      - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
-          requires:
-            - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
-      - caffe2_py2_clang3_8_ubuntu16_04_build
-      - caffe2_py2_clang3_9_ubuntu16_04_build
-      - caffe2_py2_android_ubuntu16_04_build
-      - caffe2_py2_cuda9_0_cudnn7_centos7_build
+      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_mkl_ubuntu16_04_build
+      # - caffe2_py2_mkl_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_py2_mkl_ubuntu16_04_build
+      # - caffe2_py2_gcc4_8_ubuntu14_04_build
+      # - caffe2_py2_gcc4_8_ubuntu14_04_test:
+      #     requires:
+      #       - caffe2_py2_gcc4_8_ubuntu14_04_build
+      # - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      # - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
+      #     requires:
+      #       - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      # - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
+      # - caffe2_py2_clang3_8_ubuntu16_04_build
+      # - caffe2_py2_clang3_9_ubuntu16_04_build
+      # - caffe2_py2_android_ubuntu16_04_build
+      # - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
       # - caffe2_py2_ios_macos10_13_build
       # - caffe2_py2_system_macos10_13_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && cat /fdafjdajfoadpfja") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
@@ -200,7 +200,7 @@ caffe2_linux_build_defaults: &caffe2_linux_build_defaults
         export id=$(docker run -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && cat /fdafjdajfoadpfja") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./ci_build_script.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
@@ -954,65 +954,65 @@ workflows:
       - pytorch_linux_trusty_py2_7_9_test:
           requires:
             - pytorch_linux_trusty_py2_7_9_build
-      # - pytorch_linux_trusty_py2_7_build
-      # - pytorch_linux_trusty_py2_7_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py2_7_build
-      # - pytorch_linux_trusty_py3_5_build
-      # - pytorch_linux_trusty_py3_5_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_5_build
-      # - pytorch_linux_trusty_py3_6_gcc4_8_build
-      # - pytorch_linux_trusty_py3_6_gcc4_8_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc4_8_build
-      # - pytorch_linux_trusty_py3_6_gcc5_4_build
-      # - pytorch_linux_trusty_py3_6_gcc5_4_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc5_4_build
-      # - pytorch_linux_trusty_py3_6_gcc7_build
-      # - pytorch_linux_trusty_py3_6_gcc7_test:
-      #     requires:
-      #       - pytorch_linux_trusty_py3_6_gcc7_build
-      # - pytorch_linux_trusty_pynightly_build
-      # - pytorch_linux_trusty_pynightly_test:
-      #     requires:
-      #       - pytorch_linux_trusty_pynightly_build
-      # - pytorch_linux_xenial_py3_clang5_asan_build
-      # - pytorch_linux_xenial_py3_clang5_asan_test:
-      #     requires:
-      #       - pytorch_linux_xenial_py3_clang5_asan_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_short_perf_test_gpu:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_doc_push:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda8_cudnn6_py3_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      # - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
-      # - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
-      #     requires:
-      #       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      - pytorch_linux_trusty_py2_7_build
+      - pytorch_linux_trusty_py2_7_test:
+          requires:
+            - pytorch_linux_trusty_py2_7_build
+      - pytorch_linux_trusty_py3_5_build
+      - pytorch_linux_trusty_py3_5_test:
+          requires:
+            - pytorch_linux_trusty_py3_5_build
+      - pytorch_linux_trusty_py3_6_gcc4_8_build
+      - pytorch_linux_trusty_py3_6_gcc4_8_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc4_8_build
+      - pytorch_linux_trusty_py3_6_gcc5_4_build
+      - pytorch_linux_trusty_py3_6_gcc5_4_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc5_4_build
+      - pytorch_linux_trusty_py3_6_gcc7_build
+      - pytorch_linux_trusty_py3_6_gcc7_test:
+          requires:
+            - pytorch_linux_trusty_py3_6_gcc7_build
+      - pytorch_linux_trusty_pynightly_build
+      - pytorch_linux_trusty_pynightly_test:
+          requires:
+            - pytorch_linux_trusty_pynightly_build
+      - pytorch_linux_xenial_py3_clang5_asan_build
+      - pytorch_linux_xenial_py3_clang5_asan_test:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_asan_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_multigpu_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX2_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn6_py3_NO_AVX_NO_AVX2_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_short_perf_test_gpu:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_doc_push:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn6_py3_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda9_cudnn7_py3_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+      - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
+          requires:
+            - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
 
       # - pytorch_macos_10_13_py3_build
       # - pytorch_macos_10_13_py3_test:
@@ -1024,31 +1024,31 @@ workflows:
       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
           requires:
             - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_mkl_ubuntu16_04_build
-      # - caffe2_py2_mkl_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_py2_mkl_ubuntu16_04_build
-      # - caffe2_py2_gcc4_8_ubuntu14_04_build
-      # - caffe2_py2_gcc4_8_ubuntu14_04_test:
-      #     requires:
-      #       - caffe2_py2_gcc4_8_ubuntu14_04_build
-      # - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      # - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
-      #     requires:
-      #       - caffe2_onnx_py2_gcc5_ubuntu16_04_build
-      # - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
-      # - caffe2_py2_clang3_8_ubuntu16_04_build
-      # - caffe2_py2_clang3_9_ubuntu16_04_build
-      # - caffe2_py2_android_ubuntu16_04_build
-      # - caffe2_py2_cuda9_0_cudnn7_centos7_build
+      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build
+      - caffe2_py2_mkl_ubuntu16_04_build
+      - caffe2_py2_mkl_ubuntu16_04_test:
+          requires:
+            - caffe2_py2_mkl_ubuntu16_04_build
+      - caffe2_py2_gcc4_8_ubuntu14_04_build
+      - caffe2_py2_gcc4_8_ubuntu14_04_test:
+          requires:
+            - caffe2_py2_gcc4_8_ubuntu14_04_build
+      - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      - caffe2_onnx_py2_gcc5_ubuntu16_04_test:
+          requires:
+            - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+      - caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build
+      - caffe2_py2_clang3_8_ubuntu16_04_build
+      - caffe2_py2_clang3_9_ubuntu16_04_build
+      - caffe2_py2_android_ubuntu16_04_build
+      - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
       # - caffe2_py2_ios_macos10_13_build
       # - caffe2_py2_system_macos10_13_build


### PR DESCRIPTION
ASAN test timeout such as https://circleci.com/gh/pytorch/pytorch/165649?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link doesn't actually show where the timeout happened because of the bash output buffering. This PR turns off the buffering to better surface the error. 