### PR TITLE
Changes based on @gchanan's review of #13420

### DIFF
--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -17,9 +17,7 @@ struct OffsetCalculator {
   using offset_type = at::cuda::Array<uint32_t, NARGS>;
 
   OffsetCalculator(int dims, const int64_t* sizes, const int64_t* const* strides) : dims(dims) {
-    if (dims > MAX_DIMS) {
-      throw std::runtime_error("tensor has too many (>25) dims");
-    }
+    AT_CHECK(dims <= MAX_DIMS, "tensor has too many (>25) dims");
     for (int i = 0; i < MAX_DIMS; ++i) {
       if (i < dims) {
         sizes_[i] = IntDivider<uint32_t>(sizes[i]);

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -303,7 +303,7 @@ static Tensor restride_src(const Tensor& src, int64_t dims_before, int64_t dims_
                            IntList replacement_shape) {
   auto shape = DimVector(src.sizes());
   auto strides = DimVector(src.strides());
-  int end = dims_before + dims_indexed;
+  int64_t end = dims_before + dims_indexed;
   shape.erase(shape.begin() + dims_before, shape.begin() + end);
   strides.erase(strides.begin() + dims_before, strides.begin() + end);
   shape.insert(shape.begin() + dims_before, replacement_shape.begin(), replacement_shape.end());
@@ -311,7 +311,7 @@ static Tensor restride_src(const Tensor& src, int64_t dims_before, int64_t dims_
   return src.as_strided(shape, strides);
 }
 
-// Add dimensions of size 1 to an index tensor so that it's can be broadcast to the result
+// Add dimensions of size 1 to an index tensor so that it can be broadcast to the result
 // shape and iterated over element-wise like the result tensor and the restrided src.
 static Tensor reshape_indexer(const Tensor& index, int64_t dims_before, int64_t dims_after) {
   auto orig_shape = index.sizes();
@@ -340,6 +340,16 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
       indexed_sizes.push_back(src.size(dim));
       indexed_strides.push_back(src.stride(dim) * element_size_bytes);
     }
+  }
+
+  // Check if the indexed subspace contains a dim of size 0, but the replacement
+  // shape does not. This implies that an index is out of bounds, because there
+  // is no number that's a valid index for an empty tensor. Normally, out of
+  // bounds is handled in the indexing kernel, but this case fails earlier in
+  // restride_src with an unhelpful error message.
+  if (std::find(indexed_sizes.begin(), indexed_sizes.end(), 0) != indexed_sizes.end() &&
+      std::find(replacement_shape.begin(), replacement_shape.end(), 0) == replacement_shape.end()) {
+    AT_ERROR("index is out of bounds for dim with size 0");
   }
 
   this->dims_before = dims_before;

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -128,7 +128,7 @@ void TensorIterator::compute_types() {
         AT_ERROR("output with type ", op.tensor.type().toString(),
                  " doesn't match the desired type ", type().toString());
       } else if (op.tensor.dim() == 0) {
-        op.tensor = op.tensor.toType(*op.type);
+        op.tensor = op.tensor.to(*op.type);
       } else {
         AT_ERROR("expected type ", type().toString(), " but got ",
             op.tensor.type().toString());

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -104,6 +104,12 @@ class TestIndexing(TestCase):
             self.assertEqual(torch.empty(2, 0, 6, 4, 5, device=device),
                              x[:, torch.empty(0, 6, dtype=torch.int64, device=device)])
 
+        x = torch.empty(10, 0)
+        self.assertEqual(x[[1, 2]].shape, (2, 0))
+        self.assertEqual(x[[], []].shape, (0,))
+        with self.assertRaisesRegex(RuntimeError, 'for dim with size 0'):
+            x[:, [0, 1]]
+
     def test_empty_ndim_index_bool(self):
         devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
         for device in devices:

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1172,7 +1172,7 @@ Example::
 
 add_docstr_all('index_put_',
                r"""
-index_put_(indices, value) -> Tensor
+index_put_(indices, value, accumulate=False) -> Tensor
 
 Puts values from the tensor :attr:`value` into the tensor :attr:`self` using
 the indices specified in :attr:`indices` (which is a tuple of Tensors). The

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1179,9 +1179,14 @@ the indices specified in :attr:`indices` (which is a tuple of Tensors). The
 expression ``tensor.index_put_(indices, value)`` is equivalent to
 ``tensor[indices] = value``. Returns :attr:`self`.
 
+If :attr:`accumulate` is ``True``, the elements in :attr:`tensor` are added to
+:attr:`self`. If accumulate is ``False``, the behavior is undefined if indices
+contain duplicate elements.
+
 Args:
     indices (tuple of LongTensor): tensors used to index into `self`.
     value (Tensor): tensor of same dtype as `self`.
+    accumulate (bool): whether to accumulate into self
 """)
 
 add_docstr_all('index_select',


### PR DESCRIPTION
```
The most significant change is that this fixes the error message when
indexing an empty tensor with an out-of-bounds index. For example:

  x = torch.ones(10, 0)
  x[:, [3, 4]]
```