### PR TITLE
Remove Context dependency from Tensor class

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -950,48 +950,35 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
       if (data_type_.copy()) {
         AT_ASSERTM(
             device_type() == ::at::DeviceType::CPU,
-            "In CopyFrom source and dest tensors must both be CPU for meta copy, "
-            "but dest tensor was ", device_type());
+            "In CopyFrom source and dest tensors must both be CPU for "
+            "non-POD copy, but dest tensor was ",
+            device_type());
         AT_ASSERTM(
             src.device_type() == ::at::DeviceType::CPU,
-            "In CopyFrom source and dest tensors must both be CPU for meta copy, "
-            "but src tensor was ", src.device_type());
+            "In CopyFrom source and dest tensors must both be CPU for "
+            "non-POD copy, but src tensor was ",
+            src.device_type());
         data_type_.copy()(src.data(), raw_mutable_data(data_type_), numel());
       } else {
         // The following copy uses the current (thread local) stream for copying
-        // and also takes the current GPU id previously set through CUDA API
-        // as we don't invoke SwitchToDevice anywhere
-        // TODO: this logic is overly complex and can be replaced with simple
-        // dispatch based on two device types
+        // and also takes the GPU id from the device() field passed in.
         //
-        // We'll need to use a non-CPU context to perform the copy if
-        // one of the context is not CPU since only non-CPU context
-        // knows how to copy between CPU and that context
-        if (src.device_type() != ::at::DeviceType::CPU || device_type() == ::at::DeviceType::CPU) {
-          if (!context) {
-            CreateContext(src.GetDevice())
-                ->CopyBytesToDevice(
-                    numel() * itemsize(),
-                    src.data(),
-                    raw_mutable_data(data_type_),
-                    device_type());
-          } else {
-            AT_ASSERTM(
-                context->device_type() == src.device_type(),
-                "Type for provided context does not match the type of source");
-            context->CopyBytesToDevice(
-                numel() * itemsize(), src.data(), raw_mutable_data(data_type_), device_type());
-          }
-        } else {
-          // In case source context is CPU, and target context is non-CPU
-          // We'll have to create a Context from target and perform the
-          // copy using that context
-          CreateContext(GetDevice())
-              ->CopyBytesFromCPU(
-                  numel() * itemsize(),
-                  src.data(),
-                  raw_mutable_data(data_type_));
-        }
+        // TODO: Potentially more enforcements are necessary to avoid accidental
+        // switch to sync copy if the currently set device is wrong.
+        //
+        // Specifically, we might need to switch to a different context device
+        // here explicitly to avoid relying on user synchronizing things
+        // properly.
+        //
+        // note: raw_mutable_data initializes device here
+        void* new_data = raw_mutable_data(data_type_);
+        at::CopyBytes(
+            numel() * itemsize(),
+            src.data(),
+            src.device(),
+            new_data,
+            device(),
+            context != nullptr);
       }
     }
   }
@@ -1037,8 +1024,29 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
     auto* newData = raw_mutable_data(data_type_);
     AT_ASSERTM(
         context != nullptr, "Context must be provided to Extend the tensor");
-    context->CopyItemsSameDevice(
-        data_type_, oldSize, oldData.get(), newData);
+    if (data_type_.copy()) {
+      AT_ASSERTM(
+          device_type() == ::at::DeviceType::CPU,
+          "non-POD types work only on CPU");
+      data_type_.copy()(oldData.get(), newData, oldSize);
+    } else {
+      // The following copy uses the current (thread local) stream for copying
+      // and also takes the GPU id from the device() field passed in.
+      //
+      // TODO: Potentially more enforcements are necessary to avoid accidental
+      // switch to sync copy if the currently set device is wrong.
+      //
+      // Specifically, we might need to switch to a different context device
+      // here explicitly to avoid relying on user synchronizing things
+      // properly.
+      at::CopyBytes(
+          oldSize * itemsize(),
+          oldData.get(),
+          device(),
+          newData,
+          device(),
+          true); // non-blocking
+    }
     reserved_ = true;
     sizes_ = newDims;
     numel_ = newNumel;

--- a/aten/src/ATen/core/context_base.cpp
+++ b/aten/src/ATen/core/context_base.cpp
@@ -1,5 +1,7 @@
 #include <ATen/core/context_base.h>
 
