### PR TITLE
Use realpath for loaded libraries

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -4,6 +4,8 @@ import contextlib
 import ctypes
 import sys
 import types
+import os.path
+
 import torch.jit
 
 # Query `hasattr` only once.
@@ -92,6 +94,7 @@ class _Ops(types.ModuleType):
         Arguments:
             path (str): A path to a shared library to load.
         """
+        path = os.path.realpath(path)
         with dl_open_guard():
             # Import the shared library into the process, thus running its
             # static (global) initialization code in order to register custom


### PR DESCRIPTION
I noticed `CDLL` needs an absolute path (when calling `torch.ops.load_library`)

@zdevito @soumith 