### PR TITLE
 Give broadcast_coalesced tensors different version counters

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1008,6 +1008,13 @@ class TestCuda(TestCase):
             self.assertEqual(bt.get_device(), bct.get_device())
             self.assertIsInstance(bct, type(bt))
 
+        # check that the tensors have different version counters
+        versions = [t._version for t in bc_tensors_t]
+        for old_version, t in zip(versions, bc_tensors_t):
+            self.assertEqual(t._version, old_version)
+            t_()
+            self.assertEqual(t._version, old_version + 1)
+
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     @skipIfRocm
     def test_broadcast_coalesced(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1085,6 +1085,7 @@ class TestCuda(TestCase):
             self.assertEqual(rc.type(), r.type())
 
         # Since we have both cuda:0 and cuda:1 inputs, the outputs must be new.
+        # We can check that they have different version counters.
         # NOTE [ Version Counter in comm.*_coalesced ]
         versions = [t._version for t in rc_tensors]
         for old_version, t in zip(versions, rc_tensors):

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -133,7 +133,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
           // See NOTE [ Version Counter in comm.*_coalesced ]
           AT_ASSERT(t.is_variable());
           Variable var = t;
-          device_outputs.push_back(std::move(make_variable(var.data(), false)));
+          device_outputs.push_back(make_variable(var.data(), false));
         }
       }
     } else {
@@ -146,7 +146,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
           // See NOTE [ Version Counter in comm.*_coalesced ]
           AT_ASSERT(t.is_variable());
           Variable var = t;
-          device_outputs.push_back(std::move(make_variable(var.data(), false)));
+          device_outputs.push_back(make_variable(var.data(), false));
         }
       }
     }

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -13,12 +13,14 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGuard.h>
 #include "c10/util/Optional.h"
+#include "torch/csrc/autograd/variable.h"
 
 #include <cstddef>
 #include <vector>
 
 namespace torch { namespace cuda {
 using namespace at;
+using namespace torch::autograd;
 
 // Some operations can be performed more efficiently if we're handling tensors
 // of a single type only. Adding this logic directly in the loop makes it a bit
@@ -67,6 +69,27 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
   return tensors;
 }
 
+// NOTE [ Version Counter in broadcast_coalesced ]
+//
+// In broadcast_coalesced, multiple variables may be coalesced into a single
+// large one, broadcast to other devices, and the get split according to the
+// original shapes.
+//
+// When splitting, the view operations will make all Variables broadcast
+// together to share a single version counter, because they are all views of the
+// large Variable. However, that large Variable is immediately discarded and all
+// these Varaibles do not share storage at all.
+//
+// For example, when two buffers are broadcast together in `DataParallel` and
+// one of them is modified in-place during `forward` but the other is needed in
+// backward, autograd engine will complain.
+//
+// We thus re-wrap these Variables after broadcasting (i.e., effetively doing
+// what is equivalent to .data in Python), and give them individual version
+// counters.
+//
+// NB: For `device[0]`, we always return the input Variables as-is, so
+//     **do not** re-wrap them.
 tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t buffer_size) {
   if (!std::all_of(tensors.begin(), tensors.end(),
                    [&](const at::Tensor& t) { return t.get_device() == devices[0]; })) {
@@ -97,8 +120,12 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
         auto & device_outputs = outputs[i];
         auto & inds = broadcast_indices[i];
         auto & vals = broadcast_values[i];
-        for (auto & t : utils::unflatten_sparse_tensors(inds, vals, chunk.tensors))
-          device_outputs.push_back(std::move(t));
+        for (auto & t : utils::unflatten_sparse_tensors(inds, vals, chunk.tensors)) {
+          // See NOTE [ Version Counter in broadcast_coalesced ]
+          AT_ASSERT(t.is_variable());
+          Variable var = t;
+          device_outputs.push_back(std::move(make_variable(var.data(), false)));
+        }
       }
     } else {
       std::vector<Tensor> results = broadcast(utils::flatten_dense_tensors(chunk.tensors),
@@ -106,8 +133,12 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t bu
       for (size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
         device_guard.set_index(devices[i]);
         auto & device_outputs = outputs[i];
-        for (auto & t : utils::unflatten_dense_tensors(results[i], chunk.tensors))
-          device_outputs.push_back(std::move(t));
+        for (auto & t : utils::unflatten_dense_tensors(results[i], chunk.tensors)) {
+          // See NOTE [ Version Counter in broadcast_coalesced ]
+          AT_ASSERT(t.is_variable());
+          Variable var = t;
+          device_outputs.push_back(std::move(make_variable(var.data(), false)));
+        }
       }
     }
   }


### PR DESCRIPTION
In `broadcast_coalesced`, since multiple variables can be "views" of a big flattened tensor, they can share the same version counter. However, this base flat tensor is not exposed and they don't share any memory locations, so this is not necessary. Furthermore, it can cause problems, e.g., when two buffers are broadcast together in `DataParallel` and one of them is modified in-place during `forward` but the other is needed in backward, autograd engine will complain.

Fixing the bug discovered at https://github.com/pytorch/pytorch/pull/13350#issuecomment-436011370

edit: This is a very real problem. E.g., consider using Spectral Norm + Batch Norm together.