### PR TITLE
    Corrected python lib path on windows to be consistent with Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,9 +233,14 @@ rel_site_packages = distutils.sysconfig.get_python_lib(prefix='')
 # full absolute path to the dir above
 full_site_packages = distutils.sysconfig.get_python_lib()
 # CMAKE: full path to python library
-cmake_python_library = "{}/{}".format(
-    distutils.sysconfig.get_config_var("LIBDIR"),
-    distutils.sysconfig.get_config_var("INSTSONAME"))
+if IS_WINDOWS:
+    cmake_python_library = "{}/libs/python{}.lib".format(
+        distutils.sysconfig.get_config_var("prefix"),
+        distutils.sysconfig.get_config_var("VERSION"))
+else:
+    cmake_python_library = "{}/{}".format(
+        distutils.sysconfig.get_config_var("LIBDIR"),
+        distutils.sysconfig.get_config_var("INSTSONAME"))
 cmake_python_include_dir = distutils.sysconfig.get_python_inc()
 
 

--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -214,11 +214,12 @@ goto:eof
   :    Invalid escape sequence \i
   : which is said to become an error in the future.
   : As an alternative, we should use forward slashes instead.
-  : Here those paths should be espaced before passing to CMake. 
+  : Here those paths should be escaped before passing to CMake. 
   set NVTOOLEXT_HOME=%NVTOOLEXT_HOME:\=/%
   set CUDNN_INCLUDE_DIR=%CUDNN_INCLUDE_DIR:\=/%
   set CUDNN_LIB_DIR=%CUDNN_LIB_DIR:\=/%
   set CUDNN_LIBRARY=%CUDNN_LIBRARY:\=/%
+  set PYTORCH_PYTHON_LIBRARY=%PYTORCH_PYTHON_LIBRARY:\=/%
 
   IF NOT "%PREBUILD_COMMAND%"=="" call "%PREBUILD_COMMAND%" %PREBUILD_COMMAND_ARGS%
   if not exist build mkdir build
@@ -226,6 +227,7 @@ goto:eof
   cmake .. %CMAKE_GENERATOR_COMMAND% ^
                   -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
                   -DTORCH_BUILD_VERSION="%PYTORCH_BUILD_VERSION%" ^
+                  -DPYTHON_LIBRARY="%PYTORCH_PYTHON_LIBRARY%" ^
                   -DBUILD_TORCH="%BUILD_TORCH%" ^
                   -DNVTOOLEXT_HOME="%NVTOOLEXT_HOME%" ^
                   -DNO_API=ON ^


### PR DESCRIPTION
The python lib path on Windows was set to an incorrect path. This fixes it to be consistent with Linux.