### PR TITLE
Use MNIST dataset in C++ integration test

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -145,7 +145,7 @@ test_libtorch() {
      else
        "$CPP_BUILD"/caffe2/bin/test_jit "[cpu]"
      fi
-     python tools/download_mnist.py --quiet -d test/cpp/api/mnist
+     python tools/download_mnist.py --quiet -d mnist
      OMP_NUM_THREADS=2 "$CPP_BUILD"/caffe2/bin/test_api
   fi
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -454,13 +454,14 @@ have more checks than older versions. In our CI, we run clang-tidy-6.0.
    uncommitted changes). Changes are picked up based on a `git diff` with the
    given revision:
   ```sh
-  $ python tools/clang_tidy.py -d build -p torch/csrc -r HEAD~1
+  $ python tools/clang_tidy.py -d build -p torch/csrc --diff 'HEAD~1'
   ```
 
 Above, it is assumed you are in the PyTorch root folder. `path/to/build` should
 be the path to where you built PyTorch from source, e.g. `build` in the PyTorch
 root folder if you used `setup.py build`. You can use `-c <clang-tidy-binary>`
-to change the clang-tidy this script uses.
+to change the clang-tidy this script uses. Make sure you have PyYaml installed,
+which is in PyTorch's `requirements.txt`.
 
 ## Caffe2 notes
 

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -112,7 +112,7 @@ bool test_mnist(
     M&& model,
     F&& forward_op,
     O&& optimizer) {
-  std::string mnist_path = "test/cpp/api/mnist";
+  std::string mnist_path = "mnist";
   if (const char* user_mnist_path = getenv("TORCH_CPP_TEST_MNIST_PATH")) {
     mnist_path = user_mnist_path;
   }
@@ -142,10 +142,11 @@ bool test_mnist(
   torch::NoGradGuard guard;
   torch::data::datasets::MNIST test_dataset(
       mnist_path, torch::data::datasets::MNIST::Mode::kTest);
+  auto images = test_dataset.images().to(device),
+       targets = test_dataset.targets().to(device);
 
-  auto result = forward_op(test_dataset.images()).max_values(/*dim=*/1);
-  torch::Tensor correct =
-      (result == test_dataset.targets()).to(torch::kFloat32);
+  auto result = std::get<1>(forward_op(images).max(/*dim=*/1));
+  torch::Tensor correct = (result == targets).to(torch::kFloat32);
   return correct.sum().item<float>() > (test_dataset.size().value() * 0.8);
 }
 

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <torch/data.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>
 #include <torch/nn/modules/dropout.h>
@@ -12,11 +13,12 @@
 
 #include <test/cpp/api/support.h>
 
+#include <cmath>
+#include <cstdlib>
+#include <random>
+
 using namespace torch::nn;
 using namespace torch::test;
-
-#include <cmath>
-#include <random>
 
 class CartPole {
   // Translated from openai/gym's cartpole.py
@@ -104,115 +106,33 @@ class CartPole {
 
 template <typename M, typename F, typename O>
 bool test_mnist(
-    uint32_t batch_size,
-    uint32_t num_epochs,
-    bool useGPU,
+    size_t batch_size,
+    size_t number_of_epochs,
+    bool with_cuda,
     M&& model,
     F&& forward_op,
     O&& optimizer) {
-  struct MNIST_Reader {
-    FILE* fp_;
-
-    explicit MNIST_Reader(const char* path) {
-      fp_ = fopen(path, "rbe");
-      if (!fp_)
-        throw std::runtime_error("failed to open file");
-    }
-
-    ~MNIST_Reader() {
-      if (fp_)
-        fclose(fp_);
-    }
-
-    uint32_t read_int() {
-      uint8_t buf[4];
-      if (fread(buf, sizeof(buf), 1, fp_) != 1) {
-        throw std::runtime_error("failed to read an integer");
-      }
-      return buf[0] << 24u | buf[1] << 16u | buf[2] << 8u | buf[3];
-    }
-
-    uint8_t read_byte() {
-      uint8_t i;
-      if (fread(&i, sizeof(i), 1, fp_) != 1) {
-        throw std::runtime_error("failed to read an byte");
-      }
-      return i;
-    }
-  };
-
-  auto readData = [&](std::string fn) {
-    MNIST_Reader rd(fn.c_str());
-
-    /* int image_magic = */ rd.read_int();
-    int image_count = rd.read_int();
-    int image_rows = rd.read_int();
-    int image_cols = rd.read_int();
-
-    auto data = torch::empty({image_count, 1, image_rows, image_cols});
-    auto a_data = data.accessor<float, 4>();
-
-    for (int c = 0; c < image_count; c++) {
-      for (int i = 0; i < image_rows; i++) {
-        for (int j = 0; j < image_cols; j++) {
-          a_data[c][0][i][j] = float(rd.read_byte()) / 255;
-        }
-      }
-    }
-
-    return data.toBackend(useGPU ? torch::Backend::CUDA : torch::Backend::CPU);
-  };
-
-  auto readLabels = [&](std::string fn) {
-    MNIST_Reader rd(fn.c_str());
-    /* int label_magic = */ rd.read_int();
-    int label_count = rd.read_int();
-
-    auto data = torch::empty({label_count}, torch::kInt64);
-    auto a_data = data.accessor<int64_t, 1>();
-
-    for (int i = 0; i < label_count; ++i) {
-      a_data[i] = static_cast<int64_t>(rd.read_byte());
-    }
-    return data.toBackend(useGPU ? torch::Backend::CUDA : torch::Backend::CPU);
-  };
-
-  auto trdata = readData("test/cpp/api/mnist/train-images-idx3-ubyte");
-  auto trlabel = readLabels("test/cpp/api/mnist/train-labels-idx1-ubyte");
-  auto tedata = readData("test/cpp/api/mnist/t10k-images-idx3-ubyte");
-  auto telabel = readLabels("test/cpp/api/mnist/t10k-labels-idx1-ubyte");
-
-  if (useGPU) {
-    model->to(torch::kCUDA);
+  std::string mnist_path = "test/cpp/api/mnist";
+  if (const char* user_mnist_path = getenv("TORCH_CPP_TEST_MNIST_PATH")) {
+    mnist_path = user_mnist_path;
   }
 
-  std::random_device device;
-  std::mt19937 generator(device());
+  auto train_dataset =
+      torch::data::datasets::MNIST(
+          mnist_path, torch::data::datasets::MNIST::Mode::kTrain)
+          .map(torch::data::transforms::Stack<>());
 
-  for (auto epoch = 0U; epoch < num_epochs; epoch++) {
-    auto shuffled_inds = std::vector<int>(trdata.size(0));
-    for (int i = 0; i < trdata.size(0); i++) {
-      shuffled_inds[i] = i;
-    }
-    std::shuffle(shuffled_inds.begin(), shuffled_inds.end(), generator);
+  auto data_loader =
+      torch::data::make_data_loader(std::move(train_dataset), batch_size);
 
-    const auto backend = useGPU ? torch::kCUDA : torch::kCPU;
-    auto inp =
-        torch::empty({batch_size, 1, trdata.size(2), trdata.size(3)}, backend);
-    auto lab =
-        torch::empty({batch_size}, torch::device(backend).dtype(torch::kInt64));
-    for (auto p = 0U; p < shuffled_inds.size() - batch_size; p++) {
-      inp[p % batch_size] = trdata[shuffled_inds[p]];
-      lab[p % batch_size] = trlabel[shuffled_inds[p]];
+  torch::Device device(with_cuda ? torch::kCUDA : torch::kCPU);
+  model->to(device);
 
-      if (p % batch_size != batch_size - 1)
-        continue;
-      inp.set_requires_grad(true);
-      torch::Tensor x = forward_op(inp);
-      inp.set_requires_grad(false);
-      torch::Tensor y = lab;
-      torch::Tensor loss = torch::nll_loss(x, y);
-
+  for (size_t epoch = 0; epoch < number_of_epochs; epoch++) {
+    for (torch::data::Example<> batch : *data_loader) {
+      auto data = batch.data.to(device), targets = batch.target.to(device);
+      torch::Tensor prediction = forward_op(std::move(data));
+      torch::Tensor loss = torch::nll_loss(prediction, std::move(targets));
       optimizer.zero_grad();
       loss.backward();
       optimizer.step();
@@ -220,9 +140,13 @@ bool test_mnist(
   }
 
   torch::NoGradGuard guard;
-  auto result = std::get<1>(forward_op(tedata).max(1));
-  torch::Tensor correct = (result == telabel).toType(torch::kFloat32);
-  return correct.sum().item<float>() > telabel.size(0) * 0.8;
+  torch::data::datasets::MNIST test_dataset(
+      mnist_path, torch::data::datasets::MNIST::Mode::kTest);
+
+  auto result = forward_op(test_dataset.images()).max_values(/*dim=*/1);
+  torch::Tensor correct =
+      (result == test_dataset.targets()).to(torch::kFloat32);
+  return correct.sum().item<float>() > (test_dataset.size().value() * 0.8);
 }
 
 struct IntegrationTest : torch::test::SeedingFixture {};
@@ -354,8 +278,8 @@ TEST_F(IntegrationTest, MNIST_CUDA) {
 
   ASSERT_TRUE(test_mnist(
       32, // batch_size
-      3, // num_epochs
-      true, // useGPU
+      3, // number_of_epochs
+      true, // with_cuda
       model,
       forward,
       optimizer));
@@ -390,8 +314,8 @@ TEST_F(IntegrationTest, MNISTBatchNorm_CUDA) {
 
   ASSERT_TRUE(test_mnist(
       32, // batch_size
-      3, // num_epochs
-      true, // useGPU
+      3, // number_of_epochs
+      true, // with_cuda
       model,
       forward,
       optimizer));

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -45,7 +45,7 @@ bool test_RNN_xor(Func&& model_maker, bool cuda = false) {
 
     const auto backend = cuda ? torch::kCUDA : torch::kCPU;
     auto inputs =
-        torch::rand({nlen, bs, 1}, backend).round().toType(torch::kFloat32);
+        torch::rand({nlen, bs, 1}, backend).round().to(torch::kFloat32);
     auto labels = inputs.sum(0).detach();
     inputs.set_requires_grad(true);
 

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -42,9 +42,9 @@ def run_shell_command(arguments):
     """Executes a shell command."""
     if VERBOSE:
         print(" ".join(arguments))
-    result = subprocess.run(arguments, stdout=subprocess.PIPE)
-    output = result.stdout.decode().strip()
-    if result.returncode != 0:
+    try:
+        output = subprocess.check_output(arguments).decode().strip()
+    except subprocess.CalledProcessError:
         raise RuntimeError("Error executing {}: {}".format(" ".join(arguments), output))
 
     return output

--- a/torch/csrc/api/include/torch/data/datasets/mnist.h
+++ b/torch/csrc/api/include/torch/data/datasets/mnist.h
@@ -31,6 +31,12 @@ class MNIST : public Dataset<MNIST> {
   /// Returns true if this is the training subset of MNIST.
   bool is_train() const noexcept;
 
+  /// Returns all images stacked into a single tensor.
+  const Tensor& images() const;
+
+  /// Returns all targets stacked into a single tensor.
+  const Tensor& targets() const;
+
  private:
   Tensor images_, targets_;
 };

--- a/torch/csrc/api/src/data/datasets/mnist.cpp
+++ b/torch/csrc/api/src/data/datasets/mnist.cpp
@@ -112,6 +112,14 @@ bool MNIST::is_train() const noexcept {
   return images_.size(0) == kTrainSize;
 }
 
+const Tensor& MNIST::images() const {
+  return images_;
+}
+
+const Tensor& MNIST::targets() const {
+  return targets_;
+}
+
 } // namespace datasets
 } // namespace data
 } // namespace torch


### PR DESCRIPTION
We have an MNIST reader in the C++ data API, so we can get rid of the custom one currently implemented in the integration tests.

@ebetica