### PR TITLE
Move most scalar checks from nn.yaml into THNN/THCUNN code.

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -3,17 +3,20 @@
 - name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight={}, int64_t reduction=Reduction::Mean)
   cname: BCECriterion
   scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: l1_loss(Tensor self, Tensor target, int64_t reduction=Reduction::Mean)
   cname: AbsCriterion
   scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: mse_loss(Tensor self, Tensor target, int64_t reduction=Reduction::Mean)
   cname: MSECriterion
   scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: multi_margin_loss(Tensor self, LongTensor target, Scalar p=1, Scalar margin=1, Tensor weight={}, int64_t reduction=Reduction::Mean)
   cname: MultiMarginCriterion
@@ -44,12 +47,14 @@
 - name: smooth_l1_loss(Tensor self, Tensor target, int64_t reduction=Reduction::Mean)
   cname: SmoothL1Criterion
   scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: soft_margin_loss(Tensor self, Tensor target, int64_t reduction=Reduction::Mean)
   cname: SoftMarginCriterion
   scalar_check:
-    output: reduction != Reduction::None || self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 # Activation functions
 
@@ -57,8 +62,8 @@
   cname: ELU
   has_inplace: True
   scalar_check:
-    output: self_->dim() == 0
-    grad_input: output_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: glu(Tensor self, int64_t dim=-1)
   cname: GatedLinear
@@ -66,25 +71,29 @@
     dim: self
   scalar_check:
     output: 'false'
+    grad_input: 'false'
 
 - name: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1)
   cname: HardTanh
   has_inplace: True
   scalar_check:
-    output: self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: leaky_relu(Tensor self, Scalar negative_slope=0.01)
   cname: LeakyReLU
   has_inplace: True
   scalar_check:
-    output: self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: log_sigmoid(Tensor self)
   cname: LogSigmoid
   buffers: [buffer]
   scalar_check:
-    output: self_->dim() == 0
-    buffer: self_->dim() == 0
+    output: 'false'
+    buffer: 'false'
+    grad_input: 'false'
 
 # NOTE: we treat noise as an input (it's really a buffer) because the codegen
 # can't handle in-place functions that have buffers
@@ -92,79 +101,130 @@
   cname: RReLU
   has_inplace: True
   scalar_check:
-    output: self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: softplus(Tensor self, Scalar beta=1, Scalar threshold=20)
   cname: SoftPlus
   scalar_check:
-    output: self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: softshrink(Tensor self, Scalar lambd=0.5)
   cname: SoftShrink
   scalar_check:
-    output: self_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 # Pooling
 
 - name: adaptive_avg_pool2d(Tensor self, IntList[2] output_size)
   cname: SpatialAdaptiveAveragePooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: adaptive_avg_pool3d(Tensor self, IntList[3] output_size)
   cname: VolumetricAdaptiveAveragePooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: adaptive_max_pool2d(Tensor self, IntList[2] output_size)
   cname: SpatialAdaptiveMaxPooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: adaptive_max_pool3d(Tensor self, IntList[3] output_size)
   cname: VolumetricAdaptiveMaxPooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: avg_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, bool ceil_mode=false, bool count_include_pad=true)
   cname: SpatialAveragePooling
   default_init:
     stride: kernel_size
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: avg_pool3d(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, bool ceil_mode=false, bool count_include_pad=true)
   cname: VolumetricAveragePooling
   default_init:
     stride: kernel_size
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: fractional_max_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] output_size, Tensor random_samples)
   cname: SpatialFractionalMaxPooling
   scalar_check:
+    grad_input: 'false'
+  scalar_check:
     output: 'false'
