### PR TITLE
Fix include paths for typeid.h

### DIFF
--- a/aten/src/ATen/core/ScalarType.h
+++ b/aten/src/ATen/core/ScalarType.h
@@ -2,7 +2,7 @@
 
 #include "ATen/core/ArrayRef.h"
 #include "ATen/core/Half.h"
-#include "ATen/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <cstdint>
 #include <iostream>

--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include <ATen/core/intrusive_ptr.h>
-#include <ATen/core/typeid.h>
+#include <c10/util/typeid.h>
 #include <c10/macros/Macros.h>
 
 namespace caffe2 {

--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -8,7 +8,7 @@
 
 #include <ATen/core/ATenGeneral.h>
 #include <ATen/core/Allocator.h>
-#include <ATen/core/typeid.h>
+#include <c10/util/typeid.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Registry.h>
 

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -3,7 +3,7 @@
 #else
 
 #include <ATen/core/intrusive_ptr.h>
-#include <ATen/core/typeid.h>
+#include <c10/util/typeid.h>
 
 scalar_t* THCStorage_(data)(THCState *state, const THCStorage *self)
 {

--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -1,4 +1,4 @@
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/core/types.h"
 #include <gtest/gtest.h>
 

--- a/caffe2/contrib/gloo/context.cc
+++ b/caffe2/contrib/gloo/context.cc
@@ -1,6 +1,6 @@
 #include "context.h"
 
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <gloo/types.h>
 

--- a/caffe2/core/allocator.cc
+++ b/caffe2/core/allocator.cc
@@ -1,7 +1,7 @@
 #include <ATen/core/Allocator.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 C10_DEFINE_bool(
     caffe2_report_cpu_memory_usage,

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/common.h"
 
 #include <ATen/core/blob.h>
-#include <ATen/core/typeid.h>
+#include <c10/util/typeid.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/tensor.h"
 

--- a/caffe2/core/blob_serialization.h
+++ b/caffe2/core/blob_serialization.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/blob_serializer_base.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/core/types.h"
 #include "caffe2/utils/simple_queue.h"
 

--- a/caffe2/core/blob_stats.h
+++ b/caffe2/core/blob_stats.h
@@ -2,7 +2,7 @@
 
 #include "c10/util/Registry.h"
 #include "caffe2/core/blob.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <unordered_map>
 

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -10,7 +10,7 @@
 #include "caffe2/core/context_base.h"
 #include "caffe2/core/event.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/proto/caffe2_pb.h"
 
 #include <ATen/core/ATenCoreTest.h>

--- a/caffe2/core/dispatch/DispatchKey.h
+++ b/caffe2/core/dispatch/DispatchKey.h
@@ -2,7 +2,7 @@
 
 #include "caffe2/core/dispatch/DeviceId.h"
 #include "caffe2/core/dispatch/LayoutId.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <vector>
 #include <functional>

--- a/caffe2/core/int8_serialization.cc
+++ b/caffe2/core/int8_serialization.cc
@@ -2,7 +2,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor_int8.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/core/types.h"
 
 namespace caffe2 {

--- a/caffe2/core/module.h
+++ b/caffe2/core/module.h
@@ -14,7 +14,7 @@
 #include <mutex>
 
 #include "caffe2/core/common.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 

--- a/caffe2/core/qtensor.h
+++ b/caffe2/core/qtensor.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 

--- a/caffe2/core/storage.h
+++ b/caffe2/core/storage.h
@@ -14,7 +14,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/flags.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <ATen/core/Allocator.h>
 #include <c10/Device.h>

--- a/caffe2/core/tensor_int8.cc
+++ b/caffe2/core/tensor_int8.cc
@@ -1,5 +1,5 @@
 #include "caffe2/core/tensor_int8.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 CAFFE_KNOWN_TYPE(int8::Int8TensorCPU);

--- a/caffe2/core/typeid.h
+++ b/caffe2/core/typeid.h
@@ -1,7 +1,0 @@
-#pragma once
-
-// If I omit this header, the Windows build fails.  The error message
-// was sufficiently bad that I couldn't figure out which downstream file
-// was missing the include of common.h.  So keep it here for BC.
-#include <caffe2/core/common.h>
-#include <ATen/core/typeid.h>

--- a/caffe2/core/types.cc
+++ b/caffe2/core/types.cc
@@ -1,5 +1,5 @@
 #include "caffe2/core/types.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 #include <atomic>
 #include <memory>

--- a/caffe2/core/types.h
+++ b/caffe2/core/types.h
@@ -7,7 +7,7 @@
 
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/proto/caffe2_pb.h"
 #include <ATen/core/Half.h>
 

--- a/caffe2/distributed/store_handler.cc
+++ b/caffe2/distributed/store_handler.cc
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 

--- a/caffe2/mobile/contrib/opengl/core/GLImage.cc
+++ b/caffe2/mobile/contrib/opengl/core/GLImage.cc
@@ -1,7 +1,7 @@
 
 #include "GLImage.h"
 #include "arm_neon_support.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 CAFFE_KNOWN_TYPE(GLImage<float>);

--- a/caffe2/mpi/mpi_common.cc
+++ b/caffe2/mpi/mpi_common.cc
@@ -2,7 +2,7 @@
 
 #include <thread>
 
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 #include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {

--- a/caffe2/operators/quant_decode_op.cc
+++ b/caffe2/operators/quant_decode_op.cc
@@ -1,7 +1,7 @@
 #include "quant_decode_op.h"
 #include <stdint.h>
 #include "caffe2/core/tensor.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 

--- a/caffe2/operators/quant_decode_op.h
+++ b/caffe2/operators/quant_decode_op.h
@@ -4,7 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
-#include "caffe2/core/typeid.h"
+#include <c10/util/typeid.h>
 
 namespace caffe2 {
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13528 Move IdWrapper to c10/util&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D12912238/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13529 Remove typeid -> Half dependency&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12912236/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13530 Move typeid to c10/util&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12912240/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#13531 Fix include paths for typeid.h**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12912237/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13532 Move c10 dispatcher prototype to c10/&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D12912235/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13609 Move intrusive_ptr to c10/util&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12937090/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13610 Fix include paths for intrusive_ptr&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12937091/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13533 Register caffe2 layer norm with c10 dispatcher&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12912242/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13488 Call c10 layer_norm from PyTorch&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12894385/)

Now that typeid.h lives in c10/util, the include paths should reflect that.

Differential Revision: [D12912237](https://our.internmc.facebook.com/intern/diff/D12912237/)