### PR TITLE
Minor fix to reenable nvtx sequence numbers for the forward methods of custom (Python) autograd functions

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -705,6 +705,8 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
 {
   HANDLE_TH_ERRORS
   torch::autograd::profiler::RecordFunction record(((PyTypeObject*)cls)->tp_name);
+  torch::autograd::profiler::RecordFunction record(((PyTypeObject*)cls)->tp_name, 
+                                                   Function::peek_at_next_sequence_nr());
 
   THPObjectPtr backward_cls(PyObject_GetAttrString(cls, "_backward_cls"));
   if (!backward_cls) return nullptr;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -674,7 +674,8 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
 PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
 {
   HANDLE_TH_ERRORS
-  torch::autograd::profiler::RecordFunction record(Py_TYPE(self)->tp_name);
+  torch::autograd::profiler::RecordFunction record(Py_TYPE(self)->tp_name,
+                                                   Function::peek_at_next_sequence_nr());
 
   auto info_pair = unpack_input<true>(_inputs);
   auto& unpacked_input = info_pair.first;
@@ -704,7 +705,6 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
 PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
 {
   HANDLE_TH_ERRORS
-  torch::autograd::profiler::RecordFunction record(((PyTypeObject*)cls)->tp_name);
   torch::autograd::profiler::RecordFunction record(((PyTypeObject*)cls)->tp_name, 
                                                    Function::peek_at_next_sequence_nr());
 


### PR DESCRIPTION
Some of our arch people (@mkolod, Aditya Agrawal, @kevinstephano) notified me that the sequence number annotations weren't showing up for forward methods of custom autograd functions, which was breaking their nvprof dump parsing.  Two one-line fixes in the appropriate code paths.

