### PR TITLE
Fix legacy TH resize behavior

### DIFF
--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -4,6 +4,7 @@
 #include "THC/THCTensor.hpp"
 
 #include "ATen/cuda/CUDAGuard.h"
+#include "ATen/native/Resize.h"
 
 namespace at { namespace native {
 
@@ -12,16 +13,17 @@ namespace at { namespace native {
 // to benchmark than THC; I can't get gbenchmark to call fns from THTensor.cpp
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size) {
-  if (new_size + self->storage_offset() > 0) {
-    if (!THTensor_getStoragePtr(self)) {
-      AT_ERROR("Tensor: invalid null storage");
-    }
-    if (new_size + self->storage_offset() > self->storage().numel()) {
-      THCStorage_resize(
-          globalContext().getTHCState(),
-          THTensor_getStoragePtr(self),
-          new_size + self->storage_offset());
-    }
+  if (new_size == 0) {
+    return;
+  }
+  if (!THTensor_getStoragePtr(self)) {
+    AT_ERROR("Tensor: invalid null storage");
+  }
+  if (new_size > self->storage().numel()) {
+    THCStorage_resize(
+        globalContext().getTHCState(),
+        THTensor_getStoragePtr(self),
+        new_size);
   }
 }
 
@@ -40,18 +42,14 @@ inline TensorImpl* resize_impl_cuda_(
     guard.set_index(self->storage().device().index());
   }
 
+  int64_t storage_offset = self->storage_offset();
   int64_t storage_size = 1;
   if (stride) {
     self->set_sizes_and_strides(size, *stride);
-    // NB: storage size can be different from numel.
-    for (size_t dim = 0; dim < size.size(); ++dim) {
-      // FIXME: Don't rely on storage_size being negative because this
-      // may not be true for some edge cases.
-      storage_size += (size[dim] - 1) * stride.value()[dim];
-    }
+    storage_size = computeStorageSize(size, *stride, storage_offset);
   } else {
     self->set_sizes_contiguous(size);
-    storage_size = self->numel();
+    storage_size = self->numel() + storage_offset;
   }
   maybe_resize_storage_cuda(self, storage_size);
 


### PR DESCRIPTION
Cleaning up some bad code I found: TH used a potentially incorrect check to detect tensors with arbitary zero-dims. This PR fixes that.

Test Plan:
- run tests

