### PR TITLE
Print default values and introduce ir view classes

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -24,7 +24,12 @@ struct Argument {
         N_(std::move(N)),
         default_value_(std::move(default_value)),
         kwarg_only_(kwarg_only),
-        alias_info_(std::move(alias_info)) {}
+        alias_info_(std::move(alias_info)) {
+          if (default_value_ && default_value_->isTensor()) {
+            auto t = default_value_->toTensor();
+            AT_ASSERT(!t.defined() || t.is_variable());
+          }
+        }
   const std::string& name() const {
     return name_;
   }

--- a/test/expect/TestJit.test_cu_escaped_number.expect
+++ b/test/expect/TestJit.test_cu_escaped_number.expect
@@ -1,3 +1,3 @@
-def script(self,
+def graph(self,
     a: Tensor) -> Tuple[]:
   print("hi\016")

--- a/test/expect/TestJit.test_import_method.expect
+++ b/test/expect/TestJit.test_import_method.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     x: Tensor,
     y: Tensor) -> Tensor:
   return aten.add(aten.mul(x, 2), y, alpha=1)

--- a/test/expect/TestJit.test_pretty_printer-empty_float_list_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-empty_float_list_test.expect
@@ -1,3 +1,3 @@
-def script(self,
+def graph(self,
     y: Tensor) -> List[float]:
   return [1., 2., 3.]

--- a/test/expect/TestJit.test_pretty_printer-empty_int_list_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-empty_int_list_test.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     y: Tensor) -> int:
   x = annotate(List[int], [])
   return aten.select(x, 0)

--- a/test/expect/TestJit.test_pretty_printer-if_one.expect
+++ b/test/expect/TestJit.test_pretty_printer-if_one.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     a: Tensor,
     b: Tensor) -> Tensor:
   if bool(aten.lt(a, b)):

--- a/test/expect/TestJit.test_pretty_printer-if_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-if_test.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     a: Tensor,
     b: Tensor) -> Tensor:
   if bool(aten.lt(a, b)):

--- a/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-loop_use_test.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     y_1: Tensor) -> Tuple[Tensor, Tensor]:
   x = aten.add(y_1, 1, 1)
   z_1 = aten.add(x, 5, 1)

