### PR TITLE
Add sourceRank() to ProcessGroup::Work

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -307,26 +307,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
 
           .def(
               "recv_anysource",
-              [](::c10d::ProcessGroup& pg,
-                 std::vector<at::Tensor>& input,
-                 at::Tensor& srcRankTensor,
-                 int tag) {
-                if (srcRankTensor.type().scalarType() != at::kInt) {
-                  throw std::runtime_error(
-                      "source rank tensor needs to be "
-                      "CPU int tensor");
-                }
-                if (srcRankTensor.numel() != 1) {
-                  throw std::runtime_error(
-                      "source rank tensor needs to "
-                      "contain only one element");
-                }
-                return pg.recvAnysource(
-                    input, static_cast<int*>(srcRankTensor.data_ptr()), tag);
-              },
-              py::arg("tensors"),
-              py::arg("src_rank"),
-              py::arg("tag"),
+              &::c10d::ProcessGroup::recvAnysource,
               py::call_guard<py::gil_scoped_release>())
 
           .def(
@@ -438,6 +419,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
       .def("is_completed", &::c10d::ProcessGroup::Work::isCompleted)
       .def("is_success", &::c10d::ProcessGroup::Work::isSuccess)
       .def("exception", &::c10d::ProcessGroup::Work::exception)
+      .def("source_rank", &::c10d::ProcessGroup::Work::sourceRank)
       .def("synchronize", &::c10d::ProcessGroup::Work::synchronize)
       .def(
           "wait",

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -630,9 +630,9 @@ def recv(tensor,
         pg = group
 
     if src is None:
-        rank_tensor = torch.IntTensor([-1])
-        pg.recv_anysource([tensor], rank_tensor, tag).wait()
-        src_rank = rank_tensor[0].item()
+        work = pg.recv_anysource([tensor], tag)
+        work.wait()
+        src_rank = work.source_rank()
         if group == GroupMember.WORLD:
             return src_rank
         else:

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -19,6 +19,12 @@ std::exception_ptr ProcessGroup::Work::exception() const {
   return exception_;
 }
 
+int ProcessGroup::Work::sourceRank() const {
+  throw std::runtime_error(
+      "sourceRank() may only be called on work objects "
+      "that correspond to a recv or recv-from-any call.");
+}
+
 void ProcessGroup::Work::synchronize() {}
 
 void ProcessGroup::Work::wait() {

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -49,6 +49,9 @@ class ProcessGroup {
     // Returns exception if isSuccess() returned false.
     virtual std::exception_ptr exception() const;
 
+    // Returns source rank if this objects represents a recv-from-any.
+    virtual int sourceRank() const;
+
     // Ensures that operations on the output tensors that are invoked
     // after this function returns are correctly sequenced after the
     // asynchronous completion of this work.
@@ -136,7 +139,6 @@ class ProcessGroup {
 
   virtual std::shared_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensors,
-      int* srcRank,
       int tag) = 0;
 
   virtual std::shared_ptr<ProcessGroup::Work> barrier(

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -107,15 +107,16 @@ class ProcessGroupGloo : public ProcessGroup {
    public:
     explicit RecvWork(
         at::Tensor& tensor,
-        std::unique_ptr<::gloo::transport::UnboundBuffer> buffer,
-        int* srcRank);
+        std::unique_ptr<::gloo::transport::UnboundBuffer> buffer);
+
+    int sourceRank() const override;
 
     void wait() override;
 
    protected:
     at::Tensor tensor_;
     std::unique_ptr<::gloo::transport::UnboundBuffer> buffer_;
-    int* srcRank_;
+    int srcRank_;
   };
 
   struct Options {
@@ -180,7 +181,6 @@ class ProcessGroupGloo : public ProcessGroup {
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensors,
-      int* srcRank,
       int tag) override;
 
   std::shared_ptr<ProcessGroup::Work> barrier(

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -79,12 +79,14 @@ class ProcessGroupMPI : public ProcessGroup {
 
   class AsyncWork : public ProcessGroup::Work {
    public:
-    AsyncWork(at::Tensor tensor, MPI_Request request, int* srcRank = nullptr);
+    AsyncWork(at::Tensor tensor, MPI_Request request);
     virtual ~AsyncWork();
 
     bool isCompleted() override;
 
     bool isSuccess() const override;
+
+    int sourceRank() const override;
 
     void wait() override;
 
@@ -93,7 +95,6 @@ class ProcessGroupMPI : public ProcessGroup {
 
     at::Tensor tensor_;
     MPI_Request request_;
-    int* const srcRank_;
     MPI_Status status_;
   };
 
@@ -144,7 +145,6 @@ class ProcessGroupMPI : public ProcessGroup {
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensor,
-      int* srcRank,
       int tag);
 
   std::shared_ptr<ProcessGroup::Work> barrier(

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -633,7 +633,6 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recv(
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recvAnysource(
     std::vector<at::Tensor>& /* unused */,
-    int* /* unused */,
     int /* unused */) {
   throw std::runtime_error("ProcessGroupNCCL does not support recv");
 }

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -142,7 +142,6 @@ class ProcessGroupNCCL : public ProcessGroup {
 
   std::shared_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensors,
-      int* srcRank,
       int tag) override;
 
   std::shared_ptr<ProcessGroup::Work> barrier(

--- a/torch/lib/c10d/test/ProcessGroupMPITest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupMPITest.cpp
@@ -310,7 +310,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
         works.push_back(std::move(work));
       } else {
         std::shared_ptr<::c10d::ProcessGroup::Work> work =
-            pg->recvAnysource(tensors, &srcRanks[i], 0);
+            pg->recvAnysource(tensors, 0);
         works.push_back(std::move(work));
       }
       ++i;


### PR DESCRIPTION
Summary:
This function is only implemented for the subclasses where it makes
sense. If it's not overridden it will throw an error. Having this
function removes the need for a pointer passing hack to pass the
source rank of a recv operation back to the caller. Instead, the
caller can now call `source_rank` on the work object and achieve
the same result.

Closes #11804.

Differential Revision: D13230898
