### PR TITLE
Explicitly setting full path to ninja build file

### DIFF
--- a/tools/setup_helpers/ninja_builder.py
+++ b/tools/setup_helpers/ninja_builder.py
@@ -18,7 +18,7 @@ class NinjaBuilder(object):
             os.mkdir(BUILD_DIR)
         self.ninja_program = os.path.join(ninja.BIN_DIR, 'ninja')
         self.name = name
-        self.filename = os.path.join(BUILD_DIR, 'build.{}.ninja'.format(name))
+        self.filename = os.path.realpath(os.path.join(BUILD_DIR, 'build.{}.ninja'.format(name)))
         self.writer = ninja.Writer(open(self.filename, 'w'))
         self.writer.rule('do_cmd', '$cmd')
         self.writer.rule('compile', '$cmd')


### PR DESCRIPTION
In NinjaBuilder, a relative path is created to the ninja file; this relative path presents problems in some environments such as Windows Subsystem for Linux (WSL). See https://github.com/pytorch/pytorch/issues/10857 for more info.

This change creates an explicit path rather than a relative path.