### PR TITLE
[jit] Export BatchNorm functional and module, add necessary JIT support

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3671,6 +3671,13 @@ a")
         with self.assertRaisesRegex(RuntimeError, "previously has type"):
             self.checkScript(reassign_nested, (), optimize=False)
 
+        def list_ctor(x):
+            y = list([1, 2, 3])
+            z = list(x.size())
+            return
+
+        self.checkScript(reassign, (), optimize=False)
+
     def test_list_gather(self):
         def index():
             a = [1, 2, 3]
@@ -4996,6 +5003,24 @@ a")
                     self.i = (3, 4, {})
 
         f = Foo()
+
+    def test_script_module_param_buffer_mutation(self):
+        # TODO: add param mutation test case after JIT support it
+        class ModuleBufferMutate(torch.jit.ScriptModule):
+            __constants__ = ['training']
+
+            def __init__(self):
+                super(ModuleBufferMutate, self).__init__(False)
+                self.register_buffer('running_var', torch.tensor(0, dtype=torch.long))
+
+            @torch.jit.script_method
+            def forward(self):
+                if self.training:
+                    self.running_var += 1
+                return self.running_var
+
+        m = ModuleBufferMutate()
+        self.assertEqual(m(), 1)
 
     def test_script_module_for(self):
         class M(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3671,13 +3671,6 @@ a")
         with self.assertRaisesRegex(RuntimeError, "previously has type"):
             self.checkScript(reassign_nested, (), optimize=False)
 
-        def list_ctor(x):
-            y = list([1, 2, 3])
-            z = list(x.size())
-            return
-
-        self.checkScript(reassign, (), optimize=False)
-
     def test_list_gather(self):
         def index():
             a = [1, 2, 3]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9653,6 +9653,9 @@ S = 5
 # )
 nn_module_tests = [
     ('AlphaDropout', (), ((S,),)),
+    ('BatchNorm1d', (10,), ((S, 10),)),
+    ('BatchNorm2d', (10,), ((S, 10, S, S),)),
+    ('BatchNorm3d', (10,), ((S, 10, S, S, S),)),
     ('Dropout', (), ((S,),)),
     ('Dropout2d', (), ((S, S),)),
     ('Dropout3d', (), ((S, S, S),)),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -853,6 +853,7 @@ Operator(                                                                      \
 
 #define CREATE_LIST_OPS(decl_type, c_type) \
     Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
+    Operator("aten::list(" decl_type "[] a) -> " decl_type "[]", [](Stack& stack) { return 0; }), \
     Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
     Operator( \
         "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -853,7 +853,6 @@ Operator(                                                                      \
 
 #define CREATE_LIST_OPS(decl_type, c_type) \
     Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>), \
-    Operator("aten::list(" decl_type "[] a) -> " decl_type "[]", [](Stack& stack) { return 0; }), \
     Operator("aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type "[]", listAdd<Shared<c_type>, c_type::ElemType>), \
     Operator( \
         "aten::slice(" decl_type "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type "[]", \

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1432,7 +1432,8 @@ private:
     const auto lhsSugaredVar = environment_stack->getSugaredVar(Var(lhs.value()).name());
     const auto lhsValue = lhsSugaredVar->attr(lhs.range(), method, lhs.selector().name())->asValue(lhs.range(), method);
     if (lhsValue->type()->isSubtypeOf(DynamicType::get())) {
-      // for tensors, emit the corresponding in-place op
+      // for module parameter/buffer assignment, only consider tensor types,
+      // emit the corresponding in-place op
       const auto rhs = NamedValue(stmt.rhs().range(), emitExpr(stmt.rhs()));
       const auto self = NamedValue(stmt.lhs().range(), "self", lhsValue);
       emitBuiltinCall(
@@ -1446,8 +1447,8 @@ private:
 
     } else {
         throw ErrorReport(stmt.lhs())
-            << "unexpected expression on "
-            << "left-hand side of augmented assignment.";
+            << "left-hand side of augmented assignment to module "
+            << "parameters/buffers can only be tensor types";
     }
   }
 
@@ -2428,7 +2429,6 @@ void defineMethodsInModule(std::shared_ptr<Module> m, const std::vector<Def>& de
 const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
   static std::unordered_map<std::string, TypePtr> map = {
     {"Tensor", DynamicType::get()},
-    {"number", NumberType::get()},
     {"int", IntType::get()},
     {"float", FloatType::get()},
     {"bool", BoolType::get()},

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1427,6 +1427,20 @@ private:
     }
   }
 
+  // This will be called when there is a class param or module buffer
+  // mutation which make the LHS of the expr be a select expression
+  //
+  // Example like:
+  // class A(Module):
+  //  def __init__():
+  //    self.register_buffer("running_var", torch.zeros(1))
+  //
+  //  def forward():
+  //    self.num_batches += 1
+  //
+  // In this case we will only consider the scenario that the module
+  // buffer type is a tensor, and we emit the corresponding tensor
+  // in place op, and throw error for other unsupported types
   void emitAugAssignmentToSelectVar(const AugAssign& stmt) {
     const auto lhs = Select(stmt.lhs());
     const auto lhsSugaredVar = environment_stack->getSugaredVar(Var(lhs.value()).name());

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1379,9 +1379,6 @@ def _find_builtin(fn):
 
 
 _register_builtin(len, 'aten::len')
-_register_builtin(list, 'aten::list')
-
-
 _register_builtin(_wait, 'aten::wait')
 
 # torch.jit.Error

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1379,6 +1379,7 @@ def _find_builtin(fn):
 
 
 _register_builtin(len, 'aten::len')
+_register_builtin(list, 'aten::list')
 
 
 _register_builtin(_wait, 'aten::wait')

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1421,7 +1421,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
     :class:`~torch.nn.BatchNorm3d` for details.
     """
     if training:
-        size = list(input.size())
+        size = input.size()
         # XXX: JIT script does not support the reduce from functools, and mul op is a
         # builtin, which cannot be used as a value to a func yet, so rewrite this size
         # check to a simple equivalent for loop

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1413,8 +1413,10 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
     return ret
 
 
+@torch._jit_internal.weak_script
 def batch_norm(input, running_mean, running_var, weight=None, bias=None,
                training=False, momentum=0.1, eps=1e-5):
+    # type: (Tensor, Tensor, Tensor, Optional[Tensor], Optional[Tensor], bool, float, float) -> Tensor
     r"""Applies Batch Normalization for each channel across a batch of data.
 
     See :class:`~torch.nn.BatchNorm1d`, :class:`~torch.nn.BatchNorm2d`,

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -3,12 +3,15 @@ from .module import Module
 from torch.nn.parameter import Parameter
 from .. import functional as F
 from .. import init
+from ..._jit_internal import weak_module, weak_script_method
 
 
 # TODO: check contiguous in THNN
 # TODO: use separate backend functions?
+@weak_module
 class _BatchNorm(Module):
     _version = 2
+    __constants__ = ['training', 'track_running_stats', 'momentum']
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
                  track_running_stats=True):
@@ -49,6 +52,7 @@ class _BatchNorm(Module):
     def _check_input_dim(self, input):
         raise NotImplementedError
 
+    @weak_script_method
     def forward(self, input):
         self._check_input_dim(input)
 
@@ -57,7 +61,7 @@ class _BatchNorm(Module):
         if self.training and self.track_running_stats:
             self.num_batches_tracked += 1
             if self.momentum is None:  # use cumulative moving average
-                exponential_average_factor = 1.0 / self.num_batches_tracked.item()
+                exponential_average_factor = 1.0 / float(self.num_batches_tracked)
             else:  # use exponential moving average
                 exponential_average_factor = self.momentum
 
@@ -86,6 +90,7 @@ class _BatchNorm(Module):
             missing_keys, unexpected_keys, error_msgs)
 
 
+@weak_module
 class BatchNorm1d(_BatchNorm):
     r"""Applies Batch Normalization over a 2D or 3D input (a mini-batch of 1D
     inputs with optional additional channel dimension) as described in the paper

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -11,7 +11,7 @@ from ..._jit_internal import weak_module, weak_script_method
 @weak_module
 class _BatchNorm(Module):
     _version = 2
-    __constants__ = ['training', 'track_running_stats', 'momentum']
+    __constants__ = ['training', 'track_running_stats', 'momentum', 'eps']
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
                  track_running_stats=True):
@@ -163,6 +163,7 @@ class BatchNorm1d(_BatchNorm):
                              .format(input.dim()))
 
 
+@weak_module
 class BatchNorm2d(_BatchNorm):
     r"""Applies Batch Normalization over a 4D input (a mini-batch of 2D inputs
     with additional channel dimension) as described in the paper
@@ -235,6 +236,7 @@ class BatchNorm2d(_BatchNorm):
                              .format(input.dim()))
 
 
+@weak_module
 class BatchNorm3d(_BatchNorm):
     r"""Applies Batch Normalization over a 5D input (a mini-batch of 3D inputs
     with additional channel dimension) as described in the paper

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import torch
 from .module import Module
 from torch.nn.parameter import Parameter


### PR DESCRIPTION
This PR did three things:

1. It export the BatchNorm functional and module, and rewrite some of the components to stay align with the current supported JIT features
2. In the process of export, add necessary compiler support for in_place op aug assign
4. change the test_jit behavior in add_module_test to utilize a single rng state during module initialization