### PR TITLE
Remove potential infinite loop from test_c10d.py

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -162,14 +162,17 @@ def create_tcp_store(addr):
     """
     Creates a TCP store. Retries if the chosen port is already in use.
     """
-    while True:
+    ports = []
+    for _ in range(10):
         try:
             port = common.find_free_port()
+            ports.append(port)
             return c10d.TCPStore(addr, port, True)
         except RuntimeError as error:
             if str(error) == "Address already in use":
                 continue
             raise
+    raise RuntimeError("Unable to find free port (tried %s)" % ", ".join(ports))
 
 
 class TCPStoreTest(TestCase, StoreTestBase):


### PR DESCRIPTION
Summary:
If common.find_free_port() returns the same port over and over again,
and the TCPStore fails to bind to it over and over again, this
function has the potential to loop forever. If we can't find a free
port after 10 tries, we are safe to assume something is wrong...

Differential Revision: D13017700
