### PR TITLE
[jit] don't throw in matchTypeVariables

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -936,15 +936,6 @@ template<> inline TypePtr getTypePtr<std::vector<int64_t>>() { return ListType::
 
 CAFFE2_API TypePtr inferTypeFrom(const IValue& value);
 
-struct CAFFE2_API TypeMatchError : public std::exception {
-  TypeMatchError(std::string msg_)
-  : msg_(std::move(msg_)) {}
-  const char * what() const noexcept override {
-    return msg_.c_str();
-  }
-private:
-  std::string msg_;
-};
 using TypeEnv = std::unordered_map<std::string, TypePtr>;
 struct MatchTypeReturn {
   c10::optional<TypePtr> type; // nullopt if there is no match

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -946,7 +946,14 @@ private:
   std::string msg_;
 };
 using TypeEnv = std::unordered_map<std::string, TypePtr>;
-CAFFE2_API TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv & type_env);
+struct MatchTypeReturn {
+  c10::optional<TypePtr> type; // nullopt if there is no match
+  std::string errMsg; // is there is no match, this contains the reason
+};
+
+CAFFE2_API MatchTypeReturn
+matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env);
+
 CAFFE2_API TypePtr evalTypeVariables(TypePtr type, TypeEnv & type_env);
 
 } // namespace c10

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -201,63 +201,96 @@ c10::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
   return c10::nullopt;
 }
 
