### PR TITLE
allow models loaded from disk with nn.LogSoftmax or nn.Softmax layers to be exported to onnx

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -827,7 +827,7 @@ class Softmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        super(Softmax, self).__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
 
@@ -893,7 +893,7 @@ class LogSoftmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        super(LogSoftmax, self).__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
 


### PR DESCRIPTION
Summary:
nn.Module sets a few base properties in its __setstate__ method which the onnx exporter apparently needs.

Currently trying to load a saved model from disk and then export that model to onnx fails with:
`AttributeError: 'LogSoftmax' object has no attribute '_state_dict_hooks'`

Very easy to fix, just need to call nn.Module's __setstate__ method to make sure the core state members get set up.

Differential Revision: D12983011
