### PR TITLE
swap with empty vector to force deallocation

### DIFF
--- a/caffe2/operators/quantized/server/conv_dnnlowp_acc16_op.cc
+++ b/caffe2/operators/quantized/server/conv_dnnlowp_acc16_op.cc
@@ -170,7 +170,7 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
           W_quantized_.data() + group_id * (M / group_) * kernel_dim,
           kernel_dim));
     }
-    W_quantized_.clear();
+    vector<int8_t>().swap(W_quantized_);
   }
 
   return true;

--- a/caffe2/operators/quantized/server/conv_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/conv_dnnlowp_op.cc
@@ -421,7 +421,7 @@ bool ConvDNNLowPOp<T, ReluFused>::GetQuantizationParameters_() {
   PreComputeRowColumnOffsets_();
   if (!Wq_packed_.empty() && !FLAGS_caffe2_dnnlowp_dump_tensors) {
     // From here, W_quantized_ is not used anymore when we have Wq_packed_
-    W_quantized_.clear();
+    vector<T_signed>().swap(W_quantized_);
   }
 
   QuantizeBias_();

--- a/caffe2/operators/quantized/server/fully_connected_dnnlowp_acc16_op.cc
+++ b/caffe2/operators/quantized/server/fully_connected_dnnlowp_acc16_op.cc
@@ -105,7 +105,7 @@ bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
         K));
 
     if (is_weight_constant_) {
-      W_quantized_.clear();
+      vector<T_signed>().swap(W_quantized_);
     }
   }
 

--- a/caffe2/operators/quantized/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/fully_connected_dnnlowp_op.cc
@@ -514,7 +514,7 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   }
   if (Wq_packed_ && !FLAGS_caffe2_dnnlowp_dump_tensors) {
     // From here, W_quantized_ is not used anymore when we have Wq_packed_
-    W_quantized_.clear();
+    vector<T_signed>().swap(W_quantized_);
   }
 
   // Quantize bias

--- a/caffe2/operators/quantized/server/fully_connected_rowwise_dnnlowp_op.cc
+++ b/caffe2/operators/quantized/server/fully_connected_rowwise_dnnlowp_op.cc
@@ -325,7 +325,7 @@ bool FullyConnectedRowWiseDNNLowPOp<T>::GetQuantizationParameters_() {
   }
 
   if (Wq_packed_) {
-    W_quantized_.clear();
+    vector<T_signed>().swap(W_quantized_);
   }
   if (!is_weight_constant_ || b_quantized_.empty()) {
       // Quantize bias


### PR DESCRIPTION
Summary: v.clear() doesn't guarantee deallocation and it was causing memory capacity issues

Differential Revision: D12941938
