### PR TITLE
when BUILD_CAFFE2_OPS is OFF, torch-python needs a direct dep on nccl

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -694,6 +694,7 @@ if (BUILD_PYTHON)
       ${TORCH_SRC_DIR}/csrc/cuda/nccl.cpp
       ${TORCH_SRC_DIR}/csrc/cuda/python_nccl.cpp)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
+    list(APPEND TORCH_PYTHON_LINK_LIBRARIES __caffe2_nccl)
     if (USE_SYSTEM_NCCL)
     endif()
   endif()


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/14431 tracks supporting this with CI