### PR TITLE
Add tensor table in ModelDef and use it for jit script serialization and deserialization

### DIFF
--- a/caffe2/proto/torch.proto
+++ b/caffe2/proto/torch.proto
@@ -10,8 +10,10 @@ message ParameterDef {
   // whether this parameter is registered as buffer or not
   optional bool is_buffer = 2;
 
-  // tensor type parameter
-  optional caffe2.TensorProto tensor = 3;
+  // do not store tensor in parameter anymore, and retire field 3
+  // optional caffe2.TensorProto tensor = 3;
+  // the id in the tensor table, defined in TensorProto.name
+  optional string tensor_id = 5;
   // objects other than tensors will be added here
 
   optional string name = 4;
@@ -99,4 +101,7 @@ message ModelDef {
   //   - publish_time - string
   repeated caffe2.Argument annotations = 6;
 
+  // the table contains all the tensor information
+  // the tensor id is defined as TensorProto.name
+  repeated caffe2.TensorProto tensors = 7;
 }

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -31,6 +31,8 @@ namespace {
 namespace onnx_torch = ::torch::onnx;
 namespace onnx = ::ONNX_NAMESPACE;
 
+class ScriptModuleSerializer;
+
 std::string getExportableSchemaStringForMethod(const script::Method& method) {
   const auto& schema = method.getSchema();
   for (const auto& argument : schema.arguments()) {
@@ -437,13 +439,11 @@ class MethodEncoder : public EncoderBase {
  public:
   MethodEncoder(
       const script::Method& method,
-      std::unordered_map<const void*, uint64_t>* storage_map,
-      std::unordered_map<at::Tensor*, std::string>* parameter_map,
-      PyTorchStreamWriter* writer);
+      const ScriptModuleSerializer& serializer);
 
   std::string EncodeMethod(
       const script::Method& method,
-      const std::string prefix);
+      const std::string& prefix);
 
  private:
   void EncodeTensor(
@@ -463,26 +463,133 @@ class MethodEncoder : public EncoderBase {
                       const TypePtr& type,
                       const std::string& name);
 
-  PyTorchStreamWriter* stream_writer_;
-  // Used to deduplicate tensor storages
-  std::unordered_map<const void*, uint64_t>* storage_dedup_map_;
-
-  // Used to keep track of Parameter names so Methods can refer to them
-  std::unordered_map<at::Tensor*, std::string>* parameter_map_;
+  // serializer already serialized all the tensors, and stores
+  // the tensor and parameter tables
+  const ScriptModuleSerializer* serializer_;
 
   // Used to create sequential dummy names for node types
   size_t type_counter_ = 0;
 };
 
+// this is a serializer class which saves script modules to pt files. the
+// content of the file is written using PyTorchStreamWriter, for details please
+// check caffe2/serialize/inline_container.h. all the records except the last
+// one are tensor data, and the last record is a serialized ModelProto, defined
+// in caffe2/proto/torch.proto. ModelProto contains all the metadata of the
+// model, and it is serialized as json.
+class ScriptModuleSerializer final {
+ public:
+  ScriptModuleSerializer(const std::string& filename);
+
+  ScriptModuleSerializer(std::ostream* ofs);
+
+  void serialize(const script::Module& module);
+
+  uint64_t lookupTensorId(const at::Tensor* tensor) const;
+
+  const std::string& lookupParamName(const at::Tensor* tensor) const;
+
+ private:
+  void convertToModel(const script::Module& module, torch::ModelDef* model_def);
+
+  // add a tensor to the tensorTable
+  void addTensor(const at::Tensor* tensor);
+
+  // recursively collect the tensors in a block and add them to the tensorTable
+  void findTensorInBlock(const Block& block);
+
+  // recursively iterate over the whole module to collect the information of
+  // tensors and parameters
+  void collectInfo(const script::Module& module, const std::string& prefix);
+
+  // write the content of the tensor to the file/stream, and save the
+  // offset in the storageMap_
+  void convertAndWriteTensor(
+      const at::Tensor& tensor,
+      caffe2::TensorProto* tensor_proto);
+
+  // dump all the tensors in the tensorTable_ to a ModelDef (metadata) and
+  // the file/stream (the content), assuming all the information of the
+  // tensors has been collected. the method calls convertAndWriteTensor
+  // to dump the content of a tensor
+  void writeTensorTable(torch::ModelDef* model_def);
+
+  void convertModule(
+      const script::Module& module,
+      const std::string& name,
+      torch::ModuleDef* module_def);
+
+  void convertParameter(
+      const script::NamedParameter& param,
+      torch::ParameterDef* param_def);
+
+  void convertMethod(
+      const script::Method& method,
+      torch::MethodDef* method_def);
+
+  std::ofstream ofs_;
+  PyTorchStreamWriter writer_;
+  // storage_ptr => record_offset
+  std::unordered_map<const void*, uint64_t> storageMap_;
+  // tensor => param name
+  std::unordered_map<const at::Tensor*, std::string> paramMap_;
+  // tensor => tensor_id
+  std::unordered_map<const at::Tensor*, uint64_t> tensorTable_;
+  // used for generating table id for tensors
+  uint64_t nextTensorId_ = 0;
+};
+
+// MethodEncoder's methods
 MethodEncoder::MethodEncoder(
     const script::Method& method,
-    std::unordered_map<const void*, uint64_t>* storage_map,
-    std::unordered_map<at::Tensor*, std::string>* parameter_map,
-    PyTorchStreamWriter* writer)
+    const ScriptModuleSerializer& serializer)
     : EncoderBase(onnx_torch::OperatorExportTypes::RAW, false) {
-  storage_dedup_map_ = storage_map;
-  parameter_map_ = parameter_map;
-  stream_writer_ = writer;
+  serializer_ = &serializer;
+}
+
+std::string MethodEncoder::EncodeMethod(
+    const script::Method& method,
+    const std::string& prefix) {
+  onnx::ModelProto model_proto;
+  model_proto.set_doc_string("THIS PROTO IS NOT STANDARD ONNX");
+  auto* node_proto = model_proto.mutable_graph()->add_node();
+  node_proto->set_name(prefix + method.name());
+
+  // We store the schema string in the docstring.
+  node_proto->set_doc_string(getExportableSchemaStringForMethod(method));
+
+  // Store member_inputs of Method in input
+  for (auto& member_input : method.params()) {
+    const auto& param_name = serializer_->lookupParamName(member_input);
+    node_proto->add_input(param_name);
+  }
+
+  auto attr_proto = node_proto->add_attribute();
+  attr_proto->set_type(onnx::AttributeProto_AttributeType_GRAPH);
+
+  for (auto node : method.graph()->nodes()) {
+    if (node->kind() == prim::PythonOp) {
+      auto py_node = static_cast<torch::jit::PythonOp*>(node);
+      throw std::runtime_error(
+          "Couldn't export Python operator " + py_node->name() +
+          "\n\nDefined at:\n" + getNodeStackTraceString(node));
+    }
+  }
+  EncodeBlock(attr_proto->mutable_g(), method.graph()->block(), {});
+  std::string torch_script;
+  AT_ASSERT(model_proto.SerializeToString(&torch_script));
+  return torch_script;
+}
+
+void MethodEncoder::EncodeTensor(
+    onnx::TensorProto* tensor_proto,
+    const at::Tensor& tensor,
+    const c10::optional<std::string> external_ref) {
+  uint64_t tensor_id = serializer_->lookupTensorId(&tensor);
+  tensor_proto->set_name(c10::to_string(tensor_id));
+  // No need to store the content of the tensor to the file/stream
+  // any more, since it is already saved at the beginning of the
+  // serialization in writeTensorTable
 }
 
 void MethodEncoder::EncodeIntermediateValueInfo(
@@ -604,82 +711,241 @@ void MethodEncoder::EncodeValueInfo(
   EncodeTypeInfo(graph_proto, v, n->type(), n->uniqueName());
 }
 
-std::string MethodEncoder::EncodeMethod(
-    const script::Method& method,
-    const std::string prefix) {
-  onnx::ModelProto model_proto;
-  model_proto.set_doc_string("THIS PROTO IS NOT STANDARD ONNX");
-  auto* node_proto = model_proto.mutable_graph()->add_node();
-  node_proto->set_name(prefix + method.name());
-
-  // We store the schema string in the docstring.
-  node_proto->set_doc_string(getExportableSchemaStringForMethod(method));
-
-  // Store member_inputs of Method in input
-  for (auto &member_input : method.params()) {
-    auto it = parameter_map_->find(member_input);
-    JIT_ASSERT(it != parameter_map_->end());
-    node_proto->add_input(it->second);
-  }
-
-  auto attr_proto = node_proto->add_attribute();
-  attr_proto->set_type(onnx::AttributeProto_AttributeType_GRAPH);
-
-  for (auto node : method.graph()->nodes()) {
-    if (node->kind() == prim::PythonOp) {
-      auto py_node = static_cast<torch::jit::PythonOp*>(node);
-      throw std::runtime_error(
-          "Couldn't export Python operator " + py_node->name() +
-          "\n\nDefined at:\n" + getNodeStackTraceString(node));
-    }
-  }
-  EncodeBlock(attr_proto->mutable_g(), method.graph()->block(), {});
-  std::string torch_script;
-  AT_ASSERT(model_proto.SerializeToString(&torch_script));
-  return torch_script;
+// ScriptModuleSerializer's methods
+ScriptModuleSerializer::ScriptModuleSerializer(const std::string& filename)
+    : ofs_(
+          filename,
+          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary),
+      writer_(&ofs_) {
+  // TODO appropriate support for mmap, right now we still use stream writer
 }
 
-void MethodEncoder::EncodeTensor(
-    onnx::TensorProto* tensor_proto,
+ScriptModuleSerializer::ScriptModuleSerializer(std::ostream* ofs)
+    : ofs_(), writer_(ofs) {}
+
+void ScriptModuleSerializer::serialize(const script::Module& module) {
+  torch::ModelDef model_def;
+  convertToModel(module, &model_def);
+  std::string output;
+  // NB: cannot use MessageToJsonString, since fbcode's protobuf is too old
+  // be consistent with MessageToJsonString
+  std::string url_prefix = "type.googleapis.com";
+  std::unique_ptr<::google::protobuf::util::TypeResolver> resolver(
+      ::google::protobuf::util::NewTypeResolverForDescriptorPool(
+          url_prefix, model_def.GetDescriptor()->file()->pool()));
+  ::google::protobuf::util::Status convert_result =
+      ::google::protobuf::util::BinaryToJsonString(
+          resolver.get(),
+          url_prefix + "/" + model_def.GetDescriptor()->full_name(),
+          model_def.SerializeAsString(),
+          &output);
+  if (!convert_result.ok()) {
+    std::stringstream ss;
+    ss << convert_result;
+    AT_ERROR(ss.str());
+  }
+  auto record_id = writer_.writeRecord(output.data(), output.size());
+  AT_ASSERT(record_id != 0);
+  writer_.writeEndOfFile();
+}
+
+uint64_t ScriptModuleSerializer::lookupTensorId(
+    const at::Tensor* tensor) const {
+  auto it = tensorTable_.find(tensor);
+  AT_ASSERT(it != tensorTable_.end());
+  return it->second;
+}
+
+const std::string& ScriptModuleSerializer::lookupParamName(
+    const at::Tensor* tensor) const {
+  auto it = paramMap_.find(tensor);
+  AT_ASSERT(it != paramMap_.end());
+  return it->second;
+}
+
+void ScriptModuleSerializer::convertToModel(
+    const script::Module& module,
+    torch::ModelDef* model_def) {
+  model_def->set_name("script-model");
+  model_def->set_producer_name("pytorch");
+  model_def->set_producer_version("1.0"); // TODO: set the producer version
+                                          // using appropriate function call
+  model_def->set_proto_version(torch::ProtoVersion::PROTO_VERSION_NEWEST);
+  std::string main_module_name = "";
+  nextTensorId_ = 0;
+  collectInfo(module, main_module_name);
+  writeTensorTable(model_def);
+  convertModule(module, main_module_name, model_def->mutable_main_module());
+}
+
+void ScriptModuleSerializer::addTensor(const at::Tensor* tensor) {
+  if (tensorTable_.find(tensor) == tensorTable_.end()) {
+    tensorTable_[tensor] = nextTensorId_;
+    ++nextTensorId_;
+  }
+}
+
+void ScriptModuleSerializer::findTensorInBlock(const Block& block) {
+  for (auto node : block.nodes()) {
+    for (auto attr_name : node->attributeNames()) {
+      AT_ASSERT(attr_name.is_attr());
+      switch (node->kindOf(attr_name)) {
+        case AttributeKind::f:
+        case AttributeKind::fs:
+        case AttributeKind::i:
+        case AttributeKind::is:
+        case AttributeKind::s:
+        case AttributeKind::ss:
+          break;
+        case AttributeKind::t: {
+          const at::Tensor* tensor = &node->t(attr_name);
+          addTensor(tensor);
+        } break;
+        case AttributeKind::ts: {
+          for (auto& v : node->ts(attr_name)) {
+            const at::Tensor* tensor = &v;
+            addTensor(tensor);
+          }
+        } break;
+        case AttributeKind::g: {
+          findTensorInBlock(*node->g(attr_name)->block());
+        } break;
+        case AttributeKind::gs: {
+          for (auto& v : node->gs(attr_name)) {
+            findTensorInBlock(*v->block());
+          }
+        } break;
+        default:
+          AT_ERROR("unexpected attribute kind");
+      }
+    }
+    for (auto b : node->blocks()) {
+      findTensorInBlock(*b);
+    }
+  }
+}
+
+void ScriptModuleSerializer::collectInfo(
+    const script::Module& module,
+    const std::string& prefix) {
+  for (const auto& elem : module.get_parameters()) {
+    const script::NamedParameter& param = elem.value();
+    paramMap_[param.slot()] = prefix + param.name;
+    addTensor(param.slot());
+  }
+  for (const auto& elem : module.get_methods()) {
+    findTensorInBlock(*elem.value()->graph()->block());
+  }
+  for (const auto& elem : module.get_modules()) {
+    collectInfo(*elem->module, prefix + elem.key() + ".");
+  }
+}
+
+void ScriptModuleSerializer::convertAndWriteTensor(
     const at::Tensor& tensor,
-    const c10::optional<std::string> external_ref) {
-  auto storage_ptr = tensor.storage().unsafeGetStorageImpl();
-  auto dedup_it = storage_dedup_map_->find(storage_ptr);
-  if (dedup_it != storage_dedup_map_->end()) {
-    tensor_proto->add_int64_data(dedup_it->second);
-  } else {
-    at::Tensor t = tensor;
+    caffe2::TensorProto* tensor_proto) {
+  auto tensor_it = tensorTable_.find(&tensor);
+  AT_ASSERT(tensor_it != tensorTable_.end());
+  tensor_proto->set_name(c10::to_string(tensor_it->second));
+  for (auto d : tensor.sizes()) {
+    tensor_proto->add_dims(d);
+  }
+  tensor_proto->set_data_type(caffe2::TypeMetaToDataType(
+      at::scalarTypeToTypeMeta(tensor.type().scalarType())));
+  tensor_proto->set_storage_type(caffe2::TensorProto_StorageType_EXTERNAL);
+  caffe2::ExternalDataProto* external_data =
+      tensor_proto->mutable_external_data();
+  for (auto s : tensor.strides()) {
+    external_data->add_strides(s);
+  }
+  external_data->set_offset(tensor.storage_offset());
+  uint64_t record_size =
+      tensor.type().elementSizeInBytes() * tensor.storage().size();
+  external_data->set_record_size(record_size);
+  auto* key = tensor.storage().unsafeGetStorageImpl();
+  auto storage_it = storageMap_.find(key);
+  if (storage_it == storageMap_.end()) {
+    // TODO HIP support
+    uint64_t record_id;
     if (tensor.storage().device_type() == at::DeviceType::CUDA) {
       // NB: This new tensor is created to support cuda tensors.
       // Storages can be mutated when converting tensors from cuda to cpu,
       // and we need a cpu tensor to copy data from.
-      t = at::getType(tensor)._th_tensor(
-          tensor.storage(),
-          /* storageOffset = */ 0,
-          /* size = */ { static_cast<int64_t>(tensor.storage().size()) },
-          /* stride = */ { 1 })
-        .cpu();
+      at::Tensor t = at::getType(tensor)
+                         ._th_tensor(
+                             tensor.storage(),
+                             /* storageOffset = */ 0,
+                             /* size = */
+                             {static_cast<int64_t>(tensor.storage().size())},
+                             /* stride = */ {1})
+                         .cpu();
+      AT_ASSERT(
+          t.type().elementSizeInBytes() * t.storage().size() == record_size);
+      record_id = writer_.writeRecord(
+          t.storage().data(),
+          t.type().elementSizeInBytes() * t.storage().size());
+    } else {
+      record_id = writer_.writeRecord(tensor.storage().data(), record_size);
     }
-
-    auto record_number = stream_writer_->writeRecord(
-      static_cast<char*>(t.storage().data()), t.type().elementSizeInBytes() * t.storage().size());
-    tensor_proto->add_int64_data(record_number);
-    (*storage_dedup_map_)[storage_ptr] = record_number;
+    external_data->set_record_id(c10::to_string(record_id));
+    storageMap_[key] = record_id;
+  } else {
+    external_data->set_record_id(c10::to_string(storage_it->second));
   }
+  // TODO handle device case, set the device_detail and load to CUDA device
+}
 
-  for (auto &d : tensor.sizes()) {
-    tensor_proto->add_dims(d);
-  }
-  tensor_proto->set_data_type(ATenTypeToOnnxType(tensor.type().scalarType()));
-
-  tensor_proto->add_int64_data(tensor.storage_offset());
-  for (auto &d : tensor.strides()) {
-    tensor_proto->add_int64_data(d);
+void ScriptModuleSerializer::writeTensorTable(torch::ModelDef* model_def) {
+  // NB: we don't reserve any order for tensors in the tensorTable_
+  for (const auto& kv : tensorTable_) {
+    auto* tensor_proto = model_def->add_tensors();
+    convertAndWriteTensor(*kv.first, tensor_proto);
   }
 }
 
+void ScriptModuleSerializer::convertModule(
+    const script::Module& module,
+    const std::string& name,
+    torch::ModuleDef* module_def) {
+  module_def->set_name(name);
+  module_def->set_optimize(module.is_optimized());
+  for (const auto& elem : module.get_parameters()) {
+    torch::ParameterDef* param_def = module_def->add_parameters();
+    convertParameter(elem.value(), param_def);
+  }
+  for (auto& elem : module.get_methods()) {
+    torch::MethodDef* method_def = module_def->add_methods();
+    convertMethod(*elem.value(), method_def);
+  }
+  for (const auto& elem : module.get_modules()) {
+    torch::ModuleDef* sub_def = module_def->add_submodules();
+    convertModule(*elem->module, elem.key(), sub_def);
+  }
+}
+
+void ScriptModuleSerializer::convertParameter(
+    const script::NamedParameter& param,
+    torch::ParameterDef* param_def) {
+  param_def->set_name(param.name);
+  param_def->set_is_buffer(param.is_buffer);
+  param_def->set_require_gradient(param.slot()->requires_grad());
+  auto it = tensorTable_.find(param.slot());
+  AT_ASSERT(it != tensorTable_.end());
+  param_def->set_tensor_id(c10::to_string(it->second));
+}
+
+void ScriptModuleSerializer::convertMethod(
+    const script::Method& method,
+    torch::MethodDef* method_def) {
+  // TODO encode the real torch script instead of ModelProto
+  MethodEncoder encoder(method, *this);
+  // we already keep the tree structure in the top level module,
+  // so pass "" as prefix
+  std::string torch_script = encoder.EncodeMethod(method, "");
+  method_def->set_onnx_proto(torch_script);
+}
+
 // Pretty printing
-namespace {
 constexpr char indent_char = ' ';
 constexpr size_t indent_multiplier = 2;
 
@@ -847,166 +1113,13 @@ void dump(const onnx::ModelProto& model, std::ostream& stream, size_t indent) {
   stream << idt(indent) << "}\n";
 }
 
-class ScriptModuleSerializer final {
- public:
-  ScriptModuleSerializer(const std::string& filename)
-      : ofs_(
-            filename,
-            std::ofstream::out | std::ofstream::trunc | std::ofstream::binary),
-        writer_(&ofs_) {
-    // TODO appropriate support for mmap, right now we still use stream writer
-  }
-  ScriptModuleSerializer(std::ostream* ofs) : ofs_(), writer_(ofs) {}
-  void serialize(const script::Module& module) {
-    torch::ModelDef model_def;
-    convertToModel(module, &model_def);
-    std::string output;
-    // NB: cannot use MessageToJsonString, since fbcode's protobuf is too old
-    // be consistent with MessageToJsonString
-    std::string url_prefix = "type.googleapis.com";
-    std::unique_ptr<::google::protobuf::util::TypeResolver> resolver(
-        ::google::protobuf::util::NewTypeResolverForDescriptorPool(
-            url_prefix, model_def.GetDescriptor()->file()->pool()));
-    ::google::protobuf::util::Status convert_result =
-        ::google::protobuf::util::BinaryToJsonString(
-            resolver.get(),
-            url_prefix + "/" + model_def.GetDescriptor()->full_name(),
-            model_def.SerializeAsString(),
-            &output);
-    if (!convert_result.ok()) {
-      std::stringstream ss;
-      ss << convert_result;
-      AT_ERROR(ss.str());
-    }
-    auto record_id = writer_.writeRecord(output.data(), output.size());
-    writer_.writeEndOfFile();
-  }
-
- private:
-  void convertToModel(
-      const script::Module& module,
-      torch::ModelDef* model_def) {
-    model_def->set_name("script-model");
-    model_def->set_producer_name("pytorch");
-    model_def->set_producer_version("1.0"); // TODO: set the producer version
-                                            // using appropriate function call
-    model_def->set_proto_version(torch::ProtoVersion::PROTO_VERSION_NEWEST);
-    std::string main_module_name = "";
-    collectParamsInfo(module, main_module_name);
-    convertModule(module, main_module_name, model_def->mutable_main_module());
-  }
-  void collectParamsInfo(
-      const script::Module& module,
-      const std::string& prefix) {
-    for (const auto& elem : module.get_parameters()) {
-      const script::NamedParameter& param = elem.value();
-      parameterMap_[param.slot()] = prefix + param.name;
-    }
-    for (const auto& elem : module.get_modules()) {
-      collectParamsInfo(*elem->module, prefix + elem.key() + ".");
-    }
-  }
-  void convertModule(
-      const script::Module& module,
-      const std::string& name,
-      torch::ModuleDef* module_def) {
-    module_def->set_name(name);
-    module_def->set_optimize(module.is_optimized());
-    for (const auto& elem : module.get_parameters()) {
-      torch::ParameterDef* param_def = module_def->add_parameters();
-      convertParameter(elem.value(), param_def);
-    }
-    for (auto& elem : module.get_methods()) {
-      torch::MethodDef* method_def = module_def->add_methods();
-      convertMethod(*elem.value(), method_def);
-    }
-    for (const auto& elem : module.get_modules()) {
-      torch::ModuleDef* sub_def = module_def->add_submodules();
-      convertModule(*elem->module, elem.key(), sub_def);
-    }
-  }
-  void convertParameter(
-      const script::NamedParameter& param,
-      torch::ParameterDef* param_def) {
-    param_def->set_name(param.name);
-    param_def->set_is_buffer(param.is_buffer);
-    param_def->set_require_gradient(param.slot()->requires_grad());
-    convertTensor(*(param.slot()), param_def->mutable_tensor());
-  }
-  void convertTensor(
-      const at::Tensor& tensor,
-      caffe2::TensorProto* tensor_proto) {
-    for (auto d : tensor.sizes()) {
-      tensor_proto->add_dims(d);
-    }
-    tensor_proto->set_data_type(caffe2::TypeMetaToDataType(
-        at::scalarTypeToTypeMeta(tensor.type().scalarType())));
-    tensor_proto->set_storage_type(caffe2::TensorProto_StorageType_EXTERNAL);
-    caffe2::ExternalDataProto* external_data =
-        tensor_proto->mutable_external_data();
-    for (auto s : tensor.strides()) {
-      external_data->add_strides(s);
-    }
-    external_data->set_offset(tensor.storage_offset());
-    uint64_t record_size =
-        tensor.type().elementSizeInBytes() * tensor.storage().size();
-    external_data->set_record_size(record_size);
-    auto* key = tensor.storage().unsafeGetStorageImpl();
-    auto it = storageMap_.find(key);
-    if (it == storageMap_.end()) {
-      // TODO HIP support
-      uint64_t record_id;
-      if (tensor.storage().device_type() == at::DeviceType::CUDA) {
-        // NB: This new tensor is created to support cuda tensors.
-        // Storages can be mutated when converting tensors from cuda to cpu,
-        // and we need a cpu tensor to copy data from.
-        at::Tensor t = at::getType(tensor)
-                           ._th_tensor(
-                               tensor.storage(),
-                               /* storageOffset = */ 0,
-                               /* size = */
-                               {static_cast<int64_t>(tensor.storage().size())},
-                               /* stride = */ {1})
-                           .cpu();
-        AT_ASSERT(
-            t.type().elementSizeInBytes() * t.storage().size() == record_size);
-        record_id = writer_.writeRecord(
-            t.storage().data(),
-            t.type().elementSizeInBytes() * t.storage().size());
-      } else {
-        record_id = writer_.writeRecord(tensor.storage().data(), record_size);
-      }
-      external_data->set_record_id(c10::to_string(record_id));
-      storageMap_[key] = record_id;
-    } else {
-      external_data->set_record_id(c10::to_string(it->second));
-    }
-    // TODO handle device case, set the device_detail and load to CUDA device
-  }
-  void convertMethod(script::Method& method, torch::MethodDef* method_def) {
-    // TODO encode the real torch script instead of ModelProto
-    MethodEncoder encoder(
-        method, &storageMap_, &parameterMap_, &writer_);
-    // we already keep the tree structure in the top level module,
-    // so pass "" as prefix
-    std::string torch_script = encoder.EncodeMethod(method, "");
-    method_def->set_onnx_proto(torch_script);
-  }
-  std::unordered_map<const void*, uint64_t>
-      storageMap_; // storage_ptr => record_offset
-  std::ofstream ofs_;
-  PyTorchStreamWriter writer_;
-  std::unordered_map<at::Tensor*, std::string> parameterMap_;
-};
-
-} // namespace
-
 std::string prettyPrint(const onnx::ModelProto& model) {
   std::stringstream ss;
   dump(model, ss, 0);
   return ss.str();
 }
-}
+
+} // namespace
 
 std::string PrettyPrintExportedGraph(
                         const std::shared_ptr<Graph> &graph,

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -28,14 +28,14 @@ namespace onnx = ::ONNX_NAMESPACE;
 
 // IR graph construction
 
+class ScriptModuleDeserializer;
+
 class MethodDecoder {
  public:
   MethodDecoder(
       const onnx::ModelProto& model_proto,
-      const std::unordered_map<std::string, at::Tensor*>& param_map,
       script::Module* parent_module,
-      std::unordered_map<uint64_t, std::shared_ptr<at::Storage>>* storage_map,
-      PyTorchStreamReader* stream_reader_);
+      ScriptModuleDeserializer* deserializer);
 
  private:
   std::shared_ptr<Graph> buildGraph(const onnx::GraphProto& graph_proto);
@@ -56,18 +56,60 @@ class MethodDecoder {
 
   TypePtr buildType(const onnx::TypeProto& type_proto);
 
-  at::Tensor buildTensorCommon(const onnx::TensorProto& tensor_proto,
-                               const uint64_t record_number,
-                               const int64_t storage_offset,
-                               const std::vector<int64_t>& strides);
-
   std::pair<std::shared_ptr<script::Module>, std::string> parseFullName(
       ModuleLookup module_lookup,
       const std::string fullname);
 
-  PyTorchStreamReader* stream_reader_;
-  std::unordered_map<uint64_t, std::shared_ptr<at::Storage>>* storage_map_;
+  // deserializer already loads the metadata of tensors, and it is used to
+  // load tensors
+  ScriptModuleDeserializer* deserializer_;
   std::unordered_map<std::string, const onnx::TypeProto*> value_type_map_;
+};
+
+// this is a deserializer class which loads script modules from pt files. the
+// content of the file is written using PyTorchStreamWriter, for details please
+// check caffe2/serialize/inline_container.h. all the records except the last
+// one are tensor data, and the last record is a serialized ModelProto, defined
+// in caffe2/proto/torch.proto. ModelProto contains all the metadata of the
+// model, and it is serialized as json.
+class ScriptModuleDeserializer final {
+ public:
+  ScriptModuleDeserializer(const std::string& filename);
+
+  ScriptModuleDeserializer(std::istream* is);
+
+  void deserialize(ModuleLookup module_lookup);
+
+  // given the tensor id, load the data of the tensor from file/stream,
+  // and return a new tensor which contains the loaded data
+  at::Tensor loadTensor(uint64_t tensor_id);
+
+  at::Tensor* lookupTensor(const std::string& param_name) const;
+
+ private:
+  // recursively load all the parameters of a module, and construct a
+  // parameter map (i.e., name => tensor). call loadTensor to load and
+  // create a new tensor
+  void loadParams(
+      const torch::ModuleDef& module_def,
+      const std::string& prefix);
+
+  void convertModule(
+      const torch::ModuleDef& module_def,
+      script::Module* module);
+
+  std::ifstream ifs_;
+  PyTorchStreamReader reader_;
+  // this is a hack to make sure the script module created in C++ is the
+  // same as created in Python
+  ModuleLookup moduleLookup_;
+  std::vector<std::string> moduleStack_;
+  // record_id => storage
+  std::unordered_map<uint64_t, std::shared_ptr<at::Storage>> storageMap_;
+  // tensor_id => TensorProto
+  std::unordered_map<uint64_t, const caffe2::TensorProto*> metaMap_;
+  // parameter_name => at::Tensor
+  std::unordered_map<std::string, at::Tensor*> paramMap_;
 };
 
 at::ScalarType MethodDecoder::onnxTypeToATenType(int32_t onnx_type) {
@@ -90,6 +132,28 @@ at::ScalarType MethodDecoder::onnxTypeToATenType(int32_t onnx_type) {
       return at::kDouble;
     default:
       throw std::runtime_error("Unsupported data type");
+  }
+}
+
+MethodDecoder::MethodDecoder(
+    const onnx::ModelProto& model_proto,
+    script::Module* parent_module,
+    ScriptModuleDeserializer* deserializer) {
+  deserializer_ = deserializer;
+  const auto& graph_proto = model_proto.graph();
+  for (const auto& node_proto : graph_proto.node()) {
+    std::vector<at::Tensor*> member_inputs;
+    const std::string& name = node_proto.name();
+    for (const auto& param_name : node_proto.input()) {
+      at::Tensor* tensor = deserializer_->lookupTensor(param_name);
+      member_inputs.push_back(tensor);
+    }
+    auto graph = buildGraph(node_proto.attribute(0).g());
+    parent_module->create_method(name, graph, member_inputs);
+    // We store the schema in the docstring so we can parse the schema and
+    // assign it to the method.
+    auto schema = parseSchema(node_proto.doc_string());
+    parent_module->get_method(name).setSchema(std::move(schema));
   }
 }
 
@@ -275,47 +339,6 @@ void MethodDecoder::buildIntermediateValue(
   value->setType(buildType(*it->second));
 }
 
-at::Tensor MethodDecoder::buildTensor(const onnx::TensorProto& tensor_proto) {
-  std::vector<int64_t> strides;
-  // We've stored two other values (record no., storage_offset) before strides; ignore it
-  std::move(tensor_proto.int64_data().begin() + 2, tensor_proto.int64_data().end(), std::back_inserter(strides));
-  return buildTensorCommon(tensor_proto,
-                           /* record_number = */ tensor_proto.int64_data(0),
-                           /* storage_offset = */ tensor_proto.int64_data(1),
-                           strides);
-}
-
-at::Tensor MethodDecoder::buildTensorCommon(
-    const onnx::TensorProto& tensor_proto,
-    const uint64_t record_number,
-    const int64_t storage_offset,
-    const std::vector<int64_t>& strides) {
-  // NB: storage_offset and strides are passed in separately because
-  // because they are encoded differently for parameters and tensors
-  auto type = onnxTypeToATenType(tensor_proto.data_type());
-  std::vector<int64_t> dims;
-  std::move(tensor_proto.dims().begin(), tensor_proto.dims().end(), std::back_inserter(dims));
-
-  // Find or create the storage
-  auto storage_it = storage_map_->find(record_number);
-  if (storage_it == storage_map_->end()) {
-    at::DataPtr storage_ptr;
-    int64_t size;
-    std::tie(storage_ptr, size) =
-        stream_reader_->getRecordWithKey(record_number);
-    auto storage = std::make_shared<at::Storage>(
-      at::CPU(type).typeMeta(),
-      std::move(storage_ptr),
-      size / at::CPU(type).typeMeta().itemsize(),
-      nullptr);
-    storage_map_->insert(std::make_pair(record_number, storage));
-    return at::CPU(type)._th_tensor(*storage, storage_offset, dims, strides);
-  }
-
-  auto storage = storage_it->second.get();
-  return at::CPU(type)._th_tensor(*storage, storage_offset, dims, strides);
-}
-
 // Given a full name of a parameter or method,
 // return the parent submodule and local name
 std::pair<std::shared_ptr<script::Module>, std::string> MethodDecoder::
@@ -333,171 +356,156 @@ std::pair<std::shared_ptr<script::Module>, std::string> MethodDecoder::
   return std::make_pair(module_lookup(vec), std::move(last));
 }
 
-MethodDecoder::MethodDecoder(
-    const onnx::ModelProto& model_proto,
-    const std::unordered_map<std::string, at::Tensor*>& param_map,
-    script::Module* parent_module,
-    std::unordered_map<uint64_t, std::shared_ptr<at::Storage>>* storage_map,
-    PyTorchStreamReader* stream_reader) {
-  storage_map_ = storage_map;
-  stream_reader_ = stream_reader;
-  const auto& graph_proto = model_proto.graph();
-  for (const auto& node_proto : graph_proto.node()) {
-    std::vector<at::Tensor*> member_inputs;
-    const std::string& name = node_proto.name();
-    for (const auto& param_name : node_proto.input()) {
-      auto it = param_map.find(param_name);
-      AT_ASSERTM(it != param_map.end(), "cannot find parameter ", param_name);
-      member_inputs.push_back(it->second);
-    }
-    auto graph = buildGraph(node_proto.attribute(0).g());
-    parent_module->create_method(name, graph, member_inputs);
-    // We store the schema in the docstring so we can parse the schema and
-    // assign it to the method.
-    auto schema = parseSchema(node_proto.doc_string());
-    parent_module->get_method(name).setSchema(std::move(schema));
+at::Tensor MethodDecoder::buildTensor(const onnx::TensorProto& tensor_proto) {
+  uint64_t tensor_id = caffe2::stoull(tensor_proto.name());
+  return deserializer_->loadTensor(tensor_id);
+}
+
+ScriptModuleDeserializer::ScriptModuleDeserializer(const std::string& filename)
+    : ifs_(filename, std::ifstream::in | std::ifstream::binary),
+      reader_(&ifs_) {
+  // TODO appropriate support for mmap, right now still use stream reader
+}
+
+ScriptModuleDeserializer::ScriptModuleDeserializer(std::istream* is)
+    : ifs_(), reader_(is) {}
+
+void ScriptModuleDeserializer::deserialize(ModuleLookup module_lookup) {
+  torch::ModelDef model_def;
+  at::DataPtr data_ptr;
+  size_t data_size;
+  std::tie(data_ptr, data_size) = reader_.getLastRecord();
+  // NB: cannot use JsonStringToMessage, since fbcode's protobuf is too old
+  // be consistent with JsonStringToMessage
+  std::string url_prefix = "type.googleapis.com";
+  std::unique_ptr<::google::protobuf::util::TypeResolver> resolver(
+      ::google::protobuf::util::NewTypeResolverForDescriptorPool(
+          url_prefix, model_def.GetDescriptor()->file()->pool()));
+  std::string json_string = std::string(
+      static_cast<char*>(data_ptr.get()),
+      static_cast<char*>(data_ptr.get()) + data_size);
+  std::string binary_string;
+  auto convert_result = ::google::protobuf::util::JsonToBinaryString(
+      resolver.get(),
+      url_prefix + "/" + model_def.GetDescriptor()->full_name(),
+      json_string,
+      &binary_string);
+  if (!convert_result.ok()) {
+    std::stringstream ss;
+    ss << convert_result;
+    AT_ERROR(ss.str());
+  }
+  AT_ASSERTM(
+      model_def.ParseFromString(binary_string),
+      "JSON transcoder produced invalid protobuf output.");
+  moduleLookup_ = module_lookup;
+
+  metaMap_.clear();
+  for (int i = 0; i < model_def.tensors_size(); ++i) {
+    const auto& tensor_proto = model_def.tensors(i);
+    uint64_t tensor_id = caffe2::stoull(tensor_proto.name());
+    metaMap_[tensor_id] = &tensor_proto;
+  }
+
+  const auto& module_def = model_def.main_module();
+
+  loadParams(module_def, module_def.name());
+  // TODO: this can be simplified when C++/Python interop lands,
+  // and the submodules would be created as the same in either C++ or Python
+  std::shared_ptr<script::Module> module = moduleLookup_(moduleStack_);
+  convertModule(module_def, module.get());
+}
+
+at::Tensor ScriptModuleDeserializer::loadTensor(uint64_t tensor_id) {
+  auto it = metaMap_.find(tensor_id);
+  AT_ASSERT(it != metaMap_.end());
+  const caffe2::TensorProto& tensor_proto = *it->second;
+  std::vector<int64_t> dims;
+  for (int i = 0; i < tensor_proto.dims_size(); ++i) {
+    dims.push_back(tensor_proto.dims(i));
+  }
+  AT_ASSERT(
+      tensor_proto.storage_type() == caffe2::TensorProto_StorageType_EXTERNAL);
+  const caffe2::ExternalDataProto& external_data = tensor_proto.external_data();
+  std::vector<int64_t> strides;
+  for (int i = 0; i < external_data.strides_size(); ++i) {
+    strides.push_back(external_data.strides(i));
+  }
+  auto type = at::typeMetaToScalarType(
+      caffe2::DataTypeToTypeMeta(tensor_proto.data_type()));
+  uint64_t record_id = caffe2::stoull(external_data.record_id());
+  AT_ASSERT(record_id != 0);
+  auto storage_it = storageMap_.find(record_id);
+  if (storage_it == storageMap_.end()) {
+    at::DataPtr storage_ptr;
+    uint64_t record_size;
+    std::tie(storage_ptr, record_size) = reader_.getRecordWithKey(record_id);
+    AT_ASSERT(record_size == external_data.record_size());
+    auto storage = std::make_shared<at::Storage>(
+        at::CPU(type).typeMeta(),
+        std::move(storage_ptr),
+        record_size / at::CPU(type).typeMeta().itemsize(),
+        nullptr); // NB: we didn't set any allocator for the tensor
+    storageMap_.insert(std::make_pair(record_id, storage));
+    return at::CPU(type)._th_tensor(
+        *storage, external_data.offset(), dims, strides);
+  }
+  return at::CPU(type)._th_tensor(
+      *(storage_it->second.get()), external_data.offset(), dims, strides);
+}
+
+at::Tensor* ScriptModuleDeserializer::lookupTensor(
+    const std::string& param_name) const {
+  auto it = paramMap_.find(param_name);
+  AT_ASSERTM(it != paramMap_.end(), "cannot find parameter ", param_name);
+  return it->second;
+}
+
+void ScriptModuleDeserializer::loadParams(
+    const torch::ModuleDef& module_def,
+    const std::string& prefix) {
+  std::shared_ptr<script::Module> module = moduleLookup_(moduleStack_);
+  for (int i = 0; i < module_def.parameters_size(); ++i) {
+    const torch::ParameterDef& param_def = module_def.parameters(i);
+    uint64_t tensor_id = caffe2::stoull(param_def.tensor_id());
+    at::Tensor tensor = loadTensor(tensor_id);
+    autograd::Variable variable =
+        autograd::make_variable(tensor, param_def.require_gradient());
+    module->register_parameter(
+        param_def.name(), variable, param_def.is_buffer());
+    paramMap_[prefix + param_def.name()] =
+        module->parameter_slot(param_def.name());
+  }
+  for (int i = 0; i < module_def.submodules_size(); ++i) {
+    const torch::ModuleDef& sub_def = module_def.submodules(i);
+    moduleStack_.push_back(sub_def.name());
+    loadParams(sub_def, prefix + sub_def.name() + ".");
+    moduleStack_.pop_back();
   }
 }
 
-// this is a deserializer class which loads script modules from pt files. the
-// content of the file is written using PyTorchStreamWriter, for details please
-// check caffe2/serialize/inline_container.h. all the records except the last
-// one are tensor data, and the last record is a serialized ModelProto, defined
-// in caffe2/proto/torch.proto. ModelProto contains all the metadata of the
-// model, and it is serialized as json.
-class ScriptModuleDeserializer final {
- public:
-  ScriptModuleDeserializer(const std::string& filename)
-      : ifs_(filename, std::ifstream::in | std::ifstream::binary),
-        reader_(&ifs_) {
-    // TODO appropriate support for mmap, right now still use stream reader
-  }
-  ScriptModuleDeserializer(std::istream* is) : ifs_(), reader_(is) {}
-  void deserialize(ModuleLookup module_lookup) {
-    torch::ModelDef model_def;
-    at::DataPtr data_ptr;
-    size_t data_size;
-    std::tie(data_ptr, data_size) = reader_.getLastRecord();
-    // NB: cannot use JsonStringToMessage, since fbcode's protobuf is too old
-    // be consistent with JsonStringToMessage
-    std::string url_prefix = "type.googleapis.com";
-    std::unique_ptr<::google::protobuf::util::TypeResolver> resolver(
-        ::google::protobuf::util::NewTypeResolverForDescriptorPool(
-            url_prefix, model_def.GetDescriptor()->file()->pool()));
-    std::string json_string = std::string(
-        static_cast<char*>(data_ptr.get()),
-        static_cast<char*>(data_ptr.get()) + data_size);
-    std::string binary_string;
-    auto convert_result = ::google::protobuf::util::JsonToBinaryString(
-        resolver.get(),
-        url_prefix + "/" + model_def.GetDescriptor()->full_name(),
-        json_string,
-        &binary_string);
-    if (!convert_result.ok()) {
-      std::stringstream ss;
-      ss << convert_result;
-      AT_ERROR(ss.str());
-    }
+void ScriptModuleDeserializer::convertModule(
+    const torch::ModuleDef& module_def,
+    script::Module* module) {
+  module->set_optimized(module_def.optimize());
+  for (int i = 0; i < module_def.methods_size(); ++i) {
+    const torch::MethodDef& method_def = module_def.methods(i);
+    // TODO read unhacked torch script, right now it's serialized onnx proto
+    ::ONNX_NAMESPACE::ModelProto method_proto;
     AT_ASSERTM(
-        model_def.ParseFromString(binary_string),
-        "JSON transcoder produced invalid protobuf output.");
-    moduleLookup_ = module_lookup;
-    const auto& module_def = model_def.main_module();
-    collectParamsInfo(module_def, module_def.name());
-    // TODO: this can be simplified when C++/Python interop lands,
-    // and the submodules would be created as the same in either C++ or Python
-    std::shared_ptr<script::Module> module = moduleLookup_(moduleStack_);
-    convertModule(module_def, module.get());
+        method_proto.ParseFromString(method_def.onnx_proto()),
+        "cannot parse method proto (i.e., hacked onnx proto)");
+    MethodDecoder decoder(method_proto, module, this);
+    (void)decoder;
   }
-
- private:
-  void collectParamsInfo(
-      const torch::ModuleDef& module_def,
-      const std::string& prefix) {
-    std::shared_ptr<script::Module> module = moduleLookup_(moduleStack_);
-    for (int i = 0; i < module_def.parameters_size(); ++i) {
-      const torch::ParameterDef& param_def = module_def.parameters(i);
-      at::Tensor tensor = createTensor(param_def.tensor());
-      autograd::Variable variable =
-          autograd::make_variable(tensor, param_def.require_gradient());
-      module->register_parameter(
-          param_def.name(), variable, param_def.is_buffer());
-      parameterMap_[prefix + param_def.name()] =
-          module->parameter_slot(param_def.name());
-    }
-    for (int i = 0; i < module_def.submodules_size(); ++i) {
-      const torch::ModuleDef& sub_def = module_def.submodules(i);
-      moduleStack_.push_back(sub_def.name());
-      collectParamsInfo(sub_def, prefix + sub_def.name() + ".");
-      moduleStack_.pop_back();
-    }
+  for (int i = 0; i < module_def.submodules_size(); ++i) {
+    const torch::ModuleDef& sub_def = module_def.submodules(i);
+    moduleStack_.push_back(sub_def.name());
+    std::shared_ptr<script::Module> sub = moduleLookup_(moduleStack_);
+    convertModule(sub_def, sub.get());
+    moduleStack_.pop_back();
   }
-  void convertModule(
-      const torch::ModuleDef& module_def,
-      script::Module* module) {
-    module->set_optimized(module_def.optimize());
-    for (int i = 0; i < module_def.methods_size(); ++i) {
-      const torch::MethodDef& method_def = module_def.methods(i);
-      // TODO read unhacked torch script, right now it's serialized onnx proto
-      ::ONNX_NAMESPACE::ModelProto method_proto;
-      AT_ASSERTM(
-          method_proto.ParseFromString(method_def.onnx_proto()),
-          "cannot parse method proto (i.e., hacked onnx proto)");
-      MethodDecoder decoder(
-          method_proto, parameterMap_, module, &storageMap_, &reader_);
-      (void)decoder;
-    }
-    for (int i = 0; i < module_def.submodules_size(); ++i) {
-      const torch::ModuleDef& sub_def = module_def.submodules(i);
-      moduleStack_.push_back(sub_def.name());
-      std::shared_ptr<script::Module> sub = moduleLookup_(moduleStack_);
-      convertModule(sub_def, sub.get());
-      moduleStack_.pop_back();
-    }
-  }
-  at::Tensor createTensor(const caffe2::TensorProto& tensor_proto) {
-    std::vector<int64_t> dims;
-    for (int i = 0; i < tensor_proto.dims_size(); ++i) {
-      dims.push_back(tensor_proto.dims(i));
-    }
-    AT_ASSERT(
-        tensor_proto.storage_type() ==
-        caffe2::TensorProto_StorageType_EXTERNAL);
-    const caffe2::ExternalDataProto& external_data =
-        tensor_proto.external_data();
-    std::vector<int64_t> strides;
-    for (int i = 0; i < external_data.strides_size(); ++i) {
-      strides.push_back(external_data.strides(i));
-    }
-    auto type = at::typeMetaToScalarType(
-        caffe2::DataTypeToTypeMeta(tensor_proto.data_type()));
-    uint64_t record_id = c10::stoull(external_data.record_id());
-    AT_ASSERT(record_id != 0);
-    auto storage_it = storageMap_.find(record_id);
-    if (storage_it == storageMap_.end()) {
-      at::DataPtr storage_ptr;
-      uint64_t record_size;
-      std::tie(storage_ptr, record_size) = reader_.getRecordWithKey(record_id);
-      AT_ASSERT(record_size == external_data.record_size());
-      auto storage = std::make_shared<at::Storage>(
-          at::CPU(type).typeMeta(),
-          std::move(storage_ptr),
-          record_size / at::CPU(type).typeMeta().itemsize(),
-          nullptr); // NB: we didn't set any allocator for the tensor
-      storageMap_.insert(std::make_pair(record_id, storage));
-      return at::CPU(type)._th_tensor(
-          *storage, external_data.offset(), dims, strides);
-    }
-    return at::CPU(type)._th_tensor(
-        *(storage_it->second.get()), external_data.offset(), dims, strides);
-  }
-  std::ifstream ifs_;
-  PyTorchStreamReader reader_;
-  ModuleLookup moduleLookup_;
-  std::vector<std::string> moduleStack_;
-  std::unordered_map<uint64_t, std::shared_ptr<at::Storage>> storageMap_;
-  std::unordered_map<std::string, at::Tensor*> parameterMap_;
-};
+}
 
 }  // namespace
 


### PR DESCRIPTION
As we discussed, the tensors in the torch script will be associated with the tensor data in the serialized file. So let's add a table of tensor (actually it's a repeated TensorProto filed) in the ModelDef. TensorProto.name will be the id.

#accept2ship