### PR TITLE
Reslove lint and infer warning

### DIFF
--- a/caffe2/operators/quantized/server/caffe2_dnnlowp_utils.h
+++ b/caffe2/operators/quantized/server/caffe2_dnnlowp_utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "caffe2/core/operator.h"
-#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/operators/quantized/server/dnnlowp.h"
+#include "caffe2/utils/eigen_utils.h"
 
 namespace dnnlowp {
 

--- a/caffe2/operators/quantized/server/conv_dnnlowp_op.h
+++ b/caffe2/operators/quantized/server/conv_dnnlowp_op.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <fbgemm/Fbgemm.h>
+#include <fbgemm/src/FbgemmI8Depthwise.h>
 #include "caffe2/operators/conv_op.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 #include "caffe2/operators/quantized/server/caffe2_dnnlowp_utils.h"
 #include "caffe2/operators/quantized/server/conv_pool_dnnlowp_op_base.h"
 #include "caffe2/operators/quantized/server/dnnlowp.h"
-#include <fbgemm/Fbgemm.h>
-#include <fbgemm/src/FbgemmI8Depthwise.h>
 #include "caffe2/operators/quantized/server/op_wrapper.h"
 
 namespace caffe2 {

--- a/caffe2/operators/quantized/server/dnnlowp.h
+++ b/caffe2/operators/quantized/server/dnnlowp.h
@@ -8,8 +8,8 @@
 
 #include <x86intrin.h>
 
-#include "caffe2/utils/cpuid.h"
 #include "caffe2/operators/quantized/server/dynamic_histogram.h"
+#include "caffe2/utils/cpuid.h"
 
 namespace dnnlowp {
 

--- a/caffe2/operators/quantized/server/elementwise_add_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/elementwise_add_dnnlowp_op.cc
@@ -1,7 +1,7 @@
-#include "caffe2/caffe2/operators/elementwise_add_op.h"
+#include "caffe2/operators/elementwise_add_op.h"
+#include "caffe2/operators/quantized/server/sigmoid.h"
 #include "elementwise_dnnlowp_op.h"
 #include "op_wrapper.h"
-#include "caffe2/operators/quantized/server/sigmoid.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/quantized/server/group_norm_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/group_norm_dnnlowp_op.cc
@@ -7,8 +7,8 @@
 
 #include <omp.h>
 
-#include "caffe2/caffe2/utils/eigen_utils.h"
-#include "caffe2/caffe2/utils/math.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/quantized/server/tanh.cc
+++ b/caffe2/operators/quantized/server/tanh.cc
@@ -23,7 +23,6 @@ static int GetPassRegionEnd_(
 
   // largest x s.t. |tanh(x) - x| < max_abs_err_
   int in_pos_qmax = (1 << (num_in_bits - 1)) - 1;
-  float quantization_error = out_qparams.scale/2;
 
   float scale_multiplier = in_qparams.scale / out_qparams.scale;
   int log2_scale_multiplier = (int)round(log2(scale_multiplier));


### PR DESCRIPTION
Summary: Reslove lint and infer warning shown in the dnnlowp migration diff.

Differential Revision: D12905972
