### PR TITLE
Catch error by reference in module.cpp

### DIFF
--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -335,7 +335,7 @@ std::shared_ptr<Module> Module::shared_from_this_checked() const {
   std::shared_ptr<const Module> ptr;
   try {
     ptr = shared_from_this();
-  } catch (std::bad_weak_ptr) {
+  } catch (const std::bad_weak_ptr& e) {
     AT_ERROR(
         "It looks like you attempted to retrieve your top-level module "
         "as a shared_ptr, but it is not stored in a shared_ptr. "


### PR DESCRIPTION
Summary:
"catch by reference, throw by value"

Catching polymorpic type std::bad_weak_ptr was an error earlier.

Differential Revision: D12982626
