### PR TITLE
im2col fused acc16 convolution

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
@@ -1,5 +1,4 @@
 #include "conv_dnnlowp_acc16_op.h"
-#include "dnnlowp_op.h"
 
 // #define DNNLOWP_ACC16_IN_SLOW_PATH
 // #define DNNLOWP_MEASURE_TIME_BREAKDOWN
@@ -10,6 +9,7 @@
 #include <omp.h>
 #endif
 
+#include "dnnlowp_op.h"
 #include "dnnlowp_partition.h"
 #include "im2col_dnnlowp.h"
 
@@ -31,10 +31,15 @@ ConvDNNLowPAcc16Op<ReluFused>::ConvDNNLowPAcc16Op(
           FLAGS_dnnlowp_nbits_in_non_outlier)),
       copy_to_32bit_frequency_(OperatorBase::GetSingleArgument<int>(
           "copy_to_32bit_frequency",
-          FLAGS_dnnlowp_copy_to_32bit_frequency)) {}
+          FLAGS_dnnlowp_copy_to_32bit_frequency)) {
+  CAFFE_ENFORCE_GT(nbits_in_non_outlier_, 0);
+}
 
 template <bool ReluFused>
 bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNCHW() {
+  if (fallback_to_32_bit_accumulation_) {
+    return BaseType::RunOnDeviceWithOrderNCHW();
+  }
   const Tensor& X = InputTensorCPU_(INPUT);
   if (X.template IsType<uint8_t>()) {
     return RunOnDeviceWithOrderNCHWAndType_<uint8_t>();
@@ -46,6 +51,9 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNCHW() {
 
 template <bool ReluFused>
 bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWC() {
+  if (fallback_to_32_bit_accumulation_) {
+    return BaseType::RunOnDeviceWithOrderNHWC();
+  }
   const Tensor& X = InputTensorCPU_(INPUT);
   if (X.template IsType<uint8_t>()) {
     return RunOnDeviceWithOrderNHWCAndType_<uint8_t>();
@@ -61,9 +69,18 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
     return false;
   }
 
+  if (fallback_to_32_bit_accumulation_) {
+    return true;
+  }
+
   int kernel_dim = this->KernelDim_();
+  const Tensor& X = InputTensorCPU_(INPUT);
+  int C = X.dim32(X.ndim() - 1);
   const auto& filter = InputTensorCPU_(FILTER);
   int M = filter.dim32(0);
+
+  bool packW = ConvPoolOpBase<CPUContext>::order_ == StorageOrder::NHWC &&
+      GetCpuId().avx2();
 
   // Separate out outliers
   if (!Wq_outlier_ &&
@@ -75,8 +92,7 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
     for (int group_id = 0; group_id < group_; ++group_id) {
       for (int i = 0; i < (M / group_) * kernel_dim; ++i) {
         int8_t w = W_quantized_[group_id * (M / group_) * kernel_dim + i];
-        bool is_outlier = nbits_in_non_outlier_ == 0 ||
-            w < -(1 << (nbits_in_non_outlier_ - 1)) ||
+        bool is_outlier = w < -(1 << (nbits_in_non_outlier_ - 1)) ||
             w >= (1 << (nbits_in_non_outlier_ - 1));
         if (is_outlier) {
           ++outlier_cnt;
@@ -84,43 +100,60 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
       }
     }
 
-    Wq_outlier_.reset(new fbgemm::CompressedSparseColumn(kernel_dim, M));
-    Wq_outlier_->RowIdx().resize(outlier_cnt);
-    Wq_outlier_->Values().resize(outlier_cnt);
-
-    outlier_cnt = 0;
-    for (int group_id = 0; group_id < group_; ++group_id) {
-      for (int j = 0; j < M / group_; ++j) {
-        Wq_outlier_->ColPtr()[group_id * (M / group_) + j] = outlier_cnt;
-
-        for (int k = 0; k < kernel_dim; ++k) {
-          int8_t w =
-              W_quantized_[(group_id * (M / group_) + j) * kernel_dim + k];
-          bool is_outlier = nbits_in_non_outlier_ == 0 ||
-              w < -(1 << (nbits_in_non_outlier_ - 1)) ||
-              w >= (1 << (nbits_in_non_outlier_ - 1));
-          if (is_outlier) {
-            CAFFE_ENFORCE_LE(k, numeric_limits<int16_t>::max());
-            Wq_outlier_->RowIdx()[outlier_cnt] = k;
-            Wq_outlier_->Values()[outlier_cnt] = w;
-            ++outlier_cnt;
-
-            W_quantized_[(group_id * (M / group_) + j) * kernel_dim + k] = 0;
-          }
-        }
-      }
-    } // for each group
-    Wq_outlier_->ColPtr()[M] = outlier_cnt;
-
     LOG(INFO) << "Proportion of outlier for Conv layer with weight blob "
               << OperatorBase::debug_def().input(1) << " is "
-              << (float)outlier_cnt / W_quantized_.size();
+              << static_cast<float>(outlier_cnt) / W_quantized_.size();
     LOG(INFO) << "nbits_in_non_outlier " << nbits_in_non_outlier_
               << " copy_to_32bit_frequency " << copy_to_32bit_frequency_;
-  }
 
-  bool packW = ConvPoolOpBase<CPUContext>::order_ == StorageOrder::NHWC &&
-      GetCpuId().avx2();
+    if (static_cast<float>(outlier_cnt) / W_quantized_.size() <= 0.05) {
+      Wq_outlier_.reset(new fbgemm::CompressedSparseColumn(kernel_dim, M));
+      Wq_outlier_->RowIdx().resize(outlier_cnt);
+      Wq_outlier_->Values().resize(outlier_cnt);
+      Wq_outlier_->KHs().resize(outlier_cnt);
+      Wq_outlier_->KWs().resize(outlier_cnt);
+      Wq_outlier_->ICs().resize(outlier_cnt);
+
+      too_dense_to_fuse_im2col_ =
+          static_cast<float>(outlier_cnt) / W_quantized_.size() >= 0.001;
+      outlier_cnt = 0;
+      for (int group_id = 0; group_id < group_; ++group_id) {
+        for (int j = 0; j < M / group_; ++j) {
+          Wq_outlier_->ColPtr()[group_id * (M / group_) + j] = outlier_cnt;
+
+          for (int k = 0; k < kernel_dim; ++k) {
+            int8_t w =
+                W_quantized_[(group_id * (M / group_) + j) * kernel_dim + k];
+            bool is_outlier = w < -(1 << (nbits_in_non_outlier_ - 1)) ||
+                w >= (1 << (nbits_in_non_outlier_ - 1));
+            if (is_outlier) {
+              CAFFE_ENFORCE_LE(k, numeric_limits<int16_t>::max());
+              Wq_outlier_->RowIdx()[outlier_cnt] = k;
+              Wq_outlier_->Values()[outlier_cnt] = w;
+
+              int ic = group_id * (C / group_) + k % (C / group_);
+              CAFFE_ENFORCE_LE(ic, numeric_limits<int16_t>::max());
+              int kw = k / (C / group_) % this->kernel_[1];
+              int kh = k / (C / group_) / this->kernel_[1];
+              CAFFE_ENFORCE_LE(kh, this->kernel_[0]);
+              Wq_outlier_->KHs()[outlier_cnt] = kh;
+              Wq_outlier_->KWs()[outlier_cnt] = kw;
+              Wq_outlier_->ICs()[outlier_cnt] = ic;
+
+              W_quantized_[(group_id * (M / group_) + j) * kernel_dim + k] = 0;
+
+              ++outlier_cnt;
+            }
+          }
+        }
+      } // for each group
+      Wq_outlier_->ColPtr()[M] = outlier_cnt;
+    } else {
+      LOG(INFO) << "Density of outliers is too high. Falling back to acc32";
+      fallback_to_32_bit_accumulation_ = true;
+      return true;
+    }
+  }
 
   if (first_invocation_) {
     if (!packW) {
@@ -180,6 +213,9 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNCHWAndType_() {
   // Get quantization parameters
   if (!GetQuantizationParameters_()) {
     return false;
+  }
+  if (fallback_to_32_bit_accumulation_) {
+    return BaseType::template RunOnDeviceWithOrderNCHWAndType_<InType>();
   }
 
   const Tensor& X = InputTensorCPU_(INPUT);
@@ -304,11 +340,13 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNCHWAndType_() {
         vector<uint8_t> col_buffer_quantized;
         if (X.template IsType<uint8_t>()) {
           col_buffer_quantized_data =
-              (uint8_t*)col_buffer_data + tid * col_buffer_size;
+              reinterpret_cast<uint8_t*>(col_buffer_data) +
+              tid * col_buffer_size;
         } else {
           col_buffer_quantized.resize(kernel_dim * output_image_size);
           fbgemm::Quantize<uint8_t>(
-              (const float*)col_buffer_data + tid * col_buffer_size,
+              reinterpret_cast<const float*>(col_buffer_data) +
+                  tid * col_buffer_size,
               col_buffer_quantized.data(),
               col_buffer_quantized.size(),
               in_qparams_[INPUT]);
@@ -474,7 +512,7 @@ static void conv_nhwc_acc16_ref_(
 
 template <bool ReluFused>
 template <typename PackAMatrix, fbgemm::QuantizationGranularity Q_GRAN>
-void ConvDNNLowPAcc16Op<ReluFused>::DispatchFBGEMM(
+void ConvDNNLowPAcc16Op<ReluFused>::DispatchFBGEMM_(
     PackAMatrix& packA,
     const uint8_t* col_buffer_quantized_data,
     vector<int32_t>* Y_int32) {
@@ -488,6 +526,8 @@ void ConvDNNLowPAcc16Op<ReluFused>::DispatchFBGEMM(
     Y_uint8_data = Y->template mutable_data<uint8_t>();
   }
 
+  bool fuse_output_pipeline = Wq_acc16_packed_ && !dequantize_output_;
+  assert(fuse_output_pipeline);
   int kernel_dim = this->KernelDim_();
 
   int nthreads = dnnlowp_get_num_threads();
@@ -542,6 +582,77 @@ void ConvDNNLowPAcc16Op<ReluFused>::DispatchFBGEMM(
 }
 
 template <bool ReluFused>
+template <typename PackAMatrix, fbgemm::QuantizationGranularity Q_GRAN>
+void ConvDNNLowPAcc16Op<ReluFused>::DispatchSConv_(
+    PackAMatrix& packA,
+    const uint8_t* col_buffer_quantized_data,
+    vector<int32_t>* Y_int32,
+    const fbgemm::conv_param_t<>& conv_p) {
+  auto& filter = InputTensorCPU_(FILTER);
+  Tensor* Y = OutputTensorCPU_(0);
+  const int M = filter.dim32(0);
+
+  uint8_t* Y_uint8_data = nullptr;
+  if (!dequantize_output_) {
+    // Output is uint8_t
+    Y_uint8_data = Y->template mutable_data<uint8_t>();
+  }
+
+  bool fuse_output_pipeline = Wq_acc16_packed_ && !dequantize_output_;
+  assert(fuse_output_pipeline);
+
+  int nthreads = dnnlowp_get_num_threads();
+  int tid = dnnlowp_get_thread_num();
+
+  using namespace fbgemm;
+  DoNothing<> doNothingObj{};
+  ReQuantizeOutput<ReluFused, Q_GRAN> reqObj(
+      doNothingObj,
+      this->requantization_multipliers_.data(),
+      out_qparams_.zero_point,
+      in_qparams_[INPUT].zero_point,
+      this->filter_zero_points_.data(),
+      packA.getRowOffsetBuffer(),
+      this->column_offsets_.data(),
+      InputSize() == 3 ? this->b_quantized_data_ : nullptr,
+      M,
+      group_);
+
+  if (nbits_in_non_outlier_ < 8) {
+    DoSConvOnInpBuffer<
+        typename ReQuantizeOutput<ReluFused>::outType,
+        int32_t,
+        ReQuantizeOutput<ReluFused, Q_GRAN>>
+        sconvObj(
+            reqObj,
+            col_buffer_quantized_data,
+            conv_p,
+            in_qparams_[INPUT].zero_point,
+            *Wq_outlier_);
+
+    fbgemmPacked(
+        packA,
+        *Wq_acc16_packed_,
+        Y_uint8_data,
+        Y_int32->data(),
+        M,
+        sconvObj,
+        tid,
+        nthreads);
+  } else {
+    fbgemmPacked(
+        packA,
+        *Wq_acc16_packed_,
+        Y_uint8_data,
+        Y_int32->data(),
+        M,
+        reqObj,
+        tid,
+        nthreads);
+  }
+}
+
+template <bool ReluFused>
 void ConvDNNLowPAcc16Op<ReluFused>::ConvOutlier_(
     const uint8_t* col_buffer,
     vector<int32_t>* Y_int32) {
@@ -554,10 +665,6 @@ void ConvDNNLowPAcc16Op<ReluFused>::ConvOutlier_(
 
     const int kernel_dim = this->KernelDim_();
     const int output_image_size = this->GetDimsSize(*Y);
-
-    if (nbits_in_non_outlier_ == 0) {
-      memset(Y_int32->data(), 0, sizeof((*Y_int32)[0]) * M * N);
-    }
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -613,6 +720,10 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWCAndType_() {
     return false;
   }
 
+  if (fallback_to_32_bit_accumulation_) {
+    return BaseType::template RunOnDeviceWithOrderNHWCAndType_<InType>();
+  }
+
 #ifdef DNNLOWP_MEASURE_TIME_BREAKDOWN
   t_end = chrono::system_clock::now();
   double dt = chrono::duration<double>(t_end - t_begin).count();
@@ -643,7 +754,15 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWCAndType_() {
     t_begin = chrono::system_clock::now();
 #endif
 
-    bool no_im2col = this->NoIm2ColNHWC_();
+    bool fuse_output_pipeline = Wq_acc16_packed_ && !dequantize_output_;
+    bool no_im2col = this->NoIm2ColNHWC_() ||
+        (fuse_output_pipeline && X.template IsType<uint8_t>() &&
+         accumulate(
+             this->dilation_.begin(),
+             this->dilation_.end(),
+             1,
+             multiplies<int>()) == 1 &&
+         !too_dense_to_fuse_im2col_);
 
     // Im2Col, followed by gemm.
     auto f2 = [&](Tensor* col_buffer_) {
@@ -659,10 +778,11 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWCAndType_() {
 #endif
 
       // quantize col_buffer
-      uint8_t* col_buffer_quantized_data = nullptr;
+      const uint8_t* col_buffer_quantized_data = nullptr;
       vector<uint8_t> col_buffer_quantized;
       if (X.template IsType<uint8_t>()) {
-        col_buffer_quantized_data = (uint8_t*)col_buffer_data;
+        col_buffer_quantized_data =
+            reinterpret_cast<const uint8_t*>(col_buffer_data);
       } else {
         col_buffer_quantized.resize(
             group_ * kernel_dim * output_image_size * N);
@@ -692,14 +812,21 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWCAndType_() {
       t_begin = chrono::system_clock::now();
 #endif
 
-      bool fuse_output_pipeline =
-          Wq_acc16_packed_ && nbits_in_non_outlier_ > 0 && !dequantize_output_;
-
       using namespace fbgemm;
       int row_offset_size_per_thread = -1;
       int x_pack_buf_size_per_thread = -1;
+      bool fuse_im2col = Wq_acc16_packed_ && X.template IsType<uint8_t>() &&
+          X.template data<uint8_t>() == col_buffer_quantized_data &&
+          kernel_.size() <= 2 && !this->IsConvGEMM_() && fuse_output_pipeline;
       if (Wq_acc16_packed_) {
-        if (fuse_output_pipeline) {
+        if (fuse_im2col) {
+          row_offset_size_per_thread =
+              PackAWithIm2Col<uint8_t, int16_t>::rowOffsetBufferSize();
+          x_pack_buf_size_per_thread =
+              PackAWithIm2Col<uint8_t, int16_t>::packedBufferSize();
+          row_offsets_.resize(
+              dnnlowp_get_max_threads() * row_offset_size_per_thread);
+        } else if (fuse_output_pipeline) {
           row_offset_size_per_thread =
               PackAWithRowOffset<uint8_t, int16_t>::rowOffsetBufferSize();
           x_pack_buf_size_per_thread =
@@ -714,81 +841,112 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWCAndType_() {
             dnnlowp_get_max_threads() * x_pack_buf_size_per_thread);
       }
 
-      if (nbits_in_non_outlier_ > 0) {
-        // Main GEMM for non-outlier
-        if (Wq_acc16_packed_) {
-          // fast path
+      // Main GEMM for non-outlier
+      if (Wq_acc16_packed_)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-          {
-            int nthreads = dnnlowp_get_num_threads();
-            int tid = dnnlowp_get_thread_num();
+      {
+        // fast path
+        int nthreads = dnnlowp_get_num_threads();
+        int tid = dnnlowp_get_thread_num();
 
-            if (fuse_output_pipeline) {
-              PackAWithRowOffset<uint8_t, int16_t> packA(
-                  matrix_op_t::NoTranspose,
-                  N * output_image_size,
-                  group_ * kernel_dim,
-                  col_buffer_quantized_data,
-                  group_ * kernel_dim,
-                  X_pack_buf_.data() + tid * x_pack_buf_size_per_thread,
-                  group_,
-                  row_offsets_.data() + tid * row_offset_size_per_thread);
-
-              if (this->quantize_groupwise_) {
-                DispatchFBGEMM<
-                    PackAWithRowOffset<uint8_t, int16_t>,
-                    QuantizationGranularity::GROUP>(
-                    packA, col_buffer_quantized_data, Y_int32);
-              } else {
-                DispatchFBGEMM<
-                    PackAWithRowOffset<uint8_t, int16_t>,
-                    QuantizationGranularity::TENSOR>(
-                    packA, col_buffer_quantized_data, Y_int32);
-              }
-            } else {
-              // !fuse_output_pipeline
-              PackAMatrix<uint8_t, int16_t> packA(
-                  matrix_op_t::NoTranspose,
-                  N * output_image_size,
-                  group_ * kernel_dim,
-                  col_buffer_quantized_data,
-                  group_ * kernel_dim,
-                  X_pack_buf_.data() + tid * x_pack_buf_size_per_thread,
-                  group_); // group
-
-              DoNothing<int32_t, int32_t> doNothingObj{};
-              memCopy<> memCopyObj(doNothingObj);
-              fbgemmPacked(
-                  packA,
-                  *Wq_acc16_packed_,
-                  Y_int32->data(),
-                  Y_int32->data(),
-                  M,
-                  memCopyObj,
-                  tid, // thread_id
-                  nthreads); // num_threads
-            }
-          } // omp parallel
-        } else {
-          // slow path
-          conv_nhwc_acc16_ref_(
-              group_,
+        if (fuse_im2col) {
+          conv_param_t<> conv_p(
               N,
-              output_image_size,
+              C,
               M,
-              kernel_dim,
+              {X.dim32(1), kernel_.size() == 2 ? X.dim32(2) : 1},
+              group_,
+              {this->kernel_[0], kernel_.size() == 2 ? this->kernel_[1] : 1},
+              {this->stride_[0], kernel_.size() == 2 ? this->stride_[1] : 1},
+              {this->pads_[0],
+               kernel_.size() == 2 ? this->pads_[1] : 0,
+               kernel_.size() == 2 ? this->pads_[2] : this->pads_[1],
+               kernel_.size() == 2 ? this->pads_[3] : 0});
+
+          PackAWithIm2Col<uint8_t, int16_t> packA(
+              conv_p,
               col_buffer_quantized_data,
-              W_quantized_.data(),
-              Y_int32->data()
+              // buffer for packed matrix
+              X_pack_buf_.data() + tid * x_pack_buf_size_per_thread,
+              in_qparams_[INPUT].zero_point,
+              row_offsets_.data() + tid * row_offset_size_per_thread);
+
+          if (this->quantize_groupwise_) {
+            DispatchSConv_<
+                PackAWithIm2Col<uint8_t, int16_t>,
+                QuantizationGranularity::GROUP>(
+                packA, col_buffer_quantized_data, Y_int32, conv_p);
+          } else {
+            DispatchSConv_<
+                PackAWithIm2Col<uint8_t, int16_t>,
+                QuantizationGranularity::TENSOR>(
+                packA, col_buffer_quantized_data, Y_int32, conv_p);
+          }
+        } else if (fuse_output_pipeline) {
+          // no im2col fusion
+          PackAWithRowOffset<uint8_t, int16_t> packA(
+              matrix_op_t::NoTranspose,
+              N * output_image_size,
+              group_ * kernel_dim,
+              col_buffer_quantized_data,
+              group_ * kernel_dim,
+              X_pack_buf_.data() + tid * x_pack_buf_size_per_thread,
+              group_,
+              row_offsets_.data() + tid * row_offset_size_per_thread);
+
+          if (this->quantize_groupwise_) {
+            DispatchFBGEMM_<
+                PackAWithRowOffset<uint8_t, int16_t>,
+                QuantizationGranularity::GROUP>(
+                packA, col_buffer_quantized_data, Y_int32);
+          } else {
+            DispatchFBGEMM_<
+                PackAWithRowOffset<uint8_t, int16_t>,
+                QuantizationGranularity::TENSOR>(
+                packA, col_buffer_quantized_data, Y_int32);
+          }
+        } else {
+          // no im2col fusion and !fuse_output_pipeline
+          PackAMatrix<uint8_t, int16_t> packA(
+              matrix_op_t::NoTranspose,
+              N * output_image_size,
+              group_ * kernel_dim,
+              col_buffer_quantized_data,
+              group_ * kernel_dim,
+              X_pack_buf_.data() + tid * x_pack_buf_size_per_thread,
+              group_); // group
+
+          DoNothing<int32_t, int32_t> doNothingObj{};
+          memCopy<> memCopyObj(doNothingObj);
+          fbgemmPacked(
+              packA,
+              *Wq_acc16_packed_,
+              Y_int32->data(),
+              Y_int32->data(),
+              M,
+              memCopyObj,
+              tid, // thread_id
+              nthreads); // num_threads
+        } // omp parallel
+      } else {
+        // slow path
+        conv_nhwc_acc16_ref_(
+            group_,
+            N,
+            output_image_size,
+            M,
+            kernel_dim,
+            col_buffer_quantized_data,
+            W_quantized_.data(),
+            Y_int32->data()
 #ifdef DNNLOWP_ACC16_IN_SLOW_PATH
-                  ,
-              this
+                ,
+            this
 #endif
-          );
-        } // slow path
-      } // nbits_in_non_outlier_ > 0
+        );
+      } // slow path
 
 #ifdef DNNLOWP_MEASURE_TIME_BREAKDOWN
       t_end = chrono::system_clock::now();

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
@@ -214,7 +214,7 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         weight_quantized=st.booleans(),
-        nbits_in_non_outlier=st.sampled_from((0, 6)),
+        nbits_in_non_outlier=st.sampled_from((1, 6, 8)),
         share_col_buffer=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
         preserve_weight_sparsity=st.booleans(),
@@ -248,55 +248,38 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         input_channels = input_channels_per_group * group
         output_channels = output_channels_per_group * group
 
-        if nbits_in_non_outlier == 0:
-            X, W, b = generate_conv_inputs(
-                stride,
-                pad,
-                kernel,
-                dilation,
-                size,
-                group,
-                input_channels_per_group,
-                output_channels_per_group,
-                batch_size,
-                order,
-                preserve_activation_sparsity=preserve_activation_sparsity,
-                preserve_weight_sparsity=preserve_weight_sparsity,
-            )
+        X_min = 0 if preserve_activation_sparsity else -77
+        X_max = X_min + 255
+        X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
+        X = np.round(X).astype(np.float32)
+        X[..., 0] = X_min
+        X[0, 0, 0, 1] = X_max
+
+        if preserve_weight_sparsity:
+            W_min = -128
+            W_max = 100
         else:
-            X_min = 0 if preserve_activation_sparsity else -77
-            X_max = X_min + 255
-            X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
-            X = np.round(X).astype(np.float32)
-            X[..., 0] = X_min
-            X[0, 0, 0, 1] = X_max
-
-            if preserve_weight_sparsity:
-                W_min = -128
-                W_max = 100
-            else:
-                W_min = -100
-                W_max = W_min + 255
-            W = (
-                np.random.rand(
-                    output_channels, kernel, kernel, input_channels_per_group
-                )
-                * 4
-                - 2
-                + W_min
-                + 128
+            W_min = -100
+            W_max = W_min + 255
+        W = (
+            np.random.rand(
+                output_channels, kernel, kernel, input_channels_per_group
             )
-            W = np.round(W).astype(np.float32)
-            W[0, 0, 0, 0] = W_min
-            W[1, 0, 0, 0] = W_max
-            W[..., 1] = W_min + 128
+            * 4
+            - 2
+            + W_min
+            + 128
+        )
+        W = np.round(W).astype(np.float32)
+        W[0, 0, 0, 0] = W_min
+        W[1, 0, 0, 0] = W_max
+        W[..., 1] = W_min + 128  # "zeros"
 
-            if order == "NCHW":
-                X = nhwc2nchw(X)
-                W = nhwc2nchw(W)
+        if order == "NCHW":
+            X = nhwc2nchw(X)
+            W = nhwc2nchw(W)
 
-            # No input quantization error in bias
-            b = np.round(np.random.randn(output_channels)).astype(np.float32)
+        b = np.round(np.random.randn(output_channels)).astype(np.float32)
 
         Output = collections.namedtuple("Output", ["Y", "op_type", "engine", "order"])
         outputs = []

--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -98,8 +98,7 @@ template <typename T, bool ReluFused>
 bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3FastPath_() {
   const Tensor& X = InputTensorCPU_(INPUT);
   return StorageOrder::NHWC == ConvPoolOpBase<CPUContext>::order_ &&
-      is_same<T, uint8_t>::value && X.template IsType<T>() &&
-      OperatorBase::debug_def().engine() != "DNNLOWP_ACC16" &&
+      is_same<T, uint8_t>::value && X.template IsType<T>() && !Acc16() &&
       group_ == X.dim32(X.dim() - 1) && group_ % 8 == 0 &&
       this->kernel_.size() == 2 && kernel_h() == 3 && kernel_w() == 3 &&
       stride_h() == stride_w() && (stride_h() == 1 || stride_h() == 2) &&
@@ -112,8 +111,7 @@ template <typename T, bool ReluFused>
 bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3x3FastPath_() {
   const Tensor& X = InputTensorCPU_(INPUT);
   bool ret = StorageOrder::NHWC == ConvPoolOpBase<CPUContext>::order_ &&
-      is_same<T, uint8_t>::value && X.template IsType<T>() &&
-      OperatorBase::debug_def().engine() != "DNNLOWP_ACC16" &&
+      is_same<T, uint8_t>::value && X.template IsType<T>() && !Acc16() &&
       group_ == X.dim32(X.dim() - 1) && group_ % 8 == 0 &&
       this->kernel_.size() == 3 && this->kernel_[0] == 3 &&
       this->kernel_[1] == 3 && this->kernel_[2] == 3 &&
@@ -291,8 +289,7 @@ void ConvDNNLowPOp<T, ReluFused>::QuantizeWeight_() {
   int M = filter.dim32(0);
 
   bool packW = ConvPoolOpBase<CPUContext>::order_ == StorageOrder::NHWC &&
-      OperatorBase::debug_def().engine() != "DNNLOWP_ACC16" &&
-      is_same<T, uint8_t>::value && GetCpuId().avx2() &&
+      !Acc16() && is_same<T, uint8_t>::value && GetCpuId().avx2() &&
       !FLAGS_caffe2_dnnlowp_force_slow_path;
 
   bool depthwise_3x3_fast_path = false, depthwise_3x3x3_fast_path = false;
@@ -393,9 +390,7 @@ void ConvDNNLowPOp<T, ReluFused>::QuantizeWeight_() {
         reason = "fbgemm only supports 8-bit integers";
       } else if (!GetCpuId().avx2()) {
         reason = "fbgemm only supports AVX2+";
-      } else if (
-          OperatorBase::debug_def().engine() == "DNNLOWP_ACC16" ||
-          depthwise_3x3_fast_path) {
+      } else if (Acc16()) {
         reason = "";
       } else if (FLAGS_caffe2_dnnlowp_force_slow_path) {
         reason = "slow path enforced";
@@ -1072,7 +1067,7 @@ static void conv_nhwc_ref_(
 
 template <typename T, bool ReluFused>
 template <typename PackAMatrix, fbgemm::QuantizationGranularity Q_GRAN>
-void ConvDNNLowPOp<T, ReluFused>::DispatchFBGEMM(
+void ConvDNNLowPOp<T, ReluFused>::DispatchFBGEMM_(
     PackAMatrix& packA,
     vector<int32_t>* Y_int32) {
   auto& filter = InputTensorCPU_(FILTER);
@@ -1289,11 +1284,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             row_offsets_.data() + tid * row_offset_size_per_thread);
 
         if (quantize_groupwise_) {
-          DispatchFBGEMM<
+          DispatchFBGEMM_<
               PackAWithIm2Col<uint8_t>,
               QuantizationGranularity::GROUP>(packA, Y_int32);
         } else {
-          DispatchFBGEMM<
+          DispatchFBGEMM_<
               PackAWithIm2Col<uint8_t>,
               QuantizationGranularity::TENSOR>(packA, Y_int32);
         }
@@ -1323,11 +1318,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             row_offsets_.data() + tid * row_offset_size_per_thread);
 
         if (quantize_groupwise_) {
-          DispatchFBGEMM<
+          DispatchFBGEMM_<
               PackAWithIm2Col<uint8_t, int32_t, 3>,
               QuantizationGranularity::GROUP>(packA, Y_int32);
         } else {
-          DispatchFBGEMM<
+          DispatchFBGEMM_<
               PackAWithIm2Col<uint8_t, int32_t, 3>,
               QuantizationGranularity::TENSOR>(packA, Y_int32);
         }
@@ -1346,11 +1341,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
           row_offsets_.data() + tid * row_offset_size_per_thread);
 
       if (quantize_groupwise_) {
-        DispatchFBGEMM<
+        DispatchFBGEMM_<
             PackAWithRowOffset<uint8_t>,
             QuantizationGranularity::GROUP>(packA, Y_int32);
       } else {
-        DispatchFBGEMM<
+        DispatchFBGEMM_<
             PackAWithRowOffset<uint8_t>,
             QuantizationGranularity::TENSOR>(packA, Y_int32);
       }

--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -26,6 +26,11 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   bool RunOnDeviceWithOrderNCHW() override;
   bool RunOnDeviceWithOrderNHWC() override;
 
+  template <typename InType>
+  bool RunOnDeviceWithOrderNCHWAndType_();
+  template <typename InType>
+  bool RunOnDeviceWithOrderNHWCAndType_();
+
   virtual bool GetQuantizationParameters_();
 
   /**
@@ -51,6 +56,10 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
       int m,
       int nthreads,
       int thread_id);
+
+  virtual bool Acc16() const {
+    return false;
+  }
 
   Tensor col_buffer_{CPU};
   Tensor img_shape_device_{CPU};
@@ -101,13 +110,8 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   bool TakeDepthWise3x3FastPath_();
   bool TakeDepthWise3x3x3FastPath_();
 
-  template <typename InType>
-  bool RunOnDeviceWithOrderNCHWAndType_();
-  template <typename InType>
-  bool RunOnDeviceWithOrderNHWCAndType_();
-
   template <typename PackAMatrix, fbgemm::QuantizationGranularity Q_GRAN>
-  void DispatchFBGEMM(PackAMatrix& packA, vector<std::int32_t>* Y_int32);
+  void DispatchFBGEMM_(PackAMatrix& packA, vector<std::int32_t>* Y_int32);
 
   template <typename InType>
   void ConvNHWCCore_(

--- a/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
@@ -192,7 +192,7 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         order=st.sampled_from(["NHWC"]),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
-        nbits_in_non_outlier=st.sampled_from((0, 6)),
+        nbits_in_non_outlier=st.sampled_from((1, 6, 8)),
         share_col_buffer=st.booleans(),
         **hu.gcs_cpu_only
     )
@@ -221,54 +221,38 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         input_channels = input_channels_per_group * group
         output_channels = output_channels_per_group * group
 
-        if nbits_in_non_outlier == 0:
-            X, W, b = generate_conv_inputs(
-                stride,
-                pad,
-                kernel,
-                dilation,
-                size,
-                group,
-                input_channels_per_group,
-                output_channels_per_group,
-                batch_size,
-                order,
-                True,  # group-wise
+        X_min = -77
+        X_max = X_min + 255
+        X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
+        X = np.round(X).astype(np.float32)
+        X[..., 0] = X_min
+        X[0, 0, 0, 1] = X_max
+
+        W_min = -100
+        W_max = W_min + 255
+        W = (
+            np.random.rand(
+                output_channels, kernel, kernel, input_channels_per_group
             )
-        else:
-            X_min = -77
-            X_max = X_min + 255
-            X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
-            X = np.round(X).astype(np.float32)
-            X[..., 0] = X_min
-            X[0, 0, 0, 1] = X_max
+            * 4
+            - 2
+            + W_min
+            + 128
+        )
+        W = np.round(W).astype(np.float32)
+        W[..., 1] = W_min + 128  # "zeros"
+        for g in range(group):
+            W[g * output_channels_per_group, 0, 0, 0] = W_min
+            W[g * output_channels_per_group + 1, 0, 0, 0] = W_max
+            W[
+                g * output_channels_per_group : (g + 1) * output_channels_per_group,
+            ] += g
 
-            W_min = -100
-            W_max = W_min + 255
-            W = (
-                np.random.rand(
-                    output_channels, kernel, kernel, input_channels_per_group
-                )
-                * 4
-                - 2
-                + W_min
-                + 128
-            )
-            W = np.round(W).astype(np.float32)
-            W[..., 1] = W_min + 128  # "zeros"
-            for g in range(group):
-                W[g * output_channels_per_group, 0, 0, 0] = W_min
-                W[g * output_channels_per_group + 1, 0, 0, 0] = W_max
-                W[
-                    g * output_channels_per_group : (g + 1) * output_channels_per_group,
-                ] += g
+        if order == "NCHW":
+            X = nhwc2nchw(X)
+            W = nhwc2nchw(W)
 
-            if order == "NCHW":
-                X = nhwc2nchw(X)
-                W = nhwc2nchw(W)
-
-            # No input quantization error in bias
-            b = np.round(np.random.randn(output_channels)).astype(np.float32)
+        b = np.round(np.random.randn(output_channels)).astype(np.float32)
 
         Output = collections.namedtuple("Output", ["Y", "op_type", "engine", "order"])
         outputs = []


### PR DESCRIPTION
Summary:
This diff completes a series of diffs that hopefully provides good speedups in resnet50 over the current int8 perf and resnext101 over fp32, using im2col fusion.
We may need to further optimize sparse convolution depending on the performance we will see.

Minor things:
conv acc16 operator doesn't allow nbits_in_non_outlier == 0 anymore. This option was not useful anyway because nbits_in_non_outlier == 0 means everything is outlier and for that we can just use conv acc32 operator.

Differential Revision: D13192349
