### PR TITLE
Remove outdated css and font files in html docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,8 +167,6 @@ def setup(app):
     # and can be moved outside of this function (and the setup(app) function
     # can be deleted).
     html_css_files = [
-        'https://fonts.googleapis.com/css?family=Lato',
-        'css/pytorch_theme.css',  # relative to paths in `html_static_path`
         'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css'
     ]
 


### PR DESCRIPTION
The stylesheet at docs/source/_static/css/pytorch_theme.css is no longer necessary for the html docs build. The new html docs theme styles are located at https://github.com/pytorch/pytorch_sphinx_theme.

The Lato font is also no longer used in the new theme.

