### PR TITLE
[C++ frontend] Fix dataloader iterator test

### DIFF
--- a/torch/csrc/api/include/torch/data/dataloader.h
+++ b/torch/csrc/api/include/torch/data/dataloader.h
@@ -282,8 +282,8 @@ std::unique_ptr<DataLoader<Dataset, Sampler>> make_data_loader(
 /// Creates a new `DataLoader`, inferring the necessary template types from
 /// the given arguments.
 template <
-    typename Dataset,
     typename Sampler = samplers::RandomSampler,
+    typename Dataset,
     typename =
         torch::enable_if_t<std::is_constructible<Sampler, size_t>::value>>
 std::unique_ptr<DataLoader<Dataset, Sampler>> make_data_loader(


### PR DESCRIPTION
I noticed the test `DataLoaderTest.CanDereferenceIteratorMultipleTimes` doesn't test proper progression of the iterator. I also added a test for using `std::copy`.

Fixes https://github.com/pytorch/pytorch/issues/14276

@ebetica @ezyang @apaszke 