### PR TITLE
Fix out of order member fields initializaitons

### DIFF
--- a/aten/src/THCUNN/HardTanh.cu
+++ b/aten/src/THCUNN/HardTanh.cu
@@ -10,9 +10,7 @@ struct hardtanhupdateOutput_functor
   const T min_val_;
 
   hardtanhupdateOutput_functor(T min_val, T max_val)
-    : min_val_(min_val)
-    , max_val_(max_val)
-  {}
+      : max_val_(max_val), min_val_(min_val) {}
 
   __device__ void operator()(T *output, const T *input) const
   {
@@ -40,9 +38,7 @@ struct hardtanhupdateGradInput_functor
   const T min_val_;
 
   hardtanhupdateGradInput_functor(T min_val, T max_val)
-    : min_val_(min_val)
-    , max_val_(max_val)
-  {}
+      : max_val_(max_val), min_val_(min_val) {}
 
   __device__ void operator()(T *gradInput, const T *input, const T *gradOutput) const
   {


### PR DESCRIPTION
@xw285cornell 

Unfortunately it's not easy to add -Werror=reorder flag since there are out of order initializations in thrust headers as well, and the rocm cmake macro hip_include_directories doesn't offer a way to include headers as external headers. 