### PR TITLE
Apply weight-decay before momentum in the SGD optimizer.

### DIFF
--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -24,6 +24,11 @@ void SGD::step() {
     }
 
     auto update = options.learning_rate_ * p.grad();
+
+    if (options.weight_decay_ > 0) {
+      update += options.learning_rate_ * options.weight_decay_ * p;
+    }
+
     if (options.momentum_ != 0) {
       const auto dampening = iteration_ == 0 ? 1 : 1 - options.dampening_;
       auto& momentum = buffer_at(momentum_buffers, i);
@@ -35,10 +40,6 @@ void SGD::step() {
       } else {
         update = momentum;
       }
-    }
-
-    if (options.weight_decay_ > 0) {
-      update += options.learning_rate_ * options.weight_decay_ * p;
     }
 
     NoGradGuard guard;


### PR DESCRIPTION
While trying to understand why two implementations of the same model, one in Python, one using the C++ api (via some [ocaml wrappers](https://github.com/LaurentMazare/ocaml-torch)) did not perform equally well, I noticed that the Python and C++ implementation of SGD slightly differ on weight decay.

- In the [Python version](https://github.com/pytorch/pytorch/blob/master/torch/optim/sgd.py#L91-L93) weight decay is applied *before* momentum (and so momentum applies to the weight decay).
- In the C++ implementation the weight decay is applied *after* momentum.

In the couple computer-vision models I have looked at the Python version performs a little better so this PR tweaks the C++ implementation to perform weight-decay *before* momentum. This is possibly caused by having more regularization - maybe increasing the weight decay while keeping the current code would hold the same improvements however a nice advantage of this change is to put the C++ and Python version in line. After this change my Python and C++/ocaml models performed similarly when using the same weight-decay parameter. 

Maybe there was some real reason to have weight decay after momentum in the C++ version but I haven't found any.