### PR TITLE
Make JOIN_TIMEOUT longer for ppc64le

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -15,7 +15,7 @@ from torch import multiprocessing as mp
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MP_STATUS_CHECK_INTERVAL
-from common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN,
+from common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, IS_PPC, NO_MULTIPROCESSING_SPAWN,
                           skipIfRocm, load_tests)
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -34,7 +34,7 @@ if not NO_MULTIPROCESSING_SPAWN:
     mp = mp.get_context(method='spawn')
 
 
-JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 8.5
+JOIN_TIMEOUT = 17.0 if IS_WINDOWS or IS_PPC else 8.5
 
 
 class TestDatasetRandomSplit(TestCase):


### PR DESCRIPTION
This should resolve the issue on ppc64le getting FAIL: test_proper_exit (__main__.TestDataLoader). This only happens when the CI build machine is very busy and fails with a timeout.