### PR TITLE
Use nested variant of getValueTrace to allow more flexible tracing script modules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1465,6 +1465,30 @@ class TestJit(JitTestCase):
         x = torch.randn(5, 5)
         self.assertEqual(foo(x), x + x + x)
 
+    def test_trace_script(self):
+        @torch.jit.script
+        def func1(x):
+            # type: (Tuple[Tensor, Tensor]) -> Tensor
+            return x[0] + x[1]
+
+        @torch.jit.script
+        def func2(x):
+            # type: (List[Tensor]) -> Tensor
+            return x[0] + x[1]
+
+        a = torch.randn(5)
+        b = torch.randn(5)
+
+        expected = func1((a, b))
+        traced = torch.jit.trace(func1, ((a, b),))
+        result = traced((a, b))
+        self.assertEqual(expected, result)
+
+        expected = func2((a, b))
+        traced = torch.jit.trace(func2, ((a, b),))
+        result = traced((a, b))
+        self.assertEqual(expected, result)
+
     def test_einsum(self):
         def outer(x, y):
             return torch.einsum('i,j->ij', (x, y))

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -495,8 +495,8 @@ private:
   void runTraced(Stack & stack) {
     auto state = tracer::getTracingState();
     auto inputs = last(stack, num_inputs);
-    auto input_values = fmap(inputs, [](const IValue & v) {
-      return tracer::getValueTrace(v.toTensor());
+    auto input_values = fmap(inputs, [&](const IValue & v) {
+      return tracer::getNestedValueTrace(state, v);
     });
 
     ArgumentSpec spec(autograd::GradMode::is_enabled(), inputs, num_flat_inputs);

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -495,8 +495,8 @@ private:
   void runTraced(Stack & stack) {
     auto state = tracer::getTracingState();
     auto inputs = last(stack, num_inputs);
-    auto input_values = fmap(inputs, [&](const IValue & v) {
-      return tracer::getNestedValueTrace(state, v);
+    auto input_values = fmap(inputs, [](const IValue & v) {
+      return tracer::getNestedValueTrace(v);
     });
 
     ArgumentSpec spec(autograd::GradMode::is_enabled(), inputs, num_flat_inputs);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -80,7 +80,12 @@ inline Value* getNestedValueTrace(const std::shared_ptr<TracingState>& state, co
         DynamicType::get(),
         fmap(v.toTensorListRef(), [&](const IValue &v) {
           return getNestedValueTrace(state, v);
-	)))->output();
+	})))->output();
+  } else if (v.isTuple()) {
+    return state->graph->insertNode(state->graph->createTuple(
+	fmap(v.toTuple()->elements(), [&](const IValue &v) {
+          return getNestedValueTrace(state, v);
+	})))->output();
   }
   return getValueTrace(v.toTensor());
 }

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -74,6 +74,18 @@ inline Value* getValueTrace(const Variable& var) {
   return it->second;
 }
 
+inline Value* getNestedValueTrace(const std::shared_ptr<TracingState>& state, const IValue &v) {
+  if (v.isTensorList()) {
+    return state->graph->insertNode(state->graph->createList(
+        DynamicType::get(),
+        fmap(v.toTensorListRef(), [&](const IValue &v) {
+          return getNestedValueTrace(state, v);
+	)))->output();
+  }
+  return getValueTrace(v.toTensor());
+}
+
+
 inline Value* getOutputTrace(const std::shared_ptr<TracingState>& state, const Variable& var, size_t output_no) {
   if (!var.defined()) {
     Node *n = state->graph->createUndefined();


### PR DESCRIPTION
When tracing scripted functions, we used to only allow Tensor arguments.
This enables tracing script modules with List[Tensor] or Tuple[Tensor, Tensor] arguments (passing
tuples).

Fixes: #13566
