### PR TITLE
remove CAFFE2_API from IdWrapper

### DIFF
--- a/c10/util/IdWrapper.h
+++ b/c10/util/IdWrapper.h
@@ -23,7 +23,7 @@ namespace c10 {
  * for you, given the underlying type supports it.
  */
 template <class ConcreteType, class UnderlyingType>
-class C10_API IdWrapper {
+class IdWrapper {
  public:
   using underlying_type = UnderlyingType;
   using concrete_type = ConcreteType;


### PR DESCRIPTION
it doesn't really make sense on a template class. Also it breaks if
you try to build in debug on Windows, so this will save someone some
frustration in the future.

