### PR TITLE
Fix a bug that causes nvcc to emit an unknown option error

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -342,7 +342,7 @@ endforeach()
 set(CUDA_PROPAGATE_HOST_FLAGS_BLACKLIST "-Werror")
 if (NOT MSVC)
   list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
-  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
+  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
 endif()
 
 # Debug and Release symbol support


### PR DESCRIPTION
Using `"-Xcompiler -fPIC"` causes nvcc to emit the following:

    nvcc fatal   : Unknown option 'Xcompiler -fPIC'

As per fixes lower down in the file (see also issue #7126 on GitHub),
the fix is to replace it with `"-Xcompiler" "-fPIC"`. This one was
apparently missed when the original fix was applied.

