### PR TITLE
c10d doesn't work with torch namespace

### DIFF
--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -215,7 +215,7 @@ inline at::Tensor flattenDenseTensors(at::TensorList tensors) {
   if (tensors.size() == 1) {
     return flatten(tensors[0]);
   }
-  return at::cat(fmap(tensors, flatten));
+  return at::cat(::c10d::fmap(tensors, flatten));
 }
 
 inline at::Tensor newLikeFlat(


### PR DESCRIPTION
If both `Utils.hpp` and the `torch` namespace is included in the same file, the compiler won't know which fmap to use. I believe this is because of ADL. This change fixes that issue for me.