### PR TITLE
[ATen] Rename _local_scalar to item()

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -59,7 +59,7 @@ inline Tensor Tensor::operator[](Tensor index) const {
       index.dim() == 0,
       "Can only index with tensors that are scalars (zero-dim)");
   // The Scalar(Tensor) constructor is explicit, so we need to call it.
-  return this->operator[](index._local_scalar());
+  return this->operator[](index.item());
 }
 inline Tensor Tensor::operator[](int64_t index) const {
   return select(0, index);

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -512,7 +512,7 @@ public:
   Tensor to(Device device, ScalarType dtype, bool non_blocking=false, bool copy=false) const;
   Tensor to(ScalarType dtype, bool non_blocking=false, bool copy=false) const;
   Tensor to(const Tensor & other, bool non_blocking=false, bool copy=false) const;
-  Scalar _local_scalar() const;
+  Scalar item() const;
   void* data_ptr() const;
   Tensor & set_(Storage source);
   Tensor & set_(Storage source, int64_t storage_offset, IntList size, IntList stride={});

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -786,8 +786,8 @@ inline Tensor Tensor::to(ScalarType dtype, bool non_blocking, bool copy) const {
 inline Tensor Tensor::to(const Tensor & other, bool non_blocking, bool copy) const {
     return type().to(*this, other, non_blocking, copy);
 }
-inline Scalar Tensor::_local_scalar() const {
-    return type()._local_scalar(*this);
+inline Scalar Tensor::item() const {
+    return type().item(*this);
 }
 inline void* Tensor::data_ptr() const {
     return type().data_ptr(*this);
@@ -1313,13 +1313,13 @@ inline bool is_sparse(Tensor self) {
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)
 #undef DEFINE_CAST
 
-#define DEFINE_TO_C_TYPE(T, name, _)   \
-  template <>                          \
-  inline T Tensor::item() const {      \
-    return _local_scalar().to##name(); \
+#define DEFINE_ITEM(T, name, _)   \
+  template <>                     \
+  inline T Tensor::item() const { \
+    return item().to##name();     \
   }
 
-AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO_C_TYPE)
-#undef DEFINE_TO_C_TYPE
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_ITEM)
+#undef DEFINE_ITEM
 
 } //namespace at

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -431,7 +431,7 @@ struct CAFFE2_API Type {
   virtual Tensor to(const Tensor & self, Device device, ScalarType dtype, bool non_blocking, bool copy) const = 0;
   virtual Tensor to(const Tensor & self, ScalarType dtype, bool non_blocking, bool copy) const = 0;
   virtual Tensor to(const Tensor & self, const Tensor & other, bool non_blocking, bool copy) const = 0;
-  virtual Scalar _local_scalar(const Tensor & self) const = 0;
+  virtual Scalar item(const Tensor & self) const = 0;
   virtual void* data_ptr(const Tensor & self) const = 0;
   virtual Tensor & set_(Tensor & self, Storage source) const = 0;
   virtual Tensor & set_(Tensor & self, Storage source, int64_t storage_offset, IntList size, IntList stride) const = 0;

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -564,8 +564,7 @@ def is_mutable_formal_argument(argument, option):
 
 
 def check_methods_do_not_start_with_underscore(name, is_method):
-    if name in {'_local_scalar', '_values', '_indices', '_nnz', '_dimI',
-                '_dimV', '_coalesced_'}:
+    if name in {'_values', '_indices', '_nnz', '_dimI', '_dimV', '_coalesced_'}:
         return
     if is_method and name.startswith('_') and not name.startswith('__') and not name.startswith('_th_'):
         message = "Function '{}' starts with a single underscore and is ".format(name)
@@ -1302,7 +1301,7 @@ def create_derived(backend_type_env, declarations):
         if broadcasts_arg:
             return []
         zero_dim_actuals = [arg['name']
-                            if arg['name'] != zero_dim_dispatch else "at::_local_scalar({})".format(arg['name'])
+                            if arg['name'] != zero_dim_dispatch else "{}.item()".format(arg['name'])
                             for arg in option['formals_list']]
         return [ZERO_DIM_CHECK.substitute(env, check_name=zero_dim_dispatch, zero_dim_actuals=zero_dim_actuals)]
 

--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -4,7 +4,7 @@
 namespace at {
 namespace native {
 
-Scalar _local_scalar(const Tensor& self) {
+Scalar item(const Tensor& self) {
   int64_t numel = self.numel();
   AT_CHECK(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
   if (self.is_sparse()) {

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -65,7 +65,7 @@ bool is_nonzero(const Tensor& self) {
   if (n > 1) {
     AT_ERROR("bool value of Tensor with more than one value is ambiguous");
   }
-  Scalar localScalar = at::_local_scalar(self);
+  Scalar localScalar = self.item();
   if (localScalar.isFloatingPoint()) {
     return localScalar.to<double>() != 0;
   } else if (localScalar.isIntegral()){

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2321,9 +2321,8 @@
 
 - func: meshgrid(TensorList tensors) -> TensorList
 
-# This has a method dispatch to work around circular include problems
-- func: _local_scalar(Tensor self) -> Scalar
-  variants: function, method
+- func: item(Tensor self) -> Scalar
+  variants: method
 
 # NB: Does NOT check precondition that numel == 1
 # WARNING: Use of cpu_half here is generally not supported; please

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -126,13 +126,13 @@ inline bool is_sparse(Tensor self) {
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)
 #undef DEFINE_CAST
 
-#define DEFINE_TO_C_TYPE(T, name, _)   \
-  template <>                          \
-  inline T Tensor::item() const {      \
-    return _local_scalar().to##name(); \
+#define DEFINE_ITEM(T, name, _)   \
+  template <>                     \
+  inline T Tensor::item() const { \
+    return item().to##name();     \
   }
 
-AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO_C_TYPE)
-#undef DEFINE_TO_C_TYPE
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_ITEM)
+#undef DEFINE_ITEM
 
 } //namespace at

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -87,7 +87,7 @@ TEST(TestScalar, TestScalar) {
   Tensor next_h = i2h.add(h2h);
   next_h = next_h.tanh();
 
-  ASSERT_ANY_THROW(at::_local_scalar(Tensor{}));
+  ASSERT_ANY_THROW(Tensor{}.item());
 
   test_overflow();
 
@@ -100,8 +100,7 @@ TEST(TestScalar, TestScalar) {
   // check Scalar.toTensor on Scalars backed by different data types
   ASSERT_EQ(scalar_to_tensor(bar).scalar_type(), kDouble);
   ASSERT_EQ(scalar_to_tensor(what).scalar_type(), kLong);
-  ASSERT_EQ(
-      scalar_to_tensor(ones({})._local_scalar()).scalar_type(), kDouble);
+  ASSERT_EQ(scalar_to_tensor(ones({}).item()).scalar_type(), kDouble);
 
   if (x.scalar_type() != ScalarType::Half) {
     AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -10,12 +10,12 @@
 
 template <typename T>
 bool exactly_equal(at::Tensor left, T right) {
-  return at::_local_scalar(left).to<T>() == right;
+  return left.item<T>() == right;
 }
 
 template <typename T>
 bool almost_equal(at::Tensor left, T right, T tolerance = 1e-4) {
-  return std::abs(at::_local_scalar(left).to<T>() - right) < tolerance;
+  return std::abs(left.item<T>() - right) < tolerance;
 }
 
 #define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)            \
@@ -276,5 +276,31 @@ TEST(TensorTest, FromBlobWithStrides) {
       // NOTE: This is column major because the strides are swapped.
       EXPECT_EQ(tensor[i][j].item<int32_t>(), 1 + (j * tensor.size(1)) + i);
     }
+  }
+}
+
+TEST(TensorTest, Item) {
+  {
+    torch::Tensor tensor = torch::tensor(3.14);
+    torch::Scalar scalar = tensor.item();
+    ASSERT_NEAR(scalar.to<float>(), 3.14, 1e-5);
+  }
+  {
+    torch::Tensor tensor = torch::tensor(123);
+    torch::Scalar scalar = tensor.item();
+    ASSERT_EQ(scalar.to<int>(), 123);
+  }
+}
+
+TEST(TensorTest, Item_CUDA) {
+  {
+    torch::Tensor tensor = torch::tensor(3.14, torch::kCUDA);
+    torch::Scalar scalar = tensor.item();
+    ASSERT_NEAR(scalar.to<float>(), 3.14, 1e-5);
+  }
+  {
+    torch::Tensor tensor = torch::tensor(123, torch::kCUDA);
+    torch::Scalar scalar = tensor.item();
+    ASSERT_EQ(scalar.to<int>(), 123);
   }
 }

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -29,7 +29,7 @@ SKIP_PYTHON_BINDINGS = [
     'arange.*', 'range.*', '_gesv.*', '_getri.*', '_inverse.*',
     '_potrs.*', '_cholesky.*',
     'slice', 'randint(_out)?',
-    '_local_scalar', '_local_scalar_dense',
+    'item', '_local_scalar_dense',
     'max_pool1d', 'max_pool2d', 'max_pool3d', 'linear', 'to',
     'copy_sparse_to_sparse_',
 ]

--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -90,7 +90,7 @@ torch::Tensor LBFGS::step(LossClosure closure) {
       Tensor q = flat_grad.neg();
       for (int64_t i = num_old - 1; i >= 0; i--) {
         al.at(i) = old_stps.at(i).dot(q) * ro.at(i);
-        q.add_(old_dirs.at(i), -al.at(i).item<float>());
+        q.add_(old_dirs.at(i), -al.at(i).item());
       }
 
       // Multiply by initial Hessian
@@ -100,7 +100,7 @@ torch::Tensor LBFGS::step(LossClosure closure) {
 
       for (int64_t i = 0; i < num_old; i++) {
         Tensor be_i = old_dirs.at(i).dot(r) * ro.at(i);
-        r.add_(old_stps.at(i), (al.at(i) - be_i).item<float>());
+        r.add_(old_stps.at(i), (al.at(i) - be_i).item());
       }
       prev_flat_grad.copy_(flat_grad);
     }

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -254,7 +254,7 @@ struct Attributes {
           at::Tensor tensor = t(name);
           // 1-elem tensors are usually boxed scalars, so print them like it
           if (tensor.numel() == 1) {
-            auto scalar_tensor = at::_local_scalar(tensor.view({}));
+            auto scalar_tensor = tensor.view({}).item();
             out << "{";
             if (scalar_tensor.isFloatingPoint()) {
               out << scalar_tensor.toDouble();

--- a/torch/csrc/jit/passes/canonicalize_ops.cpp
+++ b/torch/csrc/jit/passes/canonicalize_ops.cpp
@@ -71,7 +71,7 @@ static void CanonicalizeOps(Block* block) {
         if (other->dim() == 0) {
           WithInsertPoint insert_guard {*it};
           auto graph = it->owningGraph();
-          auto new_other = graph->insertConstant(other->_local_scalar());
+          auto new_other = graph->insertConstant(other->item());
           std::vector<Value*> inputs = it->inputs().vec();
           inputs.at(1) = new_other;
           Value * new_output = graph->insertNode(graph->create(it->kind(), inputs))->output();

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -228,7 +228,7 @@ inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar
   // Zero-dim tensors are converted to Scalars as-is. Note this doesn't currently
   // handle most NumPy scalar types except np.float64.
   if (THPVariable_Check(args[i])) {
-    return at::_local_scalar(((THPVariable*)args[i])->cdata);
+    return ((THPVariable*)args[i])->cdata.item();
   }
   if (THPUtils_checkLong(args[i])) {
     return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));


### PR DESCRIPTION
Make `at::_local_scalar` more "official" by renaming it to `item()`.

@gchanan 