### PR TITLE
Unpin Sphinx.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.7.9
+sphinx
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex


### PR DESCRIPTION
Sphinx 1.8.2 is released, per https://github.com/sphinx-doc/sphinx/issues/5419

Fixes #11618

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

