### PR TITLE
[jit] Validate schema with no returns

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4300,6 +4300,12 @@ a")
         self.checkScript(one_return, [a], optimize=True)
         self.checkScript(multiple_returns, [a], optimize=True)
 
+        with self.assertRaisesRegex(RuntimeError, "Expected 1 return value"):
+            @torch.jit.script
+            def no_return_bad_annotation(a):
+                # type: (Tensor) -> Tensor
+                a + 1
+
     def test_error(self):
         @torch.jit.script
         def foo(a):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3728,7 +3728,7 @@ a")
     def test_mutable_list_function_inline(self):
         @torch.jit.script
         def bar(y):
-            # type: (List[int]) -> List[int]
+            # type: (List[int])
             y.append(4)
 
         @torch.jit.script

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -874,6 +874,12 @@ struct to_ir {
         }
         returns.push_back({"", type});
       }
+    } else if (schema.returns().size() > 0) {
+      // schema has returns but there's no return nodes in graph
+      throw ErrorReport() << "Expected " << schema.returns().size()
+                          << " return value"
+                          << (schema.returns().size() > 1 ? "s" : "")
+                          << " but found no return statement";
     }
 
     method.setSchema({def.name().name(), std::move(arguments), std::move(returns)});


### PR DESCRIPTION
If there is no return type then the returns of the schema are not
checked against the returns in the graph, so this PR adds an error if
that case is detected.

