### PR TITLE
Allowing TaskGroups to carry remote nets

### DIFF
--- a/caffe2/python/task.py
+++ b/caffe2/python/task.py
@@ -198,6 +198,13 @@ class TaskGroup(object):
         self._report_steps = []
         self._workspace_type = workspace_type
         self._tasks_by_node = None
+        self._remote_nets = []
+
+    def add_remote_net(self, net):
+        self._remote_nets.append(net)
+
+    def remote_nets(self):
+        return self._remote_nets
 
     def add(self, task):
         assert not self._already_used, (


### PR DESCRIPTION
Summary:
Sometimes, when we are creating a TaskGroup, we are in fact creating a TaskGroup for a distributed job. In some cases, we may want to register a few nets as "remote" to a TaskGroup. The remote net should have sufficient attributes on where they should be executed later on.

This diff adds the remote net attribute to the TaskGroup class. It exposes two minimal functionalities: adding a remote net, and getting all remote nets added to a TaskGroup.

Differential Revision: D13188320
