### PR TITLE
Change all namespace fbgemm in the old fbgemm to namespace fbgemm0

### DIFF
--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
@@ -94,7 +94,7 @@ bool ChannelShuffleDNNLowPOp<T>::RunOnDeviceWithOrderNHWC() {
 #endif
     for (auto i = 0; i < X.numel(); i += C) {
       // Transpose each C = GxK matrix
-      fbgemm::transpose_4rows(
+      fbgemm2::transpose_4rows(
           K, (const std::uint8_t*)(X_data + i), (std::uint8_t*)(Y_data + i));
     }
   } else {

--- a/caffe2/quantization/server/transpose.cc
+++ b/caffe2/quantization/server/transpose.cc
@@ -2,11 +2,9 @@
 
 #include <x86intrin.h>
 
-namespace fbgemm
-{
+namespace fbgemm2 {
 
-void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
-{
+void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst) {
   constexpr int M = 4;
   int j;
   // vectorized loop
@@ -15,10 +13,10 @@ void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
     // b : b0 b1 ... b31
     // c : c0 c1 ... c31
     // d : d0 d1 ... d31
-    __m256i a = _mm256_lddqu_si256((const __m256i *)(src + j + 0 * N));
-    __m256i b = _mm256_lddqu_si256((const __m256i *)(src + j + 1 * N));
-    __m256i c = _mm256_lddqu_si256((const __m256i *)(src + j + 2 * N));
-    __m256i d = _mm256_lddqu_si256((const __m256i *)(src + j + 3 * N));
+    __m256i a = _mm256_lddqu_si256((const __m256i*)(src + j + 0 * N));
+    __m256i b = _mm256_lddqu_si256((const __m256i*)(src + j + 1 * N));
+    __m256i c = _mm256_lddqu_si256((const __m256i*)(src + j + 2 * N));
+    __m256i d = _mm256_lddqu_si256((const __m256i*)(src + j + 3 * N));
 
     // even-odd interleaving
     // ab_lo : a0 b0 a1 b1 ...  a7  b7 | a16 b16 ... a23 b23
@@ -42,24 +40,24 @@ void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
 
     // Storing with 128-bit lanes are permuted so that everything is in order
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 0 * 32),
+        (__m256i*)(dst + j * M + 0 * 32),
         _mm256_permute2f128_si256(y0, y1, 0x20));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 1 * 32),
+        (__m256i*)(dst + j * M + 1 * 32),
         _mm256_permute2f128_si256(y2, y3, 0x20));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 2 * 32),
+        (__m256i*)(dst + j * M + 2 * 32),
         _mm256_permute2f128_si256(y0, y1, 0x31));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 3 * 32),
+        (__m256i*)(dst + j * M + 3 * 32),
         _mm256_permute2f128_si256(y2, y3, 0x31));
   }
   // scalar loop for remainder
-  for ( ; j < N; ++j) {
+  for (; j < N; ++j) {
     for (int i = 0; i < M; ++i) {
       dst[j * M + i] = src[j + i * N];
     }
   }
 }
 
-} // namespace fbgemm
+} // namespace fbgemm2

--- a/caffe2/quantization/server/transpose.h
+++ b/caffe2/quantization/server/transpose.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace fbgemm
-{
+namespace fbgemm2 {
 
 /**
  * Transpose 4xN matrix with unsigned 8-byte integers
@@ -11,4 +10,4 @@ namespace fbgemm
  */
 void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst);
 
-}
+} // namespace fbgemm2


### PR DESCRIPTION
Summary:
We would like to rename the old fbgemm to “fbgemm0”, and the new fbgemm2 to “fbgemm”:

This DIFF changes all namespace fbgemm to namespace fbgemm0.

Reviewed By: jspark1105

Differential Revision: D12848727