+    grad_input: 'false'
 
 - name: max_pool2d_with_indices(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, IntList[2] dilation=1, bool ceil_mode=false)
   cname: SpatialDilatedMaxPooling
   default_init:
     stride: kernel_size
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: max_pool3d_with_indices(Tensor self, IntList[3] kernel_size, IntList[3] stride={}, IntList[3] padding=0, IntList[3] dilation=1, bool ceil_mode=false)
   cname: VolumetricDilatedMaxPooling
   default_init:
     stride: kernel_size
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: max_unpool2d(Tensor self, LongTensor indices, IntList[2] output_size)
   cname: SpatialMaxUnpooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: max_unpool3d(Tensor self, LongTensor indices, IntList[3] output_size, IntList[3] stride, IntList[3] padding)
   cname: VolumetricMaxUnpooling
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 # Padding
 
 - name: reflection_pad1d(Tensor self, IntList[2] padding)
   cname: TemporalReflectionPadding
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: reflection_pad2d(Tensor self, IntList[4] padding)
   cname: SpatialReflectionPadding
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: replication_pad1d(Tensor self, IntList[2] padding)
   cname: TemporalReplicationPadding
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: replication_pad2d(Tensor self, IntList[4] padding)
   cname: SpatialReplicationPadding
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: replication_pad3d(Tensor self, IntList[6] padding)
   cname: VolumetricReplicationPadding
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 # Upsampling
 
@@ -174,31 +234,37 @@
 - name: upsample_linear1d(Tensor self, IntList[1] output_size, bool align_corners)
   cname: TemporalUpSamplingLinear
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 - name: upsample_bilinear2d(Tensor self, IntList[2] output_size, bool align_corners)
   cname: SpatialUpSamplingBilinear
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 - name: upsample_trilinear3d(Tensor self, IntList[3] output_size, bool align_corners)
   cname: VolumetricUpSamplingTrilinear
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 - name: upsample_nearest1d(Tensor self, IntList[1] output_size)
   cname: TemporalUpSamplingNearest
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 - name: upsample_nearest2d(Tensor self, IntList[2] output_size)
   cname: SpatialUpSamplingNearest
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 - name: upsample_nearest3d(Tensor self, IntList[3] output_size)
   cname: VolumetricUpSamplingNearest
   scalar_check:
+    self: 'false'
     grad_input: 'false'
 
 
@@ -208,14 +274,14 @@
 - name: _sigmoid(Tensor self)
   cname: Sigmoid
   scalar_check:
-    output: self_->dim() == 0
-    grad_input: output_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 - name: _tanh(Tensor self)
   cname: Tanh
   scalar_check:
-    output: self_->dim() == 0
-    grad_input: output_->dim() == 0
+    output: 'false'
+    grad_input: 'false'
 
 # Convolutions
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -226,6 +226,11 @@ void THTensor_(resizeAs)(THTensor *self, THTensor *src)
     THTensor_(resizeNd)(self, src->dim(), THTensor_getSizePtr(src), NULL);
 }
 
