### PR TITLE
[c10d] Make NCCL backend support barrier op

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -125,8 +125,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronize() {
     cudaEvents_[i].block(currentStream);
     // If we use the work to do barrier, we should block here
     if (!barrierTensors_.empty()) {
-      at::cuda::OptionalCUDAGuard gpuGuard;
-      gpuGuard.set_index(devices_[i].index());
+      at::cuda::CUDAGuard gpuGuard(devices_[i]);
       AT_CUDA_CHECK(cudaStreamSynchronize(currentStream.stream()));
     }
   }

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -123,6 +123,12 @@ void ProcessGroupNCCL::WorkNCCL::synchronize() {
     auto currentStream = at::cuda::getCurrentCUDAStream(devices_[i].index());
     // Block the current stream on the NCCL stream
     cudaEvents_[i].block(currentStream);
+    // If we use the work to do barrier, we should block here
+    if (!barrierTensors_.empty()) {
+      at::cuda::OptionalCUDAGuard gpuGuard;
+      gpuGuard.set_index(devices_[i].index());
+      AT_CUDA_CHECK(cudaStreamSynchronize(currentStream.stream()));
+    }
   }
 }
 
@@ -203,6 +209,9 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
         "Not able to create/get the NCCL Communicator since "
         "the GPU devices are not known");
   }
+
+  lastDevices_ = devices;
+
   if (devNCCLCommMap_.find(devicesKey) != devNCCLCommMap_.end()) {
     // Reuse the cached communicator if there is one.
     return devNCCLCommMap_[devicesKey];
@@ -289,8 +298,8 @@ void ProcessGroupNCCL::tensorCheckHelper(
 
   for (size_t i = 0; i < input.size(); ++i) {
     //  Check to make sure it's a GPU dense tensor
-    if (!(input[i].is_cuda() && !input[i].is_sparse() &&
-          output[i].is_cuda() && !output[i].is_sparse())) {
+    if (!(input[i].is_cuda() && !input[i].is_sparse() && output[i].is_cuda() &&
+          !output[i].is_sparse())) {
       throw std::runtime_error(
           "Only CUDA dense tensor is supported for NCCL "
           "collective operations");
@@ -554,6 +563,43 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
   return work;
 }
 
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier() {
+  std::vector<at::Device> devices;
+  if (lastDevices_.empty()) {
+    // This means there is not yet a NCCL collective being called
+    // Here we have to use the best guesses and will use a single GPU to call
+    // allreduce to achieve barrier.
+    // In case the multiple processes fall into the same node, we use rank to
+    // ensure that each process is on a different GPU
+    auto numGPUs = at::cuda::getNumGPUs();
+    int16_t deviceIdx = static_cast<int16_t>(rank_ % numGPUs);
+    devices.push_back(at::Device(at::DeviceType::CUDA, deviceIdx));
+  } else {
+    devices = lastDevices_;
+  }
+
+  std::vector<at::Tensor> barrierTensors;
+  barrierTensors.reserve(devices.size());
+
+  at::cuda::OptionalCUDAGuard gpuGuard;
+  for (auto& device : devices) {
+    gpuGuard.set_index(device.index());
+    barrierTensors.push_back(at::empty(
+        {1},
+        at::TensorOptions().device(at::DeviceType::CUDA).dtype(at::kByte)));
+  }
+
+  // All reduce to achieve the barrier
+  auto work = allreduce(barrierTensors);
+
+  // Work will take over barrierTensors
+  auto ncclWork = dynamic_cast<ProcessGroupNCCL::WorkNCCL*>(work.get());
+  AT_CHECK(ncclWork);
+  ncclWork->barrierTensors_ = std::move(barrierTensors);
+
+  return work;
+}
+
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(
     std::vector<std::vector<at::Tensor>>& /* unused */,
     std::vector<at::Tensor>& /* unused */,
@@ -587,10 +633,6 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recvAnysource(
     int* /* unused */,
     int /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support recv");
-}
-
-std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier() {
-  throw std::runtime_error("ProcessGroupNCCL does not support barrier");
 }
 
 std::unordered_map<int, int> ProcessGroupNCCL::getGroupRank() {

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -92,6 +92,9 @@ class ProcessGroupNCCL : public ProcessGroup {
     // The CUDA events tracking this work item on multiple CUDA devices
     std::vector<at::cuda::CUDAEvent> cudaEvents_;
 
+    // Tensors used for barrier op
+    std::vector<at::Tensor> barrierTensors_;
+
     friend class ProcessGroupNCCL;
   };
 
@@ -196,6 +199,9 @@ class ProcessGroupNCCL : public ProcessGroup {
 
   // ID of this process group
   std::string processGroupID_;
+
+  // Devices used from the last collective call
+  std::vector<at::Device> lastDevices_;
 
   // processGroupID tracking
   static std::mutex pgTrackingLock_;


### PR DESCRIPTION
This is a feature request from: https://github.com/pytorch/pytorch/issues/13573

As the title says, this PR makes NCCL backend support barrier op.

There are a couple scenarios that need to be addressed:
(1) When there is already a NCCL op happened, we need to record what GPU device(s)  the previous op happened and queue the allreduce barrier op on the same GPU device
(2) When there is no NCCL op yet, we will try to use a single GPU and separate each process from a single GPU as the best effort.

As for the async work, during wait, we would like not just wait on the NCCL kernel to be completed, but also block the thread until the current stream and nccl stream return.

`test_distributed` should cover the test. I also manually tested both scenarios. 