### PR TITLE
Fix document about torch.get_default_dtype()

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1977,7 +1977,7 @@ Example::
 
 add_docstr(torch.get_default_dtype,
            r"""
-get_default_dtype() -> :class:`torch.dtype`
+get_default_dtype() -> torch.dtype
 
 Get the current default floating point :class:`torch.dtype`.
 


### PR DESCRIPTION
Minor fix.
```
torch.get_default_dtype() → :class:`torch.dtype`
```
→
```
torch.get_default_dtype() → torch.dtype
```
:class: is not rendered in https://pytorch.org/docs/stable/torch.html