+void THTensor_(resize0d)(THTensor *tensor)
+{
+  THTensor_(resizeNd)(tensor, 0, {}, nullptr);
+}
+
 void THTensor_(resize1d)(THTensor *tensor, int64_t size0)
 {
   int64_t size[1] = {size0};
@@ -588,6 +593,18 @@ void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t stora
 void THTensor_(resizeNd)(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
 {
   return THTensor_resizeNd(self, nDimension, size, stride);
+}
+
+void THTensor_(set0d)(THTensor *tensor, scalar_t value)
+{
+  THArgCheck(THTensor_nDimension(tensor) == 0, 1, "tensor must have no dimensions");
+  THStorage_(set)(THTensor_getStoragePtr(tensor), tensor->storage_offset(), value);
+}
+
+scalar_t THTensor_(get0d)(const THTensor *tensor)
+{
+  THArgCheck(THTensor_nDimension(tensor) == 0, 1, "tensor must have no dimensions");
+  return THStorage_(get)(THTensor_getStoragePtr(tensor), tensor->storage_offset());
 }
 
 void THTensor_(set1d)(THTensor *tensor, int64_t x0, scalar_t value)

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -75,6 +75,7 @@ TH_API THTensor *THTensor_(newUnfold)(THTensor *tensor, int dimension_, int64_t 
 // values, unless you are doing some size and stride tricks, do not use resize*.
 TH_API void THTensor_(resizeNd)(THTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
 TH_API void THTensor_(resizeAs)(THTensor *tensor, THTensor *src);
+TH_API void THTensor_(resize0d)(THTensor *tensor);
 TH_API void THTensor_(resize1d)(THTensor *tensor, int64_t size0_);
 TH_API void THTensor_(resize2d)(THTensor *tensor, int64_t size0_, int64_t size1_);
 TH_API void THTensor_(resize3d)(THTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
@@ -119,11 +120,13 @@ TH_API void THTensor_(free)(THTensor *self);
 TH_API void THTensor_(freeCopyTo)(THTensor *self, THTensor *dst);
 
 /* Slow access methods [check everything] */
+TH_API void THTensor_(set0d)(THTensor *tensor, scalar_t value);
 TH_API void THTensor_(set1d)(THTensor *tensor, int64_t x0, scalar_t value);
 TH_API void THTensor_(set2d)(THTensor *tensor, int64_t x0, int64_t x1, scalar_t value);
 TH_API void THTensor_(set3d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, scalar_t value);
 TH_API void THTensor_(set4d)(THTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, scalar_t value);
 
+TH_API scalar_t THTensor_(get0d)(const THTensor *tensor);
 TH_API scalar_t THTensor_(get1d)(const THTensor *tensor, int64_t x0);
 TH_API scalar_t THTensor_(get2d)(const THTensor *tensor, int64_t x0, int64_t x1);
 TH_API scalar_t THTensor_(get3d)(const THTensor *tensor, int64_t x0, int64_t x1, int64_t x2);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -250,6 +250,11 @@ void THCTensor_(resizeAs)(THCState *state, THCTensor *self, THCTensor *src)
   THCTensor_resizeAs(state, self, src);
 }
 
+void THCTensor_(resize0d)(THCState *state, THCTensor *tensor)
+{
+  THCTensor_resizeNd(state, tensor, 0, {}, nullptr);
+}
+
 void THCTensor_(resize1d)(THCState *state, THCTensor *tensor, int64_t size0)
 {
   int64_t size[1] = {size0};
@@ -534,6 +539,19 @@ void THCTensor_(setStorageNd)(THCState *state, THCTensor *self, THCStorage *stor
 void THCTensor_(resizeNd)(THCState *state, THCTensor *self, int nDimension, const int64_t *size, const int64_t *stride)
 {
   THCTensor_resizeNd(state, self, nDimension, size, stride);
+}
+
+void THCTensor_(set0d)(THCState *state, THCTensor *tensor, scalar_t value)
+{
+  THArgCheck(THTensor_nDimension(tensor) == 0, 1, "tensor must have no dimensions");
+  THCStorage_(set)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset(), value);
+}
+
+
+scalar_t THCTensor_(get0d)(THCState *state, const THCTensor *tensor)
+{
+  THArgCheck(THTensor_nDimension(tensor) == 0, 1, "tensor must have no dimensions dimension");
+  return THCStorage_(get)(state, THTensor_getStoragePtr(tensor), tensor->storage_offset());
 }
 
 void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, scalar_t value)

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -71,6 +71,7 @@ THC_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input
 // values, unless you are doing some size and stride tricks, do not use resize*.
 THC_API void THCTensor_(resizeNd)(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
 THC_API void THCTensor_(resizeAs)(THCState *state, THCTensor *tensor, THCTensor *src);
+THC_API void THCTensor_(resize0d)(THCState *state, THCTensor *tensor);
 THC_API void THCTensor_(resize1d)(THCState *state, THCTensor *tensor, int64_t size0_);
 THC_API void THCTensor_(resize2d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_);
 THC_API void THCTensor_(resize3d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
@@ -113,11 +114,13 @@ THC_API void THCTensor_(free)(THCState *state, THCTensor *self);
 THC_API void THCTensor_(freeCopyTo)(THCState *state, THCTensor *self, THCTensor *dst);
 
 /* Slow access methods [check everything] */
+THC_API void THCTensor_(set0d)(THCState *state, THCTensor *tensor, scalar_t value);
 THC_API void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, scalar_t value);
 THC_API void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, scalar_t value);
 THC_API void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, scalar_t value);
 THC_API void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, scalar_t value);
 
+THC_API scalar_t THCTensor_(get0d)(THCState *state, const THCTensor *tensor);
 THC_API scalar_t THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0);
 THC_API scalar_t THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1);
 THC_API scalar_t THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2);

--- a/aten/src/THCUNN/generic/AbsCriterion.cu
+++ b/aten/src/THCUNN/generic/AbsCriterion.cu
@@ -19,7 +19,7 @@ void THNN_(AbsCriterion_updateOutput)(
     return;
   }
 
-  THCTensor_(resize1d)(state, output, 1);
+  THCTensor_(resize0d)(state, output);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
 
@@ -36,7 +36,7 @@ void THNN_(AbsCriterion_updateOutput)(
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);
 
