### PR TITLE
Remove debugging code in test_cholesky_batched

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5346,8 +5346,6 @@ class _TestTorchMixin(object):
             A = cast(random_symmetric_pd_matrix(n, *batch_dims))
             cholesky_exp = torch.stack([m.cholesky(upper=upper) for m in A.reshape(-1, n, n)])
             cholesky_exp = cholesky_exp.reshape_as(A)
-            print(torch.cholesky(A, upper=upper))
-            print(cholesky_exp)
             self.assertEqual(cholesky_exp, torch.cholesky(A, upper=upper))
 
         for upper, batchsize in product([True, False], [(3,), (3, 4), (2, 3, 4)]):


### PR DESCRIPTION
They didn't turn up in my tests because I use pytest which doesn't
print debug statements if the tests pass

cc: @bddppq 
