### PR TITLE
Two small improvements to TorchConfig.cmake

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -16,7 +16,7 @@
 
 include(FindPackageHandleStandardArgs)
 
-if ($ENV{TORCH_INSTALL_PREFIX})
+if (DEFINED ENV{TORCH_INSTALL_PREFIX})
   set(TORCH_INSTALL_PREFIX $ENV{TORCH_INSTALL_PREFIX})
 else()
   # Assume we are in <install-prefix>/share/cmake/Torch/TorchConfig.cmake
@@ -36,7 +36,7 @@ else()
 endif()
 
 # Library dependencies.
-find_package(Caffe2 REQUIRED)
+find_package(Caffe2 REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 add_library(torch UNKNOWN IMPORTED)


### PR DESCRIPTION
- Fix the test for TORCH_INSTALL_PREFIX in the environment.
  The previous version didn't actually work.
- Add a guess path to find_package for Caffe2. I'd suspect that
  it's close to the Torch one.

I noticed these while compiling PyTorch custom ops, in particular for the C++ side when you don't want to go through Python.
