### PR TITLE
Make clang-tidy shut up about Python C API macros.

### DIFF
--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -43,9 +43,9 @@ Py_ssize_t THPVariable_length(PyObject* self) {
 static int64_t count_specified_dimensions(PyObject* index) {
   // Count the number of indexed dimensions (everything but ellipsis and None)
   int64_t count = 0;
-  auto size = PyTuple_GET_SIZE(index);
+  auto size = PyTuple_GET_SIZE(index); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
   for (Py_ssize_t i = 0; i < size; i++) {
-    PyObject* obj = PyTuple_GET_ITEM(index, i);
+    PyObject* obj = PyTuple_GET_ITEM(index, i); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     if (THPVariable_Check(obj)) {
       auto& var = reinterpret_cast<THPVariable*>(obj)->cdata;
       if (var.type().scalarType() == kByte) {
@@ -53,7 +53,7 @@ static int64_t count_specified_dimensions(PyObject* index) {
       } else {
         count++;
       }
-    } else if (obj != Py_None && obj != Py_Ellipsis && obj != Py_True && obj != Py_False) {
+    } else if (obj != Py_None && obj != Py_Ellipsis && obj != Py_True && obj != Py_False) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
       count++;
     }
   }
@@ -134,7 +134,7 @@ static Variable boolToIndexingTensor(const Variable& self, bool value) {
 }
 
 static Variable applySlicing(const Variable& self, PyObject* index, variable_list& outIndices) {
-  int64_t size = PyTuple_GET_SIZE(index);
+  int64_t size = PyTuple_GET_SIZE(index); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
   int64_t dim = 0;
   int64_t specified_dims = count_specified_dimensions(index);
 
@@ -151,7 +151,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
 
   Variable result = self;
   for (int64_t i = 0; i < size; i++) {
-    PyObject* obj = PyTuple_GET_ITEM(index, i);
+    PyObject* obj = PyTuple_GET_ITEM(index, i); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     if (THPUtils_checkLong(obj)) {
       result = applySelect(result, dim, THPUtils_unpackLong(obj));
     } else if (PySlice_Check(obj)) {
@@ -164,7 +164,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       dim++;
     } else if (PyBool_Check(obj)) {
       result = result.unsqueeze(dim);
-      handle_var(boolToIndexingTensor(result, obj == Py_True));
+      handle_var(boolToIndexingTensor(result, obj == Py_True)); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
       auto scalar_type = var.type().scalarType();
@@ -266,7 +266,7 @@ static THPObjectPtr wrapTuple(PyObject* index) {
   if (treatSequenceAsTuple(index)) {
     res = PySequence_Tuple(index);
   } else {
-    res = PyTuple_Pack(1, index);
+    res = PyTuple_Pack(1, index); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
   }
   if (!res) throw python_error();
   return res;
@@ -340,14 +340,14 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   auto value = valueToTensor(self_.type(), py_value);
 
   // handle simple types: integers, slices, ellipsis, bool
-  if (index == Py_False) {
+  if (index == Py_False) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     // do nothing for false (technically we should check the size, but we don't have
     // real 0-sized shapes.
     return 0;
   } else if (index == Py_Ellipsis) {
     copy_to(self_, value);
     return 0;
-  } else if (index == Py_None || index == Py_True) {
+  } else if (index == Py_None || index == Py_True) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     copy_to(self_.unsqueeze(0), value);
     return 0;
   } else if (THPUtils_checkLong(index)) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14480 Make clang-tidy shut up about Python C API macros.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13235001/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14421 Expunge direct device index handling from tensor_conversion_dispatch&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13221302/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14414 Delete at::current_device(), Context::current_device() and Context::getNumGPUs()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13218540/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14499 Delete hasCuDNN from Context.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13241355/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14500 Replace THCState_getCurrentStream with direct at::cuda::getCurrentCUDAStream()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13241401/)



Differential Revision: [D13235001](https://our.internmc.facebook.com/intern/diff/D13235001/)