### PR TITLE
Fix caffe2 => onnx exporter for ConvTranspose

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -287,13 +287,13 @@ void OnnxExporter::CopyCaffe2ArgToOnnxAttr(
     AttributeProto* attr,
     const std::string& op_type,
     const caffe2::Argument& arg) {
-  std::string name;
+  std::string name =
+      caffe2::get_default(get_renamed_attrs(), arg.name(), arg.name());
   const auto& per_op_renamed_attr_lut = get_per_op_renamed_attrs();
   const auto it = per_op_renamed_attr_lut.find(op_type);
   if (it != per_op_renamed_attr_lut.end()) {
-    name = caffe2::get_default(it->second, arg.name(), arg.name());
-  } else {
-    name = caffe2::get_default(get_renamed_attrs(), arg.name(), arg.name());
+    // Per-op attribute renames override the global attribute renames
+    name = caffe2::get_default(it->second, arg.name(), name);
   }
   attr->set_name(name);
 
@@ -1046,4 +1046,3 @@ void OnnxExporter::InitOpToTensorProto(
 
 } // namespace onnx
 } // namespace caffe2
-

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -86,11 +86,10 @@ class Caffe2Frontend(object):
     def _common_caffe2_arg_to_onnx_attr(cls, op_def, arg):
         # name
         op_type = op_def.type
+        name = cls._global_renamed_args.get(arg.name, arg.name)
         if op_type in cls._per_op_renamed_args:
-            name = cls._per_op_renamed_args[op_type].get(
-                arg.name, arg.name)
-        else:
-            name = cls._global_renamed_args.get(arg.name, arg.name)
+            # Per-op attribute renames override the global attribute renames
+            name = cls._per_op_renamed_args[op_type].get(arg.name, name)
 
         # value
         if arg.HasField('f'):


### PR DESCRIPTION
Summary:
ConvTranspose has a per-operator attribute rename, which meant that the
global attribute rename for kernels => kernel_shape was not applied.
Changing the behavior so that the global renames always apply, but per-op
renames can override those for specific attributes.

Note: The python frontend path isn't actually used for ConvTranspose, but I
thought it would be good to make it consistent.

Differential Revision: D13113395
