### PR TITLE
[jit] Fix ScriptModule/WeakScriptModuleProxy to accept None as Module param

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9820,7 +9820,7 @@ S = 5
 # )
 nn_module_tests = [
     ('AlphaDropout', (), ((S,),)),
-    ('BatchNorm1d', (10,), ((S, 10),)),
+    ('BatchNorm1d', (10, 1e-5, 0.1, False), ((S, 10),)),
     ('BatchNorm2d', (10,), ((S, 10, S, S),)),
     ('BatchNorm3d', (10,), ((S, 10, S, S, S),)),
     ('Dropout', (), ((S,),)),

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -420,6 +420,10 @@ at::Tensor ScriptModuleDeserializer::loadTensor(uint64_t tensor_id) {
   auto it = metaMap_.find(tensor_id);
   AT_ASSERT(it != metaMap_.end());
   const caffe2::TensorProto& tensor_proto = *it->second;
+  if (!tensor_proto.has_storage_type()) {
+    return at::Tensor();
+  }
+
   std::vector<int64_t> dims;
   for (int i = 0; i < tensor_proto.dims_size(); ++i) {
     dims.push_back(tensor_proto.dims(i));

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -324,13 +324,15 @@ struct Module {
     return get_method("forward")(inputs);
   }
 
-  void register_parameter(const std::string & name, autograd::Variable v, bool is_buffer) {
+  void register_parameter(const std::string & name, c10::optional<autograd::Variable> v, bool is_buffer) {
+    // If Module parameter is None from Python, turn it into undefined tensor
+    auto v_val = v.value_or(at::Tensor());
     if(auto p = parameters.find(name)){
-      *p->slot() = v;
+      *p->slot() = v_val;
       p->is_buffer = is_buffer;
       return;
     }
-    parameters.insert(name, NamedParameter(name, std::move(v), is_buffer));
+    parameters.insert(name, NamedParameter(name, std::move(v_val), is_buffer));
   }
   void register_module(const std::string& name, std::shared_ptr<Module> module) {
     modules.insert(name, {name, std::move(module)});

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1104,8 +1104,11 @@ if _enabled:
             # Copy Parameters / Modules / Buffers
             for name in dir(original):
                 item = getattr(original, name)
-                if isinstance(item, Parameter) or (isinstance(item, Module) and item is not self):
+                if isinstance(item, Module) and item is not self:
                     ScriptModule.__setattr__(self, name, item)
+
+            for name in original._parameters:
+                self.register_parameter(name, original._parameters[name])
             for name in original._buffers:
                 self.register_buffer(name, original._buffers[name])
 


### PR DESCRIPTION
This PR is a part of task to unblock standard library

1. it makes ScriptModule and WeakScriptModuleProxy to accept NoneType as a module parameter, and interpreted as an undefined tensor. 
2. It also changes the export/import to accept undefined tensor in module parameters