### PR TITLE
Support custimzed timeout when fetching blob from KVStore

### DIFF
--- a/caffe2/distributed/file_store_handler.cc
+++ b/caffe2/distributed/file_store_handler.cc
@@ -93,12 +93,14 @@ void FileStoreHandler::set(const std::string& name, const std::string& data) {
   CAFFE_ENFORCE_EQ(rv, 0, "rename: ", strerror(errno));
 }
 
-std::string FileStoreHandler::get(const std::string& name) {
+std::string FileStoreHandler::get(
+    const std::string& name,
+    const std::chrono::milliseconds& timeout) {
   auto path = objectPath(name);
   std::string result;
 
   // Block until key is set
-  wait({name});
+  wait({name}, timeout);
 
   std::ifstream ifs(path.c_str(), std::ios::in);
   if (!ifs) {

--- a/caffe2/distributed/file_store_handler.h
+++ b/caffe2/distributed/file_store_handler.h
@@ -11,7 +11,9 @@ class CAFFE2_API FileStoreHandler : public StoreHandler {
 
   virtual void set(const std::string& name, const std::string& data) override;
 
-  virtual std::string get(const std::string& name) override;
+  virtual std::string get(
+      const std::string& name,
+      const std::chrono::milliseconds& timeout = kDefaultTimeout) override;
 
   virtual int64_t add(const std::string& name, int64_t value) override;
 

--- a/caffe2/distributed/redis_store_handler.cc
+++ b/caffe2/distributed/redis_store_handler.cc
@@ -14,7 +14,8 @@ RedisStoreHandler::RedisStoreHandler(
     std::string& prefix)
     : host_(host), port_(port), prefix_(prefix) {
   struct timeval tv = {
-      .tv_sec = 5, .tv_usec = 0,
+      .tv_sec = 5,
+      .tv_usec = 0,
   };
 
   redis_ = redisConnectWithTimeout(host.c_str(), port, tv);
@@ -51,9 +52,11 @@ void RedisStoreHandler::set(const std::string& name, const std::string& data) {
       " (perhaps you reused a run ID you have used before?)");
 }
 
-std::string RedisStoreHandler::get(const std::string& name) {
+std::string RedisStoreHandler::get(
+    const std::string& name,
+    const std::chrono::milliseconds& timeout) {
   // Block until key is set
-  wait({name});
+  wait({name}, timeout);
 
   auto key = compoundKey(name);
   void* ptr = redisCommand(redis_, "GET %b", key.c_str(), (size_t)key.size());
@@ -114,4 +117,4 @@ void RedisStoreHandler::wait(
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 }
-}
+} // namespace caffe2

--- a/caffe2/distributed/redis_store_handler.h
+++ b/caffe2/distributed/redis_store_handler.h
@@ -17,7 +17,9 @@ class CAFFE2_API RedisStoreHandler : public StoreHandler {
 
   virtual void set(const std::string& name, const std::string& data) override;
 
-  virtual std::string get(const std::string& name) override;
+  virtual std::string get(
+      const std::string& name,
+      const std::chrono::milliseconds& timeout = kDefaultTimeout) override;
 
   virtual int64_t add(const std::string& name, int64_t value) override;
 

--- a/caffe2/distributed/store_handler.h
+++ b/caffe2/distributed/store_handler.h
@@ -27,10 +27,12 @@ class CAFFE2_API StoreHandler {
 
   /*
    * Get the data for the key.
-   * The call should wait until the key is stored with default timeout
+   * The call should wait until the key is stored with specified timeout
    * and return data if set else fail.
    */
-  virtual std::string get(const std::string& name) = 0;
+  virtual std::string get(
+      const std::string& name,
+      const std::chrono::milliseconds& timeout = kDefaultTimeout) = 0;
 
   /*
    * Does an atomic add operation on the key and returns the latest updated


### PR DESCRIPTION
Summary:
Worker nodes sometimes witness timeout failures when getting session_id blob from Zeus, which due to delays in master node setting the blob.
This diff will add flexibility to specify longer timeout for getting blobs from Zeus.

Differential Revision: D12926156
