### PR TITLE
Fixes for some Windows compiler warnings

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -474,7 +474,7 @@ interleave2(const Vec256<T>& a, const Vec256<T>& b) {
 
 template <typename src_T, typename dst_T>
 void convert(const src_T *src, dst_T *dst, int64_t n) {
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 # pragma unroll  
 #endif
   for (int64_t i = 0; i < n; i++) {

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -474,7 +474,9 @@ interleave2(const Vec256<T>& a, const Vec256<T>& b) {
 
 template <typename src_T, typename dst_T>
 void convert(const src_T *src, dst_T *dst, int64_t n) {
-#pragma unroll
+#if (!defined _MSC_VER)  
+# pragma unroll  
+#endif
   for (int64_t i = 0; i < n; i++) {
     *dst = static_cast<dst_T>(*src);
     src++;

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -212,13 +212,17 @@ template <>
 void convert(const int32_t *src, float *dst, int64_t n) {
   int64_t i;
   // int32_t and float have same size
-#pragma unroll
+#if (!defined _MSC_VER)  
+# pragma unroll  
+#endif
   for (i = 0; i <= (n - Vec256<int32_t>::size); i += Vec256<int32_t>::size) {
     auto input_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
     auto output_vec = _mm256_cvtepi32_ps(input_vec);
     _mm256_storeu_ps(reinterpret_cast<float*>(dst + i), output_vec);
   }
-#pragma unroll
+#if (!defined _MSC_VER)  
+# pragma unroll  
+#endif
   for (; i < n; i++) {
     dst[i] = static_cast<float>(src[i]);
   }
@@ -228,13 +232,17 @@ template <>
 void convert(const int32_t *src, double *dst, int64_t n) {
   int64_t i;
   // int32_t has half the size of double
-#pragma unroll
+#if (!defined _MSC_VER)  
+# pragma unroll  
+#endif
   for (i = 0; i <= (n - Vec256<double>::size); i += Vec256<double>::size) {
     auto input_128_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
     auto output_vec = _mm256_cvtepi32_pd(input_128_vec);
     _mm256_storeu_pd(reinterpret_cast<double*>(dst + i), output_vec);
   }
-#pragma unroll
+#if (!defined _MSC_VER)  
+# pragma unroll  
+#endif
   for (; i < n; i++) {
     dst[i] = static_cast<double>(src[i]);
   }

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -212,7 +212,7 @@ template <>
 void convert(const int32_t *src, float *dst, int64_t n) {
   int64_t i;
   // int32_t and float have same size
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 # pragma unroll  
 #endif
   for (i = 0; i <= (n - Vec256<int32_t>::size); i += Vec256<int32_t>::size) {
@@ -220,7 +220,7 @@ void convert(const int32_t *src, float *dst, int64_t n) {
     auto output_vec = _mm256_cvtepi32_ps(input_vec);
     _mm256_storeu_ps(reinterpret_cast<float*>(dst + i), output_vec);
   }
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 # pragma unroll  
 #endif
   for (; i < n; i++) {
@@ -232,7 +232,7 @@ template <>
 void convert(const int32_t *src, double *dst, int64_t n) {
   int64_t i;
   // int32_t has half the size of double
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 # pragma unroll  
 #endif
   for (i = 0; i <= (n - Vec256<double>::size); i += Vec256<double>::size) {
@@ -240,7 +240,7 @@ void convert(const int32_t *src, double *dst, int64_t n) {
     auto output_vec = _mm256_cvtepi32_pd(input_128_vec);
     _mm256_storeu_pd(reinterpret_cast<double*>(dst + i), output_vec);
   }
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 # pragma unroll  
 #endif
   for (; i < n; i++) {

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -308,7 +308,9 @@ static inline void
 mask_scatter_add(const scalar_t *src, scalar_t* base_addr,
                  const int_same_size_t<scalar_t> *offsets,
                  const int_same_size_t<scalar_t> *mask, int64_t len) {
-  #pragma unroll
+  #if (!defined _MSC_VER)  
+  # pragma unroll  
+  #endif
   for (int64_t i = 0; i < len; i++) {
     if (mask[i] & 0x01) {
       base_addr[offsets[i]] += src[i];
@@ -429,7 +431,9 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     auto i_sw_offset = i_nw_offset + iVec(inp_sH);
     auto i_se_offset = i_sw_offset + iVec(inp_sW);
 
-    #pragma unroll
+    #if (!defined _MSC_VER)  
+    # pragma unroll  
+    #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
 
@@ -501,7 +505,9 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     scalar_t gInp_corner_arr[Vec::size];
 
     auto gx = Vec(0), gy = Vec(0);
-    #pragma unroll
+    #if (!defined _MSC_VER)  
+    # pragma unroll  
+    #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
       auto gInp_slice_C_ptr = gInp_slice[c].data();
@@ -592,7 +598,9 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     auto out_ptr = out_slice.data() + offset;
     auto out_sC = out_slice.stride(0);
     auto inp_slice_ptr = inp_slice.data();
-    #pragma unroll
+    #if (!defined _MSC_VER)  
+    # pragma unroll  
+    #endif
     for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
       // mask_gather zeros out the mask, so we need to make a copy
       auto mask_copy = mask;
@@ -627,7 +635,9 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     integer_t gInp_offset_arr[iVec::size];
     i_gInp_offset.store(gInp_offset_arr);
 
-    #pragma unroll
+    #if (!defined _MSC_VER)  
+    # pragma unroll  
+    #endif
     for (int64_t c = 0; c < C; ++c) {
       mask_scatter_add(gOut_slice[c].data() + offset, gInp_slice[c].data(),
                        gInp_offset_arr, mask_arr, len);
@@ -733,12 +743,16 @@ static inline void grid_sample_2d_grid_slice_iterator(
     auto spatial_offset = 0;
     auto i_offsets_delta = iVec(grid_sW * step);
 
-    #pragma unroll
+    #if (!defined _MSC_VER)  
+    # pragma unroll  
+    #endif
     for (int64_t h = 0; h < out_H; h++) {
       auto grid_ptr_x = grid_ptr + h * grid_sH;
       auto grid_ptr_y = grid_ptr_x + grid_sCoor;
       auto i_offsets = iVec::arange(0, grid_sW);
-      #pragma unroll
+      #if (!defined _MSC_VER)  
+      # pragma unroll  
+      #endif
       for (int64_t w = 0; w < out_W; w += step) {
         auto len = std::min(step, out_W - w);
         if (len < step) {

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -308,7 +308,7 @@ static inline void
 mask_scatter_add(const scalar_t *src, scalar_t* base_addr,
                  const int_same_size_t<scalar_t> *offsets,
                  const int_same_size_t<scalar_t> *mask, int64_t len) {
-  #if (!defined _MSC_VER)  
+  #ifndef _MSC_VER  
   # pragma unroll  
   #endif
   for (int64_t i = 0; i < len; i++) {
@@ -431,7 +431,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     auto i_sw_offset = i_nw_offset + iVec(inp_sH);
     auto i_se_offset = i_sw_offset + iVec(inp_sW);
 
-    #if (!defined _MSC_VER)  
+    #ifndef _MSC_VER  
     # pragma unroll  
     #endif
     for (int64_t c = 0; c < C; ++c) {
@@ -505,7 +505,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     scalar_t gInp_corner_arr[Vec::size];
 
     auto gx = Vec(0), gy = Vec(0);
-    #if (!defined _MSC_VER)  
+    #ifndef _MSC_VER  
     # pragma unroll  
     #endif
     for (int64_t c = 0; c < C; ++c) {
@@ -598,7 +598,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     auto out_ptr = out_slice.data() + offset;
     auto out_sC = out_slice.stride(0);
     auto inp_slice_ptr = inp_slice.data();
-    #if (!defined _MSC_VER)  
+    #ifndef _MSC_VER  
     # pragma unroll  
     #endif
     for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
@@ -635,7 +635,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     integer_t gInp_offset_arr[iVec::size];
     i_gInp_offset.store(gInp_offset_arr);
 
-    #if (!defined _MSC_VER)  
+    #ifndef _MSC_VER  
     # pragma unroll  
     #endif
     for (int64_t c = 0; c < C; ++c) {
@@ -743,14 +743,14 @@ static inline void grid_sample_2d_grid_slice_iterator(
     auto spatial_offset = 0;
     auto i_offsets_delta = iVec(grid_sW * step);
 
-    #if (!defined _MSC_VER)  
+    #ifndef _MSC_VER  
     # pragma unroll  
     #endif
     for (int64_t h = 0; h < out_H; h++) {
       auto grid_ptr_x = grid_ptr + h * grid_sH;
       auto grid_ptr_y = grid_ptr_x + grid_sCoor;
       auto i_offsets = iVec::arange(0, grid_sW);
-      #if (!defined _MSC_VER)  
+      #ifndef _MSC_VER  
       # pragma unroll  
       #endif
       for (int64_t w = 0; w < out_W; w += step) {

--- a/aten/src/ATen/test/test_install/CMakeLists.txt
+++ b/aten/src/ATen/test/test_install/CMakeLists.txt
@@ -3,6 +3,8 @@ find_package(ATen REQUIRED)
 include_directories(${ATEN_INCLUDE_DIR})
 
 # C++11
-set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
+if (not MSVC) 
+    set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}") 
+endif()
 add_executable(main main.cpp)
 target_link_libraries(main ${ATEN_LIBRARIES})

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -247,8 +247,8 @@
 
 #ifdef _OPENMP
 
-#if (defined _WIN32)  
-// MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.  
+#ifdef _WIN32  
+// MSVC doesn't support loop pragmas, but does support others. Create a new macro to account for those differences.  
 #define PRAGMA_LOOP(P)    // Noop  
 #define PRAGMA(P)         __pragma(P)
 #else

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -247,10 +247,13 @@
 
 #ifdef _OPENMP
 
-#ifndef _WIN32
-#define PRAGMA(P) _Pragma(#P)
+#if (defined _WIN32)  
+// MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.  
+#define PRAGMA_LOOP(P)    // Noop  
+#define PRAGMA(P)         __pragma(P)
 #else
-#define PRAGMA(P) __pragma(P)
+#define PRAGMA_LOOP(P)    _Pragma(#P)  
+#define PRAGMA(P)         _Pragma(#P)
 #endif
 
 #include <omp.h>
@@ -369,7 +372,7 @@
     TYPE2 *tp = THTensor_getStoragePtr(TENSOR2)->data<TYPE2>()+TENSOR2->storage_offset();                        \
     ptrdiff_t iter = 0;                                                                        \
     if(tp != (TYPE2*)rp) {                                                                             \
-      PRAGMA(ivdep) \
+      PRAGMA_LOOP(ivdep) \
       PRAGMA( omp parallel for if (SIZE > OMP_THRESHOLD * 10) firstprivate(rp, tp)) \
       for (iter = 0; iter < SIZE; iter++) {                             \
         TYPE2 *TENSOR2##_data = tp+iter;                                \
@@ -377,7 +380,7 @@
         CODE                                                            \
       }\
     } else {\
-      PRAGMA(simd) \
+      PRAGMA_LOOP(simd) \
       PRAGMA( omp parallel for if (SIZE > OMP_THRESHOLD * 10) firstprivate(rp, tp) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE2* TENSOR2##_data = tp+iter;\
@@ -449,7 +452,7 @@
     TYPE3 *srcp = THTensor_getStoragePtr(TENSOR3)->data<TYPE3>()+TENSOR3->storage_offset();                               \
     ptrdiff_t iter = 0;\
     if(tp != (TYPE2*)rp) {                                                                             \
-      PRAGMA(ivdep) \
+      PRAGMA_LOOP(ivdep) \
       PRAGMA( omp parallel for if (SIZE > OMP_THRESHOLD * 10) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE1 *TENSOR1##_data = rp+iter;\
@@ -458,7 +461,7 @@
         CODE                                \
       } \
     } else {\
-      PRAGMA(simd) \
+      PRAGMA_LOOP(simd) \
       PRAGMA( omp parallel for if (SIZE > OMP_THRESHOLD * 10) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE1 *TENSOR1##_data = rp+iter;\

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -13,10 +13,13 @@
 
 #ifdef _OPENMP
 
-#ifndef _WIN32
-#define PRAGMA(P) _Pragma(#P)
+#if (defined _WIN32)  
+// MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.  
+#define PRAGMA_LOOP(P)    // Noop  
+#define PRAGMA(P)         __pragma(P)
 #else
-#define PRAGMA(P) __pragma(P)
+#define PRAGMA_LOOP(P)    _Pragma(#P)  
+#define PRAGMA(P)         _Pragma(#P)
 #endif
 
 #define TH_TENSOR_APPLY_CONTIG(TYPE, TENSOR, CODE) \

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -13,7 +13,7 @@
 
 #ifdef _OPENMP
 
-#if (defined _WIN32)  
+#ifdef _WIN32  
 // MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.  
 #define PRAGMA_LOOP(P)    // Noop  
 #define PRAGMA(P)         __pragma(P)

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -11,9 +11,11 @@ using c10::intrusive_ptr_target;
 using c10::make_intrusive;
 using c10::weak_intrusive_ptr;
 
+#if (!defined _MSC_VER)
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wself-move"
+#endif
 
 namespace {
 class SomeClass0Parameters : public intrusive_ptr_target {};

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -11,7 +11,7 @@ using c10::intrusive_ptr_target;
 using c10::make_intrusive;
 using c10::weak_intrusive_ptr;
 
-#if (!defined _MSC_VER)
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wself-move"

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -17,9 +17,10 @@
 #include <utility>
 #include <type_traits>
 
+#if (!defined _MSC_VER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-
+#endif
 #ifdef _MSC_VER
 #define SKA_NOINLINE(...) __declspec(noinline) __VA_ARGS__
 #else
@@ -1457,4 +1458,6 @@ namespace ska
 
 } // end namespace ska
 
+#if (!defined _MSC_VER)
 #pragma GCC diagnostic pop
+#endif

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 
-#if (!defined _MSC_VER)
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #endif
@@ -1458,6 +1458,6 @@ namespace ska
 
 } // end namespace ska
 
-#if (!defined _MSC_VER)
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #endif

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -72,7 +72,7 @@ class C10_API intrusive_ptr_target {
 // We also have to disable -Wunknown-warning-option and -Wpragmas, because
 // some other compilers don't know about -Wterminate or -Wexceptions and
 // will show a warning about unknown warning options otherwise.
-#if (defined _MSC_VER)  
+#ifdef _MSC_VER
 #  pragma warning(push)  
 #  pragma warning(disable: 4297) // function assumed not to throw an exception but does  
 #else  
@@ -88,7 +88,7 @@ class C10_API intrusive_ptr_target {
     AT_ASSERTM(
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
-#if (defined _MSC_VER)  
+#ifdef _MSC_VER
 #  pragma warning(pop)  
 #else  
 #  pragma GCC diagnostic pop  

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -72,18 +72,27 @@ class C10_API intrusive_ptr_target {
 // We also have to disable -Wunknown-warning-option and -Wpragmas, because
 // some other compilers don't know about -Wterminate or -Wexceptions and
 // will show a warning about unknown warning options otherwise.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#pragma GCC diagnostic ignored "-Wterminate"
-#pragma GCC diagnostic ignored "-Wexceptions"
+#if (defined _MSC_VER)  
+#  pragma warning(push)  
+#  pragma warning(disable: 4297) // function assumed not to throw an exception but does  
+#else  
+#  pragma GCC diagnostic push  
+#  pragma GCC diagnostic ignored "-Wpragmas"  
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"  
+#  pragma GCC diagnostic ignored "-Wterminate"  
+#  pragma GCC diagnostic ignored "-Wexceptions"  
+#endif
     AT_ASSERTM(
         refcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has intrusive_ptr to it");
     AT_ASSERTM(
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
-#pragma GCC diagnostic pop
+#if (defined _MSC_VER)  
+#  pragma warning(pop)  
+#else  
+#  pragma GCC diagnostic pop  
+#endif
   }
 
   constexpr intrusive_ptr_target() noexcept : refcount_(0), weakcount_(0) {}

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -430,14 +430,14 @@ class C10_API TypeMeta {
     // variable template. '-Wpragmas' and '-Wunknown-warning-option' has to be
     // disabled for compilers that don't know '-Wundefined-var-template' and
     // would error at our attempt to disable it.
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 #  pragma GCC diagnostic push  
 #  pragma GCC diagnostic ignored "-Wpragmas"  
 #  pragma GCC diagnostic ignored "-Wunknown-warning-option"  
 #  pragma GCC diagnostic ignored "-Wundefined-var-template"  
 #endif
     return TypeMeta(_typeMetaDataInstance<T>());
-#if (!defined _MSC_VER)  
+#ifndef _MSC_VER  
 #  pragma GCC diagnostic pop  
 #endif
   }

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -430,12 +430,16 @@ class C10_API TypeMeta {
     // variable template. '-Wpragmas' and '-Wunknown-warning-option' has to be
     // disabled for compilers that don't know '-Wundefined-var-template' and
     // would error at our attempt to disable it.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#pragma GCC diagnostic ignored "-Wundefined-var-template"
+#if (!defined _MSC_VER)  
+#  pragma GCC diagnostic push  
+#  pragma GCC diagnostic ignored "-Wpragmas"  
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"  
+#  pragma GCC diagnostic ignored "-Wundefined-var-template"  
+#endif
     return TypeMeta(_typeMetaDataInstance<T>());
-#pragma GCC diagnostic pop
+#if (!defined _MSC_VER)  
+#  pragma GCC diagnostic pop  
+#endif
   }
 
  private:

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -239,10 +239,8 @@ target_include_directories(caffe2 SYSTEM PRIVATE "${Caffe2_DEPENDENCY_INCLUDE}")
 # Set standard properties on the target
 torch_set_target_props(caffe2)
 
-if (MSVC)
-target_compile_options(caffe2 INTERFACE "-std=c++11")
-else()
-target_compile_options(caffe2 INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-std=c++11>")
+if (NOT MSVC) 
+  target_compile_options(caffe2 INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-std=c++11>") 
 endif()
 
 target_compile_options(caffe2 PRIVATE "-DCAFFE2_BUILD_MAIN_LIB")

--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -93,7 +93,7 @@ using std::vector;
 #define CAFFE2_NORETURN __attribute__((noreturn))
 #endif
 
-#if defined(_MSC_VER)
+#if (defined _MSC_VER && !defined NOMINMAX)
 #define NOMINMAX
 #endif
 


### PR DESCRIPTION
Implement some simple fixes to clean up windows build by fixing compiler warnings. Three main types of warnings were fixes:

1. GCC specific pragmas were changed to not be used on windows.
2. cmake flags that don't exist on windows were removed from windows build
3. Fix a macro that was defined multiple times on Windows.