### PR TITLE
More robust ->match behavior

### DIFF
--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -384,7 +384,7 @@ public:
     registerPendingOperators();
     auto it = operators_by_sig_literal.find(name);
     if (it == operators_by_sig_literal.end()) {
-      auto op_ptr_it = operators_by_sig.find(name);
+      auto op_ptr_it = operators_by_sig.find(canonicalSchemaString(parseSchema(name)));
       // Handy debugging code that dumps all operators we know about on mismatch
 #if 0
       if (op_ptr_it == operators_by_sig.end()) {


### PR DESCRIPTION
Allow schema matching against string literals to work even with
white space and other minor differences.

