### PR TITLE
Add c10 cuda library.

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -60,6 +60,10 @@ target_include_directories(
 
 add_subdirectory(test)
 
+if(USE_CUDA)
+  add_subdirectory(cuda)
+endif()
+
 # ---[ Installation
 # Note: for now, we will put all export path into one single Caffe2Targets group
 # to deal with the cmake deployment need. Inside the Caffe2Targets set, the

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Build file for the C10 CUDA.
+#
+# C10 CUDA is a minimal library, but it does depend on CUDA.
+
+include(../../cmake/public/utils.cmake)
+include(../../cmake/public/cuda.cmake)
+
+# ---[ Configure macro file.
+set(C10_CUDA_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # used in cmake_macros.h.in
+# Probably have to do this :(
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/impl/cuda_cmake_macros.h.in
+    ${CMAKE_BINARY_DIR}/c10/cuda/impl/cuda_cmake_macros.h)
+
+# Note: if you want to add ANY dependency to the c10 library, make sure you
+# check with the core PyTorch developers as the dependendency will be
+# transitively passed on to all libraries dependent on PyTorch.
+file(GLOB C10_CUDA_SRCS
+        *.cpp
+        *.cu
+        impl/*.cpp
+        impl/*.cu
+        )
+file(GLOB_RECURSE C10_CUDA_ALL_TEST_FILES test/*.cpp)
+file(GLOB_RECURSE C10_CUDA_HEADERS *.h)
+set(CUDA_LINK_LIBRARIES_KEYWORD PRIVATE)
+torch_cuda_based_add_library(c10_cuda ${C10_CUDA_SRCS} ${C10_CUDA_HEADERS})
+set(CUDA_LINK_LIBRARIES_KEYWORD)
+# If building shared library, set dllimport/dllexport proper.
+target_compile_options(c10_cuda PRIVATE "-DC10_CUDA_BUILD_MAIN_LIB")
+# Enable hidden visibility if compiler supports it.
+if (${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
+  target_compile_options(c10_cuda PRIVATE "-fvisibility=hidden")
+endif()
+
+# ---[ Dependency of c10_cuda
+target_link_libraries(c10_cuda PUBLIC c10)
+
+target_link_libraries(c10_cuda INTERFACE caffe2::cudart)
+
+target_include_directories(
+    c10_cuda PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>)
+
+add_subdirectory(test)
+
+# ---[ Installation
+# Note: for now, we will put all export path into one single Caffe2Targets group
+# to deal with the cmake deployment need. Inside the Caffe2Targets set, the
+# individual libraries like libc10.so and libcaffe2.so are still self-contained.
+install(TARGETS c10_cuda EXPORT Caffe2Targets DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+install(FILES ${CMAKE_BINARY_DIR}/c10/cuda/impl/cuda_cmake_macros.h
+  DESTINATION include/c10/cuda/impl)

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <c10/cuda/impl/cuda_cmake_macros.h>
+
+// See c10/macros/Export.h for a detailed explanation of what the function
+// of these macros are.  We need one set of macros for every separate library
+// we build.
+
+#ifdef _WIN32
+#if defined(C10_CUDA/BUILD_SHARED_LIBS)
+#define C10_CUDA_EXPORT __declspec(dllexport)
+#define C10_CUDA_IMPORT __declspec(dllimport)
+#else
+#define C10_CUDA_EXPORT
+#define C10_CUDA_IMPORT
+#endif
+#else // _WIN32
+#if defined(__GNUC__)
+#define C10_CUDA_EXPORT __attribute__((__visibility__("default")))
+#else // defined(__GNUC__)
+#define C10_CUDA_EXPORT
+#endif // defined(__GNUC__)
+#define C10_CUDA_IMPORT C10_CUDA_EXPORT
+#endif // _WIN32
+
+// This one is being used by libc10_cuda.so
+#ifdef C10_CUDA_BUILD_MAIN_LIB
+#define C10_CUDA_API C10_CUDA_EXPORT
+#else
+#define C10_CUDA_API C10_CUDA_IMPORT
+#endif

--- a/c10/cuda/impl/CUDATest.cpp
+++ b/c10/cuda/impl/CUDATest.cpp
@@ -1,0 +1,22 @@
+// Just a little test file to make sure that the CUDA library works
+
+#include <c10/cuda/impl/CUDATest.h>
+
+#include <cuda_runtime.h>
+
+namespace c10 {
+namespace cuda {
+namespace impl {
+
+int c10_cuda_test() {
+  int r;
+  cudaGetDevice(&r);
+  return r;
+}
+
+// This function is not exported
+int c10_cuda_private_test() {
+  return 2;
+}
+
+}}} // namespace c10::cuda::impl

--- a/c10/cuda/impl/CUDATest.h
+++ b/c10/cuda/impl/CUDATest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <c10/cuda/CUDAMacros.h>
+
+namespace c10 {
+namespace cuda {
+namespace impl {
+
+C10_CUDA_API int c10_cuda_test();
+
+}}} /// namespace c10::cuda::impl

--- a/c10/cuda/impl/cuda_cmake_macros.h.in
+++ b/c10/cuda/impl/cuda_cmake_macros.h.in
@@ -1,0 +1,6 @@
+#pragma once
+
+// Automatically generated header file for the C10 CUDA library.  Do not
+// include this file directly.  Instead, include c10/cuda/CUDAMacros.h
+
+#cmakedefine C10_CUDA_BUILD_SHARED_LIBS

--- a/c10/cuda/test/CMakeLists.txt
+++ b/c10/cuda/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+# ---[ Test binaries.
+
+file(GLOB_RECURSE C10_CUDA_ALL_TEST_FILES *.cpp)
+if (BUILD_TEST)
+  foreach(test_src ${C10_CUDA_ALL_TEST_FILES})
+    get_filename_component(test_file_name ${test_src} NAME_WE)
+    set(test_name "c10_cuda_${test_file_name}")
+    add_executable(${test_name} "${test_src}")
+    target_link_libraries(${test_name} c10_cuda gtest_main)
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    if (INSTALL_TEST)
+      install(TARGETS ${test_name} DESTINATION test)
+    endif()
+  endforeach()
+endif()

--- a/c10/cuda/test/impl/CUDATest.cpp
+++ b/c10/cuda/test/impl/CUDATest.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <c10/cuda/impl/CUDATest.h>
+
+using namespace c10::cuda::impl;
+
+TEST(CUDATest, SmokeTest) {
+  c10_cuda_test();
+}

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -325,6 +325,7 @@ if(USE_CUDA)
   torch_cuda_based_add_library(caffe2_gpu ${Caffe2_GPU_SRCS})
   set(CUDA_LINK_LIBRARIES_KEYWORD)
   target_link_libraries(caffe2_gpu INTERFACE caffe2::cudart)
+  target_link_libraries(caffe2_gpu PUBLIC c10_cuda)
 
   target_include_directories(
       caffe2_gpu INTERFACE $<INSTALL_INTERFACE:include>)

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -1,5 +1,10 @@
 # ---[ cuda
 
+# Poor man's include guard
+if(TARGET caffe2::cudart)
+  return()
+endif()
+
 # sccache is only supported in CMake master and not in the newest official
 # release (3.11.3) yet. Hence we need our own Modules_CUDA_fix to enable sccache.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../Modules_CUDA_fix)


### PR DESCRIPTION
Right now, this is not used by anything, and only tests if the CUDA
headers are available (and not, e.g., that linking works.)

Extra changes:
- cmake/public/cuda.cmake now is correctly include guarded, so you
  can include it multiple times without trouble.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