-  THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, scalar_t>::to(sum));
+  THCTensor_(set0d)(state, output, ScalarConvert<accreal, scalar_t>::to(sum));
 }
 
 void THNN_(AbsCriterion_updateGradInput)(
@@ -73,7 +73,7 @@ void THNN_(AbsCriterion_updateGradInput)(
   thrust::device_ptr<scalar_t> gradInput_data(THCTensor_(data)(state, gradInput));
 
   thrust::transform(input_data, input_data+size, target_data, gradInput_data,
-                    abs_updateGradInput_functor<scalar_t>(norm, THCTensor_(get1d)(state, gradOutput, 0)));
+                    abs_updateGradInput_functor<scalar_t>(norm, THCTensor_(get0d)(state, gradOutput)));
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);

--- a/aten/src/THCUNN/generic/BCECriterion.cu
+++ b/aten/src/THCUNN/generic/BCECriterion.cu
@@ -24,7 +24,7 @@ void THNN_(BCECriterion_updateOutput)(
     return;
   }
 
-  THCTensor_(resize1d)(state, output, 1);
+  THCTensor_(resize0d)(state, output);
   ptrdiff_t size = THCTensor_(nElement)(state, input);
 
   input = THCTensor_(newContiguous)(state, input);
@@ -63,7 +63,7 @@ void THNN_(BCECriterion_updateOutput)(
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);
 
-  THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, scalar_t>::to(sum));
+  THCTensor_(set0d)(state, output, ScalarConvert<accreal, scalar_t>::to(sum));
 }
 
 void THNN_(BCECriterion_updateGradInput)(
@@ -95,7 +95,7 @@ void THNN_(BCECriterion_updateGradInput)(
   THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
-  scalar_t norm = ScalarConvert<accreal, scalar_t>::to((reduction == Reduction::Mean ? accreal(1)/size : accreal(1)) * THCTensor_(get1d)(state, gradOutput, 0));
+  scalar_t norm = ScalarConvert<accreal, scalar_t>::to((reduction == Reduction::Mean ? accreal(1)/size : accreal(1)) * THCTensor_(get0d)(state, gradOutput));
 
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);

--- a/aten/src/THCUNN/generic/MSECriterion.cu
+++ b/aten/src/THCUNN/generic/MSECriterion.cu
@@ -13,7 +13,7 @@ void THNN_(MSECriterion_updateOutput)(
   THCUNN_assertSameGPU(state, 3, input, target, output);
 
   if (reduction != Reduction::None) {
-    THCTensor_(resize1d)(state, output, 1);
+    THCTensor_(resize0d)(state, output);
 
     ptrdiff_t size = THCTensor_(nElement)(state, input);
 
@@ -36,7 +36,7 @@ void THNN_(MSECriterion_updateOutput)(
     THCTensor_(free)(state, input);
     THCTensor_(free)(state, target);
 
-    THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, scalar_t>::to(sum));
+    THCTensor_(set0d)(state, output, ScalarConvert<accreal, scalar_t>::to(sum));
     return;
   }
 
@@ -65,7 +65,7 @@ void THNN_(MSECriterion_updateGradInput)(
 
     THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
     accreal norm = reduction == Reduction::Mean ? (accreal)(2)/size : (accreal)(2);
-    norm *= ScalarConvert<scalar_t, accreal>::to(THCTensor_(get1d)(state, gradOutput, 0));
+    norm *= ScalarConvert<scalar_t, accreal>::to(THCTensor_(get0d)(state, gradOutput));
 
     input = THCTensor_(newContiguous)(state, input);
     target = THCTensor_(newContiguous)(state, target);

--- a/aten/src/THCUNN/generic/SmoothL1Criterion.cu
+++ b/aten/src/THCUNN/generic/SmoothL1Criterion.cu
@@ -23,7 +23,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
     return;
   }
 
-  THCTensor_(resize1d)(state, output, 1);
+  THCTensor_(resize0d)(state, output);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
 
@@ -47,7 +47,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);
 
-  THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, scalar_t>::to(sum));
+  THCTensor_(set0d)(state, output, ScalarConvert<accreal, scalar_t>::to(sum));
 }
 
 void THNN_(SmoothL1Criterion_updateGradInput)(
@@ -93,7 +93,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     input_data, input_data+size, target_data, gradInput_data,
-    smoothl1_updateGradInput_functor<scalar_t>(norm, THCTensor_(get1d)(state, gradOutput, 0))
+    smoothl1_updateGradInput_functor<scalar_t>(norm, THCTensor_(get0d)(state, gradOutput))
   );
 
   THCTensor_(free)(state, input);

