### PR TITLE
Add cost for non-linear ops

### DIFF
--- a/caffe2/observers/CMakeLists.txt
+++ b/caffe2/observers/CMakeLists.txt
@@ -8,8 +8,22 @@ if(USE_OBSERVERS)
   set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} ${Caffe2_CONTRIB_OBSERVERS_CPU_SRC})
   set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
 
+  # ---[ GPU test files
+  file(GLOB tmp *_gpu_test.cc)
+  set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS} ${tmp})
+
+  # ---[ HIP test files
+  file(GLOB tmp hip/*_test.cc)
+  set(Caffe2_HIP_TEST_SRCS ${Caffe2_HIP_TEST_SRCS} ${tmp})
+
   # ---[ CPU test files
   file(GLOB tmp *_test.cc)
   set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} ${tmp})
+  exclude(Caffe2_CPU_TEST_SRCS "${Caffe2_CPU_TEST_SRCS}" ${Caffe2_GPU_TEST_SRCS})
+  exclude(Caffe2_CPU_TEST_SRCS "${Caffe2_CPU_TEST_SRCS}" ${Caffe2_HIP_TEST_SRCS})
+
+  # ---[ Send the lists to the parent scope.
   set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} PARENT_SCOPE)
+  set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS} PARENT_SCOPE)
+  set(Caffe2_HIP_TEST_SRCS ${Caffe2_HIP_TEST_SRCS} PARENT_SCOPE)
 endif()

--- a/caffe2/observers/profile_observer_gpu.cc
+++ b/caffe2/observers/profile_observer_gpu.cc
@@ -58,7 +58,10 @@ void ProfileOperatorObserver::Dump() const {
       LOG(INFO) << "Output " << o << ": " << printer.MetaStr(*tensor);
     }
   }
-
+  LOG(INFO) << "Cost (flops, bytes_read, bytes_written, op_type):";
+  LOG(INFO) << std::setw(15) << std::setfill(' ') << cost_.flops << " "
+            << cost_.bytes_read << " " << cost_.bytes_written << " "
+            << subject_->debug_def().type();
   LOG(INFO) << "--------- Finished operator " << subject_->debug_def().type()
             << " in " << run_time_ << " ms ---------";
 }
@@ -82,6 +85,9 @@ void ProfileOperatorObserver::Start() {
     }
   } else {
     start_time_ = timer_.MilliSeconds();
+
+    cost_ = getOpCost();
+    updateDetailedStat(cost_);
   }
 }
 
@@ -118,6 +124,32 @@ std::unique_ptr<ObserverBase<OperatorBase>> ProfileOperatorObserver::rnnCopy(
     int rnn_order) const {
   return std::unique_ptr<ObserverBase<OperatorBase>>(
       new ProfileOperatorObserver(
-          subject, netObserver_, net_position_, rnn_order));
+          subject, stat_, netObserver_, net_position_, rnn_order));
 }
+
+ProfileObserver::~ProfileObserver() {
+  static std::mutex loggingMutex;
+  std::lock_guard<std::mutex> lock(loggingMutex);
+
+  CaffeMap<string, OpSchema::Cost> cost_per_op_type = getAggregatedOpTypeCost();
+  // sort by decreasing flops.
+  std::vector<std::pair<std::string, OpSchema::Cost>> cost_per_op_type_vec(
+      cost_per_op_type.begin(), cost_per_op_type.end());
+  std::sort(
+      cost_per_op_type_vec.begin(),
+      cost_per_op_type_vec.end(),
+      [](const std::pair<std::string, OpSchema::Cost>& left,
+         const std::pair<std::string, OpSchema::Cost>& right) {
+        return left.second.flops > right.second.flops;
+      });
+  LOG(INFO) << "================ Detailed stats for net " << net_name_
+            << " ================";
+  LOG(INFO) << "Aggregated Cost (flops, bytes_read, bytes_written, op_type):";
+  for (const auto& item : cost_per_op_type_vec) {
+    LOG(INFO) << std::setw(15) << std::setfill(' ') << item.second.flops << " "
+              << item.second.bytes_read << " " << item.second.bytes_written
+              << " " << item.first;
+  }
+}
+
 } // namespace caffe2

--- a/caffe2/observers/profile_observer_gpu_test.cc
+++ b/caffe2/observers/profile_observer_gpu_test.cc
@@ -1,0 +1,81 @@
+#include "caffe2/core/common.h"
+#include "caffe2/core/net.h"
+#include "caffe2/core/observer.h"
+#include "caffe2/core/operator.h"
+#include "profile_observer.h"
+
+#include <gtest/gtest.h>
+#include "caffe2/utils/proto_utils.h"
+
+namespace caffe2 {
+
+namespace {
+
+OperatorDef* add_op(
+    const vector<string>& input,
+    const vector<string>& output,
+    const string& type,
+    NetDef* net) {
+  CHECK(net);
+  auto& op = *net->add_op();
+  op.set_type(type);
+  for (const auto& in : input) {
+    op.add_input(in);
+  }
+  for (const auto& out : output) {
+    op.add_output(out);
+  }
+
+  return net->mutable_op(net->op_size() - 1);
+}
+
+void fill_tensor(
+    const vector<int64_t>& shape,
+    const vector<float>& data,
+    TensorCPU* tensor) {
+  tensor->Resize(shape);
+  CAFFE_ENFORCE_EQ(data.size(), tensor->size());
+  auto ptr = tensor->mutable_data<float>();
+  for (int i = 0; i < tensor->size(); ++i) {
+    ptr[i] = data[i];
+  }
+}
+
+void add_blob(
+    const string& name,
+    const vector<int64_t>& shape,
+    const vector<float>& data,
+    Workspace* ws) {
+  auto* blob = ws->CreateBlob(name);
+  fill_tensor(shape, data, BlobGetMutableTensor(blob, CPU));
+}
+
+} // namespace
+
+TEST(ProfileObserverTest, TestFC) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N, int K) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X", "W", "b"}, {"Y"}, "FC", net_def.get());
+    add_blob("W", {N, K}, vector<float>(N * K), &ws);
+    add_blob("b", {N}, vector<float>(N), &ws);
+    add_blob("X", {M, K}, vector<float>(M * K), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3, K = 4;
+  NetBase* net = ws.CreateNet(create_net_def(M, N, K), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  const auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["FC"].flops == M * N * (2 * K + 1));
+  CAFFE_ENFORCE(
+      cost_per_op_type["FC"].bytes_read == (K * (M + N) + N) * sizeof(float));
+  CAFFE_ENFORCE(cost_per_op_type["FC"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+} // namespace caffe2

--- a/caffe2/observers/profile_observer_gpu_test.cc
+++ b/caffe2/observers/profile_observer_gpu_test.cc
@@ -29,25 +29,27 @@ OperatorDef* add_op(
   return net->mutable_op(net->op_size() - 1);
 }
 
+template <typename T = float>
 void fill_tensor(
     const vector<int64_t>& shape,
-    const vector<float>& data,
+    const vector<T>& data,
     TensorCPU* tensor) {
   tensor->Resize(shape);
   CAFFE_ENFORCE_EQ(data.size(), tensor->size());
-  auto ptr = tensor->mutable_data<float>();
+  auto ptr = tensor->mutable_data<T>();
   for (int i = 0; i < tensor->size(); ++i) {
     ptr[i] = data[i];
   }
 }
 
+template <typename T = float>
 void add_blob(
     const string& name,
     const vector<int64_t>& shape,
-    const vector<float>& data,
+    const vector<T>& data,
     Workspace* ws) {
   auto* blob = ws->CreateBlob(name);
-  fill_tensor(shape, data, BlobGetMutableTensor(blob, CPU));
+  fill_tensor<T>(shape, data, BlobGetMutableTensor(blob, CPU));
 }
 
 } // namespace
@@ -76,6 +78,166 @@ TEST(ProfileObserverTest, TestFC) {
   CAFFE_ENFORCE(
       cost_per_op_type["FC"].bytes_read == (K * (M + N) + N) * sizeof(float));
   CAFFE_ENFORCE(cost_per_op_type["FC"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestLog) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X"}, {"Y"}, "Log", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["Log"].flops == M * N);
+  CAFFE_ENFORCE(cost_per_op_type["Log"].bytes_read == M * N * sizeof(float));
+  CAFFE_ENFORCE(cost_per_op_type["Log"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestLSTMUnit) {
+  Workspace ws;
+  auto create_net_def = [&ws](int N, int D) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op(
+        {"H_PREV", "C_PREV", "G", "SEQ_LEN", "TIMESTEP"},
+        {"H", "C"},
+        "LSTMUnit",
+        net_def.get());
+    add_blob("H_PREV", {1, N, D}, vector<float>(N * D), &ws);
+    add_blob("C_PREV", {1, N, D}, vector<float>(N * D), &ws);
+    add_blob("G", {1, N, 4 * D}, vector<float>(N * 4 * D), &ws);
+    add_blob<int>("SEQ_LEN", {N}, vector<int>(N, 2), &ws);
+    add_blob<int>("TIMESTEP", {1}, vector<int>(1, 1), &ws);
+    return net_def;
+  };
+
+  int N = 2, D = 3;
+  NetBase* net = ws.CreateNet(create_net_def(N, D), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["LSTMUnit"].flops == D * N);
+  CAFFE_ENFORCE(
+      cost_per_op_type["LSTMUnit"].bytes_read == D * N * sizeof(float));
+  CAFFE_ENFORCE(
+      cost_per_op_type["LSTMUnit"].bytes_written == D * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestSigmoid) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X"}, {"Y"}, "Sigmoid", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["Sigmoid"].flops == M * N);
+  CAFFE_ENFORCE(
+      cost_per_op_type["Sigmoid"].bytes_read == M * N * sizeof(float));
+  CAFFE_ENFORCE(
+      cost_per_op_type["Sigmoid"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestPow) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X", "E"}, {"Y"}, "Pow", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    add_blob("E", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["Pow"].flops == M * N);
+  CAFFE_ENFORCE(cost_per_op_type["Pow"].bytes_read == M * N * sizeof(float));
+  CAFFE_ENFORCE(cost_per_op_type["Pow"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestTanh) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X"}, {"Y"}, "Tanh", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["Tanh"].flops == M * N);
+  CAFFE_ENFORCE(cost_per_op_type["Tanh"].bytes_read == M * N * sizeof(float));
+  CAFFE_ENFORCE(
+      cost_per_op_type["Tanh"].bytes_written == M * N * sizeof(float));
+  net->DetachObserver(ref);
+}
+
+TEST(CostObserverTest, TestSoftmax) {
+  Workspace ws;
+  auto create_net_def = [&ws](int M, int N) {
+    auto net_def = std::make_shared<NetDef>();
+    net_def->set_name("test");
+    add_op({"X"}, {"Y"}, "Softmax", net_def.get());
+    add_blob("X", {M, N}, vector<float>(M * N), &ws);
+    return net_def;
+  };
+
+  int M = 2, N = 3;
+  NetBase* net = ws.CreateNet(create_net_def(M, N), true /*overwrite*/);
+  auto net_ob = caffe2::make_unique<ProfileObserver>(net);
+  auto* ob = net_ob.get();
+  auto* ref = net->AttachObserver(std::move(net_ob));
+  net->Run();
+  CAFFE_ENFORCE(ob);
+  auto cost_per_op_type = ob->getAggregatedOpTypeCost();
+  CAFFE_ENFORCE(cost_per_op_type["Softmax"].flops == M * N);
+  CAFFE_ENFORCE(
+      cost_per_op_type["Softmax"].bytes_read == M * N * sizeof(float));
+  CAFFE_ENFORCE(
+      cost_per_op_type["Softmax"].bytes_written == M * N * sizeof(float));
   net->DetachObserver(ref);
 }
 } // namespace caffe2

