### PR TITLE
Add ability to annotate jit types inside function

### DIFF
--- a/test/expect/TestScript.test_cat_lifts.expect
+++ b/test/expect/TestScript.test_cat_lifts.expect
@@ -6,7 +6,7 @@ graph(%x : Dynamic) {
 }
 graph(%x : Dynamic) {
   %1 : int = prim::Constant[value=1]()
-  %2 : Dynamic[] = aten::_construct_empty_tensor_list()
+  %2 : Dynamic[] = prim::ListConstruct()
   %3 : Dynamic = aten::cat(%2, %1)
   return (%3);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -29,7 +29,7 @@ from common_methods_invocations import create_input, unpack_variables, \
     exclude_tensor_method, non_differentiable, EXCLUDE_GRADCHECK, EXCLUDE_FUNCTIONAL
 from copy import deepcopy
 import random
-
+from typing import List, Optional
 from torch.jit.frontend import NotSupportedError
 from torch.jit import BatchTensor
 
@@ -2771,8 +2771,6 @@ class TestScript(JitTestCase):
 
     def test_type_annotate(self):
 
-        from typing import List, Optional
-
         def foo(a):
             return torch.jit.annotate(torch.Tensor, a)
 
@@ -3504,7 +3502,7 @@ a")
 
         @torch.jit.script
         def foo2(x):
-            return torch.cat(torch.jit._construct_empty_tensor_list(), dim=1)
+            return torch.cat([], dim=1)
 
         @torch.jit.script
         def foo3(x):
@@ -3539,13 +3537,13 @@ a")
             self.checkScript(reassign_from_empty_literal, (), optimize=False)
 
         def reassign_from_empty_builtin():
-            x = torch.jit._construct_empty_int_list()
+            x = torch.jit.annotate(List[int], [])
             if True:
                 x = [1, 2, 3]
-            y = torch.jit._construct_empty_float_list()
+            y = torch.jit.annotate(List[float], [])
             if True:
                 y = [1.0, 2.0, 3.0]
-            z = torch.jit._construct_empty_tensor_list()
+            z = []
             if True:
                 z = [torch.randn([1])]
             return
@@ -3560,7 +3558,7 @@ a")
             self.checkScript(reassign_bad_type, (), optimize=False)
 
         def reassign_nested():
-            x = torch.jit._construct_empty_int_list()
+            x = torch.jit.annotate(List[int], [])
             if True:
                 x = [1, 2, 3]
                 if True:
@@ -3610,7 +3608,7 @@ a")
         self.checkScript(func, ())
 
         def func2():
-            a = torch.jit._construct_empty_tensor_list()
+            a = []
             return len(a) == 0
 
         self.checkScript(func2, ())
@@ -3666,7 +3664,7 @@ a")
 
         def test_list_add_empty():
             a = [1, 2, 3]
-            b = torch.jit._construct_empty_int_list()
+            b = torch.jit.annotate(List[int], [])
             c = a + b
             return c == [1, 2, 3]
 
@@ -3723,7 +3721,7 @@ a")
 
         def test_backward_slice():
             a = [0, 1, 2, 3, 4]
-            return a[3:2] == torch.jit._construct_empty_int_list()
+            return a[3:2] == torch.jit.annotate(List[int], [])
         self.checkScript(test_backward_slice, ())
 
         def test_over_slice():
@@ -3764,7 +3762,7 @@ a")
         self.checkScript(test_append_if_else, ())
 
         def test_append_loop():
-            a = torch.jit._construct_empty_int_list()
+            a = torch.jit.annotate(List[int], [])
             for i in range(5):
                 a.append(i)
 
@@ -3772,7 +3770,7 @@ a")
         self.checkScript(test_append_loop, ())
 
         def test_append_loop_if():
-            a = torch.jit._construct_empty_int_list()
+            a = torch.jit.annotate(List[int], [])
             for i in range(5):
                 if i > 3:
                     a.append(i)
@@ -3783,7 +3781,7 @@ a")
         self.checkScript(test_append_loop_if, ())
 
         def test_nested_loop():
-            a = torch.jit._construct_empty_int_list()
+            a = torch.jit.annotate(List[int], [])
             for i in range(2):
                 for j in range(2):
                     a.append(i + j)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2769,6 +2769,28 @@ class TestScript(JitTestCase):
 
         return ge
 
+    def test_type_annotate(self):
+
+        from typing import List, Optional
+
+        def foo(a):
+            return torch.jit.annotate(torch.Tensor, a)
+
+        self.checkScript(foo, (torch.rand(3),))
+
+        def bar():
+            a = torch.jit.annotate(List[int], [])
+            for i in range(10):
+                a.append(4)
+            return a
+
+        self.checkScript(bar, ())
+
+        with self.assertRaisesRegex(RuntimeError, "expected"):
+            @torch.jit.script
+            def baz(a):
+                return torch.jit.annotate(int, a)
+
     def test_robust_op_resolution(self):
         neg = torch.add  # misleading name to make sure we resolve by function
 

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -881,27 +881,6 @@ Operator(                                                                      \
     DEFINE_BOOL_OP(aten::__and__, a && b)
     DEFINE_BOOL_OP(aten::__or__, a || b)
 
-    Operator("aten::_construct_empty_int_list() -> int[]",
-        [](const Node* node) -> Operation {
-          return [=](Stack& stack){
-            push(stack, std::vector<int64_t>());
-            return 0;
-        };
-      }),
-    Operator("aten::_construct_empty_float_list() -> float[]",
-        [](const Node* node) -> Operation {
-          return [=](Stack& stack){
-            push(stack, std::vector<double>());
-            return 0;
-        };
-      }),
-    Operator("aten::_construct_empty_tensor_list() -> Tensor[]",
-        [](const Node* node) -> Operation {
-          return [=](Stack& stack){
-            push(stack, std::vector<at::Tensor>());
-            return 0;
-        };
-      }),
     Operator(
         "aten::neg(int self) -> int",
         [](const Node* node) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -296,8 +296,8 @@ struct Environment {
             as_simple_value->type()->kind() == TypeKind::ListType) {
           errMsg << "\n. (Note: empty lists are constructed as Tensor[]; "
                  << "if you want an empty list of a different type, "
-                 << "use `_construct_empty_foo_list`, "
-                 << "where `foo` is `int` or `float`)";
+                 << "use `torch.jit.annotate(List[T], [])`, "
+                 << "where `T` is the type of elements in the list)";
         }
         throw ErrorReport(loc) << errMsg.str();
       }
@@ -1754,7 +1754,9 @@ private:
       return emitForkExpr(loc, forked, inputs, attributes);
     } else if (auto annotate_value = dynamic_cast<AnnotateValue*>(sv.get())) {
       if (apply.inputs().size() != 2) {
-        throw ErrorReport(loc) << "expected exactly two arguments to attribute but found " << apply.inputs().size();
+        throw ErrorReport(loc)
+            << "expected exactly two arguments to attribute but found "
+            << apply.inputs().size();
       }
       if (apply.attributes().size() > 0) {
         throw ErrorReport(loc) << "attribute takes no keyword arguments";

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -780,6 +780,7 @@ inline bool isSupportedListElementType(TypePtr type) {
 }
 
 static FunctionSchema extractSchemaFromDef(const Def &def, bool is_method);
+TypePtr parseTypeFromExpr(Expr expr);
 
 struct to_ir {
   to_ir(
@@ -1732,12 +1733,13 @@ private:
     return getValues(trees.tree()->trees(), maybe_unpack);
   }
 
-  std::shared_ptr<SugaredValue> emitApplyExpr(Apply &apply, size_t n_binders) {
-    auto sv = emitSugaredExpr(apply.callee(), 1);
-    auto attributes = fmap(apply.attributes(), [&](const Attribute& attr) {
+  std::vector<NamedValue> emitAttributes(const List<Attribute> attributes) {
+    return fmap(attributes, [&](const Attribute& attr) {
       return NamedValue(attr.range(), attr.name().name(), emitExpr(attr.value()));
     });
-
+  }
+  std::shared_ptr<SugaredValue> emitApplyExpr(Apply &apply, size_t n_binders) {
+    auto sv = emitSugaredExpr(apply.callee(), 1);
     auto loc = apply.callee().range();
     if (auto fork_value = dynamic_cast<ForkValue*>(sv.get())) {
       auto& trees = apply.inputs().tree()->trees();
@@ -1748,15 +1750,32 @@ private:
       auto forked = emitSugaredExpr(Expr(trees[0]), 1);
       TreeList sliced_trees(trees.begin() + 1, trees.end());
       auto inputs = getNamedValues(sliced_trees, true);
+      auto attributes = emitAttributes(apply.attributes());
       return emitForkExpr(loc, forked, inputs, attributes);
+    } else if (auto annotate_value = dynamic_cast<AnnotateValue*>(sv.get())) {
+      if (apply.inputs().size() != 2) {
+        throw ErrorReport(loc) << "expected exactly two arguments to attribute but found " << apply.inputs().size();
+      }
+      if (apply.attributes().size() > 0) {
+        throw ErrorReport(loc) << "attribute takes no keyword arguments";
+      }
+      TypePtr type = parseTypeFromExpr(apply.inputs()[0]);
+      Value* expr = emitExpr(apply.inputs()[1], type);
+      if (!expr->type()->isSubtypeOf(type)) {
+        throw ErrorReport(apply.inputs())
+            << "expected an expression of type " << type->python_str()
+            << " but found " << expr->type()->python_str();
+      }
+      return std::make_shared<SimpleValue>(expr);
     } else {
       auto inputs = getNamedValues(apply.inputs(), true);
+      auto attributes = emitAttributes(apply.attributes());
       return sv->call(loc, method, inputs, attributes, n_binders);
     }
   }
 
-  Value* emitExpr(Expr tree) {
-    return emitSugaredExpr(tree, 1)->asValue(tree.range(), method);
+  Value* emitExpr(Expr tree, TypePtr type_hint = nullptr) {
+    return emitSugaredExpr(tree, 1, type_hint)->asValue(tree.range(), method);
   }
 
   NodeKind reverseComparision(NodeKind kind) {
@@ -1774,7 +1793,12 @@ private:
 
   // any expression that can produce a SugaredValue is handled here
   // expressions that only return a single Value* are handled in emitSimpleExpr
-  std::shared_ptr<SugaredValue> emitSugaredExpr(Expr tree, size_t n_binders) {
+  // type_hint is set if there is a type that this value is expected to be
+  // e.g. a : List[int] = []
+  // or a = torch.jit.annotate(List[int], [])
+  // the caller is responsible for checking that the result matches type_hint
+  // emitSugaredExpr is free to ignore it.
+  std::shared_ptr<SugaredValue> emitSugaredExpr(Expr tree, size_t n_binders, TypePtr type_hint=nullptr) {
     switch(tree.kind()) {
       case TK_VAR:
         return environment_stack->getSugaredVar(Var(tree).name());
@@ -1788,7 +1812,7 @@ private:
         return emitApplyExpr(apply, n_binders);
       } break;
       default:
-        return std::make_shared<SimpleValue>(emitSimpleExpr(tree));
+        return std::make_shared<SimpleValue>(emitSimpleExpr(tree, type_hint));
     }
   }
 
@@ -1863,7 +1887,8 @@ private:
   }
 
   Value* emitSimpleExpr(
-      const TreeRef& tree) {
+      const TreeRef& tree,
+      TypePtr type_hint = nullptr) {
     switch (tree->kind()) {
       case '@':
       case TK_POW:
@@ -1933,9 +1958,16 @@ private:
         auto ll = ListLiteral(tree);
         auto values = getValues(ll.inputs(), /*maybe_unpack=*/true);
 
-        // If this is an empty list literal `[]`, construct an empty Tensor[]
-        const auto elem_type =
-            values.empty() ? DynamicType::get() : values.at(0)->type();
+        // determine the element type of the list
+        // if we have a type hint of List[T], use T
+        // if the list is non-empty use type_of(list[0])
+        // otherwise assume it is List[Tensor]
+        TypePtr elem_type = DynamicType::get();
+        if (type_hint && type_hint->kind() == TypeKind::ListType) {
+          elem_type = type_hint->expect<ListType>()->getElementType();
+        } else if (!values.empty()) {
+          elem_type = values.at(0)->type();
+        }
         for (auto v : values) {
           if (v->type() != elem_type) {
             throw ErrorReport(tree)
@@ -2343,8 +2375,6 @@ const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
   return map;
 }
 
-TypePtr parseTypeFromExpr(Expr expr);
-
 const std::unordered_map<std::string, std::function<TypePtr(Subscript)>> &subscript_to_type_fns() {
   static std::unordered_map<std::string, std::function<TypePtr(Subscript)>> map = {
     {"Tuple", [](Subscript subscript) -> TypePtr {
@@ -2372,30 +2402,44 @@ const std::unordered_map<std::string, std::function<TypePtr(Subscript)>> &subscr
   return map;
 }
 
+bool  isTorch(Expr expr) {
+  return expr.kind() == TK_VAR && Var(expr).name().name() == "torch";
+}
+
+// gets the base type name given namespaces where the types live
+// turns torch.Tensor -> Tensor, X -> X
+c10::optional<std::string> parseBaseTypeName(Expr expr) {
+  switch (expr.kind()) {
+    case TK_VAR: {
+      return Var(expr).name().name();
+    }
+    case '.': {
+      auto select = Select(expr);
+      const std::string& name = select.selector().name();
+      if (isTorch(select.value()) && name == "Tensor")
+        return "Tensor";
+    }
+  }
+  return at::nullopt;
+}
+
 TypePtr parseTypeFromExpr(Expr expr) {
-  if (expr.kind() == TK_VAR) {
-    auto ident = Var(expr).name();
-    auto itr = ident_to_type_lut().find(ident.name());
+  if (expr.kind() == TK_SUBSCRIPT) {
+    auto subscript = Subscript(expr);
+    auto value_name = parseBaseTypeName(subscript.value());
+    if (!value_name) {
+      throw ErrorReport(subscript.value().range()) << "Subscripted type must be a type identifier";
+    }
+    if (!subscript_to_type_fns().count(*value_name)) {
+      throw ErrorReport(subscript.range()) << "Unknown type constructor " << *value_name;
+    }
+    return subscript_to_type_fns().at(*value_name)(subscript);
+  } else if (auto name = parseBaseTypeName(expr)) {
+    auto itr = ident_to_type_lut().find(*name);
     if (itr != ident_to_type_lut().end()) {
       return itr->second;
     }
-    throw ErrorReport(expr.range()) << "Unknown type name " << ident.name();
-  } else if (expr.kind() == TK_SUBSCRIPT) {
-    auto subscript = Subscript(expr);
-    if (subscript.value().kind() != TK_VAR) {
-      throw ErrorReport(subscript.value().range()) << "Subscripted type must be a type identifier";
-    }
-    auto value_name = Var(subscript.value()).name().name();
-    if (!subscript_to_type_fns().count(value_name)) {
-      throw ErrorReport(subscript.range()) << "Unknown type constructor " << value_name;
-    }
-    return subscript_to_type_fns().at(value_name)(subscript);
-  } else if (expr.kind() == '.') {
-    auto select = Select(expr);
-    if (select.value().kind() == TK_VAR && Var(select.value()).name().name() == "torch"
-        && select.selector().name() == "Tensor") {
-      return ident_to_type_lut().at("Tensor");
-    }
+    throw ErrorReport(expr) << "Unknown type name " << *name;
   }
   throw ErrorReport(expr.range()) << "Expression of type " << kindToString(expr.kind())
                                   << " cannot be used in a type expression";

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -142,20 +142,20 @@ struct TORCH_API BuiltinModule : public SugaredValue {
   }
 };
 
+// These SugaredValues have special handling in the compiler because they
+// change the normal evalution order of the expression they participate in.
+// They are exposed here so that the python frontend can inject them
+// when it sees the equivalent thing in python
 struct TORCH_API ForkValue : public SugaredValue {
   ForkValue() = default;
-
   std::string kind() const override {
     return "fork";
   }
-
-  std::shared_ptr<SugaredValue> call(
-      SourceRange loc,
-      Method& m,
-      at::ArrayRef<NamedValue> attributes,
-      at::ArrayRef<NamedValue> inputs,
-      size_t n_binders) override {
-    AT_ERROR("Cannot call a fork value directly");
+};
+struct TORCH_API AnnotateValue : public SugaredValue {
+  AnnotateValue() = default;
+  std::string kind() const override {
+    return "annotate";
   }
 };
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -316,6 +316,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     return std::make_shared<PythonModuleValue>(obj);
   } else if (obj.ptr() == py::module::import("torch.jit").attr("_fork").ptr()) {
     return std::make_shared<ForkValue>();
+  } else if (obj.ptr() == py::module::import("torch.jit").attr("annotate").ptr()) {
+    return std::make_shared<AnnotateValue>();
   }
 
   py::object builtin_name = py::module::import("torch.jit").attr("_find_builtin")(obj);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1443,5 +1443,10 @@ class _disable_tracing(object):
         self.state = None
 
 
+# for use in python if using annotate
+def annotate(the_type, the_value):
+    # noop in python
+    return the_value
+
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1401,29 +1401,6 @@ def _find_builtin(fn):
     return _get_builtin_table().get(id(fn))
 
 
-# Python equivalents for the empty list construction builtins. We need
-# these otherwise the tests won't execute in regular Python mode.
-def _construct_empty_int_list():
-    return []
-
-
-_register_builtin(_construct_empty_int_list, 'aten::_construct_empty_int_list')
-
-
-def _construct_empty_float_list():
-    return []
-
-
-_register_builtin(_construct_empty_float_list, 'aten::_construct_empty_float_list')
-
-
-def _construct_empty_tensor_list():
-    return []
-
-
-_register_builtin(_construct_empty_tensor_list, 'aten::_construct_empty_tensor_list')
-
-
 _register_builtin(len, 'aten::len')
 
 


### PR DESCRIPTION
This adds torch.jit.annotate for annotating the type of an intermediate.
This is Py2/3 compatible, e.g.:

```
from torch.jit import annotate
from typing import List

@torch.jit.script
def foo():
  a = annotate(List[int], [])
```

This is needed to output valid python programs from our IR. It removes
the need for the empty list constructors.

A future patch can add support to the C++ parser and Python 3,
via desugaring:

```
a : int = b
a = anntoate(int, b)
```

But this functionality is not required for serialization so is not added in this patch.