### PR TITLE
Preemptively test for out-of-order length.

### DIFF
--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -22,7 +22,7 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
   AT_CHECK(lengths[batch_size - 1] > 0,
            "Length of all samples has to be greater than 0, but found an element "
            "in 'lengths' that is <= 0");
-  for(auto i = 0; i < batch_size - 1; i++ ) {
+  for(auto i = 0; i < batch_size - 1; i++) {
     if (lengths[batch_size - 1 - i] > lengths[batch_size - 2 - i]) {
       AT_ERROR("'lengths' array has to be sorted in decreasing order");
     }
@@ -73,6 +73,7 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
       }
       prev_l = l;
     }
+    AT_CHECK(l >= prev_l);
   }
 
   return std::make_tuple(at::cat(steps), batch_sizes_t);

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -22,6 +22,11 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
   AT_CHECK(lengths[batch_size - 1] > 0,
            "Length of all samples has to be greater than 0, but found an element "
            "in 'lengths' that is <= 0");
+  for(auto i = 0; i < batch_size - 1; i++ ) {
+    if (lengths[batch_size - 1 - i] > lengths[batch_size - 2 - i]) {
+      AT_ERROR("'lengths' array has to be sorted in decreasing order");
+    }
+  }
 
   std::vector<at::Tensor> steps;
   steps.reserve(batch_size);
@@ -67,8 +72,6 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
         (*batch_sizes++) = current_batch_size;
       }
       prev_l = l;
-    } else if (prev_l > l) {
-      AT_ERROR("'lengths' array has to be sorted in decreasing order");
     }
   }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -143,6 +143,13 @@ class PackedSequenceTest(TestCase):
         unpacked, _ = rnn_utils.pad_packed_sequence(packed)
         self.assertEqual(unpacked.type(), cuda_type_str)
 
+    def test_wrong_order(self):
+        # https://github.com/pytorch/pytorch/issues/13324
+        a = torch.ones(25, 300)
+        b = torch.ones(22, 300)
+        b_a = rnn_utils.pad_sequence([b, a])
+        self.assertRaises(RuntimeError, lambda: rnn_utils.pack_padded_sequence(b_a, [22, 25]))
+
     def test_total_length(self):
         padded, lengths = self._padded_sequence(torch.FloatTensor)
         max_length = max(lengths)


### PR DESCRIPTION
Summary:

torch.nn.utils.rnn.pack_padded_sequence segment fault if not in
decreasing order #13324

We were seeing this segfault on throw, pre-emptively checking avoids
this:

*** Error in `/home/bvaughan/anaconda3/bin/python': double free or corruption (!prev): 0x00005555566e7510 ***

Test Plan:

Added unit test based on example provided in issue.

Reviewers:

Subscribers:

Tasks:

Tags:

