### PR TITLE
Temporarily skip test_spectral_norm on CUDA 8

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1727,7 +1727,11 @@ class TestNN(NNTestCase):
         self.assertIsInstance(m, nn.Linear)
 
     @skipIfRocm
-    @unittest.skipIf(TEST_CUDA and torch.version.cuda.startswith('8.'), 'Test is flaky on CUDA 8')
+    @unittest.skipIf(
+        (TEST_CUDA and
+         torch.version.cuda is not None and
+         torch.version.cuda.startswith('8.')),
+        'Test is flaky on CUDA 8')
     def test_spectral_norm(self):
         input = torch.randn(3, 5)
         m = nn.Linear(5, 7)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1727,6 +1727,7 @@ class TestNN(NNTestCase):
         self.assertIsInstance(m, nn.Linear)
 
     @skipIfRocm
+    @unittest.skipIf(TEST_CUDA and torch.version.cuda.startswith('8.'), 'Test is flaky on CUDA 8')
     def test_spectral_norm(self):
         input = torch.randn(3, 5)
         m = nn.Linear(5, 7)


### PR DESCRIPTION
Test is flaky on CUDA 8. See #13818

