### PR TITLE
Update cuda.get/set_rng_state doc

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -9,7 +9,9 @@ torch.cuda
 Random Number Generator
 -------------------------
 .. autofunction:: get_rng_state
+.. autofunction:: get_rng_state_all
 .. autofunction:: set_rng_state
+.. autofunction:: set_rng_state_all
 .. autofunction:: manual_seed
 .. autofunction:: manual_seed_all
 .. autofunction:: seed

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5514,7 +5514,7 @@ full_like(input, fill_value, out=None, dtype=None, layout=torch.strided, device=
 
 Returns a tensor with the same size as :attr:`input` filled with :attr:`fill_value`.
 ``torch.full_like(input, fill_value)`` is equivalent to
-``torch.full_like(input.size(), fill_value, dtype=input.dtype, layout=input.layout, device=input.device)``.
+``torch.full(input.size(), fill_value, dtype=input.dtype, layout=input.layout, device=input.device)``.
 
 Args:
     {input}

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -3,6 +3,7 @@ from . import _lazy_init, _lazy_call, device_count, device as device_ctx_manager
 
 __all__ = ['get_rng_state', 'get_rng_state_all',
            'set_rng_state', 'set_rng_state_all',
+           'manual_seed', 'manual_seed_all',
            'seed', 'seed_all', 'initial_seed']
 
 

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -1,8 +1,8 @@
-from torch import _C
+from torch import _C, device
 from . import _lazy_init, _lazy_call, device_count, device as device_ctx_manager
 
 
-def get_rng_state(device=torch.device('cuda')):
+def get_rng_state(device=device('cuda')):
     r"""Returns the random number generator state of the current
     GPU as a ByteTensor.
 
@@ -28,7 +28,7 @@ def get_rng_state_all():
     return results
 
 
-def set_rng_state(new_state, device=torch.device('cuda')):
+def set_rng_state(new_state, device=device('cuda')):
     r"""Sets the random number generator state of the current GPU.
 
     Args:

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -1,6 +1,10 @@
 from torch import _C, device
 from . import _lazy_init, _lazy_call, device_count, device as device_ctx_manager
 
+__all__ = ['get_rng_state', 'get_rng_state_all',
+           'set_rng_state', 'set_rng_state_all',
+           'seed', 'seed_all', 'initial_seed']
+
 
 def get_rng_state(device=device('cuda')):
     r"""Returns the random number generator state of the current

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -2,13 +2,13 @@ from torch import _C
 from . import _lazy_init, _lazy_call, device_count, device as device_ctx_manager
 
 
-def get_rng_state(device=-1):
+def get_rng_state(device=torch.device('cuda')):
     r"""Returns the random number generator state of the current
     GPU as a ByteTensor.
 
     Args:
-        device (int, optional): The device to return the RNG state of.
-            Default: -1 (i.e., use the current device).
+        device (torch.device or int, optional): The device to return the RNG state of.
+            Default: ``torch.device('cuda')`` (i.e., the current CUDA device).
 
     .. warning::
         This function eagerly initializes CUDA.
@@ -28,11 +28,13 @@ def get_rng_state_all():
     return results
 
 
-def set_rng_state(new_state, device=-1):
+def set_rng_state(new_state, device=torch.device('cuda')):
     r"""Sets the random number generator state of the current GPU.
 
     Args:
         new_state (torch.ByteTensor): The desired state
+        device (torch.device or int, optional): The device to set the RNG state.
+            Default: ``torch.device('cuda')`` (i.e., the current CUDA device).
     """
     new_state_copy = new_state.clone()
 


### PR DESCRIPTION
Now that `cuda.get/set_rng_state` accept `device` objects, the default value should be an device object, and doc should mention so.