### PR TITLE
Make InterpresterStateImpl a intrusive_ptr_target

### DIFF
--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -50,12 +50,13 @@ struct InterpreterState {
   c10::intrusive_ptr<Future> runAsync(Stack& stack);
   c10::intrusive_ptr<Future> getFuture();
   ~InterpreterState();
-  // create a copy of InterpreterState with its current state
-  // used when retain_graph=True
-  InterpreterState clone() const;
 private:
-  InterpreterState(InterpreterStateImpl * pImpl);
-  std::shared_ptr<InterpreterStateImpl> pImpl;
+  InterpreterState(c10::intrusive_ptr<c10::intrusive_ptr_target> pImpl);
+  // Ideally we should use c10::intrusive_ptr<InterpreterStateImpl> for pImpl;
+  // but intrusive_ptr requires full definition of InterpreterStateImpl,
+  // which we need to hide in the header.
+  c10::intrusive_ptr<c10::intrusive_ptr_target> pImpl;
+  friend struct InterpreterStateImpl;
 };
 
 // Created by wait()


### PR DESCRIPTION
InterpresterStateImpl con continue its lifecycle by increment the ref
count itself. This patch also removes InterpresterState::clone()
interface that conflicts with intrusive_ptr_target that disallows copy.

