### PR TITLE
[jit] schematize some prim ops

### DIFF
--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -63,7 +63,7 @@ Value* insertConstant(
 RegisterOperators reg({
   // Implementation of constant node, computes and IValue
   Operator(
-      prim::Constant,
+      FunctionSchema(prim::Constant, {}, {}, /*vararg=*/false, /*varret=*/true),
       [](const Node* node) -> Operation {
         TypePtr type = node->output()->type();
         if(type->isSubtypeOf(DynamicType::get())) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -64,7 +64,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::TensorToBool,
+        "prim::TensorToBool(Tensor a) -> bool",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             at::Tensor a;
@@ -75,7 +75,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::TensorToNum,
+        "prim::TensorToNum(Tensor a) -> Scalar",
         [](const Node* node) -> Operation {
           if(node->output()->type() == IntType::get()) {
             return [](Stack& stack) {
@@ -96,7 +96,7 @@ RegisterOperators reg({
           }
         }),
     Operator(
-        prim::ImplicitTensorToNum,
+        "prim::ImplicitTensorToNum(Tensor a) -> Scalar",
         [](const Node* node) -> Operation {
           if(node->output()->type() == IntType::get()) {
             return [](Stack& stack) {
@@ -119,7 +119,7 @@ RegisterOperators reg({
           }
         }),
     Operator(
-        prim::NumToTensor,
+        "prim::NumToTensor(Scalar a) -> Tensor",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             at::Scalar s;
@@ -129,7 +129,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::BoolToTensor,
+        "prim::BoolToTensor(bool a) -> Tensor",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             bool b;
@@ -141,7 +141,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::IntToFloat,
+        "prim::IntToFloat(int a) -> float",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             int64_t i;
@@ -151,7 +151,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::FloatToInt,
+        "prim::FloatToInt(float a) -> int",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             double d;
@@ -161,7 +161,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::StringToFloat,
+        "prim::StringToFloat(str a) -> float",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
             auto s = pop(stack).toString();


### PR DESCRIPTION
We're relying on the default function schema (which contains no argument information) in places where we don't need to. This is bad because alias analysis will be very conservative when it doesn't have schema information present.