### PR TITLE
Fix CUDA_tensor_apply1 base case

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -247,8 +247,8 @@ template <typename Op,
           typename Offset>
 struct ApplyOp1<Op, scalar, IndexType, ADims, 0, Offset> {
 __device__ __forceinline__
-static void apply(detail::TensorInfo<scalar, IndexType> &a, int n,
-                  const Op &op, IndexType linearIndex, Offset offset) {
+static void apply(detail::TensorInfo<scalar, IndexType> &a, const Op &op,
+                  int n, IndexType linearIndex, Offset offset) {
   op(a.data[offset]);
 }
 };
@@ -635,7 +635,7 @@ inline dim3 getApplyBlock() {
 
 template <typename scalar, int step, typename Op>
 inline bool CUDA_tensor_apply1(at::Tensor a,
-                               Op op,
+                               const Op op,
                                TensorArgType aType = TensorArgType::ReadWrite) {
   checkBackend("CUDA_tensor_apply1", {a}, Backend::CUDA);
   auto dim = a.dim();


### PR DESCRIPTION
I got some build errors when modifying the `bernoulli_tensor_cuda_kernel` in my Generator refactor https://github.com/pytorch/pytorch/pull/13070. Turns out the functions signature for `CUDA_tensor_apply1` was a little wrong. This PR fixes it. Following is the code and error I was getting before this patch:

Code:
```
template<typename scalar_t, typename prob_t>
void bernoulli_tensor_cuda_kernel(
    at::Tensor& ret, const at::Tensor& p,
    std::pair<uint64_t, uint64_t> seeds) {
  // The template argument `4` below indicates that we want to operate on four
  // element at each time. See NOTE [ CUDA_tensor_applyN helpers ] for details.
  at::cuda::CUDA_tensor_apply2<scalar_t, prob_t, 4>(
      ret, p,
      [seeds] __device__(scalar_t& v1, const prob_t& p1) {
      at::cuda::Philox4_32_10 engine(
                                seeds.first,
                                blockIdx.x * blockDim.x + threadIdx.x,
                                seeds.second);
      auto x = at::cuda::standard_uniform_distribution(engine);
      assert(0 <= p1 && p1 <= 1);
      v1 = static_cast<scalar_t>(x <= p1);
    }
  );
}
```

Error:
```
ov 15 23:43:03 /var/lib/jenkins/workspace/aten/src/ATen/cuda/CUDAApplyUtils.cuh(236): error: no suitable conversion function from "const lambda [](uint8_t &)->void" to "int" exists
Nov 15 23:43:03           detected during:
Nov 15 23:43:03             instantiation of "void at::cuda::<unnamed>::ApplyOp1<Op, scalar, IndexType, ADims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar, IndexType> &, const Op &, int, IndexType, Offsets...) [with Op=lambda [](uint8_t &)->void, scalar=uint8_t, IndexType=unsigned int, ADims=1, remaining_steps=1, Offsets=<>]" 
Nov 15 23:43:03 (282): here
Nov 15 23:43:03             instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply1<Op,scalar,IndexType,ADims,step>(at::cuda::detail::TensorInfo<scalar, IndexType>, IndexType, Op) [with Op=lambda [](uint8_t &)->void, scalar=uint8_t, IndexType=unsigned int, ADims=1, step=1]" 
Nov 15 23:43:03 (735): here
Nov 15 23:43:03             instantiation of "__nv_bool at::cuda::CUDA_tensor_apply1<scalar,step,Op>(at::Tensor, Op, at::cuda::TensorArgType) [with scalar=uint8_t, step=1, Op=lambda [](uint8_t &)->void]" 
Nov 15 23:43:03 (774): here
Nov 15 23:43:03             instantiation of "__nv_bool at::cuda::CUDA_tensor_apply1<scalar,Op>(at::Tensor, Op, at::cuda::TensorArgType) [with scalar=uint8_t, Op=lambda [](uint8_t &)->void]" 
Nov 15 23:43:03 /var/lib/jenkins/workspace/aten/src/ATen/native/cuda/Distributions.cu(118): here
Nov 15 23:43:03             instantiation of "void <unnamed>::bernoulli_scalar_cuda_kernel<scalar_t>(at::Tensor &, double, std::pair<uint64_t, uint64_t>) [with scalar_t=uint8_t]" 
Nov 15 23:43:03 /var/lib/jenkins/workspace/aten/src/ATen/native/cuda/Distributions.cu(227): here
Nov 15 23:43:03 
```