### PR TITLE
Add matplotlib to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==1.7.9
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
+matplotlib


### PR DESCRIPTION
Used in docs/source/scripts/build_activation_images.py.

Don't know if we need a specific version. I installed the latest version (3.0.2) and that works. 