### PR TITLE
add unwrap optional operator

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7256,6 +7256,13 @@ a")
 
         self.checkScript(test, (3,))
 
+        with self.assertRaisesRegex(AssertionError, "Unwrapping null optional"):
+            test(None)
+
+        test_script = torch.jit.script(test)
+        with self.assertRaisesRegex(RuntimeError, "Unwrapping null optional"):
+            test_script(None)
+
         with self.assertRaisesRegex(RuntimeError, "cannot match a optional to int"):
             @torch.jit.script
             def test_test():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7247,6 +7247,20 @@ a")
         # output is None in script and () in python
         self.assertEqual(test_indexing_end_out_of_bounds(), None)
 
+    def test_unwrap_optional_builtin(self):
+        def test(x):
+            # type: (Optional[int]) -> int
+            x = torch.jit._unwrap_optional(x)
+            x = x + x
+            return x
+
+        self.checkScript(test, (3,))
+
+        with self.assertRaisesRegex(RuntimeError, "cannot match a optional to int"):
+            @torch.jit.script
+            def test_test():
+                return torch.jit._unwrap_optional(1)
+
     def test_indexing_error(self):
         with self.assertRaisesRegex(RuntimeError, "Indexing only supported on lists, tensors, and tuples"):
             @torch.jit.script

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -520,7 +520,15 @@ RegisterOperators reg({
             };
           }
         }),
-    Operator("aten::_unwrap_optional(t? optional) -> t", noop),
+    Operator("aten::_unwrap_optional(t? optional) -> t",
+      [](const Node* node) -> Operation {
+        return [=](Stack& stack) {
+          auto val = pop(stack);
+          JIT_ASSERTM(!val.isNone(), "Unwrapping null optional");
+          push(stack, val);
+          return 0;
+        };
+      }),
     Operator(
         prim::fork,
         [](const Node* node) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -520,6 +520,7 @@ RegisterOperators reg({
             };
           }
         }),
+    Operator("aten::_unwrap_optional(t? optional) -> t", noop),
     Operator(
         prim::fork,
         [](const Node* node) {

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -245,6 +245,15 @@ TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
       ss << "cannot match a future to " << actual->str();
       throw TypeMatchError(ss.str());
     }
+  } else if (auto opt_formal = formal->cast<OptionalType>()) {
+    if (auto opt_actual = actual->cast<OptionalType>()) {
+      return OptionalType::create(matchTypeVariables(
+          opt_formal->getElementType(), opt_actual->getElementType(), type_env));
+    } else {
+      std::stringstream ss;
+      ss << "cannot match a optional to " << actual->str();
+      throw TypeMatchError(ss.str());
+    }
   }
 
   AT_ERROR("unhandled free variable container: ", formal->str());

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1320,6 +1320,10 @@ def _should_skip(mod, name):
     return mod is torch.nn.functional and name in _builtin_blacklist
 
 
+def _unwrap_optional(x):
+    return x
+
+
 # lazily built to ensure the correct initialization order
 def _get_builtin_table():
     global _builtin_table
@@ -1340,6 +1344,7 @@ def _get_builtin_table():
     _builtin_table[id(_pair)] = "aten::_pair"
     _builtin_table[id(_triple)] = "aten::_triple"
     _builtin_table[id(_quadruple)] = "aten::_quadruple"
+    _builtin_table[id(_unwrap_optional)] = "aten::_unwrap_optional"
 
     return _builtin_table
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1321,6 +1321,7 @@ def _should_skip(mod, name):
 
 
 def _unwrap_optional(x):
+    assert x is not None, "Unwrapping null optional"
     return x
 
 


### PR DESCRIPTION
Add a builtin to refine the type of Optional[T] -> T. This is a short-term solution to unblock porting of the the standard library. 