### PR TITLE
Remove _th_ndimension, which doesn't actually do anything.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1,14 +1,4 @@
 [[
-  name: _th_ndimension
-  cname: nDimension
-  cpu_half: True
-  device_guard: False
-  return: long
-  arguments:
-    - THTensor* self
-]]
-[[
-[[
   name: _th_set_
   cname: set
   cpu_half: True

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -262,7 +262,6 @@ public:
 
   //example
   //Tensor * add(Tensor & b);
-  int64_t _th_ndimension() const;
   Tensor & _th_set_(Storage source);
   Tensor & _th_set_(Storage source, int64_t storage_offset, IntList size, IntList stride={});
   Tensor & _th_set_(const Tensor & source);

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -53,9 +53,6 @@ inline void Tensor::set_data(Tensor new_data) {
 }
 
 // all static inline to allow for inlining of the non-dynamic part of dispatch
-inline int64_t Tensor::_th_ndimension() const {
-    return type()._th_ndimension(*this);
-}
 inline Tensor & Tensor::_th_set_(Storage source) {
     return type()._th_set_(*this, source);
 }

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -168,7 +168,6 @@ struct CAFFE2_API Type {
 
   // example
   // virtual Tensor * add(Tensor & a, Tensor & b) = 0;
-  virtual int64_t _th_ndimension(const Tensor & self) const = 0;
   virtual Tensor & _th_set_(Tensor & self, Storage source) const = 0;
   virtual Tensor & _th_set_(Tensor & self, Storage source, int64_t storage_offset, IntList size, IntList stride) const = 0;
   virtual Tensor & _th_set_(Tensor & self, const Tensor & source) const = 0;

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -5,10 +5,6 @@ namespace at { namespace native {
 
 // Methods
 
-int64_t ndimension(const Tensor& self) {
-  return self._th_ndimension();
-}
-
 void* data_ptr(const Tensor & self) {
   return self.unsafeGetTensorImpl()->slow_data();
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2359,10 +2359,6 @@
 
 # wrappers for legacy TH methods
 
-- func: ndimension(Tensor self) -> int64_t
-  variants: method
-  device_guard: false
-
 - func: data_ptr(Tensor self) -> void*
   variants: method
   device_guard: false


### PR DESCRIPTION
Tensor.ndimension is hardcoded.

