### PR TITLE
Update path in CI script to access ninja

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -29,6 +29,8 @@ fi
 if [[ "$BUILD_ENVIRONMENT" != *ppc64le* ]]; then
   # JIT C++ extensions require ninja.
   pip install -q ninja --user
+  # ninja is installed in /var/lib/jenkins/.local/bin
+  export PATH="/var/lib/jenkins/.local/bin:$PATH"
 
   # TODO: move this to Docker
   pip install -q hypothesis --user

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -90,6 +90,13 @@ THD_DISTRIBUTED_TESTS_CONFIG = {
 SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n) for n in dir(signal)
                              if n.startswith('SIG') and '_' not in n)
 
+CPP_EXTENSIONS_ERROR = """
+Ninja (https://ninja-build.org) must be available to run C++ extensions tests,
+but it could not be found. Install ninja with `pip install ninja`
+or `conda install ninja`. Alternatively, disable C++ extensions test with
+`run_test.py --exclude cpp_extensions`.
+"""
+
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)
@@ -140,10 +147,8 @@ def test_cpp_extensions(executable, test_module, test_directory, options):
     try:
         cpp_extension.verify_ninja_availability()
     except RuntimeError:
-        print(
-            'Ninja is not available. Skipping C++ extensions test. '
-            "Install ninja with 'pip install ninja' or 'conda install ninja'.")
-        return 0
+        print(CPP_EXTENSIONS_ERROR)
+        return 1
     return_code = shell([sys.executable, 'setup.py', 'install', '--root', './install'],
                         os.path.join(test_directory, 'cpp_extensions'))
     if return_code != 0:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -333,6 +333,7 @@ class BuildExtension(build_ext):
         check_compiler_abi_compatibility(compiler)
 
     def _add_compile_flag(self, extension, flag):
+        extension.extra_compile_args = copy.copy(extension.extra_compile_args)
         if isinstance(extension.extra_compile_args, dict):
             for args in extension.extra_compile_args.values():
                 args.append(flag)


### PR DESCRIPTION
We weren't running C++ extensions tests in CI.
Also, let's error hard when `ninja` is not available instead of skipping C++ extensions tests.

Fixes https://github.com/pytorch/pytorch/issues/13622

@ezyang @soumith @yf225 