### PR TITLE
 Avoid grabbing DeviceGuard in at::empty when possible

### DIFF
--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -113,11 +113,11 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
 }
 
 inline int64_t sum_intlist(ArrayRef<int64_t> list) {
-  return std::accumulate(list.begin(), list.end(), 0);
+  return std::accumulate(list.begin(), list.end(), 0L);
 }
 
 inline int64_t prod_intlist(ArrayRef<int64_t> list) {
-  return std::accumulate(list.begin(), list.end(), 1, std::multiplies<int64_t>());
+  return std::accumulate(list.begin(), list.end(), 1L, std::multiplies<int64_t>());
 }
 
 } // at

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -113,11 +113,11 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
 }
 
 inline int64_t sum_intlist(ArrayRef<int64_t> list) {
-  return std::accumulate(list.begin(), list.end(), 0L);
+  return std::accumulate(list.begin(), list.end(), 0ll);
 }
 
 inline int64_t prod_intlist(ArrayRef<int64_t> list) {
-  return std::accumulate(list.begin(), list.end(), 1L, std::multiplies<int64_t>());
+  return std::accumulate(list.begin(), list.end(), 1ll, std::multiplies<int64_t>());
 }
 
 } // at

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -107,11 +107,22 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 Tensor empty_cpu(IntList size, const TensorOptions& options) {
   AT_ASSERT(options.backend() == Backend::CPU);
   AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'
+
+  auto* allocator = at::getCPUAllocator();
+  int64_t nelements = prod_intlist(size);
+  auto dtype = options.dtype();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    options.dtype(), 0, at::getCPUAllocator(), true);
+    dtype,
+    nelements,
+    allocator->allocate(nelements * dtype.itemsize()),
+    allocator,
+    /*resizeable=*/true);
 
   auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId(), false);
-  resize_cpu_(tensor, size);  // avoid dispatch overhead
+  // Default TensorImpl has size [0]
+  if (size.size() != 1 || size[0] != 0) {
+    tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);
+  }
   return tensor;
 }
 

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -29,7 +29,7 @@ inline TensorImpl* resize_impl_cuda_(
     TensorImpl* self,
     IntList size,
     c10::optional<IntList> stride,
-    bool device_guard=true) {
+    bool device_guard = true) {
   if (self->sizes() == size && (!stride || self->strides() == stride)) {
     return self;
   }

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -2,6 +2,7 @@
 #include "ATen/InitialTensorOptions.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/cuda/CUDAContext.h"
+#include "ATen/native/cuda/Resize.cuh"
 #include "c10/util/Exception.h"
 
 #include <THC/THCGeneral.h>
@@ -46,7 +47,10 @@ Tensor empty_cuda(IntList size, const TensorOptions& options) {
     options.dtype(), 0, cuda::getCUDADeviceAllocator(), true);
 
   auto tensor = detail::make_tensor<TensorImpl>(storage_impl, CUDATensorId(), false);
-  resize_cuda_(tensor, size); // avoid dispatch overhead
+  // For performance reasons,
+  // 1) avoid the dispatching overhead
+  // 2) Don't use another DeviceGuard -- at::empty(...) already uses one.
+  resize_cuda_helper_(tensor, size, /*device_guard=*/false);
   return tensor;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -680,10 +680,13 @@
     CUDA: resize_cuda_
 
 - func: empty_out(Tensor result, IntList size) -> Tensor
+  device_guard: False
 
 - func: empty_like(Tensor self) -> Tensor
+  device_guard: False
 
 - func: empty_like(Tensor self, *, TensorOptions options) -> Tensor
+  device_guard: False
 
 - func: empty_strided(IntList size, IntList stride, *, TensorOptions options={}) -> Tensor
 
@@ -1662,9 +1665,11 @@
 - func: prod_out(Tensor result, Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
 
 - func: t(Tensor self) -> Tensor
+  device_guard: False
   variants: function, method
 
 - func: t_(Tensor self) -> Tensor
+  device_guard: False
   variants: method
 
 - func: tan(Tensor self) -> Tensor


### PR DESCRIPTION
Changed at::empty to allocate the correct amount of memory instead of
"allocate 0 memory and then resize it to the necessary size".

This leads to a 300 ns speedup for at::empty for a cuda tensor of size (64, 2048).
(1790ns -> 1460ns for at::empty).

Also does the following:
Removes DeviceGuards for:
- empty_* functions that end up calling functions that already have a
  DeviceGuard
- t(), which gets called a lot in LSTMs,
- Remove one of the two DeviceGuard that at::empty(...) uses. It only
  needs one for correctness, the other comes from the resize_
  implementation.

Test Plan:
- run tests