### PR TITLE
fix handling of single input in gradcheck

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2669,6 +2669,13 @@ class TestAutograd(TestCase):
         # check one of them is using the computed buffer
         self.assertTrue(p_a == p_g or p_b == p_g)
 
+    def test_gradcheck_single_input(self):
+        def f(inp):
+            return inp.mul(5)
+
+        gradcheck(f, torch.rand(10, dtype=torch.float64, requires_grad=True))
+        gradgradcheck(f, torch.rand(10, dtype=torch.float64, requires_grad=True))
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):


### PR DESCRIPTION
Now gradcheck properly accept a single Tensor as input. It was almost supported already but not completely.
Should fix the confusion from #13540 