### PR TITLE
consistent rounding

### DIFF
--- a/caffe2/quantization/server/dnnlowp.h
+++ b/caffe2/quantization/server/dnnlowp.h
@@ -74,8 +74,9 @@ T Quantize(float src, std::int32_t zero_point, float scale,
            bool result_is_signed = std::is_signed<T>::value) {
   const float transformed_val = zero_point + src / scale;
   return clamp<std::int64_t, T>(
-      (std::int64_t)round(transformed_val),
-      result_precision, result_is_signed);
+      static_cast<std::int64_t>(std::nearbyint(transformed_val)),
+      result_precision,
+      result_is_signed);
 }
 
 template <typename T>

--- a/caffe2/quantization/server/dynamic_histogram.cc
+++ b/caffe2/quantization/server/dynamic_histogram.cc
@@ -206,12 +206,14 @@ const Histogram *DynamicHistogram::Finalize() {
 
       // dst_bin_cnt is the count from src_bin that should go to dst_bin
       // The remainder should go to dst_bin2
-      // TODO: This is only run at the beginning when there is only
-      // one bin, we should optimize this with the unlikely compiler hints
-      uint64_t dst_bin_cnt = src_bin_width == 0 ? 0 : std::min(
-        (uint64_t)round(
-          (dst_bin_end - src_bin_begin) / src_bin_width * bins[i]),
-        bins[i]);
+      // rint is the fastest way to round
+      // (https://stackoverflow.com/questions/485525/round-for-float-in-c/5849630)
+      uint64_t dst_bin_cnt = src_bin_width == 0
+          ? 0
+          : std::min(
+                static_cast<uint64_t>(rint(
+                    (dst_bin_end - src_bin_begin) / src_bin_width * bins[i])),
+                bins[i]);
 
       final_histogram_->Add(dst_bin_begin + dst_bin_width / 2, dst_bin_cnt);
       if (dst_bin_cnt < bins[i]) {

--- a/caffe2/quantization/server/requantization_test.cc
+++ b/caffe2/quantization/server/requantization_test.cc
@@ -46,9 +46,9 @@ TEST(Requantization, BatchRequantizationUnitTest) {
 
     for (int j = 0; j < LEN; ++j) {
       expected[j] = clamp(
-        target_qparams.zero_point +
-          std::round((double)src[j] * real_multiplier),
-        8);
+          target_qparams.zero_point +
+              std::nearbyint(static_cast<double>(src[j]) * real_multiplier),
+          8);
     }
 
     unsigned long long cycle_begin = __rdtsc();

--- a/caffe2/quantization/server/tanh.cc
+++ b/caffe2/quantization/server/tanh.cc
@@ -25,7 +25,7 @@ static int GetPassRegionEnd_(
   int in_pos_qmax = (1 << (num_in_bits - 1)) - 1;
 
   float scale_multiplier = in_qparams.scale / out_qparams.scale;
-  int log2_scale_multiplier = (int)round(log2(scale_multiplier));
+  int log2_scale_multiplier = nearbyint(log2(scale_multiplier));
 
   int x_q;
   for (x_q = 0; x_q < in_pos_qmax; ++x_q) {
@@ -76,7 +76,7 @@ Tanh<T>::Tanh(double max_abs_err) : max_abs_err_(max_abs_err) {
     double y_begin = tanh((i - 0.5) * in_qparams_.scale);
     double y_end = tanh((i + 0.5) * in_qparams_.scale);
 
-    int y_avg_q = (int)round((y_begin + y_end) / 2 / out_qparams_.scale);
+    int y_avg_q = nearbyint((y_begin + y_end) / 2 / out_qparams_.scale);
     assert(y_avg_q*out_qparams_.scale - y_begin < max_abs_err);
     assert(y_end - y_avg_q*out_qparams_.scale < max_abs_err);
     assert(y_avg_q >= 0);
@@ -110,7 +110,7 @@ T Tanh<T>::Compute(T x) const {
   if (x_mag < x_pq_index_) {
     // pass region
     float scale_multiplier = in_qparams_.scale / out_qparams_.scale;
-    int log2_scale_multiplier = (int)round(log2(scale_multiplier));
+    int log2_scale_multiplier = nearbyint(log2(scale_multiplier));
     if (log2_scale_multiplier < 0) {
       y = x_sgn * (x_mag >> (-log2_scale_multiplier));
     }


### PR DESCRIPTION
Summary:
The vectorized code was rounding to even in halfway cases with _mm256_round_ps + (_MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC) (see more details in https://software.intel.com/en-us/node/523819), but we were still using std::round in a couple of places which does rounding away from zero in halfway cases.
With this diff, we use std::nearbyint in all scalar code (except a few cases where we don't care exact rounding mode and uses rint which is the fastest in general) to be more consistent. nearbyint is the same as what the vectorized code does only when the current rounding mode is FE_TONEAREST but in practice this is OK because we almost always use the default rounding mode FE_TONEAREST.

This is inspired by Marat's diff for mobile quantization.

Reviewed By: dskhudia

Differential Revision: D13017719
