### PR TITLE
Remove partially initialized Tensor + ShareData

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -24,6 +24,10 @@ inline bool BlobIsTensorType(const Blob& blob, DeviceType device_type) {
   return tensor && *tensor && tensor->GetDeviceType() == device_type;
 }
 
+inline Tensor* BlobSetTensor(Blob* blob, const Tensor& tensor) {
+  return blob->Reset<Tensor>(new Tensor(tensor));
+}
+
 inline Tensor*
 BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
   if (blob->IsType<Tensor>()) {
@@ -38,7 +42,7 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
           tensor->raw_mutable_data();
         } else {
           // create a new Tensor when the data_type doesn't match
-          return blob->Reset<Tensor>(new Tensor(caffe2::empty(dims, options)));
+          return BlobSetTensor(blob, caffe2::empty(dims, options));
         }
         return tensor;
       }
@@ -49,7 +53,7 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
   VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<Tensor>()
           << " dims: " << dims;
   // << " options: " << options; (operator<< for Options is in at:: now)
-  return blob->Reset<Tensor>(new Tensor(caffe2::empty(dims, options)));
+  return BlobSetTensor(blob, caffe2::empty(dims, options));
 }
 
 inline Tensor* BlobGetMutableTensor(Blob* blob, DeviceType device_type) {
@@ -64,7 +68,8 @@ inline Tensor* BlobGetMutableTensor(Blob* blob, DeviceType device_type) {
   // or that Tensor had the wrong DeviceType.
   VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<Tensor>()
           << " DeviceType:" << device_type;
-  return blob->Reset<Tensor>(new Tensor(device_type));
+
+  return BlobSetTensor(blob, Tensor(device_type));
 }
 
 }  // namespace caffe2

--- a/caffe2/predictor/predictor.cc
+++ b/caffe2/predictor/predictor.cc
@@ -13,29 +13,15 @@ void enforceIsTensor(Workspace* ws, const std::string& name) {
       BlobIsTensorType(*blob, CPU), "Blob is not a CPU Tensor: ", name);
 }
 
-TensorCPU* getTensor(Workspace* ws, const std::string& name) {
+Blob* getBlob(Workspace* ws, const std::string& name) {
   enforceIsTensor(ws, name);
   auto* blob = ws->GetBlob(name);
   CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
-  return BlobGetMutableTensor(blob, CPU);
+  return blob;
 }
 
-void shareInputTensor(
-    Workspace* ws,
-    const std::string& name,
-    const TensorCPU& input) {
-  auto tensor = getTensor(ws, name);
-  tensor->ResizeLike(input);
-  tensor->ShareData(input);
-}
-
-void exportOutputTensor(
-    Workspace* ws,
-    const std::string& name,
-    TensorCPU& output) {
-  auto tensor = getTensor(ws, name);
-  output.Resize(tensor->sizes());
-  output.ShareData(*tensor);
+const Tensor& getTensor(Workspace* ws, const std::string& name) {
+  return *BlobGetMutableTensor(getBlob(ws, name), CPU);
 }
 
 } // namespace
@@ -71,8 +57,9 @@ bool Predictor::operator()(const TensorList& inputs, TensorList* outputs) {
       inputs.size() <=
       static_cast<unsigned>(config_.predict_net->external_input_size()));
   for (size_t i = 0; i < inputs.size(); ++i) {
-    shareInputTensor(
-        config_.ws.get(), config_.predict_net->external_input(i), inputs[i]);
+    BlobSetTensor(
+        getBlob(config_.ws.get(), config_.predict_net->external_input(i)),
+        inputs[i]);
   }
 
   if (!config_.ws->RunNet(config_.predict_net->name())) {
@@ -80,11 +67,8 @@ bool Predictor::operator()(const TensorList& inputs, TensorList* outputs) {
   }
   outputs->clear();
   for (size_t i = 0; i < config_.predict_net->external_output_size(); ++i) {
-    outputs->emplace_back(CPU);
-    exportOutputTensor(
-        config_.ws.get(),
-        config_.predict_net->external_output(i),
-        outputs->back());
+    outputs->push_back(
+        getTensor(config_.ws.get(), config_.predict_net->external_output(i)));
   }
   return true;
 }
@@ -101,7 +85,7 @@ bool Predictor::run_map_workspace(const TensorMap& inputs) {
           "Input can't be found: ",
           input.first);
     }
-    shareInputTensor(config_.ws.get(), input.first, input.second);
+    BlobSetTensor(getBlob(config_.ws.get(), input.first), input.second);
   }
 
   return config_.ws->RunNet(config_.predict_net->name());
@@ -113,11 +97,8 @@ bool Predictor::operator()(const TensorMap& inputs, TensorList* outputs) {
   }
   outputs->clear();
   for (size_t i = 0; i < config_.predict_net->external_output_size(); ++i) {
-    outputs->emplace_back(CPU);
-    exportOutputTensor(
-        config_.ws.get(),
-        config_.predict_net->external_output(i),
-        outputs->back());
+    outputs->push_back(
+        getTensor(config_.ws.get(), config_.predict_net->external_output(i)));
   }
   return true;
 }
@@ -128,8 +109,7 @@ bool Predictor::operator()(const TensorMap& inputs, TensorMap* outputs) {
   }
 
   for (const std::string& outputName : output_names()) {
-    auto iter = outputs->emplace(outputName, TensorCPU(CPU));
-    exportOutputTensor(config_.ws.get(), outputName, iter.first->second);
+    outputs->emplace(outputName, getTensor(config_.ws.get(), outputName));
   }
   return true;
 }

--- a/caffe2/predictor/predictor.h
+++ b/caffe2/predictor/predictor.h
@@ -35,6 +35,9 @@ class CAFFE2_API Predictor {
   // Postcondition:
   //   outputs->size() == run_net.external_inputs.size()
 
+  // NOTE: output is a part of thread local workspace
+  // and is only valid until the next predictor execution.
+
   // Returns true on success
   bool operator()(const TensorList& inputs, TensorList* outputs);
 


### PR DESCRIPTION
Summary:
Currently Tensor is a shared pointer to the underlying implementation, rather than a value, copying
the pointer will share the underlying TensorImpl, ShareData probably don't make sense anymore.

Differential Revision: D12871708
