### PR TITLE
[wip][pt1][tensor] BlobGetMutableTensor returns Tensor

### DIFF
--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -71,7 +71,7 @@ CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(25, detail::_guard_long_unique<long>);
 CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(
     26,
     detail::_guard_long_unique<std::vector<long>>);
-
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(27, _CaffeHighestPreallocatedTypeId)
+// 27 is TensorImplPtr see tensor.cc
+CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(28, _CaffeHighestPreallocatedTypeId)
 
 } // namespace caffe2

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -605,6 +605,6 @@ CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(25, detail::_guard_long_unique<long>)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(
     26,
     detail::_guard_long_unique<std::vector<long>>)
-
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(27, _CaffeHighestPreallocatedTypeId)
+// 27 is TensorImplPtr see tensor.h
+CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(28, _CaffeHighestPreallocatedTypeId)
 } // namespace caffe2

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -10,10 +10,13 @@
 
 #include <ATen/core/blob.h>
 #include <c10/util/typeid.h>
+#include <ATen/core/intrusive_ptr.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/tensor.h"
 
 namespace caffe2 {
+
+using TensorImplPtr = c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl>;
 
 inline bool BlobIsTensorType(const Blob& blob, DeviceType device_type) {
   bool is_match = blob.meta().Match<Tensor>();
@@ -24,10 +27,40 @@ inline bool BlobIsTensorType(const Blob& blob, DeviceType device_type) {
   return tensor && *tensor && tensor->GetDeviceType() == device_type;
 }
 
+inline bool XBlobIsTensorType(const Blob& blob, DeviceType device_type) {
+  if (!blob.meta().Match<TensorImplPtr>()) {
+    return false;
+  }
+  const auto& tensor_impl_ptr = blob.Get<TensorImplPtr>();
+  return tensor_impl_ptr && tensor_impl_ptr->device_type() == device_type;
+}
+
 inline Tensor* BlobSetTensor(Blob* blob, const Tensor& tensor) {
   return blob->Reset<Tensor>(new Tensor(tensor));
 }
 
+inline Tensor
+XBlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
+  auto* tensor_impl_ptr = blob->GetMutableOrNull<TensorImplPtr>();
+  // Create a new Tensor(TensorImpl) when either the stored object is not TensorImplPtr
+  // or data type does not match or device type does not match
+  if (!tensor_impl_ptr || (*tensor_impl_ptr)->dtype() != options.dtype()
+      || (*tensor_impl_ptr).get()->GetDevice() != options.device()) {
+    VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<TensorImplPtr>()
+            << " dims: " << dims  << " options: " << options;
+    return Tensor(*blob->Reset<TensorImplPtr>(new TensorImplPtr(caffe2::empty(dims, options).getTensorImpl())));
+  } else {
+    auto& tensor_impl = *tensor_impl_ptr;
+    if (tensor_impl->sizes() != dims) {
+      // Resize when the dims doesn't match
+      tensor_impl->Resize(dims);
+    }
+    tensor_impl.get()->raw_mutable_data(tensor_impl->dtype());
+  }
+  return Tensor(*tensor_impl_ptr);
+}
+
+// need to keep both for clangr codemod
 inline Tensor*
 BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
   if (blob->IsType<Tensor>()) {
@@ -40,9 +73,8 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
         }
         if (tensor->dtype() == options.dtype()) {
           tensor->raw_mutable_data();
-        } else {
-          // create a new Tensor when the data_type doesn't match
-          return BlobSetTensor(blob, caffe2::empty(dims, options));
+        } else {          // create a new Tensor when the data_type doesn't match
+          return blob->Reset<Tensor>(new Tensor(caffe2::empty(dims, options)));
         }
         return tensor;
       }
@@ -53,8 +85,10 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
   VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<Tensor>()
           << " dims: " << dims;
   // << " options: " << options; (operator<< for Options is in at:: now)
-  return BlobSetTensor(blob, caffe2::empty(dims, options));
+  // TODO: Blob store Tensor directly?
+  return blob->Reset<Tensor>(new Tensor(caffe2::empty(dims, options)));
 }
+
 
 inline Tensor* BlobGetMutableTensor(Blob* blob, DeviceType device_type) {
   if (blob->IsType<Tensor>()) {
@@ -63,13 +97,11 @@ inline Tensor* BlobGetMutableTensor(Blob* blob, DeviceType device_type) {
       return tensor;
     }
   }
-
   // if we're here, then either Blob didn't hold a Tensor
   // or that Tensor had the wrong DeviceType.
   VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<Tensor>()
           << " DeviceType:" << device_type;
-
-  return BlobSetTensor(blob, Tensor(device_type));
+  return blob->Reset<Tensor>(new Tensor(device_type));
 }
 
 }  // namespace caffe2

