### PR TITLE
Clean up caffe2/tools/build_pytorch_libs.{sh,bat}

### DIFF
--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -8,12 +8,11 @@ set BASE_DIR=%cd:\=/%
 set TORCH_LIB_DIR=%cd:\=/%/torch/lib
 set INSTALL_DIR=%cd:\=/%/torch/lib/tmp_install
 set THIRD_PARTY_DIR=%cd:\=/%/third_party
-set BASIC_C_FLAGS= /I%INSTALL_DIR%/include /I%INSTALL_DIR%/include/TH /I%INSTALL_DIR%/include/THC /I%INSTALL_DIR%/include/THS /I%INSTALLDIR%/include/THCS /I%INSTALLDIR%/include/THPP /I%INSTALLDIR%/include/THNN /I%INSTALLDIR%/include/THCUNN
-set BASIC_CUDA_FLAGS= -I%INSTALL_DIR%/include -I%INSTALL_DIR%/include/TH -I%INSTALL_DIR%/include/THC -I%INSTALL_DIR%/include/THS -I%INSTALLDIR%/include/THCS -I%INSTALLDIR%/include/THPP -I%INSTALLDIR%/include/THNN -I%INSTALLDIR%/include/THCUNN
+set BASIC_C_FLAGS=
+set BASIC_CUDA_FLAGS=
 set LDFLAGS=/LIBPATH:%INSTALL_DIR%/lib
 :: set TORCH_CUDA_ARCH_LIST=6.1
 
-set CWRAP_FILES=%BASE_DIR%/torch/lib/ATen/Declarations.cwrap;%BASE_DIR%/torch/lib/ATen/Local.cwrap;%BASE_DIR%/torch/lib/THNN/generic/THNN.h;%BASE_DIR%/torch/lib/THCUNN/generic/THCUNN.h;%BASE_DIR%/torch/lib/ATen/nn.yaml
 set C_FLAGS=%BASIC_C_FLAGS% /D_WIN32 /Z7 /EHa /DNOMINMAX
 set LINK_FLAGS=/DEBUG:FULL
 : End cmake variables
@@ -28,8 +27,6 @@ set /a USE_NNPACK=0
 set /a USE_QNNPACK=0
 set /a USE_GLOO_IBVERBS=0
 set /a USE_MKLDNN=0
-
-set /a NO_NNPACK=1
 
 set _BUILD_ARGS=
 
@@ -56,7 +53,6 @@ if "%1"=="--use-rocm" (
 
 if "%1"=="--use-nnpack" (
   set /a USE_NNPACK=1
-  set /a NO_NNPACK=0
   goto :process_args_processed
 )
 
@@ -163,32 +159,15 @@ goto:eof
   if not exist build mkdir build\%~1
   pushd build\%~1
   cmake ../../%~1 %CMAKE_GENERATOR_COMMAND% ^
-                  -DCMAKE_MODULE_PATH=%BASE_DIR%/cmake/FindCUDA ^
-                  -DTorch_FOUND="1" ^
                   -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" ^
                   -DCMAKE_C_FLAGS="%C_FLAGS%" ^
                   -DCMAKE_SHARED_LINKER_FLAGS="%LINK_FLAGS%" ^
                   -DCMAKE_CXX_FLAGS="%C_FLAGS% %CPP_FLAGS%" ^
                   -DCUDA_NVCC_FLAGS="%BASIC_CUDA_FLAGS%" ^
-                  -Dcwrap_files="%CWRAP_FILES%" ^
-                  -DTH_INCLUDE_PATH="%INSTALL_DIR%/include" ^
-                  -DTH_LIB_PATH="%INSTALL_DIR%/lib" ^
-                  -DTH_LIBRARIES="%INSTALL_DIR%/lib/caffe2.lib" ^
-                  -DTHS_LIBRARIES="%INSTALL_DIR%/lib/caffe2.lib" ^
-                  -DTHC_LIBRARIES="%INSTALL_DIR%/lib/caffe2_gpu.lib" ^
-                  -DTHCS_LIBRARIES="%INSTALL_DIR%/lib/caffe2_gpu.lib" ^
-                  -DC10_LIBRARIES="%INSTALL_DIR%/lib/c10.lib" ^
-                  -DCAFFE2_LIBRARIES="%INSTALL_DIR%/lib/caffe2.lib" ^
-                  -DTHNN_LIBRARIES="%INSTALL_DIR%/lib/caffe2.lib" ^
-                  -DTHCUNN_LIBRARIES="%INSTALL_DIR%/lib/caffe2_gpu.lib" ^
-                  -DTH_SO_VERSION=1 ^
-                  -DTHC_SO_VERSION=1 ^
-                  -DTHNN_SO_VERSION=1 ^
-                  -DTHCUNN_SO_VERSION=1 ^
                   -DUSE_CUDA=%USE_CUDA% ^
                   -DBUILD_EXAMPLES=OFF ^
                   -DBUILD_TEST=%BUILD_TEST% ^
-                  -DNO_NNPACK=%NO_NNPACK% ^
+                  -DUSE_NNPACK=%USE_NNPACK% ^
                   -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
   IF ERRORLEVEL 1 exit 1
   IF NOT ERRORLEVEL 0 exit 1

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -145,11 +145,6 @@ if [[ $USE_GLOO_IBVERBS -eq 1 ]]; then
     GLOO_FLAGS+=" -DUSE_IBVERBS=1"
     THD_FLAGS="-DUSE_GLOO_IBVERBS=1"
 fi
-CWRAP_FILES="\
-$BASE_DIR/torch/lib/ATen/Declarations.cwrap;\
-$BASE_DIR/torch/lib/THNN/generic/THNN.h;\
-$BASE_DIR/torch/lib/THCUNN/generic/THCUNN.h;\
-$BASE_DIR/torch/lib/ATen/nn.yaml"
 CUDA_NVCC_FLAGS=$C_FLAGS
 if [[ -z "$CUDA_DEVICE_DEBUG" ]]; then
   CUDA_DEVICE_DEBUG=0


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#13954 Clean up caffe2/tools/build_pytorch_libs.{sh,bat}**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13056152/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #13916 Move AlignOf, SmallVector and ArrayRef to c10.&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13046722/)

- Remove extra include directories from BASIC_C_FLAGS.  We suspect that
  in some rare cases on Windows, this can cause us to get confused about
  which header to include.  Make this agree with build_pytorch_libs.sh
  Ditto with BASIC_CUDA_FLAGS
- Delete CWRAP_FILES from both places; it's unused in sh, and it's
  dead in CMAKE
- Delete NO_NNPACK in Windows, replace with USE_NNPACK (I'm not sure
  if this actually does anything on Windows lol)
- Delete a bunch of defunct cmake arguments from the build (NOT
  build_caffe2) target.

Differential Revision: [D13056152](https://our.internmc.facebook.com/intern/diff/D13056152/)