### PR TITLE
 Use SmallVector for TensorImpl sizes and strides.

### DIFF
--- a/aten/src/ATen/core/SmallVector.h
+++ b/aten/src/ATen/core/SmallVector.h
@@ -198,6 +198,16 @@ class SmallVectorTemplateCommon : public SmallVectorBase {
     return const_pointer(begin());
   }
 
+  // SmallVector::at is NOT from LLVM.
+  reference at(size_type idx) {
+    assert(idx < size());
+    return begin()[idx];
+  }
+  const_reference at(size_type idx) const {
+    assert(idx < size());
+    return begin()[idx];
+  }
+
   reference operator[](size_type idx) {
     assert(idx < size());
     return begin()[idx];

--- a/aten/src/ATen/core/TensorImpl.cpp
+++ b/aten/src/ATen/core/TensorImpl.cpp
@@ -37,8 +37,7 @@ TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::Ty
       data_type_(data_type),
       type_id_(type_id),
       is_variable_(is_variable) {
-  strides_.reset(new int64_t[1]);
-  strides_[0] = 1;
+  strides_.push_back(1);
 }
 
 IntList TensorImpl::sizes() const {
@@ -46,7 +45,7 @@ IntList TensorImpl::sizes() const {
 }
 
 IntList TensorImpl::strides() const {
-  return IntList{strides_.get(), sizes_.size()};
+  return strides_;
 }
 
 bool TensorImpl::compute_contiguous() const {

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -1477,7 +1477,7 @@ protected:
 //    storage pointer
 //    sizes SmallVector (begin)
 //    sizes SmallVector (end)
-//    sizes SmallVector (reserved)
+//    sizes SmallVector (capacity)
 //    sizes SmallVector (pre-allocated 0)
 //    sizes SmallVector (pre-allocated 1)
 //    sizes SmallVector (pre-allocated 2)
@@ -1485,7 +1485,7 @@ protected:
 //    sizes SmallVector (pre-allocated 4)
 //    strides SmallVector (begin)
 //    strides SmallVector (end)
-//    strides SmallVector (reserved)
+//    strides SmallVector (capacity)
 //    strides SmallVector (pre-allocated 0)
 //    strides SmallVector (pre-allocated 1)
 //    strides SmallVector (pre-allocated 2)

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -1465,9 +1465,22 @@ protected:
 //    strong refcount           TODO: pack these into one word
 //    weak refcount
 //    storage pointer
-//    sizes SmallVector
-//    sizes vector (reserved)   TODO: get rid of me
-//    strides SmallVector
+//    sizes SmallVector (begin)
+//    sizes SmallVector (end)
+//    sizes SmallVector (reserved)
+//    sizes SmallVector (pre-allocated 0)
+//    sizes SmallVector (pre-allocated 1)
+//    sizes SmallVector (pre-allocated 2)
+//    sizes SmallVector (pre-allocated 3)
+//    sizes SmallVector (pre-allocated 4)
+//    strides SmallVector (begin)
+//    strides SmallVector (end)
+//    strides SmallVector (reserved)
+//    strides SmallVector (pre-allocated 0)
+//    strides SmallVector (pre-allocated 1)
+//    strides SmallVector (pre-allocated 2)
+//    strides SmallVector (pre-allocated 3)
+//    strides SmallVector (pre-allocated 4)
 //    storage offset
 //    numel
 //    data type pointer

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -790,7 +790,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     auto new_dim = new_size.size();
 
     sizes_.resize(new_dim);
-    for (int64_t dim = 0; dim < new_dim; ++dim) {
+    for (size_t dim = 0; dim < new_dim; ++dim) {
       sizes_[dim] = new_size[dim];
     }
 
@@ -820,7 +820,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     auto new_dim = new_size.size();
 
     sizes_.resize(new_dim);
-    for (int64_t dim = 0; dim < new_dim; ++dim) {
+    for (size_t dim = 0; dim < new_dim; ++dim) {
       sizes_[dim] = new_size[dim];
     }
 


### PR DESCRIPTION
This removes dynamic allocations for sizes/strides for tensors with <= 5
dims. This should cover the most common tensor use cases; we use a lot
of 4D tensors in images (N, C, H, W) and LSTMs use tensors with 3 or fewer dims.

Benchmarking results can be found here:
https://gist.github.com/zou3519/ce4182722ae7e2a228bc8b57ae60b0e9
The quick summary is that this PR:
- makes aten LSTM's forward pass ~1ms faster and improves JIT lstm perf
  as well
- Tensor as_strided is now 200ns faster for dimensions <= 5
- at::empty performance is 200ns slower for dimensions > 5. For dims <= 5,
  there is no noticeable perf change.
- Variable ops are 200-500ns faster because Variables never used their
  sizes/strides fields in the first place.

Test Plan:
- run tests