### PR TITLE
[TESTING] cumsum/cumprod derivatives not depending on TH.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2320,21 +2320,25 @@ class TestAutograd(TestCase):
         self._test_where_functional(lambda t: t.cuda())
 
     def test_reduce_dtype(self):
-        def test_reduction(op):
+        def test_reduction(op, has_no_dim):
             x = torch.randn(3, 3, dtype=torch.float, requires_grad=True)
-            grad1, = torch.autograd.grad([op(x)], [x])
-            grad2, = torch.autograd.grad([op(x, dtype=torch.double)], [x])
-            self.assertEqual(grad1, grad2)
-            self.assertEqual(grad2.dtype, torch.float)
 
-            gi = torch.randn(3, dtype=torch.float)
+            if has_no_dim:
+                grad1, = torch.autograd.grad([op(x)], [x])
+                grad2, = torch.autograd.grad([op(x, dtype=torch.double)], [x])
+                self.assertEqual(grad1, grad2)
+                self.assertEqual(grad2.dtype, torch.float)
+
+            gi = torch.randn(op(x, dim=0).shape, dtype=torch.float)
             grad1, = torch.autograd.grad([op(x, dim=0)], [x], gi)
             grad2, = torch.autograd.grad([op(x, dim=0, dtype=torch.double)], [x], gi.double())
             self.assertEqual(grad1, grad2)
             self.assertEqual(grad2.dtype, torch.float)
 
-        test_reduction(torch.sum)
-        test_reduction(torch.prod)
+        test_reduction(torch.sum, True)
+        test_reduction(torch.prod, True)
+        test_reduction(torch.cumsum, False)
+        test_reduction(torch.cumprod, False)
 
     def test_inplace_view_backprop_base(self):
         # modify view and back-prop through base

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -214,11 +214,17 @@
   self: other.cross(grad, dim)
   other: grad.cross(self, dim)
 
-- name: _th_cumprod(Tensor self, int64_t dim)
+- name: cumprod(Tensor self, int64_t dim)
   self: cumprod_backward(grad, self, dim)
 
-- name: _th_cumsum(Tensor self, int64_t dim)
+- name: cumprod(Tensor self, int64_t dim, *, ScalarType dtype)
+  self: cumprod_backward(grad, self, dim, dtype)
+
+- name: cumsum(Tensor self, int64_t dim)
   self: cumsum_backward(grad, dim)
+
+- name: cumsum(Tensor self, int64_t dim, *, ScalarType dtype)
+  self: cumsum_backward(grad, dim, self.type().scalarType())
 
 - name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad)
   self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -366,6 +366,10 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
   return grad_input;
 }
 
+Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim, ScalarType dtype) {
+  return cumprod_backward(grad.to(input.scalar_type()), input, dim);
+}
+
 Tensor gesv_backward_self(const Tensor & grad, const Tensor & self, const Tensor & A) {
   return std::get<0>(at::gesv(grad, A.transpose(-2, -1)));
 }
@@ -387,6 +391,10 @@ Tensor cumsum_backward(const Tensor & x, int64_t dim) {
   ret -= ret_sum.expand(ret.sizes());
   ret += x;
   return ret;
+}
+
+Tensor cumsum_backward(const Tensor &x, int64_t dim, ScalarType input_dtype) {
+  return cumsum_backward(x.to(input_dtype), dim);
 }
 
 Tensor logsumexp_backward(Tensor grad, const Tensor & self, Tensor result, int64_t dim, bool keepdim) {

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -18,6 +18,7 @@ using at::Tensor;
 using at::IntList;
 using at::Type;
 using at::TensorGeometry;
+using at::ScalarType;
 using c10::optional;
 
 inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs) {


### PR DESCRIPTION
This is identical to https://github.com/pytorch/pytorch/pull/13467 but doesn't include the tests in common_invocations.

