### PR TITLE
Turn fbgemm off by default for pytorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ option(CAFFE2_STATIC_LINK_CUDA "Statically link CUDA libraries" OFF)
 cmake_dependent_option(
     USE_CUDNN "Use cuDNN" ON
     "USE_CUDA" OFF)
-option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" ON)
+option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" OFF)
 option(USE_FFMPEG "Use ffmpeg" OFF)
 option(USE_GFLAGS "Use GFLAGS" ON)
 option(USE_GLOG "Use GLOG" ON)

--- a/tools/setup_helpers/fbgemm.py
+++ b/tools/setup_helpers/fbgemm.py
@@ -1,6 +1,12 @@
 from .env import check_env_flag
 
+USE_FBGEMM = False
+
 if check_env_flag('NO_FBGEMM'):
     USE_FBGEMM = False
 else:
-    USE_FBGEMM = True
+    #Enable FBGEMM if explicitly enabled
+    if check_env_flag('USE_FBGEMM'):
+        USE_FBGEMM = True
+    else:
+        USE_FBGEMM = False


### PR DESCRIPTION
Summary: Setting USE_FBGEMM to OFF by default until we figure out properly separating avx2 code. See [this issue](https://github.com/pytorch/pytorch/issues/13993).  Pytorch can still be compiled with fbgemm by using USE_FBGEMM=ON.

Reviewed By: jspark1105

Differential Revision: D13090454
