### PR TITLE
[ROCm] Cleanup caffe2 hipify exclude patterns

### DIFF
--- a/tools/amd_build/build_caffe2_amd.py
+++ b/tools/amd_build/build_caffe2_amd.py
@@ -26,7 +26,6 @@ includes = [
 ]
 
 ignores = [
-    "caffe2/operators/depthwise_3x3_conv_op.cu",
     "caffe2/operators/depthwise_3x3_conv_op_cudnn.cu",
     "caffe2/operators/pool_op_cudnn.cu",
     '**/hip/**',


### PR DESCRIPTION
depthwise_3x3_conv_op.cu does not exist

