### PR TITLE
Enable Caffe2 test on centos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -949,6 +949,15 @@ jobs:
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
+  caffe2_py2_cuda9_0_cudnn7_centos7_test:
+    environment:
+      JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-centos7-test
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-centos7:230"
+      CUDA_VERSION: "9.0"
+      BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-centos7"
+    resource_class: gpu.medium
+    <<: *caffe2_linux_test_defaults
+
   caffe2_py2_ios_macos10_13_build:
     environment:
       JOB_BASE_NAME: caffe2-py2-ios-macos10.13-build
@@ -1069,6 +1078,9 @@ workflows:
       - caffe2_py2_clang7_ubuntu16_04_build
       - caffe2_py2_android_ubuntu16_04_build
       - caffe2_py2_cuda9_0_cudnn7_centos7_build
+      - caffe2_py2_cuda9_0_cudnn7_centos7_test:
+          requires:
+            - caffe2_py2_cuda9_0_cudnn7_centos7_build
 
       - caffe2_py2_ios_macos10_13_build
       - caffe2_py2_system_macos10_13_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,7 +946,6 @@ jobs:
       JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-centos7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-centos7:230"
       BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-centos7"
-      BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda9_0_cudnn7_centos7_test:


### PR DESCRIPTION
Turns out we don't have any centos test CI job