### PR TITLE
CircleCI: enable OSX jobs again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1014,11 +1014,11 @@ workflows:
           requires:
             - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
 
-      # - pytorch_macos_10_13_py3_build
-      # - pytorch_macos_10_13_py3_test:
-      #     requires:
-      #       - pytorch_macos_10_13_py3_build
-      # - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build
+      - pytorch_macos_10_13_py3_build
+      - pytorch_macos_10_13_py3_test:
+          requires:
+            - pytorch_macos_10_13_py3_build
+      - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build
 
       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_build
       - caffe2_py2_cuda8_0_cudnn6_ubuntu16_04_test:
@@ -1050,5 +1050,5 @@ workflows:
       - caffe2_py2_android_ubuntu16_04_build
       - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
-      # - caffe2_py2_ios_macos10_13_build
-      # - caffe2_py2_system_macos10_13_build
+      - caffe2_py2_ios_macos10_13_build
+      - caffe2_py2_system_macos10_13_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,6 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
           # moreutils installs a `parallel` executable by default, which conflicts with the executable from the `parallel` formulae
           brew install moreutils --without-parallel
           brew install cmake
-
           brew install expect
 
           # Reinitialize submodules
@@ -691,6 +690,7 @@ jobs:
             export IN_CIRCLECI=1
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the `parallel` formulae
             brew install moreutils --without-parallel
+            brew install expect
 
             # Install sccache
             sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
@@ -734,6 +734,7 @@ jobs:
             export IN_CIRCLECI=1
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the `parallel` formulae
             brew install moreutils --without-parallel
+            brew install expect
 
             cp -r /Users/distiller/pytorch-ci-env/workspace/. /Users/distiller/project
 
@@ -758,6 +759,7 @@ jobs:
 
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the `parallel` formulae
             brew install moreutils --without-parallel
+            brew install expect
 
             # Install CUDA 9.2
             sudo rm -rf ~/cuda_9.2.64_mac_installer.app || true


### PR DESCRIPTION
CircleCI now offers 60x OSX concurrency, which is 2x of what we currently have in Jenkins. This should help alleviate the OSX CI wait time.