### PR TITLE
Merge Caffe2 and PyTorch thread pool definitions

### DIFF
--- a/aten/src/ATen/core/thread_pool.cpp
+++ b/aten/src/ATen/core/thread_pool.cpp
@@ -3,23 +3,138 @@
 
 namespace c10 {
 
-ThreadPool::ThreadPool() { /* intended to leave empty */ }
+ThreadPool::ThreadPool(std::size_t pool_size, int numa_node_id)
+    : threads_(pool_size),
+      running_(true),
+      complete_(true),
+      available_(pool_size),
+      total_(pool_size),
+      numa_node_id_(numa_node_id) {
+  for (std::size_t i = 0; i < pool_size; ++i) {
+    threads_[i] = std::thread(std::bind(&ThreadPool::main_loop, this, i));
+  }
+}
 
-ThreadPool::~ThreadPool() { /* intended to leave empty */ }
+ThreadPool::~ThreadPool() {
+  // Set running flag to false then notify all threads.
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    running_ = false;
+    condition_.notify_all();
+  }
 
-void ThreadPool::schedule(std::function<void(void)> task) {
-  tasks.push(task);
+  for (auto& t : threads_) {
+    try {
+      t.join();
+    } catch (const std::exception&) {
+    }
+  }
+}
+
+size_t ThreadPool::size() const {
+  return threads_.size();
+}
+
+size_t ThreadPool::numAvailable() const {
+  return available_;
+}
+
+bool ThreadPool::inThreadPool() const {
+  for (auto& thread : threads_) {
+    if (thread.get_id() == std::this_thread::get_id()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ThreadPool::run(const std::function<void()>& func) {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  // Set task and signal condition variable so that a worker thread will
+  // wake up and use the task.
+  tasks_.push(task_element_t(func));
+  complete_ = false;
+  condition_.notify_one();
+}
+
+void ThreadPool::waitWorkComplete() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (!complete_) {
+    completed_.wait(lock);
+  }
 }
 
 void ThreadPool::workOnTasksUntilCompleted(
     c10::intrusive_ptr<ivalue::Future> future) {
+  if (future->completed()) {
+    return;
+  }
+  std::condition_variable finished;
+  future->addCallback([&] { finished.notify_all(); });
+
+  std::unique_lock<std::mutex> future_lock(future->get_mutex());
   while (!future->completed()) {
-    auto task = tasks.front();
-    tasks.pop();
-    task();
+    finished.wait(future_lock);
   }
 }
 
-ThreadPool global_work_queue;
+void ThreadPool::main_loop(std::size_t index) {
+  init_thread();
+
+  while (running_) {
+    // Wait on condition variable while the task is empty and
+    // the pool is still running.
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (tasks_.empty() && running_) {
+      condition_.wait(lock);
+    }
+    // If pool is no longer running, break out of loop.
+    if (!running_) {
+      break;
+    }
+
+    // Copy task locally and remove from the queue.  This is
+    // done within its own scope so that the task object is
+    // destructed immediately after running the task.  This is
+    // useful in the event that the function contains
+    // shared_ptr arguments bound via bind.
+    {
+      auto tasks = tasks_.front();
+      tasks_.pop();
+      // Decrement count, indicating thread is no longer available.
+      --available_;
+
+      lock.unlock();
+
+      // Run the task.
+      try {
+        if (tasks.run_with_id) {
+          tasks.with_id(index);
+        } else {
+          tasks.no_id();
+        }
+      } catch (const std::exception&) {
+      }
+
+      // Update status of empty, maybe
+      // Need to recover the lock first
+      lock.lock();
+
+      // Increment count, indicating thread is available.
+      ++available_;
+      if (tasks_.empty() && available_ == total_) {
+        complete_ = true;
+        completed_.notify_one();
+      }
+    }
+  } // while running_
+}
+
+ThreadPool& global_work_queue() {
+  static ThreadPool thread_pool(1);
+
+  return thread_pool;
+}
 
 } // namespace c10

--- a/aten/src/ATen/core/thread_pool.h
+++ b/aten/src/ATen/core/thread_pool.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <queue>
+#include <thread>
+#include <utility>
 
 #include <c10/util/intrusive_ptr.h>
 
@@ -11,19 +15,91 @@ namespace ivalue {
 struct Future;
 } // namespace ivalue
 
-struct C10_API ThreadPool final {
-  ThreadPool();
+// TODO: move this to C10 and make it C10_API
+class CAFFE2_API TaskThreadPoolBase {
+ public:
+  virtual void run(const std::function<void()>& func) = 0;
+
+  virtual size_t size() const = 0;
+
+  /**
+   * The number of available (i.e. idle) threads in this thread pool.
+   */
+  virtual size_t numAvailable() const = 0;
+
+  /**
+   * Check if the current thread is from the thread pool.
+   */
+  virtual bool inThreadPool() const = 0;
+
+  virtual ~TaskThreadPoolBase() noexcept {}
+};
+
+class CAFFE2_API ThreadPool : public c10::TaskThreadPoolBase {
+ protected:
+  struct task_element_t {
+    bool run_with_id;
+    const std::function<void()> no_id;
+    const std::function<void(std::size_t)> with_id;
+
+    explicit task_element_t(const std::function<void()>& f)
+        : run_with_id(false), no_id(f), with_id(nullptr) {}
+    explicit task_element_t(const std::function<void(std::size_t)>& f)
+        : run_with_id(true), no_id(nullptr), with_id(f) {}
+  };
+
+  std::queue<task_element_t> tasks_;
+  std::vector<std::thread> threads_;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  std::condition_variable completed_;
+  bool running_;
+  bool complete_;
+  std::size_t available_;
+  std::size_t total_;
+  int numa_node_id_;
+
+ public:
+  ThreadPool() = delete;
+
+  explicit ThreadPool(std::size_t pool_size, int numa_node_id = -1);
 
   ~ThreadPool();
 
-  void schedule(std::function<void(void)> task);
+  size_t size() const override;
 
+  size_t numAvailable() const override;
+
+  bool inThreadPool() const override;
+
+  void run(const std::function<void()>& func) override;
+
+  template <typename Task>
+  void runTaskWithID(Task task) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    // Set task and signal condition variable so that a worker thread will
+    // wake up and use the task.
+    tasks_.push(
+        task_element_t(static_cast<std::function<void(std::size_t)>>(task)));
+    complete_ = false;
+    condition_.notify_one();
+  }
+
+  /// @brief Wait for queue to be empty
+  void waitWorkComplete();
+
+  // @brief Wait for the specific future to finish in the queue
   void workOnTasksUntilCompleted(c10::intrusive_ptr<ivalue::Future> future);
 
+ protected:
+  virtual void init_thread() {}
+
  private:
-  std::queue<std::function<void(void)>> tasks;
+  // @brief Entry point for pool threads.
+  void main_loop(std::size_t index);
 };
 
-C10_API extern ThreadPool global_work_queue;
+CAFFE2_API ThreadPool& global_work_queue();
 
 } // namespace c10

--- a/caffe2/utils/thread_pool.h
+++ b/caffe2/utils/thread_pool.h
@@ -1,179 +1,21 @@
 #ifndef CAFFE2_UTILS_THREAD_POOL_H_
 #define CAFFE2_UTILS_THREAD_POOL_H_
 
-#include <condition_variable>
-#include <functional>
-#include <mutex>
-#include <queue>
-#include <thread>
-#include <utility>
-
+#include "ATen/core/thread_pool.h"
 #include "caffe2/core/numa.h"
 #include "caffe2/utils/thread_name.h"
 
 namespace caffe2 {
 
-class CAFFE2_API TaskThreadPoolBase {
- public:
-  virtual void run(const std::function<void()>& func) = 0;
-  virtual size_t size() const = 0;
-  virtual size_t numAvailable() const = 0;
-  virtual ~TaskThreadPoolBase() {}
-};
-
-class CAFFE2_API TaskThreadPool : public TaskThreadPoolBase {
- private:
-  struct task_element_t {
-    bool run_with_id;
-    const std::function<void()> no_id;
-    const std::function<void(std::size_t)> with_id;
-
-    explicit task_element_t(const std::function<void()>& f)
-        : run_with_id(false), no_id(f), with_id(nullptr) {}
-    explicit task_element_t(const std::function<void(std::size_t)>& f)
-        : run_with_id(true), no_id(nullptr), with_id(f) {}
-  };
-
-  std::queue<task_element_t> tasks_;
-  std::vector<std::thread> threads_;
-  std::mutex mutex_;
-  std::condition_variable condition_;
-  std::condition_variable completed_;
-  bool running_;
-  bool complete_;
-  std::size_t available_;
-  std::size_t total_;
-  int numa_node_id_;
-
+class CAFFE2_API TaskThreadPool : public c10::ThreadPool {
  public:
   explicit TaskThreadPool(std::size_t pool_size, int numa_node_id = -1)
-      : threads_(pool_size),
-        running_(true),
-        complete_(true),
-        available_(pool_size),
-        total_(pool_size),
-        numa_node_id_(numa_node_id) {
-    for (std::size_t i = 0; i < pool_size; ++i) {
-      threads_[i] = std::thread(std::bind(&TaskThreadPool::main_loop, this, i));
-    }
-  }
+      : ThreadPool(pool_size, numa_node_id) {}
 
-  // Set running flag to false then notify all threads.
-  ~TaskThreadPool() override {
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      running_ = false;
-      condition_.notify_all();
-    }
-
-    try {
-      for (auto& t : threads_) {
-        t.join();
-      }
-    } catch (const std::exception&) {
-    }
-  }
-
-  size_t size() const override {
-    return threads_.size();
-  }
-
-  /**
-   * The number of available (i.e. idle) threads in this thread pool.
-   */
-  size_t numAvailable() const override {
-    return available_;
-  }
-
-  /// @brief Add task to the thread pool if a thread is currently available.
-  template <typename Task>
-  void runTask(Task task) {
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    // Set task and signal condition variable so that a worker thread will
-    // wake up and use the task.
-    tasks_.push(task_element_t(static_cast<std::function<void()>>(task)));
-    complete_ = false;
-    condition_.notify_one();
-  }
-
-  void run(const std::function<void()>& func) override {
-    runTask(func);
-  }
-
-  template <typename Task>
-  void runTaskWithID(Task task) {
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    // Set task and signal condition variable so that a worker thread will
-    // wake up and use the task.
-    tasks_.push(
-        task_element_t(static_cast<std::function<void(std::size_t)>>(task)));
-    complete_ = false;
-    condition_.notify_one();
-  }
-
-  /// @brief Wait for queue to be empty
-  void waitWorkComplete() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    while (!complete_) {
-      completed_.wait(lock);
-    }
-  }
-
- private:
-  /// @brief Entry point for pool threads.
-  void main_loop(std::size_t index) {
+  // TODO move this to ATen/core/thread_pool.h
+  void init_thread() override {
     setThreadName("CaffeTaskThread");
     NUMABind(numa_node_id_);
-
-    while (running_) {
-      // Wait on condition variable while the task is empty and
-      // the pool is still running.
-      std::unique_lock<std::mutex> lock(mutex_);
-      while (tasks_.empty() && running_) {
-        condition_.wait(lock);
-      }
-      // If pool is no longer running, break out of loop.
-      if (!running_) {
-        break;
-      }
-
-      // Copy task locally and remove from the queue.  This is
-      // done within its own scope so that the task object is
-      // destructed immediately after running the task.  This is
-      // useful in the event that the function contains
-      // shared_ptr arguments bound via bind.
-      {
-        auto tasks = tasks_.front();
-        tasks_.pop();
-        // Decrement count, indicating thread is no longer available.
-        --available_;
-
-        lock.unlock();
-
-        // Run the task.
-        try {
-          if (tasks.run_with_id) {
-            tasks.with_id(index);
-          } else {
-            tasks.no_id();
-          }
-        } catch (const std::exception&) {
-        }
-
-        // Update status of empty, maybe
-        // Need to recover the lock first
-        lock.lock();
-
-        // Increment count, indicating thread is available.
-        ++available_;
-        if (tasks_.empty() && available_ == total_) {
-          complete_ = true;
-          completed_.notify_one();
-        }
-      }
-    } // while running_
   }
 };
 

--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -791,7 +791,7 @@ bool VideoInputOp<Context>::Prefetch() {
     // read data
     reader_->Read(&key, &value);
 
-    thread_pool_->runTask(std::bind(
+    thread_pool_->run(std::bind(
         &VideoInputOp<Context>::DecodeAndTransform,
         this,
         std::string(value),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -549,7 +549,7 @@ RegisterOperators reg({
 
             push(stack, forked_interprester.getFuture());
 
-            c10::global_work_queue.schedule(std::move(continuation));
+            c10::global_work_queue().run(std::move(continuation));
             return 0;
           };
         }),


### PR DESCRIPTION
(1) Move Caffe2 thread pool to aten
(2) Use the same thread pool definition for PyTorch interpreter
(3) Make ivalue::Future thread-safe

