### PR TITLE
Expand legacy macros for THTensor in THTensor.h

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -287,7 +287,7 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
         env['THType'] = scalar_name
         env['THStorage'] = "TH{}Storage".format(scalar_name)
         env['THTensor'] = 'TH{}Tensor'.format(scalar_name)
-        env['THIndexTensor'] = 'THLongTensor'
+        env['THIndexTensor'] = 'THTensor'
         env['state'] = []
         env['isCUDA'] = 'false'
         env['storage_device'] = 'throw std::runtime_error("CPU storage has no device");'

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -4,9 +4,9 @@
 #include "ATen/core/Reduction.h"
 
 // for TH compat test only...
-struct THFloatTensor;
-extern "C" THFloatTensor * THFloatTensor_newWithSize2d(size_t a, size_t b);
-extern "C" void THFloatTensor_fill(THFloatTensor *, float v);
+struct THTensor;
+extern "C" THTensor * THFloatTensor_newWithSize2d(size_t a, size_t b);
+extern "C" void THFloatTensor_fill(THTensor *, float v);
 
 #include <iostream>
 #include <chrono>
@@ -206,7 +206,7 @@ void TestZeroDim(Type& type) {
 
 void TestTensorFromTH() {
   int a = 4;
-  THFloatTensor* t = THFloatTensor_newWithSize2d(a, a);
+  THTensor* t = THFloatTensor_newWithSize2d(a, a);
   THFloatTensor_fill(t, a);
   Tensor tt = CPU(kFloat).unsafeTensorFromTH(t, false);
   ASSERT_NO_THROW(tt);

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -15,17 +15,6 @@ typedef struct at_Tensor_Impl at_Tensor_Impl;
 #define THTensor at_Tensor_Impl
 #endif
 
-// These used to be distinct types; for some measure of backwards compatibility and documentation
-// alias these to the single THTensor type.
-#define THFloatTensor THTensor
-#define THDoubleTensor THTensor
-#define THHalfTensor THTensor
-#define THByteTensor THTensor
-#define THCharTensor THTensor
-#define THShortTensor THTensor
-#define THIntTensor THTensor
-#define THLongTensor THTensor
-
 /**** access methods ****/
 TH_API THStorage* THTensor_(storage)(const THTensor *self);
 TH_API ptrdiff_t THTensor_(storageOffset)(const THTensor *self);

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -27,7 +27,7 @@ void THTensor_(zero)(THTensor *r_)
   THTensor_(fill)(r_, 0);
 }
 
-void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
+void THTensor_(maskedFill)(THTensor *tensor, THTensor *mask, scalar_t value)
 {
 #ifdef _OPENMP
   int64_t tensor_size = THTensor_(nElement)(tensor);
@@ -55,7 +55,7 @@ void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
     });
 }
 
-void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
+void THTensor_(maskedCopy)(THTensor *tensor, THTensor *mask, THTensor* src )
 {
   THTensor *srct = THTensor_(newContiguous)(src);
   scalar_t *src_data = srct->data<scalar_t>();
@@ -90,7 +90,7 @@ void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
   c10::raw::intrusive_ptr::decref(srct);
 }
 
-void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask)
+void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THTensor *mask)
 {
   ptrdiff_t numel = THByteTensor_sumall(mask);
   scalar_t *tensor_data;
@@ -115,7 +115,7 @@ void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask
 }
 
 // Finds non-zero elements of a tensor and returns their subscripts
-void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
+void THTensor_(nonzero)(THTensor *subscript, THTensor *tensor)
 {
   ptrdiff_t numel = 0;
   int64_t *subscript_data;
@@ -154,7 +154,7 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
                   ++i;);
 }
 
-void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index)
+void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THTensor *index)
 {
   ptrdiff_t i, numel;
   THTensor *tSlice, *sSlice;
@@ -228,7 +228,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   THLongTensor_free(index);
 }
 
-void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
+void THTensor_(indexCopy)(THTensor *tensor, int dim, THTensor *index, THTensor *src)
 {
   ptrdiff_t i, numel;
   THTensor *tSlice, *sSlice;
@@ -286,7 +286,7 @@ static inline int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t nu
   return linearIndex < 0 ? linearIndex + numel : linearIndex;
 }
 
-void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
+void THTensor_(take)(THTensor *r_, THTensor *src, THTensor *index)
 {
   THTensor_(resizeNd)(r_, index->dim(), THTensor_getSizePtr(index), NULL);
   THTensor* dst = THTensor_(newContiguous)(r_);
@@ -329,7 +329,7 @@ void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
   THTensor_(freeCopyTo)(dst, r_);
 }
 
-void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int accumulate)
+void THTensor_(put)(THTensor *tensor, THTensor *index, THTensor *src, int accumulate)
 {
   THArgCheck(THLongTensor_nElement(index) == THTensor_(nElement)(src), 3,
     "src should have the same number of elements as index");
@@ -355,7 +355,7 @@ void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int ac
   THLongTensor_free(index);
 }
 
-void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
+void THTensor_(indexAdd)(THTensor *tensor, int dim, THTensor *index, THTensor *src)
 {
   ptrdiff_t i, numel;
   THTensor *tSlice, *sSlice;
@@ -396,7 +396,7 @@ void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTenso
   THLongTensor_free(index);
 }
 
-void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val)
+void THTensor_(indexFill)(THTensor *tensor, int dim, THTensor *index, scalar_t val)
 {
   ptrdiff_t i, numel;
   THTensor *tSlice;
@@ -426,7 +426,7 @@ void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar
   THLongTensor_free(index);
 }
 
-void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index)
+void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THTensor *index)
 {
   int64_t elems_per_row, i, idx;
 
@@ -453,7 +453,7 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
                        })
 }
 
-void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
+void THTensor_(scatter)(THTensor *tensor, int dim, THTensor *index, THTensor *src)
 {
   int64_t elems_per_row, i, idx;
   int index_ndim_legacy_all = THTensor_nDimensionLegacyAll(index);
@@ -485,7 +485,7 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
                        })
 }
 
-void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
+void THTensor_(scatterAdd)(THTensor *tensor, int dim, THTensor *index, THTensor *src)
 {
   int64_t elems_per_row, i, idx;
   int index_ndim_legacy_all = THTensor_nDimensionLegacyAll(index);
@@ -517,7 +517,7 @@ void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTen
                        })
 }
 
-void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val)
+void THTensor_(scatterFill)(THTensor *tensor, int dim, THTensor *index, scalar_t val)
 {
   int64_t elems_per_row, i, idx;
   int index_ndim_legacy_all = THLongTensor_nDimensionLegacyAll(index);

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -124,7 +124,7 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   }
 
   int n, nrhs, lda, ldb, info;
