### PR TITLE
fix bug in utils/cpp_extension.py

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -171,7 +171,7 @@ def check_compiler_abi_compatibility(compiler):
         if sys.platform == 'linux':
             minimum_required_version = MINIMUM_GCC_VERSION
             version = subprocess.check_output([compiler, '-dumpfullversion', '-dumpversion'])
-            if not isinstance(version,str):
+            if not isinstance(version, str):
                 version = version.decode()
             version = version.split('.')
         else:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -171,6 +171,8 @@ def check_compiler_abi_compatibility(compiler):
         if sys.platform == 'linux':
             minimum_required_version = MINIMUM_GCC_VERSION
             version = subprocess.check_output([compiler, '-dumpfullversion', '-dumpversion'])
+            if not isinstance(version,str):
+                version = version.decode()
             version = version.split('.')
         else:
             minimum_required_version = MINIMUM_MSVC_VERSION


### PR DESCRIPTION
when i build [maskrcnn-benchmark](https://github.com/facebookresearch/maskrcnn-benchmark) , this file throws this warning :
```
lib/python3.7/site-packages/torch/utils/cpp_extension.py:182: UserWarning: Error checking compiler version for g++: a bytes-like object is required, not 'str' warnings.warn('Error checking compiler version for {}: {}'.format(compiler, error))
```
and i checked subprocess.check_output return bytes not str in python3 , so it is some bug here.i hope remove this warning.