### PR TITLE
implement concatenation of sparse tensors

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -74,18 +74,18 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
   // E.g.: catting [[1,2],[0,0]] and [[0,0],[3,4]]
   // yields [[1,2,0,0],[0,0,3,4]]
   AT_CHECK(wrapped < sparse_dim,
-           "Can't cat or stack tensors of sparse dim ", sparse_dim, "along non-sparse dimension ", dim);
+           "Concatenating or stacking tensors of sparse dim ", sparse_dim, "along non-sparse dimension ", dim, " not supported.");
   IntList sizes = tensors[0].sizes();
   for (size_t i = 0; i < tensors.size(); ++i) {
     auto const &t = tensors[i];
     AT_CHECK(t.is_sparse(),
-             "Can't cat dense tensor at position ", i, " with sparse tensor(s).");
+             "Concatenating dense tensor at position ", i, " with sparse tensor(s) not supported.");
     AT_CHECK(sizes_match_except(sizes, t.sizes(), wrapped),
-             "Tensor at position ", i, " of sizes ", t.sizes(), " can't be concatenated with tensor of sizes ", sizes,
-             " along dimension ", dim);
+             "Concatenating tensor at position ", i, " of sizes ", t.sizes(), " with tensor of sizes ", sizes,
+             " along dimension ", dim, " not supported.");
     AT_CHECK(t.sparse_dim() == sparse_dim && t.dense_dim() == dense_dim,
              "Tensor at position ", i, " has dimension: sparse ", t.sparse_dim(), ", dense ", t.dense_dim(),
-             ". Can't cat with tensor of dimensions ", sparse_dim, ", ", dense_dim);
+             ". Concatenating with tensor of dimensions ", sparse_dim, ", ", dense_dim, " not supported.");
     indices.push_back(t._indices());
     values.push_back(t._values());
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -88,11 +88,11 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
   // We now need to move the indices of each
   // input tensor up along `dim` by an appropriate amount.
   // E.g., if t1 has indices [[2,3,4],[5,6,7]], 
-  // and sizes [7, 10]
+  // and sizes [10, 7]
   // then torch.cat((t1,t1,t1),1) should have indices
-  // [[2,3,4,2,3,4,2,3,4],[5,6,7,10,11,12,15,16,17]],
-  // so we need to increase idxs[1][3:6] by 5 
-  // and idxs[1][6:9] by 10.
+  // [[2,3,4,2,3,4,2,3,4],[5,6,7,12,13,14,19,20,21]],
+  // so we need to increase idxs[1][3:6] by 7 
+  // and idxs[1][6:9] by 14.
   int64_t col = 0;
   int64_t cumulative_offset = 0;
   for (size_t i = 0; i < tensors.size(); ++i) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -49,7 +49,73 @@ Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim) {
   return at::_th_cat_out(result, tensors, dim);
 }
 
