### PR TITLE
Fix cuda out of memory test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -834,7 +834,7 @@ class TestCuda(TestCase):
         tensor = torch.zeros(1024, device='cuda')
 
         with self.assertRaisesRegex(RuntimeError, "Tried to allocate 80.00 GiB"):
-            torch.randn(1024 * 1024 * 1024 * 80, dtype=torch.int8, device='cuda')
+            torch.empty(1024 * 1024 * 1024 * 80, dtype=torch.int8, device='cuda')
 
         # ensure out of memory error doesn't disturb subsequent kernel
         tensor.fill_(1)


### PR DESCRIPTION
torch.randn(big_number_here, dtype=torch.int8) is wrong because randn
isn't implemented for torch.int8. I've changed it to use torch.empty
instead.

