### PR TITLE
Binding for prctl(PR_SET_PDEATHSIG)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,9 @@ Checks: '
   ,-cppcoreguidelines-pro-type-static-cast-downcast
   ,-cppcoreguidelines-pro-bounds-pointer-arithmetic
   ,-cppcoreguidelines-pro-bounds-constant-array-index
+  ,-cppcoreguidelines-pro-type-cstyle-cast
   ,-cppcoreguidelines-pro-type-reinterpret-cast
+  ,-cppcoreguidelines-pro-type-vararg
   ,-cppcoreguidelines-special-member-functions
   ,-cppcoreguidelines-interfaces-global-init
   ,-cppcoreguidelines-owning-memory

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -532,6 +532,7 @@ if (BUILD_PYTHON)
     ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/python_tree_views.cpp
+    ${TORCH_SRC_DIR}/csrc/multiprocessing/init.cpp
     ${TORCH_SRC_DIR}/csrc/nn/THNN.cpp
     ${TORCH_SRC_DIR}/csrc/onnx/init.cpp
     ${TORCH_SRC_DIR}/csrc/serialization.cpp

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -29,6 +29,7 @@
 #include "torch/csrc/autograd/generated/python_nn_functions.h"
 #include "torch/csrc/autograd/python_legacy_variable.h"
 #include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/multiprocessing/init.h"
 #include "torch/csrc/tensor/python_tensor.h"
 #include "torch/csrc/utils/tensor_dtypes.h"
 #include "torch/csrc/utils/python_strings.h"
@@ -522,6 +523,7 @@ PyObject* initModule() {
   THPUtils_addPyMethodDefs(methods, TorchMethods);
   THPUtils_addPyMethodDefs(methods, DataLoaderMethods);
   THPUtils_addPyMethodDefs(methods, torch::autograd::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::multiprocessing::python_functions());
 #ifdef USE_CUDA
   THPUtils_addPyMethodDefs(methods, THCPModule_methods());
 #endif

--- a/torch/csrc/multiprocessing/init.cpp
+++ b/torch/csrc/multiprocessing/init.cpp
@@ -2,10 +2,9 @@
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/pybind.h>
 
-#include <iostream>
 #include <stdexcept>
 
-#if __linux__
+#if defined(__linux__)
 #include <sys/prctl.h>
 #endif
 
@@ -29,7 +28,7 @@ PyObject* multiprocessing_init(PyObject* _unused) {
   auto module = py::handle(multiprocessing_module).cast<py::module>();
 
   module.def("_prctl_pr_set_pdeathsig", [](int signal) {
-#if __linux__
+#if defined(__linux__)
     auto rv = prctl(PR_SET_PDEATHSIG, signal);
     SYSASSERT(rv, "prctl");
 #endif

--- a/torch/csrc/multiprocessing/init.cpp
+++ b/torch/csrc/multiprocessing/init.cpp
@@ -1,0 +1,59 @@
+#include <torch/csrc/python_headers.h>
+#include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include <iostream>
+#include <stdexcept>
+
+#if __linux__
+#include <sys/prctl.h>
+#endif
+
+#define SYSASSERT(rv, ...)                                                 \
+  if ((rv) < 0) {                                                          \
+    throw std::system_error(errno, std::system_category(), ##__VA_ARGS__); \
+  }
+
+namespace torch {
+namespace multiprocessing {
+
+namespace {
+
+PyObject* multiprocessing_init(PyObject* _unused) {
+  auto multiprocessing_module =
+      THPObjectPtr(PyImport_ImportModule("torch.multiprocessing"));
+  if (!multiprocessing_module) {
+    throw python_error();
+  }
+
+  auto module = py::handle(multiprocessing_module).cast<py::module>();
+
+  module.def("_prctl_pr_set_pdeathsig", [](int signal) {
+#if __linux__
+    auto rv = prctl(PR_SET_PDEATHSIG, signal);
+    SYSASSERT(rv, "prctl");
+#endif
+  });
+
+  Py_RETURN_TRUE;
+}
+
+} // namespace
+
+// multiprocessing methods on torch._C
+static PyMethodDef methods[] = {
+    {
+        "_multiprocessing_init",
+        (PyCFunction)multiprocessing_init,
+        METH_NOARGS,
+        nullptr,
+    },
+    {nullptr, nullptr, 0, nullptr},
+};
+
+PyMethodDef* python_functions() {
+  return methods;
+}
+
+} // namespace multiprocessing
+} // namespace torch

--- a/torch/csrc/multiprocessing/init.h
+++ b/torch/csrc/multiprocessing/init.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/csrc/python_headers.h>
+
+namespace torch {
+namespace multiprocessing {
+
+PyMethodDef* python_functions();
+
+} // namespace multiprocessing
+} // namespace torch

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -13,6 +13,7 @@ memory.
 Because of the similarity of APIs we do not document most of this package
 contents, and we recommend referring to very good docs of the original module.
 """
+import torch
 import sys
 from .reductions import init_reductions
 import multiprocessing
@@ -25,6 +26,11 @@ from multiprocessing import *
 
 
 __all__ += multiprocessing.__all__
+
+
+# This call adds a Linux specific prctl(2) wrapper function to this module.
+# See https://github.com/pytorch/pytorch/pull/14391 for more information.
+torch._C._multiprocessing_init()
 
 
 if sys.version_info < (3, 3):

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -5,8 +5,18 @@ import multiprocessing.connection
 import signal
 import sys
 
+from . import _prctl_pr_set_pdeathsig
+
 
 def _wrap(fn, i, args, error_queue):
+    # prctl(2) is a Linux specific system call.
+    # On other systems the following function call has no effect.
+    #
+    # This is set to ensure that non-daemonic child processes can
+    # terminate if their parent terminates before they do.
+    #
+    _prctl_pr_set_pdeathsig(signal.SIGINT)
+
     try:
         fn(i, *args)
     except KeyboardInterrupt:
@@ -38,6 +48,9 @@ class SpawnContext:
             process.sentinel: index
             for index, process in enumerate(processes)
         }
+
+    def pids(self):
+        return [int(process.pid) for process in self.processes]
 
     def join(self, timeout=None):
         r"""

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -11,10 +11,8 @@ from . import _prctl_pr_set_pdeathsig
 def _wrap(fn, i, args, error_queue):
     # prctl(2) is a Linux specific system call.
     # On other systems the following function call has no effect.
-    #
     # This is set to ensure that non-daemonic child processes can
     # terminate if their parent terminates before they do.
-    #
     _prctl_pr_set_pdeathsig(signal.SIGINT)
 
     try:


### PR DESCRIPTION
If torch.multiprocessing.spawn is used to launch non-daemonic
processes (the default since #14391), the spawned children won't be
automatically terminated when the parent terminates.

On Linux, we can address this by setting PR_SET_PDEATHSIG, which
delivers a configurable signal to child processes when their parent
terminates.

Fixes #14394.
