### PR TITLE
Improve support for cling/jupyter notebooks

### DIFF
--- a/cmake/ClingPragmas.cmake
+++ b/cmake/ClingPragmas.cmake
@@ -1,0 +1,58 @@
+# CMake's infuriating scoping rules: a function call creates a new
+# "copy-on-write" variable scope. This means if you have a list $L in the first
+# call, then recurse, $L will still be the old value it had in the first call,
+# so appending to the list will create $L from before plus some new items.
+# However, when you return into the previous frame, $L will be back to the value
+# it had before recursing. For sanity, we just reset the list to an empty
+# variable at the start of each frame, and then pass back a new list from every
+# frame and concatenate it after a recursive call.
+function(get_link_libraries OUTPUT_LIST TARGETS)
+  set(LIBS) # Reset to a new variable
+  foreach(T ${TARGETS})
+    if (TARGET ${T})
+      # If T is an alias to another target, resolve this alias.
+      get_target_property(A ${T} ALIASED_TARGET)
+      if (A)
+        set(T ${A})
+      endif()
+      # Check if we've already been to this target.
+      list(FIND VISITED_TARGETS ${T} INDEX)
+      if (${INDEX} EQUAL -1)
+        # Add to the visited targets, so we don't visit this target (vertex)
+        # again.
+        list(APPEND VISITED_TARGETS ${T})
+        # If this is not an interface library, it has a physical location we
+        # want to collect.
+        get_target_property(TARGET_TYPE ${T} TYPE)
+        if (NOT TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+          get_target_property(L ${T} LOCATION)
+          list(APPEND LIBS ${L})
+        endif()
+        # Recurse for any link dependencies.
+        get_target_property(LINK_DEPS ${T} INTERFACE_LINK_LIBRARIES)
+        if (LINK_DEPS)
+          get_link_libraries(D "${LINK_DEPS}")
+          list(APPEND LIBS ${D})
+        endif()
+      endif()
+    endif()
+  endforeach()
+  # Forward these variables to the upper scope.
+  set(VISITED_TARGETS ${VISITED_TARGETS} PARENT_SCOPE)
+  set(${OUTPUT_LIST} ${LIBS} PARENT_SCOPE)
+endfunction()
+
+get_link_libraries(LINK_LIB_PATHS "${TORCH_LIBRARIES}")
+
+set(CLING_PRAGMAS_OUTPUT_FILE "${TORCH_INSTALL_PREFIX}/cling_pragmas.h")
+
+add_custom_command(
+  OUTPUT ${CLING_PRAGMAS_OUTPUT_FILE}
+  COMMAND python ${TORCH_INSTALL_PREFIX}/tools/gen_cling_pragmas.py
+    --include-dirs ${TORCH_INCLUDE_DIRS}
+    --library-dirs ${TORCH_INSTALL_PREFIX}/lib
+    --libraries ${LINK_LIB_PATHS}
+    --output ${CLING_PRAGMAS_OUTPUT_FILE}
+  WORKING_DIRECTORY ${TORCH_INSTALL_PREFIX})
+
+add_custom_target(cling_pragmas DEPENDS ${CLING_PRAGMAS_OUTPUT_FILE})

--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -14,6 +14,11 @@
 #
 #   torch
 
+# If ON, generates a file cling_pragmas.h under the install root that can be
+# included in the cling interpreter to load all necessary include paths, library
+# paths and libraries.
+option(TORCH_GENERATE_CLING_PRAGMAS OFF)
+
 include(FindPackageHandleStandardArgs)
 
 if (DEFINED ENV{TORCH_INSTALL_PREFIX})
@@ -66,6 +71,14 @@ if (@USE_CUDA@)
       ${CUDA_LIBRARIES})
   endif()
   list(APPEND TORCH_LIBRARIES ${TORCH_CUDA_LIBRARIES})
+endif()
+
+if (TORCH_GENERATE_CLING_PRAGMAS)
+  add_custom_command instead
+  configure_file(
+      ${CMAKE_CURRENT_LIST_DIR}/cling_pragmas.h
+      ${TORCH_INSTALL_PREFIX}/cling_pragmas.h
+      @ONLY)
 endif()
 
 # When we build libtorch with the old GCC ABI, dependent libraries must too.