--- a/test/expect/TestJit.test_pretty_printer-print_weird_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-print_weird_test.expect
@@ -1,3 +1,3 @@
-def script(self,
+def graph(self,
     y: Tensor) -> Tuple[]:
   print("hi\016")

--- a/test/expect/TestJit.test_pretty_printer-python_op_name_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-python_op_name_test.expect
@@ -1,3 +1,3 @@
-def script(self,
+def graph(self,
     y: Tensor) -> Tensor:
   return ^python_fn()(y)

--- a/test/expect/TestJit.test_pretty_printer-while_if_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-while_if_test.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     a_1: Tensor,
     b_1: Tensor) -> Tensor:
   a, b, c = a_1, b_1, 0

--- a/test/expect/TestJit.test_pretty_printer-while_test.expect
+++ b/test/expect/TestJit.test_pretty_printer-while_test.expect
@@ -1,4 +1,4 @@
-def script(self,
+def graph(self,
     a_1: Tensor,
     i_1: Tensor) -> Tensor:
   a, i = a_1, i_1

--- a/test/expect/TestScript.test_python_frontend.expect
+++ b/test/expect/TestScript.test_python_frontend.expect
@@ -4,13 +4,16 @@
     (list
       (param
         (ident x)
-        (variable (ident Tensor)))
+        (variable (ident Tensor))
+        (option))
       (param
         (ident y)
-        (variable (ident Tensor)))
+        (variable (ident Tensor))
+        (option))
       (param
         (ident z)
-        (variable (ident Tensor))))
+        (variable (ident Tensor))
+        (option)))
     (option))
   (list
     (assign

--- a/torch/csrc/jit/ir_views.h
+++ b/torch/csrc/jit/ir_views.h
@@ -3,8 +3,8 @@
 namespace torch {
 namespace jit {
 
-struct IfStmt {
-  explicit IfStmt(Node* node) : node_(node) {
+struct IfView {
+  explicit IfView(Node* node) : node_(node) {
     JIT_ASSERT(node->kind() == prim::If);
   }
   Value* cond() const {
@@ -36,8 +36,8 @@ struct IfStmt {
   Node* node_;
 };
 
-struct LoopStmt {
-  explicit LoopStmt(Node* node) : node_(node) {
+struct LoopView {
+  explicit LoopView(Node* node) : node_(node) {
     JIT_ASSERT(node->kind() == prim::Loop);
   }
   Block* bodyBlock() const {

--- a/torch/csrc/jit/ir_views.h
+++ b/torch/csrc/jit/ir_views.h
@@ -1,0 +1,87 @@
+#include "torch/csrc/jit/ir.h"
+
+namespace torch {
+namespace jit {
+
+struct IfStmt {
+  explicit IfStmt(Node* node) : node_(node) {
+    JIT_ASSERT(node->kind() == prim::If);
+  }
+  Value* cond() const {
+    return node_->input(0);
+  }
+  Block* thenBlock() const {
+    return node_->blocks().at(0);
+  }
+  Block* elseBlock() const {
+    return node_->blocks().at(1);
+  }
+  ArrayRef<Value*> thenOutputs() const {
+    return thenBlock()->outputs();
+  }
+  ArrayRef<Value*> elseOutputs() const {
+    return elseBlock()->outputs();
+  }
+  ArrayRef<Value*> outputs() const {
+    return node_->outputs();
+  }
+  Node* node() const {
+    return node_;
+  }
+  operator Node*() const {
+    return node_;
+  }
+
+ private:
+  Node* node_;
+};
+
+struct LoopStmt {
+  explicit LoopStmt(Node* node) : node_(node) {
+    JIT_ASSERT(node->kind() == prim::Loop);
+  }
+  Block* bodyBlock() const {
+    return node_->blocks().at(0);
+  }
+  Value* cond() const {
+    return node_->input(0);
+  }
+  Value* maxTripCount() const {
+    return node_->input(0);
+  }
+  Value* inputCond() const {
+    return node_->input(1);
+  }
+  Value* nextCond() const {
+    return bodyBlock()->outputs().at(0);
+  }
+  Value* currentTripCount() const {
+    return bodyBlock()->inputs().at(0);
+  }
+  ArrayRef<Value*> carriedInputs() const {
+    // skip trip count and cond
+    return node_->inputs().slice(2);
+  }
+  ArrayRef<Value*> carriedOutputs() const {
+    return node_->outputs();
+  }
+  ArrayRef<Value*> bodyCarriedInputs() const {
+    // skip trip count and cond
+    return bodyBlock()->inputs().slice(1);
+  }
+  ArrayRef<Value*> bodyCarriedOutputs() const {
+    return bodyBlock()->outputs().slice(1);
+  }
+  Node* node() const {
+    return node_;
+  }
+  operator Node*() const {
+    return node_;
+  }
+
+ private:
+  Node* node_;
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -184,6 +184,7 @@ void AliasDb::analyze(Node* node) {
     case prim::FusedConcat:
     case prim::MMTreeReduce:
     case prim::MMBatchSide:
+    case prim::None:
       return analyzeCreator(node);
     case prim::TupleUnpack:
     case prim::TupleIndex:

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -336,7 +336,7 @@ struct PythonPrintPass {
     }
   }
 
-  void printIf(IfStmt stmt) {
+  void printIf(IfView stmt) {
     assignValuesToTheirUniqueNames(stmt.outputs());
     indent() << "if " << useOf(stmt.cond()) << ":\n";
     {
@@ -356,7 +356,7 @@ struct PythonPrintPass {
   // our way of encoding loops makes them difficult to turn back into python syntax.
   // we have to check properties of the condition and trip count inputs to
   // figure out which one it initially was
-  static bool shouldEmitAsForLoop(LoopStmt stmt) {
+  static bool shouldEmitAsForLoop(LoopView stmt) {
       auto trip_count = toIValue(stmt.maxTripCount());
       auto cond_input = toIValue(stmt.inputCond());
       auto cond_next = toIValue(stmt.nextCond());
@@ -381,7 +381,7 @@ struct PythonPrintPass {
       }
   }
 
-  void printLoop(LoopStmt stmt) {
+  void printLoop(LoopView stmt) {
 
     // Loop carried dependencies are handled by assigning their initial
     // values to the node->outputs() before the loop,
@@ -442,10 +442,10 @@ struct PythonPrintPass {
         }
         break;
       case prim::Loop:
-        printLoop(LoopStmt(node));
+        printLoop(LoopView(node));
         break;
       case prim::If:
-        printIf(IfStmt(node));
+        printIf(IfView(node));
         break;
       case prim::TupleUnpack:
       case prim::ListUnpack:

--- a/torch/csrc/jit/passes/python_print.h
+++ b/torch/csrc/jit/passes/python_print.h
@@ -6,6 +6,12 @@
 
 
 namespace torch { namespace jit {
-TORCH_API std::vector<at::Tensor> PythonPrint(std::ostream& out, const Graph& graph, bool enforce_importable=false);
+
+namespace script {
+  struct Method;
+}
+
+TORCH_API std::vector<at::Tensor> PythonPrint(std::ostream& out, Graph& graph, bool enforce_importable=false);
+TORCH_API std::vector<at::Tensor> PythonPrint(std::ostream& out, script::Method& graph, bool enforce_importable=false);
 TORCH_API bool printerHasSpecialCaseFor(c10::Symbol sym);
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -223,11 +223,6 @@ void initPythonIRBindings(PyObject * module_) {
       g.prettyPrint(oss);
       return oss.str();
     })
-    .def("python_print", [](Graph &g) {
-      std::ostringstream oss;
-      std::vector<at::Tensor> constants = PythonPrint(oss, g, true);
-      return std::make_pair(oss.str(), std::move(constants));
-    })
     .GS(createFusionGroup)
     .def("createClone",[](Graph & g, Node * n, py::object fn) {
       return g.createClone(n, [&](Value * e) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -892,31 +892,31 @@ private:
 
   std::vector<IValue> evaluateDefaults(const SourceRange& r, const std::vector<Expr>& default_types, const std::vector<Expr>& default_exprs) {
     std::vector<IValue> default_values;
-    if (default_exprs.size() > 0) {
-      // To evaluate the default expressions, we create a graph with no inputs,
-      // and whose returns are the default values we need.
-      // We then run constant prop on this graph and check the results are constant.
-      // This approach avoids having to have separate handling of default arguments
-      // from standard expressions by piecing together existing machinery for
-      // graph generation, constant propgation, and constant extraction.
-      auto tuple_type = Subscript::create(
-          r,
-          Var::create(r, Ident::create(r, "Tuple")),
-          List<Expr>::create(r, default_types));
-      auto blank_decl =
-          Decl::create(r, List<Param>::create(r, {}), Maybe<Expr>::create(r, tuple_type));
+    if (default_exprs.empty())
+      return default_values;
+    // To evaluate the default expressions, we create a graph with no inputs,
+    // and whose returns are the default values we need.
+    // We then run constant prop on this graph and check the results are constant.
+    // This approach avoids having to have separate handling of default arguments
+    // from standard expressions by piecing together existing machinery for
+    // graph generation, constant propgation, and constant extraction.
+    auto tuple_type = Subscript::create(
+        r,
+        Var::create(r, Ident::create(r, "Tuple")),
+        List<Expr>::create(r, default_types));
+    auto blank_decl =
+        Decl::create(r, List<Param>::create(r, {}), Maybe<Expr>::create(r, tuple_type));
 
-      auto tuple_expr = TupleLiteral::create(r, List<Expr>::create(r, default_exprs));
-      auto ret = Return::create(r, List<Expr>::create(r, { tuple_expr }));
-      auto def = Def::create(
-          r,
-          Ident::create(r, "defaults"),
-          blank_decl,
-          List<Stmt>::create(r, {ret}));
-      auto m = std::make_shared<Module>();
-      defineMethodsInModule(m, {def}, {resolver}, nullptr);
-      m->get_method("defaults").run(default_values);
-    }
+    auto tuple_expr = TupleLiteral::create(r, List<Expr>::create(r, default_exprs));
+    auto ret = Return::create(r, List<Expr>::create(r, { tuple_expr }));
+    auto def = Def::create(
+        r,
+        Ident::create(r, "defaults"),
+        blank_decl,
+        List<Stmt>::create(r, {ret}));
+    auto m = std::make_shared<Module>();
+    defineMethodsInModule(m, {def}, {resolver}, nullptr);
+    m->get_method("defaults").run(default_values);
     return default_values;
   }
 

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -85,7 +85,7 @@ void initTreeViewBindings(PyObject *module) {
 
   py::class_<Param, TreeView>(m, "Param")
     .def(py::init([](const Expr& type, const Ident& name) {
-      return Param::create(name.range(), name, type);
+      return Param::create(name.range(), name, type, Maybe<Expr>::create(name.range()));
     }));
   py::class_<Attribute, TreeView>(m, "Attribute")
     .def(py::init([](const Ident& name, const Expr& value) {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -297,8 +297,8 @@ struct Param : public TreeView {
   explicit Param(const TreeRef& tree) : TreeView(tree) {
     tree_->match(TK_PARAM);
   }
-  static Param create(const SourceRange& range, const Ident& ident, const Expr& type) {
-    return Param(Compound::create(TK_PARAM, range, {ident, type}));
+  static Param create(const SourceRange& range, const Ident& ident, const Expr& type, Maybe<Expr> def) {
+    return Param(Compound::create(TK_PARAM, range, {ident, type, def}));
   }
   Ident ident() const {
     return Ident(subtree(0));
@@ -306,9 +306,11 @@ struct Param : public TreeView {
   Expr type() const {
     return Expr(subtree(1));
   }
-  template<typename T>
-  T typeExpect() const {
-    return T(type());
+  Maybe<Expr> defaultValue() const {
+    return Maybe<Expr>(subtree(2));
+  }
+  Param withType(Expr typ) const {
+    return Param::create(range(), ident(), typ, defaultValue());
   }
 };
 


### PR DESCRIPTION
[Stacked commit, only review the last commit]

This PR adds support for printing default values in python printing as well as the logic
for parsing default values back in using the parser. For simplicity, this PR simply
creates a subgraph of the constant expressions and then runs that graph to generate the defaults.
A more lightweight approach should be possible later, but would require more machinery.

To make reading code in the printer easier, this also add ir_views.h.
Similar to tree_views.h these classes can provide views of some commonly used IR nodes
that have complicated structure and common operations on that structure.

Currently it has only read-only views for prim::If and prim::Loop,
but we should eventually add helpers to manipulate If/Loop nodes as well.