### PR TITLE
Bugfix for undefined references to class ProfilingInfo.

### DIFF
--- a/caffe2/contrib/prof/CMakeLists.txt
+++ b/caffe2/contrib/prof/CMakeLists.txt
@@ -2,6 +2,7 @@ if (USE_PROF)
   set(Caffe2_CONTRIB_PROF_CPU_SRCS
       "${CMAKE_CURRENT_SOURCE_DIR}/prof_dag_net.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/prof_dag_stats_op.cc"
+      "${CMAKE_CURRENT_SOURCE_DIR}/profiling_info.cc"
   )
   set(Caffe2_CONTRIB_PROF_GPU_SRCS
       "${CMAKE_CURRENT_SOURCE_DIR}/cuda_profile_ops.cc"

--- a/caffe2/contrib/prof/profiling_info.cc
+++ b/caffe2/contrib/prof/profiling_info.cc
@@ -5,7 +5,7 @@ namespace caffe2 {
 namespace contrib {
 namespace prof {
 
-bool ProfilingInfo::Init(const NetDef& netDef) {
+CAFFE2_API bool ProfilingInfo::Init(const NetDef& netDef) {
   bool success = true;
   int opIdx = 0;
   name_ = netDef.name();
@@ -28,7 +28,7 @@ bool ProfilingInfo::Init(const NetDef& netDef) {
   return success;
 }
 
-bool ProfilingInfo::Restore(
+CAFFE2_API bool ProfilingInfo::Restore(
     const NetDef& netDef,
     const ProfDAGProtos& profile) {
   if (netDef.name() != profile.net_name()) {
@@ -56,7 +56,7 @@ bool ProfilingInfo::Restore(
   return success;
 }
 
-bool ProfilingInfo::GetOperatorAndDataStats(
+CAFFE2_API bool ProfilingInfo::GetOperatorAndDataStats(
     const NetDef& netDef,
     bool oldFormat,
     ProfDAGProtos* serialized) const {
@@ -98,7 +98,7 @@ bool ProfilingInfo::GetOperatorAndDataStats(
   return success;
 }
 
-bool ProfilingInfo::GetOperatorTypeStats(
+CAFFE2_API bool ProfilingInfo::GetOperatorTypeStats(
     const NetDef& netDef,
     ProfDAGProtos* serialized) const {
   bool success = true;

--- a/caffe2/contrib/prof/profiling_info.h
+++ b/caffe2/contrib/prof/profiling_info.h
@@ -16,22 +16,22 @@ class ProfilingInfo {
   using OperatorMapType = std::unordered_map<int, ProfilingOperatorAnnotation>;
   // Generates a fresh data structure to be initialized. Use Init() or Restore()
   // below to initialize the data structure.
-  ProfilingInfo() {}
+  ProfilingInfo() = default;
   // Generates 0-initialized stats for node and blob profiles from a given
   // NetDef. Use this to start profiling.
-  bool Init(const NetDef& netDef);
+  CAFFE2_API bool Init(const NetDef& netDef);
   // Uses ProfDAGProtos for existing profile, and NetDef for graph definition,
   // and restores the state. Returns whether profile and net_def were
   // consistent. This is defined over the "indices" of operators and outputs:
   // the indices within the net_def should exist with the profile, and the names
   // should match. Errors are handled with best effort: matching state is
   // populated.
-  bool Restore(const NetDef& netDef, const ProfDAGProtos& profile);
+  CAFFE2_API bool Restore(const NetDef& netDef, const ProfDAGProtos& profile);
   // Appends ProfDAGProtos from the internal representation representing each
   // operator and blob in the graph as separate entities. Returns false if
   // NetDef is inconsistent with the original. It uses the old format when
   // oldFormat is set, which looks like: net__opidx__optype.
-  bool GetOperatorAndDataStats(
+  CAFFE2_API bool GetOperatorAndDataStats(
       const NetDef& net_def,
       bool oldFormat,
       ProfDAGProtos* serialized) const;
@@ -39,8 +39,9 @@ class ProfilingInfo {
   // false if NetDef is inconsistent with the original. This function is only
   // used for oldFormat because the information is redundant. The user of the
   // library can iterate over the map and recreate if needed.
-  bool GetOperatorTypeStats(const NetDef& net_def, ProfDAGProtos* serialized)
-      const;
+  CAFFE2_API bool GetOperatorTypeStats(
+      const NetDef& net_def,
+      ProfDAGProtos* serialized) const;
 
   // Accessors.
   const BlobMapType& getBlobMap() {


### PR DESCRIPTION
Fix #14158.

**Issue:**
`profiling_info.cc` is not listed in CMakeLists, causing errors while building unit tests.

**Solution:**
1. Add `profiling_info.cc` into source list `Caffe2_CONTRIB_PROF_CPU_SRCS `.
2. Export missing functions in library interface using `CAFFE2_API`.