### PR TITLE
Fix typo in CTC loss doc comments.

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1506,7 +1506,7 @@ def ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0,
             `T = input length`, and `N = batch size`.
             The logarithmized probabilities of the outputs
             (e.g. obtained with :func:`torch.nn.functional.log_softmax`).
-        targets: :math:`(N, S)` or `(sum(target_lenghts))`.
+        targets: :math:`(N, S)` or `(sum(target_lengths))`.
             Targets (cannot be blank). In the second form, the targets are assumed to be concatenated.
         input_lengths: :math:`(N)`.
             Lengths of the inputs (must each be :math:`\leq T`)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1148,7 +1148,7 @@ class CTCLoss(_Loss):
             `T = input length`, and `N = batch size`.
             The logarithmized probabilities of the outputs
             (e.g. obtained with :func:`torch.nn.functional.log_softmax`).
-        targets: Tensor of size :math:`(N, S)` or `(sum(target_lenghts))`.
+        targets: Tensor of size :math:`(N, S)` or `(sum(target_lengths))`.
             Targets (cannot be blank). In the second form, the targets are assumed to be concatenated.
         input_lengths: Tuple or tensor of size :math:`(N)`.
             Lengths of the inputs (must each be :math:`\leq T`)


### PR DESCRIPTION
`target_lenghts` -> `target_lengths`