### PR TITLE
Change all namespace fbgemm2 in the new fbgemm2 to namespace fbgemm

### DIFF
--- a/caffe2/quantization/server/batch_matmul_dnnlowp_op.cc
+++ b/caffe2/quantization/server/batch_matmul_dnnlowp_op.cc
@@ -335,9 +335,9 @@ bool BatchMatMulDNNLowPOp<T>::RunOnDevice() {
               B_qparams_[i]);
         }
 
-        Bq_packed_.emplace_back(new fbgemm2::PackBMatrix<int8_t>(
-            trans_b_ ? fbgemm2::matrix_op_t::Transpose
-                     : fbgemm2::matrix_op_t::NoTranspose,
+        Bq_packed_.emplace_back(new fbgemm::PackBMatrix<int8_t>(
+            trans_b_ ? fbgemm::matrix_op_t::Transpose
+                     : fbgemm::matrix_op_t::NoTranspose,
             K,
             N,
             B_quantized_temp.data(),
@@ -416,7 +416,7 @@ bool BatchMatMulDNNLowPOp<T>::RunOnDevice() {
   vector<T> A_temp, B_temp;
   if (!Bq_packed_.empty()) {
     // fast path
-    using namespace fbgemm2;
+    using namespace fbgemm;
 
     const T* A_quantized = nullptr;
     if (A.template IsType<T>() || !dequantize_output_) {

--- a/caffe2/quantization/server/batch_matmul_dnnlowp_op.h
+++ b/caffe2/quantization/server/batch_matmul_dnnlowp_op.h
@@ -39,7 +39,7 @@ class BatchMatMulDNNLowPOp final
   bool is_B_constant_{false};
 
   std::vector<std::int8_t> B_quantized_;
-  std::vector<std::unique_ptr<fbgemm2::PackBMatrix<std::int8_t>>> Bq_packed_;
+  std::vector<std::unique_ptr<fbgemm::PackBMatrix<std::int8_t>>> Bq_packed_;
   std::vector<std::uint8_t> A_pack_buf_;
   std::vector<std::int32_t> row_offsets_, column_offsets_;
 

--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
@@ -94,7 +94,7 @@ bool ChannelShuffleDNNLowPOp<T>::RunOnDeviceWithOrderNHWC() {
 #endif
     for (auto i = 0; i < X.numel(); i += C) {
       // Transpose each C = GxK matrix
-      fbgemm2::transpose_4rows(
+      fbgemm::transpose_4rows(
           K, (const std::uint8_t*)(X_data + i), (std::uint8_t*)(Y_data + i));
     }
   } else {

--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
@@ -94,7 +94,7 @@ bool ChannelShuffleDNNLowPOp<T>::RunOnDeviceWithOrderNHWC() {
 #endif
     for (auto i = 0; i < X.numel(); i += C) {
       // Transpose each C = GxK matrix
-      fbgemm::transpose_4rows(
+      fbgemm2::transpose_4rows(
           K, (const std::uint8_t*)(X_data + i), (std::uint8_t*)(Y_data + i));
     }
   } else {

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.h
@@ -44,11 +44,11 @@ class ConvDNNLowPAcc16Op final
       const std::uint8_t* col_buffer,
       vector<std::int32_t>* Y_int32);
 
-  std::vector<std::unique_ptr<fbgemm2::PackBMatrix<std::int8_t, std::int16_t>>>
+  std::vector<std::unique_ptr<fbgemm::PackBMatrix<std::int8_t, std::int16_t>>>
       Wq_acc16_packed_;
 
   // Wq outlier in CSC format
-  std::vector<fbgemm2::CompressedSparseColumn> Wq_outlier_;
+  std::vector<fbgemm::CompressedSparseColumn> Wq_outlier_;
 
   int nbits_in_non_outlier_;
   int copy_to_32bit_frequency_;

--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -103,12 +103,12 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   std::vector<dnnlowp::RequantizationParams> requantization_params_;
 
   // used in fast path for T == uint8_t
-  std::vector<std::unique_ptr<fbgemm2::PackBMatrix<std::int8_t>>> Wq_packed_;
+  std::vector<std::unique_ptr<fbgemm::PackBMatrix<std::int8_t>>> Wq_packed_;
 
   // For depthwise 3x3 conv
-  std::unique_ptr<fbgemm2::Packed3x3ConvMatrix> Wq_depthwise_3x3_packed_;
+  std::unique_ptr<fbgemm::Packed3x3ConvMatrix> Wq_depthwise_3x3_packed_;
   // For depthwise 3x3x3 conv
-  std::unique_ptr<fbgemm2::Packed3x3x3ConvMatrix> Wq_depthwise_3x3x3_packed_;
+  std::unique_ptr<fbgemm::Packed3x3x3ConvMatrix> Wq_depthwise_3x3x3_packed_;
 
   // pre-computed biases and offsets
   std::vector<std::int32_t> b_quantized_;

--- a/caffe2/quantization/server/fbgemm_pack_matrix_cache.cc
+++ b/caffe2/quantization/server/fbgemm_pack_matrix_cache.cc
@@ -9,8 +9,8 @@ using namespace std;
 namespace caffe2 {
 
 template <typename ACC_T>
-shared_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>> GetOrCreateFbgemmPackBMatrix(
-    fbgemm2::matrix_op_t trans,
+shared_ptr<fbgemm::PackBMatrix<int8_t, ACC_T>> GetOrCreateFbgemmPackBMatrix(
+    fbgemm::matrix_op_t trans,
     int32_t m,
     int32_t n,
     const void* orig_data,
@@ -19,7 +19,7 @@ shared_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>> GetOrCreateFbgemmPackBMatrix(
     int32_t zero_point) {
   static std::map<
       std::tuple<int, int, const void*>,
-      weak_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>>>
+      weak_ptr<fbgemm::PackBMatrix<int8_t, ACC_T>>>
       cache;
   static mutex cache_mutex;
 
@@ -27,7 +27,7 @@ shared_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>> GetOrCreateFbgemmPackBMatrix(
 
   // Create a new packed matrix and compare with cached one if there's any.
   // TODO: make this cheaper by computing hash of fdata.
-  auto new_packed = make_shared<fbgemm2::PackBMatrix<int8_t, ACC_T>>(
+  auto new_packed = make_shared<fbgemm::PackBMatrix<int8_t, ACC_T>>(
       trans,
       m,
       n,
@@ -59,9 +59,9 @@ shared_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>> GetOrCreateFbgemmPackBMatrix(
   }
 }
 
-template shared_ptr<fbgemm2::PackBMatrix<int8_t, int16_t>>
+template shared_ptr<fbgemm::PackBMatrix<int8_t, int16_t>>
 GetOrCreateFbgemmPackBMatrix<int16_t>(
-    fbgemm2::matrix_op_t trans,
+    fbgemm::matrix_op_t trans,
     int32_t m,
     int32_t n,
     const void* orig_data,
@@ -69,9 +69,9 @@ GetOrCreateFbgemmPackBMatrix<int16_t>(
     int32_t ld,
     int32_t zero_point);
 
-template shared_ptr<fbgemm2::PackBMatrix<int8_t, int32_t>>
+template shared_ptr<fbgemm::PackBMatrix<int8_t, int32_t>>
 GetOrCreateFbgemmPackBMatrix<int32_t>(
-    fbgemm2::matrix_op_t trans,
+    fbgemm::matrix_op_t trans,
     int32_t m,
     int32_t n,
     const void* orig_data,

--- a/caffe2/quantization/server/fbgemm_pack_matrix_cache.h
+++ b/caffe2/quantization/server/fbgemm_pack_matrix_cache.h
@@ -10,9 +10,9 @@ namespace caffe2 {
  * sharing the same weight.
  */
 template <typename ACC_T>
-std::shared_ptr<fbgemm2::PackBMatrix<int8_t, ACC_T>>
+std::shared_ptr<fbgemm::PackBMatrix<int8_t, ACC_T>>
 GetOrCreateFbgemmPackBMatrix(
-    fbgemm2::matrix_op_t trans,
+    fbgemm::matrix_op_t trans,
     std::int32_t m,
     std::int32_t n,
     const void* orig_data,

--- a/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
@@ -67,7 +67,7 @@ bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
         }
       }
 
-      Wq_outlier_.reset(new fbgemm2::CompressedSparseColumn(K, N));
+      Wq_outlier_.reset(new fbgemm::CompressedSparseColumn(K, N));
       Wq_outlier_->RowIdx().resize(outlier_cnt);
       Wq_outlier_->Values().resize(outlier_cnt);
 
@@ -97,8 +97,8 @@ bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
       LOG(INFO) << "copy_to_32bit_frequency " << copy_to_32bit_frequency_;
     }
 
-    Wq_acc16_packed_.reset(new fbgemm2::PackBMatrix<int8_t, int16_t>(
-        fbgemm2::matrix_op_t::Transpose,
+    Wq_acc16_packed_.reset(new fbgemm::PackBMatrix<int8_t, int16_t>(
+        fbgemm::matrix_op_t::Transpose,
         K,
         N,
         reinterpret_cast<const int8_t*>(W_quantized_.data()),
@@ -114,7 +114,7 @@ bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
   Y_shape_cache_[canonical_axis] = N;
   Y->Resize(Y_shape_cache_);
 
-  using namespace fbgemm2;
+  using namespace fbgemm;
   // main GEMM
   // TODO : omp parallelization
   Y_int32_.resize(Y->size());

--- a/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.h
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.h
@@ -25,11 +25,11 @@ class FullyConnectedDNNLowPAcc16Op final
   using BaseType::W_quantized_;
 
  private:
-  std::unique_ptr<fbgemm2::PackBMatrix<std::int8_t, std::int16_t>>
+  std::unique_ptr<fbgemm::PackBMatrix<std::int8_t, std::int16_t>>
       Wq_acc16_packed_;
 
   // Wq outlier in CSC format
-  std::unique_ptr<fbgemm2::CompressedSparseColumn> Wq_outlier_;
+  std::unique_ptr<fbgemm::CompressedSparseColumn> Wq_outlier_;
   int nbits_in_non_outlier_;
   int copy_to_32bit_frequency_;
 }; // class FullyConnectedDNNLowPAcc16Op

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -9,7 +9,8 @@
 #include "mmio.h"
 
 C10_DEFINE_bool(
-    dnnlowp_enforce_default_caffe2_operators, false,
+    dnnlowp_enforce_default_caffe2_operators,
+    false,
     "When true, enforce to use the default Caffe2 operators inside DNNLOWP"
     "instead of using its own implementation that uses AVX2 instructions"
     "(currently only honored by FC)");
@@ -22,15 +23,16 @@ using namespace std;
 
 template <typename T>
 FullyConnectedDNNLowPOp<T>::FullyConnectedDNNLowPOp(
-    const OperatorDef& operator_def, Workspace *ws)
-  : BaseType(operator_def, ws),
-    axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)),
-    axis_w_(OperatorBase::GetSingleArgument<int32_t>("axis_w", 1)),
-    is_weight_constant_(
-        OperatorBase::GetSingleArgument<bool>("constant_weight", true)) {
+    const OperatorDef& operator_def,
+    Workspace* ws)
+    : BaseType(operator_def, ws),
+      axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)),
+      axis_w_(OperatorBase::GetSingleArgument<int32_t>("axis_w", 1)),
+      is_weight_constant_(
+          OperatorBase::GetSingleArgument<bool>("constant_weight", true)) {
   if (!is_weight_constant_) {
-    LOG(INFO) <<
-      operator_def.output(0) << " is_weight_constant " << is_weight_constant_;
+    LOG(INFO) << operator_def.output(0) << " is_weight_constant "
+              << is_weight_constant_;
   }
 
   VLOG(2) << "DNNLOWP FC with output " << operator_def.output(0);
@@ -43,29 +45,27 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
 
   BaseType::ParseDNNLowPOperatorArguments_();
 
-  if ((!GetCpuId().avx2() ||
-        FLAGS_dnnlowp_enforce_default_caffe2_operators) &&
+  if ((!GetCpuId().avx2() || FLAGS_dnnlowp_enforce_default_caffe2_operators) &&
       dequantize_output_) {
     if (!GetCpuId().avx2()) {
       static int log_occurences = 0;
       if (log_occurences < 32) {
         ++log_occurences;
-        LOG(WARNING) <<
-            "Falling back to the default Caffe2 operator because AVX2 "
-            "instruction is not available";
+        LOG(WARNING)
+            << "Falling back to the default Caffe2 operator because AVX2 "
+               "instruction is not available";
       }
     } else {
       static int log_occurences = 0;
       if (log_occurences < 32) {
         ++log_occurences;
-        LOG(WARNING) <<
-            "Falling back to the default Caffe2 operator because "
-            "dnnlowp_enforce_default_caffe2_operators option is on";
+        LOG(WARNING) << "Falling back to the default Caffe2 operator because "
+                        "dnnlowp_enforce_default_caffe2_operators option is on";
       }
     }
 
     Fp32Op_()->DequantizeInput();
-    FullyConnectedOp<CPUContext> *fp32_op = Fp32Op_()->Get();
+    FullyConnectedOp<CPUContext>* fp32_op = Fp32Op_()->Get();
     if (!fp32_op->RunOnDevice()) {
       return false;
     }
@@ -103,21 +103,21 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
 
   const auto& X = InputTensorCPU_(0);
   const auto& W = InputTensorCPU_(1);
-  auto *Y = OutputTensorCPU_(0);
+  auto* Y = OutputTensorCPU_(0);
   const auto canonical_axis = X.canonical_axis_index(axis_);
   const auto M = X.size_to_dim(canonical_axis);
   const auto K = X.size_from_dim(canonical_axis);
   const auto canonical_axis_w = W.canonical_axis_index(axis_w_);
   const int N = W.size_to_dim(canonical_axis_w);
 
-  const T_signed *Wdata = W_quantized_.data();
+  const T_signed* Wdata = W_quantized_.data();
 
   Y_shape_cache_ = X.sizes().vec();
   Y_shape_cache_.resize(canonical_axis + 1);
   Y_shape_cache_[canonical_axis] = N;
   Y->Resize(Y_shape_cache_);
 
-  const T *Xdata = nullptr;
+  const T* Xdata = nullptr;
   vector<T> X_temp;
 
   if (VLOG_IS_ON(3)) {
@@ -129,7 +129,7 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
   }
   if (Wq_packed_) {
     // fast path to use fbgemm
-    using namespace fbgemm2;
+    using namespace fbgemm;
 
     if (X.template IsType<T>() || !dequantize_output_) {
       // Only when input and output are float, we don't need input to be
@@ -142,8 +142,8 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
       if (VLOG_IS_ON(3)) {
         t_end = chrono::system_clock::now();
         double dt = chrono::duration<double>(t_end - t_begin).count();
-        VLOG(3) <<
-          "@PERF this=" << this << " input quantization: " << dt * 1e3 << " ms";
+        VLOG(3) << "@PERF this=" << this << " input quantization: " << dt * 1e3
+                << " ms";
         t_begin = chrono::system_clock::now();
       }
     }
@@ -276,8 +276,8 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
     if (VLOG_IS_ON(3)) {
       t_end = chrono::system_clock::now();
       double dt = chrono::duration<double>(t_end - t_begin).count();
-      VLOG(3) <<
-        "@PERF this=" << this << " input quantization: " << dt * 1e3 << " ms";
+      VLOG(3) << "@PERF this=" << this << " input quantization: " << dt * 1e3
+              << " ms";
       t_begin = chrono::system_clock::now();
     }
 
@@ -297,17 +297,11 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
   if (FLAGS_caffe2_dnnlowp_dump_tensors) {
     // Dump input activation
     StoreMatrixInMatrixMarketFormat(
-        M,
-        K,
-        Xdata,
-        OperatorBase::debug_def().input(0));
+        M, K, Xdata, OperatorBase::debug_def().input(0));
 
     // Dump weight
     StoreMatrixInMatrixMarketFormat(
-        N,
-        K,
-        Wdata,
-        OperatorBase::debug_def().input(1));
+        N, K, Wdata, OperatorBase::debug_def().input(1));
   }
 
   if (VLOG_IS_ON(3)) {
@@ -323,7 +317,7 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
   // row_offset, and const_offset in this way.
   if (dequantize_output_) {
     if (!Wq_packed_) {
-      float *Ydata = OutputTensorCPU_(0)->template mutable_data<float>();
+      float* Ydata = OutputTensorCPU_(0)->template mutable_data<float>();
 
       for (int i = 0; i < M; ++i) {
         int32_t row_offset = 0;
@@ -334,16 +328,16 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
 
         for (int j = 0; j < N; ++j) {
           Y_int32_[i * N + j] -=
-            in_qparams_[0].zero_point * column_offsets_[j] + row_offset;
-          Ydata[i * N + j] =
-            Y_int32_[i * N + j] * in_qparams_[0].scale * in_qparams_[1].scale +
-            b_dequantized_data_[j];
+              in_qparams_[0].zero_point * column_offsets_[j] + row_offset;
+          Ydata[i * N + j] = Y_int32_[i * N + j] * in_qparams_[0].scale *
+                  in_qparams_[1].scale +
+              b_dequantized_data_[j];
         }
       }
     }
   } else {
     if (!Wq_packed_) {
-      T *Ydata = GetQuantizedOutputData_();
+      T* Ydata = GetQuantizedOutputData_();
       for (int i = 0; i < M; ++i) {
         int32_t row_offset = 0;
         for (int k = 0; k < K; ++k) {
@@ -353,11 +347,11 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
 
         for (int j = 0; j < N; ++j) {
           Y_int32_[i * N + j] -=
-            in_qparams_[0].zero_point * column_offsets_[j] + row_offset;
+              in_qparams_[0].zero_point * column_offsets_[j] + row_offset;
           Y_int32_[i * N + j] += b_quantized_data_[j];
 
-          Ydata[i * N + j] = Requantize<T>(
-            Y_int32_[i * N + j], requantization_params_);
+          Ydata[i * N + j] =
+              Requantize<T>(Y_int32_[i * N + j], requantization_params_);
         }
       }
     }
@@ -392,16 +386,16 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
 
   chrono::time_point<chrono::system_clock> t_begin, t_end;
   if (VLOG_IS_ON(3)) {
-      t_begin = chrono::system_clock::now();
-    }
+    t_begin = chrono::system_clock::now();
+  }
   // Choose quantization for X
   in_qparams_[0] = GetInputTensorQuantizationParamsOf(this, 0, qfactory_.get());
 
   if (VLOG_IS_ON(3)) {
     t_end = chrono::system_clock::now();
     double dt = chrono::duration<double>(t_end - t_begin).count();
-    VLOG(3) << "@PERF this=" << this
-    << " GetInputTensorQuantizationParamsOf " << dt * 1e3 << " ms";
+    VLOG(3) << "@PERF this=" << this << " GetInputTensorQuantizationParamsOf "
+            << dt * 1e3 << " ms";
     t_begin = chrono::system_clock::now();
   }
 
@@ -449,7 +443,7 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
       if (fast_path) {
         // fast path using fbgemm
         Wq_packed_ = GetOrCreateFbgemmPackBMatrix<int32_t>(
-            fbgemm2::matrix_op_t::Transpose,
+            fbgemm::matrix_op_t::Transpose,
             K,
             N,
             W.raw_data(),
@@ -492,8 +486,7 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   if (VLOG_IS_ON(3)) {
     t_end = chrono::system_clock::now();
     double dt = chrono::duration<double>(t_end - t_begin).count();
-    VLOG(3) << "@PERF this=" << this
-    << " Quantize W " << dt * 1e3 << " ms";
+    VLOG(3) << "@PERF this=" << this << " Quantize W " << dt * 1e3 << " ms";
     t_begin = chrono::system_clock::now();
   }
   // Pre-compute column_offset
@@ -510,8 +503,8 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   if (VLOG_IS_ON(3)) {
     t_end = chrono::system_clock::now();
     double dt = chrono::duration<double>(t_end - t_begin).count();
-    VLOG(3) << "@PERF this=" << this
-    << " Calculate column offset " << dt * 1e3 << " ms";
+    VLOG(3) << "@PERF this=" << this << " Calculate column offset " << dt * 1e3
+            << " ms";
     t_begin = chrono::system_clock::now();
   }
   if (Wq_packed_ && !FLAGS_caffe2_dnnlowp_dump_tensors) {
@@ -520,8 +513,7 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   }
 
   // Quantize bias
-  if (!is_weight_constant_ ||
-      (!b_quantized_data_ && !b_dequantized_data_) ||
+  if (!is_weight_constant_ || (!b_quantized_data_ && !b_dequantized_data_) ||
       in_qparams_[0].scale != in_qparams0_scale_old_) {
     const auto& bias = InputTensorCPU_(2);
     if (OperatorBase::InputIsType<int8::Int8TensorCPU>(2)) {
@@ -569,8 +561,7 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   if (VLOG_IS_ON(3)) {
     t_end = chrono::system_clock::now();
     double dt = chrono::duration<double>(t_end - t_begin).count();
-    VLOG(3) << "@PERF this=" << this
-    << " Quantize bias " << dt * 1e3 << " ms";
+    VLOG(3) << "@PERF this=" << this << " Quantize bias " << dt * 1e3 << " ms";
     t_begin = chrono::system_clock::now();
   }
 
@@ -578,12 +569,11 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
     GetOutputQuantizationParams_();
 
     float real_multiplier =
-      in_qparams_[0].scale * in_qparams_[1].scale / out_qparams_.scale;
-    requantization_params_ =
-      qfactory_->ChooseRequantizationMultiplier(real_multiplier, out_qparams_);
+        in_qparams_[0].scale * in_qparams_[1].scale / out_qparams_.scale;
+    requantization_params_ = qfactory_->ChooseRequantizationMultiplier(
+        real_multiplier, out_qparams_);
     requantization_param_selected_ = true;
-  }
-  else {
+  } else {
     if (measure_quantization_error_) {
       // to measure quantization error, run ref impl.
       Fp32Op_()->DequantizeInput();
@@ -593,19 +583,25 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   if (VLOG_IS_ON(3)) {
     t_end = chrono::system_clock::now();
     double dt = chrono::duration<double>(t_end - t_begin).count();
-    VLOG(3) << "@PERF this=" << this
-    << " GetOutputQuantizationParams " << dt * 1e3 << " ms";
+    VLOG(3) << "@PERF this=" << this << " GetOutputQuantizationParams "
+            << dt * 1e3 << " ms";
     t_begin = chrono::system_clock::now();
   }
   return true;
 }
 
 REGISTER_CPU_OPERATOR_WITH_ENGINE(
-  FC, DNNLOWP, FullyConnectedDNNLowPOp<uint8_t>);
+    FC,
+    DNNLOWP,
+    FullyConnectedDNNLowPOp<uint8_t>);
 REGISTER_CPU_OPERATOR_WITH_ENGINE(
-  FC, DNNLOWP_16, FullyConnectedDNNLowPOp<uint16_t>);
+    FC,
+    DNNLOWP_16,
+    FullyConnectedDNNLowPOp<uint16_t>);
 
 REGISTER_CPU_OPERATOR_WITH_ENGINE(
-  Int8FC, DNNLOWP, FullyConnectedDNNLowPOp<uint8_t>);
+    Int8FC,
+    DNNLOWP,
+    FullyConnectedDNNLowPOp<uint8_t>);
 
 } // namespace caffe2

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.h
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.h
@@ -31,7 +31,7 @@ class FullyConnectedDNNLowPOp
   using T_signed = typename std::make_signed<T>::type;
 
   // used in fast path for T == uint8_t
-  std::shared_ptr<fbgemm2::PackBMatrix<std::int8_t>> Wq_packed_;
+  std::shared_ptr<fbgemm::PackBMatrix<std::int8_t>> Wq_packed_;
   std::vector<std::uint8_t> X_pack_buf_;
 
   std::vector<std::int32_t> Y_int32_;

--- a/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.cc
@@ -86,7 +86,7 @@ bool FullyConnectedRowWiseDNNLowPOp<T>::RunOnDevice() {
   }
   if (Wq_packed_) {
     // fast path using fbgemm
-    using namespace fbgemm2;
+    using namespace fbgemm;
     int row_offset_size_per_thread = M;
     int x_pack_buf_size_per_thread =
         PackAMatrix<uint8_t>::packedBufferSize();
@@ -279,8 +279,8 @@ bool FullyConnectedRowWiseDNNLowPOp<T>::GetQuantizationParameters_() {
         // fast path using fbgemm
         LOG(INFO)
             << "Using fast path with int8 fbgemm and generating Wq_packed_";
-        Wq_packed_.reset(new fbgemm2::PackBMatrix<int8_t>(
-            fbgemm2::matrix_op_t::Transpose,
+        Wq_packed_.reset(new fbgemm::PackBMatrix<int8_t>(
+            fbgemm::matrix_op_t::Transpose,
             K,
             N,
             reinterpret_cast<const int8_t*>(W_quantized_.data()),

--- a/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.h
+++ b/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.h
@@ -30,7 +30,7 @@ class FullyConnectedRowWiseDNNLowPOp final
   using T_signed = typename std::make_signed<T>::type;
 
   // used in fast path for T == uint8_t
-  std::unique_ptr<fbgemm2::PackBMatrix<std::int8_t>> Wq_packed_;
+  std::unique_ptr<fbgemm::PackBMatrix<std::int8_t>> Wq_packed_;
   std::vector<std::uint8_t> X_pack_buf_;
 
   // used in slow path for T != uint8_t

--- a/caffe2/quantization/server/transpose.cc
+++ b/caffe2/quantization/server/transpose.cc
@@ -2,7 +2,7 @@
 
 #include <x86intrin.h>
 
-namespace fbgemm2 {
+namespace fbgemm {
 
 void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst) {
   constexpr int M = 4;
@@ -60,4 +60,4 @@ void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst) {
   }
 }
 
-} // namespace fbgemm2
+} // namespace fbgemm

--- a/caffe2/quantization/server/transpose.cc
+++ b/caffe2/quantization/server/transpose.cc
@@ -2,11 +2,9 @@
 
 #include <x86intrin.h>
 
-namespace fbgemm
-{
+namespace fbgemm2 {
 
-void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
-{
+void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst) {
   constexpr int M = 4;
   int j;
   // vectorized loop
@@ -15,10 +13,10 @@ void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
     // b : b0 b1 ... b31
     // c : c0 c1 ... c31
     // d : d0 d1 ... d31
-    __m256i a = _mm256_lddqu_si256((const __m256i *)(src + j + 0 * N));
-    __m256i b = _mm256_lddqu_si256((const __m256i *)(src + j + 1 * N));
-    __m256i c = _mm256_lddqu_si256((const __m256i *)(src + j + 2 * N));
-    __m256i d = _mm256_lddqu_si256((const __m256i *)(src + j + 3 * N));
+    __m256i a = _mm256_lddqu_si256((const __m256i*)(src + j + 0 * N));
+    __m256i b = _mm256_lddqu_si256((const __m256i*)(src + j + 1 * N));
+    __m256i c = _mm256_lddqu_si256((const __m256i*)(src + j + 2 * N));
+    __m256i d = _mm256_lddqu_si256((const __m256i*)(src + j + 3 * N));
 
     // even-odd interleaving
     // ab_lo : a0 b0 a1 b1 ...  a7  b7 | a16 b16 ... a23 b23
@@ -42,24 +40,24 @@ void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst)
 
     // Storing with 128-bit lanes are permuted so that everything is in order
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 0 * 32),
+        (__m256i*)(dst + j * M + 0 * 32),
         _mm256_permute2f128_si256(y0, y1, 0x20));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 1 * 32),
+        (__m256i*)(dst + j * M + 1 * 32),
         _mm256_permute2f128_si256(y2, y3, 0x20));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 2 * 32),
+        (__m256i*)(dst + j * M + 2 * 32),
         _mm256_permute2f128_si256(y0, y1, 0x31));
     _mm256_storeu_si256(
-        (__m256i *)(dst + j * M + 3 * 32),
+        (__m256i*)(dst + j * M + 3 * 32),
         _mm256_permute2f128_si256(y2, y3, 0x31));
   }
   // scalar loop for remainder
-  for ( ; j < N; ++j) {
+  for (; j < N; ++j) {
     for (int i = 0; i < M; ++i) {
       dst[j * M + i] = src[j + i * N];
     }
   }
 }
 
-} // namespace fbgemm
+} // namespace fbgemm2

--- a/caffe2/quantization/server/transpose.h
+++ b/caffe2/quantization/server/transpose.h
@@ -2,8 +2,7 @@
 
 #include <cstdint>
 
-namespace fbgemm
-{
+namespace fbgemm2 {
 
 /**
  * Transpose 4xN matrix with unsigned 8-byte integers
@@ -11,4 +10,4 @@ namespace fbgemm
  */
 void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst);
 
-}
+} // namespace fbgemm2

--- a/caffe2/quantization/server/transpose.h
+++ b/caffe2/quantization/server/transpose.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace fbgemm2 {
+namespace fbgemm {
 
 /**
  * Transpose 4xN matrix with unsigned 8-byte integers
@@ -10,4 +10,4 @@ namespace fbgemm2 {
  */
 void transpose_4rows(int N, const std::uint8_t* src, std::uint8_t* dst);
 
-} // namespace fbgemm2
+} // namespace fbgemm


### PR DESCRIPTION
Summary:
We would like to rename the old fbgemm to “fbgemm0”, and the new fbgemm2 to “fbgemm”:

This DIFF changes all namespace fbgemm2 to namespace fbgemm.

The purpose is to avoid the confusion of "fbgemm2" when we release our FBGEMM open source.

Reviewed By: jspark1105

Differential Revision: D12850449
