### PR TITLE
[jit] Add list() op and re-arrange some builtins

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7267,7 +7267,7 @@ a")
     def test_unwrap_optional_builtin(self):
         def test(x):
             # type: (Optional[int]) -> int
-            x = torch.jit._unwrap_optional(x)
+            x = torch._jit_internal._unwrap_optional(x)
             x = x + x
             return x
 
@@ -7284,6 +7284,10 @@ a")
             @torch.jit.script
             def test_test():
                 return torch.jit._unwrap_optional(1)
+
+        @torch.jit.script
+        def test_test():
+            return torch._jit_internal._unwrap_optional(1)
 
     def test_indexing_error(self):
         with self.assertRaisesRegex(RuntimeError, "Indexing only supported on lists, tensors, and tuples"):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -104,3 +104,14 @@ def weak_script_method(fn):
         "original_method": fn
     }
     return fn
+
+
+def _unwrap_optional(x):
+    assert x is not None, "Unwrapping null optional"
+    return x
+
+
+# Python equivalents for the empty list construction builtins. We need
+# these otherwise the tests won't execute in regular Python mode.
+def _construct_empty_int_list():
+    return []

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -651,6 +651,13 @@ Operation listLen(const Node* node) {
 }
 
 template <typename T>
+Operation listList(const Node* node) {
+  return [=](Stack& stack) {
+    return 0;
+  };
+}
+
+template <typename T>
 Operation listEq(const Node* node) {
   return [=](Stack& stack) {
     T a;
@@ -783,6 +790,7 @@ Operator(                                                                      \
 #define CREATE_LIST_OPS(decl_type, c_type) \
     Operator("aten::select(" decl_type "[] a, int b) -> " decl_type, listSelect<Shared<c_type>>), \
     Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
+    Operator("aten::list(" decl_type "[] a) -> " decl_type "[]", listList<Shared<c_type>>), \
     Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
     Operator( \
         "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -250,9 +250,14 @@ TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
       return OptionalType::create(matchTypeVariables(
           opt_formal->getElementType(), opt_actual->getElementType(), type_env));
     } else {
-      std::stringstream ss;
-      ss << "cannot match a optional to " << actual->str();
-      throw TypeMatchError(ss.str());
+      // Allow matching to `None`
+      if (actual->isSubtypeOf(NoneType::get())) {
+        return OptionalType::create(opt_formal->getElementType());
+      }
+
+      // If the actual type is a non-optional, allow matching to the formal if
+      // its element type matches the actual
+      return matchTypeVariables(opt_formal->getElementType(), actual, type_env);
     }
   }
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -7,7 +7,7 @@ import torch.jit.annotations
 from torch._six import raise_from, with_metaclass, get_function_from_type
 from .._jit_internal import createResolutionCallback, _compiled_weak_fns, \
     _weak_script_methods, _weak_modules, _weak_types, COMPILED, \
-    COMPILATION_PENDING
+    COMPILATION_PENDING, _unwrap_optional, _construct_empty_int_list
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple
 import torch.testing
 from collections import defaultdict, OrderedDict, namedtuple
@@ -1334,11 +1334,6 @@ def _should_skip(mod, name):
     return mod is torch.nn.functional and name in _builtin_blacklist
 
 
-def _unwrap_optional(x):
-    assert x is not None, "Unwrapping null optional"
-    return x
-
-
 # lazily built to ensure the correct initialization order
 def _get_builtin_table():
     global _builtin_table
@@ -1360,6 +1355,7 @@ def _get_builtin_table():
     _builtin_table[id(_triple)] = "aten::_triple"
     _builtin_table[id(_quadruple)] = "aten::_quadruple"
     _builtin_table[id(_unwrap_optional)] = "aten::_unwrap_optional"
+    _builtin_table[id(list)] = "aten::list"
 
     return _builtin_table
 
@@ -1370,12 +1366,6 @@ def _register_builtin(fn, op):
 
 def _find_builtin(fn):
     return _get_builtin_table().get(id(fn))
-
-
-# Python equivalents for the empty list construction builtins. We need
-# these otherwise the tests won't execute in regular Python mode.
-def _construct_empty_int_list():
-    return []
 
 
 _register_builtin(_construct_empty_int_list, 'aten::_construct_empty_int_list')


### PR DESCRIPTION
This PR is a prelude to converting `max_unpool1d` to weak script
* adds a `list()` noop (this is just a stand-in for now to appease the compiler, in a (near) future PR this will be made to actually follow Python semantics)
* moves `_unwrap_optional` and `_construct_empty_int_list` to
`_jit_internal.py` so they can be used from `torch.nn`
* allows passing non-optional values for optional parameters

