### PR TITLE
[JIT] Fix optional import/export, export multi-margin-loss

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -758,6 +758,9 @@ struct CAFFE2_API BoolType : public Type {
     return "bool";
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
+    if(auto rhs_ = rhs->cast<OptionalType>()) {
+      return this->isSubtypeOf(rhs_->getElementType());
+    }
     return *this == *rhs || rhs->kind() == TypeKind::BoolType;
   }
   static const TypeKind Kind = TypeKind::BoolType;

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -251,9 +251,10 @@ TypePtr MethodDecoder::buildType(const onnx::TypeProto& type_proto) {
   } else if (kind == "StringType") {
     return StringType::get();
   } else if (kind.find("OptionalType") == 0) {
-    onnx::TypeProto elem_proto(type_proto);
-    elem_proto.set_denotation(kind.substr(strlen("OptionalType:")));
-    return OptionalType::create(buildType(elem_proto));
+    auto subkind = shape_proto.dim(0);
+    auto it = value_type_map_.find(subkind.dim_param());
+    JIT_ASSERT(it != value_type_map_.end());
+    return OptionalType::create(buildType(*it->second));
   } else if (kind.find("TypeVar:") == 0) {
     return VarType::create(kind.substr(strlen("TypeVar:")));
   } else {

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -250,7 +250,7 @@ TypePtr MethodDecoder::buildType(const onnx::TypeProto& type_proto) {
     return GeneratorType::get();
   } else if (kind == "StringType") {
     return StringType::get();
-  } else if (kind.find("OptionalType") == 0) {
+  } else if (kind == "OptionalType") {
     auto subkind = shape_proto.dim(0);
     auto it = value_type_map_.find(subkind.dim_param());
     JIT_ASSERT(it != value_type_map_.end());

--- a/torch/nn/_reduction.py
+++ b/torch/nn/_reduction.py
@@ -1,5 +1,6 @@
 import warnings
 from .._jit_internal import weak_script
+import torch
 
 # NB: Keep this file in sync with enums in aten/src/ATen/core/Reduction.h
 
@@ -28,7 +29,7 @@ def get_enum(reduction):
 # We use these functions in torch/legacy as well, in which case we'll silence the warning
 @weak_script
 def legacy_get_string(size_average, reduce, emit_warning=True):
-    # type: (bool, bool, bool) -> str
+    # type: (Optional[bool], Optional[bool], bool) -> str
     warning = "size_average and reduce args will be deprecated, please use reduction='{}' instead."
 
     if size_average is None:
@@ -36,6 +37,8 @@ def legacy_get_string(size_average, reduce, emit_warning=True):
     if reduce is None:
         reduce = True
 
+    size_average = torch.jit._unwrap_optional(size_average)
+    reduce = torch.jit._unwrap_optional(reduce)
     if size_average and reduce:
         ret = 'mean'
     elif reduce:
@@ -49,5 +52,5 @@ def legacy_get_string(size_average, reduce, emit_warning=True):
 
 @weak_script
 def legacy_get_enum(size_average, reduce, emit_warning=True):
-    # type: (bool, bool, bool) -> int
+    # type: (Optional[bool], Optional[bool], bool) -> int
     return get_enum(legacy_get_string(size_average, reduce, emit_warning))


### PR DESCRIPTION
This PR did two thing:

1. it fix the optional import/export to include any type including tensor types (previously we only support base types), this is essential to unblock optional tensor type annotation in our test logic
2. it tries to export mult_margin_loss functional to serve as a example of optional undefined tensor use case. 