### PR TITLE
Import a method from an python_print string

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -39,14 +39,15 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
     case IValue::Tag::Double: {
       double d = v.toDouble();
       int64_t i = int64_t(d);
-      if (std::isnormal(d) && double(i) == d) {
+      int c = std::fpclassify(d);
+      if ((c == FP_NORMAL || c == FP_ZERO) && double(i) == d) {
         return out << i << ".";
       }
       return out << v.toDouble();
     } case IValue::Tag::Int:
       return out << v.toInt();
     case IValue::Tag::Bool:
-      return out << v.toBool();
+      return out << (v.toBool() ? "True" : "False");
     case IValue::Tag::Tuple:
       return printList(out, v.toTuple(), "(", ")");
     case IValue::Tag::IntList:

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -170,7 +170,11 @@ using OptionalTypePtr = std::shared_ptr<OptionalType>;
 // Subtype hierarchy for Optional:
 // 1. Optional[T] isSubtypeOf Optional[R] iff T isSubtypeOf R
 // 2. T isSubtypeOf Optional[R] if T isSubtypeOf R
-// 3. NoneType isSubtypeOf any Optional Type
+// Note: NoneType is NOT a subtype of any optional.
+// instead NoneType is convertable in schema matching to any Optional[T]
+// it is handled this way because it is not possible to match None to Optional[T]
+// and extract T. Intead, we always create an instance of the prim::None instruction
+// with a particular type: v: Optional[int] = prim::None()
 struct CAFFE2_API OptionalType: public Type {
   static OptionalTypePtr create(TypePtr element) {
     return OptionalTypePtr(new OptionalType(std::move(element))); // NOLINT(modernize-make-shared)
@@ -679,6 +683,11 @@ struct CAFFE2_API NumberType : public Type {
   std::string str() const override {
     return "Scalar"; // match what PythonArgParser says for clarity
   }
+  std::string python_str() const override {
+    return "number"; // technically not a valid python type, but
+                     // we need to use it when parsing back in annotations
+                     // for implicit conversions
+  }
   static const TypeKind Kind = TypeKind::NumberType;
   // global singleton
   static NumberTypePtr get();
@@ -785,6 +794,9 @@ struct CAFFE2_API StringType : public Type {
   std::string str() const override {
     return "string";
   }
+  std::string python_str() const override {
+    return "str";
+  }
   bool isSubtypeOf(const TypePtr rhs) const override {
     if(auto rhs_ = rhs->cast<OptionalType>()) {
       return this->isSubtypeOf(rhs_->getElementType());
@@ -812,8 +824,7 @@ struct CAFFE2_API NoneType : public Type {
   }
 
   bool isSubtypeOf(const TypePtr rhs) const override {
-    return rhs->kind() == TypeKind::NoneType ||
-           rhs->kind() == TypeKind::OptionalType;
+    return rhs->kind() == TypeKind::NoneType;
   }
 
   std::string str() const override {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -291,10 +291,15 @@ MatchTypeReturn matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type
       }
       ret.type = OptionalType::create(*optionedType.type);
       return ret;
-    } else {
+    } else if (!actual->isSubtypeOf(NoneType::get())) {
       // If the actual type is a non-optional, allow matching to the formal if
-      // its element type matches the actual
+      // its element type matches the actual.
+      // Don't match None because it is already an optional (but one of
+      // unknown type).
       return matchTypeVariables(opt_formal->getElementType(), actual, type_env);
+    } else {
+      ret.errMsg = "cannot match an Optional[T] to None, because there is no way to determine T from None.";
+      return ret;
     }
   }
 

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -899,11 +899,11 @@ const auto cf_examples = R"JIT(
     return a
 )JIT";
 void testControlFlow() {
-  script::Module cu;
+  auto cu = std::make_shared<script::Module>();
   script::defineMethodsInModule(
       cu, cf_examples, script::nativeResolver, nullptr);
   auto run = [&](const std::string& name, std::vector<IValue> stack) {
-    auto graph = cu.get_method(name).graph();
+    auto graph = cu->get_method(name).graph();
     Code code(graph);
     InterpreterState interp(code);
     interp.run(stack);

--- a/test/expect/TestJit.test_import_method.expect
+++ b/test/expect/TestJit.test_import_method.expect
@@ -1,0 +1,4 @@
+def script(self,
+    x: Tensor,
+    y: Tensor) -> Tensor:
+  return aten.add(aten.mul(x, 2), y, alpha=1)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -155,6 +155,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_1.cpp
   ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_2.cpp
   ${TORCH_SRC_DIR}/csrc/jit/graph_executor.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/import_method.cpp
   ${TORCH_SRC_DIR}/csrc/jit/import.cpp
   ${TORCH_SRC_DIR}/csrc/jit/interpreter.cpp
   ${TORCH_SRC_DIR}/csrc/jit/constants.cpp
@@ -194,6 +195,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
   ${TORCH_SRC_DIR}/csrc/jit/tracer.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/hooks_for_testing.cpp
   ${TORCH_SRC_DIR}/csrc/torch.cpp
   ${TORCH_SRC_DIR}/csrc/utils/tensor_flatten.cpp
   ${TORCH_SRC_DIR}/csrc/utils/variadic.cpp

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,7 @@ namespace jit {
 
 std::shared_ptr<script::Module> compile(const std::string& source) {
   auto module = std::make_shared<script::Module>();
-  defineMethodsInModule(*module, source, script::nativeResolver, /*self=*/nullptr);
+  defineMethodsInModule(module, source, script::nativeResolver, /*self=*/nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/hooks_for_testing.cpp
+++ b/torch/csrc/jit/hooks_for_testing.cpp
@@ -1,0 +1,17 @@
+#include "torch/csrc/jit/hooks_for_testing.h"
+#include "torch/csrc/jit/script/module.h"
+
+namespace torch {
+namespace jit {
+
+static std::function<void(std::shared_ptr<script::Module> module)> emit_module_callback;
+TORCH_API void didFinishEmitModule(std::shared_ptr<script::Module> module) {
+  if(emit_module_callback)
+    emit_module_callback(module);
+
+}
+TORCH_API void setEmitModuleHook(std::function<void(std::shared_ptr<script::Module> module)> cb) {
+  emit_module_callback = cb;
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/hooks_for_testing.h
+++ b/torch/csrc/jit/hooks_for_testing.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <functional>
+#include "torch/csrc/WindowsTorchApiMacro.h"
+#include <memory>
+
+namespace torch {
+namespace jit {
+namespace script {
+struct Module;
+}
+TORCH_API void didFinishEmitModule(std::shared_ptr<script::Module> module);
+TORCH_API void setEmitModuleHook(std::function<void(std::shared_ptr<script::Module> module)> cb);
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/import_method.cpp
+++ b/torch/csrc/jit/import_method.cpp
@@ -1,0 +1,114 @@
+#include "torch/csrc/jit/import_method.h"
+#include "torch/csrc/jit/script/parser.h"
+
+namespace torch { namespace jit {
+
+
+// this is a much simpler accessor that only handles modules, parameters, and
+// and methods. It does not depend on python to work.
+struct ModuleAccessorValue : public script::SugaredValue {
+  ModuleAccessorValue(std::shared_ptr<script::Module> module)
+  : module(std::move(module)) {}
+  std::string kind() const override {
+    return "module";
+  }
+  // select an attribute on it, e.g. `this.field`
+  std::shared_ptr<SugaredValue> attr(SourceRange loc, script::Method & m, const std::string& field) override {
+    if(script::NamedModule* v = module->find_module(field)) {
+      return std::make_shared<ModuleAccessorValue>(v->module);
+    } else if(script::NamedParameter* v = module->find_parameter(field)) {
+      return std::make_shared<script::SimpleValue>(m.get_or_add_parameter(v->slot()));
+    } else if(script::Method* m = module->find_method(field)) {
+      return std::make_shared<script::MethodValue>(module, *m);
+    }
+    return script::SugaredValue::attr(loc, m, field);
+  }
+private:
+  std::shared_ptr<script::Module> module;
+};
+
+// This value maps attributes CONSTANTS.c0 CONSTANTS.c1 to entries
+// in the 'constants' vector. This table is will be stored in a container format
+// and given to the import_method when restoring the code.
+struct ConstantTableValue : public script::SugaredValue {
+  ConstantTableValue(ArrayRef<at::Tensor> constants)
+  : constants_(constants) {}
+  std::string kind() const override {
+    return "CONSTANTS";
+  }
+  // select an attribute on it, e.g. `this.field`
+  std::shared_ptr<SugaredValue> attr(SourceRange loc, script::Method & m, const std::string& field) override {
+    const char* field_s = field.c_str();
+    char* end;
+    int64_t offset = std::strtoll(field_s + 1, &end, 10);
+    if(field.size() < 2 || *end != 0)
+      throw script::ErrorReport(loc) << "invalid constant specifier: " << field;
+    if (offset < 0 || size_t(offset) >= constants_.size()) {
+      throw script::ErrorReport(loc) << "constant index " << offset
+                                     << " is out of bounds (constant table has "
+                                     << constants_.size() << " entries).";
+    }
+    Value* value = m.graph()->insertConstant(constants_[offset], loc);
+    return std::make_shared<script::SimpleValue>(value);
+  }
+
+ private:
+   ArrayRef<at::Tensor> constants_;
+};
+
+static size_t parseVersionNumber(script::Lexer& L) {
+  auto range = L.cur().range;
+  auto name = L.expect(script::TK_IDENT).text();
+  L.expect('=');
+  std::string version_text = L.expect(script::TK_NUMBER).text();
+  L.expect(script::TK_NEWLINE);
+  auto version = script::Const::create(L.cur().range, version_text);
+  if (name != "op_version_set")
+    throw script::ErrorReport(range) << "expected an assignment to op_version_set";
+  if (!version.isIntegral())
+    throw script::ErrorReport(range) << "expected an integral version but found " << version.text();
+   return size_t(version.asIntegral());
+}
+
+void import_method(const std::shared_ptr<script::Module>& mod, const std::string& src, const std::vector<at::Tensor>& constant_table) {
+  script::Parser p(src);
+
+  size_t version = parseVersionNumber(p.lexer());
+  auto aten = std::make_shared<script::BuiltinModule>("aten", version);
+  auto prim = std::make_shared<script::BuiltinModule>("prim", version);
+  auto constants = std::make_shared<ConstantTableValue>(constant_table);
+  auto fork = std::make_shared<script::ForkValue>();
+  auto annotate = std::make_shared<script::AnnotateValue>();
+
+  auto resolver = [&](const std::string& name, script::Method& m, const SourceRange& loc)
+  -> std::shared_ptr<script::SugaredValue> {
+    if(name == "aten")
+      return aten;
+    if (name == "prim")
+      return prim;
+    if (name == "CONSTANTS")
+      return constants;
+    if (name == "fork")
+      return fork;
+    if (name == "annotate")
+      return annotate;
+    if (name == "inf") {
+      return std::make_shared<script::SimpleValue>(
+          m.graph()->insertConstant(std::numeric_limits<float>::infinity()));
+    }
+    return nullptr;
+  };
+
+  std::vector<script::Def> definitions;
+  std::vector<script::Resolver> resolvers;
+
+  while (p.lexer().cur().kind != script::TK_EOF) {
+    auto def = script::Def(p.parseFunction(/*is_method=*/true));
+    definitions.emplace_back(def);
+    resolvers.emplace_back(resolver);
+  }
+  auto self = std::make_shared<ModuleAccessorValue>(mod);
+  script::defineMethodsInModule(mod, definitions, resolvers, self);
+}
+
+}}

--- a/torch/csrc/jit/import_method.h
+++ b/torch/csrc/jit/import_method.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/script/module.h"
+#include "torch/csrc/jit/script/compiler.h"
+
+namespace torch {
+namespace jit {
+
+TORCH_API void import_method(const std::shared_ptr<script::Module>& mod, const std::string& src, const std::vector<at::Tensor>& constant_table);
+
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1217,6 +1217,12 @@ Node* Graph::createUndefined() {
   return create(prim::Undefined);
 }
 
+Node* Graph::createNone(TypePtr typ) {
+  Node * n = create(prim::None);
+  n->output()->setType(OptionalType::create(typ));
+  return n;
+}
+
 Node * Graph::createNoneGenerator() {
   auto n = create(prim::NoneGenerator);
   n->output()->setType(GeneratorType::get());

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -138,7 +138,6 @@ public:
   }
   bool isNone() const {
     return type()->kind() == TypeKind::NoneType;
-
   }
   size_t unique() const {
     return unique_;
@@ -836,6 +835,8 @@ public:
   TORCH_API Node * create(NodeKind kind, size_t num_outputs=1);
   TORCH_API Node * create(NodeKind kind, ArrayRef<Value*> inputs, size_t num_outputs=1);
 
+
+  TORCH_API Node* createNone(TypePtr typ); // value of None with type Optional[typ]
   TORCH_API Node* createUndefined();
   TORCH_API Node* createNoneGenerator();
   TORCH_API Node* createFusionGroup();

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -508,6 +508,7 @@ const Operator& getOperatorFor(const Node* node) {
   for(auto & candidate : candidates) {
     er << "  " << candidate->schema() << "\n";
   }
+  er << *node->owningGraph() << "\n";
   throw er;
 }
 

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -21,6 +21,8 @@ std::unordered_set<Symbol> skip_list = {
   prim::Constant,
   prim::Undefined,
   prim::NoneGenerator,
+  prim::None, // it is already a constant and propagating it will lose
+              // important type information about which Optional type it is
   // TODO (zach): we should consider skipping tensor factories in the cases
   // where the constant tensor would be large but cheap to create.
  };

--- a/torch/csrc/jit/passes/python_print.h
+++ b/torch/csrc/jit/passes/python_print.h
@@ -1,13 +1,11 @@
 #pragma once
 #include "torch/csrc/WindowsTorchApiMacro.h"
+#include "torch/csrc/jit/ir.h"
 #include <iostream>
+#include <vector>
 
-namespace c10 {
-  struct Symbol;
-}
 
 namespace torch { namespace jit {
-struct Graph;
-TORCH_API std::ostream& PythonPrint(std::ostream& out, const Graph& graph);
+TORCH_API std::vector<at::Tensor> PythonPrint(std::ostream& out, const Graph& graph, bool enforce_importable=false);
 TORCH_API bool printerHasSpecialCaseFor(c10::Symbol sym);
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/jit/export.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
+#include "torch/csrc/jit/passes/python_print.h"
 #include "torch/csrc/jit/argument_spec.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
@@ -221,6 +222,11 @@ void initPythonIRBindings(PyObject * module_) {
       std::ostringstream oss;
       g.prettyPrint(oss);
       return oss.str();
+    })
+    .def("python_print", [](Graph &g) {
+      std::ostringstream oss;
+      std::vector<at::Tensor> constants = PythonPrint(oss, g, true);
+      return std::make_pair(oss.str(), std::move(constants));
     })
     .GS(createFusionGroup)
     .def("createClone",[](Graph & g, Node * n, py::object fn) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -209,7 +209,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        prim::Undefined,
+        "prim::Undefined() -> Tensor",
         [](const Node* node) {
           return [](Stack& stack) {
             stack.emplace_back(at::Tensor());
@@ -225,7 +225,7 @@ RegisterOperators reg({
         };
       }),
     Operator(
-        prim::NoneGenerator,
+        "prim::NoneGenerator() -> Generator",
         [](const Node* node) {
           return [](Stack& stack) {
             stack.emplace_back();

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -71,7 +71,7 @@ private:
   void loadSource(const std::string& source) {
     auto module = std::make_shared<script::Module>();
     defineMethodsInModule(
-        *module, source, script::nativeResolver, /*self=*/nullptr);
+        module, source, script::nativeResolver, /*self=*/nullptr);
     modules.push_back(module);
     for (auto& method : module->get_methods()) {
       builtins_by_name[Symbol::fromQualString("aten::" + method.key())].push_back(

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -9,6 +9,7 @@
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/jit/operator.h"
 #include "torch/csrc/jit/script/builtin_functions.h"
+#include "torch/csrc/jit/hooks_for_testing.h"
 
 #include "torch/csrc/jit/constants.h"
 
@@ -433,6 +434,45 @@ inline bool convertibleToList(TypePtr type, TypePtr list_type_) {
   return false;
 }
 
+// applies implict conversion from value trying to turn it into type concrete_type
+// it succeeds if the return_value->isSubclassOf(concrete_type)
+Value* tryConvertToType(
+    const SourceRange& loc,
+    Graph& graph,
+    TypePtr concrete_type,
+    Value* value,
+    bool convert_tensors_to_nums) {
+  // Allow homogeneous tuples to be casted implicitly to lists of appropriate
+  // types
+  if (convertibleToList(value->type(), concrete_type) &&
+      value->type()->kind() == TypeKind::TupleType) {
+    auto unpacked = createTupleUnpack(value);
+    auto elem_type = concrete_type->expect<ListType>()->getElementType();
+    value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
+  }
+
+  if (value->type()->isSubtypeOf(NoneType::get()) && !concrete_type->isSubtypeOf(NoneType::get())){
+    if (concrete_type->isSubtypeOf(GeneratorType::get())) {
+      value = graph.insertNode(graph.createNoneGenerator())->output();
+    } else if (concrete_type->isSubtypeOf(OptionalType::ofTensor())) {
+      // create undefined tensor when None pass to a optional[tensor] formal arg
+      value = graph.insertNode(graph.createUndefined())->output();
+    } else if (auto optional_type = concrete_type->cast<OptionalType>()) {
+      value = graph.insertNode(graph.createNone(optional_type->getElementType()))->output();
+    }
+  }
+
+  //implicit conversion of tensors to scalars
+  if(convert_tensors_to_nums && concrete_type->isSubtypeOf(NumberType::get())
+      && value->type()->isSubtypeOf(DynamicType::get())) {
+      auto n = graph.createImplicitTensorToNum(concrete_type, value);
+      value = graph.insertNode(n)
+        ->setSourceLocation(std::make_shared<SourceRange>(loc))
+        ->output();
+  }
+  return value;
+}
+
 Value* tryMatchArgument(
     const Argument& arg,
     Graph& graph,
@@ -462,32 +502,7 @@ Value* tryMatchArgument(
   }
   const auto concrete_type = *matched_type.type;
 
-  // Allow homogeneous tuples to be casted implicitly to lists of appropriate types
-  if (convertibleToList(value->type(), concrete_type) &&
-      value->type()->kind() == TypeKind::TupleType) {
-    auto unpacked = createTupleUnpack(value);
-    auto elem_type = concrete_type->expect<ListType>()->getElementType();
-    value = graph.insertNode(graph.createList(elem_type, unpacked))->output();
-  }
-
-  if (value->type()->isSubtypeOf(NoneType::get()) && !concrete_type->isSubtypeOf(NoneType::get())){
-    if (concrete_type->isSubtypeOf(GeneratorType::get())) {
-      value = graph.insertNode(graph.createNoneGenerator())->output();
-    }
-    if (concrete_type->isSubtypeOf(OptionalType::ofTensor())) {
-      // create undefined tensor when None pass to a optional[tensor] formal arg
-      value = graph.insertNode(graph.createUndefined())->output();
-    }
-  }
-
-  //implicit conversion of tensors to scalars
-  if(convert_tensors_to_nums && concrete_type->isSubtypeOf(NumberType::get())
-      && value->type()->isSubtypeOf(DynamicType::get())) {
-      auto n = graph.createImplicitTensorToNum(concrete_type, value);
-      value = graph.insertNode(n)
-        ->setSourceLocation(std::make_shared<SourceRange>(loc))
-        ->output();
-  }
+  value = tryConvertToType(loc, graph, concrete_type, value, convert_tensors_to_nums);
 
   if(!value->type()->isSubtypeOf(concrete_type)) {
     err() << "expected a value of type " << concrete_type->str() << " for argument '" << arg.name() << "' but found "
@@ -726,7 +741,6 @@ Value* emitBuiltinCall(
           attributes,
           failure_messages,
           convert_tensors_to_nums);
-
       if (matched_schema) {
         return emitBuiltinNode(*matched_schema, loc, graph, name);
       }
@@ -866,11 +880,11 @@ struct to_ir {
       }
       auto range = return_stmt.range();
       size_t return_type_idx = 0;
-      for (auto& r : results) {
-        graph->registerOutput(r);
+      for (auto r : results) {
         TypePtr type = DynamicType::get();
         if (!schema.is_varret()) {
           type = schema.returns().at(return_type_idx).type();
+          r = tryConvertToType(range, *graph, type, r, /*convert_tensors_to_nums=*/false);
           if (!r->type()->isSubtypeOf(type)) {
             throw ErrorReport(return_stmt.range()) << "Return value at position "
               << return_type_idx << " was annotated as having type " << type->str()
@@ -878,6 +892,7 @@ struct to_ir {
           }
           return_type_idx++;
         }
+        graph->registerOutput(r);
         returns.emplace_back("", type);
       }
     } else if (schema.returns().size() > 0) {
@@ -1771,7 +1786,12 @@ private:
         throw ErrorReport(loc) << "attribute takes no keyword arguments";
       }
       TypePtr type = parseTypeFromExpr(apply.inputs()[0]);
-      Value* expr = emitExpr(apply.inputs()[1], type);
+      Value* expr = tryConvertToType(
+          apply.range(),
+          *graph,
+          type,
+          emitExpr(apply.inputs()[1], type),
+          /*convert_tensors_to_nums=*/true);
       if (!expr->type()->isSubtypeOf(type)) {
         throw ErrorReport(apply.inputs())
             << "expected an expression of type " << type->python_str()
@@ -2340,7 +2360,7 @@ std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> input
   return outputs;
 }
 
-void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const std::vector<Resolver>& resolvers, SugaredValuePtr self) {
+void defineMethodsInModule(std::shared_ptr<Module> m, const std::vector<Def>& definitions, const std::vector<Resolver>& resolvers, SugaredValuePtr self) {
   JIT_ASSERT(definitions.size() == resolvers.size());
   auto resolver_it = resolvers.begin();
   std::vector<Method*> methods;
@@ -2368,13 +2388,14 @@ void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, cons
       JIT_ASSERT(resolver);
       to_ir(def, resolver, self,  method);
     };
-    Method& method = m.create_method(name, creator);
+    Method& method = m->create_method(name, creator);
     function_table[name] = &method;
     methods.push_back(&method);
   }
   for(Method* method : methods) {
     method->ensure_defined();
   }
+  didFinishEmitModule(m);
 }
 
 const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
@@ -2384,6 +2405,9 @@ const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
     {"float", FloatType::get()},
     {"bool", BoolType::get()},
     {"str", StringType::get()},
+    // technically this is not a python type but we need it when
+    // parsing serialized methods that use implicit converions to Scalar
+    {"number", NumberType::get()},
   };
   return map;
 }
@@ -2570,7 +2594,7 @@ FunctionSchema extractSchemaFromDef(const Def &def, bool is_method) {
     return FunctionSchema(name, args, returns, false, is_varret);
 }
 
-void defineMethodsInModule(Module & m, const std::string& source, Resolver resolver, SugaredValuePtr self) {
+void defineMethodsInModule(std::shared_ptr<Module> m, const std::string& source, Resolver resolver, SugaredValuePtr self) {
   Parser p(source);
   std::vector<Def> definitions;
   std::vector<Resolver> resolvers;

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -170,14 +170,14 @@ inline std::shared_ptr<SugaredValue> nativeResolver(const std::string& name, Met
 }
 
 TORCH_API void defineMethodsInModule(
-  Module & m,
+  std::shared_ptr<Module> m,
   const std::vector<Def>& definitions,
   const std::vector<Resolver>& resolvers, /* determines how we handle free variables in each definition*/
   std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
 );
 
 // same as above but parse the definitions from source
-TORCH_API void defineMethodsInModule(Module & m, const std::string& source, Resolver resolver, std::shared_ptr<SugaredValue> self);
+TORCH_API void defineMethodsInModule(std::shared_ptr<Module> m, const std::string& source, Resolver resolver, std::shared_ptr<SugaredValue> self);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -27,6 +27,7 @@ namespace script {
 #define TC_FORALL_TOKEN_KINDS(_)                 \
   _(TK_EOF, "eof", "")                           \
   _(TK_WHITESPACE, "whitespace", "")             \
+  _(TK_WHITESPACE_EOF, "whitespace_eof", "")     \
   _(TK_NUMBER, "number", "")                     \
   _(TK_NEWLINE, "newline", "")                   \
   _(TK_INDENT, "indent", "")                     \
@@ -272,6 +273,17 @@ struct SharedParserData {
             str, pos + 1, continuation, !continuation, kind, start, len);
       }
     }
+    // we handle white space before EOF because in the case we have something like
+    // the following where we need to generate the dedent token
+    // if foo:
+    //   ...
+    // else:
+    //   pass
+    if (whitespace_token) {
+      *kind = pos == str.size() ? TK_WHITESPACE_EOF : TK_WHITESPACE;
+      *len = pos - *start;
+      return true;
+    }
     if (pos == str.size()) {
       *kind = TK_EOF;
       *start = pos;
@@ -279,11 +291,6 @@ struct SharedParserData {
       return true;
     }
     // invariant: the next token is not whitespace or newline
-    if (whitespace_token) {
-      *kind = TK_WHITESPACE;
-      *len = pos - *start;
-      return true;
-    }
     *start = pos;
     // check for a valid number
     if (isNumber(str, pos, len)) {
@@ -445,8 +452,16 @@ struct Lexer {
       case '}':
         nesting--;
         break;
-      case TK_WHITESPACE: {
-        int depth = r.range.size();
+      case TK_WHITESPACE:
+      case TK_WHITESPACE_EOF: {
+        int depth =
+            r.kind == TK_WHITESPACE_EOF ? indent_stack.front() : r.range.size();
+        // note: TK_WHITESPACE_EOF is whitespace right before the EOF token
+        // just like we allow the code to be indented to a particular initial
+        // indent level, we allow the final indent to be anything and set
+        // it back to the initial indent level. This allows the code to be
+        // put into string literals inside code without worrying about final
+        // whitespace
         if (depth > indent_stack.back()) {
           indent_stack.push_back(depth);
           r.kind = TK_INDENT;
@@ -458,20 +473,12 @@ struct Lexer {
             indent_stack.pop_back();
             next_tokens.emplace_back(TK_DEDENT, r.range);
             if (indent_stack.size() == 0) {
-              reportError("invalid ident level", r);
+              reportError("invalid indent level " + std::to_string(depth), r);
             }
           }
           return; // We've already queued the tokens
         }
       } break;
-      case TK_EOF:
-        if (indent_stack.size() > 1) {
-          next_tokens.emplace_back(TK_NEWLINE, r.range);
-          next_tokens.emplace_back(TK_DEDENT, r.range);
-          indent_stack.pop_back();
-          return;
-        }
-        break;
       default:
         break;
     }

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -54,7 +54,11 @@ void addInputs(Node *n, const char * name, const c10::optional<at::Scalar>& valu
   if(value) {
     detail::genericAddInput(n, *value);
   } else {
-    detail::genericAddInput(n, IValue());
+    Graph * g = n->owningGraph();
+    Value* none =
+        g->insertNode(g->createNone(NumberType::get()))
+            ->output();
+    n->addInput(none);
   }
 }
 void addInputs(Node *n, const char * name, const std::string& value) { detail::genericAddInput(n, value); }


### PR DESCRIPTION
* Add hooks to get a callback whenever a valid graph is produced in the compiler or through tracing. These hooks can be used to pretty_print and then reparse every graph our tests produce to check that the serialization function works correctly. Currently this is guarded by an environment variable since there are a few remaining failures.
* Fix printing bugs: True and False rather than 1 and 0, print 0. for floating point zero
* Change behavior of NoneType. It is now no longer a subtype of Optional but instead implicitly converts to it, returning a prim::Node with an Option[T] type for some specific T. This allows functions like `_unwrap_optional` to correctly match against a None while still deriving the right type. 
* Fix a bug where empty blocks did not correctly emit "pass" in printer.
* Fix a bug where prim::Undefine sometimes cannot be printed as None because it is being used in a schema-less op. This should be fixable once Optional[T] always uses the same None object.
* Other minor printing bugs
 