### PR TITLE
Fixed c10d test

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1135,7 +1135,7 @@ class ProcessGroupNCCLTest(TestCase):
             works.append(work)
 
         # Barrier will ensure that all previous work is completed
-        pg.barrier()
+        pg.barrier().wait()
 
         for i in range(2, self.num_gpus + 1):
             for j in range(i):


### PR DESCRIPTION
Most likely a typo.

Tested on 8-GPU machine

```
tengli@learnfair062:~/pytorch/test$ python test_c10d.py ProcessGroupNCCLTest.test_barrier
.
----------------------------------------------------------------------
Ran 1 test in 29.341s

OK
```