### PR TITLE
codemod tensor.type().is_cuda(), tensor.type().is_sparse()

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -152,7 +152,7 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   atDLMTensor->tensor.deleter = &deleter;
   atDLMTensor->tensor.dl_tensor.data = src.data_ptr();
   int64_t device_id = 0;
-  if (src.type().is_cuda()) {
+  if (src.is_cuda()) {
     device_id = src.get_device();
   }
   atDLMTensor->tensor.dl_tensor.ctx = getDLContext(src.type(), device_id);

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -180,7 +180,7 @@ AT_ERROR("${api_name} only supports a 0-dimensional ${check_name} tensor, but go
 """)
 
 SPARSE_CHECK = CodeTemplate("""\
-if(${check_name}.type().is_sparse()) {
+if(${check_name}.is_sparse()) {
     return static_cast<const TypeExtendedInterface*>(this)->${api_name}(${sparse_actuals});
 }""")
 

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -49,7 +49,7 @@ Tensor batch_norm(
   }
 
   bool use_cudnn = false;
-  use_cudnn = (input.type().is_cuda()
+  use_cudnn = (input.is_cuda()
                && (input.type().scalarType() != at::kHalf
                  || weight.type().scalarType() == at::kFloat)
                && weight.defined() && bias.defined()
@@ -68,7 +68,7 @@ Tensor batch_norm(
                         training, momentum, eps));
   }
 
-  bool use_miopen = (input.type().is_cuda()
+  bool use_miopen = (input.is_cuda()
                && input.dim() <= MIOPEN_DIM_MAX
                && input.type().scalarType() != at::kDouble
                && (input.type().scalarType() == weight.type().scalarType())

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -431,7 +431,7 @@ Tensor& norm_out(Tensor &result, const Tensor &self, Scalar p, int64_t dim, bool
 }
 
 Tensor _norm(const Tensor &self, Scalar p) {
-  if (self.type().is_sparse()) {
+  if (self.is_sparse()) {
     return at::native_norm(self, p);
   } else {
     AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -151,7 +151,7 @@ Tensor empty_like(const Tensor& self) {
 }
 
 Tensor empty_like(const Tensor& self, const TensorOptions& options) {
-  if (options.layout() == kSparse && self.type().is_sparse()) {
+  if (options.layout() == kSparse && self.is_sparse()) {
     auto res = at::empty({0}, options); // to be resized
     res.sparse_resize_and_clear_(self.sizes(), self.sparse_dim(), self.dense_dim());
     return res;
@@ -523,7 +523,7 @@ Tensor zeros_like(const Tensor& self) {
 }
 
 Tensor zeros_like(const Tensor& self, const TensorOptions& options) {
-  if (options.layout() == kSparse && self.type().is_sparse()) {
+  if (options.layout() == kSparse && self.is_sparse()) {
     auto res = at::empty({0}, options); // to be resized
     res.sparse_resize_and_clear_(self.sizes(), self.sparse_dim(), self.dense_dim());
     return res;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -273,7 +273,7 @@ Tensor repeat(const Tensor& self, IntList repeats) {
 }
 
 Tensor reshape(const Tensor& self, IntList proposed_shape) {
-  if (self.type().is_sparse()) {
+  if (self.is_sparse()) {
     AT_ERROR("reshape is not implemented for sparse tensors");
   }
   auto shape = infer_size(proposed_shape, self.numel());

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -6,7 +6,7 @@
 namespace at { namespace native {
 
 bool is_cuda(const Tensor& self) {
-  return self.type().is_cuda();
+  return self.is_cuda();
 }
 
 bool is_distributed(const Tensor& self) {
@@ -31,7 +31,7 @@ bool is_signed(const Tensor &self) {
 }
 
 bool is_sparse(const Tensor& self) {
-  return self.type().is_sparse();
+  return self.is_sparse();
 }
 
 Tensor type_as(const Tensor& self, const Tensor& other) {

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -50,7 +50,7 @@ Tensor _weight_norm
   auto v = v_in.contiguous();
   auto g = g_in.contiguous();
 
-  bool can_use_fused = v.type().is_cuda() && (dim == 0 || dim == v.dim() - 1);
+  bool can_use_fused = v.is_cuda() && (dim == 0 || dim == v.dim() - 1);
 
   if (can_use_fused) {
     // weight_norm does not have a derivative defined for it, so this will route back through

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -182,7 +182,7 @@ const Variable & VariableType::checked_cast_variable(const Tensor & t, const cha
   if (!t.defined()) {
     AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor for argument #", pos, " '", name, "'");
   }
-  if (!isVariableType(t.type())) {
+  if (!t.is_variable()) {
     AT_ERROR("Expected object of type Variable but found type ", t.type().toString(), " for argument #", pos, " '", name, "'");
   }
   return as_variable_ref(t);
@@ -192,7 +192,7 @@ Variable & VariableType::checked_cast_variable(Tensor & t, const char * name, in
   if (!t.defined()) {
     AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor for argument #", pos, " '", name, "'");
   }
-  if (!isVariableType(t.type())) {
+  if (!t.is_variable()) {
     AT_ERROR("Expected object of type Variable but found type ", t.type().toString(), " for argument #", pos, " '", name, "'");
   }
   return as_variable_ref(t);

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -42,7 +42,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   if (!grad.defined()) {
     // under following condition, we can avoid clone()
     if (!GradMode::is_enabled()
-        && !new_grad.type().is_sparse()
+        && !new_grad.is_sparse()
         && new_grad.is_contiguous()
         && new_grad.use_count() == 1) {
       // first check it is in first-order grad only mode
@@ -60,7 +60,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     // the users. Thanks to this case we can avoid changing the grad tensor,
     // a thing never promised and documented, but used in some hacks seen
     // on the internet.
-    if (grad_variable.type().is_sparse() && !new_grad.type().is_sparse()) {
+    if (grad_variable.is_sparse() && !new_grad.is_sparse()) {
       grad_variable.data() = new_grad.data() + grad_variable.data();
     } else {
       grad_variable.data() += new_grad.data();

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -22,7 +22,7 @@ void InputBuffer::add(size_t pos, Variable var) {
   } else {
     at::DeviceGuard device_guard(var);
     // ATen doesn't route sparse additions correctly...
-    if (old_var.type().is_sparse()) {
+    if (old_var.is_sparse()) {
       buffer[pos] = var + old_var;
     } else {
       buffer[pos] = old_var + var;
@@ -32,7 +32,7 @@ void InputBuffer::add(size_t pos, Variable var) {
 
 auto InputBuffer::device() const -> int {
   for (auto& var : buffer) {
-    if (var.defined() && var.type().is_cuda()) {
+    if (var.defined() && var.is_cuda()) {
       return var.get_device();
     }
   }

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -169,11 +169,11 @@ static void check_single_result(PyObject* _original, PyObject* _result, PyObject
     throw std::runtime_error(ss.str());
   }
 
-  if (original.type().is_cuda() != result.type().is_cuda()) {
+  if (original.is_cuda() != result.is_cuda()) {
     std::stringstream ss;
     auto name = hook_name(hook);
     ss << "hook '" << name << "' has changed the type of value";
-    if (original.type().is_cuda()) {
+    if (original.is_cuda()) {
       ss << " (was CUDA tensor got CPU tensor)";
     } else {
       ss << " (was CPU tensor got CUDA tensor)";

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -247,7 +247,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
 
   THPUtils_assertRet(-1, grad.type() == var.type() || gradIsSparse,
       "assigned grad has data of a different type");
-  if (var.type().is_cuda()) {
+  if (var.is_cuda()) {
     THPUtils_assertRet(-1, grad.get_device() == var.get_device(),
         "assigned grad has data located on a different device");
   }

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -177,7 +177,7 @@ at::Tensor gather(
   std::vector<int64_t> expected_size(first_size.begin(), first_size.end());
   for (const auto& tensor : tensors) {
     AT_CHECK(
-        tensor.type().is_cuda(), "Gather expects all inputs to have CUDA type");
+        tensor.is_cuda(), "Gather expects all inputs to have CUDA type");
     AT_ASSERT(tensor.ndimension() == static_cast<int64_t>(expected_size.size()));
     expected_size[dim] = tensor.size(dim);
     for (size_t dimension = 0; dimension < expected_size.size(); ++dimension) {

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -133,8 +133,8 @@ void _check_inputs(
     auto input = inputs[i];
     auto output = outputs[i];
 
-    if (!(input.type().is_cuda() && !input.type().is_sparse() &&
-          output.type().is_cuda() && !output.type().is_sparse())) {
+    if (!(input.is_cuda() && !input.is_sparse() &&
+          output.is_cuda() && !output.is_sparse())) {
       throw std::runtime_error(
           "input and output elements have to be cuda dense Tensors");
     }

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -81,7 +81,7 @@ struct ArgumentSpec {
       if ((arg.defined_ = t.defined())) {
         arg.requires_grad_ = with_grad && autograd::Variable(t).requires_grad();
         arg.dim_ = t.dim();
-        arg.device_ = t.type().is_cuda() ? t.get_device() : -1;
+        arg.device_ = t.is_cuda() ? t.get_device() : -1;
         arg.type_ = static_cast<unsigned>(t.type().scalarType());
       }
 
@@ -203,7 +203,7 @@ struct CompleteArgumentSpec {
         pod.defined = t.defined();
         if (pod.defined) {
           pod.type = static_cast<int>(t.type().scalarType());
-          pod.device = (!t.type().is_cuda()) ? -1 : t.get_device();
+          pod.device = (!t.is_cuda()) ? -1 : t.get_device();
           pod.requires_grad = with_grad && autograd::as_variable_ref(t).requires_grad();
           total_dims += t.ndimension();
           auto sizes = t.sizes();

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -16,7 +16,7 @@ struct IODescriptor {
     VariableMetadata(const autograd::Variable& var)
       : sizes(var.sizes().vec())
       , type(var.type().scalarType())
-      , device(var.type().is_cuda() ? var.get_device() : -1)
+      , device(var.is_cuda() ? var.get_device() : -1)
       , requires_grad(var.requires_grad()) {}
 
     bool operator==(const VariableMetadata& o) const {

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -301,7 +301,7 @@ struct TORCH_API TensorType : public Type {
 protected:
   TensorType(const at::Tensor& tensor, TypeKind kind=TypeKind::TensorType)
     : TensorType(tensor.type().scalarType(),
-                 tensor.type().is_cuda() ? tensor.get_device() : -1,
+                 tensor.is_cuda() ? tensor.get_device() : -1,
                  tensor.dim(),
                  tensor.is_variable() && tensor.requires_grad(),
                  kind) {}

--- a/torch/csrc/nn/type_checks.h
+++ b/torch/csrc/nn/type_checks.h
@@ -28,7 +28,7 @@ static inline int get_device(PyObject* args) {
     PyObject* arg = PyTuple_GET_ITEM(args, i);
     if (THPVariable_Check(arg)) {
       auto& tensor = THPVariable_UnpackData(arg);
-      if (tensor.type().is_cuda()) {
+      if (tensor.is_cuda()) {
         return tensor.get_device();
       }
     }

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -388,7 +388,7 @@ at::Type& get_default_tensor_type() {
 }
 
 Device getDevice(const at::Tensor& tensor) {
-  if (tensor.type().is_cuda()) {
+  if (tensor.is_cuda()) {
     return at::Device(at::DeviceType::CUDA, tensor.get_device());
   }
   return at::Device(at::DeviceType::CPU);

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -345,8 +345,8 @@ bool DataChannelNccl::_tensorCheckHelper(
 
   for (size_t i = 0; i < input.size(); ++i) {
     //  Check to make sure it's a GPU dense tensor
-    if (!(input[i].type().is_cuda() && !input[i].type().is_sparse() &&
-          output[i].type().is_cuda() && !output[i].type().is_sparse())) {
+    if (!(input[i].is_cuda() && !input[i].is_sparse() &&
+          output[i].is_cuda() && !output[i].is_sparse())) {
       throw std::runtime_error(
           "Only CUDA dense tensor is supported for NCCL "
           "collective operations");

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -308,8 +308,8 @@ void ProcessGroupNCCL::tensorCheckHelper(
 
   for (size_t i = 0; i < input.size(); ++i) {
     //  Check to make sure it's a GPU dense tensor
-    if (!(input[i].type().is_cuda() && !input[i].type().is_sparse() &&
-          output[i].type().is_cuda() && !output[i].type().is_sparse())) {
+    if (!(input[i].is_cuda() && !input[i].is_sparse() &&
+          output[i].is_cuda() && !output[i].is_sparse())) {
       throw std::runtime_error(
           "Only CUDA dense tensor is supported for NCCL "
           "collective operations");


### PR DESCRIPTION
Followup to #12841

Changed these to not require type dispatch:
tensor.type().is_cuda() -> tensor.is_cuda()
tensor.type().is_sparse() -> tensor.is_sparse()
isVariable(tensor.type()) -> tensor.is_variable()

This probably does not affect performance
very much in most cases but it is nice to have.

