### PR TITLE
[c10d] Barrier synchronizes with prior work before completing

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -973,7 +973,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         with self.assertRaisesRegex(RuntimeError, " (Timed out|closed) "):
             pg.barrier().wait()
 
-    @unittest.skip("Implementation of this functionality pending; see #14373")
     def test_barrier_implies_wait(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
@@ -987,10 +986,10 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.allreduce(tensor)
 
         # Barrier should ensure all previous work has completed
-        pg.barrier()
+        pg.barrier().wait()
 
         for i, tensor in enumerate(tensors):
-            self.assertEqual(torch.full(size, float(i * (i + 1) / 2)), tensor)
+            self.assertEqual(torch.full(size, float(i * self.world_size)), tensor)
 
 
 class ProcessGroupNCCLTest(TestCase):

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -204,7 +204,7 @@ class ProcessGroupGloo : public ProcessGroup {
   uint32_t nextTag();
 
   // Entrypoint for worker threads.
-  void runLoop(int threadIndex);
+  void runLoop(int workerIndex);
 
   // Queue work to run on worker thread.
   void enqueue(std::shared_ptr<AsyncWork> work);

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -204,15 +204,22 @@ class ProcessGroupGloo : public ProcessGroup {
   uint32_t nextTag();
 
   // Entrypoint for worker threads.
-  void runLoop(void);
+  void runLoop(int threadIndex);
 
-  // Queue std::function to run on worker thread.
-  void enqueue(std::function<void()> fn);
+  // Queue work to run on worker thread.
+  void enqueue(std::shared_ptr<AsyncWork> work);
 
-  std::deque<std::function<void()>> queue_;
-  std::mutex queueMutex_;
-  std::condition_variable queueProduceCV_;
-  std::condition_variable queueConsumeCV_;
+  // Keep both a queue of pending work, and a vector with in progress work.
+  // Both of these can only be mutated when holding the queue lock.
+  // We keep both around instead of just the queue, so we can grab a weak_ptr
+  // to all in progress and pending work when executing a barrier.
+  // When executing a barrier, we need to ensure that all prior work
+  // has completed before completing itself.
+  std::deque<std::shared_ptr<AsyncWork>> workQueue_;
+  std::vector<std::shared_ptr<AsyncWork>> workInProgress_;
+  std::mutex workMutex_;
+  std::condition_variable workProduceCV_;
+  std::condition_variable workConsumeCV_;
 };
 
 } // namespace c10d


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14294 [c10d] Use new style barrier support in c10d/gloo&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13111509/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14295 [c10d] Remove algorithm caching in ProcessGroupGloo&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13111781/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14296 [c10d][easy] Refer to all work with ProcessGroup prefix&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13128977/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14297 [c10d] Add option structs and timeout field&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13158474/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14298 [c10d] Make ProcessGroup::Work::wait() throw&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13158475/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14386 [c10d] Barrier synchronizes with prior work before completing**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13205022/)

See #13573, #14142, and #14271 for discussion.

This change updates ProcessGroupGloo to ensure that all prior
operations have completed before executing the barrier.

Differential Revision: [D13205022](https://our.internmc.facebook.com/intern/diff/D13205022/)