### PR TITLE
handle flat rolling (no dim specified) T36264909

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -610,7 +610,7 @@ public:
   Tensor transpose(int64_t dim0, int64_t dim1) const;
   Tensor & transpose_(int64_t dim0, int64_t dim1);
   Tensor flip(IntList dims) const;
-  Tensor roll(IntList shifts, IntList dims) const;
+  Tensor roll(IntList shifts, IntList dims={}) const;
   Tensor rot90(int64_t k=1, IntList dims={0,1}) const;
   Tensor trunc() const;
   Tensor & trunc_();

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -74,9 +74,9 @@ Tensor roll_cpu(const Tensor& self, IntList shifts, IntList dims) {
   int64_t start = (size - shifts[0]) % size;
   // Behavior of % is different in C++ vs Python for negative numbers. This
   // corrects the difference.
-  if (start < 0)
+  if (start < 0) {
     start = start + size;
-
+  }
   auto tensors = self.unbind(dim);
   std::vector<Tensor> vec = std::vector<Tensor>(size);
   int64_t index = 0;

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -58,11 +58,15 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
 }
 
 Tensor roll_cpu(const Tensor& self, IntList shifts, IntList dims) {
-  // todo: support rolling along no or multiple dimensions as in numpy.roll.
-  AT_CHECK(dims.size() == 1, "only single dimension roll currently supported");
+  if (dims.size() == 0 && shifts.size() == 1) {
+    auto flattened = self.contiguous().view(self.numel());
+    return roll_cpu(flattened, shifts[0], 0).view(self.sizes());
+  }
   AT_CHECK(shifts.size() == dims.size(), "shifts and dimensions must align");
+  // todo: support rolling along multiple dimensions as in numpy.roll.
+  AT_CHECK(dims.size() == 1, "only single dimension roll currently supported");
   // avoid a div zero error below.
-  if( self.numel() == 0 ) {
+  if (self.numel() == 0) {
     return self.clone();
   }
   int64_t dim = dims[0];
@@ -70,7 +74,8 @@ Tensor roll_cpu(const Tensor& self, IntList shifts, IntList dims) {
   int64_t start = (size - shifts[0]) % size;
   // Behavior of % is different in C++ vs Python for negative numbers. This
   // corrects the difference.
-  if( start < 0 ) start = start + size;
+  if (start < 0)
+    start = start + size;
 
   auto tensors = self.unbind(dim);
   std::vector<Tensor> vec = std::vector<Tensor>(size);

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -150,9 +150,13 @@ void roll_cuda_kernel(scalar_t* in_tensor, scalar_t* out_tensor, int64_t N,
 
 // Roll a tensor along a dimension
 Tensor roll_cuda(const Tensor& self, IntList shifts, IntList dims) {
-  // todo: support rolling along no or multiple dimensions as in numpy.roll.
-  AT_CHECK(dims.size() == 1, "only single dimension roll currently supported");
+  if (dims.size() == 0 && shifts.size() == 1) {
+    auto flattened = self.contiguous().view(self.numel());
+    return roll_cuda(flattened, shifts[0], 0).view(self.sizes());
+  }
   AT_CHECK(shifts.size() == dims.size(), "shifts and dimensions must align");
+  // todo: support rolling along multiple dimensions as in numpy.roll.
+  AT_CHECK(dims.size() == 1, "only single dimension roll currently supported");
 
   auto in_tensor = self;
   if(!self.is_contiguous()) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1696,7 +1696,7 @@
     CPU: flip_cpu
     CUDA: flip_cuda
 
-- func: roll(Tensor self, IntList[1] shifts, IntList[1] dims) -> Tensor
+- func: roll(Tensor self, IntList[1] shifts, IntList[1] dims={}) -> Tensor
   variants: function, method
   dispatch:
     CPU: roll_cpu

--- a/test/common_methods_invocations.py
+++ b/test/common_methods_invocations.py
@@ -190,6 +190,7 @@ method_tests = [
     ('roll', (S, S, S), (2, 0,), 'd20'),
     ('roll', (S, S, S), (-1, 0), 'neg_shift'),
     ('roll', (S, S, S), (10000, 1), 'loop_shift'),
+    ('roll', (S, S, S), (2,), 'flattened'),
     ('rot90', (S, S, S), (1, [0, 1],), 'k1_d01'),
     ('rot90', (S, S, S), (1, [1, 2],), 'k1_d12'),
     ('rot90', (S, S, S), (1, [1, -1],), 'k1_neg_d'),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7319,7 +7319,6 @@ class _TestTorchMixin(object):
             self.assertEqual(expected, data.roll(1), "roll with no dims should flatten and roll.")
             self.assertEqual(expected, data.roll(1, dims=None), "roll with no dims should flatten and roll.")
 
-
     def test_reversed(self):
         val = torch.arange(0, 10)
         self.assertEqual(reversed(val), torch.arange(9, -1, -1))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6710,6 +6710,7 @@ class _TestTorchMixin(object):
             # roll
             self.assertEqual(x, x.roll(0, 1).roll(0, -1))
             self.assertEqual(x, x.roll(1, x.size(1)))
+            self.assertEqual(x, x.roll(1))
 
             # unbind
             self.assertEqual((), x.unbind(0))
@@ -7316,6 +7317,8 @@ class _TestTorchMixin(object):
             # test roll with no dimension specified
             expected = numbers.roll(1, 0).view(2, 4)
             self.assertEqual(expected, data.roll(1), "roll with no dims should flatten and roll.")
+            self.assertEqual(expected, data.roll(1, dims=None), "roll with no dims should flatten and roll.")
+
 
     def test_reversed(self):
         val = torch.arange(0, 10)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7313,6 +7313,10 @@ class _TestTorchMixin(object):
             self.assertEqual(expected, rolled,
                              "non contiguous tensor rolled to {} instead of {} ".format(rolled, expected))
 
+            # test roll with no dimension specified
+            expected = numbers.roll(1, 0).view(2, 4)
+            self.assertEqual(expected, data.roll(1), "roll with no dims should flatten and roll.")
+
     def test_reversed(self):
         val = torch.arange(0, 10)
         self.assertEqual(reversed(val), torch.arange(9, -1, -1))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4689,7 +4689,7 @@ Example::
 
 add_docstr(torch.roll,
            r"""
-roll(input, shifts, dims) -> Tensor
+roll(input, shifts, dims=None) -> Tensor
 
 Roll the tensor along the given dimension. Elements that are shifted beyond the
 last position are re-introduced at the first position. If a dimension is not

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4692,7 +4692,9 @@ add_docstr(torch.roll,
 roll(input, shifts, dims) -> Tensor
 
 Roll the tensor along the given dimension. Elements that are shifted beyond the
-last position are re-introduced at the first position.
+last position are re-introduced at the first position. If a dimension is not
+specified, the tensor will be flattened before rolling and then restored
+to the original shape.
 
 Args:
     input (Tensor): the input tensor


### PR DESCRIPTION
update roll to behave as in numpy.roll when dimension to roll not specified.
