### PR TITLE
fix null-pointer-use in reshape_op.h

### DIFF
--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -50,8 +50,11 @@ class ReshapeOp : public Operator<Context> {
 
       // Bit awkward, but needed so works on both CPU and CUDA contexts
       std::vector<T> tmpv(shape.numel());
-      context_.CopyBytesToCPU(shape.numel() * sizeof(T), shape_data, &tmpv[0]);
-      actual_new_shape.assign(tmpv.begin(), tmpv.begin() + shape.numel());
+      if (shape.numel() > 0) {
+        context_.CopyBytesToCPU(
+            shape.numel() * sizeof(T), shape_data, &tmpv[0]);
+        actual_new_shape.assign(tmpv.begin(), tmpv.begin() + shape.numel());
+      }
     }
 
     // Copy over the dimensions for those that are specified zero.


### PR DESCRIPTION
Summary:
UndefinedBehaviorSanitizer: null-pointer-use ../fbcode/third-party-buck/gcc-5-glibc-2.23/build/libgcc/include/c++/5.5.0/bits/stl_vector.h:794:16
```
Here we take the address of the first element in the empty vector. Fix the error by guarding against empty source.

Differential Revision: D12989957