--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -14,11 +14,6 @@
 #
 #   torch
 
-# If ON, generates a file cling_pragmas.h under the install root that can be
-# included in the cling interpreter to load all necessary include paths, library
-# paths and libraries.
-option(TORCH_GENERATE_CLING_PRAGMAS OFF)
-
 include(FindPackageHandleStandardArgs)
 
 if (DEFINED ENV{TORCH_INSTALL_PREFIX})
@@ -73,13 +68,43 @@ if (@USE_CUDA@)
   list(APPEND TORCH_LIBRARIES ${TORCH_CUDA_LIBRARIES})
 endif()
 
-if (TORCH_GENERATE_CLING_PRAGMAS)
-  add_custom_command instead
-  configure_file(
-      ${CMAKE_CURRENT_LIST_DIR}/cling_pragmas.h
-      ${TORCH_INSTALL_PREFIX}/cling_pragmas.h
-      @ONLY)
-endif()
+function(get_link_libraries OUTPUT_LIST TARGET)
+    get_target_property(IMPORTED ${TARGET} IMPORTED)
+    list(APPEND VISITED_TARGETS ${TARGET})
+    if (IMPORTED)
+        get_target_property(LIBS ${TARGET} INTERFACE_LINK_LIBRARIES)
+    else()
+        get_target_property(LIBS ${TARGET} LINK_LIBRARIES)
+    endif()
+    set(LIB_FILES "")
+    foreach(LIB ${LIBS})
+        if (TARGET ${LIB})
+            list(FIND VISITED_TARGETS ${LIB} VISITED)
+            if (${VISITED} EQUAL -1)
+                get_target_property(LIB_FILE ${LIB} LOCATION)
+                get_link_libraries(LINK_LIB_FILES ${LIB})
+                list(APPEND LIB_FILES ${LIB_FILE} ${LINK_LIB_FILES})
+            endif()
+        endif()
+    endforeach()
+    set(VISITED_TARGETS ${VISITED_TARGETS} PARENT_SCOPE)
+    set(${OUTPUT_LIST} ${LIB_FILES} PARENT_SCOPE)
+endfunction()
+
+set(L get_link_libraries(caffe2_library))
+message(L)
+
+set(CLING_PRAGMAS_OUTPUT_FILE "${TORCH_INSTALL_PREFIX}/cling_pragmas.h")
+add_custom_command(
+  OUTPUT ${CLING_PRAGMAS_OUTPUT_FILE}
+  COMMAND python ${TORCH_INSTALL_PREFIX}/tools/gen_cling_pragmas.py
+    --root ${TORCH_INSTALL_PREFIX}
+    --include-dirs ${TORCH_INCLUDE_DIRS}
+    --library-dirs ${TORCH_INSTALL_PREFIX}/lib
+    --libraries ${TORCH_LIBRARIES}
+    --output ${CLING_PRAGMAS_OUTPUT_FILE}
+  WORKING_DIRECTORY ${TORCH_INSTALL_PREFIX})
+add_custom_target(cling_pragmas DEPENDS ${CLING_PRAGMAS_OUTPUT_FILE})
 
 # When we build libtorch with the old GCC ABI, dependent libraries must too.
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -68,44 +68,6 @@ if (@USE_CUDA@)
   list(APPEND TORCH_LIBRARIES ${TORCH_CUDA_LIBRARIES})
 endif()
 