-  THIntTensor *ipiv;
+  THTensor *ipiv;
   THTensor *ra__;  // working version of A matrix to be passed into lapack GELS
   THTensor *rb__;  // working version of B matrix to be passed into lapack GELS
 
@@ -422,7 +422,7 @@ void THTensor_(gesdd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra
   int k, m, n, lda, ldu, ldvt, lwork, info;
   THTensor *work;
   scalar_t wkopt;
-  THIntTensor *iwork;
+  THTensor *iwork;
 
   THTensor *ra__ = NULL;
   THTensor *ru__ = NULL;
@@ -545,7 +545,7 @@ void THTensor_(getri)(THTensor *ra_, THTensor *a)
 
   int m, n, lda, info, lwork;
   scalar_t wkopt;
-  THIntTensor *ipiv;
+  THTensor *ipiv;
   THTensor *work;
   THTensor *ra__ = NULL;
 
@@ -759,7 +759,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, const char *uplo)
  * `tol`    - double; user defined tolerance, or < 0 for automatic choice.
               The algorithm terminates when the pivot <= tol.
  */
-void THTensor_(pstrf)(THTensor *ra_, THIntTensor *rpiv_, THTensor *a, const char *uplo, scalar_t tol) {
+void THTensor_(pstrf)(THTensor *ra_, THTensor *rpiv_, THTensor *a, const char *uplo, scalar_t tol) {
   THArgCheck(THTensor_nDimensionLegacyAll(a) == 2, 1, "A should be 2 dimensional");
   THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
@@ -998,7 +998,7 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, co
   c10::raw::intrusive_ptr::decref(work);
 }
 
-void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinfo_, int pivot, THTensor *a)
+void THTensor_(btrifact)(THTensor *ra_, THTensor *rpivots_, THTensor *rinfo_, int pivot, THTensor *a)
 {
   AT_CHECK(THTensor_(nDimension)(a) == 3, "expected 3D tensor, got size: ", a->sizes());
   if (!pivot) {
@@ -1034,7 +1034,7 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
 
   THTensor *ai = THTensor_(new)();
   THTensor *rai = THTensor_(new)();
-  THIntTensor *rpivoti = THIntTensor_new();
+  THTensor *rpivoti = THIntTensor_new();
 
   int info = 0;
   int *info_ptr = &info;
@@ -1073,7 +1073,7 @@ void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinf
   }
 }
 
-void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor *pivots)
+void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THTensor *pivots)
 {
   AT_CHECK(!atf->is_empty() && THTensor_(nDimensionLegacyNoScalars)(atf) == 3, "expected non-empty 3D tensor, got size: ",
            atf->sizes());
@@ -1141,7 +1141,7 @@ void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor
 
   THTensor *ai = THTensor_(new)();
   THTensor *rbi = THTensor_(new)();
-  THIntTensor *pivoti = THIntTensor_new();
+  THTensor *pivoti = THIntTensor_new();
 
   if (!THIntTensor_isContiguous(pivots)) {
       THError("Error: rpivots_ is not contiguous.");

--- a/aten/src/TH/generic/THTensorLapack.h
+++ b/aten/src/TH/generic/THTensorLapack.h
@@ -18,9 +18,9 @@ TH_API void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a);
 TH_API void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a);
 TH_API void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau);
 TH_API void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, const char *side, const char *trans);
-TH_API void THTensor_(pstrf)(THTensor *ra_, THIntTensor *rpiv_, THTensor*a, const char* uplo, scalar_t tol);
+TH_API void THTensor_(pstrf)(THTensor *ra_, THTensor *rpiv_, THTensor*a, const char* uplo, scalar_t tol);
 
-TH_API void THTensor_(btrifact)(THTensor *ra_, THIntTensor *rpivots_, THIntTensor *rinfo_, int pivot, THTensor *a);
-TH_API void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THIntTensor *pivots);
+TH_API void THTensor_(btrifact)(THTensor *ra_, THTensor *rpivots_, THTensor *rinfo_, int pivot, THTensor *a);
+TH_API void THTensor_(btrisolve)(THTensor *rb_, THTensor *b, THTensor *atf, THTensor *pivots);
 
 #endif

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -5,23 +5,23 @@
 TH_API void THTensor_(fill)(THTensor *r_, scalar_t value);
 TH_API void THTensor_(zero)(THTensor *r_);
 
-TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value);
-TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
-TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THByteTensor *mask);
+TH_API void THTensor_(maskedFill)(THTensor *tensor, THTensor *mask, scalar_t value);
+TH_API void THTensor_(maskedCopy)(THTensor *tensor, THTensor *mask, THTensor* src);
+TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THTensor *mask);
 
-TH_API void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor);
+TH_API void THTensor_(nonzero)(THTensor *subscript, THTensor *tensor);
 
-TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
-TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
-TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THLongTensor *index);
-TH_API void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int accumulate);
+TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THTensor *index);
+TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THTensor *index, THTensor *src);
+TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THTensor *index, THTensor *src);
+TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THTensor *index, scalar_t val);
+TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THTensor *index);
+TH_API void THTensor_(put)(THTensor *tensor, THTensor *index, THTensor *src, int accumulate);
 
-TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
-TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
+TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THTensor *index);
+TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THTensor *index, THTensor *src);
+TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THTensor *index, THTensor *src);
+TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THTensor *index, scalar_t val);
 
 TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
@@ -76,11 +76,11 @@ TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, scalar_t 
 
 TH_API ptrdiff_t THTensor_(numel)(THTensor *t);
 void THTensor_(preserveReduceDimSemantics)(THTensor *r_, int in_dims, int reduce_dimension, int keepdim);
-TH_API void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
-TH_API void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
-TH_API void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, int64_t k, int dimension, int keepdim);
-TH_API void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
-TH_API void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
+TH_API void THTensor_(max)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim);
+TH_API void THTensor_(min)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim);
+TH_API void THTensor_(kthvalue)(THTensor *values_, THTensor *indices_, THTensor *t, int64_t k, int dimension, int keepdim);
+TH_API void THTensor_(mode)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim);
+TH_API void THTensor_(median)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);
@@ -102,8 +102,8 @@ TH_API void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal 
 TH_API void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step);
 TH_API void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n);
 
-TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder);
-TH_API void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted);
+TH_API void THTensor_(sort)(THTensor *rt_, THTensor *ri_, THTensor *t, int dimension, int descendingOrder);
+TH_API void THTensor_(topk)(THTensor *rt_, THTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted);
 TH_API void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k);
 TH_API void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k);
 TH_API void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension);
