### PR TITLE
Fix missing symbol linker error when using libtorch generated on windows :

### DIFF
--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -75,11 +75,11 @@ struct Method {
   std::shared_ptr<Graph> graph_for(const Stack& inputs) {
     return get_executor().graphFor(inputs);
   }
-  std::shared_ptr<Graph> graph() const {
+  TORCH_API std::shared_ptr<Graph> graph() const {
     return graph_;
   }
 
-  const std::string & name() const {
+  TORCH_API const std::string & name() const {
     return name_;
   }
   // emit a function call by inlining the callees Graph into this one
@@ -89,13 +89,13 @@ struct Method {
   std::vector<Value*> emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs);
 
   // if this isn't yet defined, run its method_creator function
-  void ensure_defined();
+  TORCH_API void ensure_defined();
 
 
   size_t num_inputs() const {
     return graph()->inputs().size() - member_inputs.size();
   }
-  Value * get_or_add_parameter(at::Tensor* slot) {
+  TORCH_API Value * get_or_add_parameter(at::Tensor* slot) {
     auto it = member_input_index.find(slot);
     if(it != member_input_index.end()) {
       return graph()->inputs().at(it->second);
@@ -157,7 +157,7 @@ struct Method {
     return *this;
   }
 
-  const FunctionSchema& getSchema() const {
+  TORCH_API const FunctionSchema& getSchema() const {
     if(schema == nullptr) {
       schema = make_unique<FunctionSchema>(defaultSchemaFor(*this));
     }


### PR DESCRIPTION
Libtorch is missing some symbols when generated on windows, causing linker errors when using it.

It seems like there were some issues in the past with enabling   CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to export all symbols during the build.
(See the link below :
    - Enabling CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS :  https://github.com/pytorch/pytorch/pull/3617?fbclid=IwAR084kOPgLUvYjpJMvGG_Q22IPcvmzlywamytdhxd5U3hELkESO6yM8BGfo  
    - Disabling CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS :  https://github.com/pytorch/pytorch/issues/9092?fbclid=IwAR0QSeEcXNh8A1zrgCQvsEq-0S0GJvHBywhZ6kDvoHe6TeRUsTNRzzgXea0 and https://github.com/pytorch/pytorch/pull/9693?fbclid=IwAR2cSya4fbeHvF-BYkXk2NesXjQ3ZWg9vHJ3ivrT9GDJYqHSpg518KAMzW8 )
	
So enabling CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is not an option. But some symbols are still missing for Libtorch to be working.
We added some functions to TORCH_API in this PR, but we might be missing some.
(We also tried adding the whole structure Method  (struct TORCH_API Method { ... }) instead of adding the functions separately, but the build fails with a "one or more multiply defined symbols found" error)

Do you have any recommendations on how to detect functions that should/shouldn't be in TORCH_API, so the build is successful and the generated Libtorch has all the required exported symbols?

I also attached toch_exports_missing.txt, which contains the symbols that are exported with the CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS flag enabled but not in the current Libtorch version.
( by generating the output for both torch.dll libraries with "dumpbin /EXPORTS torch.dll" and comparing both outputs and generating the difference)
So any symbol that could be missing from Libtorch should be in this list, but the list has more than 8000 symbols, and I am not sure which ones require to be exported and added to TORCH_API.

This PR currently exports the missing symbols for torch::jit::script::Method that appears in the attached list (in the exception of defaultSchemaFor, and emit_call_to that cause a "multiply defined symbols" error).


[torch_exports_missing.txt](https://github.com/pytorch/pytorch/files/2558466/torch_exports_missing.txt)
