### PR TITLE
FeedTensor returns a Tensor (#13641)

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -432,8 +432,8 @@ void addObjectMethods(py::module& m) {
               CAFFE_THROW(
                   "Unexpected type of argument -- expected numpy array");
             }
-            TensorFeeder<CPUContext>().FeedTensor(
-                DeviceOption{}, reinterpret_cast<PyArrayObject*>(obj.ptr()), t);
+            *t = TensorFeeder<CPUContext>().FeedTensor(
+                DeviceOption{}, reinterpret_cast<PyArrayObject*>(obj.ptr()));
 #else
             CAFFE_THROW("Caffe2 compiled without NumPy support.");
 #endif // USE_NUMPY
@@ -751,15 +751,15 @@ void addObjectMethods(py::module& m) {
             for (const auto pair : inputs) {
               const auto& name = pair.first;
               const auto& input = pair.second;
-              tensors_data.emplace(name, Tensor(CPU));
 #ifdef USE_NUMPY
               CAFFE_ENFORCE(
                   PyArray_Check(input.ptr()),
                   "Input must be of type numpy array.");
               PyArrayObject* array =
                   reinterpret_cast<PyArrayObject*>(input.ptr());
-              TensorFeeder<CPUContext>().FeedTensor(
-                  DeviceOption(), array, &tensors_data.at(name));
+              tensors_data.emplace(
+                  name,
+                  TensorFeeder<CPUContext>().FeedTensor(DeviceOption(), array));
 #else
               CAFFE_THROW("Caffe2 was compiled without NumPy support.");
 #endif // USE_NUMPY
@@ -777,9 +777,6 @@ void addObjectMethods(py::module& m) {
           [](caffe2::onnx::Caffe2BackendRep& instance,
              std::vector<py::object> inputs) -> std::vector<py::object> {
             std::vector<TensorCPU> tensors_data;
-            for (auto i = 0; i < inputs.size(); ++i) {
-              tensors_data.emplace_back(caffe2::CPU);
-            }
 #ifdef USE_NUMPY
             for (auto i = 0; i < inputs.size(); ++i) {
               auto input = inputs[i];
@@ -788,8 +785,8 @@ void addObjectMethods(py::module& m) {
                   "Input must be of type numpy array.");
               PyArrayObject* array =
                   reinterpret_cast<PyArrayObject*>(input.ptr());
-              TensorFeeder<CPUContext>().FeedTensor(
-                  DeviceOption(), array, &(tensors_data[i]));
+              tensors_data.push_back(
+                  TensorFeeder<CPUContext>().FeedTensor(DeviceOption(), array));
             }
 #else
             CAFFE_THROW("Caffe2 was compiled without NumPy support.");
@@ -890,9 +887,6 @@ void addObjectMethods(py::module& m) {
           [](Predictor& instance,
              std::vector<py::object> inputs) -> std::vector<py::object> {
             std::vector<Tensor> tensors_data;
-            for (auto i = 0; i < inputs.size(); ++i) {
-              tensors_data.emplace_back(CPU);
-            }
 #ifdef USE_NUMPY
             for (auto i = 0; i < inputs.size(); ++i) {
               auto input = inputs[i];
@@ -901,8 +895,8 @@ void addObjectMethods(py::module& m) {
                   "Input must be of type numpy array.");
               PyArrayObject* array =
                   reinterpret_cast<PyArrayObject*>(input.ptr());
-              TensorFeeder<CPUContext>().FeedTensor(
-                  DeviceOption(), array, &(tensors_data[i]));
+              tensors_data.push_back(
+                  TensorFeeder<CPUContext>().FeedTensor(DeviceOption(), array));
             }
 #else
             CAFFE_THROW("Caffe2 was compiled without NumPy support.");
@@ -924,14 +918,14 @@ void addObjectMethods(py::module& m) {
             for (const auto pair : inputs) {
               const auto& name = pair.first;
               const auto& input = pair.second;
-              tensors_data.emplace(name, Tensor(CPU));
               CAFFE_ENFORCE(
                   PyArray_Check(input.ptr()),
                   "Input must be of type numpy array.");
               PyArrayObject* array =
                   reinterpret_cast<PyArrayObject*>(input.ptr());
-              TensorFeeder<CPUContext>().FeedTensor(
-                  DeviceOption(), array, &tensors_data.at(name));
+              tensors_data.emplace(
+                  name,
+                  TensorFeeder<CPUContext>().FeedTensor(DeviceOption(), array));
             }
 #else
             CAFFE_THROW("Caffe2 was compiled without NumPy support.");
@@ -1455,6 +1449,7 @@ void addGlobalMethods(py::module& m) {
               feeder,
               "Unknown device type encountered in FeedBlob: ",
               option.device_type());
+          // TODO: Blob store Tensor directly?
           feeder->Feed(option, array, blob);
           return true;
         }

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -97,7 +97,7 @@ static_assert(
     "We make an assumption that int is always int32 for numpy "
     "type mapping.");
 
-int CaffeToNumpyType(const TypeMeta& meta);
+int CaffeToNumpyType(const TypeMeta& dtype);
 const TypeMeta& NumpyTypeToCaffe(int numpy_type);
 
 class TensorFetcher : public BlobFetcherBase {
@@ -106,12 +106,12 @@ class TensorFetcher : public BlobFetcherBase {
     return FetchTensor(blob.Get<Tensor>(), true).obj;
   }
 
-  // Checks whether the data with type `meta` needs to be copied in the context
+  // Checks whether the data with type `dtype` needs to be copied in the context
   // of `tensor`
-  bool NeedsCopy(const Tensor* tensor, const TypeMeta& meta) const {
+  bool NeedsCopy(const Tensor* tensor, const TypeMeta& dtype) const {
 #ifdef USE_NUMPY
     return tensor->GetDeviceType() != CPU ||
-        CaffeToNumpyType(meta) == NPY_OBJECT;
+        CaffeToNumpyType(dtype) == NPY_OBJECT;
 #else
     return tensor->GetDeviceType() != CPU;
 #endif // USE_NUMPY
@@ -176,18 +176,15 @@ class TensorFetcher : public BlobFetcherBase {
 template <class Context>
 class TensorFeeder : public BlobFeederBase {
  public:
-  void FeedTensor(
-      const DeviceOption& option,
-      PyArrayObject* original_array,
-      Tensor* tensor) {
+  Tensor FeedTensor(const DeviceOption& option, PyArrayObject* original_array) {
 #ifdef USE_NUMPY
     PyArrayObject* array = PyArray_GETCONTIGUOUS(original_array);
     auto g = MakeGuard([&]() { Py_XDECREF(array); });
 
     const auto npy_type = PyArray_TYPE(array);
-    const TypeMeta& meta = NumpyTypeToCaffe(npy_type);
+    const TypeMeta& dtype = NumpyTypeToCaffe(npy_type);
     CAFFE_ENFORCE(
-        meta.id() != TypeIdentifier::uninitialized(),
+        dtype.id() != TypeIdentifier::uninitialized(),
         "This numpy data type is not supported: ",
         PyArray_TYPE(array),
         ".");
@@ -200,14 +197,16 @@ class TensorFeeder : public BlobFeederBase {
     for (int i = 0; i < ndim; ++i) {
       dims.push_back(npy_dims[i]);
     }
-    tensor->Resize(dims);
 
+    Tensor tensor;
     // Now, copy the data to the tensor.
     switch (npy_type) {
       case NPY_OBJECT: {
         PyObject** input = reinterpret_cast<PyObject**>(PyArray_DATA(array));
-        auto* outPtr = tensor->template mutable_data<std::string>();
-        for (int i = 0; i < tensor->numel(); ++i) {
+        tensor = caffe2::empty(
+            dims, at::dtype<std::string>().device(Context::GetDeviceType()));
+        auto* outPtr = tensor.template mutable_data<std::string>();
+        for (int i = 0; i < tensor.numel(); ++i) {
           char* str;
           Py_ssize_t strSize;
 #if PY_MAJOR_VERSION > 2
@@ -239,23 +238,24 @@ class TensorFeeder : public BlobFeederBase {
             "instead of unicode strings.");
         break;
       default:
+        tensor = caffe2::empty(
+            dims, at::TensorOptions(dtype).device(Context::GetDeviceType()));
         context.CopyBytesFromCPU(
-            tensor->numel() * meta.itemsize(),
+            tensor.numel() * dtype.itemsize(),
             static_cast<void*>(PyArray_DATA(array)),
-            tensor->raw_mutable_data(meta));
+            tensor.raw_mutable_data());
     }
     context.FinishDeviceComputation();
+    return tensor;
 #else
     CAFFE_THROW("Caffe2 compiled without NumPy support.");
+    return caffe2::Tensor(); // will not reach here
 #endif // USE_NUMPY
   }
 
   virtual void
   Feed(const DeviceOption& option, PyArrayObject* original_array, Blob* blob) {
-    FeedTensor(
-        option,
-        original_array,
-        BlobGetMutableTensor(blob, Context::GetDeviceType()));
+    blob->Reset<Tensor>(new Tensor(FeedTensor(option, original_array)));
   }
 };
 

--- a/caffe2/python/pybind_state_ideep.cc
+++ b/caffe2/python/pybind_state_ideep.cc
@@ -176,8 +176,8 @@ public:
         DeviceOption cpu_option(option);
         cpu_option.set_device_type(DeviceTypeProto::PROTO_CPU);
         TensorFeeder<CPUContext> cpu_tensor_feeder;
-        cpu_tensor_feeder.FeedTensor(
-            cpu_option, original_array, BlobGetMutableTensor(blob, CPU));
+        blob->Reset<Tensor>(new Tensor(
+            cpu_tensor_feeder.FeedTensor(cpu_option, original_array)));
       }
     } catch (ideep::error &e) {
       LOG(ERROR) << "IDEEP error: " << e.message;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/13641

FeedTensor function used to take a pointer to Tensor and feed the content using Resize
and mutable_data, but since Tensor is a pointer now, we can just return a Tensor instead.

Differential Revision: D13091163