@@ -111,12 +111,12 @@ TH_API void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInpu
 
 TH_API int THTensor_(equal)(THTensor *ta, THTensor *tb);
 
-TH_API void THTensor_(ltValue)(THByteTensor *r_, THTensor* t, scalar_t value);
-TH_API void THTensor_(leValue)(THByteTensor *r_, THTensor* t, scalar_t value);
-TH_API void THTensor_(gtValue)(THByteTensor *r_, THTensor* t, scalar_t value);
-TH_API void THTensor_(geValue)(THByteTensor *r_, THTensor* t, scalar_t value);
-TH_API void THTensor_(neValue)(THByteTensor *r_, THTensor* t, scalar_t value);
-TH_API void THTensor_(eqValue)(THByteTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(ltValue)(THTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(leValue)(THTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(gtValue)(THTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(geValue)(THTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(neValue)(THTensor *r_, THTensor* t, scalar_t value);
+TH_API void THTensor_(eqValue)(THTensor *r_, THTensor* t, scalar_t value);
 
 TH_API void THTensor_(ltValueT)(THTensor *r_, THTensor* t, scalar_t value);
 TH_API void THTensor_(leValueT)(THTensor *r_, THTensor* t, scalar_t value);
@@ -125,12 +125,12 @@ TH_API void THTensor_(geValueT)(THTensor *r_, THTensor* t, scalar_t value);
 TH_API void THTensor_(neValueT)(THTensor *r_, THTensor* t, scalar_t value);
 TH_API void THTensor_(eqValueT)(THTensor *r_, THTensor* t, scalar_t value);
 
-TH_API void THTensor_(ltTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
-TH_API void THTensor_(leTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
-TH_API void THTensor_(gtTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
-TH_API void THTensor_(geTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
-TH_API void THTensor_(neTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
-TH_API void THTensor_(eqTensor)(THByteTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(ltTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(leTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(gtTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(geTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(neTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
+TH_API void THTensor_(eqTensor)(THTensor *r_, THTensor *ta, THTensor *tb);
 
 TH_API void THTensor_(ltTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);
 TH_API void THTensor_(leTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -72,7 +72,7 @@ void THTensor_(preserveReduceDimSemantics)(
   }
 }
 
-void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim)
+void THTensor_(max)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim)
 {
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyAll)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
@@ -132,7 +132,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     tempValues_->set_size(dimension,THTensor_sizeLegacyNoScalars(t, dimension));
     tempValues_->set_stride(dimension, 0);
 
-    THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
+    THTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
     tempIndices_->set_size(dimension,THTensor_sizeLegacyNoScalars(t, dimension));
     tempIndices_->set_stride(dimension, 0);
@@ -153,7 +153,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   }
 }
 
-void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim)
+void THTensor_(min)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim)
 {
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyAll)(t), 2, "dimension %d out of range",
       dimension + TH_INDEX_BASE);
@@ -213,7 +213,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     tempValues_->set_size(dimension,THTensor_sizeLegacyNoScalars(t, dimension));
     tempValues_->set_stride(dimension, 0);
 
-    THLongTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
+    THTensor *tempIndices_ = THLongTensor_newWithTensor(indices_);
     // tempIndices_.expand_as(t)
     tempIndices_->set_size(dimension,THTensor_sizeLegacyNoScalars(t, dimension));
     tempIndices_->set_stride(dimension, 0);
@@ -885,7 +885,7 @@ static void THTensor_(quicksortdescend)(scalar_t *arr, int64_t *idx, int64_t ele
 #undef MAX_LEVELS
 #undef M_SMALL
 
-void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder)
+void THTensor_(sort)(THTensor *rt_, THTensor *ri_, THTensor *t, int dimension, int descendingOrder)
 {
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyNoScalars)(t), 2, "invalid dimension %d",
       dimension + TH_INDEX_BASE);
@@ -1036,10 +1036,10 @@ scalar_t THTensor_(medianall)(THTensor *tensor)
   return theMedian;
 }
 
-void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim)
+void THTensor_(mode)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim)
 {
   THTensor *temp_;
-  THLongTensor *tempi_;
+  THTensor *tempi_;
   scalar_t *temp__data;
   int64_t *tempi__data;
   int64_t t_size_dim;
@@ -1102,10 +1102,10 @@ void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int
   }
 }
 
-void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, int64_t k, int dimension, int keepdim)
+void THTensor_(kthvalue)(THTensor *values_, THTensor *indices_, THTensor *t, int64_t k, int dimension, int keepdim)
 {
   THTensor *temp_;
-  THLongTensor *tempi_;
+  THTensor *tempi_;
   scalar_t *temp__data;
   int64_t *tempi__data;
   int64_t t_size_dim;
@@ -1150,7 +1150,7 @@ void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t,
   }
 }
 
-void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim)
+void THTensor_(median)(THTensor *values_, THTensor *indices_, THTensor *t, int dimension, int keepdim)
 {
   int64_t t_size_dim, k;
 
@@ -1162,7 +1162,7 @@ void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, i
   THTensor_(kthvalue)(values_, indices_, t, k+1, dimension, keepdim);
 }
 
-void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted)
+void THTensor_(topk)(THTensor *rt_, THTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted)
 {
   int numDims = THTensor_(nDimensionLegacyNoScalars)(t);
   THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
@@ -1174,7 +1174,7 @@ void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, i
   THTensor_(resize1d)(tmpResults, sliceSize);
   scalar_t *tmp__data = tmpResults->data<scalar_t>();
 
-  THLongTensor *tmpIndices = THLongTensor_new();
+  THTensor *tmpIndices = THLongTensor_new();
   THLongTensor_resize1d(tmpIndices, sliceSize);
   int64_t *tmpi__data = THLongTensor_data(tmpIndices);
 
@@ -1439,7 +1439,7 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb)
 }
 
 #define TENSOR_IMPLEMENT_LOGICAL(NAME,OP)				\
