### PR TITLE
Change assert --> CUDA_ASSERT_KERNEL to avoid hip undefined __assert_fail

### DIFF
--- a/caffe2/operators/top_k_radix_selection.cuh
+++ b/caffe2/operators/top_k_radix_selection.cuh
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_OPERATORS_TOP_K_RADIX_SELECTION_H_
 #define CAFFE2_OPERATORS_TOP_K_RADIX_SELECTION_H_
 
+#include "caffe2/core/common_gpu.h"
 #include "caffe2/utils/GpuDefs.cuh"
 #include "caffe2/utils/GpuScanUtils.cuh"
 #include "caffe2/utils/math.h"
@@ -75,7 +76,7 @@ struct TopKTypeConfig<short> {
   typedef unsigned int RadixType;
 
   static inline __device__ RadixType convert(short v) {
-    assert(sizeof(short) == 2);
+    CUDA_KERNEL_ASSERT(sizeof(short) == 2);
     return 32768u + v;
   }
 
@@ -89,7 +90,7 @@ struct TopKTypeConfig<int> {
   typedef unsigned int RadixType;
 
   static inline __device__ RadixType convert(int v) {
-    assert(sizeof(int) == 4);
+    CUDA_KERNEL_ASSERT(sizeof(int) == 4);
     return 2147483648u + v;
   }
 
@@ -103,7 +104,7 @@ struct TopKTypeConfig<long> {
   typedef unsigned long long int RadixType;
 
   static inline __device__ RadixType convert(long v) {
-    assert(sizeof(long) == 8);
+    CUDA_KERNEL_ASSERT(sizeof(long) == 8);
     return 9223372036854775808ull + v;
   }
 
@@ -244,7 +245,7 @@ __device__ DataType findPattern(DataType* smem,
   }
 
   // should not get here
-  assert(false);
+  CUDA_KERNEL_ASSERT(false);
   return (DataType)0;
 }
 
@@ -406,7 +407,7 @@ __global__ void gatherTopK(const T* inputPtr,
 
     if (hasTopK) {
       int writeIndex = writeIndexStart + index;
-      assert(writeIndex < outputSliceSize);
+      CUDA_KERNEL_ASSERT(writeIndex < outputSliceSize);
 
       int topKOffset = writeIndex;
       int indexOffset = writeIndex;
@@ -423,7 +424,7 @@ __global__ void gatherTopK(const T* inputPtr,
   // writeIndexStart. There might be more than that number available,
   // in which case we have to choose the first seen set. We do this
   // via a prefix sum to calculate indices for writing results.
-  assert(outputSliceSize >= writeIndexStart);
+  CUDA_KERNEL_ASSERT(outputSliceSize >= writeIndexStart);
   int topKRemaining = (outputSliceSize - writeIndexStart);
 
   for (int i = threadIdx.x; i < numIterations; i += blockDim.x) {
@@ -437,7 +438,7 @@ __global__ void gatherTopK(const T* inputPtr,
 
     if (hasTopK && index < topKRemaining) {
       int writeIndex = writeIndexStart + index;
-      assert(writeIndex < outputSliceSize);
+      CUDA_KERNEL_ASSERT(writeIndex < outputSliceSize);
 
       int topKOffset = writeIndex;
       int indexOffset = writeIndex;


### PR DESCRIPTION
Summary:
Change assert --> CUDA_ASSERT_KERNEL to avoid hip undefined __assert_fail()

Otherwise crash trace:

```
caffe2/caffe2/operators/hip/top_k_radix_selection_hip.cuh:409:7: error:  '__assert_fail':  no overloaded function has restriction specifiers that are compatible with the ambient context 'gatherTopK'
      assert(writeIndex < outputSliceSize);
      ^
glibc/include/assert.h:88:6: note: expanded from macro 'assert'
   : __assert_fail (#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))
     ^
```

Differential Revision: D13042820
