### PR TITLE
Remove compileFunction

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -779,6 +779,8 @@ inline bool isSupportedListElementType(TypePtr type) {
       type->isSubtypeOf(NumberType::get());
 }
 
+static FunctionSchema extractSchemaFromDef(const Def &def, bool is_method);
+
 struct to_ir {
   to_ir(
       Def def,
@@ -2335,12 +2337,6 @@ void defineMethodsInModule(Module & m, const std::string& source, Resolver resol
     resolvers.push_back(resolver);
   }
   defineMethodsInModule(m, definitions, resolvers, self);
-}
-
-std::shared_ptr<Graph> compileFunction(Def def, Resolver resolver) {
-  Module m;
-  defineMethodsInModule(m, {def}, {resolver}, nullptr);
-  return m.get_method(def.name().name()).graph();
 }
 
 std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -177,7 +177,6 @@ TORCH_API void defineMethodsInModule(
 
 // same as above but parse the definitions from source
 TORCH_API void defineMethodsInModule(Module & m, const std::string& source, Resolver resolver, std::shared_ptr<SugaredValue> self);
-TORCH_API std::shared_ptr<Graph> compileFunction(Def def, Resolver resolver);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.
@@ -223,8 +222,6 @@ TORCH_API c10::optional<MatchedSchema> tryMatchSchema(
   at::ArrayRef<NamedValue> attributes,
   std::ostream& failure_messages,
   bool convert_tensors_to_nums);
-
-TORCH_API FunctionSchema extractSchemaFromDef(const Def &def, bool is_method=false);
 
 TORCH_API Value* emitBuiltinCall(
   const SourceRange& loc,

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -330,6 +330,10 @@ struct Def : public TreeView {
   explicit Def(const TreeRef& tree) : TreeView(tree) {
     tree->match(TK_DEF);
   }
+  Def withName(std::string new_name) const {
+    auto new_ident = Ident::create(name().range(), new_name);
+    return create(range(), new_ident, decl(), statements());
+  }
   Ident name() const {
     return Ident(subtree(0));
   }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -618,18 +618,11 @@ def script(fn, optimize=True, _frames_up=0, _rcb=None):
     if _rcb is None:
         _rcb = createResolutionCallback(_frames_up + 1)
     ast = get_jit_ast(fn, is_method=False)
-    graph = _jit_script_compile(ast, _rcb)
     mod = ScriptModule()
-    mod._create_method_from_graph('forward', graph)
-    # TODO: refactor everything so we're not 1) creating a ScriptModule
-    # 2) Throwing everything away except for the graph 3) Creating a new
-    # ScriptModule and dumping that graph in 4) Re-populating the schema
-    # because it was lost doing the previous
-    mod.__getattr__('forward').forward_schema(ast, get_default_args(fn), False)
+    _jit_script_compile(mod, ast, _rcb, get_default_args(fn))
     # Forward docstrings
     mod.__doc__ = fn.__doc__
     return mod
-
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))
 


### PR DESCRIPTION
This finishes a TODO to get torch.jit.script to go through the same
pathway as methods, removing the need for forward_schema and
for compileFunction.

