### PR TITLE
Remove partially initialized Tensor in Deserialization (#13642)

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -231,7 +231,7 @@ void fillInputBlob(
       // int total_size = tensor_proto->float_data_size();
       caffe2::TensorCPU* tensor =
           new caffe2::TensorCPU(dims, caffe2::DeviceType::CPU);
-      serializer.Deserialize(*tensor_proto, tensor);
+      serializer.DeserializeToTensor(*tensor_proto, tensor);
       blob->Reset(tensor);
     }
     // todo: for other types

--- a/caffe2/core/blob_serialization.h
+++ b/caffe2/core/blob_serialization.h
@@ -55,6 +55,28 @@ CAFFE2_API string SerializeBlob(const Blob& blob, const string& name);
 CAFFE2_API void DeserializeBlob(const string& content, Blob* result);
 CAFFE2_API void DeserializeBlob(const BlobProto& proto, Blob* result);
 
+/*
+ * Get an empty Tensor from the TensorProto given the meta data in proto (data
+ * type and size of the Tensor) without actually filling in the data.
+ *
+ * We need this function because we want to construct a fully initialized Tensor
+ * in the beginning instead of keeping partially initialized Tensor around the
+ * process. Consider the case when we have a Tensor that is split into multiple
+ * protos during serialization, in deserialization, we have to fill the Tensor
+ * in multiple calls to Deserialize, therefore we need to create a new Tensor
+ * with the correct size and data type before the call to Deserialize, because
+ * otherwise we will have to check whether the function call is the first call
+ * to initialize the underlying Tensor, which makes the function stateful and
+ * complicated.
+ *
+ * The legacy code get away with this problem by passing in a partially
+ * initialized Tensor and use Resize and mutable_data to set the correct size,
+ * data type and allocate memory for the Tensor, so the state is encoded in
+ * these function calls. e.g. mutable_data will allocate memory on the first
+ * call and it will return a pointer to the allocated memory on later calls.
+ */
+CAFFE2_API Tensor EmptyTensorFromProto(const TensorProto& proto);
+
 /**
  * @brief TensorSerializer is the serializer for Tensors.
  *
@@ -106,7 +128,22 @@ class CAFFE2_API TensorSerializer : public BlobSerializerBase {
 class CAFFE2_API TensorDeserializer : public BlobDeserializerBase {
  public:
   void Deserialize(const BlobProto& proto, Blob* blob) override;
-  void Deserialize(const TensorProto& proto, Tensor* tensor);
+
+  /* There are cases when a Tensor is split into multiple protos and
+   * we have to call Deserialize multiple times to get the complete deserialized
+   * Tensor, each call will fill part of the Tensor given the segment begin and
+   * end information in proto, therefore we have to pass in the Tensor pointer
+   * rather than create a new Tensor everytime.
+   *
+   * Precondition: Tensor must be initialized
+   */
+  void DeserializeToTensor(const TensorProto& proto, Tensor* tensor);
+
+  /* Deserialize the proto and return a new Tensor
+   * This is a utility function that combines EmptyTensorFromProto and
+   * Deserialize(const TensorProto&, Tensor*);
+   */
+  Tensor Deserialize(const TensorProto& proto);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -1142,10 +1142,12 @@ TEST(TensorSerialization, MistakenlySerializingDtypeUninitializedTensor) {
   LOG(INFO) << "serialized proto: " << b.DebugString();
 
   Blob new_blob;
+  // Deserializing an empty Tensor gives a {0}-dim, float CPU Tensor
   DeserializeBlob(output, &new_blob);
   const Tensor& new_tensor = new_blob.Get<Tensor>();
   LOG(INFO) << "tensor " << new_tensor.DebugString();
-  EXPECT_FALSE(new_tensor.dtype_initialized());
+  EXPECT_TRUE(new_tensor.dtype_initialized());
+  LOG(INFO) << "dtype:" << new_tensor.dtype();
   EXPECT_EQ(0, new_tensor.numel());
   EXPECT_EQ(1, new_tensor.dim());
 }

--- a/caffe2/operators/map_ops.h
+++ b/caffe2/operators/map_ops.h
@@ -245,9 +245,8 @@ class MapDeserializer : public BlobDeserializerBase {
         tensor_protos.ParseFromString(proto.content()),
         "Fail to parse TensorProtos");
     TensorDeserializer deser;
-    Tensor key_tensor(CPU), value_tensor(CPU);
-    deser.Deserialize(tensor_protos.protos(0), &key_tensor);
-    deser.Deserialize(tensor_protos.protos(1), &value_tensor);
+    Tensor key_tensor = deser.Deserialize(tensor_protos.protos(0));
+    Tensor value_tensor = deser.Deserialize(tensor_protos.protos(1));
     auto* key_data = key_tensor.data<KEY_T>();
     auto* value_data = value_tensor.data<VALUE_T>();
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/13642

Previously we pass in a patially initialized Tensor to Deserialize and it will fill
it with the result of deserialization of a tensor proto. Now we want it to return
a Tensor directly since it's just a shared pointer to TensorImpl.

Reviewed By: ezyang

Differential Revision: D12874357
