### PR TITLE
Add proper from_blob overloads

### DIFF
--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -40,13 +40,6 @@ inline Tensor from_blob(
   return at::getType(options).tensorFromBlob(data, sizes, strides, deleter);
 }
 
-inline Tensor from_blob(
-    void* data,
-    IntList sizes,
-    const TensorOptions& options = {}) {
-  return native::from_blob(data, sizes, /*deleter=*/[](void*) {}, options);
-}
-
 // These functions are defined in native/TensorFactories.cpp.
 #define TENSOR(T, S, _1)                                                      \
   CAFFE2_API Tensor tensor(ArrayRef<T> values, const TensorOptions& options); \

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -228,14 +228,16 @@ TEST(TensorTest, UsesOptionsThatAreSupplied) {
 }
 
 TEST(TensorTest, FromBlob) {
-  std::vector<int32_t> v = {1, 2, 3};
-  auto tensor = torch::from_blob(v.data(), v.size(), torch::kInt32);
+  std::vector<double> v = {1.0, 2.0, 3.0};
+  auto tensor = torch::from_blob(
+      v.data(), v.size(), torch::dtype(torch::kFloat64).requires_grad(true));
   ASSERT_TRUE(tensor.is_variable());
-  ASSERT_EQ(tensor.dtype(), torch::kInt32);
+  ASSERT_TRUE(tensor.requires_grad());
+  ASSERT_EQ(tensor.dtype(), torch::kFloat64);
   ASSERT_EQ(tensor.numel(), 3);
-  ASSERT_EQ(tensor[0].item<int32_t>(), 1);
-  ASSERT_EQ(tensor[1].item<int32_t>(), 2);
-  ASSERT_EQ(tensor[2].item<int32_t>(), 3);
+  ASSERT_EQ(tensor[0].item<double>(), 1);
+  ASSERT_EQ(tensor[1].item<double>(), 2);
+  ASSERT_EQ(tensor[2].item<double>(), 3);
 }
 
 TEST(TensorTest, FromBlobUsesDeleter) {
@@ -260,7 +262,10 @@ TEST(TensorTest, FromBlobWithStrides) {
   };
   // clang-format on
   auto tensor = torch::from_blob(
-      v.data(), /*sizes=*/{3, 3}, /*strides=*/{1, 3}, /*dtype=*/torch::kInt32);
+      v.data(),
+      /*sizes=*/{3, 3},
+      /*strides=*/{1, 3},
+      torch::kInt32);
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.dtype(), torch::kInt32);
   ASSERT_EQ(tensor.numel(), 9);

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -72,7 +72,6 @@ TEST(TensorTest, ToTensorAndTensorAttributes) {
   REQUIRE_TENSOR_OPTIONS(at::kCPU, -1, at::kInt, at::kStrided);
 }
 
-
 // Not currently supported.
 // TEST(TensorTest, ToLayout) {
 //   auto tensor = at::empty({3, 4});
@@ -95,8 +94,10 @@ TEST(TensorTest, ToOptionsWithRequiresGrad) {
     ASSERT_TRUE(tensor.requires_grad());
 
     // Throws if requires_grad is set in TensorOptions
-    ASSERT_THROW(tensor.to(at::TensorOptions().requires_grad(true)), c10::Error);
-    ASSERT_THROW(tensor.to(at::TensorOptions().requires_grad(false)), c10::Error);
+    ASSERT_THROW(
+        tensor.to(at::TensorOptions().requires_grad(true)), c10::Error);
+    ASSERT_THROW(
+        tensor.to(at::TensorOptions().requires_grad(false)), c10::Error);
   }
   {
     auto tensor = torch::empty({3, 4});
@@ -107,8 +108,10 @@ TEST(TensorTest, ToOptionsWithRequiresGrad) {
     ASSERT_FALSE(tensor.requires_grad());
 
     // Throws if requires_grad is set in TensorOptions
-    ASSERT_THROW(tensor.to(at::TensorOptions().requires_grad(true)), c10::Error);
-    ASSERT_THROW(tensor.to(at::TensorOptions().requires_grad(false)), c10::Error);
+    ASSERT_THROW(
+        tensor.to(at::TensorOptions().requires_grad(true)), c10::Error);
+    ASSERT_THROW(
+        tensor.to(at::TensorOptions().requires_grad(false)), c10::Error);
   }
 }
 
