### PR TITLE
[JIT] More JIT type hierarchy refinement

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -752,9 +752,6 @@ struct CAFFE2_API BoolType : public Type {
   std::string str() const override {
     return "bool";
   }
-  std::string python_str() const override {
-    return "bool";
-  }
   bool isSubtypeOf(const TypePtr rhs) const override {
     if(auto rhs_ = rhs->cast<OptionalType>()) {
       return this->isSubtypeOf(rhs_->getElementType());
@@ -815,9 +812,6 @@ struct CAFFE2_API NoneType : public Type {
     return rhs->kind() == TypeKind::NoneType;
   }
   std::string str() const override {
-    return "None";
-  }
-  std::string python_str() const override {
     return "None";
   }
   static const TypeKind Kind = TypeKind::NoneType;


### PR DESCRIPTION
JIT type system hierarchy refinement and refactors:

1. Make NumberType be the base type of IntType FloatType 
2. Make single type container like OptionalType and FutureType share SingleElementType base type
3. Some refactors to make it more robust, e.g. adding python_str() for some types so that we have proper python_print serialization format 