### PR TITLE
CAFFE2_INCLUDE_DIRS points to invalid path

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -138,4 +138,4 @@ get_filename_component(
 # Note: the current list dir is _INSTALL_PREFIX/share/cmake/Gloo.
 get_filename_component(
     _INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/lib/include")
+set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/include")


### PR DESCRIPTION
I know that including CAFFE2_INCLUDE_DIRS in include headers are not necessary for newer cmakes. But I had this in one of my old projects and **cmake gave me error that "/usr/lib/include" is invalid path**. 

It seems like "${_INSTALL_PREFIX}/lib/include" should be changed to "${_INSTALL_PREFIX}/include" as all caffe2 headers are in /include rather than /lib/include/

Please correct me if I am wrong?