### PR TITLE
Back out "Revert D12967258: Support more data types in ONNXIFI transform"

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -102,6 +102,29 @@ NodeProto AddShapeNode(const std::string& input, const std::string& output) {
 
 } // namespace
 
+::ONNX_NAMESPACE::TensorProto::DataType Caffe2TypeToOnnxType(
+    caffe2::TensorProto::DataType t) {
+#define CAFFE2_TO_ONNX_TYPE(x)   \
+  case (caffe2::TensorProto::x): \
+    return ::ONNX_NAMESPACE::TensorProto::x
+  switch (t) {
+    CAFFE2_TO_ONNX_TYPE(FLOAT);
+    CAFFE2_TO_ONNX_TYPE(BOOL);
+    CAFFE2_TO_ONNX_TYPE(INT8);
+    CAFFE2_TO_ONNX_TYPE(UINT8);
+    CAFFE2_TO_ONNX_TYPE(UINT16);
+    CAFFE2_TO_ONNX_TYPE(INT16);
+    CAFFE2_TO_ONNX_TYPE(INT32);
+    CAFFE2_TO_ONNX_TYPE(INT64);
+    CAFFE2_TO_ONNX_TYPE(FLOAT16);
+    default:
+      LOG(WARNING) << "Unsupported Caffe2 tensor type: " << t
+                   << ", fallback to FLOAT";
+      return ::ONNX_NAMESPACE::TensorProto::FLOAT;
+  }
+#undef CAFFE2_TO_ONNX_TYPE
+}
+
 std::unordered_map<std::string, std::string> SsaRewrite(
     caffe2::NetDef* init_net,
     caffe2::NetDef* pred_net) {

--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffe2/core/common.h"
+#include "caffe2/core/tensor.h"
 #include "caffe2/onnx/helper.h"
 #include "caffe2/proto/caffe2_pb.h"
 #include "onnx/onnx_pb.h"
@@ -28,6 +29,9 @@ using ConvertedResult =
 CAFFE2_API std::unordered_map<std::string, std::string> SsaRewrite(
     caffe2::NetDef* init_net,
     caffe2::NetDef* pred_net);
+
+::ONNX_NAMESPACE::TensorProto::DataType Caffe2TypeToOnnxType(
+    caffe2::TensorProto::DataType t);
 
 class CAFFE2_API OnnxExporter {
   using SpecialOpConverter = ConvertedResult (OnnxExporter::*)(

--- a/caffe2/operators/onnxifi_op.h
+++ b/caffe2/operators/onnxifi_op.h
@@ -14,6 +14,14 @@ namespace caffe2 {
 
 template <typename T, typename Context>
 class OnnxifiOp final : public Operator<Context> {
+  struct TensorInfo {
+    TensorInfo() {}
+    TensorInfo(TensorInfo&&) = default;
+    TensorInfo& operator=(TensorInfo&&) = default;
+    std::vector<uint64_t> dims;
+    uint64_t onnxifi_type;
+  };
+
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   OnnxifiOp(const OperatorDef& operator_def, Workspace* ws)
@@ -35,14 +43,15 @@ class OnnxifiOp final : public Operator<Context> {
       output_desc_.back().name = output.c_str();
 
       // For output, we try to get its output size hint
-      const std::string key = c10::str("output_size_hint_", output_idx);
-      auto output_size_hint = this->template GetRepeatedArgument<int>(key);
-      if (!output_size_hint.empty()) {
-        std::vector<int64_t> dims;
-        for (const auto v : output_size_hint) {
-          dims.push_back(v);
+      const std::string key = c10::str("output_shape_hint_", output_idx);
+      auto output_shape_hint = this->template GetRepeatedArgument<int>(key);
+      if (!output_shape_hint.empty()) {
+        TensorInfo info;
+        info.onnxifi_type = output_shape_hint.front();
+        for (int i = 1; i < output_shape_hint.size(); ++i) {
+          info.dims.push_back(output_shape_hint[i]);
         }
-        output_size_hints_.emplace(output_idx, std::move(dims));
+        output_shape_hints_.emplace(output_idx, std::move(info));
       }
       ++output_idx;
     }
@@ -127,11 +136,17 @@ class OnnxifiOp final : public Operator<Context> {
   bool RunOnDevice() override;
 
  private:
-  void SetOutputShape(int output_idx, std::vector<int64_t>* dims) {
-    const auto it = output_size_hints_.find(output_idx);
-    if (it != output_size_hints_.end()) {
-      *dims = it->second;
+  uint64_t SetOutputShapeAndType(int output_idx, std::vector<size_t>* dims) {
+    uint64_t type = ONNXIFI_DATATYPE_FLOAT32;
+    const auto it = output_shape_hints_.find(output_idx);
+    if (it != output_shape_hints_.end()) {
+      std::copy(
+          it->second.dims.begin(),
+          it->second.dims.end(),
+          std::back_inserter(*dims));
+      type = it->second.onnxifi_type;
     }
+    return type;
   }
 
   void BuildPropertyList(
@@ -163,7 +178,7 @@ class OnnxifiOp final : public Operator<Context> {
   std::vector<std::vector<uint64_t>> output_shapes_;
 
   // output shape hints
-  std::unordered_map<int, std::vector<int64_t>> output_size_hints_;
+  std::unordered_map<int, TensorInfo> output_shape_hints_;
 };
 
 } // namespace caffe2

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -27,7 +27,27 @@ void AnnotateOpIndex(NetDef* net) {
   }
 }
 
-// TODO(yinghai): Remove the awkward conversion between unordered_map and map
+uint64_t OnnxifiDataType(caffe2::TensorProto::DataType t) {
+#define CAFFE2_TO_ONNXIFI_TYPE(x, y) \
+  case (caffe2::TensorProto::x):     \
+    return y
+  switch (t) {
+    CAFFE2_TO_ONNXIFI_TYPE(FLOAT, ONNXIFI_DATATYPE_FLOAT32);
+    CAFFE2_TO_ONNXIFI_TYPE(INT8, ONNXIFI_DATATYPE_INT8);
+    CAFFE2_TO_ONNXIFI_TYPE(UINT8, ONNXIFI_DATATYPE_UINT8);
+    CAFFE2_TO_ONNXIFI_TYPE(INT16, ONNXIFI_DATATYPE_INT16);
+    CAFFE2_TO_ONNXIFI_TYPE(UINT16, ONNXIFI_DATATYPE_UINT16);
+    CAFFE2_TO_ONNXIFI_TYPE(INT32, ONNXIFI_DATATYPE_INT32);
+    CAFFE2_TO_ONNXIFI_TYPE(INT64, ONNXIFI_DATATYPE_INT64);
+    CAFFE2_TO_ONNXIFI_TYPE(FLOAT16, ONNXIFI_DATATYPE_FLOAT16);
+    default:
+      LOG(WARNING) << "Unsupported Caffe2 tensor type: " << t
+                   << ", fallback to FLOAT";
+      return ONNXIFI_DATATYPE_FLOAT32;
+  }
+#undef CAFFE2_TO_ONNXIFI_TYPE
+}
+
 std::unordered_map<std::string, TensorShape> InferShapes(
     Workspace* ws,
     NetDef* pred_net,
@@ -55,7 +75,8 @@ std::unordered_map<std::string, TensorShape> InferShapes(
     ws_local.RunNetOnce(*pred_net);
     const std::vector<std::string> ws_blobs = ws_local.Blobs();
     for (const auto& s : ws_blobs) {
-      auto shape = GetTensorShapeOfBlob(ws_local.GetBlob(s));
+      const Blob* b = ws_local.GetBlob(s);
+      auto shape = GetTensorShapeOfBlob(b);
       if (!shape.unknown_shape()) {
         shape_hints.emplace(s, std::move(shape));
       }
@@ -89,7 +110,7 @@ std::vector<::ONNX_NAMESPACE::ValueInfoProto> ConvertToValueInfo(
     } else {
       auto* tensor_type = value_info.mutable_type()->mutable_tensor_type();
       tensor_type->set_elem_type(
-          ::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT);
+          onnx::Caffe2TypeToOnnxType(it->second.data_type()));
       auto* shape = tensor_type->mutable_shape();
       for (int i = 0; i < it->second.dims().size(); ++i) {
         shape->add_dim()->set_dim_value(it->second.dims(i));
@@ -125,7 +146,7 @@ OnnxifiTransformer::OnnxifiTransformer(bool infer_shapes, bool debug)
 
 OperatorDef OnnxifiTransformer::BuildOnnxifiOp(
     const std::string& onnx_model_str,
-    const std::unordered_map<std::string, std::vector<int>>& output_size_hints,
+    const std::unordered_map<std::string, TensorShape>& output_shape_hints,
     const std::unordered_set<std::string>& initialization_list,
     const caffe2::NetDef& net) {
   OperatorDef op;
@@ -156,13 +177,14 @@ OperatorDef OnnxifiTransformer::BuildOnnxifiOp(
   // Add output size hints
   for (int i = 0; i < op.output_size(); ++i) {
     const auto& o = op.output(i);
-    const auto it = output_size_hints.find(o);
-    if (it != output_size_hints.end()) {
-      const auto& dims = it->second;
-      auto* output_size_hint_arg = op.add_arg();
-      output_size_hint_arg->set_name(c10::str("output_size_hint_", i));
-      for (const auto& d : dims) {
-        output_size_hint_arg->add_ints(d);
+    const auto it = output_shape_hints.find(o);
+    if (it != output_shape_hints.end()) {
+      const auto& shape = it->second;
+      auto* output_shape_hint_arg = op.add_arg();
+      output_shape_hint_arg->set_name(c10::str("output_shape_hint_", i));
+      output_shape_hint_arg->add_ints(OnnxifiDataType(shape.data_type()));
+      for (const auto& d : shape.dims()) {
+        output_shape_hint_arg->add_ints(d);
       }
 
       VLOG(2) << "Adding output hint: " << o;
@@ -234,20 +256,16 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
     io_names.emplace_back(output);
   }
   auto io_vec = ConvertToValueInfo(io_names, *shape_hints);
-  std::unordered_map<std::string, std::vector<int>> output_shape_hints;
+  std::unordered_map<std::string, TensorShape> output_shape_hints;
   for (const auto& i : io_vec) {
     onnx_model.mutable_graph()->add_output()->CopyFrom(i);
-    auto ret = output_shape_hints.emplace(i.name(), std::vector<int>());
-    auto& vec = ret.first->second;
     const auto it = shape_hints->find(i.name());
     CAFFE_ENFORCE(
         it != shape_hints->end(),
         "Cannot find shape info for output ",
         i.name());
     const auto& shape = it->second;
-    for (int k = 0; k < shape.dims().size(); ++k) {
-      vec.push_back(shape.dims(k));
-    }
+    output_shape_hints.emplace(i.name(), shape);
   }
 
   // Convert inputs and figure out weights
@@ -352,7 +370,7 @@ void OnnxifiTransformer::Transform(
   auto shape_hints_ordered =
       SsaRewriteAndMapNames(ws, pred_net, input_shape_hints);
   Workspace mapped_ws(ws, input_mapping_);
-  auto shape_hints =
+  std::unordered_map<std::string, TensorShape> shape_hints =
       InferShapes(&mapped_ws, pred_net, &shape_hints_ordered, infer_shapes_);
 
   CAFFE_ENFORCE(pred_net, "Predict net cannot be nullptr");

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -50,8 +50,7 @@ class CAFFE2_API OnnxifiTransformer {
 
   OperatorDef BuildOnnxifiOp(
       const std::string& onnx_model_str,
-      const std::unordered_map<std::string, std::vector<int>>&
-          output_size_hints,
+      const std::unordered_map<std::string, TensorShape>& output_size_hints,
       const std::unordered_set<std::string>& initialization_list,
       const caffe2::NetDef& net);
 

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -19,6 +19,8 @@ from caffe2.python.models.download import downloadFromURLToFile, getURLFromName,
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.onnx.tests.test_utils import TestCase
 
+ONNXIFI_DATATYPE_FLOAT32 = 1
+
 
 def _print_net(net):
     for i in net.external_input:
@@ -51,7 +53,7 @@ class OnnxifiTest(TestCase):
             ["X"],
             ["Y"],
             onnx_model=model_def.SerializeToString(),
-            output_size_hint_0=[batch_size, 1, 3, 2])
+            output_shape_hint_0=[ONNXIFI_DATATYPE_FLOAT32, batch_size, 1, 3, 2])
         workspace.FeedBlob("X", X)
         workspace.RunOperatorOnce(op)
         Y = workspace.FetchBlob("Y")
@@ -92,7 +94,7 @@ class OnnxifiTest(TestCase):
             ["Y"],
             onnx_model=model_def.SerializeToString(),
             initializers=["W", "W"],
-            output_size_hint_0=[1, 1, 3, 3])
+            output_shape_hint_0=[ONNXIFI_DATATYPE_FLOAT32, 1, 1, 3, 3])
         workspace.FeedBlob("X", X)
         workspace.FeedBlob("W", W)
         workspace.RunOperatorOnce(op)


### PR DESCRIPTION
Summary:
Original commit changeset: 2cf95bdc5ed8

Looks like in iOS, `uint64_t` is not the same as `size_t`. :( Fixed it here.

Differential Revision: D13017390
