### PR TITLE
[jit] allow `Node::isAfter` to work across blocks

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -1199,6 +1199,26 @@ void testTopologicalIndex() {
     ASSERT_FALSE(node3->isBefore(node2));
     ASSERT_FALSE(node3->isAfter(node4));
 
+    // Built up a block structure
+    //  node3
+    //   /\        ...
+    //  A  B     block1
+    //      \      ...
+    //      C    block2
+    auto block1 = node3->addBlock();
+    auto A = graph.create(prim::Undefined);
+    block1->appendNode(A);
+    auto B = graph.create(prim::Undefined);
+    block1->appendNode(B);
+    auto block2 = B->addBlock();
+    auto C = graph.create(prim::Undefined);
+    block2->appendNode(C);
+
+    // Check isAfter on different block levels
+    ASSERT_TRUE(node1->isBefore(A));
+    ASSERT_TRUE(A->isBefore(B));
+    ASSERT_TRUE(A->isBefore(C));
+
     // make sure things don't blow up on deletions
     node2->destroy();
     auto node2p = graph.create(prim::Undefined);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -867,9 +867,32 @@ bool Node::isBefore(const Node * n) const {
 }
 
 bool Node::isAfter(const Node * n) const {
-  JIT_ASSERT(this->owningBlock() == n->owningBlock());
+  JIT_ASSERT(this->owningGraph() == n->owningGraph());
 
-  return this->topo_position_ > n->topo_position_;
+  if (this->owningBlock() == n->owningBlock()) {
+    return this->topo_position_ > n->topo_position_;
+  }
+
+  // These nodes don't share a common block. Traverse the blockchains upward
+  // until we find the first common block.
+  auto lhs = this;
+  while (lhs) {
+    JIT_ASSERT(lhs->owningBlock());
+
+    auto rhs = n;
+    while (rhs) {
+      JIT_ASSERT(rhs->owningBlock());
+
+      if (lhs->owningBlock() == rhs->owningBlock()) {
+        return lhs->isAfter(rhs);
+      }
+      rhs = rhs->owningBlock()->owningNode();
+    }
+
+    lhs = lhs->owningBlock()->owningNode();
+  }
+  // should never reach here, since both nodes are ultimately in the same graph
+  JIT_ASSERT(false);
 }
 
 Node* Node::insertBefore(Node * n) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -700,7 +700,13 @@ struct Block {
   Graph * owningGraph() {
     return graph_;
   }
+  const Graph * owningGraph() const {
+    return graph_;
+  }
   Node * owningNode() {
+    return owning_node_;
+  }
+  const Node * owningNode() const {
     return owning_node_;
   }
   // clone all inputs, nodes, and outputs from src and append them


### PR DESCRIPTION
Extend `isAfter` to work for nodes in different blocks. This is useful if we want to ask a question like "are any of the uses of value `v` after this node", since uses may be inside inner blocks.