### PR TITLE
Allow building libraries with setuptools that dont have abi suffix

### DIFF
--- a/test/cpp_extensions/no_python_abi_suffix_test/no_python_abi_suffix_test.cpp
+++ b/test/cpp_extensions/no_python_abi_suffix_test/no_python_abi_suffix_test.cpp
@@ -1,0 +1,1 @@
+void dummy(int) { }

--- a/test/cpp_extensions/no_python_abi_suffix_test/setup.py
+++ b/test/cpp_extensions/no_python_abi_suffix_test/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+setup(
+    name="no_python_abi_suffix_test",
+    ext_modules=[
+        CppExtension("no_python_abi_suffix_test", ["no_python_abi_suffix_test.cpp"])
+    ],
+    cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
+)

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -1,7 +1,7 @@
 import sys
 import torch.cuda
 from setuptools import setup
-from torch.utils.cpp_extension import CppExtension, CUDAExtension
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 from torch.utils.cpp_extension import CUDA_HOME
 
 CXX_FLAGS = [] if sys.platform == 'win32' else ['-g', '-Werror']
@@ -27,4 +27,4 @@ setup(
     name='torch_test_cpp_extension',
     packages=['torch_test_cpp_extension'],
     ext_modules=ext_modules,
-    cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension})
+    cmdclass={'build_ext': BuildExtension})

--- a/test/custom_operator/model.py
+++ b/test/custom_operator/model.py
@@ -4,16 +4,15 @@ import sys
 
 import torch
 
-SHARED_LIBRARY_NAMES = {
-    'linux': 'libcustom_ops.so',
-    'darwin': 'libcustom_ops.dylib',
-    'win32': 'custom_ops.dll'
-}
-
 
 def get_custom_op_library_path():
-    path = os.path.abspath('build/{}'.format(
-        SHARED_LIBRARY_NAMES[sys.platform]))
+    if sys.platform.startswith("win32"):
+        library_filename = "custom_ops.dll"
+    elif sys.platform.startswith("darwin"):
+        library_filename = "libcustom_ops.dylib"
+    else:
+        library_filename = "libcustom_ops.so"
+    path = os.path.abspath("build/{}".format(library_filename))
     assert os.path.exists(path), path
     return path
 
@@ -30,7 +29,8 @@ class Model(torch.jit.ScriptModule):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Serialize a script module with custom ops")
+        description="Serialize a script module with custom ops"
+    )
     parser.add_argument("--export-script-module-to", required=True)
     options = parser.parse_args()
 
@@ -40,5 +40,5 @@ def main():
     model.save(options.export_script_module_to)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -147,8 +147,13 @@ def test_cpp_extensions(executable, test_module, test_directory, options):
     except RuntimeError:
         print(CPP_EXTENSIONS_ERROR)
         return 1
+    cpp_extensions_test_dir = os.path.join(test_directory, 'cpp_extensions')
     return_code = shell([sys.executable, 'setup.py', 'install', '--root', './install'],
-                        os.path.join(test_directory, 'cpp_extensions'))
+                        cwd=cpp_extensions_test_dir)
+    if return_code != 0:
+        return return_code
+    return_code = shell([sys.executable, 'setup.py', 'install', '--root', './install'],
+                        cwd=os.path.join(cpp_extensions_test_dir, 'no_python_abi_suffix_test'))
     if return_code != 0:
         return return_code
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -152,10 +152,11 @@ def test_cpp_extensions(executable, test_module, test_directory, options):
                         cwd=cpp_extensions_test_dir)
     if return_code != 0:
         return return_code
-    return_code = shell([sys.executable, 'setup.py', 'install', '--root', './install'],
-                        cwd=os.path.join(cpp_extensions_test_dir, 'no_python_abi_suffix_test'))
-    if return_code != 0:
-        return return_code
+    if sys.platform != 'win32':
+        return_code = shell([sys.executable, 'setup.py', 'install', '--root', './install'],
+                            cwd=os.path.join(cpp_extensions_test_dir, 'no_python_abi_suffix_test'))
+        if return_code != 0:
+            return return_code
 
     python_path = os.environ.get('PYTHONPATH', '')
     try:

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -417,6 +417,7 @@ class TestCppExtension(common.TestCase):
         else:
             ext = "so"
         root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
+        print(list(os.walk(os.path.join("cpp_extensions", "no_python_abi_suffix_test"))))
         matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
         self.assertEqual(len(matches), 1, str(matches))
         self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext), str(matches))

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -381,7 +381,6 @@ class TestCppExtension(common.TestCase):
         self.assertEqual(len(net.parameters()), 4)
 
         p = net.named_parameters()
-        self.assertEqual(type(p), dict)
         self.assertEqual(len(p), 4)
         self.assertIn('fc.weight', p)
         self.assertIn('fc.bias', p)
@@ -418,8 +417,8 @@ class TestCppExtension(common.TestCase):
             ext = "so"
         root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "install")
         matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext))
+        self.assertEqual(len(matches), 1, str(matches))
+        self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext), str(matches))
 
 
 if __name__ == '__main__':

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -401,6 +401,7 @@ class TestCppExtension(common.TestCase):
             is_python_module=False)
         self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
 