-function(get_link_libraries OUTPUT_LIST TARGET)
-    get_target_property(IMPORTED ${TARGET} IMPORTED)
-    list(APPEND VISITED_TARGETS ${TARGET})
-    if (IMPORTED)
-        get_target_property(LIBS ${TARGET} INTERFACE_LINK_LIBRARIES)
-    else()
-        get_target_property(LIBS ${TARGET} LINK_LIBRARIES)
-    endif()
-    set(LIB_FILES "")
-    foreach(LIB ${LIBS})
-        if (TARGET ${LIB})
-            list(FIND VISITED_TARGETS ${LIB} VISITED)
-            if (${VISITED} EQUAL -1)
-                get_target_property(LIB_FILE ${LIB} LOCATION)
-                get_link_libraries(LINK_LIB_FILES ${LIB})
-                list(APPEND LIB_FILES ${LIB_FILE} ${LINK_LIB_FILES})
-            endif()
-        endif()
-    endforeach()
-    set(VISITED_TARGETS ${VISITED_TARGETS} PARENT_SCOPE)
-    set(${OUTPUT_LIST} ${LIB_FILES} PARENT_SCOPE)
-endfunction()
-
-set(L get_link_libraries(caffe2_library))
-message(L)
-
-set(CLING_PRAGMAS_OUTPUT_FILE "${TORCH_INSTALL_PREFIX}/cling_pragmas.h")
-add_custom_command(
-  OUTPUT ${CLING_PRAGMAS_OUTPUT_FILE}
-  COMMAND python ${TORCH_INSTALL_PREFIX}/tools/gen_cling_pragmas.py
-    --root ${TORCH_INSTALL_PREFIX}
-    --include-dirs ${TORCH_INCLUDE_DIRS}
-    --library-dirs ${TORCH_INSTALL_PREFIX}/lib
-    --libraries ${TORCH_LIBRARIES}
-    --output ${CLING_PRAGMAS_OUTPUT_FILE}
-  WORKING_DIRECTORY ${TORCH_INSTALL_PREFIX})
-add_custom_target(cling_pragmas DEPENDS ${CLING_PRAGMAS_OUTPUT_FILE})
-
 # When we build libtorch with the old GCC ABI, dependent libraries must too.
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=@GLIBCXX_USE_CXX11_ABI@")
@@ -119,5 +81,9 @@ set_target_properties(torch PROPERTIES
 if (TORCH_CXX_FLAGS)
   set_property(TARGET torch PROPERTY INTERFACE_COMPILE_OPTIONS "${TORCH_CXX_FLAGS}")
 endif()
+
+# CMake code to create a target that generates a header with pragmas for cling
+# (the C++ interpreter).
+include(${CMAKE_CURRENT_LIST_DIR}/ClingPragmas.cmake)
 
 find_package_handle_standard_args(torch DEFAULT_MSG TORCH_LIBRARY TORCH_INCLUDE_DIRS)

--- a/tools/gen_cling_pragmas.py
+++ b/tools/gen_cling_pragmas.py
@@ -7,8 +7,7 @@ of PyTorch.
 import argparse
 import os.path
 
-FILE_TEMPLATE = """
-#pragma once
+FILE_TEMPLATE = """#pragma once
 
 // Include directories
 {}
@@ -18,6 +17,8 @@ FILE_TEMPLATE = """
 
 // Libraries
 {}
+
+#include <torch/torch.h>
 """
 
 # Mainly taken from https://github.com/QuantStack/xeus-cling/issues/87#issuecomment-349053121
@@ -27,7 +28,6 @@ LIBRARIES_TEMPLATE = '#pragma cling load("{}")'
 
 
 parser = argparse.ArgumentParser(description="Generate cling_pragmas.h")
-parser.add_argument("--root", required=True)
 parser.add_argument("--include-dirs", nargs="+", required=True)
 parser.add_argument("--library-dirs", nargs="+", required=True)
 parser.add_argument("--libraries", nargs="+", required=True)
@@ -35,16 +35,13 @@ parser.add_argument("-o", "--output")
 options = parser.parse_args()
 
 
-def format_paths(template, paths, relative=True):
-    for path in paths:
-        if relative:
-            path = os.path.join(options.root, path)
-        yield template.format(path)
+def format_paths(template, paths):
+    return [template.format(path) for path in paths]
 
 
 include_dirs = format_paths(INCLUDE_DIR_TEMPLATE, options.include_dirs)
 library_dirs = format_paths(LIBRARY_DIR_TEMPLATE, options.library_dirs)
-libraries = format_paths(LIBRARIES_TEMPLATE, options.libraries, relative=False)
+libraries = format_paths(LIBRARIES_TEMPLATE, options.libraries)
 
 source = FILE_TEMPLATE.format(
     "\n".join(include_dirs), "\n".join(library_dirs), "\n".join(libraries)

--- a/tools/gen_cling_pragmas.py
+++ b/tools/gen_cling_pragmas.py
@@ -1,3 +1,9 @@
+"""
+Generates a single header file that may be included in cling/jupyter, which
+has all the necessary pragmas for cling to see all further headers and libraries
+of PyTorch.
+"""
+
 import argparse
 import os.path
 
@@ -14,38 +20,38 @@ FILE_TEMPLATE = """
 {}
 """
 
-INCLUDE_DIR_TEMPLATE = "#pragma cling add_include_path({})"
-LIBRARY_DIR_TEMPLATE = "#pragma cling add_library_path({})"
-LIBRARIES_TEMPLATE = "#pragma cling load({})"
+# Mainly taken from https://github.com/QuantStack/xeus-cling/issues/87#issuecomment-349053121
+INCLUDE_DIR_TEMPLATE = '#pragma cling add_include_path("{}")'
+LIBRARY_DIR_TEMPLATE = '#pragma cling add_library_path("{}")'
+LIBRARIES_TEMPLATE = '#pragma cling load("{}")'
 
 
-parser = argparse.ArgumentParser(description='Generate cling_pragmas.h')
-parser.add_argument('--include-dirs', nargs="+", required=True)
-parser.add_argument('--library-dirs', nargs="+", required=True)
-parser.add_argument('--libraries', nargs="+", required=True)
-parser.add_argument('-o', '--output')
+parser = argparse.ArgumentParser(description="Generate cling_pragmas.h")
+parser.add_argument("--root", required=True)
+parser.add_argument("--include-dirs", nargs="+", required=True)
+parser.add_argument("--library-dirs", nargs="+", required=True)
+parser.add_argument("--libraries", nargs="+", required=True)
+parser.add_argument("-o", "--output")
 options = parser.parse_args()
 
 
-def format_paths(template, paths):
+def format_paths(template, paths, relative=True):
     for path in paths:
-        relative_path = "{}/{}".format("${{CLING_PRAGMAS_ROOT}}", path)
-        yield template.format(relative_path)
-
+        if relative:
+            path = os.path.join(options.root, path)
+        yield template.format(path)
 
 
 include_dirs = format_paths(INCLUDE_DIR_TEMPLATE, options.include_dirs)
 library_dirs = format_paths(LIBRARY_DIR_TEMPLATE, options.library_dirs)
-libraries = format_paths(LIBRARIES_TEMPLATE, options.libraries)
+libraries = format_paths(LIBRARIES_TEMPLATE, options.libraries, relative=False)
 
 source = FILE_TEMPLATE.format(
-  "\n".join(include_dirs),
-  "\n".join(library_dirs),
-  "\n".join(libraries),
+    "\n".join(include_dirs), "\n".join(library_dirs), "\n".join(libraries)
 )
 
 if options.output:
-  with open(options.output, "w") as output_file:
-    output_file.write(source)
+    with open(options.output, "w") as output_file:
+        output_file.write(source)
 else:
-  print(source)
+    print(source)

--- a/tools/gen_cling_pragmas.py
+++ b/tools/gen_cling_pragmas.py
@@ -1,0 +1,51 @@
+import argparse
+import os.path
+
+FILE_TEMPLATE = """
+#pragma once
+
+// Include directories
+{}
+
+// Library directories
+{}
+
+// Libraries
+{}
+"""
+
+INCLUDE_DIR_TEMPLATE = "#pragma cling add_include_path({})"
+LIBRARY_DIR_TEMPLATE = "#pragma cling add_library_path({})"
+LIBRARIES_TEMPLATE = "#pragma cling load({})"
+
+
+parser = argparse.ArgumentParser(description='Generate cling_pragmas.h')
+parser.add_argument('--include-dirs', nargs="+", required=True)
+parser.add_argument('--library-dirs', nargs="+", required=True)
+parser.add_argument('--libraries', nargs="+", required=True)
+parser.add_argument('-o', '--output')
+options = parser.parse_args()
+
+
+def format_paths(template, paths):
+    for path in paths:
+        relative_path = "{}/{}".format("${{CLING_PRAGMAS_ROOT}}", path)
+        yield template.format(relative_path)
+
+
+
+include_dirs = format_paths(INCLUDE_DIR_TEMPLATE, options.include_dirs)
+library_dirs = format_paths(LIBRARY_DIR_TEMPLATE, options.library_dirs)
+libraries = format_paths(LIBRARIES_TEMPLATE, options.libraries)
+
+source = FILE_TEMPLATE.format(
+  "\n".join(include_dirs),
+  "\n".join(library_dirs),
+  "\n".join(libraries),
+)
+
+if options.output:
+  with open(options.output, "w") as output_file:
+    output_file.write(source)
+else:
+  print(source)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -482,6 +482,7 @@ configure_file(
 install(FILES
     ${PROJECT_BINARY_DIR}/TorchConfigVersion.cmake
     ${PROJECT_BINARY_DIR}/TorchConfig.cmake
+    ${TORCH_ROOT}/cmake/ClingPragmas.cmake
     DESTINATION share/cmake/Torch)
 
 if (USE_DISTRIBUTED)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -432,6 +432,8 @@ install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
         FILES_MATCHING PATTERN "*.h")
 install(FILES "${TORCH_SRC_DIR}/script.h" "${TORCH_SRC_DIR}/extension.h"
         DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch)
+install(FILES "${TOOLS_PATH}/gen_cling_pragmas.py"
+        DESTINATION tools)
 
 install(TARGETS torch
   RUNTIME DESTINATION "${TORCH_INSTALL_BIN_DIR}"


### PR DESCRIPTION
This PR is intended to make it easier to use cling/jupyter notebooks for the C++ frontend. The only complexity around this is that the C++ jupyter notebook needs special instructions (pragmas) for all the include directories, library directories and shared libraries to load. Typing these directories out manually is annoying. This PR adds a tool that can generate a header from our CMake config which already includes all of these pragmas. This means end-users only need to include this one generated header to access PyTorch in a Jupyter notebook. Right now, the expected usage is that you'd install libtorch from the website, and then write your own small CMake file that depends on libtorch:

```cmake
cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
project(foo)
find_package(Torch REQUIRED)
```

The `find_package` statement will automatically create a target `cling_pragmas`, so you could then write:

```sh
$ mkdir build && cd build
$ cmake -DCMAKE_PREFIX_PATH=/path/to/libtorch ..
$ make cling_pragmas
```

This will generate a header like `/Users/psag/Documents/pytorch/torch/lib/tmp_install/cling_pragmas.h` which looks something like:

```
#pragma once

// Include directories
#pragma cling add_include_path("/Users/psag/Documents/pytorch/torch/lib/tmp_install/include")
#pragma cling add_include_path("/Users/psag/Documents/pytorch/torch/lib/tmp_install/include/torch/csrc/api/include")

// Library directories
#pragma cling add_library_path("/Users/psag/Documents/pytorch/torch/lib/tmp_install/lib")

// Libraries
#pragma cling load("/Users/psag/Documents/pytorch/torch/lib/tmp_install/lib/libtorch.dylib")
#pragma cling load("/Users/psag/Documents/pytorch/torch/lib/tmp_install/lib/libcaffe2.dylib")
#pragma cling load("/Users/psag/Documents/pytorch/torch/lib/tmp_install/lib/libc10.dylib")

#include <torch/torch.h>
```

with absolute paths set correctly. Then, in the jupyter notebook, you can simply `#include "/Users/psag/Documents/pytorch/torch/lib/tmp_install/cling_pragmas.h"` and you're good to go:

![image](https://user-images.githubusercontent.com/6429851/49189681-321e0300-f324-11e8-8497-78d2d08aa87f.png)

What do folks think of this?

@soumith @ezyang @fmassa @t-vi @ebetica 