### PR TITLE
Fix a bug in tuple assignment

### DIFF
--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -14,10 +14,10 @@
     (option))
   (list
     (assign
-      (list (variable (ident q)))
+      (variable (ident q))
       (None))
     (assign
-      (list (variable (ident q)))
+      (variable (ident q))
       (-
         (+
           (variable (ident x))
@@ -29,13 +29,12 @@
           (list)
           (list))))
     (expression statement
-      (list
-        (apply
-          (variable (ident print))
-          (list (variable (ident q)))
-          (list))))
+      (apply
+        (variable (ident print))
+        (list (variable (ident q)))
+        (list)))
     (assign
-      (list (variable (ident w)))
+      (variable (ident w))
       (unary minus
         (variable (ident z))))
     (if
@@ -46,7 +45,7 @@
         (variable (ident z)))
       (list
         (assign
-          (list (variable (ident m)))
+          (variable (ident m))
           (if
             (not (variable (ident z)))
             (variable (ident x))
@@ -62,7 +61,7 @@
           (variable (ident z))))
       (list
         (assign
-          (list (variable (ident q)))
+          (variable (ident q))
           (variable (ident x)))))
     (assert
       (eq (const 1) (const 1))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6571,9 +6571,15 @@ a")
             cu = torch.jit.CompilationUnit('''
             def single_starred_lhs(x):
                 a = (x, x, x)
-                *b = a
+                *b, = a
                 return b
             ''')
+
+    def test_singleton_tuple_unpack(self):
+        def foo(a):
+            b, = (a,)
+            return b + 1
+        self.checkScript(foo, (torch.rand(3),))
 
     def test_multi_reduction(self):
         with self.assertRaisesRegex(
@@ -6592,7 +6598,7 @@ a")
                 return torch.unsqueeze(3, 4, 5, 6, 7, 8)
 
     def test_invalid_lhs_assignment(self):
-        with self.assertRaisesRegex(RuntimeError, 'lhs of assignment must be a variable or starred expression'):
+        with self.assertRaisesRegex(RuntimeError, 'unexpected expression'):
             cu = torch.jit.CompilationUnit('''
             def invalid_lhs_assignment(x):
                 x + 1 = x
@@ -6683,7 +6689,7 @@ a")
             SomeModule()
 
     def test_single_starred_expr_for_loop(self):
-        with self.assertRaisesRegex(RuntimeError, 'Starred unpacking is currently not supported for for loops'):
+        with self.assertRaisesRegex(RuntimeError, 'unexpected expression'):
             cu = torch.jit.CompilationUnit('''
             def test():
                 x = 0

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -937,10 +937,8 @@ private:
           }
           break;
         case TK_EXPR_STMT: {
-          auto exprs = ExprStmt(stmt).exprs();
-          for (const auto& expr : exprs) {
-            emitSugaredExpr(expr, 0);
-          }
+          auto expr = ExprStmt(stmt).expr();
+          emitSugaredExpr(expr, 0);
         }
         break;
         case TK_RAISE:
@@ -1260,8 +1258,7 @@ private:
     }
 
     if (targets[0].kind() != TK_VAR) {
-      throw ErrorReport(targets[0]) << "Starred unpacking is currently not"
-          << " supported for for loops.";
+      throw ErrorReport(targets[0]) << "unexpected expression in variable initialization of for loop";
     }
     auto target = Var(targets[0]).name();
 
@@ -1376,6 +1373,9 @@ private:
   // Emit nodes for augmented assignments like `+=`
   void emitAugAssignment(const AugAssign& stmt) {
     auto lhs = Var(stmt.lhs());
+    if (lhs.kind() != TK_VAR) {
+      throw ErrorReport(lhs) << "expected a variable on the left-hand side";
+    }
     auto lhsValue = environment_stack->getSugaredVar(lhs.name())
                         ->asValue(lhs.range(), method);
     if (lhsValue->type()->isSubtypeOf(DynamicType::get())) {
@@ -1420,57 +1420,68 @@ private:
     }
   }
 
-  void emitAssignment(const Assign& stmt) {
-    bool starred_unpack = calcNumStarredUnpack(stmt.lhs(), stmt.range());
-
-    size_t n_binders = stmt.lhs().size();
+  void emitTupleAssign(const TupleLiteral& tl, const Expr& rhs) {
+    size_t n_binders = tl.inputs().size();
+    bool starred_unpack = calcNumStarredUnpack(tl.inputs(), tl.range());
     if(starred_unpack)
       n_binders--;
-
-    auto output = emitSugaredExpr(stmt.rhs(), n_binders);
-
-    if(stmt.lhs().size() == 1) {
-      JIT_ASSERT(!starred_unpack);
-      auto v = Var(stmt.lhs()[0]);
-      environment_stack->setSugaredVar(v.range(), v.name().name(), output);
-      return;
-    }
+    auto output = emitSugaredExpr(rhs, n_binders);
 
     auto outputs = output->asTuple(
-        stmt.rhs().range(),
+        rhs.range(),
         method,
         starred_unpack ? c10::nullopt : c10::optional<size_t>{n_binders});
     if(outputs.size() < n_binders) {
-      throw ErrorReport(stmt)
+      throw ErrorReport(tl)
         << "need " << (starred_unpack ? "at least " : "")
         << n_binders << " values to unpack but found only "
         << outputs.size();
     }
     if(outputs.size() > n_binders && !starred_unpack) {
-      throw ErrorReport(stmt)
+      throw ErrorReport(tl)
       << "too many values to unpack: need " << n_binders << " but found "
       << outputs.size();
     }
     int i = 0;
-    for (auto assignee : stmt.lhs()) {
-      if (assignee.kind() == TK_VAR) {
-        environment_stack->setSugaredVar(assignee.range(), Var(assignee).name().name(), outputs.at(i));
-        i++;
-      } else if (assignee.kind() == TK_STARRED) {
-        auto var = Starred(assignee).expr();
-        if (var.kind() != TK_VAR) {
-          throw ErrorReport(var) << "Cannot pack a tuple into a non-variable.";
-        }
-        size_t n_matched = outputs.size() - n_binders;
-        ArrayRef<std::shared_ptr<SugaredValue>> outputs_ref = outputs;
-        auto values = fmap(outputs_ref.slice(i, n_matched), [&](const std::shared_ptr<SugaredValue>& v) {
-          return v->asValue(assignee.range(), method);
-        });
-        auto tup = graph->insertNode(graph->createTuple(values))->output();
-        environment_stack->setVar(
-          var.range(), Var(var).name().name(), tup);
-        i += n_matched;
+    for (auto assignee : tl.inputs()) {
+      switch(assignee.kind()) {
+        case TK_VAR:
+          environment_stack->setSugaredVar(assignee.range(), Var(assignee).name().name(), outputs.at(i));
+          i++;
+          break;
+        case TK_STARRED: {
+          auto var = Starred(assignee).expr();
+          if (var.kind() != TK_VAR) {
+            throw ErrorReport(var) << "Cannot pack a tuple into a non-variable.";
+          }
+          size_t n_matched = outputs.size() - n_binders;
+          ArrayRef<std::shared_ptr<SugaredValue>> outputs_ref = outputs;
+          auto values = fmap(outputs_ref.slice(i, n_matched), [&](const std::shared_ptr<SugaredValue>& v) {
+            return v->asValue(assignee.range(), method);
+          });
+          auto tup = graph->insertNode(graph->createTuple(values))->output();
+          environment_stack->setVar(
+            var.range(), Var(var).name().name(), tup);
+          i += n_matched;
+        } break;
+        default:
+        throw ErrorReport(assignee) << "unexpected expression on the left-hand side";
       }
+    }
+  }
+
+  void emitAssignment(const Assign& stmt) {
+    switch(stmt.lhs().kind()) {
+      case TK_VAR: {
+        auto v = Var(stmt.lhs());
+        environment_stack->setSugaredVar(
+            v.range(), v.name().name(), emitSugaredExpr(stmt.rhs(), 1));
+      } break;
+      case TK_TUPLE_LITERAL:
+        emitTupleAssign(TupleLiteral(stmt.lhs()), stmt.rhs());
+        break;
+      default:
+        throw ErrorReport(stmt.lhs()) << "unexpected expression on left-hand side of assignment.";
     }
   }
 

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -122,9 +122,8 @@ void initTreeViewBindings(PyObject *module) {
 
 
   py::class_<Assign, Stmt>(m, "Assign")
-    .def(py::init([](std::vector<Expr> lhs, const Expr& rhs) {
-      auto r = lhs.at(0).range();
-      return Assign::create(r, List<Expr>::create(r, std::move(lhs)), rhs);
+    .def(py::init([](const Expr& lhs, const Expr& rhs) {
+      return Assign::create(lhs.range(), lhs, rhs);
     }));
   py::class_<AugAssign, Stmt>(m, "AugAssign")
     .def(py::init([](const Expr& lhs, std::string kind_str, const Expr& rhs) {
@@ -169,9 +168,8 @@ void initTreeViewBindings(PyObject *module) {
         wrap_list(range, std::move(body)));
   }));
   py::class_<ExprStmt, Stmt>(m, "ExprStmt")
-    .def(py::init([](std::vector<Expr>& exprs) {
-      auto r = exprs[0].range();
-      return ExprStmt::create(r, wrap_list(r, std::move(exprs)));
+    .def(py::init([](const Expr& expr) {
+      return ExprStmt::create(expr.range(), expr);
     }));
 
   py::class_<Var, Expr>(m, "Var")

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -26,8 +26,9 @@ namespace script {
 //       | For(List<Expr> targets, List<Expr> iters, List<Stmt> body)   TK_FOR
 //       | While(Expr cond, List<Stmt> body)                            TK_WHILE
 //       | Global(List<Ident> idents)                                   TK_GLOBAL
-//       -- NB: the only type of Expr's allowed on lhs are Starred and Var
-//       | Assign(List<Expr> lhs, Expr rhs)                             TK_ASSIGN
+//       -- NB: the only type of Expr's allowed on lhs are Var
+//          Or a tuple containing Var with an optional terminating Starred
+//       | Assign(Expr lhs, Expr rhs)                                  TK_ASSIGN
 //       | AugAssign(Expr lhs, AugAssignKind aug_op, Expr rhs)          TK_AUG_ASSIGN
 //       | Return(List<Expr> values)                                    TK_RETURN
 //       | ExprStmt(List<Expr> expr)                                    TK_EXPR_STMT
@@ -470,12 +471,12 @@ struct Assign : public Stmt {
   }
   static Assign create(
       const SourceRange& range,
-      const List<Expr>& lhs,
+      const Expr& lhs,
       const Expr& rhs) {
     return Assign(Compound::create(TK_ASSIGN, range, {lhs, rhs}));
   }
-  List<Expr> lhs() const {
-    return List<Expr>(subtree(0));
+  Expr lhs() const {
+    return Expr(subtree(0));
   }
   Expr rhs() const {
     return Expr(subtree(1));
@@ -539,10 +540,10 @@ struct ExprStmt : public Stmt {
   explicit ExprStmt(const TreeRef& tree) : Stmt(tree) {
     tree_->match(TK_EXPR_STMT);
   }
-  List<Expr> exprs() {
-    return List<Expr>(subtree(0));
+  Expr expr() {
+    return Expr(subtree(0));
   }
-  static ExprStmt create(const SourceRange& range, const List<Expr>& list) {
+  static ExprStmt create(const SourceRange& range, const Expr list) {
     return ExprStmt(Compound::create(TK_EXPR_STMT, range, {list}));
   }
 };

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -238,16 +238,7 @@ class StmtBuilder(Builder):
             # then it is a docstring. Just ignore it.
             return None
         else:
-            return ExprStmt([build_expr(ctx, value)])
-
-    @staticmethod
-    def get_assign_lhs_expr(ctx, expr):
-        var = build_expr(ctx, expr)
-        if not isinstance(var, Var) and not isinstance(var, Starred):
-            raise NotSupportedError(var.range(),
-                                    "the only expressions allowed on the left hand side of "
-                                    "assignments are variable names and starred expressions")
-        return var
+            return ExprStmt(build_expr(ctx, value))
 
     @staticmethod
     def build_Assign(ctx, stmt):
@@ -256,9 +247,8 @@ class StmtBuilder(Builder):
             start_point = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + 1)
             raise NotSupportedError(ctx.make_raw_range(start_point.start, rhs.range().end),
                                     "Performing multiple assignments in a single line isn't supported")
-        py_lhs = stmt.targets[0]
-        py_lhs_exprs = py_lhs.elts if isinstance(py_lhs, ast.Tuple) else [py_lhs]
-        return Assign([StmtBuilder.get_assign_lhs_expr(ctx, e) for e in py_lhs_exprs], rhs)
+        lhs = build_expr(ctx, stmt.targets[0])
+        return Assign(lhs, rhs)
 
     @staticmethod
     def build_Return(ctx, stmt):
@@ -287,7 +277,7 @@ class StmtBuilder(Builder):
 
     @staticmethod
     def build_AugAssign(ctx, stmt):
-        lhs = StmtBuilder.get_assign_lhs_expr(ctx, stmt.target)
+        lhs = build_expr(ctx, stmt.target)
         rhs = build_expr(ctx, stmt.value)
         op = type(stmt.op)
         if op in StmtBuilder.augassign_map:
@@ -312,7 +302,7 @@ class StmtBuilder(Builder):
     def build_For(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + len("for"))
         return For(
-            r, [StmtBuilder.get_assign_lhs_expr(ctx, stmt.target)],
+            r, [build_expr(ctx, stmt.target)],
             [build_expr(ctx, stmt.iter)], build_stmts(ctx, stmt.body))
 
     @staticmethod
@@ -328,7 +318,7 @@ class StmtBuilder(Builder):
         if stmt.dest:
             raise NotSupportedError(r, "print statements with non-default destinations aren't supported")
         args = [build_expr(ctx, val) for val in stmt.values]
-        return ExprStmt([Apply(Var(Ident(r, "print")), args, [])])
+        return ExprStmt(Apply(Var(Ident(r, "print")), args, []))
 
     @staticmethod
     def build_Pass(ctx, stmt):


### PR DESCRIPTION
Previously, we did not distinguish between `a = b` (simple assignment),
and `a, = b` (tuple destructuring of a singleton tuple).

The second case would fail in the string frontend, and would not unpack
in the python frontend. This patch fixes both issues and also cleans up
the error reporting for unexpected expressions on the LHS.

Will likely conflict with #13486

