### PR TITLE
Append parameters when checking graphs for TorchScript Methods

### DIFF
--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -350,6 +350,7 @@ struct GraphExecutorImpl {
   }
 
   std::shared_ptr<Graph> graphFor(const Stack& stack) const {
+    JIT_ASSERT(stack.size() >= num_inputs);
     auto inputs = last(stack, num_inputs);
     ArgumentSpec spec(autograd::GradMode::is_enabled(), inputs, num_flat_inputs);
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -58,7 +58,7 @@ struct Method {
 
   void run(Stack & stack) {
     for(at::Tensor* tp : member_inputs) {
-      stack.push_back(*tp);
+      stack.emplace_back(*tp);
     }
     get_executor().run(stack);
   }
@@ -72,7 +72,10 @@ struct Method {
     return stack.front();
   }
 
-  std::shared_ptr<Graph> graph_for(const Stack& inputs) {
+  std::shared_ptr<Graph> graph_for(Stack inputs) {
+    for(at::Tensor* tp : member_inputs) {
+      inputs.emplace_back(*tp);
+    }
     return get_executor().graphFor(inputs);
   }
   std::shared_ptr<Graph> graph() const {


### PR DESCRIPTION
Also, add an assertion in the GraphExecutor to make sure we don't
access memory out of bounds.

