### PR TITLE
Fixed a small error in docstrings for ConvTranspose3d

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -832,7 +832,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         >>> # With square kernels and equal stride
         >>> m = nn.ConvTranspose3d(16, 33, 3, stride=2)
         >>> # non-square kernels and unequal stride and with padding
-        >>> m = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(0, 4, 2))
+        >>> m = nn.ConvTranspose3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(0, 4, 2))
         >>> input = torch.randn(20, 16, 10, 50, 100)
         >>> output = m(input)
 


### PR DESCRIPTION
In the example for ConvTranspose3d, the docstring had "Conv3d" instead of "ConvTranspose3d" in one instance.