-TypePtr matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
-  if(!formal->hasFreeVariables())
-    return formal;
+MatchTypeReturn matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env) {
+  MatchTypeReturn ret;
+  if(!formal->hasFreeVariables()) {
+    ret.type = formal;
+    return ret;
+  }
+
   if(auto vt = formal->cast<VarType>()) {
     auto it = type_env.find(vt->name());
     if(it == type_env.end()) {
       type_env[vt->name()] = actual;
-      return actual;
+      ret.type = actual;
+      return ret;
     } else if(auto unified = unifyTypes(it->second, actual)) {
       type_env[vt->name()] = *unified;
-      return *unified;
+      ret.type = *unified;
+      return ret;
     }
     std::stringstream ss;
     ss << "type variable '" << vt->name() <<"' previously matched to type " <<
       it->second->str() << " is matched to type " << actual->str();
-    throw TypeMatchError(ss.str());
+    ret.errMsg = ss.str();
+    return ret;
   } else if(auto lt_formal = formal->cast<ListType>()) {
     if(auto lt_actual = actual->cast<ListType>()) {
-      return ListType::create(matchTypeVariables(lt_formal->getElementType(), lt_actual->getElementType(), type_env));
+      const auto innerType = matchTypeVariables(
+          lt_formal->getElementType(),
+          lt_actual->getElementType(),
+          type_env);
+      if (!innerType.type) {
+        // propagate the errMsg onward
+        return innerType;
+      }
+      ret.type = ListType::create(*innerType.type);
+      return ret;
     } else {
       std::stringstream ss;
       ss << "cannot match a list to " << actual->str();
-      throw TypeMatchError(ss.str());
+      ret.errMsg = ss.str();
+      return ret;
     }
   } else if(auto tp_formal = formal->cast<TupleType>()) {
     if(auto tp_actual = actual->cast<TupleType>()) {
       if(tp_formal->elements().size() != tp_actual->elements().size()) {
-        std::stringstream ss;
-        throw TypeMatchError("cannot match tuples of mismatched size");
+        ret.errMsg = "cannot match tuples of mismatched size";
+        return ret;
       }
       std::vector<TypePtr> elements;
       for(size_t i = 0; i < tp_formal->elements().size(); ++i) {
-        TypePtr result = matchTypeVariables(
+        const auto result = matchTypeVariables(
             tp_formal->elements()[i],
             tp_actual->elements()[i],
             type_env);
-        elements.push_back(result);
+        if (!result.type) {
+          return result;
+        }
+        elements.push_back(*result.type);
       }
-      return TupleType::create(std::move(elements));
+      ret.type = TupleType::create(std::move(elements));
+      return ret;
     } else {
       std::stringstream ss;
       ss << "cannot match a tuple to " << actual->str();
-      throw TypeMatchError(ss.str());
+      ret.errMsg = ss.str();
+      return ret;
     }
   } else if (auto lt_formal = formal->cast<FutureType>()) {
     if (auto lt_actual = actual->cast<FutureType>()) {
-      return FutureType::create(matchTypeVariables(
-          lt_formal->getElementType(), lt_actual->getElementType(), type_env));
+      const auto innerType = matchTypeVariables(
+          lt_formal->getElementType(), lt_actual->getElementType(), type_env);
+      if (!innerType.type) {
+        return innerType;
+      }
+      ret.type = FutureType::create(*innerType.type);
+      return ret;
     } else {
       std::stringstream ss;
       ss << "cannot match a future to " << actual->str();
-      throw TypeMatchError(ss.str());
+      ret.errMsg = ss.str();
+      return ret;
     }
   } else if (auto opt_formal = formal->cast<OptionalType>()) {
     if (auto opt_actual = actual->cast<OptionalType>()) {
-      return OptionalType::create(matchTypeVariables(
-          opt_formal->getElementType(), opt_actual->getElementType(), type_env));
+      const auto optionedType = matchTypeVariables(
+          opt_formal->getElementType(), opt_actual->getElementType(), type_env);
+      if (!optionedType.type) {
+        return optionedType;
+      }
+      ret.type = OptionalType::create(*optionedType.type);
+      return ret;
     } else {
       // If the actual type is a non-optional, allow matching to the formal if
       // its element type matches the actual

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -459,7 +459,7 @@ bool Operator::matches(const Node* node) const {
 
   TypeEnv type_env;
   for(size_t i = 0; i < formals.size(); ++i) {
-    at::MatchTypeReturn matched_type =
+    const MatchTypeReturn matched_type =
         matchTypeVariables(formals[i].type(), actuals[i]->type(), type_env);
     if (!matched_type.type) {
       return false;

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -459,13 +459,13 @@ bool Operator::matches(const Node* node) const {
 
   TypeEnv type_env;
   for(size_t i = 0; i < formals.size(); ++i) {
-    try {
-      TypePtr formal = matchTypeVariables(formals[i].type(), actuals[i]->type(), type_env);
-      // mismatched input type
-      if (!actuals[i]->type()->isSubtypeOf(formal)) {
-        return false;
-      }
-    } catch(TypeMatchError& err) {
+    at::MatchTypeReturn matched_type =
+        matchTypeVariables(formals[i].type(), actuals[i]->type(), type_env);
+    if (!matched_type.type) {
+      return false;
+    }
+    TypePtr formal = *matched_type.type;
+    if (!actuals[i]->type()->isSubtypeOf(formal)) {
       return false;
     }
   }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -451,7 +451,7 @@ Value* tryMatchArgument(
     value = graph.insertNode(graph.createList(value->type(), repeated))->output();
   }
 
-  at::MatchTypeReturn matched_type =
+  const MatchTypeReturn matched_type =
       matchTypeVariables(arg.type(), value->type(), type_env);
   if (!matched_type.type) {
     err() << "could not match type " << value->type()->str() << " to "

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -451,15 +451,16 @@ Value* tryMatchArgument(
     value = graph.insertNode(graph.createList(value->type(), repeated))->output();
   }
 
-  TypePtr concrete_type;
-  try {
-    concrete_type = matchTypeVariables(arg.type(), value->type(), type_env);
-  } catch(TypeMatchError& e) {
+  at::MatchTypeReturn matched_type =
+      matchTypeVariables(arg.type(), value->type(), type_env);
+  if (!matched_type.type) {
     err() << "could not match type " << value->type()->str() << " to "
-          << arg.type()->str() << " in argument '" << arg.name() << "': " << e.what() << "\n"
+          << arg.type()->str() << " in argument '" << arg.name()
+          << "': " << matched_type.errMsg << "\n"
           << named_value.locOr(loc);
     return nullptr;
   }
+  const auto concrete_type = *matched_type.type;
 
   // Allow homogeneous tuples to be casted implicitly to lists of appropriate types
   if (convertibleToList(value->type(), concrete_type) &&

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -13,9 +13,9 @@ namespace torch { namespace jit {
 using ::c10::Type;
 using ::c10::TypePtr;
 using ::c10::TypeEnv;
-using ::c10::TypeMatchError;
 
 using ::c10::getTypePtr;
 using ::c10::TypeKind;
+using ::c10::MatchTypeReturn;
 
 }} // namespace torch::jit


### PR DESCRIPTION
Avoid throwing on match errors. In general, it's not good to throw when failure is expected.

But the real reason I'm doing this is it makes it annoying to set a breakpoint on exceptions in my debugger 😛 