### PR TITLE
[c10d] Fixed file init_method write/read race

### DIFF
--- a/torch/lib/c10d/FileStore.cpp
+++ b/torch/lib/c10d/FileStore.cpp
@@ -87,7 +87,8 @@ class File {
     while (true) {
       fd_ = syscall(std::bind(::open, path.c_str(), flags, 0644));
       // Only retry when the file doesn't exist, since we are waiting for the
-      // file to be created in this case
+      // file to be created in this case to address the following issue:
+      // https://github.com/pytorch/pytorch/issues/13750
       if (fd_ >= 0 || (fd_ < 0 && errno != ENOENT)) {
         break;
       }

--- a/torch/lib/c10d/FileStore.cpp
+++ b/torch/lib/c10d/FileStore.cpp
@@ -86,7 +86,9 @@ class File {
     const auto start = std::chrono::steady_clock::now();
     while (true) {
       fd_ = syscall(std::bind(::open, path.c_str(), flags, 0644));
-      if (fd_ >= 0) {
+      // Only retry when the file doesn't exist, since we are waiting for the
+      // file to be created in this case
+      if (fd_ >= 0 || (fd_ < 0 && errno != ENOENT)) {
         break;
       }
       const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(


### PR DESCRIPTION
This should fix the race among multiple processes: https://github.com/pytorch/pytorch/issues/13750

Essentially, the reader is trying to open the file, and will error out if it doesn't exist, we here factor in the timeout option of FileStore to apply a timeout for creating a file (should always be created anyway unless something is wrong), and more importantly, waiting for the file to be created.

Tested on both NFS and local drive, the race disappears when 8 concurrent processes do distributed training.