### PR TITLE
Validate matching input shapes in Int8Add operator

### DIFF
--- a/caffe2/operators/quantized/int8_add_op.h
+++ b/caffe2/operators/quantized/int8_add_op.h
@@ -32,6 +32,11 @@ class Int8AddOp final : public Operator<CPUContext> {
     const auto& B = Inputs()[1]->template Get<Int8TensorCPU>();
     auto* Y = Outputs()[0]->template GetMutable<Int8TensorCPU>();
 
+    CAFFE_ENFORCE_EQ(
+        A.t.sizes(),
+        B.t.sizes(),
+        "inputs must have the same shape (broadcast semantics is not supported)");
+
     /*
      * Record quantization parameters for A and B inputs, because if the op is
      * in-place, we may overwrite these parameters later, when we set


### PR DESCRIPTION
Summary: Default engine doesn't support broadcast semantics in Int8Add operator. This patch adds a check that shapes are equivalent.

Differential Revision: D13250922