-  void THTensor_(NAME##Value)(THByteTensor *r_, THTensor* t, scalar_t value)	\
+  void THTensor_(NAME##Value)(THTensor *r_, THTensor* t, scalar_t value)	\
   {									\
     THByteTensor_resizeNd(r_, t->dim(), THTensor_getSizePtr(t), NULL);		\
     TH_TENSOR_APPLY2(unsigned char, r_, scalar_t, t,			\
@@ -1451,7 +1451,7 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb)
     TH_TENSOR_APPLY2(scalar_t, r_, scalar_t, t,					\
 		     *r__data = (*t_data OP value) ? 1 : 0;); \
   }									\
-  void THTensor_(NAME##Tensor)(THByteTensor *r_, THTensor *ta, THTensor *tb) \
+  void THTensor_(NAME##Tensor)(THTensor *r_, THTensor *ta, THTensor *tb) \
   {									\
     THByteTensor_resizeNd(r_, ta->dim(), THTensor_getSizePtr(ta), NULL);		\
     TH_TENSOR_APPLY3(unsigned char, r_, scalar_t, ta, scalar_t, tb,		\

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -133,12 +133,12 @@ void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, 
   TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)THRandom_logNormal(_generator, mean, stdv););
 }
 
-void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor *q)
+void THTensor_(multinomialAliasSetup)(THTensor *probs, THTensor *J, THTensor *q)
 {
   int64_t inputsize = THTensor_(nElement)(probs);
   int64_t i = 0;
-  THLongTensor *smaller = THLongTensor_newWithSize1d(inputsize);
-  THLongTensor *larger = THLongTensor_newWithSize1d(inputsize);
+  THTensor *smaller = THLongTensor_newWithSize1d(inputsize);
+  THTensor *larger = THLongTensor_newWithSize1d(inputsize);
   int64_t small_c = 0;
   int64_t large_c = 0;
   THLongTensor_resize1d(J, inputsize);
@@ -220,7 +220,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
   THLongTensor_free(smaller);
   THLongTensor_free(larger);
 }
-void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator, THLongTensor *J, THTensor *q)
+void THTensor_(multinomialAliasDraw)(THTensor *self, THGenerator *_generator, THTensor *J, THTensor *q)
 {
   std::lock_guard<std::mutex> lock(_generator->mutex);
   int64_t K = THLongTensor_nElement(J);
@@ -244,13 +244,13 @@ void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator
       THLongTensor_fastSet1d(self, i, sample_idx-1L);
     }
 }
-void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
+void THTensor_(multinomial)(THTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
 {
   std::lock_guard<std::mutex> lock(_generator->mutex);
   int64_t start_dim = THTensor_(nDimensionLegacyAll)(prob_dist);
   int64_t n_dist;
   int64_t n_categories;
-  THDoubleTensor* cum_dist;
+  THTensor* cum_dist;
   int64_t i,j,k;
 
   if (start_dim == 1)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -17,9 +17,9 @@ TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
 TH_API void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda);
 TH_API void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma);
 TH_API void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
-TH_API void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement);
-TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);
-TH_API void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator, THLongTensor *J, THTensor *q);
+TH_API void THTensor_(multinomial)(THTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement);
+TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THTensor *J, THTensor *q);
+TH_API void THTensor_(multinomialAliasDraw)(THTensor *self, THGenerator *_generator, THTensor *J, THTensor *q);
 #endif
 
 #if defined(TH_REAL_IS_BYTE)

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -44,7 +44,7 @@ __host__ void createGeneratorState(THCGenerator* gen, uint64_t seed)
   gen->state.philox_seed_offset = 0;
 }
 
-__host__ void THCRandom_getRNGState(THCState* state, THByteTensor *rng_state)
+__host__ void THCRandom_getRNGState(THCState* state, THTensor *rng_state)
 {
   THCGenerator* gen = THCRandom_getGenerator(state);
   std::lock_guard<std::mutex> lock(gen->mutex);
@@ -68,7 +68,7 @@ __global__ void set_rngstate_kernel(curandStateMtgp32 *state, mtgp32_kernel_para
   state[threadIdx.x].k = kernel;
 }
 
-__host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_state)
+__host__ void THCRandom_setRNGState(THCState* state, THTensor *rng_state)
 {
   THCGenerator* gen = THCRandom_getGenerator(state);
   std::lock_guard<std::mutex> lock(gen->mutex);

--- a/aten/src/THC/THCTensorRandom.h
+++ b/aten/src/THC/THCTensorRandom.h
@@ -26,8 +26,8 @@ THC_API uint64_t THCRandom_seedAll(struct THCState *state);
 THC_API void THCRandom_manualSeed(struct THCState *state, uint64_t the_seed_);
 THC_API void THCRandom_manualSeedAll(struct THCState *state, uint64_t the_seed_);
 THC_API uint64_t THCRandom_initialSeed(struct THCState *state);
-THC_API void THCRandom_getRNGState(struct THCState *state, THByteTensor *rng_state);
-THC_API void THCRandom_setRNGState(struct THCState *state, THByteTensor *rng_state);
+THC_API void THCRandom_getRNGState(struct THCState *state, THTensor *rng_state);
+THC_API void THCRandom_setRNGState(struct THCState *state, THTensor *rng_state);
 
 THC_API struct curandStateMtgp32* THCRandom_generatorStates(struct THCState* state);
 

--- a/aten/src/THC/generic/THCTensorCopy.h
+++ b/aten/src/THC/generic/THCTensorCopy.h
@@ -4,14 +4,14 @@
 
 THC_API void THCTensor_(copy)(THCState *state, THCTensor *self, THCTensor *src);
 THC_API void THCTensor_(copyIgnoringOverlaps)(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_(copyByte)(THCState *state, THCTensor *self, THByteTensor *src);
-THC_API void THCTensor_(copyChar)(THCState *state, THCTensor *self, THCharTensor *src);
-THC_API void THCTensor_(copyShort)(THCState *state, THCTensor *self, THShortTensor *src);
-THC_API void THCTensor_(copyInt)(THCState *state, THCTensor *self, THIntTensor *src);
-THC_API void THCTensor_(copyLong)(THCState *state, THCTensor *self, THLongTensor *src);
-THC_API void THCTensor_(copyFloat)(THCState *state, THCTensor *self, THFloatTensor *src);
-THC_API void THCTensor_(copyDouble)(THCState *state, THCTensor *self, THDoubleTensor *src);
-THC_API void THCTensor_(copyHalf)(THCState *state, THCTensor *self, struct THHalfTensor *src);
+THC_API void THCTensor_(copyByte)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyChar)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyShort)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyInt)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyLong)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyFloat)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyDouble)(THCState *state, THCTensor *self, THTensor *src);
+THC_API void THCTensor_(copyHalf)(THCState *state, THCTensor *self, struct THTensor *src);
 
 THC_API void THCTensor_(copyCudaByte)(THCState *state, THCTensor *dst, struct THCudaByteTensor *src);
 THC_API void THCTensor_(copyCudaChar)(THCState *state, THCTensor *dst, struct THCudaCharTensor *src);
