### PR TITLE
Address jittering issues in python_print

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -43,7 +43,11 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       if ((c == FP_NORMAL || c == FP_ZERO) && double(i) == d) {
         return out << i << ".";
       }
-      return out << v.toDouble();
+      auto orig_prec = out.precision();
+      return out
+        << std::setprecision(std::numeric_limits<double>::max_digits10)
+        << v.toDouble()
+        << std::setprecision(orig_prec);
     } case IValue::Tag::Int:
       return out << v.toInt();
     case IValue::Tag::Bool:

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -38,10 +38,12 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return out << v.toTensor();
     case IValue::Tag::Double: {
       double d = v.toDouble();
-      int64_t i = int64_t(d);
       int c = std::fpclassify(d);
-      if ((c == FP_NORMAL || c == FP_ZERO) && double(i) == d) {
-        return out << i << ".";
+      if (c == FP_NORMAL || c == FP_ZERO) {
+        int64_t i = int64_t(d);
+        if (double(i) == d) {
+          return out << i << ".";
+        }
       }
       auto orig_prec = out.precision();
       return out

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@
 #   DEBUG
 #     build with -O0 and -g (debug symbols)
 #
+#   REL_WITH_DEB_INFO
+#     build with optimizations and -g (debug symbols)
+#
 #   MAX_JOBS
 #     maximum number of compile jobs we should use to compile your code
 #
@@ -189,6 +192,7 @@ from tools.setup_helpers.dist_check import USE_DISTRIBUTED, \
 ################################################################################
 
 DEBUG = check_env_flag('DEBUG')
+REL_WITH_DEB_INFO = check_env_flag('REL_WITH_DEB_INFO')
 IS_WINDOWS = (platform.system() == 'Windows')
 IS_DARWIN = (platform.system() == 'Darwin')
 IS_LINUX = (platform.system() == 'Linux')
@@ -834,6 +838,10 @@ if DEBUG:
     else:
         extra_compile_args += ['-O0', '-g']
         extra_link_args += ['-O0', '-g']
+
+if REL_WITH_DEB_INFO:
+    extra_compile_args += ['-g']
+    extra_link_args += ['-g']
 
 
 def make_relative_rpath(path):

--- a/test/expect/TestBatched.test_if_else.expect
+++ b/test/expect/TestBatched.test_if_else.expect
@@ -16,7 +16,7 @@ graph(%a.1_data : Dynamic
   %dims.1 : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %16 : Long() = prim::NumToTensor(%6)
   %alpha : float = prim::TensorToNum(%16)
-  %data.5 : Dynamic = aten::sub(%a.1_data, %b_data, %alpha)
+  %data : Dynamic = aten::sub(%a.1_data, %b_data, %alpha)
   %mask : Dynamic = aten::mul(%a.1_mask, %b_mask)
   %dims : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %21 : bool = prim::Constant[value=1]()
@@ -25,24 +25,24 @@ graph(%a.1_data : Dynamic
   %data.2 : Dynamic = aten::mul(%7, %23)
   %25 : int = aten::dim(%data.2)
   %26 : bool = aten::eq(%25, %22)
-  %cond_data : Dynamic, %cond_mask : Dynamic, %data : Dynamic = prim::If(%26)
+  %cond_data : Dynamic, %cond_mask : Dynamic = prim::If(%26)
     block0() {
-      %30 : int = aten::dim(%data.1)
-      %31 : int = aten::sub(%30, %22)
-      %data.4 : Dynamic = prim::Loop(%31, %21, %data.2)
-        block0(%_ : int, %34 : Dynamic) {
-          %35 : int = aten::dim(%34)
-          %data.3 : Dynamic = aten::unsqueeze(%34, %35)
+      %29 : int = aten::dim(%data.1)
+      %30 : int = aten::sub(%29, %22)
+      %data.4 : Dynamic = prim::Loop(%30, %21, %data.2)
+        block0(%32 : int, %33 : Dynamic) {
+          %34 : int = aten::dim(%33)
+          %data.3 : Dynamic = aten::unsqueeze(%33, %34)
           -> (%21, %data.3)
         }
       %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data.1)
       %cond_mask.1 : Dynamic = aten::expand_as(%data.4, %mask.1)
-      -> (%cond_data.1, %cond_mask.1, %data.4)
+      -> (%cond_data.1, %cond_mask.1)
     }
     block1() {
-      -> (%data.2, %data.2, %data.2)
+      -> (%data.2, %data.2)
     }
-  %res_data : Dynamic = aten::where(%cond_data, %data.1, %data.5)
+  %res_data : Dynamic = aten::where(%cond_data, %data.1, %data)
   %res_mask : Dynamic = aten::where(%cond_mask, %mask.1, %mask)
   %res_dims : Dynamic = aten::__or__(%dims.1, %dims)
   return (%res_data, %res_mask, %res_dims);

--- a/test/expect/TestBatched.test_if_else_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_else_with_scalar.expect
@@ -17,7 +17,7 @@ graph(%a.1_data : Dynamic
   %dims.1 : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %17 : Long() = prim::NumToTensor(%6)
   %alpha : float = prim::TensorToNum(%17)
-  %data.5 : Dynamic = aten::sub(%a.1_data, %b_data, %alpha)
+  %data : Dynamic = aten::sub(%a.1_data, %b_data, %alpha)
   %mask : Dynamic = aten::mul(%a.1_mask, %b_mask)
   %dims : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %22 : bool = prim::Constant[value=1]()
@@ -26,24 +26,24 @@ graph(%a.1_data : Dynamic
   %data.2 : Dynamic = aten::mul(%10, %24)
   %26 : int = aten::dim(%data.2)
   %27 : bool = aten::eq(%26, %23)
-  %cond_data : Dynamic, %cond_mask : Dynamic, %data : Dynamic = prim::If(%27)
+  %cond_data : Dynamic, %cond_mask : Dynamic = prim::If(%27)
     block0() {
-      %31 : int = aten::dim(%data.1)
-      %32 : int = aten::sub(%31, %23)
-      %data.4 : Dynamic = prim::Loop(%32, %22, %data.2)
-        block0(%_ : int, %35 : Dynamic) {
-          %36 : int = aten::dim(%35)
-          %data.3 : Dynamic = aten::unsqueeze(%35, %36)
+      %30 : int = aten::dim(%data.1)
+      %31 : int = aten::sub(%30, %23)
+      %data.4 : Dynamic = prim::Loop(%31, %22, %data.2)
+        block0(%33 : int, %34 : Dynamic) {
+          %35 : int = aten::dim(%34)
+          %data.3 : Dynamic = aten::unsqueeze(%34, %35)
           -> (%22, %data.3)
         }
       %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data.1)
       %cond_mask.1 : Dynamic = aten::expand_as(%data.4, %mask.1)
-      -> (%cond_data.1, %cond_mask.1, %data.4)
+      -> (%cond_data.1, %cond_mask.1)
     }
     block1() {
-      -> (%data.2, %data.2, %data.2)
+      -> (%data.2, %data.2)
     }
-  %res_data : Dynamic = aten::where(%cond_data, %data.1, %data.5)
+  %res_data : Dynamic = aten::where(%cond_data, %data.1, %data)
   %res_mask : Dynamic = aten::where(%cond_mask, %mask.1, %mask)
   %res_dims : Dynamic = aten::__or__(%dims.1, %dims)
   return (%res_data, %res_mask, %res_dims);

--- a/test/expect/TestBatched.test_if_noelse.expect
+++ b/test/expect/TestBatched.test_if_noelse.expect
@@ -11,7 +11,7 @@ graph(%a.1_data : Dynamic
   %10 : bool = prim::TensorToBool(%7)
   %11 : Long() = prim::NumToTensor(%6)
   %alpha : float = prim::TensorToNum(%11)
-  %data.1 : Dynamic = aten::add(%a.1_data, %b_data, %alpha)
+  %data : Dynamic = aten::add(%a.1_data, %b_data, %alpha)
   %mask : Dynamic = aten::mul(%a.1_mask, %b_mask)
   %dims : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %16 : bool = prim::Constant[value=1]()
@@ -20,24 +20,24 @@ graph(%a.1_data : Dynamic
   %data.2 : Dynamic = aten::mul(%7, %18)
   %20 : int = aten::dim(%data.2)
   %21 : bool = aten::eq(%20, %17)
-  %cond_data : Dynamic, %cond_mask : Dynamic, %data : Dynamic = prim::If(%21)
+  %cond_data : Dynamic, %cond_mask : Dynamic = prim::If(%21)
     block0() {
-      %25 : int = aten::dim(%data.1)
-      %26 : int = aten::sub(%25, %17)
-      %data.4 : Dynamic = prim::Loop(%26, %16, %data.2)
-        block0(%_ : int, %29 : Dynamic) {
-          %30 : int = aten::dim(%29)
-          %data.3 : Dynamic = aten::unsqueeze(%29, %30)
+      %24 : int = aten::dim(%data)
+      %25 : int = aten::sub(%24, %17)
+      %data.4 : Dynamic = prim::Loop(%25, %16, %data.2)
+        block0(%27 : int, %28 : Dynamic) {
+          %29 : int = aten::dim(%28)
+          %data.3 : Dynamic = aten::unsqueeze(%28, %29)
           -> (%16, %data.3)
         }
-      %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data.1)
+      %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data)
       %cond_mask.1 : Dynamic = aten::expand_as(%data.4, %mask)
-      -> (%cond_data.1, %cond_mask.1, %data.4)
+      -> (%cond_data.1, %cond_mask.1)
     }
     block1() {
-      -> (%data.2, %data.2, %data.2)
+      -> (%data.2, %data.2)
     }
-  %res_data : Dynamic = aten::where(%cond_data, %data.1, %a.1_data)
+  %res_data : Dynamic = aten::where(%cond_data, %data, %a.1_data)
   %res_mask : Dynamic = aten::where(%cond_mask, %mask, %a.1_mask)
   %res_dims : Dynamic = aten::__or__(%dims, %a.1_dims)
   return (%res_data, %res_mask, %res_dims);

--- a/test/expect/TestBatched.test_if_noelse_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_noelse_with_scalar.expect
@@ -12,7 +12,7 @@ graph(%a.1_data : Dynamic
   %11 : bool = prim::TensorToBool(%10)
   %12 : Long() = prim::NumToTensor(%6)
   %alpha : float = prim::TensorToNum(%12)
-  %data.1 : Dynamic = aten::add(%a.1_data, %b_data, %alpha)
+  %data : Dynamic = aten::add(%a.1_data, %b_data, %alpha)
   %mask : Dynamic = aten::mul(%a.1_mask, %b_mask)
   %dims : Dynamic = aten::__or__(%a.1_dims, %b_dims)
   %17 : bool = prim::Constant[value=1]()
@@ -21,24 +21,24 @@ graph(%a.1_data : Dynamic
   %data.2 : Dynamic = aten::mul(%10, %19)
   %21 : int = aten::dim(%data.2)
   %22 : bool = aten::eq(%21, %18)
-  %cond_data : Dynamic, %cond_mask : Dynamic, %data : Dynamic = prim::If(%22)
+  %cond_data : Dynamic, %cond_mask : Dynamic = prim::If(%22)
     block0() {
-      %26 : int = aten::dim(%data.1)
-      %27 : int = aten::sub(%26, %18)
-      %data.4 : Dynamic = prim::Loop(%27, %17, %data.2)
-        block0(%_ : int, %30 : Dynamic) {
-          %31 : int = aten::dim(%30)
-          %data.3 : Dynamic = aten::unsqueeze(%30, %31)
+      %25 : int = aten::dim(%data)
+      %26 : int = aten::sub(%25, %18)
+      %data.4 : Dynamic = prim::Loop(%26, %17, %data.2)
+        block0(%28 : int, %29 : Dynamic) {
+          %30 : int = aten::dim(%29)
+          %data.3 : Dynamic = aten::unsqueeze(%29, %30)
           -> (%17, %data.3)
         }
-      %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data.1)
+      %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data)
       %cond_mask.1 : Dynamic = aten::expand_as(%data.4, %mask)
-      -> (%cond_data.1, %cond_mask.1, %data.4)
+      -> (%cond_data.1, %cond_mask.1)
     }
     block1() {
-      -> (%data.2, %data.2, %data.2)
+      -> (%data.2, %data.2)
     }
-  %res_data : Dynamic = aten::where(%cond_data, %data.1, %a.1_data)
+  %res_data : Dynamic = aten::where(%cond_data, %data, %a.1_data)
   %res_mask : Dynamic = aten::where(%cond_mask, %mask, %a.1_mask)
   %res_dims : Dynamic = aten::__or__(%dims, %a.1_dims)
   return (%res_data, %res_mask, %res_dims);

--- a/test/expect/TestBatched.test_while.expect
+++ b/test/expect/TestBatched.test_while.expect
@@ -19,10 +19,10 @@ graph(%a.1_data : Dynamic
     block0(%loop_num : int, %cond_data.2 : Dynamic, %cond_mask.2 : Dynamic, %cond_dims : Dynamic, %6_data : Dynamic, %6_mask : Dynamic, %6_dims : Dynamic) {
       %30 : Long() = prim::NumToTensor(%6)
       %alpha : float = prim::TensorToNum(%30)
-      %data.1 : Dynamic = aten::sub(%6_data, %b_data, %alpha)
+      %data : Dynamic = aten::sub(%6_data, %b_data, %alpha)
       %mask : Dynamic = aten::mul(%6_mask, %b_mask)
       %dims : Dynamic = aten::__or__(%6_dims, %b_dims)
-      %35 : Dynamic = aten::gt(%data.1, %b_data)
+      %35 : Dynamic = aten::gt(%data, %b_data)
       %36 : Dynamic = aten::mul(%mask, %b_mask)
       %37 : Dynamic = aten::__or__(%dims, %b_dims)
       %38 : bool = prim::TensorToBool(%35)
@@ -32,32 +32,32 @@ graph(%a.1_data : Dynamic
       %data.2 : Dynamic = aten::mul(%cond_data.2, %41)
       %43 : int = aten::dim(%data.2)
       %44 : bool = aten::eq(%43, %40)
-      %cond_data : Dynamic, %cond_mask : Dynamic, %data : Dynamic = prim::If(%44)
+      %cond_data : Dynamic, %cond_mask : Dynamic = prim::If(%44)
         block0() {
-          %48 : int = aten::dim(%data.1)
-          %49 : int = aten::sub(%48, %40)
-          %data.4 : Dynamic = prim::Loop(%49, %39, %data.2)
-            block0(%_ : int, %52 : Dynamic) {
-              %53 : int = aten::dim(%52)
-              %data.3 : Dynamic = aten::unsqueeze(%52, %53)
+          %47 : int = aten::dim(%data)
+          %48 : int = aten::sub(%47, %40)
+          %data.4 : Dynamic = prim::Loop(%48, %39, %data.2)
+            block0(%50 : int, %51 : Dynamic) {
+              %52 : int = aten::dim(%51)
+              %data.3 : Dynamic = aten::unsqueeze(%51, %52)
               -> (%39, %data.3)
             }
-          %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data.1)
+          %cond_data.1 : Dynamic = aten::expand_as(%data.4, %data)
           %cond_mask.1 : Dynamic = aten::expand_as(%data.4, %mask)
-          -> (%cond_data.1, %cond_mask.1, %data.4)
+          -> (%cond_data.1, %cond_mask.1)
         }
         block1() {
-          -> (%data.2, %data.2, %data.2)
+          -> (%data.2, %data.2)
         }
-      %res_data : Dynamic = aten::where(%cond_data, %data.1, %6_data)
+      %res_data : Dynamic = aten::where(%cond_data, %data, %6_data)
       %res_mask : Dynamic = aten::where(%cond_mask, %mask, %6_mask)
       %res_dims : Dynamic = aten::__or__(%dims, %6_dims)
-      %60 : int = prim::Constant[value=0]()
-      %61 : Dynamic = aten::mul(%35, %36)
-      %62 : Dynamic = aten::sum(%61)
-      %63 : Dynamic = aten::gt(%62, %60)
-      %64 : bool = prim::TensorToBool(%63)
-      -> (%64, %35, %36, %37, %res_data, %res_mask, %res_dims)
+      %59 : int = prim::Constant[value=0]()
+      %60 : Dynamic = aten::mul(%35, %36)
+      %61 : Dynamic = aten::sum(%60)
+      %62 : Dynamic = aten::gt(%61, %59)
+      %63 : bool = prim::TensorToBool(%62)
+      -> (%63, %35, %36, %37, %res_data, %res_mask, %res_dims)
     }
   return (%a, %21, %22);
 }

--- a/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
@@ -3,8 +3,8 @@ def script(self,
   x = aten.add(y_1, 1, 1)
   z_1 = aten.add(x, 5, 1)
   y, z = y_1, z_1
-  t = bool(aten.lt(y_1, 8))
-  while t:
+  _0 = bool(aten.lt(y_1, 8))
+  while _0:
     y_2 = aten.add_(y, 1, 1)
-    t, y, z = bool(aten.lt(y_2, 8)), y_2, x
+    _0, y, z = bool(aten.lt(y_2, 8)), y_2, x
   return x, z

--- a/test/expect/TestJit.test_pretty_printer-while_if_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-while_if_test.expect
@@ -2,13 +2,13 @@ def script(self,
     a_1: Tensor,
     b_1: Tensor) -> Tensor:
   a, b, c = a_1, b_1, 0
-  t = bool(aten.lt(a_1, 10))
-  while t:
+  _0 = bool(aten.lt(a_1, 10))
+  while _0:
     a_2 = aten.add(a, 1, 1)
     b_2 = aten.add(b, 1, 1)
     if bool(aten.gt(a_2, b_2)):
       c_4 = 2
     else:
       c_4 = 3
-    t, a, b, c = bool(aten.lt(a_2, 10)), a_2, b_2, c_4
+    _0, a, b, c = bool(aten.lt(a_2, 10)), a_2, b_2, c_4
   return aten.add(aten.add(a, 1, 1), c, 1)

--- a/test/expect/TestJit.test_pretty_printer-while_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-while_test.expect
@@ -2,9 +2,9 @@ def script(self,
     a_1: Tensor,
     i_1: Tensor) -> Tensor:
   a, i = a_1, i_1
-  t = bool(aten.lt(i_1, 3))
-  while t:
+  _0 = bool(aten.lt(i_1, 3))
+  while _0:
     a_2 = aten.mul_(a, a)
     i_2 = aten.add_(i, 1, 1)
-    t, a, i = bool(aten.lt(i_2, 3)), a_2, i_2
+    _0, a, i = bool(aten.lt(i_2, 3)), a_2, i_2
   return a

--- a/test/expect/TestScript.test_constant_pooling.expect
+++ b/test/expect/TestScript.test_constant_pooling.expect
@@ -29,5 +29,5 @@ graph(%cond : Dynamic) {
        = prim::Print(%d, %e, %d, %5, %y.4, %5)
       -> (%c.1, %y.4)
     }
-  return (%a, %3, %c, %5);
+  return (%a, %3, %c, %5, %y);
 }

--- a/test/expect/TestScript.test_onnx_export_script_module_loop.expect
+++ b/test/expect/TestScript.test_onnx_export_script_module_loop.expect
@@ -15,7 +15,7 @@ ModelProto {
         Node {type: "Loop", inputs: [2,1,x.1], outputs: [4], attributes: [{ name: 'body', type: graph, value:
             GraphProto {
               name: "torch-jit-export1"
-              inputs: [{name: "_", type:Tensor dims: },{name: "cond.1", type:Tensor dims: },{name: "7", type:Tensor dims: }]
+              inputs: [{name: "5", type:Tensor dims: },{name: "cond.1", type:Tensor dims: },{name: "7", type:Tensor dims: }]
               outputs: [{name: "1", type:Tensor dims: },{name: "8", type:Tensor dims: }]
               initializers: []
               nodes: [

--- a/torch/csrc/jit/import_method.cpp
+++ b/torch/csrc/jit/import_method.cpp
@@ -27,6 +27,16 @@ private:
   std::shared_ptr<script::Module> module;
 };
 
+struct ConstantValue : public script::SugaredValue {
+  ConstantValue(IValue value)
+  : value_(std::move(value)) {}
+  IValue value_;
+  std::string kind() const override { return "constant"; }
+  Value * asValue(SourceRange loc, script::Method & m) override {
+    return m.graph()->insertConstant(value_);
+  }
+};
+
 // This value maps attributes CONSTANTS.c0 CONSTANTS.c1 to entries
 // in the 'constants' vector. This table is will be stored in a container format
 // and given to the import_method when restoring the code.
@@ -74,29 +84,23 @@ void import_method(const std::shared_ptr<script::Module>& mod, const std::string
   script::Parser p(src);
 
   size_t version = parseVersionNumber(p.lexer());
-  auto aten = std::make_shared<script::BuiltinModule>("aten", version);
-  auto prim = std::make_shared<script::BuiltinModule>("prim", version);
-  auto constants = std::make_shared<ConstantTableValue>(constant_table);
-  auto fork = std::make_shared<script::ForkValue>();
-  auto annotate = std::make_shared<script::AnnotateValue>();
+
+  std::unordered_map<std::string, std::shared_ptr<script::SugaredValue>> env = {
+    {"aten", std::make_shared<script::BuiltinModule>("aten", version)},
+    {"prim", std::make_shared<script::BuiltinModule>("prim", version)},
+    {"CONSTANTS", std::make_shared<ConstantTableValue>(constant_table)},
+    {"fork", std::make_shared<script::ForkValue>()},
+    {"annotate", std::make_shared<script::AnnotateValue>()},
+    {"inf", std::make_shared<ConstantValue>(std::numeric_limits<double>::infinity())},
+    {"nan", std::make_shared<ConstantValue>(std::numeric_limits<double>::quiet_NaN())},
+  };
 
   auto resolver = [&](const std::string& name, script::Method& m, const SourceRange& loc)
   -> std::shared_ptr<script::SugaredValue> {
-    if(name == "aten")
-      return aten;
-    if (name == "prim")
-      return prim;
-    if (name == "CONSTANTS")
-      return constants;
-    if (name == "fork")
-      return fork;
-    if (name == "annotate")
-      return annotate;
-    if (name == "inf") {
-      return std::make_shared<script::SimpleValue>(
-          m.graph()->insertConstant(std::numeric_limits<float>::infinity()));
-    }
-    return nullptr;
+    auto it = env.find(name);
+    if (it == env.end())
+      return nullptr;
+    return it->second;
   };
 
   std::vector<script::Def> definitions;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -171,6 +171,10 @@ public:
     return uses_;
   }
 
+  bool hasUses() const {
+    return !uses().empty();
+  }
+
   TORCH_API void replaceFirstUseWith(Value * newValue);
 
   // Replaces all uses of this value with 'newValue'.

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -36,10 +36,47 @@ bool hasSideEffects(Node * node, bool_memo_type& memo) {
   return has_side_effects;
 }
 
+void removeDeadIfOutputs(Node* node) {
+  if (node->kind() != prim::If)
+    return;
+  for(size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
+    size_t i = i_1 - 1;
+    if (!node->outputs().at(i)->hasUses()) {
+      node->eraseOutput(i);
+      for (Block* b : node->blocks()) {
+        b->eraseOutput(i);
+      }
+    }
+  }
+}
+
+void removeDeadLoopOutputs(Node* node) {
+  if (node->kind() != prim::Loop)
+    return;
+  auto loop_body = node->blocks().at(0);
+  auto loop_input_offset = 2; // offset of loop carried deps in input list
+  auto loop_body_offset = 1; // offset to the loop carried dependencies in block inputs/outputs
+
+  for(size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
+    size_t i = i_1 - 1;
+    if (!node->outputs().at(i)->hasUses() &&
+        !loop_body->inputs().at(loop_body_offset + i)->hasUses()) {
+      node->eraseOutput(i);
+      node->removeInput(loop_input_offset + i);
+      loop_body->eraseInput(loop_body_offset + i);
+      loop_body->eraseOutput(loop_body_offset + i);
+    }
+  }
+}
+
 void EliminateDeadCode(Block *block, bool recurse, bool_memo_type& memo) {
   auto nodes = block->nodes().reverse();
   for (auto it = nodes.begin(); it != nodes.end(); it++) {
     auto node = *it;
+    // note these occur before the recursion because we want to uncover
+    // dead code in the blocks used to calculate the output
+    removeDeadIfOutputs(node);
+    removeDeadLoopOutputs(node);
     if (recurse) {
       for (Block * block : node->blocks())
         EliminateDeadCode(block, true, memo);

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/jit/passes/lower_tuples.h"
 
 #include "c10/util/Exception.h"
 
@@ -63,6 +64,8 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
     tracer::exit(toStack(out));
     auto graph = enter_info.first->graph;
     EliminateDeadCode(graph);
+    LowerSimpleTuples(graph);
+
     return graph;
   } catch (...) {
     tracer::abandon();

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -158,13 +158,13 @@ struct SharedParserData {
 #undef ADD_CASE
   }
 #ifdef _WIN32
-  double strtod_c(const char * str, char** end) {
+  static double strtod_c(const char * str, char** end) {
     /// NOLINTNEXTLINE(hicpp-signed-bitwise)
     static _locale_t loc = _create_locale(LC_ALL, "C");
     return _strtod_l(str, end, loc);
   }
 #else
-  double strtod_c(const char * str, char** end) {
+  static double strtod_c(const char * str, char** end) {
     /// NOLINTNEXTLINE(hicpp-signed-bitwise)
     static locale_t loc = newlocale(LC_ALL_MASK, "C", nullptr);
     return strtod_l(str, end, loc);

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -634,7 +634,7 @@ struct Const : public Expr {
     return std::stoll(subtree(0)->stringValue());
   }
   double asFloatingPoint() const {
-    return std::stod(subtree(0)->stringValue());
+    return SharedParserData::strtod_c(subtree(0)->stringValue().c_str(), nullptr);
   }
   const std::string& text() const {
     return subtree(0)->stringValue();


### PR DESCRIPTION
export - print a method with python_print
import - import a method with import_method

We want to ensure:

    export(g) == export(import(export(g)))

That is after after exporting/importing once, the graph will stay exactly
the same. This is less strict that g == import(export(g)) which would
require us to maintain a lot more information about the structure of the
IR and about the names of debug symbols.

This PR addresses this with the following fixes:
* print out double-precision numbers with high enough precision such
  that they always parse in the same way
* when creating loop-carried dependencies, sort them
  by variable name, ensuring a consistent order
* parse nan correctly
* DCE: remove unused outputs of if statements, and loop-carried dependencies
  in loops that are dead both after the loop and inside the body of the
  loop.
* Do not set uniqueName for variables whose names are _[0-9]+, these
  are probably rare in user code, and we need a way to communicate
  that we do not care about a variable name when re-parsing the graph.
  Otherwise temporary variable names will jitter around.
* Expand the definition of a constant in printing code to None,
  and family.
* Allow re-treeing to work as long as the only thing in its way is a
  constant node. These do not have side effects but are sometimes
  inserted in a different order when tracing compared to how we print them.
* Print all constant nodes out first in the order in which they are used_val
 (or, if they are inlined, ensure they get assigned CONSTANT.cX number
  in a consistent order). Cleanup tuples (this is done in the compiler,
  but not in the tracer, leading to some tuple indexing jitter if not
  done).
* use strtod_l, not std::stod which can throw exceptions

Other:
* Add REL_WITH_DEB_INFO to setup.py. It already existed for the
  cmake files. Threading it into setup.py allows us to turn on
  debug symbols with optimization everywhere.
* enable round trip testing for all generated graphs. This only adds
  ~6 seconds to total build time but tests printing for every graph.

