### PR TITLE
Remove default constructor lines that do nothing, and fix warnings with clang trunk

### DIFF
--- a/caffe2/distributed/store_handler.h
+++ b/caffe2/distributed/store_handler.h
@@ -59,7 +59,6 @@ class CAFFE2_API StoreHandler {
  */
 struct CAFFE2_API StoreHandlerNotAvailableException
     : public std::runtime_error {
-  StoreHandlerNotAvailableException() = default;
   explicit StoreHandlerNotAvailableException(const std::string& msg)
       : std::runtime_error(msg) {}
 };
@@ -72,7 +71,6 @@ struct CAFFE2_API StoreHandlerNotAvailableException
  * Timeout accessing the store.
  */
 struct CAFFE2_API StoreHandlerTimeoutException : public std::runtime_error {
-  StoreHandlerTimeoutException() = default;
   explicit StoreHandlerTimeoutException(const std::string& msg)
       : std::runtime_error(msg) {}
 };


### PR DESCRIPTION
The lines removed in this diff were no-op, but confusing: the default constructors in `store_handler.h` are implicitly deleted, since `std::runtime_error` has no default constructor.

Clang added a warning for this behavior [in September 2018](https://reviews.llvm.org/rL343285) (note that the warning is not just for cxx2a, despite the slightly confusing commit message), so building pytorch with a recent build of clang trunk causes spew of this warning, which is fixed by the present PR.