+#include <c10/util/Logging.h>
+
 namespace at {
 
 C10_DEFINE_TYPED_REGISTRY(
@@ -8,6 +10,49 @@ C10_DEFINE_TYPED_REGISTRY(
     at::BaseContext,
     std::unique_ptr,
     at::Device);
+
+// First dimension of the array is `bool async`: 0 is sync,
+// 1 is async (non-blocking)
+static CopyBytesFunction g_copy_bytes[2][COMPILE_TIME_MAX_DEVICE_TYPES]
+                                     [COMPILE_TIME_MAX_DEVICE_TYPES];
+
+_CopyBytesFunctionRegisterer::_CopyBytesFunctionRegisterer(
+    DeviceType fromType,
+    DeviceType toType,
+    CopyBytesFunction func_sync,
+    CopyBytesFunction func_async) {
+  auto from = static_cast<int>(fromType);
+  auto to = static_cast<int>(toType);
+  if (!func_async) {
+    // default to the sync function
+    func_async = func_sync;
+  }
+  CHECK(
+      g_copy_bytes[0][from][to] == nullptr &&
+      g_copy_bytes[1][from][to] == nullptr)
+      << "Duplicate registration for device type pair "
+      << c10::DeviceTypeName(fromType) << ", " << c10::DeviceTypeName(toType);
+  g_copy_bytes[0][from][to] = func_sync;
+  g_copy_bytes[1][from][to] = func_async;
+}
+
+void CopyBytes(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device,
+    bool async) {
+  auto ptr = g_copy_bytes[async ? 1 : 0][static_cast<int>(src_device.type())]
+                         [static_cast<int>(dst_device.type())];
+  CAFFE_ENFORCE(
+      ptr,
+      "No function found for copying from ",
+      c10::DeviceTypeName(src_device.type()),
+      " to ",
+      c10::DeviceTypeName(dst_device.type()));
+  ptr(nbytes, src, src_device, dst, dst_device);
+}
 
 } // namespace at
 

--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -63,25 +63,6 @@ class CAFFE2_API BaseContext {
 
   virtual void CopyBytesToCPU(size_t nbytes, const void* src, void* dst) = 0;
 
-  virtual void CopyBytesToDevice(
-      size_t nbytes,
-      const void* src,
-      void* dst,
-      DeviceType type) {
-    if (type == DeviceType::CPU) {
-      CopyBytesToCPU(nbytes, src, dst);
-    } else if (type == device_type()) {
-      CopyBytesSameDevice(nbytes, src, dst);
-    } else {
-      AT_ERROR(
-          "CopyBytesToDevice can only copy to CPU or between same "
-          "device. Can't copy from: ",
-          device_type(),
-          " to",
-          type);
-    }
-  }
-
   template <typename T>
   inline void CopySameDevice(size_t n, const T* src, T* dst) {
     static_assert(
@@ -175,9 +156,41 @@ inline std::unique_ptr<at::BaseContext> CreateContext(
 
 } // namespace at
 
+// TODO: move it to a separate file in c10 if possible
+namespace at {
+
+using CopyBytesFunction = void (*)(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device);
+
+struct CAFFE2_API _CopyBytesFunctionRegisterer {
+  _CopyBytesFunctionRegisterer(
+      DeviceType from,
+      DeviceType to,
+      CopyBytesFunction func_sync,
+      CopyBytesFunction func_async = nullptr);
+};
+
+#define REGISTER_COPY_BYTES_FUNCTION(from, to, ...)           \
+  namespace {                                                 \
+  static _CopyBytesFunctionRegisterer C10_ANONYMOUS_VARIABLE( \
+      g_copy_function)(from, to, __VA_ARGS__);                \
+  }
+
+CAFFE2_API void CopyBytes(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device,
+    bool async);
+} // namespace at
+
 namespace caffe2 {
 
 using at::BaseContext;
 using at::CreateContext;
-
 } // namespace caffe2

--- a/c10/DeviceType.h
+++ b/c10/DeviceType.h
@@ -29,6 +29,9 @@ enum class DeviceType : int16_t {
   ONLY_FOR_TEST = 20901, // This device type is only for test.
 };
 
+// define explicit int constant
+constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
+    static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
 C10_API std::string DeviceTypeName(
     DeviceType d,
     bool lower_case = false);

--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -222,6 +222,8 @@ void TensorSerializer::Serialize(
   const TensorProto::DataType data_type = TypeMetaToDataType(input.dtype());
   proto.set_data_type(data_type);
   StoreDeviceDetail(input, &proto);
+  // TODO: use DeviceGuard here instead of context and employ explicit sync
+  // copy
   auto uniq_ptr = CreateContext(input.GetDevice());
   // A lot of copypaste is error prone. Should we create a macro for this?
   switch (data_type) {

--- a/caffe2/core/context.cc
+++ b/caffe2/core/context.cc
@@ -5,10 +5,6 @@
 #include <process.h>
 #endif
 
-namespace at {
-
-REGISTER_CONTEXT(DeviceType::CPU, caffe2::CPUContext);
-} // namespace at
 namespace caffe2 {
 
 uint32_t RandomNumberSeed() {
@@ -28,4 +24,41 @@ uint32_t RandomNumberSeed() {
       kPrime2 * tv_sec + kPrime3 * tv_usec;
 }
 
+namespace {
+inline void CopyBytesImpl(size_t nbytes, const void* src, void* dst) {
+  if (nbytes == 0) {
+    return;
+  }
+  CAFFE_ENFORCE(src);
+  CAFFE_ENFORCE(dst);
+  memcpy(dst, src, nbytes);
+}
+
+void CopyBytesWrapper(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device) {
+  CopyBytesImpl(nbytes, src, dst);
+}
+} // namespace
+
+void CPUContext::CopyBytesSameDevice(
+    size_t nbytes,
+    const void* src,
+    void* dst) {
+  CopyBytesImpl(nbytes, src, dst);
+}
+
 } // namespace caffe2
+
+namespace at {
+
+REGISTER_CONTEXT(DeviceType::CPU, caffe2::CPUContext);
+
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::CPU,
+    DeviceType::CPU,
+    caffe2::CopyBytesWrapper);
+} // namespace at

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -79,14 +79,7 @@ class CAFFE2_API CPUContext final : public BaseContext {
     return GetCPUAllocator()->allocate(nbytes);
   }
 
-  void CopyBytesSameDevice(size_t nbytes, const void* src, void* dst) override {
-    if (nbytes == 0) {
-      return;
-    }
-    CAFFE_ENFORCE(src);
-    CAFFE_ENFORCE(dst);
-    memcpy(dst, src, nbytes);
-  }
+  void CopyBytesSameDevice(size_t nbytes, const void* src, void* dst) override;
 
   void CopyBytesFromCPU(size_t nbytes, const void* src, void* dst) override {
     CopyBytesSameDevice(nbytes, src, dst);

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -72,6 +72,79 @@ REGISTER_CONTEXT(DeviceType::CUDA, caffe2::CUDAContext);
 
 namespace caffe2 {
 
+// Generic implementation - CUDA will handle the right function to call for us
+void CUDAContext::CopyBytesAsync(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device) {
+  // TODO: verify that the CUDA handles copy from device to device correctly
+  // even without SetDevice()
+  // TODO: verify whether source or dest device should be a priority in picking
+  // the stream
+  // NB: right now the cross-device copy logic is invoked only in the contexts
+  // when surrounding code explicitly manages data dependencies and sets up
+  // events, so it's fine.  In order to make it a standalone function proper
+  // synchronization between stream is required
+  int gpu_id = 0;
+  if (dst_device.type() == DeviceType::CUDA) {
+    gpu_id = dst_device.index();
+  } else if (src_device.type() == DeviceType::CUDA) {
+    gpu_id = src_device.index();
+  } else {
+    LOG(FATAL) << "shouldn't be called with non-cuda device";
+  }
+  CUDA_ENFORCE(cudaMemcpyAsync(
+      dst,
+      src,
+      nbytes,
+      cudaMemcpyDefault,
+      CUDAContext::getCudaObjects().GetStream(gpu_id)));
+}
+
+void CUDAContext::CopyBytesSync(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device) {
+  // This emulates Caffe2 original behavior where sync copy doesn't change the
+  // device. It's probably better for clarity to switch to the target device
+  // explicitly here, but in the worst case CUDA would sync for us.
+  // TODO: change it to DeviceGuard
+  CUDAContext context(-1); // take current device
+  CUDA_ENFORCE(cudaMemcpyAsync(
+      dst, src, nbytes, cudaMemcpyDefault, context.cuda_stream()));
+  // destructor of context synchronizes
+}
+
+// For the CPU context, we also allow a (probably expensive) function
+// to copy the data from a cuda context. Inside the function, we create
+// a temporary CUDAContext object to carry out the copy. From the caller's
+// side, these functions are synchronous with respect to the host, similar
+// to a normal CPUContext::CopyBytes<CPUContext, CPUContext> call.
+template <>
+inline void CPUContext::CopyBytes<CUDAContext, CPUContext>(
+    size_t nbytes,
+    const void* src,
+    void* dst) {
+  CUDAContext context(GetGPUIDForPointer(src));
+  context.CopyBytes<CUDAContext, CPUContext>(nbytes, src, dst);
+}
+template <>
+inline void CPUContext::CopyBytes<CPUContext, CUDAContext>(
+    size_t nbytes,
+    const void* src,
+    void* dst) {
+  CUDAContext context(GetGPUIDForPointer(dst));
+  context.CopyBytes<CPUContext, CUDAContext>(nbytes, src, dst);
+}
+
+} // namespace caffe2
+
+namespace caffe2 {
+
 ThreadLocalCUDAObjects& CUDAContext::getCudaObjects() {
   static thread_local ThreadLocalCUDAObjects cuda_objects_;
   return cuda_objects_;
@@ -426,4 +499,24 @@ struct DefaultCUDAAllocator final : public at::Allocator {
 static DefaultCUDAAllocator g_cuda_alloc;
 REGISTER_ALLOCATOR(CUDA, &g_cuda_alloc);
 
-}  // namespace caffe2
+} // namespace caffe2
+
+namespace at {
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::CUDA,
+    DeviceType::CUDA,
+    caffe2::CUDAContext::CopyBytesSync,
+    caffe2::CUDAContext::CopyBytesAsync);
+
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::CUDA,
+    DeviceType::CPU,
+    caffe2::CUDAContext::CopyBytesSync,
+    caffe2::CUDAContext::CopyBytesAsync);
+
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::CPU,
+    DeviceType::CUDA,
+    caffe2::CUDAContext::CopyBytesSync,
+    caffe2::CUDAContext::CopyBytesAsync);
+} // namespace at

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -300,6 +300,19 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     CopyBytes<SrcContext, DstContext>(n * meta.itemsize(), src, dst);
   }
 
+  static void CopyBytesAsync(
+      size_t nbytes,
+      const void* src,
+      Device src_device,
+      void* dst,
+      Device dst_device);
+  static void CopyBytesSync(
+      size_t nbytes,
+      const void* src,
+      Device src_device,
+      void* dst,
+      Device dst_device);
+
   // By default CUDA operators have async device parts
   static bool HasAsyncPartDefault() {
     return true;
@@ -332,24 +345,6 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   curandGenerator_t curand_generator_{nullptr};
   static ThreadLocalCUDAObjects& getCudaObjects();
 };
-
-// For the CPU context, we also allow a (probably expensive) function
-// to copy the data from a cuda context. Inside the function, we create
-// a temporary CUDAContext object to carry out the copy. From the caller's
-// side, these functions are synchronous with respect to the host, similar
-// to a normal CPUContext::CopyBytes<CPUContext, CPUContext> call.
-template<>
-inline void CPUContext::CopyBytes<CUDAContext, CPUContext>(
-    size_t nbytes, const void* src, void* dst) {
-  CUDAContext context(GetGPUIDForPointer(src));
-  context.CopyBytes<CUDAContext, CPUContext>(nbytes, src, dst);
-}
-template<>
-inline void CPUContext::CopyBytes<CPUContext, CUDAContext>(
-    size_t nbytes, const void* src, void* dst) {
-  CUDAContext context(GetGPUIDForPointer(dst));
-  context.CopyBytes<CPUContext, CUDAContext>(nbytes, src, dst);
-}
 
 /**
  * An allocator that does the CPU memory allocation with pinned memory.

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -159,7 +159,7 @@ void ReinitializeAndCopyFrom(
     Tensor* t,
     at::TensorOptions options,
     const Tensor& src,
-    BaseContext* context) {
+    bool async) {
   auto device_type = options.device().type();
   CAFFE_ENFORCE(t != nullptr, "Target tensor ptr is null.");
   if (!*t || device_type != t->GetDeviceType()) {
@@ -172,7 +172,7 @@ void ReinitializeAndCopyFrom(
       t->dtype(),
       " to: ",
       src.dtype());
-  t->CopyFrom(src, context);
+  t->CopyFrom(src, async);
 }
 
 namespace {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -97,23 +97,22 @@ class CAFFE2_API Tensor final {
     return impl_.get()->GetDevice();
   }
 
-  void CopyFrom(const Tensor& src, BaseContext* context = nullptr) const {
-    impl_.get()->CopyFrom(*src.impl_.get(), context);
+  void CopyFrom(const Tensor& src, bool async = false) const {
+    impl_.get()->CopyFrom(*src.impl_.get(), async);
   }
 
   /**
    * @brief Extend the outer-most dimension of this tensor
    *        to dimension of `num`.
    */
-  void ExtendTo(int64_t num, float growthPct, BaseContext* context) const {
+  void ExtendTo(int64_t num, float growthPct) const {
     CAFFE_ENFORCE_GE_WITH_CALLER(impl_->dim(), 1);
     CAFFE_ENFORCE_GE_WITH_CALLER(growthPct, 0);
-    CAFFE_ENFORCE(context != nullptr, "Context must be provided.");
-    Extend(num - impl_->size(0), growthPct, context);
+    Extend(num - impl_->size(0), growthPct);
   }
 
-  void Extend(int64_t num, float growthPct, BaseContext* context) const {
-    impl_.get()->Extend(num, growthPct, context);
+  void Extend(int64_t num, float growthPct) const {
+    impl_.get()->Extend(num, growthPct);
   }
 
   /**
@@ -451,7 +450,7 @@ CAFFE2_API void ReinitializeAndCopyFrom(
     Tensor* t,
     at::TensorOptions options,
     const Tensor& src,
-    BaseContext* context = nullptr);
+    bool async = false);
 
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(12, Tensor)
 

--- a/caffe2/experiments/operators/tt_pad_op.h
+++ b/caffe2/experiments/operators/tt_pad_op.h
@@ -52,7 +52,7 @@ class TTPadOp final : public Operator<Context> {
       int64_t padded_dim0 = (X_dim0 / scale_ + 1) * scale_;
       auto dim0_diff = padded_dim0 - X_dim0;
       // set growthPct to the upper bound percentage: (100 * scale_ / X_dim0)
-      X_pad->Extend(dim0_diff, 100 * scale_ / X_dim0, &context_);
+      X_pad->Extend(dim0_diff, 100 * scale_ / X_dim0);
 
       auto* X_pad_data = X_pad->template mutable_data<T>();
       int64_t X_size = X_dim0 * X_dim1;

--- a/caffe2/ideep/utils/ideep_register.cc
+++ b/caffe2/ideep/utils/ideep_register.cc
@@ -6,7 +6,37 @@
 
 namespace at {
 REGISTER_CONTEXT(DeviceType::IDEEP, caffe2::IDEEPContext);
+
+namespace {
+void CopyBytesWrapper(
+    size_t nbytes,
+    const void* src,
+    Device src_device,
+    void* dst,
+    Device dst_device) {
+  if (nbytes == 0) {
+    return;
+  }
+  CAFFE_ENFORCE(src);
+  CAFFE_ENFORCE(dst);
+  memcpy(dst, src, nbytes);
+}
+} // namespace
+
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::IDEEP,
+    DeviceType::CPU,
+    CopyBytesWrapper);
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::CPU,
+    DeviceType::IDEEP,
+    CopyBytesWrapper);
+REGISTER_COPY_BYTES_FUNCTION(
+    DeviceType::IDEEP,
+    DeviceType::IDEEP,
+    CopyBytesWrapper);
 } // namespace at
+
 namespace caffe2 {
 
 CAFFE_KNOWN_TYPE(ideep::tensor);

--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
@@ -2302,8 +2302,8 @@ class MPSCNNGenerateProposalsCPPOp final : public Operator<CPUContext> {
       int csz = im_i_boxes.rows();
       int cur_start_idx = out_rois->dim(0);
 
-      out_rois->Extend(csz, 50, &context_);
-      out_rois_probs->Extend(csz, 50, &context_);
+      out_rois->Extend(csz, 50);
+      out_rois_probs->Extend(csz, 50);
 
       // write rois
       Eigen::Map<ERArrXXf> cur_rois(

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -167,9 +167,9 @@ bool BoxWithNMSLimitOp<CPUContext>::RunOnDevice() {
 
     // Write results
     int cur_start_idx = out_scores->size(0);
-    out_scores->Extend(total_keep_count, 50, &context_);
-    out_boxes->Extend(total_keep_count, 50, &context_);
-    out_classes->Extend(total_keep_count, 50, &context_);
+    out_scores->Extend(total_keep_count, 50);
+    out_boxes->Extend(total_keep_count, 50);
+    out_classes->Extend(total_keep_count, 50);
 
     int cur_out_idx = 0;
     for (int j = 1; j < num_classes; j++) {
@@ -202,7 +202,7 @@ bool BoxWithNMSLimitOp<CPUContext>::RunOnDevice() {
     }
 
     if (out_keeps) {
-      out_keeps->Extend(total_keep_count, 50, &context_);
+      out_keeps->Extend(total_keep_count, 50);
 
       Eigen::Map<EArrXi> out_keeps_arr(
           out_keeps->template mutable_data<int>() + cur_start_idx,

--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -776,7 +776,7 @@ class AppendOp final : public Operator<Context> {
       CAFFE_ENFORCE(a.sizes()[i] == b.sizes()[i]);
     }
     auto oldSize = c->numel();
-    c->Extend(b.sizes()[0], kDatasetGrowthPct, &context_);
+    c->Extend(b.sizes()[0], kDatasetGrowthPct);
     auto* dst = (char*)c->raw_mutable_data() + oldSize * b.dtype().itemsize();
     context_.CopyItemsSameDevice(b.dtype(), b.numel(), b.raw_data(), dst);
     return true;
@@ -826,7 +826,7 @@ class AtomicAppendOp final : public Operator<Context> {
         continue;
       }
       auto oldSize = c->numel();
-      c->Extend(b.sizes()[0], kDatasetGrowthPct, &context_);
+      c->Extend(b.sizes()[0], kDatasetGrowthPct);
       auto* dst = (char*)c->raw_mutable_data() + oldSize * b.dtype().itemsize();
       context_.CopyItemsSameDevice(b.dtype(), b.numel(), b.raw_data(), dst);
     }

--- a/caffe2/operators/expand_squeeze_dims_op.h
+++ b/caffe2/operators/expand_squeeze_dims_op.h
@@ -26,7 +26,7 @@ class ExpandDimsOp : public Operator<Context> {
   bool RunOnDevice() override {
     auto& input = Input(0);
     auto* output = Output(0);
-    output->CopyFrom(input, &context_);
+    output->CopyFrom(input, true /*async*/);
     if (dims_.empty()) {
       return true;
     }
@@ -70,7 +70,7 @@ class SqueezeOp : public Operator<Context> {
   bool RunOnDevice() override {
     auto& input = Input(0);
     auto* output = Output(0);
-    output->CopyFrom(input, &context_);
+    output->CopyFrom(input, true /*async*/);
 
     CAFFE_ENFORCE_GT(
         input.dim(),

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -284,8 +284,8 @@ bool GenerateProposalsOp<CPUContext>::RunOnDevice() {
   for (int i = 0; i < num_images; i++) {
     roi_counts += im_boxes[i].rows();
   }
-  out_rois->Extend(roi_counts, 50, &context_);
-  out_rois_probs->Extend(roi_counts, 50, &context_);
+  out_rois->Extend(roi_counts, 50);
+  out_rois_probs->Extend(roi_counts, 50);
   float* out_rois_ptr = out_rois->template mutable_data<float>();
   float* out_rois_probs_ptr = out_rois_probs->template mutable_data<float>();
   for (int i = 0; i < num_images; i++) {

--- a/caffe2/operators/last_n_window_collector.cc
+++ b/caffe2/operators/last_n_window_collector.cc
@@ -71,7 +71,7 @@ class LastNWindowCollectorOp : public Operator<Context> {
     if (num_entries == 0) {
       if (!output_initialized) {
         // Get both shape and meta
-        output->CopyFrom(input, &context_);
+        output->CopyFrom(input, true /*async*/);
       }
       return true;
     }
@@ -83,7 +83,7 @@ class LastNWindowCollectorOp : public Operator<Context> {
 
     // output_num is >= output_batch_size
     if (output_num > output_batch_size) {
-      output->ExtendTo(output_num, 50, &context_);
+      output->ExtendTo(output_num, 50);
     }
 
     auto* output_data =

--- a/caffe2/operators/mean_op.h
+++ b/caffe2/operators/mean_op.h
@@ -23,7 +23,7 @@ class MeanOp final : public Operator<Context> {
     auto* output = Output(0);
 
     output->ResizeLike(input0);
-    output->CopyFrom(input0, &context_);
+    output->CopyFrom(input0, true /*async*/);
 
     if (InputSize() == 1) {
       return true;
@@ -102,7 +102,7 @@ class MeanGradientOp : public Operator<Context> {
     for (int i = 1; i < num_inputs; i++) {
       auto* cur_dX = Output(i);
       cur_dX->ResizeLike(dY);
-      cur_dX->CopyFrom(*dX0, &context_);
+      cur_dX->CopyFrom(*dX0, true /*async*/);
     }
 
     return true;

--- a/caffe2/operators/onnx_while_op.h
+++ b/caffe2/operators/onnx_while_op.h
@@ -171,7 +171,7 @@ class ONNXWhileOp final : public Operator<Context> {
                 scan_outputs_sizes[i],
                 "Size of scan output changed across iterations");
             dims.insert(dims.begin(), itr);
-            scan_output_target->Extend(1, 100, &context_);
+            scan_output_target->Extend(1, 100);
 
             int64_t timestep_size = 1;
             for (const int64_t t : scan_outputs_sizes[i]) {

--- a/caffe2/operators/reservoir_sampling.cc
+++ b/caffe2/operators/reservoir_sampling.cc
@@ -103,9 +103,9 @@ class ReservoirSamplingOp final : public Operator<Context> {
     auto output_num =
         std::min<size_t>(numToCollect_, output_batch_size + num_to_copy);
     // output_num is >= output_batch_size
-    output->ExtendTo(output_num, 50, &context_);
+    output->ExtendTo(output_num, 50);
     if (pos_to_object) {
-      pos_to_object->ExtendTo(output_num, 50, &context_);
+      pos_to_object->ExtendTo(output_num, 50);
     }
 
     auto* output_data =

--- a/caffe2/operators/rmac_regions_op.cc
+++ b/caffe2/operators/rmac_regions_op.cc
@@ -58,7 +58,7 @@ bool RMACRegionsOp<CPUContext>::RunOnDevice() {
         (l + Hd - 1 > 0) ? ((H - region_size) / (1.0 * (l + Hd - 1))) : 0;
 
     int cur_rows = output->dim32(0);
-    output->Extend((l + Wd) * (l + Hd), 50, &context_);
+    output->Extend((l + Wd) * (l + Hd), 50);
     auto* outputData = output->template mutable_data<float>() + cur_rows * 5;
 
     for (int i = 0; i < l + Wd; ++i) {
@@ -87,7 +87,7 @@ bool RMACRegionsOp<CPUContext>::RunOnDevice() {
 
   // Replicate regions for all items in batch
   int num_rois = output->dim32(0);
-  output->Extend((batch_size - 1) * num_rois, 50, &context_);
+  output->Extend((batch_size - 1) * num_rois, 50);
   auto* outputData = output->template mutable_data<float>();
   for (int b = 1; b < batch_size; ++b) {
     // Copy all rois

--- a/caffe2/operators/sequence_ops.h
+++ b/caffe2/operators/sequence_ops.h
@@ -120,9 +120,9 @@ class RemovePaddingOp final : public Operator<Context> {
 
   bool RunOnDevice() override {
     if (startPaddingWidth_ == 0 && endPaddingWidth_ == 0) {
-      Output(0)->CopyFrom(Input(0), &context_);
+      Output(0)->CopyFrom(Input(0), true /*async*/);
       if (OutputSize() == 2) {
-        Output(1)->CopyFrom(Input(1), &context_);
+        Output(1)->CopyFrom(Input(1), true /*async*/);
       }
       return true;
     }
@@ -160,9 +160,9 @@ class AddPaddingOp final : public Operator<Context> {
 
   bool RunOnDevice() override {
     if (startPaddingWidth_ == 0 && endPaddingWidth_ == 0) {
-      Output(0)->CopyFrom(Input(0), &context_);
+      Output(0)->CopyFrom(Input(0), true /*async*/);
       if (OutputSize() == 2) {
-        Output(1)->CopyFrom(Input(1), &context_);
+        Output(1)->CopyFrom(Input(1), true /*async*/);
       }
       return true;
     }

--- a/caffe2/operators/slice_op.cu
+++ b/caffe2/operators/slice_op.cu
@@ -123,9 +123,9 @@ bool SliceImplGpu(
   }
   if (dim == -1) {
     if (!backward) {
-      output->CopyFrom(data, context);
+      output->CopyFrom(data, true /*async*/);
     } else {
-      gdata->CopyFrom(*go, context);
+      gdata->CopyFrom(*go, true /*async*/);
     }
     return true;
   }

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -85,9 +85,9 @@ bool SliceImpl(
   }
   if (dim == -1) {
     if (!backward) {
-      output->CopyFrom(data, context);
+      output->CopyFrom(data, true /*async*/);
     } else {
-      gdata->CopyFrom(*go, context);
+      gdata->CopyFrom(*go, true /*async*/);
     }
     return true;
   }

--- a/caffe2/operators/stop_gradient.h
+++ b/caffe2/operators/stop_gradient.h
@@ -14,7 +14,7 @@ class StopGradientOp : public Operator<Context> {
     const auto& in = Input(0);
     auto* out = Output(0);
     if (out != &in) {
-      out->CopyFrom(in, &context_);
+      out->CopyFrom(in, true /*async*/);
     }
     return true;
   }

--- a/caffe2/operators/utility_ops.cu
+++ b/caffe2/operators/utility_ops.cu
@@ -130,7 +130,7 @@ bool NanCheckOp<CUDAContext>::RunOnDevice() {
   // This op should act as an identity matrix if we don't find any NaNs/infs.
   // Copy over the data if we are not doing this in-place.
   if (&X != Y) {
-    Y->CopyFrom(X, &context_);
+    Y->CopyFrom(X, true /*async*/);
   }
   return true;
 }

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -196,7 +196,7 @@ class EnsureDenseOp final : public Operator<Context> {
     // allow the output to be copied from the input
     if (&input != output) {
       output->ResizeLike(input);
-      output->CopyFrom(input, &context_);
+      output->CopyFrom(input, true /*async*/);
     }
     return true;
   }
@@ -257,7 +257,7 @@ class SumOp : public Operator<Context> {
     auto& input0 = Input(0);
     auto* output = Output(0);
     if (InputSize() == 1) {
-      output->CopyFrom(input0, &context_);
+      output->CopyFrom(input0, true /*async*/);
       return true;
     }
     output->ResizeLike(input0);

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -162,6 +162,8 @@ class TensorFetcher : public BlobFetcherBase {
     }
 
     if (result.copied) {
+      // TODO: use DeviceGuard here instead of context and employ explicit sync
+      // copy
       auto context = CreateContext(tensor.GetDeviceType());
       context->CopyBytesToCPU(tensor.nbytes(), tensor.raw_data(), outPtr);
       context->FinishDeviceComputation();

--- a/caffe2/queue/queue_ops.h
+++ b/caffe2/queue/queue_ops.h
@@ -160,7 +160,7 @@ class SafeDequeueBlobsOp final : public Operator<Context> {
               size,
               " total columns");
 
-          out->Extend(in.sizes()[0], kTensorGrowthPct, &context_);
+          out->Extend(in.sizes()[0], kTensorGrowthPct);
           auto* dst =
               (char*)out->raw_mutable_data() + oldSize * in.dtype().itemsize();
           context_.template CopyItems<Context, Context>(

--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -808,14 +808,17 @@ bool VideoInputOp<Context>::Prefetch() {
   // prefetch function as well.
   if (!std::is_same<Context, CPUContext>::value) {
     if (get_rgb_) {
-      prefetched_clip_rgb_on_device_.CopyFrom(prefetched_clip_rgb_, &context_);
+      prefetched_clip_rgb_on_device_.CopyFrom(
+          prefetched_clip_rgb_, true /*async*/);
     }
     if (get_optical_flow_) {
-      prefetched_clip_of_on_device_.CopyFrom(prefetched_clip_of_, &context_);
+      prefetched_clip_of_on_device_.CopyFrom(
+          prefetched_clip_of_, true /*async*/);
     }
-    prefetched_label_on_device_.CopyFrom(prefetched_label_, &context_);
+    prefetched_label_on_device_.CopyFrom(prefetched_label_, true /*async*/);
     if (get_video_id_) {
-      prefetched_video_id_on_device_.CopyFrom(prefetched_video_id_, &context_);
+      prefetched_video_id_on_device_.CopyFrom(
+          prefetched_video_id_, true /*async*/);
     }
   }
   return true;
@@ -828,34 +831,34 @@ bool VideoInputOp<Context>::CopyPrefetched() {
     auto* clip_rgb_output =
         OperatorBase::Output<Tensor>(index++, Context::GetDeviceType());
     if (std::is_same<Context, CPUContext>::value) {
-      clip_rgb_output->CopyFrom(prefetched_clip_rgb_, &context_);
+      clip_rgb_output->CopyFrom(prefetched_clip_rgb_, true /*async*/);
     } else {
-      clip_rgb_output->CopyFrom(prefetched_clip_rgb_on_device_, &context_);
+      clip_rgb_output->CopyFrom(prefetched_clip_rgb_on_device_, true /*async*/);
     }
   }
   if (get_optical_flow_) {
     auto* clip_of_output =
         OperatorBase::Output<Tensor>(index++, Context::GetDeviceType());
     if (std::is_same<Context, CPUContext>::value) {
-      clip_of_output->CopyFrom(prefetched_clip_of_, &context_);
+      clip_of_output->CopyFrom(prefetched_clip_of_, true /*async*/);
     } else {
-      clip_of_output->CopyFrom(prefetched_clip_of_on_device_, &context_);
+      clip_of_output->CopyFrom(prefetched_clip_of_on_device_, true /*async*/);
     }
   }
   auto* label_output =
       OperatorBase::Output<Tensor>(index++, Context::GetDeviceType());
   if (std::is_same<Context, CPUContext>::value) {
-    label_output->CopyFrom(prefetched_label_, &context_);
+    label_output->CopyFrom(prefetched_label_, true /*async*/);
   } else {
-    label_output->CopyFrom(prefetched_label_on_device_, &context_);
+    label_output->CopyFrom(prefetched_label_on_device_, true /*async*/);
   }
   if (get_video_id_) {
     auto* video_id_output =
         OperatorBase::Output<Tensor>(index, Context::GetDeviceType());
     if (std::is_same<Context, CPUContext>::value) {
-      video_id_output->CopyFrom(prefetched_video_id_, &context_);
+      video_id_output->CopyFrom(prefetched_video_id_, true /*async*/);
     } else {
-      video_id_output->CopyFrom(prefetched_video_id_on_device_, &context_);
+      video_id_output->CopyFrom(prefetched_video_id_on_device_, true /*async*/);
     }
   }
   return true;


### PR DESCRIPTION
Summary:
Removes reference to Context proper and instead adds a bool argument for async copy (the same as `copy_`)

For CopyFrom - I haven't tweaked all callsites yet. Instead I rely on a terrible hack that pointer to context is implicitly converted to bool when passed, haha :) It's not a good code and I propose to fix it in a follow up diff (maybe using clangr tooling).

Differential Revision: D13117981
