### PR TITLE
[c10d] Error msg on TCP backend

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -45,11 +45,16 @@ class DistBackend(object):
     GLOO = "gloo"
     NCCL = "nccl"
     MPI = "mpi"
+    TCP = "tcp"
 
     def __new__(cls, name):
         if not isinstance(name, string_classes):
             raise ValueError("Backend name must be a string, but got: {}".format(name))
         value = getattr(DistBackend, name.upper(), DistBackend.UNDEFINED)
+        if value == DistBackend.TCP:
+            raise ValueError("TCP backend has been deprecated. Please use "
+                             "Gloo or MPI backend for collective operations "
+                             "on CPU tensors.")
         if value == DistBackend.UNDEFINED:
             raise ValueError("Invalid backend: '{}'".format(name))
         return value


### PR DESCRIPTION
Clean it up from my queue:

https://github.com/pytorch/pytorch/issues/12721


```
>>> torch.distributed.init_process_group(backend="tcp")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/home/tengli/pytorch/torch/distributed/distributed_c10d.py", line 275, in init_process_group
    backend = DistBackend(backend)
  File "/private/home/tengli/pytorch/torch/distributed/distributed_c10d.py", line 55, in __new__
    raise ValueError("TCP backend has been deprecated. Please use "
ValueError: TCP backend has been deprecated. Please use Gloo or MPI backends for collective operations on CPU tensors.
```