### PR TITLE
Make sure we bind input/output of Onnxifi op positionally

### DIFF
--- a/caffe2/operators/onnxifi_op.cc
+++ b/caffe2/operators/onnxifi_op.cc
@@ -118,10 +118,11 @@ OnnxifiOp<float, CPUContext>::BuildInitializationList(
 
 template <>
 bool OnnxifiOp<float, CPUContext>::RunOnDevice() {
+  CAFFE_ENFORCE_EQ(input_desc_.size(), InputSize());
   for (unsigned i = 0U; i < InputSize(); ++i) {
     const auto& input_tensor = Input(i);
     const auto tensor_dims = input_tensor.sizes();
-    auto& tensor_descriptor = input_desc_.at(i);
+    auto& tensor_descriptor = input_desc_[i];
     tensor_descriptor.tag = ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1;
     tensor_descriptor.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
     tensor_descriptor.dimensions = tensor_dims.size();
@@ -130,10 +131,11 @@ bool OnnxifiOp<float, CPUContext>::RunOnDevice() {
     SetInputTensorDescriptorTypeAndBuffer(input_tensor, &tensor_descriptor);
   }
 
+  CAFFE_ENFORCE_EQ(output_desc_.size(), OutputSize());
   for (unsigned i = 0U; i < OutputSize(); ++i) {
     std::vector<size_t> tensor_dims;
     uint64_t type = SetOutputShapeAndType(i, &tensor_dims);
-    auto& tensor_descriptor = output_desc_.at(i);
+    auto& tensor_descriptor = output_desc_[i];
     tensor_descriptor.tag = ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1;
     tensor_descriptor.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
     tensor_descriptor.dimensions = tensor_dims.size();

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -171,13 +171,19 @@ OperatorDef OnnxifiTransformer::BuildOnnxifiOp(
   }
 
   // Add the input/output
+  auto* input_names = op.add_arg();
+  input_names->set_name("input_names");
   for (const auto& input : net.external_input()) {
     if (!initialization_list.count(input)) {
       op.add_input(input);
+      input_names->add_strings(input);
     }
   }
+  auto* output_names = op.add_arg();
+  output_names->set_name("output_names");
   for (const auto& output : net.external_output()) {
     op.add_output(output);
+    output_names->add_strings(output);
   }
 
   // Add output size hints

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -53,6 +53,8 @@ class OnnxifiTest(TestCase):
             ["X"],
             ["Y"],
             onnx_model=model_def.SerializeToString(),
+            input_names=["X"],
+            output_names=["Y"],
             output_shape_hint_0=[ONNXIFI_DATATYPE_FLOAT32, batch_size, 1, 3, 2])
         workspace.FeedBlob("X", X)
         workspace.RunOperatorOnce(op)
@@ -88,17 +90,21 @@ class OnnxifiTest(TestCase):
             outputs=[make_tensor_value_info("Y", onnx.TensorProto.FLOAT,
                 [1, 1, 3, 3])])
         model_def = make_model(graph_def, producer_name='conv-test')
+        # We intentional rewrite the input/output name so test that the
+        # input/output binding of c2 op is positional
         op = core.CreateOperator(
             "Onnxifi",
-            ["X"],
-            ["Y"],
+            ["X0"],
+            ["Y0"],
             onnx_model=model_def.SerializeToString(),
-            initializers=["W", "W"],
+            initializers=["W", "W0"],
+            input_names=["X"],
+            output_names=["Y"],
             output_shape_hint_0=[ONNXIFI_DATATYPE_FLOAT32, 1, 1, 3, 3])
-        workspace.FeedBlob("X", X)
-        workspace.FeedBlob("W", W)
+        workspace.FeedBlob("X0", X)
+        workspace.FeedBlob("W0", W)
         workspace.RunOperatorOnce(op)
-        Y = workspace.FetchBlob("Y")
+        Y = workspace.FetchBlob("Y0")
         np.testing.assert_almost_equal(Y, Y_without_padding)
 
 


### PR DESCRIPTION
Summary: This is to pick up the residual task of T36325466 to make sure that input/output binding of c2 Onnxifi op is positional.

Differential Revision: D13134470
