### PR TITLE
[C++ frontend] Unflake the ordering enforcement test

### DIFF
--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -833,26 +833,47 @@ TEST(DataLoaderTest, RespectsTimeout) {
   ASSERT_LT(duration.count(), 1);
 }
 
-struct OrderingTestDataset : datasets::BatchDataset<DummyDataset, int> {
-  int get_batch(torch::ArrayRef<size_t> indices) override {
-    static int thread_counter = 0;
-    thread_local int thread_id = thread_counter++;
-    static std::condition_variable cv;
-    static std::mutex mutex;
-    static std::array<size_t, 4> order = {3, 1, 0, 2};
-    static std::atomic<size_t> index{0};
+namespace {
+std::atomic<size_t> ordering_test_counter{0};
+std::condition_variable ordering_test_cv;
+std::mutex ordering_test_mutex;
+const std::array<size_t, 4> ordering_test_order = {3, 1, 0, 2};
+std::atomic<size_t> ordering_test_index{0};
+} // namespace
 
-    std::unique_lock<std::mutex> lock(mutex);
-    cv.wait(lock, [&] { return order.at(index) == thread_id; });
-    ++index;
-    cv.notify_all();
+struct OrderingTestDataset : datasets::BatchDataset<DummyDataset, int> {
+  OrderingTestDataset() = default;
+
+  // This copy constructor will be called when we copy the dataset into a
+  // particular thread.
+  OrderingTestDataset(const OrderingTestDataset& other)
+      : id(ordering_test_counter++) {}
+
+  OrderingTestDataset(OrderingTestDataset&& other) noexcept = default;
+  OrderingTestDataset& operator=(const OrderingTestDataset& other) = delete;
+  OrderingTestDataset& operator=(OrderingTestDataset&& other) noexcept = delete;
+
+  int get_batch(torch::ArrayRef<size_t> indices) override {
+    std::unique_lock<std::mutex> lock(ordering_test_mutex);
+    // block until order.at(index) == my_thread_id (until it's this thread's
+    // turn)
+    ordering_test_cv.wait(lock, [this] {
+      return ordering_test_order.at(ordering_test_index.load()) == this->id;
+    });
+    // Make one step in the order.
+    ++ordering_test_index;
     lock.unlock();
-    return thread_id;
+    // Wake up the other threads to check if it's their turn to return.
+    ordering_test_cv.notify_all();
+
+    return id;
   }
 
   torch::optional<size_t> size() const {
     return 4;
   }
+
+  size_t id = 0;
 };
 
 TEST(DataLoaderTest, EnforcesOrderingAmongThreadsWhenConfigured) {

--- a/torch/csrc/api/include/torch/data/dataloader.h
+++ b/torch/csrc/api/include/torch/data/dataloader.h
@@ -41,8 +41,9 @@ class DataLoader {
       // has its own copy of the dataset. This means the dataset must be
       // trivially copiable, or else we don't expect more than one worker to
       // be in use.
-      workers_.emplace_back(
-          [this, dataset] { this->worker_thread(std::move(dataset)); });
+      workers_.emplace_back([this, dataset]() mutable {
+        this->worker_thread(std::move(dataset));
+      });
     }
     if (options_.workers == 0) {
       main_thread_dataset_ = torch::make_unique<Dataset>(std::move(dataset));


### PR DESCRIPTION
Attempts to unflake the dataloader ordering enforcement test. I think the issue was that the `thread_counter` variable was not atomic. I've made it atomic, and also global just to make it a bit clearer.

Fixes https://github.com/pytorch/pytorch/issues/13634

@colesbury @SsnL @ezyang 