### PR TITLE
[DONT MERGE] demonstrate cause of shape bug at flip()

### DIFF
--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -30,6 +30,10 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
 
   // check if distance between two flip dims >= 2, where permute of output tensor is needed,
   // because the advanced indexing puts all non-consecutive indices in the beginning of the tensor
+  auto out_tensor = self.index(TensorList(final_indices));
+  auto out_sizes_idx = std::vector<int64_t>(out_tensor.dim());
+  std::iota(out_sizes_idx.begin(), out_sizes_idx.end(), 0);
+
   bool to_permute = false;
   int64_t first = flip_dims_v[0], second = flip_dims_v[0];
   for (int64_t i = 1; i < flip_dims_size; i++) {
@@ -49,11 +53,10 @@ Tensor flip_cpu(const Tensor& self, IntList dims) {
         permute_order.emplace_back(i);
       }
     }
-    auto out_tensor = self.index(TensorList(final_indices));
-    return out_tensor.permute(IntList(permute_order));
+    std::sort(out_sizes_idx.begin(), out_sizes_idx.end(),
+              [&permute_order](int64_t i1, int64_t i2) {return permute_order[i1] < permute_order[i2];});
+    return out_tensor.permute(out_sizes_idx);
   }
-
-  auto out_tensor = self.index(TensorList(final_indices));
   return out_tensor;
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7228,6 +7228,7 @@ class _TestTorchMixin(object):
 
     @staticmethod
     def _test_flip(self, use_cuda=False):
+        device = torch.device('cuda') if use_cuda else torch.device('cpu')
         if use_cuda:
             cuda = torch.device("cuda")
             data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device=cuda).view(2, 2, 2)
@@ -7282,6 +7283,15 @@ class _TestTorchMixin(object):
         # test empty tensor, should just return an empty tensor of the same shape
         data = torch.tensor([])
         self.assertEqual(data, data.flip(0))
+
+        # test for shape
+        data = torch.randn(2, 3, 4, device=device)
+        size = [2, 3, 4]
+        test_dims = []
+        for i in range(1, 3):
+            test_dims += combinations(range(len(size)), i)
+        for ds in test_dims:
+            self.assertEqual(size, list(data.flip(ds).size()))
 
     def test_flip(self):
         self._test_flip(self, use_cuda=False)


### PR DESCRIPTION
- this demonstrate the root cause of the bug at https://github.com/pytorch/pytorch/issues/13292, and proposing a fix for it
- the cause is because of bug at permute:
```
>>> a = torch.randn(1, 2, 3, 4)
>>> a_flip = flip(a, [1, 3])
>>> a_flip.shape
torch.Size([2, 4, 1, 3]) # need to permute([2, 0, 3, 1])

# =====  original flip() impl only works for this case =======
>>> a = torch.randn(1, 2, 3, 4)
>>> a_flip = flip(a, [0, 2])
>>> a_flip.shape
torch.Size([1, 3, 2, 4]) # need to permute([0, 2, 1, 3])

>>> a = torch.randn(1, 2, 3, 4)
>>> a_flip = flip(a, [0, 3])
>>> a_flip.shape
torch.Size([1, 4, 2, 3]) # need to permute([0, 2, 3, 1])
```
- performance:
```
>>> a = torch.randn(1000, 1000)
>>> %timeit -r 10 a.flip(0, 1)
15.2 ms ± 2.57 ms per loop (mean ± std. dev. of 10 runs, 100 loops each)
```

cc @fmassa @SsnL 