### PR TITLE
Remove some more unnecessary DeviceGuard

### DIFF
--- a/aten/src/ATen/native/cuda/Resize.cu
+++ b/aten/src/ATen/native/cuda/Resize.cu
@@ -6,10 +6,7 @@
 namespace at { namespace native {
 
 Tensor& resize_cuda_(Tensor& self, IntList size) {
-  auto* self_ = self.unsafeGetTensorImpl();
-  resize_impl_cuda_(self_, size, /*strides=*/c10::nullopt);
-  self_->maybe_zero_dim(size.size() == 0);
-  return self;
+  return resize_cuda_helper_(self, size);
 }
 
 }}

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -25,11 +25,11 @@ static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size)
   }
 }
 
+template <bool device_guard = true>
 inline TensorImpl* resize_impl_cuda_(
     TensorImpl* self,
     IntList size,
-    c10::optional<IntList> stride,
-    bool device_guard=true) {
+    c10::optional<IntList> stride) {
   if (self->sizes() == size && (!stride || self->strides() == stride)) {
     return self;
   }
@@ -55,6 +55,14 @@ inline TensorImpl* resize_impl_cuda_(
   }
   maybe_resize_storage_cuda(self, storage_size);
 
+  return self;
+}
+
+template <bool device_guard = true>
+inline Tensor& resize_cuda_helper_(Tensor& self, IntList size) {
+  auto* self_ = self.unsafeGetTensorImpl();
+  resize_impl_cuda_<device_guard>(self_, size, /*strides=*/c10::nullopt);
+  self_->maybe_zero_dim(size.size() == 0);
   return self;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -675,13 +675,13 @@
     CUDA: resize_cuda_
 
 - func: empty_out(Tensor result, IntList size) -> Tensor
-  device_guard: False
+  device_guard: False  # calls resize_ which uses a DeviceGuard
 
 - func: empty_like(Tensor self) -> Tensor
-  device_guard: False
+  device_guard: False  # calls empty which uses a DeviceGuard
 
 - func: empty_like(Tensor self, *, TensorOptions options) -> Tensor
-  device_guard: False
+  device_guard: False  # calls empty which uses a DeviceGuard
 
 - func: empty_strided(IntList size, IntList stride, *, TensorOptions options={}) -> Tensor
 
@@ -1659,11 +1659,11 @@
 - func: prod_out(Tensor result, Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
 
 - func: t(Tensor self) -> Tensor
-  device_guard: False
+  device_guard: False  # Does not allocate storage or launch kernels
   variants: function, method
 
 - func: t_(Tensor self) -> Tensor
-  device_guard: False
+  device_guard: False  # Does not allocate storage or launch kernels
   variants: method
 
 - func: tan(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -675,10 +675,13 @@
     CUDA: resize_cuda_
 
 - func: empty_out(Tensor result, IntList size) -> Tensor
+  device_guard: False
 
 - func: empty_like(Tensor self) -> Tensor
+  device_guard: False
 
 - func: empty_like(Tensor self, *, TensorOptions options) -> Tensor
+  device_guard: False
 
 - func: empty_strided(IntList size, IntList stride, *, TensorOptions options={}) -> Tensor
 
@@ -1656,9 +1659,11 @@
 - func: prod_out(Tensor result, Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
 
 - func: t(Tensor self) -> Tensor
+  device_guard: False
   variants: function, method
 
 - func: t_(Tensor self) -> Tensor
+  device_guard: False
   variants: method
 
 - func: tan(Tensor self) -> Tensor

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -105,7 +105,7 @@ void THCTensor_resizeNd(THCState *state, THCTensor *self, int nDimension, const 
   if (stride) {
     strides = at::IntList(stride, nDimension);
   }
-  at::native::resize_impl_cuda_(self, sizes, strides, /*device_guard=*/false);
+  at::native::resize_impl_cuda_</*device_guard=*/false>(self, sizes, strides);
 }
 
 void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src)


### PR DESCRIPTION
Removes DeviceGuards for:
- empty_* functions that end up calling functions that already have a
  DeviceGuard
- t(), which gets called a lot in LSTMs,
- Remove one of the two DeviceGuard that at::empty(...) uses. It only
  needs one for correctness, the other comes from the resize_
  implementation.

Test Plan:
- code reading

