### PR TITLE
nomnigraph - easy - support blob renaming

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -183,6 +183,11 @@ class CAFFE2_API Tensor : public NeuralNetData {
   const std::string getName() const {
     return name_;
   }
+
+  void setName(const std::string& name) {
+    name_ = name;
+  }
+
   ~Tensor() {}
 
  private:

--- a/caffe2/core/nomnigraph/tests/NeuralNetTest.cc
+++ b/caffe2/core/nomnigraph/tests/NeuralNetTest.cc
@@ -18,6 +18,8 @@ TEST(NeuralNetGraph, ReplaceGraph) {
 
   auto input1 = graph.createNode(util::make_unique<Tensor>("input1"));
   auto input2 = graph.createNode(util::make_unique<Tensor>("input2"));
+  // Test renaming blob
+  nn::get<Tensor>(input2)->setName("input2_renamed");
   auto sum = graph.createNode(util::make_unique<Sum>());
   auto sumOutput = graph.createNode(util::make_unique<Tensor>("sumOutput"));
   auto relu = graph.createNode(util::make_unique<Relu>());


### PR DESCRIPTION
Summary: Support renaming a blob in nomnigraph

Differential Revision: D13026762
