### PR TITLE
Disable QNNPACK for multi-architecture iOS builds

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -125,19 +125,37 @@ set(CONFU_DEPENDENCIES_BINARY_DIR ${PROJECT_BINARY_DIR}/confu-deps
 
 # ---[ QNNPACK
 if(USE_QNNPACK)
-  if (NOT IOS AND NOT (CMAKE_SYSTEM_NAME MATCHES "^(Android|Linux|Darwin)$"))
-    message(WARNING
-      "Target platform \"${CMAKE_SYSTEM_NAME}\" is not supported in QNNPACK. "
-      "Supported platforms are Android, iOS, Linux, and macOS. "
-      "Turn this warning off by USE_QNNPACK=OFF.")
-    set(USE_QNNPACK OFF)
-  endif()
-  if (NOT IOS AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i686|AMD64|x86_64|armv[0-9].*|arm64|aarch64)$"))
-    message(WARNING
-      "Target architecture \"${CMAKE_SYSTEM_PROCESSOR}\" is not supported in QNNPACK. "
-      "Supported platforms are x86, x86-64, ARM, and ARM64. "
-      "Turn this warning off by USE_QNNPACK=OFF.")
-    set(USE_QNNPACK OFF)
+  if (IOS)
+    list(LENGTH IOS_ARCH IOS_ARCH_COUNT)
+    if (IOS_ARCH_COUNT GREATER 1)
+      message(WARNING
+        "Multi-architecture (${IOS_ARCH}) builds are not supported in QNNPACK. "
+        "Specify a single architecture in IOS_ARCH and re-configure, or "
+        "turn this warning off by USE_QNNPACK=OFF.")
+      set(USE_QNNPACK OFF)
+    endif()
+    if (NOT IOS_ARCH MATCHES "^(i386|x86_64|armv7.*|arm64.*)$")
+      message(WARNING
+        "Target architecture \"${IOS_ARCH}\" is not supported in QNNPACK. "
+        "Supported architectures are x86, x86-64, ARM, and ARM64. "
+        "Turn this warning off by USE_QNNPACK=OFF.")
+      set(USE_QNNPACK OFF)
+    endif()
+  else()
+    if (NOT IOS AND NOT (CMAKE_SYSTEM_NAME MATCHES "^(Android|Linux|Darwin)$"))
+      message(WARNING
+        "Target platform \"${CMAKE_SYSTEM_NAME}\" is not supported in QNNPACK. "
+        "Supported platforms are Android, iOS, Linux, and macOS. "
+        "Turn this warning off by USE_QNNPACK=OFF.")
+      set(USE_QNNPACK OFF)
+    endif()
+    if (NOT IOS AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i686|AMD64|x86_64|armv[0-9].*|arm64|aarch64)$"))
+      message(WARNING
+        "Target architecture \"${CMAKE_SYSTEM_PROCESSOR}\" is not supported in QNNPACK. "
+        "Supported architectures are x86, x86-64, ARM, and ARM64. "
+        "Turn this warning off by USE_QNNPACK=OFF.")
+      set(USE_QNNPACK OFF)
+    endif()
   endif()
   if (USE_QNNPACK)
     set(CAFFE2_THIRD_PARTY_ROOT "${PROJECT_SOURCE_DIR}/third_party")

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -46,6 +46,14 @@ else
   CMAKE_ARGS+=("-DIOS_PLATFORM=OS")
 fi
 
+# IOS_ARCH controls type of iOS architecture (see ios-cmake)
+if [ -n "${IOS_ARCH:-}" ]; then
+  CMAKE_ARGS+=("-DIOS_ARCH=${IOS_ARCH}")
+else
+  # IOS_ARCH is not set, default to arm64
+  CMAKE_ARGS+=("-DIOS_ARCH=arm64")
+fi
+
 # Don't build binaries or tests (only the library)
 CMAKE_ARGS+=("-DBUILD_TEST=OFF")
 CMAKE_ARGS+=("-DBUILD_BINARY=OFF")


### PR DESCRIPTION
QNNPACK contains assembly files, and CMake tries to build them for wrong architectures in multi-arch builds. This patch has two effects:
- Disables QNNPACK in multi-arch iOS builds
- Specifies a single `IOS_ARCH=arm64` by default (covers most iPhones/iPads on the market)