--- a/aten/src/THCUNN/generic/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/SoftMarginCriterion.cu
@@ -24,7 +24,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
 
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);
-  THCTensor_(resize1d)(state, output, 1);
+  THCTensor_(resize0d)(state, output);
 
   thrust::device_ptr<scalar_t> input_data(THCTensor_(data)(state, input));
   thrust::device_ptr<scalar_t> target_data(THCTensor_(data)(state, target));
@@ -36,7 +36,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);
 
-  THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, scalar_t>::to(sum));
+  THCTensor_(set0d)(state, output, ScalarConvert<accreal, scalar_t>::to(sum));
 }
 
 void THNN_(SoftMarginCriterion_updateGradInput)(
@@ -72,7 +72,7 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
   thrust::device_ptr<scalar_t> gradInput_data(THCTensor_(data)(state, gradInput));
 
   thrust::transform(input_data, input_data+size, target_data, gradInput_data,
-                    softmargin_updateGradInput_functor<scalar_t, accreal>(norm, THCTensor_(get1d)(state, gradOutput, 0)));
+                    softmargin_updateGradInput_functor<scalar_t, accreal>(norm, THCTensor_(get0d)(state, gradOutput)));
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);

--- a/aten/src/THNN/generic/AbsCriterion.c
+++ b/aten/src/THNN/generic/AbsCriterion.c
@@ -20,7 +20,7 @@ void THNN_(AbsCriterion_updateOutput)(
   }
 
   scalar_t sum = 0;
-  THTensor_(resize1d)(output, 1);
+  THTensor_(resize0d)(output);
   TH_TENSOR_APPLY2(scalar_t, input, scalar_t, target,
     sum += fabs(*input_data - *target_data);
   );
