### PR TITLE
[C++ Frontend] Add SharedDataset

### DIFF
--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -14,9 +14,11 @@
 #include <future>
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 using namespace torch::data; // NOLINT
@@ -536,6 +538,53 @@ TEST(DataTest, DataShuttlePopResultTimesOut) {
   torch::data::detail::DataShuttle<int, int> shuttle;
   shuttle.push_job(1);
   ASSERT_THROWS_WITH(shuttle.pop_result(10 * kMillisecond), "Timeout");
+}
+
+struct UncopyableDataset : datasets::Dataset<UncopyableDataset, int> {
+  UncopyableDataset(const std::string& /* unused */)
+      : mutex(torch::make_unique<std::mutex>()) {}
+
+  UncopyableDataset(UncopyableDataset&&) = default;
+  UncopyableDataset& operator=(UncopyableDataset&&) = default;
+
+  UncopyableDataset(const UncopyableDataset&) = delete;
+  UncopyableDataset& operator=(const UncopyableDataset&) = delete;
+
+  int get(size_t index) override {
+    {
+      std::lock_guard<std::mutex> guard(*mutex);
+      thread_ids.insert(std::this_thread::get_id());
+    }
+    return 1 + index;
+  }
+  torch::optional<size_t> size() const override {
+    return 100;
+  }
+
+  std::unique_ptr<std::mutex> mutex;
+  std::unordered_set<std::thread::id> thread_ids;
+};
+
+TEST(DataTest, TestSharedDatasetReallyIsShared) {
+  auto shared_dataset =
+      torch::data::datasets::make_shared_dataset<UncopyableDataset>(
+          "uncopyable");
+  auto data_loader = torch::data::make_data_loader(
+      shared_dataset, torch::data::DataLoaderOptions().workers(3));
+
+  for (auto batch : *data_loader) {
+    /* exhaust */
+  }
+
+  ASSERT_EQ(shared_dataset->thread_ids.size(), 3);
+}
+
+TEST(DataTest, TestSharedDatasetDoesNotIncurCopyWhenPassedDatasetObject) {
+  // This will not compile if a copy is made.
+  auto shared_dataset =
+      torch::data::datasets::make_shared_dataset<UncopyableDataset>(
+          UncopyableDataset("uncopyable"));
+  ASSERT_EQ(shared_dataset.size().value(), 100);
 }
 
 struct TestIndex : public torch::data::samplers::CustomBatchRequest {

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -565,7 +565,7 @@ struct UncopyableDataset : datasets::Dataset<UncopyableDataset, int> {
   std::unordered_set<std::thread::id> thread_ids;
 };
 
-TEST(DataTest, TestSharedDatasetReallyIsShared) {
+TEST(DataTest, SharedBatchDatasetReallyIsShared) {
   auto shared_dataset =
       torch::data::datasets::make_shared_dataset<UncopyableDataset>(
           "uncopyable");
@@ -579,7 +579,7 @@ TEST(DataTest, TestSharedDatasetReallyIsShared) {
   ASSERT_EQ(shared_dataset->thread_ids.size(), 3);
 }
 
-TEST(DataTest, TestSharedDatasetDoesNotIncurCopyWhenPassedDatasetObject) {
+TEST(DataTest, SharedBatchDatasetDoesNotIncurCopyWhenPassedDatasetObject) {
   // This will not compile if a copy is made.
   auto shared_dataset =
       torch::data::datasets::make_shared_dataset<UncopyableDataset>(

--- a/torch/csrc/api/include/torch/data/datasets.h
+++ b/torch/csrc/api/include/torch/data/datasets.h
@@ -3,4 +3,5 @@
 #include <torch/data/datasets/base.h>
 #include <torch/data/datasets/map.h>
 #include <torch/data/datasets/mnist.h>
+#include <torch/data/datasets/shared.h>
 #include <torch/data/datasets/tensor.h>

--- a/torch/csrc/api/include/torch/data/datasets/shared.h
+++ b/torch/csrc/api/include/torch/data/datasets/shared.h
@@ -2,8 +2,6 @@
 
 #include <torch/data/datasets/base.h>
 
-#include <c10/util/Exception.h>
-
 #include <memory>
 #include <utility>
 
@@ -11,6 +9,14 @@ namespace torch {
 namespace data {
 namespace datasets {
 
+/// A dataset that wraps another dataset in a shared pointer and implements the
+/// `BatchDataset` API, delegating all calls to the shared instance. This is
+/// useful when you want all worker threads in the dataloader to access the same
+/// dataset instance. The dataset must take care of synchronization and
+/// thread-safe access itself.
+///
+/// Use `torch::data::datasets::make_shared_dataset()` to create a new
+/// `SharedDataset` like you would a `std::shared_ptr`.
 template <typename UnderlyingDataset>
 class SharedDataset : BatchDataset<
                           SharedDataset<UnderlyingDataset>,
@@ -20,32 +26,38 @@ class SharedDataset : BatchDataset<
   using BatchType = typename UnderlyingDataset::BatchType;
   using BatchRequestType = typename UnderlyingDataset::BatchRequestType;
 
+  /// Constructs a new `SharedDataset` from a `shared_ptr` to the
+  /// `UnderlyingDataset`.
   /* implicit */ SharedDataset(
       std::shared_ptr<UnderlyingDataset> shared_dataset)
       : dataset_(std::move(shared_dataset)) {}
 
+  /// Calls `get_batch` on the underlying dataset.
   BatchType get_batch(BatchRequestType request) override {
-    AT_ASSERT(dataset_ != nullptr);
     return dataset_->get_batch(std::move(request));
   }
 
+  /// Returns the `size` from the underlying dataset.
   optional<size_t> size() const override {
-    AT_ASSERT(dataset_ != nullptr);
     return dataset_->size();
   }
 
+  /// Accesses the underlying dataset.
   UnderlyingDataset& operator*() {
     return *dataset_;
   }
 
+  /// Accesses the underlying dataset.
   const UnderlyingDataset& operator*() const {
     return *dataset_;
   }
 
+  /// Accesses the underlying dataset.
   UnderlyingDataset* operator->() {
     return dataset_.get();
   }
 
+  /// Accesses the underlying dataset.
   const UnderlyingDataset* operator->() const {
     return dataset_.get();
   }
@@ -54,6 +66,9 @@ class SharedDataset : BatchDataset<
   std::shared_ptr<UnderlyingDataset> dataset_;
 };
 
+/// Constructs a new `SharedDataset` by creating a
+/// `shared_ptr<UnderlyingDatase>`. All arguments are forwarded to
+/// `make_shared<UnderlyingDataset>`.
 template <typename UnderlyingDataset, typename... Args>
 SharedDataset<UnderlyingDataset> make_shared_dataset(Args&&... args) {
   return std::make_shared<UnderlyingDataset>(std::forward<Args>(args)...);

--- a/torch/csrc/api/include/torch/data/datasets/shared.h
+++ b/torch/csrc/api/include/torch/data/datasets/shared.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <torch/data/datasets/base.h>
+
+#include <c10/util/Exception.h>
+
+#include <memory>
+#include <utility>
+
+namespace torch {
+namespace data {
+namespace datasets {
+
+template <typename UnderlyingDataset>
+class SharedDataset : BatchDataset<
+                          SharedDataset<UnderlyingDataset>,
+                          typename UnderlyingDataset::BatchType,
+                          typename UnderlyingDataset::BatchRequestType> {
+ public:
+  using BatchType = typename UnderlyingDataset::BatchType;
+  using BatchRequestType = typename UnderlyingDataset::BatchRequestType;
+
+  /* implicit */ SharedDataset(
+      std::shared_ptr<UnderlyingDataset> shared_dataset)
+      : dataset_(std::move(shared_dataset)) {}
+
+  BatchType get_batch(BatchRequestType request) override {
+    AT_ASSERT(dataset_ != nullptr);
+    return dataset_->get_batch(std::move(request));
+  }
+
+  optional<size_t> size() const override {
+    AT_ASSERT(dataset_ != nullptr);
+    return dataset_->size();
+  }
+
+  UnderlyingDataset& operator*() {
+    return *dataset_;
+  }
+
+  const UnderlyingDataset& operator*() const {
+    return *dataset_;
+  }
+
+  UnderlyingDataset* operator->() {
+    return dataset_.get();
+  }
+
+  const UnderlyingDataset* operator->() const {
+    return dataset_.get();
+  }
+
+ private:
+  std::shared_ptr<UnderlyingDataset> dataset_;
+};
+
+template <typename UnderlyingDataset, typename... Args>
+SharedDataset<UnderlyingDataset> make_shared_dataset(Args&&... args) {
+  return std::make_shared<UnderlyingDataset>(std::forward<Args>(args)...);
+}
+} // namespace datasets
+} // namespace data
+} // namespace torch

--- a/torch/csrc/api/include/torch/data/datasets/shared.h
+++ b/torch/csrc/api/include/torch/data/datasets/shared.h
@@ -16,19 +16,19 @@ namespace datasets {
 /// thread-safe access itself.
 ///
 /// Use `torch::data::datasets::make_shared_dataset()` to create a new
-/// `SharedDataset` like you would a `std::shared_ptr`.
+/// `SharedBatchDataset` like you would a `std::shared_ptr`.
 template <typename UnderlyingDataset>
-class SharedDataset : BatchDataset<
-                          SharedDataset<UnderlyingDataset>,
+class SharedBatchDataset : BatchDataset<
+                          SharedBatchDataset<UnderlyingDataset>,
                           typename UnderlyingDataset::BatchType,
                           typename UnderlyingDataset::BatchRequestType> {
  public:
   using BatchType = typename UnderlyingDataset::BatchType;
   using BatchRequestType = typename UnderlyingDataset::BatchRequestType;
 
-  /// Constructs a new `SharedDataset` from a `shared_ptr` to the
+  /// Constructs a new `SharedBatchDataset` from a `shared_ptr` to the
   /// `UnderlyingDataset`.
-  /* implicit */ SharedDataset(
+  /* implicit */ SharedBatchDataset(
       std::shared_ptr<UnderlyingDataset> shared_dataset)
       : dataset_(std::move(shared_dataset)) {}
 
@@ -66,11 +66,11 @@ class SharedDataset : BatchDataset<
   std::shared_ptr<UnderlyingDataset> dataset_;
 };
 
-/// Constructs a new `SharedDataset` by creating a
+/// Constructs a new `SharedBatchDataset` by creating a
 /// `shared_ptr<UnderlyingDatase>`. All arguments are forwarded to
 /// `make_shared<UnderlyingDataset>`.
 template <typename UnderlyingDataset, typename... Args>
-SharedDataset<UnderlyingDataset> make_shared_dataset(Args&&... args) {
+SharedBatchDataset<UnderlyingDataset> make_shared_dataset(Args&&... args) {
   return std::make_shared<UnderlyingDataset>(std::forward<Args>(args)...);
 }
 } // namespace datasets


### PR DESCRIPTION
This PR adds a `SharedDataset` to the C++ frontend data API, which allows wrapping a shared_ptr to a dataset into a class that conforms to the `Dataset` interface (with `get_batch`). This enables use cases where a custom dataset is (1) thread-safe and (2) expensive to copy. All workers will reference a single instance of this dataset. No additional copies are incurred.

@jaliyae @apaszke 