### PR TITLE
Relax limits for gradients in test_jit's checkGraph

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -383,7 +383,7 @@ class JitTestCase(TestCase):
             for g2, g2_ge in zip(grads2, grads2_ge):
                 if g2 is None and g2_ge is None:
                     continue
-                self.assertTrue(torch.allclose(g2, g2_ge, atol=7e-4, rtol=1e-4))
+                self.assertTrue(torch.allclose(g2, g2_ge, atol=8e-4, rtol=8e-4))
 
         return ge
 
@@ -1478,7 +1478,7 @@ class TestJit(JitTestCase):
     def test_ge_unoptimized(self):
         self.run_ge_tests(False, False)
 
-    def _test_proper_fused_abs(self, device='cpu'):
+    def _test_fused_abs(self, device='cpu'):
 
         @torch.jit.script
         def func(x):
@@ -1490,14 +1490,14 @@ class TestJit(JitTestCase):
 
     @unittest.skipIf(IS_WINDOWS or IS_SANDCASTLE, "NYI: fuser support for Windows or Sandcastle")
     @enable_cpu_fuser
-    def test_proper_fused_abs_cpu(self):
-        self._test_proper_fused_abs()
+    def test_fused_abs_cpu(self):
+        self._test_fused_abs()
 
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @skipIfRocm
-    def test_proper_fused_abs_cuda(self):
-        self._test_proper_fused_abs(device="cuda")
+    def test_fused_abs_cuda(self):
+        self._test_fused_abs(device="cuda")
 
     @unittest.skipIf(IS_WINDOWS or IS_SANDCASTLE, "NYI: fuser support for Windows or Sandcastle")
     @enable_cpu_fuser


### PR DESCRIPTION
- This should help TestJit.test_lstm_fusion_concat_cuda
  to be less flaky. (Checked on manual_seed 0..99)
  Fixes: #14026
- Revert the renaming of test_fused_abs that was introduced
  to game the order of tests to avoid the flakiness above.

