### PR TITLE
OSS build fix

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -30,7 +30,7 @@ C10_DEFINE_bool(
     "Dump quantized input and weight tensors used in Conv and FC operators "
     "during the first iteration");
 
-DECLARE_bool(caffe2_dnnlowp_force_slow_path);
+C10_DECLARE_bool(caffe2_dnnlowp_force_slow_path);
 
 namespace caffe2 {
 

--- a/caffe2/quantization/server/dnnlowp.cc
+++ b/caffe2/quantization/server/dnnlowp.cc
@@ -50,7 +50,7 @@ C10_DEFINE_int32(
   dnnlowp_copy_to_32bit_frequency, 32,
   "When outlier-aware quantization is used, this option specifies how often "
   "we spill 16-bit accumulated numbers to 32-bit during the first pass");
-DEFINE_bool(
+C10_DEFINE_bool(
     caffe2_dnnlowp_force_slow_path,
     false,
     "When true, use slow path in quantization");


### PR DESCRIPTION
Summary: We can only use C10_* in OSS. The build is only broken if built with USE_FBGEMM=ON

Differential Revision: D13121781
