### PR TITLE
nomnigraph - easy - expose hasProduce(NodeRef) to python

### DIFF
--- a/caffe2/python/nomnigraph_test.py
+++ b/caffe2/python/nomnigraph_test.py
@@ -96,6 +96,13 @@ class TestBindings(test_util.TestCase):
         dfg.createEdge(op, w)
         dfg.createEdge(x, op)
 
+        # subgraph
+        sg = ng.NNSubgraph()
+        sg.addNode(x)
+        sg.addNode(op)
+        sg.induceEdges()
+        assert len(sg) == 2
+
     @given(size=st.sampled_from([10, 50]))
     def test_edges_complex(self, size):
         random.seed(1337)

--- a/caffe2/python/nomnigraph_test.py
+++ b/caffe2/python/nomnigraph_test.py
@@ -128,10 +128,12 @@ class TestBindings(test_util.TestCase):
         nn = ng.NNModule(net)
         fc = nn.controlFlow[0]
         relu = nn.controlFlow[1]
+        assert not fc.inputs[0].hasProducer()
         assert fc.inputs[0].name == "X"
         assert fc.inputs[1].name == "W"
         assert relu.outputs[0].name == "Z"
         assert relu.inputs[0].name == "Y"
+        assert relu.inputs[0].hasProducer()
         assert relu.inputs[0].producer.name == "FC"
         assert fc.outputs[0].consumers[0].name == "Relu"
 

--- a/caffe2/python/pybind_state_nomni.cc
+++ b/caffe2/python/pybind_state_nomni.cc
@@ -382,7 +382,14 @@ void addNomnigraphMethods(pybind11::module& m) {
 
   // Subgraph matching API
   py::class_<NNSubgraph> nnsubgraph(m, "NNSubgraph");
-  nnsubgraph.def("__len__", [](NNSubgraph& s) { return s.getNodes().size(); })
+  nnsubgraph.def(py::init<>())
+      .def("__len__", [](NNSubgraph& s) { return s.getNodes().size(); })
+      .def(
+          "addNode",
+          [](NNSubgraph* sg, NNGraph::NodeRef node) { sg->addNode(node); })
+      .def(
+          "induceEdges",
+          [](NNSubgraph* sg) { nom::algorithm::induceEdges(sg); })
       .def_property_readonly(
           "nodes",
           [](NNSubgraph& s) {

--- a/caffe2/python/pybind_state_nomni.cc
+++ b/caffe2/python/pybind_state_nomni.cc
@@ -328,6 +328,7 @@ void addNomnigraphMethods(pybind11::module& m) {
           "tensor", getTensor, py::return_value_policy::reference)
       .def("getInputs", getInputs, py::return_value_policy::reference)
       .def("getOutputs", getOutputs, py::return_value_policy::reference)
+      .def("hasProducer", [](NNGraph::NodeRef n) { return nn::hasProducer(n); })
       .def("getProducer", getProducer, py::return_value_policy::reference)
       .def("getConsumers", getConsumers, py::return_value_policy::reference)
       .def_property_readonly(


### PR DESCRIPTION
Summary: Expose hasProduce(NodeRef) to python

Reviewed By: bwasti

Differential Revision: D13092930