@@ -22,14 +22,14 @@ THC_API void THCTensor_(copyCudaFloat)(THCState *state, THCTensor *dst, struct T
 THC_API void THCTensor_(copyCudaDouble)(THCState *state, THCTensor *dst, struct THCudaDoubleTensor *src);
 THC_API void THCTensor_(copyCudaHalf)(THCState *state, THCTensor *dst, struct THCudaHalfTensor *src);
 
-THC_API void TH_CONCAT_2(THByteTensor_copyCuda  , Real)  (THCState *state, THByteTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THCharTensor_copyCuda  , Real)  (THCState *state, THCharTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THShortTensor_copyCuda , Real)  (THCState *state, THShortTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THIntTensor_copyCuda   , Real)  (THCState *state, THIntTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THLongTensor_copyCuda  , Real)  (THCState *state, THLongTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THFloatTensor_copyCuda , Real)  (THCState *state, THFloatTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THDoubleTensor_copyCuda, Real)  (THCState *state, THDoubleTensor *self, THCTensor *src);
-THC_API void TH_CONCAT_2(THHalfTensor_copyCuda, Real)    (THCState *state, THHalfTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THByteTensor_copyCuda  , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THCharTensor_copyCuda  , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THShortTensor_copyCuda , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THIntTensor_copyCuda   , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THLongTensor_copyCuda  , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THFloatTensor_copyCuda , Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THDoubleTensor_copyCuda, Real)  (THCState *state, THTensor *self, THCTensor *src);
+THC_API void TH_CONCAT_2(THHalfTensor_copyCuda, Real)    (THCState *state, THTensor *self, THCTensor *src);
 THC_API void THCTensor_(copyCuda) (THCState *state, THCTensor *self, THCTensor *src);
 
 THC_API void THTensor_(copyCuda) (THCState *state, THTensor *self, THCTensor *src);

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -20,7 +20,7 @@ void THCTensor_(maskedFill)(THCState* state,
 }
 
 void THCTensor_(maskedFillByte)(THCState* state,
-                                THCTensor *tensor, THByteTensor *mask, scalar_t value)
+                                THCTensor *tensor, THTensor *mask, scalar_t value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, tensor));
   THCudaByteTensor* maskCuda = THCudaByteTensor_newWithSize(state, mask->sizes(), {});
@@ -96,7 +96,7 @@ void THCTensor_(maskedCopy)(THCState* state,
 }
 
 void THCTensor_(maskedCopyByte)(THCState* state,
-                                THCTensor *tensor, THByteTensor *mask, THCTensor *src) {
+                                THCTensor *tensor, THTensor *mask, THCTensor *src) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCudaByteTensor* maskCuda = THCudaByteTensor_newWithSize(state, mask->sizes(), {});
   THCudaByteTensor_copyByte(state, maskCuda, mask);
@@ -167,7 +167,7 @@ void THCTensor_(maskedSelect)(THCState* state,
 
 // FIXME: remove now that we have THCudaByteTensor?
 void THCTensor_(maskedSelectByte)(THCState* state,
-                                  THCTensor *tensor, THCTensor *src, THByteTensor *mask)
+                                  THCTensor *tensor, THCTensor *src, THTensor *mask)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCudaByteTensor* maskCuda = THCudaByteTensor_newWithSize(state, mask->sizes(), {});

