### PR TITLE
[c10d] Robust NCCL barrier improvement to cover all devices combinations

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -126,7 +126,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronize() {
     // If we use the work to do barrier, we should block here
     if (!barrierTensors_.empty()) {
       at::cuda::CUDAGuard gpuGuard(devices_[i]);
-      AT_CUDA_CHECK(cudaStreamSynchronize(currentStream.stream()));
+      AT_CUDA_CHECK(cudaDeviceSynchronize());
     }
   }
 }

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -200,8 +200,8 @@ class ProcessGroupNCCL : public ProcessGroup {
   // ID of this process group
   std::string processGroupID_;
 
-  // Devices used from the last collective call
-  std::vector<at::Device> lastDevices_;
+  // Device Indexes used for all collectives in this group
+  std::set<int> usedDeviceIdxs_;
 
   // processGroupID tracking
   static std::mutex pgTrackingLock_;


### PR DESCRIPTION
This covers the very edgy case when we run the same NCCL process group with multiple GPU combinations instead of the last GPU combination. We always keep track of what GPUs have been used previously in the NCCL process group and barrier() itself will synchronize on each GPU's NCCL stream.

Test covered as well. Tested on 8-GPU machine

as part of improving: https://github.com/pytorch/pytorch/issues/13573