### PR TITLE
[Test][Don't review/merge] Remove the relu&abs&sign in LPPool

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -485,7 +485,8 @@ def lp_pool1d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     else:
         out = avg_pool1d(input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode)
 
-    return (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1. / norm_type)
+    return out.mul(kernel_size).pow(1. / norm_type)
+    #return (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1. / norm_type)
 
 
 def adaptive_max_pool1d(input, output_size, return_indices=False):


### PR DESCRIPTION
In #6766 we used a hacky way to make sure the gradient of LPPool is correct when sum is 0, but it does not make sense. 