### PR TITLE
[c10d] Disabling NCCL coalesced bcast test since it hangs in CI

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -37,6 +37,7 @@ TestSkip = namedtuple('TestSkip', 'exit_code, message')
 TEST_SKIPS = {
     "multi-gpu": TestSkip(75, "Need at least 2 CUDA devices"),
     "nccl": TestSkip(76, "c10d not compiled with NCCL support"),
+    "known_issues": TestSkip(77, "Test skipped due to known issues")
 }
 
 
@@ -58,6 +59,15 @@ def skip_if_not_nccl(func):
         if hasattr(c10d, "ProcessGroupNCCL"):
             return func(*args, **kwargs)
         sys.exit(TEST_SKIPS['nccl'].exit_code)
+
+    return wrapper
+
+
+def skip_for_known_issues(func):
+    """Skips a test due to known issues (for c10d)."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        sys.exit(TEST_SKIPS['known_issues'].exit_code)
 
     return wrapper
 
@@ -1176,6 +1186,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     @skip_if_not_nccl
+    @skip_for_known_issues
     def test_dist_broadcast_coalesced_nccl(self):
         store = c10d.FileStore(self.file.name)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)


### PR DESCRIPTION
Functionality test shouldn't be affected since we have both backends testing for the same thing.