### PR TITLE
fix TensorPrinter when tensor have 0 size.

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -523,6 +523,11 @@ void TensorPrinter::Print(const Tensor& tensor) {
   // One most likely doesn't want to print int64-number of items for visual
   // inspection, so we cast down to int here.
   int total_count = static_cast<int>(std::min(tensor.numel(), int64_t(limit_)));
+
+  if (total_count == 0) {
+    return;
+  }
+
   const T* tensor_data = tensor.template data<T>();
   for (int i = 0; i < total_count - 1; ++i) {
     values_stream << tensor_data[i] << ",";


### PR DESCRIPTION
Summary:
if totoal_count == 0, it crash on:

  values_stream << tensor_data[total_count - 1];

Differential Revision: D13066438