--- a/aten/src/THC/generic/THCTensorMasked.h
+++ b/aten/src/THC/generic/THCTensorMasked.h
@@ -10,7 +10,7 @@ THC_API void THCTensor_(maskedFill)(THCState *state,
 // FIXME: remove now that we have THCudaByteTensor?
 THC_API void THCTensor_(maskedFillByte)(THCState *state,
                                         THCTensor *tensor,
-                                        THByteTensor *mask,
+                                        THTensor *mask,
                                         scalar_t value);
 
 THC_API void THCTensor_(maskedCopy)(THCState *state,
@@ -21,7 +21,7 @@ THC_API void THCTensor_(maskedCopy)(THCState *state,
 // FIXME: remove now that we have THCudaByteTensor?
 THC_API void THCTensor_(maskedCopyByte)(THCState *state,
                                         THCTensor *tensor,
-                                        THByteTensor *mask,
+                                        THTensor *mask,
                                         THCTensor *src);
 
 THC_API void THCTensor_(maskedSelect)(THCState *state,
@@ -33,6 +33,6 @@ THC_API void THCTensor_(maskedSelect)(THCState *state,
 THC_API void THCTensor_(maskedSelectByte)(THCState *state,
                                           THCTensor *tensor,
                                           THCTensor *src,
-                                          THByteTensor *mask);
+                                          THTensor *mask);
 
 #endif

--- a/aten/src/THNN/THNN.h
+++ b/aten/src/THNN/THNN.h
@@ -9,10 +9,10 @@
 
 #define THNN_(NAME) TH_CONCAT_3(THNN_, Real, NAME)
 
-#define THIndexTensor THLongTensor
+#define THIndexTensor THTensor
 #define THIndexTensor_(NAME) THLongTensor_ ## NAME
 
-#define THIntegerTensor THIntTensor
+#define THIntegerTensor THTensor
 #define THIntegerTensor_(NAME) THIntTensor_ ## NAME
 
 typedef int64_t THIndex_t;

--- a/aten/src/THNN/doc/style_guidelines.md
+++ b/aten/src/THNN/doc/style_guidelines.md
@@ -36,7 +36,7 @@ e.g.
 void THNN_(ClassNLLCriterion_updateOutput)(
           THNNState* state,
           THTensor *input,
-          THLongTensor *target,
+          THTensor *target,
           THTensor *output,
           THTensor *weights,
           THTensor *total_weight,

--- a/aten/src/THNN/generic/IndexLinear.c
+++ b/aten/src/THNN/generic/IndexLinear.c
@@ -21,7 +21,7 @@
 #define THNN_INDEXLINEAR_SIGN(a) ( ( (a) < 0 )  ?  -1   : ( (a) > 0 ) )
 #endif
 
-static bool THNN_(checkKeysValues)(THLongTensor* keys, THTensor* values)
+static bool THNN_(checkKeysValues)(THTensor* keys, THTensor* values)
 {
   return THLongTensor_size(keys, 0) == THTensor_(nElement)(values)
                 && THTensor_(nDimensionLegacyAll)(values) == 1
@@ -30,11 +30,11 @@ static bool THNN_(checkKeysValues)(THLongTensor* keys, THTensor* values)
 
 void THNN_(IndexLinear_updateOutput)(
           THNNState *state,
-          THLongTensor *keys,
+          THTensor *keys,
           int64_t keysOffset,
           THTensor *values,
-          THLongTensor *sizes,
-          THLongTensor *cumSumSizes,
+          THTensor *sizes,
+          THTensor *cumSumSizes,
           THTensor *output,
           THTensor *weight,
           THTensor *bias,
@@ -241,8 +241,8 @@ void THNN_(IndexLinear_updateParameters)(
           THTensor *gradBias,
           THTensor *weight,
           THTensor *bias,
-          THLongTensor *runningKeys,
-          THLongTensor *cumSumSizes,
+          THTensor *runningKeys,
+          THTensor *cumSumSizes,
           int64_t keysOffset,
           accreal weightDecay_,
           accreal learningRate_)
@@ -381,11 +381,11 @@ void THNN_(IndexLinear_updateParameters)(
 
 void THNN_(IndexLinear_accUpdateGradParameters)(
           THNNState *state,
-          THLongTensor *keys,
+          THTensor *keys,
           int64_t keysOffset,
           THTensor *values,
-          THLongTensor *sizes,
-          THLongTensor *cumSumSizes,
+          THTensor *sizes,
+          THTensor *cumSumSizes,
           THTensor *gradOutput,
           THTensor *weight,
           THTensor *bias,
@@ -580,11 +580,11 @@ void THNN_(IndexLinear_accUpdateGradParameters)(
 
 void THNN_(IndexLinear_accGradParameters)(
           THNNState *state,
-          THLongTensor *keys,
+          THTensor *keys,
           int64_t keysOffset,
           THTensor *values,
-          THLongTensor *sizes,
-          THLongTensor *cumSumSizes,
+          THTensor *sizes,
+          THTensor *cumSumSizes,
           THTensor *gradOutput,
           THTensor *gradWeight,
           THTensor *gradBias,
@@ -605,7 +605,7 @@ void THNN_(IndexLinear_accGradParameters)(
   int64_t* sizesData = THLongTensor_data(sizes);
 
   /* COmpute the cumulative sizes */
-  THLongTensor* cumSizes = THLongTensor_new();
+  THTensor* cumSizes = THLongTensor_new();
   THLongTensor_cumsum(cumSizes, sizes, 0);
   int64_t* cumSizesData = THLongTensor_data(cumSizes);
 

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -59,7 +59,7 @@ void THNN_(SparseLinear_updateOutput)(
 
   int64_t nnz = THTensor_(size)(input, 0);
 
-  THLongTensor * csr = THLongTensor_newWithSize1d(batchSize+1);
+  THTensor * csr = THLongTensor_newWithSize1d(batchSize+1);
   THLongTensor_zero(csr);
 
   weight = THTensor_(newContiguous)(weight);
@@ -193,7 +193,7 @@ void THNN_(SparseLinear_accGradParameters)(
 
   int64_t nnz = THTensor_(size)(input, 0);
 
-  THLongTensor* csc = THLongTensor_newWithSize1d(inDim+1);
+  THTensor* csc = THLongTensor_newWithSize1d(inDim+1);
   THLongTensor_zero(csc);
   weight = THTensor_(newContiguous)(weight);
 
@@ -359,7 +359,7 @@ void THNN_(SparseLinear_updateParameters)(
   THTensor_(resize1d)(offsets, cnt);
 
   THTensor* uniqueOffsets = THTensor_(new)();
-  THLongTensor* ri = THLongTensor_new();
+  THTensor* ri = THLongTensor_new();
   THTensor_(sort)(uniqueOffsets, ri, offsets, 0, 0);
   THLongTensor_free(ri);
   c10::raw::intrusive_ptr::decref(offsets);
@@ -435,7 +435,7 @@ void THNN_(SparseLinear_legacyUpdateParameters)(
   THTensor_(resize1d)(offsets, cnt);
 
   THTensor* uniqueOffsets = THTensor_(new)();
-  THLongTensor* ri = THLongTensor_new();
+  THTensor* ri = THLongTensor_new();
   THTensor_(sort)(uniqueOffsets, ri, offsets, 0, 0);
   THLongTensor_free(ri);
   c10::raw::intrusive_ptr::decref(offsets);

--- a/test/ffi/src/cpu/lib.h
+++ b/test/ffi/src/cpu/lib.h
@@ -1,6 +1,6 @@
 
-void good_func(THFloatTensor *tensor, int a, float b);
-void bad_func(THFloatTensor *tensor, int a, float b);
-THFloatTensor * new_tensor(int a);
+void good_func(THTensor *tensor, int a, float b);
+void bad_func(THTensor *tensor, int a, float b);
+THTensor * new_tensor(int a);
 float int_to_float(int a);
 

--- a/test/ffi/src/cpu/lib1.c
+++ b/test/ffi/src/cpu/lib1.c
@@ -1,14 +1,14 @@
 #include <TH/TH.h>
 
-void good_func(THFloatTensor *tensor, int a, float b)
+void good_func(THTensor *tensor, int a, float b)
 {
   THFloatTensor_mul(tensor, tensor, a);
   THFloatTensor_add(tensor, tensor, b);
 }
 
-THFloatTensor * new_tensor(int a)
+THTensor * new_tensor(int a)
 {
-  THFloatTensor *t = THFloatTensor_newWithSize2d(a, a);
+  THTensor *t = THFloatTensor_newWithSize2d(a, a);
   THFloatTensor_fill(t, a);
   return t;
 }

--- a/test/ffi/src/cpu/lib2.c
+++ b/test/ffi/src/cpu/lib2.c
@@ -1,6 +1,6 @@
 #include <TH/TH.h>
 
-void bad_func(THFloatTensor *tensor, int a, float b)
+void bad_func(THTensor *tensor, int a, float b)
 {
   THFloatTensor_mul(tensor, tensor, a);
   THFloatTensor_add(tensor, tensor, b);

--- a/test/ffi/src/cuda/cudalib.h
+++ b/test/ffi/src/cuda/cudalib.h
@@ -1,5 +1,5 @@
 
-void good_func(THFloatTensor *tensor, int a, float b);
+void good_func(THTensor *tensor, int a, float b);
 void cuda_func(THCudaTensor *tensor, int a, float b);
-THFloatTensor * new_tensor(int a);
+THTensor * new_tensor(int a);
 float int_to_float(int a);

--- a/test/ffi/src/lib.h
+++ b/test/ffi/src/lib.h
@@ -1,5 +1,5 @@
 
-void my_func(THFloatTensor *tensor, int a, float b);
+void my_func(THTensor *tensor, int a, float b);
 void my_cuda_func(THCudaTensor *tensor, int a, float b);
-THFloatTensor * new_t(int a);
+THTensor * new_t(int a);
 float new_int(int a);

--- a/tools/cwrap/plugins/NNExtension.py
+++ b/tools/cwrap/plugins/NNExtension.py
@@ -30,10 +30,10 @@ $METHODS
 class NNExtension(CWrapPlugin):
 
     TYPE_UNPACK = {
-        'THFloatTensor*': Template('THNN_FloatTensor_Unpack($arg)'),
-        'THDoubleTensor*': Template('THNN_DoubleTensor_Unpack($arg)'),
-        'THLongTensor*': Template('THNN_LongTensor_Unpack($arg)'),
-        'THIntTensor*': Template('THNN_IntTensor_Unpack($arg)'),
+        'THTensor*': Template('THNN_FloatTensor_Unpack($arg)'),
+        'THTensor*': Template('THNN_DoubleTensor_Unpack($arg)'),
+        'THTensor*': Template('THNN_LongTensor_Unpack($arg)'),
+        'THTensor*': Template('THNN_IntTensor_Unpack($arg)'),
         'THCudaHalfTensor*': Template('THNN_CudaHalfTensor_Unpack($arg)'),
         'THCudaTensor*': Template('THNN_CudaFloatTensor_Unpack($arg)'),
         'THCudaDoubleTensor*': Template('THNN_CudaDoubleTensor_Unpack($arg)'),
@@ -50,10 +50,10 @@ class NNExtension(CWrapPlugin):
     }
 
     TYPE_CHECK = {
-        'THFloatTensor*': Template('THNN_FloatTensor_Check($arg)'),
-        'THDoubleTensor*': Template('THNN_DoubleTensor_Check($arg)'),
-        'THLongTensor*': Template('THNN_LongTensor_Check($arg)'),
-        'THIntTensor*': Template('THNN_IntTensor_Check($arg)'),
+        'THTensor*': Template('THNN_FloatTensor_Check($arg)'),
+        'THTensor*': Template('THNN_DoubleTensor_Check($arg)'),
+        'THTensor*': Template('THNN_LongTensor_Check($arg)'),
+        'THTensor*': Template('THNN_IntTensor_Check($arg)'),
         'THCudaHalfTensor*': Template('THNN_CudaHalfTensor_Check($arg)'),
         'THCudaTensor*': Template('THNN_CudaFloatTensor_Check($arg)'),
         'THCudaDoubleTensor*': Template('THNN_CudaDoubleTensor_Check($arg)'),
@@ -89,12 +89,12 @@ PyObject * $name(PyObject *_unused, PyObject *args)
         'THCudaTensor*': 'torch.cuda.FloatTensor',
         'THCudaDoubleTensor*': 'torch.cuda.DoubleTensor',
         'THCudaLongTensor*': 'torch.cuda.LongTensor',
-        'THDoubleTensor*': 'torch.DoubleTensor',
-        'THFloatTensor*': 'torch.FloatTensor',
+        'THTensor*': 'torch.DoubleTensor',
+        'THTensor*': 'torch.FloatTensor',
         'THBoolTensor*': 'torch.ByteTensor',
-        'THLongTensor*': 'torch.LongTensor',
+        'THTensor*': 'torch.LongTensor',
         'THIndexTensor*': 'torch.LongTensor',
-        'THIntTensor*': 'torch.IntTensor',
+        'THTensor*': 'torch.IntTensor',
         'THLongStorage*': 'torch.LongStorage',
         'long': 'int',
         'int64_t': 'int',

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -8,10 +8,10 @@ from collections import OrderedDict
 class THPPlugin(CWrapPlugin):
 
     TYPE_UNPACK = {
-        'THFloatTensor*': Template('((THPFloatTensor*)$arg)->cdata'),
-        'THDoubleTensor*': Template('((THPDoubleTensor*)$arg)->cdata'),
-        'THLongTensor*': Template('((THPLongTensor*)$arg)->cdata'),
-        'THIntTensor*': Template('((THPIntTensor*)$arg)->cdata'),
+        'THTensor*': Template('((THPFloatTensor*)$arg)->cdata'),
+        'THTensor*': Template('((THPDoubleTensor*)$arg)->cdata'),
+        'THTensor*': Template('((THPLongTensor*)$arg)->cdata'),
+        'THTensor*': Template('((THPIntTensor*)$arg)->cdata'),
         'THTensor*': Template('((THPTensor*)$arg)->cdata'),
         'THBoolTensor*': Template('((THPBoolTensor*)$arg)->cdata'),
         'THIndexTensor*': Template('((THPIndexTensor*)$arg)->cdata'),
@@ -47,10 +47,10 @@ class THPPlugin(CWrapPlugin):
     }
 
     TYPE_CHECK = {
-        'THDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THPDoubleTensorClass'),
-        'THFloatTensor*': Template('(PyObject*)Py_TYPE($arg) == THPFloatTensorClass'),
-        'THLongTensor*': Template('(PyObject*)Py_TYPE($arg) == THPLongTensorClass'),
-        'THIntTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIntTensorClass'),
+        'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPDoubleTensorClass'),
+        'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPFloatTensorClass'),
+        'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPLongTensorClass'),
+        'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIntTensorClass'),
         'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPTensorClass'),
         'THBoolTensor*': Template('(PyObject*)Py_TYPE($arg) == THPBoolTensorClass'),
         'THIndexTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIndexTensorClass'),
@@ -91,7 +91,7 @@ class THPPlugin(CWrapPlugin):
         'THTensor*': Template('return THPTensor_(New)($result);'),
         'THSTensor*': Template('return THSPTensor_(New)($result);'),
         'THIndexTensor*': Template('return THPIndexTensor_(New)($result);'),
-        'THLongTensor*': Template('return THPLongTensor_New($result);'),
+        'THTensor*': Template('return THPLongTensor_New($result);'),
         'THLongStorage*': Template('return THPLongStorage_New($result);'),
         'THCudaIntTensor*': Template('return THCPIntTensor_New($result);'),
         'THCudaLongTensor*': Template('return THCPLongTensor_New($result);'),
@@ -158,8 +158,8 @@ ${cpu}
 
     ALLOCATE_TYPE = {
         'THTensor*': _allocate('', ALLOCATE_TMPL),
-        'THLongTensor*': _allocate('Long', ALLOCATE_TMPL),
-        'THIntTensor*': _allocate('Int', ALLOCATE_TMPL),
+        'THTensor*': _allocate('Long', ALLOCATE_TMPL),
+        'THTensor*': _allocate('Int', ALLOCATE_TMPL),
         'THBoolTensor*': _allocate('Byte', ALLOCATE_TMPL, ALLOCATE_CUDA),
         'THIndexTensor*': _allocate('Long', ALLOCATE_TMPL, ALLOCATE_CUDA),
         'THIntegerTensor*': _allocate('Int', ALLOCATE_TMPL, ALLOCATE_CUDA),
@@ -173,13 +173,13 @@ ${cpu}
         'THStorage*': '" THPStorageStr "',
         'THGenerator*': 'torch.Generator',
         'THLongStorage*': '" THPModuleStr "LongStorage',
-        'THLongTensor*': '" THPModuleStr "LongTensor',
-        'THIntTensor*': '" THPModuleStr "IntTensor',
+        'THTensor*': '" THPModuleStr "LongTensor',
+        'THTensor*': '" THPModuleStr "IntTensor',
         'THBoolTensor*': '" THPModuleStr "ByteTensor',
         'THIndexTensor*': '" THPModuleStr "LongTensor',
         'THIntegerTensor*': '" THPModuleStr "IntTensor',
-        'THFloatTensor*': '" THPModuleStr "FloatTensor',
-        'THDoubleTensor*': '" THPModuleStr "DoubleTensor',
+        'THTensor*': '" THPModuleStr "FloatTensor',
+        'THTensor*': '" THPModuleStr "DoubleTensor',
         'THCudaTensor*': 'torch.cuda.FloatTensor',
         'THCudaDoubleTensor*': 'torch.cuda.DoubleTensor',
         'THCudaIntTensor*': 'torch.cuda.IntTensor',
@@ -431,7 +431,7 @@ ${cpu}
             return " || ".join(defineds)
 
         for declaration in declarations:
-            # Disable all methods for THHalfTensor, unless cpu_half is True
+            # Disable all methods for THTensor, unless cpu_half is True
 
             dfstr = backends_types_to_defined_if_string(declaration)
             if len(dfstr) > 0:

--- a/tools/nnwrap/generate_wrappers.py
+++ b/tools/nnwrap/generate_wrappers.py
@@ -29,8 +29,8 @@ COMMON_TRANSFORMS = {
 }
 COMMON_CPU_TRANSFORMS = {
     'THNNState*': 'void*',
-    'THIndexTensor*': 'THLongTensor*',
-    'THIntegerTensor*': 'THIntTensor*',
+    'THIndexTensor*': 'THTensor*',
+    'THIntegerTensor*': 'THTensor*',
 }
 COMMON_GPU_TRANSFORMS = {
     'THCState*': 'void*',
@@ -39,12 +39,12 @@ COMMON_GPU_TRANSFORMS = {
 
 TYPE_TRANSFORMS = {
     'Float': {
-        'THTensor*': 'THFloatTensor*',
+        'THTensor*': 'THTensor*',
         'real': 'float',
         'accreal': 'double',
     },
     'Double': {
-        'THTensor*': 'THDoubleTensor*',
+        'THTensor*': 'THTensor*',
         'real': 'double',
         'accreal': 'double',
     },

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -70,7 +70,7 @@ static PyObject * THPGenerator_getState(THPGenerator *self)
   HANDLE_TH_ERRORS
   THGenerator *generator = THPGenerator_TH_CData(self);
   Variable var = torch::empty({0}, at::device(at::kCPU).dtype(at::kByte));
-  THByteTensor_getRNGState(generator, (THByteTensor*)(var.data().unsafeGetTensorImpl()));
+  THByteTensor_getRNGState(generator, (THTensor*)(var.data().unsafeGetTensorImpl()));
   return THPVariable_Wrap(std::move(var));
   END_HANDLE_TH_ERRORS
 }
@@ -88,7 +88,7 @@ static PyObject * THPGenerator_setState(THPGenerator *self, PyObject *_new_state
     throw TypeError("expected a torch.ByteTensor, but got %s", type_name.c_str());
   }
   THGenerator *generator = THPGenerator_TH_CData(self);
-  THByteTensor_setRNGState(generator, (THByteTensor*)tensor.unsafeGetTensorImpl());
+  THByteTensor_setRNGState(generator, (THTensor*)tensor.unsafeGetTensorImpl());
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -120,7 +120,7 @@ PyObject * THCPModule_getRNGState(PyObject *_unused)
   using namespace torch::autograd;
   HANDLE_TH_ERRORS
   Variable var = torch::empty(0, at::device(at::kCPU).dtype(at::kByte));
-  THCRandom_getRNGState(state, (THByteTensor*)(var.data().unsafeGetTensorImpl()));
+  THCRandom_getRNGState(state, (THTensor*)(var.data().unsafeGetTensorImpl()));
   return THPVariable_Wrap(var);
   END_HANDLE_TH_ERRORS
 }
@@ -133,7 +133,7 @@ PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *obj)
         Py_TYPE(obj)->tp_name);
   }
   auto& tensor = THPVariable_UnpackData(obj);
-  THCRandom_setRNGState(state, (THByteTensor*)tensor.unsafeGetTensorImpl());
+  THCRandom_setRNGState(state, (THTensor*)tensor.unsafeGetTensorImpl());
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/nn/type_checks.h
+++ b/torch/csrc/nn/type_checks.h
@@ -52,20 +52,20 @@ static inline bool THNN_IntTensor_Check(PyObject* obj) {
   return torch::nn::check_type(obj, at::TypeID::CPUInt);
 }
 
-static inline THFloatTensor* THNN_FloatTensor_Unpack(PyObject* obj) {
-  return torch::nn::unpack<THFloatTensor>(obj);
+static inline THTensor* THNN_FloatTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THTensor>(obj);
 }
 
-static inline THDoubleTensor* THNN_DoubleTensor_Unpack(PyObject* obj) {
-  return torch::nn::unpack<THDoubleTensor>(obj);
+static inline THTensor* THNN_DoubleTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THTensor>(obj);
 }
 
-static inline THLongTensor* THNN_LongTensor_Unpack(PyObject* obj) {
-  return torch::nn::unpack<THLongTensor>(obj);
+static inline THTensor* THNN_LongTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THTensor>(obj);
 }
 
-static inline THIntTensor* THNN_IntTensor_Unpack(PyObject* obj) {
-  return torch::nn::unpack<THIntTensor>(obj);
+static inline THTensor* THNN_IntTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THTensor>(obj);
 }
 
 #ifdef USE_CUDA


### PR DESCRIPTION

We have a number of type names which are macro-converted to "THTensor."
The code comment says "These used to be distinct types; for some measure of
backwards compatibility and documentation alias these to the single THTensor type."
It seems we could just expand these to reduce a bit of complexity in
reading the code.



