### PR TITLE
Fix overflow error in stats_put_ops

### DIFF
--- a/caffe2/operators/stats_put_ops.h
+++ b/caffe2/operators/stats_put_ops.h
@@ -48,22 +48,24 @@ struct TemplatePutOp : public Operator<CPUContext> {
     int64_t bound_value =
         std::numeric_limits<int64_t>::max() / magnitude_expand_;
 
+    int64_t int_value;
     if (bound_) {
       if (isNan(input)) {
-        input = 0;
-      } else if (input < -bound_value) {
-        input = -bound_value;
-      } else if (input > bound_value) {
-        input = bound_value;
+        int_value = 0;
+      } else if (input <= -bound_value) {
+        int_value = std::numeric_limits<int64_t>::min();
+      } else if (input >= bound_value) {
+        int_value = std::numeric_limits<int64_t>::max();
+      } else {
+        int_value = input * magnitude_expand_;
       }
     } else {
       CAFFE_ENFORCE(
           std::abs(static_cast<int64_t>(input)) < bound_value,
           "Input value is too large for the given magnitude expansion!");
       CAFFE_ENFORCE(!isNan(input), "Input value cannot be NaN!");
+      int_value = input * magnitude_expand_;
     }
-
-    int64_t int_value = input * magnitude_expand_;
 
     CAFFE_EVENT(stat_, stat_value, int_value);
 

--- a/caffe2/python/operator_test/stats_put_ops_test.py
+++ b/caffe2/python/operator_test/stats_put_ops_test.py
@@ -69,7 +69,38 @@ class TestPutOps(TestCase):
         self.assertIn(stat_name + sum_postfix, stat_dict)
         self.assertIn(stat_name + count_postfix, stat_dict)
         self.assertEquals(stat_dict[stat_name + sum_postfix],
-         9 * magnitude_expand)
+            9223372036854775807)
+        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+
+    def test_clamp_with_out_of_bounds(self):
+        put_value = float(1e20)
+        magnitude_expand = 1000000000000
+        stat_name = "stat".encode('ascii')
+        sum_postfix = "/stat_value/sum".encode("ascii")
+        count_postfix = "/stat_value/count".encode("ascii")
+
+        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+
+        workspace.RunOperatorOnce(core.CreateOperator(
+            "AveragePut",
+            "value",
+            [],
+            stat_name=stat_name,
+            magnitude_expand=magnitude_expand,
+            bound=True))
+
+        workspace.RunOperatorOnce(core.CreateOperator(
+            'StatRegistryExport', [], ['k', 'v', 't']))
+
+        k = workspace.FetchBlob('k')
+        v = workspace.FetchBlob('v')
+
+        stat_dict = dict(zip(k, v))
+
+        self.assertIn(stat_name + sum_postfix, stat_dict)
+        self.assertIn(stat_name + count_postfix, stat_dict)
+        self.assertEquals(stat_dict[stat_name + sum_postfix],
+            9223372036854775807)
         self.assertEquals(stat_dict[stat_name + count_postfix], 1)
 
     def test_avg_put_ops(self):


### PR DESCRIPTION
Summary:
I was hitting this error:

caffe2/caffe2/operators/stats_put_ops.h:66:25: runtime error: 9.22337e+18 is outside the range of representable values of type 'long'

So, the assignment from int64_t to float loses some precision and because of that we overflow.

Reproduced this issue with this diff D12945013

Reviewed By: mlappelbaum, jdshi-fb

Differential Revision: D12927086