--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -48,7 +48,7 @@ XBlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
       || (*tensor_impl_ptr).get()->GetDevice() != options.device()) {
     VLOG(1) << "Create new mutable object " << TypeMeta::TypeName<TensorImplPtr>()
             << " dims: " << dims  << " options: " << options;
-    return Tensor(*blob->Reset<TensorImplPtr>(new TensorImplPtr(caffe2::empty(dims, options).getTensorImpl())));
+    return Tensor(*blob->Reset<TensorImplPtr>(new TensorImplPtr(caffe2::empty(dims, options).getIntrusivePtr())));
   } else {
     auto& tensor_impl = *tensor_impl_ptr;
     if (tensor_impl->sizes() != dims) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -506,7 +506,7 @@ class Operator : public OperatorBase {
   Tensor XOutput(int idx, at::IntList dims, at::TensorOptions options) {
     if (options.device_opt() == c10::nullopt) {
       return OperatorBase::XOutputTensor(
-          idx, dims, at::TensorOptions(options).device(context_.device()));
+          idx, dims, options.device(context_.device()));
     }
     return OperatorBase::XOutputTensor(idx, dims, options);
   }
@@ -514,7 +514,7 @@ class Operator : public OperatorBase {
   Tensor* Output(int idx, at::IntList dims, at::TensorOptions options) {
     if (options.device_opt() == c10::nullopt) {
       return OperatorBase::OutputTensor(
-          idx, dims, at::TensorOptions(options).device(context_.device()));
+          idx, dims, options.device(context_.device()));
     }
     return OperatorBase::OutputTensor(idx, dims, options);
   }

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -127,6 +127,14 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     return BlobGetMutableTensor(outputs_.at(idx), type);
   }
 
+  inline Tensor
+  XOutputTensor(int idx, at::IntList dims, at::TensorOptions options) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        options.device_opt() != c10::nullopt,
+        "device must be provided in option.");
+    return XBlobGetMutableTensor(outputs_.at(idx), dims, options);
+  }
+
   inline Tensor*
   OutputTensor(int idx, at::IntList dims, at::TensorOptions options) {
     CAFFE_ENFORCE_WITH_CALLER(
@@ -495,13 +503,22 @@ class Operator : public OperatorBase {
     return OperatorBase::template Input<Tensor>(idx, type);
   }
 
-  inline Tensor* Output(int idx, at::IntList dims, at::TensorOptions options) {
+  Tensor XOutput(int idx, at::IntList dims, at::TensorOptions options) {
+    if (options.device_opt() == c10::nullopt) {
+      return OperatorBase::XOutputTensor(
+          idx, dims, at::TensorOptions(options).device(context_.device()));
+    }
+    return OperatorBase::XOutputTensor(idx, dims, options);
+  }
+
+  Tensor* Output(int idx, at::IntList dims, at::TensorOptions options) {
     if (options.device_opt() == c10::nullopt) {
       return OperatorBase::OutputTensor(
           idx, dims, at::TensorOptions(options).device(context_.device()));
     }
     return OperatorBase::OutputTensor(idx, dims, options);
   }
+
 
   inline Tensor* Output(int idx, DeviceType type = Context::GetDeviceType()) {
     return OperatorBase::template Output<Tensor>(idx, type);

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -5,6 +5,8 @@
 namespace caffe2 {
 
 CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(12, Tensor);
+using TensorImplPtr = c10::intrusive_ptr<at::TensorImpl, at::UndefinedTensorImpl>;
+CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(27, TensorImplPtr);
 
 TensorPrinter::TensorPrinter(
     const std::string& tensor_name,

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -32,15 +32,17 @@ class CAFFE2_API Tensor final {
     return impl_.defined();
   }
 
-  Tensor(TensorImplPtr ptr) {
-    impl_ = ptr;
+  Tensor(TensorImplPtr ptr) : impl_(std::move(ptr)){
+    if (impl_.get() == nullptr) {
+      throw std::runtime_error("TensorBaseImpl with nullptr not supported");
+    }
   }
 
   TensorImpl* unsafeGetTensorImpl() const {
     return impl_.get();
   }
 
-  TensorImplPtr getTensorImpl() {
+  const TensorImplPtr& getIntrusivePtr() const {
     return impl_;
   }
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -32,8 +32,16 @@ class CAFFE2_API Tensor final {
     return impl_.defined();
   }
 
+  Tensor(TensorImplPtr ptr) {
+    impl_ = ptr;
+  }
+
   TensorImpl* unsafeGetTensorImpl() const {
     return impl_.get();
+  }
+
+  TensorImplPtr getTensorImpl() {
+    return impl_;
   }
 
   /**
@@ -449,6 +457,9 @@ CAFFE2_API void ReinitializeAndCopyFrom(
     BaseContext* context = nullptr);
 
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(12, Tensor)
+
+using TensorImplPtr = c10::intrusive_ptr<at::TensorImpl, at::UndefinedTensorImpl>;
+CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(27, TensorImplPtr)
 
 using TensorCPU = Tensor;
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14136 [wip][pt1][tensor] BlobGetMutableTensor returns Tensor**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D12934074/)

Since now Tensor is a shared_ptr, it doesn't make sense to have Tensor* around anymore,
this diff is changing Tensor* to Tensor in the interface.
We'll store pointer to intrusive_ptr to TensorImpl in Tensor and create Tensor object on  the fly
when returning from BlobGetMutableTensor.
Another motivation is we want Blob to store intrusive_ptr of TensorImpl because IValue can store intrusive ptr. Without this change, IValue will have to store Blob which is an extra level of indirection.

This diff should be rebased on the diffs that removes Resize/ResizeLike+mutable_data

To remove Tensor*, we'll do following
```
auto* Y = Ouptut(0);
Y->mutable_data...
```
-->
```
auto Y = Output(0);
Y.mutable_data...
```

But to run clangr codemod, we'll keep both APIs in different names, e.g. `Output` and `XOutput`, and do the refactor and then delete the old method and rename the new method into the old one.
For example for `Output`, we'll first codemod the callsites from `Output` to `XOutput`, then delete the old `Output` and rename `XOutput` to `Output` in the end.


Differential Revision: [D12934074](https://our.internmc.facebook.com/intern/diff/D12934074/)