### PR TITLE
Add Int8BatchPermutation op in DNNLOWP

### DIFF
--- a/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op.cc
@@ -1,0 +1,64 @@
+#include "caffe2/operators/quantized/server/batch_permutation_dnnlowp_op.h"
+
+namespace caffe2 {
+
+template <typename T>
+bool BatchPermutationDNNLowPOp<T>::RunOnDevice() {
+  using namespace dnnlowp;
+
+  BaseType::ParseDNNLowPOperatorArguments_();
+
+  // Choose quantization params
+  in_qparams_[INPUT] =
+      GetInputTensorQuantizationParamsOf(this, INPUT, qfactory_.get());
+
+  const auto& X = InputTensorCPU_(INPUT);
+  const auto& indices = Input(INDICES);
+  auto* Y = OutputTensorCPU_(OUTPUT);
+
+  CAFFE_ENFORCE(indices.ndim() == 1, "indices must be 1-d");
+  CAFFE_ENFORCE(
+      X.dim32(0) == indices.dim32(0),
+      "X.dim32(0) must be equal to indices.dim32(0)",
+      "(",
+      X.dim32(0),
+      " vs. ",
+      indices.dim32(0),
+      ")");
+  CAFFE_ENFORCE_GT(X.dim32(0), 0);
+
+  Y->ResizeLike(X);
+  const T* X_data = X.template data<T>();
+  const int* indices_data = indices.template data<int>();
+  T* Y_data = Y->template mutable_data<T>();
+
+  int N = X.dim32(0);
+  int K = X.numel() / N;
+
+#pragma omp parallel for
+  for (int i = 0; i < N; ++i) {
+    int origIdx = i * K;
+    int permuteIdx = indices_data[i] * K;
+    std::memcpy(Y_data + origIdx, X_data + permuteIdx, K * sizeof(T));
+  }
+
+  // Even if there is a pre-chosen quantization parameters for the output,
+  // it is ignored because batch permutation output quantization should be same
+  // as the input.
+  PropagateOutputTensorQuantizationParams(this, 0, in_qparams_[INPUT]);
+
+  return true;
+}
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    BatchPermutation,
+    DNNLOWP,
+    BatchPermutationDNNLowPOp<uint8_t>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    Int8BatchPermutation,
+    DNNLOWP,
+    BatchPermutationDNNLowPOp<uint8_t>);
+
+OPERATOR_SCHEMA(Int8BatchPermutation).NumInputs(2).NumOutputs(1);
+
+} // namespace caffe2

--- a/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op.h
+++ b/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op.h
@@ -1,0 +1,30 @@
+#ifndef DEEPLEARNING_QUANTIZATION_CAFFE2_BATCH_PERMUTATION_DNNLOWP_OP_H_
+#define DEEPLEARNING_QUANTIZATION_CAFFE2_BATCH_PERMUTATION_DNNLOWP_OP_H_
+
+#include "caffe2/fb/operators/batch_permutation_op.h"
+#include "caffe2/operators/quantized/server/dnnlowp_op.h"
+
+namespace caffe2 {
+
+using BatchPermutationFP32Op = BatchPermutationOp<float, CPUContext>;
+
+template <typename T>
+class BatchPermutationDNNLowPOp final
+    : public DNNLowPOp<T, BatchPermutationFP32Op> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CPUContext);
+  USE_DNNLOWP_OPERATOR_BASE_FUNCTIONS(T, BatchPermutationFP32Op);
+
+  BatchPermutationDNNLowPOp(const OperatorDef& operator_def, Workspace* ws)
+      : BaseType(operator_def, ws) {}
+
+  bool RunOnDevice() override;
+
+ private:
+  INPUT_TAGS(INPUT, INDICES);
+  OUTPUT_TAGS(OUTPUT);
+};
+
+} // namespace caffe2
+
+#endif // DEEPLEARNING_QUANTIZATION_CAFFE2_BATCH_PERMUTATION_DNNLOWP_OP_H_

--- a/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op_test.py
+++ b/caffe2/operators/quantized/server/batch_permutation_dnnlowp_op_test.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, dyndep, workspace
+from hypothesis import given
+
+
+dyndep.InitOpsLibrary("//caffe2/caffe2/operators/quantized/server:dnnlowp_ops")
+
+
+class DNNLowPBatchPermutationOpTest(hu.HypothesisTestCase):
+    @given(N=st.integers(min_value=1, max_value=100), **hu.gcs_cpu_only)
+    def test_batch_permutation(self, N, gc, dc):
+        X = np.round(np.random.rand(N, 10, 20, 3) * 255).astype(np.float32)
+        indices = np.arange(N).astype(np.int32)
+        np.random.shuffle(indices)
+
+        quantize = core.CreateOperator(
+            "Quantize",
+            ["X"],
+            ["X_q"],
+            engine="DNNLOWP",
+        )
+        batch_perm = core.CreateOperator(
+            "BatchPermutation",
+            ["X_q", "indices"],
+            ["Y_q"],
+            engine="DNNLOWP",
+        )
+
+        net = core.Net("test_net")
+        net.Proto().op.extend([quantize, batch_perm])
+
+        workspace.FeedBlob("X", X)
+        workspace.FeedBlob("indices", indices)
+        workspace.RunNetOnce(net)
+        X_q = workspace.FetchInt8Blob("X_q").data
+        Y_q = workspace.FetchInt8Blob("Y_q").data
+
+        def batch_permutation_ref(X, indices):
+            return np.array([X[i] for i in indices])
+
+        Y_q_ref = batch_permutation_ref(X_q, indices)
+        np.testing.assert_allclose(Y_q, Y_q_ref)


### PR DESCRIPTION
Summary:
This is used by OCR's FPN model to detect small/dense text. Just a simple
permutations along the batch dim based on the input indices, and we can avoid
the unnecessary quantize/dequantize ops.

Reviewed By: csummersea

Differential Revision: D12894055
