### PR TITLE
Fix exception catching to catch c10::Error properly

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -710,7 +710,7 @@ Workspace chooseAlgorithm(
   search::getWorkspaceSize(args, *algo, &workspace_size);
   try {
     return Workspace(workspace_size);
-  } catch (std::runtime_error& e) {
+  } catch (const std::exception& e) {
     cudaGetLastError(); // clear OOM error
 
     // switch to default algorithm and record it in the cache to prevent

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -522,7 +522,7 @@ Workspace chooseAlgorithm(
   workspace_size = getWorkspaceSize(args, *algo);
   try {
     return Workspace(workspace_size);
-  } catch (std::runtime_error& e) {
+  } catch (const std::exception& e) {
     hipGetLastError(); // clear OOM error
 
     // switch to default algorithm and record it in the cache to prevent

--- a/aten/src/ATen/test/test_assert.h
+++ b/aten/src/ATen/test/test_assert.h
@@ -41,7 +41,7 @@ static inline void barf(const char *fmt, ...) {
       fn;                                                       \
       _passed = true;                                           \
       els;                                                      \
-    } catch (std::runtime_error &e) {                           \
+    } catch (const std::exception &e) {                         \
       ASSERT(!_passed);                                         \
       catc;                                                     \
     }                                                           \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -334,7 +334,7 @@ void testFromQualString() {
     try {
       Symbol::fromQualString(input);
       ASSERT_TRUE(0);
-    } catch (std::runtime_error c) {
+    } catch (const std::exception& c) {
     }
   }
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -113,7 +113,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         THCStorage_(set)(LIBRARY_STATE self->cdata, i, value);
 #endif
       }
-    } catch (std::runtime_error &e) {
+    } catch (const std::exception &e) {
       THPUtils_setError("tried to construct a storage from a sequence (%s), "
           "but one of the items was of type %s instead of %s",
           THPUtils_typename(first_arg),

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -311,7 +311,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(int i, std::vector<in
       } else {
         res[idx] = THPUtils_unpackIndex(obj);
       }
-    } catch (std::runtime_error &e) {
+    } catch (const std::exception &e) {
       throw TypeError("%s(): argument '%s' must be %s, but found element of type %s at pos %d",
           signature.name.c_str(), signature.params[i].name.c_str(),
           signature.params[i].type_name().c_str(), Py_TYPE(obj)->tp_name, idx + 1);


### PR DESCRIPTION
In particular, this was breaking the logic for cudnn algorithm to fall back to a less memory hungry algorithm if the selected one OOM when creating the workspace.
c10::Error are subclass of `std::exception` and not `std::runtime_error`.

I removed `runtime_error` in all places in our code and replaced them with `const exception`.