### PR TITLE
[c10d] Fixed new_group won't work for two or more different rank groups

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -423,7 +423,16 @@ They are used in specifying strategies for reduction collectives, e.g.,
 #ifdef USE_C10D_NCCL
   shared_ptr_class_<::c10d::ProcessGroupNCCL>(
       module, "ProcessGroupNCCL", processGroup)
-      .def(py::init<const std::shared_ptr<::c10d::Store>&, int, int>());
+      .def(
+          py::init<
+              const std::shared_ptr<::c10d::Store>&,
+              int,
+              int,
+              const std::string&>(),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("groupName") = "");
 #endif
 
 #ifdef USE_C10D_MPI

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -374,8 +374,8 @@ def init_process_group(backend,
 def _new_process_group_helper(world_size,
                               rank,
                               group_ranks,
-                              in_group=True,
-                              group_name="",
+                              in_group,
+                              group_name,
                               timeout=_default_pg_timeout):
     """
     Create a new distributed process group. And the new process group can be
@@ -422,7 +422,7 @@ def _new_process_group_helper(world_size,
             if not is_nccl_available():
                 raise RuntimeError("Distributed package doesn't have NCCL "
                                    "built in")
-            pg = ProcessGroupNCCL(store, rank, world_size)
+            pg = ProcessGroupNCCL(store, rank, world_size, group_name)
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
         else:
@@ -1197,6 +1197,15 @@ def new_group(ranks=None, timeout=_default_pg_timeout):
     _check_default_pg()
 
     global _pg_group_ranks
+    global _group_count
+    global _pg_names
+
+    group_name = str(_group_count)
+    _group_count += 1
+
+    if group_name in _pg_names.values():
+        raise RuntimeError("The specified group name has already been "
+                           "created, please use a different group name")
 
     default_backend, _ = _pg_map[_default_pg]
     global_rank = _default_pg.rank()
@@ -1231,6 +1240,7 @@ def new_group(ranks=None, timeout=_default_pg_timeout):
                                        group_rank,
                                        input_ranks,
                                        in_group,
+                                       group_name,
                                        timeout=timeout)
     else:
         # Release ranks not in the group
@@ -1241,6 +1251,8 @@ def new_group(ranks=None, timeout=_default_pg_timeout):
             pg = _new_process_group_helper(group_world_size,
                                            group_rank,
                                            input_ranks,
+                                           True,
+                                           group_name,
                                            timeout=timeout)
 
     # Create the global rank to group rank mapping

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -156,19 +156,19 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   // for all processes
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
   // Default group is an empty string
-  auto groupKey = groupName_ + "_";
+  const auto groupKey = groupName_ + "_";
   if (processGroupCounterMap_.count(groupKey) == 0) {
     processGroupCounterMap_[groupKey] = -1;
   }
   ++processGroupCounterMap_[groupKey];
-  processGroupID_ = std::to_string(processGroupCounterMap_[groupName_]);
-  groupPgId_ = groupName_ + "_" + processGroupID_;
-  pgUniqueNCCLIDCnt_[groupPgId_] = -1;
+  processGroupID_ = std::to_string(processGroupCounterMap_[groupKey]);
+  groupPgID_ = groupName_ + "_" + processGroupID_;
+  pgUniqueNCCLIDCnt_[groupPgID_] = -1;
 }
 
 ProcessGroupNCCL::~ProcessGroupNCCL() {
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  pgUniqueNCCLIDCnt_.erase(groupPgId_);
+  pgUniqueNCCLIDCnt_.erase(groupPgID_);
 }
 
 void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
@@ -178,8 +178,7 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
   // NCCL unique ID created
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
   auto groupPgId = groupName_ + "_" + processGroupID_;
-  auto uniqueNCCLIDCnt = pgUniqueNCCLIDCnt_[groupPgId_] + 1;
-  pgUniqueNCCLIDCnt_[groupPgId_] = uniqueNCCLIDCnt;
+  const auto uniqueNCCLIDCnt = ++pgUniqueNCCLIDCnt_[groupPgID_];
 
   lock.unlock();
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -140,26 +140,35 @@ void ProcessGroupNCCL::WorkNCCL::wait() {
   synchronize();
 }
 
-std::unordered_map<ssize_t, ssize_t> ProcessGroupNCCL::pgUniqueNCCLIDCnt_;
-ssize_t ProcessGroupNCCL::processGroupCounter_ = -1;
+std::unordered_map<std::string, ssize_t> ProcessGroupNCCL::pgUniqueNCCLIDCnt_;
+std::unordered_map<std::string, ssize_t>
+    ProcessGroupNCCL::processGroupCounterMap_;
+
 std::mutex ProcessGroupNCCL::pgTrackingLock_;
 
 ProcessGroupNCCL::ProcessGroupNCCL(
     const std::shared_ptr<Store>& store,
     int rank,
-    int size)
-    : ProcessGroup(rank, size), store_(store) {
+    int size,
+    const std::string& groupName)
+    : ProcessGroup(rank, size), store_(store), groupName_(groupName) {
   // Generate the Process Group ID for current PG, this needs to be identical
   // for all processes
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  ++processGroupCounter_;
-  pgUniqueNCCLIDCnt_[processGroupCounter_] = -1;
-  processGroupID_ = std::to_string(processGroupCounter_);
+  // Default group is an empty string
+  auto groupKey = groupName_ + "_";
+  if (processGroupCounterMap_.count(groupKey) == 0) {
+    processGroupCounterMap_[groupKey] = -1;
+  }
+  ++processGroupCounterMap_[groupKey];
+  processGroupID_ = std::to_string(processGroupCounterMap_[groupName_]);
+  groupPgId_ = groupName_ + "_" + processGroupID_;
+  pgUniqueNCCLIDCnt_[groupPgId_] = -1;
 }
 
 ProcessGroupNCCL::~ProcessGroupNCCL() {
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  pgUniqueNCCLIDCnt_.erase(std::stoull(processGroupID_));
+  pgUniqueNCCLIDCnt_.erase(groupPgId_);
 }
 
 void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
@@ -168,9 +177,9 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
   // The key is a combination of processGroupID_ and the current count of
   // NCCL unique ID created
   std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  auto processGroupIDKey = std::stoull(processGroupID_);
-  auto uniqueNCCLIDCnt = pgUniqueNCCLIDCnt_[processGroupIDKey] + 1;
-  pgUniqueNCCLIDCnt_[processGroupIDKey] = uniqueNCCLIDCnt;
+  auto groupPgId = groupName_ + "_" + processGroupID_;
+  auto uniqueNCCLIDCnt = pgUniqueNCCLIDCnt_[groupPgId_] + 1;
+  pgUniqueNCCLIDCnt_[groupPgId_] = uniqueNCCLIDCnt;
 
   lock.unlock();
 

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -98,7 +98,11 @@ class ProcessGroupNCCL : public ProcessGroup {
   };
 
   // Constructor will also check the number of available GPUs in the system
-  ProcessGroupNCCL(const std::shared_ptr<Store>& store, int rank, int size);
+  ProcessGroupNCCL(
+      const std::shared_ptr<Store>& store,
+      int rank,
+      int size,
+      const std::string& groupName = "");
 
   virtual ~ProcessGroupNCCL();
 
@@ -169,6 +173,9 @@ class ProcessGroupNCCL : public ProcessGroup {
   // Store that is used to exchange each Ranks's NCCL unique ID
   std::shared_ptr<Store> store_;
 
+  // The process group name
+  std::string groupName_;
+
   // The NCCL communicator that the process group has cached.
   // The key is a list of GPU devices that an operation is operating on
   // The GPU devices are stored in a device sequence and the cache NCCL
@@ -201,13 +208,21 @@ class ProcessGroupNCCL : public ProcessGroup {
   // ID of this process group
   std::string processGroupID_;
 
+  // Group Prefix and ID of this process group
+  std::string groupPgId_;
+
   // Device Indexes used for all collectives in this group
   std::set<int> usedDeviceIdxs_;
 
   // processGroupID tracking
   static std::mutex pgTrackingLock_;
-  static std::unordered_map<ssize_t, ssize_t> pgUniqueNCCLIDCnt_;
-  static ssize_t processGroupCounter_;
+
+  // map from the key: "group name + pg counter (ID)" to the
+  // unique NCCL ID count. This needs to be group and pg specific
+  static std::unordered_map<std::string, ssize_t> pgUniqueNCCLIDCnt_;
+
+  // map from group name to the pg counter (ID) wtihin that group
+  static std::unordered_map<std::string, ssize_t> processGroupCounterMap_;
 };
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -98,6 +98,19 @@ class ProcessGroupNCCL : public ProcessGroup {
   };
 
   // Constructor will also check the number of available GPUs in the system
+  //
+  // Group support:
+  //
+  // In order to support multiple NCCL process groups, each of which has
+  // different group ranks, we need to use groupName to identify each group
+  // to ensure the correct behavior. In other words, each process group that
+  // has different group ranks needs to have a different and unique groupName
+  // to avoid clashing into undefined behaviors.
+  //
+  // In Python frontend API of torch.distributed, it guarantees that each group
+  // will have a unique name to be passed into the ProcessGroupNCCL constructor.
+  // If you would like to use ProcessGroupNCCL constructor directly, it is
+  // your reponsibility to do so as well.
   ProcessGroupNCCL(
       const std::shared_ptr<Store>& store,
       int rank,
@@ -209,7 +222,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::string processGroupID_;
 
   // Group Prefix and ID of this process group
-  std::string groupPgId_;
+  std::string groupPgID_;
 
   // Device Indexes used for all collectives in this group
   std::set<int> usedDeviceIdxs_;
@@ -219,9 +232,22 @@ class ProcessGroupNCCL : public ProcessGroup {
 
   // map from the key: "group name + pg counter (ID)" to the
   // unique NCCL ID count. This needs to be group and pg specific
+  //
+  // For each process group, we need a uniform unique NCCL ID counter to ensure
+  // that NCCL operation in this process group can be completed successfully.
+  // Since each process group ID belongs to a group name, the key to this map
+  // is a combination of group name and ProcessGroupNCCL ID.
   static std::unordered_map<std::string, ssize_t> pgUniqueNCCLIDCnt_;
 
-  // map from group name to the pg counter (ID) wtihin that group
+  // map from group name to the pg counter (ID) within that group
+  //
+  // For each group with the "group name" (which is the key), we need to
+  // keep track of a unique process group ID when creating a new
+  // ProcessGroupNCCL for this "group name". Therefore, the value of this
+  // map keeps the unique ProcessGroupNCCL's ID for a specific group with
+  // the "group name". The reason we need a per-group process group ID counter
+  // is that different group can have different ranks and we need ensure that
+  // each group has its own uniform process group ID for all its ranks.
   static std::unordered_map<std::string, ssize_t> processGroupCounterMap_;
 };
 


### PR DESCRIPTION
This fixed two things:

(1) NCCL group doesn't support 2 or more groups, this is because, we need a group name in ProcessGroupNCCL class to keep track of the ProcessGroup ID within that group name, and also the NCCL unique ID within that group name and process group ID.  Otherwise, different processes will create different NCCL PG in different orders and can clash on these names.  This will fix the NCCL problem.

(2)  When using new_group, each rank should enter this function and update its global group name counter to ensure that every rank always operates on the same group name.


With both fixes: repro code in: https://github.com/pytorch/pytorch/issues/14528 should work with both NCCL and Gloo backends.

```
tengli@learnfair096:~$ python -m torch.distributed.launch --nproc_per_node=8 --nnodes=1 --node_rank=0 --master_addr=127.0.0.1 --master_port=30000 ~/github_issues/nccl_group.py
rank: 0 - val: 6.0
rank: 2 - val: 6.0
rank: 3 - val: 6.0
rank: 1 - val: 6.0
rank: 4 - val: 22.0
rank: 6 - val: 22.0
rank: 5 - val: 22.0
rank: 7 - val: 22.0
```