### PR TITLE
[pytorch] Remove protobuf dependency in pytorch cmake file.

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -572,7 +572,6 @@ if (BUILD_PYTHON)
     ${TORCH_ROOT}/third_party/build/nccl/include
     ${TORCH_ROOT}/third_party/gloo
     ${TORCH_ROOT}/third_party/onnx
-    ${TORCH_ROOT}/third_party/protobuf/src
     ${TORCH_ROOT}/third_party/pybind11/include
 
     ${TORCH_SRC_DIR}/csrc


### PR DESCRIPTION
Currently, pytorch doesn't dependent on protobuf. So, we don't need to include the protobuf dir in pytorch cmake file.
And if we build caffe2 without custom-protobuf[1], we will have the protobuf mismatched problem.

[1]
https://github.com/pytorch/pytorch/blob/92dbd0219f6fbdb1db105386386ccf92c0758e86/CMakeLists.txt#L65