### PR TITLE
Option to preserve bitwise accuracy of gradient checkpointed vs non-checkpointed dropout

### DIFF
--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -1,6 +1,20 @@
 torch.utils.checkpoint
 ======================
 
+.. note::
+    Checkpointing is implemented by rerunning a forward-pass segment for
+    each checkpointed segment during backward.  This can cause persistent
+    states like the RNG state to be advanced than they would without
+    checkpointing.  By default, checkpointing includes logic to juggle
+    the RNG state such that checkpointed passes making use of RNG
+    (through dropout for example) have deterministic output as
+    compared to non-checkpointed passes.  The logic to stash and restore
+    RNG states can incur a moderate performance hit depending on the runtime
+    of checkpointed operations.  If deterministic output compared to
+    non-checkpointed passes is not required, set the global flag
+    ``torch.utils.checkpoint.preserve_rng_state=False`` to omit stashing and
+    restoring the RNG state during each checkpoint.
+
 .. currentmodule:: torch.utils.checkpoint
 .. autofunction:: checkpoint
 .. autofunction:: checkpoint_sequential

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -169,7 +169,7 @@ class TestCheckpoint(TestCase):
             state = torch.get_rng_state()
 
             out = phase1(inp)
-            out = checkpoint(run_fn, out, preserve_rng_state=True)
+            out = checkpoint(run_fn, out)
             out.sum().backward()
             grad_with_checkpointing = inp.grad
 
@@ -198,7 +198,7 @@ class TestCheckpoint(TestCase):
             state = torch.cuda.get_rng_state()
 
             out = phase1(inp)
-            out = checkpoint(run_fn, out, preserve_rng_state=True)
+            out = checkpoint(run_fn, out)
             out.sum().backward()
             grad_with_checkpointing = inp.grad
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -158,52 +158,60 @@ class TestCheckpoint(TestCase):
             self.assertEqual(grad_checkpointed[name], grad_not_checkpointed[name])
 
     def test_checkpoint_rng_cpu(self):
-        inp = torch.randn(10000, device='cpu').requires_grad_()
-        model = torch.nn.Dropout()
+        for i in range(5):
+            inp = torch.randn(20000, device='cpu').requires_grad_()
+            phase1 = torch.nn.Dropout()
+            phase2 = torch.nn.Dropout()
 
-        def run_fn(input):
-            return model(input)
+            def run_fn(input):
+                return phase2(input)
 
-        state = torch.get_rng_state()
+            state = torch.get_rng_state()
 
-        output = checkpoint(run_fn, inp, preserve_rng_state=True)
-        output.sum().backward()
-        grad_with_checkpointing = inp.grad
+            out = phase1(inp)
+            out = checkpoint(run_fn, out, preserve_rng_state=True)
+            out.sum().backward()
+            grad_with_checkpointing = inp.grad
 
-        torch.set_rng_state(state)
+            torch.set_rng_state(state)
 
-        inp.grad = None
+            inp.grad = None
 
-        output = run_fn(inp)
-        output.sum().backward()
-        grad_no_checkpointing = inp.grad
+            out = phase1(inp)
+            out = run_fn(out)
+            out.sum().backward()
+            grad_no_checkpointing = inp.grad
 
-        self.assertEqual(grad_with_checkpointing, grad_no_checkpointing)
+            self.assertEqual(grad_with_checkpointing, grad_no_checkpointing)
 
     @unittest.skipIf(not HAS_CUDA, 'No CUDA')
     @skipIfRocm
     def test_checkpoint_rng_cuda(self):
-        inp = torch.randn(10000, device='cuda').requires_grad_()
-        model = torch.nn.Dropout()
+        for i in range(5):
+            inp = torch.randn(20000, device='cuda').requires_grad_()
+            phase1 = torch.nn.Dropout()
+            phase2 = torch.nn.Dropout()
 
-        def run_fn(input):
-            return model(input)
+            def run_fn(input):
+                return phase2(input)
 
-        state = torch.cuda.get_rng_state()
+            state = torch.cuda.get_rng_state()
 
-        output = checkpoint(run_fn, inp, preserve_rng_state=True)
-        output.sum().backward()
-        grad_with_checkpointing = inp.grad
+            out = phase1(inp)
+            out = checkpoint(run_fn, out, preserve_rng_state=True)
+            out.sum().backward()
+            grad_with_checkpointing = inp.grad
 
-        torch.cuda.set_rng_state(state)
+            torch.cuda.set_rng_state(state)
 
-        inp.grad = None
+            inp.grad = None
 
-        output = run_fn(inp)
-        output.sum().backward()
-        grad_no_checkpointing = inp.grad
+            out = phase1(inp)
+            out = run_fn(out)
+            out.sum().backward()
+            grad_no_checkpointing = inp.grad
 
-        self.assertEqual(grad_with_checkpointing, grad_no_checkpointing)
+            self.assertEqual(grad_with_checkpointing, grad_no_checkpointing)
 
 
 class TestDataLoader(TestCase):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -43,6 +43,7 @@ class CheckpointFunction(torch.autograd.Function):
             # (If the user intends that the context is initialized later, within their
             # run_function, we SHOULD actually stash the cuda state here.  Unfortunately,
             # we have no way to anticipate this will happen before we run the function.)
+            ctx.had_cuda_in_fwd = False
             if torch.cuda._initialized:
                 ctx.had_cuda_in_fwd = True
                 ctx.fwd_cuda_rng_state = torch.cuda.get_rng_state()


### PR DESCRIPTION
This issue was noticed, and fix proposed, by @raulpuric.

Checkpointing is implemented by rerunning a forward-pass segment for each checkpointed segment during backward.  This can result in the RNG state advancing more than it would without checkpointing, which can cause checkpoints that include dropout invocations to lose end-to-end bitwise accuracy as compared to non-checkpointed passes.  

The present PR contains optional logic to juggle the RNG states such that checkpointed passes containing dropout achieve bitwise accuracy with non-checkpointed equivalents.**  The user requests this behavior by supplying `preserve_rng_state=True` to `torch.utils.checkpoint` or `torch.utils.checkpoint_sequential`.

Currently, `preserve_rng_state=True` may incur a moderate performance hit because restoring MTGP states can be expensive.  However, restoring Philox states is dirt cheap, so @syed-ahmed's [RNG refactor](https://github.com/pytorch/pytorch/pull/13070#discussion_r235179882), once merged, will make this option more or less free.

I'm a little wary of the [def checkpoint(function, *args, preserve_rng_state=False):](https://github.com/pytorch/pytorch/pull/14253/files#diff-58da227fc9b1d56752b7dfad90428fe0R75) argument-passing method (specifically, putting a kwarg after a variable argument list).  Python 3 seems happy with it.
Edit:  It appears Python 2.7 is NOT happy with a [kwarg after *args](https://travis-ci.org/pytorch/pytorch/builds/457706518?utm_source=github_status&utm_medium=notification).  `preserve_rng_state` also needs to be communicated in a way that doesn't break any existing usage.  I'm open to suggestions (a global flag perhaps)?


**Batchnorm may still be an issue, but that's a battle for another day.