### PR TITLE
Modify one line to run with CUDA on Python3

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -30,7 +30,7 @@ _cudart = None
 def find_cuda_windows_lib():
     proc = Popen(['where', 'cudart64*.dll'], stdout=PIPE, stderr=PIPE, stdin=PIPE)
     out, err = proc.communicate()
-    out = out.decode().strip()
+    out = out.strip()
     if len(out) > 0:
         if out.find('\r\n') != -1:
             out = out.split('\r\n')[0]


### PR DESCRIPTION
In torch/cuda/init.py for Python3 users, the line 33:
`out = out.decode().strip()`
shuld be replaced with:
`out = out.strip() `
as in Python3 the type `str` does not have method "decode".
If a Python3 user runs pytorch on CUDA without modifying this line, the program will raise an AttributeError with message "AttributeError: 'str' object has no attribute 'decode'".