### PR TITLE
Eliminate necessity of HIPify on AccumulateType.h

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -6,9 +6,12 @@
 // Example:
 //   using accscalar_t = acc_type<scalar_t, true>;
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__)
 #include <cuda.h>
 #include <cuda_fp16.h>
+#elif defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
 #endif
 
 namespace at {
@@ -16,7 +19,7 @@ namespace at {
 template <typename T, bool is_cuda>
 struct AccumulateType { };
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 template <> struct AccumulateType<half, true> { using type = float; };
 #endif
 template <> struct AccumulateType<Half, true> { using type = float; };


### PR DESCRIPTION
I'd like to NOT HIPify files that are not in a cuda/
directory, so hand-HIPify AccumulateType.h

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

