### PR TITLE
BlobGetMutableTensor returns Tensor (#14136)

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -28,6 +28,8 @@ inline Tensor* BlobSetTensor(Blob* blob, const Tensor& tensor) {
   return blob->Reset<Tensor>(new Tensor(tensor));
 }
 
+// need to keep both functions that returns Tensor* and the one
+// returns Tensor for clangr codemod
 inline Tensor*
 BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
   if (blob->IsType<Tensor>()) {
@@ -56,6 +58,11 @@ BlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
           << " dims: " << dims;
   // << " options: " << options; (operator<< for Options is in at:: now)
   return BlobSetTensor(blob, caffe2::empty(dims, options));
+}
+
+inline Tensor
+XBlobGetMutableTensor(Blob* blob, at::IntList dims, at::TensorOptions options) {
+  return *BlobGetMutableTensor(blob, dims, options);
 }
 
 inline Tensor* BlobGetMutableTensor(Blob* blob, DeviceType device_type) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -127,6 +127,14 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     return BlobGetMutableTensor(outputs_.at(idx), type);
   }
 
+  inline Tensor
+  XOutputTensor(int idx, at::IntList dims, at::TensorOptions options) {
+    CAFFE_ENFORCE_WITH_CALLER(
+        options.device_opt() != c10::nullopt,
+        "device must be provided in option.");
+    return XBlobGetMutableTensor(outputs_.at(idx), dims, options);
+  }
+
   inline Tensor*
   OutputTensor(int idx, at::IntList dims, at::TensorOptions options) {
     CAFFE_ENFORCE_WITH_CALLER(
@@ -495,7 +503,15 @@ class Operator : public OperatorBase {
     return OperatorBase::template Input<Tensor>(idx, type);
   }
 
-  inline Tensor* Output(int idx, at::IntList dims, at::TensorOptions options) {
+  Tensor XOutput(int idx, at::IntList dims, at::TensorOptions options) {
+    if (options.device_opt() == c10::nullopt) {
+      return OperatorBase::XOutputTensor(
+          idx, dims, options.device(context_.device()));
+    }
+    return OperatorBase::XOutputTensor(idx, dims, options);
+  }
+
+  Tensor* Output(int idx, at::IntList dims, at::TensorOptions options) {
     if (options.device_opt() == c10::nullopt) {
       return OperatorBase::OutputTensor(
           idx, dims, options.device(context_.device()));


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/14136

Since now Tensor is a shared_ptr, it doesn't make sense to have Tensor* around anymore,
this diff is changing Tensor* to Tensor in the interface.
We'll store pointer to intrusive_ptr to TensorImpl in Tensor and create Tensor object on  the fly
when returning from BlobGetMutableTensor.
Another motivation is we want Blob to store intrusive_ptr of TensorImpl because IValue can store intrusive ptr. Without this change, IValue will have to store Blob which is an extra level of indirection.

To remove Tensor*, we'll do following
```
auto* Y = Ouptut(0);
Y->mutable_data...
```
-->
```
auto Y = Output(0);
Y.mutable_data...
```

But to run clangr codemod, we'll keep both APIs in different names, e.g. `Output` and `XOutput`, and do the refactor and then delete the old method and rename the new method into the old one.
For example for `Output`, we'll first codemod the callsites from `Output` to `XOutput`, then delete the old `Output` and rename `XOutput` to `Output` in the end.

This diff should be rebased on the diffs that removes Resize/ResizeLike+mutable_data

Differential Revision: D12934074