+static bool sizes_match_except(IntList s1, IntList s2, int64_t dim_except) {
+  if (s1.size() != s2.size()) {
+    return false;
+  }
+  for (int64_t i = 0; i < s1.size(); ++i) {
+    if (i != dim_except && s1[i] != s2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static Tensor cat_sparse(TensorList tensors, int64_t dim) {
+  std::vector<Tensor> indices;
+  std::vector<Tensor> values;
+  int64_t sparse_dim = tensors[0].sparse_dim();
+  int64_t dense_dim = tensors[0].dense_dim();
+  AT_CHECK(dim < sparse_dim,
+           "Can't cat or stack tensors of sparse dim ", sparse_dim, "along non-sparse dimension ", dim);
+  IntList sizes = tensors[0].sizes();
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    auto const &t = tensors[i];
+    AT_CHECK(t.is_sparse(),
+             "Can't cat dense tensor at position ", i, " with sparse tensor(s).");
+    AT_CHECK(t.sparse_dim() == sparse_dim && t.dense_dim() == dense_dim,
+             "Tensor at position ", i, " has dimension: sparse ", t.sparse_dim(), ", dense ", t.dense_dim(),
+             ". Can't cat with tensor of dimensions ", sparse_dim, ", ", dense_dim);
+    AT_CHECK(sizes_match_except(sizes, t.sizes(), dim),
+             "Tensor at position ", i, " of sizes ", t.sizes(), " can't be concatenated with tensor of sizes ", sizes,
+             " along dimension ", dim);
+    indices.push_back(t._indices());
+    values.push_back(t._values());
+  }
+  Tensor idxs = native::cat(indices, 1);
+  Tensor vals = native::cat(values, 0);
+  
+  // We now need to move the indices of each
+  // input tensor up along `dim` by an appropriate amount.
+  // E.g., if t1 has indices [[2,3,4],[5,6,7]], 
+  // and sizes [7, 10]
+  // then torch.cat((t1,t1,t1),1) should have indices
+  // [[2,3,4,2,3,4,2,3,4],[5,6,7,10,11,12,15,16,17]],
+  // so we need to increase idxs[1][3:6] by 5 
+  // and idxs[1][6:9] by 10.
+  int64_t col = 0;
+  int64_t cumulative_offset = 0;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    auto const &t = tensors[i];
+    int64_t this_piece_size = t._nnz();
+    // cumulative_offset is zero for the first piece, so
+    // don't waste time doing this operation unless i > 0.
+    if (i > 0) {
+      idxs[dim].narrow(0, col, this_piece_size) += cumulative_offset;
+    }
+    cumulative_offset += t.size(dim);
+    col += this_piece_size;
+  }
+  auto sizes_copy = sizes.vec();
+  sizes_copy[dim] = cumulative_offset;
+  return native::sparse_coo_tensor(idxs, vals, sizes_copy, tensors[0].options());
+}
+
 Tensor cat(TensorList tensors, int64_t dim) {
+  if (tensors.size() > 0 && 
+        tensors[0].is_sparse()) {
+    return cat_sparse(tensors, dim);
+  }
   check_cat_no_zero_dim(tensors);
   dim = legacy_cat_wrap_dim(dim, tensors);
   return at::_th_cat(tensors, dim);

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -679,7 +679,7 @@ class TestSparse(TestCase):
         # shapes: list of tuples (sparse_dims, nnz, sizes)
         def test_shapes(shapes, dim, fail_message=None):
             inputs = [self._gen_sparse(shape[0], shape[1], shape[2])[0]
-                    for shape in shapes]
+                      for shape in shapes]
             if fail_message:
                 with self.assertRaisesRegex(RuntimeError, fail_message):
                     torch.cat(inputs, dim)
@@ -688,24 +688,25 @@ class TestSparse(TestCase):
                 dense_result = torch.cat([t.to_dense() for t in inputs], dim)
                 self.assertEqual(dense_result, result.to_dense())
 
-        test_shapes([(3, 10, [2,3,4]), (3, 10, [2,1,4]), (3, 10, [2,4,4])], 1)
-        test_shapes([(3, 10, [2,3,4]), (3, 10, [2,1,4])], 0,
-                "can't be concatenated.*along dimension 0")
+        test_shapes(
+            [(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4]), (3, 10, [2, 4, 4])], 1)
+        test_shapes([(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4])], 0,
+                    "can't be concatenated.*along dimension 0")
         # hybrid sparse/dense
-        test_shapes([(2, 10, [2,3,4]), (2, 10, [2,1,4]), (2, 10, [2,4,4])], 1)
-        test_shapes([(2, 10, [2,3,4]), (2, 10, [2,1,4])], 2,
-                "Can't cat.*along non-sparse dimension 2")
+        test_shapes(
+            [(2, 10, [2, 3, 4]), (2, 10, [2, 1, 4]), (2, 10, [2, 4, 4])], 1)
+        test_shapes([(2, 10, [2, 3, 4]), (2, 10, [2, 1, 4])], 2,
+                    "Can't cat.*along non-sparse dimension 2")
         # mismatched dimensions
-        test_shapes([(2, 10, [2,3,4]), (3, 10, [2,3,4])], 0,
-                "Can't cat with tensor of dimensions")
+        test_shapes([(2, 10, [2, 3, 4]), (3, 10, [2, 3, 4])], 0,
+                    "Can't cat with tensor of dimensions")
 
         # sparse with dense
-        sp = self._gen_sparse(3, 10, [2,3,4])[0]
+        sp = self._gen_sparse(3, 10, [2, 3, 4])[0]
         dn = sp.to_dense()
         with self.assertRaisesRegex(RuntimeError,
-                "Can't cat dense tensor.*with sparse"):
+                                    "Can't cat dense tensor.*with sparse"):
             torch.cat((sp, dn))
-
 
     @cpu_only
     def test_mm(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -691,16 +691,18 @@ class TestSparse(TestCase):
 
         test_shapes(
             [(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4]), (3, 10, [2, 4, 4])], 1)
+
+        # mismatched sizes
         test_shapes([(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4])], 0,
