### PR TITLE
Allow blacklist ops in onnxifi transform

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -26,7 +26,8 @@ class CAFFE2_API OnnxifiTransformer {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& external_inputs,
-      const std::unordered_map<std::string, TensorShape>& shape_hints);
+      const std::unordered_map<std::string, TensorShape>& shape_hints,
+      const std::unordered_set<int>& blacklisted_ops);
 
   const std::unordered_map<std::string, std::string>& input_mapping() const {
     return input_mapping_;

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1650,7 +1650,11 @@ void addGlobalMethods(py::module& m) {
         }
         OnnxifiTransformer ts(infer_shapes, debug_builder);
         ts.Transform(
-            GetCurrentWorkspace(), &pred_net, external_inputs, tensor_shapes);
+            GetCurrentWorkspace(),
+            &pred_net,
+            external_inputs,
+            tensor_shapes,
+            {});
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary: This diff allows us to specify a set of op positions which we don't want to offload to onnxifi backend. This is pretty useful for debugging.

Differential Revision: D12945523
