### PR TITLE
Allow torch.utils.cpp_extension.load to load shared libraries that aren't Python modules

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -387,6 +387,18 @@ class TestCppExtension(common.TestCase):
         self.assertIn('bn.weight', p)
         self.assertIn('bn.bias', p)
 
+    def test_returns_shared_library_path_when_return_library_path_is_true(self):
+        library_path = torch.utils.cpp_extension.load_inline(
+            name="return_library_path",
+            cpp_sources="void foo() { }",
+            functions="foo",
+            verbose=True,
+            return_library_path=True)
+
+        self.assertTrue(os.path.exists(library_path))
+        extensions = {'linux': '.so', 'darwin': '.dylib', 'win32': '.dll'}
+        self.assertTrue(os.path.splitext(library_path), extensions[sys.platform])
+
 
 if __name__ == '__main__':
     common.run_tests()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -523,7 +523,8 @@ def load(name,
          extra_include_paths=None,
          build_directory=None,
          verbose=False,
-         with_cuda=None):
+         with_cuda=None,
+         return_library_path=False):
     '''
     Loads a PyTorch C++ extension just-in-time (JIT).
 
@@ -576,9 +577,13 @@ def load(name,
             automatically determined based on the existence of ``.cu`` or
             ``.cuh`` in ``sources``. Set it to `True`` to force CUDA headers
             and libraries to be included.
+        return_library_path: If ``True``, returns the path to the compiled shared
+            library instead of importing it as a Python module.
 
     Returns:
-        The loaded PyTorch extension as a Python module.
+        The loaded PyTorch extension as a Python module unless ``return_library_path``
+        is ``True``, in which case only the path to the compiled shared library is
+        returned.
 
     Example:
         >>> from torch.utils.cpp_extension import load
@@ -597,7 +602,8 @@ def load(name,
         extra_include_paths,
         build_directory or _get_build_directory(name, verbose),
         verbose,
-        with_cuda)
+        with_cuda,
+        return_library_path)
 
 
 def load_inline(name,
@@ -610,7 +616,8 @@ def load_inline(name,
                 extra_include_paths=None,
                 build_directory=None,
                 verbose=False,
-                with_cuda=None):
+                with_cuda=None,
+                return_library_path=False):
     '''
     Loads a PyTorch C++ extension just-in-time (JIT) from string sources.
 
@@ -724,7 +731,8 @@ def load_inline(name,
         extra_include_paths,
         build_directory,
         verbose,
-        with_cuda)
+        with_cuda,
+        return_library_path)
 
 
 def _jit_compile(name,
@@ -735,7 +743,8 @@ def _jit_compile(name,
                  extra_include_paths,
                  build_directory,
                  verbose,
-                 with_cuda=None):
+                 with_cuda,
+                 return_library_path):
     old_version = JIT_EXTENSION_VERSIONER.get_version(name)
     version = JIT_EXTENSION_VERSIONER.bump_version_if_changed(
         name,
@@ -774,7 +783,7 @@ def _jit_compile(name,
 
     if verbose:
         print('Loading extension module {}...'.format(name))
-    return _import_module_from_library(name, build_directory)
+    return _import_module_from_library(name, build_directory, return_library_path)
 
 
 def _write_ninja_file_and_build(name,
@@ -911,12 +920,15 @@ def _build_extension_module(name, build_directory, verbose):
         raise RuntimeError(message)
 
 
-def _import_module_from_library(module_name, path):
+def _import_module_from_library(module_name, path, return_library_path):
     # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
     file, path, description = imp.find_module(module_name, [path])
     # Close the .so file after load.
     with file:
-        return imp.load_module(module_name, file, path, description)
+        if return_library_path:
+            return path
+        else:
+            return imp.load_module(module_name, file, path, description)
 
 
 def _write_ninja_file(path,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -524,7 +524,7 @@ def load(name,
          build_directory=None,
          verbose=False,
          with_cuda=None,
-         is_python_module=False):
+         is_python_module=True):
     '''
     Loads a PyTorch C++ extension just-in-time (JIT).
 
@@ -619,7 +619,7 @@ def load_inline(name,
                 build_directory=None,
                 verbose=False,
                 with_cuda=None,
-                is_python_module=False):
+                is_python_module=True):
     '''
     Loads a PyTorch C++ extension just-in-time (JIT) from string sources.
 


### PR DESCRIPTION
For custom TorchScript operators, `torch.ops.load_library` must be used and passed the path to the shared library containing the custom ops. Our C++ extensions stuff generally is meant to build a Python module and import it. This PR changes `torch.utils.cpp_extension.load` to have an option to just return the shared library path instead of importing it as a Python module, so you can then pass it to `torch.ops.load_library`. This means folks can re-use `torch.utils.cpp_extension.load` and `torch.utils.cpp_extension.load_inline` to even write their custom ops inline. I think @t-vi  and @fmassa will appreciate this.

@soumith 

