### PR TITLE
Fix clang-tidy for Python2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -454,13 +454,14 @@ have more checks than older versions. In our CI, we run clang-tidy-6.0.
    uncommitted changes). Changes are picked up based on a `git diff` with the
    given revision:
   ```sh
-  $ python tools/clang_tidy.py -d build -p torch/csrc -r HEAD~1
+  $ python tools/clang_tidy.py -d build -p torch/csrc --diff 'HEAD~1'
   ```
 
 Above, it is assumed you are in the PyTorch root folder. `path/to/build` should
 be the path to where you built PyTorch from source, e.g. `build` in the PyTorch
 root folder if you used `setup.py build`. You can use `-c <clang-tidy-binary>`
-to change the clang-tidy this script uses.
+to change the clang-tidy this script uses. Make sure you have PyYaml installed,
+which is in PyTorch's `requirements.txt`.
 
 ## Caffe2 notes
 

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -42,9 +42,9 @@ def run_shell_command(arguments):
     """Executes a shell command."""
     if VERBOSE:
         print(" ".join(arguments))
-    result = subprocess.run(arguments, stdout=subprocess.PIPE)
-    output = result.stdout.decode().strip()
-    if result.returncode != 0:
+    try:
+        output = subprocess.check_output(arguments).decode().strip()
+    except subprocess.CalledProcessError:
         raise RuntimeError("Error executing {}: {}".format(" ".join(arguments), output))
 
     return output


### PR DESCRIPTION
`clang_tidy.py` doesn't run with Python2 right now. Needs a minor fix

@ezyang 