### PR TITLE
Remove at references in c10 Allocator.h

### DIFF
--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ATen/core/ATenGeneral.h"
-#include "c10/core/Allocator.h"
+#include <c10/core/Allocator.h>
 #include "ATen/core/Deprecated.h"
 #include "ATen/core/Generator.h"
 #include "ATen/core/Layout.h"
@@ -30,7 +30,6 @@
 #endif
 
 namespace c10 {
-struct Allocator;
 struct Storage;
 }
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ATen/core/ATenGeneral.h"
-#include "c10/core/Allocator.h"
+#include <c10/core/Allocator.h>
 #include "ATen/core/Deprecated.h"
 #include "ATen/core/Generator.h"
 #include "ATen/core/Layout.h"
@@ -30,7 +30,6 @@
 #endif
 
 namespace c10 {
-struct Allocator;
 struct Storage;
 }
 

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -64,16 +64,16 @@ class DataPtr {
 // NB: Device is NOT tested for here; a CUDA nullptr is as much a nullptr as a
 // CPU nullptr
 
-inline bool operator==(const at::DataPtr& dp, std::nullptr_t) noexcept {
+inline bool operator==(const DataPtr& dp, std::nullptr_t) noexcept {
   return !dp;
 }
-inline bool operator==(std::nullptr_t, const at::DataPtr& dp) noexcept {
+inline bool operator==(std::nullptr_t, const DataPtr& dp) noexcept {
   return !dp;
 }
-inline bool operator!=(const at::DataPtr& dp, std::nullptr_t) noexcept {
+inline bool operator!=(const DataPtr& dp, std::nullptr_t) noexcept {
   return dp;
 }
-inline bool operator!=(std::nullptr_t, const at::DataPtr& dp) noexcept {
+inline bool operator!=(std::nullptr_t, const DataPtr& dp) noexcept {
   return dp;
 }
 
@@ -100,7 +100,7 @@ inline bool operator!=(std::nullptr_t, const at::DataPtr& dp) noexcept {
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual at::DataPtr allocate(size_t n) const = 0;
+  virtual DataPtr allocate(size_t n) const = 0;
 
   // If this returns a non nullptr, it means that allocate()
   // is guaranteed to return a unique_ptr with this deleter attached;
@@ -127,7 +127,7 @@ struct C10_API InefficientStdFunctionContext {
   InefficientStdFunctionContext(
       std::unique_ptr<void, std::function<void(void*)>>&& ptr)
       : ptr_(std::move(ptr)) {}
-  static at::DataPtr makeDataPtr(
+  static DataPtr makeDataPtr(
       void* ptr,
       const std::function<void(void*)>& deleter,
       Device device);
@@ -146,12 +146,12 @@ namespace caffe2 {
  *  Also note that this is not thraed-safe, and we assume this function will
  *  only be called during initialization.
  */
-C10_API void SetAllocator(at::DeviceType t, at::Allocator* alloc);
-C10_API at::Allocator* GetAllocator(const at::DeviceType& t);
+C10_API void SetAllocator(DeviceType t, Allocator* alloc);
+C10_API Allocator* GetAllocator(const DeviceType& t);
 
-template <at::DeviceType t>
+template <DeviceType t>
 struct AllocatorRegisterer {
-  explicit AllocatorRegisterer(at::Allocator* alloc) {
+  explicit AllocatorRegisterer(Allocator* alloc) {
     SetAllocator(t, alloc);
   }
 };


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14434 Remove at references in c10 Allocator.h**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13224015/)

The referenced classes live now in c10, so we don't need to specify their namespace.

Differential Revision: [D13224015](https://our.internmc.facebook.com/intern/diff/D13224015/)