### PR TITLE
[c10d] Remove header generated at configuration time

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/python_headers.h>
 
-#include <c10d/Def.hpp>
 #include <c10d/FileStore.hpp>
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/ProcessGroupGloo.hpp>

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -41,7 +41,6 @@ endif()
 if(MPI_FOUND)
   option(USE_C10D_MPI "USE C10D MPI" ON)
 endif()
-configure_file(cmake/Def.hpp.in ${CMAKE_BINARY_DIR}/include/c10d/Def.hpp @ONLY)
 
 set(C10D_SRCS
   FileStore.cpp
@@ -64,12 +63,12 @@ else()
 endif()
 
 
-if(USE_NCCL)
+if(USE_C10D_NCCL)
   list(APPEND C10D_SRCS ProcessGroupNCCL.cpp)
   list(APPEND C10D_LIBS __caffe2_nccl)
 endif()
 
-if(MPI_FOUND)
+if(USE_C10D_MPI)
   list(APPEND C10D_SRCS ProcessGroupMPI.cpp)
   list(APPEND C10D_LIBS ${MPI_LIBRARIES})
 endif()
@@ -110,6 +109,14 @@ target_include_directories(c10d PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 # For torch/csrc/utils/hash.h and torch/csrc/utils/functional.h
 target_include_directories(c10d PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
+if(USE_C10D_NCCL)
+  target_compile_definitions(c10d INTERFACE USE_C10D_NCCL)
+endif()
+
+if(USE_C10D_MPI)
+  target_compile_definitions(c10d INTERFACE USE_C10D_MPI)
+endif()
+
 copy_header(FileStore.hpp)
 copy_header(PrefixStore.hpp)
 copy_header(ProcessGroup.hpp)
@@ -119,18 +126,17 @@ copy_header(Types.hpp)
 copy_header(Utils.hpp)
 copy_header(ProcessGroupGloo.hpp)
 
-if(USE_NCCL)
+if(USE_C10D_NCCL)
   copy_header(ProcessGroupNCCL.hpp)
   copy_header(NCCLUtils.hpp)
 endif()
 
-if(MPI_FOUND)
+if(USE_C10D_MPI)
   target_include_directories(c10d PUBLIC ${MPI_INCLUDE_PATH})
   copy_header(ProcessGroupMPI.hpp)
 endif()
 
 target_link_libraries(c10d PUBLIC ${C10D_LIBS})
-target_include_directories(c10d PRIVATE ${CMAKE_BINARY_DIR}/include)
 
 install(TARGETS c10d
   RUNTIME DESTINATION bin

--- a/torch/lib/c10d/Def.hpp
+++ b/torch/lib/c10d/Def.hpp
@@ -1,4 +1,0 @@
-#pragma once
-
-// This is a placeholder for the header that is generated CMake.
-// It is needed if you include the c10d headers directly from this directory.

--- a/torch/lib/c10d/cmake/Def.hpp.in
+++ b/torch/lib/c10d/cmake/Def.hpp.in
@@ -1,4 +1,0 @@
-#pragma once
-
-#cmakedefine USE_C10D_NCCL
-#cmakedefine USE_C10D_MPI


### PR DESCRIPTION
The build was picking up the empty stub header instead of the generated
one. Because of the large number of include paths we end up passing to
the compiler it is brittle to have both an empty stub file and a
generated file and expect the compiler to pick up the right one.

With the recent change to compile everything from a single CMake run we
can now use native CMake facilities to propagate macros that indicate
backend support. The stanzas target_compile_definitions with the
INTERFACE flag ensure that these macros are set only for downstream
consumers of the c10d target.
