### PR TITLE
Fix the bug in dispatch_to when calling cpu()

### DIFF
--- a/test/expect/TestJit.test_export_tensoroption_to.expect
+++ b/test/expect/TestJit.test_export_tensoroption_to.expect
@@ -14,7 +14,7 @@ ModelProto {
         Node {type: "Constant", inputs: [], outputs: [3], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
         Node {type: "Shape", inputs: [3], outputs: [4], attributes: []},
         Node {type: "Expand", inputs: [2,4], outputs: [5], attributes: []},
-        Node {type: "Cast", inputs: [5], outputs: [6], attributes: [{ name: 'to', type: int, value: 1}]},
+        Node {type: "Cast", inputs: [5], outputs: [6], attributes: [{ name: 'to', type: int, value: 11}]},
         Node {type: "Add", inputs: [6,0], outputs: [7], attributes: []}
       ]
     }

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -259,7 +259,7 @@ static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
 
 static Tensor dispatch_to(const Tensor & self, Device device, bool non_blocking, bool copy) {
   AutoNoGIL no_gil;
-  return self.to(device, non_blocking, copy);
+  return self.to(self.options().device(device), non_blocking, copy);
 }
 
 static Tensor dispatch_to(const Tensor & self, ScalarType dtype, bool non_blocking, bool copy) {


### PR DESCRIPTION
When we added to in #13146, we did not emit the cast correctly in one of the dispatch overloads, then when we call .cpu(), the dtype will always be the default float type, which is wrong. 

CC @jamesr66a @eellison 