+    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
     def test_no_python_abi_suffix_sets_the_correct_library_name(self):
         # For this test, run_test.py will call `python setup.py install` in the
         # cpp_extensions/no_python_abi_suffix_test folder, where the
@@ -415,7 +416,7 @@ class TestCppExtension(common.TestCase):
             ext = "dylib"
         else:
             ext = "so"
-        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "install")
+        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
         matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
         self.assertEqual(len(matches), 1, str(matches))
         self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext), str(matches))

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -29,7 +29,7 @@ IS_WINDOWS = sys.platform == 'win32'
 
 class TestCppExtension(common.TestCase):
     def setUp(self):
-        if sys.platform != 'win32':
+        if not IS_WINDOWS:
             default_build_root = torch.utils.cpp_extension.get_default_build_root()
             if os.path.exists(default_build_root):
                 shutil.rmtree(default_build_root)
@@ -121,7 +121,7 @@ class TestCppExtension(common.TestCase):
     @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
     def test_jit_cudnn_extension(self):
         # implementation of CuDNN ReLU
-        if sys.platform == 'win32':
+        if IS_WINDOWS:
             extra_ldflags = ['cudnn.lib']
         else:
             extra_ldflags = ['-lcudnn']
@@ -410,7 +410,12 @@ class TestCppExtension(common.TestCase):
         # library does not have an ABI suffix like
         # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
         # On Python 2 there is no ABI suffix anyway.
-        ext = {"win32": "dll", "linux": "so", "darwin": "dylib"}[sys.platform]
+        if IS_WINDOWS:
+            ext = "dll"
+        elif sys.platform.startswith("darwin"):
+            ext = "dylib"
+        else:
+            ext = "so"
         root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "install")
         matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
         self.assertEqual(len(matches), 1)

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -402,6 +402,20 @@ class TestCppExtension(common.TestCase):
             is_python_module=False)
         self.assertEqual(torch.ops.test.func(torch.eye(5)), torch.eye(5))
 
+    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
+        # For this test, run_test.py will call `python setup.py install` in the
+        # cpp_extensions/no_python_abi_suffix_test folder, where the
+        # `BuildExtension` class has a `no_python_abi_suffix` option set to
+        # `True`. This *should* mean that on Python 3, the produced shared
+        # library does not have an ABI suffix like
+        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
+        # On Python 2 there is no ABI suffix anyway.
+        ext = {"win32": "dll", "linux": "so", "darwin": "dylib"}[sys.platform]
+        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "install")
+        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext))
+
 
 if __name__ == '__main__':
     common.run_tests()

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -410,17 +410,11 @@ class TestCppExtension(common.TestCase):
         # library does not have an ABI suffix like
         # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
         # On Python 2 there is no ABI suffix anyway.
-        if IS_WINDOWS:
-            ext = "dll"
-        elif sys.platform.startswith("darwin"):
-            ext = "dylib"
-        else:
-            ext = "so"
         root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
         print(list(os.walk(os.path.join("cpp_extensions", "no_python_abi_suffix_test"))))
-        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith(ext)]
+        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
         self.assertEqual(len(matches), 1, str(matches))
-        self.assertEqual(matches[0], "{}.{}".format("no_python_abi_suffix_test", ext), str(matches))
+        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", str(matches))
 
 
 if __name__ == '__main__':

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -191,7 +191,11 @@ def check_compiler_abi_compatibility(compiler):
     return False
 
 
-class BuildExtension(build_ext):
+# See below for why we inherit BuildExtension from object.
+# https://stackoverflow.com/questions/1713038/super-fails-with-error-typeerror-argument-1-must-be-type-not-classobj-when
+
+
+class BuildExtension(build_ext, object):
     '''
     A custom :mod:`setuptools` build extension .
 
@@ -390,6 +394,7 @@ class BuildExtension(build_ext):
         # non-C++11 symbols
         if _is_binary_build():
             self._add_compile_flag(extension, '-D_GLIBCXX_USE_CXX11_ABI=0')
+
 
 def CppExtension(name, sources, *args, **kwargs):
     '''


### PR DESCRIPTION
When using `setuptools` to build a Python extension, setuptools will automatically add an ABI suffix like `cpython-37m-x86_64-linux-gnu` to the shared library name when using Python 3. This is required for extensions meant to be imported as Python modules. When we use setuptools to build shared libraries not meant as Python modules, for example libraries that define and register TorchScript custom ops, having your library called `my_ops.cpython-37m-x86_64-linux-gnu.so` is a bit annoying compared to just `my_ops.so`, especially since you have to reference the library name when loading it with `torch.ops.load_library` in Python.

This PR fixes this by adding a `with_options` class method to the `torch.utils.cpp_extension.BuildExtension` which allows configuring the `BuildExtension`. In this case, the first option we add is `no_python_abi_suffix`, which we then use in `get_ext_filename` (override from `setuptools.build_ext`) to throw away the ABI suffix.

I've added a test `setup.py` in a `no_python_abi_suffix_test` folder.

Fixes https://github.com/pytorch/pytorch/issues/14188

@t-vi @fmassa @soumith 