-                    "can't be concatenated.*along dimension 0")
+                    "Concatenating tensor.*of sizes \\[2, 1, 4].*of sizes \\[2, 3, 4]")
         # hybrid sparse/dense
         test_shapes(
             [(2, 10, [2, 3, 4]), (2, 10, [2, 1, 4]), (2, 10, [2, 4, 4])], 1)
         test_shapes([(2, 10, [2, 3, 4]), (2, 10, [2, 1, 4])], 2,
-                    "Can't cat.*along non-sparse dimension 2")
+                    "Concatenating.*along non-sparse dimension 2")
         # mismatched dimensions
         test_shapes([(2, 10, [2, 3, 4]), (3, 10, [2, 3, 4])], 0,
-                    "Can't cat with tensor of dimensions")
+                    "has dimension: sparse 3, dense 0.*Concatenating with tensor of dimensions 2, 1")
         # wrapped dimension
         test_shapes(
             [(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4]), (3, 10, [2, 4, 4])], -2)
@@ -709,7 +711,7 @@ class TestSparse(TestCase):
         sp = self._gen_sparse(3, 10, [2, 3, 4])[0]
         dn = sp.to_dense()
         with self.assertRaisesRegex(RuntimeError,
-                                    "Can't cat dense tensor.*with sparse"):
+                                    "Concatenating dense tensor.*with sparse"):
             torch.cat((sp, dn))
 
     @cpu_only

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -675,6 +675,38 @@ class TestSparse(TestCase):
         test_shape(2, 20, [3, 17, 19, 5])
         test_shape(2, 20, [3, 17, 19, 0])
 
+    def test_cat(self):
+        # shapes: list of tuples (sparse_dims, nnz, sizes)
+        def test_shapes(shapes, dim, fail_message=None):
+            inputs = [self._gen_sparse(shape[0], shape[1], shape[2])[0]
+                    for shape in shapes]
+            if fail_message:
+                with self.assertRaisesRegex(RuntimeError, fail_message):
+                    torch.cat(inputs, dim)
+            else:
+                result = torch.cat(inputs, dim)
+                dense_result = torch.cat([t.to_dense() for t in inputs], dim)
+                self.assertEqual(dense_result, result.to_dense())
+
+        test_shapes([(3, 10, [2,3,4]), (3, 10, [2,1,4]), (3, 10, [2,4,4])], 1)
+        test_shapes([(3, 10, [2,3,4]), (3, 10, [2,1,4])], 0,
+                "can't be concatenated.*along dimension 0")
+        # hybrid sparse/dense
+        test_shapes([(2, 10, [2,3,4]), (2, 10, [2,1,4]), (2, 10, [2,4,4])], 1)
+        test_shapes([(2, 10, [2,3,4]), (2, 10, [2,1,4])], 2,
+                "Can't cat.*along non-sparse dimension 2")
+        # mismatched dimensions
+        test_shapes([(2, 10, [2,3,4]), (3, 10, [2,3,4])], 0,
+                "Can't cat with tensor of dimensions")
+
+        # sparse with dense
+        sp = self._gen_sparse(3, 10, [2,3,4])[0]
+        dn = sp.to_dense()
+        with self.assertRaisesRegex(RuntimeError,
+                "Can't cat dense tensor.*with sparse"):
+            torch.cat((sp, dn))
+
+
     @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk, nnz):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -675,6 +675,7 @@ class TestSparse(TestCase):
         test_shape(2, 20, [3, 17, 19, 5])
         test_shape(2, 20, [3, 17, 19, 0])
 
+    @skipIfRocm
     def test_cat(self):
         # shapes: list of tuples (sparse_dims, nnz, sizes)
         def test_shapes(shapes, dim, fail_message=None):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -701,6 +701,9 @@ class TestSparse(TestCase):
         # mismatched dimensions
         test_shapes([(2, 10, [2, 3, 4]), (3, 10, [2, 3, 4])], 0,
                     "Can't cat with tensor of dimensions")
+        # wrapped dimension
+        test_shapes(
+            [(3, 10, [2, 3, 4]), (3, 10, [2, 1, 4]), (3, 10, [2, 4, 4])], -2)
 
         # sparse with dense
         sp = self._gen_sparse(3, 10, [2, 3, 4])[0]


### PR DESCRIPTION
With this change applied, `torch.cat` works for sparse tensors.

The algorithm is just to concatenate the values, and give the new values the proper indices (which will be the same as their old indices in every dimension except the catted dimension, and their old indices plus the sum of the size of every previous tensor in the catted dimension).

This is my first time contributing to PyTorch so please feel free to tell me if this approach seems totally wrong.

Coming next: `torch.stack` for sparse tensors. 