### PR TITLE
Add filler for SparseLengthsWeightedSum

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -371,7 +371,21 @@ class CAFFE2_API OpSchema {
     return device_inference_function_(def);
   }
 
-  // The helper is build sparse input with values, keys, and lengths; e.g.:
+  // The helper is build sparse input with values, keys, weights and lengths;
+  // e.g.:
+  // values  = [1, 2, 3, 2, 4, 6, 7, 3, 6]
+  // keys    = [0, 1, 4, 0, 1, 2, 5, 1, 2]
+  // weights = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  //            \_____/  \________/  \__/
+  // lengths =    [3,        4,       2]
+  OpSchema& WeightedValueKeyLengthInputFillers(
+      size_t value_index,
+      size_t key_index,
+      size_t length_index,
+      size_t weight_index);
+
+  // The helper is build sparse input with values, keys, weights and lengths;
+  // e.g.:
   // values  = [1, 2, 3, 2, 4, 6, 7, 3, 6]
   // keys    = [0, 1, 4, 0, 1, 2, 5, 1, 2]
   //            \_____/  \________/  \__/

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.cc
@@ -42,7 +42,11 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(SparseLengthsWeightedSumFused8BitRowwise)
     .NumInputs(4)
     .NumOutputs(1)
-    .DisallowInputFillers() // TODO: Enable the fillers
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsFused8BitRowwiseOp<CPUContext, true>::DATA,
+        SparseLengthsFused8BitRowwiseOp<CPUContext, true>::INDICES,
+        SparseLengthsFused8BitRowwiseOp<CPUContext, true>::LENGTHS,
+        SparseLengthsFused8BitRowwiseOp<CPUContext, true>::WEIGHTS)
     .SetDoc(R"DOC(
 Performs the same operation as SparseLengthsWeightedSum,
 but operating on 8-bit rowwise quantized matrices with fused storage

--- a/caffe2/operators/lengths_reducer_ops.cc
+++ b/caffe2/operators/lengths_reducer_ops.cc
@@ -99,7 +99,11 @@ using SparseLengthsWeightedSumDef = AbstractSparseLengthsDef<
 OPERATOR_SCHEMA(SparseLengthsWeightedSum)
     .NumInputs(SparseLengthsWeightedSumDef::ForwardOp::kNumInputs)
     .NumOutputs(1)
-    .DisallowInputFillers() // TODO: enable input fillers
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsWeightedSumOp::DATA,
+        SparseLengthsWeightedSumOp::INDICES,
+        SparseLengthsWeightedSumOp::LENGTHS,
+        SparseLengthsWeightedSumOp::WEIGHT)
     .SetDoc(FormatDoc<SparseLengthsWeightedSumDef>())
     .Output(0, "OUTPUT", "Aggregated tensor")
     .FillUsing(SparseLengthsWeightedSumDef::PopulateSchema);

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -77,9 +77,23 @@ DataRandomFiller::DataRandomFiller(
             caffe2::to_string(op_types.size()));
 
     for (size_t j = 0; j < op.input_size(); ++j) {
-      inputs_.emplace(
-          op.input(j),
-          std::make_pair(get_tensor_filler(op, j, op_dims), op_types[j]));
+      inputs_[op.input(j)] =
+          std::make_pair(get_tensor_filler(op, j, op_dims), op_types[j]);
+    }
+
+    // Hack, we normal have a path of
+    // length -> LengthsiRangeFill -> Gather -> w -> SparseLengthsWeighted*
+    //       \---------------------------------------/
+    // So when we generate the value of length, we need to bound it to the size
+    // of weight input of Gather too
+    if (op.type().find("SparseLengthsWeighted") == 0 && i > 0) {
+      const auto& prev_op = run_net.op(i - 1);
+      if (prev_op.type() == "Gather") {
+        const auto& prev_dims = input_dims[i - 1];
+        VLOG(1) << "Setting max length value to " << prev_dims[0].front()
+                << " for " << op.input(3);
+        inputs_[op.input(3)].first.Max(prev_dims[0].front());
+      }
     }
 
     for (size_t j = 0; j < op.output_size(); ++j) {

--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -77,10 +77,13 @@ class TensorFiller {
     return *this;
   }
 
-  // a helper function to construct the lengths vector for sparse features
+  // A helper function to construct the lengths vector for sparse features
+  // We try to pad least one index per batch unless the total_length is 0
   template <class Type>
   TensorFiller& SparseLengths(Type total_length) {
-    return FixedSum(total_length).Min(0).Max(total_length);
+    return FixedSum(total_length)
+        .Min(std::min(static_cast<Type>(1), total_length))
+        .Max(total_length);
   }
 
   // a helper function to construct the segments vector for sparse features

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -716,6 +716,21 @@ TEST_F(BroadcastTest, BroadcastFloatTest) {
       {1.0f, 1.0f, 2.0f, 2.0f, 1.0f, 1.0f, 2.0f, 2.0f});
 }
 
+class RandFixedSumTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    cpu_context_ = make_unique<CPUContext>(option_);
+  }
+  DeviceOption option_;
+  std::unique_ptr<CPUContext> cpu_context_;
+};
+
+TEST_F(RandFixedSumTest, UpperBound) {
+  std::vector<int> l(20);
+  math::RandFixedSum<int, CPUContext>(
+      20, 1, 1000, 1000, l.data(), cpu_context_.get());
+}
+
 class MomentsTest : public testing::Test {
  protected:
   void SetUp() override {


### PR DESCRIPTION
This diff adds support to fillers for SparseLengthsWeight* ops. It does 3 things:
- Add the fillers for SparseLengthsWeight* ops
- Add filling heuristics to consider the path of LengthsRangeFill -> Gather -> SparseLengthsWeightedSum, where the length input is shared by LengthsRangeFill and SparseLengthsWeightedSum. Therefore, we need to carefully bound the value of that length input so that at Gather, it does not index out-of-bound for the weight input of Gather.
- Fix and simplify the logic of math::RandFixedSum, where we just keep rejecting the generated value if it violates the invariants.

Differential Revision: D13048216
