### PR TITLE
Jit load error msg

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -178,8 +178,7 @@ class PyTorchStreamReader final {
     std::streamsize read_bytes = in_->gcount();
     AT_ASSERTM(
         read_bytes == 8,
-        "Expected to read 8 bytes but got %llu bytes",
-        read_bytes);
+        "Expected to read 8 bytes but got ", read_bytes, " bytes");
     cursor_ += read_bytes;
     return retval;
   }
@@ -206,11 +205,11 @@ class PyTorchStreamReader final {
     uint64_t file_format_version = read64BitIntegerLittleEndian();
     AT_ASSERTM(
         file_format_version <= kMaxSupportedFileFormatVersion,
-        "Attempted to read a PyTorch file with version "
-        "%llu, but the maximum supported version for reading is "
-        "%llu. Your PyTorch installation may be too old.",
+        "Attempted to read a PyTorch file with version ",
         file_format_version,
-        kMaxSupportedFileFormatVersion);
+        ", but the maximum supported version for reading is ",
+        kMaxSupportedFileFormatVersion,
+        ". Your PyTorch installation may be too old.");
     seekToNextAlignmentBoundary();
   }
 

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -411,9 +411,7 @@ std::shared_ptr<script::Module> load(std::istream& in) {
 std::shared_ptr<script::Module> load(const std::string& filename) {
   std::ifstream in(filename, std::ios_base::binary);
 
-  if (in.fail()) {
-    throw std::runtime_error("load: could not open file " + filename);
-  }
+  AT_CHECK(! in.fail(), "load: could not open file ", filename);
 
   auto module = load(in);
 

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -411,6 +411,10 @@ std::shared_ptr<script::Module> load(std::istream& in) {
 std::shared_ptr<script::Module> load(const std::string& filename) {
   std::ifstream in(filename, std::ios_base::binary);
 
+  if (in.fail()) {
+    throw std::runtime_error("load: could not open file " + filename);
+  }
+
   auto module = load(in);
 
   return module;


### PR DESCRIPTION
When loading a non-existant / non-openeable file, the current error message is
```
Expected to read 8 bytes but got %llu bytes0
```

This
- fixes two ASSERTM formatting calls (including the above),
- throws a more specific error message if the ifstream constructor sets `.fail`.

Here is someone apparently confused by the current message: https://github.com/facebookresearch/maskrcnn-benchmark/pull/138#issuecomment-437848307