@@ -228,8 +231,45 @@ TEST(TensorTest, FromBlob) {
   std::vector<int32_t> v = {1, 2, 3};
   auto tensor = torch::from_blob(v.data(), v.size(), torch::kInt32);
   ASSERT_TRUE(tensor.is_variable());
+  ASSERT_EQ(tensor.dtype(), torch::kInt32);
   ASSERT_EQ(tensor.numel(), 3);
   ASSERT_EQ(tensor[0].item<int32_t>(), 1);
   ASSERT_EQ(tensor[1].item<int32_t>(), 2);
   ASSERT_EQ(tensor[2].item<int32_t>(), 3);
+}
+
+TEST(TensorTest, FromBlobUsesDeleter) {
+  bool called = false;
+  {
+    std::vector<int32_t> v = {1, 2, 3};
+    auto tensor = torch::from_blob(
+        v.data(),
+        v.size(),
+        /*deleter=*/[&called](void* data) { called = true; },
+        torch::kInt32);
+  }
+  ASSERT_TRUE(called);
+}
+
+TEST(TensorTest, FromBlobWithStrides) {
+  // clang-format off
+  std::vector<int32_t> v = {
+    1, 2, 3,
+    4, 5, 6,
+    7, 8, 9
+  };
+  // clang-format on
+  auto tensor = torch::from_blob(
+      v.data(), /*sizes=*/{3, 3}, /*strides=*/{1, 3}, /*dtype=*/torch::kInt32);
+  ASSERT_TRUE(tensor.is_variable());
+  ASSERT_EQ(tensor.dtype(), torch::kInt32);
+  ASSERT_EQ(tensor.numel(), 9);
+  const std::vector<int64_t> expected_strides = {1, 3};
+  ASSERT_EQ(tensor.strides(), expected_strides);
+  for (int64_t i = 0; i < tensor.size(0); ++i) {
+    for (int64_t j = 0; j < tensor.size(1); ++j) {
+      // NOTE: This is column major because the strides are swapped.
+      EXPECT_EQ(tensor[i][j].item<int32_t>(), 1 + (j * tensor.size(1)) + i);
+    }
+  }
 }

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -4,6 +4,8 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/ArrayRef.h>
+#include <torch/csrc/autograd/variable.h>
+#include <torch/csrc/jit/tracer.h>
 
 #include <functional>
 #include <initializer_list>
@@ -43,8 +45,9 @@ inline at::Tensor from_blob(
     at::IntList strides,
     const std::function<void(void*)>& deleter,
     const at::TensorOptions& options = {}) {
-  return at::from_blob(
-      data, sizes, strides, deleter, options.is_variable(true));
+  at::Tensor tensor =
+      at::from_blob(data, sizes, strides, deleter, options.is_variable(false));
+  return autograd::make_variable(tensor, options.requires_grad());
 }
 
 inline at::Tensor from_blob(
@@ -52,12 +55,12 @@ inline at::Tensor from_blob(
     at::IntList sizes,
     at::IntList strides,
     const at::TensorOptions& options = {}) {
-  return at::from_blob(
+  return torch::from_blob(
       data,
       sizes,
       strides,
       /*deleter=*/[](void*) {},
-      options.is_variable(true));
+      options);
 }
 
 inline at::Tensor from_blob(
@@ -65,15 +68,16 @@ inline at::Tensor from_blob(
     at::IntList sizes,
     const std::function<void(void*)>& deleter,
     const at::TensorOptions& options = {}) {
-  return at::from_blob(data, sizes, deleter, options.is_variable(true));
+  at::Tensor tensor =
+      at::from_blob(data, sizes, deleter, options.is_variable(false));
+  return autograd::make_variable(tensor, options.requires_grad());
 }
 
 inline at::Tensor from_blob(
     void* data,
     at::IntList sizes,
     const at::TensorOptions& options = {}) {
-  return at::from_blob(
-      data, sizes, /*deleter=*/[](void*) {}, options.is_variable(true));
+  return torch::from_blob(data, sizes, /*deleter=*/[](void*) {}, options);
 }
 
 ${function_definitions}


### PR DESCRIPTION
There was an overload for `torch::from_blob` missing that allowed passing strides.

@ezyang @soumith 