### PR TITLE
[jit] extend alias annotations

### DIFF
--- a/aten/src/ATen/core/alias_info.h
+++ b/aten/src/ATen/core/alias_info.h
@@ -1,37 +1,88 @@
 #pragma once
+#include <unordered_set>
 #include <vector>
 #include <ATen/core/interned_strings.h>
+#include "c10/util/Exception.h"
 
 namespace c10 {
-
-struct AliasInfo {
+class AliasInfo {
+ public:
   // Symbol for the set that can alias
-  static Symbol wildcard() {
-     static const Symbol wc = Symbol::fromQualString("alias::*");
-     return wc;
+  static AliasInfo createWildcard() {
+    AliasInfo ret;
+    ret.addSet(wildcard());
+    return ret;
   }
-  AliasInfo(std::vector<Symbol> sets = {},
-            std::vector<AliasInfo> contained_types = {})
-  : sets_(std::move(sets))
-  , contained_types_(std::move(contained_types)) {}
 
+  void setIsWrite(bool isWrite) {
+    isWrite_ = isWrite;
+  }
 
-  // all sets it can be in
-  const std::vector<Symbol>& sets() {
+  bool isWrite() const {
+    return isWrite_;
+  }
+
+  void addSet(Symbol aliasSet) {
+    sets_.insert(aliasSet);
+  }
+
+  const std::unordered_set<Symbol>& sets() const {
     return sets_;
+  }
+
+  Symbol set() const {
+    AT_ASSERT(sets_.size() == 1);
+    return *sets_.begin();
+  }
+
+  bool isWildcard() const {
+    return sets_.count(wildcard()) != 0;
+  }
+
+  void unionWith(const AliasInfo& other) {
+    for (const auto& alias : other.sets()) {
+      sets_.insert(alias);
+    }
   }
   // the alias info for the contained types of the type
   // e.g. if this is an annotation on List[T], `sets` refers to
   // the alias sets that the list may be in
   // while containedTypes()[0] refers to the sets that members of the list
   // may be in
-  const std::vector<AliasInfo>& containedTypes() {
-    return contained_types_;
+  void addContainedType(AliasInfo aliasInfo) {
+    containedTypes_.push_back(std::move(aliasInfo));
+  }
+  const std::vector<AliasInfo>& containedTypes() const {
+    return containedTypes_;
   }
 
-private:
-  std::vector<Symbol> sets_;
-  std::vector<AliasInfo> contained_types_;
+ private:
+  static Symbol wildcard() {
+    static const Symbol wc = Symbol::fromQualString("alias::*");
+    return wc;
+  }
+  std::unordered_set<Symbol> sets_;
+  std::vector<AliasInfo> containedTypes_;
+  bool isWrite_ = false;
 };
 
+// DEBUG ONLY; this does not match the way things are represented in the schema
+inline std::ostream& operator<<(std::ostream& out, const AliasInfo& aliasInfo) {
+  out << "(";
+  bool first = true;
+  for (const auto& set : aliasInfo.sets()) {
+    if (first) {
+      first = false;
+    } else {
+      out << "|";
+    }
+    out << set.toUnqualString();
+  }
+  out << ")";
+
+  if (!aliasInfo.containedTypes().empty()) {
+    out << " CONTAINS " << aliasInfo.containedTypes()[0];
+  }
+  return out;
+}
 } // namespace c10

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -23,7 +23,8 @@ struct Argument {
         type_(type ? type : DynamicType::get()),
         N_(std::move(N)),
         default_value_(std::move(default_value)),
-        kwarg_only_(kwarg_only) {}
+        kwarg_only_(kwarg_only),
+        alias_info_(std::move(alias_info)) {}
   const std::string& name() const {
     return name_;
   }
@@ -39,20 +40,13 @@ struct Argument {
   bool kwarg_only() const {
     return kwarg_only_;
   }
-  const AliasInfo& alias_info() const {
-    if(!alias_info_) {
-      alias_info_ = createBlankAliasInfo(type_);
-    }
-    return *alias_info_;
+  const c10::optional<AliasInfo>& alias_info() const {
+    return alias_info_;
   }
+
 private:
-  static AliasInfo createBlankAliasInfo(TypePtr typ) {
-    auto contained = fmap(typ->containedTypes(), createBlankAliasInfo);
-    return AliasInfo({}, std::move(contained));
-  }
   std::string name_;
   TypePtr type_;
-  mutable c10::optional<AliasInfo> alias_info_;
   // for list types, an optional statically known length for the list
   // e.g. for int[3]: type = ListType::ofInts(), N = 3
   // If present, this will allow scalars to be broadcast to this length to
@@ -62,6 +56,7 @@ private:
   c10::optional<IValue> default_value_;
   // is this only specifyable as a keyword argument?
   bool kwarg_only_;
+  c10::optional<AliasInfo> alias_info_;
 };
 
 struct FunctionSchema {
@@ -70,14 +65,13 @@ struct FunctionSchema {
       std::vector<Argument> arguments,
       std::vector<Argument> returns,
       bool is_vararg = false,
-      bool is_varret = false,
-      std::vector<Symbol> writes = {})
+      bool is_varret = false)
       : name_(std::move(name)),
         arguments_(std::move(arguments)),
         returns_(std::move(returns)),
         is_vararg_(is_vararg),
-        is_varret_(is_varret),
-        writes_(std::move(writes)) {}
+        is_varret_(is_varret) {}
+
   FunctionSchema(
       Symbol name,
       std::vector<Argument> arguments,
@@ -103,8 +97,6 @@ private:
   const bool is_vararg_;
   const bool is_varret_;
 
-  // set of alias sets in Arguments that are written to by this op
-  const std::vector<Symbol> writes_;
 public:
   const std::string& name() const {
     return name_;
@@ -115,9 +107,6 @@ public:
   const std::vector<Argument>& returns() const {
     return returns_;
   }
-  const std::vector<Symbol>& writes() const {
-    return writes_;
-  }
   bool is_vararg() const {
     return is_vararg_;
   }
@@ -125,7 +114,10 @@ public:
     return is_varret_;
   }
   bool is_mutable() const {
-    return writes().size() > 0;
+    return std::any_of(
+        arguments_.cbegin(), arguments_.cend(), [](const Argument& arg) {
+          return arg.alias_info() && arg.alias_info()->isWrite();
+        });
   }
   c10::optional<int> argumentIndexWithName(const std::string& name) const {
     for(size_t i = 0; i < arguments().size(); ++i) {
@@ -134,8 +126,6 @@ public:
     }
     return c10::nullopt;
   }
-
- private:
 };
 
 // for debugging, make sure we can describe the call site

--- a/torch/csrc/jit/alias_info.h
+++ b/torch/csrc/jit/alias_info.h
@@ -4,5 +4,5 @@ namespace torch { namespace jit {
 
 using ::c10::AliasInfo;
 
-}} // namespace torch::jit
-
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/canonicalize_ops.cpp
+++ b/torch/csrc/jit/passes/canonicalize_ops.cpp
@@ -15,7 +15,7 @@ struct ChunkOutput {
 static c10::optional<std::vector<ChunkOutput>> getChunkOutputs(Node* chunk) {
   std::vector<ChunkOutput> outputs;
   for (auto list_use : chunk->output()->uses()) {
-    if (list_use.user->matches("aten::select(Tensor[] a, int b) -> Tensor", attr::b)) {
+    if (list_use.user->matches("aten::select(Tensor[] list, int idx) -> Tensor", attr::b)) {
       outputs.emplace_back(list_use.user->output(),
                             list_use.user->get<int64_t>(attr::b).value());
     } else if (list_use.user->kind() == prim::ListUnpack) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -833,17 +833,30 @@ Operator(                                                                      \
         return 0;
       }
     ),
-#define CREATE_LIST_OPS(decl_type, c_type) \
+    Operator(
+        "aten::append(Tensor[](a!) self, Tensor(c) el) -> Tensor[](a!)",
+        listAppend<Shared<TensorList>, at::Tensor>),
+    Operator("aten::select(Tensor[](a) list, int idx) -> Tensor(*)", listSelect<Shared<TensorList>>),
+    Operator("aten::_set_item(Tensor[](a!) l, int idx, Tensor el) -> Tensor[](a!)", listSetItem<Shared<TensorList>, at::Tensor>),
+
+  // Mutable ops for lists containing immutable types.
+#define CREATE_IMMUTABLE_LIST_OPS(decl_type, c_type) \
     Operator("aten::select(" decl_type "[] a, int b) -> " decl_type, listSelect<Shared<c_type>>), \
+    Operator( \
+        "aten::append(" decl_type "[](a!) self, " decl_type " el) -> " decl_type "[](a!)", \
+        listAppend<Shared<c_type>, c_type::ElemType>), \
     Operator("aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type " el) -> " decl_type"[](a!)", listSetItem<Shared<c_type>, c_type::ElemType>), \
+
+    CREATE_IMMUTABLE_LIST_OPS("int", IntList)
+    CREATE_IMMUTABLE_LIST_OPS("float", DoubleList)
+    CREATE_IMMUTABLE_LIST_OPS("t", GenericList)
+
+#define CREATE_LIST_OPS(decl_type, c_type) \
     Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
     Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
     Operator( \
         "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \
         listSlice<Shared<c_type>, c_type::ElemType>), \
-    Operator( \
-        "aten::append(" decl_type "[](a!) self, " decl_type " el) -> " decl_type "[](a!)", \
-        listAppend<Shared<c_type>, c_type::ElemType>), \
 
 
     CREATE_LIST_OPS("int", IntList)


### PR DESCRIPTION
Grab bag of additions to alias annotations that were useful when writing the alias analysis pass. Not very organized since these were mostly split off from that PR.
- Switch alias sets to actual sets, since we will want to union them.
- Correctly parse alias set unions `a|b`, and correctly parse wildcards
- Move writes into `AliasInfo`, which cleans up some code that was passing a `writes` vector everywhere and simplifies tracking aliased writes during analysis.
- Change Tensor list extraction ops to return wildcard tensors.
