### PR TITLE
propagate python op error msg

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7713,6 +7713,20 @@ a")
         ge_graph = jit_trace.__getattr__('forward').graph_for(x, y, c)
         self.assertExpectedGraph(ge_graph, 'jit')
 
+    def test_pyop_exception_message(self):
+        class Foo(torch.jit.ScriptModule):
+            def __init__(self):
+                super(Foo, self).__init__()
+                self.conv = nn.Conv2d(1, 10, kernel_size=5)
+
+            @torch.jit.script_method
+            def forward(self, x):
+                return self.conv(x)
+        foo = Foo()
+        # testing that the correct error message propagates
+        with self.assertRaisesRegex(RuntimeError, "Expected 4-dimensional input for 4-dimensional weight"):
+            foo(torch.ones([123]))  # wrong size
+
     def test_exceptions(self):
         cu = torch.jit.CompilationUnit('''
             def foo(cond):

--- a/torch/csrc/jit/python_interpreter.cpp
+++ b/torch/csrc/jit/python_interpreter.cpp
@@ -31,7 +31,7 @@ namespace {
 Operation createPythonOperation(const Node* op_) {
   AutoGIL gil;
   const PythonOp* op = static_cast<const PythonOp*>(op_);
-  const py::function func = 
+  const py::function func =
     py::reinterpret_borrow<const py::function>(py::handle(const_cast<PythonOp*>(op)->pyobj.get()));
 
   size_t num_inputs = 0;
@@ -50,7 +50,7 @@ Operation createPythonOperation(const Node* op_) {
     size_t next_tensor = 0;
     for (auto arg_type : op->cconv) {
       if (arg_type == 'c') {
-        py_inputs[i] = 
+        py_inputs[i] =
           py::reinterpret_borrow<const py::object>(const_cast<PythonOp*>(op)->scalar_args[next_scalar++].get());
       } else if (arg_type == 'd') {
         py_inputs[i] = toPyObject(std::move(peek(stack, next_tensor, num_inputs)));
@@ -63,7 +63,7 @@ Operation createPythonOperation(const Node* op_) {
       py::object py_output(func(*py_inputs));
       stack.push_back(returnToIValue(op->output()->type(), py_output));
     } catch (py::error_already_set & e) {
-      throw python_error();
+      throw std::runtime_error(e.what());
     }
     return 0;
   };


### PR DESCRIPTION
Correctly propagate the error msg from a python op to the JIT interpreter. In the interpreter we wrap the exception and re-throw it as a Runtime Exception. Potentially in a future diff we can throw the same type of python exception as was originally thrown.

Fix for https://github.com/pytorch/pytorch/issues/13560