### PR TITLE
[JIT] Optional undefined tensor support

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -609,7 +609,7 @@ inline optional<T> IValue::toOptional() {
 }
 
 inline bool IValue::isSameIdentity(IValue& rhs) {
-  // We choose to not use memcmp for payload check due to potenntial random padding characters on union type
+  // We choose to not use memcmp for payload check due to potential random padding characters on union type
 
   // Semantics:
   // 1. None is None, False is False, and True is True are all true

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -614,10 +614,9 @@ inline bool IValue::isSameIdentity(IValue& rhs) {
   // Semantics:
   // 1. None is None, False is False, and True is True are all true
   // 2. If it is a tensor type, we need to take undefined tensor into account
-  // 3. Undefined_tensor is None should be true
+  // 3. Undefined_tensor is None and vice versa should be true
   // 4. If it is a reference type (i.e. is_intrusive_ptr), then is is True when the pointed-to object is the same.
   // 5. False for all other comparisons.
-  std::cout<<"this tag kind: " << this->tagKind() << " rhs tag kind: " << rhs.tagKind() << std::endl;
   if (this->isNone() && rhs.isNone()) {
     return true;
   } else if (this->isBool() && rhs.isBool()) {
@@ -629,6 +628,9 @@ inline bool IValue::isSameIdentity(IValue& rhs) {
   } else if (this->isTensor() && rhs.isNone()) {
     // special case: undefined tensor and None are the same identity
     return !this->is_intrusive_ptr;
+  } else if (this->isNone() && rhs.isTensor()) {
+    // special case: undefined tensor and None are the same identity
+    return !rhs.is_intrusive_ptr;
   } else {
     // for objects holding in IValue, do shallow compare on pointer address to testify the identity
     return this->is_intrusive_ptr && rhs.is_intrusive_ptr

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -613,13 +613,22 @@ inline bool IValue::isSameIdentity(IValue& rhs) {
 
   // Semantics:
   // 1. None is None, False is False, and True is True are all true
-  // 2. If it is a reference type (i.e. is_intrusive_ptr), then is is True when the pointed-to object is the same.
-  // 3. False for all other comparisons.
+  // 2. If it is a tensor type, we need to take undefined tensor into account
+  // 3. Undefined_tensor is None should be true
+  // 4. If it is a reference type (i.e. is_intrusive_ptr), then is is True when the pointed-to object is the same.
+  // 5. False for all other comparisons.
+  std::cout<<"this tag kind: " << this->tagKind() << " rhs tag kind: " << rhs.tagKind() << std::endl;
   if (this->isNone() && rhs.isNone()) {
     return true;
   } else if (this->isBool() && rhs.isBool()) {
     // for bool type, do equality check
     return this->toBool() == rhs.toBool();
+  } else if (this->isTensor() && rhs.isTensor()) {
+    // for tensor type, just check the as_intrusive_ptr since is_intrusive_ptr is false for undefined tensor
+    return this->payload.as_intrusive_ptr == rhs.payload.as_intrusive_ptr;
+  } else if (this->isTensor() && rhs.isNone()) {
+    // special case: undefined tensor and None are the same identity
+    return !this->is_intrusive_ptr;
   } else {
     // for objects holding in IValue, do shallow compare on pointer address to testify the identity
     return this->is_intrusive_ptr && rhs.is_intrusive_ptr

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -230,6 +230,12 @@ struct CAFFE2_API DynamicType : public Type {
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
+  bool isSubtypeOf(const TypePtr rhs) const override {
+    if(auto rhs_ = rhs->cast<OptionalType>()) {
+      return this->isSubtypeOf(rhs_->getElementType());
+    }
+    return *this == *rhs;
+  }
   std::string str() const override {
     return "Tensor";
   }
@@ -256,6 +262,9 @@ struct CAFFE2_API UndefinedTensorType : public Type {
     return rhs.kind() == kind();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
+    if(auto rhs_ = rhs->cast<OptionalType>()) {
+      return this->isSubtypeOf(rhs_->getElementType());
+    }
     return rhs->kind() == TypeKind::DynamicType ||
            rhs->kind() == TypeKind::UndefinedTensorType;
   }
@@ -307,6 +316,9 @@ struct CAFFE2_API TensorType : public Type {
            dim() == rt->dim();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
+    if(auto rhs_ = rhs->cast<OptionalType>()) {
+      return this->isSubtypeOf(rhs_->getElementType());
+    }
     if (rhs->kind() == TypeKind::DynamicType)
       return true;
     return rhs->kind() == TypeKind::TensorType && *this == *rhs;
@@ -393,6 +405,9 @@ struct CAFFE2_API CompleteTensorType : public TensorType {
            device() == rt->device();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
+    if(auto rhs_ = rhs->cast<OptionalType>()) {
+      return this->isSubtypeOf(rhs_->getElementType());
+    }
     if (rhs->kind() == TypeKind::DynamicType)
       return true;
     if (rhs->kind() == TypeKind::TensorType)

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -166,6 +166,11 @@ inline bool operator!=(const Type & lhs, const Type & rhs) {
 struct OptionalType;
 using OptionalTypePtr = std::shared_ptr<OptionalType>;
 // This type represents an optional type, for each element type.
+// Optional[T] can accept both T and None(nullopt in C++)
+// Subtype hierarchy for Optional:
+// 1. Optional[T] isSubtypeOf Optional[R] iff T isSubtypeOf R
+// 2. T isSubtypeOf Optional[R] if T isSubtypeOf R
+// 3. NoneType isSubtypeOf any Optional Type
 struct OptionalType: public Type {
   static OptionalTypePtr create(TypePtr element) {
     return OptionalTypePtr(new OptionalType(std::move(element))); // NOLINT(modernize-make-shared)
@@ -234,7 +239,7 @@ struct CAFFE2_API DynamicType : public Type {
     if(auto rhs_ = rhs->cast<OptionalType>()) {
       return this->isSubtypeOf(rhs_->getElementType());
     }
-    return *this == *rhs;
+    return Type::isSubtypeOf(rhs);
   }
   std::string str() const override {
     return "Tensor";

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -171,7 +171,7 @@ using OptionalTypePtr = std::shared_ptr<OptionalType>;
 // 1. Optional[T] isSubtypeOf Optional[R] iff T isSubtypeOf R
 // 2. T isSubtypeOf Optional[R] if T isSubtypeOf R
 // 3. NoneType isSubtypeOf any Optional Type
-struct OptionalType: public Type {
+struct CAFFE2_API OptionalType: public Type {
   static OptionalTypePtr create(TypePtr element) {
     return OptionalTypePtr(new OptionalType(std::move(element))); // NOLINT(modernize-make-shared)
   }
@@ -209,8 +209,9 @@ struct OptionalType: public Type {
   bool hasFreeVariables() const override {
     return has_free_variables_;
   }
-
   static const TypeKind Kind = TypeKind::OptionalType;
+  // common cast Optional[Tensor] for undefined tensor type
+  static OptionalTypePtr ofTensor();
 private:
   OptionalType(TypePtr elem)
   : Type(TypeKind::OptionalType)
@@ -247,45 +248,46 @@ struct CAFFE2_API DynamicType : public Type {
   static const TypeKind Kind = TypeKind::DynamicType;
   // global singleton
   static DynamicTypePtr get();
-private:
-  DynamicType()
-  : Type(TypeKind::DynamicType) {}
+protected:
+  DynamicType(TypeKind kind=TypeKind::DynamicType)
+  : Type(kind) {}
 };
 
 struct UndefinedTensorType;
 using UndefinedTensorTypePtr = std::shared_ptr<UndefinedTensorType>;
 // This type represents an undefined tensor.
-struct CAFFE2_API UndefinedTensorType : public Type {
-  static const TypeKind Kind = TypeKind::UndefinedTensorType;
+struct CAFFE2_API UndefinedTensorType : public DynamicType {
   static UndefinedTensorTypePtr create() {
     return UndefinedTensorTypePtr(new UndefinedTensorType()); // NOLINT(modernize-make-shared)
   }
 
   DEFINE_IS_SUBCLASS(UndefinedTensorType);
 
+  bool requires_grad() const override { return false; }
+
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
     return rhs->kind() == TypeKind::DynamicType ||
-           rhs->kind() == TypeKind::UndefinedTensorType;
+           rhs->kind() == TypeKind::UndefinedTensorType ||
+           DynamicType::isSubtypeOf(rhs);
   }
   std::string str() const override {
     return "UndefinedTensor";
   }
+
+  static const TypeKind Kind = TypeKind::UndefinedTensorType;
+  // global singleton
   static UndefinedTensorTypePtr get();
 protected:
-  UndefinedTensorType(): Type(TypeKind::UndefinedTensorType) {}
+  UndefinedTensorType(): DynamicType(TypeKind::UndefinedTensorType) {}
 };
 
 struct TensorType;
 using TensorTypePtr = std::shared_ptr<TensorType>;
 // This type represents a single Tensor with a specific size
-struct CAFFE2_API TensorType : public Type {
-  static const TypeKind Kind = TypeKind::TensorType;
+struct CAFFE2_API TensorType : public DynamicType {
   template<typename ... T>
   static TensorTypePtr create( T&& ... all ) {
     return TensorTypePtr(new TensorType( std::forward<T>(all)... )); // NOLINT(modernize-make-shared)
@@ -321,12 +323,9 @@ struct CAFFE2_API TensorType : public Type {
            dim() == rt->dim();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    if (rhs->kind() == TypeKind::DynamicType)
-      return true;
-    return rhs->kind() == TypeKind::TensorType && *this == *rhs;
+    return rhs->kind() == TypeKind::DynamicType ||
+          (rhs->kind() == TypeKind::TensorType && Type::isSubtypeOf(rhs)) ||
+          DynamicType::isSubtypeOf(rhs);
   }
   bool isSubclass(const TypeKind kind) const override {
     return kind == TypeKind::DynamicType ||
@@ -338,6 +337,8 @@ struct CAFFE2_API TensorType : public Type {
     return "Tensor";
   }
 
+  static const TypeKind Kind = TypeKind::TensorType;
+
 protected:
   TensorType(const at::Tensor& tensor, TypeKind kind=TypeKind::TensorType)
     : TensorType(tensor.type().scalarType(),
@@ -346,7 +347,7 @@ protected:
                  tensor.is_variable() && tensor.requires_grad(),
                  kind) {}
   TensorType(at::ScalarType scalar_type, int device, int dim, bool requires_grad=true, TypeKind kind=TypeKind::TensorType)
-    : Type(kind)
+    : DynamicType(kind)
     , scalar_type_(scalar_type)
     , requires_grad_(at::isFloatingType(scalar_type) && requires_grad)
     , device_(device)
@@ -374,8 +375,6 @@ struct CAFFE2_API CompleteTensorType : public TensorType {
   static CompleteTensorTypePtr create(at::ScalarType scalar_type, int device, at::IntList sizes, at::IntList strides) {
     return CompleteTensorTypePtr(new CompleteTensorType(scalar_type, device, sizes, strides)); // NOLINT(modernize-make-shared)
   }
-
-  static const TypeKind Kind = TypeKind::CompleteTensorType;
 
   const std::vector<int64_t>& sizes() const { return sizes_; }
   const std::vector<int64_t>& strides() const { return strides_; }
@@ -410,14 +409,10 @@ struct CAFFE2_API CompleteTensorType : public TensorType {
            device() == rt->device();
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    if (rhs->kind() == TypeKind::DynamicType)
-      return true;
     if (rhs->kind() == TypeKind::TensorType)
       return *expect<TensorType>() ==  *rhs;
-    return *this == *rhs;
+    return rhs->kind() == TypeKind::DynamicType ||
+           DynamicType::isSubtypeOf(rhs);
   }
   bool isSubclass(const TypeKind kind) const override {
     return kind == TypeKind::DynamicType ||
@@ -436,6 +431,9 @@ struct CAFFE2_API CompleteTensorType : public TensorType {
     }
     return prod;
   }
+
+  static const TypeKind Kind = TypeKind::CompleteTensorType;
+
   static TypePtr fromNumberType(TypePtr typ);
   static TypePtr fromBoolType();
 
@@ -863,13 +861,13 @@ struct VarType : public Type {
   std::string str() const override {
     return name();
   }
-  static const TypeKind Kind = TypeKind::VarType;
   const std::string& name() const {
     return name_;
   }
   bool hasFreeVariables() const override {
     return true;
   }
+  static const TypeKind Kind = TypeKind::VarType;
 private:
   VarType(std::string name_)
   : Type(TypeKind::VarType), name_(std::move(name_)) {}

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -105,6 +105,10 @@ StringTypePtr StringType::get() {
   static auto value = StringType::create();
   return value;
 }
+OptionalTypePtr OptionalType::ofTensor() {
+  static auto value = OptionalType::create(DynamicType::get());
+  return value;
+}
 ListTypePtr ListType::ofTensors() {
   static auto value = ListType::create(DynamicType::get());
   return value;

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4184,8 +4184,8 @@ a")
             return output
 
         def none_args(x):
-            # type: (Optional[Tensor])
-            return x
+            # type: (Optional[Tensor]) -> Optional[Tensor]
+            return None
 
         self.checkScript(none_stmt, [torch.arange(0, 2)], optimize=True)
         self.checkScript(none_args, [None], optimize=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4178,12 +4178,12 @@ a")
         self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
 
     def test_script_None(self):
-        def func(x):
+        def none_stmt(x):
             output = None
             output = x
             return output
 
-        self.checkScript(func, [torch.arange(0, 2)], optimize=True)
+        self.checkScript(none_stmt, [torch.arange(0, 2)], optimize=True)
 
     def test_script_clamp_none(self):
         def test_script_clamp_max_none(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4177,13 +4177,48 @@ a")
 
         self.assertEqual(test_script_for_in_range_if_ast(*inputs).shape[0], 20)
 
-    def test_script_None(self):
+    def test_script_optional_none(self):
         def none_stmt(x):
             output = None
             output = x
             return output
 
+        def none_args(x):
+            # type: (Optional[Tensor])
+            return x
+
         self.checkScript(none_stmt, [torch.arange(0, 2)], optimize=True)
+        self.checkScript(none_args, [None], optimize=True)
+
+        # test undefined tensor None as default param
+        def test_script_optional_tensor_none(x=None):
+            # type: (Optional[Tensor]) -> Tensor
+            res = torch.zeros(1, dtype=torch.int8)
+            if x is None:
+                res = res + 1
+            else:
+                res = torch.jit._unwrap_optional(x)
+            return res
+
+        fn = test_script_optional_tensor_none
+        scripted_fn = torch.jit.script(fn)
+        self.assertEqual(fn(), scripted_fn())
+        self.assertEqual(fn(torch.zeros(1)), scripted_fn(torch.zeros(1)))
+
+        # test typical None as default param
+        def test_script_optional_other_none(x=None):
+            # type: (Optional[float]) -> float
+            res = 2.0
+            if x is None:
+                res = res + 1.0
+            else:
+                res = torch.jit._unwrap_optional(x)
+            return res
+
+        fn = test_script_optional_other_none
+        scripted_fn = torch.jit.script(fn)
+        self.assertEqual(fn(), scripted_fn())
+        self.assertEqual(fn(1.0), scripted_fn(1.0))
 
     def test_script_clamp_none(self):
         def test_script_clamp_max_none(x):

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -44,6 +44,7 @@ TYPE_MAP = {
     'Scalar': 'Scalar',
     'Scalar?': 'Scalar?',
     'Tensor': 'Tensor',
+    'Tensor?': 'Tensor?',
     'TensorList': 'Tensor[]',
     # this appears in return values instead of TensorList
     # since TensorList is a ArrayRef in arguments but a vector
@@ -69,6 +70,8 @@ def jit_type_of(arg):
     if is_sized_intlist_arg(arg):
         typ = 'int[{}]'.format(arg['size'])
 
+    if arg.get('is_nullable') and '?' not in typ:
+        typ = '{}?'.format(typ)
     return typ
 
 

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -649,7 +649,7 @@ bool PropagateTensorShapeOnNode(Node * node, bool insert_expands) {
   //     Knowing the type and device of weights or biases is usually enough to
   //     infer the output type.
   static const register_formula_for nn_ops_first_input_preserving {{
-    "aten::batch_norm(Tensor input, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+    "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
     "aten::conv1d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor",
     "aten::conv2d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor",
     "aten::conv3d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor",
@@ -657,7 +657,7 @@ bool PropagateTensorShapeOnNode(Node * node, bool insert_expands) {
     "aten::conv_transpose1d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] output_padding, int groups, int[] dilation) -> Tensor",
     "aten::conv_transpose2d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] output_padding, int groups, int[] dilation) -> Tensor",
     "aten::conv_transpose3d(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] output_padding, int groups, int[] dilation) -> Tensor",
-    "aten::convolution(Tensor input, Tensor weight, Tensor bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor",
+    "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor",
     "aten::adaptive_avg_pool1d(Tensor self, int[] output_size) -> Tensor",
     "aten::adaptive_avg_pool2d(Tensor self, int[] output_size) -> Tensor",
     "aten::adaptive_avg_pool3d(Tensor self, int[] output_size) -> Tensor",
@@ -1016,7 +1016,7 @@ bool PropagateTensorShapeOnNode(Node * node, bool insert_expands) {
       node->output()->setType(weight_type->withDim(indices_type->dim() + 1));
       return true;
     }
-  } else if (node->matches("aten::bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor bias) -> Tensor")) {
+  } else if (node->matches("aten::bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias) -> Tensor")) {
     if (auto type = input_type(0)) {
       node->output()->setType(type);
       return true;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -472,7 +472,11 @@ Value* tryMatchArgument(
   if (value->type()->isSubtypeOf(NoneType::get())){
     if (concrete_type->isSubtypeOf(GeneratorType::get())) {
       value = graph.insertNode(graph.createNoneGenerator())->output();
-    } else if (concrete_type->isSubtypeOf(DynamicType::get())) {
+    }
+    auto concrete_opt_type = concrete_type->cast<OptionalType>();
+    if ((concrete_opt_type && concrete_opt_type->getElementType()->isSubtypeOf(DynamicType::get())) ||
+        concrete_type->isSubtypeOf(DynamicType::get())) {
+      // create undefined tensor when None pass to a optional[tensor] formal arg
       value = graph.insertNode(graph.createUndefined())->output();
     }
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -469,13 +469,11 @@ Value* tryMatchArgument(
     value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
   }
 
-  if (value->type()->isSubtypeOf(NoneType::get())){
+  if (value->type()->isSubtypeOf(NoneType::get()) && !concrete_type->isSubtypeOf(NoneType::get())){
     if (concrete_type->isSubtypeOf(GeneratorType::get())) {
       value = graph.insertNode(graph.createNoneGenerator())->output();
     }
-    auto concrete_opt_type = concrete_type->cast<OptionalType>();
-    if ((concrete_opt_type && concrete_opt_type->getElementType()->isSubtypeOf(DynamicType::get())) ||
-        concrete_type->isSubtypeOf(DynamicType::get())) {
+    if (concrete_type->isSubtypeOf(OptionalType::ofTensor())) {
       // create undefined tensor when None pass to a optional[tensor] formal arg
       value = graph.insertNode(graph.createUndefined())->output();
     }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1355,6 +1355,7 @@ _builtin_blacklist = {
     'dropout2d',
     'dropout3d',
     'feature_alpha_dropout',
+    'bilinear',
 }
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1166,7 +1166,9 @@ def linear(input, weight, bias=None):
     return output
 
 
+@torch._jit_internal.weak_script
 def bilinear(input1, input2, weight, bias=None):
+    # type: (Tensor, Tensor, Tensor, Optional[Tensor]) -> Tensor
     return torch.bilinear(input1, input2, weight, bias)
 
 


### PR DESCRIPTION
This PR is a part of task to unblock standard library export. 
* we treat None differently from Tensor and other types, when passing None as Tensor, it's an undefined tensor rather than the None IValue. 
* Refine the type system so that we have correct tensor types hierarchy (Dynamic/Tensor/CompleteTensor), Dynamic should be at the top of the inheritance hierarchy.
* It also tries to export bilinear as an example of undefined tensor(None) input. 