### PR TITLE
Fix -Wreturn-std-move

### DIFF
--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -12,7 +12,8 @@ FUNCTION_TEMPLATE = CodeTemplate("""\
 inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
   at::Tensor tensor = at::${name}(${actuals});
-  auto result = autograd::make_variable(tensor, /*requires_grad=*/${requires_grad});
+  at::Tensor result =
+    autograd::make_variable(tensor, /*requires_grad=*/${requires_grad});
   ${post_record_trace}
   return result;
 }


### PR DESCRIPTION
On clang-7 (internal) a warning, `-Wreturn-std-move`, is being emitted and raised to an error via `-Werror` for the code this PR fixes. The reason is that `autograd::make_variable` returns an `autograd::Variable`, so returning it from a function that returns `at::Tensor` disallows the compiler from eliding the return value (RVO). So let's explicitly convert the `autograd::Variable` to an `at::Tensor` before returning it.

@ezyang 