@@ -28,7 +28,7 @@ void THNN_(AbsCriterion_updateOutput)(
   if (reduction == Reduction::Mean)
     sum /= THTensor_(nElement)(input);
 
-  THTensor_(set1d)(output, 0, sum);
+  THTensor_(set0d)(output, sum);
 }
 
 void THNN_(AbsCriterion_updateGradInput)(

--- a/aten/src/THNN/generic/BCECriterion.c
+++ b/aten/src/THNN/generic/BCECriterion.c
@@ -38,7 +38,7 @@ void THNN_(BCECriterion_updateOutput)(
     return;
   }
 
-	THTensor_(resize1d)(output, 1);
+	THTensor_(resize0d)(output);
   scalar_t sum = 0;
 
   if (weights) {
@@ -66,7 +66,7 @@ void THNN_(BCECriterion_updateOutput)(
   if (reduction == Reduction::Mean)
     sum /= THTensor_(nElement)(input);
 
-  THTensor_(set1d)(output, 0, sum);
+  THTensor_(set0d)(output, sum);
 }
 
 void THNN_(BCECriterion_updateGradInput)(

--- a/aten/src/THNN/generic/MSECriterion.c
+++ b/aten/src/THNN/generic/MSECriterion.c
@@ -12,7 +12,7 @@ void THNN_(MSECriterion_updateOutput)(
   THNN_CHECK_SHAPE(input, target);
 
   if (reduction != Reduction::None) {
-    THTensor_(resize1d)(output, 1);
+    THTensor_(resize0d)(output);
 
     accreal sum = 0;
 
@@ -24,7 +24,7 @@ void THNN_(MSECriterion_updateOutput)(
     if (reduction == Reduction::Mean)
       sum /= THTensor_(nElement)(input);
 
-    THTensor_(set1d)(output, 0, (scalar_t)sum);
+    THTensor_(set0d)(output, (scalar_t)sum);
     return;
   }
 
@@ -49,7 +49,7 @@ void THNN_(MSECriterion_updateGradInput)(
   if (reduction != Reduction::None) {
     THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, 1);
     scalar_t norm = reduction == Reduction::Mean ? 2./((scalar_t)THTensor_(nElement)(input)) : 2.;
-    norm *= THTensor_(get1d)(gradOutput, 0);
+    norm *= THTensor_(get0d)(gradOutput);
     TH_TENSOR_APPLY3(scalar_t, gradInput, scalar_t, input, scalar_t, target,
       *gradInput_data = norm * (*input_data - *target_data);
     );

--- a/aten/src/THNN/generic/SmoothL1Criterion.c
+++ b/aten/src/THNN/generic/SmoothL1Criterion.c
@@ -20,7 +20,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
     return;
   }
 
-  THTensor_(resize1d)(output, 1);
+  THTensor_(resize0d)(output);
 
   scalar_t sum = 0;
   TH_TENSOR_APPLY2(scalar_t, input, scalar_t, target,
@@ -31,7 +31,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
   if (reduction == Reduction::Mean)
     sum /= THTensor_(nElement)(input);
 
-  THTensor_(set1d)(output, 0, sum);
+  THTensor_(set0d)(output, sum);
 }
 
 void THNN_(SmoothL1Criterion_updateGradInput)(

--- a/aten/src/THNN/generic/SoftMarginCriterion.c
+++ b/aten/src/THNN/generic/SoftMarginCriterion.c
@@ -19,7 +19,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
     return;
   }
 
-  THTensor_(resize1d)(output, 1);
+  THTensor_(resize0d)(output);
 
   scalar_t sum;
 
@@ -31,7 +31,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   if (reduction == Reduction::Mean)
     sum /= THTensor_(nElement)(input);
 
-  THTensor_(set1d)(output, 0, sum);
+  THTensor_(set0d)(output, sum);
 }
 
 void THNN_(SoftMarginCriterion_updateGradInput)(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2696,6 +2696,52 @@ class TestNN(NNTestCase):
         self.assertRaises(AssertionError, lambda: F.pad(inputs, (1, 1)))
         self.assertRaises(AssertionError, lambda: F.pad(inputs, (1,)))
 
+    def test_nn_scalars(self):
+        # One off tests to ensure scalars from nn.yaml are properly applied
+        def verify_scalars(input, output):
+            if input.dim() == 0:
+                self.assertEqual((), output.shape)
+            else:
+                self.assertNotEqual((), output.shape)
+            output.sum().backward()
+            self.assertEqual(input.shape, input.grad.shape)
+
+        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        for device in devices:
+            for input_shape in [(5, 6), ()]:
+                for module in [torch.nn.ELU, torch.nn.Hardtanh, torch.nn.LeakyReLU, torch.nn.LogSigmoid,
+                               torch.nn.RReLU, torch.nn.Softshrink, torch.nn.Softplus, torch.nn.Sigmoid,
+                               torch.nn.Tanh]:
+                    input = torch.randn(input_shape, device=device, requires_grad=True)
+                    m = module()
+                    output = m(input)
+                    verify_scalars(input, output)
+
+    def test_nn_scalars_reductions(self):
+        # One off tests to ensure scalars from nn.yaml are properly applied
+        def verify_reduction_scalars(input, reduction, output):
+            if reduction != 'none' or input.dim() == 0:
+                self.assertEqual((), output.shape)
+            else:
+                self.assertNotEqual((), output.shape)
+            output.sum().backward()
+            self.assertEqual(input.shape, input.grad.shape)
+
+        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+        for device in devices:
+            for input_shape in [(5, 6), ()]:
+                for reduction in ['none', 'mean', 'sum']:
+                    for module in [torch.nn.BCELoss, torch.nn.L1Loss, torch.nn.MSELoss,
+                                   torch.nn.SmoothL1Loss, torch.nn.SoftMarginLoss]:
+                        input = torch.randn(input_shape, device=device, requires_grad=True)
+                        target = torch.empty(input_shape, device=device).random_(2)
+                        sigmoid = nn.Sigmoid()
+
+                        input = torch.randn(input_shape, device=device, requires_grad=True)
+                        m = module(reduction=reduction)
+                        output = m(sigmoid(input), target)
+                        verify_reduction_scalars(input, reduction, output)
+
     def test_normalize(self):
         inputs = torch.randn(1, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=1, dim=-1), (inputs,)))


### PR DESCRIPTION
This includes everything in nn.yaml except for convolutions, multi_margin_loss, multi_label_margin_loss, nll_loss, and nll_loss2d.

Note that scalar_check False just means we don't do any extra scalar checks (we could elide this from the generated code, which I may do in a later commit).

