### PR TITLE
Update atol scale in dnnlowp test

### DIFF
--- a/caffe2/quantization/server/dnnlowp_test_utils.py
+++ b/caffe2/quantization/server/dnnlowp_test_utils.py
@@ -9,7 +9,7 @@ from hypothesis import assume
 # The error bound is derived based on assumption that there's no input
 # quantization error.
 def check_quantized_results_close(
-        outputs, ref=None, symmetric=False, atol_scale=0.51):
+        outputs, ref=None, symmetric=False, atol_scale=0.53):
     if ref is None:
         ref = outputs[0][0]
     ref_min = min(np.min(ref), 0)


### PR DESCRIPTION
Summary: Update atol scale of dnnlowp test. Can't reproduce the flaky test error in the task locally even after setting the same seed value, but found according to comments in check_quantized_results_close(), atol_scale should be 1/1.9=0.526315789473684, which is larger than current value 0.51. So increase the atol_scale to 0.53.

Reviewed By: jspark1105

Differential Revision: D13108415
