### PR TITLE
Use integer math to compute output size of pooling operations

### DIFF
--- a/aten/src/THCUNN/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/VolumetricDilatedMaxPooling.cu
@@ -8,8 +8,6 @@
 #include "THCHalfAutoNumerics.cuh"
 #include "THCAtomics.cuh"
 
-#include <cfloat>
-
 template <typename Dtype>
 __global__ void cuda_VolumetricDilatedMaxPooling_updateOutput(
   Dtype* inputData, int inputT, int inputH, int inputW,
@@ -31,9 +29,9 @@ __global__ void cuda_VolumetricDilatedMaxPooling_updateOutput(
     int tStart = oFrame  * dT - padT;
     int hStart = oRow    * dH - padH;
     int wStart = oColumn * dW - padW;
-    int tEnd = fminf(tStart + (kT - 1) * dilationT + 1, inputT);
-    int hEnd = fminf(hStart + (kH - 1) * dilationH + 1, inputH);
-    int wEnd = fminf(wStart + (kW - 1) * dilationW + 1, inputW);
+    int tEnd = min(tStart + (kT - 1) * dilationT + 1, inputT);
+    int hEnd = min(hStart + (kH - 1) * dilationH + 1, inputH);
+    int wEnd = min(wStart + (kW - 1) * dilationW + 1, inputW);
 
     while(tStart < 0)
       tStart += dilationT;
@@ -92,9 +90,9 @@ __global__ void cuda_VolumetricDilatedMaxPooling_updateOutput(
     int tStart = oFrame  * dT - padT;
     int hStart = oRow    * dH - padH;
     int wStart = oColumn * dW - padW;
-    int tEnd = fminf(tStart + (kT - 1) * dilationT + 1, inputT);
-    int hEnd = fminf(hStart + (kH - 1) * dilationH + 1, inputH);
-    int wEnd = fminf(wStart + (KERNEL_WIDTH - 1) * dilationW + 1, inputW);
+    int tEnd = min(tStart + (kT - 1) * dilationT + 1, inputT);
+    int hEnd = min(hStart + (kH - 1) * dilationH + 1, inputH);
+    int wEnd = min(wStart + (KERNEL_WIDTH - 1) * dilationW + 1, inputW);
 
     while(tStart < 0)
       tStart += dilationT;

--- a/aten/src/THCUNN/generic/SpatialAveragePooling.cu
+++ b/aten/src/THCUNN/generic/SpatialAveragePooling.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/common.h>
+#include "pooling_shape.h"
 
 static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   THCState *state,
@@ -35,27 +36,10 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   int64_t nInputPlane = input->size(dimh-1);
   int64_t nInputRows = input->size(dimh);
   int64_t nInputCols = input->size(dimw);
-  int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
-  if(ceil_mode) {
-    nOutputCols = ceil(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = ceil(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  int64_t nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, 1, ceil_mode);
+  int64_t nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, 1, ceil_mode);
 
   if (nOutputCols < 1 || nOutputRows < 1)
     THError("Given input size: (%dx%dx%d). "
@@ -101,23 +85,8 @@ void THNN_(SpatialAveragePooling_updateOutput)(
     batchSize = input->size(0);
   }
 
-  if(ceil_mode) {
-    nOutputCols = ceil(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = ceil(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, 1, ceil_mode);
+  nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, 1, ceil_mode);
 
   input = THCTensor_(newContiguous)(state, input);
   scalar_t* input_data = THCTensor_(data)(state, input);
@@ -187,23 +156,8 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
   nInputCols = input->size(dimCol);
   nInputRows = input->size(dimRow);
 
-  if(ceil_mode) {
-    nOutputCols = ceil(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = ceil(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - kW + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - kH + 2*padH) / float(dH)) + 1;
-  }
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, 1, ceil_mode);
+  nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, 1, ceil_mode);
 
   THCUNN_check_dim_size(state, gradOutput, input->dim(), dimRow, nOutputRows);
   THCUNN_check_dim_size(state, gradOutput, input->dim(), dimCol, nOutputCols);

--- a/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/common.h>
+#include "pooling_shape.h"
 
 static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
                          THCState *state,
@@ -41,27 +42,10 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
   int64_t nInputPlane = input->size(dimh-1);
   int64_t nInputRows = input->size(dimh);
   int64_t nInputCols = input->size(dimw);
-  int64_t nOutputRows, nOutputCols;
   int64_t nOutputPlane = nInputPlane;
 
-  if(ceil_mode) {
-    nOutputCols = ceil(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-    nOutputRows = ceil(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  int64_t nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, dilationH, ceil_mode);
+  int64_t nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, dilationW, ceil_mode);
 
   if (nOutputCols < 1 || nOutputRows < 1)
     THError("Given input size: (%dx%dx%d). "
@@ -115,24 +99,8 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
     batchSize = input->size(0);
   }
 
-  if(ceil_mode) {
-    nOutputCols = ceil(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-    nOutputRows = ceil(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, dilationW, ceil_mode);
+  nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, dilationH, ceil_mode);
 
   input = THCTensor_(newContiguous)(state, input);
   scalar_t* input_data = THCTensor_(data)(state, input);
@@ -194,24 +162,8 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
     batchSize = input->size(0);
   }
 
-  if(ceil_mode) {
-     nOutputCols = ceil(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-     nOutputRows = ceil(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-  else {
-    nOutputCols = floor(float(nInputCols - (dilationW * (kW - 1) + 1) + 2*padW) / float(dW)) + 1;
-    nOutputRows = floor(float(nInputRows - (dilationH * (kH - 1) + 1) + 2*padH) / float(dH)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((nOutputRows - 1)*dH >= nInputRows + padH)
-      --nOutputRows;
-    if ((nOutputCols  - 1)*dW >= nInputCols  + padW)
-      --nOutputCols;
-  }
+  nOutputCols = pooling_output_shape<int64_t>(nInputCols, kW, padW, dW, dilationW, ceil_mode);
+  nOutputRows = pooling_output_shape<int64_t>(nInputRows, kH, padH, dH, dilationH, ceil_mode);
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   THCTensor_(resizeAs)(state, gradInput, input);

--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/VolumetricAveragePooling.cu"
 #else
 
+#include "pooling_shape.h"
+
 static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
                          THCState *state,
                          THCTensor *input,
@@ -71,33 +73,9 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
              "padT = %d, padW = %d, padH = %d, kT = %d, kW = %d, kH = %d",
              padT, padW, padH, kT, kW, kH);
 
-  int outputTime;
-  int outputHeight;
-  int outputWidth;
-
-  if (ceil_mode)
-  {
-    outputTime   = ceil(float(inputTime   - kT + 2*padT) / float(dT)) + 1;
-    outputHeight = ceil(float(inputHeight - kH + 2*padH) / float(dH)) + 1;
-    outputWidth  = ceil(float(inputWidth  - kW + 2*padW) / float(dW)) + 1;
-  }
-  else
-  {
-    outputTime   = floor(float(inputTime   - kT + 2*padT) / float(dT)) + 1;
-    outputHeight = floor(float(inputHeight - kH + 2*padH) / float(dH)) + 1;
-    outputWidth  = floor(float(inputWidth  - kW + 2*padW) / float(dW)) + 1;
-  }
-  if (padT || padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((outputTime   - 1)*dT >= inputTime   + padT)
-      --outputTime;
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  int outputTime = pooling_output_shape<int>(inputTime, kT, padT, dT, 1, ceil_mode);
+  int outputHeight = pooling_output_shape<int>(inputHeight, kH, padH, dH, 1, ceil_mode);
+  int outputWidth = pooling_output_shape<int>(inputWidth, kW, padW, dW, 1, ceil_mode);
 
   if (gradOutput != NULL)
   {
@@ -159,33 +137,9 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
     inputWidth  = THCTensor_(size)(state, input, 4);
   }
 
-  int outputTime;
-  int outputHeight;
-  int outputWidth;
-
-  if (ceil_mode)
-  {
-    outputTime   = ceil(float(inputTime   - kT + 2*padT) / float(dT)) + 1;
-    outputHeight = ceil(float(inputHeight - kH + 2*padH) / float(dH)) + 1;
-    outputWidth  = ceil(float(inputWidth  - kW + 2*padW) / float(dW)) + 1;
-  }
-  else
-  {
-    outputTime   = floor(float(inputTime   - kT + 2*padT) / float(dT)) + 1;
-    outputHeight = floor(float(inputHeight - kH + 2*padH) / float(dH)) + 1;
-    outputWidth  = floor(float(inputWidth  - kW + 2*padW) / float(dW)) + 1;
-  }
-  if (padT || padH || padW)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((outputTime   - 1)*dT >= inputTime   + padT)
-      --outputTime;
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  int outputTime = pooling_output_shape<int>(inputTime, kT, padT, dT, 1, ceil_mode);
+  int outputHeight = pooling_output_shape<int>(inputHeight, kH, padH, dH, 1, ceil_mode);
+  int outputWidth = pooling_output_shape<int>(inputWidth, kW, padW, dW, 1, ceil_mode);
 
   if (!fiveDimensionalInput) /* 4D */
   {

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/VolumetricDilatedMaxPooling.cu"
 #else
 
+#include "pooling_shape.h"
+
 #define UPDATE_OUTPUT_KERNEL_WIDTH(KW) case KW:                         \
   cuda_VolumetricDilatedMaxPooling_updateOutput<KW>                     \
   <<<grid, block, 0, THCState_getCurrentStream(state)>>>(               \
@@ -77,28 +79,9 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
              "kT: %d kW: %d, kH: %d, padT: %d, padW: %d, padH: %d",
              kT, kW, kH, padT, padW, padH);
 
-  if (ceilMode)
-  {
-    outputTime   = (int)(ceil((float)(inputTime - (dilationT * (kT - 1) + 1) + 2*padT) / dT)) + 1;
-    outputHeight = (int)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int)(ceil((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    outputTime   = (int)(floor((float)(inputTime - (dilationT * (kT - 1) + 1) + 2*padT) / dT)) + 1;
-    outputHeight = (int)(floor((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int)(floor((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-
-  if (padT || padW || padH)
-  {
-    if ((outputTime - 1)*dT >= inputTime + padT)
-      --outputTime;
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  outputTime = pooling_output_shape<int>(inputTime, kT, padT, dT, dilationT, ceilMode);
+  outputHeight = pooling_output_shape<int>(inputHeight, kH, padH, dH, dilationH, ceilMode);
+  outputWidth = pooling_output_shape<int>(inputWidth, kW, padW, dW, dilationW, ceilMode);
 
   if (outputTime < 1 || outputHeight < 1 || outputWidth < 1)
     THError("Given input size: (%dx%dx%dx%d). Calculated output size: (%dx%dx%dx%d). Output size is too small",
@@ -180,28 +163,9 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
     AT_ERROR("non-empty 4D or 5D tensor expected, got size: ", input->sizes());
   }
 
-  if (ceilMode)
-  {
-    outputTime   = (int)(ceil((float)(inputTime - (dilationT * (kT - 1) + 1) + 2*padT) / dT)) + 1;
-    outputHeight = (int)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int)(ceil((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    outputTime   = (int)(floor((float)(inputTime - (dilationT * (kT - 1) + 1) + 2*padT) / dT)) + 1;
-    outputHeight = (int)(floor((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int)(floor((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-
-  if (padT || padW || padH)
-  {
-    if ((outputTime - 1)*dT >= inputTime + padT)
-      --outputTime;
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  outputTime = pooling_output_shape<int>(inputTime, kT, padT, dT, dilationT, ceilMode);
+  outputHeight = pooling_output_shape<int>(inputHeight, kH, padH, dH, dilationH, ceilMode);
+  outputWidth = pooling_output_shape<int>(inputWidth, kW, padW, dW, dilationW, ceilMode);
 
   if (!fiveDimensionalInput) /* 4D */
   {

--- a/aten/src/THCUNN/generic/pooling_shape.h
+++ b/aten/src/THCUNN/generic/pooling_shape.h
@@ -1,0 +1,18 @@
+#ifndef THCUNN_POOLING_SHAPE_H
+#define THCUNN_POOLING_SHAPE_H
+
+template<typename T>
+__host__ __forceinline__
+static T pooling_output_shape(
+        T inputSize, T kernelSize, T pad, T stride, T dilation, bool ceil_mode) {
+    T outputSize = ((inputSize + 2 * pad - dilation * (kernelSize - 1) - 1 + (ceil_mode ? stride - 1 : 0)) / stride + 1);
+    if (pad) {
+        // ensure that the last pooling starts inside the image
+        // needed to avoid problems in ceil mode
+        if ((outputSize - 1) * stride >= inputSize + pad)
+          --outputSize;
+    }
+    return outputSize;
+}
+
+#endif

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -3,6 +3,7 @@
 #else
 
 #include "pooling_shape.h"
+#include <algorithm>
 
 static inline void THNN_(SpatialAveragePooling_shapeCheck)(
 	THTensor *input, THTensor *gradOutput,
@@ -130,13 +131,13 @@ void THNN_(SpatialAveragePooling_updateOutput)(
           /* Compute the mean of the input image... */
           int64_t hstart = yy * dH - padH;
           int64_t wstart = xx * dW - padW;
-          int64_t hend = fminf(hstart + kH, inputHeight + padH);
-          int64_t wend = fminf(wstart + kW, inputWidth + padW);
+          int64_t hend = std::min(hstart + kH, inputHeight + padH);
+          int64_t wend = std::min(wstart + kW, inputWidth + padW);
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = fmaxf(hstart, 0);
-          wstart = fmaxf(wstart, 0);
-          hend = fminf(hend, inputHeight);
-          wend = fminf(wend, inputWidth);
+          hstart = std::max(hstart, (int64_t) 0);
+          wstart = std::max(wstart, (int64_t) 0);
+          hend = std::min(hend, inputHeight);
+          wend = std::min(wend, inputWidth);
 
           scalar_t sum = 0;
 
@@ -245,13 +246,13 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
         {
           int64_t hstart = yy * dH - padH;
           int64_t wstart = xx * dW - padW;
-          int64_t hend = fminf(hstart + kH, inputHeight + padH);
-          int64_t wend = fminf(wstart + kW, inputWidth + padW);
+          int64_t hend = std::min(hstart + kH, inputHeight + padH);
+          int64_t wend = std::min(wstart + kW, inputWidth + padW);
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = fmaxf(hstart, 0);
-          wstart = fmaxf(wstart, 0);
-          hend = fminf(hend, inputHeight);
-          wend = fminf(wend, inputWidth);
+          hstart = std::max(hstart, (int64_t) 0);
+          wstart = std::max(wstart, (int64_t) 0);
+          hend = std::min(hend, inputHeight);
+          wend = std::min(wend, inputWidth);
 
           scalar_t z = *ptr_gradOutput++;
 

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -3,6 +3,7 @@
 #else
 
 #include "pooling_shape.h"
+#include <algorithm>
 
 static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
 	THTensor *input, THTensor *gradOutput, THIndexTensor *indices,
@@ -93,8 +94,8 @@ static void THNN_(SpatialDilatedMaxPooling_updateOutput_frame)(
       {
         int64_t hstart = i * dH - padH;
         int64_t wstart = j * dW - padW;
-        int64_t hend = fminf(hstart + (kH - 1) * dilationH + 1, iheight);
-        int64_t wend = fminf(wstart + (kW - 1) * dilationW + 1, iwidth);
+        int64_t hend = std::min(hstart + (kH - 1) * dilationH + 1, iheight);
+        int64_t wend = std::min(wstart + (kW - 1) * dilationW + 1, iwidth);
         while(hstart < 0)
           hstart += dilationH;
         while(wstart < 0)

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -2,6 +2,8 @@
 #define TH_GENERIC_FILE "generic/SpatialDilatedMaxPooling.c"
 #else
 
+#include "pooling_shape.h"
+
 static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
 	THTensor *input, THTensor *gradOutput, THIndexTensor *indices,
 	int kH, int kW, int dH, int dW, int padH, int padW,
@@ -37,29 +39,10 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
   int64_t nInputPlane = input->size(dimh-1);
   int64_t inputHeight = input->size(dimh);
   int64_t inputWidth = input->size(dimw);
-  int64_t outputHeight, outputWidth;
   int64_t nOutputPlane = nInputPlane;
 
-  if (ceil_mode)
-  {
-    outputHeight = (int64_t)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int64_t)(ceil((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    outputHeight = (int64_t)(floor((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int64_t)(floor((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  int64_t outputHeight = pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, dilationH, ceil_mode);
+  int64_t outputWidth = pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, dilationW, ceil_mode);
 
   if (outputWidth < 1 || outputHeight < 1)
     THError("Given input size: (%dx%dx%d). "
@@ -193,26 +176,8 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   nInputPlane = input->size(dimh-1);
   inputHeight = input->size(dimh);
   inputWidth = input->size(dimw);
-  if (ceil_mode)
-  {
-    outputHeight = (int64_t)(ceil((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int64_t)(ceil((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    outputHeight = (int64_t)(floor((float)(inputHeight - (dilationH * (kH - 1) + 1) + 2*padH) / dH)) + 1;
-    outputWidth  = (int64_t)(floor((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
-  }
-
-  if (padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((outputHeight - 1)*dH >= inputHeight + padH)
-      --outputHeight;
-    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
-      --outputWidth;
-  }
+  outputHeight = pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, dilationH, ceil_mode);
+  outputWidth = pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, dilationW, ceil_mode);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -3,6 +3,7 @@
 #else
 
 #include "pooling_shape.h"
+#include <algorithm>
 
 static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
                          THNNState *state,
@@ -129,16 +130,16 @@ static void THNN_(VolumetricAveragePooling_updateOutput_frame)(
           int64_t tstart = ti * dT - padT;
           int64_t hstart = i  * dH - padH;
           int64_t wstart = j  * dW - padW;
-          int64_t tend = fminf(tstart + kT, itime + padT);
-          int64_t hend = fminf(hstart + kH, iheight + padH);
-          int64_t wend = fminf(wstart + kW, iwidth + padW);
+          int64_t tend = std::min(tstart + kT, itime + padT);
+          int64_t hend = std::min(hstart + kH, iheight + padH);
+          int64_t wend = std::min(wstart + kW, iwidth + padW);
           int64_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
-          tstart = fmaxf(tstart, 0);
-          hstart = fmaxf(hstart, 0);
-          wstart = fmaxf(wstart, 0);
-          tend = fmin(tend, itime);
-          hend = fmin(hend, iheight);
-          wend = fmin(wend, iwidth);
+          tstart = std::max(tstart, (int64_t) 0);
+          hstart = std::max(hstart, (int64_t) 0);
+          wstart = std::max(wstart, (int64_t) 0);
+          tend = std::min(tend, itime);
+          hend = std::min(hend, iheight);
+          wend = std::min(wend, iwidth);
 
           int divide_factor;
           if (count_include_pad)
@@ -318,16 +319,16 @@ static void THNN_(VolumetricAveragePooling_updateGradInput_frame)(
           int64_t tstart = ti * dT - padT;
           int64_t hstart = i  * dH - padH;
           int64_t wstart = j  * dW - padW;
-          int64_t tend = fminf(tstart + kT, itime + padT);
-          int64_t hend = fminf(hstart + kH, iheight + padH);
-          int64_t wend = fminf(wstart + kW, iwidth + padW);
+          int64_t tend = std::min(tstart + kT, itime + padT);
+          int64_t hend = std::min(hstart + kH, iheight + padH);
+          int64_t wend = std::min(wstart + kW, iwidth + padW);
           int64_t pool_size = (tend -tstart) * (hend - hstart) * (wend - wstart);
-          tstart = fmaxf(tstart, 0);
-          hstart = fmaxf(hstart, 0);
-          wstart = fmaxf(wstart, 0);
-          tend = fminf(tend, itime);
-          hend = fminf(hend, iheight);
-          wend = fminf(wend, iwidth);
+          tstart = std::max(tstart, (int64_t) 0);
+          hstart = std::max(hstart, (int64_t) 0);
+          wstart = std::max(wstart, (int64_t) 0);
+          tend = std::min(tend, itime);
+          hend = std::min(hend, iheight);
+          wend = std::min(wend, iwidth);
 
           int64_t divide_factor;
           if (count_include_pad)

--- a/aten/src/THNN/generic/VolumetricAveragePooling.c
+++ b/aten/src/THNN/generic/VolumetricAveragePooling.c
@@ -2,6 +2,8 @@
 #define TH_GENERIC_FILE "generic/VolumetricAveragePooling.c"
 #else
 
+#include "pooling_shape.h"
+
 static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
                          THNNState *state,
                          THTensor *input,
@@ -66,29 +68,9 @@ static inline void THNN_(VolumetricAveragePooling_shapeCheck)(
   iheight = input->size(dimh);
   iwidth  = input->size(dimw);
 
-  if (ceil_mode) {
-    otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
-    oheight = (int64_t)(ceil((float)(iheight - kH + 2*padH) / dH)) + 1;
-    owidth  = (int64_t)(ceil((float)(iwidth  - kW + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    otime   = (int64_t)(floor((float)(itime   - kT + 2*padT) / dT)) + 1;
-    oheight = (int64_t)(floor((float)(iheight - kH + 2*padH) / dH)) + 1;
-    owidth  = (int64_t)(floor((float)(iwidth  - kW + 2*padW) / dW)) + 1;
-  }
-
-  if (padT || padW || padH)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((otime   - 1)*dT >= itime   + padT)
-      --otime;
-    if ((oheight - 1)*dH >= iheight + padH)
-      --oheight;
-    if ((owidth  - 1)*dW >= iwidth  + padW)
-      --owidth;
-  }
+  otime = pooling_output_shape<int64_t>(itime, kT, padT, dT, 1, ceil_mode);
+  oheight = pooling_output_shape<int64_t>(iheight, kH, padH, dH, 1, ceil_mode);
+  owidth = pooling_output_shape<int64_t>(iwidth, kW, padW, dW, 1, ceil_mode);
 
   if (otime < 1 || owidth < 1 || oheight < 1)
     THError("Given input size: (%dx%dx%dx%d). "
@@ -235,29 +217,9 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   itime   = input->size(dimt);
   iheight = input->size(dimh);
   iwidth  = input->size(dimw);
-  if (ceil_mode)
-  {
-    otime   = (int64_t)(ceil((float)(itime   - kT + 2*padT) / dT)) + 1;
-    oheight = (int64_t)(ceil((float)(iheight - kH + 2*padH) / dH)) + 1;
-    owidth  = (int64_t)(ceil((float)(iwidth  - kW + 2*padW) / dW)) + 1;
-  }
-  else
-  {
-    otime   = (int64_t)(floor((float)(itime   - kT + 2*padT) / dT)) + 1;
-    oheight = (int64_t)(floor((float)(iheight - kH + 2*padH) / dH)) + 1;
-    owidth  = (int64_t)(floor((float)(iwidth  - kW + 2*padW) / dW)) + 1;
-  }
-  if (padT || padH || padW)
-  {
-    // ensure that the last pooling starts inside the image
-    // needed to avoid problems in ceil mode
-    if ((otime   - 1)*dT >= itime   + padT)
-      --otime;
-    if ((oheight - 1)*dH >= iheight + padH)
-      --oheight;
-    if ((owidth  - 1)*dW >= iwidth  + padW)
-      --owidth;
-  }
+  otime = pooling_output_shape<int64_t>(itime, kT, padT, dT, 1, ceil_mode);
+  oheight = pooling_output_shape<int64_t>(iheight, kH, padH, dH, 1, ceil_mode);
+  owidth = pooling_output_shape<int64_t>(iwidth, kW, padW, dW, 1, ceil_mode);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -3,6 +3,7 @@
 #else
 
 #include "pooling_shape.h"
+#include <algorithm>
 
 static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
                          THNNState *state,
@@ -122,9 +123,9 @@ static void THNN_(VolumetricDilatedMaxPooling_updateOutput_frame)(
           int64_t start_h = i * dH - pH;
           int64_t start_w = j * dW - pW;
 
-          int64_t end_t = fminf(start_t + (kT - 1) * dilationT + 1, itime);
-          int64_t end_h = fminf(start_h + (kH - 1) * dilationH + 1, iheight);
-          int64_t end_w = fminf(start_w + (kW - 1) * dilationW + 1, iwidth);
+          int64_t end_t = std::min(start_t + (kT - 1) * dilationT + 1, itime);
+          int64_t end_h = std::min(start_h + (kH - 1) * dilationH + 1, iheight);
+          int64_t end_w = std::min(start_w + (kW - 1) * dilationW + 1, iwidth);
 
           while(start_t < 0)
             start_t += dilationT;

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -2,6 +2,8 @@
 #define TH_GENERIC_FILE "generic/VolumetricDilatedMaxPooling.c"
 #else
 
+#include "pooling_shape.h"
+
 static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
                          THNNState *state,
                          THTensor *input,
@@ -55,29 +57,9 @@ static inline void THNN_(VolumetricDilatedMaxPooling_shapeCheck)(
   itime   = input->size(dimt);
   iheight = input->size(dimh);
   iwidth  = input->size(dimw);
-  if (ceilMode)
-  {
-    otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
-    oheight = (int)(ceil((float)(iheight - (dilationH * (kH - 1) + 1) + 2*pH) / dH)) + 1;
-    owidth  = (int)(ceil((float)(iwidth  - (dilationW * (kW - 1) + 1) + 2*pW) / dW)) + 1;
-  }
-  else
-  {
-    otime = (int)(floor((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
-    oheight = (int)(floor((float)(iheight - (dilationH * (kH - 1) + 1) + 2*pH) / dH)) + 1;
-    owidth  = (int)(floor((float)(iwidth  - (dilationW * (kW - 1) + 1) + 2*pW) / dW)) + 1;
-  }
-
-  if (pT || pW || pH)
-  {
-    // ensure that the last pooling starts inside the image
-    if ((otime - 1)*dT >= itime + pT)
-      --otime;
-    if ((oheight - 1)*dH >= iheight + pH)
-      --oheight;
-    if ((owidth  - 1)*dW >= iwidth  + pW)
-      --owidth;
-  }
+  otime = pooling_output_shape<int64_t>(itime, kT, pT, dT, dilationT, ceilMode);
+  oheight = pooling_output_shape<int64_t>(iheight, kH, pH, dH, dilationH, ceilMode);
+  owidth = pooling_output_shape<int64_t>(iwidth, kW, pW, dW, dilationW, ceilMode);
 
   if (otime < 1 || owidth < 1 || oheight < 1)
     THError("Given input size: (%dx%dx%dx%d). Calculated output size: (%dx%dx%dx%d). Output size is too small",
@@ -245,29 +227,9 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   itime   = input->size(dimt);
   iheight = input->size(dimh);
   iwidth  = input->size(dimw);
-  if (ceilMode)
-  {
-    otime = (int)(ceil((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
-    oheight = (int)(ceil((float)(iheight - (dilationH * (kH - 1) + 1) + 2*pH) / dH)) + 1;
-    owidth  = (int)(ceil((float)(iwidth  - (dilationW * (kW - 1) + 1) + 2*pW) / dW)) + 1;
-  }
-  else
-  {
-    otime = (int)(floor((float)(itime - (dilationT * (kT - 1) + 1) + 2*pT) / dT)) + 1;
-    oheight = (int)(floor((float)(iheight - (dilationH * (kH - 1) + 1) + 2*pH) / dH)) + 1;
-    owidth  = (int)(floor((float)(iwidth  - (dilationW * (kW - 1) + 1) + 2*pW) / dW)) + 1;
-  }
-
-  if (pT || pW || pH)
-  {
-    // ensure that the last pooling starts inside the image
-    if ((otime - 1)*dT >= itime + pT)
-      --otime;
-    if ((oheight - 1)*dH >= iheight + pH)
-      --oheight;
-    if ((owidth  - 1)*dW >= iwidth  + pW)
-      --owidth;
-  }
+  otime = pooling_output_shape<int64_t>(itime, kT, pT, dT, dilationT, ceilMode);
+  oheight = pooling_output_shape<int64_t>(iheight, kH, pH, dH, dilationH, ceilMode);
+  owidth = pooling_output_shape<int64_t>(iwidth, kW, pW, dW, dilationW, ceilMode);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);

--- a/aten/src/THNN/generic/pooling_shape.h
+++ b/aten/src/THNN/generic/pooling_shape.h
@@ -1,0 +1,17 @@
+#ifndef THNN_POOLING_SHAPE_H
+#define THNN_POOLING_SHAPE_H
+
+template<typename T>
+static inline T pooling_output_shape(
+        T inputSize, T kernelSize, T pad, T stride, T dilation, bool ceil_mode) {
+    T outputSize = ((inputSize + 2 * pad - dilation * (kernelSize - 1) - 1 + (ceil_mode ? stride - 1 : 0)) / stride + 1);
+    if (pad) {
+        // ensure that the last pooling starts inside the image
+        // needed to avoid problems in ceil mode
+        if ((outputSize - 1) * stride >= inputSize + pad)
+          --outputSize;
+    }
+    return outputSize;
+}
+
+#endif


### PR DESCRIPTION
As reported in #13386, the pooling operations can return wrong results for large inputs. The root of the problem is that while the output shape is initially being computed with integer operations, it is converted to float32 for division by the stride and applying either a `ceil` or a `floor` depending on the `ceil_mode`. Since even moderately large integers (the smallest being 16,777,217) cannot be expressed exactly in float32, this leads to wrong result shapes.

This PR relies purely on integer operations to perform the shape computation, including the ceil/floor distinction. Since I could not stand all that duplicated code, I pulled it out into a `pooling_shape.h` header, similar to the existing `linear_upsampling.h` header. I hope this is acceptable, let me know if you'd like to see it solved differently. I've also added tests to `test_nn.py` that fail without my changes and pass with my changes. They cover `{max,avg}_pool{1,2,3}d()` for CPU and GPU.

Fixes #13386.