--- a/caffe2/operators/lstm_unit_op.cc
+++ b/caffe2/operators/lstm_unit_op.cc
@@ -2,9 +2,37 @@
 
 namespace caffe2 {
 REGISTER_CPU_OPERATOR(LSTMUnit, LSTMUnitOp<CPUContext>);
+
+namespace {
+
+// Since the actual flops of the non-linear operator depends on the
+// implementation, we use the number of non-linear operations as the proxy for
+// the analytical flops for non-linear operator
+OpSchema::Cost CostInferenceForLSTMUnit(
+    const OperatorDef& def,
+    const vector<TensorShape>& in) {
+  struct OpSchema::Cost c;
+  ArgumentHelper helper(def);
+
+  auto in1 = GetDimsVector(in[1]);
+  // Extract N
+  const auto N = in1[1];
+  const auto D = in1[2];
+
+  const auto& X = in[0];
+  c.flops = D * N;
+  c.bytes_read = D * N * sizeof(X.data_type());
+  c.bytes_written = D * N * sizeof(X.data_type());
+  c.params_bytes = 0;
+  return c;
+}
+} // namespace
+
+using namespace std::placeholders;
 OPERATOR_SCHEMA(LSTMUnit)
     .NumInputs(4, 5)
     .NumOutputs(2)
+    .CostInferenceFunction(std::bind(CostInferenceForLSTMUnit, _1, _2))
     .SetDoc(R"DOC(
 LSTMUnit computes the activations of a standard LSTM (without peephole
 connections), in a sequence-length aware fashion.

--- a/caffe2/operators/pow_op.cc
+++ b/caffe2/operators/pow_op.cc
@@ -80,11 +80,36 @@ REGISTER_CPU_OPERATOR(
         EigenPowFunctor,
         SameTypeAsInput>)
 
+namespace {
+// Since the actual flops of the non-linear operator depends on the
+// implementation, we use the number of non-linear operations as the proxy for
+// the analytical flops for non-linear operator
+OpSchema::Cost CostInferenceForPow(
+    const OperatorDef& def,
+    const vector<TensorShape>& in) {
+  CAFFE_ENFORCE_EQ(in.size(), 2, "Pow requires two input");
+  struct OpSchema::Cost c;
+  ArgumentHelper helper(def);
+
+  const uint64_t input_size =
+      size_to_dim_(in[0].dims().size(), GetDimsVector(in[0]));
+
+  const auto& X = in[0];
+  c.flops = input_size;
+  c.bytes_read = input_size * sizeof(X.data_type());
+  c.bytes_written = input_size * sizeof(X.data_type());
+  c.params_bytes = 0;
+  return c;
+}
+} // namespace
+
+using namespace std::placeholders;
 OPERATOR_SCHEMA(Pow)
     .NumInputs(1, 2)
     .NumOutputs(1)
     .AllowInplace({{0, 0}, {1, 0}})
     .IdenticalTypeAndShapeOfInput(0)
+    .CostInferenceFunction(std::bind(CostInferenceForPow, _1, _2))
     .SetDoc(R"DOC(
 The *Pow* op takes an input data tensor $X$ and an exponent parameter *exponent*, which can be a scalar or another tensor. As output, it produces a single output data tensor $Y$, where the function $f(x) = x^{exponent}$ has been applied to $X$ elementwise.
 
@@ -137,9 +162,14 @@ Y:  [ 1.  4.  9. 16. 25. 36.]
 
 )DOC")
     .Input(0, "X", "Input data blob to be operated on.")
-    .Input(1, "exponent", "Exponent blob containing the exponent(s) for calculation. Do not use if setting exponent via argument.")
+    .Input(
+        1,
+        "exponent",
+        "Exponent blob containing the exponent(s) for calculation. Do not use if setting exponent via argument.")
     .Output(0, "Y", "Output data blob with the same shape as the input.")
-    .Arg("exponent", "The exponent of the power function. Do not use if setting exponent via input.")
+    .Arg(
+        "exponent",
+        "The exponent of the power function. Do not use if setting exponent via input.")
     .Arg("axis", "*(type: int; default: -1)*")
     .Arg("broadcast", "*(type: bool; default: False)*");
 

--- a/caffe2/operators/sigmoid_op.cc
+++ b/caffe2/operators/sigmoid_op.cc
@@ -20,12 +20,37 @@ REGISTER_CPU_OPERATOR(
         CPUContext,
         SigmoidFunctor<CPUContext>>);
 
+namespace {
+// Since the actual flops of the non-linear operator depends on the
+// implementation, we use the number of non-linear operations as the proxy for
+// the analytical flops for non-linear operator
+OpSchema::Cost CostInferenceForSigmoid(
+    const OperatorDef& def,
+    const vector<TensorShape>& in) {
+  CAFFE_ENFORCE_EQ(in.size(), 1, "Sigmoid requires one input");
+  struct OpSchema::Cost c;
+  ArgumentHelper helper(def);
+
+  const uint64_t input_size =
+      size_to_dim_(in[0].dims().size(), GetDimsVector(in[0]));
+
+  const auto& X = in[0];
+  c.flops = input_size;
+  c.bytes_read = input_size * sizeof(X.data_type());
+  c.bytes_written = input_size * sizeof(X.data_type());
+  c.params_bytes = 0;
+  return c;
+}
+} // namespace
+
+using namespace std::placeholders;
 // Input: X, output: Y
 OPERATOR_SCHEMA(Sigmoid)
     .NumInputs(1)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
     .IdenticalTypeAndShape()
+    .CostInferenceFunction(std::bind(CostInferenceForSigmoid, _1, _2))
     .SetDoc(R"DOC(
 Apply the Sigmoid function element-wise to the input tensor. This is often used
 as a non-linear activation function in a neural network. The sigmoid function is

--- a/caffe2/operators/softmax_op.cc
+++ b/caffe2/operators/softmax_op.cc
@@ -82,10 +82,35 @@ REGISTER_CPU_GRADIENT_OPERATOR(
     SoftmaxGradient,
     SoftmaxGradientOp<float, CPUContext>);
 
+namespace {
+// Since the actual flops of the non-linear operator depends on the
+// implementation, we use the number of non-linear operations as the proxy for
+// the analytical flops for non-linear operator
+OpSchema::Cost CostInferenceForSoftmax(
+    const OperatorDef& def,
+    const vector<TensorShape>& in) {
+  CAFFE_ENFORCE_EQ(in.size(), 1, "Softmax requires one input");
+  struct OpSchema::Cost c;
+  ArgumentHelper helper(def);
+
+  const uint64_t input_size =
+      size_to_dim_(in[0].dims().size(), GetDimsVector(in[0]));
+
+  const auto& X = in[0];
+  c.flops = input_size;
+  c.bytes_read = input_size * sizeof(X.data_type());
+  c.bytes_written = input_size * sizeof(X.data_type());
+  c.params_bytes = 0;
+  return c;
+}
+} // namespace
+
+using namespace std::placeholders;
 OPERATOR_SCHEMA(Softmax)
     .NumInputs(1)
     .NumOutputs(1)
     .IdenticalTypeAndShape()
+    .CostInferenceFunction(std::bind(CostInferenceForSoftmax, _1, _2))
     .SetDoc(R"DOC(
 
 Applies the Softmax function to an n-dimensional input Tensor rescaling them so

--- a/caffe2/operators/tanh_op.cc
+++ b/caffe2/operators/tanh_op.cc
@@ -24,11 +24,36 @@ REGISTER_CPU_OPERATOR(
         CPUContext,
         TanhFunctor<CPUContext>>);
 
+namespace {
+// Since the actual flops of the non-linear operator depends on the
+// implementation, we use the number of non-linear operations as the proxy for
+// the analytical flops for non-linear operator
+OpSchema::Cost CostInferenceForTanh(
+    const OperatorDef& def,
+    const vector<TensorShape>& in) {
+  CAFFE_ENFORCE_EQ(in.size(), 1, "Tanh requires one input");
+  struct OpSchema::Cost c;
+  ArgumentHelper helper(def);
+
+  const uint64_t input_size =
+      size_to_dim_(in[0].dims().size(), GetDimsVector(in[0]));
+
+  const auto& X = in[0];
+  c.flops = input_size;
+  c.bytes_read = input_size * sizeof(X.data_type());
+  c.bytes_written = input_size * sizeof(X.data_type());
+  c.params_bytes = 0;
+  return c;
+}
+} // namespace
+
+using namespace std::placeholders;
 OPERATOR_SCHEMA(Tanh)
     .NumInputs(1)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
     .IdenticalTypeAndShape()
+    .CostInferenceFunction(std::bind(CostInferenceForTanh, _1, _2))
     .SetDoc(R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise. This
 operation can be done in an in-place fashion too, by providing the same input


### PR DESCRIPTION
Summary:
(This diff is the same as D10439558, which was reverted since it's stacked on the reverted diff D10428917. D10428917 was fixed in D13117066 so rebase this diff on it.)

Add cost inference function to non-linear ops. Since the actual flops of the non-linear operator depends on the implementation, we use the number of non-linear operations as the proxy for the analytical flops for non-linear operators.

Differential Revision: D13158381
